### PR TITLE
fix: Finish adding `typed_lit` to help schema determination in SQL "extract" func

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -997,11 +997,11 @@ fn parse_extract(expr: Expr, field: &DateTimeField) -> PolarsResult<Expr> {
         DateTimeField::Minute => expr.dt().minute(),
         DateTimeField::Second => expr.dt().second(),
         DateTimeField::Millisecond | DateTimeField::Milliseconds => {
-            (expr.clone().dt().second() * lit(1_000))
+            (expr.clone().dt().second() * typed_lit(1_000f64))
                 + expr.dt().nanosecond().div(typed_lit(1_000_000f64))
         },
         DateTimeField::Microsecond | DateTimeField::Microseconds => {
-            (expr.clone().dt().second() * lit(1_000_000))
+            (expr.clone().dt().second() * typed_lit(1_000_000f64))
                 + expr.dt().nanosecond().div(typed_lit(1_000f64))
         },
         DateTimeField::Nanosecond | DateTimeField::Nanoseconds => {

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -86,7 +86,6 @@ def test_datetime_to_time(time_unit: Literal["ns", "us", "ms"]) -> None:
         ),
     ],
 )
-@pytest.mark.skip(reason="don't understand; will ask @alex")
 def test_extract(part: str, dtype: pl.DataType, expected: list[Any]) -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
@ritchie46: here you go ;)

(Otherwise it seems the `dt.second` op can overflow `int8` during scaling and wrap around to odd values; not immediately obvious why it decided to do this now vs earlier, but the solution is straightforward).