### PR TITLE
chore: make Duration.is_constant_duration less strict for non-timezone-aware case

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -269,7 +269,7 @@ pub(super) fn date_offset(s: &[Series]) -> PolarsResult<Series> {
                         let offset = Duration::parse(offset);
                         tz.is_none()
                             || tz.as_deref() == Some("UTC")
-                            || offset.is_constant_duration()
+                            || offset.is_constant_duration(tz.as_deref())
                     },
                     None => false,
                 },

--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -32,7 +32,7 @@ pub struct Duration {
     months: i64,
     // the number of weeks for the duration
     weeks: i64,
-    // the number of nanoseconds for the duration
+    // the number of days for the duration
     days: i64,
     // the number of nanoseconds for the duration
     nsecs: i64,
@@ -363,8 +363,14 @@ impl Duration {
         self.nsecs == 0
     }
 
-    pub fn is_constant_duration(&self) -> bool {
-        self.months == 0 && self.weeks == 0 && self.days == 0
+    pub fn is_constant_duration(&self, time_zone: Option<&str>) -> bool {
+        if time_zone.is_none() || time_zone == Some("UTC") {
+            self.months == 0
+        } else {
+            // For non-native, non-UTC time zones, 1 calendar day is not
+            // necessarily 24 hours due to daylight savings time.
+            self.months == 0 && self.weeks == 0 && self.days == 0
+        }
     }
 
     /// Returns the nanoseconds from the `Duration` without the weeks or months part.
@@ -372,7 +378,7 @@ impl Duration {
         self.nsecs
     }
 
-    /// Estimated duration of the window duration. Not a very good one if months != 0.
+    /// Estimated duration of the window duration. Not a very good one if not a constant duration.
     #[doc(hidden)]
     pub const fn duration_ns(&self) -> i64 {
         self.months * 28 * 24 * 3600 * NANOSECONDS


### PR DESCRIPTION
splitting this off from https://github.com/pola-rs/polars/pull/15638

There's currently a method `Duration.is_constant_duration`, which returns `false` if the duration contains calendar durations (months, weeks, days).
However, for the time-zone-naive case (and the UTC case), days and weeks are constant durations too, as they're not affected by daylight saving time

There's no implication for the current tests (but it will help with #15638, as there `half_life` has to be a constant duration)