### PR TITLE
feat(Python): Allow left/center as table cell alignment format for notebooks

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -773,7 +773,7 @@ class Config(contextlib.ContextDecorator):
         cls, format: Literal["LEFT", "CENTER", "RIGHT"] | None
     ) -> type[Config]:
         """
-        Set table cell alignment.
+        Set table cell alignment for `print()` and `Ipython.display.display()` (interactive notebooks) outputs.
 
         Parameters
         ----------

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -773,7 +773,8 @@ class Config(contextlib.ContextDecorator):
         cls, format: Literal["LEFT", "CENTER", "RIGHT"] | None
     ) -> type[Config]:
         """
-        Set table cell alignment for `print()` and `Ipython.display.display()` (interactive notebooks) outputs.
+        Set table cell alignment of `print()`
+        and `Ipython.display.display()` (interactive notebooks) outputs.
 
         Parameters
         ----------

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -775,8 +775,8 @@ class Config(contextlib.ContextDecorator):
         """
         Set table cell alignment.
 
-        This changes the outputs of `print()` (for all users)
-        and `Ipython.display.display()` (for interactive notebook users).
+        This changes the output format of `print()
+        and `Ipython.display.display()` (for display in Jupyter Notebooks).
 
         Parameters
         ----------
@@ -823,8 +823,8 @@ class Config(contextlib.ContextDecorator):
         """
         Set table cell alignment for numeric columns.
 
