### PR TITLE
feat: Additional `uint` datatype support for the SQL interface

### DIFF
--- a/py-polars/tests/unit/sql/test_cast.py
+++ b/py-polars/tests/unit/sql/test_cast.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
@@ -14,6 +17,7 @@ def test_cast() -> None:
             "b": [1.1, 2.2, 3.3, 4.4, 5.5],
             "c": ["a", "b", "c", "d", "e"],
             "d": [True, False, True, False, True],
+            "e": [-1, 0, None, 1, 2],
         }
     )
     # test various dtype casts, using standard ("CAST <col> AS <dtype>")
@@ -25,11 +29,29 @@ def test_cast() -> None:
               -- float
               CAST(a AS DOUBLE PRECISION) AS a_f64,
               a::real AS a_f32,
+              b::float(24) AS b_f32,
+              b::float(25) AS b_f64,
+              e::float8 AS e_f64,
+              e::float4 AS e_f32,
+
               -- integer
               CAST(b AS TINYINT) AS b_i8,
               CAST(b AS SMALLINT) AS b_i16,
               b::bigint AS b_i64,
               d::tinyint AS d_i8,
+              a::int1 AS a_i8,
+              a::int2 AS a_i16,
+              a::int4 AS a_i32,
+              a::int8 AS a_i64,
+
+              -- unsigned integer
+              CAST(a AS TINYINT UNSIGNED) AS a_u8,
+              d::uint1 AS d_u8,
+              a::uint2 AS a_u16,
+              b::uint4 AS b_u32,
+              b::uint8 AS b_u64,
+              CAST(a AS BIGINT UNSIGNED) AS a_u64,
+
               -- string/binary
               CAST(a AS CHAR) AS a_char,
               CAST(b AS VARCHAR) AS b_varchar,
@@ -37,35 +59,110 @@ def test_cast() -> None:
               c::bytes AS c_bytes,
               c::VARBINARY AS c_varbinary,
               CAST(d AS CHARACTER VARYING) AS d_charvar,
