### PR TITLE
feat: Don't require data to be sorted by `by` column in `rolling_*_by` operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ name = "polars-time"
 version = "0.39.2"
 dependencies = [
  "atoi",
+ "bytemuck",
  "chrono",
  "chrono-tz",
  "now",

--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -16,6 +16,7 @@ polars-ops = { workspace = true }
 polars-utils = { workspace = true }
 
 atoi = { workspace = true }
+bytemuck = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true, optional = true }
 now = { version = "0.1" }

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -73,6 +73,7 @@ fn rolling_agg_by<T>(
         TimeUnit,
         Option<&TimeZone>,
         DynArgs,
+        Option<&[IdxSize]>,
     ) -> PolarsResult<ArrayRef>,
 ) -> PolarsResult<Series>
 where
@@ -83,20 +84,9 @@ where
     }
     let ca = ca.rechunk();
     let by = by.rechunk();
+    polars_ensure!(ca.len() == by.len(), InvalidOperation: "`by` column in `rolling_*_by` must be the same length as values column");
     ensure_duration_matches_data_type(options.window_size, by.dtype(), "window_size")?;
     polars_ensure!(!options.window_size.is_zero() && !options.window_size.negative, InvalidOperation: "`window_size` must be strictly positive");
-    if by.is_sorted_flag() != IsSorted::Ascending && options.warn_if_unsorted {
-        polars_warn!(format!(
-            "Series is not known to be sorted by `by` column in `rolling_*_by` operation.\n\
-            \n\
-            To silence this warning, you may want to try:\n\
-            - sorting your data by your `by` column beforehand;\n\
-            - setting `.set_sorted()` if you already know your data is sorted;\n\
-            - passing `warn_if_unsorted=False` if this warning is a false-positive\n  \
-                (this is known to happen when combining rolling aggregations with `over`);\n\n\
-            before passing calling the rolling aggregation function.\n",
-        ));
-    }
     let (by, tz) = match by.dtype() {
         DataType::Datetime(tu, tz) => (by.cast(&DataType::Datetime(*tu, None))?, tz),
         DataType::Date => (
@@ -109,32 +99,60 @@ where
             "date/datetime"),
     };
     let by = by.datetime().unwrap();
-    let by_values = by.cont_slice().map_err(|_| {
-        polars_err!(
-            ComputeError:
-            "`by` column should not have null values in 'rolling by' expression"
-        )
-    })?;
     let tu = by.time_unit();
 
-    let arr = ca.downcast_iter().next().unwrap();
-    if arr.null_count() > 0 {
-        polars_bail!(InvalidOperation: "'Expr.rolling_*(..., by=...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'")
-    }
-    let values = arr.values().as_slice();
     let func = rolling_agg_fn_dynamic;
