### PR TITLE
Fix: StringNameSpace.replace_all docstring

### DIFF
--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1216,7 +1216,7 @@ class StringNameSpace:
 
     def replace_all(self, pattern: str, value: str, *, literal: bool = False) -> Series:
         r"""
-        Replace first matching regex/literal substring with a new string value.
+        Replace all matching regex/literal substrings with a new string value.
 
         Parameters
         ----------
@@ -1227,12 +1227,10 @@ class StringNameSpace:
             String that will replace the matched substring.
         literal
             Treat `pattern` as a literal string.
-        n
-            Number of matches to replace.
 
         See Also
         --------
-        replace_all
+        replace
 
         Notes
         -----


### PR DESCRIPTION
Randomly spotted, when browsing through the on-line documentation.

Note: the `ExprStringNameSpace.replace_all` docstring is correct.