### PR TITLE
fix: Crash/incorrect group_by/n_unique on categoricals created by (q)cut

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -279,6 +279,10 @@ impl CategoricalChunked {
         self
     }
 
+    pub fn _with_fast_unique(self, toggle: bool) -> Self {
+        self.with_fast_unique(toggle)
+    }
+
     /// Get a reference to the mapping of categorical types to the string values.
     pub fn get_rev_map(&self) -> &Arc<RevMapping> {
         if let DataType::Categorical(Some(rev_map), _) | DataType::Enum(Some(rev_map), _) =

--- a/py-polars/tests/unit/operations/test_cut.py
+++ b/py-polars/tests/unit/operations/test_cut.py
@@ -120,3 +120,47 @@ def test_cut_bin_name_in_agg_context() -> None:
     )
     schema = pl.Struct({"brk": pl.Float64, "a_bin": pl.Categorical("physical")})
     assert df.schema == {"cut": schema, "qcut": schema, "qcut_uniform": schema}
+
+
+@pytest.mark.parametrize(
+    ("breaks", "expected_labels", "expected_physical", "expected_unique"),
+    [
+        (
+            [2, 4],
+            pl.Series("x", ["(-inf, 2]", "(-inf, 2]", "(2, 4]", "(2, 4]", "(4, inf]"]),
+            pl.Series("x", [0, 0, 1, 1, 2], dtype=pl.UInt32),
+            3,
+        ),
+        (
+            [99, 101],
+            pl.Series("x", 5 * ["(-inf, 99]"]),
+            pl.Series("x", 5 * [0], dtype=pl.UInt32),
+            1,
+        ),
+    ],
+)
+def test_cut_fast_unique_15981(
+    breaks: list[int],
+    expected_labels: pl.Series,
+    expected_physical: pl.Series,
+    expected_unique: int,
+) -> None:
+    s = pl.Series("x", [1, 2, 3, 4, 5])
+
+    include_breaks = False
+    s_cut = s.cut(breaks, include_breaks=include_breaks)
+
+    assert_series_equal(s_cut.cast(pl.String), expected_labels)
+    assert_series_equal(s_cut.to_physical(), expected_physical)
+    assert s_cut.n_unique() == s_cut.to_physical().n_unique() == expected_unique
+    s_cut.to_frame().group_by(s.name).len()
+
+    include_breaks = True
+    s_cut = (
+        s.cut(breaks, include_breaks=include_breaks).struct.field("category").alias("x")
+    )
+
+    assert_series_equal(s_cut.cast(pl.String), expected_labels)
+    assert_series_equal(s_cut.to_physical(), expected_physical)
+    assert s_cut.n_unique() == s_cut.to_physical().n_unique() == expected_unique
+    s_cut.to_frame().group_by(s.name).len()


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/15981.

We recently added the categories upfront to make them deterministic, but we forgot to ensure that the fast unique setting was set properly:

```python
>>> pl.Series([1]).cut([1, 2, 3])
shape: (1,)
Series: '' [cat]
[
	"(-inf, 1]"
]
>>> pl.Series([1]).cut([1, 2, 3]).n_unique()
4
```

As a note, it looks like `CategoricalChunkedBuilder` automatically sets fast unique to `true` by default:

https://github.com/pola-rs/polars/blob/d5cf03856929ffa25180873754faef8238fc3b5d/crates/polars-core/src/chunked_array/logical/categorical/builder.rs#L195-L206
