### PR TITLE
docs: update the link to R API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   -
   <a href="https://pola-rs.github.io/nodejs-polars/index.html">Node.js</a>
   -
-  <a href="https://rpolars.github.io/index.html">R</a>
+  <a href="https://pola-rs.github.io/r-polars/index.html">R</a>
   |
   <b>StackOverflow</b>:
   <a href="https://stackoverflow.com/questions/tagged/python-polars">Python</a>


### PR DESCRIPTION
A follow up for pola-rs/r-polars#1067

We have moved the document to the repo's GitHub Pages.