### PR TITLE
feat(python,rust): add date pattern `dd.mm.YYYY`

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/patterns.rs
+++ b/crates/polars-time/src/chunkedarray/string/patterns.rs
@@ -2,6 +2,7 @@
 //! parsing different orders of dates in a single column.
 
 pub(super) static DATE_D_M_Y: &[&str] = &[
+    "%d.%m.%Y", // 31.12.2021
     "%d-%m-%Y", // 31-12-2021
     "%d/%m/%Y", // 31/12/2021
 ];

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -133,6 +133,26 @@ def test_to_date_non_exact_strptime() -> None:
 
 
 @pytest.mark.parametrize(
+    ("time_string", "expected"),
+    [
+        ("01-02-2024", date(2024, 2, 1)),
+        ("01.02.2024", date(2024, 2, 1)),
+        ("01/02/2024", date(2024, 2, 1)),
+        ("2024-02-01", date(2024, 2, 1)),
+        ("2024/02/01", date(2024, 2, 1)),
+        ("31-12-2024", date(2024, 12, 31)),
+        ("31.12.2024", date(2024, 12, 31)),
+        ("31/12/2024", date(2024, 12, 31)),
+        ("2024-12-31", date(2024, 12, 31)),
+        ("2024/12/31", date(2024, 12, 31)),
+    ],
+)
+def test_to_date_all_inferred_date_patterns(time_string: str, expected: date) -> None:
+    result = pl.Series([time_string]).str.to_date()
+    assert result[0] == expected
+
+
+@pytest.mark.parametrize(
     ("value", "attr"),
     [
         ("a", "to_date"),


### PR DESCRIPTION
close #14990

- add `dd.mm.YYYY` date pattern which is widely used.
- enables automatic date inference for `to_date` as well as in `read_csv`
- also added tests for all date patterns

```python
pl.DataFrame({"D.M.Y": ["01.02.2020", "03.04.2020", "31.12.2020"]}).with_columns(
    pl.all().str.to_date()
)

shape: (3, 1)
┌────────────┐
│ D.M.Y      │
│ ---        │
│ date       │
╞════════════╡
│ 2020-02-01 │
│ 2020-04-03 │
│ 2020-12-31 │
└────────────┘


pl.read_csv(
    source="dates\n01.02.2020\n03.04.2020\n31.12.2020".encode(),
    try_parse_dates=True,
)

shape: (3, 1)
┌────────────┐
│ dates      │
│ ---        │
│ date       │
╞════════════╡
│ 2020-02-01 │
│ 2020-04-03 │
│ 2020-12-31 │
└────────────┘
```