### PR TITLE
fix(python): Handle non-Sequence iterables in filter

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -28,10 +28,15 @@ from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
-    from collections.abc import Reversible
+    from collections.abc import Iterator, Reversible
 
     from polars import DataFrame
     from polars.type_aliases import PolarsDataType, SizeUnit
+
+    if sys.version_info >= (3, 13):
+        from typing import TypeIs
+    else:
+        from typing_extensions import TypeIs
 
     if sys.version_info >= (3, 10):
         from typing import ParamSpec, TypeGuard
@@ -56,7 +61,7 @@ def _process_null_values(
         return null_values
 
 
-def _is_generator(val: object) -> bool:
+def _is_generator(val: object | Iterator[T]) -> TypeIs[Iterator[T]]:
     return (
         (isinstance(val, (Generator, Iterable)) and not isinstance(val, Sized))
         or isinstance(val, MappingView)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -41,6 +41,7 @@ from polars._utils.parse_expr_input import (
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     _in_notebook,
+    _is_generator,
     is_bool_sequence,
     is_sequence,
     normalize_filepath,
@@ -2798,7 +2799,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 return self.clear()  # type: ignore[return-value]
             elif p is True:
                 continue  # no-op; matches all rows
-            elif is_bool_sequence(p, include_series=True):
+            if _is_generator(p):
+                p = tuple(p)
+            if is_bool_sequence(p, include_series=True):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
             elif (
                 (is_seq := is_sequence(p))

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2800,7 +2800,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             elif p is True:
                 continue  # no-op; matches all rows
             if _is_generator(p):
-                p: Iterable[IntoExprColumn] = tuple(p)
+                p = tuple(p)  # type: ignore[arg-type]
             if is_bool_sequence(p, include_series=True):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
             elif (

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2800,7 +2800,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             elif p is True:
                 continue  # no-op; matches all rows
             if _is_generator(p):
-                p = tuple(p)
+                p: Iterable[IntoExprColumn] = tuple(p)
             if is_bool_sequence(p, include_series=True):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
             elif (

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2800,7 +2800,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             elif p is True:
                 continue  # no-op; matches all rows
             if _is_generator(p):
-                p = tuple(p)  # type: ignore[arg-type]
+                p = tuple(p)
             if is_bool_sequence(p, include_series=True):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
             elif (

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -211,6 +211,20 @@ def test_filter_multiple_predicates() -> None:
     assert ldf.filter(predicate="==").select("description").collect().item() == "eq"
 
 
+def test_filter_seq_iterable() -> None:
+    ldf = pl.LazyFrame(
+        {
+            "a": [1, 1, 1],
+            "b": [1, 1, 2],
+            "c": [3, 1, 2],
+        }
+    )
+    predicate = [pl.lit(True)]
+    assert_frame_equal(
+        ldf.filter(predicate).collect(), ldf.filter(iter(predicate)).collect()
+    )
+
+
 def test_apply_custom_function() -> None:
     ldf = pl.LazyFrame(
         {

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -211,7 +211,18 @@ def test_filter_multiple_predicates() -> None:
     assert ldf.filter(predicate="==").select("description").collect().item() == "eq"
 
 
-def test_filter_seq_iterable() -> None:
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        [pl.lit(True)],
+        iter([pl.lit(True)]),
+        [True, True, True],
+        iter([True, True, True]),
+        (p for p in (pl.col("c") < 9,)),
+        (p for p in (pl.col("a") > 0, pl.col("b") > 0)),
+    ],
+)
+def test_filter_seq_iterable_all_true(predicate: Any) -> None:
     ldf = pl.LazyFrame(
         {
             "a": [1, 1, 1],
@@ -219,10 +230,7 @@ def test_filter_seq_iterable() -> None:
             "c": [3, 1, 2],
         }
     )
-    predicate = [pl.lit(True)]
-    assert_frame_equal(
-        ldf.filter(predicate).collect(), ldf.filter(iter(predicate)).collect()
-    )
+    assert_frame_equal(ldf, ldf.filter(predicate))
 
 
 def test_apply_custom_function() -> None:


### PR DESCRIPTION
Fixes #16253

I tried to keep the logic as close to the original as possible. 
E.g, prioritising the fast paths. 

Was wondering if the `is_sequence` check that follows is the best option though.

Edit:
To elaborate on the `is_sequence` comment further.

Acceptable inputs at that stage are:

1. One or more `Expr`
2. An `str` representing a column name in `self.columns`
3. A `Sequence` that is not a `Series`

Where parsing `3` is defered to `parse_as_list_of_expressions`.