### PR TITLE
ci(rust): Pin coverage job to MacOS 13 for now

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -34,7 +34,9 @@ jobs:
   coverage-rust:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
-    runs-on: macos-latest
+    # Pinned on macos-13 because latest does not work:
+    # https://github.com/pola-rs/polars/issues/15917
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 
@@ -85,7 +87,7 @@ jobs:
   coverage-python:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/15917

Will look into this when I'm back from vacation. At least the CI can run normally until then.