### PR TITLE
feat: Support non-coalescing joins in default engine

### DIFF
--- a/crates/polars-lazy/src/physical_plan/streaming/checks.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/checks.rs
@@ -28,7 +28,14 @@ pub(super) fn streamable_join(args: &JoinArgs) -> bool {
     let supported = match args.how {
         #[cfg(feature = "cross_join")]
         JoinType::Cross => true,
-        JoinType::Inner | JoinType::Left | JoinType::Outer { .. } => true,
+        JoinType::Inner | JoinType::Left => {
+            // no-coalescing not yet supported in streaming
+            matches!(
+                args.coalesce,
+                JoinCoalesce::JoinSpecific | JoinCoalesce::CoalesceColumns
+            )
+        },
+        JoinType::Outer { .. } => true,
         _ => false,
     };
     supported && !args.validation.needs_checks()

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6001,6 +6001,7 @@ class DataFrame:
         suffix: str = "_right",
         validate: JoinValidation = "m:m",
         join_nulls: bool = False,
+        coalesce: bool | None = None,
     ) -> DataFrame:
         """
         Join in SQL-like fashion.
@@ -6055,6 +6056,11 @@ class DataFrame:
                 - This is currently not supported the streaming engine.
         join_nulls
             Join on null values. By default null values will never produce matches.
+        coalesce
+            Coalescing behavior (merging of join columns).
+            - None: -> join specific.
+            - True: -> Always coalesce join columns.
+            - False: -> Never coalesce join columns.
 
         Returns
         -------
@@ -6155,6 +6161,7 @@ class DataFrame:
                 suffix=suffix,
                 validate=validate,
                 join_nulls=join_nulls,
+                coalesce=coalesce,
             )
             .collect(_eager=True)
         )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3709,6 +3709,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Force the physical plan to evaluate the computation of both DataFrames up to
             the join in parallel.
 
+
         Examples
         --------
         >>> from datetime import datetime
@@ -3812,6 +3813,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         suffix: str = "_right",
         validate: JoinValidation = "m:m",
         join_nulls: bool = False,
+        coalesce: bool | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
     ) -> Self:
@@ -3835,8 +3837,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 right table
             * *outer*
                  Returns all rows when there is a match in either left or right table
-            * *outer_coalesce*
-                 Same as 'outer', but coalesces the key columns
             * *cross*
                  Returns the Cartesian product of rows from both tables
             * *semi*
@@ -3869,6 +3869,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 - This is currently not supported the streaming engine.
         join_nulls
             Join on null values. By default null values will never produce matches.
+        coalesce
+            Coalescing behavior (merging of join columns).
+            - None: -> join specific.
+            - True: -> Always coalesce join columns.
+            - False: -> Never coalesce join columns.
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both
             DataFrames up to the join in parallel.
@@ -3978,7 +3983,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = "must specify `on` OR `left_on` and `right_on`"
             raise ValueError(msg)
 
-        coalesce = None
         if how == "outer_coalesce":
             coalesce = True
 


### PR DESCRIPTION
closes #14925

Left join still coalesces by default. Would need a breaking release to change the default.