### PR TITLE
feat(python): don't require pyarrow for converting pandas to Polars if all columns have simple numpy-backed datatypes

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -22,6 +22,7 @@ from polars._utils.construction.utils import (
     get_first_non_none,
     is_namedtuple,
     is_pydantic_model,
+    is_simple_numpy_backed_pandas_series,
 )
 from polars._utils.various import (
     find_stacklevel,
@@ -56,6 +57,7 @@ from polars.datatypes.constructor import (
     py_type_to_constructor,
 )
 from polars.dependencies import (
+    _PYARROW_AVAILABLE,
     _check_for_numpy,
     dataclasses,
 )
@@ -408,6 +410,15 @@ def pandas_to_pyseries(
     """Construct a PySeries from a pandas Series or DatetimeIndex."""
     if not name and values.name is not None:
         name = str(values.name)
+    if is_simple_numpy_backed_pandas_series(values):
+        return pl.Series(name, values.to_numpy(), nan_to_null=nan_to_null)._s
+    if not _PYARROW_AVAILABLE:
+        msg = (
+            "pyarrow is required for converting a pandas series to Polars, "
+            "unless it is a simple numpy-backed one "
+            "(e.g. 'int64', 'bool', 'float32' - not 'Int64')"
+        )
+        raise ImportError(msg)
     return arrow_to_pyseries(
         name, plc.pandas_series_to_arrow(values, nan_to_null=nan_to_null)
     )

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -998,3 +998,41 @@ def test_from_avro_valid_time_zone_13032() -> None:
     result = cast(pl.Series, pl.from_arrow(arr))
     expected = pl.Series([datetime(2021, 1, 1)], dtype=pl.Datetime("ns", "UTC"))
     assert_series_equal(result, expected)
+
+
+def test_from_pandas_pyarrow_not_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "polars._utils.construction.dataframe._PYARROW_AVAILABLE", False
+    )
+    monkeypatch.setattr("polars._utils.construction.series._PYARROW_AVAILABLE", False)
+    data: dict[str, Any] = {
+        "a": [1, 2],
+        "b": ["one", "two"],
+        "c": np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[ns]"),
+        "d": np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[us]"),
+        "e": np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[ms]"),
+        "f": np.array([1, 2], dtype="timedelta64[ns]"),
+        "g": np.array([1, 2], dtype="timedelta64[us]"),
+        "h": np.array([1, 2], dtype="timedelta64[ms]"),
+        "i": [True, False],
+    }
+    result = pl.from_pandas(pd.DataFrame(data))
+    expected = pl.DataFrame(data)
+    assert_frame_equal(result, expected)
+    for col in data:
+        s_pd = pd.Series(data[col])
+        result_s = pl.from_pandas(s_pd)
+        expected_s = pl.Series(data[col])
+        assert_series_equal(result_s, expected_s)
+    with pytest.raises(ImportError, match="pyarrow is required"):
+        pl.from_pandas(pd.DataFrame({"a": [1, 2, 3]}, dtype="Int64"))
+    with pytest.raises(ImportError, match="pyarrow is required"):
+        pl.from_pandas(pd.Series([1, 2, 3], dtype="Int64"))
+    with pytest.raises(ImportError, match="pyarrow is required"):
+        pl.from_pandas(
+            pd.DataFrame({"a": pd.to_datetime(["2020-01-01T00:00+01:00"]).to_series()})
+        )
+    with pytest.raises(ImportError, match="pyarrow is required"):
+        pl.from_pandas(pd.DataFrame({"a": [None, "foo"]}))


### PR DESCRIPTION
closes #15845

On main:
- converting from pandas to Polars without PyArrow installed always raises

Here:
- if a dataframe only has simple numpy-backed dtypes (like 'int64', 'bool', 'datetime64[ms]', ...), then conversion to Polars can happen without PyArrow installed. If PyArrow isn't installed, it raises
- if a dataframe has more complex dtypes (like categorical, nullable integers, anything pyarrow-backed), then pyarrow is required

Technically it's possible to convert pandas to Polars using the dataframe interchange protocol, although there have been too many bugs on the pandas side, I don't feel comfortable suggesting it as a solution

This is a simple fix which addresses scikit-learn's reported issue (wanting to convert pandas to Polars in their docs) which doesn't go via PyArrow and doesn't use the unreliable interchange protocol. The `include_index` part seems a bit buggy to me (#15938 ) so for now I'm excluding that case (scikit-learn don't need it anyway)