### PR TITLE
feat(python): Support passing instantiated adbc/alchemy connection objects to `write_database`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3332,8 +3332,8 @@ class DataFrame:
 
             import_optional(
                 module_name="sqlalchemy",
-                min_prefix="pandas >= 2.2 requires",
                 min_version=("2.0" if pd_version >= parse_version("2.2") else "1.4"),
+                min_err_prefix="pandas >= 2.2 requires",
             )
             # note: the catalog (database) should be a part of the connection string
             from sqlalchemy.engine import create_engine

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -144,6 +144,7 @@ if TYPE_CHECKING:
         ColumnWidthsDefinition,
         ComparisonOperator,
         ConditionalFormatDict,
+        ConnectionOrCursor,
         CsvQuoteStyle,
         DbWriteEngine,
         FillNullStrategy,
@@ -3161,13 +3162,14 @@ class DataFrame:
     def write_database(
         self,
         table_name: str,
-        connection: str,
+        connection: ConnectionOrCursor | str,
         *,
         if_table_exists: DbWriteMode = "fail",
-        engine: DbWriteEngine = "sqlalchemy",
+        engine: DbWriteEngine | None = None,
+        engine_options: dict[str, Any] | None = None,
     ) -> int:
         """
-        Write a polars frame to a database.
+        Write the data in a Polars DataFrame to a database.
 
         Parameters
         ----------
@@ -3176,7 +3178,8 @@ class DataFrame:
             SQL database. If your table name contains special characters, it should
             be quoted.
         connection
-            Connection URI string, for example:
+            An existing SQLAlchemy or ADBC connection against the target database, or
+            a URI string that will be used to instantiate such a connection, such as:
 
             * "postgresql://user:pass@server:port/database"
             * "sqlite:////path/to/database.db"
@@ -3187,7 +3190,38 @@ class DataFrame:
             * 'append' will append to an existing table.
             * 'fail' will fail if table already exists.
         engine : {'sqlalchemy', 'adbc'}
-            Select the engine to use for writing frame data.
+            Select the engine to use for writing frame data; only necessary when
+            supplying a URI string (defaults to 'sqlalchemy' if unset)
+        engine_options
+            Additional options to pass to the engine's associated insert method:
+
+            * "sqlalchemy" - currently inserts using Pandas' `to_sql` method, though
+              this will eventually be phased out in favour of a native solution.
+            * "adbc" - inserts using the ADBC cursor's `adbc_ingest` method.
+
+        Examples
+        --------
+        Insert into a temporary table using a PostgreSQL URI and the ADBC engine:
+
+        >>> df.write_database(
+        ...     table_name="target_table",
+        ...     connection="postgresql://user:pass@server:port/database",
+        ...     engine="adbc",
+        ...     engine_options={"temporary": True},
+        ... )  # doctest: +SKIP
+
+        Insert into a table using a `pyodbc` SQLAlchemy connection to SQL Server
+        that was instantiated with "fast_executemany=True" to improve performance:
+
+        >>> pyodbc_uri = (
+        ...     "mssql+pyodbc://user:pass@server:1433/test?"
+        ...     "driver=ODBC+Driver+18+for+SQL+Server"
+        ... )
+        >>> engine = create_engine(pyodbc_uri, fast_executemany=True)  # doctest: +SKIP
+        >>> df.write_database(
+        ...     table_name="target_table",
+        ...     connection=engine,
+        ... )  # doctest: +SKIP
 
         Returns
         -------
@@ -3199,6 +3233,16 @@ class DataFrame:
             allowed = ", ".join(repr(m) for m in valid_write_modes)
             msg = f"write_database `if_table_exists` must be one of {{{allowed}}}, got {if_table_exists!r}"
             raise ValueError(msg)
+
+        if engine is None:
+            if (
+                isinstance(connection, str)
+                or (module_root := type(connection).__module__.split(".", 1)[0])
+                == "sqlalchemy"
+            ):
+                engine = "sqlalchemy"
+            elif module_root.startswith("adbc"):
+                engine = "adbc"
 
         def unpack_table_name(name: str) -> tuple[str | None, str | None, str]:
             """Unpack optionally qualified table name to catalog/schema/table tuple."""
@@ -3237,7 +3281,12 @@ class DataFrame:
                 )
                 raise ValueError(msg)
 
-            with _open_adbc_connection(connection) as conn, conn.cursor() as cursor:
+            conn = (
+                _open_adbc_connection(connection)
+                if isinstance(connection, str)
+                else connection
+            )
+            with conn, conn.cursor() as cursor:
                 catalog, db_schema, unpacked_table_name = unpack_table_name(table_name)
                 n_rows: int
                 if adbc_version >= (0, 7):
@@ -3265,26 +3314,35 @@ class DataFrame:
                     )
                 else:
                     n_rows = cursor.adbc_ingest(
-                        unpacked_table_name, self.to_arrow(), mode
+                        table_name=unpacked_table_name,
+                        data=self.to_arrow(),
+                        mode=mode,
+                        **(engine_options or {}),
                     )
                 conn.commit()
             return n_rows
 
         elif engine == "sqlalchemy":
             if not _PANDAS_AVAILABLE:
-                msg = "writing with engine 'sqlalchemy' currently requires pandas.\n\nInstall with: pip install pandas"
+                msg = "writing with 'sqlalchemy' engine currently requires pandas.\n\nInstall with: pip install pandas"
                 raise ModuleNotFoundError(msg)
-            elif parse_version(pd.__version__) < (1, 5):
-                msg = f"writing with engine 'sqlalchemy' requires pandas 1.5.x or higher, found {pd.__version__!r}"
+            elif (pd_version := parse_version(pd.__version__)) < (1, 5):
+                msg = f"writing with 'sqlalchemy' engine requires pandas >= 1.5; found {pd.__version__!r}"
                 raise ModuleUpgradeRequired(msg)
-            try:
-                from sqlalchemy import create_engine
-            except ModuleNotFoundError as exc:
-                msg = "'sqlalchemy' not found\n\nInstall with: pip install polars[sqlalchemy]"
-                raise ModuleNotFoundError(msg) from exc
 
+            import_optional(
+                module_name="sqlalchemy",
+                min_prefix="pandas >= 2.2 requires",
+                min_version=("2.0" if pd_version >= parse_version("2.2") else "1.4"),
+            )
             # note: the catalog (database) should be a part of the connection string
-            engine_sa = create_engine(connection)
+            from sqlalchemy.engine import create_engine
+
+            engine_sa = (
+                create_engine(connection)
+                if isinstance(connection, str)
+                else connection.engine  # type: ignore[union-attr]
+            )
             catalog, db_schema, unpacked_table_name = unpack_table_name(table_name)
             if catalog:
                 msg = f"Unexpected three-part table name; provide the database/catalog ({catalog!r}) on the connection URI"
@@ -3300,11 +3358,16 @@ class DataFrame:
                 con=engine_sa,
                 if_exists=if_table_exists,
                 index=False,
+                **(engine_options or {}),
             )
             return -1 if res is None else res
-        else:
+
+        elif isinstance(engine, str):
             msg = f"engine {engine!r} is not supported"
             raise ValueError(msg)
+        else:
+            msg = f"unrecognised connection type {connection!r}"
+            raise TypeError(msg)
 
     @overload
     def write_delta(

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -229,6 +229,7 @@ def import_optional(
     err_prefix: str = "required package",
     err_suffix: str = "not found",
     min_version: str | tuple[int, ...] | None = None,
+    min_prefix: str = "requires",
     install_message: str | None = None,
 ) -> Any:
     """
