### PR TITLE
fix: `rolling_*_by was throwing incorrect error when dataframe was sorted by contained multiple chunks

### DIFF
--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -82,6 +82,7 @@ where
         return Ok(Series::new_empty(ca.name(), ca.dtype()));
     }
     let ca = ca.rechunk();
+    let by = by.rechunk();
     ensure_duration_matches_data_type(options.window_size, by.dtype(), "window_size")?;
     polars_ensure!(!options.window_size.is_zero() && !options.window_size.negative, InvalidOperation: "`window_size` must be strictly positive");
     if by.is_sorted_flag() != IsSorted::Ascending && options.warn_if_unsorted {

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1021,6 +1021,19 @@ def test_temporal_windows_size_without_by_15977() -> None:
             df.select(pl.col("a").rolling_mean("3d"))
 
 
+def test_incorrect_nulls_16246() -> None:
+    df = pl.concat(
+        [
+            pl.DataFrame({"a": [datetime(2020, 1, 1)], "b": [1]}),
+            pl.DataFrame({"a": [datetime(2021, 1, 1)], "b": [1]}),
+        ],
+        rechunk=False,
+    )
+    result = df.select(pl.col("b").rolling_max_by("a", "1d"))
+    expected = pl.DataFrame({"b": [1, 1]})
+    assert_frame_equal(result, expected)
+
+
 def interval_defs() -> SearchStrategy[ClosedInterval]:
     closed: list[ClosedInterval] = ["left", "right", "both", "none"]
     return st.sampled_from(closed)


### PR DESCRIPTION
closes #16246 