+
+              -- boolean
+              e::bool AS e_bool,
+              e::boolean AS e_boolean
             FROM df
             """
         )
     assert res.schema == {
         "a_f64": pl.Float64,
         "a_f32": pl.Float32,
+        "b_f32": pl.Float32,
+        "b_f64": pl.Float64,
+        "e_f64": pl.Float64,
+        "e_f32": pl.Float32,
         "b_i8": pl.Int8,
         "b_i16": pl.Int16,
         "b_i64": pl.Int64,
         "d_i8": pl.Int8,
+        "a_i8": pl.Int8,
+        "a_i16": pl.Int16,
+        "a_i32": pl.Int32,
+        "a_i64": pl.Int64,
+        "a_u8": pl.UInt8,
+        "d_u8": pl.UInt8,
+        "a_u16": pl.UInt16,
+        "b_u32": pl.UInt32,
+        "b_u64": pl.UInt64,
+        "a_u64": pl.UInt64,
         "a_char": pl.String,
         "b_varchar": pl.String,
         "c_blob": pl.Binary,
         "c_bytes": pl.Binary,
         "c_varbinary": pl.Binary,
         "d_charvar": pl.String,
+        "e_bool": pl.Boolean,
+        "e_boolean": pl.Boolean,
     }
-    assert res.rows() == [
-        (1.0, 1.0, 1, 1, 1, 1, "1", "1.1", b"a", b"a", b"a", "true"),
-        (2.0, 2.0, 2, 2, 2, 0, "2", "2.2", b"b", b"b", b"b", "false"),
-        (3.0, 3.0, 3, 3, 3, 1, "3", "3.3", b"c", b"c", b"c", "true"),
-        (4.0, 4.0, 4, 4, 4, 0, "4", "4.4", b"d", b"d", b"d", "false"),
-        (5.0, 5.0, 5, 5, 5, 1, "5", "5.5", b"e", b"e", b"e", "true"),
+    assert res.select(cs.by_dtype(pl.Float32)).rows() == pytest.approx(
+        [
+            (1.0, 1.100000023841858, -1.0),
+            (2.0, 2.200000047683716, 0.0),
+            (3.0, 3.299999952316284, None),
+            (4.0, 4.400000095367432, 1.0),
+            (5.0, 5.5, 2.0),
+        ]
+    )
+    assert res.select(cs.by_dtype(pl.Float64)).rows() == [
+        (1.0, 1.1, -1.0),
+        (2.0, 2.2, 0.0),
+        (3.0, 3.3, None),
+        (4.0, 4.4, 1.0),
+        (5.0, 5.5, 2.0),
+    ]
+    assert res.select(cs.integer()).rows() == [
+        (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+        (2, 2, 2, 0, 2, 2, 2, 2, 2, 0, 2, 2, 2, 2),
+        (3, 3, 3, 1, 3, 3, 3, 3, 3, 1, 3, 3, 3, 3),
+        (4, 4, 4, 0, 4, 4, 4, 4, 4, 0, 4, 4, 4, 4),
+        (5, 5, 5, 1, 5, 5, 5, 5, 5, 1, 5, 5, 5, 5),
+    ]
+    assert res.select(cs.string()).rows() == [
+        ("1", "1.1", "true"),
+        ("2", "2.2", "false"),
+        ("3", "3.3", "true"),
+        ("4", "4.4", "false"),
+        ("5", "5.5", "true"),
+    ]
+    assert res.select(cs.binary()).rows() == [
+        (b"a", b"a", b"a"),
+        (b"b", b"b", b"b"),
+        (b"c", b"c", b"c"),
+        (b"d", b"d", b"d"),
+        (b"e", b"e", b"e"),
+    ]
+    assert res.select(cs.boolean()).rows() == [
+        (True, True),
+        (False, False),
+        (None, None),
+        (True, True),
+        (True, True),
     ]
 
     with pytest.raises(ComputeError, match="unsupported use of FORMAT in CAST"):
         pl.SQLContext(df=df, eager_execution=True).execute(
             "SELECT CAST(a AS STRING FORMAT 'HEX') FROM df"
         )
+
+
+@pytest.mark.parametrize(
+    ("values", "cast_op", "error"),
+    [
+        ([1.0, -1.0], "values::uint8", "conversion from `f64` to `u64` failed"),
+        ([10, 0, -1], "values::uint4", "conversion from `i64` to `u32` failed"),
+        ([int(1e8)], "values::int1", "conversion from `i64` to `i8` failed"),
+        (["a", "b"], "values::date", "conversion from `str` to `date` failed"),
+        (["a", "b"], "values::time", "conversion from `str` to `time` failed"),
+        (["a", "b"], "values::int4", "conversion from `str` to `i32` failed"),
+    ],
+)
+def test_cast_errors(values: Any, cast_op: str, error: str) -> None:
+    df = pl.DataFrame({"values": values})
+
+    with pytest.raises(ComputeError, match=error):
+        df.sql(f"SELECT {cast_op} FROM df")
 
 
 def test_cast_json() -> None:


### PR DESCRIPTION
Finally got to grips with destructuring a nested `vec` ("hello `as_slice`"😜) so was able to cleanly register some custom datatypes with the SQL parser.

## Patch notes

* PostgreSQL supports the following integer types `int2`,`int4`,`int8` (for which we also allow the `smallint`, `integer` and `bigint` aliases). Unfortunately it does not offer _unsigned_ ints, and the parser doesn't offer them (directly) either. We also allow `tinyint` for 1 byte ints.

* There is an extension called `pguint`[^1] (maintained by one of the PostgreSQL core developers) that adds `uint1`,`uint2`,`uint4`, and `uint8` types (as well as `int1`). 

* This PR adds support for recognising these additional integer types by registering them with the parser's `SQLDataType::Custom` extension point.

* Also contains a fix for "CAST", making it strict by default; previously we might silently eat invalid/overflowing casts and return `null` values, which is not desirable.

* Sorted type parsing code into blocks of related dtypes (vs lexical order) for clarity.

## Example

```python
import polars as pl

df = pl.DataFrame({"n": [1,2,3]})

df.sql("""
  SELECT 
    n::int1   AS ni8,   -- new
    n::int2   AS ni16,
    n::int4   AS ni32,
    n::int8   AS ni64,
    n::float4 AS nf32,
    n::float8 AS nf64,
    n::uint1  AS nu8,   -- new
    n::uint2  AS nu16,  -- new
    n::uint4  AS nu32,  -- new
    n::uint8  AS nu64,  -- new
  FROM self
""")

# shape: (3, 10)
# ┌─────┬──────┬──────┬──────┬──────┬──────┬─────┬──────┬──────┬──────┐
# │ ni8 ┆ ni16 ┆ ni32 ┆ ni64 ┆ nf32 ┆ nf64 ┆ nu8 ┆ nu16 ┆ nu32 ┆ nu64 │
# │ --- ┆ ---  ┆ ---  ┆ ---  ┆ ---  ┆ ---  ┆ --- ┆ ---  ┆ ---  ┆ ---  │
# │ i8  ┆ i16  ┆ i32  ┆ i64  ┆ f32  ┆ f64  ┆ u8  ┆ u16  ┆ u32  ┆ u64  │
# ╞═════╪══════╪══════╪══════╪══════╪══════╪═════╪══════╪══════╪══════╡
# │ 1   ┆ 1    ┆ 1    ┆ 1    ┆ 1.0  ┆ 1.0  ┆ 1   ┆ 1    ┆ 1    ┆ 1    │
# │ 2   ┆ 2    ┆ 2    ┆ 2    ┆ 2.0  ┆ 2.0  ┆ 2   ┆ 2    ┆ 2    ┆ 2    │
# │ 3   ┆ 3    ┆ 3    ┆ 3    ┆ 3.0  ┆ 3.0  ┆ 3   ┆ 3    ┆ 3    ┆ 3    │
# └─────┴──────┴──────┴──────┴──────┴──────┴─────┴──────┴──────┴──────┘
```
_(Note that PostgreSQL defines its datatype sizes in bytes, not bits)_.

[^1]: https://github.com/petere/pguint