### PR TITLE
fix: create (q)cut labels in fixed order

### DIFF
--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -2,15 +2,19 @@ use polars_core::prelude::*;
 
 fn map_cats(
     s: &Series,
-    cutlabs: &[String],
+    labels: &[String],
     sorted_breaks: &[f64],
     left_closed: bool,
     include_breaks: bool,
 ) -> PolarsResult<Series> {
-    let cl: Vec<&str> = cutlabs.iter().map(String::as_str).collect();
-
     let out_name = format!("{}_bin", s.name());
+
+    // Create new categorical and pre-register labels for consistent categorical indexes.
     let mut bld = CategoricalChunkedBuilder::new(&out_name, s.len(), Default::default());
+    for label in labels {
+        bld.register_value(label);
+    }
+
     let s2 = s.cast(&DataType::Float64)?;
     // It would be nice to parallelize this
     let s_iter = s2.f64()?.into_iter();
@@ -38,7 +42,7 @@ fn map_cats(
                     brk_vals.append_null();
                 },
                 Some(idx) => unsafe {
-                    bld.append_value(cl.get_unchecked(idx));
+                    bld.append_value(labels.get_unchecked(idx));
                     brk_vals.append_value(*right_ends.get_unchecked(idx));
                 },
             });
@@ -49,49 +53,56 @@ fn map_cats(
         Ok(bld
             .drain_iter_and_finish(s_iter.map(|opt| {
                 opt.filter(|x| !x.is_nan()).map(|x| unsafe {
-                    *cl.get_unchecked(sorted_breaks.partition_point(|v| op(&x, v)))
+                    labels
+                        .get_unchecked(sorted_breaks.partition_point(|v| op(&x, v)))
+                        .as_str()
                 })
             }))
             .into_series())
     }
 }
 
+pub fn compute_labels(breaks: &[f64], left_closed: bool) -> PolarsResult<Vec<String>> {
+    let lo = std::iter::once(&f64::NEG_INFINITY).chain(breaks.iter());
+    let hi = breaks.iter().chain(std::iter::once(&f64::INFINITY));
+
+    let ret = lo
+        .zip(hi)
+        .map(|(l, h)| {
+            if left_closed {
+                format!("[{}, {})", l, h)
+            } else {
+                format!("({}, {}]", l, h)
+            }
+        })
+        .collect();
+    Ok(ret)
+}
+
 pub fn cut(
     s: &Series,
-    breaks: Vec<f64>,
+    mut breaks: Vec<f64>,
     labels: Option<Vec<String>>,
     left_closed: bool,
     include_breaks: bool,
 ) -> PolarsResult<Series> {
-    polars_ensure!(!breaks.iter().any(|x| x.is_nan()), ComputeError: "Breaks cannot be NaN");
     // Breaks must be sorted to cut inputs properly.
-    let mut breaks = breaks;
-    let sorted_breaks = breaks.as_mut_slice();
-    sorted_breaks.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
-    polars_ensure!(sorted_breaks.windows(2).all(|x| x[0] != x[1]), Duplicate: "Breaks are not unique");
-    if !sorted_breaks.is_empty() {
-        polars_ensure!(sorted_breaks[0] > f64::NEG_INFINITY, ComputeError: "Don't include -inf in breaks");
-        polars_ensure!(sorted_breaks[sorted_breaks.len() - 1] < f64::INFINITY, ComputeError: "Don't include inf in breaks");
+    polars_ensure!(!breaks.iter().any(|x| x.is_nan()), ComputeError: "breaks cannot be NaN");
+    breaks.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+
+    polars_ensure!(breaks.windows(2).all(|x| x[0] != x[1]), Duplicate: "breaks are not unique");
+    if !breaks.is_empty() {
+        polars_ensure!(breaks[0] > f64::NEG_INFINITY, ComputeError: "don't include -inf in breaks");
+        polars_ensure!(breaks[breaks.len() - 1] < f64::INFINITY, ComputeError: "don't include inf in breaks");
     }
 
-    let cutlabs = match labels {
-        Some(ll) => {
-            polars_ensure!(ll.len() == sorted_breaks.len() + 1, ShapeMismatch: "Provide nbreaks + 1 labels");
-            ll
-        },
-        None => (std::iter::once(&f64::NEG_INFINITY).chain(sorted_breaks.iter()))
-            .zip(sorted_breaks.iter().chain(std::iter::once(&f64::INFINITY)))
-            .map(|v| {
-                if left_closed {
-                    format!("[{}, {})", v.0, v.1)
-                } else {
-                    format!("({}, {}]", v.0, v.1)
-                }
-            })
-            .collect::<Vec<String>>(),
+    let cut_labels = if let Some(l) = labels {
+        polars_ensure!(l.len() == breaks.len() + 1, ShapeMismatch: "provide len(quantiles) + 1 labels");
+        l
+    } else {
+        compute_labels(&breaks, left_closed)?
     };
-
-    map_cats(s, &cutlabs, sorted_breaks, left_closed, include_breaks)
+    map_cats(s, &cut_labels, &breaks, left_closed, include_breaks)
 }
 
 pub fn qcut(
@@ -102,6 +113,8 @@ pub fn qcut(
     allow_duplicates: bool,
     include_breaks: bool,
 ) -> PolarsResult<Series> {
+    polars_ensure!(!probs.iter().any(|x| x.is_nan()), ComputeError: "quantiles cannot be NaN");
+
     let s = s.cast(&DataType::Float64)?;
     let s2 = s.sort(SortOptions::default())?;
     let ca = s2.f64()?;
@@ -119,27 +132,16 @@ pub fn qcut(
     let mut qbreaks: Vec<_> = probs.iter().map(f).collect();
     qbreaks.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
 
-    // When probs are spaced too closely for the number of repeated values in the distribution
-    // some quantiles may be duplicated. The only thing to do if we want to go on, is to drop
-    // the repeated values and live with some bins being larger than intended.
-    if allow_duplicates {
-        let lfilt = match labels {
-            None => None,
-            Some(ll) => {
-                polars_ensure!(ll.len() == qbreaks.len() + 1,
-                    ShapeMismatch: "Wrong number of labels");
-                let blen = ll.len();
-                Some(
-                    ll.into_iter()
-                        .enumerate()
-                        .filter(|(i, _)| *i == 0 || *i == blen - 1 || qbreaks[*i] != qbreaks[i - 1])
-                        .unzip::<_, _, Vec<_>, Vec<_>>()
-                        .1,
-                )
-            },
-        };
-        qbreaks.dedup();
-        return cut(&s, qbreaks, lfilt, left_closed, include_breaks);
+    if !allow_duplicates {
+        polars_ensure!(qbreaks.windows(2).all(|x| x[0] != x[1]), Duplicate: "quantiles are not unique while allow_duplicates=False");
     }
-    cut(&s, qbreaks, labels, left_closed, include_breaks)
+
+    let cut_labels = if let Some(l) = labels {
+        polars_ensure!(l.len() == qbreaks.len() + 1, ShapeMismatch: "provide len(quantiles) + 1 labels");
+        l
+    } else {
+        compute_labels(&qbreaks, left_closed)?
+    };
+
+    map_cats(&s, &cut_labels, &qbreaks, left_closed, include_breaks)
 }


### PR DESCRIPTION
This fixes https://github.com/pola-rs/polars/issues/15670, that is if you pass a fixed set of labels everything works now.

For dynamically generated labels like in https://github.com/pola-rs/polars/issues/15781 there are still issues, but they lie in the way categoricals are combined in the `over` handling. Perhaps @c-peters can look at that.


Also fixes https://github.com/pola-rs/polars/issues/13038.