### PR TITLE
feat(python): raise if `storage_options` is passed to read_csv but `fsspec` isnt available

### DIFF
--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -133,6 +133,9 @@ def prepare_file_arg(
     fsspec too.
     """
     storage_options = storage_options or {}
+    if storage_options and not _FSSPEC_AVAILABLE:
+        msg = "`fsspec` is required for `storage_options` argument"
+        raise ImportError(msg)
 
     # Small helper to use a variable as context
     @contextmanager

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2071,3 +2071,13 @@ def test_csv_float_decimal() -> None:
         pl.InvalidOperationError, match=r"'decimal_float' argument cannot be combined"
     ):
         pl.read_csv(floats, decimal_float=True)
+
+
+def test_fsspec_not_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("polars.io._utils._FSSPEC_AVAILABLE", False)
+    with pytest.raises(
+        ImportError, match=r"`fsspec` is required for `storage_options` argument"
+    ):
+        pl.read_csv(
+            "s3://foods/cabbage.csv", storage_options={"key": "key", "secret": "secret"}
+        )


### PR DESCRIPTION
Currently Polars just raises a file not found error