### PR TITLE
chore(python): More PyO3 0.21 Bound<> APIs, and finally disable gil-refs backwards compat feature on pyo3 crate

### DIFF
--- a/crates/polars-plan/src/dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_udf.rs
@@ -6,6 +6,7 @@ use polars_core::error::*;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::Series;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
 #[cfg(feature = "serde")]
 use serde::ser::Error;
@@ -67,9 +68,9 @@ impl Serialize for PythonFunction {
             let dumped = pickle
                 .call1((python_function,))
                 .map_err(|s| S::Error::custom(format!("cannot pickle {s}")))?;
-            let dumped = dumped.extract::<&PyBytes>().unwrap();
+            let dumped = dumped.extract::<PyBackedBytes>().unwrap();
 
-            serializer.serialize_bytes(dumped.as_bytes())
+            serializer.serialize_bytes(&dumped)
         })
     }
 }
@@ -192,8 +193,8 @@ impl SeriesUdf for PythonUdfExpression {
             let dumped = pickle
                 .call1((self.python_function.clone(),))
                 .map_err(from_pyerr)?;
-            let dumped = dumped.extract::<&PyBytes>().unwrap();
-            buf.extend_from_slice(dumped.as_bytes());
+            let dumped = dumped.extract::<PyBackedBytes>().unwrap();
+            buf.extend_from_slice(&dumped);
             Ok(())
         })
     }

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -27,7 +27,7 @@ ndarray = { workspace = true }
 num-traits = { workspace = true }
 numpy = { version = "0.21", default-features = false }
 once_cell = { workspace = true }
-pyo3 = { workspace = true, features = ["abi3-py38", "extension-module", "multiple-pymethods", "gil-refs"] }
+pyo3 = { workspace = true, features = ["abi3-py38", "extension-module", "multiple-pymethods"] }
 pyo3-built = { version = "0.5", optional = true }
 recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }

--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -8,7 +8,6 @@ use polars_core::utils::any_values_to_supertype_and_n_dtypes;
 use pyo3::exceptions::{PyOverflowError, PyTypeError};
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PySequence, PyString, PyTuple};
 
 use super::{decimal_to_digits, struct_dict, ObjectValue, Wrap};
@@ -172,8 +171,8 @@ pub(crate) fn py_object_to_any_value<'py>(
     }
 
     fn get_bytes<'py>(ob: &Bound<'py, PyAny>, _strict: bool) -> PyResult<AnyValue<'py>> {
-        let value = ob.extract::<PyBackedBytes>().unwrap();
-        Ok(AnyValue::BinaryOwned(value.to_vec()))
+        let value = ob.extract::<Vec<u8>>().unwrap();
+        Ok(AnyValue::BinaryOwned(value))
     }
 
     fn get_date(ob: &Bound<'_, PyAny>, _strict: bool) -> PyResult<AnyValue<'static>> {

--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -8,6 +8,7 @@ use polars_core::utils::any_values_to_supertype_and_n_dtypes;
 use pyo3::exceptions::{PyOverflowError, PyTypeError};
 use pyo3::intern;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PySequence, PyString, PyTuple};
 
 use super::{decimal_to_digits, struct_dict, ObjectValue, Wrap};
@@ -171,8 +172,8 @@ pub(crate) fn py_object_to_any_value<'py>(
     }
 
     fn get_bytes<'py>(ob: &Bound<'py, PyAny>, _strict: bool) -> PyResult<AnyValue<'py>> {
-        let value = ob.extract::<&'py [u8]>().unwrap();
-        Ok(AnyValue::Binary(value))
+        let value = ob.extract::<PyBackedBytes>().unwrap();
+        Ok(AnyValue::BinaryOwned(value.to_vec()))
     }
 
     fn get_date(ob: &Bound<'_, PyAny>, _strict: bool) -> PyResult<AnyValue<'static>> {

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -275,18 +275,21 @@ impl ToPyObject for Wrap<DataType> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<Field> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<Field> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let name = ob.getattr(intern!(py, "name"))?.str()?.to_str()?;
+        let name = ob
+            .getattr(intern!(py, "name"))?
+            .str()?
+            .extract::<PyBackedStr>()?;
         let dtype = ob
             .getattr(intern!(py, "dtype"))?
             .extract::<Wrap<DataType>>()?;
-        Ok(Wrap(Field::new(name, dtype.0)))
+        Ok(Wrap(Field::new(&name, dtype.0)))
     }
 }
 
