### PR TITLE
fix(rust): Do not reverse null indices in descending arg_sort

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
@@ -48,17 +48,10 @@ where
     let idx = if nulls_last {
         let mut idx = Vec::with_capacity(len);
         idx.extend(iter);
-        if descending {
-            idx.extend(nulls_idx.into_iter().rev());
-        } else {
-            idx.extend(nulls_idx);
-        }
+        idx.extend(nulls_idx);
         idx
     } else {
         let ptr = nulls_idx.as_ptr() as usize;
-        if descending {
-            nulls_idx.reverse();
-        }
         nulls_idx.extend(iter);
         // We had a realloc.
         debug_assert_eq!(nulls_idx.as_ptr() as usize, ptr);

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -730,7 +730,7 @@ mod test {
         });
         let idx = idx.cont_slice().unwrap();
         // the duplicates are in reverse order of appearance, so we cannot reverse expected
-        let expected = [4, 2, 1, 5, 6, 0, 3, 7];
+        let expected = [2, 4, 1, 5, 6, 0, 3, 7];
         assert_eq!(idx, expected);
     }
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -348,7 +348,6 @@ def test_sort_maintain_order() -> None:
     assert l1 == l2 == ["A", "B", "C"]
 
 
-@pytest.mark.xfail(reason="https://github.com/pola-rs/polars/issues/9940")
 @pytest.mark.parametrize("nulls_last", [False, True], ids=["nulls_first", "nulls_last"])
 def test_sort_maintain_order_descending_repeated_nulls(nulls_last: bool) -> None:
     got = (

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -348,6 +348,21 @@ def test_sort_maintain_order() -> None:
     assert l1 == l2 == ["A", "B", "C"]
 
 
+@pytest.mark.xfail(reason="https://github.com/pola-rs/polars/issues/9940")
+@pytest.mark.parametrize("nulls_last", [False, True], ids=["nulls_first", "nulls_last"])
+def test_sort_maintain_order_descending_repeated_nulls(nulls_last: bool) -> None:
+    got = (
+        pl.LazyFrame({"A": [None, -1, 1, 1, None], "B": [1, 2, 3, 4, 5]})
+        .sort("A", descending=True, maintain_order=True, nulls_last=nulls_last)
+        .collect()
+    )
+    if nulls_last:
+        expect = pl.DataFrame({"A": [1, 1, -1, None, None], "B": [3, 4, 2, 1, 5]})
+    else:
+        expect = pl.DataFrame({"A": [None, None, 1, 1, -1], "B": [1, 5, 3, 4, 2]})
+    assert_frame_equal(got, expect)
+
+
 def test_replace() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
     s = pl.Series("c", [True, False, True])


### PR DESCRIPTION
Since nulls compare equal, a stable sort should select the nulls in
the order of the input series, independently of whether we asked for a
descending or ascending sort of the Series.

- Closes https://github.com/pola-rs/polars/issues/9940