### PR TITLE
fix: do not panic when comparing against categorical with incompatible dtype

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -273,21 +273,6 @@ impl DataType {
         matches!(self, DataType::Binary)
     }
 
-    pub fn is_string(&self) -> bool {
-        matches!(self, DataType::String)
-    }
-
-    pub fn is_categorical(&self) -> bool {
-        #[cfg(feature = "dtype-categorical")]
-        {
-            matches!(self, DataType::Categorical(_, _) | DataType::Enum(_, _))
-        }
-        #[cfg(not(feature = "dtype-categorical"))]
-        {
-            false
-        }
-    }
-
     pub fn is_object(&self) -> bool {
         #[cfg(feature = "object")]
         {

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -273,6 +273,21 @@ impl DataType {
         matches!(self, DataType::Binary)
     }
 
+    pub fn is_string(&self) -> bool {
+        matches!(self, DataType::String)
+    }
+
+    pub fn is_categorical(&self) -> bool {
+        #[cfg(feature = "dtype-categorical")]
+        {
+            matches!(self, DataType::Categorical(_, _) | DataType::Enum(_, _))
+        }
+        #[cfg(not(feature = "dtype-categorical"))]
+        {
+            false
+        }
+    }
+
     pub fn is_object(&self) -> bool {
         #[cfg(feature = "object")]
         {

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -85,19 +85,19 @@ macro_rules! impl_compare {
 
 fn validate_types(left: &DataType, right: &DataType) -> PolarsResult<()> {
     use DataType::*;
-    #[cfg(feature = "dtype-categorical")]
-    {
-        let mismatch = matches!(left, String | Categorical(_, _) | Enum(_, _))
-            && right.is_numeric()
-            || left.is_numeric() && matches!(right, String | Categorical(_, _) | Enum(_, _));
-        polars_ensure!(!mismatch, ComputeError: "cannot compare string with numeric data");
-    }
-    #[cfg(not(feature = "dtype-categorical"))]
-    {
-        let mismatch = matches!(left, String) && right.is_numeric()
-            || left.is_numeric() && matches!(right, String);
-        polars_ensure!(!mismatch, ComputeError: "cannot compare string with numeric data");
-    }
+
+    match (left, right) {
+        (String, dt) | (dt, String) if dt.is_numeric() => {
+            polars_bail!(ComputeError: "cannot compare string with numeric type ({})", dt)
+        },
+        #[cfg(feature = "dtype-categorical")]
+        (Categorical(_, _) | Enum(_, _), dt) | (dt, Categorical(_, _) | Enum(_, _))
+            if !(dt.is_categorical() | dt.is_string()) =>
+        {
+            polars_bail!(ComputeError: "cannot compare categorical with {}", dt);
+        },
+        _ => (),
+    };
     Ok(())
 }
 

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -92,7 +92,7 @@ fn validate_types(left: &DataType, right: &DataType) -> PolarsResult<()> {
         },
         #[cfg(feature = "dtype-categorical")]
         (Categorical(_, _) | Enum(_, _), dt) | (dt, Categorical(_, _) | Enum(_, _))
-            if !(dt.is_categorical() | dt.is_string()) =>
+            if !(dt.is_categorical() | dt.is_string() | dt.is_enum()) =>
         {
             polars_bail!(ComputeError: "cannot compare categorical with {}", dt);
         },

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -366,3 +366,10 @@ def test_total_ordering_bool_series(lhs: bool | None, rhs: bool | None) -> None:
     )
     with context:
         verify_total_ordering_broadcast(lhs, rhs, False, pl.Boolean)
+
+
+def test_cat_compare_with_bool() -> None:
+    data = pl.DataFrame([pl.Series("col1", ["a", "b"], dtype=pl.Categorical)])
+
+    with pytest.raises(pl.ComputeError, match="cannot compare categorical with bool"):
+        data.filter(pl.col("col1") == True)  # noqa: E712

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -99,7 +99,7 @@ def test_not_found_error() -> None:
 
 def test_string_numeric_comp_err() -> None:
     with pytest.raises(
-        pl.ComputeError, match="cannot compare string with numeric data"
+        pl.ComputeError, match="cannot compare string with numeric type"
     ):
         pl.DataFrame({"a": [1.1, 21, 31, 21, 51, 61, 71, 81]}).select(pl.col("a") < "9")
 


### PR DESCRIPTION
This is a small 'bandaid' fix for comparisons between non-compatible dtypes and categorical to avoid panicking

fix #15844