### PR TITLE
fix: ewm_mean_by was skipping initial nulls when it was already sorted by "by" column

### DIFF
--- a/crates/polars-ops/src/series/ops/ewm_by.rs
+++ b/crates/polars-ops/src/series/ops/ewm_by.rs
@@ -129,7 +129,9 @@ where
             out.push(Some(prev_result));
             skip_rows = idx + 1;
             break;
-        };
+        } else {
+            out.push(None)
+        }
     }
     values
         .iter()

--- a/py-polars/tests/unit/operations/test_ewm_by.py
+++ b/py-polars/tests/unit/operations/test_ewm_by.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
     from polars.type_aliases import PolarsIntegerType, TimeUnit
 
 
-def test_ewma_by_date() -> None:
+@pytest.mark.parametrize("sort", [True, False])
+def test_ewma_by_date(sort: bool) -> None:
     df = pl.LazyFrame(
         {
             "values": [3.0, 1.0, 2.0, None, 4.0],
@@ -25,6 +26,8 @@ def test_ewma_by_date() -> None:
             ],
         }
     )
+    if sort:
+        df = df.sort("times")
     result = df.select(
         pl.col("values").ewm_mean_by("times", half_life=timedelta(days=2)),
     )


### PR DESCRIPTION
On the latest release, initial null values are skipped when the dataframe is already known to be sorted by `'by'`, resulting in errors like
```
ShapeError: unable to add a column of length 4 to a DataFrame of height 5
```