### PR TITLE
feat(rust): Add RLE to `RLE_DICTIONARY` encoder

### DIFF
--- a/crates/polars-arrow/src/compute/cast/binary_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binary_to.rs
@@ -139,6 +139,7 @@ pub fn binary_to_dictionary<O: Offset, K: DictionaryKey>(
     from: &BinaryArray<O>,
 ) -> PolarsResult<DictionaryArray<K>> {
     let mut array = MutableDictionaryArray::<K, MutableBinaryArray<O>>::new();
+    array.reserve(from.len());
     array.try_extend(from.iter())?;
 
     Ok(array.into())

--- a/crates/polars-arrow/src/compute/cast/binview_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binview_to.rs
@@ -21,6 +21,7 @@ pub(super) fn binview_to_dictionary<K: DictionaryKey>(
     from: &BinaryViewArray,
 ) -> PolarsResult<DictionaryArray<K>> {
     let mut array = MutableDictionaryArray::<K, MutableBinaryViewArray<[u8]>>::new();
+    array.reserve(from.len());
     array.try_extend(from.iter())?;
 
     Ok(array.into())
@@ -30,6 +31,7 @@ pub(super) fn utf8view_to_dictionary<K: DictionaryKey>(
     from: &Utf8ViewArray,
 ) -> PolarsResult<DictionaryArray<K>> {
     let mut array = MutableDictionaryArray::<K, MutableBinaryViewArray<str>>::new();
+    array.reserve(from.len());
     array.try_extend(from.iter())?;
 
     Ok(array.into())

--- a/crates/polars-arrow/src/compute/cast/primitive_to.rs
+++ b/crates/polars-arrow/src/compute/cast/primitive_to.rs
@@ -318,6 +318,7 @@ pub fn primitive_to_dictionary<T: NativeType + Eq + Hash, K: DictionaryKey>(
     let mut array = MutableDictionaryArray::<K, _>::try_empty(MutablePrimitiveArray::<T>::from(
         from.data_type().clone(),
     ))?;
+    array.reserve(from.len());
     array.try_extend(iter)?;
 
     Ok(array.into())

--- a/crates/polars-arrow/src/compute/cast/utf8_to.rs
+++ b/crates/polars-arrow/src/compute/cast/utf8_to.rs
@@ -27,6 +27,7 @@ pub fn utf8_to_dictionary<O: Offset, K: DictionaryKey>(
     from: &Utf8Array<O>,
 ) -> PolarsResult<DictionaryArray<K>> {
     let mut array = MutableDictionaryArray::<K, MutableUtf8Array<O>>::new();
+    array.reserve(from.len());
     array.try_extend(from.iter())?;
 
     Ok(array.into())

--- a/crates/polars-io/src/parquet/write/writer.rs
+++ b/crates/polars-io/src/parquet/write/writer.rs
@@ -102,7 +102,7 @@ where
         WriteOptions {
             write_statistics: self.statistics,
             compression: self.compression,
-            version: Version::V2,
+            version: Version::V1,
             data_pagesize_limit: self.data_page_size,
         }
     }

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -1,7 +1,6 @@
 use arrow::array::{Array, BinaryViewArray, DictionaryArray, DictionaryKey, Utf8ViewArray};
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::datatypes::{ArrowDataType, IntegerType};
-use num_traits::ToPrimitive;
 use polars_error::{polars_bail, PolarsResult};
 
 use super::binary::{
@@ -47,30 +46,6 @@ pub(crate) fn encode_as_dictionary_optional(
 
     if (array.values().len() as f64) / (len_before as f64) > 0.75 {
         return None;
-    }
-    if array.values().len().to_u16().is_some() {
-        let array = arrow::compute::cast::cast(
-            array,
-            &ArrowDataType::Dictionary(
-                IntegerType::UInt16,
-                Box::new(array.values().data_type().clone()),
-                false,
-            ),
-            Default::default(),
-        )
-        .unwrap();
-
-        let array = array
-            .as_any()
-            .downcast_ref::<DictionaryArray<u16>>()
-            .unwrap();
-        return Some(array_to_pages(
-            array,
-            type_,
-            nested,
-            options,
-            Encoding::RleDictionary,
-        ));
     }
 
     Some(array_to_pages(

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -16,23 +16,19 @@ use super::primitive::{
 use super::{binview, nested, Nested, WriteOptions};
 use crate::arrow::read::schema::is_nullable;
 use crate::arrow::write::{slice_nested_leaf, utils};
-use crate::parquet::encoding::hybrid_rle::encode_u32;
+use crate::parquet::encoding::hybrid_rle::encode;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::{DictPage, Page};
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::statistics::{serialize_statistics, ParquetStatistics};
-use crate::write::{to_nested, DynIter, ParquetType};
+use crate::write::DynIter;
 
 pub(crate) fn encode_as_dictionary_optional(
     array: &dyn Array,
+    nested: &[Nested],
     type_: PrimitiveType,
     options: WriteOptions,
 ) -> Option<PolarsResult<DynIter<'static, PolarsResult<Page>>>> {
-    let nested = to_nested(array, &ParquetType::PrimitiveType(type_.clone()))
-        .ok()?
-        .pop()
-        .unwrap();
-
     let dtype = Box::new(array.data_type().clone());
 
     let len_before = array.len();
@@ -71,7 +67,7 @@ pub(crate) fn encode_as_dictionary_optional(
         return Some(array_to_pages(
             array,
             type_,
-            &nested,
+            nested,
             options,
             Encoding::RleDictionary,
         ));
@@ -80,7 +76,7 @@ pub(crate) fn encode_as_dictionary_optional(
     Some(array_to_pages(
         array,
         type_,
-        &nested,
+        nested,
         options,
         Encoding::RleDictionary,
     ))
@@ -116,7 +112,7 @@ fn serialize_keys_values<K: DictionaryKey>(
         buffer.push(num_bits as u8);
 
         // followed by the encoded indices.
-        Ok(encode_u32(buffer, keys, num_bits)?)
+        Ok(encode::<u32, _, _>(buffer, keys, num_bits)?)
     } else {
         let num_bits = utils::get_bit_width(keys.clone().max().unwrap_or(0) as u64);
 
@@ -124,7 +120,7 @@ fn serialize_keys_values<K: DictionaryKey>(
         buffer.push(num_bits as u8);
 
         // followed by the encoded indices.
-        Ok(encode_u32(buffer, keys, num_bits)?)
+        Ok(encode::<u32, _, _>(buffer, keys, num_bits)?)
     }
 }
 

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -219,7 +219,7 @@ pub fn array_to_pages(
         // Only take this path for primitive columns
         if matches!(nested.first(), Some(Nested::Primitive(_, _, _))) {
             if let Some(result) =
-                encode_as_dictionary_optional(primitive_array, type_.clone(), options)
+                encode_as_dictionary_optional(primitive_array, nested, type_.clone(), options)
             {
                 return result;
             }

--- a/crates/polars-parquet/src/arrow/write/nested/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/nested/mod.rs
@@ -6,7 +6,7 @@ use polars_error::PolarsResult;
 pub use rep::num_values;
 
 use super::Nested;
-use crate::parquet::encoding::hybrid_rle::encode_u32;
+use crate::parquet::encoding::hybrid_rle::encode;
 use crate::parquet::read::levels::get_bit_width;
 use crate::parquet::write::Version;
 
@@ -41,12 +41,12 @@ fn write_rep_levels(buffer: &mut Vec<u8>, nested: &[Nested], version: Version) -
     match version {
         Version::V1 => {
             write_levels_v1(buffer, |buffer: &mut Vec<u8>| {
-                encode_u32(buffer, levels, num_bits)?;
+                encode::<u32, _, _>(buffer, levels, num_bits)?;
                 Ok(())
             })?;
         },
         Version::V2 => {
-            encode_u32(buffer, levels, num_bits)?;
+            encode::<u32, _, _>(buffer, levels, num_bits)?;
         },
     }
 
@@ -65,10 +65,10 @@ fn write_def_levels(buffer: &mut Vec<u8>, nested: &[Nested], version: Version) -
 
     match version {
         Version::V1 => write_levels_v1(buffer, move |buffer: &mut Vec<u8>| {
-            encode_u32(buffer, levels, num_bits)?;
+            encode::<u32, _, _>(buffer, levels, num_bits)?;
             Ok(())
         }),
-        Version::V2 => Ok(encode_u32(buffer, levels, num_bits)?),
+        Version::V2 => Ok(encode::<u32, _, _>(buffer, levels, num_bits)?),
     }
 }
 

--- a/crates/polars-parquet/src/arrow/write/utils.rs
+++ b/crates/polars-parquet/src/arrow/write/utils.rs
@@ -4,7 +4,7 @@ use polars_error::*;
 
 use super::{Version, WriteOptions};
 use crate::parquet::compression::CompressionOptions;
-use crate::parquet::encoding::hybrid_rle::encode_bool;
+use crate::parquet::encoding::hybrid_rle::encode;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::metadata::Descriptor;
 use crate::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, DataPageHeaderV2};
@@ -14,7 +14,7 @@ use crate::parquet::statistics::ParquetStatistics;
 fn encode_iter_v1<I: Iterator<Item = bool>>(buffer: &mut Vec<u8>, iter: I) -> PolarsResult<()> {
     buffer.extend_from_slice(&[0; 4]);
     let start = buffer.len();
-    encode_bool(buffer, iter)?;
+    encode::<bool, _, _>(buffer, iter, 1)?;
     let end = buffer.len();
     let length = end - start;
 
@@ -25,7 +25,7 @@ fn encode_iter_v1<I: Iterator<Item = bool>>(buffer: &mut Vec<u8>, iter: I) -> Po
 }
 
 fn encode_iter_v2<I: Iterator<Item = bool>>(writer: &mut Vec<u8>, iter: I) -> PolarsResult<()> {
-    Ok(encode_bool(writer, iter)?)
+    Ok(encode::<bool, _, _>(writer, iter, 1)?)
 }
 
 fn encode_iter<I: Iterator<Item = bool>>(

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/encoder.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/encoder.rs
@@ -3,98 +3,216 @@ use std::io::Write;
 use super::bitpacked_encode;
 use crate::parquet::encoding::{bitpacked, ceil8, uleb128};
 
-/// RLE-hybrid encoding of `u32`. This currently only yields bitpacked values.
-pub fn encode_u32<W: Write, I: Iterator<Item = u32>>(
-    writer: &mut W,
-    iterator: I,
-    num_bits: u32,
-) -> std::io::Result<()> {
-    let num_bits = num_bits as u8;
-    // the length of the iterator.
-    let length = iterator.size_hint().1.unwrap();
+// Arbitrary value that balances memory usage and storage overhead
+const MAX_VALUES_PER_LITERAL_RUN: usize = (1 << 10) * 8;
 
-    // write the length + indicator
-    let mut header = ceil8(length) as u64;
-    header <<= 1;
-    header |= 1; // it is bitpacked => first bit is set
-    let mut container = [0; 10];
-    let used = uleb128::encode(header, &mut container);
-    writer.write_all(&container[..used])?;
+pub trait Encoder<T: PartialEq + Default + Copy> {
+    fn bitpacked_encode<W: Write, I: Iterator<Item = T>>(
+        writer: &mut W,
+        iterator: I,
+        num_bits: usize,
+    ) -> std::io::Result<()>;
 
-    bitpacked_encode_u32(writer, iterator, num_bits as usize)?;
-
-    Ok(())
+    fn run_length_encode<W: Write>(
+        writer: &mut W,
+        run_length: usize,
+        value: T,
+        bit_width: u32,
+    ) -> std::io::Result<()>;
 }
 
 const U32_BLOCK_LEN: usize = 32;
 
-fn bitpacked_encode_u32<W: Write, I: Iterator<Item = u32>>(
-    writer: &mut W,
-    mut iterator: I,
-    num_bits: usize,
-) -> std::io::Result<()> {
-    // the length of the iterator.
-    let length = iterator.size_hint().1.unwrap();
+impl Encoder<u32> for u32 {
+    fn bitpacked_encode<W: Write, I: Iterator<Item = u32>>(
+        writer: &mut W,
+        mut iterator: I,
+        num_bits: usize,
+    ) -> std::io::Result<()> {
+        // the length of the iterator.
+        let length = iterator.size_hint().1.unwrap();
 
-    let chunks = length / U32_BLOCK_LEN;
-    let remainder = length - chunks * U32_BLOCK_LEN;
-    let mut buffer = [0u32; U32_BLOCK_LEN];
+        let mut header = ceil8(length) as u64;
+        header <<= 1;
+        header |= 1; // it is bitpacked => first bit is set
+        let mut container = [0; 10];
+        let used = uleb128::encode(header, &mut container);
+        writer.write_all(&container[..used])?;
 
-    // simplified from ceil8(U32_BLOCK_LEN * num_bits) since U32_BLOCK_LEN = 32
-    let compressed_chunk_size = 4 * num_bits;
+        let chunks = length / U32_BLOCK_LEN;
+        let remainder = length - chunks * U32_BLOCK_LEN;
+        let mut buffer = [0u32; U32_BLOCK_LEN];
 
-    for _ in 0..chunks {
-        iterator
-            .by_ref()
-            .take(U32_BLOCK_LEN)
-            .zip(buffer.iter_mut())
-            .for_each(|(item, buf)| *buf = item);
+        // simplified from ceil8(U32_BLOCK_LEN * num_bits) since U32_BLOCK_LEN = 32
+        let compressed_chunk_size = 4 * num_bits;
 
-        let mut packed = [0u8; 4 * U32_BLOCK_LEN];
-        bitpacked::encode_pack::<u32>(&buffer, num_bits, packed.as_mut());
-        writer.write_all(&packed[..compressed_chunk_size])?;
+        for _ in 0..chunks {
+            iterator
+                .by_ref()
+                .take(U32_BLOCK_LEN)
+                .zip(buffer.iter_mut())
+                .for_each(|(item, buf)| *buf = item);
+
+            let mut packed = [0u8; 4 * U32_BLOCK_LEN];
+            bitpacked::encode_pack::<u32>(&buffer, num_bits, packed.as_mut());
+            writer.write_all(&packed[..compressed_chunk_size])?;
+        }
+
+        if remainder != 0 {
+            // Must be careful here to ensure we write a multiple of `num_bits`
+            // (the bit width) to align with the spec. Some readers also rely on
+            // this - see https://github.com/pola-rs/polars/pull/13883.
+
+            // this is ceil8(remainder * num_bits), but we ensure the output is a
+            // multiple of num_bits by rewriting it as ceil8(remainder) * num_bits
+            let compressed_remainder_size = ceil8(remainder) * num_bits;
+            iterator
+                .by_ref()
+                .take(remainder)
+                .zip(buffer.iter_mut())
+                .for_each(|(item, buf)| *buf = item);
+
+            let mut packed = [0u8; 4 * U32_BLOCK_LEN];
+            bitpacked::encode_pack(&buffer[..remainder], num_bits, packed.as_mut());
+            writer.write_all(&packed[..compressed_remainder_size])?;
+        };
+        Ok(())
     }
 
-    if remainder != 0 {
-        // Must be careful here to ensure we write a multiple of `num_bits`
-        // (the bit width) to align with the spec. Some readers also rely on
-        // this - see https://github.com/pola-rs/polars/pull/13883.
+    fn run_length_encode<W: Write>(
+        writer: &mut W,
+        run_length: usize,
+        value: u32,
+        bit_width: u32,
+    ) -> std::io::Result<()> {
+        // write the length + indicator
+        let mut header = run_length as u64;
+        header <<= 1;
+        let mut container = [0; 10];
+        let used = uleb128::encode(header, &mut container);
+        writer.write_all(&container[..used])?;
 
-        // this is ceil8(remainder * num_bits), but we ensure the output is a
-        // multiple of num_bits by rewriting it as ceil8(remainder) * num_bits
-        let compressed_remainder_size = ceil8(remainder) * num_bits;
-        iterator
-            .by_ref()
-            .take(remainder)
-            .zip(buffer.iter_mut())
-            .for_each(|(item, buf)| *buf = item);
-
-        let mut packed = [0u8; 4 * U32_BLOCK_LEN];
-        bitpacked::encode_pack(&buffer, num_bits, packed.as_mut());
-        writer.write_all(&packed[..compressed_remainder_size])?;
-    };
-    Ok(())
+        let num_bytes = ceil8(bit_width as usize);
+        let bytes = value.to_le_bytes();
+        writer.write_all(&bytes[..num_bytes])?;
+        Ok(())
+    }
 }
 
-/// the bitpacked part of the encoder.
-pub fn encode_bool<W: Write, I: Iterator<Item = bool>>(
+impl Encoder<bool> for bool {
+    fn bitpacked_encode<W: Write, I: Iterator<Item = bool>>(
+        writer: &mut W,
+        iterator: I,
+        _num_bits: usize,
+    ) -> std::io::Result<()> {
+        // the length of the iterator.
+        let length = iterator.size_hint().1.unwrap();
+
+        let mut header = ceil8(length) as u64;
+        header <<= 1;
+        header |= 1; // it is bitpacked => first bit is set
+        let mut container = [0; 10];
+        let used = uleb128::encode(header, &mut container);
+        writer.write_all(&container[..used])?;
+        bitpacked_encode(writer, iterator)?;
+        Ok(())
+    }
+
+    fn run_length_encode<W: Write>(
+        writer: &mut W,
+        run_length: usize,
+        value: bool,
+        _bit_width: u32,
+    ) -> std::io::Result<()> {
+        // write the length + indicator
+        let mut header = run_length as u64;
+        header <<= 1;
+        let mut container = [0; 10];
+        let used = uleb128::encode(header, &mut container);
+        writer.write_all(&container[..used])?;
+        writer.write_all(&(value as u8).to_le_bytes())?;
+        Ok(())
+    }
+}
+
+#[allow(clippy::comparison_chain)]
+pub fn encode<T: PartialEq + Default + Copy + Encoder<T>, W: Write, I: Iterator<Item = T>>(
     writer: &mut W,
     iterator: I,
+    num_bits: u32,
 ) -> std::io::Result<()> {
-    // the length of the iterator.
-    let length = iterator.size_hint().1.unwrap();
-
-    // write the length + indicator
-    let mut header = ceil8(length) as u64;
-    header <<= 1;
-    header |= 1; // it is bitpacked => first bit is set
-    let mut container = [0; 10];
-    let used = uleb128::encode(header, &mut container);
-
-    writer.write_all(&container[..used])?;
-
-    // encode the iterator
-    bitpacked_encode(writer, iterator)
+    let mut consecutive_repeats: usize = 0;
+    let mut previous_val = T::default();
+    let mut buffered_bits = [previous_val; MAX_VALUES_PER_LITERAL_RUN];
+    let mut buffer_idx = 0;
+    let mut literal_run_idx = 0;
+    for val in iterator {
+        if val == previous_val {
+            consecutive_repeats += 1;
+            // Run is long enough to RLE, no need to buffer values
+            if consecutive_repeats >= 8 {
+                // Run is long enough to RLE, no need to buffer values
+                if consecutive_repeats > 8 {
+                    continue;
+                } else {
+                    // Ensure literal run has multiple of 8 values
+                    // Take from consecutive repeats if needed to pad up
+                    let literal_padding = (8 - (literal_run_idx % 8)) % 8;
+                    consecutive_repeats -= literal_padding;
+                    literal_run_idx += literal_padding;
+                }
+            }
+            // Too short to RLE, continue to buffer values
+        } else if consecutive_repeats > 8 {
+            // Flush literal run, if any, before RLE run
+            if literal_run_idx > 0 {
+                T::bitpacked_encode(
+                    writer,
+                    buffered_bits.iter().copied().take(literal_run_idx),
+                    num_bits as usize,
+                )?;
+                literal_run_idx = 0;
+            }
+            T::run_length_encode(writer, consecutive_repeats, previous_val, num_bits)?;
+            consecutive_repeats = 1;
+            buffer_idx = 0;
+        } else {
+            // Not enough consecutive repeats to RLE, extend literal run
+            literal_run_idx = buffer_idx;
+            consecutive_repeats = 1;
+        }
+        // If buffer is full, bit-pack as literal run and reset
+        if buffer_idx == MAX_VALUES_PER_LITERAL_RUN {
+            T::bitpacked_encode(
+                writer,
+                buffered_bits.iter().copied().take(literal_run_idx),
+                num_bits as usize,
+            )?;
+            // Consecutive repeats may be consolidated into literal run
+            consecutive_repeats -= buffer_idx - literal_run_idx;
+            buffer_idx = 0;
+            literal_run_idx = 0;
+        }
+        buffered_bits[buffer_idx] = val;
+        previous_val = val;
+        buffer_idx += 1;
+    }
+    // Not enough consecutive repeats to RLE, extend literal run
+    if consecutive_repeats <= 8 {
+        literal_run_idx = buffer_idx;
+        consecutive_repeats = 0;
+    }
+    if literal_run_idx > 0 {
+        T::bitpacked_encode(
+            writer,
+            buffered_bits.iter().copied().take(literal_run_idx),
+            num_bits as usize,
+        )?;
+    }
+    if consecutive_repeats > 8 {
+        T::run_length_encode(writer, consecutive_repeats, previous_val, num_bits)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -108,7 +226,7 @@ mod tests {
 
         let mut vec = vec![];
 
-        encode_bool(&mut vec, iter)?;
+        encode::<bool, _, _>(&mut vec, iter, 1)?;
 
         assert_eq!(vec, vec![(2 << 1 | 1), 0b10011101u8, 0b00011101]);
 
@@ -119,9 +237,10 @@ mod tests {
     fn bool_from_iter() -> std::io::Result<()> {
         let mut vec = vec![];
 
-        encode_bool(
+        encode::<bool, _, _>(
             &mut vec,
             vec![true, true, true, true, true, true, true, true].into_iter(),
+            1,
         )?;
 
         assert_eq!(vec, vec![(1 << 1 | 1), 0b11111111]);
@@ -132,7 +251,7 @@ mod tests {
     fn test_encode_u32() -> std::io::Result<()> {
         let mut vec = vec![];
 
-        encode_u32(&mut vec, vec![0, 1, 2, 1, 2, 1, 1, 0, 3].into_iter(), 2)?;
+        encode::<u32, _, _>(&mut vec, vec![0, 1, 2, 1, 2, 1, 1, 0, 3].into_iter(), 2)?;
 
         assert_eq!(
             vec,
@@ -153,7 +272,7 @@ mod tests {
 
         let values = (0..128).map(|x| x % 4);
 
-        encode_u32(&mut vec, values, 2)?;
+        encode::<u32, _, _>(&mut vec, values, 2)?;
 
         let length = 128;
         let expected = 0b11_10_01_00u8;
@@ -170,7 +289,7 @@ mod tests {
         let values = vec![3, 3, 0, 3, 2, 3, 3, 3, 3, 1, 3, 3, 3, 0, 3].into_iter();
 
         let mut vec = vec![];
-        encode_u32(&mut vec, values, 2)?;
+        encode::<u32, _, _>(&mut vec, values, 2)?;
 
         let expected = vec![5, 207, 254, 247, 51];
         assert_eq!(expected, vec);

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -4,7 +4,7 @@ mod decoder;
 mod encoder;
 pub use bitmap::{encode_bool as bitpacked_encode, BitmapIter};
 pub use decoder::Decoder;
-pub use encoder::{encode_bool, encode_u32};
+pub use encoder::encode;
 use polars_utils::iter::FallibleIterator;
 
 use super::bitpacked;
@@ -137,7 +137,7 @@ mod tests {
 
         let data = (0..1000).collect::<Vec<_>>();
 
-        encode_u32(&mut buffer, data.iter().cloned(), num_bits).unwrap();
+        encode::<u32, _, _>(&mut buffer, data.iter().cloned(), num_bits).unwrap();
 
         let decoder = HybridRleDecoder::try_new(&buffer, num_bits, data.len())?;
 

--- a/crates/polars/tests/it/io/parquet/write/binary.rs
+++ b/crates/polars/tests/it/io/parquet/write/binary.rs
@@ -1,4 +1,4 @@
-use polars_parquet::parquet::encoding::hybrid_rle::encode_bool;
+use polars_parquet::parquet::encoding::hybrid_rle::encode;
 use polars_parquet::parquet::encoding::Encoding;
 use polars_parquet::parquet::error::Result;
 use polars_parquet::parquet::metadata::Descriptor;
@@ -25,7 +25,7 @@ fn unzip_option(array: &[Option<Vec<u8>>]) -> Result<(Vec<u8>, Vec<u8>)> {
             false
         }
     });
-    encode_bool(&mut validity, iter)?;
+    encode::<bool, _, _>(&mut validity, iter, 1)?;
 
     // write the length, now that it is known
     let mut validity = validity.into_inner();

--- a/crates/polars/tests/it/io/parquet/write/primitive.rs
+++ b/crates/polars/tests/it/io/parquet/write/primitive.rs
@@ -1,4 +1,4 @@
-use polars_parquet::parquet::encoding::hybrid_rle::encode_bool;
+use polars_parquet::parquet::encoding::hybrid_rle::encode;
 use polars_parquet::parquet::encoding::Encoding;
 use polars_parquet::parquet::error::Result;
 use polars_parquet::parquet::metadata::Descriptor;
@@ -24,7 +24,7 @@ fn unzip_option<T: NativeType>(array: &[Option<T>]) -> Result<(Vec<u8>, Vec<u8>)
             false
         }
     });
-    encode_bool(&mut validity, iter)?;
+    encode::<bool, _, _>(&mut validity, iter, 1)?;
 
     // write the length, now that it is known
     let mut validity = validity.into_inner();

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -894,6 +894,7 @@ def test_no_glob_windows(tmp_path: Path) -> None:
     assert_frame_equal(pl.scan_parquet(str(p1), glob=False).collect(), df)
 
 
+@pytest.mark.slow()
 def test_hybrid_rle() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -892,3 +892,45 @@ def test_no_glob_windows(tmp_path: Path) -> None:
     df.write_parquet(str(p2))
 
     assert_frame_equal(pl.scan_parquet(str(p1), glob=False).collect(), df)
+
+
+def test_hybrid_rle() -> None:
+    df = pl.DataFrame(
+        {
+            # Test primitive types
+            "i64": pl.repeat(int(2**63 - 1), n=10000, dtype=pl.Int64, eager=True),
+            "u64": pl.repeat(int(2**64 - 1), n=10000, dtype=pl.UInt64, eager=True),
+            "i8": pl.repeat(-int(2**7 - 1), n=10000, dtype=pl.Int8, eager=True),
+            "u8": pl.repeat(int(2**8 - 1), n=10000, dtype=pl.UInt8, eager=True),
+            "string": pl.repeat("a", n=10000, dtype=pl.String, eager=True),
+            "categorical": pl.Series((["a"] * 9 + ["b"]) * 1000, dtype=pl.Categorical),
+            # Test filling up bit-packing buffer
+            "large_bit_pack": ([0] * 5 + [1] * 5) * 1000,
+            # Test mix of bit-packed and RLE runs
+            "bit_pack_and_rle": (
+                [0] + [1] * 19 + [2] * 8 + [3] * 12 + [4] * 5 + [5] * 5
+            )
+            * 200,
+            # Test some null values
+            "nulls_included": (
+                [None] + [1] * 19 + [None] * 8 + [3] * 12 + [4] * 5 + [None] * 5
+            )
+            * 200,
+            # Test filling up bit-packing buffer for encode_bool,
+            # which is only used to encode validities
+            # Also checks that runs are handled correctly if buffer
+            # is flushed (at MAX_VALUES_PER_LITERAL_RUN values)
+            "large_bit_pack_validity": [0, None] * 4092
+            + [0] * 9
+            + [1] * 9
+            + [2] * 10
+            + [0] * 1788,
+        }
+    )
+    f = io.BytesIO()
+    df.write_parquet(f)
+    f.seek(0)
+    for column in pq.ParquetFile(f).metadata.to_dict()["row_groups"][0]["columns"]:
+        assert "RLE_DICTIONARY" in column["encodings"]
+    f.seek(0)
+    assert_frame_equal(pl.read_parquet(f), df)


### PR DESCRIPTION
The `RLE_DICTIONARY` encoder currently only supports bit-packing. After this PR, the encoder will switch between bit-packing and RLE depending on whether a run is longer than 8 ([always bit-pack a multiple of 8 values at a time](https://parquet.apache.org/docs/file-format/data-pages/encodings/)).

This addresses the specific case pointed out in #10680. With these changes, I get 2745 bytes for `pl_zstd.pq` and 2962 bytes for `pa_zstd.pq` after running the following code:

```python
from random import randint
import polars as pl
rand_value = randint(1, 10**15)
df = pl.DataFrame({
    'A': [rand_value for _ in range(10_000_000)],
}, schema={
    'A': pl.UInt64,
})
df.write_parquet('pa_zstd.pq', compression='zstd', use_pyarrow=True)
# Match PyArrow default row group size
df.write_parquet('pl_zstd.pq', compression='zstd', use_pyarrow=False, row_group_size=1024**2)
```

At first, the additional logic did slow down the encoder significantly. To address this, I did some profiling and made two optimizations.

- The encoder begins by casting the input array to a dictionary array. Currently, the dictionary is created with `u32` keys and downcasted to `u16` if possible. I removed this downcasting step because it seemed unnecessary (f7e803a).
- When populating the dictionary array, I noticed that a lot of time is spent in memcpy because the key vector is grown one value at a time. I resolved this by reserving the right vector size from the start (14fe89c).

After these optimizations, the `RLE_DICTIONARY` encoder performs on par with or only slightly worse than `use_pyarrow=True` in most cases (faster than current encoding performance). However, the performance can be up to 50% worse than `use_pyarrow=True` (matching current encoding performance) with high cardinality data that frequently switches between RLE and bit-packing:

```python
import itertools
import polars as pl
# Performance degrades with frequent switches between RLE and bit-packing
t = pl.DataFrame({'a': itertools.chain.from_iterable([[i] * 9 + [i+1] * 8 for i in range(100000)])})
```

Some other changes:

- Allow nested types to use `RLE_DICTIONARY` encoding (9c73a61). For some reason, dictionary arrays do not scale well for large nested columns. I cannot figure out what is causing this. For example:

```python
nested_tbl = pl.DataFrame({'a': [[0] * 8 + [2] * 9 + [1] * 8 + [3] * 9] * 5000000})
int_tbl = pl.DataFrame({'a': ([0] * 8 + [2] * 9 + [1] * 8 + [3] * 9) * 5000000})
# 12 seconds, most of which is spent casting to dictionary array
nested_tbl.write_parquet('tmp.pq')
# 3 seconds
int_tbl.write_parquet('tmp.pq')
```

- Currently, we use V2 data pages for Parquet. This comes with [unclear advantages](https://stackoverflow.com/questions/77654784/what-is-the-difference-between-data-page-version-1-0-and-2-0-in-parquet-files) and one significant disadvantage. Unlike V1 data pages, V2 data pages do not compress definition and repetition levels. This leads to larger file sizes when columns have nested types. Since [PyArrow currently defaults to V1 data pages](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_table.html#pyarrow-parquet-write-table), I believe Polars can safely do the same and reap the file size benefits (d38e1f4).

This does not fully resolve the linked issue because it still does not provide users any way of manually specifying encodings like in PyArrow.
