### PR TITLE
fix: raise if index count like 2i is used when performing rolling, group_by_dynamic, upsample, or other temporal operatios

### DIFF
--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -842,10 +842,12 @@ def test_upsample_index(
         ),
     ],
 )
+@pytest.mark.parametrize("maintain_order", [True, False])
 def test_upsample_index_invalid(
     df: pl.DataFrame,
     every: str,
     offset: str,
+    maintain_order: bool,
 ) -> None:
     df = pl.DataFrame(
         {
@@ -855,9 +857,14 @@ def test_upsample_index_invalid(
     ).set_sorted("index")
     # On Python3.8, mypy complains about combining two context managers into a
     # tuple, so we nest them instead.
-    with pytest.raises(ComputeError, match=r"cannot combine time .* integer"):  # noqa: SIM117
+    with pytest.raises(pl.InvalidOperationError, match=r"must be a parsed integer"):  # noqa: SIM117
         with pytest.deprecated_call():
-            df.upsample(time_column="index", every=every, offset=offset)
+            df.upsample(
+                time_column="index",
+                every=every,
+                offset=offset,
+                maintain_order=maintain_order,
+            )
 
 
 def test_microseconds_accuracy() -> None:

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -930,3 +930,28 @@ def test_rolling_returns_scalar_15656() -> None:
     result = df.group_by("c").agg(pl.col("b").rolling_mean("2d", by="a")).sort("c")
     expected = pl.DataFrame({"c": [1, 2, 3], "b": [[4.0], [5.0], [6.0]]})
     assert_frame_equal(result, expected)
+
+
+def test_rolling_invalid() -> None:
+    df = pl.DataFrame(
+        {
+            "values": [1, 4],
+            "times": [datetime(2020, 1, 3), datetime(2020, 1, 1)],
+        },
+    )
+    with pytest.raises(
+        pl.InvalidOperationError, match="duration may not be a parsed integer"
+    ):
+        (
+            df.sort("times")
+            .rolling("times", period="3000i")
+            .agg(pl.col("values").sum().alias("sum"))
+        )
+    with pytest.raises(
+        pl.InvalidOperationError, match="duration must be a parsed integer"
+    ):
+        (
+            df.with_row_index()
+            .rolling("index", period="3000d")
+            .agg(pl.col("values").sum().alias("sum"))
+        )


### PR DESCRIPTION
closes #15749
