### PR TITLE
feat(rust): Improves documentation for GCP and adds setters to ScanArgsParquet

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -354,10 +354,13 @@ impl CloudOptions {
     /// # Example
     ///
     /// ```
-    /// use polars::io::cloud::{ CloudOptions, GoogleConfigKey };
+    /// use polars_io::cloud::options::{ CloudOptions, GoogleConfigKey };
     ///
     /// let cloud_options = CloudOptions::default()
-    ///     .with_gcp([GoogleConfigKey::ServiceAccountKey, "*********"]);
+    ///     .with_gcp([
+    ///         (GoogleConfigKey::ServiceAccountKey, "*********"),
+    ///         (GoogleConfigKey::ServiceAccount, "path/to/sa.json"),
+    ///     ]);
     /// ```
     #[cfg(feature = "gcp")]
     pub fn with_gcp<I: IntoIterator<Item = (GoogleConfigKey, impl Into<String>)>>(

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -347,6 +347,18 @@ impl CloudOptions {
     }
 
     /// Set the configuration for GCP connections. This is the preferred API from rust.
+    ///
+    /// This method takes an iterator of tuples with the configuration
+    /// keys and values. The keys must be of type [`GoogleConfigKey`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use polars::io::cloud::{ CloudOptions, GoogleConfigKey };
+    ///
+    /// let cloud_options = CloudOptions::default()
+    ///     .with_gcp([GoogleConfigKey::ServiceAccountKey, "*********"]);
+    /// ```
     #[cfg(feature = "gcp")]
     pub fn with_gcp<I: IntoIterator<Item = (GoogleConfigKey, impl Into<String>)>>(
         mut self,

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -36,6 +36,63 @@ impl Default for ScanArgsParquet {
     }
 }
 
+impl ScanArgsParquet {
+    /// Setter for the `n_rows` field.
+    #[inline(always)]
+    pub fn n_rows(mut self, n_rows: Option<usize>) -> Self {
+        self.n_rows = n_rows;
+        self
+    }
+    /// Setter for the `cache` field.
+    #[inline(always)]
+    pub fn cache(mut self, cache: bool) -> Self {
+        self.cache = cache;
+        self
+    }
+    /// Setter for the `parallel` field.
+    #[inline(always)]
+    pub fn parallel(mut self, parallel: ParallelStrategy) -> Self {
+        self.parallel = parallel;
+        self
+    }
+    /// Setter for the `rechunk` field.
+    #[inline(always)]
+    pub fn rechunk(mut self, rechunk: bool) -> Self {
+        self.rechunk = rechunk;
+        self
+    }
+    /// Setter for the `row_index` field.
+    #[inline(always)]
+    pub fn row_index(mut self, row_index: Option<RowIndex>) -> Self {
+        self.row_index = row_index;
+        self
+    }
+    /// Setter for the `low_memory` field.
+    #[inline(always)]
+    pub fn low_memory(mut self, low_memory: bool) -> Self {
+        self.low_memory = low_memory;
+        self
+    }
+    /// Setter for the `cloud_options` field.
+    #[inline(always)]
+    pub fn cloud_options(mut self, cloud_options: Option<CloudOptions>) -> Self {
+        self.cloud_options = cloud_options;
+        self
+    }
+    /// Setter for the `use_statistics` field.
+    #[inline(always)]
+    pub fn use_statistics(mut self, use_statistics: bool) -> Self {
+        self.use_statistics = use_statistics;
+        self
+    }
+    /// Setter for the `hive_options` field.
+    #[inline(always)]
+    pub fn hive_options(mut self, hive_options: HiveOptions) -> Self {
+        self.hive_options = hive_options;
+        self
+    }
+}
+
 #[derive(Clone)]
 struct LazyParquetReader {
     args: ScanArgsParquet,


### PR DESCRIPTION
This is a very small PR that makes some small quality of life improvements. 

I added some setters for [ScanArgsParquet](https://docs.rs/polars/latest/polars/prelude/struct.ScanArgsParquet.html#) to make it easier to built these options.

I added some documentation for CloudOptions `with_gcp` to make it more clear on how to use.