### PR TITLE
feat(rust): Add build git hash to the created_by field in newly made parquet files

### DIFF
--- a/crates/polars-parquet/build.rs
+++ b/crates/polars-parquet/build.rs
@@ -1,0 +1,11 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .expect("`git` should be available");
+    let git_hash = String::from_utf8(output.stdout)
+        .expect("couldn't parse `git rev-parse HEAD` output");
+    println!("cargo:rustc-env=POLARS_GIT_HASH={}", git_hash);
+}

--- a/crates/polars-parquet/build.rs
+++ b/crates/polars-parquet/build.rs
@@ -2,10 +2,10 @@ use std::process::Command;
 
 fn main() {
     let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .expect("`git` should be available");
-    let git_hash = String::from_utf8(output.stdout)
-        .expect("couldn't parse `git rev-parse HEAD` output");
+    let git_hash =
+        String::from_utf8(output.stdout).expect("couldn't parse `git rev-parse HEAD` output");
     println!("cargo:rustc-env=POLARS_GIT_HASH={}", git_hash);
 }

--- a/crates/polars-parquet/src/arrow/write/file.rs
+++ b/crates/polars-parquet/src/arrow/write/file.rs
@@ -53,7 +53,7 @@ impl<W: Write> FileWriter<W> {
     pub fn try_new(writer: W, schema: ArrowSchema, options: WriteOptions) -> PolarsResult<Self> {
         let parquet_schema = to_parquet_schema(&schema)?;
 
-        let created_by = Some("Polars".to_string());
+        let created_by = Some(format!("Polars (build {})", env!("POLARS_GIT_HASH")));
 
         Ok(Self {
             writer: crate::parquet::write::FileWriter::new(

--- a/crates/polars-parquet/src/arrow/write/sink.rs
+++ b/crates/polars-parquet/src/arrow/write/sink.rs
@@ -52,7 +52,7 @@ where
         }
 
         let parquet_schema = crate::arrow::write::to_parquet_schema(&schema)?;
-        let created_by = Some("Polars".to_string());
+        let created_by = Some(format!("Polars (build {})", env!("POLARS_GIT_HASH")));
         let writer = FileStreamer::new(
             writer,
             parquet_schema.clone(),


### PR DESCRIPTION
Fixes #15910 by adding the git hash to the created_by field when writing parquet files. This is done by setting an env var containing the hash in a Rust build script, which is then used with the env! macro (it should be the standard way in the Rust ecosystem to do this without adding an extra crate, which feels overkill for our current needs).

Example of output:
```
created_by: Some(
    "Polars (build 8d3519341592c7f806fcb86a8d7e24e65ef5ead4)",
),
```

This is my first contribution, so any feedback is appreciated! :)