### PR TITLE
docs(rust): Solve inconsistency between code and comment

### DIFF
--- a/crates/polars-arrow/src/array/list/mod.rs
+++ b/crates/polars-arrow/src/array/list/mod.rs
@@ -104,7 +104,7 @@ impl<O: Offset> ListArray<O> {
 impl<O: Offset> ListArray<O> {
     /// Slices this [`ListArray`].
     /// # Panics
-    /// panics iff `offset + length >= self.len()`
+    /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
             offset + length <= self.len(),

--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -101,7 +101,7 @@ impl MapArray {
 impl MapArray {
     /// Returns a slice of this [`MapArray`].
     /// # Panics
-    /// panics iff `offset + length >= self.len()`
+    /// panics iff `offset + length > self.len()`
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
             offset + length <= self.len(),

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -330,7 +330,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// Note that if it is the first time a null appears in this array,
     /// this initializes the validity bitmap (`O(N)`).
     /// # Panic
-    /// Panics iff index is larger than `self.len()`.
+    /// Panics iff `index >= self.len()`.
     pub fn set(&mut self, index: usize, value: Option<T>) {
         assert!(index < self.len());
         // SAFETY:

--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -227,7 +227,7 @@ impl UnionArray {
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
     /// # Panic
-    /// This function panics iff `offset + length >= self.len()`.
+    /// This function panics iff `offset + length > self.len()`.
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -145,7 +145,7 @@ impl<T> Buffer<T> {
 
     /// Slices this buffer starting at `offset`.
     /// # Panics
-    /// Panics iff `offset` is larger than `len`.
+    /// Panics iff `offset + length` is larger than `len`.
     #[inline]
     pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(


### PR DESCRIPTION
This PR fixed some inconsistency between code and comment in #15968 .

Closes #15968 