-impl FromPyObject<'_> for Wrap<DataType> {
+impl<'py> FromPyObject<'py> for Wrap<DataType> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let py = ob.py();
         let type_name = ob.get_type().qualname()?;
@@ -429,15 +432,15 @@ impl ToPyObject for Wrap<TimeUnit> {
 }
 
 impl<'s> FromPyObject<'s> for Wrap<Row<'s>> {
-    fn extract(ob: &'s PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'s, PyAny>) -> PyResult<Self> {
         let vals = ob.extract::<Vec<Wrap<AnyValue<'s>>>>()?;
         let vals = vec_extract_wrapped(vals);
         Ok(Wrap(Row(vals)))
     }
 }
 
-impl FromPyObject<'_> for Wrap<Schema> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<Schema> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let dict = ob.extract::<&PyDict>()?;
 
         Ok(Wrap(
@@ -528,7 +531,7 @@ impl From<PyObject> for ObjectValue {
 }
 
 impl<'a> FromPyObject<'a> for ObjectValue {
-    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
         Python::with_gil(|py| {
             Ok(ObjectValue {
                 inner: ob.to_object(py),
@@ -560,7 +563,7 @@ impl Default for ObjectValue {
 }
 
 impl<'a, T: NativeType + FromPyObject<'a>> FromPyObject<'a> for Wrap<Vec<T>> {
-    fn extract(obj: &'a PyAny) -> PyResult<Self> {
+    fn extract_bound(obj: &Bound<'a, PyAny>) -> PyResult<Self> {
         let seq = obj.downcast::<PySequence>()?;
         let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
         for item in seq.iter()? {
@@ -571,8 +574,8 @@ impl<'a, T: NativeType + FromPyObject<'a>> FromPyObject<'a> for Wrap<Vec<T>> {
 }
 
 #[cfg(feature = "asof_join")]
-impl FromPyObject<'_> for Wrap<AsofStrategy> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<AsofStrategy> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*(ob.extract::<PyBackedStr>()?) {
             "backward" => AsofStrategy::Backward,
             "forward" => AsofStrategy::Forward,
@@ -587,8 +590,8 @@ impl FromPyObject<'_> for Wrap<AsofStrategy> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<InterpolationMethod> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<InterpolationMethod> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*(ob.extract::<PyBackedStr>()?) {
             "linear" => InterpolationMethod::Linear,
             "nearest" => InterpolationMethod::Nearest,
@@ -603,8 +606,8 @@ impl FromPyObject<'_> for Wrap<InterpolationMethod> {
 }
 
 #[cfg(feature = "avro")]
-impl FromPyObject<'_> for Wrap<Option<AvroCompression>> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<Option<AvroCompression>> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "uncompressed" => None,
             "snappy" => Some(AvroCompression::Snappy),
@@ -619,8 +622,8 @@ impl FromPyObject<'_> for Wrap<Option<AvroCompression>> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<CategoricalOrdering> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<CategoricalOrdering> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "physical" => CategoricalOrdering::Physical,
             "lexical" => CategoricalOrdering::Lexical,
@@ -634,8 +637,8 @@ impl FromPyObject<'_> for Wrap<CategoricalOrdering> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<StartBy> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<StartBy> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "window" => StartBy::WindowBound,
             "datapoint" => StartBy::DataPoint,
@@ -656,8 +659,8 @@ impl FromPyObject<'_> for Wrap<StartBy> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<ClosedWindow> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<ClosedWindow> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "left" => ClosedWindow::Left,
             "right" => ClosedWindow::Right,
@@ -674,8 +677,8 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
 }
 
 #[cfg(feature = "csv")]
-impl FromPyObject<'_> for Wrap<CsvEncoding> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<CsvEncoding> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "utf8" => CsvEncoding::Utf8,
             "utf8-lossy" => CsvEncoding::LossyUtf8,
@@ -690,8 +693,8 @@ impl FromPyObject<'_> for Wrap<CsvEncoding> {
 }
 
 #[cfg(feature = "ipc")]
-impl FromPyObject<'_> for Wrap<Option<IpcCompression>> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<Option<IpcCompression>> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "uncompressed" => None,
             "lz4" => Some(IpcCompression::LZ4),
@@ -706,8 +709,8 @@ impl FromPyObject<'_> for Wrap<Option<IpcCompression>> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<JoinType> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<JoinType> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "inner" => JoinType::Inner,
             "left" => JoinType::Left,
@@ -730,8 +733,8 @@ impl FromPyObject<'_> for Wrap<JoinType> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<Label> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<Label> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "left" => Label::Left,
             "right" => Label::Right,
@@ -746,8 +749,8 @@ impl FromPyObject<'_> for Wrap<Label> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<ListToStructWidthStrategy> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<ListToStructWidthStrategy> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "first_non_null" => ListToStructWidthStrategy::FirstNonNull,
             "max_width" => ListToStructWidthStrategy::MaxWidth,
@@ -761,8 +764,8 @@ impl FromPyObject<'_> for Wrap<ListToStructWidthStrategy> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<NonExistent> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<NonExistent> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "null" => NonExistent::Null,
             "raise" => NonExistent::Raise,
@@ -776,8 +779,8 @@ impl FromPyObject<'_> for Wrap<NonExistent> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<NullBehavior> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<NullBehavior> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "drop" => NullBehavior::Drop,
             "ignore" => NullBehavior::Ignore,
@@ -791,8 +794,8 @@ impl FromPyObject<'_> for Wrap<NullBehavior> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<NullStrategy> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<NullStrategy> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "ignore" => NullStrategy::Ignore,
             "propagate" => NullStrategy::Propagate,
@@ -807,8 +810,8 @@ impl FromPyObject<'_> for Wrap<NullStrategy> {
 }
 
 #[cfg(feature = "parquet")]
-impl FromPyObject<'_> for Wrap<ParallelStrategy> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<ParallelStrategy> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "auto" => ParallelStrategy::Auto,
             "columns" => ParallelStrategy::Columns,
@@ -824,8 +827,8 @@ impl FromPyObject<'_> for Wrap<ParallelStrategy> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<IndexOrder> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<IndexOrder> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "fortran" => IndexOrder::Fortran,
             "c" => IndexOrder::C,
@@ -839,8 +842,8 @@ impl FromPyObject<'_> for Wrap<IndexOrder> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<QuantileInterpolOptions> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "lower" => QuantileInterpolOptions::Lower,
             "higher" => QuantileInterpolOptions::Higher,
@@ -857,8 +860,8 @@ impl FromPyObject<'_> for Wrap<QuantileInterpolOptions> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<RankMethod> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<RankMethod> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "min" => RankMethod::Min,
             "max" => RankMethod::Max,
@@ -876,8 +879,8 @@ impl FromPyObject<'_> for Wrap<RankMethod> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<Roll> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<Roll> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "raise" => Roll::Raise,
             "forward" => Roll::Forward,
@@ -892,8 +895,8 @@ impl FromPyObject<'_> for Wrap<Roll> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<TimeUnit> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<TimeUnit> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "ns" => TimeUnit::Nanoseconds,
             "us" => TimeUnit::Microseconds,
@@ -908,8 +911,8 @@ impl FromPyObject<'_> for Wrap<TimeUnit> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<UniqueKeepStrategy> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "first" => UniqueKeepStrategy::First,
             "last" => UniqueKeepStrategy::Last,
@@ -926,8 +929,8 @@ impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
 }
 
 #[cfg(feature = "ipc")]
-impl FromPyObject<'_> for Wrap<IpcCompression> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<IpcCompression> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "zstd" => IpcCompression::ZSTD,
             "lz4" => IpcCompression::LZ4,
@@ -942,8 +945,8 @@ impl FromPyObject<'_> for Wrap<IpcCompression> {
 }
 
 #[cfg(feature = "search_sorted")]
-impl FromPyObject<'_> for Wrap<SearchSortedSide> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<SearchSortedSide> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "any" => SearchSortedSide::Any,
             "left" => SearchSortedSide::Left,
@@ -958,8 +961,8 @@ impl FromPyObject<'_> for Wrap<SearchSortedSide> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<ClosedInterval> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<ClosedInterval> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "both" => ClosedInterval::Both,
             "left" => ClosedInterval::Left,
@@ -975,8 +978,8 @@ impl FromPyObject<'_> for Wrap<ClosedInterval> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<WindowMapping> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<WindowMapping> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "group_to_rows" => WindowMapping::GroupsToRows,
             "join" => WindowMapping::Join,
@@ -991,8 +994,8 @@ impl FromPyObject<'_> for Wrap<WindowMapping> {
     }
 }
 
-impl FromPyObject<'_> for Wrap<JoinValidation> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<JoinValidation> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "1:1" => JoinValidation::OneToOne,
             "1:m" => JoinValidation::OneToMany,
@@ -1009,8 +1012,8 @@ impl FromPyObject<'_> for Wrap<JoinValidation> {
 }
 
 #[cfg(feature = "csv")]
