### PR TITLE
tests(python): Mark `iceberg` tests/requirements "ci-only" and make some related user guide updates

### DIFF
--- a/docs/development/contributing/ide.md
+++ b/docs/development/contributing/ide.md
@@ -122,7 +122,7 @@ At this point, a second (Rust) debugger is attached to the Python debugger.
 The result is two simultaneous debuggers operating on the same running instance.
 Breakpoints in the Python code will stop on the Python debugger and breakpoints in the Rust code will stop on the Rust debugger.
 
-## PyCharm / RustRover / CLion
+## JetBrains (PyCharm, RustRover, CLion)
 
 !!! info
 

--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -104,6 +104,18 @@ We use the Makefile to conveniently run the following formatting and linting too
 
 If this all runs correctly, you're ready to start contributing to the Polars codebase!
 
+(Note: there are a very small number of specialized dependencies that are not installed by default.
+If you still encounter an error message about a missing dependency after having run `make requirements`,
+try running `make requirements-all` to install _all_ known dependencies).
+
+### Keeping your local environment up to date
+
+Note that dependencies are inevitably updated over time; this includes both the packages that we depend on
+in the code, and the formatting and linting tools we use. In order to simplify keeping your local environment
+current, there is the `make requirements` command. This command will update all Python dependencies and tools
+to their latest specified versions. Running this command in case of an unexpected error after updating the
+Polars codebase is often a good idea.
+
 ### Working on your issue
 
 Create a new git branch from the `main` branch in your local repository, and start coding!

--- a/docs/development/contributing/test.md
+++ b/docs/development/contributing/test.md
@@ -25,10 +25,13 @@ This will compile the Rust bindings and then run the unit tests.
 
 If you're working in the Python code only, you can avoid recompiling every time by simply running `pytest` instead from your virtual environment.
 
