### PR TITLE
feat(python): Expose plan and expression nodes through `NodeTraverser` to Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,6 +3248,7 @@ dependencies = [
  "polars-ops",
  "polars-parquet",
  "polars-plan",
+ "polars-time",
  "polars-utils",
  "pyo3",
  "pyo3-built",

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2020 Ritchie Vink
+Some portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -10,7 +10,7 @@ mod bounds;
 #[cfg(feature = "business")]
 mod business;
 #[cfg(feature = "dtype-categorical")]
-mod cat;
+pub mod cat;
 #[cfg(feature = "round_series")]
 mod clip;
 #[cfg(feature = "dtype-struct")]
@@ -38,13 +38,13 @@ mod nan;
 mod peaks;
 #[cfg(feature = "ffi_plugin")]
 mod plugin;
-mod pow;
+pub mod pow;
 #[cfg(feature = "random")]
 mod random;
 #[cfg(feature = "range")]
 mod range;
 #[cfg(feature = "rolling_window")]
-mod rolling;
+pub mod rolling;
 #[cfg(feature = "round_series")]
 mod round;
 #[cfg(feature = "row_hash")]
@@ -63,7 +63,7 @@ mod struct_;
 #[cfg(any(feature = "temporal", feature = "date_offset"))]
 mod temporal;
 #[cfg(feature = "trigonometry")]
-mod trigonometry;
+pub mod trigonometry;
 mod unique;
 
 use std::fmt::{Display, Formatter};
@@ -88,10 +88,10 @@ pub use self::boolean::BooleanFunction;
 #[cfg(feature = "business")]
 pub(super) use self::business::BusinessFunction;
 #[cfg(feature = "dtype-categorical")]
-pub(crate) use self::cat::CategoricalFunction;
+pub use self::cat::CategoricalFunction;
 #[cfg(feature = "temporal")]
 pub(super) use self::datetime::TemporalFunction;
-pub(super) use self::pow::PowFunction;
+pub use self::pow::PowFunction;
 #[cfg(feature = "range")]
 pub(super) use self::range::RangeFunction;
 #[cfg(feature = "rolling_window")]

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -21,7 +21,7 @@ pub mod dt;
 mod expr;
 mod expr_dyn_fn;
 mod from;
-pub(crate) mod function_expr;
+pub mod function_expr;
 pub mod functions;
 mod list;
 #[cfg(feature = "meta")]

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -14,6 +14,7 @@ polars-lazy = { workspace = true, features = ["python"] }
 polars-ops = { workspace = true }
 polars-parquet = { workspace = true, optional = true }
 polars-plan = { workspace = true }
+polars-time = { workspace = true }
 polars-utils = { workspace = true }
 
 ahash = { workspace = true }

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -453,6 +453,16 @@ impl FromPyObject<'_> for Wrap<Schema> {
     }
 }
 
+impl IntoPy<PyObject> for Wrap<&Schema> {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        let dict = PyDict::new(py);
+        for (k, v) in self.0.iter() {
+            dict.set_item(k.as_str(), Wrap(v.clone())).unwrap();
+        }
+        dict.into_py(py)
+    }
+}
+
 #[derive(Clone, Debug)]
 #[repr(transparent)]
 pub struct ObjectValue {

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -1,5 +1,6 @@
 mod exitable;
 mod visit;
+mod visitor;
 
 use std::collections::HashMap;
 use std::io::BufWriter;

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -1,4 +1,5 @@
 mod exitable;
+mod visit;
 
 use std::collections::HashMap;
 use std::io::BufWriter;

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -1,7 +1,6 @@
 mod exitable;
 mod visit;
 pub(crate) mod visitor;
-
 use std::collections::HashMap;
 use std::io::BufWriter;
 use std::num::NonZeroUsize;
@@ -15,6 +14,7 @@ use polars_core::prelude::*;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
+pub(crate) use visit::PyExprIR;
 
 use crate::arrow_interop::to_rust::pyarrow_schema_to_rust;
 use crate::error::PyPolarsErr;

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -1,6 +1,6 @@
 mod exitable;
 mod visit;
-mod visitor;
+pub(crate) mod visitor;
 
 use std::collections::HashMap;
 use std::io::BufWriter;

--- a/py-polars/src/lazyframe/visit.rs
+++ b/py-polars/src/lazyframe/visit.rs
@@ -1,0 +1,86 @@
+use std::sync::RwLock;
+
+use polars_plan::logical_plan::ALogicalPlan;
+use polars_plan::prelude::AExpr;
+use polars_utils::arena::{Arena, Node};
+
+use super::*;
+
+#[pyclass]
+struct NodeTraverser {
+    root: Node,
+    lp_arena: Arc<RwLock<Arena<ALogicalPlan>>>,
+    expr_arena: Arc<RwLock<Arena<AExpr>>>,
+    scratch: Vec<Node>,
+}
+
+impl NodeTraverser {
+    fn fill_inputs(&mut self) {
+        let lp_arena = self.lp_arena.read().unwrap();
+        let this_node = lp_arena.get(self.root);
+        self.scratch.clear();
+        this_node.copy_exprs(&mut self.scratch);
+    }
+
+    fn fill_expressions(&mut self) {
+        let lp_arena = self.lp_arena.read().unwrap();
+        let this_node = lp_arena.get(self.root);
+        self.scratch.clear();
+        this_node.copy_inputs(&mut self.scratch);
+    }
+
+    fn scratch_to_list(&mut self) -> PyObject {
+        Python::with_gil(|py| {
+            PyList::new(py, self.scratch.drain(..).map(|node| node.0)).to_object(py)
+        })
+    }
+}
+
+#[pymethods]
+impl NodeTraverser {
+    fn get_exprs(&mut self) -> PyObject {
+        self.fill_expressions();
+        self.scratch_to_list()
+    }
+
+    fn get_inputs(&mut self) -> PyObject {
+        self.fill_inputs();
+        self.scratch_to_list()
+    }
+
+    fn set_node(&mut self, node: usize) {
+        self.root = Node(node);
+    }
+
+    fn view_current_node(&self) -> PyObject {
+        // Insert Python objects/struct that map to our plan here
+        todo!()
+    }
+
+    fn view_expression(&self, node: usize) -> PyObject {
+        let expr_arena = self.expr_arena.read().unwrap();
+        let _expr = expr_arena.get(Node(node));
+        // Insert Python objects/struct that map to our expr here
+        todo!()
+    }
+}
+
+#[pymethods]
+#[allow(clippy::should_implement_trait)]
+impl PyLazyFrame {
+    fn visit(&self) -> PyResult<NodeTraverser> {
+        let mut lp_arena = Arena::with_capacity(16);
+        let mut expr_arena = Arena::with_capacity(16);
+        let root = self
+            .ldf
+            .clone()
+            .optimize(&mut lp_arena, &mut expr_arena)
+            .map_err(PyPolarsErr::from)?;
+        Ok(NodeTraverser {
+            root,
+            lp_arena: Arc::new(RwLock::new(lp_arena)),
+            expr_arena: Arc::new(RwLock::new(expr_arena)),
+            scratch: vec![],
+        })
+    }
+}

--- a/py-polars/src/lazyframe/visit.rs
+++ b/py-polars/src/lazyframe/visit.rs
@@ -95,7 +95,7 @@ impl NodeTraverser {
         self.scratch_to_list()
     }
 
-    /// Get Schema as python dict<str, pl.DataType>
+    /// Get Schema of current node as python dict<str, pl.DataType>
     fn get_schema(&self, py: Python<'_>) -> PyObject {
         let lp_arena = self.lp_arena.read().unwrap();
         let schema = lp_arena.get(self.root).schema(&lp_arena).into_owned();
@@ -139,12 +139,8 @@ impl NodeTraverser {
     }
 
     fn view_current_node(&self, py: Python<'_>) -> PyResult<PyObject> {
-        self.view_node(py, self.root.0)
-    }
-
-    fn view_node(&self, py: Python<'_>, node: usize) -> PyResult<PyObject> {
         let lp_arena = self.lp_arena.read().unwrap();
-        let lp_node = lp_arena.get(Node(node));
+        let lp_node = lp_arena.get(self.root);
         nodes::into_py(py, lp_node)
     }
 

--- a/py-polars/src/lazyframe/visit.rs
+++ b/py-polars/src/lazyframe/visit.rs
@@ -1,17 +1,29 @@
 use std::sync::RwLock;
+use pyo3::prelude::*;
 
-use polars_plan::logical_plan::ALogicalPlan;
-use polars_plan::prelude::AExpr;
+use polars_plan::logical_plan::IR;
+use polars_plan::prelude::{AExpr, FunctionNode, PythonOptions};
+use polars_plan::prelude::expr_ir::ExprIR;
+use polars_plan::prelude::python_udf::PythonFunction;
 use polars_utils::arena::{Arena, Node};
-
 use super::*;
+
+#[derive(Clone)]
+#[pyclass]
+struct PyExprIR {
+    #[pyo3(get)]
+    node: usize,
+    #[pyo3(get)]
+    output_name: String
+}
 
 #[pyclass]
 struct NodeTraverser {
     root: Node,
-    lp_arena: Arc<RwLock<Arena<ALogicalPlan>>>,
+    lp_arena: Arc<RwLock<Arena<IR>>>,
     expr_arena: Arc<RwLock<Arena<AExpr>>>,
     scratch: Vec<Node>,
+    expr_scratch: Vec<ExprIR>
 }
 
 impl NodeTraverser {
@@ -19,14 +31,14 @@ impl NodeTraverser {
         let lp_arena = self.lp_arena.read().unwrap();
         let this_node = lp_arena.get(self.root);
         self.scratch.clear();
-        this_node.copy_exprs(&mut self.scratch);
+        this_node.copy_exprs(&mut self.expr_scratch);
     }
 
     fn fill_expressions(&mut self) {
         let lp_arena = self.lp_arena.read().unwrap();
         let this_node = lp_arena.get(self.root);
-        self.scratch.clear();
-        this_node.copy_inputs(&mut self.scratch);
+        self.expr_scratch.clear();
+        this_node.copy_exprs(&mut self.expr_scratch);
     }
 
     fn scratch_to_list(&mut self) -> PyObject {
@@ -34,22 +46,54 @@ impl NodeTraverser {
             PyList::new(py, self.scratch.drain(..).map(|node| node.0)).to_object(py)
         })
     }
+
+    fn expr_to_list(&mut self) -> PyObject {
+        Python::with_gil(|py| {
+            PyList::new(py, self.expr_scratch.drain(..).map(|e| {
+                PyExprIR {
+                    node: e.node().0,
+                    output_name: e.output_name().into()
+                }.into_py(py)
+            })).to_object(py)
+        })
+    }
 }
 
 #[pymethods]
 impl NodeTraverser {
+    /// Get expression nodes
     fn get_exprs(&mut self) -> PyObject {
         self.fill_expressions();
-        self.scratch_to_list()
+        self.expr_to_list()
     }
 
+    /// Get input nodes
     fn get_inputs(&mut self) -> PyObject {
         self.fill_inputs();
         self.scratch_to_list()
     }
 
+    /// Set the current node in the plan.
     fn set_node(&mut self, node: usize) {
         self.root = Node(node);
+    }
+
+    /// Set a python UDF that will replace the subtree location with this function src.
+    fn set_udf(&mut self, function: PyObject, schema: Wrap<Schema>) {
+        let ir = IR::PythonScan {
+            options: PythonOptions{
+                scan_fn: Some(function.into()),
+                schema: Arc::new(schema.0),
+                output_schema: None,
+                with_columns: None,
+                pyarrow: false,
+                predicate: None,
+                n_rows: None,
+            },
+            predicate: None
+        };
+        let mut lp_arena = self.lp_arena.write().unwrap();
+        lp_arena.replace(self.root, ir);
     }
 
     fn view_current_node(&self) -> PyObject {
@@ -81,6 +125,7 @@ impl PyLazyFrame {
             lp_arena: Arc::new(RwLock::new(lp_arena)),
             expr_arena: Arc::new(RwLock::new(expr_arena)),
             scratch: vec![],
+            expr_scratch: vec![]
         })
     }
 }

