### PR TITLE
feat: `dt.truncate` supports broadcasting lhs

### DIFF
--- a/crates/polars-time/src/truncate.rs
+++ b/crates/polars-time/src/truncate.rs
@@ -1,7 +1,8 @@
 use arrow::legacy::time_zone::Tz;
 use arrow::temporal_conversions::{MILLISECONDS, SECONDS_IN_DAY};
-use polars_core::chunked_array::ops::arity::try_binary_elementwise;
+use polars_core::prelude::arity::broadcast_try_binary_elementwise;
 use polars_core::prelude::*;
+use polars_utils::cache::FastFixedCache;
 
 use crate::prelude::*;
 
@@ -21,36 +22,25 @@ impl PolarsTruncate for DatetimeChunked {
             TimeUnit::Milliseconds => Window::truncate_ms,
         };
 
-        let out = match every.len() {
-            1 => {
-                if let Some(every) = every.get(0) {
-                    let every = Duration::parse(every);
-                    if every.negative {
-                        polars_bail!(ComputeError: "cannot truncate a Datetime to a negative duration")
-                    }
+        // A sqrt(n) cache is not too small, not too large.
+        let mut duration_cache = FastFixedCache::new((every.len() as f64).sqrt() as usize);
+        let out = broadcast_try_binary_elementwise(self, every, |opt_timestamp, opt_every| match (
+            opt_timestamp,
+            opt_every,
+        ) {
+            (Some(timestamp), Some(every)) => {
+                let every =
+                    *duration_cache.get_or_insert_with(every, |every| Duration::parse(every));
 
-                    let w = Window::new(every, every, offset);
-                    self.0
-                        .try_apply_nonnull_values_generic(|timestamp| func(&w, timestamp, tz))
-                } else {
-                    Ok(Int64Chunked::full_null(self.name(), self.len()))
+                if every.negative {
+                    polars_bail!(ComputeError: "cannot truncate a Datetime to a negative duration")
                 }
+
+                let w = Window::new(every, every, offset);
+                func(&w, timestamp, tz).map(Some)
             },
-            _ => try_binary_elementwise(self, every, |opt_timestamp, opt_every| {
-                match (opt_timestamp, opt_every) {
-                    (Some(timestamp), Some(every)) => {
-                        let every = Duration::parse(every);
-                        if every.negative {
-                            polars_bail!(ComputeError: "cannot truncate a Datetime to a negative duration")
-                        }
-
-                        let w = Window::new(every, every, offset);
-                        func(&w, timestamp, tz).map(Some)
-                    },
-                    _ => Ok(None),
-                }
-            }),
-        };
+            _ => Ok(None),
+        });
         Ok(out?.into_datetime(self.time_unit(), self.time_zone().clone()))
     }
 }
@@ -63,41 +53,26 @@ impl PolarsTruncate for DateChunked {
         offset: &str,
     ) -> PolarsResult<Self> {
         let offset = Duration::parse(offset);
-        let out = match every.len() {
-            1 => {
-                if let Some(every) = every.get(0) {
-                    let every = Duration::parse(every);
+        // A sqrt(n) cache is not too small, not too large.
+        let mut duration_cache = FastFixedCache::new((every.len() as f64).sqrt() as usize);
+        let out = broadcast_try_binary_elementwise(&self.0, every, |opt_t, opt_every| {
+            match (opt_t, opt_every) {
+                (Some(t), Some(every)) => {
+                    const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
+                    let every =
+                        *duration_cache.get_or_insert_with(every, |every| Duration::parse(every));
                     if every.negative {
                         polars_bail!(ComputeError: "cannot truncate a Date to a negative duration")
                     }
 
                     let w = Window::new(every, every, offset);
-                    self.try_apply_nonnull_values_generic(|t| {
-                        const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
-                        Ok((w.truncate_ms(MSECS_IN_DAY * t as i64, None)? / MSECS_IN_DAY) as i32)
-                    })
-                } else {
-                    Ok(Int32Chunked::full_null(self.name(), self.len()))
-                }
-            },
-            _ => try_binary_elementwise(&self.0, every, |opt_t, opt_every| {
-                match (opt_t, opt_every) {
-                    (Some(t), Some(every)) => {
-                        const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
-                        let every = Duration::parse(every);
-                        if every.negative {
-                            polars_bail!(ComputeError: "cannot truncate a Date to a negative duration")
-                        }
-
-                        let w = Window::new(every, every, offset);
-                        Ok(Some(
-                            (w.truncate_ms(MSECS_IN_DAY * t as i64, None)? / MSECS_IN_DAY) as i32,
-                        ))
-                    },
-                    _ => Ok(None),
-                }
-            }),
-        };
+                    Ok(Some(
+                        (w.truncate_ms(MSECS_IN_DAY * t as i64, None)? / MSECS_IN_DAY) as i32,
+                    ))
+                },
+                _ => Ok(None),
+            }
+        });
         Ok(out?.into_date())
     }
 }

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2300,6 +2300,33 @@ def test_asof_join_by_forward() -> None:
     }
 
 
+def test_truncate_broadcast_left() -> None:
+    df = pl.DataFrame({"every": [None, "1y", "1mo", "1d", "1h"]})
+    out = df.select(
+        date=pl.lit(date(2024, 4, 19)).dt.truncate(pl.col("every")),
+        datetime=pl.lit(datetime(2024, 4, 19, 10, 30, 20)).dt.truncate(pl.col("every")),
+    )
+    expected = pl.DataFrame(
+        {
+            "date": [
+                None,
+                date(2024, 1, 1),
+                date(2024, 4, 1),
+                date(2024, 4, 19),
+                date(2024, 4, 19),
+            ],
+            "datetime": [
+                None,
+                datetime(2024, 1, 1),
+                datetime(2024, 4, 1),
+                datetime(2024, 4, 19),
+                datetime(2024, 4, 19, 10),
+            ],
+        }
+    )
+    assert_frame_equal(out, expected)
+
+
 def test_truncate_expr() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Probably not much, but this should also improve some performance as the duration parsing cache.

Closes #15743.