### PR TITLE
docs(python): improve docstring of `(Expr|Series).map_elements`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4609,6 +4609,8 @@ class Expr:
               `pl.col("col_name").sqrt()`.
             - For mapping inner elements of lists, consider:
               `pl.col("col_name").list.eval(pl.element().sqrt())`.
+            - For mapping inner elements of structs, consider:
+              `pl.col("col_name").struct.field("field_name").sqrt()`.
 
         The UDF is applied to each element of a column. Note that, in a GroupBy
         context, the column will have been pre-aggregated and so each element

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4613,7 +4613,8 @@ class Expr:
               `pl.col("col_name").struct.field("field_name").sqrt()`.
 
             If you want to replace the original column or field,
-            consider `.with_columns` and `.with_fields`.
+            consider :meth:`.with_columns <polars.DataFrame.with_columns>`
+            and :meth:`.with_fields <polars.Expr.struct.with_fields>`.
 
             >>> new_expr = pl.col("col_name").sqrt()
             >>> df.with_columns(new_expr)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4616,12 +4616,6 @@ class Expr:
             consider :meth:`.with_columns <polars.DataFrame.with_columns>`
             and :meth:`.with_fields <polars.Expr.struct.with_fields>`.
 
-            >>> new_expr = pl.col("col_name").sqrt()
-            >>> df.with_columns(new_expr)
-
-            >>> new_expr = pl.col("col_name").struct.field("field_name").sqrt()
-            >>> df.with_columns(pl.col("col_name").struct.with_fields(new_expr))
-
         The UDF is applied to each element of a column. Note that, in a GroupBy
         context, the column will have been pre-aggregated and so each element
         will itself be a Series. Therefore, depending on the context,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4609,8 +4609,17 @@ class Expr:
               `pl.col("col_name").sqrt()`.
             - For mapping inner elements of lists, consider:
               `pl.col("col_name").list.eval(pl.element().sqrt())`.
-            - For mapping inner elements of structs, consider:
+            - For mapping elements of struct fields, consider:
               `pl.col("col_name").struct.field("field_name").sqrt()`.
+
+            If you want to replace the original column or field,
+            consider `.with_columns` and `.with_fields`.
+
+            >>> new_expr = pl.col("col_name").sqrt()
+            >>> df.with_columns(new_expr)
+
+            >>> new_expr = pl.col("col_name").struct.field("field_name").sqrt()
+            >>> df.with_columns(pl.col("col_name").struct.with_fields(new_expr))
 
         The UDF is applied to each element of a column. Note that, in a GroupBy
         context, the column will have been pre-aggregated and so each element

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5477,7 +5477,7 @@ class Series:
             - For mapping elements of a series, consider: `s.sqrt()`.
             - For mapping inner elements of lists, consider:
               `s.list.eval(pl.element().sqrt())`.
-            - For mapping inner elements of structs, consider:
+            - For mapping elements of struct fields, consider:
               `s.struct.field("field_name").sqrt()`.
 
         If the function returns a different datatype, the return_dtype arg should

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5477,6 +5477,8 @@ class Series:
             - For mapping elements of a series, consider: `s.sqrt()`.
             - For mapping inner elements of lists, consider:
               `s.list.eval(pl.element().sqrt())`.
+            - For mapping inner elements of structs, consider:
+              `s.struct.field("field_name").sqrt()`.
 
         If the function returns a different datatype, the return_dtype arg should
         be set, otherwise the method will fail.


### PR DESCRIPTION
Mention:
`col("col_name").struct.field("field_name").native_method()`.

(Follow-up on #15887).