### PR TITLE
fix: pass series name to apply for cut/qcut

### DIFF
--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1414,6 +1414,10 @@ impl Expr {
             left_closed,
             include_breaks,
         })
+        .with_function_options(|mut opt| {
+            opt.pass_name_to_apply = true;
+            opt
+        })
     }
 
     #[cfg(feature = "cutqcut")]
@@ -1432,6 +1436,10 @@ impl Expr {
             left_closed,
             allow_duplicates,
             include_breaks,
+        })
+        .with_function_options(|mut opt| {
+            opt.pass_name_to_apply = true;
+            opt
         })
     }
 
@@ -1452,6 +1460,10 @@ impl Expr {
             left_closed,
             allow_duplicates,
             include_breaks,
+        })
+        .with_function_options(|mut opt| {
+            opt.pass_name_to_apply = true;
+            opt
         })
     }
 

--- a/py-polars/tests/unit/operations/test_cut.py
+++ b/py-polars/tests/unit/operations/test_cut.py
@@ -110,3 +110,13 @@ def test_cut_deprecated_label_name() -> None:
         s.cut([0.1], category_label="x")
     with pytest.deprecated_call():
         s.cut([0.1], break_point_label="x")
+
+
+def test_cut_bin_name_in_agg_context() -> None:
+    df = pl.DataFrame({"a": [1]}).select(
+        cut=pl.col("a").cut([1, 2], include_breaks=True).over(1),
+        qcut=pl.col("a").qcut([1], include_breaks=True).over(1),
+        qcut_uniform=pl.col("a").qcut(1, include_breaks=True).over(1),
+    )
+    schema = pl.Struct({"brk": pl.Float64, "a_bin": pl.Categorical("physical")})
+    assert df.schema == {"cut": schema, "qcut": schema, "qcut_uniform": schema}


### PR DESCRIPTION
We should pass the name to apply, otherwise the name of bin column will be `_bin`.