### PR TITLE
docs(python): Align docstring phrasing in `Series/Expr.dt.truncate/round`

### DIFF
--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -202,7 +202,7 @@ class ExprDateTimeNameSpace:
             - `'latest'`: use the latest datetime
 
             .. deprecated:: 0.19.3
-                This is now auto-inferred, you can safely remove this argument.
+                This is now automatically inferred; you can safely omit this argument.
 
         Notes
         -----
@@ -321,12 +321,12 @@ class ExprDateTimeNameSpace:
 
         if use_earliest is not None:
             issue_deprecation_warning(
-                "`use_earliest` is deprecated. It is now auto-inferred, you can safely remove this argument.",
+                "`use_earliest` is deprecated. It is now automatically inferred; you can safely omit this argument.",
                 version="0.19.13",
             )
         if ambiguous is not None:
             issue_deprecation_warning(
-                "`ambiguous` is deprecated. It is now auto-inferred, you can safely remove this argument.",
+                "`ambiguous` is deprecated. It is now automatically inferred; you can safely omit this argument.",
                 version="0.19.13",
             )
         every = parse_as_expression(every, str_as_lit=True)
@@ -383,7 +383,7 @@ class ExprDateTimeNameSpace:
             - `'latest'`: use the latest datetime
 
             .. deprecated:: 0.19.3
-                This is now auto-inferred, you can safely remove this argument.
+                This is now automatically inferred; you can safely omit this argument.
 
         Returns
         -------
@@ -478,7 +478,7 @@ class ExprDateTimeNameSpace:
 
         if ambiguous is not None:
             issue_deprecation_warning(
-                "`ambiguous` is deprecated. It is now auto-inferred, you can safely remove this argument.",
+                "`ambiguous` is deprecated. It is now automatically inferred; you can safely omit this argument.",
                 version="0.19.13",
             )
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1703,7 +1703,7 @@ class DateTimeNameSpace:
             - `'latest'`: use the latest datetime
 
             .. deprecated:: 0.19.3
-                This is now auto-inferred, you can safely remove this argument.
+                This is now automatically inferred; you can safely omit this argument.
 
         Notes
         -----
@@ -1845,7 +1845,7 @@ class DateTimeNameSpace:
             - `'latest'`: use the latest datetime
 
             .. deprecated:: 0.19.3
-                This is now auto-inferred, you can safely remove this argument.
+                This is now automatically inferred; you can safely omit this argument.
 
         Returns
         -------


### PR DESCRIPTION
Continuation of https://github.com/pola-rs/polars/pull/15648
Applies suggested phrasing from that PR consistently throughout docstring and deprecation warning.