### PR TITLE
fix(python): Allow passing files opened by fsspec in `read_parquet`

### DIFF
--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -162,8 +162,8 @@ def read_parquet(
             memory_map=memory_map,
         )
 
-    # Read binary types using `read_parquet`
-    elif isinstance(source, (io.BufferedIOBase, io.RawIOBase, bytes)):
+    # Read file and bytes inputs using `read_parquet`
+    elif isinstance(source, (io.IOBase, bytes)):
         return _read_parquet_binary(
             source,
             columns=columns,


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/15760

Files opened by fsspec do not subclass BufferedIOBase or RawIOBase, so they slipped through the cracks. This should fix it.

I opened an issue with fsspec to suggest fixing the subclassing: https://github.com/fsspec/filesystem_spec/issues/1583