### PR TITLE
fix(python): Improve error handling of `ParameterCollisionError` in `read_excel`

### DIFF
--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -503,13 +503,17 @@ def _read_spreadsheet(
 
     # normalise some top-level parameters to 'read_options' entries
     if engine == "calamine":
-        if ("schema_sample_rows" in read_options) and (infer_schema_length != N_INFER_DEFAULT):
+        if ("schema_sample_rows" in read_options) and (
+            infer_schema_length != N_INFER_DEFAULT
+        ):
             msg = 'cannot specify both `infer_schema_length` and `read_options["schema_sample_rows"]`'
             raise ParameterCollisionError(msg)
         read_options["schema_sample_rows"] = infer_schema_length
 
     elif engine == "xlsx2csv":
-        if ("infer_schema_length" in read_options) and (infer_schema_length != N_INFER_DEFAULT):
+        if ("infer_schema_length" in read_options) and (
+            infer_schema_length != N_INFER_DEFAULT
+        ):
             msg = 'cannot specify both `infer_schema_length` and `read_options["infer_schema_length"]`'
             raise ParameterCollisionError(msg)
         read_options["infer_schema_length"] = infer_schema_length

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -503,13 +503,13 @@ def _read_spreadsheet(
 
     # normalise some top-level parameters to 'read_options' entries
     if engine == "calamine":
-        if "schema_sample_rows" in read_options:
+        if ("schema_sample_rows" in read_options) and (infer_schema_length != N_INFER_DEFAULT):
             msg = 'cannot specify both `infer_schema_length` and `read_options["schema_sample_rows"]`'
             raise ParameterCollisionError(msg)
         read_options["schema_sample_rows"] = infer_schema_length
 
     elif engine == "xlsx2csv":
-        if "infer_schema_length" in read_options:
+        if ("infer_schema_length" in read_options) and (infer_schema_length != N_INFER_DEFAULT):
             msg = 'cannot specify both `infer_schema_length` and `read_options["infer_schema_length"]`'
             raise ParameterCollisionError(msg)
         read_options["infer_schema_length"] = infer_schema_length


### PR DESCRIPTION
#15808  introduces a collision check between infer_schema_length and read_options["schema_sample_rows"]. However, users who previously specified only the `infer_schema_length` in `read_options` may still encounter the `ParameterCollisionError`.