--- a/py-polars/src/lazyframe/visit.rs
+++ b/py-polars/src/lazyframe/visit.rs
@@ -98,15 +98,15 @@ impl NodeTraverser {
     /// Get Schema of current node as python dict<str, pl.DataType>
     fn get_schema(&self, py: Python<'_>) -> PyObject {
         let lp_arena = self.lp_arena.lock().unwrap();
-        let schema = lp_arena.get(self.root).schema(&lp_arena).into_owned();
-        Wrap(schema.as_ref()).into_py(py)
+        let schema = lp_arena.get(self.root).schema(&lp_arena);
+        Wrap(&**schema).into_py(py)
     }
 
     /// Get expression dtype.
     fn get_dtype(&self, expr_node: usize, py: Python<'_>) -> PyResult<PyObject> {
         let expr_node = Node(expr_node);
         let lp_arena = self.lp_arena.lock().unwrap();
-        let schema = lp_arena.get(self.root).schema(&lp_arena).into_owned();
+        let schema = lp_arena.get(self.root).schema(&lp_arena);
         let expr_arena = self.expr_arena.lock().unwrap();
         let field = expr_arena
             .get(expr_node)
@@ -160,8 +160,8 @@ impl NodeTraverser {
         let mut expr_arena = self.expr_arena.lock().unwrap();
         Ok((
             expressions
-                .iter()
-                .map(|e| to_aexpr(e.inner.clone(), &mut expr_arena).0)
+                .into_iter()
+                .map(|e| to_aexpr(e.inner, &mut expr_arena).0)
                 .collect(),
             expr_arena.len(),
         ))

--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -1,0 +1,494 @@
+use pyo3::prelude::*;
+use polars_plan::prelude::{FileCount, FileScanOptions};
+use crate::dataframe::PyDataFrame;
+use super::*;
+
+#[pyclass]
+pub struct PlanPythonScan {
+    #[pyo3(get)]
+    options: PyObject,
+    #[pyo3(get)]
+    predicate: PyObject,
+}
+
+#[pyclass]
+/// Slice the table
+pub struct PlanSlice {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    offset: i64,
+    #[pyo3(get)]
+    len: IdxSize,
+}
+
+#[pyclass]
+pub struct PlanSelection {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    predicate: PyObject,
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct PyFileOptions {
+    inner: FileScanOptions,
+}
+
+#[pymethods]
+impl PyFileOptions {
+    #[getter]
+    fn n_rows(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self
+            .inner
+            .n_rows
+            .map_or_else(|| py.None(), |n| n.into_py(py)))
+    }
+    #[getter]
+    fn with_columns(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self
+            .inner
+            .with_columns
+            .as_ref()
+            .map_or_else(|| py.None(), |cols| cols.to_object(py)))
+    }
+    #[getter]
+    fn cache(&self, _py: Python<'_>) -> PyResult<bool> {
+        Ok(self.inner.cache)
+    }
+    #[getter]
+    fn row_index(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self
+            .inner
+            .row_index
+            .as_ref()
+            .map_or_else(|| py.None(), |n| (&n.name, n.offset).to_object(py)))
+    }
+    #[getter]
+    fn rechunk(&self, _py: Python<'_>) -> PyResult<bool> {
+        Ok(self.inner.rechunk)
+    }
+    #[getter]
+    fn file_counter(&self, _py: Python<'_>) -> PyResult<FileCount> {
+        Ok(self.inner.file_counter)
+    }
+    #[getter]
+    fn hive_partitioning(&self, _py: Python<'_>) -> PyResult<bool> {
+        Ok(self.inner.hive_partitioning)
+    }
+}
+
+#[pyclass]
+pub struct PlanScan {
+    #[pyo3(get)]
+    paths: PyObject,
+    #[pyo3(get)]
+    file_info: PyObject,
+    #[pyo3(get)]
+    predicate: PyObject,
+    #[pyo3(get)]
+    output_schema: PyObject,
+    #[pyo3(get)]
+    file_options: PyFileOptions,
+    #[pyo3(get)]
+    scan_type: PyObject,
+}
+
+#[pyclass]
+pub struct PlanDataFrameScan {
+    #[pyo3(get)]
+    df: PyDataFrame,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef
+    #[pyo3(get)]
+    output_schema: PyObject, // Option<SchemaRef> Optional[dict]
+    #[pyo3(get)]
+    projection: PyObject,
+    #[pyo3(get)]
+    selection: PyObject,
+}
+
+#[pyclass]
+/// Column selection
+pub struct PlanProjection {
+    #[pyo3(get)]
+    expr: Vec<PyObject>,
+    #[pyo3(get)]
+    cse_expr: Vec<PyObject>,
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+    options: (), //ProjectionOptions,
+}
+
+#[pyclass]
+/// Sort the table
+pub struct PlanSort {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    by_column: Vec<PyObject>,
+    #[pyo3(get)]
+    args: PyObject, // SortArguments,
+}
+
+/// Cache the input at this point in the LP
+#[pyclass]
+pub struct PlanCache {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    id_: usize,
+    #[pyo3(get)]
+    count: usize,
+}
+
+#[pyclass]
+/// Groupby aggregation
+pub struct PlanAggregate {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    keys: Vec<PyObject>,
+    #[pyo3(get)]
+    aggs: Vec<PyObject>,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+    apply: (), // Option<Arc<dyn DataFrameUdf>>,
+    #[pyo3(get)]
+    maintain_order: bool,
+    #[pyo3(get)]
+    options: PyObject, // Arc<GroupbyOptions>,
+}
+
+#[pyclass]
+/// Join operation
+pub struct PlanJoin {
+    #[pyo3(get)]
+    input_left: PyObject,
+    #[pyo3(get)]
+    input_right: PyObject,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+    #[pyo3(get)]
+    left_on: Vec<PyObject>,
+    #[pyo3(get)]
+    right_on: Vec<PyObject>,
+    #[pyo3(get)]
+    options: PyObject, // Arc<JoinOptions>,
+}
+
+#[pyclass]
+/// Adding columns to the table without a Join
+pub struct PlanHStack {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    exprs: Vec<PyObject>,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+    options: (), // ProjectionOptions,
+}
+
+#[pyclass]
+/// Remove duplicates from the table
+pub struct PlanDistinct {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    options: PyObject, // DistinctOptions,
+}
+#[pyclass]
+/// A (User Defined) Function
+pub struct PlanMapFunction {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    function: PyObject, // FunctionNode,
+}
+#[pyclass]
+pub struct PlanUnion {
+    #[pyo3(get)]
+    inputs: Vec<PyObject>,
+    #[pyo3(get)]
+    options: PyObject, // UnionOptions,
+}
+#[pyclass]
+/// Horizontal concatenation of multiple plans
+pub struct PlanHConcat {
+    #[pyo3(get)]
+    inputs: Vec<PyObject>,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+    options: (), // HConcatOptions,
+}
+#[pyclass]
+/// This allows expressions to access other tables
+pub struct PlanExtContext {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    contexts: Vec<PyObject>,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+}
+
+#[pyclass]
+pub struct PlanSink {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    payload: PyObject, // SinkType,
+}
+
+// Expressions
+#[pyclass]
+pub struct ExprAlias {
+    #[pyo3(get)]
+    expr: PyObject,
+    #[pyo3(get)]
+    name: PyObject,
+}
+
+#[pymethods]
+impl ExprAlias {
+    fn reconstruct(&self, expr: PyObject) -> Self {
+        Self {
+            expr,
+            name: self.name.clone(),
+        }
+    }
+}
+
+#[pyclass]
+pub struct ExprColumn {
+    #[pyo3(get)]
+    name: PyObject,
+}
+
+#[pymethods]
+impl ExprColumn {
+    fn reconstruct(&self, name: PyObject) -> Self {
+        Self { name }
+    }
+    #[new]
+    fn new(name: PyObject) -> Self {
+        Self { name }
+    }
+}
+
+#[pyclass]
+pub struct ExprLiteral {
+    #[pyo3(get)]
+    value: PyObject,
+    #[pyo3(get)]
+    dtype: PyObject,
+}
+
+impl ExprLiteral {
+    fn new(py: Python<'_>, value: PyObject, dtype: PyObject) -> Self {
+        Self {
+            value,
+            dtype: dtype,
+        }
+    }
+}
+
+#[pymethods]
+impl ExprLiteral {
+    fn reconstruct(&self, value: PyObject, dtype: PyObject) -> Self {
+        Self { value, dtype }
+    }
+}
+
+#[pyclass]
+pub struct ExprBinaryExpr {
+    #[pyo3(get)]
+    left: PyObject,
+    #[pyo3(get)]
+    op: PyOperator,
+    #[pyo3(get)]
+    right: PyObject,
+}
+
+#[pymethods]
+impl ExprBinaryExpr {
+    fn reconstruct(&self, left: PyObject, right: PyObject) -> Self {
+        Self {
+            left,
+            op: self.op,
+            right,
+        }
+    }
+}
+
+#[pyclass]
+pub struct ExprCast {
+    #[pyo3(get)]
+    expr: PyObject,
+    #[pyo3(get)]
+    dtype: PyObject,
+}
+
+impl ExprCast {
+    fn new(py: Python<'_>, expr: PyObject, dtype: PyObject) -> Self {
+        Self { expr, dtype }
+    }
+}
+
+#[pymethods]
+impl ExprCast {
+    fn reconstruct(&self, expr: PyObject, dtype: PyObject) -> Self {
+        Self { expr, dtype }
+    }
+}
+
+#[pyclass]
+pub struct ExprSort {
+    #[pyo3(get)]
+    expr: PyObject,
+    #[pyo3(get)]
+    options: PyObject,
+}
+
+#[pymethods]
+impl ExprSort {
+    fn reconstruct(&self, expr: PyObject) -> Self {
+        Self {
+            expr,
+            options: self.options.clone(),
+        }
+    }
+}
+
+#[pyclass]
+pub struct ExprGather {
+    #[pyo3(get)]
+    expr: PyObject,
+    #[pyo3(get)]
+    idx: PyObject,
+    #[pyo3(get)]
+    scalar: bool,
+}
+
+#[pymethods]
+impl ExprGather {
+    fn reconstruct(&self, expr: PyObject, idx: PyObject, scalar: bool) -> Self {
+        Self { expr, idx, scalar }
+    }
+}
+
+#[pyclass]
+pub struct ExprFilter {
+    #[pyo3(get)]
+    input: PyObject,
+    #[pyo3(get)]
+    by: PyObject,
+}
+
+#[pymethods]
+impl ExprFilter {
+    fn reconstruct(&self, input: PyObject, by: PyObject) -> Self {
+        Self { input, by }
+    }
+}
+
+#[pyclass]
+pub struct ExprSortBy {
+    #[pyo3(get)]
+    expr: PyObject,
+    #[pyo3(get)]
+    by: Vec<PyObject>,
+    #[pyo3(get)]
+    descending: PyObject,
+}
+
+#[pymethods]
+impl ExprSortBy {
+    fn reconstruct(&self, expr: PyObject, by: Vec<PyObject>) -> Self {
+        Self {
+            expr,
+            by,
+            descending: self.descending.clone(),
+        }
+    }
+}
+
+#[pyclass]
+pub struct ExprAgg {
+    #[pyo3(get)]
+    name: PyObject,
+    #[pyo3(get)]
+    arguments: PyObject,
+    #[pyo3(get)]
+    // Arbitrary control options
+    options: PyObject,
+}
+
+#[pymethods]
+impl ExprAgg {
+    fn reconstruct(&self, arguments: PyObject) -> Self {
+        Self {
+            name: self.name.clone(),
+            arguments,
+            options: self.options.clone(),
+        }
+    }
+}
+
+#[pyclass]
+pub struct ExprTernary {
+    #[pyo3(get)]
+    predicate: PyObject,
+    #[pyo3(get)]
+    truthy: PyObject,
+    #[pyo3(get)]
+    falsy: PyObject,
+}
+
+#[pymethods]
+impl ExprTernary {
+    fn reconstruct(&self, predicate: PyObject, truthy: PyObject, falsy: PyObject) -> Self {
+        Self {
+            predicate,
+            truthy,
+            falsy,
+        }
+    }
+}
+
+#[pyclass]
+pub struct ExprFunction {
+    #[pyo3(get)]
+    input: Vec<PyObject>,
+    #[pyo3(get)]
+    function_data: PyObject,
+    #[pyo3(get)]
+    options: PyObject,
+}
+
+#[pymethods]
+impl ExprFunction {
+    fn reconstruct(&self, input: Vec<PyObject>) -> Self {
+        Self {
+            input,
+            function_data: self.function_data.clone(),
+            options: self.options.clone(),
+        }
+    }
+}
+
+#[pyclass]
+pub struct ExprCount {}
+
+#[pyclass]
+pub struct ExprWindow {
+    #[pyo3(get)]
+    function: PyObject,
+    #[pyo3(get)]
+    partition_by: PyObject,
+    #[pyo3(get)]
+    options: PyObject,
+}

--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -1,494 +1,840 @@
-// use pyo3::prelude::*;
-// use polars_plan::prelude::{FileCount, FileScanOptions};
-// use crate::dataframe::PyDataFrame;
-// use super::*;
-//
-// #[pyclass]
-// pub struct PlanPythonScan {
-//     #[pyo3(get)]
-//     options: PyObject,
-//     #[pyo3(get)]
-//     predicate: PyObject,
-// }
-//
-// #[pyclass]
-// /// Slice the table
-// pub struct PlanSlice {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     offset: i64,
-//     #[pyo3(get)]
-//     len: IdxSize,
-// }
-//
-// #[pyclass]
-// pub struct PlanSelection {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     predicate: PyObject,
-// }
-//
-// #[pyclass]
-// #[derive(Clone)]
-// pub struct PyFileOptions {
-//     inner: FileScanOptions,
-// }
-//
-// #[pymethods]
-// impl PyFileOptions {
-//     #[getter]
-//     fn n_rows(&self, py: Python<'_>) -> PyResult<PyObject> {
-//         Ok(self
-//             .inner
-//             .n_rows
-//             .map_or_else(|| py.None(), |n| n.into_py(py)))
-//     }
-//     #[getter]
-//     fn with_columns(&self, py: Python<'_>) -> PyResult<PyObject> {
-//         Ok(self
-//             .inner
-//             .with_columns
-//             .as_ref()
-//             .map_or_else(|| py.None(), |cols| cols.to_object(py)))
-//     }
-//     #[getter]
-//     fn cache(&self, _py: Python<'_>) -> PyResult<bool> {
-//         Ok(self.inner.cache)
-//     }
-//     #[getter]
-//     fn row_index(&self, py: Python<'_>) -> PyResult<PyObject> {
-//         Ok(self
-//             .inner
-//             .row_index
-//             .as_ref()
-//             .map_or_else(|| py.None(), |n| (&n.name, n.offset).to_object(py)))
-//     }
-//     #[getter]
-//     fn rechunk(&self, _py: Python<'_>) -> PyResult<bool> {
-//         Ok(self.inner.rechunk)
-//     }
-//     #[getter]
-//     fn file_counter(&self, _py: Python<'_>) -> PyResult<FileCount> {
-//         Ok(self.inner.file_counter)
-//     }
-//     #[getter]
-//     fn hive_partitioning(&self, _py: Python<'_>) -> PyResult<bool> {
-//         Ok(self.inner.hive_partitioning)
-//     }
-// }
-//
-// #[pyclass]
-// pub struct PlanScan {
-//     #[pyo3(get)]
-//     paths: PyObject,
-//     #[pyo3(get)]
-//     file_info: PyObject,
-//     #[pyo3(get)]
-//     predicate: PyObject,
-//     #[pyo3(get)]
-//     output_schema: PyObject,
-//     #[pyo3(get)]
-//     file_options: PyFileOptions,
-//     #[pyo3(get)]
-//     scan_type: PyObject,
-// }
-//
-// #[pyclass]
-// pub struct PlanDataFrameScan {
-//     #[pyo3(get)]
-//     df: PyDataFrame,
-//     #[pyo3(get)]
-//     schema: PyObject, // SchemaRef
-//     #[pyo3(get)]
-//     output_schema: PyObject, // Option<SchemaRef> Optional[dict]
-//     #[pyo3(get)]
-//     projection: PyObject,
-//     #[pyo3(get)]
-//     selection: PyObject,
-// }
-//
-// #[pyclass]
-// /// Column selection
-// pub struct PlanProjection {
-//     #[pyo3(get)]
-//     expr: Vec<PyObject>,
-//     #[pyo3(get)]
-//     cse_expr: Vec<PyObject>,
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     schema: PyObject, // SchemaRef,
-//     options: (), //ProjectionOptions,
-// }
-//
-// #[pyclass]
-// /// Sort the table
-// pub struct PlanSort {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     by_column: Vec<PyObject>,
-//     #[pyo3(get)]
-//     args: PyObject, // SortArguments,
-// }
-//
-// /// Cache the input at this point in the LP
-// #[pyclass]
-// pub struct PlanCache {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     id_: usize,
-//     #[pyo3(get)]
-//     count: usize,
-// }
-//
-// #[pyclass]
-// /// Groupby aggregation
-// pub struct PlanAggregate {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     keys: Vec<PyObject>,
-//     #[pyo3(get)]
-//     aggs: Vec<PyObject>,
-//     #[pyo3(get)]
-//     schema: PyObject, // SchemaRef,
-//     apply: (), // Option<Arc<dyn DataFrameUdf>>,
-//     #[pyo3(get)]
-//     maintain_order: bool,
-//     #[pyo3(get)]
-//     options: PyObject, // Arc<GroupbyOptions>,
-// }
-//
-// #[pyclass]
-// /// Join operation
-// pub struct PlanJoin {
-//     #[pyo3(get)]
-//     input_left: PyObject,
-//     #[pyo3(get)]
-//     input_right: PyObject,
-//     #[pyo3(get)]
-//     schema: PyObject, // SchemaRef,
-//     #[pyo3(get)]
-//     left_on: Vec<PyObject>,
-//     #[pyo3(get)]
-//     right_on: Vec<PyObject>,
-//     #[pyo3(get)]
-//     options: PyObject, // Arc<JoinOptions>,
-// }
-//
-// #[pyclass]
-// /// Adding columns to the table without a Join
-// pub struct PlanHStack {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     exprs: Vec<PyObject>,
-//     #[pyo3(get)]
-//     schema: PyObject, // SchemaRef,
-//     options: (), // ProjectionOptions,
-// }
-//
-// #[pyclass]
-// /// Remove duplicates from the table
-// pub struct PlanDistinct {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     options: PyObject, // DistinctOptions,
-// }
-// #[pyclass]
-// /// A (User Defined) Function
-// pub struct PlanMapFunction {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     function: PyObject, // FunctionNode,
-// }
-// #[pyclass]
-// pub struct PlanUnion {
-//     #[pyo3(get)]
-//     inputs: Vec<PyObject>,
-//     #[pyo3(get)]
-//     options: PyObject, // UnionOptions,
-// }
-// #[pyclass]
-// /// Horizontal concatenation of multiple plans
-// pub struct PlanHConcat {
-//     #[pyo3(get)]
-//     inputs: Vec<PyObject>,
-//     #[pyo3(get)]
-//     schema: PyObject, // SchemaRef,
-//     options: (), // HConcatOptions,
-// }
-// #[pyclass]
-// /// This allows expressions to access other tables
-// pub struct PlanExtContext {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     contexts: Vec<PyObject>,
-//     #[pyo3(get)]
-//     schema: PyObject, // SchemaRef,
-// }
-//
-// #[pyclass]
-// pub struct PlanSink {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     payload: PyObject, // SinkType,
-// }
-//
-// // Expressions
-// #[pyclass]
-// pub struct ExprAlias {
-//     #[pyo3(get)]
-//     expr: PyObject,
-//     #[pyo3(get)]
-//     name: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprAlias {
-//     fn reconstruct(&self, expr: PyObject) -> Self {
-//         Self {
-//             expr,
-//             name: self.name.clone(),
-//         }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprColumn {
-//     #[pyo3(get)]
-//     name: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprColumn {
-//     fn reconstruct(&self, name: PyObject) -> Self {
-//         Self { name }
-//     }
-//     #[new]
-//     fn new(name: PyObject) -> Self {
-//         Self { name }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprLiteral {
-//     #[pyo3(get)]
-//     value: PyObject,
-//     #[pyo3(get)]
-//     dtype: PyObject,
-// }
-//
-// impl ExprLiteral {
-//     fn new(py: Python<'_>, value: PyObject, dtype: PyObject) -> Self {
-//         Self {
-//             value,
-//             dtype: dtype,
-//         }
-//     }
-// }
-//
-// #[pymethods]
-// impl ExprLiteral {
-//     fn reconstruct(&self, value: PyObject, dtype: PyObject) -> Self {
-//         Self { value, dtype }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprBinaryExpr {
-//     #[pyo3(get)]
-//     left: PyObject,
-//     #[pyo3(get)]
-//     op: PyOperator,
-//     #[pyo3(get)]
-//     right: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprBinaryExpr {
-//     fn reconstruct(&self, left: PyObject, right: PyObject) -> Self {
-//         Self {
-//             left,
-//             op: self.op,
-//             right,
-//         }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprCast {
-//     #[pyo3(get)]
-//     expr: PyObject,
-//     #[pyo3(get)]
-//     dtype: PyObject,
-// }
-//
-// impl ExprCast {
-//     fn new(py: Python<'_>, expr: PyObject, dtype: PyObject) -> Self {
-//         Self { expr, dtype }
-//     }
-// }
-//
-// #[pymethods]
-// impl ExprCast {
-//     fn reconstruct(&self, expr: PyObject, dtype: PyObject) -> Self {
-//         Self { expr, dtype }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprSort {
-//     #[pyo3(get)]
-//     expr: PyObject,
-//     #[pyo3(get)]
-//     options: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprSort {
-//     fn reconstruct(&self, expr: PyObject) -> Self {
-//         Self {
-//             expr,
-//             options: self.options.clone(),
-//         }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprGather {
-//     #[pyo3(get)]
-//     expr: PyObject,
-//     #[pyo3(get)]
-//     idx: PyObject,
-//     #[pyo3(get)]
-//     scalar: bool,
-// }
-//
-// #[pymethods]
-// impl ExprGather {
-//     fn reconstruct(&self, expr: PyObject, idx: PyObject, scalar: bool) -> Self {
-//         Self { expr, idx, scalar }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprFilter {
-//     #[pyo3(get)]
-//     input: PyObject,
-//     #[pyo3(get)]
-//     by: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprFilter {
-//     fn reconstruct(&self, input: PyObject, by: PyObject) -> Self {
-//         Self { input, by }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprSortBy {
-//     #[pyo3(get)]
-//     expr: PyObject,
-//     #[pyo3(get)]
-//     by: Vec<PyObject>,
-//     #[pyo3(get)]
-//     descending: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprSortBy {
-//     fn reconstruct(&self, expr: PyObject, by: Vec<PyObject>) -> Self {
-//         Self {
-//             expr,
-//             by,
-//             descending: self.descending.clone(),
-//         }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprAgg {
-//     #[pyo3(get)]
-//     name: PyObject,
-//     #[pyo3(get)]
-//     arguments: PyObject,
-//     #[pyo3(get)]
-//     // Arbitrary control options
-//     options: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprAgg {
-//     fn reconstruct(&self, arguments: PyObject) -> Self {
-//         Self {
-//             name: self.name.clone(),
-//             arguments,
-//             options: self.options.clone(),
-//         }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprTernary {
-//     #[pyo3(get)]
-//     predicate: PyObject,
-//     #[pyo3(get)]
-//     truthy: PyObject,
-//     #[pyo3(get)]
-//     falsy: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprTernary {
-//     fn reconstruct(&self, predicate: PyObject, truthy: PyObject, falsy: PyObject) -> Self {
-//         Self {
-//             predicate,
-//             truthy,
-//             falsy,
-//         }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprFunction {
-//     #[pyo3(get)]
-//     input: Vec<PyObject>,
-//     #[pyo3(get)]
-//     function_data: PyObject,
-//     #[pyo3(get)]
-//     options: PyObject,
-// }
-//
-// #[pymethods]
-// impl ExprFunction {
-//     fn reconstruct(&self, input: Vec<PyObject>) -> Self {
-//         Self {
-//             input,
-//             function_data: self.function_data.clone(),
-//             options: self.options.clone(),
-//         }
-//     }
-// }
-//
-// #[pyclass]
-// pub struct ExprCount {}
-//
-// #[pyclass]
-// pub struct ExprWindow {
-//     #[pyo3(get)]
-//     function: PyObject,
-//     #[pyo3(get)]
-//     partition_by: PyObject,
-//     #[pyo3(get)]
-//     options: PyObject,
-// }
+use polars_plan::dsl::function_expr::rolling::RollingFunction;
+use polars_plan::dsl::function_expr::trigonometry::TrigonometricFunction;
+use polars_plan::dsl::BooleanFunction;
+use polars_plan::prelude::{
+    AAggExpr, AExpr, FunctionExpr, GroupbyOptions, LiteralValue, Operator, PowFunction,
+    WindowMapping, WindowType,
+};
+use polars_rs::series::IsSorted;
+use polars_time::prelude::RollingGroupOptions;
+use pyo3::exceptions::PyNotImplementedError;
+use pyo3::prelude::*;
+
+use crate::Wrap;
+
+#[pyclass]
+pub struct Alias {
+    #[pyo3(get)]
+    expr: usize,
+    #[pyo3(get)]
+    name: PyObject,
+}
+
+#[pyclass]
+pub struct Column {
+    #[pyo3(get)]
+    name: PyObject,
+}
+
+#[pyclass]
+pub struct Literal {
+    #[pyo3(get)]
+    value: PyObject,
+    #[pyo3(get)]
+    dtype: PyObject,
+}
+
+#[pyclass]
+pub enum PyOperator {
+    Eq,
+    EqValidity,
+    NotEq,
+    NotEqValidity,
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+    Plus,
+    Minus,
+    Multiply,
+    Divide,
+    TrueDivide,
+    FloorDivide,
+    Modulus,
+    And,
+    Or,
+    Xor,
+    LogicalAnd,
+    LogicalOr,
+}
+
+#[pymethods]
+impl PyOperator {
+    fn __hash__(&self) -> u64 {
+        use PyOperator::*;
+        match self {
+            Eq => Eq as u64,
+            EqValidity => EqValidity as u64,
+            NotEq => NotEq as u64,
+            NotEqValidity => NotEqValidity as u64,
+            Lt => Lt as u64,
+            LtEq => LtEq as u64,
+            Gt => Gt as u64,
+            GtEq => GtEq as u64,
+            Plus => Plus as u64,
+            Minus => Minus as u64,
+            Multiply => Multiply as u64,
+            Divide => Divide as u64,
+            TrueDivide => TrueDivide as u64,
+            FloorDivide => FloorDivide as u64,
+            Modulus => Modulus as u64,
+            And => And as u64,
+            Or => Or as u64,
+            Xor => Xor as u64,
+            LogicalAnd => LogicalAnd as u64,
+            LogicalOr => LogicalOr as u64,
+        }
+    }
+}
+
+impl IntoPy<PyObject> for Wrap<Operator> {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        match self.0 {
+            Operator::Eq => PyOperator::Eq,
+            Operator::EqValidity => PyOperator::EqValidity,
+            Operator::NotEq => PyOperator::NotEq,
+            Operator::NotEqValidity => PyOperator::NotEqValidity,
+            Operator::Lt => PyOperator::Lt,
+            Operator::LtEq => PyOperator::LtEq,
+            Operator::Gt => PyOperator::Gt,
+            Operator::GtEq => PyOperator::GtEq,
+            Operator::Plus => PyOperator::Plus,
+            Operator::Minus => PyOperator::Minus,
+            Operator::Multiply => PyOperator::Multiply,
+            Operator::Divide => PyOperator::Divide,
+            Operator::TrueDivide => PyOperator::TrueDivide,
+            Operator::FloorDivide => PyOperator::FloorDivide,
+            Operator::Modulus => PyOperator::Modulus,
+            Operator::And => PyOperator::And,
+            Operator::Or => PyOperator::Or,
+            Operator::Xor => PyOperator::Xor,
+            Operator::LogicalAnd => PyOperator::LogicalAnd,
+            Operator::LogicalOr => PyOperator::LogicalOr,
+        }
+        .into_py(py)
+    }
+}
+
+#[pyclass]
+pub struct BinaryExpr {
+    #[pyo3(get)]
+    left: usize,
+    #[pyo3(get)]
+    op: PyObject,
+    #[pyo3(get)]
+    right: usize,
+}
+
+#[pyclass]
+pub struct Cast {
+    #[pyo3(get)]
+    expr: usize,
+    #[pyo3(get)]
+    dtype: PyObject,
+    #[pyo3(get)]
+    strict: bool,
+}
+
+#[pyclass]
+pub struct Sort {
+    #[pyo3(get)]
+    expr: usize,
+    #[pyo3(get)]
+    options: PyObject,
+}
+
+#[pyclass]
+pub struct Gather {
+    #[pyo3(get)]
+    expr: usize,
+    #[pyo3(get)]
+    idx: usize,
+    #[pyo3(get)]
+    scalar: bool,
+}
+
+#[pyclass]
+pub struct Filter {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    by: usize,
+}
+
+#[pyclass]
+pub struct SortBy {
+    #[pyo3(get)]
+    expr: usize,
+    #[pyo3(get)]
+    by: Vec<usize>,
+    #[pyo3(get)]
+    descending: Vec<bool>,
+}
+
+#[pyclass]
+pub struct Agg {
+    #[pyo3(get)]
+    name: PyObject,
+    #[pyo3(get)]
+    arguments: usize,
+    #[pyo3(get)]
+    // Arbitrary control options
+    options: PyObject,
+}
+
+#[pyclass]
+pub struct Ternary {
+    #[pyo3(get)]
+    predicate: usize,
+    #[pyo3(get)]
+    truthy: usize,
+    #[pyo3(get)]
+    falsy: usize,
+}
+
+#[pyclass]
+pub struct Function {
+    #[pyo3(get)]
+    input: Vec<usize>,
+    #[pyo3(get)]
+    function_data: PyObject,
+    #[pyo3(get)]
+    options: PyObject,
+}
+
+#[pyclass]
+pub struct Len {}
+
+#[pyclass]
+pub struct Window {
+    #[pyo3(get)]
+    function: usize,
+    #[pyo3(get)]
+    partition_by: Vec<usize>,
+    #[pyo3(get)]
+    options: PyObject,
+}
+
+#[pyclass]
+pub struct PyWindowMapping {
+    inner: WindowMapping,
+}
+
+#[pymethods]
+impl PyWindowMapping {
+    #[getter]
+    fn kind(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let result = match self.inner {
+            WindowMapping::GroupsToRows => "groups_to_rows".to_object(py),
+            WindowMapping::Explode => "explode".to_object(py),
+            WindowMapping::Join => "join".to_object(py),
+        };
+        Ok(result.into_py(py))
+    }
+}
+
+#[pyclass]
+pub struct PyRollingGroupOptions {
+    inner: RollingGroupOptions,
+}
+
+#[pymethods]
+impl PyRollingGroupOptions {
+    #[getter]
+    fn index_column(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self.inner.index_column.to_object(py))
+    }
+
+    #[getter]
+    fn period(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let result = vec![
+            self.inner.period.months().to_object(py),
+            self.inner.period.weeks().to_object(py),
+            self.inner.period.days().to_object(py),
+            self.inner.period.nanoseconds().to_object(py),
+            self.inner.period.parsed_int.to_object(py),
+        ]
+        .into_py(py);
+        Ok(result)
+    }
+
+    #[getter]
+    fn offset(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let result = vec![
+            self.inner.offset.months().to_object(py),
+            self.inner.offset.weeks().to_object(py),
+            self.inner.offset.days().to_object(py),
+            self.inner.offset.nanoseconds().to_object(py),
+            self.inner.offset.parsed_int.to_object(py),
+        ]
+        .into_py(py);
+        Ok(result)
+    }
+
+    #[getter]
+    fn closed_window(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let result = match self.inner.closed_window {
+            polars::time::ClosedWindow::Left => "left".to_object(py),
+            polars::time::ClosedWindow::Right => "right".to_object(py),
+            polars::time::ClosedWindow::Both => "both".to_object(py),
+            polars::time::ClosedWindow::None => "none".to_object(py),
+        };
+        Ok(result.into_py(py))
+    }
+
+    #[getter]
+    fn check_sorted(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self.inner.check_sorted.into_py(py))
+    }
+}
+
+#[pyclass]
+pub struct PyGroupbyOptions {
+    inner: GroupbyOptions,
+}
+
+impl PyGroupbyOptions {
+    pub(crate) fn new(inner: GroupbyOptions) -> Self {
+        Self { inner }
+    }
+}
+
+#[pymethods]
+impl PyGroupbyOptions {
+    #[getter]
+    fn slice(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self
+            .inner
+            .slice
+            .map_or_else(|| py.None(), |f| f.to_object(py)))
+    }
+
+    #[getter]
+    fn rolling(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self.inner.rolling.as_ref().map_or_else(
+            || py.None(),
+            |f| PyRollingGroupOptions { inner: f.clone() }.into_py(py),
+        ))
+    }
+}
+
+pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
+    let result = match expr {
+        AExpr::Explode(_) => return Err(PyNotImplementedError::new_err("explode")),
+        AExpr::Alias(inner, name) => Alias {
+            expr: inner.0,
+            name: name.to_object(py),
+        }
+        .into_py(py),
+        AExpr::Column(name) => Column {
+            name: name.to_object(py),
+        }
+        .into_py(py),
+        AExpr::Literal(lit) => {
+            use LiteralValue::*;
+            let dtype: PyObject = Wrap(lit.get_datatype()).to_object(py);
+            match lit {
+                Float32(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                Float64(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                Int8(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                Int16(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                Int32(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                Int64(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                UInt8(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                UInt16(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                UInt32(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                UInt64(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                Boolean(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                String(v) => Literal {
+                    value: v.to_object(py),
+                    dtype,
+                },
+                Null => Literal {
+                    value: py.None(),
+                    dtype,
+                },
+                Binary(_) => return Err(PyNotImplementedError::new_err("binary literal")),
+                Range { .. } => return Err(PyNotImplementedError::new_err("range literal")),
+                Date(..) | DateTime(..) => Literal {
+                    value: Wrap(lit.to_any_value().unwrap()).to_object(py),
+                    dtype,
+                },
+                Duration(_, _) => return Err(PyNotImplementedError::new_err("duration literal")),
+                Time(_) => return Err(PyNotImplementedError::new_err("time literal")),
+                Series(_) => return Err(PyNotImplementedError::new_err("series literal")),
+            }
+        }
+        .into_py(py),
+        AExpr::BinaryExpr { left, op, right } => BinaryExpr {
+            left: left.0,
+            op: Wrap(*op).into_py(py),
+            right: right.0,
+        }
+        .into_py(py),
+        AExpr::Cast {
+            expr,
+            data_type,
+            strict,
+        } => Cast {
+            expr: expr.0,
+            dtype: Wrap(data_type.clone()).to_object(py),
+            strict: *strict,
+        }
+        .into_py(py),
+        AExpr::Sort { expr, options } => Sort {
+            expr: expr.0,
+            options: (
+                options.maintain_order,
+                options.nulls_last,
+                options.descending,
+            )
+                .to_object(py),
+        }
+        .into_py(py),
+        AExpr::Gather {
+            expr,
+            idx,
+            returns_scalar,
+        } => Gather {
+            expr: expr.0,
+            idx: idx.0,
+            scalar: *returns_scalar,
+        }
+        .into_py(py),
+        AExpr::Filter { input, by } => Filter {
+            input: input.0,
+            by: by.0,
+        }
+        .into_py(py),
+        AExpr::SortBy {
+            expr,
+            by,
+            descending,
+        } => SortBy {
+            expr: expr.0,
+            by: by.iter().map(|n| n.0).collect(),
+            descending: descending.clone(),
+        }
+        .into_py(py),
+        AExpr::Agg(aggexpr) => match aggexpr {
+            AAggExpr::Min {
+                input,
+                propagate_nans,
+            } => Agg {
+                name: "min".to_object(py),
+                arguments: input.0,
+                options: propagate_nans.to_object(py),
+            },
+            AAggExpr::Max {
+                input,
+                propagate_nans,
+            } => Agg {
+                name: "max".to_object(py),
+                arguments: input.0,
+                options: propagate_nans.to_object(py),
+            },
+            AAggExpr::Median(n) => Agg {
+                name: "median".to_object(py),
+                arguments: n.0,
+                options: py.None(),
+            },
+            AAggExpr::NUnique(n) => Agg {
+                name: "nunique".to_object(py),
+                arguments: n.0,
+                options: py.None(),
+            },
+            AAggExpr::First(n) => Agg {
+                name: "first".to_object(py),
+                arguments: n.0,
+                options: py.None(),
+            },
+            AAggExpr::Last(n) => Agg {
+                name: "last".to_object(py),
+                arguments: n.0,
+                options: py.None(),
+            },
+            AAggExpr::Mean(n) => Agg {
+                name: "mean".to_object(py),
+                arguments: n.0,
+                options: py.None(),
+            },
+            AAggExpr::Implode(_) => return Err(PyNotImplementedError::new_err("implode")),
+            AAggExpr::Quantile { .. } => return Err(PyNotImplementedError::new_err("quantile")),
+            AAggExpr::Sum(n) => Agg {
+                name: "sum".to_object(py),
+                arguments: n.0,
+                options: py.None(),
+            },
+            AAggExpr::Count(n, include_null) => Agg {
+                name: "count".to_object(py),
+                arguments: n.0,
+                options: include_null.to_object(py),
+            },
+            AAggExpr::Std(n, ddof) => Agg {
+                name: "std".to_object(py),
+                arguments: n.0,
+                options: ddof.to_object(py),
+            },
+            AAggExpr::Var(n, ddof) => Agg {
+                name: "var".to_object(py),
+                arguments: n.0,
+                options: ddof.to_object(py),
+            },
+            AAggExpr::AggGroups(n) => Agg {
+                name: "agg_groups".to_object(py),
+                arguments: n.0,
+                options: py.None(),
+            },
+        }
+        .into_py(py),
+        AExpr::Ternary {
+            predicate,
+            truthy,
+            falsy,
+        } => Ternary {
+            predicate: predicate.0,
+            truthy: truthy.0,
+            falsy: falsy.0,
+        }
+        .into_py(py),
+        AExpr::AnonymousFunction { .. } => {
+            return Err(PyNotImplementedError::new_err("anonymousfunction"))
+        },
+        AExpr::Function {
+            input,
+            function,
+            // TODO: expose options
+            options: _,
+        } => Function {
+            input: input.iter().map(|n| n.node().0).collect(),
+            function_data: match function {
+                FunctionExpr::ArrayExpr(_) => {
+                    return Err(PyNotImplementedError::new_err("array expr"))
+                },
+                FunctionExpr::BinaryExpr(_) => {
+                    return Err(PyNotImplementedError::new_err("binary expr"))
+                },
+                FunctionExpr::Categorical(_) => {
+                    return Err(PyNotImplementedError::new_err("categorical expr"))
+                },
+                FunctionExpr::ListExpr(_) => {
+                    return Err(PyNotImplementedError::new_err("list expr"))
+                },
+                FunctionExpr::StringExpr(_) => {
+                    return Err(PyNotImplementedError::new_err("string expr"))
+                },
+                FunctionExpr::StructExpr(_) => {
+                    return Err(PyNotImplementedError::new_err("struct expr"))
+                },
+                FunctionExpr::TemporalExpr(_) => {
+                    return Err(PyNotImplementedError::new_err("temporal expr"))
+                },
+                FunctionExpr::Boolean(boolfun) => match boolfun {
+                    BooleanFunction::IsNull => ("is_null",).to_object(py),
+                    BooleanFunction::IsNotNull => ("is_not_null",).to_object(py),
+                    _ => return Err(PyNotImplementedError::new_err("boolean expr")),
+                },
+                FunctionExpr::Abs => ("abs",).to_object(py),
+                FunctionExpr::Hist { .. } => return Err(PyNotImplementedError::new_err("hist")),
+                FunctionExpr::NullCount => ("null_count",).to_object(py),
+                FunctionExpr::Pow(f) => match f {
+                    PowFunction::Generic => ("pow",).to_object(py),
+                    PowFunction::Sqrt => ("sqrt",).to_object(py),
+                    PowFunction::Cbrt => ("cbrt",).to_object(py),
+                },
+                FunctionExpr::Hash(_, _, _, _) => {
+                    return Err(PyNotImplementedError::new_err("hash"))
+                },
+                FunctionExpr::ArgWhere => ("argwhere",).to_object(py),
+                FunctionExpr::SearchSorted(_) => {
+                    return Err(PyNotImplementedError::new_err("search sorted"))
+                },
+                FunctionExpr::Range(_) => return Err(PyNotImplementedError::new_err("range")),
+                FunctionExpr::DateOffset => {
+                    return Err(PyNotImplementedError::new_err("date offset"))
+                },
+                FunctionExpr::Trigonometry(trigfun) => match trigfun {
+                    TrigonometricFunction::Cos => ("cos",),
+                    TrigonometricFunction::Cot => ("cot",),
+                    TrigonometricFunction::Sin => ("sin",),
+                    TrigonometricFunction::Tan => ("tan",),
+                    TrigonometricFunction::ArcCos => ("arccos",),
+                    TrigonometricFunction::ArcSin => ("arcsin",),
+                    TrigonometricFunction::ArcTan => ("arctan",),
+                    TrigonometricFunction::Cosh => ("cosh",),
+                    TrigonometricFunction::Sinh => ("sinh",),
+                    TrigonometricFunction::Tanh => ("tanh",),
+                    TrigonometricFunction::ArcCosh => ("arccosh",),
+                    TrigonometricFunction::ArcSinh => ("arcsinh",),
+                    TrigonometricFunction::ArcTanh => ("arctanh",),
+                    TrigonometricFunction::Degrees => ("degrees",),
+                    TrigonometricFunction::Radians => ("radians",),
+                }
+                .to_object(py),
+                FunctionExpr::Atan2 => ("atan2",).to_object(py),
+                FunctionExpr::Sign => ("sign",).to_object(py),
+                FunctionExpr::FillNull { super_type: _ } => {
+                    return Err(PyNotImplementedError::new_err("fill null"))
+                },
+                FunctionExpr::RollingExpr(rolling) => match rolling {
+                    RollingFunction::Min(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling min"))
+                    },
+                    RollingFunction::MinBy(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling min by"))
+                    },
+                    RollingFunction::Max(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling max"))
+                    },
+                    RollingFunction::MaxBy(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling max by"))
+                    },
+                    RollingFunction::Mean(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling mean"))
+                    },
+                    RollingFunction::MeanBy(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling mean by"))
+                    },
+                    RollingFunction::Sum(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling sum"))
+                    },
+                    RollingFunction::SumBy(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling sum by"))
+                    },
+                    RollingFunction::Quantile(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling quantile"))
+                    },
+                    RollingFunction::QuantileBy(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling quantile by"))
+                    },
+                    RollingFunction::Var(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling var"))
+                    },
+                    RollingFunction::VarBy(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling var by"))
+                    },
+                    RollingFunction::Std(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling std"))
+                    },
+                    RollingFunction::StdBy(_) => {
+                        return Err(PyNotImplementedError::new_err("rolling std by"))
+                    },
+                    RollingFunction::Skew(_, _) => {
+                        return Err(PyNotImplementedError::new_err("rolling skew"))
+                    },
+                },
+                FunctionExpr::ShiftAndFill => {
+                    return Err(PyNotImplementedError::new_err("shift and fill"))
+                },
+                FunctionExpr::Shift => ("shift",).to_object(py),
+                FunctionExpr::DropNans => ("dropnan",).to_object(py),
+                FunctionExpr::DropNulls => ("dropnull",).to_object(py),
+                FunctionExpr::Mode => ("mode",).to_object(py),
+                FunctionExpr::Skew(_) => return Err(PyNotImplementedError::new_err("skew")),
+                FunctionExpr::Kurtosis(_, _) => {
+                    return Err(PyNotImplementedError::new_err("kurtosis"))
+                },
+                FunctionExpr::Reshape(_) => return Err(PyNotImplementedError::new_err("reshape")),
+                FunctionExpr::RepeatBy => return Err(PyNotImplementedError::new_err("repeat by")),
+                FunctionExpr::ArgUnique => ("argunique",).to_object(py),
+                FunctionExpr::Rank {
+                    options: _,
+                    seed: _,
+                } => return Err(PyNotImplementedError::new_err("rank")),
+                FunctionExpr::Clip {
+                    has_min: _,
+                    has_max: _,
+                } => return Err(PyNotImplementedError::new_err("clip")),
+                FunctionExpr::AsStruct => return Err(PyNotImplementedError::new_err("as struct")),
+                FunctionExpr::TopK(_) => return Err(PyNotImplementedError::new_err("top k")),
+                FunctionExpr::CumCount { reverse } => ("cumcount", reverse).to_object(py),
+                FunctionExpr::CumSum { reverse } => ("cumsum", reverse).to_object(py),
+                FunctionExpr::CumProd { reverse } => ("cumprod", reverse).to_object(py),
+                FunctionExpr::CumMin { reverse } => ("cummin", reverse).to_object(py),
+                FunctionExpr::CumMax { reverse } => ("cummax", reverse).to_object(py),
+                FunctionExpr::Reverse => return Err(PyNotImplementedError::new_err("reverse")),
+                FunctionExpr::ValueCounts {
+                    sort: _,
+                    parallel: _,
+                } => return Err(PyNotImplementedError::new_err("value counts")),
+                FunctionExpr::UniqueCounts => {
+                    return Err(PyNotImplementedError::new_err("unique counts"))
+                },
+                FunctionExpr::ApproxNUnique => {
+                    return Err(PyNotImplementedError::new_err("approx nunique"))
+                },
+                FunctionExpr::Coalesce => return Err(PyNotImplementedError::new_err("coalesce")),
+                FunctionExpr::ShrinkType => {
+                    return Err(PyNotImplementedError::new_err("shrink type"))
+                },
+                FunctionExpr::Diff(_, _) => return Err(PyNotImplementedError::new_err("diff")),
+                FunctionExpr::PctChange => {
+                    return Err(PyNotImplementedError::new_err("pct change"))
+                },
+                FunctionExpr::Interpolate(_) => {
+                    return Err(PyNotImplementedError::new_err("interpolate"))
+                },
+                FunctionExpr::Entropy {
+                    base: _,
+                    normalize: _,
+                } => return Err(PyNotImplementedError::new_err("entropy")),
+                FunctionExpr::Log { base: _ } => return Err(PyNotImplementedError::new_err("log")),
+                FunctionExpr::Log1p => return Err(PyNotImplementedError::new_err("log1p")),
+                FunctionExpr::Exp => return Err(PyNotImplementedError::new_err("exp")),
+                FunctionExpr::Unique(_) => return Err(PyNotImplementedError::new_err("unique")),
+                FunctionExpr::Round { decimals: _ } => {
+                    return Err(PyNotImplementedError::new_err("round"))
+                },
+                FunctionExpr::RoundSF { digits: _ } => {
+                    return Err(PyNotImplementedError::new_err("round sf"))
+                },
+                FunctionExpr::Floor => ("floor",).to_object(py),
+                FunctionExpr::Ceil => ("ceil",).to_object(py),
+                FunctionExpr::UpperBound => {
+                    return Err(PyNotImplementedError::new_err("upper bound"))
+                },
+                FunctionExpr::LowerBound => {
+                    return Err(PyNotImplementedError::new_err("lower bound"))
+                },
+                FunctionExpr::Fused(_) => return Err(PyNotImplementedError::new_err("fused")),
+                FunctionExpr::ConcatExpr(_) => {
+                    return Err(PyNotImplementedError::new_err("concat expr"))
+                },
+                FunctionExpr::Correlation { .. } => {
+                    return Err(PyNotImplementedError::new_err("corr"))
+                },
+                FunctionExpr::PeakMin => return Err(PyNotImplementedError::new_err("peak min")),
+                FunctionExpr::PeakMax => return Err(PyNotImplementedError::new_err("peak max")),
+                FunctionExpr::Cut { .. } => return Err(PyNotImplementedError::new_err("cut")),
+                FunctionExpr::QCut { .. } => return Err(PyNotImplementedError::new_err("qcut")),
+                FunctionExpr::RLE => return Err(PyNotImplementedError::new_err("rle")),
+                FunctionExpr::RLEID => return Err(PyNotImplementedError::new_err("rleid")),
+                FunctionExpr::ToPhysical => {
+                    return Err(PyNotImplementedError::new_err("to physical"))
+                },
+                FunctionExpr::Random { .. } => {
+                    return Err(PyNotImplementedError::new_err("random"))
+                },
+                FunctionExpr::SetSortedFlag(sorted) => (
+                    "setsorted",
+                    match sorted {
+                        IsSorted::Ascending => "ascending",
+                        IsSorted::Descending => "descending",
+                        IsSorted::Not => "not",
+                    },
+                )
+                    .to_object(py),
+                FunctionExpr::FfiPlugin { .. } => {
+                    return Err(PyNotImplementedError::new_err("ffi plugin"))
+                },
+                FunctionExpr::BackwardFill { limit: _ } => {
+                    return Err(PyNotImplementedError::new_err("backward fill"))
+                },
+                FunctionExpr::ForwardFill { limit: _ } => {
+                    return Err(PyNotImplementedError::new_err("forward fill"))
+                },
+                FunctionExpr::SumHorizontal => {
+                    return Err(PyNotImplementedError::new_err("sum horizontal"))
+                },
+                FunctionExpr::MaxHorizontal => {
+                    return Err(PyNotImplementedError::new_err("max horizontal"))
+                },
+                FunctionExpr::MeanHorizontal => {
+                    return Err(PyNotImplementedError::new_err("mean horizontal"))
+                },
+                FunctionExpr::MinHorizontal => {
+                    return Err(PyNotImplementedError::new_err("min horizontal"))
+                },
+                FunctionExpr::EwmMean { options: _ } => {
+                    return Err(PyNotImplementedError::new_err("ewm mean"))
+                },
+                FunctionExpr::EwmStd { options: _ } => {
+                    return Err(PyNotImplementedError::new_err("ewm std"))
+                },
+                FunctionExpr::EwmVar { options: _ } => {
+                    return Err(PyNotImplementedError::new_err("ewm var"))
+                },
+                FunctionExpr::Replace { return_dtype: _ } => {
+                    return Err(PyNotImplementedError::new_err("replace"))
+                },
+                FunctionExpr::Negate => return Err(PyNotImplementedError::new_err("negate")),
+                FunctionExpr::FillNullWithStrategy(_) => {
+                    return Err(PyNotImplementedError::new_err("fill null with strategy"))
+                },
+                FunctionExpr::GatherEvery { n, offset } => {
+                    ("strided_slice", offset, n).to_object(py)
+                },
+                FunctionExpr::Reinterpret(_) => {
+                    return Err(PyNotImplementedError::new_err("reinterpret"))
+                },
+                FunctionExpr::ExtendConstant => {
+                    return Err(PyNotImplementedError::new_err("extend constant"))
+                },
+                FunctionExpr::Business(_) => {
+                    return Err(PyNotImplementedError::new_err("business"))
+                },
+            },
+            options: py.None(),
+        }
+        .into_py(py),
+        AExpr::Window {
+            function,
+            partition_by,
+            options,
+        } => {
+            let function = function.0;
+            let partition_by = partition_by.iter().map(|n| n.0).collect();
+            let options = match options {
+                WindowType::Over(options) => PyWindowMapping { inner: *options }.into_py(py),
+                WindowType::Rolling(options) => PyRollingGroupOptions {
+                    inner: options.clone(),
+                }
+                .into_py(py),
+            };
+            Window {
+                function,
+                partition_by,
+                options,
+            }
+            .into_py(py)
+        },
+        AExpr::Wildcard => return Err(PyNotImplementedError::new_err("wildcard")),
+        AExpr::Slice { .. } => return Err(PyNotImplementedError::new_err("slice")),
+        AExpr::Nth(_) => return Err(PyNotImplementedError::new_err("nth")),
+        AExpr::Len => Len {}.into_py(py),
+    };
+    Ok(result)
+}

--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -1,494 +1,494 @@
-use pyo3::prelude::*;
-use polars_plan::prelude::{FileCount, FileScanOptions};
-use crate::dataframe::PyDataFrame;
-use super::*;
-
-#[pyclass]
-pub struct PlanPythonScan {
-    #[pyo3(get)]
-    options: PyObject,
-    #[pyo3(get)]
-    predicate: PyObject,
-}
-
-#[pyclass]
-/// Slice the table
-pub struct PlanSlice {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    offset: i64,
-    #[pyo3(get)]
-    len: IdxSize,
-}
-
-#[pyclass]
-pub struct PlanSelection {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    predicate: PyObject,
-}
-
-#[pyclass]
-#[derive(Clone)]
-pub struct PyFileOptions {
-    inner: FileScanOptions,
-}
-
-#[pymethods]
-impl PyFileOptions {
-    #[getter]
-    fn n_rows(&self, py: Python<'_>) -> PyResult<PyObject> {
-        Ok(self
-            .inner
-            .n_rows
-            .map_or_else(|| py.None(), |n| n.into_py(py)))
-    }
-    #[getter]
-    fn with_columns(&self, py: Python<'_>) -> PyResult<PyObject> {
-        Ok(self
-            .inner
-            .with_columns
-            .as_ref()
-            .map_or_else(|| py.None(), |cols| cols.to_object(py)))
-    }
-    #[getter]
-    fn cache(&self, _py: Python<'_>) -> PyResult<bool> {
-        Ok(self.inner.cache)
-    }
-    #[getter]
-    fn row_index(&self, py: Python<'_>) -> PyResult<PyObject> {
-        Ok(self
-            .inner
-            .row_index
-            .as_ref()
-            .map_or_else(|| py.None(), |n| (&n.name, n.offset).to_object(py)))
-    }
-    #[getter]
-    fn rechunk(&self, _py: Python<'_>) -> PyResult<bool> {
-        Ok(self.inner.rechunk)
-    }
-    #[getter]
-    fn file_counter(&self, _py: Python<'_>) -> PyResult<FileCount> {
-        Ok(self.inner.file_counter)
-    }
-    #[getter]
-    fn hive_partitioning(&self, _py: Python<'_>) -> PyResult<bool> {
-        Ok(self.inner.hive_partitioning)
-    }
-}
-
-#[pyclass]
-pub struct PlanScan {
-    #[pyo3(get)]
-    paths: PyObject,
-    #[pyo3(get)]
-    file_info: PyObject,
-    #[pyo3(get)]
-    predicate: PyObject,
-    #[pyo3(get)]
-    output_schema: PyObject,
-    #[pyo3(get)]
-    file_options: PyFileOptions,
-    #[pyo3(get)]
-    scan_type: PyObject,
-}
-
-#[pyclass]
-pub struct PlanDataFrameScan {
-    #[pyo3(get)]
-    df: PyDataFrame,
-    #[pyo3(get)]
-    schema: PyObject, // SchemaRef
-    #[pyo3(get)]
-    output_schema: PyObject, // Option<SchemaRef> Optional[dict]
-    #[pyo3(get)]
-    projection: PyObject,
-    #[pyo3(get)]
-    selection: PyObject,
-}
-
-#[pyclass]
-/// Column selection
-pub struct PlanProjection {
-    #[pyo3(get)]
-    expr: Vec<PyObject>,
-    #[pyo3(get)]
-    cse_expr: Vec<PyObject>,
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    schema: PyObject, // SchemaRef,
-    options: (), //ProjectionOptions,
-}
-
-#[pyclass]
-/// Sort the table
-pub struct PlanSort {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    by_column: Vec<PyObject>,
-    #[pyo3(get)]
-    args: PyObject, // SortArguments,
-}
-
-/// Cache the input at this point in the LP
-#[pyclass]
-pub struct PlanCache {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    id_: usize,
-    #[pyo3(get)]
-    count: usize,
-}
-
-#[pyclass]
-/// Groupby aggregation
-pub struct PlanAggregate {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    keys: Vec<PyObject>,
-    #[pyo3(get)]
-    aggs: Vec<PyObject>,
-    #[pyo3(get)]
-    schema: PyObject, // SchemaRef,
-    apply: (), // Option<Arc<dyn DataFrameUdf>>,
-    #[pyo3(get)]
-    maintain_order: bool,
-    #[pyo3(get)]
-    options: PyObject, // Arc<GroupbyOptions>,
-}
-
-#[pyclass]
-/// Join operation
-pub struct PlanJoin {
-    #[pyo3(get)]
-    input_left: PyObject,
-    #[pyo3(get)]
-    input_right: PyObject,
-    #[pyo3(get)]
-    schema: PyObject, // SchemaRef,
-    #[pyo3(get)]
-    left_on: Vec<PyObject>,
-    #[pyo3(get)]
-    right_on: Vec<PyObject>,
-    #[pyo3(get)]
-    options: PyObject, // Arc<JoinOptions>,
-}
-
-#[pyclass]
-/// Adding columns to the table without a Join
-pub struct PlanHStack {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    exprs: Vec<PyObject>,
-    #[pyo3(get)]
-    schema: PyObject, // SchemaRef,
-    options: (), // ProjectionOptions,
-}
-
-#[pyclass]
-/// Remove duplicates from the table
-pub struct PlanDistinct {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    options: PyObject, // DistinctOptions,
-}
-#[pyclass]
-/// A (User Defined) Function
-pub struct PlanMapFunction {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    function: PyObject, // FunctionNode,
-}
-#[pyclass]
-pub struct PlanUnion {
-    #[pyo3(get)]
-    inputs: Vec<PyObject>,
-    #[pyo3(get)]
-    options: PyObject, // UnionOptions,
-}
-#[pyclass]
-/// Horizontal concatenation of multiple plans
-pub struct PlanHConcat {
-    #[pyo3(get)]
-    inputs: Vec<PyObject>,
-    #[pyo3(get)]
-    schema: PyObject, // SchemaRef,
-    options: (), // HConcatOptions,
-}
-#[pyclass]
-/// This allows expressions to access other tables
-pub struct PlanExtContext {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    contexts: Vec<PyObject>,
-    #[pyo3(get)]
-    schema: PyObject, // SchemaRef,
-}
-
-#[pyclass]
-pub struct PlanSink {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    payload: PyObject, // SinkType,
-}
-
-// Expressions
-#[pyclass]
-pub struct ExprAlias {
-    #[pyo3(get)]
-    expr: PyObject,
-    #[pyo3(get)]
-    name: PyObject,
-}
-
-#[pymethods]
-impl ExprAlias {
-    fn reconstruct(&self, expr: PyObject) -> Self {
-        Self {
-            expr,
-            name: self.name.clone(),
-        }
-    }
-}
-
-#[pyclass]
-pub struct ExprColumn {
-    #[pyo3(get)]
-    name: PyObject,
-}
-
-#[pymethods]
-impl ExprColumn {
-    fn reconstruct(&self, name: PyObject) -> Self {
-        Self { name }
-    }
-    #[new]
-    fn new(name: PyObject) -> Self {
-        Self { name }
-    }
-}
-
-#[pyclass]
-pub struct ExprLiteral {
-    #[pyo3(get)]
-    value: PyObject,
-    #[pyo3(get)]
-    dtype: PyObject,
-}
-
-impl ExprLiteral {
-    fn new(py: Python<'_>, value: PyObject, dtype: PyObject) -> Self {
-        Self {
-            value,
-            dtype: dtype,
-        }
-    }
-}
-
-#[pymethods]
-impl ExprLiteral {
-    fn reconstruct(&self, value: PyObject, dtype: PyObject) -> Self {
-        Self { value, dtype }
-    }
-}
-
-#[pyclass]
-pub struct ExprBinaryExpr {
-    #[pyo3(get)]
-    left: PyObject,
-    #[pyo3(get)]
-    op: PyOperator,
-    #[pyo3(get)]
-    right: PyObject,
-}
-
-#[pymethods]
-impl ExprBinaryExpr {
-    fn reconstruct(&self, left: PyObject, right: PyObject) -> Self {
-        Self {
-            left,
-            op: self.op,
-            right,
-        }
-    }
-}
-
-#[pyclass]
-pub struct ExprCast {
-    #[pyo3(get)]
-    expr: PyObject,
-    #[pyo3(get)]
-    dtype: PyObject,
-}
-
-impl ExprCast {
-    fn new(py: Python<'_>, expr: PyObject, dtype: PyObject) -> Self {
-        Self { expr, dtype }
-    }
-}
-
-#[pymethods]
-impl ExprCast {
-    fn reconstruct(&self, expr: PyObject, dtype: PyObject) -> Self {
-        Self { expr, dtype }
-    }
-}
-
-#[pyclass]
-pub struct ExprSort {
-    #[pyo3(get)]
-    expr: PyObject,
-    #[pyo3(get)]
-    options: PyObject,
-}
-
-#[pymethods]
-impl ExprSort {
-    fn reconstruct(&self, expr: PyObject) -> Self {
-        Self {
-            expr,
-            options: self.options.clone(),
-        }
-    }
-}
-
-#[pyclass]
-pub struct ExprGather {
-    #[pyo3(get)]
-    expr: PyObject,
-    #[pyo3(get)]
-    idx: PyObject,
-    #[pyo3(get)]
-    scalar: bool,
-}
-
-#[pymethods]
-impl ExprGather {
-    fn reconstruct(&self, expr: PyObject, idx: PyObject, scalar: bool) -> Self {
-        Self { expr, idx, scalar }
-    }
-}
-
-#[pyclass]
-pub struct ExprFilter {
-    #[pyo3(get)]
-    input: PyObject,
-    #[pyo3(get)]
-    by: PyObject,
-}
-
-#[pymethods]
-impl ExprFilter {
-    fn reconstruct(&self, input: PyObject, by: PyObject) -> Self {
-        Self { input, by }
-    }
-}
-
-#[pyclass]
-pub struct ExprSortBy {
-    #[pyo3(get)]
-    expr: PyObject,
-    #[pyo3(get)]
-    by: Vec<PyObject>,
-    #[pyo3(get)]
-    descending: PyObject,
-}
-
-#[pymethods]
-impl ExprSortBy {
-    fn reconstruct(&self, expr: PyObject, by: Vec<PyObject>) -> Self {
-        Self {
-            expr,
-            by,
-            descending: self.descending.clone(),
-        }
-    }
-}
-
-#[pyclass]
-pub struct ExprAgg {
-    #[pyo3(get)]
-    name: PyObject,
-    #[pyo3(get)]
-    arguments: PyObject,
-    #[pyo3(get)]
-    // Arbitrary control options
-    options: PyObject,
-}
-
-#[pymethods]
-impl ExprAgg {
-    fn reconstruct(&self, arguments: PyObject) -> Self {
-        Self {
-            name: self.name.clone(),
-            arguments,
-            options: self.options.clone(),
-        }
-    }
-}
-
-#[pyclass]
-pub struct ExprTernary {
-    #[pyo3(get)]
-    predicate: PyObject,
-    #[pyo3(get)]
-    truthy: PyObject,
-    #[pyo3(get)]
-    falsy: PyObject,
-}
-
-#[pymethods]
-impl ExprTernary {
-    fn reconstruct(&self, predicate: PyObject, truthy: PyObject, falsy: PyObject) -> Self {
-        Self {
-            predicate,
-            truthy,
-            falsy,
-        }
-    }
-}
-
-#[pyclass]
-pub struct ExprFunction {
-    #[pyo3(get)]
-    input: Vec<PyObject>,
-    #[pyo3(get)]
-    function_data: PyObject,
-    #[pyo3(get)]
-    options: PyObject,
-}
-
-#[pymethods]
-impl ExprFunction {
-    fn reconstruct(&self, input: Vec<PyObject>) -> Self {
-        Self {
-            input,
-            function_data: self.function_data.clone(),
-            options: self.options.clone(),
-        }
-    }
-}
-
-#[pyclass]
-pub struct ExprCount {}
-
-#[pyclass]
-pub struct ExprWindow {
-    #[pyo3(get)]
-    function: PyObject,
-    #[pyo3(get)]
-    partition_by: PyObject,
-    #[pyo3(get)]
-    options: PyObject,
-}
+// use pyo3::prelude::*;
+// use polars_plan::prelude::{FileCount, FileScanOptions};
+// use crate::dataframe::PyDataFrame;
+// use super::*;
+//
+// #[pyclass]
+// pub struct PlanPythonScan {
+//     #[pyo3(get)]
+//     options: PyObject,
+//     #[pyo3(get)]
+//     predicate: PyObject,
+// }
+//
+// #[pyclass]
+// /// Slice the table
+// pub struct PlanSlice {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     offset: i64,
+//     #[pyo3(get)]
+//     len: IdxSize,
+// }
+//
+// #[pyclass]
+// pub struct PlanSelection {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     predicate: PyObject,
+// }
+//
+// #[pyclass]
+// #[derive(Clone)]
+// pub struct PyFileOptions {
+//     inner: FileScanOptions,
+// }
+//
+// #[pymethods]
+// impl PyFileOptions {
+//     #[getter]
+//     fn n_rows(&self, py: Python<'_>) -> PyResult<PyObject> {
+//         Ok(self
+//             .inner
+//             .n_rows
+//             .map_or_else(|| py.None(), |n| n.into_py(py)))
+//     }
+//     #[getter]
+//     fn with_columns(&self, py: Python<'_>) -> PyResult<PyObject> {
+//         Ok(self
+//             .inner
+//             .with_columns
+//             .as_ref()
+//             .map_or_else(|| py.None(), |cols| cols.to_object(py)))
+//     }
+//     #[getter]
+//     fn cache(&self, _py: Python<'_>) -> PyResult<bool> {
+//         Ok(self.inner.cache)
+//     }
+//     #[getter]
+//     fn row_index(&self, py: Python<'_>) -> PyResult<PyObject> {
+//         Ok(self
+//             .inner
+//             .row_index
+//             .as_ref()
+//             .map_or_else(|| py.None(), |n| (&n.name, n.offset).to_object(py)))
+//     }
+//     #[getter]
+//     fn rechunk(&self, _py: Python<'_>) -> PyResult<bool> {
+//         Ok(self.inner.rechunk)
+//     }
+//     #[getter]
+//     fn file_counter(&self, _py: Python<'_>) -> PyResult<FileCount> {
+//         Ok(self.inner.file_counter)
+//     }
+//     #[getter]
+//     fn hive_partitioning(&self, _py: Python<'_>) -> PyResult<bool> {
+//         Ok(self.inner.hive_partitioning)
+//     }
+// }
+//
+// #[pyclass]
+// pub struct PlanScan {
+//     #[pyo3(get)]
+//     paths: PyObject,
+//     #[pyo3(get)]
+//     file_info: PyObject,
+//     #[pyo3(get)]
+//     predicate: PyObject,
+//     #[pyo3(get)]
+//     output_schema: PyObject,
+//     #[pyo3(get)]
+//     file_options: PyFileOptions,
+//     #[pyo3(get)]
+//     scan_type: PyObject,
+// }
+//
+// #[pyclass]
+// pub struct PlanDataFrameScan {
+//     #[pyo3(get)]
+//     df: PyDataFrame,
+//     #[pyo3(get)]
+//     schema: PyObject, // SchemaRef
+//     #[pyo3(get)]
+//     output_schema: PyObject, // Option<SchemaRef> Optional[dict]
+//     #[pyo3(get)]
+//     projection: PyObject,
+//     #[pyo3(get)]
+//     selection: PyObject,
+// }
+//
+// #[pyclass]
+// /// Column selection
+// pub struct PlanProjection {
+//     #[pyo3(get)]
+//     expr: Vec<PyObject>,
+//     #[pyo3(get)]
+//     cse_expr: Vec<PyObject>,
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     schema: PyObject, // SchemaRef,
+//     options: (), //ProjectionOptions,
+// }
+//
+// #[pyclass]
+// /// Sort the table
+// pub struct PlanSort {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     by_column: Vec<PyObject>,
+//     #[pyo3(get)]
+//     args: PyObject, // SortArguments,
+// }
+//
+// /// Cache the input at this point in the LP
+// #[pyclass]
+// pub struct PlanCache {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     id_: usize,
+//     #[pyo3(get)]
+//     count: usize,
+// }
+//
+// #[pyclass]
+// /// Groupby aggregation
+// pub struct PlanAggregate {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     keys: Vec<PyObject>,
+//     #[pyo3(get)]
+//     aggs: Vec<PyObject>,
+//     #[pyo3(get)]
+//     schema: PyObject, // SchemaRef,
+//     apply: (), // Option<Arc<dyn DataFrameUdf>>,
+//     #[pyo3(get)]
+//     maintain_order: bool,
+//     #[pyo3(get)]
+//     options: PyObject, // Arc<GroupbyOptions>,
+// }
+//
+// #[pyclass]
+// /// Join operation
+// pub struct PlanJoin {
+//     #[pyo3(get)]
+//     input_left: PyObject,
+//     #[pyo3(get)]
+//     input_right: PyObject,
+//     #[pyo3(get)]
+//     schema: PyObject, // SchemaRef,
+//     #[pyo3(get)]
+//     left_on: Vec<PyObject>,
+//     #[pyo3(get)]
+//     right_on: Vec<PyObject>,
+//     #[pyo3(get)]
+//     options: PyObject, // Arc<JoinOptions>,
+// }
+//
+// #[pyclass]
+// /// Adding columns to the table without a Join
+// pub struct PlanHStack {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     exprs: Vec<PyObject>,
+//     #[pyo3(get)]
+//     schema: PyObject, // SchemaRef,
+//     options: (), // ProjectionOptions,
+// }
+//
+// #[pyclass]
+// /// Remove duplicates from the table
+// pub struct PlanDistinct {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     options: PyObject, // DistinctOptions,
+// }
+// #[pyclass]
+// /// A (User Defined) Function
+// pub struct PlanMapFunction {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     function: PyObject, // FunctionNode,
+// }
+// #[pyclass]
+// pub struct PlanUnion {
+//     #[pyo3(get)]
+//     inputs: Vec<PyObject>,
+//     #[pyo3(get)]
+//     options: PyObject, // UnionOptions,
+// }
+// #[pyclass]
+// /// Horizontal concatenation of multiple plans
+// pub struct PlanHConcat {
+//     #[pyo3(get)]
+//     inputs: Vec<PyObject>,
+//     #[pyo3(get)]
+//     schema: PyObject, // SchemaRef,
+//     options: (), // HConcatOptions,
+// }
+// #[pyclass]
+// /// This allows expressions to access other tables
+// pub struct PlanExtContext {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     contexts: Vec<PyObject>,
+//     #[pyo3(get)]
+//     schema: PyObject, // SchemaRef,
+// }
+//
+// #[pyclass]
+// pub struct PlanSink {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     payload: PyObject, // SinkType,
+// }
+//
+// // Expressions
+// #[pyclass]
+// pub struct ExprAlias {
+//     #[pyo3(get)]
+//     expr: PyObject,
+//     #[pyo3(get)]
+//     name: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprAlias {
+//     fn reconstruct(&self, expr: PyObject) -> Self {
+//         Self {
+//             expr,
+//             name: self.name.clone(),
+//         }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprColumn {
+//     #[pyo3(get)]
+//     name: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprColumn {
+//     fn reconstruct(&self, name: PyObject) -> Self {
+//         Self { name }
+//     }
+//     #[new]
+//     fn new(name: PyObject) -> Self {
+//         Self { name }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprLiteral {
+//     #[pyo3(get)]
+//     value: PyObject,
+//     #[pyo3(get)]
+//     dtype: PyObject,
+// }
+//
+// impl ExprLiteral {
+//     fn new(py: Python<'_>, value: PyObject, dtype: PyObject) -> Self {
+//         Self {
+//             value,
+//             dtype: dtype,
+//         }
+//     }
+// }
+//
+// #[pymethods]
+// impl ExprLiteral {
+//     fn reconstruct(&self, value: PyObject, dtype: PyObject) -> Self {
+//         Self { value, dtype }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprBinaryExpr {
+//     #[pyo3(get)]
+//     left: PyObject,
+//     #[pyo3(get)]
+//     op: PyOperator,
+//     #[pyo3(get)]
+//     right: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprBinaryExpr {
+//     fn reconstruct(&self, left: PyObject, right: PyObject) -> Self {
+//         Self {
+//             left,
+//             op: self.op,
+//             right,
+//         }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprCast {
+//     #[pyo3(get)]
+//     expr: PyObject,
+//     #[pyo3(get)]
+//     dtype: PyObject,
+// }
+//
+// impl ExprCast {
+//     fn new(py: Python<'_>, expr: PyObject, dtype: PyObject) -> Self {
+//         Self { expr, dtype }
+//     }
+// }
+//
+// #[pymethods]
+// impl ExprCast {
+//     fn reconstruct(&self, expr: PyObject, dtype: PyObject) -> Self {
+//         Self { expr, dtype }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprSort {
+//     #[pyo3(get)]
+//     expr: PyObject,
+//     #[pyo3(get)]
+//     options: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprSort {
+//     fn reconstruct(&self, expr: PyObject) -> Self {
+//         Self {
+//             expr,
+//             options: self.options.clone(),
+//         }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprGather {
+//     #[pyo3(get)]
+//     expr: PyObject,
+//     #[pyo3(get)]
+//     idx: PyObject,
+//     #[pyo3(get)]
+//     scalar: bool,
+// }
+//
+// #[pymethods]
+// impl ExprGather {
+//     fn reconstruct(&self, expr: PyObject, idx: PyObject, scalar: bool) -> Self {
+//         Self { expr, idx, scalar }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprFilter {
+//     #[pyo3(get)]
+//     input: PyObject,
+//     #[pyo3(get)]
+//     by: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprFilter {
+//     fn reconstruct(&self, input: PyObject, by: PyObject) -> Self {
+//         Self { input, by }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprSortBy {
+//     #[pyo3(get)]
+//     expr: PyObject,
+//     #[pyo3(get)]
+//     by: Vec<PyObject>,
+//     #[pyo3(get)]
+//     descending: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprSortBy {
+//     fn reconstruct(&self, expr: PyObject, by: Vec<PyObject>) -> Self {
+//         Self {
+//             expr,
+//             by,
+//             descending: self.descending.clone(),
+//         }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprAgg {
+//     #[pyo3(get)]
+//     name: PyObject,
+//     #[pyo3(get)]
+//     arguments: PyObject,
+//     #[pyo3(get)]
+//     // Arbitrary control options
+//     options: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprAgg {
+//     fn reconstruct(&self, arguments: PyObject) -> Self {
+//         Self {
+//             name: self.name.clone(),
+//             arguments,
+//             options: self.options.clone(),
+//         }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprTernary {
+//     #[pyo3(get)]
+//     predicate: PyObject,
+//     #[pyo3(get)]
+//     truthy: PyObject,
+//     #[pyo3(get)]
+//     falsy: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprTernary {
+//     fn reconstruct(&self, predicate: PyObject, truthy: PyObject, falsy: PyObject) -> Self {
+//         Self {
+//             predicate,
+//             truthy,
+//             falsy,
+//         }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprFunction {
+//     #[pyo3(get)]
+//     input: Vec<PyObject>,
+//     #[pyo3(get)]
+//     function_data: PyObject,
+//     #[pyo3(get)]
+//     options: PyObject,
+// }
+//
+// #[pymethods]
+// impl ExprFunction {
+//     fn reconstruct(&self, input: Vec<PyObject>) -> Self {
+//         Self {
+//             input,
+//             function_data: self.function_data.clone(),
+//             options: self.options.clone(),
+//         }
+//     }
+// }
+//
+// #[pyclass]
+// pub struct ExprCount {}
+//
+// #[pyclass]
+// pub struct ExprWindow {
+//     #[pyo3(get)]
+//     function: PyObject,
+//     #[pyo3(get)]
+//     partition_by: PyObject,
+//     #[pyo3(get)]
+//     options: PyObject,
+// }

--- a/py-polars/src/lazyframe/visitor/mod.rs
+++ b/py-polars/src/lazyframe/visitor/mod.rs
@@ -1,0 +1,2 @@
+mod expr_nodes;
+use polars::prelude::*;

--- a/py-polars/src/lazyframe/visitor/mod.rs
+++ b/py-polars/src/lazyframe/visitor/mod.rs
@@ -1,2 +1,1 @@
 mod expr_nodes;
-use polars::prelude::*;

--- a/py-polars/src/lazyframe/visitor/mod.rs
+++ b/py-polars/src/lazyframe/visitor/mod.rs
@@ -1,1 +1,2 @@
-mod expr_nodes;
+pub(crate) mod expr_nodes;
+pub(crate) mod nodes;

--- a/py-polars/src/lazyframe/visitor/nodes.rs
+++ b/py-polars/src/lazyframe/visitor/nodes.rs
@@ -1,0 +1,637 @@
+use polars_core::prelude::{IdxSize, UniqueKeepStrategy};
+use polars_ops::prelude::JoinType;
+use polars_plan::logical_plan::IR;
+use polars_plan::prelude::{FileCount, FileScan, FileScanOptions, FunctionNode};
+use pyo3::exceptions::PyNotImplementedError;
+use pyo3::prelude::*;
+
+use super::super::visit::PyExprIR;
+use super::expr_nodes::PyGroupbyOptions;
+use crate::{PyDataFrame, Wrap};
+
+#[pyclass]
+/// Scan a table with an optional predicate from a python function
+pub struct PythonScan {
+    #[pyo3(get)]
+    options: PyObject,
+    #[pyo3(get)]
+    predicate: Option<PyExprIR>,
+}
+
+#[pyclass]
+/// Slice the table
+pub struct Slice {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    offset: i64,
+    #[pyo3(get)]
+    len: IdxSize,
+}
+
+#[pyclass]
+/// Filter the table with a boolean expression
+pub struct Filter {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    predicate: PyExprIR,
+}
+
+#[pyclass]
+#[derive(Clone)]
+pub struct PyFileOptions {
+    inner: FileScanOptions,
+}
+
+#[pymethods]
+impl PyFileOptions {
+    #[getter]
+    fn n_rows(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self
+            .inner
+            .n_rows
+            .map_or_else(|| py.None(), |n| n.into_py(py)))
+    }
+    #[getter]
+    fn with_columns(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self
+            .inner
+            .with_columns
+            .as_ref()
+            .map_or_else(|| py.None(), |cols| cols.to_object(py)))
+    }
+    #[getter]
+    fn cache(&self, _py: Python<'_>) -> PyResult<bool> {
+        Ok(self.inner.cache)
+    }
+    #[getter]
+    fn row_index(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(self
+            .inner
+            .row_index
+            .as_ref()
+            .map_or_else(|| py.None(), |n| (&n.name, n.offset).to_object(py)))
+    }
+    #[getter]
+    fn rechunk(&self, _py: Python<'_>) -> PyResult<bool> {
+        Ok(self.inner.rechunk)
+    }
+    #[getter]
+    fn file_counter(&self, _py: Python<'_>) -> PyResult<FileCount> {
+        Ok(self.inner.file_counter)
+    }
+    #[getter]
+    fn hive_options(&self, _py: Python<'_>) -> PyResult<PyObject> {
+        Err(PyNotImplementedError::new_err("hive options"))
+    }
+}
+
+#[pyclass]
+/// Scan a table from file
+pub struct Scan {
+    #[pyo3(get)]
+    paths: PyObject,
+    #[pyo3(get)]
+    file_info: PyObject,
+    #[pyo3(get)]
+    predicate: Option<PyExprIR>,
+    #[pyo3(get)]
+    output_schema: PyObject,
+    #[pyo3(get)]
+    file_options: PyFileOptions,
+    #[pyo3(get)]
+    scan_type: PyObject,
+}
+
+#[pyclass]
+/// Scan a table from an existing dataframe
+pub struct DataFrameScan {
+    #[pyo3(get)]
+    df: PyDataFrame,
+    #[pyo3(get)]
+    schema: PyObject,
+    #[pyo3(get)]
+    output_schema: PyObject,
+    #[pyo3(get)]
+    projection: PyObject,
+    #[pyo3(get)]
+    selection: Option<PyExprIR>,
+}
+
+#[pyclass]
+/// Project out columns from a table
+pub struct SimpleProjection {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    columns: PyObject,
+    #[pyo3(get)]
+    duplicate_check: bool,
+}
+
+#[pyclass]
+/// Column selection
+pub struct Select {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    expr: Vec<PyExprIR>,
+    #[pyo3(get)]
+    cse_expr: Vec<PyExprIR>,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+    #[pyo3(get)]
+    options: (), //ProjectionOptions,
+}
+
+#[pyclass]
+/// Sort the table
+pub struct Sort {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    by_column: Vec<PyExprIR>,
+    #[pyo3(get)]
+    args: PyObject,
+}
+
+#[pyclass]
+/// Cache the input at this point in the LP
+pub struct Cache {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    id_: usize,
+    #[pyo3(get)]
+    cache_hits: u32,
+}
+
+#[pyclass]
+/// Groupby aggregation
+pub struct GroupBy {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    keys: Vec<PyExprIR>,
+    #[pyo3(get)]
+    aggs: Vec<PyExprIR>,
+    #[pyo3(get)]
+    schema: PyObject,
+    #[pyo3(get)]
+    apply: (),
+    #[pyo3(get)]
+    maintain_order: bool,
+    #[pyo3(get)]
+    options: PyObject,
+}
+
+#[pyclass]
+/// Join operation
+pub struct Join {
+    #[pyo3(get)]
+    input_left: usize,
+    #[pyo3(get)]
+    input_right: usize,
+    #[pyo3(get)]
+    schema: PyObject,
+    #[pyo3(get)]
+    left_on: Vec<PyExprIR>,
+    #[pyo3(get)]
+    right_on: Vec<PyExprIR>,
+    #[pyo3(get)]
+    options: PyObject,
+}
+
+#[pyclass]
+/// Adding columns to the table without a Join
+pub struct HStack {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    exprs: Vec<PyExprIR>,
+    #[pyo3(get)]
+    cse_exprs: Vec<PyExprIR>,
+    #[pyo3(get)]
+    schema: PyObject, // SchemaRef,
+    #[pyo3(get)]
+    options: (), // ProjectionOptions,
+}
+
+#[pyclass]
+/// Remove duplicates from the table
+pub struct Distinct {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    options: PyObject,
+}
+#[pyclass]
+/// A (User Defined) Function
+pub struct MapFunction {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    function: PyObject,
+}
+#[pyclass]
+pub struct Union {
+    #[pyo3(get)]
+    inputs: Vec<usize>,
+    #[pyo3(get)]
+    options: PyObject,
+}
+#[pyclass]
+/// Horizontal concatenation of multiple plans
+pub struct HConcat {
+    #[pyo3(get)]
+    inputs: Vec<usize>,
+    #[pyo3(get)]
+    schema: PyObject,
+    #[pyo3(get)]
+    options: (),
+}
+#[pyclass]
+/// This allows expressions to access other tables
+pub struct ExtContext {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    contexts: Vec<usize>,
+    #[pyo3(get)]
+    schema: PyObject,
+}
+
+#[pyclass]
+pub struct Sink {
+    #[pyo3(get)]
+    input: usize,
+    #[pyo3(get)]
+    payload: PyObject,
+}
+
+pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
+    let result = match plan {
+        IR::PythonScan { options, predicate } => PythonScan {
+            options: (
+                options
+                    .scan_fn
+                    .as_ref()
+                    .map_or_else(|| py.None(), |s| s.0.clone()),
+                Wrap(options.schema.as_ref()).into_py(py),
+                options
+                    .output_schema
+                    .as_ref()
+                    .map_or_else(|| py.None(), |s| Wrap(s.as_ref()).into_py(py)),
+                options
+                    .with_columns
+                    .as_ref()
+                    .map_or_else(|| py.None(), |cols| cols.to_object(py)),
+                options.pyarrow,
+                options
+                    .predicate
+                    .as_ref()
+                    .map_or_else(|| py.None(), |s| s.to_object(py)),
+                options
+                    .n_rows
+                    .map_or_else(|| py.None(), |s| s.to_object(py)),
+            )
+                .to_object(py),
+            predicate: predicate.as_ref().map(|e| e.into()),
+        }
+        .into_py(py),
+        IR::Slice { input, offset, len } => Slice {
+            input: input.0,
+            offset: *offset,
+            len: *len,
+        }
+        .into_py(py),
+        IR::Filter { input, predicate } => Filter {
+            input: input.0,
+            predicate: predicate.into(),
+        }
+        .into_py(py),
+        IR::Scan {
+            paths,
+            file_info,
+            predicate,
+            output_schema,
+            scan_type,
+            file_options,
+        } => Scan {
+            paths: paths.to_object(py),
+            // TODO: remaining file info
+            file_info: Wrap(file_info.schema.as_ref()).into_py(py),
+            predicate: predicate.as_ref().map(|e| e.into()),
+            output_schema: output_schema
+                .as_ref()
+                .map_or_else(|| py.None(), |s| Wrap(s.as_ref()).into_py(py)),
+            file_options: PyFileOptions {
+                inner: file_options.clone(),
+            },
+            scan_type: match scan_type {
+                // TODO: Actually send options through since those are important for correct reads
+                FileScan::Csv { .. } => "csv".into_py(py),
+                FileScan::Parquet { .. } => "parquet".into_py(py),
+                FileScan::Ipc { .. } => return Err(PyNotImplementedError::new_err("ipc scan")),
+                FileScan::Anonymous { .. } => {
+                    return Err(PyNotImplementedError::new_err("anonymous scan"))
+                },
+            },
+        }
+        .into_py(py),
+        IR::DataFrameScan {
+            df,
+            schema,
+            output_schema,
+            projection,
+            selection,
+        } => DataFrameScan {
+            df: PyDataFrame::new((**df).clone()),
+            schema: Wrap(schema.as_ref()).into_py(py),
+            output_schema: output_schema
+                .as_ref()
+                .map_or_else(|| py.None(), |s| Wrap(s.as_ref()).into_py(py)),
+            projection: projection
+                .as_ref()
+                .map_or_else(|| py.None(), |f| f.to_object(py)),
+            selection: selection.as_ref().map(|e| e.into()),
+        }
+        .into_py(py),
+        IR::SimpleProjection {
+            input,
+            columns,
+            duplicate_check,
+        } => SimpleProjection {
+            input: input.0,
+            columns: Wrap(columns.as_ref()).into_py(py),
+            duplicate_check: *duplicate_check,
+        }
+        .into_py(py),
+        IR::Select {
+            input,
+            expr,
+            schema,
+            options: _,
+        } => Select {
+            expr: expr.default_exprs().iter().map(|e| e.into()).collect(),
+            cse_expr: expr.cse_exprs().iter().map(|e| e.into()).collect(),
+            input: input.0,
+            schema: Wrap(schema.as_ref()).into_py(py),
+            options: (),
+        }
+        .into_py(py),
+        IR::Sort {
+            input,
+            by_column,
+            args,
+        } => Sort {
+            input: input.0,
+            by_column: by_column.iter().map(|e| e.into()).collect(),
+            args: (
+                args.maintain_order,
+                args.nulls_last,
+                &args.descending,
+                args.slice,
+            )
+                .to_object(py),
+        }
+        .into_py(py),
+        IR::Cache {
+            input,
+            id,
+            cache_hits,
+        } => Cache {
+            input: input.0,
+            id_: *id,
+            cache_hits: *cache_hits,
+        }
+        .into_py(py),
+        IR::GroupBy {
+            input,
+            keys,
+            aggs,
+            schema,
+            apply,
+            maintain_order,
+            options,
+        } => GroupBy {
+            input: input.0,
+            keys: keys.iter().map(|e| e.into()).collect(),
+            aggs: aggs.iter().map(|e| e.into()).collect(),
+            schema: Wrap(schema.as_ref()).into_py(py),
+            apply: apply.as_ref().map_or(Ok(()), |_| {
+                Err(PyNotImplementedError::new_err(format!(
+                    "apply inside GroupBy {:?}",
+                    plan
+                )))
+            })?,
+            maintain_order: *maintain_order,
+            // TODO: dynamic options
+            options: PyGroupbyOptions::new(options.as_ref().clone()).into_py(py),
+        }
+        .into_py(py),
+        IR::Join {
+            input_left,
+            input_right,
+            schema,
+            left_on,
+            right_on,
+            options,
+        } => Join {
+            input_left: input_left.0,
+            input_right: input_right.0,
+            schema: Wrap(schema.as_ref()).into_py(py),
+            left_on: left_on.iter().map(|e| e.into()).collect(),
+            right_on: right_on.iter().map(|e| e.into()).collect(),
+            options: (
+                match options.args.how {
+                    JoinType::Left => "left",
+                    JoinType::Inner => "inner",
+                    JoinType::Outer { coalesce } => {
+                        if coalesce {
+                            "outer_coalesce"
+                        } else {
+                            "outer"
+                        }
+                    },
+                    JoinType::AsOf(_) => return Err(PyNotImplementedError::new_err("asof join")),
+                    JoinType::Cross => "cross",
+                    JoinType::Semi => "leftsemi",
+                    JoinType::Anti => "leftanti",
+                },
+                options.args.join_nulls,
+                options
+                    .args
+                    .slice
+                    .map_or_else(|| py.None(), |f| f.to_object(py)),
+                options
+                    .args
+                    .suffix
+                    .as_ref()
+                    .map_or_else(|| py.None(), |f| f.to_object(py)),
+            )
+                .to_object(py),
+        }
+        .into_py(py),
+        IR::HStack {
+            input,
+            exprs,
+            schema,
+            options: _,
+        } => HStack {
+            input: input.0,
+            exprs: exprs.default_exprs().iter().map(|e| e.into()).collect(),
+            cse_exprs: exprs.cse_exprs().iter().map(|e| e.into()).collect(),
+            schema: Wrap(schema.as_ref()).into_py(py),
+            options: (),
+        }
+        .into_py(py),
+        IR::Distinct { input, options } => Distinct {
+            input: input.0,
+            // TODO, rest of options
+            options: (
+                match options.keep_strategy {
+                    UniqueKeepStrategy::First => "first",
+                    UniqueKeepStrategy::Last => "last",
+                    UniqueKeepStrategy::None => "none",
+                    UniqueKeepStrategy::Any => "any",
+                },
+                options
+                    .subset
+                    .as_ref()
+                    .map_or_else(|| py.None(), |f| f.to_object(py)),
+                options.maintain_order,
+                options.slice.map_or_else(|| py.None(), |f| f.to_object(py)),
+            )
+                .to_object(py),
+        }
+        .into_py(py),
+        IR::MapFunction { input, function } => MapFunction {
+            input: input.0,
+            function: match function {
+                FunctionNode::OpaquePython {
+                    function: _,
+                    schema: _,
+                    predicate_pd: _,
+                    projection_pd: _,
+                    streamable: _,
+                    validate_output: _,
+                } => return Err(PyNotImplementedError::new_err("opaque python mapfunction")),
+                FunctionNode::Opaque {
+                    function: _,
+                    schema: _,
+                    predicate_pd: _,
+                    projection_pd: _,
+                    streamable: _,
+                    fmt_str: _,
+                } => return Err(PyNotImplementedError::new_err("opaque rust mapfunction")),
+                FunctionNode::Pipeline {
+                    function: _,
+                    schema: _,
+                    original: _,
+                } => return Err(PyNotImplementedError::new_err("pipeline mapfunction")),
+                FunctionNode::Unnest { columns } => (
+                    "unnest",
+                    columns.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                )
+                    .to_object(py),
+                FunctionNode::DropNulls { subset } => (
+                    "drop_nulls",
+                    subset.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                )
+                    .to_object(py),
+                FunctionNode::Rechunk => ("rechunk",).to_object(py),
+                FunctionNode::MergeSorted { column } => {
+                    ("merge_sorted", column.to_string()).to_object(py)
+                },
+                FunctionNode::Rename {
+                    existing,
+                    new,
+                    swapping,
+                } => (
+                    "rename",
+                    existing.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                    new.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                    *swapping,
+                )
+                    .to_object(py),
+                FunctionNode::Explode { columns, schema } => (
+                    "explode",
+                    columns.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                    Wrap(schema.as_ref()).into_py(py),
+                )
+                    .to_object(py),
+                FunctionNode::Melt { args, schema } => (
+                    "melt",
+                    args.id_vars.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                    args.value_vars
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>(),
+                    args.variable_name
+                        .as_ref()
+                        .map_or_else(|| py.None(), |s| s.as_str().to_object(py)),
+                    args.value_name
+                        .as_ref()
+                        .map_or_else(|| py.None(), |s| s.as_str().to_object(py)),
+                    Wrap(schema.as_ref()).into_py(py),
+                )
+                    .to_object(py),
+                FunctionNode::RowIndex {
+                    name,
+                    schema,
+                    offset,
+                } => (
+                    "row_index",
+                    name.to_string(),
+                    Wrap(schema.as_ref()).into_py(py),
+                    offset.unwrap_or(0),
+                )
+                    .to_object(py),
+                FunctionNode::Count {
+                    paths: _,
+                    scan_type: _,
+                    alias: _,
+                } => return Err(PyNotImplementedError::new_err("function count")),
+            },
+        }
+        .into_py(py),
+        IR::Union { inputs, options } => Union {
+            inputs: inputs.iter().map(|n| n.0).collect(),
+            // TODO: rest of options
+            options: options.slice.map_or_else(|| py.None(), |f| f.to_object(py)),
+        }
+        .into_py(py),
+        IR::HConcat {
+            inputs,
+            schema,
+            options: _,
+        } => HConcat {
+            inputs: inputs.iter().map(|n| n.0).collect(),
+            schema: Wrap(schema.as_ref()).into_py(py),
+            options: (),
+        }
+        .into_py(py),
+        IR::ExtContext {
+            input,
+            contexts,
+            schema,
+        } => ExtContext {
+            input: input.0,
+            contexts: contexts.iter().map(|n| n.0).collect(),
+            schema: Wrap(schema.as_ref()).into_py(py),
+        }
+        .into_py(py),
+        IR::Sink {
+            input: _,
+            payload: _,
+        } => {
+            return Err(PyNotImplementedError::new_err(
+                "Not expecting to see a Sink node",
+            ))
+        },
+        IR::Invalid => return Err(PyNotImplementedError::new_err("Invalid")),
+    };
+    Ok(result)
+}

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -122,7 +122,9 @@ fn nodes(_py: Python, m: &PyModule) -> PyResult<()> {
 #[pymodule]
 fn expr_nodes(_py: Python, m: &PyModule) -> PyResult<()> {
     use crate::lazyframe::visitor::expr_nodes::*;
+    use crate::lazyframe::PyExprIR;
     // Expressions
+    m.add_class::<PyExprIR>().unwrap();
     m.add_class::<Alias>().unwrap();
     m.add_class::<Column>().unwrap();
     m.add_class::<Literal>().unwrap();

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -48,7 +48,7 @@ use jemallocator::Jemalloc;
 use mimalloc::MiMalloc;
 use pyo3::panic::PanicException;
 use pyo3::prelude::*;
-use pyo3::wrap_pyfunction;
+use pyo3::{wrap_pyfunction, wrap_pymodule};
 
 #[cfg(feature = "csv")]
 use crate::batched_csv::PyBatchedCsv;
@@ -96,6 +96,56 @@ static ALLOC: Jemalloc = Jemalloc;
 static ALLOC: MiMalloc = MiMalloc;
 
 #[pymodule]
+fn nodes(_py: Python, m: &PyModule) -> PyResult<()> {
+    use crate::lazyframe::visitor::nodes::*;
+    m.add_class::<PythonScan>().unwrap();
+    m.add_class::<Slice>().unwrap();
+    m.add_class::<Filter>().unwrap();
+    m.add_class::<Scan>().unwrap();
+    m.add_class::<DataFrameScan>().unwrap();
+    m.add_class::<SimpleProjection>().unwrap();
+    m.add_class::<Select>().unwrap();
+    m.add_class::<Sort>().unwrap();
+    m.add_class::<Cache>().unwrap();
+    m.add_class::<GroupBy>().unwrap();
+    m.add_class::<Join>().unwrap();
+    m.add_class::<HStack>().unwrap();
+    m.add_class::<Distinct>().unwrap();
+    m.add_class::<MapFunction>().unwrap();
+    m.add_class::<Union>().unwrap();
+    m.add_class::<HConcat>().unwrap();
+    m.add_class::<ExtContext>().unwrap();
+    m.add_class::<Sink>().unwrap();
+    Ok(())
+}
+
+#[pymodule]
+fn expr_nodes(_py: Python, m: &PyModule) -> PyResult<()> {
+    use crate::lazyframe::visitor::expr_nodes::*;
+    // Expressions
+    m.add_class::<Alias>().unwrap();
+    m.add_class::<Column>().unwrap();
+    m.add_class::<Literal>().unwrap();
+    m.add_class::<BinaryExpr>().unwrap();
+    m.add_class::<Cast>().unwrap();
+    m.add_class::<Sort>().unwrap();
+    m.add_class::<Gather>().unwrap();
+    m.add_class::<Filter>().unwrap();
+    m.add_class::<SortBy>().unwrap();
+    m.add_class::<Agg>().unwrap();
+    m.add_class::<Ternary>().unwrap();
+    m.add_class::<Function>().unwrap();
+    m.add_class::<Len>().unwrap();
+    m.add_class::<Window>().unwrap();
+    m.add_class::<PyOperator>().unwrap();
+    // Options
+    m.add_class::<PyWindowMapping>().unwrap();
+    m.add_class::<PyRollingGroupOptions>().unwrap();
+    m.add_class::<PyGroupbyOptions>().unwrap();
+    Ok(())
+}
+
+#[pymodule]
 fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     // Classes
     m.add_class::<PySeries>().unwrap();
@@ -110,6 +160,11 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     #[cfg(feature = "sql")]
     m.add_class::<PySQLContext>().unwrap();
 
+    // Submodules
+    // LogicalPlan objects
+    m.add_wrapped(wrap_pymodule!(nodes))?;
+    // Expr objects
+    m.add_wrapped(wrap_pymodule!(expr_nodes))?;
     // Functions - eager
     m.add_wrapped(wrap_pyfunction!(functions::concat_df))
         .unwrap();


### PR DESCRIPTION
This is a (reasonably complete) exposing of the `IR` and `AExpr` enums via `#[pyclass]` structs to Python.

The best place to start a review is probably `visitor/nodes.rs` (the `expr_nodes.rs` wrapping of expressions follows the same pattern, but there are more structs to go through). I am reasonably happy with the structure, but not fully up-to-speed on the most idiosyncratic ways of doing things. For example, should I implement `ToPyObject` for `Wrap<&IR>` rather than having an `into_py` free function?