### PR TITLE
fix: Don't override CSV reader encoding with lossy UTF-8

### DIFF
--- a/crates/polars-lazy/src/physical_plan/executors/scan/csv.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/csv.rs
@@ -39,13 +39,6 @@ impl CsvExec {
             .with_columns(with_columns)
             .with_rechunk(self.file_options.rechunk)
             .with_row_index(self.file_options.row_index.clone())
-            .map_parse_options(|parse_options| {
-                parse_options.with_encoding(
-                    // TODO: We don't know why LossyUtf8 is set here, so remove it
-                    // to see if it breaks anything.
-                    CsvEncoding::LossyUtf8,
-                )
-            })
             .with_path(Some(self.path.clone()))
             .try_into_reader_with_file_path(None)?
             ._with_predicate(predicate)

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -3,9 +3,7 @@ use std::path::PathBuf;
 
 use polars_core::export::arrow::Either;
 use polars_core::POOL;
-use polars_io::csv::read::{
-    BatchedCsvReaderMmap, BatchedCsvReaderRead, CsvEncoding, CsvReadOptions, CsvReader,
-};
+use polars_io::csv::read::{BatchedCsvReaderMmap, BatchedCsvReaderRead, CsvReadOptions, CsvReader};
 use polars_plan::global::_set_n_rows_for_scan;
 use polars_plan::prelude::FileScanOptions;
 use polars_utils::iter::EnumerateIdxTrait;

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -68,13 +68,6 @@ impl CsvSource {
             .with_columns(with_columns)
             .with_rechunk(false)
             .with_row_index(file_options.row_index)
-            .map_parse_options(|parse_options| {
-                parse_options.with_encoding(
-                    // TODO: We don't know why LossyUtf8 is set here, so remove it
-                    // to see if it breaks anything.
-                    CsvEncoding::LossyUtf8,
-                )
-            })
             .with_path(Some(path))
             .try_into_reader_with_file_path(None)?;
 


### PR DESCRIPTION
well, I traced it up to here:

https://github.com/pola-rs/polars/commit/28ed5326d5c90e771745b1a648e25ba50d600bf7#diff-e150944f2ee324c6d266b3ac68b6e0126b498ab282c7e08568a77c2f4b0d20cdR59