-impl FromPyObject<'_> for Wrap<QuoteStyle> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<QuoteStyle> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "always" => QuoteStyle::Always,
             "necessary" => QuoteStyle::Necessary,
@@ -1033,8 +1036,8 @@ pub(crate) fn parse_cloud_options(uri: &str, kv: Vec<(String, String)>) -> PyRes
 }
 
 #[cfg(feature = "list_sets")]
-impl FromPyObject<'_> for Wrap<SetOperation> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<SetOperation> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             "union" => SetOperation::Union,
             "difference" => SetOperation::Difference,

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -290,15 +290,18 @@ impl<'py> FromPyObject<'py> for Wrap<Field> {
 }
 
 impl<'py> FromPyObject<'py> for Wrap<DataType> {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let type_name = ob.get_type().qualname()?;
 
         let dtype = match &*type_name {
             "DataTypeClass" => {
                 // just the class, not an object
-                let name = ob.getattr(intern!(py, "__name__"))?.str()?.to_str()?;
-                match name {
+                let name = ob
+                    .getattr(intern!(py, "__name__"))?
+                    .str()?
+                    .extract::<PyBackedStr>()?;
+                match &*name {
                     "UInt8" => DataType::UInt8,
                     "UInt16" => DataType::UInt16,
                     "UInt32" => DataType::UInt32,

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -444,7 +444,7 @@ impl<'s> FromPyObject<'s> for Wrap<Row<'s>> {
 
 impl<'py> FromPyObject<'py> for Wrap<Schema> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let dict = ob.extract::<&PyDict>()?;
+        let dict = ob.downcast::<PyDict>()?;
 
         Ok(Wrap(
             dict.iter()

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -1,6 +1,6 @@
 use polars::prelude::*;
 use polars_core::utils::arrow::array::Utf8ViewArray;
-use pyo3::{FromPyObject, PyAny, PyResult};
+use pyo3::prelude::*;
 
 #[cfg(feature = "object")]
 use crate::object::OBJECT_NAME;
@@ -111,8 +111,8 @@ impl From<PyDataType> for DataType {
     }
 }
 
-impl FromPyObject<'_> for PyDataType {
-    fn extract(ob: &PyAny) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for PyDataType {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let dt = ob.extract::<Wrap<DataType>>()?;
         Ok(dt.0.into())
     }

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -13,7 +13,7 @@ use polars::time::*;
 use polars_core::prelude::*;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::pybacked::PyBackedStr;
+use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
 use pyo3::types::{PyBytes, PyDict, PyList};
 pub(crate) use visit::PyExprIR;
 
@@ -59,9 +59,9 @@ impl PyLazyFrame {
 
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         // Used in pickle/pickling
-        match state.extract::<&PyBytes>(py) {
+        match state.extract::<PyBackedBytes>(py) {
             Ok(s) => {
-                let lp: DslPlan = ciborium::de::from_reader(s.as_bytes())
+                let lp: DslPlan = ciborium::de::from_reader(&*s)
                     .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
                 self.ldf = LazyFrame::from(lp);
                 Ok(())

--- a/py-polars/src/map/dataframe.rs
+++ b/py-polars/src/map/dataframe.rs
@@ -89,7 +89,7 @@ pub fn apply_lambda_unknown<'a>(
                         py,
                         lambda,
                         null_count,
-                        first_value.as_deref(),
+                        first_value,
                     )
                     .into_series(),
                 )
@@ -204,17 +204,17 @@ pub fn apply_lambda_with_string_out_type<'a>(
     py: Python,
     lambda: Bound<'a, PyAny>,
     init_null_count: usize,
-    first_value: Option<&str>,
+    first_value: Option<PyBackedStr>,
 ) -> StringChunked {
     let skip = usize::from(first_value.is_some());
     if init_null_count == df.height() {
         ChunkedArray::full_null("map", df.height())
     } else {
-        let iter = apply_iter::<Cow<str>>(df, py, lambda, init_null_count, skip);
+        let iter = apply_iter::<PyBackedStr>(df, py, lambda, init_null_count, skip);
         iterator_to_string(
             iter,
             init_null_count,
-            first_value.map(Cow::Borrowed),
+            first_value,
             "map",
             df.height(),
         )

--- a/py-polars/src/map/dataframe.rs
+++ b/py-polars/src/map/dataframe.rs
@@ -84,14 +84,8 @@ pub fn apply_lambda_unknown<'a>(
             let first_value = out.extract::<PyBackedStr>().ok();
             return Ok((
                 PySeries::new(
-                    apply_lambda_with_string_out_type(
-                        df,
-                        py,
-                        lambda,
-                        null_count,
-                        first_value,
-                    )
-                    .into_series(),
+                    apply_lambda_with_string_out_type(df, py, lambda, null_count, first_value)
+                        .into_series(),
                 )
                 .into_py(py),
                 false,
@@ -211,13 +205,7 @@ pub fn apply_lambda_with_string_out_type<'a>(
         ChunkedArray::full_null("map", df.height())
     } else {
         let iter = apply_iter::<PyBackedStr>(df, py, lambda, init_null_count, skip);
-        iterator_to_string(
-            iter,
-            init_null_count,
-            first_value,
-            "map",
-            df.height(),
-        )
+        iterator_to_string(iter, init_null_count, first_value, "map", df.height())
     }
 }
 

--- a/py-polars/src/map/lazy.rs
+++ b/py-polars/src/map/lazy.rs
@@ -29,14 +29,14 @@ impl ToSeries for PyObject {
                 let res = py_polars_module
                     .getattr(py, "Series")
                     .unwrap()
-                    .call1(py, (name, PyList::new(py, [self])));
+                    .call1(py, (name, PyList::new_bound(py, [self])));
 
                 match res {
                     Ok(python_s) => python_s.getattr(py, "_s").unwrap(),
                     Err(_) => {
                         polars_bail!(ComputeError:
                             "expected a something that could convert to a `Series` but got: {}",
-                            self.as_ref(py).get_type()
+                            self.bind(py).get_type()
                         )
                     },
                 }
@@ -53,7 +53,7 @@ pub(crate) fn call_lambda_with_series(
     s: Series,
     lambda: &PyObject,
 ) -> PyResult<PyObject> {
-    let pypolars = POLARS.downcast::<PyModule>(py).unwrap();
+    let pypolars = POLARS.downcast_bound::<PyModule>(py).unwrap();
 
     // create a PySeries struct/object for Python
     let pyseries = PySeries::new(s);
@@ -75,7 +75,7 @@ pub(crate) fn binary_lambda(
 ) -> PolarsResult<Option<Series>> {
     Python::with_gil(|py| {
         // get the pypolars module
-        let pypolars = PyModule::import(py, "polars").unwrap();
+        let pypolars = PyModule::import_bound(py, "polars").unwrap();
         // create a PySeries struct/object for Python
         let pyseries_a = PySeries::new(a);
         let pyseries_b = PySeries::new(b);
@@ -97,7 +97,7 @@ pub(crate) fn binary_lambda(
             match lambda.call1(py, (python_series_wrapper_a, python_series_wrapper_b)) {
                 Ok(pyobj) => pyobj,
                 Err(e) => polars_bail!(
-                    ComputeError: "custom python function failed: {}", e.value(py),
+                    ComputeError: "custom python function failed: {}", e.value_bound(py),
                 ),
             };
         let pyseries = if let Ok(expr) = result_series_wrapper.getattr(py, "_pyexpr") {
@@ -142,7 +142,7 @@ pub(crate) fn call_lambda_with_series_slice(
     lambda: &PyObject,
     polars_module: &PyObject,
 ) -> PyObject {
-    let pypolars = polars_module.downcast::<PyModule>(py).unwrap();
+    let pypolars = polars_module.downcast_bound::<PyModule>(py).unwrap();
 
     // create a PySeries struct/object for Python
     let iter = s.iter().map(|s| {
@@ -153,12 +153,12 @@ pub(crate) fn call_lambda_with_series_slice(
 
         python_series_wrapper
     });
-    let wrapped_s = PyList::new(py, iter);
+    let wrapped_s = PyList::new_bound(py, iter);
 
     // call the lambda and get a python side Series wrapper
     match lambda.call1(py, (wrapped_s,)) {
         Ok(pyobj) => pyobj,
-        Err(e) => panic!("python function failed: {}", e.value(py)),
+        Err(e) => panic!("python function failed: {}", e.value_bound(py)),
     }
 }
 
@@ -172,7 +172,7 @@ pub fn map_mul(
 ) -> PyExpr {
     // get the pypolars module
     // do the import outside of the function to prevent import side effects in a hot loop.
-    let pypolars = PyModule::import(py, "polars").unwrap().to_object(py);
+    let pypolars = PyModule::import_bound(py, "polars").unwrap().to_object(py);
 
     let function = move |s: &mut [Series]| {
         Python::with_gil(|py| {

--- a/py-polars/src/map/mod.rs
+++ b/py-polars/src/map/mod.rs
@@ -2,7 +2,6 @@ pub mod dataframe;
 pub mod lazy;
 pub mod series;
 
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use polars::chunked_array::builder::get_list_builder;

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -39,7 +39,7 @@ fn python_function_caller_df(df: DataFrame, lambda: &PyObject) -> PolarsResult<D
         })?;
         // unpack the wrapper in a PyDataFrame
         let py_pydf = result_df_wrapper.getattr(py, "_df").map_err(|_| {
-            let pytype = result_df_wrapper.as_ref(py).get_type();
+            let pytype = result_df_wrapper.bind(py).get_type();
             PolarsError::ComputeError(
                 format!("Expected 'LazyFrame.map' to return a 'DataFrame', got a '{pytype}'",)
                     .into(),
@@ -58,7 +58,7 @@ fn python_function_caller_df(df: DataFrame, lambda: &PyObject) -> PolarsResult<D
 fn warning_function(msg: &str, warning: PolarsWarning) {
     Python::with_gil(|py| {
         let warn_fn = UTILS
-            .as_ref(py)
+            .bind(py)
             .getattr(intern!(py, "_polars_warn"))
             .unwrap();
 

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -57,10 +57,7 @@ fn python_function_caller_df(df: DataFrame, lambda: &PyObject) -> PolarsResult<D
 
 fn warning_function(msg: &str, warning: PolarsWarning) {
     Python::with_gil(|py| {
-        let warn_fn = UTILS
-            .bind(py)
-            .getattr(intern!(py, "_polars_warn"))
-            .unwrap();
+        let warn_fn = UTILS.bind(py).getattr(intern!(py, "_polars_warn")).unwrap();
 
         if let Err(e) = warn_fn.call1((msg, Wrap(warning))) {
             eprintln!("{e}")

--- a/py-polars/src/series/comparison.rs
+++ b/py-polars/src/series/comparison.rs
@@ -189,7 +189,7 @@ impl_lt_eq_num!(lt_eq_str, &str);
 struct PyDecimal(i128, usize);
 
 impl<'source> FromPyObject<'source> for PyDecimal {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+    fn extract_bound(obj: &Bound<'source, PyAny>) -> PyResult<Self> {
         if let Ok(val) = obj.extract() {
             return Ok(PyDecimal(val, 0));
         }

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -647,7 +647,7 @@ impl PySeries {
             .with_pl_flavor(true)
             .finish(&mut df)
             .expect("ipc writer");
-        Ok(PyBytes::new(py, &buf).to_object(py))
+        Ok(PyBytes::new_bound(py, &buf).to_object(py))
     }
 
     #[cfg(feature = "ipc_streaming")]

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -653,9 +653,11 @@ impl PySeries {
     #[cfg(feature = "ipc_streaming")]
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         // Used in pickle/pickling
-        match state.extract::<&PyBytes>(py) {
+
+        use pyo3::pybacked::PyBackedBytes;
+        match state.extract::<PyBackedBytes>(py) {
             Ok(s) => {
-                let c = Cursor::new(s.as_bytes());
+                let c = Cursor::new(&s);
                 let reader = IpcStreamReader::new(c);
                 let mut df = reader.finish().map_err(PyPolarsErr::from)?;
 

--- a/py-polars/src/to_numpy.rs
+++ b/py-polars/src/to_numpy.rs
@@ -43,8 +43,7 @@ where
     std::mem::forget(owner);
     PY_ARRAY_API.PyArray_SetBaseObject(py, array as *mut PyArrayObject, owner_ptr);
 
-    let any: &PyAny = py.from_owned_ptr(array);
-    any.into_py(py)
+    Py::from_owned_ptr(py, array)
 }
 
 #[pymethods]


### PR DESCRIPTION
Fixes #16142 

Note that I am not convinced we've caught _all_ usages of the old reference-style code (`&PyAny` and friends instead of `Bound<PyAny>`). Not everything is quite deprecated yet, is my impression. I have supplemented explicit warnings with some grepping, but still. But, presumably this will get caught as newer PyO3 releases come out.