-        This changes the outputs of `print()` (for all users)
-        and `Ipython.display.display()` (for interactive notebook users).
+        This changes the output format of `print()
+        and `Ipython.display.display()` (for display in Jupyter Notebooks).
 
         Parameters
         ----------

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -823,6 +823,9 @@ class Config(contextlib.ContextDecorator):
         """
         Set table cell alignment for numeric columns.
 
+        This changes the outputs of `print()` (for all users)
+        and `Ipython.display.display()` (for interactive notebook users).
+
         Parameters
         ----------
         format : str

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -773,8 +773,10 @@ class Config(contextlib.ContextDecorator):
         cls, format: Literal["LEFT", "CENTER", "RIGHT"] | None
     ) -> type[Config]:
         """
-        Set table cell alignment of `print()`
-        and `Ipython.display.display()` (interactive notebooks) outputs.
+        Set table cell alignment.
+
+        This changes the outputs of `print()` (for all users)
+        and `Ipython.display.display()` (for interactive notebook users).
 
         Parameters
         ----------

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -108,7 +108,8 @@ class HTMLFormatter:
                 with Tag(self.elements, "tr"):
                     columns = self.df.columns
                     for c in self.col_idx:
-                        with Tag(self.elements, "th", attributes=self.get_attributes(col_idx=c)):
+                        _dict = {"attributes": self.get_attributes(col_idx=c)}
+                        with Tag(self.elements, "th", **_dict):
                             if c == -1:
                                 self.elements.append("&hellip;")
                             else:
@@ -119,7 +120,8 @@ class HTMLFormatter:
                 with Tag(self.elements, "tr"):
                     dtypes = self.df._df.dtype_strings()
                     for c in self.col_idx:
-                        with Tag(self.elements, "td", attributes=self.get_attributes(col_idx=c)):
+                        _dict = {"attributes": self.get_attributes(col_idx=c)}
+                        with Tag(self.elements, "td", **_dict):
                             if c == -1:
                                 self.elements.append("&hellip;")
                             else:
@@ -132,7 +134,8 @@ class HTMLFormatter:
             for r in self.row_idx:
                 with Tag(self.elements, "tr"):
                     for c in self.col_idx:
-                        with Tag(self.elements, "td", attributes=self.get_attributes(col_idx=c)):
+                        _dict = {"attributes": self.get_attributes(col_idx=c)}
+                        with Tag(self.elements, "td", **_dict):
                             if r == -1 or c == -1:
                                 self.elements.append("&hellip;")
                             else:

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -154,11 +154,11 @@ class HTMLFormatter:
             index number of the target column.
         """
         if self.numeric_align_lower == self.overall_align_lower:
-            return
+            return None
         series = self.df[:, col_idx]
         if series.dtype.is_numeric():
             return {"align": self.numeric_align_lower}
-        return
+        return None
 
     def write(self, inner: str) -> None:
         """Append a raw string to the inner HTML."""

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -101,7 +101,8 @@ class HTMLFormatter:
         self.overall_align_lower = overall_alignment.lower()
         self.numeric_align_lower = numeric_alignment.lower()
         self.attribute_nested_dict = {
-            self.get_attributes(col_idx=col_idx) for col_idx in self.col_idx}
+            self.get_attributes(col_idx=col_idx) for col_idx in self.col_idx
+        }
 
     def write_header(self) -> None:
         """Write the header of an HTML table."""
@@ -208,9 +209,7 @@ class NotebookFormatter(HTMLFormatter):
             }}
             </style>
         """
-        style_formatted = dedent(
-            style.format(self.overall_align_lower)
-        ).strip()
+        style_formatted = dedent(style.format(self.overall_align_lower)).strip()
         self.write(style_formatted)
 
     def render(self) -> list[str]:

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -159,7 +159,7 @@ class NotebookFormatter(HTMLFormatter):
 
     def write_style(self) -> None:
         """Write <style> tag."""
-        cell_alignment = os.environ["POLARS_FMT_TABLE_CELL_ALIGNMENT"]
+        cell_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", None)
         text_align = cell_alignment.lower() if cell_alignment in ["LEFT", "CENTER"] else "RIGHT"
         style = """\
             <style>

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -47,7 +47,8 @@ class Tag:
 
 
 class HTMLFormatter:
-    """Class for HTML formatting.
+    """
+    Class for HTML formatting.
 
     Table cell alignment will be set by environment variables.
 
@@ -141,7 +142,8 @@ class HTMLFormatter:
                                 )
 
     def get_attributes(self, col_idx: int) -> dict[str, str] | None:
-        """Get HTML td/th attributes of a column.
+        """
+        Get HTML td/th attributes of a column.
 
         Parameters
         ----------

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -209,7 +209,10 @@ class NotebookFormatter(HTMLFormatter):
             }
             </style>
         """
-        self.write(dedent(style.format(self.overall_align_lower)))
+        style_formatted = dedent(
+            style.format(self.overall_align_lower)
+        ).strip()
+        self.write(style_formatted)
 
     def render(self) -> list[str]:
         """Return the lines needed to render a HTML table."""

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -146,7 +146,7 @@ class HTMLFormatter:
                                     html.escape(series._s.get_fmt(r, str_lengths))
                                 )
 
-    def get_attributes(self, col_idx: int) -> dict[str, str] | None:
+    def get_attributes(self, col_idx: int) -> dict[str, str]:
         """
         Get HTML td/th attributes of a column.
 
@@ -155,12 +155,11 @@ class HTMLFormatter:
         col_idx: int
             index number of the target column.
         """
-        if self.numeric_align_lower == self.overall_align_lower:
-            return None
-        series = self.df[:, col_idx]
-        if series.dtype.is_numeric():
-            return {"align": self.numeric_align_lower}
-        return None
+        if self.numeric_align_lower != self.overall_align_lower:
+            series = self.df[:, col_idx]
+            if series.dtype.is_numeric():
+                return {"align": self.numeric_align_lower}
+        return {}
 
     def write(self, inner: str) -> None:
         """Append a raw string to the inner HTML."""

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from textwrap import dedent
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Literal
 
 from polars.dependencies import html
 
@@ -57,11 +57,8 @@ class HTMLFormatter:
     max_cols: int
     max_rows: int
     from_series: bool
-
-    Raises
-    ------
-    ValueError: if unexpected POLARS_FMT_TABLE_CELL_ALIGNMENT value.
-    ValueError: if unexpected POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT value.
+    overall_alignment: Literal["LEFT", "CENTER", "RIGHT"]
+    numeric_alignment: Literal["LEFT", "CENTER", "RIGHT"]
     """
 
     def __init__(
@@ -71,6 +68,8 @@ class HTMLFormatter:
         max_cols: int = 75,
         max_rows: int = 40,
         from_series: bool = False,
+        overall_alignment: Literal["LEFT", "CENTER", "RIGHT"] = "RIGHT",
+        numeric_alignment: Literal["LEFT", "CENTER", "RIGHT"] = "RIGHT",
     ):
         self.df = df
         self.elements: list[str] = []
@@ -98,16 +97,8 @@ class HTMLFormatter:
         else:
             self.col_idx = range(df.width)
 
-        _overall_align = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", "RIGHT")
-        if _overall_align not in {"LEFT", "CENTER", "RIGHT"}:
-            msg = f"invalid table cell alignment: {_overall_align!r}"
-            raise ValueError(msg)
-        _numeric_align = os.environ.get("POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT", "RIGHT")
-        if _numeric_align not in {"LEFT", "CENTER", "RIGHT"}:
-            msg = f"invalid table cell numeric alignment: {_numeric_align!r}"
-            raise ValueError(msg)
-        self.overall_align_lower: _overall_align.lower()
-        self.numeric_align_lower: _numeric_align.lower()
+        self.overall_align_lower: overall_alignment.lower()
+        self.numeric_align_lower: numeric_alignment.lower()
 
     def write_header(self) -> None:
         """Write the header of an HTML table."""

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -155,6 +155,7 @@ class HTMLFormatter:
         Parameters
         ----------
         col_idx: int
+            index number of the target column.
         """
         if self.numeric_align_lower == self.overall_align_lower:
             return

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -158,16 +158,19 @@ class NotebookFormatter(HTMLFormatter):
     """
 
     def write_style(self) -> None:
+        """Write <style> tag."""
+        cell_alignment = os.environ["POLARS_FMT_TABLE_CELL_ALIGNMENT"]
+        text_align = cell_alignment.lower() if cell_alignment in ["LEFT", "CENTER"] else "RIGHT"
         style = """\
             <style>
             .dataframe > thead > tr,
             .dataframe > tbody > tr {
-              text-align: right;
+              text-align: {text_align};
               white-space: pre-wrap;
             }
             </style>
         """
-        self.write(dedent(style))
+        self.write(dedent(style.format(text_align)))
 
     def render(self) -> list[str]:
         """Return the lines needed to render a HTML table."""

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -199,13 +199,13 @@ class NotebookFormatter(HTMLFormatter):
 
     def write_style(self) -> None:
         """Write <style> tag."""
-        style = """\
+        style = """
             <style>
             .dataframe > thead > tr,
-            .dataframe > tbody > tr {
+            .dataframe > tbody > tr {{
               text-align: {};
               white-space: pre-wrap;
-            }
+            }}
             </style>
         """
         style_formatted = dedent(

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -100,6 +100,8 @@ class HTMLFormatter:
 
         self.overall_align_lower = overall_alignment.lower()
         self.numeric_align_lower = numeric_alignment.lower()
+        self.attribute_nested_dict = {
+            self.get_attributes(col_idx=col_idx) for col_idx in self.col_idx}
 
     def write_header(self) -> None:
         """Write the header of an HTML table."""
@@ -108,7 +110,7 @@ class HTMLFormatter:
                 with Tag(self.elements, "tr"):
                     columns = self.df.columns
                     for c in self.col_idx:
-                        _dict = {"attributes": self.get_attributes(col_idx=c)}
+                        _dict = self.attribute_nested_dict[c]
                         with Tag(self.elements, "th", **_dict):
                             if c == -1:
                                 self.elements.append("&hellip;")
@@ -120,7 +122,7 @@ class HTMLFormatter:
                 with Tag(self.elements, "tr"):
                     dtypes = self.df._df.dtype_strings()
                     for c in self.col_idx:
-                        _dict = {"attributes": self.get_attributes(col_idx=c)}
+                        _dict = self.attribute_nested_dict[c]
                         with Tag(self.elements, "td", **_dict):
                             if c == -1:
                                 self.elements.append("&hellip;")
@@ -134,7 +136,7 @@ class HTMLFormatter:
             for r in self.row_idx:
                 with Tag(self.elements, "tr"):
                     for c in self.col_idx:
-                        _dict = {"attributes": self.get_attributes(col_idx=c)}
+                        _dict = self.attribute_nested_dict[c]
                         with Tag(self.elements, "td", **_dict):
                             if r == -1 or c == -1:
                                 self.elements.append("&hellip;")

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -160,7 +160,7 @@ class NotebookFormatter(HTMLFormatter):
     def write_style(self) -> None:
         """Write <style> tag."""
         cell_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", None)
-        text_align = cell_alignment.lower() if cell_alignment in ["LEFT", "CENTER"] else "RIGHT"
+        text_align = cell_alignment.lower() if cell_alignment in ["LEFT", "CENTER"] else "right"
         style = """\
             <style>
             .dataframe > thead > tr,

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -98,8 +98,8 @@ class HTMLFormatter:
         else:
             self.col_idx = range(df.width)
 
-        self.overall_align_lower: overall_alignment.lower()
-        self.numeric_align_lower: numeric_alignment.lower()
+        self.overall_align_lower = overall_alignment.lower()
+        self.numeric_align_lower = numeric_alignment.lower()
 
     def write_header(self) -> None:
         """Write the header of an HTML table."""

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1274,7 +1274,8 @@ class DataFrame:
         variables:
 
         * POLARS_FMT_TABLE_CELL_ALIGNMENT: set the table cell alignment
-        * POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT: set the table cell alignment for numeric columns
+        * POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT:
+            set the table cell alignment for numeric columns
 
         Raises
         ------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1275,6 +1275,11 @@ class DataFrame:
 
         * POLARS_FMT_TABLE_CELL_ALIGNMENT: set the table cell alignment
         * POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT: set the table cell alignment for numeric columns
+
+        Raises
+        ------
+        ValueError: if unexpected POLARS_FMT_TABLE_CELL_ALIGNMENT value.
+        ValueError: if unexpected POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT value.
         """
         max_cols = int(os.environ.get("POLARS_FMT_MAX_COLS", default=75))
         if max_cols < 0:
@@ -1284,12 +1289,24 @@ class DataFrame:
         if max_rows < 0:
             max_rows = self.height
 
+        numeric_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT", "RIGHT")
+        if numeric_align not in {"LEFT", "CENTER", "RIGHT"}:
+            msg = f"invalid table cell numeric alignment: {numeric_alignment!r}"
+            raise ValueError(msg)
+
+        overall_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", "RIGHT")
+        if overall_alignment not in {"LEFT", "CENTER", "RIGHT"}:
+            msg = f"invalid table cell alignment: {overall_alignment!r}"
+            raise ValueError(msg)
+
         return "".join(
             NotebookFormatter(
                 self,
                 max_cols=max_cols,
                 max_rows=max_rows,
                 from_series=_from_series,
+                overall_alignment=overall_alignment,
+                numeric_alignment=numeric_alignment,
             ).render()
         )
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1291,7 +1291,7 @@ class DataFrame:
             max_rows = self.height
 
         numeric_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT", "RIGHT")
-        if numeric_align not in {"LEFT", "CENTER", "RIGHT"}:
+        if numeric_alignment not in {"LEFT", "CENTER", "RIGHT"}:
             msg = f"invalid table cell numeric alignment: {numeric_alignment!r}"
             raise ValueError(msg)
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1290,12 +1290,18 @@ class DataFrame:
         if max_rows < 0:
             max_rows = self.height
 
-        numeric_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT", "RIGHT")
+        numeric_alignment = os.environ.get(
+            "POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT",
+            "RIGHT",
+        )
         if numeric_alignment not in {"LEFT", "CENTER", "RIGHT"}:
             msg = f"invalid table cell numeric alignment: {numeric_alignment!r}"
             raise ValueError(msg)
 
-        overall_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", "RIGHT")
+        overall_alignment = os.environ.get(
+            "POLARS_FMT_TABLE_CELL_ALIGNMENT",
+            "RIGHT"
+        )
         if overall_alignment not in {"LEFT", "CENTER", "RIGHT"}:
             msg = f"invalid table cell alignment: {overall_alignment!r}"
             raise ValueError(msg)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1269,6 +1269,12 @@ class DataFrame:
 
         * POLARS_FMT_MAX_COLS: set the number of columns
         * POLARS_FMT_MAX_ROWS: set the number of rows
+
+        Output format can be modified by setting the following ENVIRONMENT
+        variables:
+
+        * POLARS_FMT_TABLE_CELL_ALIGNMENT: set the table cell alignment
+        * POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT: set the table cell alignment for numeric columns
         """
         max_cols = int(os.environ.get("POLARS_FMT_MAX_COLS", default=75))
         if max_cols < 0:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1290,17 +1290,17 @@ class DataFrame:
         if max_rows < 0:
             max_rows = self.height
 
+        overall_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", "RIGHT")
+        if overall_alignment not in {"LEFT", "CENTER", "RIGHT"}:
+            msg = f"invalid table cell alignment: {overall_alignment!r}"
+            raise ValueError(msg)
+
         numeric_alignment = os.environ.get(
             "POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT",
             "RIGHT",
         )
         if numeric_alignment not in {"LEFT", "CENTER", "RIGHT"}:
             msg = f"invalid table cell numeric alignment: {numeric_alignment!r}"
-            raise ValueError(msg)
-
-        overall_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", "RIGHT")
-        if overall_alignment not in {"LEFT", "CENTER", "RIGHT"}:
-            msg = f"invalid table cell alignment: {overall_alignment!r}"
             raise ValueError(msg)
 
         return "".join(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1309,8 +1309,8 @@ class DataFrame:
                 max_cols=max_cols,
                 max_rows=max_rows,
                 from_series=_from_series,
-                overall_alignment=overall_alignment,
-                numeric_alignment=numeric_alignment,
+                overall_alignment=overall_alignment,  # type: ignore[arg-type]
+                numeric_alignment=numeric_alignment,  # type: ignore[arg-type]
             ).render()
         )
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1298,10 +1298,7 @@ class DataFrame:
             msg = f"invalid table cell numeric alignment: {numeric_alignment!r}"
             raise ValueError(msg)
 
-        overall_alignment = os.environ.get(
-            "POLARS_FMT_TABLE_CELL_ALIGNMENT",
-            "RIGHT"
-        )
+        overall_alignment = os.environ.get("POLARS_FMT_TABLE_CELL_ALIGNMENT", "RIGHT")
         if overall_alignment not in {"LEFT", "CENTER", "RIGHT"}:
             msg = f"invalid table cell alignment: {overall_alignment!r}"
             raise ValueError(msg)

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -60,6 +60,44 @@ def test_df_repr_html_max_rows_default() -> None:
     assert html.count("<td>") - 2 == expected_rows
 
 
+def test_df_repl_html_table_cell_alignment() -> None:
+    df = pl.DataFrame(
+        {"a": ["group_id", "group_code", "group_name"], "b": [11, 2, 333]}
+    )
+
+    # default: overall=RIGHT, numeric=RIGHT
+    assert "text-align: right;" in df._repr_html()
+    assert '<thead><tr><th>a</th><th">b</th></tr><tr><td>str</td><td>i64</td></tr></thead>' in df._repr_html_()
+
+    # overall=RIGHT, numeric=LEFT
+    for overall_alignment in ["LEFT", "CENTER", "RIGHT"]:
+        _overall = overall_alignment.lower()
+        for numeric_alignment in ["LEFT", "CENTER", "RIGHT"]:
+            _numeric = numeric_alignment.lower()
+            with pl.Config(
+                tbl_cell_alignment=overall_alignment,
+                tbl_cell_numeric_alignment=numeric_alignment,
+            ):
+                _repr_html = df._repr_html_()
+                assert f"text-align: {_overall};" in _repr_html
+                if _overall == _numeric:
+                    # header
+                    header = f'<thead><tr><th>a</th><th">b</th></tr>'\
+                        '<tr><td>str</td><td">i64</td></tr></thead>'
+                    assert header in _repr_html
+                    # body
+                    body = f'<tr><td>str</td><td">i64</td></tr>'
+                    assert body in _repr_html
+                else:
+                    # header
+                    header = f'<thead><tr><th>a</th><th align="{_numeric}">b</th></tr>'\
+                        '<tr><td>str</td><td align="{_numeric}">i64</td></tr></thead>'
+                    assert header in _repr_html
+                    # body
+                    body = f'<tr><td>str</td><td align="{_numeric}">i64</td></tr>'
+                    assert body in _repr_html
+
+
 def test_df_repr_html_max_rows_odd() -> None:
     df = pl.DataFrame({"a": range(50)})
 

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -82,11 +82,11 @@ def test_df_repl_html_table_cell_alignment() -> None:
                 assert f"text-align: {_overall};" in _repr_html
                 if _overall == _numeric:
                     # header
-                    header = f'<thead><tr><th>a</th><th">b</th></tr>'\
+                    header = '<thead><tr><th>a</th><th">b</th></tr>'\
                         '<tr><td>str</td><td">i64</td></tr></thead>'
                     assert header in _repr_html
                     # body
-                    body = f'<tr><td>str</td><td">i64</td></tr>'
+                    body = '<tr><td>str</td><td">i64</td></tr>'
                     assert body in _repr_html
                 else:
                     # header

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -104,10 +104,7 @@ def test_df_repl_html_table_cell_alignment() -> None:
                     )
                     assert header in _repr_html
                     # body
-                    body = (
-                        "<tr><td>str</td>"
-                        f'<td align="{_numeric}">i64</td></tr>'
-                    )
+                    body = f'<tr><td>str</td><td align="{_numeric}">i64</td></tr>'
                     assert body in _repr_html
 
 

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -67,7 +67,8 @@ def test_df_repl_html_table_cell_alignment() -> None:
 
     # default: overall=RIGHT, numeric=RIGHT
     assert "text-align: right;" in df._repr_html()
-    assert '<thead><tr><th>a</th><th">b</th></tr><tr><td>str</td><td>i64</td></tr></thead>' in df._repr_html_()
+    assert '<thead><tr><th>a</th><th">b</th></tr>'\
+        '<tr><td>str</td><td>i64</td></tr></thead>' in df._repr_html_()
 
     # overall=RIGHT, numeric=LEFT
     for overall_alignment in ["LEFT", "CENTER", "RIGHT"]:
@@ -90,11 +91,14 @@ def test_df_repl_html_table_cell_alignment() -> None:
                     assert body in _repr_html
                 else:
                     # header
-                    header = f'<thead><tr><th>a</th><th align="{_numeric}">b</th></tr>'\
-                        '<tr><td>str</td><td align="{_numeric}">i64</td></tr></thead>'
+                    header = '<thead><tr><th>a</th>'\
+                        f'<th align="{_numeric}">b</th></tr>'\
+                        '<tr><td>str</td>'\
+                        f'<td align="{_numeric}">i64</td></tr></thead>'
                     assert header in _repr_html
                     # body
-                    body = f'<tr><td>str</td><td align="{_numeric}">i64</td></tr>'
+                    body = '<tr><td>str</td>'\
+                        f'<td align="{_numeric}">i64</td></tr>'
                     assert body in _repr_html
 
 

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -87,8 +87,8 @@ def test_df_repl_html_table_cell_alignment() -> None:
                 if _overall == _numeric:
                     # header
                     header = (
-                        '<thead><tr><th>a</th><th>b</th></tr>'
-                        '<tr><td>str</td><td>i64</td></tr></thead>'
+                        "<thead><tr><th>a</th><th>b</th></tr>"
+                        "<tr><td>str</td><td>i64</td></tr></thead>"
                     )
                     assert header in _repr_html
                     # body

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -67,8 +67,11 @@ def test_df_repl_html_table_cell_alignment() -> None:
 
     # default: overall=RIGHT, numeric=RIGHT
     assert "text-align: right;" in df._repr_html()
-    assert '<thead><tr><th>a</th><th">b</th></tr>'\
-        '<tr><td>str</td><td>i64</td></tr></thead>' in df._repr_html_()
+    header = (
+        '<thead><tr><th>a</th><th">b</th></tr>'
+        '<tr><td>str</td><td>i64</td></tr></thead>'
+    )
+    assert header in df._repr_html_()
 
     # overall=RIGHT, numeric=LEFT
     for overall_alignment in ["LEFT", "CENTER", "RIGHT"]:
@@ -83,8 +86,10 @@ def test_df_repl_html_table_cell_alignment() -> None:
                 assert f"text-align: {_overall};" in _repr_html
                 if _overall == _numeric:
                     # header
-                    header = '<thead><tr><th>a</th><th">b</th></tr>'\
+                    header = (
+                        '<thead><tr><th>a</th><th">b</th></tr>'
                         '<tr><td>str</td><td">i64</td></tr></thead>'
+                    )
                     assert header in _repr_html
                     # body
                     body = '<tr><td>str</td><td">i64</td></tr>'
@@ -92,15 +97,15 @@ def test_df_repl_html_table_cell_alignment() -> None:
                 else:
                     # header
                     header = (
-                        '<thead><tr><th>a</th>'
+                        "<thead><tr><th>a</th>"
                         f'<th align="{_numeric}">b</th></tr>'
-                        '<tr><td>str</td>'
+                        "<tr><td>str</td>"
                         f'<td align="{_numeric}">i64</td></tr></thead>'
                     )
                     assert header in _repr_html
                     # body
                     body = (
-                        '<tr><td>str</td>'
+                        "<tr><td>str</td>"
                         f'<td align="{_numeric}">i64</td></tr>'
                     )
                     assert body in _repr_html

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -68,7 +68,7 @@ def test_df_repl_html_table_cell_alignment() -> None:
     # default: overall=RIGHT, numeric=RIGHT
     assert "text-align: right;" in df._repr_html()
     header = (
-        '<thead><tr><th>a</th><th">b</th></tr>'
+        '<thead><tr><th>a</th><th>b</th></tr>'
         '<tr><td>str</td><td>i64</td></tr></thead>'
     )
     assert header in df._repr_html_()
@@ -87,12 +87,12 @@ def test_df_repl_html_table_cell_alignment() -> None:
                 if _overall == _numeric:
                     # header
                     header = (
-                        '<thead><tr><th>a</th><th">b</th></tr>'
-                        '<tr><td>str</td><td">i64</td></tr></thead>'
+                        '<thead><tr><th>a</th><th>b</th></tr>'
+                        '<tr><td>str</td><td>i64</td></tr></thead>'
                     )
                     assert header in _repr_html
                     # body
-                    body = '<tr><td>str</td><td">i64</td></tr>'
+                    body = '<tr><td>str</td><td>i64</td></tr>'
                     assert body in _repr_html
                 else:
                     # header

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -91,14 +91,18 @@ def test_df_repl_html_table_cell_alignment() -> None:
                     assert body in _repr_html
                 else:
                     # header
-                    header = '<thead><tr><th>a</th>'\
-                        f'<th align="{_numeric}">b</th></tr>'\
-                        '<tr><td>str</td>'\
+                    header = (
+                        '<thead><tr><th>a</th>'
+                        f'<th align="{_numeric}">b</th></tr>'
+                        '<tr><td>str</td>'
                         f'<td align="{_numeric}">i64</td></tr></thead>'
+                    )
                     assert header in _repr_html
                     # body
-                    body = '<tr><td>str</td>'\
+                    body = (
+                        '<tr><td>str</td>'
                         f'<td align="{_numeric}">i64</td></tr>'
+                    )
                     assert body in _repr_html
 
 

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -92,7 +92,7 @@ def test_df_repl_html_table_cell_alignment() -> None:
                     )
                     assert header in _repr_html
                     # body
-                    body = '<tr><td>str</td><td>i64</td></tr>'
+                    body = "<tr><td>str</td><td>i64</td></tr>"
                     assert body in _repr_html
                 else:
                     # header

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -66,7 +66,7 @@ def test_df_repl_html_table_cell_alignment() -> None:
     )
 
     # default: overall=RIGHT, numeric=RIGHT
-    assert "text-align: right;" in df._repr_html()
+    assert "text-align: right;" in df._repr_html_()
     header = (
         "<thead><tr><th>a</th><th>b</th></tr>"
         "<tr><td>str</td><td>i64</td></tr></thead>"

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -68,8 +68,8 @@ def test_df_repl_html_table_cell_alignment() -> None:
     # default: overall=RIGHT, numeric=RIGHT
     assert "text-align: right;" in df._repr_html()
     header = (
-        '<thead><tr><th>a</th><th>b</th></tr>'
-        '<tr><td>str</td><td>i64</td></tr></thead>'
+        "<thead><tr><th>a</th><th>b</th></tr>"
+        "<tr><td>str</td><td>i64</td></tr></thead>"
     )
     assert header in df._repr_html_()
 


### PR DESCRIPTION
Close #15822 

We use `polars.Config.set_tbl_cell_alignment()` to change the table cell alignment format for `print(pl.DataFrame())`.
This PR enables change format of `display(pl.DataFrame())` output on Jupyter Notebook and Google Colab.

## To-do

- [x] `NotebookFormatter.write_style()` selects text-align reading "POLARS_FMT_TABLE_CELL_ALIGNMENT" env variable
- [x] `NotebookFormatter.write_style()` selects text-align reading "POLARS_FMT_TABLE_CELL_NUMERIC_ALIGNMENT"
- [x] update docs of `polars.Config.set_tbl_cell_alignment()`
- [x] update docs of `polars.Config.set_tbl_cell_numeric_alignment()`
- [x] add additional test for display (if possible)