### PR TITLE
perf: Improve non-trivial list aggregations

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -408,7 +408,6 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.field.data_type()
     }
 
-    #[cfg(any(feature = "dtype-struct", feature = "dtype-categorical"))]
     pub(crate) unsafe fn set_dtype(&mut self, dtype: DataType) {
         self.field = Arc::new(Field::new(self.name(), dtype))
     }

--- a/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
@@ -1,6 +1,4 @@
-use arrow::legacy::kernels::concatenate::concatenate_owned_unchecked;
 use arrow::offset::Offsets;
-use polars_utils::unwrap::UnwrapUncheckedRelease;
 
 use super::*;
 use crate::chunked_array::builder::ListNullChunkedBuilder;
@@ -179,253 +177,32 @@ impl AggList for NullChunked {
 
 impl AggList for BooleanChunked {
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
-        match groups {
-            GroupsProxy::Idx(groups) => {
-                let mut builder =
-                    ListBooleanChunkedBuilder::new(self.name(), groups.len(), self.len());
-                for idx in groups.all().iter() {
-                    let ca = { self.take_unchecked(idx) };
-                    builder.append(&ca)
-                }
-                builder.finish().into_series()
-            },
-            GroupsProxy::Slice { groups, .. } => {
-                let mut builder =
-                    ListBooleanChunkedBuilder::new(self.name(), groups.len(), self.len());
-                for [first, len] in groups {
-                    let ca = self.slice(*first as i64, *len as usize);
-                    builder.append(&ca)
-                }
-                builder.finish().into_series()
-            },
-        }
+        agg_list_by_gather_and_offsets(self, groups)
     }
 }
 
 impl AggList for StringChunked {
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
-        // TODO: dispatch via binary
-        match groups {
-            GroupsProxy::Idx(groups) => {
-                let mut builder =
-                    ListStringChunkedBuilder::new(self.name(), groups.len(), self.len());
-                for idx in groups.all().iter() {
-                    let ca = { self.take_unchecked(idx) };
-                    builder.append(&ca)
-                }
-                builder.finish().into_series()
-            },
-            GroupsProxy::Slice { groups, .. } => {
-                let mut builder =
-                    ListStringChunkedBuilder::new(self.name(), groups.len(), self.len());
-                for [first, len] in groups {
-                    let ca = self.slice(*first as i64, *len as usize);
-                    builder.append(&ca)
-                }
-                builder.finish().into_series()
-            },
-        }
+        agg_list_by_gather_and_offsets(self, groups)
     }
 }
 
 impl AggList for BinaryChunked {
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
-        match groups {
-            GroupsProxy::Idx(groups) => {
-                let mut builder =
-                    ListBinaryChunkedBuilder::new(self.name(), groups.len(), self.len());
-                for idx in groups.all().iter() {
-                    let ca = { self.take_unchecked(idx) };
-                    builder.append(&ca)
-                }
-                builder.finish().into_series()
-            },
-            GroupsProxy::Slice { groups, .. } => {
-                let mut builder =
-                    ListBinaryChunkedBuilder::new(self.name(), groups.len(), self.len());
-                for [first, len] in groups {
-                    let ca = self.slice(*first as i64, *len as usize);
-                    builder.append(&ca)
-                }
-                builder.finish().into_series()
-            },
-        }
+        agg_list_by_gather_and_offsets(self, groups)
     }
