### PR TITLE
chore(python): Initial PyO3 0.21 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef41cbb417ea83b30525259e30ccef6af39b31c240bda578889494c5392d331"
+checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -3224,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a7a8b1990bd018761768d5e608a13df8bd1ac5f678456e0f301bb93e5f3ea16b"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -3243,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "650dca34d463b6cdbdb02b1d71bfd6eb6b6816afc708faebb3bac1380ff4aef7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3253,15 +3253,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3-built"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6d574e0f8cab2cdd1eeeb640cbf845c974519fa9e9b62fa9c08ecece0ca5de"
+checksum = "35ee655adc94166665a1d714b439e27857dd199b947076891d6a17d32d396cde"
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "09a7da8fc04a8a2084909b59f29e1b8474decac98b951d77b80b26dc45f046ad"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3269,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "4b8a199fce11ebb28e3569387228836ea98110e43a804a530a9fd83ade36d513"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3281,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "93fbbfd7eb553d10036513cb122b888dcd362a945a00b06c165f2ab480d4cc3b"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ object_store = { version = "0.9", default-features = false }
 once_cell = "1"
 parquet2 = { version = "0.17.2", features = ["async"], default-features = false }
 percent-encoding = "2.3"
-pyo3 = "0.20"
+pyo3 = "0.21"
 rand = "0.8"
 rand_distr = "0.4"
 raw-cpuid = "11"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -24,10 +24,10 @@ itoa = { workspace = true }
 libc = "0.2"
 ndarray = { workspace = true }
 num-traits = { workspace = true }
-numpy = { version = "0.20", default-features = false }
+numpy = { version = "0.21", default-features = false }
 once_cell = { workspace = true }
-pyo3 = { workspace = true, features = ["abi3-py38", "extension-module", "multiple-pymethods"] }
-pyo3-built = { version = "0.4", optional = true }
+pyo3 = { workspace = true, features = ["abi3-py38", "extension-module", "multiple-pymethods", "gil-refs"] }
+pyo3-built = { version = "0.5", optional = true }
 recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }
 smartstring = { workspace = true }

