### PR TITLE
docs(python): Ensure consistent docstring warning in `fill_nan` methods (pointing out that `nan` isn't `null`)

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6992,7 +6992,7 @@ class DataFrame:
 
     def fill_null(
         self,
-        value: Any | None = None,
+        value: Any | Expr | None = None,
         strategy: FillNullStrategy | None = None,
         limit: int | None = None,
         *,
@@ -7103,7 +7103,7 @@ class DataFrame:
 
         Warnings
         --------
-        Note that floating point NaNs (Not a Number) are not missing values!
+        Note that floating point NaNs (Not a Number) are not missing values.
         To replace missing values, use :func:`fill_null`.
 
         See Also

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2832,6 +2832,11 @@ class Expr:
         This method is similar to the `LAG` operation in SQL when the value for `n`
         is positive. With a negative value for `n`, it is similar to `LEAD`.
 
+        See Also
+        --------
+        backward_fill
+        forward_fill
+
         Examples
         --------
         By default, values are shifted forward by one index.
@@ -2887,7 +2892,7 @@ class Expr:
 
     def fill_null(
         self,
-        value: Any | None = None,
+        value: Any | Expr | None = None,
         strategy: FillNullStrategy | None = None,
         limit: int | None = None,
     ) -> Self:
@@ -2906,6 +2911,10 @@ class Expr:
         limit
             Number of consecutive null values to fill when using the 'forward' or
             'backward' strategy.
+
+        See Also
+        --------
+        fill_nan
 
         Examples
         --------
@@ -2993,6 +3002,20 @@ class Expr:
         """
         Fill floating point NaN value with a fill value.
 
+        Parameters
+        ----------
+        value
+            Value used to fill NaN values.
+
+        Warnings
+        --------
+        Note that floating point NaNs (Not a Number) are not missing values.
+        To replace missing values, use :func:`fill_null`.
+
+        See Also
+        --------
+        fill_null
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -3025,6 +3048,11 @@ class Expr:
         limit
             The number of consecutive null values to forward fill.
 
+        See Also
+        --------
+        backward_fill
+        shift
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -3055,6 +3083,11 @@ class Expr:
         ----------
         limit
             The number of consecutive null values to backward fill.
+
+        See Also
+        --------
+        forward_fill
+        shift
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4909,7 +4909,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def fill_null(
         self,
-        value: Any | None = None,
+        value: Any | Expr | None = None,
         strategy: FillNullStrategy | None = None,
         limit: int | None = None,
         *,
@@ -4929,6 +4929,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             'backward' strategy.
         matches_supertype
             Fill all matching supertypes of the fill `value` literal.
+
+        See Also
+        --------
+        fill_nan
 
         Examples
         --------
@@ -5046,8 +5050,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Warnings
         --------
-        Note that floating point NaN (Not a Number) are not missing values!
-        To replace missing values, use :func:`fill_null` instead.
+        Note that floating point NaNs (Not a Number) are not missing values.
+        To replace missing values, use :func:`fill_null`.
+
+        See Also
+        --------
+        fill_null
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4843,6 +4843,15 @@ class Series:
         value
             Value used to fill NaN values.
 
+        Warnings
+        --------
+        Note that floating point NaNs (Not a Number) are not missing values.
+        To replace missing values, use :func:`fill_null`.
+
+        See Also
+        --------
+        fill_null
+
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3, float("nan")])
@@ -4859,7 +4868,7 @@ class Series:
 
     def fill_null(
         self,
-        value: Any | None = None,
+        value: Any | Expr | None = None,
         strategy: FillNullStrategy | None = None,
         limit: int | None = None,
     ) -> Series:
@@ -4875,6 +4884,10 @@ class Series:
         limit
             Number of consecutive null values to fill when using the 'forward' or
             'backward' strategy.
+
+        See Also
+        --------
+        fill_nan
 
         Examples
         --------


### PR DESCRIPTION
Closes #16055.

* Turns out we already had docstring warnings to draw attention to `nan` not being `null`, but only on the DataFrame/LazyFrame `fill_nan` methods, not the Expression or Series equivalents - now present on all.
* Made `Expr` an explicit part of the typing, since it _is_ supported (and already covered by tests).
* Added some bonus `See Also` sections to further increase visibility.