### PR TITLE
feat(python): Minor DB type inference updates

### DIFF
--- a/py-polars/polars/io/database/_inference.py
+++ b/py-polars/polars/io/database/_inference.py
@@ -141,6 +141,10 @@ def _infer_dtype_from_database_typename(
         else:
             dtype = _integer_dtype_from_nbits(sz, unsigned=False, default=Int64)
 
+    # number types (note: 'number' alone is not that helpful and requires refinement)
+    elif "NUMBER" in value and "CARDINAL" in value:
+        dtype = UInt64
+
     # decimal dtypes
     elif (is_dec := ("DECIMAL" in value)) or ("NUMERIC" in value):
         if "," in modifier:
@@ -152,7 +156,7 @@ def _infer_dtype_from_database_typename(
     # string dtypes
     elif (
         any(tp in value for tp in ("VARCHAR", "STRING", "TEXT", "UNICODE"))
-        or value.startswith(("STR", "CHAR", "NCHAR", "UTF"))
+        or value.startswith(("STR", "CHAR", "BPCHAR", "NCHAR", "UTF"))
         or value.endswith(("_UTF8", "_UTF16", "_UTF32"))
     ):
         dtype = String

--- a/py-polars/tests/unit/io/database/test_inference.py
+++ b/py-polars/tests/unit/io/database/test_inference.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         # string types
         ("UTF16", pl.String),
         ("char(8)", pl.String),
+        ("BPCHAR", pl.String),
         ("nchar[128]", pl.String),
         ("varchar", pl.String),
         ("CHARACTER VARYING(64)", pl.String),
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
         ("ROWID", pl.UInt64),
         ("mediumint", pl.Int32),
         ("unsigned mediumint", pl.UInt32),
+        ("cardinal_number", pl.UInt64),
         ("smallserial", pl.Int16),
         ("serial", pl.Int32),
         ("bigserial", pl.Int64),


### PR DESCRIPTION
A much larger update for database-related type inference is brewing, but this is a minor update to catch "bpchar" and "cardinal number" type names (as used in PostgreSQL).