### PR TITLE
pref(rust!, python): Unify `sort` with `SortOptions` and `SortMultipleOptions`

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -66,6 +66,6 @@ impl CategoricalChunked {
         counts.rename("counts");
         let cols = vec![values.into_series(), counts.into_series()];
         let df = unsafe { DataFrame::new_no_checks(cols) };
-        df.sort(["counts"], true, false)
+        df.sort(["counts"], SortMultipleOptions::default().with_order(true))
     }
 }

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -66,6 +66,6 @@ impl CategoricalChunked {
         counts.rename("counts");
         let cols = vec![values.into_series(), counts.into_series()];
         let df = unsafe { DataFrame::new_no_checks(cols) };
-        df.sort(["counts"], SortMultipleOptions::default().with_order(true))
+        df.sort(["counts"], SortMultipleOptions::default().with_order_descending(true))
     }
 }

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -66,6 +66,9 @@ impl CategoricalChunked {
         counts.rename("counts");
         let cols = vec![values.into_series(), counts.into_series()];
         let df = unsafe { DataFrame::new_no_checks(cols) };
-        df.sort(["counts"], SortMultipleOptions::default().with_order_descending(true))
+        df.sort(
+            ["counts"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -42,6 +42,7 @@ pub mod zip;
 
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
+pub use sort::options::*;
 
 use crate::series::IsSorted;
 
@@ -357,35 +358,6 @@ pub trait ChunkUnique<T: PolarsDataType> {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-#[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
-pub struct SortOptions {
-    pub descending: bool,
-    pub nulls_last: bool,
-    pub multithreaded: bool,
-    pub maintain_order: bool,
-}
-
-#[derive(Clone)]
-#[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
-pub struct SortMultipleOptions {
-    pub other: Vec<Series>,
-    pub descending: Vec<bool>,
-    pub nulls_last: bool,
-    pub multithreaded: bool,
-}
-
-impl Default for SortOptions {
-    fn default() -> Self {
-        Self {
-            descending: false,
-            nulls_last: false,
-            multithreaded: true,
-            maintain_order: false,
-        }
-    }
-}
-
 /// Sort operations on `ChunkedArray`.
 pub trait ChunkSort<T: PolarsDataType> {
     #[allow(unused_variables)]
@@ -398,7 +370,12 @@ pub trait ChunkSort<T: PolarsDataType> {
     fn arg_sort(&self, options: SortOptions) -> IdxCa;
 
     /// Retrieve the indexes need to sort this and the other arrays.
-    fn arg_sort_multiple(&self, _options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    #[allow(unused_variables)]
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        _options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         polars_bail!(opq = arg_sort_multiple, T::get_dtype());
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
@@ -28,10 +28,10 @@ impl PartialOrd for CompareRow<'_> {
 
 pub fn _arg_bottom_k(
     k: usize,
-    from_n_rows: usize,
     by_column: &[Series],
     sort_options: &mut SortMultipleOptions,
 ) -> PolarsResult<NoNull<IdxCa>> {
+    let from_n_rows = by_column[0].len();
     _broadcast_descending(by_column.len(), &mut sort_options.descending);
     let encoded = _get_rows_encoded(by_column, &sort_options.descending, sort_options.nulls_last)?;
     let arr = encoded.into_array();

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
@@ -1,0 +1,81 @@
+use polars_utils::iter::EnumerateIdxTrait;
+
+use super::*;
+
+#[derive(Eq)]
+struct CompareRow<'a> {
+    idx: IdxSize,
+    bytes: &'a [u8],
+}
+
+impl PartialEq for CompareRow<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes
+    }
+}
+
+impl Ord for CompareRow<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.bytes.cmp(other.bytes)
+    }
+}
+
+impl PartialOrd for CompareRow<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub fn _arg_bottom_k(
+    k: usize,
+    from_n_rows: usize,
+    by_column: &[Series],
+    sort_options: &mut SortMultipleOptions,
+) -> PolarsResult<NoNull<IdxCa>> {
+    _broadcast_descending(by_column.len(), &mut sort_options.descending);
+    let encoded = _get_rows_encoded(by_column, &sort_options.descending, sort_options.nulls_last)?;
+    let arr = encoded.into_array();
+    let mut rows = arr
+        .values_iter()
+        .enumerate_idx()
+        .map(|(idx, bytes)| CompareRow { idx, bytes })
+        .collect::<Vec<_>>();
+
+    let sorted = if k >= from_n_rows {
+        match (sort_options.multithreaded, sort_options.maintain_order) {
+            (true, true) => POOL.install(|| {
+                rows.par_sort();
+            }),
+            (true, false) => POOL.install(|| {
+                rows.par_sort_unstable();
+            }),
+            (false, true) => rows.sort(),
+            (false, false) => rows.sort_unstable(),
+        }
+        &rows
+    } else if sort_options.maintain_order {
+        // todo: maybe there is some more efficient method, comparable to select_nth_unstable
+        if sort_options.multithreaded {
+            POOL.install(|| {
+                rows.par_sort();
+            })
+        } else {
+            rows.sort();
+        }
+        &rows[..k]
+    } else {
+        // todo: possible multi threaded `select_nth_unstable`?
+        let (lower, _el, _upper) = rows.select_nth_unstable(k);
+        if sort_options.multithreaded {
+            POOL.install(|| {
+                lower.par_sort_unstable();
+            })
+        } else {
+            lower.sort_unstable();
+        }
+        &*lower
+    };
+
+    let idx: NoNull<IdxCa> = sorted.iter().map(|cmp_row| cmp_row.idx).collect();
+    Ok(idx)
+}

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -35,35 +35,46 @@ pub(crate) fn arg_sort_multiple_impl<T: NullOrderCmp + Send + Copy>(
         .collect_trusted();
 
     let first_descending = descending[0];
-    POOL.install(|| {
-        vals.par_sort_by(|tpl_a, tpl_b| {
-            match (
-                first_descending,
-                tpl_a
-                    .1
-                    .null_order_cmp(&tpl_b.1, options.nulls_last ^ first_descending),
-            ) {
-                // if ordering is equal, we check the other arrays until we find a non-equal ordering
-                // if we have exhausted all arrays, we keep the equal ordering.
-                (_, Ordering::Equal) => {
-                    let idx_a = tpl_a.0 as usize;
-                    let idx_b = tpl_b.0 as usize;
-                    unsafe {
-                        ordering_other_columns(
-                            &compare_inner,
-                            descending.get_unchecked(1..),
-                            options.nulls_last,
-                            idx_a,
-                            idx_b,
-                        )
-                    }
-                },
-                (true, Ordering::Less) => Ordering::Greater,
-                (true, Ordering::Greater) => Ordering::Less,
-                (_, ord) => ord,
-            }
-        });
-    });
+
+    let compare = |tpl_a: &(u64, T), tpl_b: &(u64, T)| {
+        match (
+            first_descending,
+            tpl_a
+                .1
+                .null_order_cmp(&tpl_b.1, options.nulls_last ^ first_descending),
+        ) {
+            // if ordering is equal, we check the other arrays until we find a non-equal ordering
+            // if we have exhausted all arrays, we keep the equal ordering.
+            (_, Ordering::Equal) => {
+                let idx_a = tpl_a.0 as usize;
+                let idx_b = tpl_b.0 as usize;
+                unsafe {
+                    ordering_other_columns(
+                        &compare_inner,
+                        descending.get_unchecked(1..),
+                        options.nulls_last,
+                        idx_a,
+                        idx_b,
+                    )
+                }
+            },
+            (true, Ordering::Less) => Ordering::Greater,
+            (true, Ordering::Greater) => Ordering::Less,
+            (_, ord) => ord,
+        }
+    };
+
+    match (options.multithreaded, options.maintain_order) {
+        (true, true) => POOL.install(|| {
+            vals.par_sort_by(compare);
+        }),
+        (true, false) => POOL.install(|| {
+            vals.par_sort_unstable_by(compare);
+        }),
+        (false, true) => vals.sort_by(compare),
+        (false, false) => vals.sort_unstable_by(compare),
+    }
+
     let ca: NoNull<IdxCa> = vals.into_iter().map(|(idx, _v)| idx).collect_trusted();
     // Don't set to sorted. Argsort indices are not sorted.
     Ok(ca.into_inner())

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -36,7 +36,7 @@ pub(crate) fn arg_sort_multiple_impl<T: NullOrderCmp + Send + Copy>(
 
     let first_descending = descending[0];
 
-    let compare = |tpl_a: &(u64, T), tpl_b: &(u64, T)| {
+    let compare = |tpl_a: &(_, T), tpl_b: &(_, T)| -> Ordering {
         match (
             first_descending,
             tpl_a

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -24,12 +24,12 @@ pub(crate) fn args_validate<T: PolarsDataType>(
 
 pub(crate) fn arg_sort_multiple_impl<T: NullOrderCmp + Send + Copy>(
     mut vals: Vec<(IdxSize, T)>,
+    by: &[Series],
     options: &SortMultipleOptions,
 ) -> PolarsResult<IdxCa> {
     let descending = &options.descending;
-    debug_assert_eq!(descending.len() - 1, options.other.len());
-    let compare_inner: Vec<_> = options
-        .other
+    debug_assert_eq!(descending.len() - 1, by.len());
+    let compare_inner: Vec<_> = by
         .iter()
         .map(|s| s.into_total_ord_inner())
         .collect_trusted();

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -177,7 +177,7 @@ mod test {
 
             let out = df.sort(
                 ["cat", "vals"],
-                SortMultipleOptions::default().with_orders([false, false]),
+                SortMultipleOptions::default().with_order_descendings([false, false]),
             )?;
             let out = out.column("cat")?;
             let cat = out.categorical()?;
@@ -185,7 +185,7 @@ mod test {
 
             let out = df.sort(
                 ["vals", "cat"],
-                SortMultipleOptions::default().with_orders([false, false]),
+                SortMultipleOptions::default().with_order_descendings([false, false]),
             )?;
             let out = out.column("cat")?;
             let cat = out.categorical()?;

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -79,9 +79,9 @@ impl CategoricalChunked {
 
     /// Retrieve the indexes need to sort this and the other arrays.
 
-    pub(crate) fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    pub(crate) fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
         if self.uses_lexical_ordering() {
-            args_validate(self.physical(), &options.other, &options.descending)?;
+            args_validate(self.physical(), by, &options.descending)?;
             let mut count: IdxSize = 0;
 
             // we use bytes to save a monomorphisized str impl
@@ -95,9 +95,9 @@ impl CategoricalChunked {
                 })
                 .collect_trusted();
 
-            arg_sort_multiple_impl(vals, options)
+            arg_sort_multiple_impl(vals, by, options)
         } else {
-            self.physical().arg_sort_multiple(options)
+            self.physical().arg_sort_multiple(by, options)
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -79,7 +79,11 @@ impl CategoricalChunked {
 
     /// Retrieve the indexes need to sort this and the other arrays.
 
-    pub(crate) fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    pub(crate) fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         if self.uses_lexical_ordering() {
             args_validate(self.physical(), by, &options.descending)?;
             let mut count: IdxSize = 0;
@@ -171,12 +175,18 @@ mod test {
                 "vals" => [1, 1, 2, 2]
             ]?;
 
-            let out = df.sort(["cat", "vals"], vec![false, false], false)?;
+            let out = df.sort(
+                ["cat", "vals"],
+                SortMultipleOptions::default().with_orders([false, false]),
+            )?;
             let out = out.column("cat")?;
             let cat = out.categorical()?;
             assert_order(cat, &["a", "a", "b", "c"]);
 
-            let out = df.sort(["vals", "cat"], vec![false, false], false)?;
+            let out = df.sort(
+                ["vals", "cat"],
+                SortMultipleOptions::default().with_orders([false, false]),
+            )?;
             let out = out.column("cat")?;
             let cat = out.categorical()?;
             assert_order(cat, &["b", "c", "a", "a"]);

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -3,6 +3,7 @@ mod arg_sort;
 pub mod arg_sort_multiple;
 
 pub mod options;
+pub mod arg_bottom_k;
 
 #[cfg(feature = "dtype-categorical")]
 mod categorical;

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -532,7 +532,7 @@ impl ChunkSort<BinaryOffsetType> for BinaryOffsetChunked {
         by: &[Series],
         options: &SortMultipleOptions,
     ) -> PolarsResult<IdxCa> {
-        args_validate(self, &by, &options.descending)?;
+        args_validate(self, by, &options.descending)?;
 
         let mut count: IdxSize = 0;
 

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -831,7 +831,7 @@ mod test {
 
         let out = df.sort(
             ["groups", "values"],
-            SortMultipleOptions::default().with_orders([true, false]),
+            SortMultipleOptions::default().with_order_descendings([true, false]),
         )?;
         let expected = df!(
             "groups" => [3, 2, 1],
@@ -841,7 +841,7 @@ mod test {
 
         let out = df.sort(
             ["values", "groups"],
-            SortMultipleOptions::default().with_orders([false, true]),
+            SortMultipleOptions::default().with_order_descendings([false, true]),
         )?;
         let expected = df!(
             "groups" => [2, 1, 3],

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -2,8 +2,8 @@ mod arg_sort;
 
 pub mod arg_sort_multiple;
 
-pub mod options;
 pub mod arg_bottom_k;
+pub mod options;
 
 #[cfg(feature = "dtype-categorical")]
 mod categorical;
@@ -618,7 +618,11 @@ impl ChunkSort<BooleanType> for BooleanChunked {
             self.len(),
         )
     }
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         let mut vals = Vec::with_capacity(self.len());
         let mut count: IdxSize = 0;
         for arr in self.downcast_iter() {
@@ -793,7 +797,7 @@ mod test {
         let c = StringChunked::new("c", &["a", "b", "c", "d", "e", "f", "g", "h"]);
         let df = DataFrame::new(vec![a.into_series(), b.into_series(), c.into_series()])?;
 
-        let out = df.sort(["a", "b", "c"], false, false)?;
+        let out = df.sort(["a", "b", "c"], SortMultipleOptions::default())?;
         assert_eq!(
             Vec::from(out.column("b")?.i64()?),
             &[
@@ -813,7 +817,7 @@ mod test {
         let b = Int32Chunked::new("b", &[5, 4, 2, 3, 4, 5]).into_series();
         let df = DataFrame::new(vec![a, b])?;
 
-        let out = df.sort(["a", "b"], false, false)?;
+        let out = df.sort(["a", "b"], SortMultipleOptions::default())?;
         let expected = df!(
             "a" => ["a", "a", "b", "b", "c", "c"],
             "b" => [3, 5, 4, 4, 2, 5]
@@ -825,14 +829,20 @@ mod test {
             "values" => ["a", "a", "b"]
         )?;
 
-        let out = df.sort(["groups", "values"], vec![true, false], false)?;
+        let out = df.sort(
+            ["groups", "values"],
+            SortMultipleOptions::default().with_orders([true, false]),
+        )?;
         let expected = df!(
             "groups" => [3, 2, 1],
             "values" => ["b", "a", "a"]
         )?;
         assert!(out.equals(&expected));
 
-        let out = df.sort(["values", "groups"], vec![false, true], false)?;
+        let out = df.sort(
+            ["values", "groups"],
+            SortMultipleOptions::default().with_orders([false, true]),
+        )?;
         let expected = df!(
             "groups" => [2, 1, 3],
             "values" => ["a", "a", "b"]

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -675,8 +675,8 @@ pub fn _broadcast_descending(n_cols: usize, descending: &mut Vec<bool>) {
 
 pub(crate) fn prepare_arg_sort(
     columns: Vec<Series>,
-    mut descending: Vec<bool>,
-) -> PolarsResult<(Series, Vec<Series>, Vec<bool>)> {
+    sort_options: &mut SortMultipleOptions,
+) -> PolarsResult<(Series, Vec<Series>)> {
     let n_cols = columns.len();
 
     let mut columns = columns
@@ -687,8 +687,8 @@ pub(crate) fn prepare_arg_sort(
     let first = columns.remove(0);
 
     // broadcast ordering
-    _broadcast_descending(n_cols, &mut descending);
-    Ok((first, columns, descending))
+    _broadcast_descending(n_cols, &mut sort_options.descending);
+    Ok((first, columns))
 }
 
 #[cfg(test)]

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -45,8 +45,49 @@ impl Default for SortMultipleOptions {
 }
 
 impl SortMultipleOptions {
-    pub fn with_order(&mut self, descending: Vec<bool>) -> &mut Self {
+    pub fn with_order(mut self, descending: Vec<bool>) -> Self {
         self.descending = descending;
+        self
+    }
+
+    pub fn descending(self, descending: bool) -> Self {
+        self.with_order(vec![descending])
+    }
+
+    pub fn nulls_last(mut self, enabled: bool) -> Self {
+        self.nulls_last = enabled;
+        self
+    }
+
+    pub fn multithreaded(mut self, enabled: bool) -> Self {
+        self.multithreaded = enabled;
+        self
+    }
+
+    pub fn maintain_order(mut self, enabled: bool) -> Self {
+        self.maintain_order = enabled;
+        self
+    }
+}
+
+impl SortOptions {
+    pub fn descending(mut self, enabled: bool) -> Self {
+        self.descending = enabled;
+        self
+    }
+
+    pub fn nulls_last(mut self, enabled: bool) -> Self {
+        self.nulls_last = enabled;
+        self
+    }
+
+    pub fn multithreaded(mut self, enabled: bool) -> Self {
+        self.multithreaded = enabled;
+        self
+    }
+
+    pub fn maintain_order(mut self, enabled: bool) -> Self {
+        self.maintain_order = enabled;
         self
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -13,7 +13,7 @@ pub struct SortOptions {
     pub maintain_order: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub struct SortMultipleOptions {
     pub descending: Vec<bool>,
@@ -41,5 +41,12 @@ impl Default for SortMultipleOptions {
             multithreaded: true,
             maintain_order: false,
         }
+    }
+}
+
+impl SortMultipleOptions {
+    pub fn with_order(&mut self, descending: Vec<bool>) -> &mut Self {
+        self.descending = descending;
+        self
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -83,7 +83,8 @@ pub struct SortMultipleOptions {
     ///
     /// If only one value is given, it will broadcast to all columns.
     ///
-    /// Use [`SortMultipleOptions::with_orders`] or [`SortMultipleOptions::with_order`] to modify.
+    /// Use [`SortMultipleOptions::with_order_descendings`]
+    /// or [`SortMultipleOptions::with_order_descending`] to modify.
     ///
     /// # Safety
     ///

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -81,7 +81,7 @@ pub struct SortOptions {
 pub struct SortMultipleOptions {
     /// Order of the columns. Default all `false``.
     ///
-    /// If only one value is given, it will boardcast to all columns.
+    /// If only one value is given, it will broadcast to all columns.
     ///
     /// Use [`SortMultipleOptions::with_orders`] or [`SortMultipleOptions::with_order`] to modify.
     ///

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -92,8 +92,8 @@ impl SortOptions {
     }
 }
 
-impl From<SortOptions> for SortMultipleOptions {
-    fn from(value: SortOptions) -> Self {
+impl From<&SortOptions> for SortMultipleOptions {
+    fn from(value: &SortOptions) -> Self {
         SortMultipleOptions {
             descending: vec![value.descending],
             nulls_last: value.nulls_last,

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -50,3 +50,14 @@ impl SortMultipleOptions {
         self
     }
 }
+
+impl From<SortOptions> for SortMultipleOptions {
+    fn from(value: SortOptions) -> Self {
+        SortMultipleOptions {
+            descending: vec![value.descending],
+            nulls_last: value.nulls_last,
+            multithreaded: value.multithreaded,
+            maintain_order: value.maintain_order,
+        }
+    }
+}

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -16,6 +16,15 @@ pub struct SortOptions {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub struct SortMultipleOptions {
+    /// Order of the columns.
+    ///
+    /// If only one value is given, it will boardcast to all columns.
+    ///
+    /// Use [`SortMultipleOptions::with_orders`] or [`SortMultipleOptions::with_order`] to modify.
+    ///
+    /// # Safety
+    ///
+    /// Len must matches the number of columns or equal to 1.
     pub descending: Vec<bool>,
     pub nulls_last: bool,
     pub multithreaded: bool,
@@ -50,6 +59,10 @@ impl SortMultipleOptions {
     }
 
     /// Specify order for each columns
+    ///
+    /// # Safety
+    ///
+    /// Len must matches the number of columns or equal to 1.
     pub fn with_orders(mut self, descending: impl IntoIterator<Item = bool>) -> Self {
         self.descending = descending.into_iter().collect();
         self

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -45,53 +45,60 @@ impl Default for SortMultipleOptions {
 }
 
 impl SortMultipleOptions {
-    pub fn with_order(mut self, descending: Vec<bool>) -> Self {
-        self.descending = descending;
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Specify order for each columns
+    pub fn with_orders(mut self, descending: impl IntoIterator<Item = bool>) -> Self {
+        self.descending = descending.into_iter().collect();
         self
     }
 
-    pub fn descending(self, descending: bool) -> Self {
-        self.with_order(vec![descending])
+    /// Implement order for all columns
+    pub fn with_order(mut self, descending: bool) -> Self {
+        self.descending = vec![descending];
+        self
     }
 
-    pub fn nulls_last(mut self, enabled: bool) -> Self {
+    pub fn with_nulls_last(mut self, enabled: bool) -> Self {
         self.nulls_last = enabled;
         self
     }
 
-    pub fn multithreaded(mut self, enabled: bool) -> Self {
+    pub fn with_multithreaded(mut self, enabled: bool) -> Self {
         self.multithreaded = enabled;
         self
     }
 
-    pub fn maintain_order(mut self, enabled: bool) -> Self {
+    pub fn with_maintain_order(mut self, enabled: bool) -> Self {
         self.maintain_order = enabled;
         self
     }
 
-    pub fn reverse_order(mut self) -> Self {
+    pub fn with_order_reversed(mut self) -> Self {
         self.descending.iter_mut().for_each(|x| *x = !*x);
         self
     }
 }
 
 impl SortOptions {
-    pub fn descending(mut self, enabled: bool) -> Self {
+    pub fn with_order(mut self, enabled: bool) -> Self {
         self.descending = enabled;
         self
     }
 
-    pub fn nulls_last(mut self, enabled: bool) -> Self {
+    pub fn with_nulls_last(mut self, enabled: bool) -> Self {
         self.nulls_last = enabled;
         self
     }
 
-    pub fn multithreaded(mut self, enabled: bool) -> Self {
+    pub fn with_multithreaded(mut self, enabled: bool) -> Self {
         self.multithreaded = enabled;
         self
     }
 
-    pub fn maintain_order(mut self, enabled: bool) -> Self {
+    pub fn with_maintain_order(mut self, enabled: bool) -> Self {
         self.maintain_order = enabled;
         self
     }

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -32,7 +32,7 @@ pub struct SortOptions {
     /// If true sort in descending order.
     /// Default `false`.
     pub descending: bool,
-    /// If true nulls are sorted last.
+    /// Whether place null values last.
     /// Default `false`.
     pub nulls_last: bool,
     /// If true sort in multiple threads.
@@ -90,7 +90,7 @@ pub struct SortMultipleOptions {
     ///
     /// Len must matches the number of columns or equal to 1.
     pub descending: Vec<bool>,
-    /// Whether treat nulls as largest. Default `false`.
+    /// Whether place null values last. Default `false`.
     pub nulls_last: bool,
     /// Whether sort in multiple threads. Default `true`.
     pub multithreaded: bool,
@@ -142,7 +142,7 @@ impl SortMultipleOptions {
         self
     }
 
-    /// Whether treat nulls as largest. Default `false`.
+    /// Whether place null values last. Default `false`.
     pub fn with_nulls_last(mut self, enabled: bool) -> Self {
         self.nulls_last = enabled;
         self
@@ -179,7 +179,7 @@ impl SortOptions {
         self
     }
 
-    /// Whether treat nulls as largest. Default `false`.
+    /// Whether place null values last. Default `false`.
     pub fn with_nulls_last(mut self, enabled: bool) -> Self {
         self.nulls_last = enabled;
         self

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -1,0 +1,45 @@
+#[cfg(feature = "serde-lazy")]
+use serde::{Deserialize, Serialize};
+pub use slice::*;
+
+use crate::prelude::*;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+pub struct SortOptions {
+    pub descending: bool,
+    pub nulls_last: bool,
+    pub multithreaded: bool,
+    pub maintain_order: bool,
+}
+
+#[derive(Clone)]
+#[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+pub struct SortMultipleOptions {
+    pub descending: Vec<bool>,
+    pub nulls_last: bool,
+    pub multithreaded: bool,
+    pub maintain_order: bool,
+}
+
+impl Default for SortOptions {
+    fn default() -> Self {
+        Self {
+            descending: false,
+            nulls_last: false,
+            multithreaded: true,
+            maintain_order: false,
+        }
+    }
+}
+
+impl Default for SortMultipleOptions {
+    fn default() -> Self {
+        Self {
+            descending: vec![false],
+            nulls_last: false,
+            multithreaded: true,
+            maintain_order: false,
+        }
+    }
+}

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -107,3 +107,14 @@ impl From<&SortOptions> for SortMultipleOptions {
         }
     }
 }
+
+impl From<&SortMultipleOptions> for SortOptions {
+    fn from(value: &SortMultipleOptions) -> Self {
+        SortOptions {
+            descending: value.descending.first().copied().unwrap_or(false),
+            nulls_last: value.nulls_last,
+            multithreaded: value.multithreaded,
+            maintain_order: value.maintain_order,
+        }
+    }
+}

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -68,6 +68,11 @@ impl SortMultipleOptions {
         self.maintain_order = enabled;
         self
     }
+
+    pub fn reverse_order(mut self) -> Self {
+        self.descending.iter_mut().for_each(|x| *x = !*x);
+        self
+    }
 }
 
 impl SortOptions {

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -4,19 +4,82 @@ pub use slice::*;
 
 use crate::prelude::*;
 
+/// Options for single series sorting.
+///
+/// Indicating the order of sorting, nulls position, multithreading, and maintaining order.
+///
+/// # Example
+///
+/// ```
+/// # use polars_core::prelude::*;
+/// let s = Series::new("a", [Some(5), Some(2), Some(3), Some(4), None].as_ref());
+/// let sorted = s
+///     .sort(
+///         SortOptions::default()
+///             .with_order_descending(true)
+///             .with_nulls_last(true)
+///             .with_multithreaded(false),
+///     )
+///     .unwrap();
+/// assert_eq!(
+///     sorted,
+///     Series::new("a", [Some(5), Some(4), Some(3), Some(2), None].as_ref())
+/// );
+/// ```
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub struct SortOptions {
+    /// If true sort in descending order.
+    /// Default `false`.
     pub descending: bool,
+    /// If true nulls are sorted last.
+    /// Default `false`.
     pub nulls_last: bool,
+    /// If true sort in multiple threads.
+    /// Default `true`.
     pub multithreaded: bool,
+    /// If true maintain the order of equal elements.
+    /// Default `false`.
     pub maintain_order: bool,
 }
 
+/// Sort options for multi-series sorting.
+///
+/// Indicating the order of sorting, nulls position, multithreading, and maintaining order.
+///
+/// # Example
+/// ```
+/// # use polars_core::prelude::*;
+///
+/// # fn main() -> PolarsResult<()> {
+/// let df = df! {
+///     "a" => [Some(1), Some(2), None, Some(4), None],
+///     "b" => [Some(5), None, Some(3), Some(2), Some(1)]
+/// }?;
+///
+/// let out = df
+///     .sort(
+///         ["a", "b"],
+///         SortMultipleOptions::default()
+///             .with_maintain_order(true)
+///             .with_multithreaded(false)
+///             .with_order_descendings([false, true])
+///             .with_nulls_last(true),
+///     )?;
+///
+/// let expected = df! {
+///     "a" => [Some(1), Some(2), Some(4), None, None],
+///     "b" => [Some(5), None, Some(2), Some(3), Some(1)]
+/// }?;
+///
+/// assert_eq!(out, expected);
+///
+/// # Ok(())
+/// # }
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub struct SortMultipleOptions {
-    /// Order of the columns.
+    /// Order of the columns. Default all `false``.
     ///
     /// If only one value is given, it will boardcast to all columns.
     ///
@@ -26,8 +89,11 @@ pub struct SortMultipleOptions {
     ///
     /// Len must matches the number of columns or equal to 1.
     pub descending: Vec<bool>,
+    /// Whether treat nulls as largest. Default `false`.
     pub nulls_last: bool,
+    /// Whether sort in multiple threads. Default `true`.
     pub multithreaded: bool,
+    /// Whether maintain the order of equal elements. Default `false`.
     pub maintain_order: bool,
 }
 
@@ -54,41 +120,46 @@ impl Default for SortMultipleOptions {
 }
 
 impl SortMultipleOptions {
+    /// Create `SortMultipleOptions` with default values.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Specify order for each columns
+    /// Specify order for each columns. Default all `false`.
     ///
     /// # Safety
     ///
     /// Len must matches the number of columns or equal to 1.
-    pub fn with_orders(mut self, descending: impl IntoIterator<Item = bool>) -> Self {
+    pub fn with_order_descendings(mut self, descending: impl IntoIterator<Item = bool>) -> Self {
         self.descending = descending.into_iter().collect();
         self
     }
 
-    /// Implement order for all columns
-    pub fn with_order(mut self, descending: bool) -> Self {
+    /// Implement order for all columns. Default `false`.
+    pub fn with_order_descending(mut self, descending: bool) -> Self {
         self.descending = vec![descending];
         self
     }
 
+    /// Whether treat nulls as largest. Default `false`.
     pub fn with_nulls_last(mut self, enabled: bool) -> Self {
         self.nulls_last = enabled;
         self
     }
 
+    /// Whether sort in multiple threads. Default `true`.
     pub fn with_multithreaded(mut self, enabled: bool) -> Self {
         self.multithreaded = enabled;
         self
     }
 
+    /// Whether maintain the order of equal elements. Default `false`.
     pub fn with_maintain_order(mut self, enabled: bool) -> Self {
         self.maintain_order = enabled;
         self
     }
 
+    /// Reverse the order of sorting for each column.
     pub fn with_order_reversed(mut self) -> Self {
         self.descending.iter_mut().for_each(|x| *x = !*x);
         self
@@ -96,21 +167,30 @@ impl SortMultipleOptions {
 }
 
 impl SortOptions {
-    pub fn with_order(mut self, enabled: bool) -> Self {
+    /// Create `SortOptions` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Specify sorting order for the column. Default `false`.
+    pub fn with_order_descending(mut self, enabled: bool) -> Self {
         self.descending = enabled;
         self
     }
 
+    /// Whether treat nulls as largest. Default `false`.
     pub fn with_nulls_last(mut self, enabled: bool) -> Self {
         self.nulls_last = enabled;
         self
     }
 
+    /// Whether sort in multiple threads. Default `true`.
     pub fn with_multithreaded(mut self, enabled: bool) -> Self {
         self.multithreaded = enabled;
         self
     }
 
+    /// Whether maintain the order of equal elements. Default `false`.
     pub fn with_maintain_order(mut self, enabled: bool) -> Self {
         self.maintain_order = enabled;
         self

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -1079,7 +1079,7 @@ mod test {
         // Use of deprecated `sum()` for testing purposes
         #[allow(deprecated)]
         let res = df.group_by(["flt"]).unwrap().sum().unwrap();
-        let res = res.sort(["flt"], false, false).unwrap();
+        let res = res.sort(["flt"], SortMultipleOptions::default()).unwrap();
         assert_eq!(
             Vec::from(res.column("val_sum").unwrap().i32().unwrap()),
             &[Some(2), Some(2), Some(1)]

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1759,17 +1759,20 @@ impl DataFrame {
         Ok(self)
     }
 
-    /// Sort [`DataFrame`] in place by a column.
+    /// Sort [`DataFrame`] in place.
+    ///
+    /// See [`DataFrame::sort`] for more instruction.
     pub fn sort_in_place(
         &mut self,
-        by_column: impl IntoVec<SmartString>,
+        by: impl IntoVec<SmartString>,
         sort_options: SortMultipleOptions,
     ) -> PolarsResult<&mut Self> {
-        let by_column = self.select_series(by_column)?;
+        let by_column = self.select_series(by)?;
         self.columns = self.sort_impl(by_column, sort_options, None)?.columns;
         Ok(self)
     }
 
+    #[doc(hidden)]
     /// This is the dispatch of Self::sort, and exists to reduce compile bloat by monomorphization.
     pub fn sort_impl(
         &self,
@@ -1892,23 +1895,15 @@ impl DataFrame {
     ///     df.sort(&["a", "b"], SortMultipleOptions::new().with_orders([false, true]))
     /// }
     /// ```
+    ///
+    /// Also see [`DataFrame::sort_in_place`].
     pub fn sort(
         &self,
-        by_column: impl IntoVec<SmartString>,
+        by: impl IntoVec<SmartString>,
         sort_options: SortMultipleOptions,
     ) -> PolarsResult<Self> {
         let mut df = self.clone();
-        df.sort_in_place(by_column, sort_options)?;
-        Ok(df)
-    }
-
-    /// Sort the [`DataFrame`] by a single column with extra options.
-    pub fn sort_with_options(&self, by_column: &str, options: SortOptions) -> PolarsResult<Self> {
-        let mut df = self.clone();
-        let by_column = vec![df.column(by_column)?.clone()];
-        df.columns = df
-            .sort_impl(by_column, SortMultipleOptions::from(&options), None)?
-            .columns;
+        df.sort_in_place(by, sort_options)?;
         Ok(df)
     }
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1858,12 +1858,12 @@ impl DataFrame {
                 } else {
                     let (first, other, descending) = prepare_arg_sort(by_column, descending)?;
                     let options = SortMultipleOptions {
-                        other,
                         descending,
                         nulls_last,
                         multithreaded: parallel,
+                        maintain_order
                     };
-                    first.arg_sort_multiple(&options)?
+                    first.arg_sort_multiple(&other, &options)?
                 }
             },
         };

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1808,7 +1808,7 @@ impl DataFrame {
         }
 
         if let Some((0, k)) = slice {
-            return self.top_k_impl(k, by_column, sort_options.with_order_reversed());
+            return self.bottom_k_impl(k, by_column, sort_options);
         }
 
         #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1881,20 +1881,36 @@ impl DataFrame {
     ///
     /// # Example
     ///
+    /// Sort by a single column with default options:
     /// ```
     /// # use polars_core::prelude::*;
     /// fn sort_by_a(df: &DataFrame) -> PolarsResult<DataFrame> {
     ///     df.sort(["a"], Default::default())
     /// }
-    ///
+    /// ```
+    /// Sort by a single column with specific order:
+    /// ```
+    /// # use polars_core::prelude::*;
     /// fn sort_with_specific_order(df: &DataFrame, descending: bool) -> PolarsResult<DataFrame> {
-    ///     df.sort(["a"], SortMultipleOptions::new().with_order(descending))
-    /// }
-    ///
-    /// fn sort_by_multiple_columns_with_specific_order(df: &DataFrame) -> PolarsResult<DataFrame> {
-    ///     df.sort(&["a", "b"], SortMultipleOptions::new().with_orders([false, true]))
+    ///     df.sort(
+    ///         ["a"],
+    ///         SortMultipleOptions::new()
+    ///             .with_order_descending(descending)
+    ///     )
     /// }
     /// ```
+    /// Sort by multiple columns with specifying order for each column:
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// fn sort_by_multiple_columns_with_specific_order(df: &DataFrame) -> PolarsResult<DataFrame> {
+    ///     df.sort(
+    ///         &["a", "b"],
+    ///         SortMultipleOptions::new()
+    ///             .with_order_descendings([false, true])
+    ///     )
+    /// }
+    /// ```
+    /// See [`SortMultipleOptions`] for more options.
     ///
     /// Also see [`DataFrame::sort_in_place`].
     pub fn sort(

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1906,7 +1906,7 @@ impl DataFrame {
         df.columns = df
             .sort_impl(
                 by_column,
-                SortMultipleOptions::from(options),
+                SortMultipleOptions::from(&options),
                 None,
             )?
             .columns;

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1820,7 +1820,7 @@ impl DataFrame {
         }
 
         if let Some((0, k)) = slice {
-            return self.top_k_impl(k, by_column, sort_options.reverse_order());
+            return self.top_k_impl(k, by_column, sort_options.with_order_reversed());
         }
 
         #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1830,7 +1830,7 @@ impl DataFrame {
         // a lot of indirection in both sorting and take
         let mut df = self.clone();
         let df = df.as_single_chunk_par();
-        let mut take = match (by_column.len(), has_struct) {
+        let take = match (by_column.len(), has_struct) {
             (1, false) => {
                 let s = &by_column[0];
                 let options = SortOptions {
@@ -1843,10 +1843,7 @@ impl DataFrame {
                 // no need to compute the sort indices and then take by these indices
                 // simply sort and return as frame
                 if df.width() == 1 && df.check_name_to_idx(s.name()).is_ok() {
-                    let mut out = s.sort_with(options)?;
-                    if let Some((offset, len)) = slice {
-                        out = out.slice(offset, len);
-                    }
+                    let out = s.sort_with(options)?;
 
                     return Ok(out.into_frame());
                 }
@@ -1867,10 +1864,6 @@ impl DataFrame {
                 }
             },
         };
-
-        if let Some((offset, len)) = slice {
-            take = take.slice(offset, len);
-        }
 
         // SAFETY:
         // the created indices are in bounds

--- a/crates/polars-core/src/frame/top_k.rs
+++ b/crates/polars-core/src/frame/top_k.rs
@@ -1,35 +1,7 @@
-use std::cmp::Ordering;
-
-use polars_utils::iter::EnumerateIdxTrait;
 use smartstring::alias::String as SmartString;
 
 use super::*;
-use crate::prelude::sort::_broadcast_descending;
-use crate::prelude::sort::arg_sort_multiple::_get_rows_encoded;
-
-#[derive(Eq)]
-struct CompareRow<'a> {
-    idx: IdxSize,
-    bytes: &'a [u8],
-}
-
-impl PartialEq for CompareRow<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.bytes == other.bytes
-    }
-}
-
-impl Ord for CompareRow<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.bytes.cmp(other.bytes)
-    }
-}
-
-impl PartialOrd for CompareRow<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
+use crate::prelude::sort::arg_bottom_k::_arg_bottom_k;
 
 impl DataFrame {
     pub fn top_k(
@@ -48,60 +20,15 @@ impl DataFrame {
         by_column: Vec<Series>,
         mut sort_options: SortMultipleOptions,
     ) -> PolarsResult<DataFrame> {
-        _broadcast_descending(by_column.len(), &mut sort_options.descending);
-        let encoded = _get_rows_encoded(
-            &by_column,
-            &sort_options.descending,
-            sort_options.nulls_last,
-        )?;
-        let arr = encoded.into_array();
-        let mut rows = arr
-            .values_iter()
-            .enumerate_idx()
-            .map(|(idx, bytes)| CompareRow { idx, bytes })
-            .collect::<Vec<_>>();
-
-        let sorted = if k >= self.height() {
-            match (sort_options.multithreaded, sort_options.maintain_order) {
-                (true, true) => POOL.install(|| {
-                    rows.par_sort();
-                }),
-                (true, false) => POOL.install(|| {
-                    rows.par_sort_unstable();
-                }),
-                (false, true) => rows.sort(),
-                (false, false) => rows.sort_unstable(),
-            }
-            &rows
-        } else if sort_options.maintain_order {
-            // todo: maybe there is some more efficient method, comparable to select_nth_unstable
-            if sort_options.multithreaded {
-                POOL.install(|| {
-                    rows.par_sort();
-                })
-            } else {
-                rows.sort();
-            }
-            &rows[..k]
-        } else {
-            // todo: possible multi threaded `select_nth_unstable`?
-            let (lower, _el, _upper) = rows.select_nth_unstable(k);
-            if sort_options.multithreaded {
-                POOL.install(|| {
-                    lower.par_sort_unstable();
-                })
-            } else {
-                lower.sort_unstable();
-            }
-            &*lower
-        };
-
-        let idx: NoNull<IdxCa> = sorted.iter().map(|cmp_row| cmp_row.idx).collect();
-
-        let mut df = unsafe { self.take_unchecked(&idx.into_inner()) };
+        // Top k is reversed bottom k
+        sort_options = sort_options.reverse_order();
 
         let first_descending = sort_options.descending[0];
         let first_by_column = by_column[0].name().to_string();
+
+        let idx = _arg_bottom_k(k, self.height(), &by_column, &mut sort_options)?;
+
+        let mut df = unsafe { self.take_unchecked(&idx.into_inner()) };
 
         // Mark the first sort column as sorted
         // if the column did not exists it is ok, because we sorted by an expression

--- a/crates/polars-core/src/frame/top_k.rs
+++ b/crates/polars-core/src/frame/top_k.rs
@@ -11,18 +11,15 @@ impl DataFrame {
         sort_options: SortMultipleOptions,
     ) -> PolarsResult<DataFrame> {
         let by_column = self.select_series(by_column)?;
-        self.top_k_impl(k, by_column, sort_options)
+        self.bottom_k_impl(k, by_column, sort_options.with_order_reversed())
     }
 
-    pub(crate) fn top_k_impl(
+    pub(crate) fn bottom_k_impl(
         &self,
         k: usize,
         by_column: Vec<Series>,
         mut sort_options: SortMultipleOptions,
     ) -> PolarsResult<DataFrame> {
-        // Top k is reversed bottom k
-        sort_options = sort_options.with_order_reversed();
-
         let first_descending = sort_options.descending[0];
         let first_by_column = by_column[0].name().to_string();
 

--- a/crates/polars-core/src/frame/top_k.rs
+++ b/crates/polars-core/src/frame/top_k.rs
@@ -23,7 +23,7 @@ impl DataFrame {
         let first_descending = sort_options.descending[0];
         let first_by_column = by_column[0].name().to_string();
 
-        let idx = _arg_bottom_k(k, self.height(), &by_column, &mut sort_options)?;
+        let idx = _arg_bottom_k(k, &by_column, &mut sort_options)?;
 
         let mut df = unsafe { self.take_unchecked(&idx.into_inner()) };
 

--- a/crates/polars-core/src/frame/top_k.rs
+++ b/crates/polars-core/src/frame/top_k.rs
@@ -21,7 +21,7 @@ impl DataFrame {
         mut sort_options: SortMultipleOptions,
     ) -> PolarsResult<DataFrame> {
         // Top k is reversed bottom k
-        sort_options = sort_options.reverse_order();
+        sort_options = sort_options.with_order_reversed();
 
         let first_descending = sort_options.descending[0];
         let first_by_column = by_column[0].name().to_string();

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -84,7 +84,11 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, options)
     }
 }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -84,8 +84,8 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(options)
+    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, options)
     }
 }
 

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -47,7 +47,11 @@ impl private::PrivateSeries for SeriesWrap<BinaryOffsetChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, options)
     }
 }

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -47,8 +47,8 @@ impl private::PrivateSeries for SeriesWrap<BinaryOffsetChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(options)
+    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, options)
     }
 }
 

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -88,8 +88,8 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(options)
+    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, options)
     }
     fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {
         NumOpsDispatch::add_to(&self.0, rhs)

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -88,7 +88,11 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, options)
     }
     fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -119,8 +119,8 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         }
     }
 
-    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(options)
+    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, options)
     }
 }
 

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -119,7 +119,11 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         }
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, options)
     }
 }

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -129,8 +129,8 @@ macro_rules! impl_dyn_series {
                 self.0.group_tuples(multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-                self.0.deref().arg_sort_multiple(options)
+            fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+                self.0.deref().arg_sort_multiple(by, options)
             }
         }
 

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -129,7 +129,11 @@ macro_rules! impl_dyn_series {
                 self.0.group_tuples(multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+            fn arg_sort_multiple(
+                &self,
+                by: &[Series],
+                options: &SortMultipleOptions,
+            ) -> PolarsResult<IdxCa> {
                 self.0.deref().arg_sort_multiple(by, options)
             }
         }

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -134,7 +134,11 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         self.0.deref().arg_sort_multiple(by, options)
     }
 }

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -134,8 +134,8 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        self.0.deref().arg_sort_multiple(options)
+    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.deref().arg_sort_multiple(by, options)
     }
 }
 

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -194,8 +194,8 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        self.0.deref().arg_sort_multiple(options)
+    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.deref().arg_sort_multiple(by, options)
     }
 }
 

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -194,7 +194,11 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         self.0.deref().arg_sort_multiple(by, options)
     }
 }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -116,8 +116,8 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-                self.0.arg_sort_multiple(options)
+            fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+                self.0.arg_sort_multiple(by, options)
             }
         }
 

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -116,7 +116,11 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+            fn arg_sort_multiple(
+                &self,
+                by: &[Series],
+                options: &SortMultipleOptions,
+            ) -> PolarsResult<IdxCa> {
                 self.0.arg_sort_multiple(by, options)
             }
         }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -189,7 +189,11 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+            fn arg_sort_multiple(
+                &self,
+                by: &[Series],
+                options: &SortMultipleOptions,
+            ) -> PolarsResult<IdxCa> {
                 self.0.arg_sort_multiple(by, options)
             }
         }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -189,8 +189,8 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-                self.0.arg_sort_multiple(options)
+            fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+                self.0.arg_sort_multiple(by, options)
             }
         }
 

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -85,8 +85,8 @@ impl private::PrivateSeries for SeriesWrap<StringChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(options)
+    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(by, options)
     }
 }
 

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -85,7 +85,11 @@ impl private::PrivateSeries for SeriesWrap<StringChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(
+        &self,
+        by: &[Series],
+        options: &SortMultipleOptions,
+    ) -> PolarsResult<IdxCa> {
         self.0.arg_sort_multiple(by, options)
     }
 }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -321,7 +321,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
             vec![false; df.width()]
         };
 
-        let multi_options = SortMultipleOptions::from(&options).with_orders(desc);
+        let multi_options = SortMultipleOptions::from(&options).with_order_descendings(desc);
 
         let out = df.sort_impl(df.columns.clone(), multi_options, None)?;
         Ok(StructChunked::new_unchecked(self.name(), &out.columns).into_series())

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -321,7 +321,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
             vec![false; df.width()]
         };
 
-        let multi_options = SortMultipleOptions::from(options).with_order(desc);
+        let multi_options = SortMultipleOptions::from(&options).with_order(desc);
 
         let out = df.sort_impl(df.columns.clone(), multi_options, None)?;
         Ok(StructChunked::new_unchecked(self.name(), &out.columns).into_series())

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -320,14 +320,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         } else {
             vec![false; df.width()]
         };
-        let out = df.sort_impl(
-            df.columns.clone(),
-            desc,
-            options.nulls_last,
-            options.maintain_order,
-            None,
-            options.multithreaded,
-        )?;
+
+        let multi_options = SortMultipleOptions::from(options).with_order(desc);
+
+        let out = df.sort_impl(df.columns.clone(), multi_options, None)?;
         Ok(StructChunked::new_unchecked(self.name(), &out.columns).into_series())
     }
 

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -321,7 +321,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
             vec![false; df.width()]
         };
 
-        let multi_options = SortMultipleOptions::from(&options).with_order(desc);
+        let multi_options = SortMultipleOptions::from(&options).with_orders(desc);
 
         let out = df.sort_impl(df.columns.clone(), multi_options, None)?;
         Ok(StructChunked::new_unchecked(self.name(), &out.columns).into_series())

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -285,12 +285,8 @@ impl Series {
         Ok(self)
     }
 
-    pub fn sort(&self, descending: bool, nulls_last: bool) -> PolarsResult<Self> {
-        self.sort_with(SortOptions {
-            descending,
-            nulls_last,
-            ..Default::default()
-        })
+    pub fn sort(&self, sort_options: SortOptions) -> PolarsResult<Self> {
+        self.sort_with(sort_options)
     }
 
     /// Only implemented for numeric types

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -285,6 +285,21 @@ impl Series {
         Ok(self)
     }
 
+    /// Sort the series with specific options.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use polars_core::prelude::*;
+    /// # fn main() -> PolarsResult<()> {
+    /// let s = Series::new("foo", [2, 1, 3]);
+    /// let sorted = s.sort(SortOptions::default())?;
+    /// assert_eq!(sorted, Series::new("foo", [1, 2, 3]));
+    /// # Ok(())
+    /// }
+    /// ```
+    ///
+    /// See [`SortOptions`] for more options.
     pub fn sort(&self, sort_options: SortOptions) -> PolarsResult<Self> {
         self.sort_with(sort_options)
     }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -163,7 +163,8 @@ pub(crate) mod private {
             invalid_operation_panic!(zip_with_same_type, self)
         }
 
-        fn arg_sort_multiple(&self, _options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        #[allow(unused_variables)]
+        fn arg_sort_multiple(&self, by: &[Series], _options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
             polars_bail!(opq = arg_sort_multiple, self._dtype());
         }
     }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -164,7 +164,11 @@ pub(crate) mod private {
         }
 
         #[allow(unused_variables)]
-        fn arg_sort_multiple(&self, by: &[Series], _options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        fn arg_sort_multiple(
+            &self,
+            by: &[Series],
+            _options: &SortMultipleOptions,
+        ) -> PolarsResult<IdxCa> {
             polars_bail!(opq = arg_sort_multiple, self._dtype());
         }
     }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -267,14 +267,17 @@ impl LazyFrame {
     /// /// Sort DataFrame by 'sepal.width' column
     /// fn example(df: DataFrame) -> LazyFrame {
     ///       df.lazy()
-    ///         .sort("sepal.width", Default::default())
+    ///         .sort(["sepal.width"], Default::default())
     /// }
     /// ```
-    pub fn sort(self, by_column: &str, options: SortOptions) -> Self {
+    pub fn sort(self, by: impl IntoVec<SmartString>, sort_options: SortMultipleOptions) -> Self {
         let opt_state = self.get_opt_state();
         let lp = self
             .get_plan_builder()
-            .sort(vec![col(by_column)], SortMultipleOptions::from(&options))
+            .sort(
+                by.into_vec().into_iter().map(|x| col(&x)).collect(),
+                sort_options,
+            )
             .build();
         Self::from_logical_plan(lp, opt_state)
     }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -260,16 +260,39 @@ impl LazyFrame {
     ///
     /// # Example
     ///
+    /// Sort DataFrame by 'sepal.width' column:
     /// ```rust
-    /// use polars_core::prelude::*;
-    /// use polars_lazy::prelude::*;
-    ///
-    /// /// Sort DataFrame by 'sepal.width' column
-    /// fn example(df: DataFrame) -> LazyFrame {
-    ///       df.lazy()
-    ///         .sort(["sepal.width"], Default::default())
+    /// # use polars_core::prelude::*;
+    /// # use polars_lazy::prelude::*;
+    /// fn sort_by_a(df: DataFrame) -> LazyFrame {
+    ///     df.lazy().sort(["a"], Default::default())
     /// }
     /// ```
+    /// Sort by a single column with specific order:
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// # use polars_lazy::prelude::*;
+    /// fn sort_with_specific_order(df: DataFrame, descending: bool) -> LazyFrame {
+    ///     df.lazy().sort(
+    ///         ["a"],
+    ///         SortMultipleOptions::new()
+    ///             .with_order_descending(descending)
+    ///     )
+    /// }
+    /// ```
+    /// Sort by multiple columns with specifying order for each column:
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// # use polars_lazy::prelude::*;
+    /// fn sort_by_multiple_columns_with_specific_order(df: DataFrame) -> LazyFrame {
+    ///     df.lazy().sort(
+    ///         &["a", "b"],
+    ///         SortMultipleOptions::new()
+    ///             .with_order_descendings([false, true])
+    ///     )
+    /// }
+    /// ```
+    /// See [`SortMultipleOptions`] for more options.
     pub fn sort(self, by: impl IntoVec<SmartString>, sort_options: SortMultipleOptions) -> Self {
         let opt_state = self.get_opt_state();
         let lp = self

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -320,7 +320,7 @@ impl LazyFrame {
         sort_options: SortMultipleOptions,
     ) -> Self {
         // this will optimize to top-k
-        self.sort_by_exprs(by_exprs, sort_options.reverse_order()).slice(0, k)
+        self.sort_by_exprs(by_exprs, sort_options.with_order_reversed()).slice(0, k)
     }
 
     pub fn bottom_k<E: AsRef<[Expr]>>(

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -320,7 +320,8 @@ impl LazyFrame {
         sort_options: SortMultipleOptions,
     ) -> Self {
         // this will optimize to top-k
-        self.sort_by_exprs(by_exprs, sort_options.with_order_reversed()).slice(0, k)
+        self.sort_by_exprs(by_exprs, sort_options.with_order_reversed())
+            .slice(0, k)
     }
 
     pub fn bottom_k<E: AsRef<[Expr]>>(
@@ -330,11 +331,7 @@ impl LazyFrame {
         sort_options: SortMultipleOptions,
     ) -> Self {
         // this will optimize to bottom-k
-        self.sort_by_exprs(
-            by_exprs,
-            sort_options
-        )
-        .slice(0, k)
+        self.sort_by_exprs(by_exprs, sort_options).slice(0, k)
     }
 
     /// Reverse the `DataFrame` from top to bottom.

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -306,7 +306,7 @@ impl LazyFrame {
     /// /// Sort DataFrame by 'sepal.width' column
     /// fn example(df: DataFrame) -> LazyFrame {
     ///       df.lazy()
-    ///         .sort_by_exprs(vec![col("sepal.width")], vec![false], false, false)
+    ///         .sort_by_exprs(vec![col("sepal.width")], vec![false], false, false, true)
     /// }
     /// ```
     pub fn sort_by_exprs<E: AsRef<[Expr]>, B: AsRef<[bool]>>(

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -295,7 +295,7 @@ impl LazyFrame {
     /// /// Sort DataFrame by 'sepal.width' column
     /// fn example(df: DataFrame) -> LazyFrame {
     ///       df.lazy()
-    ///         .sort_by_exprs(vec![col("sepal.width")], vec![false], false, false, true)
+    ///         .sort_by_exprs(vec![col("sepal.width")], Default::default())
     /// }
     /// ```
     pub fn sort_by_exprs<E: AsRef<[Expr]>>(

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -308,9 +308,9 @@ impl LazyFrame {
     /// Add a sort operation to the logical plan.
     ///
     /// Sorts the LazyFrame by the provided list of expressions, which will be turned into
-    /// concrete columns before sorting. `reverse` is a list of `bool`, the same length as
-    /// `by_exprs`, that specifies whether each corresponding expression will be sorted
-    /// ascending (`false`) or descending (`true`).
+    /// concrete columns before sorting.
+    ///
+    /// See [`SortMultipleOptions`] for more options.
     ///
     /// # Example
     ///

--- a/crates/polars-lazy/src/lib.rs
+++ b/crates/polars-lazy/src/lib.rs
@@ -120,7 +120,7 @@
 //!         col("rain").sum().alias("sum_rain"),
 //!         col("rain").quantile(lit(0.5), QuantileInterpolOptions::Nearest).alias("median_rain"),
 //!     ])
-//!     .sort("date", Default::default())
+//!     .sort(["date"], Default::default())
 //!     .collect()
 //! }
 //! ```

--- a/crates/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/sort.rs
@@ -34,11 +34,8 @@ impl SortExec {
 
         df.sort_impl(
             by_columns,
-            std::mem::take(&mut self.args.descending),
-            self.args.nulls_last,
-            self.args.maintain_order,
+            SortMultipleOptions::from(&self.args),
             self.args.slice,
-            true,
         )
     }
 }

--- a/crates/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/sort.rs
@@ -33,11 +33,7 @@ impl SortExec {
             })
             .collect::<PolarsResult<Vec<_>>>()?;
 
-        df.sort_impl(
-            by_columns,
-            self.sort_options.clone(),
-            self.slice,
-        )
+        df.sort_impl(by_columns, self.sort_options.clone(), self.slice)
     }
 }
 

--- a/crates/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/sort.rs
@@ -3,7 +3,8 @@ use super::*;
 pub(crate) struct SortExec {
     pub(crate) input: Box<dyn Executor>,
     pub(crate) by_column: Vec<Arc<dyn PhysicalExpr>>,
-    pub(crate) args: SortArguments,
+    pub(crate) slice: Option<(i64, usize)>,
+    pub(crate) sort_options: SortMultipleOptions,
 }
 
 impl SortExec {
@@ -34,8 +35,8 @@ impl SortExec {
 
         df.sort_impl(
             by_columns,
-            SortMultipleOptions::from(&self.args),
-            self.args.slice,
+            self.sort_options.clone(),
+            self.slice,
         )
     }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -195,7 +195,7 @@ impl PhysicalExpr for SortByExpr {
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 
-                let options = self.sort_options.clone().with_orders(descending);
+                let options = self.sort_options.clone().with_order_descendings(descending);
                 s_sort_by[0].arg_sort_multiple(&s_sort_by[1..], &options)
             };
             POOL.install(|| rayon::join(series_f, sorted_idx_f))

--- a/crates/polars-lazy/src/physical_plan/node_timer.rs
+++ b/crates/polars-lazy/src/physical_plan/node_timer.rs
@@ -59,6 +59,6 @@ impl NodeTimer {
 
         let columns = vec![nodes_s, start.into_series(), end.into_series()];
         let df = unsafe { DataFrame::new_no_checks(columns) };
-        df.sort(vec!["start"], vec![false], false)
+        df.sort(vec!["start"], SortMultipleOptions::default())
     }
 }

--- a/crates/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/expr.rs
@@ -272,7 +272,7 @@ fn create_physical_expr_inner(
         SortBy {
             expr,
             by,
-            descending,
+            sort_options,
         } => {
             polars_ensure!(!by.is_empty(), InvalidOperation: "'sort_by' got an empty set");
             let phys_expr = create_physical_expr_inner(expr, ctxt, expr_arena, schema, state)?;
@@ -281,8 +281,8 @@ fn create_physical_expr_inner(
             Ok(Arc::new(SortByExpr::new(
                 phys_expr,
                 phys_by,
-                descending,
                 node_to_expr(expression, expr_arena),
+                sort_options,
             )))
         },
         Filter { input, by } => {

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -330,7 +330,8 @@ pub fn create_physical_plan(
         Sort {
             input,
             by_column,
-            args,
+            slice,
+            sort_options,
         } => {
             let input_schema = lp_arena.get(input).schema(lp_arena);
             let by_column = create_physical_expressions_from_irs(
@@ -344,7 +345,8 @@ pub fn create_physical_plan(
             Ok(Box::new(executors::SortExec {
                 input,
                 by_column,
-                args,
+                slice,
+                sort_options,
             }))
         },
         Cache {

--- a/crates/polars-lazy/src/physical_plan/streaming/checks.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/checks.rs
@@ -9,7 +9,7 @@ pub(super) fn is_streamable_sort(
 ) -> bool {
     // check if slice is positive or maintain order is true
     if sort_options.maintain_order {
-        true
+        false
     } else if let Some((offset, _)) = slice {
         *offset >= 0
     } else {

--- a/crates/polars-lazy/src/physical_plan/streaming/checks.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/checks.rs
@@ -1,19 +1,19 @@
+use polars_core::chunked_array::ops::SortMultipleOptions;
 use polars_ops::prelude::*;
 use polars_plan::logical_plan::expr_ir::ExprIR;
 use polars_plan::prelude::*;
 
-pub(super) fn is_streamable_sort(args: &SortArguments) -> bool {
+pub(super) fn is_streamable_sort(
+    slice: &Option<(i64, usize)>,
+    sort_options: &SortMultipleOptions,
+) -> bool {
     // check if slice is positive or maintain order is true
-    match args {
-        SortArguments {
-            maintain_order: true,
-            ..
-        } => false,
-        SortArguments {
-            slice: Some((offset, _)),
-            ..
-        } => *offset >= 0,
-        SortArguments { slice: None, .. } => true,
+    if sort_options.maintain_order {
+        true
+    } else if let Some((offset, _)) = slice {
+        *offset >= 0
+    } else {
+        true
     }
 }
 

--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -202,8 +202,9 @@ pub(crate) fn insert_streaming_nodes(
             Sort {
                 input,
                 by_column,
-                args,
-            } if is_streamable_sort(args) && all_column(by_column, expr_arena) => {
+                slice,
+                sort_options
+            } if is_streamable_sort(slice, sort_options) && all_column(by_column, expr_arena) => {
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Sink(root));
                 stack.push(StackFrame::new(*input, state, current_idx))

--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -203,7 +203,7 @@ pub(crate) fn insert_streaming_nodes(
                 input,
                 by_column,
                 slice,
-                sort_options
+                sort_options,
             } if is_streamable_sort(slice, sort_options) && all_column(by_column, expr_arena) => {
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Sink(root));

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -186,7 +186,10 @@ fn test_power_in_agg_list1() -> PolarsResult<()> {
                 .pow(2.0)
                 .alias("foo"),
         ])
-        .sort(["fruits"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["fruits"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .collect()?;
 
     let agg = out.column("foo")?.list()?;
@@ -216,7 +219,10 @@ fn test_power_in_agg_list2() -> PolarsResult<()> {
             .pow(2.0)
             .sum()
             .alias("foo")])
-        .sort(["fruits"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["fruits"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .collect()?;
 
     let agg = out.column("foo")?.f64()?;

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -186,7 +186,7 @@ fn test_power_in_agg_list1() -> PolarsResult<()> {
                 .pow(2.0)
                 .alias("foo"),
         ])
-        .sort(["fruits"], SortMultipleOptions::default().with_order(true))
+        .sort(["fruits"], SortMultipleOptions::default().with_order_descending(true))
         .collect()?;
 
     let agg = out.column("foo")?.list()?;
@@ -216,7 +216,7 @@ fn test_power_in_agg_list2() -> PolarsResult<()> {
             .pow(2.0)
             .sum()
             .alias("foo")])
-        .sort(["fruits"], SortMultipleOptions::default().with_order(true))
+        .sort(["fruits"], SortMultipleOptions::default().with_order_descending(true))
         .collect()?;
 
     let agg = out.column("foo")?.f64()?;

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -53,7 +53,7 @@ fn test_agg_unique_first() -> PolarsResult<()> {
         .group_by_stable([col("g")])
         .agg([
             col("v").unique().first().alias("v_first"),
-            col("v").unique().sort(false).first().alias("true_first"),
+            col("v").unique().sort(Default::default()).first().alias("true_first"),
             col("v").unique().implode(),
         ])
         .collect()?;
@@ -87,7 +87,7 @@ fn test_cum_sum_agg_as_key() -> PolarsResult<()> {
             .cum_sum(false)
             .alias("key")])
         .agg([col("depth").max().name().keep()])
-        .sort("depth", SortOptions::default())
+        .sort(["depth"], Default::default())
         .collect()?;
 
     assert_eq!(
@@ -183,11 +183,8 @@ fn test_power_in_agg_list1() -> PolarsResult<()> {
                 .alias("foo"),
         ])
         .sort(
-            "fruits",
-            SortOptions {
-                descending: true,
-                ..Default::default()
-            },
+            ["fruits"],
+            SortMultipleOptions::default().with_order(true),
         )
         .collect()?;
 
@@ -219,11 +216,9 @@ fn test_power_in_agg_list2() -> PolarsResult<()> {
             .sum()
             .alias("foo")])
         .sort(
-            "fruits",
-            SortOptions {
-                descending: true,
-                ..Default::default()
-            },
+            ["fruits"],
+            SortMultipleOptions::default()
+            .with_order(true),
         )
         .collect()?;
 
@@ -402,7 +397,7 @@ fn test_shift_elementwise_issue_2509() -> PolarsResult<()> {
         // Don't use maintain order here! That hides the bug
         .group_by([col("x")])
         .agg(&[(col("y").shift(lit(-1)) + col("x")).alias("sum")])
-        .sort("x", Default::default())
+        .sort(["x"], Default::default())
         .collect()?;
 
     let out = out.explode(["sum"])?;
@@ -430,7 +425,7 @@ fn take_aggregations() -> PolarsResult<()> {
         .lazy()
         .group_by([col("user")])
         .agg([col("book").get(col("count").arg_max()).alias("fav_book")])
-        .sort("user", Default::default())
+        .sort(["user"], Default::default())
         .collect()?;
 
     let s = out.column("fav_book")?;
@@ -457,7 +452,7 @@ fn take_aggregations() -> PolarsResult<()> {
                 )
                 .alias("ordered"),
         ])
-        .sort("user", Default::default())
+        .sort(["user"], Default::default())
         .collect()?;
     let s = out.column("ordered")?;
     let flat = s.explode()?;
@@ -469,7 +464,7 @@ fn take_aggregations() -> PolarsResult<()> {
         .lazy()
         .group_by([col("user")])
         .agg([col("book").get(lit(0)).alias("take_lit")])
-        .sort("user", Default::default())
+        .sort(["user"], Default::default())
         .collect()?;
 
     let taken = out.column("take_lit")?;
@@ -563,7 +558,7 @@ fn test_take_in_groups() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .sort("fruits", Default::default())
+        .sort(["fruits"], Default::default())
         .select([col("B").get(lit(0u32)).over([col("fruits")]).alias("taken")])
         .collect()?;
 

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -53,7 +53,11 @@ fn test_agg_unique_first() -> PolarsResult<()> {
         .group_by_stable([col("g")])
         .agg([
             col("v").unique().first().alias("v_first"),
-            col("v").unique().sort(Default::default()).first().alias("true_first"),
+            col("v")
+                .unique()
+                .sort(Default::default())
+                .first()
+                .alias("true_first"),
             col("v").unique().implode(),
         ])
         .collect()?;
@@ -182,10 +186,7 @@ fn test_power_in_agg_list1() -> PolarsResult<()> {
                 .pow(2.0)
                 .alias("foo"),
         ])
-        .sort(
-            ["fruits"],
-            SortMultipleOptions::default().with_order(true),
-        )
+        .sort(["fruits"], SortMultipleOptions::default().with_order(true))
         .collect()?;
 
     let agg = out.column("foo")?.list()?;
@@ -215,11 +216,7 @@ fn test_power_in_agg_list2() -> PolarsResult<()> {
             .pow(2.0)
             .sum()
             .alias("foo")])
-        .sort(
-            ["fruits"],
-            SortMultipleOptions::default()
-            .with_order(true),
-        )
+        .sort(["fruits"], SortMultipleOptions::default().with_order(true))
         .collect()?;
 
     let agg = out.column("foo")?.f64()?;

--- a/crates/polars-lazy/src/tests/logical.rs
+++ b/crates/polars-lazy/src/tests/logical.rs
@@ -65,7 +65,7 @@ fn test_lazy_arithmetic() {
     let lf = df
         .lazy()
         .select(&[((col("sepal.width") * lit(100)).alias("super_wide"))])
-        .sort("super_wide", SortOptions::default());
+        .sort(["super_wide"], SortMultipleOptions::default());
 
     print_plans(&lf);
 

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -272,7 +272,7 @@ pub fn test_slice_pushdown_sort() -> PolarsResult<()> {
     assert!((&lp_arena).iter(lp).all(|(_, lp)| {
         use IR::*;
         match lp {
-            Sort { args, .. } => args.slice == Some((1, 3)),
+            Sort { slice, .. } => *slice == Some((1, 3)),
             Slice { .. } => false,
             _ => true,
         }

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -262,7 +262,7 @@ pub fn test_slice_pushdown_sort() -> PolarsResult<()> {
     let _guard = SINGLE_LOCK.lock().unwrap();
     let q = scan_foods_parquet(false).limit(100);
 
-    let q = q.sort("category", SortOptions::default()).slice(1, 3);
+    let q = q.sort(["category"], SortMultipleOptions::default()).slice(1, 3);
 
     // test if optimization continued beyond the sort node
     assert!(slice_at_scan(q.clone()));

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -262,7 +262,9 @@ pub fn test_slice_pushdown_sort() -> PolarsResult<()> {
     let _guard = SINGLE_LOCK.lock().unwrap();
     let q = scan_foods_parquet(false).limit(100);
 
-    let q = q.sort(["category"], SortMultipleOptions::default()).slice(1, 3);
+    let q = q
+        .sort(["category"], SortMultipleOptions::default())
+        .slice(1, 3);
 
     // test if optimization continued beyond the sort node
     assert!(slice_at_scan(q.clone()));

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1285,10 +1285,13 @@ fn test_sort_by() -> PolarsResult<()> {
     let out = df
         .clone()
         .lazy()
-        .select([col("a").sort_by([col("b"), col("c")], SortMultipleOptions {
-            descending: vec![false],
-            ..Default::default()
-        })])
+        .select([col("a").sort_by(
+            [col("b"), col("c")],
+            SortMultipleOptions {
+                descending: vec![false],
+                ..Default::default()
+            },
+        )])
         .collect()?;
 
     let a = out.column("a")?;
@@ -1949,7 +1952,7 @@ fn test_sort_maintain_order_true() -> PolarsResult<()> {
     .lazy();
 
     let res = q
-        .sort_by_exprs([col("A")], [false], false, true)
+        .sort_by_exprs([col("A")], [false], false, true, true)
         .slice(0, 3)
         .collect()?;
     println!("{:?}", res);

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -835,7 +835,7 @@ fn test_lazy_group_by_sort_by() {
             .sort_by(
                 [col("c")],
                 SortMultipleOptions {
-                    descending: [true],
+                    descending: vec![true],
                     ..Default::default()
                 },
             )
@@ -1285,7 +1285,10 @@ fn test_sort_by() -> PolarsResult<()> {
     let out = df
         .clone()
         .lazy()
-        .select([col("a").sort_by([col("b"), col("c")], [false])])
+        .select([col("a").sort_by([col("b"), col("c")], SortMultipleOptions {
+            descending: vec![false],
+            ..Default::default()
+        })])
         .collect()?;
 
     let a = out.column("a")?;
@@ -1299,7 +1302,13 @@ fn test_sort_by() -> PolarsResult<()> {
         .clone()
         .lazy()
         .group_by_stable([col("b")])
-        .agg([col("a").sort_by([col("b"), col("c")], [false])])
+        .agg([col("a").sort_by(
+            [col("b"), col("c")],
+            SortMultipleOptions {
+                descending: vec![false],
+                ..Default::default()
+            },
+        )])
         .collect()?;
     let a = out.column("a")?.explode()?;
     assert_eq!(
@@ -1311,7 +1320,13 @@ fn test_sort_by() -> PolarsResult<()> {
     let out = df
         .lazy()
         .group_by_stable([col("b")])
-        .agg([col("a").sort_by([col("b"), col("c")], [false])])
+        .agg([col("a").sort_by(
+            [col("b"), col("c")],
+            SortMultipleOptions {
+                descending: vec![false],
+                ..Default::default()
+            },
+        )])
         .collect()?;
 
     let a = out.column("a")?.explode()?;

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -832,7 +832,10 @@ fn test_lazy_group_by_sort_by() {
         .lazy()
         .group_by([col("a")])
         .agg([col("b")
-            .sort_by([col("c")], SortMultipleOptions::default().with_order_descending(true))
+            .sort_by(
+                [col("c")],
+                SortMultipleOptions::default().with_order_descending(true),
+            )
             .first()])
         .collect()
         .unwrap()
@@ -981,7 +984,10 @@ fn test_group_by_sort_slice() -> PolarsResult<()> {
     let out1 = df
         .clone()
         .lazy()
-        .sort(["vals"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["vals"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .group_by([col("groups")])
         .agg([col("vals").head(Some(2)).alias("foo")])
         .sort(["groups"], Default::default())
@@ -1422,7 +1428,10 @@ fn test_group_by_small_ints() -> PolarsResult<()> {
         .lazy()
         .group_by([col("id_16"), col("id_32")])
         .agg([col("id_16").sum().alias("foo")])
-        .sort(["foo"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["foo"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .collect()?;
 
     assert_eq!(Vec::from(out.column("foo")?.i64()?), &[Some(2), Some(1)]);

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -832,7 +832,7 @@ fn test_lazy_group_by_sort_by() {
         .lazy()
         .group_by([col("a")])
         .agg([col("b")
-            .sort_by([col("c")], SortMultipleOptions::default().with_order(true))
+            .sort_by([col("c")], SortMultipleOptions::default().with_order_descending(true))
             .first()])
         .collect()
         .unwrap()
@@ -981,7 +981,7 @@ fn test_group_by_sort_slice() -> PolarsResult<()> {
     let out1 = df
         .clone()
         .lazy()
-        .sort(["vals"], SortMultipleOptions::default().with_order(true))
+        .sort(["vals"], SortMultipleOptions::default().with_order_descending(true))
         .group_by([col("groups")])
         .agg([col("vals").head(Some(2)).alias("foo")])
         .sort(["groups"], Default::default())
@@ -991,7 +991,7 @@ fn test_group_by_sort_slice() -> PolarsResult<()> {
         .lazy()
         .group_by([col("groups")])
         .agg([col("vals")
-            .sort(SortOptions::default().with_order(true))
+            .sort(SortOptions::default().with_order_descending(true))
             .head(Some(2))
             .alias("foo")])
         .sort(["groups"], Default::default())
@@ -1042,7 +1042,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
         .lazy()
         .select([arg_sort_by(
             [col("int"), col("flt")],
-            SortMultipleOptions::default().with_orders([true, false]),
+            SortMultipleOptions::default().with_order_descendings([true, false]),
         )])
         .collect()?;
 
@@ -1060,7 +1060,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
         .lazy()
         .select([arg_sort_by(
             [col("str"), col("flt")],
-            SortMultipleOptions::default().with_orders([true, false]),
+            SortMultipleOptions::default().with_order_descendings([true, false]),
         )])
         .collect()?;
     Ok(())
@@ -1422,7 +1422,7 @@ fn test_group_by_small_ints() -> PolarsResult<()> {
         .lazy()
         .group_by([col("id_16"), col("id_32")])
         .agg([col("id_16").sum().alias("foo")])
-        .sort(["foo"], SortMultipleOptions::default().with_order(true))
+        .sort(["foo"], SortMultipleOptions::default().with_order_descending(true))
         .collect()?;
 
     assert_eq!(Vec::from(out.column("foo")?.i64()?), &[Some(2), Some(1)]);

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -796,7 +796,7 @@ fn test_lazy_group_by_sort() {
         .agg([col("b").sort(false).first()])
         .collect()
         .unwrap()
-        .sort(["a"], false, false)
+        .sort(["a"], Default::default())
         .unwrap();
 
     assert_eq!(
@@ -810,7 +810,7 @@ fn test_lazy_group_by_sort() {
         .agg([col("b").sort(false).last()])
         .collect()
         .unwrap()
-        .sort(["a"], false, false)
+        .sort(["a"], Default::default())
         .unwrap();
 
     assert_eq!(
@@ -832,17 +832,11 @@ fn test_lazy_group_by_sort_by() {
         .lazy()
         .group_by([col("a")])
         .agg([col("b")
-            .sort_by(
-                [col("c")],
-                SortMultipleOptions {
-                    descending: vec![true],
-                    ..Default::default()
-                },
-            )
+            .sort_by([col("c")], SortMultipleOptions::default().with_order(true))
             .first()])
         .collect()
         .unwrap()
-        .sort(["a"], false, false)
+        .sort(["a"], Default::default())
         .unwrap();
 
     assert_eq!(
@@ -1059,10 +1053,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
         .lazy()
         .select([arg_sort_by(
             [col("int"), col("flt")],
-            SortMultipleOptions {
-                descending: vec![true, false],
-                ..Default::default()
-            },
+            SortMultipleOptions::default().with_orders([true, false]),
         )])
         .collect()?;
 
@@ -1080,10 +1071,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
         .lazy()
         .select([arg_sort_by(
             [col("str"), col("flt")],
-            SortMultipleOptions {
-                descending: vec![true, false],
-                ..Default::default()
-            },
+            SortMultipleOptions::default().with_orders([true, false]),
         )])
         .collect()?;
     Ok(())
@@ -1285,13 +1273,7 @@ fn test_sort_by() -> PolarsResult<()> {
     let out = df
         .clone()
         .lazy()
-        .select([col("a").sort_by(
-            [col("b"), col("c")],
-            SortMultipleOptions {
-                descending: vec![false],
-                ..Default::default()
-            },
-        )])
+        .select([col("a").sort_by([col("b"), col("c")], SortMultipleOptions::default())])
         .collect()?;
 
     let a = out.column("a")?;
@@ -1305,13 +1287,7 @@ fn test_sort_by() -> PolarsResult<()> {
         .clone()
         .lazy()
         .group_by_stable([col("b")])
-        .agg([col("a").sort_by(
-            [col("b"), col("c")],
-            SortMultipleOptions {
-                descending: vec![false],
-                ..Default::default()
-            },
-        )])
+        .agg([col("a").sort_by([col("b"), col("c")], SortMultipleOptions::default())])
         .collect()?;
     let a = out.column("a")?.explode()?;
     assert_eq!(
@@ -1323,13 +1299,7 @@ fn test_sort_by() -> PolarsResult<()> {
     let out = df
         .lazy()
         .group_by_stable([col("b")])
-        .agg([col("a").sort_by(
-            [col("b"), col("c")],
-            SortMultipleOptions {
-                descending: vec![false],
-                ..Default::default()
-            },
-        )])
+        .agg([col("a").sort_by([col("b"), col("c")], SortMultipleOptions::default())])
         .collect()?;
 
     let a = out.column("a")?.explode()?;
@@ -1952,7 +1922,12 @@ fn test_sort_maintain_order_true() -> PolarsResult<()> {
     .lazy();
 
     let res = q
-        .sort_by_exprs([col("A")], [false], false, true, true)
+        .sort_by_exprs(
+            [col("A")],
+            SortMultipleOptions::default()
+                .with_maintain_order(true)
+                .with_nulls_last(true),
+        )
         .slice(0, 3)
         .collect()?;
     println!("{:?}", res);

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -831,7 +831,15 @@ fn test_lazy_group_by_sort_by() {
     let out = df
         .lazy()
         .group_by([col("a")])
-        .agg([col("b").sort_by([col("c")], [true]).first()])
+        .agg([col("b")
+            .sort_by(
+                [col("c")],
+                SortMultipleOptions {
+                    descending: [true],
+                    ..Default::default()
+                },
+            )
+            .first()])
         .collect()
         .unwrap()
         .sort(["a"], false, false)
@@ -1049,7 +1057,13 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
     let out = df
         .clone()
         .lazy()
-        .select([arg_sort_by([col("int"), col("flt")], &[true, false])])
+        .select([arg_sort_by(
+            [col("int"), col("flt")],
+            SortMultipleOptions {
+                descending: vec![true, false],
+                ..Default::default()
+            },
+        )])
         .collect()?;
 
     assert_eq!(
@@ -1064,7 +1078,13 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
     // check if this runs
     let _out = df
         .lazy()
-        .select([arg_sort_by([col("str"), col("flt")], &[true, false])])
+        .select([arg_sort_by(
+            [col("str"), col("flt")],
+            SortMultipleOptions {
+                descending: vec![true, false],
+                ..Default::default()
+            },
+        )])
         .collect()?;
     Ok(())
 }

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -102,10 +102,9 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
         ])
         .sort_by_exprs(
             [col("sugars_g"), col("calories")],
-            [false, false],
-            false,
-            false,
-            true,
+            SortMultipleOptions::default()
+                .with_orders([false, false])
+                .with_maintain_order(true),
         );
 
     assert_streaming_with_default(q, true, false);
@@ -138,10 +137,7 @@ fn test_streaming_unique() -> PolarsResult<()> {
         .unique(None, Default::default())
         .sort_by_exprs(
             [cols(["sugars_g", "calories"])],
-            [false],
-            false,
-            false,
-            true,
+            SortMultipleOptions::default().with_maintain_order(true),
         );
 
     assert_streaming_with_default(q, true, false);
@@ -386,7 +382,12 @@ fn test_sort_maintain_order_streaming() -> PolarsResult<()> {
     .lazy();
 
     let res = q
-        .sort_by_exprs([col("A")], [false], false, true, true)
+        .sort_by_exprs(
+            [col("A")],
+            SortMultipleOptions::default()
+                .with_nulls_last(true)
+                .with_maintain_order(true),
+        )
         .slice(0, 3)
         .with_streaming(true)
         .collect()?;
@@ -413,7 +414,10 @@ fn test_streaming_outer_join() -> PolarsResult<()> {
 
     let q = lf_left
         .outer_join(lf_right, col("a"), col("a"))
-        .sort_by_exprs([all()], [false], false, false, true);
+        .sort_by_exprs(
+            [all()],
+            SortMultipleOptions::default().with_maintain_order(true),
+        );
 
     // Toggle so that the join order is swapped.
     for toggle in [true, true] {

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -102,8 +102,7 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
         ])
         .sort_by_exprs(
             [col("sugars_g"), col("calories")],
-            SortMultipleOptions::default()
-                .with_orders([false, false])
+            SortMultipleOptions::default().with_orders([false, false]),
         );
 
     assert_streaming_with_default(q, true, false);
@@ -413,10 +412,7 @@ fn test_streaming_outer_join() -> PolarsResult<()> {
 
     let q = lf_left
         .outer_join(lf_right, col("a"), col("a"))
-        .sort_by_exprs(
-            [all()],
-            SortMultipleOptions::default(),
-        );
+        .sort_by_exprs([all()], SortMultipleOptions::default());
 
     // Toggle so that the join order is swapped.
     for toggle in [true, true] {

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -105,6 +105,7 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
             [false, false],
             false,
             false,
+            true,
         );
 
     assert_streaming_with_default(q, true, false);
@@ -135,7 +136,13 @@ fn test_streaming_unique() -> PolarsResult<()> {
     let q = q
         .select([col("sugars_g"), col("calories")])
         .unique(None, Default::default())
-        .sort_by_exprs([cols(["sugars_g", "calories"])], [false], false, false);
+        .sort_by_exprs(
+            [cols(["sugars_g", "calories"])],
+            [false],
+            false,
+            false,
+            true,
+        );
 
     assert_streaming_with_default(q, true, false);
     Ok(())
@@ -379,7 +386,7 @@ fn test_sort_maintain_order_streaming() -> PolarsResult<()> {
     .lazy();
 
     let res = q
-        .sort_by_exprs([col("A")], [false], false, true)
+        .sort_by_exprs([col("A")], [false], false, true, true)
         .slice(0, 3)
         .with_streaming(true)
         .collect()?;
@@ -406,7 +413,7 @@ fn test_streaming_outer_join() -> PolarsResult<()> {
 
     let q = lf_left
         .outer_join(lf_right, col("a"), col("a"))
-        .sort_by_exprs([all()], [false], false, false);
+        .sort_by_exprs([all()], [false], false, false, true);
 
     // Toggle so that the join order is swapped.
     for toggle in [true, true] {

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -39,7 +39,7 @@ fn test_streaming_parquet() -> PolarsResult<()> {
     let q = q
         .group_by([col("sugars_g")])
         .agg([((lit(1) - col("fats_g")) + col("calories")).sum()])
-        .sort("sugars_g", Default::default());
+        .sort(["sugars_g"], Default::default());
 
     assert_streaming_with_default(q, true, false);
     Ok(())
@@ -53,7 +53,7 @@ fn test_streaming_csv() -> PolarsResult<()> {
         .select([col("sugars_g"), col("calories")])
         .group_by([col("sugars_g")])
         .agg([col("calories").sum()])
-        .sort("sugars_g", Default::default());
+        .sort(["sugars_g"], Default::default());
 
     assert_streaming_with_default(q, true, false);
     Ok(())
@@ -62,7 +62,7 @@ fn test_streaming_csv() -> PolarsResult<()> {
 #[test]
 fn test_streaming_glob() -> PolarsResult<()> {
     let q = get_csv_glob();
-    let q = q.sort("sugars_g", Default::default());
+    let q = q.sort(["sugars_g"], Default::default());
 
     assert_streaming_with_default(q, true, false);
     Ok(())
@@ -104,7 +104,6 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
             [col("sugars_g"), col("calories")],
             SortMultipleOptions::default()
                 .with_orders([false, false])
-                .with_maintain_order(true),
         );
 
     assert_streaming_with_default(q, true, false);
@@ -122,7 +121,7 @@ fn test_streaming_first_sum() -> PolarsResult<()> {
             col("calories").sum(),
             col("calories").first().alias("calories_first"),
         ])
-        .sort("sugars_g", Default::default());
+        .sort(["sugars_g"], Default::default());
 
     assert_streaming_with_default(q, true, false);
     Ok(())
@@ -137,7 +136,7 @@ fn test_streaming_unique() -> PolarsResult<()> {
         .unique(None, Default::default())
         .sort_by_exprs(
             [cols(["sugars_g", "calories"])],
-            SortMultipleOptions::default().with_maintain_order(true),
+            SortMultipleOptions::default(),
         );
 
     assert_streaming_with_default(q, true, false);
@@ -416,7 +415,7 @@ fn test_streaming_outer_join() -> PolarsResult<()> {
         .outer_join(lf_right, col("a"), col("a"))
         .sort_by_exprs(
             [all()],
-            SortMultipleOptions::default().with_maintain_order(true),
+            SortMultipleOptions::default(),
         );
 
     // Toggle so that the join order is swapped.

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -102,7 +102,7 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
         ])
         .sort_by_exprs(
             [col("sugars_g"), col("calories")],
-            SortMultipleOptions::default().with_orders([false, false]),
+            SortMultipleOptions::default().with_order_descendings([false, false]),
         );
 
     assert_streaming_with_default(q, true, false);

--- a/crates/polars-lazy/src/tests/tpch.rs
+++ b/crates/polars-lazy/src/tests/tpch.rs
@@ -78,10 +78,9 @@ fn test_q2() -> PolarsResult<()> {
         ])])
         .sort_by_exprs(
             [cols(["s_acctbal", "n_name", "s_name", "p_partkey"])],
-            [true, false, false, false],
-            false,
-            false,
-            true,
+            SortMultipleOptions::default()
+            .with_orders([true, false, false, false])
+            .with_maintain_order(true)
         )
         .limit(100)
         .with_comm_subplan_elim(true);

--- a/crates/polars-lazy/src/tests/tpch.rs
+++ b/crates/polars-lazy/src/tests/tpch.rs
@@ -79,7 +79,7 @@ fn test_q2() -> PolarsResult<()> {
         .sort_by_exprs(
             [cols(["s_acctbal", "n_name", "s_name", "p_partkey"])],
             SortMultipleOptions::default()
-                .with_orders([true, false, false, false])
+                .with_order_descendings([true, false, false, false])
                 .with_maintain_order(true),
         )
         .limit(100)

--- a/crates/polars-lazy/src/tests/tpch.rs
+++ b/crates/polars-lazy/src/tests/tpch.rs
@@ -79,8 +79,8 @@ fn test_q2() -> PolarsResult<()> {
         .sort_by_exprs(
             [cols(["s_acctbal", "n_name", "s_name", "p_partkey"])],
             SortMultipleOptions::default()
-            .with_orders([true, false, false, false])
-            .with_maintain_order(true)
+                .with_orders([true, false, false, false])
+                .with_maintain_order(true),
         )
         .limit(100)
         .with_comm_subplan_elim(true);

--- a/crates/polars-lazy/src/tests/tpch.rs
+++ b/crates/polars-lazy/src/tests/tpch.rs
@@ -81,6 +81,7 @@ fn test_q2() -> PolarsResult<()> {
             [true, false, false, false],
             false,
             false,
+            true,
         )
         .limit(100)
         .with_comm_subplan_elim(true);

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -215,7 +215,7 @@ pub fn top_k_by(
 
     let multithreaded = sort_options.multithreaded;
 
-    let idx = _arg_bottom_k(k, src.len(), by, &mut sort_options.with_order_reversed())?;
+    let idx = _arg_bottom_k(k, by, &mut sort_options.with_order_reversed())?;
 
     let result = unsafe {
         if multithreaded {

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -24,7 +24,7 @@ fn arg_partition<T, C: Fn(&T, &T) -> Ordering>(
     }
 }
 
-fn extract_target_and_k(s: &[Series]) -> PolarsResult<(u64, &Series)> {
+fn extract_target_and_k(s: &[Series]) -> PolarsResult<(usize, &Series)> {
     let k_s = &s[1];
 
     polars_ensure!(
@@ -38,7 +38,7 @@ fn extract_target_and_k(s: &[Series]) -> PolarsResult<(u64, &Series)> {
 
     let src = &s[0];
 
-    Ok((k, src))
+    Ok((k as usize, src))
 }
 
 fn top_k_num_impl<T>(ca: &ChunkedArray<T>, k: usize, descending: bool) -> ChunkedArray<T>

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -214,7 +214,7 @@ pub fn top_k_by(
     mut sort_options: SortMultipleOptions,
 ) -> PolarsResult<Series> {
     // Top k is reversed bottom k
-    sort_options = sort_options.reverse_order();
+    sort_options = sort_options.with_order_reversed();
 
     let (k, src) = extract_target_and_k(s)?;
 

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -103,7 +103,7 @@ pub fn qcut(
     include_breaks: bool,
 ) -> PolarsResult<Series> {
     let s = s.cast(&DataType::Float64)?;
-    let s2 = s.sort(false, false)?;
+    let s2 = s.sort(SortOptions::default())?;
     let ca = s2.f64()?;
 
     if ca.null_count() == ca.len() {

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -21,7 +21,12 @@ pub trait SeriesMethods: SeriesSealed {
         let cols = vec![values, counts.into_series()];
         let df = unsafe { DataFrame::new_no_checks(cols) };
         if sort {
-            df.sort(["count"], true, false)
+            df.sort(
+                ["count"],
+                SortMultipleOptions::default()
+                    .with_order(true)
+                    .with_multithreaded(parallel),
+            )
         } else {
             Ok(df)
         }

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -24,7 +24,7 @@ pub trait SeriesMethods: SeriesSealed {
             df.sort(
                 ["count"],
                 SortMultipleOptions::default()
-                    .with_order(true)
+                    .with_order_descending(true)
                     .with_multithreaded(parallel),
             )
         } else {

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -249,7 +249,7 @@ pub(super) fn sort_accumulated(
     let sort_column = df.get_columns()[sort_idx].clone();
     df.sort_impl(
         vec![sort_column],
-        SortMultipleOptions::from(sort_options),
+        SortMultipleOptions::from(&sort_options),
         slice,
     )
 }

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -221,7 +221,7 @@ impl Sink for SortSink {
                 SortOptions {
                     descending: self.sort_args.descending[0],
                     nulls_last: self.sort_args.nulls_last,
-                    multithreaded: true,
+                    multithreaded: self.sort_args.multithreaded,
                     maintain_order: self.sort_args.maintain_order,
                 },
             )?;

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -8,7 +8,6 @@ use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{AnyValue, SchemaRef, Series, SortOptions};
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
-use polars_plan::prelude::SortArguments;
 
 use crate::executors::sinks::io::{block_thread_until_io_thread_done, IOThread};
 use crate::executors::sinks::memory::MemTracker;
@@ -29,7 +28,8 @@ pub struct SortSink {
     io_thread: Arc<RwLock<Option<IOThread>>>,
     // location in the dataframe of the columns to sort by
     sort_idx: usize,
-    sort_args: SortArguments,
+    slice: Option<(i64, usize)>,
+    sort_options: SortMultipleOptions,
     // Statistics
     // sampled values so we can find the distribution.
     dist_sample: Vec<AnyValue<'static>>,
@@ -42,7 +42,12 @@ pub struct SortSink {
 }
 
 impl SortSink {
-    pub(crate) fn new(sort_idx: usize, sort_args: SortArguments, schema: SchemaRef) -> Self {
+    pub(crate) fn new(
+        sort_idx: usize,
+        slice: Option<(i64, usize)>,
+        sort_options: SortMultipleOptions,
+        schema: SchemaRef,
+    ) -> Self {
         // for testing purposes
         let ooc = std::env::var(FORCE_OOC).is_ok();
         let n_morsels_per_sink = morsels_per_sink();
@@ -54,7 +59,8 @@ impl SortSink {
             ooc,
             io_thread: Default::default(),
             sort_idx,
-            sort_args,
+            slice,
+            sort_options,
             dist_sample: vec![],
             current_chunk_rows: 0,
             current_chunks_size: 0,
@@ -168,7 +174,8 @@ impl Sink for SortSink {
             ooc: self.ooc,
             io_thread: self.io_thread.clone(),
             sort_idx: self.sort_idx,
-            sort_args: self.sort_args.clone(),
+            slice: self.slice.clone(),
+            sort_options: self.sort_options.clone(),
             dist_sample: vec![],
             current_chunk_rows: 0,
             current_chunks_size: 0,
@@ -184,12 +191,7 @@ impl Sink for SortSink {
             let io_thread = lock.take().unwrap();
 
             let dist = Series::from_any_values("", &self.dist_sample, true).unwrap();
-            let dist = dist.sort_with(SortOptions {
-                descending: self.sort_args.descending[0],
-                nulls_last: self.sort_args.nulls_last,
-                multithreaded: true,
-                maintain_order: self.sort_args.maintain_order,
-            })?;
+            let dist = dist.sort_with(SortOptions::from(&self.sort_options))?;
 
             let instant = self.ooc_start.unwrap();
             if context.verbose {
@@ -204,9 +206,9 @@ impl Sink for SortSink {
                 io_thread,
                 dist,
                 self.sort_idx,
-                self.sort_args.descending[0],
-                self.sort_args.nulls_last,
-                self.sort_args.slice,
+                self.sort_options.descending[0],
+                self.sort_options.nulls_last,
+                self.slice,
                 context.verbose,
                 self.mem_track.clone(),
                 instant,
@@ -217,13 +219,8 @@ impl Sink for SortSink {
             let df = sort_accumulated(
                 df,
                 self.sort_idx,
-                self.sort_args.slice,
-                SortOptions {
-                    descending: self.sort_args.descending[0],
-                    nulls_last: self.sort_args.nulls_last,
-                    multithreaded: self.sort_args.multithreaded,
-                    maintain_order: self.sort_args.maintain_order,
-                },
+                self.slice,
+                SortOptions::from(&self.sort_options),
             )?;
             Ok(FinalizedSink::Finished(df))
         }

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -174,7 +174,7 @@ impl Sink for SortSink {
             ooc: self.ooc,
             io_thread: self.io_thread.clone(),
             sort_idx: self.sort_idx,
-            slice: self.slice.clone(),
+            slice: self.slice,
             sort_options: self.sort_options.clone(),
             dist_sample: vec![],
             current_chunk_rows: 0,

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -173,6 +173,7 @@ impl SortSinkMultiple {
                 nulls_last: false,
                 slice: sort_args.slice,
                 maintain_order: false,
+                multithreaded: true
             },
             Arc::new(schema),
         ));

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -170,7 +170,11 @@ impl SortSinkMultiple {
             // we will set the last column as sort column
             schema.len() - 1,
             slice,
-            sort_options.clone(),
+            sort_options
+                .clone()
+                .with_order(false)
+                .with_nulls_last(false)
+                .with_maintain_order(false),
             Arc::new(schema),
         ));
 

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -5,7 +5,6 @@ use polars_core::prelude::sort::_broadcast_descending;
 use polars_core::prelude::sort::arg_sort_multiple::_get_rows_encoded_compat_array;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
-use polars_plan::prelude::*;
 use polars_row::decode::decode_rows_from_binary;
 use polars_row::EncodingField;
 
@@ -15,12 +14,12 @@ use crate::operators::{
 };
 const POLARS_SORT_COLUMN: &str = "__POLARS_SORT_COLUMN";
 
-fn get_sort_fields(sort_idx: &[usize], sort_args: &SortArguments) -> Vec<EncodingField> {
-    let mut descending = sort_args.descending.clone();
+fn get_sort_fields(sort_idx: &[usize], sort_options: &SortMultipleOptions) -> Vec<EncodingField> {
+    let mut descending = sort_options.descending.clone();
     _broadcast_descending(sort_idx.len(), &mut descending);
     descending
         .into_iter()
-        .map(|descending| EncodingField::new_sorted(descending, sort_args.nulls_last))
+        .map(|descending| EncodingField::new_sorted(descending, sort_options.nulls_last))
         .collect()
 }
 
@@ -54,7 +53,7 @@ fn sort_by_idx<V: Clone>(values: &[V], idx: &[usize]) -> Vec<V> {
 fn finalize_dataframe(
     df: &mut DataFrame,
     sort_idx: &[usize],
-    sort_args: &SortArguments,
+    sort_options: &SortMultipleOptions,
     can_decode: bool,
     sort_dtypes: Option<&[ArrowDataType]>,
     rows: &mut Vec<&'static [u8]>,
@@ -101,7 +100,7 @@ fn finalize_dataframe(
         }
 
         let first_sort_col = &mut cols[sort_idx[0]];
-        let flag = if sort_args.descending[0] {
+        let flag = if sort_options.descending[0] {
             IsSorted::Descending
         } else {
             IsSorted::Ascending
@@ -121,7 +120,8 @@ pub struct SortSinkMultiple {
     output_schema: SchemaRef,
     sort_idx: Arc<[usize]>,
     sort_sink: Box<dyn Sink>,
-    sort_args: SortArguments,
+    slice: Option<(i64, usize)>,
+    sort_options: SortMultipleOptions,
     // Needed for encoding
     sort_fields: Arc<[EncodingField]>,
     sort_dtypes: Option<Arc<[DataType]>>,
@@ -136,7 +136,8 @@ pub struct SortSinkMultiple {
 
 impl SortSinkMultiple {
     pub(crate) fn new(
-        sort_args: SortArguments,
+        slice: Option<(i64, usize)>,
+        sort_options: SortMultipleOptions,
         output_schema: SchemaRef,
         sort_idx: Vec<usize>,
     ) -> PolarsResult<Self> {
@@ -161,26 +162,22 @@ impl SortSinkMultiple {
             sort_dtypes = Some(dtypes.into());
         }
         schema.with_column(POLARS_SORT_COLUMN.into(), DataType::BinaryOffset);
-        let sort_fields = get_sort_fields(&sort_idx, &sort_args);
+        let sort_fields = get_sort_fields(&sort_idx, &sort_options);
 
         // don't set descending and nulls last as this
         // will be solved by the row encoding
         let sort_sink = Box::new(SortSink::new(
             // we will set the last column as sort column
             schema.len() - 1,
-            SortArguments {
-                descending: vec![false],
-                nulls_last: false,
-                slice: sort_args.slice,
-                maintain_order: false,
-                multithreaded: true
-            },
+            slice,
+            sort_options.clone(),
             Arc::new(schema),
         ));
 
         Ok(SortSinkMultiple {
             sort_sink,
-            sort_args,
+            slice,
+            sort_options,
             sort_idx: Arc::from(sort_idx),
             sort_fields: Arc::from(sort_fields),
             sort_dtypes,
@@ -255,7 +252,8 @@ impl Sink for SortSinkMultiple {
             sort_idx: self.sort_idx.clone(),
             sort_sink,
             sort_fields: self.sort_fields.clone(),
-            sort_args: self.sort_args.clone(),
+            slice: self.slice.clone(),
+            sort_options: self.sort_options.clone(),
             sort_column: vec![],
             can_decode: self.can_decode,
             sort_dtypes: self.sort_dtypes.clone(),
@@ -278,7 +276,7 @@ impl Sink for SortSinkMultiple {
                 finalize_dataframe(
                     &mut df,
                     self.sort_idx.as_ref(),
-                    &self.sort_args,
+                    &self.sort_options,
                     self.can_decode,
                     sort_dtypes.as_deref(),
                     &mut vec![],
@@ -290,7 +288,7 @@ impl Sink for SortSinkMultiple {
             FinalizedSink::Source(source) => Ok(FinalizedSink::Source(Box::new(DropEncoded {
                 source,
                 sort_idx: self.sort_idx.clone(),
-                sort_args: std::mem::take(&mut self.sort_args),
+                sort_options: self.sort_options.clone(),
                 can_decode: self.can_decode,
                 sort_dtypes,
                 rows: vec![],
@@ -314,7 +312,7 @@ impl Sink for SortSinkMultiple {
 struct DropEncoded {
     source: Box<dyn Source>,
     sort_idx: Arc<[usize]>,
-    sort_args: SortArguments,
+    sort_options: SortMultipleOptions,
     can_decode: bool,
     sort_dtypes: Option<Vec<ArrowDataType>>,
     rows: Vec<&'static [u8]>,
@@ -330,7 +328,7 @@ impl Source for DropEncoded {
                 finalize_dataframe(
                     &mut chunk.data,
                     self.sort_idx.as_ref(),
-                    &self.sort_args,
+                    &self.sort_options,
                     self.can_decode,
                     self.sort_dtypes.as_deref(),
                     &mut self.rows,

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -256,7 +256,7 @@ impl Sink for SortSinkMultiple {
             sort_idx: self.sort_idx.clone(),
             sort_sink,
             sort_fields: self.sort_fields.clone(),
-            slice: self.slice.clone(),
+            slice: self.slice,
             sort_options: self.sort_options.clone(),
             sort_column: vec![],
             can_decode: self.can_decode,

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -172,7 +172,7 @@ impl SortSinkMultiple {
             slice,
             sort_options
                 .clone()
-                .with_order(false)
+                .with_order_descending(false)
                 .with_nulls_last(false)
                 .with_maintain_order(false),
             Arc::new(schema),

--- a/crates/polars-pipe/src/executors/sinks/sort/source.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/source.rs
@@ -92,7 +92,17 @@ impl SortSource {
         let current_slice = self.slice;
 
         let mut df = match &mut self.slice {
-            None => sort_accumulated(df, self.sort_idx, self.descending, None, self.nulls_last),
+            None => sort_accumulated(
+                df,
+                self.sort_idx,
+                None,
+                SortOptions {
+                    descending: self.descending,
+                    nulls_last: self.nulls_last,
+                    multithreaded: true,
+                    maintain_order: false,
+                },
+            ),
             Some((offset, len)) => {
                 let df_len = df.height();
                 debug_assert!(*offset >= 0);
@@ -103,9 +113,13 @@ impl SortSource {
                     let out = sort_accumulated(
                         df,
                         self.sort_idx,
-                        self.descending,
                         current_slice,
-                        self.nulls_last,
+                        SortOptions {
+                            descending: self.descending,
+                            nulls_last: self.nulls_last,
+                            multithreaded: true,
+                            maintain_order: false,
+                        },
                     );
                     *len = len.saturating_sub(df_len);
                     *offset = 0;

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -341,7 +341,8 @@ where
         Sort {
             input,
             by_column,
-            args,
+            slice,
+            sort_options,
         } => {
             let input_schema = lp_arena.get(*input).schema(lp_arena).into_owned();
 
@@ -351,7 +352,8 @@ where
                     .unwrap();
                 let index = input_schema.try_index_of(by_column.as_ref())?;
 
-                let sort_sink = SortSink::new(index, args.clone(), input_schema);
+                let sort_sink =
+                    SortSink::new(index, slice.clone(), sort_options.clone(), input_schema);
                 Box::new(sort_sink) as Box<dyn SinkTrait>
             } else {
                 let sort_idx = by_column
@@ -364,7 +366,12 @@ where
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 
-                let sort_sink = SortSinkMultiple::new(args.clone(), input_schema, sort_idx)?;
+                let sort_sink = SortSinkMultiple::new(
+                    slice.clone(),
+                    sort_options.clone(),
+                    input_schema,
+                    sort_idx,
+                )?;
                 Box::new(sort_sink) as Box<dyn SinkTrait>
             }
         },

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -352,8 +352,7 @@ where
                     .unwrap();
                 let index = input_schema.try_index_of(by_column.as_ref())?;
 
-                let sort_sink =
-                    SortSink::new(index, slice.clone(), sort_options.clone(), input_schema);
+                let sort_sink = SortSink::new(index, *slice, sort_options.clone(), input_schema);
                 Box::new(sort_sink) as Box<dyn SinkTrait>
             } else {
                 let sort_idx = by_column
@@ -366,12 +365,8 @@ where
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 
-                let sort_sink = SortSinkMultiple::new(
-                    slice.clone(),
-                    sort_options.clone(),
-                    input_schema,
-                    sort_idx,
-                )?;
+                let sort_sink =
+                    SortSinkMultiple::new(*slice, sort_options.clone(), input_schema, sort_idx)?;
                 Box::new(sort_sink) as Box<dyn SinkTrait>
             }
         },

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -94,7 +94,7 @@ pub enum Expr {
     SortBy {
         expr: Arc<Expr>,
         by: Vec<Expr>,
-        descending: Vec<bool>,
+        sort_options: SortMultipleOptions
     },
     Agg(AggExpr),
     /// A ternary operation
@@ -234,11 +234,11 @@ impl Hash for Expr {
             Expr::SortBy {
                 expr,
                 by,
-                descending,
+                sort_options,
             } => {
                 expr.hash(state);
                 by.hash(state);
-                descending.hash(state);
+                sort_options.hash(state);
             },
             Expr::Agg(input) => input.hash(state),
             Expr::Explode(input) => input.hash(state),

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -94,7 +94,7 @@ pub enum Expr {
     SortBy {
         expr: Arc<Expr>,
         by: Vec<Expr>,
-        sort_options: SortMultipleOptions
+        sort_options: SortMultipleOptions,
     },
     Agg(AggExpr),
     /// A ternary operation

--- a/crates/polars-plan/src/dsl/functions/index.rs
+++ b/crates/polars-plan/src/dsl/functions/index.rs
@@ -5,11 +5,14 @@ use super::*;
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.
 #[cfg(feature = "range")]
-pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> Expr {
+pub fn arg_sort_by<E: AsRef<[Expr]>>(
+    by: E,
+    sort_options: SortMultipleOptions
+) -> Expr {
     let e = &by.as_ref()[0];
     let name = expr_output_name(e).unwrap();
     int_range(lit(0 as IdxSize), len().cast(IDX_DTYPE), 1, IDX_DTYPE)
-        .sort_by(by, descending)
+        .sort_by(by, sort_options)
         .alias(name.as_ref())
 }
 

--- a/crates/polars-plan/src/dsl/functions/index.rs
+++ b/crates/polars-plan/src/dsl/functions/index.rs
@@ -5,10 +5,7 @@ use super::*;
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.
 #[cfg(feature = "range")]
-pub fn arg_sort_by<E: AsRef<[Expr]>>(
-    by: E,
-    sort_options: SortMultipleOptions
-) -> Expr {
+pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, sort_options: SortMultipleOptions) -> Expr {
     let e = &by.as_ref()[0];
     let name = expr_output_name(e).unwrap();
     int_range(lit(0 as IdxSize), len().cast(IDX_DTYPE), 1, IDX_DTYPE)

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1065,7 +1065,7 @@ impl Expr {
     pub fn sort_by<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
         self,
         by: E,
-        sort_options: SortMultipleOptions
+        sort_options: SortMultipleOptions,
     ) -> Expr {
         let by = by.as_ref().iter().map(|e| e.clone().into()).collect();
         Expr::SortBy {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -409,6 +409,34 @@ impl Expr {
     }
 
     /// Sort with given options.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use polars_core::prelude::*;
+    /// # use polars_lazy::prelude::*;
+    /// # fn main() -> PolarsResult<()> {
+    /// let lf = df! {
+    ///    "a" => [Some(5), Some(4), Some(3), Some(2), None]
+    /// }?
+    /// .lazy();
+    ///
+    /// let sorted = lf
+    ///     .select(
+    ///         vec![col("a").sort(SortOptions::default())],
+    ///     )
+    ///     .collect()?;
+    ///
+    /// assert_eq!(
+    ///     sorted,
+    ///     df! {
+    ///         "a" => [None, Some(2), Some(3), Some(4), Some(5)]
+    ///     }?
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// See [`SortOptions`] for more options.
     pub fn sort(self, options: SortOptions) -> Self {
         Expr::Sort {
             expr: Arc::new(self),
@@ -1060,8 +1088,10 @@ impl Expr {
         }
     }
 
-    /// Sort this column by the ordering of another column.
+    /// Sort this column by the ordering of another column evaluated from given expr.
     /// Can also be used in a group_by context to sort the groups.
+    ///
+    /// # Example
     pub fn sort_by<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
         self,
         by: E,

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1073,17 +1073,16 @@ impl Expr {
 
     /// Sort this column by the ordering of another column.
     /// Can also be used in a group_by context to sort the groups.
-    pub fn sort_by<E: AsRef<[IE]>, IE: Into<Expr> + Clone, R: AsRef<[bool]>>(
+    pub fn sort_by<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
         self,
         by: E,
-        descending: R,
+        sort_options: SortMultipleOptions
     ) -> Expr {
         let by = by.as_ref().iter().map(|e| e.clone().into()).collect();
-        let descending = descending.as_ref().to_vec();
         Expr::SortBy {
             expr: Arc::new(self),
             by,
-            descending,
+            sort_options,
         }
     }
 

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -408,19 +408,8 @@ impl Expr {
         }
     }
 
-    /// Sort in increasing order. See [the eager implementation](Series::sort).
-    pub fn sort(self, descending: bool) -> Self {
-        Expr::Sort {
-            expr: Arc::new(self),
-            options: SortOptions {
-                descending,
-                ..Default::default()
-            },
-        }
-    }
-
     /// Sort with given options.
-    pub fn sort_with(self, options: SortOptions) -> Self {
+    pub fn sort(self, options: SortOptions) -> Self {
         Expr::Sort {
             expr: Arc::new(self),
             options,

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1092,6 +1092,28 @@ impl Expr {
     /// Can also be used in a group_by context to sort the groups.
     ///
     /// # Example
+    ///
+    /// ```rust
+    /// # use polars_core::prelude::*;
+    /// # use polars_lazy::prelude::*;
+    /// # fn main() -> PolarsResult<()> {
+    /// let lf = df! {
+    ///     "a" => [1, 2, 3, 4, 5],
+    ///     "b" => [5, 4, 3, 2, 1]
+    /// }?.lazy();
+    ///
+    /// let sorted = lf
+    ///     .select(
+    ///         vec![col("a").sort_by(col("b"), SortOptions::default())],
+    ///     )
+    ///     .collect()?;
+    ///
+    /// assert_eq!(
+    ///     sorted,
+    ///     df! { "a" => [5, 4, 3, 2, 1] }?
+    /// );
+    /// # Ok(())
+    /// # }
     pub fn sort_by<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
         self,
         by: E,

--- a/crates/polars-plan/src/logical_plan/aexpr/hash.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/hash.rs
@@ -25,7 +25,7 @@ impl Hash for AExpr {
                 options.hash(state);
             },
             AExpr::Agg(agg) => agg.hash(state),
-            AExpr::SortBy { descending, .. } => descending.hash(state),
+            AExpr::SortBy { sort_options, .. } => sort_options.hash(state),
             AExpr::Cast { strict, .. } => strict.hash(state),
             AExpr::Window { options, .. } => options.hash(state),
             AExpr::BinaryExpr { op, .. } => op.hash(state),

--- a/crates/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -148,7 +148,7 @@ pub enum AExpr {
     SortBy {
         expr: Node,
         by: Vec<Node>,
-        sort_options: SortMultipleOptions
+        sort_options: SortMultipleOptions,
     },
     Filter {
         input: Node,

--- a/crates/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -148,7 +148,7 @@ pub enum AExpr {
     SortBy {
         expr: Node,
         by: Vec<Node>,
-        descending: Vec<bool>,
+        sort_options: SortMultipleOptions
     },
     Filter {
         input: Node,

--- a/crates/polars-plan/src/logical_plan/alp/inputs.rs
+++ b/crates/polars-plan/src/logical_plan/alp/inputs.rs
@@ -69,11 +69,15 @@ impl IR {
                 options: options.clone(),
             },
             Sort {
-                by_column, args, ..
+                by_column,
+                slice,
+                sort_options,
+                ..
             } => Sort {
                 input: inputs[0],
                 by_column: by_column.clone(),
-                args: args.clone(),
+                slice: slice.clone(),
+                sort_options: sort_options.clone(),
             },
             Cache { id, cache_hits, .. } => Cache {
                 input: inputs[0],

--- a/crates/polars-plan/src/logical_plan/alp/inputs.rs
+++ b/crates/polars-plan/src/logical_plan/alp/inputs.rs
@@ -76,7 +76,7 @@ impl IR {
             } => Sort {
                 input: inputs[0],
                 by_column: by_column.clone(),
-                slice: slice.clone(),
+                slice: *slice,
                 sort_options: sort_options.clone(),
             },
             Cache { id, cache_hits, .. } => Cache {

--- a/crates/polars-plan/src/logical_plan/alp/mod.rs
+++ b/crates/polars-plan/src/logical_plan/alp/mod.rs
@@ -64,7 +64,8 @@ pub enum IR {
     Sort {
         input: Node,
         by_column: Vec<ExprIR>,
-        args: SortArguments,
+        slice: Option<(i64, usize)>,
+        sort_options: SortMultipleOptions,
     },
     Cache {
         input: Node,

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -819,8 +819,9 @@ impl LogicalPlanBuilder {
         self,
         by_column: Vec<Expr>,
         descending: Vec<bool>,
-        null_last: bool,
+        nulls_last: bool,
         maintain_order: bool,
+        multithreaded: bool,
     ) -> Self {
         let schema = try_delayed!(self.0.schema(), &self.0, into);
         let by_column = try_delayed!(rewrite_projections(by_column, &schema, &[]), &self.0, into);
@@ -829,9 +830,10 @@ impl LogicalPlanBuilder {
             by_column,
             args: SortArguments {
                 descending,
-                nulls_last: null_last,
+                nulls_last,
                 slice: None,
                 maintain_order,
+                multithreaded,
             },
         }
         .into()

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -818,23 +818,15 @@ impl LogicalPlanBuilder {
     pub fn sort(
         self,
         by_column: Vec<Expr>,
-        descending: Vec<bool>,
-        nulls_last: bool,
-        maintain_order: bool,
-        multithreaded: bool,
+        sort_options: SortMultipleOptions
     ) -> Self {
         let schema = try_delayed!(self.0.schema(), &self.0, into);
         let by_column = try_delayed!(rewrite_projections(by_column, &schema, &[]), &self.0, into);
         LogicalPlan::Sort {
             input: Arc::new(self.0),
             by_column,
-            args: SortArguments {
-                descending,
-                nulls_last,
-                slice: None,
-                maintain_order,
-                multithreaded,
-            },
+            slice: None,
+            sort_options
         }
         .into()
     }

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -815,18 +815,14 @@ impl LogicalPlanBuilder {
         .into()
     }
 
-    pub fn sort(
-        self,
-        by_column: Vec<Expr>,
-        sort_options: SortMultipleOptions
-    ) -> Self {
+    pub fn sort(self, by_column: Vec<Expr>, sort_options: SortMultipleOptions) -> Self {
         let schema = try_delayed!(self.0.schema(), &self.0, into);
         let by_column = try_delayed!(rewrite_projections(by_column, &schema, &[]), &self.0, into);
         LogicalPlan::Sort {
             input: Arc::new(self.0),
             by_column,
             slice: None,
-            sort_options
+            sort_options,
         }
         .into()
     }

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -389,14 +389,16 @@ pub fn to_alp(
         LogicalPlan::Sort {
             input,
             by_column,
-            args,
+            slice,
+            sort_options,
         } => {
             let input = to_alp(owned(input), expr_arena, lp_arena)?;
             let by_column = to_expr_irs(by_column, expr_arena);
             IR::Sort {
                 input,
                 by_column,
-                args,
+                slice,
+                sort_options,
             }
         },
         LogicalPlan::Cache {
@@ -856,14 +858,16 @@ impl IR {
             IR::Sort {
                 input,
                 by_column,
-                args,
+                slice,
+                sort_options,
             } => {
                 let input = Arc::new(convert_to_lp(input, lp_arena));
                 let by_column = expr_irs_to_exprs(by_column, expr_arena);
                 LogicalPlan::Sort {
                     input,
                     by_column,
-                    args,
+                    slice,
+                    sort_options,
                 }
             },
             IR::Cache {

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -141,14 +141,14 @@ fn to_aexpr_impl(expr: Expr, arena: &mut Arena<AExpr>, state: &mut ConversionSta
         Expr::SortBy {
             expr,
             by,
-            descending,
+            sort_options,
         } => AExpr::SortBy {
             expr: to_aexpr_impl(owned(expr), arena, state),
             by: by
                 .into_iter()
                 .map(|e| to_aexpr_impl(e, arena, state))
                 .collect(),
-            descending,
+            sort_options,
         },
         Expr::Filter { input, by } => AExpr::Filter {
             input: to_aexpr_impl(owned(input), arena, state),
@@ -567,7 +567,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
         AExpr::SortBy {
             expr,
             by,
-            descending,
+            sort_options,
         } => {
             let expr = node_to_expr(expr, expr_arena);
             let by = by
@@ -577,7 +577,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             Expr::SortBy {
                 expr: Arc::new(expr),
                 by,
-                descending,
+                sort_options,
             }
         },
         AExpr::Filter { input, by } => {

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -307,9 +307,9 @@ impl Debug for Expr {
             SortBy {
                 expr,
                 by,
-                descending,
+                sort_options,
             } => {
-                write!(f, "{expr:?}.sort_by(by={by:?}, descending={descending:?})",)
+                write!(f, "{expr:?}.sort_by(by={by:?}, sort_option={sort_options:?})",)
             },
             Filter { input, by } => {
                 write!(f, "{input:?}.filter({by:?})")

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -309,7 +309,10 @@ impl Debug for Expr {
                 by,
                 sort_options,
             } => {
-                write!(f, "{expr:?}.sort_by(by={by:?}, sort_option={sort_options:?})",)
+                write!(
+                    f,
+                    "{expr:?}.sort_by(by={by:?}, sort_option={sort_options:?})",
+                )
             },
             Filter { input, by } => {
                 write!(f, "{input:?}.filter({by:?})")

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -204,7 +204,8 @@ pub enum LogicalPlan {
     Sort {
         input: Arc<LogicalPlan>,
         by_column: Vec<Expr>,
-        args: SortArguments,
+        slice: Option<(i64, usize)>,
+        sort_options: SortMultipleOptions,
     },
     /// Slice the table
     Slice {
@@ -264,7 +265,7 @@ impl Clone for LogicalPlan {
             Self::Join { input_left, input_right, schema, left_on, right_on, options } => Self::Join { input_left: input_left.clone(), input_right: input_right.clone(), schema: schema.clone(), left_on: left_on.clone(), right_on: right_on.clone(), options: options.clone() },
             Self::HStack { input, exprs, schema, options } => Self::HStack { input: input.clone(), exprs: exprs.clone(), schema: schema.clone(), options: options.clone() },
             Self::Distinct { input, options } => Self::Distinct { input: input.clone(), options: options.clone() },
-            Self::Sort { input, by_column, args } => Self::Sort { input: input.clone(), by_column: by_column.clone(), args: args.clone() },
+            Self::Sort {input,by_column, slice, sort_options } => Self::Sort { input: input.clone(), by_column: by_column.clone(), slice: slice.clone(), sort_options: sort_options.clone() },
             Self::Slice { input, offset, len } => Self::Slice { input: input.clone(), offset: offset.clone(), len: len.clone() },
             Self::MapFunction { input, function } => Self::MapFunction { input: input.clone(), function: function.clone() },
             Self::Union { inputs, options } => Self::Union { inputs: inputs.clone(), options: options.clone() },

--- a/crates/polars-plan/src/logical_plan/optimizer/collapse_and_project.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/collapse_and_project.rs
@@ -128,12 +128,14 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
             Sort {
                 input,
                 by_column,
-                args,
+                slice,
+                sort_options,
             } => match lp_arena.get(*input) {
                 Sort { input: inner, .. } => Some(Sort {
                     input: *inner,
                     by_column: by_column.clone(),
-                    args: args.clone(),
+                    slice: *slice,
+                    sort_options: sort_options.clone(),
                 }),
                 _ => None,
             },

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -451,7 +451,8 @@ impl ProjectionPushDown {
             Sort {
                 input,
                 by_column,
-                args,
+                slice,
+                sort_options,
             } => {
                 if !acc_projections.is_empty() {
                     // Make sure that the column(s) used for the sort is projected
@@ -476,7 +477,8 @@ impl ProjectionPushDown {
                 Ok(Sort {
                     input,
                     by_column,
-                    args,
+                    slice,
+                    sort_options,
                 })
             },
             Distinct { input, options } => {

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
@@ -26,8 +26,7 @@ pub(super) fn optimize_functions(
                     sort_options,
                 } => {
                     let mut sort_options = sort_options.clone();
-                    let reversed_descending =
-                        (&sort_options.descending).iter().map(|x| !*x).collect();
+                    let reversed_descending = sort_options.descending.iter().map(|x| !*x).collect();
                     sort_options.descending = reversed_descending;
                     Some(AExpr::SortBy {
                         expr: *expr,

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
@@ -23,12 +23,18 @@ pub(super) fn optimize_functions(
                 AExpr::SortBy {
                     expr,
                     by,
-                    descending,
-                } => Some(AExpr::SortBy {
-                    expr: *expr,
-                    by: by.clone(),
-                    descending: descending.iter().map(|r| !*r).collect(),
-                }),
+                    sort_options,
+                } => {
+                    let mut sort_options = sort_options.clone();
+                    let reversed_descending =
+                        (&sort_options.descending).iter().map(|x| !*x).collect();
+                    sort_options.descending = reversed_descending;
+                    Some(AExpr::SortBy {
+                        expr: *expr,
+                        by: by.clone(),
+                        sort_options,
+                    })
+                },
                 // TODO: add support for cum_sum and other operation that allow reversing.
                 _ => None,
             }

--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -280,17 +280,19 @@ impl SlicePushDown {
                     options,
                 })
             }
-            (Sort {input, by_column, mut args}, Some(state)) => {
+            (Sort {input, by_column, mut slice,
+                sort_options}, Some(state)) => {
                 // first restart optimization in inputs and get the updated LP
                 let input_lp = lp_arena.take(input);
                 let input_lp = self.pushdown(input_lp, None, lp_arena, expr_arena)?;
                 let input= lp_arena.add(input_lp);
 
-                args.slice = Some((state.offset, state.len as usize));
+                slice = Some((state.offset, state.len as usize));
                 Ok(Sort {
                     input,
                     by_column,
-                    args
+                    slice,
+                    sort_options
                 })
             }
             (Slice {

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -304,6 +304,18 @@ pub struct SortArguments {
     pub maintain_order: bool,
 }
 
+
+impl From<&SortArguments> for SortMultipleOptions {
+    fn from(value: &SortArguments) -> Self {
+        SortMultipleOptions {
+            descending: value.descending.clone(),
+            nulls_last: value.nulls_last,
+            maintain_order: value.maintain_order,
+            multithreaded: true
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg(feature = "python")]

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -302,6 +302,7 @@ pub struct SortArguments {
     pub nulls_last: bool,
     pub slice: Option<(i64, usize)>,
     pub maintain_order: bool,
+    pub multithreaded: bool
 }
 
 
@@ -311,7 +312,7 @@ impl From<&SortArguments> for SortMultipleOptions {
             descending: value.descending.clone(),
             nulls_last: value.nulls_last,
             maintain_order: value.maintain_order,
-            multithreaded: true
+            multithreaded: value.multithreaded
         }
     }
 }

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -295,28 +295,6 @@ pub struct LogicalPlanUdfOptions {
     pub fmt_str: &'static str,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct SortArguments {
-    pub descending: Vec<bool>,
-    pub nulls_last: bool,
-    pub slice: Option<(i64, usize)>,
-    pub maintain_order: bool,
-    pub multithreaded: bool
-}
-
-
-impl From<&SortArguments> for SortMultipleOptions {
-    fn from(value: &SortArguments) -> Self {
-        SortMultipleOptions {
-            descending: value.descending.clone(),
-            nulls_last: value.nulls_last,
-            maintain_order: value.maintain_order,
-            multithreaded: value.multithreaded
-        }
-    }
-}
-
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg(feature = "python")]

--- a/crates/polars-plan/src/logical_plan/tree_format.rs
+++ b/crates/polars-plan/src/logical_plan/tree_format.rs
@@ -37,11 +37,16 @@ impl UpperExp for AExpr {
                 )
             },
             AExpr::Gather { .. } => "gather",
-            AExpr::SortBy { descending, .. } => {
+            AExpr::SortBy { sort_options, .. } => {
                 write!(f, "sort_by:")?;
-                for i in descending {
+                for i in &sort_options.descending {
                     write!(f, "{}", *i as u8)?;
                 }
+                write!(
+                    f,
+                    "{}{}",
+                    sort_options.nulls_last as u8, sort_options.multithreaded as u8
+                )?;
                 return Ok(());
             },
             AExpr::Filter { .. } => "filter",

--- a/crates/polars-plan/src/logical_plan/visitor/expr.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/expr.rs
@@ -179,7 +179,16 @@ impl AExpr {
             | (Len, Len)
             | (Slice { .. }, Slice { .. })
             | (Explode(_), Explode(_)) => true,
-            (SortBy { descending: l, .. }, SortBy { descending: r, .. }) => l == r,
+            (
+                SortBy {
+                    sort_options: l_sort_options,
+                    ..
+                },
+                SortBy {
+                    sort_options: r_sort_options,
+                    ..
+                },
+            ) => l_sort_options == r_sort_options,
             (Agg(l), Agg(r)) => l.equal_nodes(r),
             (
                 Function {

--- a/crates/polars-plan/src/logical_plan/visitor/expr.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/expr.rs
@@ -51,7 +51,7 @@ impl TreeWalker for Expr {
             Cast { expr, data_type, strict } => Cast { expr: am(expr, f)?, data_type, strict },
             Sort { expr, options } => Sort { expr: am(expr, f)?, options },
             Gather { expr, idx, returns_scalar } => Gather { expr: am(expr, &mut f)?, idx: am(idx, f)?, returns_scalar },
-            SortBy { expr, by, descending } => SortBy { expr: am(expr, &mut f)?, by: by.into_iter().map(f).collect::<Result<_, _>>()?, descending },
+            SortBy { expr, by, sort_options } => SortBy { expr: am(expr, &mut f)?, by: by.into_iter().map(f).collect::<Result<_, _>>()?, sort_options },
             Agg(agg_expr) => Agg(match agg_expr {
                 Min { input, propagate_nans } => Min { input: am(input, f)?, propagate_nans },
                 Max { input, propagate_nans } => Max { input: am(input, f)?, propagate_nans },

--- a/crates/polars-plan/src/logical_plan/visitor/hash.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/hash.rs
@@ -118,10 +118,12 @@ impl Hash for HashableEqLP<'_> {
             IR::Sort {
                 input: _,
                 by_column,
-                args,
+                slice,
+                sort_options,
             } => {
                 hash_exprs(by_column, self.expr_arena, state);
-                args.hash(state);
+                slice.hash(state);
+                sort_options.hash(state);
             },
             IR::GroupBy {
                 input: _,
@@ -321,14 +323,19 @@ impl HashableEqLP<'_> {
                 IR::Sort {
                     input: _,
                     by_column: cl,
-                    args: al,
+                    slice: l_slice,
+                    sort_options: l_options,
                 },
                 IR::Sort {
                     input: _,
                     by_column: cr,
-                    args: ar,
+                    slice: r_slice,
+                    sort_options: r_options,
                 },
-            ) => al == ar && expr_irs_eq(cl, cr, self.expr_arena),
+            ) => {
+                (l_slice == r_slice && l_options == r_options)
+                    && expr_irs_eq(cl, cr, self.expr_arena)
+            },
             (
                 IR::GroupBy {
                     input: _,

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -678,7 +678,7 @@ impl SQLContext {
             );
         }
 
-        Ok(lf.sort_by_exprs(&by, SortMultipleOptions::default().with_order(descending)))
+        Ok(lf.sort_by_exprs(&by, SortMultipleOptions::default().with_orders(descending)))
     }
 
     fn process_group_by(

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -678,7 +678,7 @@ impl SQLContext {
             );
         }
 
-        Ok(lf.sort_by_exprs(&by, descending, false, false, true))
+        Ok(lf.sort_by_exprs(&by, SortMultipleOptions::default().with_order(descending)))
     }
 
     fn process_group_by(

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -681,7 +681,7 @@ impl SQLContext {
         Ok(lf.sort_by_exprs(
             &by,
             SortMultipleOptions::default()
-                .with_orders(descending)
+                .with_order_descendings(descending)
                 .with_maintain_order(true),
         ))
     }

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -678,7 +678,7 @@ impl SQLContext {
             );
         }
 
-        Ok(lf.sort_by_exprs(&by, descending, false, false))
+        Ok(lf.sort_by_exprs(&by, descending, false, false, true))
     }
 
     fn process_group_by(

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -678,7 +678,12 @@ impl SQLContext {
             );
         }
 
-        Ok(lf.sort_by_exprs(&by, SortMultipleOptions::default().with_orders(descending)))
+        Ok(lf.sort_by_exprs(
+            &by,
+            SortMultipleOptions::default()
+                .with_orders(descending)
+                .with_maintain_order(true),
+        ))
     }
 
     fn process_group_by(

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1,4 +1,4 @@
-use polars_core::chunked_array::ops::SortMultipleOptions;
+use polars_core::chunked_array::ops::{SortMultipleOptions, SortOptions};
 use polars_core::prelude::{polars_bail, polars_err, DataType, PolarsResult};
 use polars_lazy::dsl::Expr;
 #[cfg(feature = "list_eval")]
@@ -1140,7 +1140,10 @@ impl SQLFunctionVisitor<'_> {
                 .unzip();
             self.visit_unary_no_window(|e| {
                 cumulative_f(
-                    e.sort_by(&order_by, SortMultipleOptions::default().with_orders(desc.clone())),
+                    e.sort_by(
+                        &order_by,
+                        SortMultipleOptions::default().with_orders(desc.clone()),
+                    ),
                     false,
                 )
             })
@@ -1264,7 +1267,9 @@ impl SQLFunctionVisitor<'_> {
                         .iter()
                         .map(|o| {
                             let e = parse_sql_expr(&o.expr, self.ctx)?;
-                            Ok(o.asc.map_or(e.clone(), |b| e.sort(!b)))
+                            Ok(o.asc.map_or(e.clone(), |b| {
+                                e.sort(SortOptions::default().with_order(!b))
+                            }))
                         })
                         .collect::<PolarsResult<Vec<_>>>()?;
                     expr.over(exprs)

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1142,7 +1142,7 @@ impl SQLFunctionVisitor<'_> {
                 cumulative_f(
                     e.sort_by(
                         &order_by,
-                        SortMultipleOptions::default().with_orders(desc.clone()),
+                        SortMultipleOptions::default().with_order_descendings(desc.clone()),
                     ),
                     false,
                 )
@@ -1268,7 +1268,7 @@ impl SQLFunctionVisitor<'_> {
                         .map(|o| {
                             let e = parse_sql_expr(&o.expr, self.ctx)?;
                             Ok(o.asc.map_or(e.clone(), |b| {
-                                e.sort(SortOptions::default().with_order(!b))
+                                e.sort(SortOptions::default().with_order_descending(!b))
                             }))
                         })
                         .collect::<PolarsResult<Vec<_>>>()?;

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1140,13 +1140,7 @@ impl SQLFunctionVisitor<'_> {
                 .unzip();
             self.visit_unary_no_window(|e| {
                 cumulative_f(
-                    e.sort_by(
-                        &order_by,
-                        SortMultipleOptions {
-                            descending: desc.clone(),
-                            ..Default::default()
-                        },
-                    ),
+                    e.sort_by(&order_by, SortMultipleOptions::default().with_orders(desc.clone())),
                     false,
                 )
             })

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1,3 +1,4 @@
+use polars_core::chunked_array::ops::SortMultipleOptions;
 use polars_core::prelude::{polars_bail, polars_err, DataType, PolarsResult};
 use polars_lazy::dsl::Expr;
 #[cfg(feature = "list_eval")]
@@ -1137,7 +1138,18 @@ impl SQLFunctionVisitor<'_> {
                 .collect::<PolarsResult<Vec<_>>>()?
                 .into_iter()
                 .unzip();
-            self.visit_unary_no_window(|e| cumulative_f(e.sort_by(&order_by, &desc), false))
+            self.visit_unary_no_window(|e| {
+                cumulative_f(
+                    e.sort_by(
+                        &order_by,
+                        SortMultipleOptions {
+                            descending: desc.clone(),
+                            ..Default::default()
+                        },
+                    ),
+                    false,
+                )
+            })
         } else {
             self.visit_unary(f)
         }

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -638,7 +638,7 @@ impl SQLExprVisitor<'_> {
             let (order_by, descending) = self.visit_order_by(order_by)?;
             base = base.sort_by(
                 order_by,
-                SortMultipleOptions::default().with_orders(descending),
+                SortMultipleOptions::default().with_order_descendings(descending),
             );
         }
         if let Some(limit) = &expr.limit {

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -636,10 +636,10 @@ impl SQLExprVisitor<'_> {
         let mut base = self.visit_expr(&expr.expr)?;
         if let Some(order_by) = expr.order_by.as_ref() {
             let (order_by, descending) = self.visit_order_by(order_by)?;
-            base = base.sort_by(order_by, SortMultipleOptions {
-                descending,
-                ..Default::default()
-            });
+            base = base.sort_by(
+                order_by,
+                SortMultipleOptions::default().with_orders(descending),
+            );
         }
         if let Some(limit) = &expr.limit {
             let limit = match self.visit_expr(limit)? {

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -636,7 +636,10 @@ impl SQLExprVisitor<'_> {
         let mut base = self.visit_expr(&expr.expr)?;
         if let Some(order_by) = expr.order_by.as_ref() {
             let (order_by, descending) = self.visit_order_by(order_by)?;
-            base = base.sort_by(order_by, descending);
+            base = base.sort_by(order_by, SortMultipleOptions {
+                descending,
+                ..Default::default()
+            });
         }
         if let Some(limit) = &expr.limit {
             let limit = match self.visit_expr(limit)? {

--- a/crates/polars-sql/tests/functions_cumulative.rs
+++ b/crates/polars-sql/tests/functions_cumulative.rs
@@ -30,7 +30,7 @@ fn create_expected(expr: Expr, sql: &str) -> (DataFrame, DataFrame) {
     let expected = df
         .clone()
         .select(&[expr.alias(alias)])
-        .sort(alias, SortOptions::default())
+        .sort([alias], Default::default())
         .collect()
         .unwrap();
     let mut ctx = SQLContext::new();
@@ -42,7 +42,9 @@ fn create_expected(expr: Expr, sql: &str) -> (DataFrame, DataFrame) {
 
 #[test]
 fn test_cumulative_sum() {
-    let expr = col("Sales").sort(true).cum_sum(false);
+    let expr = col("Sales")
+        .sort(SortOptions::default().with_order(true))
+        .cum_sum(false);
 
     let sql_expr = "SUM(Sales) OVER (ORDER BY Sales DESC)";
     let (expected, actual) = create_expected(expr, sql_expr);
@@ -52,7 +54,9 @@ fn test_cumulative_sum() {
 
 #[test]
 fn test_cumulative_min() {
-    let expr = col("Sales").sort(true).cum_min(false);
+    let expr = col("Sales")
+        .sort(SortOptions::default().with_order(true))
+        .cum_min(false);
 
     let sql_expr = "MIN(Sales) OVER (ORDER BY Sales DESC)";
     let (expected, actual) = create_expected(expr, sql_expr);
@@ -62,7 +66,9 @@ fn test_cumulative_min() {
 
 #[test]
 fn test_cumulative_max() {
-    let expr = col("Sales").sort(true).cum_max(false);
+    let expr = col("Sales")
+        .sort(SortOptions::default().with_order(true))
+        .cum_max(false);
 
     let sql_expr = "MAX(Sales) OVER (ORDER BY Sales DESC)";
     let (expected, actual) = create_expected(expr, sql_expr);

--- a/crates/polars-sql/tests/functions_cumulative.rs
+++ b/crates/polars-sql/tests/functions_cumulative.rs
@@ -43,7 +43,7 @@ fn create_expected(expr: Expr, sql: &str) -> (DataFrame, DataFrame) {
 #[test]
 fn test_cumulative_sum() {
     let expr = col("Sales")
-        .sort(SortOptions::default().with_order(true))
+        .sort(SortOptions::default().with_order_descending(true))
         .cum_sum(false);
 
     let sql_expr = "SUM(Sales) OVER (ORDER BY Sales DESC)";
@@ -55,7 +55,7 @@ fn test_cumulative_sum() {
 #[test]
 fn test_cumulative_min() {
     let expr = col("Sales")
-        .sort(SortOptions::default().with_order(true))
+        .sort(SortOptions::default().with_order_descending(true))
         .cum_min(false);
 
     let sql_expr = "MIN(Sales) OVER (ORDER BY Sales DESC)";
@@ -67,7 +67,7 @@ fn test_cumulative_min() {
 #[test]
 fn test_cumulative_max() {
     let expr = col("Sales")
-        .sort(SortOptions::default().with_order(true))
+        .sort(SortOptions::default().with_order_descending(true))
         .cum_max(false);
 
     let sql_expr = "MAX(Sales) OVER (ORDER BY Sales DESC)";

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -118,7 +118,10 @@ fn test_array_to_string() {
         .group_by([col("b")])
         .agg([col("a")])
         .select(&[col("b"), col("a").list().join(lit(", "), true).alias("as")])
-        .sort_by_exprs(vec![col("b"), col("as")], vec![false, false], false, true, true)
+        .sort_by_exprs(
+            vec![col("b"), col("as")],
+            SortMultipleOptions::default().with_maintain_order(true),
+        )
         .collect()
         .unwrap();
 

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -118,7 +118,7 @@ fn test_array_to_string() {
         .group_by([col("b")])
         .agg([col("a")])
         .select(&[col("b"), col("a").list().join(lit(", "), true).alias("as")])
-        .sort_by_exprs(vec![col("b"), col("as")], vec![false, false], false, true)
+        .sort_by_exprs(vec![col("b"), col("as")], vec![false, false], false, true, true)
         .collect()
         .unwrap();
 

--- a/crates/polars-sql/tests/iss_7437.rs
+++ b/crates/polars-sql/tests/iss_7437.rs
@@ -24,14 +24,14 @@ fn iss_7437() -> PolarsResult<()> {
     "#,
         )?
         .collect()?
-        .sort(["category"], vec![false], false)?;
+        .sort(["category"], SortMultipleOptions::default())?;
 
     let expected = LazyCsvReader::new("../../examples/datasets/foods1.csv")
         .finish()?
         .group_by(vec![col("category").alias("category")])
         .agg(vec![])
         .collect()?
-        .sort(["category"], vec![false], false)?;
+        .sort(["category"], Default::default())?;
 
     assert!(df_sql.equals(&expected));
     Ok(())

--- a/crates/polars-sql/tests/iss_8395.rs
+++ b/crates/polars-sql/tests/iss_8395.rs
@@ -19,7 +19,7 @@ fn iss_8395() -> PolarsResult<()> {
     let df = res.collect()?;
 
     // assert that the df only contains [vegetables, seafood]
-    let s = df.column("category")?.unique()?.sort(false, false)?;
+    let s = df.column("category")?.unique()?.sort(Default::default())?;
     let expected = Series::new("category", &["seafood", "vegetables"]);
     assert!(s.equals(&expected));
     Ok(())

--- a/crates/polars-sql/tests/iss_8419.rs
+++ b/crates/polars-sql/tests/iss_8419.rs
@@ -18,7 +18,7 @@ fn iss_8419() {
             col("Country"),
             col("Sales"),
             col("Sales")
-                .sort(SortOptions::default().with_order(true))
+                .sort(SortOptions::default().with_order_descending(true))
                 .cum_sum(false)
                 .alias("SalesCumulative"),
         ])

--- a/crates/polars-sql/tests/iss_8419.rs
+++ b/crates/polars-sql/tests/iss_8419.rs
@@ -18,11 +18,11 @@ fn iss_8419() {
             col("Country"),
             col("Sales"),
             col("Sales")
-                .sort(true)
+                .sort(SortOptions::default().with_order(true))
                 .cum_sum(false)
                 .alias("SalesCumulative"),
         ])
-        .sort("SalesCumulative", SortOptions::default())
+        .sort(["SalesCumulative"], Default::default())
         .collect()
         .unwrap();
     let mut ctx = SQLContext::new();

--- a/crates/polars-sql/tests/ops_distinct_on.rs
+++ b/crates/polars-sql/tests/ops_distinct_on.rs
@@ -1,4 +1,5 @@
-use polars_core::{chunked_array::ops::SortMultipleOptions, df};
+use polars_core::chunked_array::ops::SortMultipleOptions;
+use polars_core::df;
 use polars_lazy::prelude::*;
 use polars_sql::*;
 
@@ -30,8 +31,8 @@ fn test_distinct_on() {
         .sort_by_exprs(
             vec![col("Name"), col("Record Date")],
             SortMultipleOptions::default()
-            .with_orders([false, true])
-            .with_maintain_order(true)
+                .with_orders([false, true])
+                .with_maintain_order(true),
         )
         .group_by_stable(vec![col("Name")])
         .agg(vec![col("*").first()]);

--- a/crates/polars-sql/tests/ops_distinct_on.rs
+++ b/crates/polars-sql/tests/ops_distinct_on.rs
@@ -1,4 +1,4 @@
-use polars_core::df;
+use polars_core::{chunked_array::ops::SortMultipleOptions, df};
 use polars_lazy::prelude::*;
 use polars_sql::*;
 
@@ -29,10 +29,9 @@ fn test_distinct_on() {
     let expected = df
         .sort_by_exprs(
             vec![col("Name"), col("Record Date")],
-            vec![false, true],
-            true,
-            false,
-            true
+            SortMultipleOptions::default()
+            .with_orders([false, true])
+            .with_maintain_order(true)
         )
         .group_by_stable(vec![col("Name")])
         .agg(vec![col("*").first()]);

--- a/crates/polars-sql/tests/ops_distinct_on.rs
+++ b/crates/polars-sql/tests/ops_distinct_on.rs
@@ -32,6 +32,7 @@ fn test_distinct_on() {
             vec![false, true],
             true,
             false,
+            true
         )
         .group_by_stable(vec![col("Name")])
         .agg(vec![col("*").first()]);

--- a/crates/polars-sql/tests/ops_distinct_on.rs
+++ b/crates/polars-sql/tests/ops_distinct_on.rs
@@ -31,7 +31,7 @@ fn test_distinct_on() {
         .sort_by_exprs(
             vec![col("Name"), col("Record Date")],
             SortMultipleOptions::default()
-                .with_orders([false, true])
+                .with_order_descendings([false, true])
                 .with_maintain_order(true),
         )
         .group_by_stable(vec![col("Name")])

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -68,10 +68,7 @@ fn test_group_by_simple() -> PolarsResult<()> {
         LIMIT 100
     "#,
         )?
-        .sort(
-            ["a"],
-            Default::default(),
-        )
+        .sort(["a"], Default::default())
         .collect()?;
 
     let df_pl = df
@@ -83,10 +80,7 @@ fn test_group_by_simple() -> PolarsResult<()> {
             col("a").count().alias("total_count"),
         ])
         .limit(100)
-        .sort(
-            ["a"],
-            Default::default(),
-        )
+        .sort(["a"], Default::default())
         .collect()?;
     assert_eq!(df_sql, df_pl);
     Ok(())

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -417,7 +417,10 @@ fn test_arr_agg() {
         (
             "SELECT ARRAY_AGG(a ORDER BY a) AS a FROM df",
             vec![col("a")
-                .sort_by(vec![col("a")], vec![false])
+                .sort_by(vec![col("a")], SortMultipleOptions {
+                    descending: vec![false],
+                    ..Default::default()
+                })
                 .implode()
                 .alias("a")],
         ),
@@ -432,7 +435,10 @@ fn test_arr_agg() {
         (
             "SELECT ARRAY_AGG(a ORDER BY b LIMIT 2) FROM df",
             vec![col("a")
-                .sort_by(vec![col("b")], vec![false])
+                .sort_by(vec![col("b")], SortMultipleOptions {
+                    descending: vec![false],
+                    ..Default::default()
+                })
                 .head(Some(2))
                 .implode()],
         ),

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -505,6 +505,7 @@ fn test_group_by_2() -> PolarsResult<()> {
             vec![false, true],
             false,
             false,
+            true
         )
         .limit(2);
     let expected = expected.collect()?;

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -69,12 +69,8 @@ fn test_group_by_simple() -> PolarsResult<()> {
     "#,
         )?
         .sort(
-            "a",
-            SortOptions {
-                descending: false,
-                nulls_last: false,
-                ..Default::default()
-            },
+            ["a"],
+            Default::default(),
         )
         .collect()?;
 
@@ -88,12 +84,8 @@ fn test_group_by_simple() -> PolarsResult<()> {
         ])
         .limit(100)
         .sort(
-            "a",
-            SortOptions {
-                descending: false,
-                nulls_last: false,
-                ..Default::default()
-            },
+            ["a"],
+            Default::default(),
         )
         .collect()?;
     assert_eq!(df_sql, df_pl);

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -482,7 +482,7 @@ fn test_group_by_2() -> PolarsResult<()> {
         ])
         .sort_by_exprs(
             vec![col("count"), col("category")],
-            SortMultipleOptions::default().with_orders([false, true]),
+            SortMultipleOptions::default().with_order_descendings([false, true]),
         )
         .limit(2);
     let expected = expected.collect()?;

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -417,10 +417,7 @@ fn test_arr_agg() {
         (
             "SELECT ARRAY_AGG(a ORDER BY a) AS a FROM df",
             vec![col("a")
-                .sort_by(vec![col("a")], SortMultipleOptions {
-                    descending: vec![false],
-                    ..Default::default()
-                })
+                .sort_by(vec![col("a")], SortMultipleOptions::default())
                 .implode()
                 .alias("a")],
         ),
@@ -435,10 +432,7 @@ fn test_arr_agg() {
         (
             "SELECT ARRAY_AGG(a ORDER BY b LIMIT 2) FROM df",
             vec![col("a")
-                .sort_by(vec![col("b")], SortMultipleOptions {
-                    descending: vec![false],
-                    ..Default::default()
-                })
+                .sort_by(vec![col("b")], SortMultipleOptions::default())
                 .head(Some(2))
                 .implode()],
         ),
@@ -502,10 +496,7 @@ fn test_group_by_2() -> PolarsResult<()> {
         ])
         .sort_by_exprs(
             vec![col("count"), col("category")],
-            vec![false, true],
-            false,
-            false,
-            true
+            SortMultipleOptions::default().with_orders([false, true]),
         )
         .limit(2);
     let expected = expected.collect()?;

--- a/crates/polars/tests/it/lazy/aggregation.rs
+++ b/crates/polars/tests/it/lazy/aggregation.rs
@@ -29,7 +29,7 @@ fn test_lazy_agg() {
                 .quantile(lit(0.5), QuantileInterpolOptions::default())
                 .alias("median_rain"),
         ])
-        .sort("date", Default::default());
+        .sort(["date"], Default::default());
 
     let new = lf.collect().unwrap();
     let min = new.column("min").unwrap();

--- a/crates/polars/tests/it/lazy/expressions/apply.rs
+++ b/crates/polars/tests/it/lazy/expressions/apply.rs
@@ -52,7 +52,7 @@ fn test_groups_update_binary_shift_log() -> PolarsResult<()> {
     .lazy()
     .group_by([col("b")])
     .agg([col("a") - col("a").shift(lit(1)).log(2.0)])
-    .sort("b", Default::default())
+    .sort(["b"], Default::default())
     .explode([col("a")])
     .collect()?;
     assert_eq!(

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -218,7 +218,7 @@ fn test_when_then_otherwise_sum_in_agg() -> PolarsResult<()> {
         .agg([when(all().exclude(["groups"]).sum().eq(lit(1)))
             .then(all().exclude(["groups"]).sum())
             .otherwise(lit(NULL))])
-        .sort("groups", Default::default());
+        .sort(["groups"], Default::default());
 
     let expected = df![
         "groups" => [1, 2],
@@ -274,7 +274,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
         .agg([when(col("value").sum().eq(lit(3)))
             .then(col("value").rank(Default::default(), None))
             .otherwise(lit(Series::new("", &[10 as IdxSize])))])
-        .sort("name", Default::default())
+        .sort(["name"], Default::default())
         .collect()?;
 
     let out = out.column("value")?;
@@ -294,7 +294,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
         .agg([when(col("value").sum().eq(lit(3)))
             .then(lit(Series::new("", &[10 as IdxSize])).alias("value"))
             .otherwise(col("value").rank(Default::default(), None))])
-        .sort("name", Default::default())
+        .sort(["name"], Default::default())
         .collect()?;
 
     let out = out.column("value")?;
@@ -314,7 +314,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
         .agg([when(col("value").sum().eq(lit(3)))
             .then(col("value").rank(Default::default(), None))
             .otherwise(Null {}.lit())])
-        .sort("name", Default::default())
+        .sort(["name"], Default::default())
         .collect()?;
 
     let out = out.column("value")?;
@@ -328,7 +328,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
         .agg([when(col("value").sum().eq(lit(3)))
             .then(Null {}.lit().alias("value"))
             .otherwise(col("value").rank(Default::default(), None))])
-        .sort("name", Default::default())
+        .sort(["name"], Default::default())
         .collect()?;
 
     let out = out.column("value")?;
@@ -350,7 +350,7 @@ fn test_binary_group_consistency() -> PolarsResult<()> {
     let out = lf
         .group_by([col("category")])
         .agg([col("name").filter(col("score").eq(col("score").max()))])
-        .sort("category", Default::default())
+        .sort(["category"], Default::default())
         .collect()?;
     let out = out.column("name")?;
 

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -145,7 +145,10 @@ fn test_sort_by_in_groups() -> PolarsResult<()> {
             col("fruits"),
             col("cars"),
             col("A")
-                .sort_by([col("B")], [false])
+                .sort_by([col("B")], SortMultipleOptions {
+                    descending: vec![false],
+                    ..Default::default()
+                })
                 .implode()
                 .over([col("cars")])
                 .explode()

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -145,10 +145,7 @@ fn test_sort_by_in_groups() -> PolarsResult<()> {
             col("fruits"),
             col("cars"),
             col("A")
-                .sort_by([col("B")], SortMultipleOptions {
-                    descending: vec![false],
-                    ..Default::default()
-                })
+                .sort_by([col("B")], SortMultipleOptions::default())
                 .implode()
                 .over([col("cars")])
                 .explode()

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -247,7 +247,7 @@ fn test_window_mapping() -> PolarsResult<()> {
 
     // now sorted
     // this will trigger a fast path
-    let df = df.sort(["fruits"], vec![false], false)?;
+    let df = df.sort(["fruits"], Default::default())?;
 
     let out = df
         .clone()

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -76,7 +76,7 @@ fn test_exploded_window_function() -> PolarsResult<()> {
     let out = df
         .clone()
         .lazy()
-        .sort("fruits", Default::default())
+        .sort(["fruits"], Default::default())
         .select([
             col("fruits"),
             col("B")
@@ -95,7 +95,7 @@ fn test_exploded_window_function() -> PolarsResult<()> {
     // we implicitly also test that a literal does not upcast a column
     let out = df
         .lazy()
-        .sort("fruits", Default::default())
+        .sort(["fruits"], Default::default())
         .select([
             col("fruits"),
             col("B")
@@ -119,7 +119,7 @@ fn test_reverse_in_groups() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .sort("fruits", Default::default())
+        .sort(["fruits"], Default::default())
         .select([
             col("B"),
             col("fruits"),
@@ -140,7 +140,7 @@ fn test_sort_by_in_groups() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .sort("cars", Default::default())
+        .sort(["cars"], Default::default())
         .select([
             col("fruits"),
             col("cars"),

--- a/crates/polars/tests/it/lazy/group_by.rs
+++ b/crates/polars/tests/it/lazy/group_by.rs
@@ -21,10 +21,10 @@ fn test_filter_sort_diff_2984() -> PolarsResult<()> {
         .group_by([col("group")])
         .agg([col("id")
             .filter(col("id").lt(lit(3)))
-            .sort(false)
+            .sort(Default::default())
             .diff(1, Default::default())
             .sum()])
-        .sort("group", Default::default())
+        .sort(["group"], Default::default())
         .collect()?;
 
     assert_eq!(Vec::from(out.column("id")?.i32()?), &[Some(1), Some(0)]);
@@ -72,7 +72,7 @@ fn test_filter_diff_arithmetic() -> PolarsResult<()> {
             .diff(1, Default::default())
             * lit(2))
         .alias("diff")])
-        .sort("user", Default::default())
+        .sort(["user"], Default::default())
         .explode([col("diff")])
         .collect()?;
 
@@ -113,7 +113,7 @@ fn test_group_by_agg_list_with_not_aggregated() -> PolarsResult<()> {
         .agg([when(col("value").diff(1, NullBehavior::Ignore).gt_eq(0))
             .then(col("value").diff(1, NullBehavior::Ignore))
             .otherwise(col("value"))])
-        .sort("group", Default::default())
+        .sort(["group"], Default::default())
         .collect()?;
 
     let out = out.column("value")?;
@@ -140,7 +140,7 @@ fn test_logical_mean_partitioned_group_by_block() -> PolarsResult<()> {
         .with_column(col("duration").cast(DataType::Duration(TimeUnit::Microseconds)))
         .group_by([col("decimal")])
         .agg([col("duration").mean()])
-        .sort("duration", Default::default())
+        .sort(["duration"], Default::default())
         .collect()?;
 
     let duration = out.column("duration")?;
@@ -167,7 +167,7 @@ fn test_filter_aggregated_expression() -> PolarsResult<()> {
         .lazy()
         .group_by([col("day")])
         .agg([(col("x") - col("x").first()).filter(f)])
-        .sort("day", Default::default())
+        .sort(["day"], Default::default())
         .collect()
         .unwrap();
     let x = df.column("x")?;

--- a/docs/src/rust/user-guide/concepts/contexts.rs
+++ b/docs/src/rust/user-guide/concepts/contexts.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .lazy()
         .select([
             sum("nrs"),
-            col("names").sort(false),
+            col("names").sort(Default::default()),
             col("names").first().alias("first name"),
             (mean("nrs") * lit(10)).alias("10xnrs"),
         ])

--- a/docs/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/src/rust/user-guide/expressions/aggregation.rs
@@ -73,7 +73,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .sum()
                 .alias("pro"),
         ])
-        .sort(["pro"], SortMultipleOptions::default().with_order_descending(true))
+        .sort(
+            ["pro"],
+            SortMultipleOptions::default().with_order_descending(true),
+        )
         .limit(5)
         .collect()?;
 

--- a/docs/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/src/rust/user-guide/expressions/aggregation.rs
@@ -51,8 +51,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .sort(
             ["len"],
             SortMultipleOptions::default()
-            .with_order(true)
-            .with_nulls_last(true),
+                .with_order(true)
+                .with_nulls_last(true),
         )
         .limit(5)
         .collect()?;
@@ -73,11 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .sum()
                 .alias("pro"),
         ])
-        .sort(
-            ["pro"],
-            SortMultipleOptions::default()
-            .with_order(true)
-        )
+        .sort(["pro"], SortMultipleOptions::default().with_order(true))
         .limit(5)
         .collect()?;
 

--- a/docs/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/src/rust/user-guide/expressions/aggregation.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .sort(
             ["len"],
             SortMultipleOptions::default()
-                .with_order(true)
+                .with_order_descending(true)
                 .with_nulls_last(true),
         )
         .limit(5)
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .sum()
                 .alias("pro"),
         ])
-        .sort(["pro"], SortMultipleOptions::default().with_order(true))
+        .sort(["pro"], SortMultipleOptions::default().with_order_descending(true))
         .limit(5)
         .collect()?;
 
@@ -94,7 +94,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .sort(
             ["count"],
             SortMultipleOptions::default()
-                .with_order(true)
+                .with_order_descending(true)
                 .with_nulls_last(true),
         )
         .limit(5)
@@ -142,7 +142,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .sort(
             ["birthday"],
             SortMultipleOptions::default()
-                .with_order(true)
+                .with_order_descending(true)
                 .with_nulls_last(true),
         )
         .group_by(["state"])
@@ -163,7 +163,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .sort(
             ["birthday"],
             SortMultipleOptions::default()
-                .with_order(true)
+                .with_order_descending(true)
                 .with_nulls_last(true),
         )
         .group_by(["state"])
@@ -188,7 +188,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .sort(
             ["birthday"],
             SortMultipleOptions::default()
-                .with_order(true)
+                .with_order_descending(true)
                 .with_nulls_last(true),
         )
         .group_by(["state"])

--- a/docs/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/src/rust/user-guide/expressions/aggregation.rs
@@ -49,12 +49,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .group_by(["first_name"])
         .agg([len(), col("gender"), col("last_name").first()])
         .sort(
-            "len",
-            SortOptions {
-                descending: true,
-                nulls_last: true,
-                ..Default::default()
-            },
+            ["len"],
+            SortMultipleOptions::default()
+            .with_order(true)
+            .with_nulls_last(true),
         )
         .limit(5)
         .collect()?;
@@ -76,12 +74,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .alias("pro"),
         ])
         .sort(
-            "pro",
-            SortOptions {
-                descending: true,
-                nulls_last: false,
-                ..Default::default()
-            },
+            ["pro"],
+            SortMultipleOptions::default()
+            .with_order(true)
         )
         .limit(5)
         .collect()?;
@@ -101,12 +96,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .or(col("party").eq(lit("Pro-Administration"))),
         )
         .sort(
-            "count",
-            SortOptions {
-                descending: true,
-                nulls_last: true,
-                ..Default::default()
-            },
+            ["count"],
+            SortMultipleOptions::default()
+                .with_order(true)
+                .with_nulls_last(true),
         )
         .limit(5)
         .collect()?;
@@ -151,12 +144,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clone()
         .lazy()
         .sort(
-            "birthday",
-            SortOptions {
-                descending: true,
-                nulls_last: true,
-                ..Default::default()
-            },
+            ["birthday"],
+            SortMultipleOptions::default()
+                .with_order(true)
+                .with_nulls_last(true),
         )
         .group_by(["state"])
         .agg([
@@ -174,18 +165,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clone()
         .lazy()
         .sort(
-            "birthday",
-            SortOptions {
-                descending: true,
-                nulls_last: true,
-                ..Default::default()
-            },
+            ["birthday"],
+            SortMultipleOptions::default()
+                .with_order(true)
+                .with_nulls_last(true),
         )
         .group_by(["state"])
         .agg([
             get_person().first().alias("youngest"),
             get_person().last().alias("oldest"),
-            get_person().sort(false).first().alias("alphabetical_first"),
+            get_person()
+                .sort(Default::default())
+                .first()
+                .alias("alphabetical_first"),
         ])
         .limit(5)
         .collect()?;
@@ -198,24 +190,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clone()
         .lazy()
         .sort(
-            "birthday",
-            SortOptions {
-                descending: true,
-                nulls_last: true,
-                ..Default::default()
-            },
+            ["birthday"],
+            SortMultipleOptions::default()
+                .with_order(true)
+                .with_nulls_last(true),
         )
         .group_by(["state"])
         .agg([
             get_person().first().alias("youngest"),
             get_person().last().alias("oldest"),
-            get_person().sort(false).first().alias("alphabetical_first"),
+            get_person()
+                .sort(Default::default())
+                .first()
+                .alias("alphabetical_first"),
             col("gender")
                 .sort_by(["first_name"], SortMultipleOptions::default())
                 .first()
                 .alias("gender"),
         ])
-        .sort("state", SortOptions::default())
+        .sort(["state"], SortMultipleOptions::default())
         .limit(5)
         .collect()?;
 

--- a/docs/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/src/rust/user-guide/expressions/aggregation.rs
@@ -211,7 +211,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             get_person().last().alias("oldest"),
             get_person().sort(false).first().alias("alphabetical_first"),
             col("gender")
-                .sort_by(["first_name"], [false])
+                .sort_by(["first_name"], SortMultipleOptions::default())
                 .first()
                 .alias("gender"),
         ])

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -54,7 +54,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = filtered
         .lazy()
         .with_columns([cols(["Name", "Speed"])
-            .sort_by(["Speed"], SortMultipleOptions::default().with_order_descending(true))
+            .sort_by(
+                ["Speed"],
+                SortMultipleOptions::default().with_order_descending(true),
+            )
             .over(["Type 1"])])
         .collect()?;
     println!("{}", out);
@@ -94,13 +97,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .select([
             col("Type 1").head(Some(3)).over(["Type 1"]).flatten(),
             col("Name")
-                .sort_by(["Speed"], SortMultipleOptions::default().with_order_descending(true))
+                .sort_by(
+                    ["Speed"],
+                    SortMultipleOptions::default().with_order_descending(true),
+                )
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()
                 .alias("fastest/group"),
             col("Name")
-                .sort_by(["Attack"], SortMultipleOptions::default().with_order_descending(true))
+                .sort_by(
+                    ["Attack"],
+                    SortMultipleOptions::default().with_order_descending(true),
+                )
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = filtered
         .lazy()
         .with_columns([cols(["Name", "Speed"])
-            .sort_by(["Speed"], SortMultipleOptions::default().descending(true))
+            .sort_by(["Speed"], SortMultipleOptions::default().with_order(true))
             .over(["Type 1"])])
         .collect()?;
     println!("{}", out);
@@ -94,13 +94,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .select([
             col("Type 1").head(Some(3)).over(["Type 1"]).flatten(),
             col("Name")
-                .sort_by(["Speed"], SortMultipleOptions::default().descending(true))
+                .sort_by(["Speed"], SortMultipleOptions::default().with_order(true))
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()
                 .alias("fastest/group"),
             col("Name")
-                .sort_by(["Attack"], SortMultipleOptions::default().descending(true))
+                .sort_by(["Attack"], SortMultipleOptions::default().with_order(true))
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = filtered
         .lazy()
         .with_columns([cols(["Name", "Speed"])
-            .sort_by(["Speed"], [true])
+            .sort_by(["Speed"], SortMultipleOptions::default().descending(true))
             .over(["Type 1"])])
         .collect()?;
     println!("{}", out);
@@ -94,13 +94,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .select([
             col("Type 1").head(Some(3)).over(["Type 1"]).flatten(),
             col("Name")
-                .sort_by(["Speed"], [true])
+                .sort_by(["Speed"], SortMultipleOptions::default().descending(true))
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()
                 .alias("fastest/group"),
             col("Name")
-                .sort_by(["Attack"], [true])
+                .sort_by(["Attack"], SortMultipleOptions::default().descending(true))
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -106,7 +106,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .flatten()
                 .alias("strongest/group"),
             col("Name")
-                .sort(false)
+                .sort(Default::default())
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = filtered
         .lazy()
         .with_columns([cols(["Name", "Speed"])
-            .sort_by(["Speed"], SortMultipleOptions::default().with_order(true))
+            .sort_by(["Speed"], SortMultipleOptions::default().with_order_descending(true))
             .over(["Type 1"])])
         .collect()?;
     println!("{}", out);
@@ -94,13 +94,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .select([
             col("Type 1").head(Some(3)).over(["Type 1"]).flatten(),
             col("Name")
-                .sort_by(["Speed"], SortMultipleOptions::default().with_order(true))
+                .sort_by(["Speed"], SortMultipleOptions::default().with_order_descending(true))
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()
                 .alias("fastest/group"),
             col("Name")
-                .sort_by(["Attack"], SortMultipleOptions::default().with_order(true))
+                .sort_by(["Attack"], SortMultipleOptions::default().with_order_descending(true))
                 .head(Some(3))
                 .over(["Type 1"])
                 .flatten()

--- a/docs/src/rust/user-guide/transformations/joins.rs
+++ b/docs/src/rust/user-guide/transformations/joins.rs
@@ -185,8 +185,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:df8]
 
     // --8<-- [start:asofpre]
-    let df_trades = df_trades.sort(["time"], false, true).unwrap();
-    let df_quotes = df_quotes.sort(["time"], false, true).unwrap();
+    let df_trades = df_trades
+        .sort(
+            ["time"],
+            SortMultipleOptions::default().with_maintain_order(true),
+        )
+        .unwrap();
+    let df_quotes = df_quotes
+        .sort(
+            ["time"],
+            SortMultipleOptions::default().with_maintain_order(true),
+        )
+        .unwrap();
     // --8<-- [end:asofpre]
 
     // --8<-- [start:asof]

--- a/docs/src/rust/user-guide/transformations/time-series/rolling.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/rolling.rs
@@ -11,7 +11,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_try_parse_dates(true)
         .finish()
         .unwrap()
-        .sort(["Date"], false, true)?;
+        .sort(
+            ["Date"],
+            SortMultipleOptions::default().with_maintain_order(true),
+        )?;
     println!("{}", &df);
     // --8<-- [end:df]
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4021,6 +4021,8 @@ class DataFrame:
         *more_by: IntoExpr,
         descending: bool | Sequence[bool] = False,
         nulls_last: bool = False,
+        multithreaded: bool = True,
+        maintain_order: bool = False,
     ) -> DataFrame:
         """
         Sort the dataframe by the given columns.
@@ -4105,7 +4107,14 @@ class DataFrame:
         """
         return (
             self.lazy()
-            .sort(by, *more_by, descending=descending, nulls_last=nulls_last)
+            .sort(
+                by,
+                *more_by,
+                descending=descending,
+                nulls_last=nulls_last,
+                multithreaded=multithreaded,
+                maintain_order=maintain_order,
+            )
             .collect(_eager=True)
         )
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4038,7 +4038,11 @@ class DataFrame:
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
         nulls_last
-            Place null values last.
+            Treat null values largest.
+        multithreaded
+            Sort using multiple threads.
+        maintain_order
+            Whether the order should be maintained if elements are equal.
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4038,7 +4038,7 @@ class DataFrame:
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
         nulls_last
-            Treat null values largest.
+            Place null values last.
         multithreaded
             Sort using multiple threads.
         maintain_order

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2284,6 +2284,12 @@ class Expr:
         descending
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
+        nulls_last
+            Treat null values largest.
+        multithreaded
+            Sort using multiple threads.
+        maintain_order
+            Whether the order should be maintained if elements are equal.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2264,6 +2264,9 @@ class Expr:
         by: IntoExpr | Iterable[IntoExpr],
         *more_by: IntoExpr,
         descending: bool | Sequence[bool] = False,
+        nulls_last: bool = False,
+        multithreaded: bool = True,
+        maintain_order: bool = False,
     ) -> Self:
         """
         Sort this column by the ordering of other columns.
@@ -2388,7 +2391,11 @@ class Expr:
         elif len(by) != len(descending):
             msg = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
             raise ValueError(msg)
-        return self._from_pyexpr(self._pyexpr.sort_by(by, descending))
+        return self._from_pyexpr(
+            self._pyexpr.sort_by(
+                by, descending, nulls_last, multithreaded, maintain_order
+            )
+        )
 
     def gather(
         self, indices: int | list[int] | Expr | Series | np.ndarray[Any, Any]

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2285,7 +2285,7 @@ class Expr:
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
         nulls_last
-            Treat null values largest.
+            Place null values last.
         multithreaded
             Sort using multiple threads.
         maintain_order

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1537,6 +1537,9 @@ def arg_sort_by(
     exprs: IntoExpr | Iterable[IntoExpr],
     *more_exprs: IntoExpr,
     descending: bool | Sequence[bool] = False,
+    nulls_last: bool = False,
+    multithreaded: bool = True,
+    maintain_order: bool = False,
 ) -> Expr:
     """
     Return the row indices that would sort the column(s).
@@ -1619,7 +1622,7 @@ def arg_sort_by(
     elif len(exprs) != len(descending):
         msg = f"the length of `descending` ({len(descending)}) does not match the length of `exprs` ({len(exprs)})"
         raise ValueError(msg)
-    return wrap_expr(plr.arg_sort_by(exprs, descending))
+    return wrap_expr(plr.arg_sort_by(exprs, descending, nulls_last, multithreaded, maintain_order))
 
 
 def collect_all(

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1555,7 +1555,7 @@ def arg_sort_by(
         Sort in descending order. When sorting by multiple columns, can be specified
         per column by passing a sequence of booleans.
     nulls_last
-        Treat null values largest.
+        Place null values last.
     multithreaded
         Sort using multiple threads.
     maintain_order

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1554,6 +1554,12 @@ def arg_sort_by(
     descending
         Sort in descending order. When sorting by multiple columns, can be specified
         per column by passing a sequence of booleans.
+    nulls_last
+        Treat null values largest.
+    multithreaded
+        Sort using multiple threads.
+    maintain_order
+        Whether the order should be maintained if elements are equal.
 
     See Also
     --------
@@ -1622,7 +1628,9 @@ def arg_sort_by(
     elif len(exprs) != len(descending):
         msg = f"the length of `descending` ({len(descending)}) does not match the length of `exprs` ({len(exprs)})"
         raise ValueError(msg)
-    return wrap_expr(plr.arg_sort_by(exprs, descending, nulls_last, multithreaded, maintain_order))
+    return wrap_expr(
+        plr.arg_sort_by(exprs, descending, nulls_last, multithreaded, maintain_order)
+    )
 
 
 def collect_all(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1122,6 +1122,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Whether the order should be maintained if elements are equal.
             Note that if `true` streaming is not possible and performance might be
             worse since this requires a stable search.
+        multithreaded
+            Sort using multiple threads.
 
         Examples
         --------
@@ -1191,7 +1193,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         # Fast path for sorting by a single existing column
         if isinstance(by, str) and not more_by:
             return self._from_pyldf(
-                self._ldf.sort(by, descending, nulls_last, maintain_order, multithreaded)
+                self._ldf.sort(
+                    by, descending, nulls_last, maintain_order, multithreaded
+                )
             )
 
         by = parse_as_list_of_expressions(by, *more_by)
@@ -1238,6 +1242,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Whether the order should be maintained if elements are equal.
             Note that if `true` streaming is not possible and performance might
             be worse since this requires a stable search.
+        multithreaded
+            Sort using multiple threads.
 
         See Also
         --------
@@ -1289,7 +1295,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
             raise ValueError(msg)
         return self._from_pyldf(
-            self._ldf.top_k(k, by, descending, nulls_last, maintain_order, multithreaded)
+            self._ldf.top_k(
+                k, by, descending, nulls_last, maintain_order, multithreaded
+            )
         )
 
     def bottom_k(
@@ -1323,6 +1331,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Whether the order should be maintained if elements are equal.
             Note that if `true` streaming is not possible and performance might be
             worse since this requires a stable search.
+        multithreaded
+            Sort using multiple threads.
 
         See Also
         --------
@@ -1371,7 +1381,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if isinstance(descending, bool):
             descending = [descending]
         return self._from_pyldf(
-            self._ldf.bottom_k(k, by, descending, nulls_last, maintain_order, multithreaded)
+            self._ldf.bottom_k(
+                k, by, descending, nulls_last, maintain_order, multithreaded
+            )
         )
 
     def profile(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1101,6 +1101,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         descending: bool | Sequence[bool] = False,
         nulls_last: bool = False,
         maintain_order: bool = False,
+        multithreaded: bool = True,
     ) -> Self:
         """
         Sort the LazyFrame by the given columns.
@@ -1190,7 +1191,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         # Fast path for sorting by a single existing column
         if isinstance(by, str) and not more_by:
             return self._from_pyldf(
-                self._ldf.sort(by, descending, nulls_last, maintain_order)
+                self._ldf.sort(by, descending, nulls_last, maintain_order, multithreaded)
             )
 
         by = parse_as_list_of_expressions(by, *more_by)
@@ -1201,7 +1202,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
             raise ValueError(msg)
         return self._from_pyldf(
-            self._ldf.sort_by_exprs(by, descending, nulls_last, maintain_order)
+            self._ldf.sort_by_exprs(
+                by, descending, nulls_last, maintain_order, multithreaded
+            )
         )
 
     def top_k(
@@ -1212,6 +1215,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         descending: bool | Sequence[bool] = False,
         nulls_last: bool = False,
         maintain_order: bool = False,
+        multithreaded: bool = True,
     ) -> Self:
         """
         Return the `k` largest elements.
@@ -1285,7 +1289,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
             raise ValueError(msg)
         return self._from_pyldf(
-            self._ldf.top_k(k, by, descending, nulls_last, maintain_order)
+            self._ldf.top_k(k, by, descending, nulls_last, maintain_order, multithreaded)
         )
 
     def bottom_k(
@@ -1296,6 +1300,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         descending: bool | Sequence[bool] = False,
         nulls_last: bool = False,
         maintain_order: bool = False,
+        multithreaded: bool = True,
     ) -> Self:
         """
         Return the `k` smallest elements.
@@ -1366,7 +1371,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if isinstance(descending, bool):
             descending = [descending]
         return self._from_pyldf(
-            self._ldf.bottom_k(k, by, descending, nulls_last, maintain_order)
+            self._ldf.bottom_k(k, by, descending, nulls_last, maintain_order, multithreaded)
         )
 
     def profile(

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -236,7 +236,13 @@ class ArrayNameSpace:
         ]
         """
 
-    def sort(self, *, descending: bool = False, nulls_last: bool = False) -> Series:
+    def sort(
+        self,
+        *,
+        descending: bool = False,
+        nulls_last: bool = False,
+        multithreaded: bool = True,
+    ) -> Series:
         """
         Sort the arrays in this column.
 

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -252,6 +252,8 @@ class ArrayNameSpace:
             Sort in descending order.
         nulls_last
             Place null values last.
+        multithreaded
+            Sort using multiple threads.
 
         Examples
         --------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -281,7 +281,13 @@ class ListNameSpace:
         ]
         """
 
-    def sort(self, *, descending: bool = False, nulls_last: bool = False, multithreaded: bool = True) -> Series:
+    def sort(
+        self,
+        *,
+        descending: bool = False,
+        nulls_last: bool = False,
+        multithreaded: bool = True,
+    ) -> Series:
         """
         Sort the arrays in this column.
 
@@ -291,6 +297,8 @@ class ListNameSpace:
             Sort in descending order.
         nulls_last
             Place null values last.
+        multithreaded
+            Sort using multiple threads.
 
         Examples
         --------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -281,7 +281,7 @@ class ListNameSpace:
         ]
         """
 
-    def sort(self, *, descending: bool = False, nulls_last: bool = False) -> Series:
+    def sort(self, *, descending: bool = False, nulls_last: bool = False, multithreaded: bool = True) -> Series:
         """
         Sort the arrays in this column.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3356,6 +3356,8 @@ class Series:
             Sort in descending order.
         nulls_last
             Place null values last instead of first.
+        multithreaded
+            Sort using multiple threads.
         in_place
             Sort in-place.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3344,6 +3344,7 @@ class Series:
         *,
         descending: bool = False,
         nulls_last: bool = False,
+        multithreaded: bool = True,
         in_place: bool = False,
     ) -> Self:
         """
@@ -3381,10 +3382,12 @@ class Series:
         ]
         """
         if in_place:
-            self._s = self._s.sort(descending, nulls_last)
+            self._s = self._s.sort(descending, nulls_last, multithreaded)
             return self
         else:
-            return self._from_pyseries(self._s.sort(descending, nulls_last))
+            return self._from_pyseries(
+                self._s.sort(descending, nulls_last, multithreaded)
+            )
 
     def top_k(self, k: int | IntoExprColumn = 5) -> Series:
         r"""

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -268,7 +268,7 @@ impl PyExpr {
     fn sort_with(&self, descending: bool, nulls_last: bool) -> Self {
         self.inner
             .clone()
-            .sort_with(SortOptions {
+            .sort(SortOptions {
                 descending,
                 nulls_last,
                 multithreaded: true,

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -332,9 +332,27 @@ impl PyExpr {
         self.inner.clone().get(idx.inner).into()
     }
 
-    fn sort_by(&self, by: Vec<Self>, descending: Vec<bool>) -> Self {
+    fn sort_by(
+        &self,
+        by: Vec<Self>,
+        descending: Vec<bool>,
+        nulls_last: bool,
+        multithreaded: bool,
+        maintain_order: bool,
+    ) -> Self {
         let by = by.into_iter().map(|e| e.inner).collect::<Vec<_>>();
-        self.inner.clone().sort_by(by, descending).into()
+        self.inner
+            .clone()
+            .sort_by(
+                by,
+                SortMultipleOptions {
+                    descending,
+                    nulls_last,
+                    multithreaded,
+                    maintain_order,
+                },
+            )
+            .into()
     }
 
     fn backward_fill(&self, limit: FillNullLimit) -> Self {

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -132,11 +132,11 @@ impl PyExpr {
         self.inner
             .clone()
             .list()
-            .sort(SortOptions {
-                descending,
-                nulls_last,
-                ..Default::default()
-            })
+            .sort(
+                SortOptions::default()
+                    .with_order_descending(descending)
+                    .with_nulls_last(nulls_last),
+            )
             .into()
     }
 

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -57,11 +57,25 @@ pub fn rolling_cov(
 }
 
 #[pyfunction]
-pub fn arg_sort_by(by: Vec<PyExpr>, descending: Vec<bool>) -> PyExpr {
+pub fn arg_sort_by(
+    by: Vec<PyExpr>,
+    descending: Vec<bool>,
+    nulls_last: bool,
+    multithreaded: bool,
+    maintain_order: bool,
+) -> PyExpr {
     let by = by.into_iter().map(|e| e.inner).collect::<Vec<Expr>>();
-    dsl::arg_sort_by(by, &descending).into()
+    dsl::arg_sort_by(
+        by,
+        SortMultipleOptions {
+            descending,
+            nulls_last,
+            multithreaded,
+            maintain_order,
+        },
+    )
+    .into()
 }
-
 #[pyfunction]
 pub fn arg_where(condition: PyExpr) -> PyExpr {
     dsl::arg_where(condition.inner).into()

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -458,6 +458,7 @@ impl PyLazyFrame {
         descending: bool,
         nulls_last: bool,
         maintain_order: bool,
+        multithreaded: bool,
     ) -> Self {
         let ldf = self.ldf.clone();
         ldf.sort(
@@ -465,7 +466,7 @@ impl PyLazyFrame {
             SortOptions {
                 descending,
                 nulls_last,
-                multithreaded: true,
+                multithreaded,
                 maintain_order,
             },
         )
@@ -478,10 +479,11 @@ impl PyLazyFrame {
         descending: Vec<bool>,
         nulls_last: bool,
         maintain_order: bool,
+        multithreaded: bool,
     ) -> Self {
         let ldf = self.ldf.clone();
         let exprs = by.to_exprs();
-        ldf.sort_by_exprs(exprs, descending, nulls_last, maintain_order)
+        ldf.sort_by_exprs(exprs, descending, nulls_last, maintain_order, multithreaded)
             .into()
     }
 
@@ -492,11 +494,19 @@ impl PyLazyFrame {
         descending: Vec<bool>,
         nulls_last: bool,
         maintain_order: bool,
+        multithreaded: bool,
     ) -> Self {
         let ldf = self.ldf.clone();
         let exprs = by.to_exprs();
-        ldf.top_k(k, exprs, descending, nulls_last, maintain_order)
-            .into()
+        ldf.top_k(
+            k,
+            exprs,
+            descending,
+            nulls_last,
+            maintain_order,
+            multithreaded,
+        )
+        .into()
     }
 
     fn bottom_k(
@@ -506,10 +516,11 @@ impl PyLazyFrame {
         descending: Vec<bool>,
         nulls_last: bool,
         maintain_order: bool,
+        multithreaded: bool
     ) -> Self {
         let ldf = self.ldf.clone();
         let exprs = by.to_exprs();
-        ldf.bottom_k(k, exprs, descending, nulls_last, maintain_order)
+        ldf.bottom_k(k, exprs, descending, nulls_last, maintain_order, multithreaded)
             .into()
     }
 

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -483,8 +483,16 @@ impl PyLazyFrame {
     ) -> Self {
         let ldf = self.ldf.clone();
         let exprs = by.to_exprs();
-        ldf.sort_by_exprs(exprs, descending, nulls_last, maintain_order, multithreaded)
-            .into()
+        ldf.sort_by_exprs(
+            exprs,
+            SortMultipleOptions {
+                descending,
+                nulls_last,
+                maintain_order,
+                multithreaded,
+            },
+        )
+        .into()
     }
 
     fn top_k(
@@ -501,10 +509,12 @@ impl PyLazyFrame {
         ldf.top_k(
             k,
             exprs,
-            descending,
-            nulls_last,
-            maintain_order,
-            multithreaded,
+            SortMultipleOptions {
+                descending,
+                nulls_last,
+                maintain_order,
+                multithreaded,
+            },
         )
         .into()
     }
@@ -516,12 +526,21 @@ impl PyLazyFrame {
         descending: Vec<bool>,
         nulls_last: bool,
         maintain_order: bool,
-        multithreaded: bool
+        multithreaded: bool,
     ) -> Self {
         let ldf = self.ldf.clone();
         let exprs = by.to_exprs();
-        ldf.bottom_k(k, exprs, descending, nulls_last, maintain_order, multithreaded)
-            .into()
+        ldf.bottom_k(
+            k,
+            exprs,
+            SortMultipleOptions {
+                descending,
+                nulls_last,
+                maintain_order,
+                multithreaded,
+            },
+        )
+        .into()
     }
 
     fn cache(&self) -> Self {

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -462,9 +462,9 @@ impl PyLazyFrame {
     ) -> Self {
         let ldf = self.ldf.clone();
         ldf.sort(
-            by_column,
-            SortOptions {
-                descending,
+            [by_column],
+            SortMultipleOptions {
+                descending: vec![descending],
                 nulls_last,
                 multithreaded,
                 maintain_order,

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -283,10 +283,15 @@ impl PySeries {
         }
     }
 
-    fn sort(&mut self, descending: bool, nulls_last: bool) -> PyResult<Self> {
+    fn sort(&mut self, descending: bool, nulls_last: bool, multithreaded: bool) -> PyResult<Self> {
         Ok(self
             .series
-            .sort(descending, nulls_last)
+            .sort(
+                SortOptions::default()
+                    .with_order(descending)
+                    .with_nulls_last(nulls_last)
+                    .with_multithreaded(multithreaded),
+            )
             .map_err(PyPolarsErr::from)?
             .into())
     }

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -288,7 +288,7 @@ impl PySeries {
             .series
             .sort(
                 SortOptions::default()
-                    .with_order(descending)
+                    .with_order_descending(descending)
                     .with_nulls_last(nulls_last)
                     .with_multithreaded(multithreaded),
             )

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -384,18 +384,30 @@ def test_jit_sort_joins() -> None:
         pd_result.columns = pd.Index(["a", "b", "b_right"])
 
         # left key sorted right is not
-        pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(["a", "b"], maintain_order=True)
+        pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(
+            ["a", "b"], maintain_order=True
+        )
 
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
+        a = (
+            pl.from_pandas(pd_result)
+            .with_columns(pl.all().cast(int))
+            .sort(["a", "b"], maintain_order=True)
+        )
         assert_frame_equal(a, pl_result)
         assert pl_result["a"].flags["SORTED_ASC"]
 
         # left key sorted right is not
         pd_result = dfb.merge(dfa, on="a", how=how)
         pd_result.columns = pd.Index(["a", "b", "b_right"])
-        pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(["a", "b"], maintain_order=True)
+        pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(
+            ["a", "b"], maintain_order=True
+        )
 
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
+        a = (
+            pl.from_pandas(pd_result)
+            .with_columns(pl.all().cast(int))
+            .sort(["a", "b"], maintain_order=True)
+        )
         assert_frame_equal(a, pl_result)
         assert pl_result["a"].flags["SORTED_ASC"]
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -384,7 +384,7 @@ def test_jit_sort_joins() -> None:
         pd_result.columns = pd.Index(["a", "b", "b_right"])
 
         # left key sorted right is not
-        pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(["a", "b"])
+        pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(["a", "b"], maintain_order=True)
 
         a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
         assert_frame_equal(a, pl_result)
@@ -393,7 +393,7 @@ def test_jit_sort_joins() -> None:
         # left key sorted right is not
         pd_result = dfb.merge(dfa, on="a", how=how)
         pd_result.columns = pd.Index(["a", "b", "b_right"])
-        pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(["a", "b"])
+        pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(["a", "b"], maintain_order=True)
 
         a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
         assert_frame_equal(a, pl_result)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -386,7 +386,7 @@ def test_jit_sort_joins() -> None:
         # left key sorted right is not
         pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(["a", "b"])
 
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
         assert_frame_equal(a, pl_result)
         assert pl_result["a"].flags["SORTED_ASC"]
 
@@ -395,7 +395,7 @@ def test_jit_sort_joins() -> None:
         pd_result.columns = pd.Index(["a", "b", "b_right"])
         pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(["a", "b"])
 
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
         assert_frame_equal(a, pl_result)
         assert pl_result["a"].flags["SORTED_ASC"]
 

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -80,7 +80,7 @@ def test_expr_sort_by_nulls_last() -> None:
         {"a": [1, 2, None, None, 5], "b": [None, 1, 1, 2, None], "c": [2, 3, 1, 2, 1]}
     )
 
-    out = df.select(pl.col("a").sort_by("a", nulls_last=True, maintain_order=True))
+    out = df.select(pl.all().sort_by("a", nulls_last=True, maintain_order=True))
 
     excepted = pl.DataFrame(
         {
@@ -94,7 +94,7 @@ def test_expr_sort_by_nulls_last() -> None:
 
     # nulls first
 
-    out = df.select(pl.col("a").sort_by("a", nulls_last=False, maintain_order=True))
+    out = df.select(pl.all().sort_by("a", nulls_last=False, maintain_order=True))
 
     excepted = pl.DataFrame(
         {
@@ -132,6 +132,18 @@ def test_arg_sort_nulls() -> None:
         None,
         None,
     ]
+
+
+def test_expr_arg_sort_nulls_last() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 2, None, None, 5], "b": [None, 1, 2, 1, None], "c": [2, 3, 1, 2, 1]}
+    )
+
+    out = df.select(pl.arg_sort_by("a", "b", nulls_last=True, maintain_order=True)).to_series().to_list()
+
+    expected = [0, 1, 4, 3, 2]
+
+    assert out == expected
 
 
 def test_arg_sort_window_functions() -> None:

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -139,7 +139,11 @@ def test_expr_arg_sort_nulls_last() -> None:
         {"a": [1, 2, None, None, 5], "b": [None, 1, 2, 1, None], "c": [2, 3, 1, 2, 1]}
     )
 
-    out = df.select(pl.arg_sort_by("a", "b", nulls_last=True, maintain_order=True)).to_series().to_list()
+    out = (
+        df.select(pl.arg_sort_by("a", "b", nulls_last=True, maintain_order=True))
+        .to_series()
+        .to_list()
+    )
 
     expected = [0, 1, 4, 3, 2]
 

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -74,6 +74,37 @@ def test_sort_by() -> None:
     assert out["a"].to_list() == [1, 2, 3, 4, 5]
 
 
+def test_expr_sort_by_nulls_last() -> None:
+    # nulls last
+    df = pl.DataFrame(
+        {"a": [1, 2, None, None, 5], "b": [None, 1, 1, 2, None], "c": [2, 3, 1, 2, 1]}
+    )
+
+    out = df.select(pl.col("a").sort_by("a", nulls_last=True, maintain_order=True))
+
+    excepted = pl.DataFrame(
+        {
+            "a": [1, 2, 5, None, None],
+            "b": [None, 1, None, 1, 2],
+            "c": [2, 3, 1, 1, 2],
+        }
+    )
+
+    assert_frame_equal(out, excepted)
+
+    # nulls first
+
+    out = df.select(pl.col("a").sort_by("a", nulls_last=False, maintain_order=True))
+
+    excepted = pl.DataFrame(
+        {
+            "a": [None, None, 1, 2, 5],
+            "b": [1, 2, None, 1, None],
+            "c": [1, 2, 2, 3, 1],
+        }
+    )
+
+
 def test_sort_by_exprs() -> None:
     # make sure that the expression does not overwrite columns in the dataframe
     df = pl.DataFrame({"a": [1, 2, -1, -2]})

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -71,7 +71,11 @@ def test_streaming_joins() -> None:
             .collect(streaming=True)
         )
 
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
+        a = (
+            pl.from_pandas(pd_result)
+            .with_columns(pl.all().cast(int))
+            .sort(["a", "b"], maintain_order=True)
+        )
         assert_frame_equal(a, pl_result, check_dtype=False)
 
         pd_result = dfa.merge(dfb, on=["a", "b"], how=how)

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -67,11 +67,11 @@ def test_streaming_joins() -> None:
         pl_result = (
             dfa_pl.lazy()
             .join(dfb_pl.lazy(), on="a", how=how)
-            .sort(["a", "b"])
+            .sort(["a", "b"], maintain_order=True)
             .collect(streaming=True)
         )
 
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"], maintain_order=True)
         assert_frame_equal(a, pl_result, check_dtype=False)
 
         pd_result = dfa.merge(dfb, on=["a", "b"], how=how)


### PR DESCRIPTION
Unify all `sort`, `arg_sort` and related functions in rust. Sort by single series functions use `SortOptions` as options whereas sort by multi series functions use `SortMultipleOptions`. Add related options for python side. 

Closes #9820, closes #10365.

# `SortOptions` and `SortMultipleOptions`

## `SortOptions`

```rust
pub struct SortOptions {
    /// If true sort in descending order.
    /// Default `false`.
    pub descending: bool,
    /// Whether place null values last.
    /// Default `false`.
    pub nulls_last: bool,
    /// If true sort in multiple threads.
    /// Default `true`.
    pub multithreaded: bool,
    /// If true maintain the order of equal elements.
    /// Default `false`.
    pub maintain_order: bool,
}
```

Example: 

```rust
let s = Series::new("a", [Some(5), Some(2), Some(3), Some(4), None].as_ref());
let sorted = s
    .sort(
        SortOptions::default()
            .with_order_descending(true)
            .with_nulls_last(true)
            .with_multithreaded(false),
    )
    .unwrap();
assert_eq!(
    sorted,
    Series::new("a", [Some(5), Some(4), Some(3), Some(2), None].as_ref())
);
```

## `SortMultipleOptions` 

```rust
pub struct SortMultipleOptions {
    /// Order of the columns. Default all `false``.
    pub descending: Vec<bool>,
    /// Whether place null values last. Default `false`.
    pub nulls_last: bool,
    /// Whether sort in multiple threads. Default `true`.
    pub multithreaded: bool,
    /// Whether maintain the order of equal elements. Default `false`.
    pub maintain_order: bool,
}
```

Example: 

```rust
let df = df! {
    "a" => [Some(1), Some(2), None, Some(4), None],
    "b" => [Some(5), None, Some(3), Some(2), Some(1)]
}?;

let out = df
    .sort(
        ["a", "b"],
        SortMultipleOptions::default()
            .with_maintain_order(true)
            .with_multithreaded(false)
            .with_order_descendings([false, true])
            .with_nulls_last(true),
    )?;

let expected = df! {
    "a" => [Some(1), Some(2), Some(4), None, None],
    "b" => [Some(5), None, Some(2), Some(3), Some(1)]
}?;

assert_eq!(out, expected);
```

# Rust API changes

Deprecation: `DataFrame::sort_with_options`.

## New implementation: 

### For `DataFrame`

```rust
pub fn sort_in_place(
    &mut self,
    by: impl IntoVec<SmartString>,
    sort_options: SortMultipleOptions,
)  -> PolarsResult<&mut Self>
```

```rust
pub fn sort(
    &self,
    by: impl IntoVec<SmartString>,
    sort_options: SortMultipleOptions,
) -> PolarsResult<Self>
```

```rust
pub fn top_k(
    &self,
    k: usize,
    by_column: impl IntoVec<SmartString>,
    sort_options: SortMultipleOptions,
) -> PolarsResult<DataFrame>
```

### For `LazyFrame`

```rust
pub fn sort(self, by: impl IntoVec<SmartString>, sort_options: SortMultipleOptions) -> Self
```

```rust 
pub fn sort_by_exprs<E: AsRef<[Expr]>>(
    self,
    by_exprs: E,
    sort_options: SortMultipleOptions,
) -> Self
```

```rust
// as well as bottom k
pub fn top_k<E: AsRef<[Expr]>>(
    self,
    k: IdxSize,
    by_exprs: E,
    sort_options: SortMultipleOptions,
) -> Self
```

### For `Expr`

```rust
pub fn sort(self, options: SortOptions) -> Self
```

```rust
pub fn sort_by<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
    self,
    by: E,
    sort_options: SortMultipleOptions,
) -> Expr
```

```rust
pub fn arg_sort(self, sort_options: SortOptions) -> Self
```

### For `Series`

```rust
pub fn sort(&self, sort_options: SortOptions) -> PolarsResult<Self>
```

### For `Functions`

```rust
pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, sort_options: SortMultipleOptions) -> Expr
```

# Python API Changes

Added

- `nulls_last: bool = False`
- `multithreaded: bool = True`
- `maintain_order: bool = False` 

for all sort related apis if not exists. 