-
-    let arr = func(
-        values,
-        options.window_size,
-        by_values,
-        options.closed_window,
-        options.min_periods,
-        tu,
-        tz.as_ref(),
-        options.fn_params,
-    )?;
-    Series::try_from((ca.name(), arr))
+    let out: ArrayRef = if matches!(by.is_sorted_flag(), IsSorted::Ascending) {
+        let arr = ca.downcast_iter().next().unwrap();
+        if arr.null_count() > 0 {
+            polars_bail!(InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'")
+        }
+        let by_values = by.cont_slice().map_err(|_| {
+            polars_err!(
+                ComputeError:
+                "`by` column should not have null values in 'rolling by' expression"
+            )
+        })?;
+        let values = arr.values().as_slice();
+        func(
+            values,
+            options.window_size,
+            by_values,
+            options.closed_window,
+            options.min_periods,
+            tu,
+            tz.as_ref(),
+            options.fn_params,
+            None,
+        )?
+    } else {
+        let sorting_indices = by.arg_sort(Default::default());
+        let ca = unsafe { ca.take_unchecked(&sorting_indices) };
+        let by = unsafe { by.take_unchecked(&sorting_indices) };
+        let arr = ca.downcast_iter().next().unwrap();
+        if arr.null_count() > 0 {
+            polars_bail!(InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'")
+        }
+        let by_values = by.cont_slice().map_err(|_| {
+            polars_err!(
+                ComputeError:
+                "`by` column should not have null values in 'rolling by' expression"
+            )
+        })?;
+        let values = arr.values().as_slice();
+        func(
+            values,
+            options.window_size,
+            by_values,
+            options.closed_window,
+            options.min_periods,
+            tu,
+            tz.as_ref(),
+            options.fn_params,
+            Some(sorting_indices.cont_slice().unwrap()),
+        )?
+    };
+    Series::try_from((ca.name(), out))
 }
 
 pub trait SeriesOpsTime: AsSeries {

--- a/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -23,8 +23,6 @@ pub struct RollingOptionsDynamicWindow {
     /// Optional parameters for the rolling function
     #[cfg_attr(feature = "serde", serde(skip))]
     pub fn_params: DynArgs,
-    /// Warn if data is not known to be sorted by `by` column (if passed)
-    pub warn_if_unsorted: bool,
 }
 
 #[cfg(feature = "rolling_window_by")]
@@ -33,7 +31,6 @@ impl PartialEq for RollingOptionsDynamicWindow {
         self.window_size == other.window_size
             && self.min_periods == other.min_periods
             && self.closed_window == other.closed_window
-            && self.warn_if_unsorted == other.warn_if_unsorted
             && self.fn_params.is_none()
             && other.fn_params.is_none()
     }

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6224,7 +6224,7 @@ class Expr:
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling min based on another column.
@@ -6245,10 +6245,6 @@ class Expr:
         ----------
         by
             This column must be of dtype Datetime or Date.
-
-            .. warning::
-                The column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         window_size
             The length of the window. Can be a dynamic temporal
             size indicated by a timedelta or the following string language:
@@ -6277,6 +6273,10 @@ class Expr:
             defaults to `'right'`.
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6340,22 +6340,26 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_min_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
-            self._pyexpr.rolling_min_by(
-                by, window_size, min_periods, closed, warn_if_unsorted
-            )
+            self._pyexpr.rolling_min_by(by, window_size, min_periods, closed)
         )
 
     @unstable()
     def rolling_max_by(
         self,
-        by: str,
+        by: IntoExpr,
         window_size: timedelta | str,
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling max based on another column.
@@ -6376,10 +6380,6 @@ class Expr:
         ----------
         by
             This column must be of dtype Datetime or Date.
-
-            .. warning::
-                The column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         window_size
             The length of the window. Can be a dynamic temporal
             size indicated by a timedelta or the following string language:
@@ -6408,6 +6408,10 @@ class Expr:
             defaults to `'right'`.
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6497,22 +6501,26 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_max_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
-            self._pyexpr.rolling_max_by(
-                by, window_size, min_periods, closed, warn_if_unsorted
-            )
+            self._pyexpr.rolling_max_by(by, window_size, min_periods, closed)
         )
 
     @unstable()
     def rolling_mean_by(
         self,
-        by: str,
+        by: IntoExpr,
         window_size: timedelta | str,
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling mean based on another column.
@@ -6533,10 +6541,6 @@ class Expr:
         ----------
         by
             This column must be of dtype Datetime or Date.
-
-            .. warning::
-                The column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         window_size
             The length of the window. Can be a dynamic temporal
             size indicated by a timedelta or the following string language:
@@ -6565,6 +6569,10 @@ class Expr:
             defaults to `'right'`.
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6656,6 +6664,12 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_mean_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_mean_by(
@@ -6663,19 +6677,18 @@ class Expr:
                 window_size,
                 min_periods,
                 closed,
-                warn_if_unsorted,
             )
         )
 
     @unstable()
     def rolling_sum_by(
         self,
-        by: str,
+        by: IntoExpr,
         window_size: timedelta | str,
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling sum based on another column.
@@ -6719,15 +6732,15 @@ class Expr:
             a result.
         by
             This column must of dtype `{Date, Datetime}`
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive),
             defaults to `'right'`.
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6817,23 +6830,27 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_sum_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
-            self._pyexpr.rolling_sum_by(
-                by, window_size, min_periods, closed, warn_if_unsorted
-            )
+            self._pyexpr.rolling_sum_by(by, window_size, min_periods, closed)
         )
 
     @unstable()
     def rolling_std_by(
         self,
-        by: str,
+        by: IntoExpr,
         window_size: timedelta | str,
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
         ddof: int = 1,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling standard deviation based on another column.
@@ -6842,23 +6859,18 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        Given a `by` column `<t_0, t_1, ..., t_n>`, then `closed="left"` means
-        the windows will be:
+        Given a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
+        (the default) means the windows will be:
 
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
+            - (t_0 - window_size, t_0]
+            - (t_1 - window_size, t_1]
             - ...
-            - [t_n - window_size, t_n)
-
+            - (t_n - window_size, t_n]
 
         Parameters
         ----------
         by
             This column must be of dtype Datetime or Date.
-
-            .. warning::
-                The column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         window_size
             The length of the window. Can be a dynamic temporal
             size indicated by a timedelta or the following string language:
@@ -6889,6 +6901,10 @@ class Expr:
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6978,6 +6994,12 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_std_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_std_by(
@@ -6986,20 +7008,19 @@ class Expr:
                 min_periods,
                 closed,
                 ddof,
-                warn_if_unsorted,
             )
         )
 
     @unstable()
     def rolling_var_by(
         self,
-        by: str,
+        by: IntoExpr,
         window_size: timedelta | str,
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
         ddof: int = 1,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling variance based on another column.
@@ -7020,10 +7041,6 @@ class Expr:
         ----------
         by
             This column must be of dtype Datetime or Date.
-
-            .. warning::
-                The column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         window_size
             The length of the window. Can be a dynamic temporal
             size indicated by a timedelta or the following string language:
@@ -7054,6 +7071,10 @@ class Expr:
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -7143,6 +7164,12 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_var_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_var_by(
@@ -7151,19 +7178,18 @@ class Expr:
                 min_periods,
                 closed,
                 ddof,
-                warn_if_unsorted,
             )
         )
 
     @unstable()
     def rolling_median_by(
         self,
-        by: str,
+        by: IntoExpr,
         window_size: timedelta | str,
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling median based on another column.
@@ -7172,22 +7198,18 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        Given a `by` column `<t_0, t_1, ..., t_n>`, then `closed="left"` means
-        the windows will be:
+        Given a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
+        (the default) means the windows will be:
 
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
+            - (t_0 - window_size, t_0]
+            - (t_1 - window_size, t_1]
             - ...
-            - [t_n - window_size, t_n)
+            - (t_n - window_size, t_n]
 
         Parameters
         ----------
         by
             This column must be of dtype Datetime or Date.
-
-            .. warning::
-                The column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         window_size
             The length of the window. Can be a dynamic temporal
             size indicated by a timedelta or the following string language:
@@ -7216,6 +7238,10 @@ class Expr:
             defaults to `'right'`.
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -7281,24 +7307,28 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_median_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
-            self._pyexpr.rolling_median_by(
-                by, window_size, min_periods, closed, warn_if_unsorted
-            )
+            self._pyexpr.rolling_median_by(by, window_size, min_periods, closed)
         )
 
     @unstable()
     def rolling_quantile_by(
         self,
-        by: str,
+        by: IntoExpr,
         window_size: timedelta | str,
         *,
         quantile: float,
         interpolation: RollingInterpolationMethod = "nearest",
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling quantile based on another column.
@@ -7319,10 +7349,6 @@ class Expr:
         ----------
         by
             This column must be of dtype Datetime or Date.
-
-            .. warning::
-                The column must be sorted in ascending order. Otherwise,
-                results will not be correct.
         quantile
             Quantile between 0.0 and 1.0.
         interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
@@ -7355,6 +7381,10 @@ class Expr:
             defaults to `'right'`.
         warn_if_unsorted
             Warn if data is not known to be sorted by `by` column.
+
+            .. deprecated:: 0.20.27
+                This operation no longer requires sorted data, you can safely remove
+                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -7420,6 +7450,12 @@ class Expr:
         """
         window_size = deprecate_saturating(window_size)
         window_size = _prepare_rolling_by_window_args(window_size)
+        if warn_if_unsorted is not None:
+            issue_deprecation_warning(
+                "`warn_if_unsorted` is deprecated in `rolling_quantile_by` because it "
+                "no longer requires sorted data - you can safely remove this argument.",
+                version="0.20.27",
+            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_quantile_by(
@@ -7429,7 +7465,6 @@ class Expr:
                 window_size,
                 min_periods,
                 closed,
-                warn_if_unsorted,
             )
         )
 
@@ -7443,7 +7478,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling min (moving min) over the values in this array.
@@ -7508,10 +7543,6 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype Datetime or Date.
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
 
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_min` is deprecated - please use
@@ -7679,7 +7710,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling max (moving max) over the values in this array.
@@ -7744,10 +7775,6 @@ class Expr:
             If the `window_size` is temporal, for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype Datetime or Date.
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
 
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_max` is deprecated - please use
@@ -7941,7 +7968,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling mean (moving mean) over the values in this array.
@@ -8007,13 +8034,9 @@ class Expr:
             set the column that will be used to determine the windows. This column must
             be of dtype Datetime or Date.
 
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
-
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_mean` is deprecated - please use
-                :meth:`.rolling_max_by` instead.
+                :meth:`.rolling_mean_by` instead.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set (in which case, it defaults to `'right'`).
@@ -8205,7 +8228,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling sum (moving sum) over the values in this array.
@@ -8270,10 +8293,6 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
             of dtype `{Date, Datetime}`
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
 
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_sum` is deprecated - please use
@@ -8468,7 +8487,7 @@ class Expr:
         by: str | None = None,
         closed: ClosedInterval | None = None,
         ddof: int = 1,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling standard deviation.
@@ -8480,14 +8499,13 @@ class Expr:
         If `by` has not been specified (the default), the window at a given row will
         include the row itself, and the `window_size - 1` elements before it.
 
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="left"` means
-        the windows will be:
+        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
+        (the default) means the windows will be:
 
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
+            - (t_0 - window_size, t_0]
+            - (t_1 - window_size, t_1]
             - ...
-            - [t_n - window_size, t_n)
-
+            - (t_n - window_size, t_n]
 
         Parameters
         ----------
@@ -8530,10 +8548,6 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype Datetime or Date.
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
 
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_std` is deprecated - please use
@@ -8732,7 +8746,7 @@ class Expr:
         by: str | None = None,
         closed: ClosedInterval | None = None,
         ddof: int = 1,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling variance.
@@ -8793,10 +8807,6 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype Datetime or Date.
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
 
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_var` is deprecated - please use
@@ -8994,7 +9004,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling median.
@@ -9006,14 +9016,13 @@ class Expr:
         If `by` has not been specified (the default), the window at a given row will
         include the row itself, and the `window_size - 1` elements before it.
 
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="left"` means
-        the windows will be:
+        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
+        (the default) means the windows will be:
 
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
+            - (t_0 - window_size, t_0]
+            - (t_1 - window_size, t_1]
             - ...
-            - [t_n - window_size, t_n)
-
+            - (t_n - window_size, t_n]
 
         Parameters
         ----------
@@ -9056,10 +9065,6 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype Datetime or Date.
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
 
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_median` is deprecated - please use
@@ -9177,7 +9182,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
-        warn_if_unsorted: bool = True,
+        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling quantile.
@@ -9242,10 +9247,6 @@ class Expr:
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
             be of dtype Datetime or Date.
-
-            .. warning::
-                If passed, the column must be sorted in ascending order. Otherwise,
-                results will not be correct.
 
             .. deprecated:: 0.20.24
                 Passing `by` to `rolling_quantile` is deprecated - please use

--- a/py-polars/src/expr/rolling.rs
+++ b/py-polars/src/expr/rolling.rs
@@ -28,20 +28,18 @@ impl PyExpr {
         self.inner.clone().rolling_sum(options).into()
     }
 
-    #[pyo3(signature = (by, window_size, min_periods, closed, warn_if_unsorted))]
+    #[pyo3(signature = (by, window_size, min_periods, closed))]
     fn rolling_sum_by(
         &self,
         by: PyExpr,
         window_size: &str,
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
-            warn_if_unsorted,
             fn_params: None,
         };
         self.inner.clone().rolling_sum_by(by.inner, options).into()
@@ -65,20 +63,18 @@ impl PyExpr {
         self.inner.clone().rolling_min(options).into()
     }
 
-    #[pyo3(signature = (by, window_size, min_periods, closed, warn_if_unsorted))]
+    #[pyo3(signature = (by, window_size, min_periods, closed))]
     fn rolling_min_by(
         &self,
         by: PyExpr,
         window_size: &str,
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
-            warn_if_unsorted,
             fn_params: None,
         };
         self.inner.clone().rolling_min_by(by.inner, options).into()
@@ -101,20 +97,18 @@ impl PyExpr {
         };
         self.inner.clone().rolling_max(options).into()
     }
-    #[pyo3(signature = (by, window_size, min_periods, closed, warn_if_unsorted))]
+    #[pyo3(signature = (by, window_size, min_periods, closed))]
     fn rolling_max_by(
         &self,
         by: PyExpr,
         window_size: &str,
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
-            warn_if_unsorted,
             fn_params: None,
         };
         self.inner.clone().rolling_max_by(by.inner, options).into()
@@ -139,20 +133,18 @@ impl PyExpr {
         self.inner.clone().rolling_mean(options).into()
     }
 
-    #[pyo3(signature = (by, window_size, min_periods, closed, warn_if_unsorted))]
+    #[pyo3(signature = (by, window_size, min_periods, closed))]
     fn rolling_mean_by(
         &self,
         by: PyExpr,
         window_size: &str,
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
-            warn_if_unsorted,
             fn_params: None,
         };
 
@@ -179,7 +171,7 @@ impl PyExpr {
         self.inner.clone().rolling_std(options).into()
     }
 
-    #[pyo3(signature = (by, window_size, min_periods, closed, ddof, warn_if_unsorted))]
+    #[pyo3(signature = (by, window_size, min_periods, closed, ddof))]
     fn rolling_std_by(
         &self,
         by: PyExpr,
@@ -187,14 +179,12 @@ impl PyExpr {
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
         ddof: u8,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
             fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
-            warn_if_unsorted,
         };
 
         self.inner.clone().rolling_std_by(by.inner, options).into()
@@ -220,7 +210,7 @@ impl PyExpr {
         self.inner.clone().rolling_var(options).into()
     }
 
-    #[pyo3(signature = (by, window_size, min_periods, closed, ddof, warn_if_unsorted))]
+    #[pyo3(signature = (by, window_size, min_periods, closed, ddof))]
     fn rolling_var_by(
         &self,
         by: PyExpr,
@@ -228,14 +218,12 @@ impl PyExpr {
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
         ddof: u8,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
             fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
-            warn_if_unsorted,
         };
 
         self.inner.clone().rolling_var_by(by.inner, options).into()
@@ -259,21 +247,19 @@ impl PyExpr {
         self.inner.clone().rolling_median(options).into()
     }
 
-    #[pyo3(signature = (by, window_size, min_periods, closed, warn_if_unsorted))]
+    #[pyo3(signature = (by, window_size, min_periods, closed))]
     fn rolling_median_by(
         &self,
         by: PyExpr,
         window_size: &str,
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
             fn_params: None,
-            warn_if_unsorted,
         };
         self.inner
             .clone()
@@ -305,7 +291,7 @@ impl PyExpr {
             .into()
     }
 
-    #[pyo3(signature = (by, quantile, interpolation, window_size, min_periods, closed, warn_if_unsorted))]
+    #[pyo3(signature = (by, quantile, interpolation, window_size, min_periods, closed))]
     fn rolling_quantile_by(
         &self,
         by: PyExpr,
@@ -314,14 +300,12 @@ impl PyExpr {
         window_size: &str,
         min_periods: usize,
         closed: Wrap<ClosedWindow>,
-        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptionsDynamicWindow {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
             fn_params: None,
-            warn_if_unsorted,
         };
 
         self.inner


### PR DESCRIPTION
~~Needs rebasing onto https://github.com/pola-rs/polars/pull/16247~~

In summary this splits `rolling_apply_agg_window` into:
- `rolling_apply_agg_window_sorted` (no difference to the current `rolling_apply_agg_window`, this is the fastpath when data is already known to be sorted by `by`)
- `rolling_apply_agg_window`: doesn't require the data to be sorted by `by`, which is why it needs an extra argument (`sorting_indices`) which is used to place the results in the right place of the `out` `Vec`
- deprecated `warn_if_unsorted` on the Python side, removed it from the Rust side

**The gist of the change is `rolling_apply_agg_window` in crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs**

Perf impact:
- for data already known to be sorted: none
- for data not known to be sorted, an extra `arg_sort` is performed in order to create `sorting_indices`. Once this has been created, it's just used to place the elements in the `out` Vec in the right place (`rolling_apply_agg_window`)