### PR TITLE
build(python): Exclude `rust-toolchain.toml` from wheels

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -65,7 +65,7 @@ all = [
 ]
 
 [tool.maturin]
-include = ["rust-toolchain.toml"]
+include = [{ path = "rust-toolchain.toml", format = "sdist" }]
 
 [tool.mypy]
 files = ["polars", "tests"]


### PR DESCRIPTION
This file must be included with the `sdist` to allow compiling from source. Wheels do not need to include it though.