### PR TITLE
tests(python): Update tests for new `connectorx` (now works with 3.12)

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -28,9 +28,7 @@ SQLAlchemy
 adbc_driver_manager; python_version >= '3.9' and platform_system != 'Windows'
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 aiosqlite
-# TODO: Remove version constraint for connectorx when Python 3.12 is supported:
-# https://github.com/sfu-db/connector-x/issues/527
-connectorx; python_version <= '3.11'
+connectorx
 kuzu
 # Cloud
 cloudpickle


### PR DESCRIPTION
New `connectorx` release (0.3.3) this morning - supports Python 3.12! 🎉 

* Updated unit tests to remove the conditional skip on 3.12.
* Updated dev requirements so we don't constrain install to <= 3.11.