### PR TITLE
perf: Ensure better chunk sizes

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1636,7 +1636,7 @@ impl DataFrame {
         let n_threads = POOL.current_num_threads();
 
         let masks = split_ca(mask, n_threads).unwrap();
-        let dfs = split_df(self, n_threads).unwrap();
+        let dfs = split_df(self, n_threads);
         let dfs: PolarsResult<Vec<_>> = POOL.install(|| {
             masks
                 .par_iter()
@@ -2832,7 +2832,7 @@ impl DataFrame {
         &mut self,
         hasher_builder: Option<ahash::RandomState>,
     ) -> PolarsResult<UInt64Chunked> {
-        let dfs = split_df(self, POOL.current_num_threads())?;
+        let dfs = split_df(self, POOL.current_num_threads());
         let (cas, _) = _df_rows_to_hashes_threaded_vertical(&dfs, hasher_builder)?;
 
         let mut iter = cas.into_iter();

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -202,13 +202,13 @@ pub fn split_df_as_ref(df: &DataFrame, target: usize, strict: bool) -> Vec<DataF
 #[doc(hidden)]
 /// Split a [`DataFrame`] into `n` parts. We take a `&mut` to be able to repartition/align chunks.
 /// `strict` in that it respects `n` even if the chunks are suboptimal.
-pub fn split_df(df: &mut DataFrame, n: usize) -> Vec<DataFrame> {
-    if n == 0 || df.height() == 0 {
+pub fn split_df(df: &mut DataFrame, target: usize) -> Vec<DataFrame> {
+    if target == 0 || df.height() == 0 {
         return vec![df.clone()];
     }
     // make sure that chunks are aligned.
     df.align_chunks();
-    split_df_as_ref(df, n, true)
+    split_df_as_ref(df, target, false)
 }
 
 pub fn slice_slice<T>(vals: &[T], offset: i64, len: usize) -> &[T] {

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -137,15 +137,20 @@ pub fn split_series(s: &Series, n: usize) -> PolarsResult<Vec<Series>> {
     split_array!(s, n, i64)
 }
 
-pub fn split_df_as_ref(df: &DataFrame, n: usize, extend_sub_chunks: bool) -> Vec<DataFrame> {
+/// Split a [`DataFrame`] in `target` elements. The target doesn't have to be respected if not
+/// strict. Deviation of the target might be done to create more equal size chunks.
+///
+/// # Panics
+/// if chunks are not aligned
+pub fn split_df_as_ref(df: &DataFrame, target: usize, strict: bool) -> Vec<DataFrame> {
     let total_len = df.height();
     if total_len == 0 {
         return vec![df.clone()];
     }
 
-    let chunk_size = std::cmp::max(total_len / n, 1);
+    let chunk_size = std::cmp::max(total_len / target, 1);
 
-    if df.n_chunks() == n
+    if df.n_chunks() == target
         && df.get_columns()[0]
             .chunk_lengths()
             .all(|len| len.abs_diff(chunk_size) < 100)
@@ -153,22 +158,41 @@ pub fn split_df_as_ref(df: &DataFrame, n: usize, extend_sub_chunks: bool) -> Vec
         return flatten_df_iter(df).collect();
     }
 
-    let mut out = Vec::with_capacity(n);
+    let mut out = Vec::with_capacity(target);
 
-    for i in 0..n {
-        let offset = i * chunk_size;
-        let len = if i == (n - 1) {
-            total_len.saturating_sub(offset)
-        } else {
-            chunk_size
-        };
-        let df = df.slice((i * chunk_size) as i64, len);
-        if extend_sub_chunks && df.n_chunks() > 1 {
-            // we add every chunk as separate dataframe. This make sure that every partition
-            // deals with it.
-            out.extend(flatten_df_iter(&df))
-        } else {
-            out.push(df)
+    if df.n_chunks() == 1 || strict {
+        for i in 0..target {
+            let offset = i * chunk_size;
+            let len = if i == (target - 1) {
+                total_len.saturating_sub(offset)
+            } else {
+                chunk_size
+            };
+            let df = df.slice((i * chunk_size) as i64, len);
+            out.push(df);
+        }
+    } else {
+        let chunks = flatten_df_iter(df);
+
+        'new_chunk: for mut chunk in chunks {
+            loop {
+                let h = chunk.height();
+                if h < chunk_size {
+                    // TODO if the chunk is much smaller than chunk size, we should try to merge it with the next one.
+                    out.push(chunk);
+                    continue 'new_chunk;
+                }
+
+                // If a split leads to the next chunk being smaller than 30% take the whole chunk
+                if ((h - chunk_size) as f64 / chunk_size as f64) < 0.3 {
+                    out.push(chunk);
+                    continue 'new_chunk;
+                }
+
+                // This would be faster if we had a `split` operation.
+                out.push(chunk.slice(0, chunk_size));
+                chunk = chunk.slice(chunk_size as i64, h - chunk_size);
+            }
         }
     }
 

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -729,7 +729,7 @@ impl BatchedParquetReader {
                 // make sure that the chunks are not too large
                 let n = df.shape().0 / self.chunk_size;
                 if n > 1 {
-                    for df in split_df(&mut df, n)? {
+                    for df in split_df(&mut df, n) {
                         self.chunks_fifo.push_back(df)
                     }
                 } else {

--- a/crates/polars-io/src/parquet/write/mod.rs
+++ b/crates/polars-io/src/parquet/write/mod.rs
@@ -6,5 +6,5 @@ mod writer;
 
 pub use batched_writer::BatchedWriter;
 pub use options::{BrotliLevel, GzipLevel, ParquetCompression, ParquetWriteOptions, ZstdLevel};
-pub use polars_parquet::write::RowGroupIter;
+pub use polars_parquet::write::RowGroupIterColumns;
 pub use writer::ParquetWriter;

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -275,11 +275,12 @@ pub(crate) fn chunk_df_for_writing(
 ) -> PolarsResult<Cow<DataFrame>> {
     // ensures all chunks are aligned.
     df.align_chunks();
+    dbg!("PREPARE");
 
     let n_splits = df.height() / row_group_size;
     let result = if n_splits > 0 {
         Cow::Owned(accumulate_dataframes_vertical_unchecked(
-            split_df_as_ref(df, n_splits, false)?
+            split_df_as_ref(df, n_splits, false)
                 .into_iter()
                 .map(|mut df| {
                     // If the chunks are small enough, writing many small chunks
@@ -287,8 +288,10 @@ pub(crate) fn chunk_df_for_writing(
                     // merge them.
                     let n_chunks = df.n_chunks();
                     if n_chunks > 1 && (df.estimated_size() / n_chunks < 128 * 1024) {
+                        dbg!(df.height(), "rechunk");
                         df.as_single_chunk_par();
                     }
+                    dbg!(df.height(), df.n_chunks());
                     df
                 }),
         ))

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
@@ -71,13 +71,13 @@ fn run_partitions(
     // We do a partitioned group_by.
     // Meaning that we first do the group_by operation arbitrarily
     // split on several threads. Than the final result we apply the same group_by again.
-    let dfs = split_df(df, n_threads)?;
+    let dfs = split_df(df, n_threads);
 
     let phys_aggs = &exec.phys_aggs;
     let keys = &exec.phys_keys;
 
     let mut keys = DataFrame::from_iter(compute_keys(keys, df, state)?);
-    let splitted_keys = split_df(&mut keys, n_threads)?;
+    let splitted_keys = split_df(&mut keys, n_threads);
 
     POOL.install(|| {
         dfs.into_par_iter()

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -317,8 +317,8 @@ where
     let right_val_arr = right_asof.downcast_iter().next().unwrap();
 
     let n_threads = POOL.current_num_threads();
-    let split_by_left = split_df(by_left, n_threads).unwrap();
-    let split_by_right = split_df(by_right, n_threads).unwrap();
+    let split_by_left = split_df(by_left, n_threads);
+    let split_by_right = split_df(by_right, n_threads);
 
     let (build_hashes, random_state) =
         _df_rows_to_hashes_threaded_vertical(&split_by_right, None).unwrap();

--- a/crates/polars-parquet/src/arrow/write/file.rs
+++ b/crates/polars-parquet/src/arrow/write/file.rs
@@ -6,7 +6,7 @@ use polars_error::{PolarsError, PolarsResult};
 use super::schema::schema_to_metadata_key;
 use super::{to_parquet_schema, ThriftFileMetaData, WriteOptions};
 use crate::parquet::metadata::{KeyValue, SchemaDescriptor};
-use crate::parquet::write::{RowGroupIter, WriteOptions as FileWriteOptions};
+use crate::parquet::write::{RowGroupIterColumns, WriteOptions as FileWriteOptions};
 
 /// Attaches [`ArrowSchema`] to `key_value_metadata`
 pub fn add_arrow_schema(
@@ -71,7 +71,7 @@ impl<W: Write> FileWriter<W> {
     }
 
     /// Writes a row group to the file.
-    pub fn write(&mut self, row_group: RowGroupIter<'_, PolarsError>) -> PolarsResult<()> {
+    pub fn write(&mut self, row_group: RowGroupIterColumns<'_, PolarsError>) -> PolarsResult<()> {
         Ok(self.writer.write(row_group)?)
     }
 

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -45,8 +45,8 @@ pub use crate::parquet::schema::types::{
     FieldInfo, ParquetType, PhysicalType as ParquetPhysicalType,
 };
 pub use crate::parquet::write::{
-    compress, write_metadata_sidecar, Compressor, DynIter, DynStreamingIterator, RowGroupIter,
-    Version,
+    compress, write_metadata_sidecar, Compressor, DynIter, DynStreamingIterator,
+    RowGroupIterColumns, Version,
 };
 pub use crate::parquet::{fallible_streaming_iterator, FallibleStreamingIterator};
 

--- a/crates/polars-parquet/src/arrow/write/row_group.rs
+++ b/crates/polars-parquet/src/arrow/write/row_group.rs
@@ -4,15 +4,15 @@ use arrow::record_batch::RecordBatchT;
 use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};
 
 use super::{
-    array_to_columns, to_parquet_schema, DynIter, DynStreamingIterator, Encoding, RowGroupIter,
-    SchemaDescriptor, WriteOptions,
+    array_to_columns, to_parquet_schema, DynIter, DynStreamingIterator, Encoding,
+    RowGroupIterColumns, SchemaDescriptor, WriteOptions,
 };
 use crate::parquet::error::Error as ParquetError;
 use crate::parquet::schema::types::ParquetType;
 use crate::parquet::write::Compressor;
 use crate::parquet::FallibleStreamingIterator;
 
-/// Maps a [`RecordBatchT`] and parquet-specific options to an [`RowGroupIter`] used to
+/// Maps a [`RecordBatchT`] and parquet-specific options to an [`RowGroupIterColumns`] used to
 /// write to parquet
 /// # Panics
 /// Iff
@@ -23,7 +23,7 @@ pub fn row_group_iter<A: AsRef<dyn Array> + 'static + Send + Sync>(
     encodings: Vec<Vec<Encoding>>,
     fields: Vec<ParquetType>,
     options: WriteOptions,
-) -> RowGroupIter<'static, PolarsError> {
+) -> RowGroupIterColumns<'static, PolarsError> {
     assert_eq!(encodings.len(), fields.len());
     assert_eq!(encodings.len(), chunk.arrays().len());
     DynIter::new(
@@ -108,7 +108,7 @@ impl<
         I: Iterator<Item = PolarsResult<RecordBatchT<A>>>,
     > Iterator for RowGroupIterator<A, I>
 {
-    type Item = PolarsResult<RowGroupIter<'static, PolarsError>>;
+    type Item = PolarsResult<RowGroupIterColumns<'static, PolarsError>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let options = self.options;

--- a/crates/polars-parquet/src/parquet/write/file.rs
+++ b/crates/polars-parquet/src/parquet/write/file.rs
@@ -6,7 +6,7 @@ use parquet_format_safe::RowGroup;
 use super::indexes::{write_column_index, write_offset_index};
 use super::page::PageWriteSpec;
 use super::row_group::write_row_group;
-use super::{RowGroupIter, WriteOptions};
+use super::{RowGroupIterColumns, WriteOptions};
 use crate::parquet::error::{Error, Result};
 pub use crate::parquet::metadata::KeyValue;
 use crate::parquet::metadata::{SchemaDescriptor, ThriftFileMetaData};
@@ -146,7 +146,7 @@ impl<W: Write> FileWriter<W> {
     /// Writes a row group to the file.
     ///
     /// This call is IO-bounded
-    pub fn write<E>(&mut self, row_group: RowGroupIter<'_, E>) -> Result<()>
+    pub fn write<E>(&mut self, row_group: RowGroupIterColumns<'_, E>) -> Result<()>
     where
         Error: From<E>,
         E: std::error::Error,

--- a/crates/polars-parquet/src/parquet/write/mod.rs
+++ b/crates/polars-parquet/src/parquet/write/mod.rs
@@ -20,8 +20,10 @@ pub use row_group::ColumnOffsetsMetadata;
 
 use crate::parquet::page::CompressedPage;
 
-pub type RowGroupIter<'a, E> =
-    DynIter<'a, std::result::Result<DynStreamingIterator<'a, CompressedPage, E>, E>>;
+pub type RowGroupIterColumns<'a, E> =
+    DynIter<'a, Result<DynStreamingIterator<'a, CompressedPage, E>, E>>;
+
+pub type RowGroupIter<'a, E> = DynIter<'a, RowGroupIterColumns<'a, E>>;
 
 /// Write options of different interfaces on this crate
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/polars-parquet/src/parquet/write/row_group.rs
+++ b/crates/polars-parquet/src/parquet/write/row_group.rs
@@ -98,7 +98,6 @@ where
     let bytes_written = offset - initial;
 
     let num_rows = compute_num_rows(&columns)?;
-    dbg!(num_rows);
 
     // compute row group stats
     let file_offset = columns

--- a/crates/polars-parquet/src/parquet/write/row_group.rs
+++ b/crates/polars-parquet/src/parquet/write/row_group.rs
@@ -98,6 +98,7 @@ where
     let bytes_written = offset - initial;
 
     let num_rows = compute_num_rows(&columns)?;
+    dbg!(num_rows);
 
     // compute row group stats
     let file_offset = columns

--- a/crates/polars-parquet/src/parquet/write/stream.rs
+++ b/crates/polars-parquet/src/parquet/write/stream.rs
@@ -5,7 +5,7 @@ use parquet_format_safe::thrift::protocol::TCompactOutputStreamProtocol;
 use parquet_format_safe::{FileMetaData, RowGroup};
 
 use super::row_group::write_row_group_async;
-use super::{RowGroupIter, WriteOptions};
+use super::{RowGroupIterColumns, WriteOptions};
 use crate::parquet::error::{Error, Result};
 use crate::parquet::metadata::{KeyValue, SchemaDescriptor};
 use crate::parquet::write::indexes::{write_column_index_async, write_offset_index_async};
@@ -107,7 +107,7 @@ impl<W: AsyncWrite + Unpin + Send> FileStreamer<W> {
     }
 
     /// Writes a row group to the file.
-    pub async fn write<E>(&mut self, row_group: RowGroupIter<'_, E>) -> Result<()>
+    pub async fn write<E>(&mut self, row_group: RowGroupIterColumns<'_, E>) -> Result<()>
     where
         Error: From<E>,
         E: std::error::Error,

--- a/crates/polars-pipe/src/executors/sinks/group_by/ooc.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/ooc.rs
@@ -99,7 +99,7 @@ impl Source for GroupBySource {
                             }
                         }
 
-                        let dfs = split_df(&mut df, self.morsels_per_sink).unwrap();
+                        let dfs = split_df(&mut df, self.morsels_per_sink);
                         let chunks = dfs
                             .into_iter()
                             .map(|data| {

--- a/crates/polars-pipe/src/executors/sinks/output/parquet.rs
+++ b/crates/polars-pipe/src/executors/sinks/output/parquet.rs
@@ -4,13 +4,15 @@ use std::thread::JoinHandle;
 
 use crossbeam_channel::{bounded, Receiver, Sender};
 use polars_core::prelude::*;
-use polars_io::parquet::write::{BatchedWriter, ParquetWriteOptions, ParquetWriter, RowGroupIter};
+use polars_io::parquet::write::{
+    BatchedWriter, ParquetWriteOptions, ParquetWriter, RowGroupIterColumns,
+};
 
 use crate::executors::sinks::output::file_sink::{init_writer_thread, FilesSink, SinkWriter};
 use crate::operators::{DataChunk, FinalizedSink, PExecutionContext, Sink, SinkResult};
 use crate::pipeline::morsels_per_sink;
 
-type RowGroups = Vec<RowGroupIter<'static, PolarsError>>;
+type RowGroups = Vec<RowGroupIterColumns<'static, PolarsError>>;
 
 pub(super) fn init_row_group_writer_thread(
     receiver: Receiver<Option<(IdxSize, RowGroups)>>,

--- a/crates/polars-pipe/src/executors/sinks/sort/source.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/source.rs
@@ -133,7 +133,7 @@ impl SortSource {
         }?;
 
         // convert to chunks
-        let dfs = split_df(&mut df, self.n_threads)?;
+        let dfs = split_df(&mut df, self.n_threads);
         Ok(SourceResult::GotMoreData(self.finish_batch(dfs)))
     }
     fn print_verbose(&self, verbose: bool) {

--- a/crates/polars-pipe/src/executors/sources/frame.rs
+++ b/crates/polars-pipe/src/executors/sources/frame.rs
@@ -18,7 +18,7 @@ pub struct DataFrameSource {
 impl DataFrameSource {
     pub(crate) fn from_df(mut df: DataFrame) -> Self {
         let n_threads = POOL.current_num_threads();
-        let dfs = split_df(&mut df, n_threads).unwrap();
+        let dfs = split_df(&mut df, n_threads);
         let dfs = dfs.into_iter().enumerate();
         Self { dfs, n_threads }
     }

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -16,8 +16,8 @@ fn test_chunked_left_join() -> PolarsResult<()> {
         "plays" => ["guitar", "bass", "guitar"]
     ]?;
 
-    let band_instruments = accumulate_dataframes_vertical(split_df(&mut band_instruments, 2)?)?;
-    let band_members = accumulate_dataframes_vertical(split_df(&mut band_members, 2)?)?;
+    let band_instruments = accumulate_dataframes_vertical(split_df(&mut band_instruments, 2))?;
+    let band_members = accumulate_dataframes_vertical(split_df(&mut band_members, 2))?;
     assert_eq!(band_instruments.n_chunks(), 2);
     assert_eq!(band_members.n_chunks(), 2);
 


### PR DESCRIPTION
If a chunk in a DataFrame was 100k rows and we split at 100k - 1 we wrote row-groups of 1, which is terrible. This ensures we keep reasonable sized chunks.