### PR TITLE
fix(python): Correctly handle large timedelta objects in Series constructor

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -107,7 +107,7 @@ def _map_py_type_to_dtype(
     if issubclass(python_dtype, date):
         return Date
     if python_dtype is timedelta:
-        return Duration("us")
+        return Duration
     if python_dtype is time:
         return Time
     if python_dtype is list:

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Any
 
 import pytest
@@ -76,3 +77,14 @@ def test_preserve_decimal_precision() -> None:
     dtype = pl.Decimal(None, 1)
     s = pl.Series(dtype=dtype)
     assert s.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [None, pl.Duration("ms")])
+def test_large_timedelta(dtype: pl.DataType | None) -> None:
+    values = [timedelta.min, timedelta.max]
+    s = pl.Series(values, dtype=dtype)
+    assert s.dtype == pl.Duration("ms")
+
+    # Microsecond precision is lost
+    expected = [timedelta.min, timedelta.max - timedelta(microseconds=999)]
+    assert s.to_list() == expected

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -67,12 +67,8 @@ def test_dtype_temporal_units() -> None:
     assert pl.Duration("ns") != pl.Duration("us")
 
     # check timeunit from pytype
-    for inferred_dtype, expected_dtype in (
-        (py_type_to_dtype(datetime), pl.Datetime),
-        (py_type_to_dtype(timedelta), pl.Duration),
-    ):
-        assert inferred_dtype == expected_dtype
-        assert inferred_dtype.time_unit == "us"  # type: ignore[union-attr]
+    assert py_type_to_dtype(datetime) == pl.Datetime("us")
+    assert py_type_to_dtype(timedelta) == pl.Duration
 
     with pytest.raises(ValueError, match="invalid `time_unit`"):
         pl.Datetime("?")  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #16042