@@ -244,6 +245,8 @@ def import_optional(
         Error suffix to use in the raised exception (follows the module name).
     min_version : {str, tuple[int]}, optional
         If a minimum module version is required, specify it here.
+    min_prefix : str, optional
+        Override the standard "requires" prefix for the minimum version error message.
     install_message : str, optional
         Override the standard "Please install it using..." exception message fragment.
 
@@ -268,7 +271,7 @@ def import_optional(
         suffix = f" {err_suffix.strip(' ')}" if err_suffix else ""
         err_message = f"{prefix}'{module_name}'{suffix}.\n" + (
             install_message
-            or f"Please install it using the command `pip install {module_root}`."
+            or f"Please install using the command `pip install {module_root}`."
         )
         raise ModuleNotFoundError(err_message) from None
 
@@ -276,7 +279,11 @@ def import_optional(
         min_version = parse_version(min_version)
         mod_version = parse_version(module.__version__)
         if mod_version < min_version:
-            msg = f"requires {module_root} {min_version} or higher; found {mod_version}"
+            msg = (
+                f"{min_prefix} {module_root} "
+                f"{'.'.join(str(v) for v in min_version)} or higher"
+                f" (found {'.'.join(str(v) for v in mod_version)})"
+            )
             raise ModuleUpgradeRequired(msg)
 
     return module

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -229,7 +229,7 @@ def import_optional(
     err_prefix: str = "required package",
     err_suffix: str = "not found",
     min_version: str | tuple[int, ...] | None = None,
-    min_prefix: str = "requires",
+    min_err_prefix: str = "requires",
     install_message: str | None = None,
 ) -> Any:
     """
@@ -245,7 +245,7 @@ def import_optional(
         Error suffix to use in the raised exception (follows the module name).
     min_version : {str, tuple[int]}, optional
         If a minimum module version is required, specify it here.
-    min_prefix : str, optional
+    min_err_prefix : str, optional
         Override the standard "requires" prefix for the minimum version error message.
     install_message : str, optional
         Override the standard "Please install it using..." exception message fragment.
@@ -280,7 +280,7 @@ def import_optional(
         mod_version = parse_version(module.__version__)
         if mod_version < min_version:
             msg = (
-                f"{min_prefix} {module_root} "
+                f"{min_err_prefix} {module_root} "
                 f"{'.'.join(str(v) for v in min_version)} or higher"
                 f" (found {'.'.join(str(v) for v in mod_version)})"
             )

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -22,7 +22,7 @@ from typing import (
 if TYPE_CHECKING:
     import sys
 
-    from sqlalchemy import Engine
+    from sqlalchemy.engine import Connection, Engine
     from sqlalchemy.orm import Session
 
     from polars import DataFrame, Expr, LazyFrame, Series
@@ -247,4 +247,5 @@ class Cursor(BasicCursor):  # noqa: D101
         """Fetch results in batches."""
 
 
-ConnectionOrCursor = Union[BasicConnection, BasicCursor, Cursor, "Engine", "Session"]
+AlchemyConnection = Union["Connection", "Engine", "Session"]
+ConnectionOrCursor = Union[BasicConnection, BasicCursor, Cursor, AlchemyConnection]


### PR DESCRIPTION
Closes #16095.
Closes #16053.
Closes #15538.

Also: ref #7852.

---

So, The Great Database Write Rewrite™ is still pending, but this PR closes a number of outstanding Issues and enables various opt-in speedups to ensure that we can take better advantage of the underlying engines that we currently call into.

ℹ️ This is a non-breaking change; all existing usage is unaffected.

## Updates

* Can now supply an instantiated SQLAlchemy or ADBC connection directly; no longer limited to passing just the URI.
* This allows such connections to be established with specific optimisations, such as `fast_executemany` for pyodbc mssql connections, and other per-connection configuration parameters.
* Adds a new `engine_options` parameter that gets passed down to the chosen engine's underlying insert method (eg: pandas' `to_sql` if using SQLAlchemy, or `adbc_ingest` if using ADBC).

## Examples

Establish a pyodbc connection using "fast_executemany=True" and insert using that:
```python
from sqlalchemy import create_engine
import polars as pl

pyodbc_uri = (
    "mssql+pyodbc://user:pass@server:1433/test?"
    "driver=ODBC+Driver+18+for+SQL+Server"
)
conn = create_engine(pyodbc_uri, fast_executemany=True)

df.write_database(
    table_name="target_table",
    connection=conn,
)
```
Use a regular URI connection and pass "method='multi'" down to the `to_sql` insert method:
```python
df.write_database(
    connection="hive://user:pass@server:port/database",
    table_name="target_table",
    engine="sqlalchemy",
    engine_options={"method": "multi"},
)
```