### PR TITLE
fix: double projection check should only take the upstream projections into account

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
@@ -95,17 +95,19 @@ pub(super) fn process_projection(
 
                 check_double_projection(&e, expr_arena, &mut acc_projections, &mut projected_names);
             }
+            // do local as we still need the effect of the projection
+            // e.g. a projection is more than selecting a column, it can
+            // also be a function/ complicated expression
+            local_projection.push(e);
+        }
+
+        for e in &local_projection {
             add_expr_to_accumulated(
                 e.node(),
                 &mut acc_projections,
                 &mut projected_names,
                 expr_arena,
             );
-
-            // do local as we still need the effect of the projection
-            // e.g. a projection is more than selecting a column, it can
-            // also be a function/ complicated expression
-            local_projection.push(e);
         }
     }
     proj_pd.pushdown_and_assign(
@@ -118,6 +120,7 @@ pub(super) fn process_projection(
     )?;
 
     let builder = IRBuilder::new(input, expr_arena, lp_arena);
+    dbg!(&local_projection);
     let lp = proj_pd.finish_node(local_projection, builder);
 
     Ok(lp)

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
@@ -101,6 +101,8 @@ pub(super) fn process_projection(
             local_projection.push(e);
         }
 
+        // After we have checked double projections, we add the projections to the accumulated state.
+        // We do this in two passes, otherwise we mutate while checking.
         for e in &local_projection {
             add_expr_to_accumulated(
                 e.node(),

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
@@ -120,7 +120,6 @@ pub(super) fn process_projection(
     )?;
 
     let builder = IRBuilder::new(input, expr_arena, lp_arena);
-    dbg!(&local_projection);
     let lp = proj_pd.finish_node(local_projection, builder);
 
     Ok(lp)

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -419,3 +419,18 @@ def test_cached_schema_15651() -> None:
 
     # ensure that q's "cached" columns are still correct
     assert q.columns == q.collect().columns
+
+
+def test_double_projection_pushdown_15895() -> None:
+    df = (
+        pl.LazyFrame({"A": [0], "B": [1]})
+        .select(C="A", A="B")
+        .group_by(1)
+        .all()
+        .collect(projection_pushdown=True)
+    )
+    assert df.to_dict(as_series=False) == {
+        "literal": [1],
+        "C": [[0]],
+        "A": [[1]],
+    }


### PR DESCRIPTION
fix: #15895.