-By default, slow tests are skipped.
-Slow tests are marked as such using a [custom pytest marker](https://docs.pytest.org/en/latest/example/markers.html).
-If you wish to run slow tests, run `pytest -m slow`.
-Or run `pytest -m ""` to run _all_ tests, regardless of marker.
+By default, "slow" tests and "ci-only" tests are skipped for local test runs.
+Such tests are marked using a [custom pytest marker](https://docs.pytest.org/en/latest/example/markers.html).
+To run these tests specifically, you can run `pytest -m slow`, `pytest -m ci_only`, `pytest -m slow ci_only`
+or run `pytest -m ""` to run _all_ tests, regardless of marker.
+
+Note that the "ci-only" tests may require you to run `make requirements-all` to get additional dependencies
+(such as `torch`) that are otherwise not installed as part of the default Polars development environment.
 
 Tests can be run in parallel by running `pytest -n auto`.
 The parallelization is handled by [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/latest/).

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -193,7 +193,8 @@ else:
 @lru_cache(maxsize=None)
 def _might_be(cls: type, type_: str) -> bool:
     # infer whether the given class "might" be associated with the given
-    # module (in which case it's reasonable to do a real isinstance check)
+    # module (in which case it's reasonable to do a real isinstance check;
+    # we defer that so as not to unnecessarily trigger module import)
     try:
         return any(f"{type_}." in str(o) for o in cls.mro())
     except TypeError:

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -269,15 +269,13 @@ def _alignment_join(
     # note: can stackoverflow if the join becomes too large, so we
     # collect eagerly when hitting a large enough number of frames
     post_align_collect = len(idx_frames) >= 250
-    if how == "outer":
-        how = "outer_coalesce"
 
     def join_func(
         idx_x: tuple[int, LazyFrame],
         idx_y: tuple[int, LazyFrame],
     ) -> tuple[int, LazyFrame]:
         (_, x), (y_idx, y) = idx_x, idx_y
-        return y_idx, x.join(y, how=how, on=align_on, suffix=f":{y_idx}")
+        return y_idx, x.join(y, how=how, on=align_on, suffix=f":{y_idx}", coalesce=True)
 
     joined = reduce(join_func, idx_frames)[1].sort(by=align_on, descending=descending)
     if post_align_collect:

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -47,6 +47,7 @@ deltalake = ["deltalake >= 0.15.0"]
 fastexcel = ["fastexcel >= 0.9"]
 fsspec = ["fsspec"]
 gevent = ["gevent"]
+iceberg = ["pyiceberg >= 0.5.0"]
 matplotlib = ["matplotlib"]
 numpy = ["numpy >= 1.16.0"]
 openpyxl = ["openpyxl >= 3.0.0"]
@@ -54,7 +55,6 @@ pandas = ["pyarrow >= 7.0.0", "pandas"]
 plot = ["hvplot >= 0.9.1"]
 pyarrow = ["pyarrow >= 7.0.0"]
 pydantic = ["pydantic"]
-pyiceberg = ["pyiceberg >= 0.5.0"]
 pyxlsb = ["pyxlsb >= 1.0"]
 sqlalchemy = ["sqlalchemy", "pandas"]
 timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
@@ -62,7 +62,7 @@ torch = ["torch"]
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
 xlsxwriter = ["xlsxwriter"]
 all = [
-  "polars[adbc,async,cloudpickle,connectorx,deltalake,fastexcel,fsspec,gevent,numpy,pandas,plot,pyarrow,pydantic,pyiceberg,sqlalchemy,timezone,torch,xlsx2csv,xlsxwriter]",
+  "polars[adbc,async,cloudpickle,connectorx,deltalake,fastexcel,fsspec,gevent,numpy,pandas,plot,pyarrow,pydantic,iceberg,sqlalchemy,timezone,torch,xlsx2csv,xlsxwriter]",
 ]
 
 [tool.maturin]
@@ -100,6 +100,7 @@ module = [
   "polars.polars",
   "pyarrow.*",
   "pydantic",
+  "pyiceberg.*",
   "pyxlsb",
   "sqlalchemy.*",
   "torch.*",

--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -4,3 +4,4 @@
 # -------------------------------------------------------
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch
+pyiceberg>=0.5.0

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -44,7 +44,6 @@ pyxlsb
 xlsx2csv
 XlsxWriter
 deltalake>=0.15.0
-pyiceberg>=0.5.0
 # Csv
 zstandard
 # Plotting

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="attr-defined"
 from __future__ import annotations
 
 import contextlib
@@ -30,145 +31,135 @@ def iceberg_path(io_files_path: Path) -> str:
 @pytest.mark.filterwarnings(
     "ignore:No preferred file implementation for scheme*:UserWarning"
 )
-def test_scan_iceberg_plain(iceberg_path: str) -> None:
-    df = pl.scan_iceberg(iceberg_path)
-    assert len(df.collect()) == 3
-    assert df.schema == {
-        "id": pl.Int32,
-        "str": pl.String,
-        "ts": pl.Datetime(time_unit="us", time_zone=None),
-    }
+@pytest.mark.ci_only()
+class TestIcebergScanIO:
+    """Test coverage for `iceberg` scan ops."""
+
+    def test_scan_iceberg_plain(self, iceberg_path: str) -> None:
+        df = pl.scan_iceberg(iceberg_path)
+        assert len(df.collect()) == 3
+        assert df.schema == {
+            "id": pl.Int32,
+            "str": pl.String,
+            "ts": pl.Datetime(time_unit="us", time_zone=None),
+        }
+
+    def test_scan_iceberg_filter_on_partition(self, iceberg_path: str) -> None:
+        ts1 = datetime(2023, 3, 1, 18, 15)
+        ts2 = datetime(2023, 3, 1, 19, 25)
+        ts3 = datetime(2023, 3, 2, 22, 0)
+
+        lf = pl.scan_iceberg(iceberg_path)
+
+        res = lf.filter(pl.col("ts") >= ts2)
+        assert len(res.collect()) == 2
+
+        res = lf.filter(pl.col("ts") > ts2).select(pl.col("id"))
+        assert res.collect().rows() == [(3,)]
+
+        res = lf.filter(pl.col("ts") <= ts2).select("id", "ts")
+        assert res.collect().rows(named=True) == [
+            {"id": 1, "ts": ts1},
+            {"id": 2, "ts": ts2},
+        ]
+
+        res = lf.filter(pl.col("ts") > ts3)
+        assert len(res.collect()) == 0
+
+        for constraint in (
+            (pl.col("ts") == ts1) | (pl.col("ts") == ts3),
+            pl.col("ts").is_in([ts1, ts3]),
+        ):
+            res = lf.filter(constraint).select("id")
+            assert res.collect().rows() == [(1,), (3,)]
+
+    def test_scan_iceberg_filter_on_column(self, iceberg_path: str) -> None:
+        lf = pl.scan_iceberg(iceberg_path)
+        res = lf.filter(pl.col("id") < 2)
+        assert res.collect().rows() == [(1, "1", datetime(2023, 3, 1, 18, 15))]
+
+        res = lf.filter(pl.col("id") == 2)
+        assert res.collect().rows() == [(2, "2", datetime(2023, 3, 1, 19, 25))]
+
+        res = lf.filter(pl.col("id").is_in([1, 3]))
+        assert res.collect().rows() == [
+            (1, "1", datetime(2023, 3, 1, 18, 15)),
+            (3, "3", datetime(2023, 3, 2, 22, 0)),
+        ]
 
 
-@pytest.mark.slow()
-@pytest.mark.write_disk()
-@pytest.mark.filterwarnings(
-    "ignore:No preferred file implementation for scheme*:UserWarning"
-)
-def test_scan_iceberg_filter_on_partition(iceberg_path: str) -> None:
-    ts1 = datetime(2023, 3, 1, 18, 15)
-    ts2 = datetime(2023, 3, 1, 19, 25)
-    ts3 = datetime(2023, 3, 2, 22, 0)
+@pytest.mark.ci_only()
+class TestIcebergExpressions:
+    """Test coverage for `iceberg` expressions comprehension."""
 
-    lf = pl.scan_iceberg(iceberg_path)
+    def test_is_null_expression(self) -> None:
+        from pyiceberg.expressions import IsNull
 
-    res = lf.filter(pl.col("ts") >= ts2)
-    assert len(res.collect()) == 2
+        expr = _to_ast("(pa.compute.field('id')).is_null()")
+        assert _convert_predicate(expr) == IsNull("id")
 
-    res = lf.filter(pl.col("ts") > ts2).select(pl.col("id"))
-    assert res.collect().rows() == [(3,)]
+    def test_is_not_null_expression(self) -> None:
+        from pyiceberg.expressions import IsNull, Not
 
-    res = lf.filter(pl.col("ts") <= ts2).select("id", "ts")
-    assert res.collect().rows(named=True) == [
-        {"id": 1, "ts": ts1},
-        {"id": 2, "ts": ts2},
-    ]
+        expr = _to_ast("~(pa.compute.field('id')).is_null()")
+        assert _convert_predicate(expr) == Not(IsNull("id"))
 
-    res = lf.filter(pl.col("ts") > ts3)
-    assert len(res.collect()) == 0
+    def test_isin_expression(self) -> None:
+        from pyiceberg.expressions import In, literal
 
-    for constraint in (
-        (pl.col("ts") == ts1) | (pl.col("ts") == ts3),
-        pl.col("ts").is_in([ts1, ts3]),
-    ):
-        res = lf.filter(constraint).select("id")
-        assert res.collect().rows() == [(1,), (3,)]
+        expr = _to_ast("(pa.compute.field('id')).isin([1,2,3])")
+        assert _convert_predicate(expr) == In(
+            "id", {literal(1), literal(2), literal(3)}
+        )
 
+    def test_parse_combined_expression(self) -> None:
+        from pyiceberg.expressions import (
+            And,
+            EqualTo,
+            GreaterThan,
+            In,
+            Or,
+            Reference,
+            literal,
+        )
 
-@pytest.mark.slow()
-@pytest.mark.write_disk()
-@pytest.mark.filterwarnings(
-    "ignore:No preferred file implementation for scheme*:UserWarning"
-)
-def test_scan_iceberg_filter_on_column(iceberg_path: str) -> None:
-    lf = pl.scan_iceberg(iceberg_path)
-    res = lf.filter(pl.col("id") < 2)
-    assert res.collect().rows() == [(1, "1", datetime(2023, 3, 1, 18, 15))]
+        expr = _to_ast(
+            "(((pa.compute.field('str') == '2') & (pa.compute.field('id') > 10)) | (pa.compute.field('id')).isin([1,2,3]))"
+        )
+        assert _convert_predicate(expr) == Or(
+            left=And(
+                left=EqualTo(term=Reference(name="str"), literal=literal("2")),
+                right=GreaterThan(term="id", literal=literal(10)),
+            ),
+            right=In("id", {literal(1), literal(2), literal(3)}),
+        )
 
-    res = lf.filter(pl.col("id") == 2)
-    assert res.collect().rows() == [(2, "2", datetime(2023, 3, 1, 19, 25))]
+    def test_parse_gt(self) -> None:
+        from pyiceberg.expressions import GreaterThan
 
-    res = lf.filter(pl.col("id").is_in([1, 3]))
-    assert res.collect().rows() == [
-        (1, "1", datetime(2023, 3, 1, 18, 15)),
-        (3, "3", datetime(2023, 3, 2, 22, 0)),
-    ]
+        expr = _to_ast("(pa.compute.field('ts') > '2023-08-08')")
+        assert _convert_predicate(expr) == GreaterThan("ts", "2023-08-08")
 
+    def test_parse_gteq(self) -> None:
+        from pyiceberg.expressions import GreaterThanOrEqual
 
-def test_is_null_expression() -> None:
-    from pyiceberg.expressions import IsNull
+        expr = _to_ast("(pa.compute.field('ts') >= '2023-08-08')")
+        assert _convert_predicate(expr) == GreaterThanOrEqual("ts", "2023-08-08")
 
-    expr = _to_ast("(pa.compute.field('id')).is_null()")
-    assert _convert_predicate(expr) == IsNull("id")
+    def test_parse_eq(self) -> None:
+        from pyiceberg.expressions import EqualTo
 
+        expr = _to_ast("(pa.compute.field('ts') == '2023-08-08')")
+        assert _convert_predicate(expr) == EqualTo("ts", "2023-08-08")
 
-def test_is_not_null_expression() -> None:
-    from pyiceberg.expressions import IsNull, Not
+    def test_parse_lt(self) -> None:
+        from pyiceberg.expressions import LessThan
 
-    expr = _to_ast("~(pa.compute.field('id')).is_null()")
-    assert _convert_predicate(expr) == Not(IsNull("id"))
+        expr = _to_ast("(pa.compute.field('ts') < '2023-08-08')")
+        assert _convert_predicate(expr) == LessThan("ts", "2023-08-08")
 
+    def test_parse_lteq(self) -> None:
+        from pyiceberg.expressions import LessThanOrEqual
 
-def test_isin_expression() -> None:
-    from pyiceberg.expressions import In, literal  # type: ignore[attr-defined]
-
-    expr = _to_ast("(pa.compute.field('id')).isin([1,2,3])")
-    assert _convert_predicate(expr) == In("id", {literal(1), literal(2), literal(3)})
-
-
-def test_parse_combined_expression() -> None:
-    from pyiceberg.expressions import (  # type: ignore[attr-defined]
-        And,
-        EqualTo,
-        GreaterThan,
-        In,
-        Or,
-        Reference,
-        literal,
-    )
-
-    expr = _to_ast(
-        "(((pa.compute.field('str') == '2') & (pa.compute.field('id') > 10)) | (pa.compute.field('id')).isin([1,2,3]))"
-    )
-    assert _convert_predicate(expr) == Or(
-        left=And(
-            left=EqualTo(term=Reference(name="str"), literal=literal("2")),
-            right=GreaterThan(term="id", literal=literal(10)),
-        ),
-        right=In("id", {literal(1), literal(2), literal(3)}),
-    )
-
-
-def test_parse_gt() -> None:
-    from pyiceberg.expressions import GreaterThan
-
-    expr = _to_ast("(pa.compute.field('ts') > '2023-08-08')")
-    assert _convert_predicate(expr) == GreaterThan("ts", "2023-08-08")
-
-
-def test_parse_gteq() -> None:
-    from pyiceberg.expressions import GreaterThanOrEqual
-
-    expr = _to_ast("(pa.compute.field('ts') >= '2023-08-08')")
-    assert _convert_predicate(expr) == GreaterThanOrEqual("ts", "2023-08-08")
-
-
-def test_parse_eq() -> None:
-    from pyiceberg.expressions import EqualTo
-
-    expr = _to_ast("(pa.compute.field('ts') == '2023-08-08')")
-    assert _convert_predicate(expr) == EqualTo("ts", "2023-08-08")
-
-
-def test_parse_lt() -> None:
-    from pyiceberg.expressions import LessThan
-
-    expr = _to_ast("(pa.compute.field('ts') < '2023-08-08')")
-    assert _convert_predicate(expr) == LessThan("ts", "2023-08-08")
-
-
-def test_parse_lteq() -> None:
-    from pyiceberg.expressions import LessThanOrEqual
-
-    expr = _to_ast("(pa.compute.field('ts') <= '2023-08-08')")
-    assert _convert_predicate(expr) == LessThanOrEqual("ts", "2023-08-08")
+        expr = _to_ast("(pa.compute.field('ts') <= '2023-08-08')")
+        assert _convert_predicate(expr) == LessThanOrEqual("ts", "2023-08-08")


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/pull/16058.

Marks the iceberg tests/deps "ci-only", ensures that lint succeeds with/without the `pyiceberg` package installed, and includes some user guide additions to note the existence of `make requirements` and `make requirements-all`.