### PR TITLE
fix(python): Fix a rounding error in parametric test datetimes generation

### DIFF
--- a/py-polars/polars/testing/_constants.py
+++ b/py-polars/polars/testing/_constants.py
@@ -1,2 +1,0 @@
-# On this limit Polars will start partitioning in debug builds
-PARTITION_LIMIT = 15

--- a/py-polars/polars/testing/parametric/strategies/data.py
+++ b/py-polars/polars/testing/parametric/strategies/data.py
@@ -151,7 +151,7 @@ def datetimes(time_unit: TimeUnit = "us") -> SearchStrategy[datetime]:
         return st.datetimes()
     elif time_unit == "ns":
         return st.datetimes(
-            min_value=EPOCH + timedelta(microseconds=I64_MIN // 1000),
+            min_value=EPOCH + timedelta(microseconds=I64_MIN // 1000 + 1),
             max_value=EPOCH + timedelta(microseconds=I64_MAX // 1000),
         )
     else:

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -20,6 +20,12 @@ load_profile(
 
 
 @pytest.fixture()
+def partition_limit() -> int:
+    """The limit at which Polars will start partitioning in debug builds."""
+    return 15
+
+
+@pytest.fixture()
 def df() -> pl.DataFrame:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -10,7 +10,6 @@ import pytest
 import polars as pl
 import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
-from polars.testing._constants import PARTITION_LIMIT
 
 if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType
@@ -770,10 +769,10 @@ def test_group_by_partitioned_ending_cast(monkeypatch: Any) -> None:
     assert_frame_equal(out, expected)
 
 
-def test_group_by_series_partitioned() -> None:
+def test_group_by_series_partitioned(partition_limit: int) -> None:
     # test 15354
-    df = pl.DataFrame([0, 0] * PARTITION_LIMIT)
-    groups = pl.Series([0, 1] * PARTITION_LIMIT)
+    df = pl.DataFrame([0, 0] * partition_limit)
+    groups = pl.Series([0, 1] * partition_limit)
     df.group_by(groups).agg(pl.all().is_not_null().sum())
 
 

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -8,7 +8,6 @@ import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
-from polars.testing._constants import PARTITION_LIMIT
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -483,16 +482,20 @@ def test_streaming_groupby_binary_15116() -> None:
     }
 
 
-def test_streaming_group_by_convert_15380() -> None:
+def test_streaming_group_by_convert_15380(partition_limit: int) -> None:
     assert (
-        pl.DataFrame({"a": [1] * PARTITION_LIMIT}).group_by(b="a").len()["len"].item()
-        == PARTITION_LIMIT
+        pl.DataFrame({"a": [1] * partition_limit}).group_by(b="a").len()["len"].item()
+        == partition_limit
     )
 
 
 @pytest.mark.parametrize("streaming", [True, False])
-@pytest.mark.parametrize("n_rows", [PARTITION_LIMIT - 1, PARTITION_LIMIT + 3])
-def test_streaming_group_by_boolean_mean_15610(n_rows: int, streaming: bool) -> None:
+@pytest.mark.parametrize("n_rows_limit_offset", [-1, +3])
+def test_streaming_group_by_boolean_mean_15610(
+    n_rows_limit_offset: int, streaming: bool, partition_limit: int
+) -> None:
+    n_rows = partition_limit + n_rows_limit_offset
+
     # Also test non-streaming because it sometimes dispatched to streaming agg.
     expect = pl.DataFrame({"a": [False, True], "c": [0.0, 0.5]})
 


### PR DESCRIPTION
I didn't account for the fact that Python floordiv rounds away from zero in negative numbers.

Also moving a constant that was only used in tests to a test fixture.