### PR TITLE
test(python): Fix failing test

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -43,10 +43,12 @@ COMPRESSIONS = [
 
 
 @pytest.mark.write_disk()
-def test_write_parquet_using_pyarrow_9753(tmpdir: Path) -> None:
+def test_write_parquet_using_pyarrow_9753(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
     df = pl.DataFrame({"a": [1, 2, 3]})
     df.write_parquet(
-        tmpdir / "test.parquet",
+        tmp_path / "test.parquet",
         compression="zstd",
         statistics=True,
         use_pyarrow=True,

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 import os
-import sys
 from datetime import datetime, time, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING, cast
@@ -860,15 +859,15 @@ def test_max_statistic_parquet_writer(tmp_path: Path) -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.skipif(
-    os.environ.get("POLARS_FORCE_ASYNC") == "1" or sys.platform == "win32",
-    reason="only local",
-)
-def test_no_glob(tmpdir: Path) -> None:
+@pytest.mark.skipif(os.environ.get("POLARS_FORCE_ASYNC") == "1", reason="only local")
+def test_no_glob(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
     df = pl.DataFrame({"foo": 1})
-    p = tmpdir / "*.parquet"
-    df.write_parquet(str(p))
-    p = tmpdir / "*1.parquet"
-    df.write_parquet(str(p))
-    p = tmpdir / "*.parquet"
-    assert_frame_equal(pl.scan_parquet(str(p), glob=False).collect(), df)
+
+    p1 = tmp_path / "*.parquet"
+    df.write_parquet(str(p1))
+    p2 = tmp_path / "*1.parquet"
+    df.write_parquet(str(p2))
+
+    assert_frame_equal(pl.scan_parquet(str(p1), glob=False).collect(), df)


### PR DESCRIPTION
Don't use `tmpdir`, use `tmp_path` instead.

EDIT: That wasn't the issue - the actual issue is that Windows doesn't allow asterisks in filenames. I added a glob test for Windows.