### PR TITLE
feat: Register memory mapped files and raise when written to

### DIFF
--- a/crates/polars-io/src/ipc/mmap.rs
+++ b/crates/polars-io/src/ipc/mmap.rs
@@ -2,11 +2,10 @@ use arrow::io::ipc::read;
 use arrow::io::ipc::read::{Dictionaries, FileMetadata};
 use arrow::mmap::{mmap_dictionaries_unchecked, mmap_unchecked};
 use arrow::record_batch::RecordBatch;
-use memmap::Mmap;
 use polars_core::prelude::*;
 
 use super::ipc_file::IpcReader;
-use crate::mmap::MmapBytesReader;
+use crate::mmap::{MMapSemaphore, MmapBytesReader};
 use crate::predicates::PhysicalIoExpr;
 use crate::shared::{finish_reader, ArrowReader};
 use crate::utils::{apply_projection, columns_to_projection};
@@ -19,7 +18,10 @@ impl<R: MmapBytesReader> IpcReader<R> {
         match self.reader.to_file() {
             Some(file) => {
                 let mmap = unsafe { memmap::Mmap::map(file).unwrap() };
-                let metadata = read::read_file_metadata(&mut std::io::Cursor::new(mmap.as_ref()))?;
+                let mmap_key = self.memory_map.take().unwrap();
+                let semaphore = MMapSemaphore::new(mmap_key, mmap);
+                let metadata =
+                    read::read_file_metadata(&mut std::io::Cursor::new(semaphore.as_ref()))?;
 
                 if let Some(columns) = &self.columns {
                     let schema = &metadata.schema;
@@ -33,7 +35,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
                     metadata.schema.clone()
                 };
 
-                let reader = MMapChunkIter::new(mmap, metadata, &self.projection)?;
+                let reader = MMapChunkIter::new(Arc::new(semaphore), metadata, &self.projection)?;
 
                 finish_reader(
                     reader,
@@ -53,7 +55,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
 struct MMapChunkIter<'a> {
     dictionaries: Dictionaries,
     metadata: FileMetadata,
-    mmap: Arc<Mmap>,
+    mmap: Arc<MMapSemaphore>,
     idx: usize,
     end: usize,
     projection: &'a Option<Vec<usize>>,
@@ -61,12 +63,10 @@ struct MMapChunkIter<'a> {
 
 impl<'a> MMapChunkIter<'a> {
     fn new(
-        mmap: Mmap,
+        mmap: Arc<MMapSemaphore>,
         metadata: FileMetadata,
         projection: &'a Option<Vec<usize>>,
     ) -> PolarsResult<Self> {
-        let mmap = Arc::new(mmap);
-
         let end = metadata.blocks.len();
         // mmap the dictionaries
         let dictionaries = unsafe { mmap_dictionaries_unchecked(&metadata, mmap.clone())? };

--- a/crates/polars-lazy/src/physical_plan/executors/scan/ipc.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/ipc.rs
@@ -95,6 +95,12 @@ impl IpcExec {
 
                 let file = std::fs::File::open(path)?;
 
+                let memory_mapped = if self.options.memory_map {
+                    Some(path.clone())
+                } else {
+                    None
+                };
+
                 let df = IpcReader::new(file)
                     .with_n_rows(
                         // NOTE: If there is any file that by itself exceeds the
@@ -108,7 +114,7 @@ impl IpcExec {
                     )
                     .with_row_index(self.file_options.row_index.clone())
                     .with_projection(projection.clone())
-                    .memory_mapped(self.options.memory_map)
+                    .memory_mapped(memory_mapped)
                     .finish()?;
 
                 row_counter

--- a/crates/polars-utils/src/io.rs
+++ b/crates/polars-utils/src/io.rs
@@ -1,21 +1,30 @@
 use std::fs::File;
-use std::io::Error;
+use std::io;
 use std::path::Path;
 
 use polars_error::*;
+
+fn map_err(path: &Path, err: io::Error) -> PolarsError {
+    let path = path.to_string_lossy();
+    let msg = if path.len() > 88 {
+        let truncated_path: String = path.chars().skip(path.len() - 88).collect();
+        format!("{err}: ...{truncated_path}")
+    } else {
+        format!("{err}: {path}")
+    };
+    io::Error::new(err.kind(), msg).into()
+}
 
 pub fn open_file<P>(path: P) -> PolarsResult<File>
 where
     P: AsRef<Path>,
 {
-    std::fs::File::open(&path).map_err(|err| {
-        let path = path.as_ref().to_string_lossy();
-        let msg = if path.len() > 88 {
-            let truncated_path: String = path.chars().skip(path.len() - 88).collect();
-            format!("{err}: ...{truncated_path}")
-        } else {
-            format!("{err}: {path}")
-        };
-        Error::new(err.kind(), msg).into()
-    })
+    File::open(&path).map_err(|err| map_err(path.as_ref(), err))
+}
+
+pub fn create_file<P>(path: P) -> PolarsResult<File>
+where
+    P: AsRef<Path>,
+{
+    File::create(&path).map_err(|err| map_err(path.as_ref(), err))
 }

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -41,4 +41,4 @@ pub mod ord;
 pub mod partitioned;
 
 pub use index::{IdxSize, NullableIdxSize};
-pub use io::open_file;
+pub use io::*;

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -337,3 +337,19 @@ def test_ipc_decimal_15920(
         path = f"{tmp_path}/data"
         df.write_ipc(path)
         assert_frame_equal(pl.read_ipc(path), df)
+
+
+@pytest.mark.write_disk()
+def test_ipc_raise_on_writing_mmap(tmp_path: Path) -> None:
+    p = tmp_path / "foo.ipc"
+    df = pl.DataFrame({"foo": [1, 2, 3]})
+    # first write is allowed
+    df.write_ipc(p)
+
+    # now open as memory mapped
+    df = pl.read_ipc(p, memory_map=True)
+
+    with pytest.raises(
+        pl.ComputeError, match="cannot write to file: already memory mapped"
+    ):
+        df.write_ipc(p)


### PR DESCRIPTION
It isn't perfect, but this will at least catch the most common case in python where people read memory mapped and write to the same file.

fixes #16119