### PR TITLE
fix(rust): Treat splitting by empty string as iterating over chars

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -457,36 +457,47 @@ pub trait StringNameSpaceImpl: AsString {
     fn split_exact(&self, by: &StringChunked, n: usize) -> PolarsResult<StructChunked> {
         let ca = self.as_string();
 
-        split_to_struct(ca, by, n + 1, split)
+        split_to_struct(ca, by, n + 1, str::split, true)
     }
 
     #[cfg(feature = "dtype-struct")]
     fn split_exact_inclusive(&self, by: &StringChunked, n: usize) -> PolarsResult<StructChunked> {
         let ca = self.as_string();
 
-        split_to_struct(ca, by, n + 1, split_inclusive)
+        split_to_struct(ca, by, n + 1, str::split_inclusive, true)
     }
 
     #[cfg(feature = "dtype-struct")]
     fn splitn(&self, by: &StringChunked, n: usize) -> PolarsResult<StructChunked> {
         let ca = self.as_string();
 
-        split_to_struct(ca, by, n, |s, by| {
-            s.splitn(if by.is_empty() { n + 1 } else { n }, by)
-                .filter(|x| if by.is_empty() { !x.is_empty() } else { true })
-        })
+        split_to_struct(
+            ca,
+            by,
+            n,
+            |s, by| {
+                let substrings_count = if by.is_empty() {
+                    std::cmp::min(n, s.chars().count()) + 1
+                } else {
+                    n
+                };
+                s.splitn(substrings_count, by)
+                    .skip(if by.is_empty() { 1 } else { 0 })
+            },
+            false,
+        )
     }
 
     fn split(&self, by: &StringChunked) -> ListChunked {
         let ca = self.as_string();
 
-        split_helper(ca, by, split)
+        split_helper(ca, by, str::split)
     }
 
     fn split_inclusive(&self, by: &StringChunked) -> ListChunked {
         let ca = self.as_string();
 
-        split_helper(ca, by, split_inclusive)
+        split_helper(ca, by, str::split_inclusive)
     }
 
     /// Extract each successive non-overlapping regex match in an individual string as an array.

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -457,35 +457,21 @@ pub trait StringNameSpaceImpl: AsString {
     fn split_exact(&self, by: &StringChunked, n: usize) -> PolarsResult<StructChunked> {
         let ca = self.as_string();
 
-        split_to_struct(ca, by, n + 1, str::split, true)
+        split_to_struct(ca, by, n + 1, str::split, false)
     }
 
     #[cfg(feature = "dtype-struct")]
     fn split_exact_inclusive(&self, by: &StringChunked, n: usize) -> PolarsResult<StructChunked> {
         let ca = self.as_string();
 
-        split_to_struct(ca, by, n + 1, str::split_inclusive, true)
+        split_to_struct(ca, by, n + 1, str::split_inclusive, false)
     }
 
     #[cfg(feature = "dtype-struct")]
     fn splitn(&self, by: &StringChunked, n: usize) -> PolarsResult<StructChunked> {
         let ca = self.as_string();
 
-        split_to_struct(
-            ca,
-            by,
-            n,
-            |s, by| {
-                let substrings_count = if by.is_empty() {
-                    std::cmp::min(n, s.chars().count()) + 1
-                } else {
-                    n
-                };
-                s.splitn(substrings_count, by)
-                    .skip(if by.is_empty() { 1 } else { 0 })
-            },
-            false,
-        )
+        split_to_struct(ca, by, n, |s, by| s.splitn(n, by), true)
     }
 
     fn split(&self, by: &StringChunked) -> ListChunked {

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -472,11 +472,8 @@ pub trait StringNameSpaceImpl: AsString {
         let ca = self.as_string();
 
         split_to_struct(ca, by, n, |s, by| {
-            if by.is_empty() {
-                Box::new(s.splitn(n + 1, by).filter(|x| !x.is_empty()))
-            } else {
-                Box::new(s.splitn(n, by))
-            }
+            s.splitn(if by.is_empty() { n + 1 } else { n }, by)
+                .filter(|x| if by.is_empty() { !x.is_empty() } else { true })
         })
     }
 

--- a/crates/polars-ops/src/chunked_array/strings/split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/split.rs
@@ -15,7 +15,8 @@ impl<'a> Iterator for SplitNChars<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.n >= 2 {
+        let single_char_limit = if self.keep_remainder { 2 } else { 1 };
+        if self.n >= single_char_limit {
             self.n -= 1;
             let ch = self.s.chars().next()?;
             let first;
@@ -23,11 +24,7 @@ impl<'a> Iterator for SplitNChars<'a> {
             Some(first)
         } else if self.n == 1 && !self.s.is_empty() {
             self.n -= 1;
-            if self.keep_remainder {
-                Some(self.s)
-            } else {
-                Some(self.s.split_at(self.s.chars().next()?.len_utf8()).0)
-            }
+            Some(self.s)
         } else {
             None
         }

--- a/crates/polars-ops/src/chunked_array/strings/split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/split.rs
@@ -35,6 +35,7 @@ impl<'a> Iterator for SplitNChars<'a> {
 ///
 /// Returns at most n strings, where the last string is the entire remainder
 /// of the string if keep_remainder is True, and just the nth character otherwise.
+#[cfg(feature = "dtype-struct")]
 fn splitn_chars(s: &str, n: usize, keep_remainder: bool) -> SplitNChars<'_> {
     SplitNChars {
         s,


### PR DESCRIPTION
## Changes

This PR fixes the behavior of `str.split`, `str.split_exact` and `str.splitn` by treating splitting by an empty string as iterating over chars.

Closes #14604 