### PR TITLE
tests(python): Make `torch` install CI-only by default

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install uv
-          uv pip install --compile-bytecode -r requirements-dev.txt
+          uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt
 
       - name: Set up Rust
         run: rustup show

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ requirements: .venv  ## Install/refresh Python project requirements
 	&& $(VENV_BIN)/uv pip install --upgrade -r py-polars/docs/requirements-docs.txt \
 	&& $(VENV_BIN)/uv pip install --upgrade -r docs/requirements.txt
 
+.PHONY: requirements-all
+requirements-all: .venv  ## Install/refresh all Python requirements (including those needed for CI tests)
+	$(MAKE) requirements
+	$(VENV_BIN)/uv pip install --upgrade --compile-bytecode -r py-polars/requirements-ci.txt
+
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development
 	@unset CONDA_PREFIX \
@@ -80,7 +85,6 @@ build-release-native: .venv  ## Same as build-release, except with native CPU op
 	$(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --release \
 	$(FILTER_PIP_WARNINGS)
 
-
 .PHONY: check
 check:  ## Run cargo check with all features
 	cargo check --workspace --all-targets --all-features
@@ -108,6 +112,7 @@ pre-commit: fmt clippy clippy-default  ## Run all code quality checks
 clean:  ## Clean up caches and build artifacts
 	@$(MAKE) -s -C py-polars/ $@
 	@rm -rf .ruff_cache/
+	@rm -rf .hypothesis/
 	@rm -rf .venv/
 	@cargo clean
 

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -81,7 +81,6 @@ pre-commit: fmt clippy  ## Run all code formatting and lint/quality checks
 
 .PHONY: test
 test: .venv build  ## Run fast unittests
-	@echo "PYTEST_ARGS is set to: $(PYTEST_ARGS)"
 	$(VENV_BIN)/pytest -n auto --dist loadgroup $(PYTEST_ARGS)
 
 .PHONY: test-all

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -15,7 +15,11 @@ endif
 	@$(MAKE) -s -C .. $@
 
 .PHONY: requirements
-requirements: .venv  ## Install/refresh all project requirements
+requirements: .venv  ## Install/refresh Python project requirements
+	@$(MAKE) -s -C .. $@
+
+.PHONY: requirements-all
+requirements-all: .venv  ## Install/refresh all Python requirements (including those needed for CI tests)
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build
@@ -77,7 +81,13 @@ pre-commit: fmt clippy  ## Run all code formatting and lint/quality checks
 
 .PHONY: test
 test: .venv build  ## Run fast unittests
+	@echo "PYTEST_ARGS is set to: $(PYTEST_ARGS)"
 	$(VENV_BIN)/pytest -n auto --dist loadgroup $(PYTEST_ARGS)
+
+.PHONY: test-all
+test-all: .venv build  ## Run all tests
+	$(VENV_BIN)/pytest -n auto --dist loadgroup -m "slow or not slow"
+	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: doctest
 doctest: .venv build  ## Run doctests
@@ -92,11 +102,6 @@ docs: .venv  ## Build Python docs (incremental)
 docs-clean: .venv  ## Build Python docs (full rebuild)
 	@$(MAKE) -s -C docs clean
 	@$(MAKE) docs
-
-.PHONY: test-all
-test-all: .venv build  ## Run all tests
-	$(VENV_BIN)/pytest -n auto --dist loadgroup -m "slow or not slow"
-	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: coverage
 coverage: .venv build  ## Run tests and report coverage

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -305,7 +305,6 @@ __all__ = [
     "_check_for_pandas",
     "_check_for_pyarrow",
     "_check_for_pydantic",
-    "_LazyModule",
     # exported flags/guards
     "_DELTALAKE_AVAILABLE",
     "_PYICEBERG_AVAILABLE",

--- a/py-polars/polars/ml/torch.py
+++ b/py-polars/polars/ml/torch.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="unused-ignore"
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
@@ -26,7 +27,7 @@ except ImportError:
     raise ImportError(msg) from None
 
 
-class PolarsDataset(TensorDataset):
+class PolarsDataset(TensorDataset):  # type: ignore[misc]
     """Specialized TensorDataset for Polars DataFrames."""
 
     tensors: tuple[Tensor, ...]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -102,6 +102,7 @@ module = [
   "pydantic",
   "pyxlsb",
   "sqlalchemy.*",
+  "torch.*",
   "xlsx2csv",
   "xlsxwriter.*",
   "zoneinfo",
@@ -207,14 +208,14 @@ addopts = [
   "--strict-markers",
   "--import-mode=importlib",
   # Default to running fast tests only. To run ALL tests, run: pytest -m ""
-  "-m not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not third_party_integration",
+  "-m not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only",
 ]
 markers = [
+  "ci_only: Tests that should only run on CI by default.",
   "debug: Tests that should be run on a Polars debug build.",
   "docs: Documentation code snippets",
   "release: Tests that should be run on a Polars release build.",
   "slow: Tests with a longer than average runtime.",
-  "third_party_integration: Tests with larger non-core/third party dependencies.",
   "write_disk: Tests that write to disk",
 ]
 filterwarnings = [

--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -1,0 +1,6 @@
+# -------------------------------------------------------
+# Packages that we require for unit tests that run on CI
+# (installable via `make requirements-all`)
+# -------------------------------------------------------
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -20,7 +20,6 @@ numpy
 pandas
 pyarrow
 pydantic>=2.0.0
-torch
 # Datetime / time zones
 backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'


### PR DESCRIPTION
Streamlining the default dev environment...

* Moves `torch` package from "requirements-dev.txt" to new "requirements-ci.txt".
* Ensures that typing lint passes for `polars.ml.torch` with/without local `torch` install.
* Renames the `third_party_integration` marker to `ci_only` to better describe its purpose.
* Adds a `make requirements-all` command that installs the usual dev packages _and_ the "CI only" packages.
* Makes the top-level `torch` import in the "test_to_torch" unit tests lazy-load so that optional absence of the package doesn't cause `pytest` to complain when run locally (the CI runner will always have it installed, so no issue there).

We might want to make a couple of other packages CI-only by default, but for now this only covers the new `torch` integrations.