### PR TITLE
fix(python): Improve `map_elements` typing

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -11435,7 +11435,7 @@ class Expr:
     @deprecate_renamed_function("map_elements", version="0.19.0")
     def apply(
         self,
-        function:Callable[[Any], Any],
+        function: Callable[[Any], Any],
         return_dtype: PolarsDataType | None = None,
         *,
         skip_nulls: bool = True,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4589,7 +4589,7 @@ class Expr:
 
     def map_elements(
         self,
-        function: Callable[[Series], Series] | Callable[[Any], Any],
+        function: Callable[[Any], Any],
         return_dtype: PolarsDataType | None = None,
         *,
         skip_nulls: bool = True,
@@ -11435,7 +11435,7 @@ class Expr:
     @deprecate_renamed_function("map_elements", version="0.19.0")
     def apply(
         self,
-        function: Callable[[Series], Series] | Callable[[Any], Any],
+        function:Callable[[Any], Any],
         return_dtype: PolarsDataType | None = None,
         *,
         skip_nulls: bool = True,


### PR DESCRIPTION
Map elements accepts a callable `Callable[[Series], Series] | Callable[[Any], Any]`, this for all intensive purposes should just accept `Callable[[Any], Any]`. Previously, the former was fine in type-checkers such as Pyright, however as Eric Traut explains [here](https://github.com/microsoft/pyright/issues/7927#issuecomment-2113683345), there's not a great way for Pyright to deterministically determine which to use when evaluating lambdas, which can lead to Pyright errors when calling this function. Take this example, which will lead to an error in the latest version of Pyright, which I would imagine should be fully supported: 

```python
import polars as pl

df = pl.DataFrame(
    {
        "a": [1, 2, None],
        "b": [1.0, 2.0, 3.0],
        "c": ["a", "b", "c"],
    }
)


def transform_int(x: int) -> int:
    return x + 1

# Argument of type "Series" cannot be assigned to parameter "x" of type "int" in function "transform_int" "Series" is incompatible with "int"
df.with_columns([pl.col("a").map_elements(lambda x: transform_int(x) if x else None)])
```