### PR TITLE
chore(python): More PyO3 0.21 bound APIs

### DIFF
--- a/py-polars/src/batched_csv.rs
+++ b/py-polars/src/batched_csv.rs
@@ -6,6 +6,7 @@ use polars::io::mmap::MmapBytesReader;
 use polars::io::RowIndex;
 use polars::prelude::*;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 
 use crate::{PyDataFrame, PyPolarsErr, Wrap};
 
@@ -45,7 +46,7 @@ impl PyBatchedCsv {
         encoding: Wrap<CsvEncoding>,
         n_threads: Option<usize>,
         path: PathBuf,
-        overwrite_dtype: Option<Vec<(&str, Wrap<DataType>)>>,
+        overwrite_dtype: Option<Vec<(PyBackedStr, Wrap<DataType>)>>,
         overwrite_dtype_slice: Option<Vec<Wrap<DataType>>>,
         low_memory: bool,
         comment_prefix: Option<&str>,

--- a/py-polars/src/dataframe/general.rs
+++ b/py-polars/src/dataframe/general.rs
@@ -506,7 +506,7 @@ impl PyDataFrame {
     #[pyo3(signature = (lambda, output_type, inference_size))]
     pub fn map_rows(
         &mut self,
-        lambda: &PyAny,
+        lambda: Bound<PyAny>,
         output_type: Option<Wrap<DataType>>,
         inference_size: usize,
     ) -> PyResult<(PyObject, bool)> {
@@ -549,7 +549,7 @@ impl PyDataFrame {
     pub fn transpose(
         &mut self,
         keep_names_as: Option<&str>,
-        column_names: &PyAny,
+        column_names: &Bound<PyAny>,
     ) -> PyResult<Self> {
         let new_col_names = if let Ok(name) = column_names.extract::<Vec<String>>() {
             Some(Either::Right(name))

--- a/py-polars/src/dataframe/io.rs
+++ b/py-polars/src/dataframe/io.rs
@@ -7,12 +7,15 @@ use polars::io::avro::AvroCompression;
 use polars::io::mmap::ReaderBytes;
 use polars::io::RowIndex;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 
 use super::*;
 #[cfg(feature = "parquet")]
 use crate::conversion::parse_parquet_compression;
 use crate::conversion::Wrap;
-use crate::file::{get_either_file, get_file_like, get_mmap_bytes_reader, EitherRustPythonFile};
+use crate::file::{
+    get_either_file, get_file_like, get_mmap_bytes_reader, read_if_bytesio, EitherRustPythonFile,
+};
 
 #[pymethods]
 impl PyDataFrame {
@@ -27,7 +30,7 @@ impl PyDataFrame {
 )]
     pub fn read_csv(
         py: Python,
-        py_f: &PyAny,
+        mut py_f: Bound<PyAny>,
         infer_schema_length: Option<usize>,
         chunk_size: usize,
         has_header: bool,
@@ -41,7 +44,7 @@ impl PyDataFrame {
         encoding: Wrap<CsvEncoding>,
         n_threads: Option<usize>,
         path: Option<String>,
-        overwrite_dtype: Option<Vec<(&str, Wrap<DataType>)>>,
+        overwrite_dtype: Option<Vec<(PyBackedStr, Wrap<DataType>)>>,
         overwrite_dtype_slice: Option<Vec<Wrap<DataType>>>,
         low_memory: bool,
         comment_prefix: Option<&str>,
@@ -80,7 +83,8 @@ impl PyDataFrame {
                 .collect::<Vec<_>>()
         });
 
-        let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
+        py_f = read_if_bytesio(py_f);
+        let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
         let df = py.allow_threads(move || {
             CsvReader::new(mmap_bytes_r)
                 .infer_schema(infer_schema_length)
@@ -172,13 +176,16 @@ impl PyDataFrame {
     #[cfg(feature = "json")]
     pub fn read_json(
         py: Python,
-        py_f: &PyAny,
+        mut py_f: Bound<PyAny>,
         infer_schema_length: Option<usize>,
         schema: Option<Wrap<Schema>>,
         schema_overrides: Option<Wrap<Schema>>,
     ) -> PyResult<Self> {
         // memmap the file first.
-        let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
+
+        use crate::file::read_if_bytesio;
+        py_f = read_if_bytesio(py_f);
+        let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
 
         py.allow_threads(move || {
             let mmap_read: ReaderBytes = (&mmap_bytes_r).into();
@@ -219,12 +226,13 @@ impl PyDataFrame {
     #[cfg(feature = "json")]
     pub fn read_ndjson(
         py: Python,
-        py_f: &PyAny,
+        mut py_f: Bound<PyAny>,
         ignore_errors: bool,
         schema: Option<Wrap<Schema>>,
         schema_overrides: Option<Wrap<Schema>>,
     ) -> PyResult<Self> {
-        let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
+        py_f = read_if_bytesio(py_f);
+        let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
 
         let mut builder = JsonReader::new(mmap_bytes_r)
             .with_json_format(JsonFormat::JsonLines)
@@ -249,7 +257,7 @@ impl PyDataFrame {
     #[pyo3(signature = (py_f, columns, projection, n_rows, row_index, memory_map))]
     pub fn read_ipc(
         py: Python,
-        py_f: &PyAny,
+        mut py_f: Bound<PyAny>,
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
         n_rows: Option<usize>,
@@ -257,7 +265,8 @@ impl PyDataFrame {
         memory_map: bool,
     ) -> PyResult<Self> {
         let row_index = row_index.map(|(name, offset)| RowIndex { name, offset });
-        let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
+        py_f = read_if_bytesio(py_f);
+        let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
         let df = py.allow_threads(move || {
             IpcReader::new(mmap_bytes_r)
                 .with_projection(projection)
@@ -276,7 +285,7 @@ impl PyDataFrame {
     #[pyo3(signature = (py_f, columns, projection, n_rows, row_index, rechunk))]
     pub fn read_ipc_stream(
         py: Python,
-        py_f: &PyAny,
+        mut py_f: Bound<PyAny>,
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
         n_rows: Option<usize>,
@@ -284,7 +293,8 @@ impl PyDataFrame {
         rechunk: bool,
     ) -> PyResult<Self> {
         let row_index = row_index.map(|(name, offset)| RowIndex { name, offset });
-        let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
+        py_f = read_if_bytesio(py_f);
+        let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
         let df = py.allow_threads(move || {
             IpcStreamReader::new(mmap_bytes_r)
                 .with_projection(projection)
@@ -342,8 +352,8 @@ impl PyDataFrame {
     ) -> PyResult<()> {
         let null = null_value.unwrap_or_default();
 
-        if let Ok(s) = py_f.extract::<&str>(py) {
-            let f = std::fs::File::create(s)?;
+        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
+            let f = std::fs::File::create(&*s)?;
             py.allow_threads(|| {
                 // No need for a buffered writer, because the csv writer does internal buffering.
                 CsvWriter::new(f)
@@ -398,8 +408,8 @@ impl PyDataFrame {
     ) -> PyResult<()> {
         let compression = parse_parquet_compression(compression, compression_level)?;
 
-        if let Ok(s) = py_f.extract::<&str>(py) {
-            let f = std::fs::File::create(s)?;
+        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
+            let f = std::fs::File::create(&*s)?;
             py.allow_threads(|| {
                 ParquetWriter::new(f)
                     .with_compression(compression)
@@ -461,8 +471,8 @@ impl PyDataFrame {
         compression: Wrap<Option<IpcCompression>>,
         future: bool,
     ) -> PyResult<()> {
-        if let Ok(s) = py_f.extract::<&str>(py) {
-            let f = std::fs::File::create(s)?;
+        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
+            let f = std::fs::File::create(&*s)?;
             py.allow_threads(|| {
                 IpcWriter::new(f)
                     .with_compression(compression.0)
@@ -489,8 +499,8 @@ impl PyDataFrame {
         py_f: PyObject,
         compression: Wrap<Option<IpcCompression>>,
     ) -> PyResult<()> {
-        if let Ok(s) = py_f.extract::<&str>(py) {
-            let f = std::fs::File::create(s)?;
+        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
+            let f = std::fs::File::create(&*s)?;
             py.allow_threads(|| {
                 IpcStreamWriter::new(f)
                     .with_compression(compression.0)
@@ -519,8 +529,8 @@ impl PyDataFrame {
     ) -> PyResult<()> {
         use polars::io::avro::AvroWriter;
 
-        if let Ok(s) = py_f.extract::<&str>(py) {
-            let f = std::fs::File::create(s)?;
+        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
+            let f = std::fs::File::create(&*s)?;
             AvroWriter::new(f)
                 .with_compression(compression.0)
                 .with_name(name)

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -201,7 +201,7 @@ pub fn get_file_like(f: PyObject, truncate: bool) -> PyResult<Box<dyn FileLike>>
 }
 
 /// If the give file-like is a BytesIO, read its contents.
-pub fn read_if_bytesio<'a>(py_f: Bound<'a, PyAny>) -> Bound<'a, PyAny> {
+pub fn read_if_bytesio(py_f: Bound<PyAny>) -> Bound<PyAny> {
     if py_f.getattr("read").is_ok() {
         let Ok(bytes) = py_f.call_method0("getvalue") else {
             return py_f;

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -200,42 +200,45 @@ pub fn get_file_like(f: PyObject, truncate: bool) -> PyResult<Box<dyn FileLike>>
     }
 }
 
-pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesReader + 'a>> {
+/// If the give file-like is a BytesIO, read its contents.
+pub fn read_if_bytesio<'a>(py_f: Bound<'a, PyAny>) -> Bound<'a, PyAny> {
+    if py_f.getattr("read").is_ok() {
+        let Ok(bytes) = py_f.call_method0("getvalue") else {
+            return py_f;
+        };
+        if bytes.downcast::<PyBytes>().is_ok() {
+            return bytes.clone();
+        }
+    }
+    py_f
+}
+
+/// Create reader from PyBytes or a file-like object. To get BytesIO to have
+/// better performance, use read_if_bytesio() before calling this.
+pub fn get_mmap_bytes_reader<'a>(
+    py_f: &'a Bound<'a, PyAny>,
+) -> PyResult<Box<dyn MmapBytesReader + 'a>> {
     // bytes object
     if let Ok(bytes) = py_f.downcast::<PyBytes>() {
         Ok(Box::new(Cursor::new(bytes.as_bytes())))
     }
     // string so read file
     else if let Ok(pstring) = py_f.downcast::<PyString>() {
-        let s = pstring.to_str()?;
-        let p = std::path::Path::new(&s);
+        let s = pstring.to_cow()?;
+        let p = std::path::Path::new(&*s);
         let p = resolve_homedir(p);
         let f = polars_utils::open_file(p).map_err(PyPolarsErr::from)?;
         Ok(Box::new(f))
     }
-    // a normal python file: with open(...) as f:.
-    else if py_f.getattr("read").is_ok() {
+    // hopfully a normal python file: with open(...) as f:.
+    else {
         // we can still get a file name, inform the user of possibly wrong API usage.
-        if py_f.getattr("name").is_ok() {
+        if py_f.getattr("read").is_ok() && py_f.getattr("name").is_ok() {
             polars_warn!("Polars found a filename. \
             Ensure you pass a path to the file instead of a python file object when possible for best \
             performance.")
         }
-        // a bytesIO
-        if let Ok(bytes) = py_f.call_method0("getvalue") {
-            let bytes = bytes.downcast::<PyBytes>()?;
-            Ok(Box::new(Cursor::new(bytes.as_bytes())))
-        }
         // don't really know what we got here, just read.
-        else {
-            let f = Python::with_gil(|py| {
-                PyFileLikeObject::with_requirements(py_f.to_object(py), true, false, true)
-            })?;
-            Ok(Box::new(f))
-        }
-    }
-    // don't really know what we got here, just read.
-    else {
         let f = Python::with_gil(|py| {
             PyFileLikeObject::with_requirements(py_f.to_object(py), true, false, true)
         })?;

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -230,7 +230,7 @@ pub fn get_mmap_bytes_reader<'a>(
         let f = polars_utils::open_file(p).map_err(PyPolarsErr::from)?;
         Ok(Box::new(f))
     }
-    // hopfully a normal python file: with open(...) as f:.
+    // hopefully a normal python file: with open(...) as f:.
     else {
         // we can still get a file name, inform the user of possibly wrong API usage.
         if py_f.getattr("read").is_ok() && py_f.getattr("name").is_ok() {

--- a/py-polars/src/map/dataframe.rs
+++ b/py-polars/src/map/dataframe.rs
@@ -2,6 +2,7 @@ use polars::prelude::*;
 use polars_core::frame::row::{rows_to_schema_first_non_null, Row};
 use polars_core::series::SeriesIter;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
 use pyo3::types::{PyBool, PyFloat, PyInt, PyList, PyString, PyTuple};
 
 use super::*;
@@ -22,7 +23,7 @@ fn get_iters_skip(df: &DataFrame, skip: usize) -> Vec<std::iter::Skip<SeriesIter
 pub fn apply_lambda_unknown<'a>(
     df: &'a DataFrame,
     py: Python,
-    lambda: &'a PyAny,
+    lambda: Bound<'a, PyAny>,
     inference_size: usize,
 ) -> PyResult<(PyObject, bool)> {
     let mut null_count = 0;
@@ -30,7 +31,7 @@ pub fn apply_lambda_unknown<'a>(
 
     for _ in 0..df.height() {
         let iter = iters.iter_mut().map(|it| Wrap(it.next().unwrap()));
-        let arg = (PyTuple::new(py, iter),);
+        let arg = (PyTuple::new_bound(py, iter),);
         let out = lambda.call1(arg)?;
 
         if out.is_none() {
@@ -80,11 +81,17 @@ pub fn apply_lambda_unknown<'a>(
                 false,
             ));
         } else if out.is_instance_of::<PyString>() {
-            let first_value = out.extract::<&str>().ok();
+            let first_value = out.extract::<PyBackedStr>().ok();
             return Ok((
                 PySeries::new(
-                    apply_lambda_with_string_out_type(df, py, lambda, null_count, first_value)
-                        .into_series(),
+                    apply_lambda_with_string_out_type(
+                        df,
+                        py,
+                        lambda,
+                        null_count,
+                        first_value.as_deref(),
+                    )
+                    .into_series(),
                 )
                 .into_py(py),
                 false,
@@ -135,7 +142,7 @@ Then return a Series object."
 fn apply_iter<'a, T>(
     df: &'a DataFrame,
     py: Python<'a>,
-    lambda: &'a PyAny,
+    lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     skip: usize,
 ) -> impl Iterator<Item = Option<T>> + 'a
@@ -145,7 +152,7 @@ where
     let mut iters = get_iters_skip(df, init_null_count + skip);
     ((init_null_count + skip)..df.height()).map(move |_| {
         let iter = iters.iter_mut().map(|it| Wrap(it.next().unwrap()));
-        let tpl = (PyTuple::new(py, iter),);
+        let tpl = (PyTuple::new_bound(py, iter),);
         match lambda.call1(tpl) {
             Ok(val) => val.extract::<T>().ok(),
             Err(e) => panic!("python function failed {e}"),
@@ -157,7 +164,7 @@ where
 pub fn apply_lambda_with_primitive_out_type<'a, D>(
     df: &'a DataFrame,
     py: Python<'a>,
-    lambda: &'a PyAny,
+    lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Option<D::Native>,
 ) -> ChunkedArray<D>
@@ -178,7 +185,7 @@ where
 pub fn apply_lambda_with_bool_out_type<'a>(
     df: &'a DataFrame,
     py: Python,
-    lambda: &'a PyAny,
+    lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Option<bool>,
 ) -> ChunkedArray<BooleanType> {
@@ -195,7 +202,7 @@ pub fn apply_lambda_with_bool_out_type<'a>(
 pub fn apply_lambda_with_string_out_type<'a>(
     df: &'a DataFrame,
     py: Python,
-    lambda: &'a PyAny,
+    lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Option<&str>,
 ) -> StringChunked {
@@ -203,7 +210,7 @@ pub fn apply_lambda_with_string_out_type<'a>(
     if init_null_count == df.height() {
         ChunkedArray::full_null("map", df.height())
     } else {
-        let iter = apply_iter::<&str>(df, py, lambda, init_null_count, skip);
+        let iter = apply_iter::<Cow<str>>(df, py, lambda, init_null_count, skip);
         iterator_to_string(iter, init_null_count, first_value, "map", df.height())
     }
 }
@@ -212,7 +219,7 @@ pub fn apply_lambda_with_string_out_type<'a>(
 pub fn apply_lambda_with_list_out_type<'a>(
     df: &'a DataFrame,
     py: Python,
-    lambda: &'a PyAny,
+    lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Option<&Series>,
     dt: &DataType,
@@ -224,7 +231,7 @@ pub fn apply_lambda_with_list_out_type<'a>(
         let mut iters = get_iters_skip(df, init_null_count + skip);
         let iter = ((init_null_count + skip)..df.height()).map(|_| {
             let iter = iters.iter_mut().map(|it| Wrap(it.next().unwrap()));
-            let tpl = (PyTuple::new(py, iter),);
+            let tpl = (PyTuple::new_bound(py, iter),);
             match lambda.call1(tpl) {
                 Ok(val) => match val.getattr("_s") {
                     Ok(val) => val.extract::<PySeries>().ok().map(|ps| ps.series),
@@ -246,7 +253,7 @@ pub fn apply_lambda_with_list_out_type<'a>(
 pub fn apply_lambda_with_rows_output<'a>(
     df: &'a DataFrame,
     py: Python,
-    lambda: &'a PyAny,
+    lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Row<'a>,
     inference_size: usize,
@@ -260,7 +267,7 @@ pub fn apply_lambda_with_rows_output<'a>(
     let mut iters = get_iters_skip(df, init_null_count + skip);
     let mut row_iter = ((init_null_count + skip)..df.height()).map(|_| {
         let iter = iters.iter_mut().map(|it| Wrap(it.next().unwrap()));
-        let tpl = (PyTuple::new(py, iter),);
+        let tpl = (PyTuple::new_bound(py, iter),);
 
         let return_val = lambda.call1(tpl).map_err(|e| polars_err!(ComputeError: format!("{e}")))?;
         if return_val.is_none() {

--- a/py-polars/src/map/mod.rs
+++ b/py-polars/src/map/mod.rs
@@ -2,6 +2,7 @@ pub mod dataframe;
 pub mod lazy;
 pub mod series;
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use polars::chunked_array::builder::get_list_builder;
@@ -214,19 +215,19 @@ fn iterator_to_object(
 }
 
 fn iterator_to_string<'a>(
-    it: impl Iterator<Item = Option<&'a str>>,
+    it: impl Iterator<Item = Option<Cow<'a, str>>>,
     init_null_count: usize,
     first_value: Option<&'a str>,
     name: &str,
     capacity: usize,
 ) -> StringChunked {
+    let first_value = first_value.map(Cow::Borrowed);
     // SAFETY: we know the iterators len.
     let ca: StringChunked = unsafe {
         if init_null_count > 0 {
             (0..init_null_count)
                 .map(|_| None)
                 .chain(std::iter::once(first_value))
-                .chain(it)
                 .trust_my_length(capacity)
                 .collect_trusted()
         } else if first_value.is_some() {

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -255,7 +255,7 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn new_binary(name: &str, values: &PyAny, _strict: bool) -> PyResult<Self> {
+    fn new_binary(name: &str, values: &Bound<PyAny>, _strict: bool) -> PyResult<Self> {
         let len = values.len()?;
         let mut builder = BinaryChunkedBuilder::new(name, len);
 


### PR DESCRIPTION
Fixes #15864 

More lifetime issues... the hardest one was keeping the temporary PyBytes object read from BytesIO.getvalue() alive. Perhaps there's another way to do this.