### PR TITLE
fix: Correct the unsoundness slice range of `arr.min/max`

### DIFF
--- a/crates/polars-ops/src/chunked_array/array/min_max.rs
+++ b/crates/polars-ops/src/chunked_array/array/min_max.rs
@@ -25,7 +25,9 @@ where
         (0..values.len())
             .step_by(width)
             .map(|start| {
-                let sliced = unsafe { values.clone().sliced_unchecked(start, start + width) };
+                // SAFETY: This value array from a FixedSizeListArray,
+                // we can ensure that `start + width` will not out out range
+                let sliced = unsafe { values.clone().sliced_unchecked(start, width) };
                 arr_agg(&sliced)
             })
             .collect_arr()

--- a/py-polars/tests/unit/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/namespaces/array/test_array.py
@@ -15,6 +15,10 @@ def test_arr_min_max() -> None:
     assert s.arr.max().to_list() == [2, 4]
     assert s.arr.min().to_list() == [1, 3]
 
+    s_with_null = pl.Series("a", [[None, 2], None, [3, 4]], dtype=pl.Array(pl.Int64, 2))
+    assert s_with_null.arr.max().to_list() == [2, None, 4]
+    assert s_with_null.arr.min().to_list() == [2, None, 3]
+
 
 def test_array_min_max_dtype_12123() -> None:
     df = pl.LazyFrame(


### PR DESCRIPTION
This fixes #15646.