### PR TITLE
fix(python): Add missing `read_database` overload

### DIFF
--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -32,7 +32,7 @@ def read_database(
     query: str | Selectable,
     connection: ConnectionOrCursor | str,
     *,
-    iter_batches: Literal[False] = False,
+    iter_batches: Literal[False] = ...,
     batch_size: int | None = ...,
     schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,

--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -55,6 +55,20 @@ def read_database(
 ) -> Iterable[DataFrame]: ...
 
 
+@overload
+def read_database(
+    query: str | Selectable,
+    connection: ConnectionOrCursor | str,
+    *,
+    iter_batches: bool,
+    batch_size: int | None = ...,
+    schema_overrides: SchemaDict | None = ...,
+    infer_schema_length: int | None = ...,
+    execute_options: dict[str, Any] | None = ...,
+    **kwargs: Any,
+) -> DataFrame | Iterable[DataFrame]: ...
+
+
 def read_database(  # noqa: D417
     query: str | Selectable,
     connection: ConnectionOrCursor | str,

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -469,7 +469,7 @@ def test_read_database_mocked(
             "repeat_batch_calls", False
         ),
     )
-    res = pl.read_database(  # type: ignore[call-overload]
+    res = pl.read_database(
         query="SELECT * FROM test_data",
         connection=mc,
         iter_batches=iter_batches,

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from datetime import date
 from pathlib import Path
 from types import GeneratorType
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import pyarrow as pa
 import pytest
@@ -479,6 +479,7 @@ def test_read_database_mocked(
         assert isinstance(res, GeneratorType)
         res = pl.concat(res)
 
+    res = cast(pl.DataFrame, res)
     assert expected_call in mc.cursor().called
     assert res.rows() == [(1, "aa"), (2, "bb"), (3, "cc")]
 


### PR DESCRIPTION
This PR adds an overload when `iter_batches` is a `bool`, as opposed to `Literal[True]` or `Literal[False]`, most of the time in Polars, overloads like this aren't super helpful, as you're actually just passing in `True`/`False`.  However, with top-level functions like `read_database`, you might want to have a wrapper over it. This is basically the situation that I am in, where I have a custom version of `read_database`, with some additional functionality around retrieving the DB connection, and so want to have my own overloads on that function for `DataFrame`, and `Iterable[DataFrame]`, to make this possible there does need to be an overload for the non-literal case, at least with Pyright.

Here's basically an example of the issue I'm running into.

```python
def custom_read_db(
    query: Query,
    db: str
    *,
    iter_batches: bool = False,
) -> DataFrame | Iterable[DataFrame]:
   return pl.read_database( # Pyright error, due to the fact, there's no `DataFrame | Iterable[DataFrame]` overload.
        sql,
        connections[db],
        iter_batches=iter_batches,
    )