--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -367,7 +367,7 @@ pub(crate) fn py_object_to_any_value(ob: &PyAny, strict: bool) -> PyResult<AnyVa
         } else if ob.hasattr(intern!(py, "_s")).unwrap() {
             get_list_from_series
         } else {
-            let type_name = ob.get_type().name().unwrap();
+            let type_name = ob.get_type().qualname().unwrap();
             match &*type_name {
                 // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
                 // so need this workaround instead of `isinstance(ob, datetime)`.

--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -368,7 +368,7 @@ pub(crate) fn py_object_to_any_value(ob: &PyAny, strict: bool) -> PyResult<AnyVa
             get_list_from_series
         } else {
             let type_name = ob.get_type().name().unwrap();
-            match type_name {
+            match &*type_name {
                 // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
                 // so need this workaround instead of `isinstance(ob, datetime)`.
                 "date" => get_date,

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -285,7 +285,7 @@ impl FromPyObject<'_> for Wrap<Field> {
 impl FromPyObject<'_> for Wrap<DataType> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let py = ob.py();
-        let type_name = ob.get_type().name()?;
+        let type_name = ob.get_type().qualname()?;
 
         let dtype = match &*type_name {
             "DataTypeClass" => {

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -472,7 +472,7 @@ impl PartialEq for ObjectValue {
                 .as_ref(py)
                 .rich_compare(other.inner.as_ref(py), CompareOp::Eq)
             {
-                Ok(result) => result.is_true().unwrap(),
+                Ok(result) => result.is_truthy().unwrap(),
                 Err(_) => false,
             }
         })

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -287,7 +287,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
         let py = ob.py();
         let type_name = ob.get_type().name()?;
 
-        let dtype = match type_name {
+        let dtype = match &*type_name {
             "DataTypeClass" => {
                 // just the class, not an object
                 let name = ob.getattr(intern!(py, "__name__"))?.str()?.to_str()?;
@@ -547,7 +547,7 @@ impl Default for ObjectValue {
 
 impl<'a, T: NativeType + FromPyObject<'a>> FromPyObject<'a> for Wrap<Vec<T>> {
     fn extract(obj: &'a PyAny) -> PyResult<Self> {
-        let seq = <PySequence as PyTryFrom>::try_from(obj)?;
+        let seq = obj.downcast::<PySequence>()?;
         let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
         for item in seq.iter()? {
             v.push(item?.extract::<T>()?);

--- a/py-polars/src/map/dataframe.rs
+++ b/py-polars/src/map/dataframe.rs
@@ -266,7 +266,7 @@ pub fn apply_lambda_with_rows_output<'a>(
         if return_val.is_none() {
             Ok(&null_row)
         } else {
-            let tuple = return_val.downcast::<PyTuple>().map_err(|_| polars_err!(ComputeError: format!("expected tuple, got {}", return_val.get_type().name().unwrap())))?;
+            let tuple = return_val.downcast::<PyTuple>().map_err(|_| polars_err!(ComputeError: format!("expected tuple, got {}", return_val.get_type().qualname().unwrap())))?;
             row_buf.0.clear();
             for v in tuple {
                 let v = v.extract::<Wrap<AnyValue>>().unwrap().0;

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -165,6 +165,7 @@ impl PySeries {
     /// be handled on the Python side in a zero-copy manner.
     ///
     /// This method will cast integers to floats so that `null = np.nan`.
+    #[allow(deprecated)]  // This will be removed as part of #15215
     fn to_numpy(&self, py: Python) -> PyResult<PyObject> {
         use DataType::*;
         let s = &self.series;
@@ -249,6 +250,7 @@ where
         Some(v) => NumCast::from(v).unwrap(),
         None => U::nan(),
     };
+    #[allow(deprecated)]  // This will be removed as part of #15215
     let np_arr = PyArray1::from_iter(py, ca.iter().map(mapper));
     np_arr.into_py(py)
 }
@@ -260,6 +262,7 @@ fn date_series_to_numpy(py: Python, s: &Series) -> PyObject {
         Some(v) => v as i64,
         None => i64::MIN,
     };
+    #[allow(deprecated)]  // This will be removed as part of #15215
     let np_arr = PyArray1::from_iter(py, ca.iter().map(mapper));
     np_arr.into_py(py)
 }
@@ -267,6 +270,7 @@ fn date_series_to_numpy(py: Python, s: &Series) -> PyObject {
 fn temporal_series_to_numpy(py: Python, s: &Series) -> PyObject {
     let s_phys = s.to_physical_repr();
     let ca = s_phys.i64().unwrap();
+    #[allow(deprecated)]  // This will be removed as part of #15215
     let np_arr = PyArray1::from_iter(py, ca.iter().map(|v| v.unwrap_or(i64::MIN)));
     np_arr.into_py(py)
 }

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -165,7 +165,7 @@ impl PySeries {
     /// be handled on the Python side in a zero-copy manner.
     ///
     /// This method will cast integers to floats so that `null = np.nan`.
-    #[allow(deprecated)]  // This will be removed as part of #15215
+    #[allow(deprecated)] // This will be removed as part of #15215
     fn to_numpy(&self, py: Python) -> PyResult<PyObject> {
         use DataType::*;
         let s = &self.series;
@@ -250,7 +250,7 @@ where
         Some(v) => NumCast::from(v).unwrap(),
         None => U::nan(),
     };
-    #[allow(deprecated)]  // This will be removed as part of #15215
+    #[allow(deprecated)] // This will be removed as part of #15215
     let np_arr = PyArray1::from_iter(py, ca.iter().map(mapper));
     np_arr.into_py(py)
 }
@@ -262,7 +262,7 @@ fn date_series_to_numpy(py: Python, s: &Series) -> PyObject {
         Some(v) => v as i64,
         None => i64::MIN,
     };
-    #[allow(deprecated)]  // This will be removed as part of #15215
+    #[allow(deprecated)] // This will be removed as part of #15215
     let np_arr = PyArray1::from_iter(py, ca.iter().map(mapper));
     np_arr.into_py(py)
 }
@@ -270,7 +270,7 @@ fn date_series_to_numpy(py: Python, s: &Series) -> PyObject {
 fn temporal_series_to_numpy(py: Python, s: &Series) -> PyObject {
     let s_phys = s.to_physical_repr();
     let ca = s_phys.i64().unwrap();
-    #[allow(deprecated)]  // This will be removed as part of #15215
+    #[allow(deprecated)] // This will be removed as part of #15215
     let np_arr = PyArray1::from_iter(py, ca.iter().map(|v| v.unwrap_or(i64::MIN)));
     np_arr.into_py(py)
 }

--- a/py-polars/src/series/numpy_ufunc.rs
+++ b/py-polars/src/series/numpy_ufunc.rs
@@ -35,7 +35,7 @@ unsafe fn aligned_array<T: Element + NativeType>(
     let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
         py,
         PY_ARRAY_API.get_type_object(py, npyffi::NpyTypes::PyArray_Type),
-        #[allow(deprecated)]  // This will be removed as part of #15215
+        #[allow(deprecated)] // This will be removed as part of #15215
         T::get_dtype(py).into_dtype_ptr(),
         dims.ndim_cint(),
         dims.as_dims_ptr(),
@@ -44,8 +44,11 @@ unsafe fn aligned_array<T: Element + NativeType>(
         flags::NPY_ARRAY_OUT_ARRAY, // flag
         ptr::null_mut(),            //obj
     );
-    (#[allow(deprecated)]  // This will be removed as part of #15215
-     PyArray1::from_owned_ptr(py, ptr), buf)
+    (
+        #[allow(deprecated)] // This will be removed as part of #15215
+        PyArray1::from_owned_ptr(py, ptr),
+        buf,
+    )
 }
 
 /// Get reference counter for numpy arrays.

--- a/py-polars/src/series/numpy_ufunc.rs
+++ b/py-polars/src/series/numpy_ufunc.rs
@@ -35,6 +35,7 @@ unsafe fn aligned_array<T: Element + NativeType>(
     let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
         py,
         PY_ARRAY_API.get_type_object(py, npyffi::NpyTypes::PyArray_Type),
+        #[allow(deprecated)]  // This will be removed as part of #15215
         T::get_dtype(py).into_dtype_ptr(),
         dims.ndim_cint(),
         dims.as_dims_ptr(),
@@ -43,7 +44,8 @@ unsafe fn aligned_array<T: Element + NativeType>(
         flags::NPY_ARRAY_OUT_ARRAY, // flag
         ptr::null_mut(),            //obj
     );
-    (PyArray1::from_owned_ptr(py, ptr), buf)
+    (#[allow(deprecated)]  // This will be removed as part of #15215
+     PyArray1::from_owned_ptr(py, ptr), buf)
 }
 
 /// Get reference counter for numpy arrays.

--- a/py-polars/src/to_numpy.rs
+++ b/py-polars/src/to_numpy.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]  // This will be removed as part of #15215
 use std::ffi::{c_int, c_void};
 
 use ndarray::{Dim, Dimension, IntoDimension};

--- a/py-polars/src/to_numpy.rs
+++ b/py-polars/src/to_numpy.rs
@@ -1,4 +1,4 @@
-#![allow(deprecated)]  // This will be removed as part of #15215
+#![allow(deprecated)] // This will be removed as part of #15215
 use std::ffi::{c_int, c_void};
 
 use ndarray::{Dim, Dimension, IntoDimension};


### PR DESCRIPTION
Fixes #15621

Next step will probably be getting rid of the manual deprecation suppression by switching to the non-deprecated `numpy` APIs, in the hopes that's somewhat self-contained.