-}
-
-/// This aggregates into a [`ListChunked`] by slicing the array that is aggregated.
-/// Used for [`List`] and [`Array`] data types.
-fn agg_list_by_slicing<
-    A: PolarsDataType,
-    F: Fn(&ChunkedArray<A>, bool, &mut Vec<i64>, &mut i64, &mut Vec<ArrayRef>) -> bool,
->(
-    ca: &ChunkedArray<A>,
-    dtype: DataType,
-    groups_len: usize,
-    func: F,
-) -> Series {
-    let can_fast_explode = true;
-    let mut offsets = Vec::<i64>::with_capacity(groups_len + 1);
-    let mut length_so_far = 0i64;
-    offsets.push(length_so_far);
-
-    let mut list_values = Vec::with_capacity(groups_len);
-
-    let can_fast_explode = func(
-        ca,
-        can_fast_explode,
-        &mut offsets,
-        &mut length_so_far,
-        &mut list_values,
-    );
-    if groups_len == 0 {
-        list_values.push(ca.chunks[0].sliced(0, 0))
-    }
-    let list_values = concatenate_owned_unchecked(&list_values).unwrap();
-    let data_type = ListArray::<i64>::default_datatype(list_values.data_type().clone());
-    // SAFETY:
-    // offsets are monotonically increasing
-    let arr = ListArray::<i64>::new(
-        data_type,
-        unsafe { Offsets::new_unchecked(offsets).into() },
-        list_values,
-        None,
-    );
-    let mut listarr = ListChunked::with_chunk(ca.name(), arr);
-    if can_fast_explode {
-        listarr.set_fast_explode()
-    }
-    unsafe { listarr.to_logical(dtype) };
-    listarr.into_series()
 }
 
 impl AggList for ListChunked {
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
-        match groups {
-            GroupsProxy::Idx(groups) => {
-                let func = |ca: &ListChunked,
-                            mut can_fast_explode: bool,
-                            offsets: &mut Vec<i64>,
-                            length_so_far: &mut i64,
-                            list_values: &mut Vec<ArrayRef>| {
-                    assert!(list_values.capacity() >= groups.len());
-                    groups.iter().for_each(|(_, idx)| {
-                        let idx_len = idx.len();
-                        if idx_len == 0 {
-                            can_fast_explode = false;
-                        }
-
-                        *length_so_far += idx_len as i64;
-                        // SAFETY:
-                        // group tuples are in bounds
-                        {
-                            let mut s = ca.take_unchecked(idx);
-                            let arr = s.chunks.pop().unwrap_unchecked_release();
-                            list_values.push_unchecked(arr);
-
-                            // SAFETY:
-                            // we know that offsets has allocated enough slots
-                            offsets.push_unchecked(*length_so_far);
-                        }
-                    });
-                    can_fast_explode
-                };
-
-                agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            },
-            GroupsProxy::Slice { groups, .. } => {
-                let func = |ca: &ListChunked,
-                            mut can_fast_explode: bool,
-                            offsets: &mut Vec<i64>,
-                            length_so_far: &mut i64,
-                            list_values: &mut Vec<ArrayRef>| {
-                    assert!(list_values.capacity() >= groups.len());
-                    groups.iter().for_each(|&[first, len]| {
-                        if len == 0 {
-                            can_fast_explode = false;
-                        }
-
-                        *length_so_far += len as i64;
-                        let mut s = ca.slice(first as i64, len as usize);
-                        let arr = s.chunks.pop().unwrap_unchecked_release();
-                        list_values.push_unchecked(arr);
-
-                        {
-                            // SAFETY:
-                            // we know that offsets has allocated enough slots
-                            offsets.push_unchecked(*length_so_far);
-                        }
-                    });
-                    can_fast_explode
-                };
-
-                agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            },
-        }
+        agg_list_by_gather_and_offsets(self, groups)
     }
 }
 
 #[cfg(feature = "dtype-array")]
 impl AggList for ArrayChunked {
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
-        match groups {
-            GroupsProxy::Idx(groups) => {
-                let func = |ca: &ArrayChunked,
-                            mut can_fast_explode: bool,
-                            offsets: &mut Vec<i64>,
-                            length_so_far: &mut i64,
-                            list_values: &mut Vec<ArrayRef>| {
-                    assert!(list_values.capacity() >= groups.len());
-                    groups.iter().for_each(|(_, idx)| {
-                        let idx_len = idx.len();
-                        if idx_len == 0 {
-                            can_fast_explode = false;
-                        }
-
-                        *length_so_far += idx_len as i64;
-
-                        // SAFETY: we know that offsets has allocated enough slots
-                        offsets.push_unchecked(*length_so_far);
-
-                        // SAFETY: group tuples are in bounds
-                        {
-                            let mut s = ca.take_unchecked(idx);
-                            let arr = s.chunks.pop().unwrap_unchecked_release();
-                            list_values.push_unchecked(arr);
-                        }
-                    });
-                    can_fast_explode
-                };
-
-                agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            },
-            GroupsProxy::Slice { groups, .. } => {
-                let func = |ca: &ArrayChunked,
-                            mut can_fast_explode: bool,
-                            offsets: &mut Vec<i64>,
-                            length_so_far: &mut i64,
-                            list_values: &mut Vec<ArrayRef>| {
-                    assert!(list_values.capacity() >= groups.len());
-                    groups.iter().for_each(|&[first, len]| {
-                        if len == 0 {
-                            can_fast_explode = false;
-                        }
-
-                        *length_so_far += len as i64;
-                        // SAFETY:
-                        // we know that offsets has allocated enough slots
-                        offsets.push_unchecked(*length_so_far);
-
-                        let mut s = ca.slice(first as i64, len as usize);
-                        let arr = s.chunks.pop().unwrap_unchecked_release();
-                        list_values.push_unchecked(arr);
-                    });
-                    can_fast_explode
-                };
-
-                agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            },
-        }
+        agg_list_by_gather_and_offsets(self, groups)
     }
 }
 
@@ -522,4 +299,32 @@ impl AggList for StructChunked {
 
         chunk.into_series()
     }
+}
+
+unsafe fn agg_list_by_gather_and_offsets<T: PolarsDataType>(
+    ca: &ChunkedArray<T>,
+    groups: &GroupsProxy,
+) -> Series
+where
+    ChunkedArray<T>: ChunkTakeUnchecked<IdxCa>,
+{
+    let (gather, offsets, can_fast_explode) = groups.prepare_list_agg(ca.len());
+
+    let gathered = if let Some(gather) = gather {
+        ca.take_unchecked(&gather)
+    } else {
+        ca.clone()
+    };
+
+    let arr = gathered.chunks()[0].clone();
+    let dtype = LargeListArray::default_datatype(arr.data_type().clone());
+
+    let mut chunk =
+        ListChunked::with_chunk(ca.name(), LargeListArray::new(dtype, offsets, arr, None));
+    chunk.set_dtype(DataType::List(Box::new(ca.dtype().clone())));
+    if can_fast_explode {
+        chunk.set_fast_explode()
+    }
+
+    chunk.into_series()
 }

