### PR TITLE
feat: Extended `BytecodeParser` to handle additional math functions, and imports from the global namespace

### DIFF
--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -42,6 +42,7 @@ class StackValue(NamedTuple):
     operator_arity: int
     left_operand: str
     right_operand: str
+    from_module: str | None = None
 
 
 MapTarget: TypeAlias = Literal["expr", "frame", "series"]
@@ -103,6 +104,35 @@ class OpNames:
     )
     UNARY_VALUES = frozenset(UNARY.values())
 
+
+# math module funcs that we can map to native expressions
+_MATH_FUNCTIONS = frozenset(
+    (
+        "acos",
+        "acosh",
+        "asin",
+        "asinh",
+        "atan",
+        "atanh",
+        "cbrt",
+        "ceil",
+        "cos",
+        "cosh",
+        "degrees",
+        "exp",
+        "floor",
+        "log",
+        "log10",
+        "log1p",
+        "pow",
+        "radians",
+        "sin",
+        "sinh",
+        "sqrt",
+        "tan",
+        "tanh",
+    )
+)
 
 # numpy functions that we can map to native expressions
 _NUMPY_MODULE_ALIASES = frozenset(("np", "numpy"))
@@ -176,6 +206,17 @@ _MODULE_FUNCTIONS: list[dict[str, list[AbstractSet[str]]]] = [
         "attribute_name": [],
         "function_name": [_NUMPY_FUNCTIONS],
     },
