### PR TITLE
docs(python): Various deprecation docstring improvements

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -297,6 +297,7 @@ __all__ = [
     "PolarsDataType",
     # polars.io
     "read_avro",
+    "read_clipboard",
     "read_csv",
     "read_csv_batched",
     "read_database",
@@ -318,7 +319,6 @@ __all__ = [
     "scan_ndjson",
     "scan_parquet",
     "scan_pyarrow_dataset",
-    "read_clipboard",
     # polars.stringcache
     "StringCache",
     "disable_string_cache",

--- a/py-polars/polars/_utils/deprecation.py
+++ b/py-polars/polars/_utils/deprecation.py
@@ -80,7 +80,7 @@ def deprecate_parameter_as_positional(
     old_name: str, *, version: str
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
-    Decorator to mark a function argument as deprecated due to being made positinoal.
+    Decorator to mark a function argument as deprecated due to being made positional.
 
     Use as follows::
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4792,7 +4792,7 @@ class DataFrame:
         """
         Add a column at index 0 that counts the rows.
 
-        .. deprecated::
+        .. deprecated:: 0.20.4
             Use :meth:`with_row_index` instead.
             Note that the default column name has changed from 'row_nr' to 'index'.
 

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -193,7 +193,7 @@ class ExprDateTimeNameSpace:
             - `False`: use the latest datetime
 
             .. deprecated:: 0.19.0
-                This is now auto-inferred, you can safely remove this argument.
+                This is now automatically inferred; you can safely omit this argument.
         ambiguous
             Determine how to deal with ambiguous datetimes:
 

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -193,7 +193,7 @@ class ExprDateTimeNameSpace:
             - `False`: use the latest datetime
 
             .. deprecated:: 0.19.0
-                Use `ambiguous` instead
+                This is now auto-inferred, you can safely remove this argument.
         ambiguous
             Determine how to deal with ambiguous datetimes:
 

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2586,7 +2586,7 @@ class ExprStringNameSpace:
         """
         return self.pad_start(length, fill_char)
 
-    @deprecate_renamed_function("json_decode", version="0.19.12")
+    @deprecate_renamed_function("json_decode", version="0.19.15")
     def json_extract(
         self,
         dtype: PolarsDataType | None = None,

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -15,6 +15,7 @@ from polars.io.spreadsheet import read_excel, read_ods
 
 __all__ = [
     "read_avro",
+    "read_clipboard",
     "read_csv",
     "read_csv_batched",
     "read_database",
@@ -36,5 +37,4 @@ __all__ = [
     "scan_ndjson",
     "scan_parquet",
     "scan_pyarrow_dataset",
-    "read_clipboard",
 ]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4712,7 +4712,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Add a column at index 0 that counts the rows.
 
-        .. deprecated::
+        .. deprecated:: 0.20.4
             Use :meth:`with_row_index` instead.
             Note that the default column name has changed from 'row_nr' to 'index'.
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1694,7 +1694,7 @@ class DateTimeNameSpace:
             - `False`: use the latest datetime
 
             .. deprecated:: 0.19.0
-                Use `ambiguous` instead
+                This is now auto-inferred, you can safely remove this argument.
         ambiguous
             Determine how to deal with ambiguous datetimes:
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1694,7 +1694,7 @@ class DateTimeNameSpace:
             - `False`: use the latest datetime
 
             .. deprecated:: 0.19.0
-                This is now auto-inferred, you can safely remove this argument.
+                This is now automatically inferred; you can safely omit this argument.
         ambiguous
             Determine how to deal with ambiguous datetimes:
 


### PR DESCRIPTION
- added "Deprecated since version" to `DataFrame/LazyFrame.with_row_count`
- fix deprecated version in `Expr.str.json_extract`
  -  was discrepancy between decorator and docstring. 0.19.15 is correct.
- do not advise use of deprecated `ambiguous` parameter as a replacement for `use_earliest` parameter in `Series/Expr.dt.truncate`

Drive bys:
- alphabetise `read_clipboard` inside `__all__`
- spelling mistake