### PR TITLE
fix(python): Address overly-permissive `expand_selectors` function, minor fixes

### DIFF
--- a/docs/src/python/user-guide/expressions/column-selections.py
+++ b/docs/src/python/user-guide/expressions/column-selections.py
@@ -78,13 +78,22 @@ print(out)
 # --8<-- [start:selectors_is_selector_utility]
 from polars.selectors import is_selector
 
-out = cs.temporal()
+out = cs.numeric()
+print(is_selector(out))
+
+out = cs.boolean() | cs.numeric()
+print(is_selector(out))
+
+out = cs.numeric() + pl.lit(123)
 print(is_selector(out))
 # --8<-- [end:selectors_is_selector_utility]
 
 # --8<-- [start:selectors_colnames_utility]
 from polars.selectors import expand_selector
 
-out = cs.temporal().as_expr().dt.to_string("%Y-%h-%d")
+out = cs.temporal()
+print(expand_selector(df, out))
+
+out = ~(cs.temporal() | cs.numeric())
 print(expand_selector(df, out))
 # --8<-- [end:selectors_colnames_utility]

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -340,18 +340,12 @@ class _selector_proxy_(Expr):
             if self._attrs["name"] == "by_name":
                 return by_name(colname, *self._attrs["params"]["*names"])
             other = by_name(colname)
-        if is_selector(other):
-            return self.__and__(other)
-        else:
-            return self.as_expr().__rand__(other)
+        return self.as_expr().__rand__(other)
 
     def __ror__(self, other: Any) -> SelectorType | Expr:  # type: ignore[override]
         if is_column(other):
             other = by_name(other.meta.output_name())
-        if is_selector(other):
-            return self.__or__(other)
-        else:
-            return self.as_expr().__ror__(other)
+        return self.as_expr().__ror__(other)
 
     def as_expr(self) -> Expr:
         """


### PR DESCRIPTION
Closes #16242 (ref: https://github.com/pola-rs/polars/issues/16242#issuecomment-2112953328).

Fixes incomplete validation in `is_selector`, taking care of `expand_selector` in the process (it should have been raising a TypeError on non-selector input). Now that it's fixed, can use `is_selector` inside `_selector_proxy_` (in retrospect it was a bit of a red flag that we couldn't already do this ;p)

### Also:
* Fixes invalid uses of `__sub__` and `__rsub__`.
* Adds an example to clarify `as_expr` usage.
* Adds missing entries to module `__all__`.
* Adds a few more user guide examples.
* Adds some missing test coverage.
* Removes a few lines of dead code.