### PR TITLE
perf(python): Avoid needless copy when converting chunked Series to NumPy

### DIFF
--- a/py-polars/src/conversion/chunked_array.rs
+++ b/py-polars/src/conversion/chunked_array.rs
@@ -8,7 +8,7 @@ use crate::py_modules::UTILS;
 
 impl ToPyObject for Wrap<&StringChunked> {
     fn to_object(&self, py: Python) -> PyObject {
-        let iter = self.0.into_iter();
+        let iter = self.0.iter();
         PyList::new_bound(py, iter).into_py(py)
     }
 }
@@ -17,7 +17,7 @@ impl ToPyObject for Wrap<&BinaryChunked> {
     fn to_object(&self, py: Python) -> PyObject {
         let iter = self
             .0
-            .into_iter()
+            .iter()
             .map(|opt_bytes| opt_bytes.map(|bytes| PyBytes::new_bound(py, bytes)));
         PyList::new_bound(py, iter).into_py(py)
     }
@@ -48,7 +48,7 @@ impl ToPyObject for Wrap<&DurationChunked> {
         let time_unit = self.0.time_unit().to_ascii();
         let iter = self
             .0
-            .into_iter()
+            .iter()
             .map(|opt_v| opt_v.map(|v| convert.call1((v, time_unit)).unwrap()));
         PyList::new_bound(py, iter).into_py(py)
     }
@@ -62,7 +62,7 @@ impl ToPyObject for Wrap<&DatetimeChunked> {
         let time_zone = self.0.time_zone().to_object(py);
         let iter = self
             .0
-            .into_iter()
+            .iter()
             .map(|opt_v| opt_v.map(|v| convert.call1((v, time_unit, &time_zone)).unwrap()));
         PyList::new_bound(py, iter).into_py(py)
     }
@@ -81,7 +81,7 @@ pub(crate) fn time_to_pyobject_iter<'a>(
 ) -> impl ExactSizeIterator<Item = Option<Bound<'a, PyAny>>> {
     let utils = UTILS.bind(py);
     let convert = utils.getattr(intern!(py, "to_py_time")).unwrap().clone();
-    ca.0.into_iter()
+    ca.0.iter()
         .map(move |opt_v| opt_v.map(|v| convert.call1((v,)).unwrap()))
 }
 
@@ -113,7 +113,7 @@ pub(crate) fn decimal_to_pyobject_iter<'a>(
     let py_scale = (-(ca.scale() as i32)).to_object(py);
     // if we don't know precision, the only safe bet is to set it to 39
     let py_precision = ca.precision().unwrap_or(39).to_object(py);
-    ca.into_iter().map(move |opt_v| {
+    ca.iter().map(move |opt_v| {
         opt_v.map(|v| {
             // TODO! use AnyValue so that we have a single impl.
             const N: usize = 3;

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -270,7 +270,7 @@ fn series_to_numpy_with_copy(py: Python, s: &Series) -> PyResult<PyObject> {
                 .as_any()
                 .downcast_ref::<ObjectChunked<ObjectValue>>()
                 .unwrap();
-            let values = ca.into_iter().map(|v| v.to_object(py));
+            let values = ca.iter().map(|v| v.to_object(py));
             PyArray1::from_iter_bound(py, values).into_py(py)
         },
         Null => {

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -241,30 +241,28 @@ fn series_to_numpy_with_copy(py: Python, s: &Series) -> PyResult<PyObject> {
         },
         Time => {
             let ca = s.time().unwrap();
-            let iter = time_to_pyobject_iter(py, ca);
-            let np_arr = PyArray1::from_iter_bound(py, iter.map(|v| v.into_py(py)));
-            np_arr.into_py(py)
+            let values = time_to_pyobject_iter(py, ca).map(|v| v.into_py(py));
+            PyArray1::from_iter_bound(py, values).into_py(py)
         },
         String => {
             let ca = s.str().unwrap();
-            let np_arr = PyArray1::from_iter_bound(py, ca.iter().map(|s| s.into_py(py)));
-            np_arr.into_py(py)
+            let values = ca.iter().map(|s| s.into_py(py));
+            PyArray1::from_iter_bound(py, values).into_py(py)
         },
         Binary => {
             let ca = s.binary().unwrap();
-            let np_arr = PyArray1::from_iter_bound(py, ca.iter().map(|s| s.into_py(py)));
-            np_arr.into_py(py)
+            let values = ca.iter().map(|s| s.into_py(py));
+            PyArray1::from_iter_bound(py, values).into_py(py)
         },
         Categorical(_, _) | Enum(_, _) => {
             let ca = s.categorical().unwrap();
-            let np_arr = PyArray1::from_iter_bound(py, ca.iter_str().map(|s| s.into_py(py)));
-            np_arr.into_py(py)
+            let values = ca.iter_str().map(|s| s.into_py(py));
+            PyArray1::from_iter_bound(py, values).into_py(py)
         },
         Decimal(_, _) => {
             let ca = s.decimal().unwrap();
-            let iter = decimal_to_pyobject_iter(py, ca);
-            let np_arr = PyArray1::from_iter_bound(py, iter.map(|v| v.into_py(py)));
-            np_arr.into_py(py)
+            let values = decimal_to_pyobject_iter(py, ca).map(|v| v.into_py(py));
+            PyArray1::from_iter_bound(py, values).into_py(py)
         },
         #[cfg(feature = "object")]
         Object(_, _) => {
@@ -272,14 +270,13 @@ fn series_to_numpy_with_copy(py: Python, s: &Series) -> PyResult<PyObject> {
                 .as_any()
                 .downcast_ref::<ObjectChunked<ObjectValue>>()
                 .unwrap();
-            let np_arr =
-                PyArray1::from_iter_bound(py, ca.into_iter().map(|opt_v| opt_v.to_object(py)));
-            np_arr.into_py(py)
+            let values = ca.into_iter().map(|v| v.to_object(py));
+            PyArray1::from_iter_bound(py, values).into_py(py)
         },
         Null => {
             let n = s.len();
-            let np_arr = PyArray1::from_iter_bound(py, std::iter::repeat(f32::NAN).take(n));
-            np_arr.into_py(py)
+            let values = std::iter::repeat(f32::NAN).take(n);
+            PyArray1::from_iter_bound(py, values).into_py(py)
         },
         dt => {
             raise_err!(
@@ -352,6 +349,6 @@ where
 {
     let s_phys = s.to_physical_repr();
     let ca = s_phys.i64().unwrap();
-    let iter = ca.iter().map(|v| v.unwrap_or(i64::MIN).into());
-    PyArray1::<T>::from_iter_bound(py, iter).into_py(py)
+    let values = ca.iter().map(|v| v.unwrap_or(i64::MIN).into());
+    PyArray1::<T>::from_iter_bound(py, values).into_py(py)
 }


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

We used to always rechunk first when converting to NumPy. This is not great because:
* If we go through the copy path (e.g. Series contains nulls), we iterate over the values anyway and rechunking is unnecessary.
* If we go through the 'view' path (e.g. numeric Series without nulls), we do a copy (rechunk) but we end up with a non-writable array. Better to go through the copy path directly to ensure a writable array. Otherwise making the array writable is an additional copy.

Also changed some `into_iter` calls to `iter`.