### PR TITLE
docs: Update the Overview section of the contributing guide

### DIFF
--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -140,7 +140,8 @@ First ensure that your local `main` branch is in sync with the remote `main` bra
 
 ```bash
 git checkout main
-git pull upstream main
+git fetch upstream
+git rebase upstream/main
 ```
 
 Next, create a new git branch (feature branch) from the `main` branch in your local repository with

--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -126,13 +126,34 @@ If this all runs correctly, you're ready to start contributing to the Polars cod
 If you still encounter an error message about a missing dependency after having run `make requirements`,
 try running `make requirements-all` to install _all_ known dependencies).
 
-### Keeping your local environment up to date
 
-Note that dependencies are inevitably updated over time; this includes both the packages that we depend on
-in the code, and the formatting and linting tools we use. In order to simplify keeping your local environment
-current, there is the `make requirements` command. This command will update all Python dependencies and tools
-to their latest specified versions. Running this command in case of an unexpected error after updating the
-Polars codebase is often a good idea.
+#### Updating the development environment
+
+Dependencies are updated regulary - at least once per month.
+If you do not keep your environment up-to-date, you may notice tests or CI checks failing, or you may not be able to build Polars at all.
+
+To keep your fork in sync with the Polars repository, run:
+
+```bash
+git checkout main
+git fetch upstream
+git rebase upstream/main
+git push origin main
+```
+
+Update all Python dependencies to their latest versions by running:
+
+```bash
+make requirements
+```
+
+If the Rust toolchain version has been updated, you should update your Rust toolchain.
+Follow it up by running `cargo clean` to make sure your Cargo folder does not grow too large:
+
+```bash
+rustup update
+cargo clean
+```
 
 ### Working on your issue
 
@@ -229,32 +250,6 @@ source .venv/bin/activate
 When you are finished with making updates to your pull request, follow the steps under "Pushing your changes to GitHub" (see above).
 
 Your changes will appear on your pull request on GitHub and automatically trigger the Continuous Integration pipeline.
-
-## Updating the development environment
-
-For repeatedly contributing to Polars, the development environment needs to be updated periodically.
-
-To keep your fork in sync with the Polars repository run:
-
-```bash
-git checkout main
-git fetch upstream
-git rebase upstream/main
-git push origin main
-```
-
-For updating the project's dependencies and building and installing Python Polars run:
-
-```bash
-make requirements
-make build
-```
-
-In order to avoid running out of memory (how often depends on your machine), you should occasionally run:
-
-```bash
-cargo clean
-```
 
 ## Contributing to documentation
 

--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -242,10 +242,11 @@ git rebase upstream/main
 git push origin main
 ```
 
-For updating the project's dependencies run:
+For updating the project's dependencies and building and installing Python Polars run:
 
 ```bash
 make requirements
+make build
 ```
 
 In order to avoid running out of memory (how often depends on your machine), you should occasionally run:

--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -212,7 +212,7 @@ To stay up to date with the Polars repository, it is useful to periodically sync
 ```bash
 git checkout shiny-new-feature
 git fetch upstream
-git merge upstream/main
+git rebase upstream/main
 ```
 
 If the changes in both branches are incompatible, merge conflicts appear which need to be resolved before you can continue.
@@ -228,6 +228,31 @@ source .venv/bin/activate
 When you are finished with making updates to your pull request, follow the steps under "Pushing your changes to GitHub" (see above).
 
 Your changes will appear on your pull request on GitHub and automatically trigger the Continuous Integration pipeline.
+
+## Updating the development environment
+
+For repeatedly contributing to Polars, the development environment needs to be updated periodically.
+
+To keep your fork in sync with the Polars repository run:
+
+```bash
+git checkout main
+git fetch upstream
+git rebase upstream/main
+git push origin main
+```
+
+For updating the project's dependencies run:
+
+```bash
+make requirements
+```
+
+In order to avoid running out of memory (how often depends on your machine), you should occasionally run:
+
+```bash
+cargo clean
+```
 
 ## Contributing to documentation
 

--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -42,36 +42,33 @@ You may use the issue to discuss possible solutions.
 
 ### Setting up your local environment
 
-Polars development flow relies on both Rust and Python, which means setting up your local development environment is not trivial.
+The Polars development flow relies on both Rust and Python, which means setting up your local development environment is not trivial.
 If you run into problems, please contact us on [Discord](https://discord.gg/4UfP5cfBE7).
 
-_Note that if you are a Windows user, the steps below might not work as expected; try developing using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)._
-_Under native Windows, you may have to manually copy the contents of `toolchain.toml` to `py-polars/toolchain.toml`, as Git for Windows may not correctly handle symbolic links._
+!!! note
+
+    If you are a Windows user, the steps below might not work as expected.
+    Try developing using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
+    Under native Windows, you may have to manually copy the contents of `toolchain.toml` to `py-polars/toolchain.toml`, as Git for Windows may not correctly handle symbolic links.
+
+#### Configuring Git
 
 For contributing to Polars you need a free [GitHub account](https://github.com) and have [git](https://git-scm.com) installed on your machine.
-Start by [forking](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the Polars repository. Then clone your forked repository using `git` and set the `upstream` remote for being able to sync your fork with the Polars repository:
+Start by [forking](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the Polars repository, then clone your forked repository using `git`:
 
 ```bash
 git clone https://github.com/<username>/polars.git
 cd polars
