### PR TITLE
docs(python): Fix docstring mistake for polars.concat_str

### DIFF
--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -572,10 +572,10 @@ def concat_str(
     separator
         String that will be used to separate the values of each column.
     ignore_nulls
-        Ignore null values (default).
+        Ignore null values (default is ``False``).
 
         If set to ``False``, null values will be propagated.
-        if the row contains any null values, the output is ``None``.
+        if the row contains any null values, the output is null.
 
     Examples
     --------


### PR DESCRIPTION
The default behavior of `ignore_nulls` in `concat_str` is incorrectly documented. 

Not sure which default value is more intuitive, I simply corrected the documentation to avoid breaking changes. Though it differs from `Series.list.concat` or `Series.string.concat`, where the default value is `True`, introducing some inconsistency. 