### PR TITLE
feat(python): Minor type-inference update for `read_database`

### DIFF
--- a/py-polars/polars/io/database/_inference.py
+++ b/py-polars/polars/io/database/_inference.py
@@ -22,6 +22,7 @@ from polars.datatypes import (
     Int32,
     Int64,
     List,
+    Null,
     String,
     Time,
     UInt8,
@@ -164,6 +165,10 @@ def _infer_dtype_from_database_typename(
     elif value.startswith("BOOL"):
         dtype = Boolean
 
+    # null dtype; odd, but valid
+    elif value == "NULL":
+        dtype = Null
+
     # temporal dtypes
     elif value.startswith(("DATETIME", "TIMESTAMP")) and not (value.endswith("[D]")):
         if any((tz in value.replace(" ", "")) for tz in ("TZ", "TIMEZONE")):
@@ -173,7 +178,7 @@ def _infer_dtype_from_database_typename(
         dtype = Datetime(time_unit=(unit or "us"))  # type: ignore[arg-type]
     else:
         value = re.sub(r"\d", "", value)
-        if value in ("INTERVAL", "TIMEDELTA"):
+        if value in ("INTERVAL", "TIMEDELTA", "DURATION"):
             dtype = Duration
         elif value == "DATE":
             dtype = Date

--- a/py-polars/tests/unit/io/database/test_inference.py
+++ b/py-polars/tests/unit/io/database/test_inference.py
@@ -58,6 +58,8 @@ if TYPE_CHECKING:
         ("timestamp(5)", pl.Datetime("us")),
         ("timestamp(7)", pl.Datetime("ns")),
         ("datetime without tz", pl.Datetime("us")),
+        ("duration(2)", pl.Duration("ms")),
+        ("interval", pl.Duration("us")),
         ("date", pl.Date),
         ("time", pl.Time),
         ("date32", pl.Date),
@@ -65,6 +67,8 @@ if TYPE_CHECKING:
         # binary types
         ("BYTEA", pl.Binary),
         ("BLOB", pl.Binary),
+        # miscellaneous
+        ("NULL", pl.Null),
     ],
 )
 def test_dtype_inference_from_string(


### PR DESCRIPTION
Adds basic recognition for "DURATION" and "NULL" type names/strings.