### PR TITLE
feat(python): Validate `time_zone` in `pl.Datetime`

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -487,17 +487,14 @@ class Datetime(TemporalType):
         elif isinstance(time_zone, timezone):
             time_zone = time_zone
         else:
-            from polars._utils.convert import (
-                string_to_zoneinfo,
-            )
             from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
             if _ZONEINFO_AVAILABLE:
-                try:
-                    time_zone = string_to_zoneinfo(time_zone)
-                except (zoneinfo.ZoneInfoNotFoundError, TypeError):
+                if time_zone in zoneinfo.available_timezones():
+                    time_zone = time_zone
+                else:
                     msg = f"invalid time zone: {time_zone!r}, to see valid strings run `import zoneinfo; zoneinfo.available_timezones()`"
-                    raise ValueError(msg) from None
+                    raise ValueError(msg)
             else:
                 msg = "install polars[timezone] to handle datetimes with time zone information"
                 raise ImportError(msg)

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -485,20 +485,18 @@ class Datetime(TemporalType):
         if time_zone is None or time_zone == "*":
             return time_zone
         elif isinstance(time_zone, timezone):
-            time_zone = time_zone
+            time_zone = str(time_zone)
         else:
             from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
             if _ZONEINFO_AVAILABLE:
                 if time_zone in zoneinfo.available_timezones():
-                    time_zone = time_zone
+                    time_zone = str(time_zone)
                 else:
                     msg = f"invalid time zone: {time_zone!r}, to see valid strings run `import zoneinfo; zoneinfo.available_timezones()`"
                     raise ValueError(msg)
-            else:
-                msg = "install polars[timezone] to handle datetimes with time zone information"
-                raise ImportError(msg)
-        return str(time_zone)
+
+        return time_zone
 
 
 class Duration(TemporalType):

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -482,7 +482,9 @@ class Datetime(TemporalType):
         )
 
     def _validate_timezone(self, time_zone: str | timezone | None) -> str | None:
-        if time_zone is None or time_zone == "*" or isinstance(time_zone, timezone):
+        if time_zone is None or time_zone == "*":
+            return time_zone
+        elif isinstance(time_zone, timezone):
             time_zone = time_zone
         else:
             from polars._utils.convert import (

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -482,21 +482,21 @@ class Datetime(TemporalType):
         )
 
     def _validate_timezone(self, time_zone: str | timezone | None) -> str | None:
-        if time_zone is None or time_zone == "*":
+        if isinstance(time_zone, timezone):
+            return str(time_zone)
+        elif time_zone is None or time_zone == "*":
             return time_zone
-        elif isinstance(time_zone, timezone):
-            time_zone = str(time_zone)
         else:
             from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
             if _ZONEINFO_AVAILABLE:
                 if time_zone in zoneinfo.available_timezones():
-                    time_zone = str(time_zone)
+                    return str(time_zone)
                 else:
                     msg = f"invalid time zone: {time_zone!r}, to see valid strings run `import zoneinfo; zoneinfo.available_timezones()`"
                     raise ValueError(msg)
-
-        return time_zone
+            else:
+                return time_zone
 
 
 class Duration(TemporalType):

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1666,11 +1666,14 @@ def test_strptime_empty(time_unit: TimeUnit, time_zone: str | None) -> None:
 
 
 def test_strptime_with_invalid_tz() -> None:
-    with pytest.raises(ComputeError, match="unable to parse time zone: 'foo'"):
+    with pytest.raises(
+        ValueError,
+        match="invalid time zone: 'foo'",
+    ):
         pl.Series(["2020-01-01 03:00:00"]).str.strptime(pl.Datetime("us", "foo"))
     with pytest.raises(
-        ComputeError,
-        match="Please either drop the time zone from the function call, or set it to UTC",
+        ValueError,
+        match="invalid time zone: 'foo'",
     ):
         pl.Series(["2020-01-01 03:00:00+01:00"]).str.strptime(
             pl.Datetime("us", "foo"), "%Y-%m-%d %H:%M:%S%z"

--- a/py-polars/tests/unit/interchange/test_utils.py
+++ b/py-polars/tests/unit/interchange/test_utils.py
@@ -41,8 +41,8 @@ NE = Endianness.NATIVE
         (pl.Datetime, (DtypeKind.DATETIME, 64, "tsu:", NE)),
         (pl.Datetime(time_unit="ms"), (DtypeKind.DATETIME, 64, "tsm:", NE)),
         (
-            pl.Datetime(time_zone="Amsterdam/Europe"),
-            (DtypeKind.DATETIME, 64, "tsu:Amsterdam/Europe", NE),
+            pl.Datetime(time_zone="Europe/Amsterdam"),
+            (DtypeKind.DATETIME, 64, "tsu:Europe/Amsterdam", NE),
         ),
         (
             pl.Datetime(time_unit="ns", time_zone="Asia/Seoul"),

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -505,7 +505,7 @@ def test_err_on_time_datetime_cast() -> None:
 
 def test_err_on_invalid_time_zone_cast() -> None:
     s = pl.Series([datetime(2021, 1, 1)])
-    with pytest.raises(pl.ComputeError, match=r"unable to parse time zone: 'qwerty'"):
+    with pytest.raises(ValueError, match=r"invalid time zone: 'qwerty'"):
         s.cast(pl.Datetime("us", "qwerty"))
 
 


### PR DESCRIPTION
closes #16038 

Before
```python
pl.Datetime(time_zone="invalid_time_zone")
# Datetime(time_unit='us', time_zone='invalid_time_zone')

pl.Datetime(time_zone=object())
# Datetime(time_unit='us', time_zone=<object object at 0x7f245331d0d0>)

pl.Series([datetime(2020, 1, 1)], dtype=pl.Datetime(time_zone='cabbage'))
# ComputeError: unable to parse time zone: 'cabbage'. Please check the Time Zone Database for a list of available time zones
```

After
```python
pl.Datetime(time_zone="invalid_time_zone")
# ValueError: invalid time zone: 'invalid_time_zone', to see valid strings run `import zoneinfo; zoneinfo.available_timezones()`

pl.Datetime(time_zone=object())
# ValueError: invalid time zone: <object object at 0x7f830861fb30>, to see valid strings run `import zoneinfo; zoneinfo.available_timezones()`

pl.Series([datetime(2020, 1, 1)], dtype=pl.Datetime(time_zone='tst'))
# ValueError: invalid time zone: 'tst', to see valid strings run `import zoneinfo; zoneinfo.available_timezones()`
```

