### PR TITLE
fix: correct the error message for non-parquet file type and non-python api

### DIFF
--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -139,16 +139,16 @@ pub fn create_physical_plan(
         PythonScan { options, .. } => Ok(Box::new(executors::PythonScanExec { options })),
         Sink { payload, .. } => match payload {
             SinkType::Memory => {
-                polars_bail!(InvalidOperation: "memory sink not supported in the standard engine.")
+                polars_bail!(InvalidOperation: "memory sink not supported in the standard engine")
             },
             SinkType::File { file_type, .. } => {
                 polars_bail!(InvalidOperation:
-                    "sink_{file_type:?} not yet supported in standard engine."
+                    "sink_{file_type:?} not yet supported in standard engine. Use 'collect().write_{file_type:?}()'"
                 )
             },
             #[cfg(feature = "cloud")]
             SinkType::Cloud { .. } => {
-                polars_bail!(InvalidOperation: "cloud sink not supported in standard engine.")
+                polars_bail!(InvalidOperation: "cloud sink not supported in standard engine")
             },
         },
         Union { inputs, options } => {

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -143,7 +143,7 @@ pub fn create_physical_plan(
             },
             SinkType::File { file_type, .. } => {
                 polars_bail!(InvalidOperation:
-                    "sink_{file_type:?} not yet supported in standard engine. Use 'collect().write_{file_type:?}()'"
+                    "sink_{file_type} not yet supported in standard engine. Use 'collect().write_{file_type}()'"
                 )
             },
             #[cfg(feature = "cloud")]

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -139,11 +139,11 @@ pub fn create_physical_plan(
         PythonScan { options, .. } => Ok(Box::new(executors::PythonScanExec { options })),
         Sink { payload, .. } => match payload {
             SinkType::Memory => {
-                polars_bail!(InvalidOperation: "memory sink not supported in the standard engine")
+                polars_bail!(InvalidOperation: "memory sink not supported in the standard engine.")
             },
             SinkType::File { file_type, .. } => {
                 polars_bail!(InvalidOperation:
-                    "sink_{file_type:?} not yet supported in standard engine. Use 'collect().write_parquet()'"
+                    "sink_{file_type:?} not yet supported in standard engine."
                 )
             },
             #[cfg(feature = "cloud")]

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -342,7 +342,8 @@ pub struct FileSinkOptions {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, strum_macros::Display)]
+#[strum(serialize_all = "lowercase")]
 pub enum FileType {
     #[cfg(feature = "parquet")]
     Parquet(ParquetWriteOptions),


### PR DESCRIPTION
The current error message is incorrect under several conditions and is worth correcting.

1. `write_parquet()` etc. does not exist in Rust.
2. A message will be displayed telling us to use `write_parquet()` for file formats other than Parquet.

```python
In [1]: import polars as pl

In [2]: pl.DataFrame({"foo": [1]}).write_ipc("test.arrow")

In [3]: pl.scan_ipc("test.arrow").select(pl.col("foo") * 2).sink_ipc("test2.arrow")
---------------------------------------------------------------------------
InvalidOperationError                     Traceback (most recent call last)
Cell In[3], line 1
----> 1 pl.scan_ipc("test.arrow").select(pl.col("foo") * 2).sink_ipc("test2.arrow")

File ~/.local/lib/python3.10/site-packages/polars/_utils/unstable.py:59, in unstable.<locals>.decorate.<locals>.wrapper(*args, **kwargs)
     56 @wraps(function)
     57 def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
     58     issue_unstable_warning(f"`{function.__name__}` is considered unstable.")
---> 59     return function(*args, **kwargs)

File ~/.local/lib/python3.10/site-packages/polars/lazyframe/frame.py:2271, in LazyFrame.sink_ipc(self, path, compression, maintain_order, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, no_optimization)
   2221 """
   2222 Evaluate the query in streaming mode and write to an IPC file.
   2223 
   (...)
   2260 >>> lf.sink_ipc("out.arrow")  # doctest: +SKIP
   2261 """
   2262 lf = self._set_sink_optimizations(
   2263     type_coercion=type_coercion,
   2264     predicate_pushdown=predicate_pushdown,
   (...)
   2268     no_optimization=no_optimization,
   2269 )
-> 2271 return lf.sink_ipc(
   2272     path=path,
   2273     compression=compression,
   2274     maintain_order=maintain_order,
   2275 )

InvalidOperationError: sink_Ipc(IpcWriterOptions { compression: Some(ZSTD), maintain_order: true }) not yet supported in standard engine. Use 'collect().write_parquet()'
```

It could be changed to a longer error message including what to do in Rust and in Python, respectively, but I thought a shorter error message would be preferred here, given the other sections.