--- a/crates/polars-core/src/frame/group_by/proxy.rs
+++ b/crates/polars-core/src/frame/group_by/proxy.rs
@@ -352,10 +352,15 @@ impl GroupsProxy {
             },
             GroupsProxy::Slice { groups, .. } => {
                 let mut list_offset = Vec::with_capacity(self.len() + 1);
+                let mut gather_offsets = Vec::with_capacity(total_len);
                 let mut len_so_far = 0i64;
                 list_offset.push(len_so_far);
+
                 for g in groups {
                     let len = g[1];
+                    let offset = g[0];
+                    gather_offsets.extend(offset..offset + len);
+
                     len_so_far += len as i64;
                     list_offset.push(len_so_far);
                     can_fast_explode &= len > 0;
@@ -363,7 +368,7 @@ impl GroupsProxy {
 
                 unsafe {
                     (
-                        None,
+                        Some(IdxCa::from_vec("", gather_offsets)),
                         OffsetsBuffer::new_unchecked(list_offset.into()),
                         can_fast_explode,
                     )

--- a/crates/polars-core/src/frame/group_by/proxy.rs
+++ b/crates/polars-core/src/frame/group_by/proxy.rs
@@ -1,6 +1,7 @@
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
 
+use arrow::offset::OffsetsBuffer;
 use polars_utils::idx_vec::IdxVec;
 use polars_utils::sync::SyncPtr;
 use rayon::iter::plumbing::UnindexedConsumer;
@@ -321,6 +322,56 @@ impl GroupsProxy {
         }
     }
 
+    pub(crate) fn prepare_list_agg(
+        &self,
+        total_len: usize,
+    ) -> (Option<IdxCa>, OffsetsBuffer<i64>, bool) {
+        let mut can_fast_explode = true;
+        match self {
+            GroupsProxy::Idx(groups) => {
+                let mut list_offset = Vec::with_capacity(self.len() + 1);
+                let mut gather_offsets = Vec::with_capacity(total_len);
+
+                let mut len_so_far = 0i64;
+                list_offset.push(len_so_far);
+
+                for idx in groups {
+                    let idx = idx.1;
+                    gather_offsets.extend_from_slice(idx);
+                    len_so_far += idx.len() as i64;
+                    list_offset.push(len_so_far);
+                    can_fast_explode &= !idx.is_empty();
+                }
+                unsafe {
+                    (
+                        Some(IdxCa::from_vec("", gather_offsets)),
+                        OffsetsBuffer::new_unchecked(list_offset.into()),
+                        can_fast_explode,
+                    )
+                }
+            },
+            GroupsProxy::Slice { groups, .. } => {
+                let mut list_offset = Vec::with_capacity(self.len() + 1);
+                let mut len_so_far = 0i64;
+                list_offset.push(len_so_far);
+                for g in groups {
+                    let len = g[1];
+                    len_so_far += len as i64;
+                    list_offset.push(len_so_far);
+                    can_fast_explode &= len > 0;
+                }
+
+                unsafe {
+                    (
+                        None,
+                        OffsetsBuffer::new_unchecked(list_offset.into()),
+                        can_fast_explode,
+                    )
+                }
+            },
+        }
+    }
+
     pub fn iter(&self) -> GroupsProxyIter {
         GroupsProxyIter::new(self)
     }
@@ -343,19 +394,6 @@ impl GroupsProxy {
             GroupsProxy::Idx(groups) => groups.is_sorted_flag(),
             GroupsProxy::Slice { .. } => true,
         }
-    }
-
-    pub fn group_lengths(&self, name: &str) -> IdxCa {
-        let ca: NoNull<IdxCa> = match self {
-            GroupsProxy::Idx(groups) => groups
-                .iter()
-                .map(|(_, groups)| groups.len() as IdxSize)
-                .collect_trusted(),
-            GroupsProxy::Slice { groups, .. } => groups.iter().map(|g| g[1]).collect_trusted(),
-        };
-        let mut ca = ca.into_inner();
-        ca.rename(name);
-        ca
     }
 
     pub fn take_group_firsts(self) -> Vec<IdxSize> {

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -17,7 +17,7 @@ pub trait SeriesMethods: SeriesSealed {
         // we need to sort here as well in case of `maintain_order` because duplicates behavior is undefined
         let groups = s.group_tuples(parallel, sort)?;
         let values = unsafe { s.agg_first(&groups) };
-        let counts = groups.group_lengths("count");
+        let counts = groups.group_count().with_name("count");
         let cols = vec![values, counts.into_series()];
         let df = unsafe { DataFrame::new_no_checks(cols) };
         if sort {


### PR DESCRIPTION
Fixes performance by making it a `gather` + `offset` wrap.

fixes #15847