+    # lambda x: math.func(x)
+    # lambda x: math.func(CONSTANT)
+    {
+        "argument_1_opname": [{"LOAD_FAST", "LOAD_CONST"}],
+        "argument_2_opname": [],
+        "module_opname": [OpNames.LOAD_ATTR],
+        "attribute_opname": [],
+        "module_name": [{"math"}],
+        "attribute_name": [],
+        "function_name": [_MATH_FUNCTIONS],
+    },
     # lambda x: json.loads(x)
     {
         "argument_1_opname": [{"LOAD_FAST"}],
@@ -195,6 +236,7 @@ _MODULE_FUNCTIONS: list[dict[str, list[AbstractSet[str]]]] = [
         "module_name": [{"datetime"}],
         "attribute_name": [],
         "function_name": [{"strptime"}],
+        "check_load_global": False,  # type: ignore[dict-item]
     },
     # lambda x: module.attribute.func(x, CONSTANT)
     {
@@ -205,6 +247,7 @@ _MODULE_FUNCTIONS: list[dict[str, list[AbstractSet[str]]]] = [
         "module_name": [{"datetime", "dt"}],
         "attribute_name": [{"datetime"}],
         "function_name": [{"strptime"}],
+        "check_load_global": False,  # type: ignore[dict-item]
     },
 ]
 # In addition to `lambda x: func(x)`, also support cases when a unary operation
@@ -214,6 +257,16 @@ _MODULE_FUNCTIONS = [
     for kind in _MODULE_FUNCTIONS
     for unary in [[set(OpNames.UNARY)], []]
 ]
+# Lookup for module functions that have different names as polars expressions
+_MODULE_FUNC_TO_EXPR_NAME = {
+    "math.acos": "arccos",
+    "math.acosh": "arccosh",
+    "math.asin": "arcsin",
+    "math.asinh": "arcsinh",
+    "math.atan": "arctan",
+    "math.atanh": "arctanh",
+    "json.loads": "str.json_decode",
+}
 _RE_IMPLICIT_BOOL = re.compile(r'pl\.col\("([^"]*)"\) & pl\.col\("\1"\)\.(.+)')
 
 
@@ -246,12 +299,47 @@ def _get_all_caller_variables() -> dict[str, Any]:
     return variables
 
 
+def _get_target_name(col: str, expression: str, map_target: str) -> str:
+    """The name of the object against which the 'map' is being invoked."""
+    col_expr = f'pl.col("{col}")'
+    if map_target == "expr":
+        return col_expr
+    elif map_target == "series":
+        if re.match(r"^(s|srs\d?|series)\.", expression):
+            return expression.split(".", 1)[0]
+        # note: handle overlapping name from global variables; fallback
+        # through "s", "srs", "series" and (finally) srs0 -> srsN...
+        search_expr = expression.replace(col_expr, "")
+        for name in ("s", "srs", "series"):
+            if not re.search(rf"\b{name}\b", search_expr):
+                return name
+        n = count()
+        while True:
+            name = f"srs{next(n)}"
+            if not re.search(rf"\b{name}\b", search_expr):
+                return name
+
+    msg = f"TODO: map_target = {map_target!r}"
+    raise NotImplementedError(msg)
+
+
 class BytecodeParser:
     """Introspect UDF bytecode and determine if we can rewrite as native expression."""
 
     _map_target_name: str | None = None
+    _caller_variables: dict[str, Any] | None = None
 
     def __init__(self, function: Callable[[Any], Any], map_target: MapTarget):
+        """
+        Initialize BytecodeParser instance and prepare to introspect UDFs.
+
+        Parameters
+        ----------
+        function : callable
+            The function/lambda to disassemble and introspect.
+        map_target : {'expr','series','frame'}
+            The underlying target object type of the map operation.
+        """
         try:
             original_instructions = get_instructions(function)
         except TypeError:
@@ -264,6 +352,8 @@ class BytecodeParser:
         self._param_name = self._get_param_name(function)
         self._rewritten_instructions = RewrittenInstructions(
             instructions=original_instructions,
+            caller_variables=self._caller_variables,
+            function=function,
         )
 
     def _omit_implicit_bool(self, expr: str) -> str:
@@ -311,32 +401,6 @@ class BytecodeParser:
                 expression_blocks[inst.offset] = OpNames.CONTROL_FLOW[inst.opname]
 
         return sorted(expression_blocks.items())
-
-    def _get_target_name(self, col: str, expression: str) -> str:
-        """The name of the object against which the 'map' is being invoked."""
-        if self._map_target_name is not None:
-            return self._map_target_name
-        else:
-            col_expr = f'pl.col("{col}")'
-            if self._map_target == "expr":
-                return col_expr
-            elif self._map_target == "series":
-                # note: handle overlapping name from global variables; fallback
-                # through "s", "srs", "series" and (finally) srs0 -> srsN...
-                search_expr = expression.replace(col_expr, "")
-                for name in ("s", "srs", "series"):
-                    if not re.search(rf"\b{name}\b", search_expr):
-                        self._map_target_name = name
-                        return name
-                n = count()
-                while True:
-                    name = f"srs{next(n)}"
-                    if not re.search(rf"\b{name}\b", search_expr):
-                        self._map_target_name = name
-                        return name
-
-        msg = f"TODO: map_target = {self._map_target!r}"
-        raise NotImplementedError(msg)
 
     @property
     def map_target(self) -> MapTarget:
@@ -410,14 +474,14 @@ class BytecodeParser:
                 control_flow_blocks[jump_offset].append(inst)
 
         # convert each block to a polars expression string
-        caller_variables: dict[str, Any] = {}
         try:
             expression_strings = self._inject_nesting(
                 {
                     offset: InstructionTranslator(
                         instructions=ops,
-                        caller_variables=caller_variables,
+                        caller_variables=self._caller_variables,
                         map_target=self._map_target,
+                        function=self._function,
                     ).to_expression(
                         col=col,
                         param_name=self._param_name,
@@ -438,7 +502,8 @@ class BytecodeParser:
         else:
             polars_expr = self._omit_implicit_bool(polars_expr)
             if self._map_target == "series":
-                target_name = self._get_target_name(col, polars_expr)
+                if (target_name := self._map_target_name) is None:
+                    target_name = _get_target_name(col, polars_expr, self._map_target)
                 return polars_expr.replace(f'pl.col("{col}")', target_name)
             else:
                 return polars_expr
@@ -446,6 +511,7 @@ class BytecodeParser:
     def warn(
         self,
         col: str,
+        *,
         suggestion_override: str | None = None,
         udf_override: str | None = None,
     ) -> None:
@@ -461,7 +527,10 @@ class BytecodeParser:
         suggested_expression = suggestion_override or self.to_expression(col)
 
         if suggested_expression is not None:
-            target_name = self._get_target_name(col, suggested_expression)
+            if (target_name := self._map_target_name) is None:
+                target_name = _get_target_name(
+                    col, suggested_expression, self._map_target
+                )
             func_name = udf_override or self._function.__name__ or "..."
             if func_name == "<lambda>":
                 func_name = f"lambda {self._param_name}: ..."
@@ -471,13 +540,11 @@ class BytecodeParser:
                 if 'pl.col("")' in suggested_expression
                 else ""
             )
-            if self._map_target == "expr":
-                apitype = "expressions"
-                clsname = "Expr"
-            else:
-                apitype = "series"
-                clsname = "Series"
-
+            apitype, clsname = (
+                ("expressions", "Expr")
+                if self._map_target == "expr"
+                else ("series", "Series")
+            )
             before, after = (
                 (
                     f"  \033[31m- {target_name}.map_elements({func_name})\033[0m\n",
@@ -507,11 +574,13 @@ class InstructionTranslator:
     def __init__(
         self,
         instructions: list[Instruction],
-        caller_variables: dict[str, Any],
+        caller_variables: dict[str, Any] | None,
+        function: Callable[[Any], Any],
         map_target: MapTarget,
     ) -> None:
-        self._caller_variables: dict[str, Any] = caller_variables
         self._stack = self._to_intermediate_stack(instructions, map_target)
+        self._caller_variables = caller_variables
+        self._function = function
 
     def to_expression(self, col: str, param_name: str, depth: int) -> str:
         """Convert intermediate stack to polars expression string."""
@@ -557,7 +626,19 @@ class InstructionTranslator:
 
                     # support use of consts as numpy/builtin params, eg:
                     # "np.sin(3) + np.cos(x)", or "len('const_string') + len(x)"
-                    pfx = "np." if op in _NUMPY_FUNCTIONS else ""
+                    if (
+                        value.from_module in _NUMPY_MODULE_ALIASES
+                        and op in _NUMPY_FUNCTIONS
+                    ):
+                        pfx = "np."
+                    elif (
+                        value.from_module == "math"
+                        and _MODULE_FUNC_TO_EXPR_NAME.get(f"math.{op}", op)
+                        in _MATH_FUNCTIONS
+                    ):
+                        pfx = "math."
+                    else:
+                        pfx = ""
                     return f"{pfx}{op}({e1})"
                 return f"{op}{e1}"
             else:
@@ -574,10 +655,10 @@ class InstructionTranslator:
                     )
                 elif op == "replace":
                     if not self._caller_variables:
-                        self._caller_variables.update(_get_all_caller_variables())
-                        if not isinstance(self._caller_variables.get(e1, None), dict):
-                            msg = "require dict mapping"
-                            raise NotImplementedError(msg)
+                        self._caller_variables = _get_all_caller_variables()
+                    if not isinstance(self._caller_variables.get(e1, None), dict):
+                        msg = "require dict mapping"
+                        raise NotImplementedError(msg)
                     return f"{e2}.{op}({e1})"
                 elif op == "<<":
                     # Result of 2**e2 might be float is e2 was negative.
@@ -613,6 +694,7 @@ class InstructionTranslator:
                             operator_arity=1,
                             left_operand=stack.pop(),  # type: ignore[arg-type]
                             right_operand=None,  # type: ignore[arg-type]
+                            from_module=getattr(inst, "_from_module", None),
                         )
                         if (
                             inst.opname in OpNames.UNARY
@@ -623,13 +705,14 @@ class InstructionTranslator:
                             operator_arity=2,
                             left_operand=stack.pop(-2),  # type: ignore[arg-type]
                             right_operand=stack.pop(-1),  # type: ignore[arg-type]
+                            from_module=getattr(inst, "_from_module", None),
                         )
                     )
                 )
             return stack[0]
 
-        # TODO: dataframe.apply(...)
-        msg = f"TODO: {map_target!r} apply"
+        # TODO: dataframe.map... ?
+        msg = f"TODO: {map_target!r} map target not yet supported."
         raise NotImplementedError(msg)
 
 
@@ -639,7 +722,7 @@ class RewrittenInstructions:
 
     This significantly simplifies subsequent parsing by injecting
     synthetic POLARS_EXPRESSION ops into the Instruction stream for
-    easy identification/translation and separates the parsing logic
+    easy identification/translation, and separates the parsing logic
     from the identification of expression translation opportunities.
     """
 
@@ -654,9 +737,15 @@ class RewrittenInstructions:
             "RETURN_VALUE",
         ]
     )
-    _caller_variables: ClassVar[dict[str, Any]] = {}
 
-    def __init__(self, instructions: Iterator[Instruction]):
+    def __init__(
+        self,
+        instructions: Iterator[Instruction],
+        function: Callable[[Any], Any],
+        caller_variables: dict[str, Any] | None,
+    ):
+        self._function = function
+        self._caller_variables = caller_variables
         self._original_instructions = list(instructions)
         self._rewritten_instructions = self._rewrite(
             self._upgrade_instruction(inst)
@@ -789,63 +878,100 @@ class RewrittenInstructions:
         self, idx: int, updated_instructions: list[Instruction]
     ) -> int:
         """Replace function calls with a synthetic POLARS_EXPRESSION op."""
-        for function_kind in _MODULE_FUNCTIONS:
-            opnames: list[AbstractSet[str]] = [
-                {"LOAD_GLOBAL", "LOAD_DEREF"},
-                *function_kind["module_opname"],
-                *function_kind["attribute_opname"],
-                *function_kind["argument_1_opname"],
-                *function_kind["argument_1_unary_opname"],
-                *function_kind["argument_2_opname"],
-                OpNames.CALL,
-            ]
-            if matching_instructions := self._matches(
-                idx,
-                opnames=opnames,
-                argvals=[
-                    *function_kind["module_name"],
-                    *function_kind["attribute_name"],
-                    *function_kind["function_name"],
-                ],
-            ):
-                attribute_count = len(function_kind["attribute_name"])
-                inst1, inst2, inst3 = matching_instructions[
-                    attribute_count : 3 + attribute_count
-                ]
-                if inst1.argval == "json":
-                    expr_name = "str.json_decode"
-                elif inst1.argval == "datetime":
-                    fmt = matching_instructions[attribute_count + 3].argval
-                    expr_name = f'str.to_datetime(format="{fmt}")'
-                    if not self._is_stdlib_datetime(
-                        inst1.argval,
-                        matching_instructions[0].argval,
-                        fmt,
-                        attribute_count,
-                    ):
-                        return 0
-                else:
-                    expr_name = inst2.argval
+        for check_globals in (False, True):
+            for function_kind in _MODULE_FUNCTIONS:
+                if check_globals and not function_kind.get("check_load_global", True):
+                    return 0
 
-                px = inst1._replace(
-                    opname="POLARS_EXPRESSION",
-                    argval=expr_name,
-                    argrepr=expr_name,
-                    offset=inst3.offset,
+                opnames: list[AbstractSet[str]] = (
+                    [
+                        {"LOAD_GLOBAL", "LOAD_DEREF"},
+                        *function_kind["argument_1_opname"],
+                        *function_kind["argument_1_unary_opname"],
+                        *function_kind["argument_2_opname"],
+                        OpNames.CALL,
+                    ]
+                    if check_globals
+                    else [
+                        {"LOAD_GLOBAL", "LOAD_DEREF"},
+                        *function_kind["module_opname"],
+                        *function_kind["attribute_opname"],
+                        *function_kind["argument_1_opname"],
+                        *function_kind["argument_1_unary_opname"],
+                        *function_kind["argument_2_opname"],
+                        OpNames.CALL,
+                    ]
                 )
+                module_aliases = function_kind["module_name"]
+                if matching_instructions := self._matches(
+                    idx,
+                    opnames=opnames,
+                    argvals=[
+                        *function_kind["function_name"],
+                    ]
+                    if check_globals
+                    else [
+                        *function_kind["module_name"],
+                        *function_kind["attribute_name"],
+                        *function_kind["function_name"],
+                    ],
+                ):
+                    attribute_count = len(function_kind["attribute_name"])
+                    inst1, inst2, inst3 = matching_instructions[
+                        attribute_count : 3 + attribute_count
+                    ]
+                    if check_globals:
+                        if not self._caller_variables:
+                            self._caller_variables = _get_all_caller_variables()
+                        if (expr_name := inst1.argval) not in self._caller_variables:
+                            continue
+                        else:
+                            module_name = self._caller_variables[expr_name].__module__
+                            if not any((module_name in m) for m in module_aliases):
+                                continue
+                            expr_name = _MODULE_FUNC_TO_EXPR_NAME.get(
+                                f"{module_name}.{expr_name}", expr_name
+                            )
+                    elif inst1.argval == "json":
+                        expr_name = "str.json_decode"
+                    elif inst1.argval == "datetime":
+                        fmt = matching_instructions[attribute_count + 3].argval
+                        expr_name = f'str.to_datetime(format="{fmt}")'
+                        if not self._is_stdlib_datetime(
+                            inst1.argval,
+                            matching_instructions[0].argval,
+                            attribute_count,
+                        ):
+                            # skip these instructions if not stdlib datetime function
+                            return len(matching_instructions)
+                    elif inst1.argval == "math":
+                        expr_name = _MODULE_FUNC_TO_EXPR_NAME.get(
+                            f"math.{inst2.argval}", inst2.argval
+                        )
+                    else:
+                        expr_name = inst2.argval
 
-                # POLARS_EXPRESSION is mapped as a unary op, so switch instruction order
-                operand = inst3._replace(offset=inst1.offset)
-                updated_instructions.extend(
-                    (
-                        operand,
-                        matching_instructions[3 + attribute_count],
-                        px,
+                    # note: POLARS_EXPRESSION is mapped as unary op, so switch
+                    # instruction order/offsets (for later RPE-type stack walk)
+                    swap_inst = inst2 if check_globals else inst3
+                    px = inst1._replace(
+                        opname="POLARS_EXPRESSION",
+                        argval=expr_name,
+                        argrepr=expr_name,
+                        offset=swap_inst.offset,
                     )
-                    if function_kind["argument_1_unary_opname"]
-                    else (operand, px)
-                )
-                return len(matching_instructions)
+                    px._from_module = None if check_globals else (inst1.argval or None)  # type: ignore[attr-defined]
+                    operand = swap_inst._replace(offset=inst1.offset)
+                    updated_instructions.extend(
+                        (
+                            operand,
+                            matching_instructions[3 + attribute_count],
+                            px,
+                        )
+                        if function_kind["argument_1_unary_opname"]
+                        else (operand, px)
+                    )
+                    return len(matching_instructions)
 
         return 0
 
@@ -901,17 +1027,17 @@ class RewrittenInstructions:
         return inst
 
     def _is_stdlib_datetime(
-        self, function_name: str, module_name: str, fmt: str, attribute_count: int
+        self, function_name: str, module_name: str, attribute_count: int
     ) -> bool:
         if not self._caller_variables:
-            self._caller_variables.update(_get_all_caller_variables())
+            self._caller_variables = _get_all_caller_variables()
         vars = self._caller_variables
         return (
             attribute_count == 0 and vars.get(function_name) is datetime.datetime
         ) or (attribute_count == 1 and vars.get(module_name) is datetime)
 
 
-def _is_raw_function(function: Callable[[Any], Any]) -> tuple[str, str]:
+def _raw_function_meta(function: Callable[[Any], Any]) -> tuple[str, str]:
     """Identify translatable calls that aren't wrapped inside a lambda/function."""
     try:
         func_module = function.__class__.__module__
@@ -927,6 +1053,14 @@ def _is_raw_function(function: Callable[[Any], Any]) -> tuple[str, str]:
     elif func_module == "builtins":
         if func_name in _PYTHON_CASTS_MAP:
             return "builtins", f"cast(pl.{_PYTHON_CASTS_MAP[func_name]})"
+        elif func_name in _MATH_FUNCTIONS:
+            import math
+
+            if function is getattr(math, func_name):
+                expr_name = _MODULE_FUNC_TO_EXPR_NAME.get(
+                    f"math.{func_name}", func_name
+                )
+                return "math", f"{expr_name}()"
         elif func_name == "loads":
             import json  # double-check since it is referenced via 'builtins'
 
@@ -958,7 +1092,8 @@ def warn_on_inefficient_map(
         raise NotImplementedError(msg)
 
     # note: we only consider simple functions with a single col/param
-    if not (col := columns and columns[0]):
+    col: str = columns and columns[0]  # type: ignore[assignment]
+    if not col and col != "":
         return None
 
     # the parser introspects function bytecode to determine if we can
@@ -968,12 +1103,14 @@ def warn_on_inefficient_map(
         parser.warn(col)
     else:
         # handle bare numpy/json functions
-        module, suggestion = _is_raw_function(function)
+        module, suggestion = _raw_function_meta(function)
         if module and suggestion:
+            target_name = _get_target_name(col, suggestion, map_target)
+            parser._map_target_name = target_name
             fn = function.__name__
             parser.warn(
                 col,
-                suggestion_override=f'pl.col("{col}").{suggestion}',
+                suggestion_override=f"{target_name}.{suggestion}",
                 udf_override=fn if module == "builtins" else f"{module}.{fn}",
             )
 

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import math
 import re
 from datetime import datetime
 from functools import partial
+from math import cosh
 from typing import Any, Callable
 
 import numpy
@@ -74,7 +76,26 @@ TEST_CASES = [
         '1 / (1 + (-pl.col("a")).exp())',
     ),
     # ---------------------------------------------
-    # numpy
+    # math module
+    # ---------------------------------------------
+    ("e", "lambda x: math.asin(x)", 'pl.col("e").arcsin()'),
+    ("e", "lambda x: math.asinh(x)", 'pl.col("e").arcsinh()'),
+    ("e", "lambda x: math.atan(x)", 'pl.col("e").arctan()'),
+    ("e", "lambda x: math.atanh(x)", 'pl.col("e").arctanh()'),
+    ("e", "lambda x: math.cos(x)", 'pl.col("e").cos()'),
+    ("e", "lambda x: math.degrees(x)", 'pl.col("e").degrees()'),
+    ("e", "lambda x: math.exp(x)", 'pl.col("e").exp()'),
+    ("e", "lambda x: math.log(x)", 'pl.col("e").log()'),
+    ("e", "lambda x: math.log10(x)", 'pl.col("e").log10()'),
+    ("e", "lambda x: math.log1p(x)", 'pl.col("e").log1p()'),
+    ("e", "lambda x: math.radians(x)", 'pl.col("e").radians()'),
+    ("e", "lambda x: math.sin(x)", 'pl.col("e").sin()'),
+    ("e", "lambda x: math.sinh(x)", 'pl.col("e").sinh()'),
+    ("e", "lambda x: math.sqrt(x)", 'pl.col("e").sqrt()'),
+    ("e", "lambda x: math.tan(x)", 'pl.col("e").tan()'),
+    ("e", "lambda x: math.tanh(x)", 'pl.col("e").tanh()'),
+    # ---------------------------------------------
+    # numpy module
     # ---------------------------------------------
     ("e", "lambda x: np.arccos(x)", 'pl.col("e").arccos()'),
     ("e", "lambda x: np.arccosh(x)", 'pl.col("e").arccosh()'),
@@ -231,13 +252,15 @@ NOOP_TEST_CASES = [
 ]
 
 EVAL_ENVIRONMENT = {
-    "np": numpy,
-    "pl": pl,
     "MY_CONSTANT": MY_CONSTANT,
     "MY_DICT": MY_DICT,
     "MY_LIST": MY_LIST,
-    "dt": dt,
+    "cosh": cosh,
     "datetime": datetime,
+    "dt": dt,
+    "math": math,
+    "np": numpy,
+    "pl": pl,
 }
 
 
@@ -274,9 +297,9 @@ def test_parse_apply_functions(col: str, func: str, expr_repr: str) -> None:
                 "b": ["AB", "cd", "eF"],
                 "c": ['{"a": 1}', '{"b": 2}', '{"c": 3}'],
                 "d": ["2020-01-01", "2020-01-02", "2020-01-03"],
-                "e": [1.5, 2.4, 3.1],
+                "e": [0.5, 0.4, 0.1],
                 "f": [
-                    datetime(1999, 12, 31),
+                    datetime(1969, 12, 31),
                     datetime(2024, 5, 6),
                     datetime(2077, 10, 20),
                 ],
@@ -359,12 +382,24 @@ def test_parse_apply_raw_functions() -> None:
 def test_parse_apply_miscellaneous() -> None:
     # note: can also identify inefficient functions and methods as well as lambdas
     class Test:
-        def x10(self, x: pl.Expr) -> pl.Expr:
+        def x10(self, x: float) -> float:
             return x * 10
+
+        def mcosh(self, x: float) -> float:
+            return cosh(x)
 
     parser = BytecodeParser(Test().x10, map_target="expr")
     suggested_expression = parser.to_expression(col="colx")
     assert suggested_expression == 'pl.col("colx") * 10'
+
+    with pytest.warns(
+        PolarsInefficientMapWarning,
+        match=r"(?s)Series\.map_elements.*with this one instead.*s\.cosh\(\)",
+    ):
+        pl.Series("colx", [0.5, 0.25]).map_elements(
+            function=Test().mcosh,
+            return_dtype=pl.Float64,
+        )
 
     # note: all constants - should not create a warning/suggestion
     suggested_expression = BytecodeParser(
@@ -377,18 +412,18 @@ def test_parse_apply_miscellaneous() -> None:
         PolarsInefficientMapWarning,
         match=r"(?s)Series\.map_elements.*with this one instead.*\(np\.cos\(3\) \+ s\) - abs\(-1\)",
     ):
-        pl_series = pl.Series("srs", [0, 1, 2, 3, 4])
+        s = pl.Series("srs", [0, 1, 2, 3, 4])
         assert_series_equal(
-            pl_series.map_elements(
+            s.map_elements(
                 lambda x: numpy.cos(3) + x - abs(-1), return_dtype=pl.Float64
             ),
-            numpy.cos(3) + pl_series - 1,
+            numpy.cos(3) + s - 1,
         )
 
     # if 's' is already the name of a global variable then the series alias
     # used in the user warning will fall back (in priority order) through
     # various aliases until it finds one that is available.
-    s, srs, series = -1, 0, 1
+    s, srs, series = -1, 0, 1  # type: ignore[assignment]
     expr1 = BytecodeParser(lambda x: x + s, map_target="series")
     expr2 = BytecodeParser(lambda x: srs + x + s, map_target="series")
     expr3 = BytecodeParser(lambda x: srs + x + s - x + series, map_target="series")
@@ -399,14 +434,16 @@ def test_parse_apply_miscellaneous() -> None:
 
 
 @pytest.mark.parametrize(
-    ("data", "func", "expr_repr"),
+    ("name", "data", "func", "expr_repr"),
     [
         (
+            "srs",
             [1, 2, 3],
             lambda x: str(x),
             "s.cast(pl.String)",
         ),
         (
+            "",
             [-20, -12, -5, 0, 5, 12, 20],
             lambda x: (abs(x) != 12) and (x > 10 or x < -10 or x == 0),
             "(s.abs() != 12) & ((s > 10) | (s < -10) | (s == 0))",
@@ -417,13 +454,13 @@ def test_parse_apply_miscellaneous() -> None:
     "ignore:.*without specifying `return_dtype`:polars.exceptions.MapWithoutReturnDtypeWarning"
 )
 def test_parse_apply_series(
-    data: list[Any], func: Callable[[Any], Any], expr_repr: str
+    name: str, data: list[Any], func: Callable[[Any], Any], expr_repr: str
 ) -> None:
     # expression/series generate same warning, with 's' as the series placeholder
     with pytest.warns(
         PolarsInefficientMapWarning, match=r"(?s)Series\.map_elements.*s\.\w+\("
     ):
-        s = pl.Series("srs", data)
+        s = pl.Series(name, data)
 
         parser = BytecodeParser(func, map_target="series")
         suggested_expression = parser.to_expression(s.name)
@@ -450,8 +487,7 @@ def test_expr_exact_warning_message() -> None:
         f'  {green}+ pl.col("a") + 1{end_escape}\n'
     )
     # Check the EXACT warning message. If modifying the message in the future,
-    # please make sure to keep the `^` and `$`,
-    # and to keep the assertion on `len(warnings)`.
+    # make sure to keep the `^` and `$`, and keep the assertion on `len(warnings)`.
     with pytest.warns(PolarsInefficientMapWarning, match=rf"^{msg}$") as warnings:
         df = pl.DataFrame({"a": [1, 2, 3]})
         df.select(pl.col("a").map_elements(lambda x: x + 1, return_dtype=pl.Int64))


### PR DESCRIPTION
* Extended `BytecodeParser` so that it also identifies functions imported directly into the global namespace (previously would only have identified the more explicit `np.log10` or `numpy.log10` form), eg:
  ```python
  from numpy import log10

  df.with_columns(pl.col("x").map_elements(lambda x: log10(x)))
  df.with_columns(pl.col("x").map_elements(log10))

  # PolarsInefficientMapWarning: 
  # Expr.map_elements is significantly slower than the native expressions API.
  # Only use if you absolutely CANNOT implement your logic otherwise.
  # Replace this expression...
  #   - pl.col("x").map_elements(np.log10)
  # with this one instead:
  #   + pl.col("x").log10()

  ```
* Added detection of `math` module functions (also works with global namespace detection).
  ```python
  import math
  
  df = pl.DataFrame({"x": [1,2,3]})
  df.with_columns(pl.col("x").map_elements(math.log10))

  # PolarsInefficientMapWarning: 
  # Expr.map_elements is significantly slower than the native expressions API.
  # Only use if you absolutely CANNOT implement your logic otherwise.
  # Replace this expression...
  #   - pl.col("x").map_elements(math.log10)
  # with this one instead:
  #   + pl.col("x").log10()
  ```
* Fixed detection of inefficient `map_*` calls on `Series` with the default (empty string) name (ref: https://github.com/pola-rs/polars/issues/15587#issuecomment-2049753474).
* Fixed an edge-case involving `_caller_variables` (should have been an instance var, not a class var).
* Fixed a minor mismatch in the generated warning for `Series` where the before/after target name wasn't the same.