### PR TITLE
tests(python): Support skipping doctests associated with optional modules

### DIFF
--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import doctest
 import importlib
+import re
 import sys
 import unittest
 import warnings
@@ -53,6 +54,22 @@ if sys.version_info < (3, 12):
         stacklevel=2,
     )
 
+# associate specific doctest method names with optional modules.
+# if the module is found in the environment those doctests will
+# run; if the module is not found, their doctests are skipped.
+OPTIONAL_MODULES_AND_METHODS: dict[str, set[str]] = {
+    "torch": {"to_torch"},
+}
+OPTIONAL_MODULES: set[str] = set()
+SKIP_METHODS: set[str] = set()
+
+for mod, methods in OPTIONAL_MODULES_AND_METHODS.items():
+    try:
+        importlib.import_module(mod)
+    except ImportError:
+        SKIP_METHODS.update(methods)
+        OPTIONAL_MODULES.add(mod)
+
 
 def doctest_teardown(d: doctest.DocTest) -> None:
     # don't let config changes or string cache state leak between tests
@@ -62,11 +79,26 @@ def doctest_teardown(d: doctest.DocTest) -> None:
 
 def modules_in_path(p: Path) -> Iterator[ModuleType]:
     for file in p.rglob("*.py"):
-        # Construct path as string for import, for instance "dataframe.frame"
-        # The -3 drops the ".py"
-        file_name_import = ".".join(file.relative_to(p).parts)[:-3]
-        temp_module = importlib.import_module(p.name + "." + file_name_import)
-        yield temp_module
+        # Construct path as string for import, for instance "dataframe.frame".
+        # (The -3 drops the ".py")
+        try:
+            file_name_import = ".".join(file.relative_to(p).parts)[:-3]
+            temp_module = importlib.import_module(p.name + "." + file_name_import)
+            yield temp_module
+        except ImportError as err:
+            if not any(re.search(rf"\b{mod}\b", str(err)) for mod in OPTIONAL_MODULES):
+                raise
+
+
+class FilteredTestSuite(unittest.TestSuite):  # noqa: D101
+    def __iter__(self) -> Iterator[Any]:
+        for suite in self._tests:
+            suite._tests = [  # type: ignore[attr-defined]
+                test
+                for test in suite._tests  # type: ignore[attr-defined]
+                if test.id().rsplit(".", 1)[-1] not in SKIP_METHODS
+            ]
+            yield suite
 
 
 if __name__ == "__main__":
@@ -127,12 +159,12 @@ if __name__ == "__main__":
             doctest.DocTestSuite(
                 m,
                 extraglobs={"pl": polars, "dirpath": Path(tmpdir)},
-                optionflags=1,
                 tearDown=doctest_teardown,
+                optionflags=1,
             )
             for m in modules_in_path(src_dir)
         ]
-        test_suite = unittest.TestSuite(tests)
+        test_suite = FilteredTestSuite(tests)
 
         # Ensure that we clean up any artifacts produced by the doctests
         # with patch(polars.DataFrame.write_csv):


### PR DESCRIPTION
@MarcoGorelli 😁 

Further refines the optional nature of certain modules in the standard dev environment...

Adds a registration point in the `run_doctests` script that allows the "to_torch" doctests to be transparently skipped if the user has not installed the `torch` package; if they have it, the tests _do_ run (so the developers of such functionality will still be able to validate their doctests). Generic enough that we can register other modules/method associations as needed.