### PR TITLE
fix(rust): Add missing allow macros for windows

### DIFF
--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -45,6 +45,7 @@ mod utils;
 #[cfg(all(target_family = "unix", not(use_mimalloc), not(default_allocator)))]
 use jemallocator::Jemalloc;
 #[cfg(any(not(target_family = "unix"), use_mimalloc))]
+#[allow(unused_imports)]
 use mimalloc::MiMalloc;
 use pyo3::panic::PanicException;
 use pyo3::prelude::*;
@@ -65,6 +66,7 @@ use crate::functions::PyStringCacheHolder;
 use crate::lazyframe::{PyInProcessQuery, PyLazyFrame};
 use crate::lazygroupby::PyLazyGroupBy;
 #[cfg(debug_assertions)]
+#[allow(unused_imports)]
 use crate::memory::TracemallocAllocator;
 use crate::series::PySeries;
 #[cfg(feature = "sql")]

--- a/py-polars/src/memory.rs
+++ b/py-polars/src/memory.rs
@@ -44,6 +44,7 @@ pub struct TracemallocAllocator<A: GlobalAlloc> {
 impl<A: GlobalAlloc> TracemallocAllocator<A> {
     /// Wrap the allocator such that allocations are registered with
     /// tracemalloc.
+    #[allow(dead_code)]
     pub const fn new(wrapped_alloc: A) -> Self {
         Self { wrapped_alloc }
     }


### PR DESCRIPTION
Was unable to run `make pre-commit`:

```log
error: could not compile `py-polars` (lib) due to 3 previous errors
```

This simply adds the three missing allows.

Fixes #16129