### PR TITLE
feat(python): split out rolling_*(..., by='foo') into rolling_*_by('foo', ...)

### DIFF
--- a/py-polars/docs/source/reference/expressions/computation.rst
+++ b/py-polars/docs/source/reference/expressions/computation.rst
@@ -56,14 +56,22 @@ Computation
     Expr.rolling_apply
     Expr.rolling_map
     Expr.rolling_max
+    Expr.rolling_max_by
     Expr.rolling_mean
+    Expr.rolling_mean_by
     Expr.rolling_median
+    Expr.rolling_median_by
     Expr.rolling_min
+    Expr.rolling_min_by
     Expr.rolling_quantile
+    Expr.rolling_quantile_by
     Expr.rolling_skew
     Expr.rolling_std
+    Expr.rolling_std_by
     Expr.rolling_sum
+    Expr.rolling_sum_by
     Expr.rolling_var
+    Expr.rolling_var_by
     Expr.search_sorted
     Expr.sign
     Expr.sin

--- a/py-polars/tests/parametric/test_groupby_rolling.py
+++ b/py-polars/tests/parametric/test_groupby_rolling.py
@@ -134,9 +134,9 @@ def test_rolling_aggs(
         )
     )
     df = dataframe.sort("ts")
-    func = f"rolling_{aggregation}"
+    func = f"rolling_{aggregation}_by"
     result = df.with_columns(
-        getattr(pl.col("value"), func)(window_size=window_size, by="ts", closed=closed)
+        getattr(pl.col("value"), func)("ts", window_size=window_size, closed=closed)
     )
 
     expected_dict: dict[str, list[object]] = {"ts": [], "value": []}

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2965,7 +2965,7 @@ def test_rolling_duplicates() -> None:
             "value": [0, 1],
         }
     )
-    assert df.sort("ts").with_columns(pl.col("value").rolling_max("1d", by="ts"))[
+    assert df.sort("ts").with_columns(pl.col("value").rolling_max_by("ts", "1d"))[
         "value"
     ].to_list() == [1, 1]
 


### PR DESCRIPTION
This took...quite some effort

OK if I start with the Python side, so people get the warning sooner rather than later? I've started the Rust side, it's going to take longer to complete. On the plus side, this simplifies _a lot_, really nice suggestion from Orson here