### PR TITLE
docs(python): Fix a docstring mistake for DataType.is_float

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -203,7 +203,7 @@ class DataType(metaclass=DataTypeClass):
 
     @classmethod
     def is_float(cls) -> bool:
-        """Check whether the data type is a temporal type."""
+        """Check whether the data type is a floating point type."""
         return issubclass(cls, FloatType)
 
     @classmethod


### PR DESCRIPTION
Fixes a copy-paste related mistake where the description of `is_float` said it's checking for a temporal type instead of a floating point one which showed up in the API documentation.