### PR TITLE
feat: Add SQL support for `GROUP BY ALL` syntax and fix several issues with aliased group keys

### DIFF
--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -67,9 +67,9 @@ impl AsRef<Expr> for AggExpr {
 #[must_use]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Expr {
-    Alias(Arc<Expr>, Arc<str>),
-    Column(Arc<str>),
-    Columns(Vec<String>),
+    Alias(Arc<Expr>, ColumnName),
+    Column(ColumnName),
+    Columns(Arc<[ColumnName]>),
     DtypeColumn(Vec<DataType>),
     Literal(LiteralValue),
     BinaryExpr {
@@ -291,7 +291,7 @@ impl Default for Expr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 
 pub enum Excluded {
-    Name(Arc<str>),
+    Name(ColumnName),
     Dtype(DataType),
 }
 

--- a/crates/polars-plan/src/dsl/functions/selectors.rs
+++ b/crates/polars-plan/src/dsl/functions/selectors.rs
@@ -39,6 +39,10 @@ pub fn all() -> Expr {
 /// Select multiple columns by name.
 pub fn cols<I: IntoVec<String>>(names: I) -> Expr {
     let names = names.into_vec();
+    let names = names
+        .into_iter()
+        .map(|v| ColumnName::from(v.as_str()))
+        .collect();
     Expr::Columns(names)
 }
 

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -106,7 +106,7 @@ pub fn has_aexpr_literal(current_node: Node, arena: &Arena<AExpr>) -> bool {
 
 /// Can check if an expression tree has a matching_expr. This
 /// requires a dummy expression to be created that will be used to pattern match against.
-pub(crate) fn has_expr<F>(current_expr: &Expr, matches: F) -> bool
+pub fn has_expr<F>(current_expr: &Expr, matches: F) -> bool
 where
     F: Fn(&Expr) -> bool,
 {

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -473,27 +473,27 @@ impl SQLContext {
             } else if !contains_wildcard {
                 let schema = lf.schema()?;
                 let mut column_names = schema.get_names();
-                let mut retained_names: BTreeSet<String> = BTreeSet::new();
+                let mut retained_names = PlHashSet::new();
 
                 projections.iter().for_each(|expr| match expr {
                     Expr::Alias(_, name) => {
-                        retained_names.insert(name.to_string());
+                        retained_names.insert(name.clone());
                     },
                     Expr::Column(name) => {
-                        retained_names.insert(name.to_string());
+                        retained_names.insert(name.clone());
                     },
                     Expr::Columns(names) => names.iter().for_each(|name| {
-                        retained_names.insert(name.to_string());
+                        retained_names.insert(name.clone());
                     }),
                     Expr::Exclude(inner_expr, excludes) => {
                         if let Expr::Columns(names) = (*inner_expr).as_ref() {
                             names.iter().for_each(|name| {
-                                retained_names.insert(name.to_string());
+                                retained_names.insert(name.clone());
                             })
                         }
                         excludes.iter().for_each(|excluded| {
                             if let Excluded::Name(name) = excluded {
-                                retained_names.remove(&(name.to_string()));
+                                retained_names.remove(&(name.clone()));
                             }
                         });
                     },

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -89,41 +89,23 @@ fn test_array_to_string() {
         "b" => &[1, 1, 42],
     }
     .unwrap();
+
     let mut context = SQLContext::new();
     context.register("df", df.clone().lazy());
-    let sql = context
-        .execute(
-            r#"
-        SELECT
-            b,
-            a
-        FROM df
-        GROUP BY
-            b"#,
-        )
-        .unwrap();
-    context.register("df_1", sql.clone());
+
     let sql = r#"
-        SELECT
-            b,
-            array_to_string(a, ', ') as as,
-        FROM df_1
-        ORDER BY
-            b,
-            as"#;
+        SELECT b, ARRAY_TO_STRING(a,', ') AS a2s,
+        FROM (
+            SELECT b, ARRAY_AGG(a)
+            FROM df
+            GROUP BY b
+        ) tbl
+        ORDER BY a2s"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
-
-    let df_pl = df
-        .lazy()
-        .group_by([col("b")])
-        .agg([col("a")])
-        .select(&[col("b"), col("a").list().join(lit(", "), true).alias("as")])
-        .sort_by_exprs(
-            vec![col("b"), col("as")],
-            SortMultipleOptions::default().with_maintain_order(true),
-        )
-        .collect()
-        .unwrap();
-
-    assert!(df_sql.equals_missing(&df_pl));
+    let df_expected = df! {
+        "b" => &[1, 42],
+        "a2s" => &["first, first", "third"],
+    }
+    .unwrap();
+    assert!(df_sql.equals(&df_expected));
 }

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -63,6 +64,105 @@ def test_group_by(foods_ipc_path: Path) -> None:
         """
     )
     assert out.to_dict(as_series=False) == {"grp": ["c"], "n_dist_attr": [2]}
+
+
+def test_group_by_all() -> None:
+    df = pl.DataFrame(
+        {
+            "a": ["xx", "yy", "xx", "yy", "xx", "zz"],
+            "b": [1, 2, 3, 4, 5, 6],
+            "c": [99, 99, 66, 66, 66, 66],
+        }
+    )
+
+    # basic group/agg
+    res = df.sql(
+        """
+        SELECT
+            a,
+            SUM(b),
+            SUM(c)
+        FROM self
+        GROUP BY ALL
+        ORDER BY a
+        """
+    )
+    expected = pl.DataFrame(
+        {
+            "a": ["xx", "yy", "zz"],
+            "b": [9, 6, 6],
+            "c": [231, 165, 66],
+        }
+    )
+    assert_frame_equal(expected, res)
+
+    # more involved determination of agg/group columns
+    res = df.sql(
+        """
+        SELECT
+            SUM(b) AS sum_b,
+            SUM(c) AS sum_c,
+            (SUM(b) + SUM(c)) / 2.0 AS sum_bc_over_2,  -- nested agg
+            a as grp, --aliased group key
+        FROM self
+        GROUP BY ALL
+        ORDER BY grp
+        """
+    )
+    expected = pl.DataFrame(
+        {
+            "sum_b": [9, 6, 6],
+            "sum_c": [231, 165, 66],
+            "sum_bc_over_2": [120.0, 85.5, 36.0],
+            "grp": ["xx", "yy", "zz"],
+        }
+    )
+    assert_frame_equal(expected, res.sort(by="grp"))
+
+
+def test_group_by_all_multi() -> None:
+    dt1 = date(1999, 12, 31)
+    dt2 = date(2028, 7, 5)
+
+    df = pl.DataFrame(
+        {
+            "key": ["xx", "yy", "xx", "yy", "xx", "xx"],
+            "dt": [dt1, dt1, dt1, dt2, dt2, dt2],
+            "value": [10.5, -5.5, 20.5, 8.0, -3.0, 5.0],
+        }
+    )
+    expected = pl.DataFrame(
+        {
+            "dt": [dt1, dt1, dt2, dt2],
+            "key": ["xx", "yy", "xx", "yy"],
+            "sum_value": [31.0, -5.5, 2.0, 8.0],
+            "ninety_nine": [99, 99, 99, 99],
+        },
+        schema_overrides={"ninety_nine": pl.Int16},
+    )
+
+    # the following groupings should all be equivalent
+    for group in (
+        "ALL",
+        "1, 2",
+        "dt, key",
+    ):
+        res = df.sql(
+            f"""
+            SELECT dt, key, sum_value, ninety_nine::int2 FROM
+            (
+                SELECT
+                  dt,
+                  key,
+                  SUM(value) AS sum_value,
+                  99 AS ninety_nine
+                FROM self
+                GROUP BY {group}
+                ORDER BY dt, key
+            ) AS grp
+            """
+        )
+        assert_frame_equal(expected, res)
 
 
 def test_group_by_ordinal_position() -> None:


### PR DESCRIPTION
Closes #15585 (ref: https://github.com/pola-rs/polars/issues/14704#issuecomment-2048020360)

## Feature

`GROUP BY ALL` is a useful SQL construct (as implemented by BigQuery, DuckDB, Snowflake, etc) that allows for automatic grouping by column expressions in the SELECT clause that are not (and do not contain) aggregate/window functions.

```python
from datetime import date
import polars as pl

dt1 = date(1999, 12, 31)
dt2 = date(2028, 7, 5)

df = pl.DataFrame({
    "key": ["xx", "yy", "xx", "yy", "xx", "xx"],
    "dt": [dt1, dt1, dt1, dt2, dt2, dt2],
    "value": [10.5, -5.5, 20.5, 8.0, -3.0, 5.0],
})

df.sql(
    """
    SELECT dt, key, SUM(value) AS total,
    FROM self
    GROUP BY ALL
    ORDER BY dt, key
    """
)
# shape: (4, 3)
# ┌────────────┬─────┬───────┐
# │ dt         ┆ key ┆ total │
# │ ---        ┆ --- ┆ ---   │
# │ date       ┆ str ┆ f64   │
# ╞════════════╪═════╪═══════╡
# │ 1999-12-31 ┆ xx  ┆ 31.0  │
# │ 1999-12-31 ┆ yy  ┆ -5.5  │
# │ 2028-07-05 ┆ xx  ┆ 2.0   │
# │ 2028-07-05 ┆ yy  ┆ 8.0   │
# └────────────┴─────┴───────┘
```

## Fixes

* While implementing this I came across several errors with group-key aliasing/tracking, resolved them, and added test coverage. I'm aware of one more similar gremlin, but it's very much an edge-case and I'll address it in a subsequent PR.
* Use of `ARRAY_AGG` in conjunction with `GROUP BY` could result in a double-implode, due to our implicit array aggregation on bare `agg` columns in the regular API.
* Attempting to group by ordinal values should have raised on negative integers - and now it does.