### PR TITLE
depr(python): Change parameter `chunked` to `allow_chunks` in parametric testing strategies

### DIFF
--- a/py-polars/polars/testing/parametric/strategies/core.py
+++ b/py-polars/polars/testing/parametric/strategies/core.py
@@ -431,7 +431,7 @@ def dataframes(  # noqa: D417
                     dtype=c.dtype,
                     size=size,
                     strategy=c.strategy,
-                    allow_null=c.allow_null,  # type: ignore[arg-type].strategy,
+                    allow_null=c.allow_null,  # type: ignore[arg-type]
                     allow_chunks=allow_series_chunks,
                     unique=c.unique,
                     allowed_dtypes=allowed_dtypes,

--- a/py-polars/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/polars/testing/parametric/strategies/dtype.py
@@ -59,6 +59,8 @@ _SIMPLE_DTYPES: list[DataTypeClass] = [
     Date,
     Time,
     Null,
+    # TODO: Enable Object types by default when various issues are solved.
+    # Object,
 ]
 # Supported data type classes with arguments
 _COMPLEX_DTYPES: list[DataTypeClass] = [

--- a/py-polars/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/polars/testing/parametric/strategies/dtype.py
@@ -133,7 +133,7 @@ def dtypes(
 def _parse_dtype_restrictions(
     allowed_dtypes: Collection[PolarsDataType] | None = None,
     excluded_dtypes: Sequence[PolarsDataType] | None = None,
-) -> tuple[Sequence[PolarsDataType], Sequence[PolarsDataType]]:
+) -> tuple[list[PolarsDataType], list[PolarsDataType], list[DataType]]:
     """
     Parse data type restrictions.
 
@@ -152,6 +152,8 @@ def _parse_dtype_restrictions(
                 excluded_dtypes_class.append(dt)
 
     # Split allowed dtypes into flat and nested, excluding certain dtype classes
+    allowed_dtypes_flat: list[PolarsDataType]
+    allowed_dtypes_nested: list[PolarsDataType]
     if allowed_dtypes is None:
         allowed_dtypes_flat = [
             dt for dt in _FLAT_DTYPES if dt not in excluded_dtypes_class

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -13,7 +13,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
-integer_dtypes: list[pl.PolarsDataType] = [
+protocol_dtypes: list[pl.PolarsDataType] = [
     pl.Int8,
     pl.Int16,
     pl.Int32,
@@ -22,8 +22,6 @@ integer_dtypes: list[pl.PolarsDataType] = [
     pl.UInt16,
     pl.UInt32,
     pl.UInt64,
-]
-protocol_dtypes: list[pl.PolarsDataType] = integer_dtypes + [
     pl.Float32,
     pl.Float64,
     pl.Boolean,
@@ -167,9 +165,7 @@ def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
 
 @given(
     dataframes(
-        allowed_dtypes=(
-            integer_dtypes + [pl.Datetime]  # Smaller selection to improve performance
-        ),
+        allowed_dtypes=protocol_dtypes,
         excluded_dtypes=[
             pl.String,  # Polars String type does not match protocol spec
             pl.Categorical,  # Categoricals come back as Enums
@@ -215,9 +211,7 @@ def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
 
 @given(
     dataframes(
-        allowed_dtypes=(
-            integer_dtypes + [pl.Datetime]  # Smaller selection to improve performance
-        ),
+        allowed_dtypes=protocol_dtypes,
         excluded_dtypes=[
             pl.String,  # Polars String type does not match protocol spec
             pl.Categorical,  # Categoricals come back as Enums

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -56,7 +56,7 @@ def test_to_dataframe_pyarrow_parametric(df: pl.DataFrame) -> None:
             pl.String,  # Polars String type does not match protocol spec
             pl.Categorical,
         ],
-        chunked=False,
+        allow_chunks=False,
     )
 )
 def test_to_dataframe_pyarrow_zero_copy_parametric(df: pl.DataFrame) -> None:
@@ -101,7 +101,7 @@ def test_to_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
             pl.String,  # Polars String type does not match protocol spec
             pl.Categorical,
         ],
-        chunked=False,
+        allow_chunks=False,
         allow_null=False,  # Bug: https://github.com/pola-rs/polars/issues/16190
     )
 )
@@ -134,7 +134,7 @@ def test_from_dataframe_pyarrow_parametric(df: pl.DataFrame) -> None:
             pl.Categorical,  # Polars copies the categories to construct a mapping
             pl.Boolean,  # pyarrow exports boolean buffers as byte-packed: https://github.com/apache/arrow/issues/37991
         ],
-        chunked=False,
+        allow_chunks=False,
     )
 )
 def test_from_dataframe_pyarrow_zero_copy_parametric(df: pl.DataFrame) -> None:
@@ -176,7 +176,7 @@ def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
         # Empty dataframes cause an error due to a bug in pandas.
         # https://github.com/pandas-dev/pandas/issues/56700
         min_size=1,
-        chunked=False,
+        allow_chunks=False,
     )
 )
 @pytest.mark.skipif(
@@ -222,7 +222,7 @@ def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
         # Empty dataframes cause an error due to a bug in pandas.
         # https://github.com/pandas-dev/pandas/issues/56700
         min_size=1,
-        chunked=False,
+        allow_chunks=False,
         allow_null=False,  # Bug: https://github.com/pola-rs/polars/issues/16190
     )
 )

--- a/py-polars/tests/unit/series/buffers/test_from_buffer.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffer.py
@@ -13,7 +13,7 @@ from polars.testing.parametric import series
 @given(
     s=series(
         allowed_dtypes=(pl.INTEGER_DTYPES | pl.FLOAT_DTYPES | {pl.Boolean}),
-        chunked=False,
+        allow_chunks=False,
         allow_null=False,
     )
 )

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -24,7 +24,7 @@ TEMPORAL_DTYPES: set[pl.PolarsDataType] = (
 @given(
     s=series(
         allowed_dtypes=(pl.INTEGER_DTYPES | pl.FLOAT_DTYPES | {pl.Boolean}),
-        chunked=False,
+        allow_chunks=False,
     )
 )
 def test_series_from_buffers_numeric_with_validity(s: pl.Series) -> None:
@@ -36,7 +36,7 @@ def test_series_from_buffers_numeric_with_validity(s: pl.Series) -> None:
 @given(
     s=series(
         allowed_dtypes=(pl.INTEGER_DTYPES | pl.FLOAT_DTYPES | {pl.Boolean}),
-        chunked=False,
+        allow_chunks=False,
         allow_null=False,
     )
 )
@@ -45,7 +45,7 @@ def test_series_from_buffers_numeric(s: pl.Series) -> None:
     assert_series_equal(s, result)
 
 
-@given(s=series(allowed_dtypes=TEMPORAL_DTYPES, chunked=False))
+@given(s=series(allowed_dtypes=TEMPORAL_DTYPES, allow_chunks=False))
 def test_series_from_buffers_temporal_with_validity(s: pl.Series) -> None:
     validity = s.is_not_null()
     physical = pl.Int32 if s.dtype == pl.Date else pl.Int64

--- a/py-polars/tests/unit/testing/parametric/strategies/test_core.py
+++ b/py-polars/tests/unit/testing/parametric/strategies/test_core.py
@@ -296,6 +296,7 @@ def test_dataframes_allowed_dtypes_integer_cols(df: pl.DataFrame) -> None:
 
 
 @given(st.data())
+@settings(max_examples=1)
 def test_series_chunked_deprecated(data: st.DataObject) -> None:
     with pytest.deprecated_call():
         data.draw(series(chunked=True))


### PR DESCRIPTION
A few improvements:

* Rename `chunked` to `allow_chunks`. If allowed, hypothesis will decide whether to chunk or not.
* Improve performance when using `excluded_dtypes`
* Improve `structs` strategy to allow missing entries.