### PR TITLE
chore(rust): Remove the remaining usage of deprecated `numpy` crate APIs

### DIFF
--- a/py-polars/src/series/numpy_ufunc.rs
+++ b/py-polars/src/series/numpy_ufunc.rs
@@ -20,7 +20,7 @@ use crate::series::PySeries;
 unsafe fn aligned_array<T: Element + NativeType>(
     py: Python<'_>,
     size: usize,
-) -> (&PyArray1<T>, Vec<T>) {
+) -> (Bound<'_, PyArray1<T>>, Vec<T>) {
     let mut buf = vec![T::default(); size];
 
     // modified from
@@ -44,8 +44,9 @@ unsafe fn aligned_array<T: Element + NativeType>(
         ptr::null_mut(),            //obj
     );
     (
-        #[allow(deprecated)] // This will be removed as part of #15215
-        PyArray1::from_owned_ptr(py, ptr),
+        Bound::from_owned_ptr(py, ptr)
+            .downcast_into_exact::<PyArray1<T>>()
+            .unwrap(),
         buf,
     )
 }
@@ -53,7 +54,7 @@ unsafe fn aligned_array<T: Element + NativeType>(
 /// Get reference counter for numpy arrays.
 ///   - For CPython: Get reference counter.
 ///   - For PyPy: Reference counters for a live PyPy object = refcnt + 2 << 60.
-fn get_refcnt<T>(pyarray: &PyArray1<T>) -> isize {
+fn get_refcnt<T>(pyarray: &Bound<'_, PyArray1<T>>) -> isize {
     let refcnt = pyarray.get_refcnt();
     if refcnt >= (2 << 60) {
         refcnt - (2 << 60)
@@ -77,17 +78,17 @@ macro_rules! impl_ufuncs {
                     let (out_array, av) =
                         unsafe { aligned_array::<<$type as PolarsNumericType>::Native>(py, size) };
 
-                    debug_assert_eq!(get_refcnt(out_array), 1);
+                    debug_assert_eq!(get_refcnt(&out_array), 1);
                     // inserting it in a tuple increase the reference count by 1.
-                    let args = PyTuple::new(py, &[out_array]);
-                    debug_assert_eq!(get_refcnt(out_array), 2);
+                    let args = PyTuple::new(py, &[out_array.clone()]);
+                    debug_assert_eq!(get_refcnt(&out_array), 2);
 
                     // whatever the result, we must take the leaked memory ownership back
                     let s = match lambda.call1(args) {
                         Ok(_) => {
                             // if this assert fails, the lambda has taken a reference to the object, so we must panic
                             // args and the lambda return have a reference, making a total of 3
-                            assert_eq!(get_refcnt(out_array), 3);
+                            assert_eq!(get_refcnt(&out_array), 3);
 
                             let validity = self.series.chunks()[0].validity().cloned();
                             let ca =


### PR DESCRIPTION
Fixes #15666

(There are still many deprecated _PyO3_ APIs being used, suppressed by the `gil-refs` feature of the `pyo3` crate, so that's what I will be looking at next.)