### PR TITLE
fix(python): Fix `Series.to_numpy` for Array types with nulls and nested Arrays

### DIFF
--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -41,17 +41,10 @@ impl ListChunked {
 
     /// Get the inner values as [`Series`], ignoring the list offsets.
     pub fn get_inner(&self) -> Series {
-        let ca = self.rechunk();
-        let arr = ca.downcast_iter().next().unwrap();
-        // SAFETY:
-        // Inner dtype is passed correctly
-        unsafe {
-            Series::from_chunks_and_dtype_unchecked(
-                self.name(),
-                vec![arr.values().clone()],
-                &ca.inner_dtype(),
-            )
-        }
+        let chunks: Vec<_> = self.downcast_iter().map(|c| c.values().clone()).collect();
+
+        // SAFETY: Data type of arrays matches because they are chunks from the same array.
+        unsafe { Series::from_chunks_and_dtype_unchecked(self.name(), chunks, &self.inner_dtype()) }
     }
 
     /// Ignore the list indices and apply `func` to the inner type as [`Series`].

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4442,7 +4442,7 @@ class Series:
         if (
             use_pyarrow
             and _PYARROW_AVAILABLE
-            and self.dtype not in (Object, Datetime, Duration, Date, Array)
+            and self.dtype not in (Date, Datetime, Duration, Array, Object)
         ):
             if not allow_copy and self.n_chunks() > 1 and not self.is_empty():
                 msg = "cannot return a zero-copy array"
@@ -4451,15 +4451,6 @@ class Series:
             return self.to_arrow().to_numpy(
                 zero_copy_only=not allow_copy, writable=writable
             )
-
-        if self.dtype == Array:
-            np_array = self.explode().to_numpy(
-                allow_copy=allow_copy,
-                writable=writable,
-                use_pyarrow=use_pyarrow,
-            )
-            np_array.shape = (self.len(), self.dtype.width)  # type: ignore[attr-defined]
-            return np_array
 
         return self._s.to_numpy(allow_copy=allow_copy, writable=writable)
 

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -357,7 +357,7 @@ where
 /// Convert arrays by flattening first, converting the flat Series, and then reshaping.
 fn array_series_to_numpy(py: Python, s: &Series) -> PyObject {
     let ca = s.array().unwrap();
-    let s_inner = ca.get_inner(); // TODO: This rechunks - is there a way to avoid this?
+    let s_inner = ca.get_inner();
     let np_array_flat = series_to_numpy_with_copy(py, &s_inner).unwrap();
 
     // Reshape to the original shape.

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -173,6 +173,7 @@ impl PySeries {
             // This does not actually copy data for empty Series.
             return series_to_numpy_with_copy(py, &self.series);
         }
+
         if let Some(mut arr) = series_to_numpy_view(py, &self.series, false) {
             if writable {
                 if !allow_copy {
@@ -357,8 +358,6 @@ where
 fn array_series_to_numpy(py: Python, s: &Series) -> PyObject {
     let ca = s.array().unwrap();
     let s_inner = ca.get_inner(); // TODO: This rechunks - is there a way to avoid this?
-
-    // TODO: Do we try to zero copy here again?
     let np_array_flat = series_to_numpy_with_copy(py, &s_inner).unwrap();
 
     // Reshape to the original shape.

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -224,12 +224,13 @@ def test_series_to_numpy_bool_with_nulls() -> None:
 
 def test_series_to_numpy_array_of_int() -> None:
     values = [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]
-    s = pl.Series(values, dtype=pl.Array(pl.Array(pl.Int64, 3), 2))
+    s = pl.Series(values, dtype=pl.Array(pl.Array(pl.Int8, 3), 2))
     result = s.to_numpy(use_pyarrow=False, allow_copy=False)
 
     expected = np.array(values)
     assert_array_equal(result, expected)
-    assert result.dtype == np.int64
+    assert result.dtype == np.int8
+    assert result.shape == (2, 2, 3)
 
 
 def test_series_to_numpy_array_of_str() -> None:
@@ -270,6 +271,7 @@ def test_series_to_numpy_array_of_arrays() -> None:
     expected = np.array([[[np.nan, 2], [3, 4]], [[np.nan, np.nan], [7, 8]]])
     assert_array_equal(result, expected)
     assert result.dtype == np.float64
+    assert result.shape == (2, 2, 2)
     assert_allow_copy_false_raises(s)
 
 

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -223,8 +223,8 @@ def test_series_to_numpy_bool_with_nulls() -> None:
 
 
 def test_series_to_numpy_array_of_int() -> None:
-    values = [[1, 2], [3, 4], [5, 6]]
-    s = pl.Series(values, dtype=pl.Array(pl.Int64, 2))
+    values = [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]
+    s = pl.Series(values, dtype=pl.Array(pl.Array(pl.Int64, 3), 2))
     result = s.to_numpy(use_pyarrow=False, allow_copy=False)
 
     expected = np.array(values)
@@ -257,6 +257,17 @@ def test_series_to_numpy_array_with_nested_nulls() -> None:
     result = s.to_numpy(use_pyarrow=False)
 
     expected = np.array([[np.nan, 2.0], [3.0, 4.0], [5.0, np.nan]])
+    assert_array_equal(result, expected)
+    assert result.dtype == np.float64
+    assert_allow_copy_false_raises(s)
+
+
+def test_series_to_numpy_array_of_arrays() -> None:
+    values = [[[None, 2], [3, 4]], [None, [7, 8]]]
+    s = pl.Series(values, dtype=pl.Array(pl.Array(pl.Int64, 2), 2))
+    result = s.to_numpy(use_pyarrow=False)
+
+    expected = np.array([[[np.nan, 2], [3, 4]], [[np.nan, np.nan], [7, 8]]])
     assert_array_equal(result, expected)
     assert result.dtype == np.float64
     assert_allow_copy_false_raises(s)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/14268

#### Changes

* Move handling of Array types in `Series.to_numpy` to Rust
* Fix handling of null values (see linked issue)
* Fix handling of nested arrays