### PR TITLE
docs: add filter docstring examples to date and datetime

### DIFF
--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -92,7 +92,6 @@ def datetime_(
     ...         "minute": [15, 30, 45],
     ...     }
     ... )
-
     >>> df.with_columns(
     ...     pl.datetime(
     ...         2024,
@@ -113,6 +112,32 @@ def datetime_(
     │ 2     ┆ 5   ┆ 13   ┆ 30     ┆ 2024-02-05 13:30:00 AEDT       │
     │ 3     ┆ 6   ┆ 14   ┆ 45     ┆ 2024-03-06 14:45:00 AEDT       │
     └───────┴─────┴──────┴────────┴────────────────────────────────┘
+
+    >>> from datetime import datetime
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "start": [
+    ...             datetime(2024, 1, 1, 0, 0, 0),
+    ...             datetime(2024, 1, 1, 0, 0, 0),
+    ...             datetime(2024, 1, 1, 0, 0, 0),
+    ...         ],
+    ...         "end": [
+    ...             datetime(2024, 5, 1, 20, 15, 10),
+    ...             datetime(2024, 7, 1, 21, 25, 20),
+    ...             datetime(2024, 9, 1, 22, 35, 30),
+    ...         ],
+    ...     }
+    ... )
+    >>> df.filter(pl.col("end") > pl.datetime(2024, 6, 1))
+    shape: (2, 2)
+    ┌─────────────────────┬─────────────────────┐
+    │ start               ┆ end                 │
+    │ ---                 ┆ ---                 │
+    │ datetime[μs]        ┆ datetime[μs]        │
+    ╞═════════════════════╪═════════════════════╡
+    │ 2024-01-01 00:00:00 ┆ 2024-07-01 21:25:20 │
+    │ 2024-01-01 00:00:00 ┆ 2024-09-01 22:35:30 │
+    └─────────────────────┴─────────────────────┘
     """
     ambiguous = parse_as_expression(
         rename_use_earliest_to_ambiguous(use_earliest, ambiguous), str_as_lit=True
@@ -176,7 +201,6 @@ def date_(
     ...         "day": [4, 5, 6],
     ...     }
     ... )
-
     >>> df.with_columns(pl.date(2024, pl.col("month"), pl.col("day")))
     shape: (3, 3)
     ┌───────┬─────┬────────────┐
@@ -188,6 +212,24 @@ def date_(
     │ 2     ┆ 5   ┆ 2024-02-05 │
     │ 3     ┆ 6   ┆ 2024-03-06 │
     └───────┴─────┴────────────┘
+
+    >>> from datetime import date
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "start": [date(2024, 1, 1), date(2024, 1, 1), date(2024, 1, 1)],
+    ...         "end": [date(2024, 5, 1), date(2024, 7, 1), date(2024, 9, 1)],
+    ...     }
+    ... )
+    >>> df.filter(pl.col("end") > pl.date(2024, 6, 1))
+    shape: (2, 2)
+    ┌────────────┬────────────┐
+    │ start      ┆ end        │
+    │ ---        ┆ ---        │
+    │ date       ┆ date       │
+    ╞════════════╪════════════╡
+    │ 2024-01-01 ┆ 2024-07-01 │
+    │ 2024-01-01 ┆ 2024-09-01 │
+    └────────────┴────────────┘
     """
     return datetime_(year, month, day).cast(Date).alias("date")
 

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -113,35 +113,33 @@ def datetime_(
     │ 3     ┆ 6   ┆ 14   ┆ 45     ┆ 2024-03-06 14:45:00 AEDT       │
     └───────┴─────┴──────┴────────┴────────────────────────────────┘
 
-    We can also use `pl.datetime` for filtering. Notice that `pl.datetime` allows you
-    to overcome The Python Standard Library's limitation of not supporting nanoseconds
-    for `datetime.datetime`.
+    We can also use `pl.datetime` for filtering:
 
+    >>> from datetime import datetime
     >>> df = pl.DataFrame(
     ...     {
-    ...         'start': [
-    ...             '2024-01-01T01:04:07.123456789',
-    ...             '2024-01-01T02:05:08.234567890',
-    ...             '2024-01-01T03:06:09.345678901',
+    ...         "start": [
+    ...             datetime(2024, 1, 1, 0, 0, 0),
+    ...             datetime(2024, 1, 1, 0, 0, 0),
+    ...             datetime(2024, 1, 1, 0, 0, 0),
     ...         ],
     ...         "end": [
-    ...             '2024-05-01T04:07:00.456789012',
-    ...             '2024-06-01T05:08:01.567890123',
-    ...             '2024-07-01T06:09:02.678901234',
+    ...             datetime(2024, 5, 1, 20, 15, 10),
+    ...             datetime(2024, 7, 1, 21, 25, 20),
+    ...             datetime(2024, 9, 1, 22, 35, 30),
     ...         ],
-    ...     })
-    >>> df = df.with_columns(pl.col('start').str.to_datetime(time_unit='ns'))
-    >>> df = df.with_columns(pl.col('end').str.to_datetime(time_unit='ns'))
-    >>> df.filter(pl.col("end") > pl.datetime(2024, 6, 1, time_unit="ns"))
-    shape: (2, 2)
-    ┌───────────────────────────────┬───────────────────────────────┐
-    │ start                         ┆ end                           │
-    │ ---                           ┆ ---                           │
-    │ datetime[ns]                  ┆ datetime[ns]                  │
-    ╞═══════════════════════════════╪═══════════════════════════════╡
-    │ 2024-01-01 02:05:08.234567890 ┆ 2024-06-01 05:08:01.567890123 │
-    │ 2024-01-01 03:06:09.345678901 ┆ 2024-07-01 06:09:02.678901234 │
-    └───────────────────────────────┴───────────────────────────────┘
+    ...     }
+    ... )
+    >>> df.filter(pl.col("end") > pl.datetime(2024, 6, 1))
+        shape: (2, 2)
+    ┌─────────────────────┬─────────────────────┐
+    │ start               ┆ end                 │
+    │ ---                 ┆ ---                 │
+    │ datetime[μs]        ┆ datetime[μs]        │
+    ╞═════════════════════╪═════════════════════╡
+    │ 2024-01-01 00:00:00 ┆ 2024-07-01 21:25:20 │
+    │ 2024-01-01 00:00:00 ┆ 2024-09-01 22:35:30 │
+    └─────────────────────┴─────────────────────┘
     """
     ambiguous = parse_as_expression(
         rename_use_earliest_to_ambiguous(use_earliest, ambiguous), str_as_lit=True

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -132,7 +132,7 @@ def datetime_(
     ...     })
     >>> df = df.with_columns(pl.col('start').str.to_datetime(time_unit='ns'))
     >>> df = df.with_columns(pl.col('end').str.to_datetime(time_unit='ns'))
-    >>> df.filter(pl.col("end") > pl.datetime(2024, 6, 1))
+    >>> df.filter(pl.col("end") > pl.datetime(2024, 6, 1, time_unit="ns"))
     shape: (2, 2)
     ┌───────────────────────────────┬───────────────────────────────┐
     │ start                         ┆ end                           │

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -215,7 +215,7 @@ def date_(
     │ 3     ┆ 6   ┆ 2024-03-06 │
     └───────┴─────┴────────────┘
 
-    We can also use `pl.date` for filtering: 
+    We can also use `pl.date` for filtering:
 
     >>> from datetime import date
     >>> df = pl.DataFrame(

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -113,31 +113,35 @@ def datetime_(
     │ 3     ┆ 6   ┆ 14   ┆ 45     ┆ 2024-03-06 14:45:00 AEDT       │
     └───────┴─────┴──────┴────────┴────────────────────────────────┘
 
-    >>> from datetime import datetime
+    We can also use `pl.datetime` for filtering. Notice that `pl.datetime` allows you
+    to overcome The Python Standard Library's limitation of not supporting nanoseconds
+    for `datetime.datetime`.
+
     >>> df = pl.DataFrame(
     ...     {
-    ...         "start": [
-    ...             datetime(2024, 1, 1, 0, 0, 0),
-    ...             datetime(2024, 1, 1, 0, 0, 0),
-    ...             datetime(2024, 1, 1, 0, 0, 0),
+    ...         'start': [
+    ...             '2024-01-01T01:04:07.123456789',
+    ...             '2024-01-01T02:05:08.234567890',
+    ...             '2024-01-01T03:06:09.345678901',
     ...         ],
     ...         "end": [
-    ...             datetime(2024, 5, 1, 20, 15, 10),
-    ...             datetime(2024, 7, 1, 21, 25, 20),
-    ...             datetime(2024, 9, 1, 22, 35, 30),
+    ...             '2024-05-01T04:07:00.456789012',
+    ...             '2024-06-01T05:08:01.567890123',
+    ...             '2024-07-01T06:09:02.678901234',
     ...         ],
-    ...     }
-    ... )
+    ...     })
+    >>> df = df.with_columns(pl.col('start').str.to_datetime(time_unit='ns'))
+    >>> df = df.with_columns(pl.col('end').str.to_datetime(time_unit='ns'))
     >>> df.filter(pl.col("end") > pl.datetime(2024, 6, 1))
     shape: (2, 2)
-    ┌─────────────────────┬─────────────────────┐
-    │ start               ┆ end                 │
-    │ ---                 ┆ ---                 │
-    │ datetime[μs]        ┆ datetime[μs]        │
-    ╞═════════════════════╪═════════════════════╡
-    │ 2024-01-01 00:00:00 ┆ 2024-07-01 21:25:20 │
-    │ 2024-01-01 00:00:00 ┆ 2024-09-01 22:35:30 │
-    └─────────────────────┴─────────────────────┘
+    ┌───────────────────────────────┬───────────────────────────────┐
+    │ start                         ┆ end                           │
+    │ ---                           ┆ ---                           │
+    │ datetime[ns]                  ┆ datetime[ns]                  │
+    ╞═══════════════════════════════╪═══════════════════════════════╡
+    │ 2024-01-01 02:05:08.234567890 ┆ 2024-06-01 05:08:01.567890123 │
+    │ 2024-01-01 03:06:09.345678901 ┆ 2024-07-01 06:09:02.678901234 │
+    └───────────────────────────────┴───────────────────────────────┘
     """
     ambiguous = parse_as_expression(
         rename_use_earliest_to_ambiguous(use_earliest, ambiguous), str_as_lit=True
@@ -212,6 +216,8 @@ def date_(
     │ 2     ┆ 5   ┆ 2024-02-05 │
     │ 3     ┆ 6   ┆ 2024-03-06 │
     └───────┴─────┴────────────┘
+
+    We can also use `pl.date` for filtering: 
 
     >>> from datetime import date
     >>> df = pl.DataFrame(


### PR DESCRIPTION
contributes to #13161 

I added examples for how to use `polars.date` and `polars.datetime` in combination with row filtering in a dataframe.

ping @MarcoGorelli 