### PR TITLE
feat: Adds new index/range based selector `cs.by_index`, allows multiple indices for `nth`

### DIFF
--- a/crates/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/expr.rs
@@ -639,8 +639,8 @@ fn create_physical_expr_inner(
         Wildcard => {
             polars_bail!(ComputeError: "wildcard column selection not supported at this point")
         },
-        Nth(_) => {
-            polars_bail!(ComputeError: "nth column selection not supported at this point")
+        Nth(n) => {
+            polars_bail!(ComputeError: "nth column selection not supported at this point (n={})", n)
         },
     }
 }

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -71,6 +71,7 @@ pub enum Expr {
     Column(ColumnName),
     Columns(Arc<[ColumnName]>),
     DtypeColumn(Vec<DataType>),
+    IndexColumn(Vec<i32>),
     Literal(LiteralValue),
     BinaryExpr {
         left: Arc<Expr>,
@@ -172,6 +173,7 @@ impl Hash for Expr {
             Expr::Column(name) => name.hash(state),
             Expr::Columns(names) => names.hash(state),
             Expr::DtypeColumn(dtypes) => dtypes.hash(state),
+            Expr::IndexColumn(dtypes) => dtypes.hash(state),
             Expr::Literal(lv) => std::mem::discriminant(lv).hash(state),
             Expr::Selector(s) => s.hash(state),
             Expr::Nth(v) => v.hash(state),

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -71,7 +71,7 @@ pub enum Expr {
     Column(ColumnName),
     Columns(Arc<[ColumnName]>),
     DtypeColumn(Vec<DataType>),
-    IndexColumn(Vec<i32>),
+    IndexColumn(Arc<[i32]>),
     Literal(LiteralValue),
     BinaryExpr {
         left: Arc<Expr>,
@@ -173,7 +173,7 @@ impl Hash for Expr {
             Expr::Column(name) => name.hash(state),
             Expr::Columns(names) => names.hash(state),
             Expr::DtypeColumn(dtypes) => dtypes.hash(state),
-            Expr::IndexColumn(dtypes) => dtypes.hash(state),
+            Expr::IndexColumn(indices) => indices.hash(state),
             Expr::Literal(lv) => std::mem::discriminant(lv).hash(state),
             Expr::Selector(s) => s.hash(state),
             Expr::Nth(v) => v.hash(state),

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -71,7 +71,7 @@ pub enum Expr {
     Column(ColumnName),
     Columns(Arc<[ColumnName]>),
     DtypeColumn(Vec<DataType>),
-    IndexColumn(Arc<[i32]>),
+    IndexColumn(Arc<[i64]>),
     Literal(LiteralValue),
     BinaryExpr {
         left: Arc<Expr>,

--- a/crates/polars-plan/src/dsl/functions/selectors.rs
+++ b/crates/polars-plan/src/dsl/functions/selectors.rs
@@ -58,7 +58,7 @@ pub fn dtype_cols<DT: AsRef<[DataType]>>(dtype: DT) -> Expr {
 }
 
 /// Select multiple columns by index.
-pub fn index_cols<N: AsRef<[i32]>>(indices: N) -> Expr {
+pub fn index_cols<N: AsRef<[i64]>>(indices: N) -> Expr {
     let indices = indices.as_ref().to_vec();
     Expr::IndexColumn(Arc::from(indices))
 }

--- a/crates/polars-plan/src/dsl/functions/selectors.rs
+++ b/crates/polars-plan/src/dsl/functions/selectors.rs
@@ -56,3 +56,9 @@ pub fn dtype_cols<DT: AsRef<[DataType]>>(dtype: DT) -> Expr {
     let dtypes = dtype.as_ref().to_vec();
     Expr::DtypeColumn(dtypes)
 }
+
+/// Select multiple columns by index.
+pub fn index_cols<N: AsRef<[i32]>>(indices: N) -> Expr {
+    let indices = indices.as_ref().to_vec();
+    Expr::IndexColumn(indices)
+}

--- a/crates/polars-plan/src/dsl/functions/selectors.rs
+++ b/crates/polars-plan/src/dsl/functions/selectors.rs
@@ -60,5 +60,5 @@ pub fn dtype_cols<DT: AsRef<[DataType]>>(dtype: DT) -> Expr {
 /// Select multiple columns by index.
 pub fn index_cols<N: AsRef<[i32]>>(indices: N) -> Expr {
     let indices = indices.as_ref().to_vec();
-    Expr::IndexColumn(indices)
+    Expr::IndexColumn(Arc::from(indices))
 }

--- a/crates/polars-plan/src/dsl/meta.rs
+++ b/crates/polars-plan/src/dsl/meta.rs
@@ -54,6 +54,7 @@ impl MetaNameSpace {
     pub fn has_multiple_outputs(&self) -> bool {
         self.0.into_iter().any(|e| match e {
             Expr::Selector(_) | Expr::Wildcard | Expr::Columns(_) | Expr::DtypeColumn(_) => true,
+            Expr::IndexColumn(idxs) => idxs.len() > 1,
             Expr::Column(name) => is_regex_projection(name),
             _ => false,
         })

--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -230,8 +230,8 @@ impl AExpr {
             Wildcard => {
                 polars_bail!(ComputeError: "wildcard column selection not supported at this point")
             },
-            Nth(_) => {
-                polars_bail!(ComputeError: "nth column selection not supported at this point")
+            Nth(n) => {
+                polars_bail!(ComputeError: "nth column selection not supported at this point (n={})", n)
             },
         }
     }

--- a/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
@@ -560,6 +560,7 @@ fn expand_filter(predicate: Expr, input: Node, lp_arena: &Arena<IR>) -> PolarsRe
         | Expr::RenameAlias { .. }
         | Expr::Columns(_)
         | Expr::DtypeColumn(_)
+        | Expr::IndexColumn(_)
         | Expr::Nth(_) => true,
         _ => false,
     }) {

--- a/crates/polars-plan/src/logical_plan/conversion/expr_to_ir.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/expr_to_ir.rs
@@ -347,8 +347,15 @@ fn to_aexpr_impl(expr: Expr, arena: &mut Arena<AExpr>, state: &mut ConversionSta
             AExpr::Len
         },
         Expr::Nth(i) => AExpr::Nth(i),
+        Expr::IndexColumn(idx) => {
+            if idx.len() == 1 {
+                AExpr::Nth(idx[0].into())
+            } else {
+                panic!("no multi-value `index-columns` expected at this point")
+            }
+        },
         Expr::Wildcard => AExpr::Wildcard,
-        Expr::SubPlan { .. } => panic!("no SQLSubquery expected at this point"),
+        Expr::SubPlan { .. } => panic!("no SQL subquery expected at this point"),
         Expr::KeepName(_) => panic!("no `name.keep` expected at this point"),
         Expr::Exclude(_, _) => panic!("no `exclude` expected at this point"),
         Expr::RenameAlias { .. } => panic!("no `rename_alias` expected at this point"),

--- a/crates/polars-plan/src/logical_plan/conversion/expr_to_ir.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/expr_to_ir.rs
@@ -349,7 +349,7 @@ fn to_aexpr_impl(expr: Expr, arena: &mut Arena<AExpr>, state: &mut ConversionSta
         Expr::Nth(i) => AExpr::Nth(i),
         Expr::IndexColumn(idx) => {
             if idx.len() == 1 {
-                AExpr::Nth(idx[0].into())
+                AExpr::Nth(idx[0])
             } else {
                 panic!("no multi-value `index-columns` expected at this point")
             }

--- a/crates/polars-plan/src/logical_plan/expr_expansion.rs
+++ b/crates/polars-plan/src/logical_plan/expr_expansion.rs
@@ -292,7 +292,7 @@ fn expand_dtypes(
         let name = field.name();
         let new_expr = expr.clone();
         let new_expr =
-            replace_dtype_or_index_with_column(new_expr, ColumnName::from(name.as_str()), true);
+            replace_dtype_or_index_with_column(new_expr, &ColumnName::from(name.as_str()), true);
         let new_expr = rewrite_special_aliases(new_expr)?;
         result.push(new_expr)
     }
@@ -321,7 +321,7 @@ fn expand_indices(
                 let new_expr = expr.clone();
                 let new_expr = replace_dtype_or_index_with_column(
                     new_expr,
-                    ColumnName::from(name.as_str()),
+                    &ColumnName::from(name.as_str()),
                     false,
                 );
                 let new_expr = rewrite_special_aliases(new_expr)?;

--- a/crates/polars-plan/src/logical_plan/expr_expansion.rs
+++ b/crates/polars-plan/src/logical_plan/expr_expansion.rs
@@ -69,7 +69,11 @@ fn replace_nth(expr: Expr, schema: &Schema) -> Expr {
         if let Expr::Nth(i) = e {
             match i.negative_to_usize(schema.len()) {
                 None => {
-                    let name = if i == 0 { "first" } else { "last" };
+                    let name = match i {
+                        0 => "first",
+                        -1 => "last",
+                        _ => "nth",
+                    };
                     Expr::Column(ColumnName::from(name))
                 },
                 Some(idx) => {
@@ -184,16 +188,6 @@ fn expand_columns(
     Ok(())
 }
 
-/// This replaces the dtypes Expr with a Column Expr. It also removes the Exclude Expr from the
-/// expression chain.
-fn replace_dtype_with_column(expr: Expr, column_name: Arc<str>) -> Expr {
-    expr.map_expr(|e| match e {
-        Expr::DtypeColumn(_) => Expr::Column(column_name.clone()),
-        Expr::Exclude(input, _) => Arc::unwrap_or_clone(input),
-        e => e,
-    })
-}
-
 #[cfg(feature = "dtype-struct")]
 fn struct_index_to_field(expr: Expr, schema: &Schema) -> PolarsResult<Expr> {
     expr.try_map_expr(|e| match e {
@@ -225,6 +219,21 @@ fn struct_index_to_field(expr: Expr, schema: &Schema) -> PolarsResult<Expr> {
             }
         },
         e => Ok(e),
+    })
+}
+
+/// This replaces the dtype or index expanded Expr with a Column Expr.
+/// ()It also removes the Exclude Expr from the expression chain).
+fn replace_dtype_or_index_with_column(
+    expr: Expr,
+    column_name: Arc<str>,
+    replace_dtype: bool,
+) -> Expr {
+    expr.map_expr(|e| match e {
+        Expr::DtypeColumn(_) if replace_dtype => Expr::Column(column_name.clone()),
+        Expr::IndexColumn(_) if !replace_dtype => Expr::Column(column_name.clone()),
+        Expr::Exclude(input, _) => Arc::unwrap_or_clone(input),
+        e => e,
     })
 }
 
@@ -282,9 +291,43 @@ fn expand_dtypes(
     }) {
         let name = field.name();
         let new_expr = expr.clone();
-        let new_expr = replace_dtype_with_column(new_expr, ColumnName::from(name.as_str()));
+        let new_expr =
+            replace_dtype_or_index_with_column(new_expr, ColumnName::from(name.as_str()), true);
         let new_expr = rewrite_special_aliases(new_expr)?;
         result.push(new_expr)
+    }
+    Ok(())
+}
+
+/// replace `IndexColumn` with `col("foo")..col("bar")`
+fn expand_indices(
+    expr: &Expr,
+    result: &mut Vec<Expr>,
+    schema: &Schema,
+    indices: &[i32],
+    exclude: &PlHashSet<Arc<str>>,
+) -> PolarsResult<()> {
+    let n_fields = schema.len() as i32;
+    for idx in indices {
+        let mut idx = *idx;
+        if idx < 0 {
+            idx += n_fields;
+            if idx < 0 {
+                polars_bail!(ComputeError: "invalid column index {}", idx)
+            }
+        }
+        if let Some((name, _)) = schema.get_at_index(idx as usize) {
+            if !exclude.contains(name.as_str()) {
+                let new_expr = expr.clone();
+                let new_expr = replace_dtype_or_index_with_column(
+                    new_expr,
+                    ColumnName::from(name.as_str()),
+                    false,
+                );
+                let new_expr = rewrite_special_aliases(new_expr)?;
+                result.push(new_expr);
+            }
+        }
     }
     Ok(())
 }
@@ -400,6 +443,7 @@ fn find_flags(expr: &Expr) -> ExpansionFlags {
     for expr in expr {
         match expr {
             Expr::Columns(_) | Expr::DtypeColumn(_) => multiple_columns = true,
+            Expr::IndexColumn(idx) => multiple_columns = idx.len() > 1,
             Expr::Nth(_) => has_nth = true,
             Expr::Wildcard => has_wildcard = true,
             Expr::Selector(_) => has_selector = true,
@@ -474,19 +518,24 @@ fn replace_and_add_to_results(
     // has multiple column names
     // the expanded columns are added to the result
     if flags.multiple_columns {
-        if let Some(e) = expr
-            .into_iter()
-            .find(|e| matches!(e, Expr::Columns(_) | Expr::DtypeColumn(_)))
-        {
+        if let Some(e) = expr.into_iter().find(|e| {
+            matches!(
+                e,
+                Expr::Columns(_) | Expr::DtypeColumn(_) | Expr::IndexColumn(_)
+            )
+        }) {
             match &e {
                 Expr::Columns(names) => {
                     let exclude = prepare_excluded(&expr, schema, keys, flags.has_exclude)?;
                     expand_columns(&expr, result, names, schema, &exclude)?;
                 },
                 Expr::DtypeColumn(dtypes) => {
-                    // keep track of column excluded from the dtypes
                     let exclude = prepare_excluded(&expr, schema, keys, flags.has_exclude)?;
                     expand_dtypes(&expr, result, schema, dtypes, &exclude)?
+                },
+                Expr::IndexColumn(indices) => {
+                    let exclude = prepare_excluded(&expr, schema, keys, flags.has_exclude)?;
+                    expand_indices(&expr, result, schema, indices, &exclude)?
                 },
                 _ => {},
             }

--- a/crates/polars-plan/src/logical_plan/expr_expansion.rs
+++ b/crates/polars-plan/src/logical_plan/expr_expansion.rs
@@ -304,10 +304,10 @@ fn expand_indices(
     expr: &Expr,
     result: &mut Vec<Expr>,
     schema: &Schema,
-    indices: &[i32],
+    indices: &[i64],
     exclude: &PlHashSet<Arc<str>>,
 ) -> PolarsResult<()> {
-    let n_fields = schema.len() as i32;
+    let n_fields = schema.len() as i64;
     for idx in indices {
         let mut idx = *idx;
         if idx < 0 {

--- a/crates/polars-plan/src/logical_plan/expr_expansion.rs
+++ b/crates/polars-plan/src/logical_plan/expr_expansion.rs
@@ -226,7 +226,7 @@ fn struct_index_to_field(expr: Expr, schema: &Schema) -> PolarsResult<Expr> {
 /// ()It also removes the Exclude Expr from the expression chain).
 fn replace_dtype_or_index_with_column(
     expr: Expr,
-    column_name: Arc<str>,
+    column_name: &ColumnName,
     replace_dtype: bool,
 ) -> Expr {
     expr.map_expr(|e| match e {

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -420,6 +420,7 @@ impl Debug for Expr {
             RenameAlias { expr, .. } => write!(f, ".rename_alias({expr:?})"),
             Columns(names) => write!(f, "cols({names:?})"),
             DtypeColumn(dt) => write!(f, "dtype_columns({dt:?})"),
+            IndexColumn(idxs) => write!(f, "index_columns({idxs:?})"),
             Selector(_) => write!(f, "SELECTOR"),
         }
     }

--- a/crates/polars-plan/src/logical_plan/iterator.rs
+++ b/crates/polars-plan/src/logical_plan/iterator.rs
@@ -11,7 +11,8 @@ macro_rules! push_expr {
     ($current_expr:expr, $c:ident, $push:ident, $push_owned:ident, $iter:ident) => {{
         use Expr::*;
         match $current_expr {
-            Nth(_) | Column(_) | Literal(_) | Wildcard | Columns(_) | DtypeColumn(_) | Len => {},
+            Nth(_) | Column(_) | Literal(_) | Wildcard | Columns(_) | DtypeColumn(_)
+            | IndexColumn(_) | Len => {},
             Alias(e, _) => $push($c, e),
             BinaryExpr { left, op: _, right } => {
                 // reverse order so that left is popped first

--- a/crates/polars-plan/src/logical_plan/visitor/expr.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/expr.rs
@@ -44,6 +44,7 @@ impl TreeWalker for Expr {
             Column(_) => self,
             Columns(_) => self,
             DtypeColumn(_) => self,
+            IndexColumn(_) => self,
             Literal(_) => self,
             BinaryExpr { left, op, right } => {
                 BinaryExpr { left: am(left, &mut f)? , op, right: am(right, f)?}

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -179,7 +179,7 @@ pub fn expr_output_name(expr: &Expr) -> PolarsResult<Arc<str>> {
                 ComputeError:
                 "cannot determine output column without a context for this expression"
             ),
-            Expr::Columns(_) | Expr::DtypeColumn(_) => polars_bail!(
+            Expr::Columns(_) | Expr::DtypeColumn(_) | Expr::IndexColumn(_) => polars_bail!(
                 ComputeError:
                 "this expression may produce multiple output names"
             ),

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -94,9 +94,9 @@ fn test_array_to_string() {
     context.register("df", df.clone().lazy());
 
     let sql = r#"
-        SELECT b, ARRAY_TO_STRING(a,', ') AS a2s,
+        SELECT b, ARRAY_TO_STRING("a",', ') AS a2s,
         FROM (
-            SELECT b, ARRAY_AGG(a)
+            SELECT b, ARRAY_AGG(a) AS "a"
             FROM df
             GROUP BY b
         ) tbl

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2716,7 +2716,7 @@ class Expr:
         )
 
     def gather(
-        self, indices: int | list[int] | Expr | Series | np.ndarray[Any, Any]
+        self, indices: int | Sequence[int] | Expr | Series | np.ndarray[Any, Any]
     ) -> Self:
         """
         Take values by index.

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -18,27 +18,19 @@ __all__ = ["col"]
 
 
 def _create_col(
-    name: (
-        str
-        | int
-        | PolarsDataType
-        | Iterable[int]
-        | Iterable[str]
-        | Iterable[PolarsDataType]
-    ),
-    *more_names: str | int | PolarsDataType,
+    name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+    *more_names: str | PolarsDataType,
 ) -> Expr:
     """Create one or more column expressions representing column(s) in a DataFrame."""
     if more_names:
         if isinstance(name, str):
-            names_str = [name, *more_names]
+            names_str = [name]
+            names_str.extend(more_names)  # type: ignore[arg-type]
             return wrap_expr(plr.cols(names_str))
         elif is_polars_dtype(name):
-            dtypes = [name, *more_names]
+            dtypes = [name]
+            dtypes.extend(more_names)  # type: ignore[arg-type]
             return wrap_expr(plr.dtype_cols(dtypes))
-        elif isinstance(name, int):
-            indexes = [name, *more_names]
-            return wrap_expr(plr.index_cols(indexes))
         else:
             msg = (
                 "invalid input for `col`"
@@ -50,8 +42,6 @@ def _create_col(
         return wrap_expr(plr.col(name))
     elif is_polars_dtype(name):
         return wrap_expr(plr.dtype_cols([name]))
-    elif isinstance(name, int):
-        return wrap_expr(plr.index_cols([name]))
     elif isinstance(name, Iterable):
         names = list(name)
         if not names:
@@ -62,8 +52,6 @@ def _create_col(
             return wrap_expr(plr.cols(names))
         elif is_polars_dtype(item):
             return wrap_expr(plr.dtype_cols(names))
-        if isinstance(item, int):
-            return wrap_expr(plr.index_cols(names))
         else:
             msg = (
                 "invalid input for `col`"
@@ -83,15 +71,8 @@ def _create_col(
 class Column(Protocol):
     def __call__(
         self,
-        name: (
-            str
-            | int
-            | PolarsDataType
-            | Iterable[int]
-            | Iterable[str]
-            | Iterable[PolarsDataType]
-        ),
-        *more_names: str | int | PolarsDataType,
+        name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+        *more_names: str | PolarsDataType,
     ) -> Expr: ...
 
     def __getattr__(self, name: str) -> Expr: ...
@@ -163,15 +144,8 @@ class ColumnFactory(metaclass=ColumnFactoryMeta):
 
     def __new__(  # type: ignore[misc]
         cls,
-        name: (
-            str
-            | int
-            | PolarsDataType
-            | Iterable[str]
-            | Iterable[int]
-            | Iterable[PolarsDataType]
-        ),
-        *more_names: str | int | PolarsDataType,
+        name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+        *more_names: str | PolarsDataType,
     ) -> Expr:
         """
         Create one or more column expressions representing column(s) in a DataFrame.
@@ -179,11 +153,18 @@ class ColumnFactory(metaclass=ColumnFactoryMeta):
         Parameters
         ----------
         name
-            The name, datatype, or index of the column(s) to represent. Also accepts
-            regular expression input; regexes should start with `^` and end with `$`.
+            The name or datatype of the column(s) to represent.
+            Accepts regular expression input.
+            Regular expressions should start with `^` and end with `$`.
         *more_names
-            Additional names or datatypes of columns to represent,cspecified as
-            positional arguments.
+            Additional names or datatypes of columns to represent,
+            specified as positional arguments.
+
+        See Also
+        --------
+        first
+        last
+        nth
 
         Examples
         --------
@@ -313,15 +294,8 @@ class ColumnFactory(metaclass=ColumnFactoryMeta):
     # appease sphinx; we actually use '__new__'
     def __call__(
         self,
-        name: (
-            str
-            | int
-            | PolarsDataType
-            | Iterable[int]
-            | Iterable[str]
-            | Iterable[PolarsDataType]
-        ),
-        *more_names: str | int | PolarsDataType,
+        name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+        *more_names: str | PolarsDataType,
     ) -> Expr:
         return _create_col(name, *more_names)
 

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -695,7 +695,7 @@ def by_index(*indices: int | range | Collection[int | range]) -> SelectorType:
             raise TypeError(msg)
 
     return _selector_proxy_(
-        F.col(all_indices), name="by_index", parameters={"*indices": indices}
+        F.nth(all_indices), name="by_index", parameters={"*indices": indices}
     )
 
 

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -620,6 +620,7 @@ def by_index(*indices: int | range | Collection[int | range]) -> SelectorType:
     ...         **{f"c{i:02}": [0.5 * i] for i in range(100)},
     ...     },
     ... )
+    >>> print(df)
     shape: (1, 101)
     ┌─────┬─────┬─────┬─────┬───┬──────┬──────┬──────┬──────┐
     │ key ┆ c00 ┆ c01 ┆ c02 ┆ … ┆ c96  ┆ c97  ┆ c98  ┆ c99  │

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -282,12 +282,12 @@ class _selector_proxy_(Expr):
             set_ops = {"and": "&", "or": "|", "sub": "-"}
             if selector_name in set_ops:
                 op = set_ops[selector_name]
-                return "(%s)" % f" {op} ".join(repr(p) for p in params.values())
+                return "({})".format(f" {op} ".join(repr(p) for p in params.values()))
             else:
                 str_params = ",".join(
                     (repr(v)[1:-1] if k.startswith("*") else f"{k}={v!r}")
                     for k, v in (params or {}).items()
-                )
+                ).rstrip(",")
                 return f"cs.{selector_name}({str_params})"
 
     def __sub__(self, other: Any) -> SelectorType | Expr:  # type: ignore[override]
@@ -522,6 +522,7 @@ def by_dtype(
     See Also
     --------
     by_name : Select all columns matching the given names.
+    by_index : Select all columns matching the given indices.
 
     Examples
     --------
@@ -595,6 +596,108 @@ def by_dtype(
     )
 
 
+def by_index(*indices: int | range | Collection[int | range]) -> SelectorType:
+    """
+    Select all columns matching the given indices (or range objects).
+
+    Parameters
+    ----------
+    *indices
+        One or more column indices (or range objects).
+        Negative indexing is supported.
+
+    See Also
+    --------
+    by_dtype : Select all columns matching the given dtypes.
+    by_name : Select all columns matching the given names.
+
+    Examples
+    --------
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "key": ["abc"],
+    ...         **{f"c{i:02}": [0.5 * i] for i in range(100)},
+    ...     },
+    ... )
+    shape: (1, 101)
+    ┌─────┬─────┬─────┬─────┬───┬──────┬──────┬──────┬──────┐
+    │ key ┆ c00 ┆ c01 ┆ c02 ┆ … ┆ c96  ┆ c97  ┆ c98  ┆ c99  │
+    │ --- ┆ --- ┆ --- ┆ --- ┆   ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
+    │ str ┆ f64 ┆ f64 ┆ f64 ┆   ┆ f64  ┆ f64  ┆ f64  ┆ f64  │
+    ╞═════╪═════╪═════╪═════╪═══╪══════╪══════╪══════╪══════╡
+    │ abc ┆ 0.0 ┆ 0.5 ┆ 1.0 ┆ … ┆ 48.0 ┆ 48.5 ┆ 49.0 ┆ 49.5 │
+    └─────┴─────┴─────┴─────┴───┴──────┴──────┴──────┴──────┘
+
+    Select columns by index ("key" column and the two first/last columns):
+
+    >>> df.select(cs.by_index(0, 1, 2, -2, -1))
+    shape: (1, 5)
+    ┌─────┬─────┬─────┬──────┬──────┐
+    │ key ┆ c00 ┆ c01 ┆ c98  ┆ c99  │
+    │ --- ┆ --- ┆ --- ┆ ---  ┆ ---  │
+    │ str ┆ f64 ┆ f64 ┆ f64  ┆ f64  │
+    ╞═════╪═════╪═════╪══════╪══════╡
+    │ abc ┆ 0.0 ┆ 0.5 ┆ 49.0 ┆ 49.5 │
+    └─────┴─────┴─────┴──────┴──────┘
+
+    Select the "key" column and use a `range` object to select various columns.
+    Note that you can freely mix and match integer indices and `range` objects:
+
+    >>> df.select(cs.by_index(0, range(1, 101, 20)))
+    shape: (1, 6)
+    ┌─────┬─────┬──────┬──────┬──────┬──────┐
+    │ key ┆ c00 ┆ c20  ┆ c40  ┆ c60  ┆ c80  │
+    │ --- ┆ --- ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
+    │ str ┆ f64 ┆ f64  ┆ f64  ┆ f64  ┆ f64  │
+    ╞═════╪═════╪══════╪══════╪══════╪══════╡
+    │ abc ┆ 0.0 ┆ 10.0 ┆ 20.0 ┆ 30.0 ┆ 40.0 │
+    └─────┴─────┴──────┴──────┴──────┴──────┘
+
+    >>> df.select(cs.by_index(0, range(101, 0, -25)))
+    shape: (1, 5)
+    ┌─────┬──────┬──────┬──────┬─────┐
+    │ key ┆ c75  ┆ c50  ┆ c25  ┆ c00 │
+    │ --- ┆ ---  ┆ ---  ┆ ---  ┆ --- │
+    │ str ┆ f64  ┆ f64  ┆ f64  ┆ f64 │
+    ╞═════╪══════╪══════╪══════╪═════╡
+    │ abc ┆ 37.5 ┆ 25.0 ┆ 12.5 ┆ 0.0 │
+    └─────┴──────┴──────┴──────┴─────┘
+
+    Select all columns *except* for the even-indexed ones:
+
+    >>> df.select(~cs.by_index(range(1, 100, 2)))
+    shape: (1, 51)
+    ┌─────┬─────┬─────┬─────┬───┬──────┬──────┬──────┬──────┐
+    │ key ┆ c01 ┆ c03 ┆ c05 ┆ … ┆ c93  ┆ c95  ┆ c97  ┆ c99  │
+    │ --- ┆ --- ┆ --- ┆ --- ┆   ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
+    │ str ┆ f64 ┆ f64 ┆ f64 ┆   ┆ f64  ┆ f64  ┆ f64  ┆ f64  │
+    ╞═════╪═════╪═════╪═════╪═══╪══════╪══════╪══════╪══════╡
+    │ abc ┆ 0.5 ┆ 1.5 ┆ 2.5 ┆ … ┆ 46.5 ┆ 47.5 ┆ 48.5 ┆ 49.5 │
+    └─────┴─────┴─────┴─────┴───┴──────┴──────┴──────┴──────┘
+    """
+    all_indices = []
+    for idx in indices:
+        if isinstance(idx, int):
+            all_indices.append(idx)
+        elif isinstance(idx, range):
+            all_indices.extend(idx)
+        elif isinstance(idx, Collection):
+            for i in idx:
+                if isinstance(i, int):
+                    all_indices.append(i)
+                else:
+                    msg = f"invalid index: {i!r}"
+                    raise TypeError(msg)
+        else:
+            msg = f"invalid index: {idx!r}"
+            raise TypeError(msg)
+
+    return _selector_proxy_(
+        F.col(all_indices), name="by_index", parameters={"*indices": indices}
+    )
+
+
 def by_name(*names: str | Collection[str]) -> SelectorType:
     """
     Select all columns matching the given names.
@@ -607,6 +710,7 @@ def by_name(*names: str | Collection[str]) -> SelectorType:
     See Also
     --------
     by_dtype : Select all columns matching the given dtypes.
+    by_index : Select all columns matching the given indices.
 
     Examples
     --------

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -332,13 +332,13 @@ pub fn dtype_cols(dtypes: Vec<Wrap<DataType>>) -> PyResult<PyExpr> {
 }
 
 #[pyfunction]
-pub fn index_cols(indices: Vec<i32>) -> PyResult<PyExpr> {
-    Ok(if indices.len() == 1 {
-        dsl::nth(indices[0].into())
+pub fn index_cols(indices: Vec<i64>) -> PyExpr {
+    if indices.len() == 1 {
+        dsl::nth(indices[0])
     } else {
         dsl::index_cols(indices)
     }
-    .into())
+    .into()
 }
 
 #[pyfunction]

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -332,6 +332,16 @@ pub fn dtype_cols(dtypes: Vec<Wrap<DataType>>) -> PyResult<PyExpr> {
 }
 
 #[pyfunction]
+pub fn index_cols(indices: Vec<i32>) -> PyResult<PyExpr> {
+    Ok(if indices.len() == 1 {
+        dsl::nth(indices[0].into())
+    } else {
+        dsl::index_cols(indices)
+    }
+    .into())
+}
+
+#[pyfunction]
 #[pyo3(signature = (weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds, time_unit))]
 pub fn duration(
     weeks: Option<PyExpr>,

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -259,6 +259,8 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::dtype_cols))
         .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::index_cols))
+        .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::duration))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::first)).unwrap();

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -842,7 +842,8 @@ def test_join_on_wildcard_error() -> None:
     df = pl.DataFrame({"x": [1]})
     df2 = pl.DataFrame({"x": [1], "y": [2]})
     with pytest.raises(
-        pl.ComputeError, match="wildcard column selection not supported at this point"
+        pl.ComputeError,
+        match="wildcard column selection not supported at this point",
     ):
         df.join(df2, on=pl.all())
 
@@ -851,7 +852,8 @@ def test_join_on_nth_error() -> None:
     df = pl.DataFrame({"x": [1]})
     df2 = pl.DataFrame({"x": [1], "y": [2]})
     with pytest.raises(
-        pl.ComputeError, match="nth column selection not supported at this point (n=0)"
+        pl.ComputeError,
+        match=r"nth column selection not supported at this point \(n=0\)",
     ):
         df.join(df2, on=pl.first())
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -851,7 +851,7 @@ def test_join_on_nth_error() -> None:
     df = pl.DataFrame({"x": [1]})
     df2 = pl.DataFrame({"x": [1], "y": [2]})
     with pytest.raises(
-        pl.ComputeError, match="nth column selection not supported at this point"
+        pl.ComputeError, match="nth column selection not supported at this point (n=0)"
     ):
         df.join(df2, on=pl.first())
 

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -75,6 +75,7 @@ def test_selector_by_dtype(df: pl.DataFrame) -> None:
 def test_selector_by_index(df: pl.DataFrame) -> None:
     # one or more +ve indexes
     assert df.select(cs.by_index(0)).columns == ["abc"]
+    assert df.select(pl.nth([0, 1, 2])).columns == ["abc", "bbb", "cde"]
     assert df.select(cs.by_index(0, 1, 2)).columns == ["abc", "bbb", "cde"]
 
     # one or more -ve indexes
@@ -99,8 +100,13 @@ def test_selector_by_index(df: pl.DataFrame) -> None:
         "opp",
     ]
 
+    # expected errors
     with pytest.raises(ColumnNotFoundError):
         df.select(cs.by_index(999))
+
+    for invalid in ("one", ["two", "three"]):
+        with pytest.raises(TypeError):
+            df.select(cs.by_index(invalid))  # type: ignore[arg-type]
 
 
 def test_selector_by_name(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -71,6 +71,10 @@ def test_selector_by_dtype(df: pl.DataFrame) -> None:
     assert df.select(cs.by_dtype()).schema == {}
     assert df.select(cs.by_dtype([])).schema == {}
 
+    # expected errors
+    with pytest.raises(TypeError):
+        df.select(cs.by_dtype(999))  # type: ignore[arg-type]
+
 
 def test_selector_by_index(df: pl.DataFrame) -> None:
     # one or more +ve indexes
@@ -126,8 +130,12 @@ def test_selector_by_name(df: pl.DataFrame) -> None:
     assert df.select(cs.by_name()).columns == []
     assert df.select(cs.by_name([])).columns == []
 
+    # expected errors
     with pytest.raises(ColumnNotFoundError):
         df.select(cs.by_name("stroopwafel"))
+
+    with pytest.raises(TypeError):
+        df.select(cs.by_name(999))  # type: ignore[arg-type]
 
 
 def test_selector_contains(df: pl.DataFrame) -> None:
@@ -146,6 +154,10 @@ def test_selector_contains(df: pl.DataFrame) -> None:
         "qqR",
     ]
     assert df.select(cs.contains(("ee", "x"))).columns == ["eee"]
+
+    # expected errors
+    with pytest.raises(TypeError):
+        df.select(cs.contains(999))  # type: ignore[arg-type]
 
 
 def test_selector_datetime(df: pl.DataFrame) -> None:
@@ -233,6 +245,10 @@ def test_selector_datetime(df: pl.DataFrame) -> None:
         == df.select(~cs.datetime(["ms", "ns"], time_zone="*")).columns
     )
 
+    # expected errors
+    with pytest.raises(TypeError):
+        df.select(cs.datetime(999))  # type: ignore[arg-type]
+
 
 def test_select_decimal(df: pl.DataFrame) -> None:
     assert df.select(cs.decimal()).columns == []
@@ -287,6 +303,10 @@ def test_selector_ends_with(df: pl.DataFrame) -> None:
         "JJK",
         "qqR",
     ]
+
+    # expected errors
+    with pytest.raises(TypeError):
+        df.select(cs.ends_with(999))  # type: ignore[arg-type]
 
 
 def test_selector_first_last(df: pl.DataFrame) -> None:
@@ -388,6 +408,9 @@ def test_selector_startswith(df: pl.DataFrame) -> None:
         "opp",
         "qqR",
     ]
+    # expected errors
+    with pytest.raises(TypeError):
+        df.select(cs.starts_with(999))  # type: ignore[arg-type]
 
 
 def test_selector_temporal(df: pl.DataFrame) -> None:


### PR DESCRIPTION
Enables some interesting new column selection capabilities using indices (including negative indices) and `range` objects, as well as their union, intersection, etc (via selector combinatorics).

* Adds a new `by_index` selector that works with indices _and_ ranges.
* Allows `nth` to take _multiple_ indices.

## Examples

```python
import polars.selectors as cs
import polars as pl

df = pl.DataFrame({
    "key": ["abc"],
    **{f"c{i:02}": [0.5 * i] for i in range(100)},
})
# shape: (1, 101)
# ┌─────┬─────┬─────┬─────┬───┬──────┬──────┬──────┬──────┐
# │ key ┆ c00 ┆ c01 ┆ c02 ┆ … ┆ c96  ┆ c97  ┆ c98  ┆ c99  │
# │ --- ┆ --- ┆ --- ┆ --- ┆   ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
# │ str ┆ f64 ┆ f64 ┆ f64 ┆   ┆ f64  ┆ f64  ┆ f64  ┆ f64  │
# ╞═════╪═════╪═════╪═════╪═══╪══════╪══════╪══════╪══════╡
# │ abc ┆ 0.0 ┆ 0.5 ┆ 1.0 ┆ … ┆ 48.0 ┆ 48.5 ┆ 49.0 ┆ 49.5 │
# └─────┴─────┴─────┴─────┴───┴──────┴──────┴──────┴──────┘
```
Select "key" col and the three first/last numeric columns:
_(can freely mix/match indexes and range objects)_
```python
df.select(pl.nth([0, 1, 2, 3, -3, -2, -1]))
df.select(cs.by_index(0, 1, 2, 3, -3, -2, -1))
df.select(cs.by_index(range(0,4), range(-3,0)))
# shape: (1, 7)
# ┌─────┬─────┬─────┬─────┬──────┬──────┬──────┐
# │ key ┆ c00 ┆ c01 ┆ c02 ┆ c97  ┆ c98  ┆ c99  │
# │ --- ┆ --- ┆ --- ┆ --- ┆ ---  ┆ ---  ┆ ---  │
# │ str ┆ f64 ┆ f64 ┆ f64 ┆ f64  ┆ f64  ┆ f64  │
# ╞═════╪═════╪═════╪═════╪══════╪══════╪══════╡
# │ abc ┆ 0.0 ┆ 0.5 ┆ 1.0 ┆ 48.5 ┆ 49.0 ┆ 49.5 │
# └─────┴─────┴─────┴─────┴──────┴──────┴──────┘
```
Select every 10th column:
```python
df.select(cs.by_index(range(0,101,10)))
# shape: (1, 11)
# ┌─────┬─────┬─────┬──────┬───┬──────┬──────┬──────┬──────┐
# │ key ┆ c09 ┆ c19 ┆ c29  ┆ … ┆ c69  ┆ c79  ┆ c89  ┆ c99  │
# │ --- ┆ --- ┆ --- ┆ ---  ┆   ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
# │ str ┆ f64 ┆ f64 ┆ f64  ┆   ┆ f64  ┆ f64  ┆ f64  ┆ f64  │
# ╞═════╪═════╪═════╪══════╪═══╪══════╪══════╪══════╪══════╡
# │ abc ┆ 4.5 ┆ 9.5 ┆ 14.5 ┆ … ┆ 34.5 ┆ 39.5 ┆ 44.5 ┆ 49.5 │
# └─────┴─────┴─────┴──────┴───┴──────┴──────┴──────┴──────┘
```
Select every 25th numeric column in reverse order:
```python
df.select(cs.by_index(range(101,0,-25)))
# shape: (1, 4)
# ┌──────┬──────┬──────┬─────┐
# │ c75  ┆ c50  ┆ c25  ┆ c00 │
# │ ---  ┆ ---  ┆ ---  ┆ --- │
# │ f64  ┆ f64  ┆ f64  ┆ f64 │
# ╞══════╪══════╪══════╪═════╡
# │ 37.5 ┆ 25.0 ┆ 12.5 ┆ 0.0 │
# └──────┴──────┴──────┴─────┘
```