### PR TITLE
refactor(rust!): rename `memmap` -> `memory_map` as like Python

### DIFF
--- a/crates/polars-arrow/src/mmap/mod.rs
+++ b/crates/polars-arrow/src/mmap/mod.rs
@@ -52,7 +52,7 @@ fn read_message(
 fn get_buffers_nodes(batch: RecordBatchRef) -> PolarsResult<(VecDeque<IpcBuffer>, VecDeque<Node>)> {
     let compression = batch.compression().map_err(to_compute_err)?;
     if compression.is_some() {
-        polars_bail!(ComputeError: "mmap can only be done on uncompressed IPC files")
+        polars_bail!(ComputeError: "memory_map can only be done on uncompressed IPC files")
     }
 
     let buffers = batch

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -71,16 +71,16 @@ pub struct IpcReader<R: MmapBytesReader> {
     pub(super) projection: Option<Vec<usize>>,
     pub(crate) columns: Option<Vec<String>>,
     pub(super) row_index: Option<RowIndex>,
-    memmap: bool,
+    memory_map: bool,
     metadata: Option<read::FileMetadata>,
     schema: Option<ArrowSchemaRef>,
 }
 
 fn check_mmap_err(err: PolarsError) -> PolarsResult<()> {
     if let PolarsError::ComputeError(s) = &err {
-        if s.as_ref() == "mmap can only be done on uncompressed IPC files" {
+        if s.as_ref() == "memory_map can only be done on uncompressed IPC files" {
             eprintln!(
-                "Could not mmap compressed IPC file, defaulting to normal read. \
+                "Could not memory_map compressed IPC file, defaulting to normal read. \
                 Toggle off 'memory_map' to silence this warning."
             );
             return Ok(());
@@ -131,7 +131,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
 
     /// Set if the file is to be memory_mapped. Only works with uncompressed files.
     pub fn memory_mapped(mut self, toggle: bool) -> Self {
-        self.memmap = toggle;
+        self.memory_map = toggle;
         self
     }
 
@@ -142,7 +142,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
         predicate: Option<Arc<dyn PhysicalIoExpr>>,
         verbose: bool,
     ) -> PolarsResult<DataFrame> {
-        if self.memmap && self.reader.to_file().is_some() {
+        if self.memory_map && self.reader.to_file().is_some() {
             if verbose {
                 eprintln!("memory map ipc file")
             }
@@ -191,7 +191,7 @@ impl<R: MmapBytesReader> SerReader<R> for IpcReader<R> {
             columns: None,
             projection: None,
             row_index: None,
-            memmap: true,
+            memory_map: true,
             metadata: None,
             schema: None,
         }
@@ -203,7 +203,7 @@ impl<R: MmapBytesReader> SerReader<R> for IpcReader<R> {
     }
 
     fn finish(mut self) -> PolarsResult<DataFrame> {
-        if self.memmap && self.reader.to_file().is_some() {
+        if self.memory_map && self.reader.to_file().is_some() {
             match self.finish_memmapped(None) {
                 Ok(df) => return Ok(df),
                 Err(err) => check_mmap_err(err)?,

--- a/crates/polars-lazy/src/physical_plan/executors/scan/ipc.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/ipc.rs
@@ -107,7 +107,7 @@ impl IpcExec {
                     )
                     .with_row_index(self.file_options.row_index.clone())
                     .with_projection(projection.clone())
-                    .memory_mapped(self.options.memmap)
+                    .memory_mapped(self.options.memory_map)
                     .finish()?;
 
                 row_counter

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -12,7 +12,7 @@ pub struct ScanArgsIpc {
     pub cache: bool,
     pub rechunk: bool,
     pub row_index: Option<RowIndex>,
-    pub memmap: bool,
+    pub memory_map: bool,
     pub cloud_options: Option<CloudOptions>,
 }
 
@@ -23,7 +23,7 @@ impl Default for ScanArgsIpc {
             cache: true,
             rechunk: false,
             row_index: None,
-            memmap: true,
+            memory_map: true,
             cloud_options: Default::default(),
         }
     }
@@ -67,7 +67,7 @@ impl LazyFileListReader for LazyIpcReader {
         };
 
         let options = IpcScanOptions {
-            memmap: args.memmap,
+            memory_map: args.memory_map,
         };
 
         let mut lf: LazyFrame = LogicalPlanBuilder::scan_ipc(

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -415,7 +415,7 @@ fn test_ipc_globbing() -> PolarsResult<()> {
             cache: true,
             rechunk: false,
             row_index: None,
-            memmap: true,
+            memory_map: true,
             cloud_options: None,
         },
     )?

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -112,7 +112,7 @@ pub struct JsonWriterOptions {
 #[derive(Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IpcScanOptions {
-    pub memmap: bool,
+    pub memory_map: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -358,7 +358,7 @@ impl PyLazyFrame {
             cache,
             rechunk,
             row_index,
-            memmap: memory_map,
+            memory_map,
             #[cfg(feature = "cloud")]
             cloud_options,
         };


### PR DESCRIPTION
When reading an Arrow IPC file, the following warning message may appear, but it may be unclear what it means because the Rust API uses `memmap` instead of `memory_map`.

https://github.com/pola-rs/polars/blob/7341aeeac16e77ccdbf5fdaf2fec5ab40beafea9/crates/polars-io/src/ipc/ipc_file.rs#L84

This PR updates `memmap` arguments to `memory_map`