### PR TITLE
feat: Move diagonal & horizontal concat schema resolving to IR phase

### DIFF
--- a/crates/polars-lazy/src/dsl/functions.rs
+++ b/crates/polars-lazy/src/dsl/functions.rs
@@ -44,58 +44,10 @@ pub(crate) fn concat_impl<L: AsRef<[LazyFrame]>>(
 /// Calls [`concat`][concat()] internally.
 pub fn concat_lf_diagonal<L: AsRef<[LazyFrame]>>(
     inputs: L,
-    args: UnionArgs,
+    mut args: UnionArgs,
 ) -> PolarsResult<LazyFrame> {
-    let lfs = inputs.as_ref();
-    let schemas = lfs
-        .iter()
-        .map(|lf| lf.schema())
-        .collect::<PolarsResult<Vec<_>>>()?;
-
-    let upper_bound_width = schemas.iter().map(|sch| sch.len()).sum();
-
-    // Use Vec to preserve order
-    let mut column_names = Vec::with_capacity(upper_bound_width);
-    let mut total_schema = Vec::with_capacity(upper_bound_width);
-
-    for sch in schemas.iter() {
-        sch.iter().for_each(|(name, dtype)| {
-            if !column_names.contains(name) {
-                column_names.push(name.clone());
-                total_schema.push((name.clone(), dtype.clone()));
-            }
-        });
-    }
-    let lfs_with_all_columns = lfs
-        .iter()
-        // Zip Frames with their Schemas
-        .zip(schemas)
-        .filter_map(|(lf, lf_schema)| {
-            if lf_schema.is_empty() {
-                // if the frame is empty we discard
-                return None;
-            };
-
-            let mut lf = lf.clone();
-            for (name, dtype) in total_schema.iter() {
-                // If a name from Total Schema is not present - append
-                if lf_schema.get_field(name).is_none() {
-                    lf = lf.with_column(NULL.lit().cast(dtype.clone()).alias(name))
-                }
-            }
-
-            // Now, reorder to match schema
-            let reordered_lf = lf.select(
-                column_names
-                    .iter()
-                    .map(|col_name| col(col_name))
-                    .collect::<Vec<Expr>>(),
-            );
-            Some(Ok(reordered_lf))
-        })
-        .collect::<PolarsResult<Vec<_>>>()?;
-
-    concat(lfs_with_all_columns, args)
+    args.diagonal = true;
+    concat_impl(inputs, args)
 }
 
 /// Concat [LazyFrame]s horizontally.

--- a/crates/polars-lazy/src/dsl/functions.rs
+++ b/crates/polars-lazy/src/dsl/functions.rs
@@ -65,25 +65,11 @@ pub fn concat_lf_horizontal<L: AsRef<[LazyFrame]>>(
         opt_state.file_caching |= lf.opt_state.file_caching;
     }
 
-    let mut lps = Vec::with_capacity(lfs.len());
-    let mut schemas = Vec::with_capacity(lfs.len());
-
-    for lf in lfs.iter() {
-        let mut lf = lf.clone();
-        let schema = lf.schema()?;
-        schemas.push(schema);
-        let lp = std::mem::take(&mut lf.logical_plan);
-        lps.push(lp);
-    }
-
-    let combined_schema = merge_schemas(&schemas)?;
-
     let options = HConcatOptions {
         parallel: args.parallel,
     };
     let lp = DslPlan::HConcat {
-        inputs: lps,
-        schema: Arc::new(combined_schema),
+        inputs: lfs.iter().map(|lf| lf.logical_plan.clone()).collect(),
         options,
     };
     let mut lf = LazyFrame::from(lp);

--- a/crates/polars-lazy/src/physical_plan/executors/projection_simple.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/projection_simple.rs
@@ -5,16 +5,12 @@ use super::*;
 pub struct ProjectionSimple {
     pub(crate) input: Box<dyn Executor>,
     pub(crate) columns: SchemaRef,
-    pub(crate) duplicate_check: bool,
 }
 
 impl ProjectionSimple {
     fn execute_impl(&mut self, df: DataFrame, columns: &[SmartString]) -> PolarsResult<DataFrame> {
-        if self.duplicate_check {
-            df._select_impl(columns.as_ref())
-        } else {
-            df._select_impl_unchecked(columns.as_ref())
-        }
+        // No duplicate check as that an invariant of this node.
+        df._select_impl_unchecked(columns.as_ref())
     }
 }
 

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -598,17 +598,9 @@ pub fn create_physical_plan(
                 .collect::<PolarsResult<_>>()?;
             Ok(Box::new(executors::ExternalContext { input, contexts }))
         },
-        SimpleProjection {
-            input,
-            columns,
-            duplicate_check,
-        } => {
+        SimpleProjection { input, columns } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
-            let exec = executors::ProjectionSimple {
-                input,
-                columns,
-                duplicate_check,
-            };
+            let exec = executors::ProjectionSimple { input, columns };
             Ok(Box::new(exec))
         },
         Invalid => unreachable!(),

--- a/crates/polars-plan/src/logical_plan/alp/inputs.rs
+++ b/crates/polars-plan/src/logical_plan/alp/inputs.rs
@@ -150,14 +150,9 @@ impl IR {
                 input: inputs.pop().unwrap(),
                 payload: payload.clone(),
             },
-            SimpleProjection {
-                columns,
-                duplicate_check,
-                ..
-            } => SimpleProjection {
+            SimpleProjection { columns, .. } => SimpleProjection {
                 input: inputs.pop().unwrap(),
                 columns: columns.clone(),
-                duplicate_check: *duplicate_check,
             },
             Invalid => unreachable!(),
         }

--- a/crates/polars-plan/src/logical_plan/alp/mod.rs
+++ b/crates/polars-plan/src/logical_plan/alp/mod.rs
@@ -52,7 +52,6 @@ pub enum IR {
     SimpleProjection {
         input: Node,
         columns: SchemaRef,
-        duplicate_check: bool,
     },
     // Polars' `select` operation. This may access full materialized data.
     Select {

--- a/crates/polars-plan/src/logical_plan/builder_ir.rs
+++ b/crates/polars-plan/src/logical_plan/builder_ir.rs
@@ -91,7 +91,6 @@ impl<'a> IRBuilder<'a> {
             let lp = IR::SimpleProjection {
                 input: self.root,
                 columns: Arc::new(schema),
-                duplicate_check: false,
             };
             let node = self.lp_arena.add(lp);
             Ok(IRBuilder::new(node, self.expr_arena, self.lp_arena))
@@ -123,7 +122,6 @@ impl<'a> IRBuilder<'a> {
             let lp = IR::SimpleProjection {
                 input: self.root,
                 columns: Arc::new(schema),
-                duplicate_check: false,
             };
             let node = self.lp_arena.add(lp);
             Ok(IRBuilder::new(node, self.expr_arena, self.lp_arena))

--- a/crates/polars-plan/src/logical_plan/builder_ir.rs
+++ b/crates/polars-plan/src/logical_plan/builder_ir.rs
@@ -130,6 +130,10 @@ impl<'a> IRBuilder<'a> {
         }
     }
 
+    pub fn node(self) -> Node {
+        self.root
+    }
+
     pub fn build(self) -> IR {
         if self.root.0 == self.lp_arena.len() {
             self.lp_arena.pop().unwrap()

--- a/crates/polars-plan/src/logical_plan/conversion/convert_utils.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/convert_utils.rs
@@ -43,15 +43,19 @@ pub(super) fn convert_st_union(
     Ok(())
 }
 
+fn nodes_to_schemas(inputs: &[Node], lp_arena: &mut Arena<IR>) -> Vec<SchemaRef> {
+    inputs
+        .iter()
+        .map(|n| lp_arena.get(*n).schema(lp_arena).into_owned())
+        .collect()
+}
+
 pub(super) fn convert_diagonal_concat(
     mut inputs: Vec<Node>,
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
 ) -> Vec<Node> {
-    let schemas = inputs
-        .iter()
-        .map(|n| lp_arena.get(*n).schema(lp_arena).into_owned())
-        .collect::<Vec<_>>();
+    let schemas = nodes_to_schemas(&inputs, lp_arena);
 
     let upper_bound_width = schemas.iter().map(|sch| sch.len()).sum();
 
@@ -102,4 +106,13 @@ pub(super) fn convert_diagonal_concat(
     } else {
         inputs
     }
+}
+
+pub(super) fn h_concat_schema(
+    inputs: &[Node],
+    lp_arena: &mut Arena<IR>,
+) -> PolarsResult<SchemaRef> {
+    let schemas = nodes_to_schemas(inputs, lp_arena);
+    let combined_schema = merge_schemas(&schemas)?;
+    Ok(Arc::new(combined_schema))
 }

--- a/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
@@ -153,6 +153,10 @@ pub fn to_alp_impl(
                 .collect::<PolarsResult<Vec<_>>>()
                 .map_err(|e| e.context(failed_input!(vertical concat)))?;
 
+            if args.diagonal {
+                inputs = convert_utils::convert_diagonal_concat(inputs, lp_arena, expr_arena);
+            }
+
             if args.to_supertypes {
                 convert_utils::convert_st_union(&mut inputs, lp_arena, expr_arena)
                     .map_err(|e| e.context(failed_input!(vertical concat)))?;

--- a/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
@@ -164,16 +164,15 @@ pub fn to_alp_impl(
             let options = args.into();
             IR::Union { inputs, options }
         },
-        DslPlan::HConcat {
-            inputs,
-            schema,
-            options,
-        } => {
+        DslPlan::HConcat { inputs, options } => {
             let inputs = inputs
                 .into_iter()
                 .map(|lp| to_alp_impl(lp, expr_arena, lp_arena, convert))
-                .collect::<PolarsResult<_>>()
+                .collect::<PolarsResult<Vec<_>>>()
                 .map_err(|e| e.context(failed_input!(horizontal concat)))?;
+
+            let schema = convert_utils::h_concat_schema(&inputs, lp_arena)?;
+
             IR::HConcat {
                 inputs,
                 schema,

--- a/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
@@ -428,7 +428,6 @@ pub fn to_alp_impl(
                     IR::SimpleProjection {
                         input,
                         columns: Arc::new(output_schema),
-                        duplicate_check: false,
                     }
                 },
                 DslFunction::Stats(sf) => {

--- a/crates/polars-plan/src/logical_plan/conversion/mod.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/mod.rs
@@ -66,18 +66,14 @@ impl IR {
             },
             IR::HConcat {
                 inputs,
-                schema,
+                schema: _,
                 options,
             } => {
                 let inputs = inputs
                     .into_iter()
                     .map(|node| convert_to_lp(node, lp_arena))
                     .collect();
-                DslPlan::HConcat {
-                    inputs,
-                    schema: schema.clone(),
-                    options,
-                }
+                DslPlan::HConcat { inputs, options }
             },
             IR::Slice { input, offset, len } => {
                 let lp = convert_to_lp(input, lp_arena);

--- a/crates/polars-plan/src/logical_plan/conversion/mod.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/mod.rs
@@ -122,7 +122,7 @@ impl IR {
                     options,
                 }
             },
-            IR::SimpleProjection { input, columns, .. } => {
+            IR::SimpleProjection { input, columns } => {
                 let input = convert_to_lp(input, lp_arena);
                 let expr = columns
                     .iter_names()

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -161,7 +161,6 @@ pub enum DslPlan {
     /// Horizontal concatenation of multiple plans
     HConcat {
         inputs: Vec<DslPlan>,
-        schema: SchemaRef,
         options: HConcatOptions,
     },
     /// This allows expressions to access other tables
@@ -198,7 +197,7 @@ impl Clone for DslPlan {
             Self::Slice { input, offset, len } => Self::Slice { input: input.clone(), offset: offset.clone(), len: len.clone() },
             Self::MapFunction { input, function } => Self::MapFunction { input: input.clone(), function: function.clone() },
             Self::Union { inputs, args} => Self::Union { inputs: inputs.clone(), args: args.clone() },
-            Self::HConcat { inputs, schema, options } => Self::HConcat { inputs: inputs.clone(), schema: schema.clone(), options: options.clone() },
+            Self::HConcat { inputs, options } => Self::HConcat { inputs: inputs.clone(), options: options.clone() },
             Self::ExtContext { input, contexts, } => Self::ExtContext { input: input.clone(), contexts: contexts.clone() },
             Self::Sink { input, payload } => Self::Sink { input: input.clone(), payload: payload.clone() },
         }

--- a/crates/polars-plan/src/logical_plan/optimizer/collapse_and_project.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/collapse_and_project.rs
@@ -62,11 +62,7 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                     None
                 }
             },
-            SimpleProjection {
-                columns,
-                input,
-                duplicate_check,
-            } if !self.eager => {
+            SimpleProjection { columns, input } if !self.eager => {
                 match lp_arena.get(*input) {
                     // If there are 2 subsequent fast projections, flatten them and only take the last
                     SimpleProjection {
@@ -74,7 +70,6 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                     } => Some(SimpleProjection {
                         input: *prev_input,
                         columns: columns.clone(),
-                        duplicate_check: *duplicate_check,
                     }),
                     // Cleanup projections set in projection pushdown just above caches
                     // they are not needed.

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/hconcat.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/hconcat.rs
@@ -49,8 +49,8 @@ pub(super) fn process_hconcat(
 
         let mut schemas = Vec::with_capacity(inputs.len());
         for input in inputs.iter() {
-            let schema = lp_arena.get(*input).schema(lp_arena);
-            schemas.push(schema.as_ref().clone());
+            let schema = lp_arena.get(*input).schema(lp_arena).into_owned();
+            schemas.push(schema);
         }
         let new_schema = merge_schemas(&schemas)?;
         Arc::new(new_schema)

--- a/crates/polars-plan/src/logical_plan/visitor/hash.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/hash.rs
@@ -98,13 +98,8 @@ impl Hash for HashableEqLP<'_> {
                 projection.hash(state);
                 hash_option_expr(selection, self.expr_arena, state);
             },
-            IR::SimpleProjection {
-                columns,
-                duplicate_check,
-                input: _,
-            } => {
+            IR::SimpleProjection { columns, input: _ } => {
                 columns.hash(state);
-                duplicate_check.hash(state);
             },
             IR::Select {
                 input: _,
@@ -297,14 +292,12 @@ impl HashableEqLP<'_> {
                 IR::SimpleProjection {
                     input: _,
                     columns: cl,
-                    duplicate_check: dl,
                 },
                 IR::SimpleProjection {
                     input: _,
                     columns: cr,
-                    duplicate_check: dr,
                 },
-            ) => dl == dr && cl == cr,
+            ) => cl == cr,
             (
                 IR::Select {
                     input: _,

--- a/py-polars/src/lazyframe/visitor/nodes.rs
+++ b/py-polars/src/lazyframe/visitor/nodes.rs
@@ -118,8 +118,6 @@ pub struct DataFrameScan {
 pub struct SimpleProjection {
     #[pyo3(get)]
     input: usize,
-    #[pyo3(get)]
-    duplicate_check: bool,
 }
 
 #[pyclass]
@@ -328,15 +326,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             selection: selection.as_ref().map(|e| e.into()),
         }
         .into_py(py),
-        IR::SimpleProjection {
-            input,
-            columns: _,
-            duplicate_check,
-        } => SimpleProjection {
-            input: input.0,
-            duplicate_check: *duplicate_check,
-        }
-        .into_py(py),
+        IR::SimpleProjection { input, columns: _ } => {
+            SimpleProjection { input: input.0 }.into_py(py)
+        },
         IR::Select {
             input,
             expr,

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -74,7 +74,6 @@ data2 = pl.DataFrame({"field3": [3, 4], "field4": ["C", "D"]})
 def test_concat_diagonal(
     a: pl.DataFrame, b: pl.DataFrame, c: pl.DataFrame, strategy: ConcatMethod
 ) -> None:
-    print(a, b, c);
     for out in [
         pl.concat([a, b, c], how=strategy),
         pl.concat([a.lazy(), b.lazy(), c.lazy()], how=strategy).collect(),

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -74,6 +74,7 @@ data2 = pl.DataFrame({"field3": [3, 4], "field4": ["C", "D"]})
 def test_concat_diagonal(
     a: pl.DataFrame, b: pl.DataFrame, c: pl.DataFrame, strategy: ConcatMethod
 ) -> None:
+    print(a, b, c);
     for out in [
         pl.concat([a, b, c], how=strategy),
         pl.concat([a.lazy(), b.lazy(), c.lazy()], how=strategy).collect(),

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -161,18 +161,12 @@ def test_concat_horizontal_single_df(lazy: bool) -> None:
     assert_frame_equal(out, expected)
 
 
-@pytest.mark.parametrize("lazy", [False, True])
-def test_concat_horizontal_duplicate_col(lazy: bool) -> None:
-    a = pl.DataFrame({"a": ["a", "b"], "b": [1, 2]})
-    b = pl.DataFrame({"c": [5, 7, 8, 9], "d": [1, 2, 1, 2], "a": [1, 2, 1, 2]})
-
-    if lazy:
-        dfs: list[pl.DataFrame] | list[pl.LazyFrame] = [a.lazy(), b.lazy()]
-    else:
-        dfs = [a, b]
+def test_concat_horizontal_duplicate_col() -> None:
+    a = pl.LazyFrame({"a": ["a", "b"], "b": [1, 2]})
+    b = pl.LazyFrame({"c": [5, 7, 8, 9], "d": [1, 2, 1, 2], "a": [1, 2, 1, 2]})
 
     with pytest.raises(pl.DuplicateError):
-        pl.concat(dfs, how="horizontal")  # type: ignore[type-var]
+        pl.concat([a, b], how="horizontal").collect()
 
 
 def test_concat_vertical() -> None:


### PR DESCRIPTION
This also make diagonal concat faster as we did mutliple `with_columns` sequentially. Now they are batched.