### PR TITLE
refactor(python): Create NumPy view for Datetime/Duration Series on the Rust side

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4413,16 +4413,12 @@ class Series:
             )
 
         if self.null_count() == 0:
-            if dtype.is_integer() or dtype.is_float():
+            if dtype.is_integer() or dtype.is_float() or dtype in (Datetime, Duration):
                 np_array = self._s.to_numpy_view()
             elif dtype == Boolean:
                 raise_on_copy()
                 s_u8 = self.cast(UInt8)
                 np_array = s_u8._s.to_numpy_view().view(bool)
-            elif dtype in (Datetime, Duration):
-                np_dtype = temporal_dtype_to_numpy(dtype)
-                s_i64 = self.to_physical()
-                np_array = s_i64._s.to_numpy_view().view(np_dtype)
             elif dtype == Date:
                 raise_on_copy()
                 np_dtype = temporal_dtype_to_numpy(dtype)

--- a/py-polars/src/to_numpy.rs
+++ b/py-polars/src/to_numpy.rs
@@ -149,6 +149,7 @@ impl PyDataFrame {
             return None;
         }
         let first = self.df.get_columns().first().unwrap().dtype();
+        // TODO: Support Datetime/Duration types
         if !first.is_numeric() {
             return None;
         }


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

#### Changes

* Update the `create_borrowed_np_array` util to take a `dtype` parameter with the desired numpy dtype.
* Add support for views on Datetime/Duration Series (and remove the workaround on the Python side).

Some more work required to also support views on DataFrames with datetime/duration types, will do in another PR.