### PR TITLE
ci(python): Update benchmarks/coverage jobs with "requirements-ci"

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install Python dependencies
         working-directory: py-polars
-        run: uv pip install --compile-bytecode -r requirements-dev.txt
+        run: uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt
 
       - name: Set up Rust
         run: rustup show

--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -16,13 +16,13 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.client_payload.sha }}
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        config-file: docs/mlc-config.json
-        folder-path: docs
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.sha }}
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: docs/mlc-config.json
+          folder-path: docs
 
   lint:
     runs-on: ubuntu-latest
@@ -70,8 +70,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          uv pip install -r py-polars/requirements-dev.txt
-          uv pip install -r docs/requirements.txt
+          uv pip install -r py-polars/requirements-dev.txt -r docs/requirements.txt
 
       - name: Set up Rust
         run: rustup show

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -59,8 +59,7 @@ jobs:
       - name: Install Python dependencies
         working-directory: py-polars
         run: |
-          uv pip install -r requirements-dev.txt
-          uv pip install -r requirements-lint.txt
+          uv pip install -r requirements-dev.txt -r requirements-lint.txt
 
       # Allow untyped calls for older Python versions
       - name: Run mypy

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Install Python dependencies
         working-directory: py-polars
-        run: uv pip install --compile-bytecode -r requirements-dev.txt
+        run: uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt
 
       - name: Set up Rust
         run: rustup component add llvm-tools-preview


### PR DESCRIPTION
Added "requirements-ci.txt" where missing and tweaked some `uv` calls (by using `-r ` twice) so they only have to do a single resolve instead of two.