### PR TITLE
fix: Set default limit for String column display to 30 and fix edge cases

### DIFF
--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -106,7 +106,10 @@ macro_rules! format_array {
             $dtype
         )?;
 
-        let truncate = matches!($a.dtype(), DataType::String);
+        let truncate = matches!(
+            $a.dtype(),
+            DataType::String | DataType::Categorical(_, _) | DataType::Enum(_, _)
+        );
         let truncate_len = if truncate { get_str_len_limit() } else { 0 };
 
         let limit: usize = {

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -106,10 +106,8 @@ macro_rules! format_array {
             $dtype
         )?;
 
-        let truncate = matches!(
-            $a.dtype(),
-            DataType::String | DataType::Categorical(_, _) | DataType::Enum(_, _)
-        );
+        let dtype = $a.dtype();
+        let truncate = dtype.is_string() | dtype.is_categorical() | dtype.is_enum();
         let truncate_len = if truncate { get_str_len_limit() } else { 0 };
 
         let limit: usize = {

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -30,6 +30,7 @@ use crate::prelude::*;
 // Note: see https://github.com/pola-rs/polars/pull/13699 for the rationale
 // behind choosing 10 as the default value for default number of rows displayed
 const DEFAULT_ROW_LIMIT: usize = 10;
+#[cfg(any(feature = "fmt", feature = "fmt_no_tty"))]
 const DEFAULT_COL_LIMIT: usize = 8;
 const DEFAULT_STR_LEN_LIMIT: usize = 30;
 const DEFAULT_LIST_LEN_LIMIT: usize = 3;
@@ -113,6 +114,7 @@ fn parse_env_var_limit(name: &str, default: usize) -> usize {
 fn get_row_limit() -> usize {
     parse_env_var_limit(FMT_MAX_ROWS, DEFAULT_ROW_LIMIT)
 }
+#[cfg(any(feature = "fmt", feature = "fmt_no_tty"))]
 fn get_col_limit() -> usize {
     parse_env_var_limit(FMT_MAX_COLS, DEFAULT_COL_LIMIT)
 }

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -28,7 +28,7 @@ use crate::prelude::*;
 
 // Note: see https://github.com/pola-rs/polars/pull/13699 for the rationale
 // behind choosing 10 as the default value for default number of rows displayed
-const LIMIT: usize = 10;
+const ROW_LIMIT: usize = 10;
 
 #[derive(Copy, Clone)]
 #[repr(u8)]
@@ -166,7 +166,7 @@ fn format_object_array(
 ) -> fmt::Result {
     match object.dtype() {
         DataType::Object(inner_type, _) => {
-            let limit = std::cmp::min(LIMIT, object.len());
+            let limit = std::cmp::min(ROW_LIMIT, object.len());
             write!(
                 f,
                 "shape: ({},)\n{}: '{}' [o][{}]\n[\n",
@@ -232,7 +232,7 @@ where
     T: PolarsObject,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let limit = std::cmp::min(LIMIT, self.len());
+        let limit = std::cmp::min(ROW_LIMIT, self.len());
         let inner_type = T::type_name();
         write!(
             f,
@@ -526,7 +526,7 @@ impl Display for DataFrame {
                 .as_deref()
                 .unwrap_or("")
                 .parse()
-                .map_or(LIMIT, |n: i64| if n < 0 { height } else { n as usize });
+                .map_or(ROW_LIMIT, |n: i64| if n < 0 { height } else { n as usize });
 
             let (n_first, n_last) = if self.width() > max_n_cols {
                 ((max_n_cols + 1) / 2, max_n_cols / 2)

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -663,14 +663,14 @@ class Config(contextlib.ContextDecorator):
         ... )
         >>> df.with_columns(pl.col("txt").str.len_bytes().alias("len"))
         shape: (2, 2)
-        ┌───────────────────────────────────┬─────┐
-        │ txt                               ┆ len │
-        │ ---                               ┆ --- │
-        │ str                               ┆ u32 │
-        ╞═══════════════════════════════════╪═════╡
-        │ Play it, Sam. Play 'As Time Goes… ┆ 37  │
-        │ This is the beginning of a beaut… ┆ 48  │
-        └───────────────────────────────────┴─────┘
+        ┌─────────────────────────────────┬─────┐
+        │ txt                             ┆ len │
+        │ ---                             ┆ --- │
+        │ str                             ┆ u32 │
+        ╞═════════════════════════════════╪═════╡
+        │ Play it, Sam. Play 'As Time Go… ┆ 37  │
+        │ This is the beginning of a bea… ┆ 48  │
+        └─────────────────────────────────┴─────┘
         >>> with pl.Config(fmt_str_lengths=50):
         ...     print(df)
         shape: (2, 1)

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -107,7 +107,7 @@ class HTMLFormatter:
 
     def write_body(self) -> None:
         """Write the body of an HTML table."""
-        str_lengths = int(os.environ.get("POLARS_FMT_STR_LEN", "15"))
+        str_len_limit = int(os.environ.get("POLARS_FMT_STR_LEN", default=30))
         with Tag(self.elements, "tbody"):
             for r in self.row_idx:
                 with Tag(self.elements, "tr"):
@@ -118,7 +118,7 @@ class HTMLFormatter:
                             else:
                                 series = self.df[:, c]
                                 self.elements.append(
-                                    html.escape(series._s.get_fmt(r, str_lengths))
+                                    html.escape(series._s.get_fmt(r, str_len_limit))
                                 )
 
     def write(self, inner: str) -> None:

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1669,15 +1669,15 @@ class ExprStringNameSpace:
         ...     ).with_columns(name=pl.col("captures").struct["1"].str.to_uppercase())
         ... )
         shape: (3, 3)
-        ┌───────────────────────────────────┬───────────────────────┬──────────┐
-        │ url                               ┆ captures              ┆ name     │
-        │ ---                               ┆ ---                   ┆ ---      │
-        │ str                               ┆ struct[2]             ┆ str      │
-        ╞═══════════════════════════════════╪═══════════════════════╪══════════╡
-        │ http://vote.com/ballon_dor?candi… ┆ {"messi","python"}    ┆ MESSI    │
-        │ http://vote.com/ballon_dor?candi… ┆ {"weghorst","polars"} ┆ WEGHORST │
-        │ http://vote.com/ballon_dor?error… ┆ {null,null}           ┆ null     │
-        └───────────────────────────────────┴───────────────────────┴──────────┘
+        ┌─────────────────────────────────┬───────────────────────┬──────────┐
+        │ url                             ┆ captures              ┆ name     │
+        │ ---                             ┆ ---                   ┆ ---      │
+        │ str                             ┆ struct[2]             ┆ str      │
+        ╞═════════════════════════════════╪═══════════════════════╪══════════╡
+        │ http://vote.com/ballon_dor?can… ┆ {"messi","python"}    ┆ MESSI    │
+        │ http://vote.com/ballon_dor?can… ┆ {"weghorst","polars"} ┆ WEGHORST │
+        │ http://vote.com/ballon_dor?err… ┆ {null,null}           ┆ null     │
+        └─────────────────────────────────┴───────────────────────┴──────────┘
         """
         return wrap_expr(self._pyexpr.str_extract_groups(pattern))
 

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1582,8 +1582,8 @@ class StringNameSpace:
         shape: (2,)
         Series: 'sing' [str]
         [
-            "Welcome To My …
-            "There's No Tur…
+            "Welcome To My World"
+            "There's No Turning Back"
         ]
         """
 

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -136,7 +136,7 @@ class StructNameSpace:
         shape: (2,)
         Series: 'a' [str]
         [
-            "{"a":[1,2],"b"…
-            "{"a":[9,1,3],"…
+            "{"a":[1,2],"b":[45]}"
+            "{"a":[9,1,3],"b":null}"
         ]
         """

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -125,24 +125,26 @@ impl PySeries {
         })
     }
 
-    fn get_fmt(&self, index: usize, str_lengths: usize) -> String {
-        let val = format!("{}", self.series.get(index).unwrap());
+    /// Returns the string format of a single element of the Series.
+    fn get_fmt(&self, index: usize, str_len_limit: usize) -> String {
+        let v = format!("{}", self.series.get(index).unwrap());
         if let DataType::String | DataType::Categorical(_, _) | DataType::Enum(_, _) =
             self.series.dtype()
         {
-            let v_trunc = &val[..val
+            let v_no_quotes = &v[1..v.len() - 1];
+            let v_trunc = &v_no_quotes[..v_no_quotes
                 .char_indices()
-                .take(str_lengths)
+                .take(str_len_limit)
                 .last()
                 .map(|(i, c)| i + c.len_utf8())
                 .unwrap_or(0)];
-            if val == v_trunc {
-                val
+            if v_no_quotes == v_trunc {
+                v
             } else {
-                format!("{v_trunc}…")
+                format!("\"{v_trunc}…")
             }
         } else {
-            val
+            v
         }
     }
 

--- a/py-polars/tests/unit/test_config.py
+++ b/py-polars/tests/unit/test_config.py
@@ -339,7 +339,7 @@ def test_set_tbl_width_chars() -> None:
             "this is 10": [4, 5, 6],
         }
     )
-    assert max(len(line) for line in str(df).split("\n")) == 70
+    assert max(len(line) for line in str(df).split("\n")) == 68
 
     pl.Config.set_tbl_width_chars(60)
     assert max(len(line) for line in str(df).split("\n")) == 60

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import string
 from decimal import Decimal as D
 from typing import TYPE_CHECKING, Any, Iterator
 
@@ -26,7 +27,7 @@ def _environ() -> Iterator[None]:
             """shape: (1,)
 Series: 'foo' [str]
 [
-	"Somelongstring…
+	"Somelongstringt…
 ]
 """,
             ["Somelongstringto eeat wit me oundaf"],
@@ -36,7 +37,7 @@ Series: 'foo' [str]
             """shape: (1,)
 Series: 'foo' [str]
 [
-	"😀😁😂😃😄😅😆😇😈😉😊😋😌😎…
+	"😀😁😂😃😄😅😆😇😈😉😊😋😌😎😏…
 ]
 """,
             ["😀😁😂😃😄😅😆😇😈😉😊😋😌😎😏😐😑😒😓"],
@@ -78,8 +79,29 @@ def test_fmt_series(
     capfd: pytest.CaptureFixture[str], expected: str, values: list[Any]
 ) -> None:
     s = pl.Series(name="foo", values=values)
-    print(s)
+    with pl.Config(fmt_str_lengths=15):
+        print(s)
     out, err = capfd.readouterr()
+    assert out == expected
+
+
+def test_fmt_series_string_truncate_default(capfd: pytest.CaptureFixture[str]) -> None:
+    values = [
+        string.ascii_lowercase + "123",
+        string.ascii_lowercase + "1234",
+        string.ascii_lowercase + "12345",
+    ]
+    s = pl.Series(name="foo", values=values)
+    print(s)
+    out, _ = capfd.readouterr()
+    expected = """shape: (3,)
+Series: 'foo' [str]
+[
+	"abcdefghijklmnopqrstuvwxyz123"
+	"abcdefghijklmnopqrstuvwxyz1234"
+	"abcdefghijklmnopqrstuvwxyz1234…
+]
+"""
     assert out == expected
 
 

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -106,6 +106,22 @@ Series: 'foo' [str]
 
 
 @pytest.mark.parametrize(
+    "dtype", [pl.String, pl.Categorical, pl.Enum(["abc", "abcd", "abcde"])]
+)
+def test_fmt_series_string_truncate_cat(
+    dtype: pl.PolarsDataType, capfd: pytest.CaptureFixture[str]
+) -> None:
+    s = pl.Series(name="foo", values=["abc", "abcd", "abcde"], dtype=dtype)
+    with pl.Config(fmt_str_lengths=4):
+        print(s)
+    out, _ = capfd.readouterr()
+    result = [s.strip() for s in out.split("\n")[3:6]]
+    expected = ['"abc"', '"abcd"', '"abcd…']
+    print(result)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
     ("values", "dtype", "expected"),
     [
         (


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/15839

#### Changes

* Set the default character limit for displaying String columns to 30
  * For DataFrames, changed from 32 to 30
  * For Series, changed from 15 to 30
* Do not count quotes surrounding the value towards the character limit
* Update the HTML repr (Notebooks) to match.
* Make sure Categorical/Enum types follow the same rules (was already the case in the HTML repr).

**Example**

```python
import polars as pl

with pl.Config(fmt_str_lengths=4):
    print(pl.Series(["abc", "abcd", "abcde"]))
```
```
shape: (3,)
Series: '' [str]
[
        "abc"
        "abcd"
        "abcd…    <- note: no trailing quote
]
```