### PR TITLE
fix(python): Change recognition of numba ufunc

### DIFF
--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -23,6 +23,7 @@ from typing import (
     Iterator,
     Literal,
     NamedTuple,
+    Protocol,
     Union,
 )
 
@@ -43,6 +44,10 @@ class StackValue(NamedTuple):
     left_operand: str
     right_operand: str
     from_module: str | None = None
+
+
+class UfuncProtocol(Protocol):
+    signature: Any
 
 
 MapTarget: TypeAlias = Literal["expr", "frame", "series"]

--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -24,6 +24,7 @@ from typing import (
     Literal,
     NamedTuple,
     Protocol,
+    TypeVar,
     Union,
 )
 
@@ -37,6 +38,8 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeAlias
 
+T = TypeVar("T", bound=Callable[..., Any])
+
 
 class StackValue(NamedTuple):
     operator: str
@@ -46,8 +49,10 @@ class StackValue(NamedTuple):
     from_module: str | None = None
 
 
-class UfuncProtocol(Protocol):
+class UfuncProtocol(Protocol[T]):
     signature: Any
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 MapTarget: TypeAlias = Literal["expr", "frame", "series"]

--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -23,8 +23,6 @@ from typing import (
     Iterator,
     Literal,
     NamedTuple,
-    Protocol,
-    TypeVar,
     Union,
 )
 

--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -38,8 +38,6 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeAlias
 
-T = TypeVar("T", bound=Callable[..., Any])
-
 
 class StackValue(NamedTuple):
     operator: str
@@ -47,12 +45,6 @@ class StackValue(NamedTuple):
     left_operand: str
     right_operand: str
     from_module: str | None = None
-
-
-class UfuncProtocol(Protocol[T]):
-    signature: Any
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 MapTarget: TypeAlias = Literal["expr", "frame", "series"]

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -293,7 +293,7 @@ class Expr:
         if method != "__call__":
             msg = f"Only call is implemented not {method}"
             raise NotImplementedError(msg)
-        # Numpy/Scipy ufuncs have signature None but numba signatures always exists
+        # Numpy/Scipy ufuncs have signature None but numba signatures always exists.
         is_custom_ufunc = getattr(ufunc, "signature") is not None  # noqa: B009
         num_expr = sum(isinstance(inp, Expr) for inp in inputs)
         exprs = [

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -288,14 +288,14 @@ class Expr:
         self._pyexpr.__setstate__(state)
 
     def __array_ufunc__(
-        self, ufunc: UfuncProtocol, method: str, *inputs: Any, **kwargs: Any
+        self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any
     ) -> Self:
         """Numpy universal functions."""
         if method != "__call__":
             msg = f"Only call is implemented not {method}"
             raise NotImplementedError(msg)
         # Numpy/Scipy ufuncs have signature None but numba signatures always exists
-        is_custom_ufunc = ufunc.signature is not None
+        is_custom_ufunc = getattr(ufunc, "signature")() is not None  # noqa: B009
         num_expr = sum(isinstance(inp, Expr) for inp in inputs)
         exprs = [
             (inp, Expr, i) if isinstance(inp, Expr) else (inp, None, i)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -39,7 +39,6 @@ from polars._utils.parse_expr_input import (
     parse_as_list_of_expressions,
     parse_predicates_constraints_as_expression,
 )
-from polars._utils.udfs import UfuncProtocol
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     BUILDING_SPHINX_DOCS,
@@ -79,6 +78,7 @@ if TYPE_CHECKING:
     from io import IOBase
 
     from polars import DataFrame, LazyFrame, Series
+    from polars._utils.udfs import UfuncProtocol
     from polars._utils.various import (
         NoDefault,
     )

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -293,7 +293,8 @@ class Expr:
         if method != "__call__":
             msg = f"Only call is implemented not {method}"
             raise NotImplementedError(msg)
-        is_custom_ufunc = ufunc.__class__ != np.ufunc
+        # Numpy/Scipy ufuncs have signature None but numba signatures always exists
+        is_custom_ufunc = ufunc.signature is not None
         num_expr = sum(isinstance(inp, Expr) for inp in inputs)
         exprs = [
             (inp, Expr, i) if isinstance(inp, Expr) else (inp, None, i)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -39,6 +39,7 @@ from polars._utils.parse_expr_input import (
     parse_as_list_of_expressions,
     parse_predicates_constraints_as_expression,
 )
+from polars._utils.udfs import UfuncProtocol
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     BUILDING_SPHINX_DOCS,
@@ -287,7 +288,7 @@ class Expr:
         self._pyexpr.__setstate__(state)
 
     def __array_ufunc__(
-        self, ufunc: Callable[..., Any], method: str, *inputs: Any, **kwargs: Any
+        self, ufunc: UfuncProtocol, method: str, *inputs: Any, **kwargs: Any
     ) -> Self:
         """Numpy universal functions."""
         if method != "__call__":

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -78,7 +78,6 @@ if TYPE_CHECKING:
     from io import IOBase
 
     from polars import DataFrame, LazyFrame, Series
-    from polars._utils.udfs import UfuncProtocol
     from polars._utils.various import (
         NoDefault,
     )

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -294,7 +294,7 @@ class Expr:
             msg = f"Only call is implemented not {method}"
             raise NotImplementedError(msg)
         # Numpy/Scipy ufuncs have signature None but numba signatures always exists
-        is_custom_ufunc = getattr(ufunc, "signature")() is not None  # noqa: B009
+        is_custom_ufunc = getattr(ufunc, "signature") is not None  # noqa: B009
         num_expr = sum(isinstance(inp, Expr) for inp in inputs)
         exprs = [
             (inp, Expr, i) if isinstance(inp, Expr) else (inp, None, i)


### PR DESCRIPTION
At some point/version of numba or numpy "they" made it so the ufunc that gets handed to `__array_ufunc__` changes its class so that looking at the class doesn't distinguish a numba ufunc from a native numpy ufuncs. This is relevant because all the numpy/scipy native ufuncs are elementwise whereas the numba ufuncs probably aren't.

Luckily, it still is the case that ufuncs produced by numba have a signature field whereas the native ufuncs have signature None so I just switched the custom ufunc to that check.