### PR TITLE
test(python): Improve hypothesis strategy for decimals

### DIFF
--- a/py-polars/polars/testing/parametric/primitives.py
+++ b/py-polars/polars/testing/parametric/primitives.py
@@ -28,10 +28,10 @@ from polars.series import Series
 from polars.string_cache import StringCache
 from polars.testing.parametric.strategies import (
     _flexhash,
-    all_strategies,
     between,
     create_array_strategy,
     create_list_strategy,
+    dtype_strategies,
     scalar_strategies,
 )
 
@@ -381,11 +381,7 @@ def series(
             if strategy is None:
                 if series_dtype is Datetime or series_dtype is Duration:
                     series_dtype = series_dtype(random.choice(_time_units))  # type: ignore[operator]
-                dtype_strategy = all_strategies[
-                    series_dtype
-                    if series_dtype in all_strategies
-                    else series_dtype.base_type()
-                ]
+                dtype_strategy = draw(dtype_strategies(series_dtype))
             else:
                 dtype_strategy = strategy
 

--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -56,7 +56,6 @@ from polars.datatypes import (
     UInt16,
     UInt32,
     UInt64,
-    is_polars_dtype,
 )
 from polars.type_aliases import PolarsDataType
 
@@ -278,28 +277,10 @@ scalar_strategies: StrategyLookup = StrategyLookup(
 nested_strategies: StrategyLookup = StrategyLookup()
 
 
-def _get_strategy_dtypes(
-    *,
-    base_type: bool = False,
-    excluding: tuple[PolarsDataType] | PolarsDataType | None = None,
-) -> list[PolarsDataType]:
-    """
-    Get a list of all the dtypes for which we have a strategy.
-
-    Parameters
-    ----------
-    base_type
-        If True, return the base types for each dtype (eg:`List(String)` → `List`).
-    excluding
-        A dtype or sequence of dtypes to omit from the results.
-    """
-    excluding = (excluding,) if is_polars_dtype(excluding) else (excluding or ())  # type: ignore[assignment]
+def _get_strategy_dtypes() -> list[PolarsDataType]:
+    """Get a list of all the dtypes for which we have a strategy."""
     strategy_dtypes = list(chain(scalar_strategies.keys(), nested_strategies.keys()))
-    return [
-        (tp.base_type() if base_type else tp)
-        for tp in strategy_dtypes
-        if tp not in excluding  # type: ignore[operator]
-    ]
+    return [tp.base_type() for tp in strategy_dtypes]
 
 
 def _flexhash(elem: Any) -> int:
@@ -351,7 +332,7 @@ def create_array_strategy(
         width = randint(a=1, b=8)
 
     if inner_dtype is None:
-        strats = list(_get_strategy_dtypes(base_type=True))
+        strats = list(_get_strategy_dtypes())
         shuffle(strats)
         inner_dtype = choice(strats)
 
@@ -431,7 +412,7 @@ def create_list_strategy(
         raise ValueError(msg)
 
     if inner_dtype is None:
-        strats = list(_get_strategy_dtypes(base_type=True))
+        strats = list(_get_strategy_dtypes())
         shuffle(strats)
         inner_dtype = choice(strats)
     if size:

--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -14,6 +14,7 @@ from typing import (
     Sequence,
 )
 
+import hypothesis.strategies as st
 from hypothesis.strategies import (
     SearchStrategy,
     binary,
@@ -22,7 +23,6 @@ from hypothesis.strategies import (
     composite,
     dates,
     datetimes,
-    decimals,
     floats,
     from_type,
     integers,
@@ -116,10 +116,10 @@ strategy_time_unit = sampled_from(["ns", "us", "ms"])
 
 
 @composite
-def strategy_decimal(
+def decimals(
     draw: DrawFn, precision: int | None = None, scale: int | None = None
 ) -> PyDecimal:
-    """Draw a decimal value, varying the number of decimal places."""
+    """Returns a strategy which generates instances of Python `Decimal`."""
     if precision is None:
         precision = draw(integers(min_value=scale or 1, max_value=38))
     if scale is None:
@@ -129,7 +129,7 @@ def strategy_decimal(
     limit = 10 ** (precision - scale) - smallest_increment
 
     return draw(
-        decimals(
+        st.decimals(
             allow_nan=False,
             allow_infinity=False,
             min_value=-limit,
@@ -278,7 +278,7 @@ scalar_strategies: StrategyLookup = StrategyLookup(
         Categorical: strategy_categorical,
         String: strategy_string,
         Binary: strategy_binary,
-        Decimal: strategy_decimal(),
+        Decimal: decimals(),
     }
 )
 nested_strategies: StrategyLookup = StrategyLookup()

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+import os
 import random
 import string
 import sys
@@ -11,6 +12,11 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.testing.parametric.profiles import load_profile
+
+load_profile(
+    profile=os.environ.get("POLARS_HYPOTHESIS_PROFILE", "fast"),  # type: ignore[arg-type]
+)
 
 
 @pytest.fixture()


### PR DESCRIPTION
It's now possible to supply a precision/scale and the proper decimal values will be generated.

I also set up the `dtype_strategies` strategy which will be key to upgrading the list/array strategies (these need to be converted to a composite strategy).

Next step will be to set up a `dtypes` strategy which generates a random Polars data type. This will be used by the list/array strategies. Then I will upgrade the list/array strategies and we can finally upgrade to the latest hypothesis version.