### PR TITLE
fix: `prepare_expression_for_context` shouldn't panic if exceptions raised from optimizer

### DIFF
--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -30,7 +30,7 @@ pub(crate) fn prepare_expression_for_context(
         .without_optimizations()
         .with_simplify_expr(true)
         .select([expr.clone()]);
-    let optimized = lf.optimize(&mut lp_arena, &mut expr_arena).unwrap();
+    let optimized = lf.optimize(&mut lp_arena, &mut expr_arena)?;
     let lp = lp_arena.get(optimized);
     let aexpr = lp.get_exprs().pop().unwrap();
 

--- a/py-polars/tests/unit/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/namespaces/list/test_list.py
@@ -904,3 +904,9 @@ def test_list_get_with_null() -> None:
     )
 
     assert_frame_equal(out, expected)
+
+
+def test_list_eval_err_raise_15653() -> None:
+    df = pl.DataFrame({"foo": [[]]})
+    with pytest.raises(pl.StructFieldNotFoundError):
+        df.with_columns(bar = pl.col("foo").list.eval(pl.element().struct.field("baz")))

--- a/py-polars/tests/unit/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/namespaces/list/test_list.py
@@ -909,4 +909,4 @@ def test_list_get_with_null() -> None:
 def test_list_eval_err_raise_15653() -> None:
     df = pl.DataFrame({"foo": [[]]})
     with pytest.raises(pl.StructFieldNotFoundError):
-        df.with_columns(bar = pl.col("foo").list.eval(pl.element().struct.field("baz")))
+        df.with_columns(bar=pl.col("foo").list.eval(pl.element().struct.field("baz")))


### PR DESCRIPTION
This fixes #15653.