### PR TITLE
docs(python): Remove unwanted linebreaks from docstrings

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2046,7 +2046,7 @@ class Expr:
 
         This has time complexity:
 
-        .. math:: O(n + k \\log{}n - \frac{k}{2})
+        .. math:: O(n + k \log{}n - \frac{k}{2})
 
         Parameters
         ----------
@@ -2212,7 +2212,7 @@ class Expr:
 
         This has time complexity:
 
-        .. math:: O(n + k \\log{}n - \frac{k}{2})
+        .. math:: O(n + k \log{}n - \frac{k}{2})
 
         Parameters
         ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3402,7 +3402,7 @@ class Series:
 
         This has time complexity:
 
-        .. math:: O(n + k \\log{}n - \frac{k}{2})
+        .. math:: O(n + k \log{}n - \frac{k}{2})
 
         Parameters
         ----------
@@ -3432,7 +3432,7 @@ class Series:
 
         This has time complexity:
 
-        .. math:: O(n + k \\log{}n - \frac{k}{2})
+        .. math:: O(n + k \log{}n - \frac{k}{2})
 
         Parameters
         ----------


### PR DESCRIPTION
By changing double backslashes to single backslashes to prevent unwanted linebreak. Fixes #14454. Applies to `Series.bottom_k`, `Series.top_k`, `Expr.bottom_k` and `Expr.top_k`. I searched the Python and Rust files and did not notice any other instances where this change seemed to be needed.