+```
+
+Optionally set the `upstream` remote to be able to sync your fork with the Polars repository in the future:
+
+```bash
 git remote add upstream https://github.com/pola-rs/polars.git
 git fetch upstream
 ```
 
-Check that everything is configured correctly by running
-
-```bash
-git remote -v
-```
-
-which should give the following output:
-
-```bash
-origin	https://github.com/<username>/polars.git (fetch)
-origin	https://github.com/<username>/polars.git (push)
-upstream	https://github.com/pola-rs/polars.git (fetch)
-upstream	https://github.com/pola-rs/polars.git (push)
-```
+#### Installing dependencies
 
 In order to work on Polars effectively, you will need [Rust](https://www.rust-lang.org/), [Python](https://www.python.org/), and [dprint](https://dprint.dev/).
 
@@ -101,9 +98,15 @@ make test
 This will do a number of things:
 
 - Use Python to create a virtual environment in the `.venv` folder.
-- Use [pip](https://pip.pypa.io/) to install all Python dependencies for development, linting, and building documentation.
+- Use [pip](https://pip.pypa.io/) and [uv](https://github.com/astral-sh/uv) to install all Python dependencies for development, linting, and building documentation.
 - Use Rust to compile and install Polars in your virtual environment. _At least 8GB of RAM is recommended for this step to run smoothly._
 - Use [pytest](https://docs.pytest.org/) to run the Python unittests in your virtual environment
+
+!!! note
+
+    There are a small number of specialized dependencies that are not installed by default.
+    If you are running specific tests and encounter an error message about a missing dependency,
+    try running `make requirements-all` to install _all_ known dependencies).
 
 Check if linting also works correctly by running:
 
@@ -122,17 +125,12 @@ We use the Makefile to conveniently run the following formatting and linting too
 
 If this all runs correctly, you're ready to start contributing to the Polars codebase!
 
-(Note: there are a very small number of specialized dependencies that are not installed by default.
-If you still encounter an error message about a missing dependency after having run `make requirements`,
-try running `make requirements-all` to install _all_ known dependencies).
-
-
 #### Updating the development environment
 
-Dependencies are updated regulary - at least once per month.
+Dependencies are updated regularly - at least once per month.
 If you do not keep your environment up-to-date, you may notice tests or CI checks failing, or you may not be able to build Polars at all.
 
-To keep your fork in sync with the Polars repository, run:
+To update your environment, first make sure your fork is in sync with the Polars repository:
 
 ```bash
 git checkout main
@@ -157,21 +155,7 @@ cargo clean
 
 ### Working on your issue
 
-First ensure that your local `main` branch is in sync with the remote `main` branch of Polars:
-
-```bash
-git checkout main
-git fetch upstream
-git rebase upstream/main
-```
-
-Next, create a new git branch (feature branch) from the `main` branch in your local repository with
-
-```bash
-git checkout -b my-feature-branch
-```
-
-and start coding! Always make your changes in a feature branch and use one feature branch per bug or feature.
+Create a new git branch from the `main` branch in your local repository, and start coding!
 
 The Rust code is located in the `crates` directory, while the Python codebase is located in the `py-polars` directory.
 Both directories contain a `Makefile` with helpful commands. Most notably:
