### PR TITLE
perf: Limit the cache size for `to_datetime`

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -110,10 +110,13 @@ pub trait StringMethods: AsString {
         };
         let use_cache = use_cache && string_ca.len() > 50;
 
-        let mut convert = CachedFunc::new(|s| {
-            let naive_time = NaiveTime::parse_from_str(s, fmt).ok()?;
-            Some(time_to_time64ns(&naive_time))
-        });
+        let mut convert = CachedFunc::new(
+            |s| {
+                let naive_time = NaiveTime::parse_from_str(s, fmt).ok()?;
+                Some(time_to_time64ns(&naive_time))
+            },
+            (string_ca.len() as f64).sqrt() as usize,
+        );
         let ca = string_ca.apply_generic(|opt_s| convert.eval(opt_s?, use_cache));
         Ok(ca.with_name(string_ca.name()).into())
     }
@@ -237,21 +240,27 @@ pub trait StringMethods: AsString {
         // We can use the fast parser.
         let ca = if let Some(fmt_len) = strptime::fmt_len(fmt.as_bytes()) {
             let mut strptime_cache = StrpTimeState::default();
-            let mut convert = CachedFunc::new(|s: &str| {
-                // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
-                match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) } {
-                    // Fallback to chrono.
-                    None => NaiveDate::parse_from_str(s, &fmt).ok(),
-                    Some(ndt) => Some(ndt.date()),
-                }
-                .map(naive_date_to_date)
-            });
+            let mut convert = CachedFunc::new(
+                |s: &str| {
+                    // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
+                    match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) } {
+                        // Fallback to chrono.
+                        None => NaiveDate::parse_from_str(s, &fmt).ok(),
+                        Some(ndt) => Some(ndt.date()),
+                    }
+                    .map(naive_date_to_date)
+                },
+                (string_ca.len() as f64).sqrt() as usize,
+            );
             string_ca.apply_generic(|val| convert.eval(val?, use_cache))
         } else {
-            let mut convert = CachedFunc::new(|s| {
-                let naive_date = NaiveDate::parse_from_str(s, &fmt).ok()?;
-                Some(naive_date_to_date(naive_date))
-            });
+            let mut convert = CachedFunc::new(
+                |s| {
+                    let naive_date = NaiveDate::parse_from_str(s, &fmt).ok()?;
+                    Some(naive_date_to_date(naive_date))
+                },
+                (string_ca.len() as f64).sqrt() as usize,
+            );
             string_ca.apply_generic(|val| convert.eval(val?, use_cache))
         };
 
@@ -286,10 +295,13 @@ pub trait StringMethods: AsString {
         if tz_aware {
             #[cfg(feature = "timezones")]
             {
-                let mut convert = CachedFunc::new(|s: &str| {
-                    let dt = DateTime::parse_from_str(s, &fmt).ok()?;
-                    Some(func(dt.naive_utc()))
-                });
+                let mut convert = CachedFunc::new(
+                    |s: &str| {
+                        let dt = DateTime::parse_from_str(s, &fmt).ok()?;
+                        Some(func(dt.naive_utc()))
+                    },
+                    (string_ca.len() as f64).sqrt() as usize,
+                );
                 Ok(string_ca
                     .apply_generic(|opt_s| convert.eval(opt_s?, use_cache))
                     .with_name(string_ca.name())
@@ -308,16 +320,23 @@ pub trait StringMethods: AsString {
             // We can use the fast parser.
             let ca = if let Some(fmt_len) = self::strptime::fmt_len(fmt.as_bytes()) {
                 let mut strptime_cache = StrpTimeState::default();
-                let mut convert = CachedFunc::new(|s: &str| {
-                    // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
-                    match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) } {
-                        None => transform(s, &fmt),
-                        Some(ndt) => Some(func(ndt)),
-                    }
-                });
+                let mut convert = CachedFunc::new(
+                    |s: &str| {
+                        // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
+                        match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) }
+                        {
+                            None => transform(s, &fmt),
+                            Some(ndt) => Some(func(ndt)),
+                        }
+                    },
+                    (string_ca.len() as f64).sqrt() as usize,
+                );
                 string_ca.apply_generic(|opt_s| convert.eval(opt_s?, use_cache))
             } else {
-                let mut convert = CachedFunc::new(|s| transform(s, &fmt));
+                let mut convert = CachedFunc::new(
+                    |s| transform(s, &fmt),
+                    (string_ca.len() as f64).sqrt() as usize,
+                );
                 string_ca.apply_generic(|opt_s| convert.eval(opt_s?, use_cache))
             };
             let dt = ca.with_name(string_ca.name()).into_datetime(tu, None);

--- a/crates/polars-utils/src/cache.rs
+++ b/crates/polars-utils/src/cache.rs
@@ -7,12 +7,14 @@ use ahash::RandomState;
 use bytemuck::allocation::zeroed_vec;
 use bytemuck::Zeroable;
 
-pub struct CachedFunc<T, R, F> {
+/// A cached function that use `FastFixedCache` for access speed.
+/// It is important that the key is relatively cheap to compute.
+pub struct FastCachedFunc<T, R, F> {
     func: F,
     cache: FastFixedCache<T, R>,
 }
 
-impl<T, R, F> CachedFunc<T, R, F>
+impl<T, R, F> FastCachedFunc<T, R, F>
 where
     F: FnMut(T) -> R,
     T: std::hash::Hash + Eq + Clone,


### PR DESCRIPTION
Fix #15736.

```
s = pl.datetime_range(date(2000, 1, 1), date(2001, 1, 1), '1s', eager=True)
strings = s.dt.strftime('%Y-%m-%dT%H:%M:%S')
```

Without cache:
```
%timeit strings.str.to_datetime(format='%Y-%m-%dT%H:%M:%S', cache=False)
1.47 s ± 71.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

With cache:
```
%timeit strings.str.to_datetime(format='%Y-%m-%dT%H:%M:%S', cache=True)
```
- Before this PR
```
18.2 s ± 790 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
- After this PR
```
1.88 s ± 59.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Consider that the test data are all unique(The cache will never hit) and large, I think the overhead is acceptable.