### PR TITLE
feat(python): Render string columns in notebooks without quotes

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -686,10 +686,6 @@ class Config(contextlib.ContextDecorator):
         if n is None:
             os.environ.pop("POLARS_FMT_STR_LEN", None)
         else:
-            if n <= 0:
-                msg = "number of characters must be > 0"
-                raise ValueError(msg)
-
             os.environ["POLARS_FMT_STR_LEN"] = str(n)
         return cls
 

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -127,21 +127,20 @@ impl PySeries {
 
     /// Returns the string format of a single element of the Series.
     fn get_fmt(&self, index: usize, str_len_limit: usize) -> String {
-        let v = format!("{}", self.series.get(index).unwrap());
+        let v = self.series.str_value(index).unwrap().to_string();
         if let DataType::String | DataType::Categorical(_, _) | DataType::Enum(_, _) =
             self.series.dtype()
         {
-            let v_no_quotes = &v[1..v.len() - 1];
-            let v_trunc = &v_no_quotes[..v_no_quotes
+            let v_trunc = &v[..v
                 .char_indices()
                 .take(str_len_limit)
                 .last()
                 .map(|(i, c)| i + c.len_utf8())
                 .unwrap_or(0)];
-            if v_no_quotes == v_trunc {
+            if v == v_trunc {
                 v
             } else {
-                format!("\"{v_trunc}…")
+                format!("{v_trunc}…")
             }
         } else {
             v

--- a/py-polars/tests/unit/test_config.py
+++ b/py-polars/tests/unit/test_config.py
@@ -750,14 +750,6 @@ def test_set_streaming_chunk_size() -> None:
         cfg.set_streaming_chunk_size(0)
 
 
-def test_set_fmt_str_lengths_invalid_length() -> None:
-    with pl.Config() as cfg:
-        with pytest.raises(ValueError):
-            cfg.set_fmt_str_lengths(0)
-        with pytest.raises(ValueError):
-            cfg.set_fmt_str_lengths(-2)
-
-
 def test_warn_unstable(recwarn: pytest.WarningsRecorder) -> None:
     issue_unstable_warning()
     assert len(recwarn) == 0


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/6510

This is consistent with the regular DataFrame repr.

I've looked into implementing a setting to toggle this on/off but it turned out to be more difficult than I initially anticipated :sweat_smile: 