@@ -186,26 +170,6 @@ Two other things to keep in mind:
 
 - If you add code that should be tested, add tests.
 - If you change the public API, [update the documentation](#api-reference).
-
-#### Pushing your changes to GitHub
-
-Once you're finished with your work, make sure to add all changed files to the staging area with
-
-```bash
-git add path/to/file
-```
-
-and commit your changes by running
-
-```bash
-git commit -m "commit type and short description of your changes"
-```
-
-To push your changes from your local machine to your Polars fork on GitHub, run:
-
-```bash
-git push -u origin my-feature-branch
-```
 
 ### Pull requests
 
@@ -225,32 +189,6 @@ Once all issues are resolved, the maintainer will merge your pull request, and y
 Keep in mind that your work does not have to be perfect right away!
 If you are stuck or unsure about your solution, feel free to open a draft pull request and ask for help.
 
-#### Updating a pull request
-
-Many pull requests go through cycles of repeated reviews and updates before they get merged into the `main` branch of the Polars repository.
-
-To stay up to date with the Polars repository, it is useful to periodically sync your local feature branch with the changes in the remote `main` branch of Polars:
-
-```bash
-git checkout shiny-new-feature
-git fetch upstream
-git rebase upstream/main
-```
-
-If the changes in both branches are incompatible, merge conflicts appear which need to be resolved before you can continue.
-
-Refer to [this guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line) for how to resolve merge conflicts.
-
-To continue working on your pull request, activate your virtual environment from the root of the Polars repo with:
-
-```bash
-source .venv/bin/activate
-```
-
-When you are finished with making updates to your pull request, follow the steps under "Pushing your changes to GitHub" (see above).
-
-Your changes will appear on your pull request on GitHub and automatically trigger the Continuous Integration pipeline.
-
 ## Contributing to documentation
 
 The most important components of Polars documentation are the [user guide](https://docs.pola.rs/user-guide/), the [API references](https://docs.pola.rs/api/), and the database of questions on [StackOverflow](https://stackoverflow.com/).
@@ -263,7 +201,7 @@ The user guide is maintained in the `docs/user-guide` folder. Before creating a 
 
 The user guide is built using [MkDocs](https://www.mkdocs.org/). You install the dependencies for building the user guide by running `make build` in the root of the repo.
 
-Activate the virtual environment with the command `source .venv/bin/activate` and run `mkdocs serve` to build and serve the user guide, so you can view it locally and see updates as you make changes.
+Activate the virtual environment and run `mkdocs serve` to build and serve the user guide, so you can view it locally and see updates as you make changes.
 
 #### Creating a new user guide page
 

--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -48,11 +48,29 @@ If you run into problems, please contact us on [Discord](https://discord.gg/4UfP
 _Note that if you are a Windows user, the steps below might not work as expected; try developing using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)._
 _Under native Windows, you may have to manually copy the contents of `toolchain.toml` to `py-polars/toolchain.toml`, as Git for Windows may not correctly handle symbolic links._
 
-Start by [forking](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the Polars repository, then clone your forked repository using `git`:
+For contributing to Polars you need a free [GitHub account](https://github.com) and have [git](https://git-scm.com) installed on your machine.
+Start by [forking](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the Polars repository. Then clone your forked repository using `git` and set the `upstream` remote for being able to sync your fork with the Polars repository:
 
 ```bash
 git clone https://github.com/<username>/polars.git
 cd polars
+git remote add upstream https://github.com/pola-rs/polars.git
+git fetch upstream
+```
+
+Check that everything is configured correctly by running
+
+```bash
+git remote -v
+```
+
+which should give the following output:
+
+```bash
+origin	https://github.com/<username>/polars.git (fetch)
+origin	https://github.com/<username>/polars.git (push)
+upstream	https://github.com/pola-rs/polars.git (fetch)
+upstream	https://github.com/pola-rs/polars.git (push)
 ```
 
 In order to work on Polars effectively, you will need [Rust](https://www.rust-lang.org/), [Python](https://www.python.org/), and [dprint](https://dprint.dev/).
@@ -66,7 +84,7 @@ rustup toolchain install nightly --component miri
 
 Next, install Python, for example using [pyenv](https://github.com/pyenv/pyenv#installation).
 We recommend using the latest Python version (`3.12`).
-Make sure you deactivate any active virtual environments or conda environments, as the steps below will create a new virtual environment for Polars.
+Make sure you deactivate any active virtual environments (command: `deactivate`) or conda environments (command: `conda deactivate`), as the steps below will create a new [virtual environment](https://docs.python.org/3/tutorial/venv.html) for Polars.
 You will need Python even if you intend to work on the Rust code only, as we rely on the Python tests to verify all functionality.
 
 Finally, install [dprint](https://dprint.dev/install/).
@@ -118,7 +136,20 @@ Polars codebase is often a good idea.
 
 ### Working on your issue
 
-Create a new git branch from the `main` branch in your local repository, and start coding!
+First ensure that your local `main` branch is in sync with the remote `main` branch of Polars:
+
+```bash
+git checkout main
+git pull upstream main
+```
+
+Next, create a new git branch (feature branch) from the `main` branch in your local repository with
+
+```bash
+git checkout -b my-feature-branch
+```
+
+and start coding! Always make your changes in a feature branch and use one feature branch per bug or feature.
 
 The Rust code is located in the `crates` directory, while the Python codebase is located in the `py-polars` directory.
 Both directories contain a `Makefile` with helpful commands. Most notably:
@@ -133,6 +164,26 @@ Two other things to keep in mind:
 
 - If you add code that should be tested, add tests.
 - If you change the public API, [update the documentation](#api-reference).
+
+#### Pushing your changes to GitHub
+
+Once you're finished with your work, make sure to add all changed files to the staging area with
+
+```bash
+git add path/to/file
+```
+
+and commit your changes by running
+
+```bash
+git commit -m "commit type and short description of your changes"
+```
+
+To push your changes from your local machine to your Polars fork on GitHub, run:
+
+```bash
+git push -u origin my-feature-branch
+```
 
 ### Pull requests
 
@@ -152,9 +203,35 @@ Once all issues are resolved, the maintainer will merge your pull request, and y
 Keep in mind that your work does not have to be perfect right away!
 If you are stuck or unsure about your solution, feel free to open a draft pull request and ask for help.
 
+#### Updating a pull request
+
+Many pull requests go through cycles of repeated reviews and updates before they get merged into the `main` branch of the Polars repository.
+
+To stay up to date with the Polars repository, it is useful to periodically sync your local feature branch with the changes in the remote `main` branch of Polars:
+
+```bash
+git checkout shiny-new-feature
+git fetch upstream
+git merge upstream/main
+```
+
+If the changes in both branches are incompatible, merge conflicts appear which need to be resolved before you can continue.
+
+Refer to [this guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line) for how to resolve merge conflicts.
+
+To continue working on your pull request, activate your virtual environment from the root of the Polars repo with:
+
+```bash
+source .venv/bin/activate
+```
+
+When you are finished with making updates to your pull request, follow the steps under "Pushing your changes to GitHub" (see above).
+
+Your changes will appear on your pull request on GitHub and automatically trigger the Continuous Integration pipeline.
+
 ## Contributing to documentation
 
-The most important components of Polars documentation are the [user guide](https://docs.pola.rs/user-guide/), the API references, and the database of questions on [StackOverflow](https://stackoverflow.com/).
+The most important components of Polars documentation are the [user guide](https://docs.pola.rs/user-guide/), the [API references](https://docs.pola.rs/api/), and the database of questions on [StackOverflow](https://stackoverflow.com/).
 
 ### User guide
 
@@ -164,7 +241,7 @@ The user guide is maintained in the `docs/user-guide` folder. Before creating a 
 
 The user guide is built using [MkDocs](https://www.mkdocs.org/). You install the dependencies for building the user guide by running `make build` in the root of the repo.
 
-Activate the virtual environment and run `mkdocs serve` to build and serve the user guide, so you can view it locally and see updates as you make changes.
+Activate the virtual environment with the command `source .venv/bin/activate` and run `mkdocs serve` to build and serve the user guide, so you can view it locally and see updates as you make changes.
 
 #### Creating a new user guide page
 


### PR DESCRIPTION
I extended the "Contributing to the codebase" section under "Development" to make it easier for people to contribute to the code base. Many career changers in IT belong to an underrepresented group in tech and therefore having a more detailed documentation on how to contribute has the potential to increase the diversity of contributors to Polars. The changes will also make it easier for you to run "Contributing to Polars" community sprints (e.g. at conferences) if you're interested in running these.

In my opinion it would also be helpful to have a section about "Updating the development environment". I wasn't entirely sure how to do it but it seems like people need to run 

```
git checkout main
git fetch upstream
git merge upstream/main
make test
```

(Please correct me if I'm wrong.)

I couldn't find an issue on the issue tracker about updating the "Development" documentation so I didn't link an issue here. However, I'm happy to open an issue about it and link this PR if you prefer.

PS: Your documentation on how to contribute to Polars is already pretty good! I enjoyed working through it and everything worked like a charm! :)