### PR TITLE
fix: Mean of boolean in streaming group_by incorrectly always gave NULL

### DIFF
--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -250,7 +250,9 @@ where
                     );
                 }
                 let agg_fn = match logical_dtype.to_physical() {
-                    dt if dt.is_integer() => AggregateFunction::MeanF64(MeanAgg::<f64>::new()),
+                    dt if dt.is_integer() | dt.is_bool() => {
+                        AggregateFunction::MeanF64(MeanAgg::<f64>::new())
+                    },
                     DataType::Float32 => AggregateFunction::MeanF32(MeanAgg::<f32>::new()),
                     DataType::Float64 => AggregateFunction::MeanF64(MeanAgg::<f64>::new()),
                     dt => AggregateFunction::Null(NullAgg::new(dt)),

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -488,3 +488,26 @@ def test_streaming_group_by_convert_15380() -> None:
         pl.DataFrame({"a": [1] * PARTITION_LIMIT}).group_by(b="a").len()["len"].item()
         == PARTITION_LIMIT
     )
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.parametrize("n_rows", [PARTITION_LIMIT - 1, PARTITION_LIMIT])
+def test_streaming_group_by_boolean_mean_15610(n_rows: int, streaming: bool) -> None:
+    expect = pl.DataFrame({"a": [False, True], "c": [0.0, 0.5]})
+
+    n_repeats = n_rows // 3
+    assert n_repeats > 0
+
+    out = (
+        pl.select(
+            a=pl.repeat([True, False, True], n_repeats).explode(),
+            b=pl.repeat([True, False, False], n_repeats).explode(),
+        )
+        .lazy()
+        .group_by("a")
+        .agg(c=pl.mean("b"))
+        .sort("a")
+        .collect(streaming=streaming)
+    )
+
+    assert_frame_equal(out, expect)

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -491,7 +491,7 @@ def test_streaming_group_by_convert_15380() -> None:
 
 
 @pytest.mark.parametrize("streaming", [True, False])
-@pytest.mark.parametrize("n_rows", [PARTITION_LIMIT - 1, PARTITION_LIMIT])
+@pytest.mark.parametrize("n_rows", [PARTITION_LIMIT - 1, PARTITION_LIMIT + 3])
 def test_streaming_group_by_boolean_mean_15610(n_rows: int, streaming: bool) -> None:
     # Also test non-streaming because it sometimes dispatched to streaming agg.
     expect = pl.DataFrame({"a": [False, True], "c": [0.0, 0.5]})

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -101,7 +101,7 @@ def test_streaming_group_by_types() -> None:
             "str_sum": [None],
             "bool_first": [True],
             "bool_last": [False],
-            "bool_mean": [None],
+            "bool_mean": [0.5],
             "bool_sum": [1],
             "date_sum": [date(2074, 1, 1)],
             "date_mean": [date(2022, 1, 1)],
@@ -493,6 +493,7 @@ def test_streaming_group_by_convert_15380() -> None:
 @pytest.mark.parametrize("streaming", [True, False])
 @pytest.mark.parametrize("n_rows", [PARTITION_LIMIT - 1, PARTITION_LIMIT])
 def test_streaming_group_by_boolean_mean_15610(n_rows: int, streaming: bool) -> None:
+    # Also test non-streaming because it sometimes dispatched to streaming agg.
     expect = pl.DataFrame({"a": [False, True], "c": [0.0, 0.5]})
 
     n_repeats = n_rows // 3


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/15610

This also happened non-deterministically on the standard engine as it sometimes ran streaming, but that will probably change soon with https://github.com/pola-rs/polars/pull/15611