### PR TITLE
docs(python): improve graphviz install documentation/error message

### DIFF
--- a/docs/user-guide/lazy/query-plan.md
+++ b/docs/user-guide/lazy/query-plan.md
@@ -25,7 +25,9 @@ Below we consider the following query:
 
 ### Graphviz visualization
 
-First we visualise the non-optimized plan by setting `optimized=False`.
+To create visualizations of the query plan, [Graphviz should be installed](https://graphviz.org/download/) and added to your PATH.
+
+First we visualize the non-optimized plan by setting `optimized=False`.
 
 {{code_block('user-guide/lazy/query-plan','showplan',['show_graph'])}}
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -983,7 +983,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Show a plot of the query plan.
 
-        Note that you should have graphviz installed graphviz.org/download.
+        Note that graphviz must be installed to render the visualization (if not
+        already present you can download it here: <https://graphviz.org/download>`_).
 
         Parameters
         ----------
@@ -1052,7 +1053,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 ["dot", "-Nshape=box", "-T" + output_type], input=f"{dot}".encode()
             )
         except (ImportError, FileNotFoundError):
-            msg = "Graphviz should be installed graphviz.org/download, or Graphviz is not in your PATH"
+            msg = (
+                "The graphviz `dot` binary should be on your PATH."
+                "(If not installed you can download here: https://graphviz.org/download/)"
+            )
             raise ImportError(msg) from None
 
         if output_path:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -981,7 +981,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         streaming: bool = False,
     ) -> str | None:
         """
-        Show a plot of the query plan. Note that you should have graphviz installed.
+        Show a plot of the query plan.
+
+        Note that you should have graphviz installed graphviz.org/download.
 
         Parameters
         ----------
@@ -1050,7 +1052,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 ["dot", "-Nshape=box", "-T" + output_type], input=f"{dot}".encode()
             )
         except (ImportError, FileNotFoundError):
-            msg = "Graphviz dot binary should be on your PATH"
+            msg = "Graphviz should be installed graphviz.org/download, or Graphviz is not in your PATH"
             raise ImportError(msg) from None
 
         if output_path:


### PR DESCRIPTION
See #15755 and maybe closes #12477

Adds links pointing to graphviz install page, let me know if I should change anything