### PR TITLE
feat(rust): add cluster_with_columns plan optimization

### DIFF
--- a/crates/polars-arrow/src/bitmap/bitmap_ops.rs
+++ b/crates/polars-arrow/src/bitmap/bitmap_ops.rs
@@ -131,7 +131,13 @@ where
 }
 
 /// Apply a bitwise operation `op` to two inputs and fold the result.
-pub fn binary_fold_mut<B, F, R>(lhs: &MutableBitmap, rhs: &MutableBitmap, op: F, init: B, fold: R) -> B 
+pub fn binary_fold_mut<B, F, R>(
+    lhs: &MutableBitmap,
+    rhs: &MutableBitmap,
+    op: F,
+    init: B,
+    fold: R,
+) -> B
 where
     F: Fn(u64, u64) -> B,
     R: Fn(B, B) -> B,
@@ -148,7 +154,6 @@ where
 
     fold(result, op(rem_lhs, rem_rhs))
 }
-
 
 fn unary_impl<F, I>(iter: I, op: F, length: usize) -> Bitmap
 where

--- a/crates/polars-arrow/src/bitmap/bitmap_ops.rs
+++ b/crates/polars-arrow/src/bitmap/bitmap_ops.rs
@@ -111,7 +111,7 @@ where
     Bitmap::from_u8_vec(buffer, length)
 }
 
-/// Apply a bitwise operation `op` to two inputs and return the result as a [`Bitmap`].
+/// Apply a bitwise operation `op` to two inputs and fold the result.
 pub fn binary_fold<B, F, R>(lhs: &Bitmap, rhs: &Bitmap, op: F, init: B, fold: R) -> B
 where
     F: Fn(u64, u64) -> B,
@@ -129,6 +129,26 @@ where
 
     fold(result, op(rem_lhs, rem_rhs))
 }
+
+/// Apply a bitwise operation `op` to two inputs and fold the result.
+pub fn binary_fold_mut<B, F, R>(lhs: &MutableBitmap, rhs: &MutableBitmap, op: F, init: B, fold: R) -> B 
+where
+    F: Fn(u64, u64) -> B,
+    R: Fn(B, B) -> B,
+{
+    assert_eq!(lhs.len(), rhs.len());
+    let lhs_chunks = lhs.chunks();
+    let rhs_chunks = rhs.chunks();
+    let rem_lhs = lhs_chunks.remainder();
+    let rem_rhs = rhs_chunks.remainder();
+
+    let result = lhs_chunks
+        .zip(rhs_chunks)
+        .fold(init, |prev, (left, right)| fold(prev, op(left, right)));
+
+    fold(result, op(rem_lhs, rem_rhs))
+}
+
 
 fn unary_impl<F, I>(iter: I, op: F, length: usize) -> Bitmap
 where
@@ -245,8 +265,18 @@ fn eq(lhs: &Bitmap, rhs: &Bitmap) -> bool {
     lhs_remainder.zip(rhs_remainder).all(|(x, y)| x == y)
 }
 
-pub fn intersect_with(lhs: &Bitmap, rhs: &Bitmap) -> bool {
+pub fn intersects_with(lhs: &Bitmap, rhs: &Bitmap) -> bool {
     binary_fold(
+        lhs,
+        rhs,
+        |lhs, rhs| lhs & rhs != 0,
+        false,
+        |lhs, rhs| lhs || rhs,
+    )
+}
+
+pub fn intersects_with_mut(lhs: &MutableBitmap, rhs: &MutableBitmap) -> bool {
+    binary_fold_mut(
         lhs,
         rhs,
         |lhs, rhs| lhs & rhs != 0,

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -6,7 +6,7 @@ use either::Either;
 use polars_error::{polars_bail, PolarsResult};
 
 use super::utils::{count_zeros, fmt, get_bit, get_bit_unchecked, BitChunk, BitChunks, BitmapIter};
-use super::{chunk_iter_to_vec, intersect_with, IntoIter, MutableBitmap};
+use super::{chunk_iter_to_vec, intersects_with, IntoIter, MutableBitmap};
 use crate::bitmap::aligned::AlignedBitmapSlice;
 use crate::bitmap::iterator::{
     FastU32BitmapIter, FastU56BitmapIter, FastU64BitmapIter, TrueIdxIter,
@@ -478,8 +478,8 @@ impl Bitmap {
     /// Checks whether two [`Bitmap`]s have shared set bits.
     ///
     /// This is an optimized version of `(self & other) != 0000..`.
-    pub fn intersect_with(&self, other: &Self) -> bool {
-        intersect_with(self, other)
+    pub fn intersects_with(&self, other: &Self) -> bool {
+        intersects_with(self, other)
     }
 }
 

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -6,7 +6,7 @@ use either::Either;
 use polars_error::{polars_bail, PolarsResult};
 
 use super::utils::{count_zeros, fmt, get_bit, get_bit_unchecked, BitChunk, BitChunks, BitmapIter};
-use super::{chunk_iter_to_vec, IntoIter, MutableBitmap};
+use super::{chunk_iter_to_vec, intersect_with, IntoIter, MutableBitmap};
 use crate::bitmap::aligned::AlignedBitmapSlice;
 use crate::bitmap::iterator::{
     FastU32BitmapIter, FastU56BitmapIter, FastU64BitmapIter, TrueIdxIter,
@@ -473,6 +473,13 @@ impl Bitmap {
             length,
             unset_bit_count_cache,
         }
+    }
+
+    /// Checks whether two [`Bitmap`]s have shared set bits.
+    ///
+    /// This is an optimized version of `(self & other) != 0000..`.
+    pub fn intersect_with(&self, other: &Self) -> bool {
+        intersect_with(self, other)
     }
 }
 

--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use polars_error::{polars_bail, PolarsResult};
 
 use super::utils::{
-    count_zeros, fmt, get_bit, set, set_bit, BitChunk, BitChunks, BitChunksExactMut, BitmapIter
+    count_zeros, fmt, get_bit, set, set_bit, BitChunk, BitChunks, BitChunksExactMut, BitmapIter,
 };
 use super::{intersects_with_mut, Bitmap};
 use crate::bitmap::utils::{get_bit_unchecked, merge_reversed, set_bit_unchecked};

--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -246,6 +246,15 @@ impl MutableBitmap {
         count_zeros(&self.buffer, 0, self.length)
     }
 
+    /// Returns the number of set bits on this [`MutableBitmap`].
+    ///
+    /// Guaranteed to be `<= self.len()`.
+    /// # Implementation
+    /// This function is `O(N)`
+    pub fn set_bits(&self) -> usize {
+        self.length - self.unset_bits()
+    }
+
     /// Returns the number of unset bits on this [`MutableBitmap`].
     #[deprecated(since = "0.13.0", note = "use `unset_bits` instead")]
     pub fn null_count(&self) -> usize {

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -151,6 +151,12 @@ impl LazyFrame {
         self
     }
 
+    /// Toggle cluster with columns optimization.
+    pub fn with_cluster_with_columns(mut self, toggle: bool) -> Self {
+        self.opt_state.cluster_with_columns = toggle;
+        self
+    }
+
     /// Toggle predicate pushdown optimization.
     pub fn with_predicate_pushdown(mut self, toggle: bool) -> Self {
         self.opt_state.predicate_pushdown = toggle;

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -128,6 +128,7 @@ impl LazyFrame {
         self.with_optimizations(OptState {
             projection_pushdown: false,
             predicate_pushdown: false,
+            cluster_with_columns: false,
             type_coercion: true,
             simplify_expr: false,
             slice_pushdown: false,

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -549,27 +549,146 @@ fn test_flatten_unions() -> PolarsResult<()> {
     Ok(())
 }
 
+fn num_occurrences(s: &str, needle: &str) -> usize {
+    let mut i = 0;
+    let mut num = 0;
+
+    while let Some(n) = s[i..].find(needle) {
+        i += n + 1;
+        num += 1;
+    }
+
+    num
+}
+
 #[test]
 fn test_cluster_with_columns() -> Result<(), Box<dyn std::error::Error>> {
     use polars_core::prelude::*;
 
     let df = df!("foo" => &[0.5, 1.7, 3.2],
                  "bar" => &[4.1, 1.5, 9.2])?;
-    
-    let df = df.lazy()
+
+    let df = df
+        .lazy()
+        .without_optimizations()
+        .with_cluster_with_columns(true)
         .with_columns([col("foo") * lit(2.0)])
         .with_columns([col("bar") / lit(1.5)]);
 
-    let unoptimized = df.describe_plan().unwrap();
-    let optimized = df.describe_optimized_plan().unwrap();
+    let unoptimized = df.clone().to_alp().unwrap();
+    let optimized = df.clone().to_alp_optimized().unwrap();
+
+    let unoptimized = unoptimized.describe();
+    let optimized = optimized.describe();
 
     println!("\n---\n");
 
-    println!("Unoptimized:\n{unoptimized}");
+    println!("Unoptimized:\n{unoptimized}",);
     println!("\n---\n");
     println!("Optimized:\n{optimized}");
 
-    assert!(false);
+    assert_eq!(num_occurrences(&unoptimized, "WITH_COLUMNS"), 2);
+    assert_eq!(num_occurrences(&optimized, "WITH_COLUMNS"), 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_cluster_with_columns_dependency() -> Result<(), Box<dyn std::error::Error>> {
+    use polars_core::prelude::*;
+
+    let df = df!("foo" => &[0.5, 1.7, 3.2],
+                 "bar" => &[4.1, 1.5, 9.2])?;
+
+    let df = df
+        .lazy()
+        .without_optimizations()
+        .with_cluster_with_columns(true)
+        .with_columns([col("foo").alias("buzz")])
+        .with_columns([col("buzz")]);
+
+    let unoptimized = df.clone().to_alp().unwrap();
+    let optimized = df.clone().to_alp_optimized().unwrap();
+
+    let unoptimized = unoptimized.describe();
+    let optimized = optimized.describe();
+
+    println!("\n---\n");
+
+    println!("Unoptimized:\n{unoptimized}",);
+    println!("\n---\n");
+    println!("Optimized:\n{optimized}");
+
+    assert_eq!(num_occurrences(&unoptimized, "WITH_COLUMNS"), 2);
+    assert_eq!(num_occurrences(&optimized, "WITH_COLUMNS"), 2);
+
+    Ok(())
+}
+
+#[test]
+fn test_cluster_with_columns_partial() -> Result<(), Box<dyn std::error::Error>> {
+    use polars_core::prelude::*;
+
+    let df = df!("foo" => &[0.5, 1.7, 3.2],
+                 "bar" => &[4.1, 1.5, 9.2])?;
+
+    let df = df
+        .lazy()
+        .without_optimizations()
+        .with_cluster_with_columns(true)
+        .with_columns([col("foo").alias("buzz")])
+        .with_columns([col("buzz"), col("foo") * lit(2.0)]);
+
+    let unoptimized = df.clone().to_alp().unwrap();
+    let optimized = df.clone().to_alp_optimized().unwrap();
+
+    let unoptimized = unoptimized.describe();
+    let optimized = optimized.describe();
+
+    println!("\n---\n");
+
+    println!("Unoptimized:\n{unoptimized}",);
+    println!("\n---\n");
+    println!("Optimized:\n{optimized}");
+
+    assert!(unoptimized.contains(r#"[col("buzz"), [(col("foo")) * (2.0)]]"#));
+    assert!(unoptimized.contains(r#"[col("foo").alias("buzz")]"#));
+    assert!(optimized.contains(r#"[col("buzz")]"#));
+    assert!(optimized.contains(r#"[col("foo").alias("buzz"), [(col("foo")) * (2.0)]]"#));
+
+    Ok(())
+}
+
+#[test]
+fn test_cluster_with_columns_chain() -> Result<(), Box<dyn std::error::Error>> {
+    use polars_core::prelude::*;
+
+    let df = df!("foo" => &[0.5, 1.7, 3.2],
+                 "bar" => &[4.1, 1.5, 9.2])?;
+
+    let df = df
+        .lazy()
+        .without_optimizations()
+        .with_cluster_with_columns(true)
+        .with_columns([col("foo").alias("foo1")])
+        .with_columns([col("foo").alias("foo2")])
+        .with_columns([col("foo").alias("foo3")])
+        .with_columns([col("foo").alias("foo4")]);
+
+    let unoptimized = df.clone().to_alp().unwrap();
+    let optimized = df.clone().to_alp_optimized().unwrap();
+
+    let unoptimized = unoptimized.describe();
+    let optimized = optimized.describe();
+
+    println!("\n---\n");
+
+    println!("Unoptimized:\n{unoptimized}",);
+    println!("\n---\n");
+    println!("Optimized:\n{optimized}");
+
+    assert_eq!(num_occurrences(&unoptimized, "WITH_COLUMNS"), 3);
+    assert_eq!(num_occurrences(&optimized, "WITH_COLUMNS"), 1);
 
     Ok(())
 }

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -687,7 +687,7 @@ fn test_cluster_with_columns_chain() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n---\n");
     println!("Optimized:\n{optimized}");
 
-    assert_eq!(num_occurrences(&unoptimized, "WITH_COLUMNS"), 3);
+    assert_eq!(num_occurrences(&unoptimized, "WITH_COLUMNS"), 4);
     assert_eq!(num_occurrences(&optimized, "WITH_COLUMNS"), 1);
 
     Ok(())

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -548,3 +548,28 @@ fn test_flatten_unions() -> PolarsResult<()> {
     }
     Ok(())
 }
+
+#[test]
+fn test_cluster_with_columns() -> Result<(), Box<dyn std::error::Error>> {
+    use polars_core::prelude::*;
+
+    let df = df!("foo" => &[0.5, 1.7, 3.2],
+                 "bar" => &[4.1, 1.5, 9.2])?;
+    
+    let df = df.lazy()
+        .with_columns([col("foo") * lit(2.0)])
+        .with_columns([col("bar") / lit(1.5)]);
+
+    let unoptimized = df.describe_plan().unwrap();
+    let optimized = df.describe_optimized_plan().unwrap();
+
+    println!("\n---\n");
+
+    println!("Unoptimized:\n{unoptimized}");
+    println!("\n---\n");
+    println!("Optimized:\n{optimized}");
+
+    assert!(false);
+
+    Ok(())
+}

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -5,6 +5,8 @@ pub struct OptState {
     pub projection_pushdown: bool,
     /// Apply predicates/filters as early as possible.
     pub predicate_pushdown: bool,
+    /// Cluster sequential `with_columns` calls to independent calls.
+    pub cluster_with_columns: bool,
     /// Run many type coercion optimization rules until fixed point.
     pub type_coercion: bool,
     /// Run many expression optimization rules until fixed point.
@@ -36,6 +38,7 @@ impl Default for OptState {
         OptState {
             projection_pushdown: true,
             predicate_pushdown: true,
+            cluster_with_columns: true,
             type_coercion: true,
             simplify_expr: true,
             slice_pushdown: true,

--- a/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
@@ -1,0 +1,539 @@
+use arrow::bitmap::{Bitmap, MutableBitmap};
+use polars_core::schema::SchemaRef;
+use polars_utils::aliases::PlHashMap;
+use polars_utils::arena::{Arena, Node};
+
+use super::aexpr::{AAggExpr, AExpr};
+use super::alp::IR;
+use super::expr_ir::{ExprIR, OutputName};
+use super::ProjectionOptions;
+use crate::logical_plan::projection_expr::ProjectionExprs;
+use crate::prelude::AnonymousScan;
+
+pub struct ClusterWithColumns<'a> {
+    lp_arena: &'a mut Arena<IR>,
+    expr_arena: &'a mut Arena<AExpr>,
+}
+
+struct WithColumnsRef<'a> {
+    input: Node,
+    exprs: &'a ProjectionExprs,
+    schema: &'a SchemaRef,
+    options: &'a ProjectionOptions,
+}
+
+struct WithColumnsMut<'a> {
+    input: &'a mut Node,
+    exprs: &'a mut ProjectionExprs,
+    schema: &'a mut SchemaRef,
+    options: &'a mut ProjectionOptions,
+}
+
+// // @NOTE: We use a u128 here, because the space would otherwise be used by the fat-pointer of the
+// // boxed slice anyway.
+// pub enum BitSet {
+//     Short(u128),
+//     Long(Box<[u128]>),
+// }
+//
+// impl fmt::Debug for BitSet {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         f.debug_list().entries(self.iter()).finish()
+//     }
+// }
+//
+// pub struct BitSetIter<'a> {
+//     inner: &'a BitSet,
+//     offset: usize,
+// }
+//
+// impl<'a> Iterator for BitSetIter<'a> {
+//     type Item = usize;
+//
+//     fn next(&mut self) -> Option<Self::Item> {
+//         match self.inner {
+//             BitSet::Short(n) => {
+//                 if self.offset >= BitSet::SHORT_SIZE {
+//                     return None;
+//                 }
+//
+//                 let shifted = n >> self.offset;
+//
+//                 if *n == 0 {
+//                     self.offset = BitSet::SHORT_SIZE;
+//                     return None;
+//                 }
+//
+//                 let trailing_zeros = shifted.trailing_zeros();
+//                 self.offset += trailing_zeros as usize;
+//                 let idx = self.offset;
+//                 self.offset += 1;
+//
+//                 Some(idx)
+//             },
+//             BitSet::Long(ns) => loop {
+//                 if self.offset >= BitSet::ELEMENT_SIZE * ns.len() {
+//                     return None;
+//                 }
+//
+//                 let element_idx = self.offset / BitSet::ELEMENT_SIZE;
+//                 let element_offset = self.offset % BitSet::ELEMENT_SIZE;
+//
+//                 let n = ns[element_idx];
+//                 let shifted = n >> element_offset;
+//
+//                 if shifted == 0 {
+//                     self.offset = (element_idx + 1) * BitSet::ELEMENT_SIZE;
+//                     continue;
+//                 }
+//
+//                 let trailing_zeros = shifted.trailing_zeros();
+//                 self.offset += trailing_zeros as usize;
+//                 let idx = self.offset;
+//                 self.offset += 1;
+//
+//                 break Some(idx);
+//             },
+//         }
+//     }
+// }
+//
+// impl BitSet {
+//     const SHORT_SIZE: usize = 128;
+//     const ELEMENT_SIZE: usize = 128;
+//
+//     pub fn new(length: usize) -> Self {
+//         if length <= Self::SHORT_SIZE {
+//             Self::Short(0)
+//         } else {
+//             let num_elements =
+//                 (length / Self::ELEMENT_SIZE) + usize::from(length % Self::ELEMENT_SIZE != 0);
+//             Self::Long(vec![0; num_elements].into_boxed_slice())
+//         }
+//     }
+//
+//     pub fn iter(&self) -> BitSetIter {
+//         BitSetIter {
+//             inner: self,
+//             offset: 0,
+//         }
+//     }
+//
+//     pub fn insert(&mut self, at: usize) {
+//         match self {
+//             BitSet::Short(ref mut n) => *n |= 1 << at,
+//             BitSet::Long(ref mut ns) => {
+//                 ns[at / Self::ELEMENT_SIZE] |= 1 << (at % Self::ELEMENT_SIZE)
+//             },
+//         }
+//     }
+//
+//     pub fn is_empty(&self) -> bool {
+//         match self {
+//             BitSet::Short(n) => *n == 0,
+//             BitSet::Long(ns) => ns.iter().all(|n| *n == 0),
+//         }
+//     }
+//
+//     pub fn has_intersection(&self, other: &Self) -> bool {
+//         match (self, other) {
+//             (Self::Short(lhs), Self::Short(rhs)) => lhs & rhs != 0,
+//             (Self::Long(lhs), Self::Long(rhs)) if lhs.len() == rhs.len() => {
+//                 lhs.iter().zip(rhs.iter()).any(|(lhs, rhs)| lhs & rhs != 0)
+//             },
+//             _ => panic!("has_intersection between bitsets of differing lengths"),
+//         }
+//     }
+// }
+
+struct ColumnStatus {
+    live: MutableBitmap,
+    assign: MutableBitmap,
+}
+
+struct ColumnStatusFrozen {
+    live: Bitmap,
+    assign: Bitmap,
+}
+
+impl ColumnStatus {
+    fn new() -> Self {
+        Self {
+            live: MutableBitmap::new(),
+            assign: MutableBitmap::new(),
+        }
+    }
+
+    fn name_to_idx<'a>(
+        &mut self,
+        name_map: &mut PlHashMap<&'a str, usize>,
+        name: &'a str,
+    ) -> usize {
+        let next = self.live.len();
+
+        self.live.push(false);
+        self.assign.push(false);
+
+        *name_map.entry(name).or_insert_with(|| next)
+    }
+
+    fn freeze(self) -> ColumnStatusFrozen {
+        ColumnStatusFrozen {
+            live: self.live.freeze(),
+            assign: self.assign.freeze(),
+        }
+    }
+
+    fn append_expr_node<'a>(
+        &mut self,
+        name_map: &mut PlHashMap<&'a str, usize>,
+        node: Node,
+        expr_arena: &'a Arena<AExpr>,
+    ) {
+        let expr = expr_arena.get(node);
+
+        match expr {
+            AExpr::Explode(expr) => self.append_expr_node(name_map, *expr, expr_arena),
+            AExpr::Alias(expr, _) => self.append_expr_node(name_map, *expr, expr_arena),
+            AExpr::Column(col) => {
+                let idx = self.name_to_idx(name_map, &col);
+                self.live.set(idx, true);
+            },
+            AExpr::Literal(_) => {},
+            AExpr::BinaryExpr { left, op: _, right } => {
+                self.append_expr_node(name_map, *left, expr_arena);
+                self.append_expr_node(name_map, *right, expr_arena);
+            },
+            AExpr::Cast {
+                expr,
+                data_type: _,
+                strict: _,
+            } => self.append_expr_node(name_map, *expr, expr_arena),
+            AExpr::Sort { expr, options: _ } => self.append_expr_node(name_map, *expr, expr_arena),
+            AExpr::Gather {
+                expr,
+                idx,
+                returns_scalar: _,
+            } => {
+                self.append_expr_node(name_map, *expr, expr_arena);
+                self.append_expr_node(name_map, *idx, expr_arena);
+            },
+            AExpr::SortBy {
+                expr,
+                by,
+                sort_options: _,
+            } => {
+                self.append_expr_node(name_map, *expr, expr_arena);
+                for i in by.iter() {
+                    self.append_expr_node(name_map, *i, expr_arena);
+                }
+            },
+            AExpr::Filter { input, by } => {
+                self.append_expr_node(name_map, *input, expr_arena);
+                self.append_expr_node(name_map, *by, expr_arena);
+            },
+            AExpr::Agg(aagg_expr) => match aagg_expr {
+                AAggExpr::Min {
+                    input,
+                    propagate_nans: _,
+                }
+                | AAggExpr::Max {
+                    input,
+                    propagate_nans: _,
+                }
+                | AAggExpr::Median(input)
+                | AAggExpr::NUnique(input)
+                | AAggExpr::First(input)
+                | AAggExpr::Last(input)
+                | AAggExpr::Mean(input)
+                | AAggExpr::Implode(input)
+                | AAggExpr::Sum(input)
+                | AAggExpr::Count(input, _)
+                | AAggExpr::Std(input, _)
+                | AAggExpr::Var(input, _)
+                | AAggExpr::AggGroups(input) => self.append_expr_node(name_map, *input, expr_arena),
+                AAggExpr::Quantile {
+                    expr,
+                    quantile,
+                    interpol: _,
+                } => {
+                    self.append_expr_node(name_map, *expr, expr_arena);
+                    self.append_expr_node(name_map, *quantile, expr_arena);
+                },
+            },
+            AExpr::Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => {
+                self.append_expr_node(name_map, *predicate, expr_arena);
+                self.append_expr_node(name_map, *truthy, expr_arena);
+                self.append_expr_node(name_map, *falsy, expr_arena);
+            },
+            AExpr::AnonymousFunction {
+                input,
+                function: _,
+                output_type: _,
+                options: _,
+            } => {
+                for i in input.iter() {
+                    self.append_expr_ir(name_map, i, expr_arena);
+                }
+            },
+            AExpr::Function {
+                input,
+                function: _,
+                options: _,
+            } => {
+                for i in input.iter() {
+                    self.append_expr_ir(name_map, i, expr_arena);
+                }
+
+                // @TODO: Do we also have to do something with the `function`?
+                //
+                // From my first impression, the answer is no, but probably someone else should
+                // look at this for a second.
+            },
+            AExpr::Window {
+                function,
+                partition_by,
+                options: _,
+            } => {
+                self.append_expr_node(name_map, *function, expr_arena);
+                for i in partition_by.iter() {
+                    self.append_expr_node(name_map, *i, expr_arena);
+                }
+            },
+            AExpr::Wildcard => {
+                // @TODO: I am not really sure if we need to account for this in some way. Does
+                // this mean all of the columns?
+
+                todo!()
+            },
+            AExpr::Slice {
+                input,
+                offset,
+                length,
+            } => {
+                self.append_expr_node(name_map, *input, expr_arena);
+                self.append_expr_node(name_map, *offset, expr_arena);
+                self.append_expr_node(name_map, *length, expr_arena);
+            },
+            AExpr::Len => {},
+            AExpr::Nth(_) => {},
+        }
+    }
+
+    fn append_expr_ir<'a>(
+        &mut self,
+        name_map: &mut PlHashMap<&'a str, usize>,
+        expr_ir: &'a ExprIR,
+        expr_arena: &'a Arena<AExpr>,
+    ) {
+        match expr_ir.output_name_inner() {
+            OutputName::None => {},
+            OutputName::LiteralLhs(s) | OutputName::ColumnLhs(s) | OutputName::Alias(s) => {
+                let idx = self.name_to_idx(name_map, s);
+                self.assign.set(idx, true);
+            },
+        }
+
+        self.append_expr_node(name_map, expr_ir.node(), expr_arena);
+    }
+
+    fn from_expr_ir<'a>(
+        name_map: &mut PlHashMap<&'a str, usize>,
+        expr: &'a ExprIR,
+        expr_arena: &'a Arena<AExpr>,
+    ) -> Self {
+        // @TODO: This should not be hardcoded
+        let mut column_status = Self::new();
+        column_status.append_expr_ir(name_map, expr, expr_arena);
+        column_status
+    }
+}
+
+impl<'a> WithColumnsRef<'a> {
+    fn from_ir(ir: &'a IR) -> Option<Self> {
+        let IR::HStack {
+            input,
+            exprs,
+            schema,
+            options,
+        } = ir
+        else {
+            return None;
+        };
+
+        let input = *input;
+
+        Some(Self {
+            input,
+            exprs,
+            schema,
+            options,
+        })
+    }
+}
+
+impl<'a> WithColumnsMut<'a> {
+    fn from_ir(ir: &'a mut IR) -> Option<Self> {
+        let IR::HStack {
+            input,
+            exprs,
+            schema,
+            options,
+        } = ir
+        else {
+            return None;
+        };
+
+        Some(Self {
+            input,
+            exprs,
+            schema,
+            options,
+        })
+    }
+}
+
+enum CWCOptimization {
+    PullUpAll,
+    PullUpSubset(Bitmap),
+}
+
+impl<'a> ClusterWithColumns<'a> {
+    pub fn new(lp_arena: &'a mut Arena<IR>, expr_arena: &'a mut Arena<AExpr>) -> Self {
+        Self {
+            lp_arena,
+            expr_arena,
+        }
+    }
+
+    pub fn optimize(&mut self, root: Node) {
+        self._optimize(root);
+    }
+
+    fn has_optimization(&self, root: Node) -> Option<CWCOptimization> {
+        let ir = self.lp_arena.get(root);
+        let with_columns = WithColumnsRef::from_ir(ir)?;
+
+        let child = ir.get_input()?;
+        let child = self.lp_arena.get(child);
+        let child_with_columns = WithColumnsRef::from_ir(child)?;
+
+        // @NOTE
+        // There are dependencies i.f.f.
+        // - `child` assigns to a column that is used by `parent`
+
+        let mut name_map = PlHashMap::default();
+
+        let child_statuses: Vec<ColumnStatusFrozen> = child_with_columns
+            .exprs
+            .as_exprs()
+            .iter()
+            .map(|expr| ColumnStatus::from_expr_ir(&mut name_map, expr, self.expr_arena).freeze())
+            .collect();
+        let current_statuses: Vec<ColumnStatusFrozen> = with_columns
+            .exprs
+            .as_exprs()
+            .iter()
+            .map(|expr| ColumnStatus::from_expr_ir(&mut name_map, expr, self.expr_arena).freeze())
+            .collect();
+
+        let mut pullable = MutableBitmap::new();
+
+        pullable.reserve(child_with_columns.exprs.len());
+        for _ in 0..child_with_columns.exprs.len() {
+            pullable.push(false);
+        }
+
+        let mut all_pullable = true;
+        for (i, current_status) in current_statuses.iter().enumerate() {
+            let mut can_be_merged = true;
+
+            for child_status in child_statuses.iter() {
+                use std::ops::BitAnd;
+                if (current_status.assign.bitand(&child_status.live)).is_empty() {
+                    can_be_merged = false;
+                }
+            }
+
+            all_pullable |= can_be_merged;
+            if can_be_merged {
+                pullable.set(i, true);
+            }
+        }
+
+        if all_pullable {
+            Some(CWCOptimization::PullUpAll)
+        } else if pullable.is_empty() {
+            None
+        } else {
+            Some(CWCOptimization::PullUpSubset(pullable.freeze()))
+        }
+    }
+
+    fn apply_optimization(&mut self, root: Node, optimization: CWCOptimization) {
+        let ir = self.lp_arena.get(root);
+        let child_node = ir.get_input().unwrap();
+
+        match optimization {
+            CWCOptimization::PullUpAll => {
+                let child = self.lp_arena.take(child_node);
+                let IR::HStack {
+                    input,
+                    exprs,
+                    schema,
+                    options,
+                } = child
+                else {
+                    panic!("Specified node is not a HStack. Instead found: {child:?}");
+                };
+
+                let ir = self.lp_arena.get_mut(root);
+                let with_columns = WithColumnsMut::from_ir(ir).unwrap();
+                with_columns.exprs.exprs_mut().extend(exprs);
+                *with_columns.input = input;
+                *with_columns.schema = schema;
+                *with_columns.options = options;
+            },
+            CWCOptimization::PullUpSubset(exprs) => {
+                let child = self.lp_arena.get_mut(child_node);
+                let child_with_columns = WithColumnsMut::from_ir(child).unwrap();
+                let child_exprs = std::mem::take(child_with_columns.exprs.exprs_mut());
+
+                let ir = self.lp_arena.get_mut(root);
+                let with_columns = WithColumnsMut::from_ir(ir).unwrap();
+
+                let mut child_exprs = child_exprs
+                    .into_iter()
+                    .zip(exprs)
+                    .filter_map(|(expr, do_pullup)| {
+                        if do_pullup {
+                            with_columns.exprs.exprs_mut().push(expr);
+                            None
+                        } else {
+                            Some(expr)
+                        }
+                    })
+                    .collect();
+
+                let child = self.lp_arena.get_mut(child_node);
+                let child_with_columns = WithColumnsMut::from_ir(child).unwrap();
+                std::mem::swap(&mut child_exprs, child_with_columns.exprs.exprs_mut());
+            },
+        }
+    }
+
+    fn _optimize(&mut self, root: Node) {
+        let ir = self.lp_arena.get(root);
+        if let Some(child) = ir.get_input() {
+            self._optimize(child);
+
+            if let Some(optimization) = self.has_optimization(root) {
+                self.apply_optimization(root, optimization);
+            }
+        }
+    }
+}

--- a/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
@@ -32,183 +32,171 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
     let mut ir_stack = Vec::with_capacity(16);
     ir_stack.push(root);
 
+    // We define these here to reuse the allocations across the loops
     let mut column_map = ColumnMap::with_capacity(8);
     let mut input_genset = MutableBitmap::with_capacity(16);
     let mut current_livesets: Vec<MutableBitmap> = Vec::with_capacity(16);
-    // This keeps track of previous allocations for the current livesets. I am not sure this is
-    // worth it.
-    let mut current_livesets_pops: Vec<MutableBitmap> = Vec::with_capacity(16);
     let mut pushable = MutableBitmap::with_capacity(16);
 
-    loop {
-        let Some(current) = ir_stack.pop() else {
-            break;
+    while let Some(current) = ir_stack.pop() {
+        let current_ir = lp_arena.get(current);
+        current_ir.copy_inputs(&mut ir_stack);
+        let IR::HStack { input, .. } = current_ir else {
+            continue;
+        };
+        let input = *input;
+
+        let [current_ir, input_ir] = lp_arena.get_many_mut([current, input]);
+
+        let IR::HStack {
+            input: ref mut current_input,
+            exprs: ref mut current_exprs,
+            schema: ref mut current_schema,
+            options: ref mut current_options,
+        } = current_ir
+        else {
+            unreachable!();
+        };
+        let IR::HStack {
+            input: ref mut input_input,
+            exprs: ref mut input_exprs,
+            schema: ref mut input_schema,
+            options: ref mut input_options,
+        } = input_ir
+        else {
+            continue;
         };
 
-        while let IR::HStack { input, .. } = lp_arena.get(current) {
-            let input = *input;
+        let column_map = &mut column_map;
 
-            let [current_ir, input_ir] = lp_arena.get_many_mut([current, input]);
+        // Reuse the allocations of the previous loop
+        column_map.clear();
+        input_genset.clear();
+        current_livesets.clear();
+        pushable.clear();
 
-            let IR::HStack {
-                input: ref mut current_input,
-                exprs: ref mut current_exprs,
-                schema: ref mut current_schema,
-                options: ref mut current_options,
-            } = current_ir
-            else {
-                unreachable!();
-            };
-            let IR::HStack {
-                input: ref mut input_input,
-                exprs: ref mut input_exprs,
-                schema: ref mut input_schema,
-                options: ref mut input_options,
-            } = input_ir
-            else {
-                break;
-            };
+        // @NOTE
+        // We can pushdown any column that utilizes no live columns that are generated in the
+        // input.
 
-            let column_map = &mut column_map;
-
-            // Reuse the allocations of the previous loop
-            column_map.clear();
-            input_genset.clear();
-            current_livesets_pops.extend(std::mem::take(&mut current_livesets));
-            pushable.clear();
-
-            // @NOTE
-            // We can pushdown any column that utilizes no live columns that are generated in the
-            // input.
-
-            for input_expr in input_exprs.as_exprs() {
-                column_map_set(
-                    &mut input_genset,
-                    column_map,
-                    input_expr.output_name_arc().clone(),
-                );
-            }
-
-            for expr in current_exprs.as_exprs() {
-                // Reuse an old allocation if it is available.
-                let mut liveset = current_livesets_pops.pop().map_or_else(
-                    || MutableBitmap::from_len_zeroed(column_map.len()),
-                    |mut p| {
-                        p.clear();
-                        p.extend_constant(column_map.len(), false);
-                        p
-                    },
-                );
-
-                for live in aexpr_to_leaf_names_iter(expr.node(), expr_arena) {
-                    column_map_set(&mut liveset, column_map, live.clone());
-                }
-
-                current_livesets.push(liveset);
-            }
-
-            column_map_finalize_bitset(&mut input_genset, column_map);
-
-            // Check for every expression in the current WITH_COLUMNS node whether it can be pushed
-            // down.
-            for expr_liveset in &mut current_livesets {
-                column_map_finalize_bitset(expr_liveset, column_map);
-
-                let has_intersection = input_genset.intersects_with(&expr_liveset);
-                let is_pushable = !has_intersection;
-
-                pushable.push(is_pushable);
-            }
-
-            let pushable_set_bits = pushable.set_bits();
-
-            // There is nothing to push down. Move on.
-            if pushable_set_bits == 0 {
-                break;
-            }
-
-            // If all columns are pushable, we can merge the input into the current. This should be
-            // a relatively common case.
-            if pushable_set_bits == pushable.len() {
-                // @NOTE: To keep the schema correct, we reverse the order here. As a
-                // `WITH_COLUMNS` higher up produces later columns. This also allows us not to
-                // have to deal with schemas.
-                input_exprs
-                    .exprs_mut()
-                    .extend(std::mem::take(current_exprs.exprs_mut()));
-                std::mem::swap(current_exprs.exprs_mut(), input_exprs.exprs_mut());
-
-                *current_input = *input_input;
-                *current_options = current_options.merge_options(input_options);
-
-                // Let us just make this node invalid so we can detect when someone tries to
-                // mention it later.
-                lp_arena.take(input);
-
-                // Since we merged the current and input nodes and the input node might have
-                // optimizations with their input, we loop again on this node.
-                continue;
-            }
-
-            let mut new_current_schema = current_schema.as_ref().clone();
-            let mut new_input_schema = input_schema.as_ref().clone();
-
-            // @NOTE: We don't have to insert a SimpleProjection or redo the `current_schema` if
-            // `pushable` contains only 0..N for some N. We use these two variables to keep track
-            // of this.
-            let mut has_seen_unpushable = false;
-            let mut needs_simple_projection = false;
-
-            *current_exprs.exprs_mut() = std::mem::take(current_exprs.exprs_mut())
-                .into_iter()
-                .zip(pushable.iter())
-                .enumerate()
-                .filter_map(|(i, (expr, do_pushdown))| {
-                    if do_pushdown {
-                        needs_simple_projection = has_seen_unpushable;
-
-                        // @NOTE: It would be nice to have a `remove_at_index` here.
-                        let (column, _) = current_schema.get_at_index(i).unwrap();
-
-                        input_exprs.exprs_mut().push(expr);
-                        let datatype = new_current_schema.remove(column).unwrap();
-                        new_input_schema.with_column(column.clone(), datatype);
-
-                        None
-                    } else {
-                        has_seen_unpushable = true;
-                        Some(expr)
-                    }
-                })
-                .collect();
-
-            let options = current_options.merge_options(input_options);
-            *current_options = options;
-            *input_options = options;
-
-            // @NOTE: Here we add a simple projection to make sure that the output still
-            // has the right schema.
-            if needs_simple_projection {
-                new_current_schema.merge(new_input_schema.clone());
-                *input_schema = Arc::new(new_input_schema);
-                let proj_schema = current_schema.clone();
-                *current_schema = Arc::new(new_current_schema);
-
-                let moved_current = lp_arena.add(IR::Invalid);
-                let projection = IR::SimpleProjection {
-                    input: moved_current,
-                    columns: proj_schema,
-                };
-                let current = lp_arena.replace(current, projection);
-                lp_arena.replace(moved_current, current);
-            } else {
-                *input_schema = Arc::new(new_input_schema);
-            }
-
-            // We know that this node is done optimizing
-            break;
+        for input_expr in input_exprs.as_exprs() {
+            column_map_set(
+                &mut input_genset,
+                column_map,
+                input_expr.output_name_arc().clone(),
+            );
         }
 
-        lp_arena.get(current).copy_inputs(&mut ir_stack);
+        for expr in current_exprs.as_exprs() {
+            let mut liveset = MutableBitmap::from_len_zeroed(column_map.len());
+
+            for live in aexpr_to_leaf_names_iter(expr.node(), expr_arena) {
+                column_map_set(&mut liveset, column_map, live.clone());
+            }
+
+            current_livesets.push(liveset);
+        }
+
+        // Force that column_map is not further mutated from this point on
+        let column_map = column_map as &_;
+
+        column_map_finalize_bitset(&mut input_genset, column_map);
+
+        // Check for every expression in the current WITH_COLUMNS node whether it can be pushed
+        // down.
+        for expr_liveset in &mut current_livesets {
+            column_map_finalize_bitset(expr_liveset, column_map);
+
+            let has_intersection = input_genset.intersects_with(expr_liveset);
+            let is_pushable = !has_intersection;
+
+            pushable.push(is_pushable);
+        }
+
+        let pushable_set_bits = pushable.set_bits();
+
+        // If all columns are pushable, we can merge the input into the current. This should be
+        // a relatively common case.
+        if pushable_set_bits == pushable.len() {
+            // @NOTE: To keep the schema correct, we reverse the order here. As a
+            // `WITH_COLUMNS` higher up produces later columns. This also allows us not to
+            // have to deal with schemas.
+            input_exprs
+                .exprs_mut()
+                .extend(std::mem::take(current_exprs.exprs_mut()));
+            std::mem::swap(current_exprs.exprs_mut(), input_exprs.exprs_mut());
+
+            // Here, we perform the trick where we switch the inputs. This makes it possible to
+            // change the essentially remove the `current` node without knowing the parent of
+            // `current`. Essentially, we move the input node to the current node.
+            *current_input = *input_input;
+            *current_options = current_options.merge_options(input_options);
+
+            // Let us just make this node invalid so we can detect when someone tries to
+            // mention it later.
+            lp_arena.take(input);
+
+            // Since we merged the current and input nodes and the input node might have
+            // optimizations with their input, we loop again on this node.
+            ir_stack.pop();
+            ir_stack.push(current);
+            continue;
+        }
+
+        // There is nothing to push down. Move on.
+        if pushable_set_bits == 0 {
+            continue;
+        }
+
+        let mut new_current_schema = current_schema.as_ref().clone();
+        let mut new_input_schema = input_schema.as_ref().clone();
+
+        // @NOTE: We don't have to insert a SimpleProjection or redo the `current_schema` if
+        // `pushable` contains only 0..N for some N. We use these two variables to keep track
+        // of this.
+        let mut has_seen_unpushable = false;
+        let mut needs_simple_projection = false;
+
+        *current_exprs.exprs_mut() = std::mem::take(current_exprs.exprs_mut())
+            .into_iter()
+            .zip(pushable.iter())
+            .enumerate()
+            .filter_map(|(i, (expr, do_pushdown))| {
+                if do_pushdown {
+                    needs_simple_projection = has_seen_unpushable;
+
+                    input_exprs.exprs_mut().push(expr);
+                    let (column, datatype) = new_current_schema.shift_remove_index(i).unwrap();
+                    new_input_schema.with_column(column, datatype);
+
+                    None
+                } else {
+                    has_seen_unpushable = true;
+                    Some(expr)
+                }
+            })
+            .collect();
+
+        let options = current_options.merge_options(input_options);
+        *current_options = options;
+        *input_options = options;
+
+        // @NOTE: Here we add a simple projection to make sure that the output still
+        // has the right schema.
+        if needs_simple_projection {
+            new_current_schema.merge(new_input_schema.clone());
+            *input_schema = Arc::new(new_input_schema);
+            let proj_schema = std::mem::replace(current_schema, Arc::new(new_current_schema));
+
+            let moved_current = lp_arena.add(IR::Invalid);
+            let projection = IR::SimpleProjection {
+                input: moved_current,
+                columns: proj_schema,
+            };
+            let current = lp_arena.replace(current, projection);
+            lp_arena.replace(moved_current, current);
+        } else {
+            *input_schema = Arc::new(new_input_schema);
+        }
     }
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
@@ -217,6 +217,10 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
 
             *current_wc.exprs.exprs_mut() = current_exprs;
 
+            let options = current_wc.options.merge_options(input_wc.options);
+            *current_wc.options = options;
+            *input_wc.options = options;
+
             // @NOTE: Here we add a simple projection to make sure that the output still
             // has the right schema.
             if needs_simple_projection {

--- a/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
@@ -172,9 +172,10 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
                 std::mem::swap(current_wc.exprs.exprs_mut(), input_wc.exprs.exprs_mut());
 
                 *current_wc.input = *input_wc.input;
-                // @TODO: Is this allowed?
-                *current_wc.options = *input_wc.options;
+                *current_wc.options = current_wc.options.merge_options(input_wc.options);
 
+                // Let us just make this node invalid so we can detect when someone tries to
+                // mention it later.
                 lp_arena.take(input);
 
                 // Since we merged the current and input nodes and the input node might have

--- a/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
@@ -147,9 +147,8 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
             // down.
             let mut pushable = MutableBitmap::with_capacity(input_wc.exprs.len());
             for expr_liveset in &current_livesets {
-                let has_intersection = input_generate.intersect_with(&expr_liveset);
+                let has_intersection = input_generate.intersect_with(expr_liveset);
                 let is_pushable = !has_intersection;
-
                 pushable.push(is_pushable);
             }
             let pushable = pushable.freeze();

--- a/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cluster_with_columns.rs
@@ -312,8 +312,8 @@ impl ColumnStatus {
             AExpr::Wildcard => {
                 // @TODO: I am not really sure if we need to account for this in some way. Does
                 // this mean all of the columns?
-
-                todo!()
+                //
+                // I don't think so.
             },
             AExpr::Slice {
                 input,

--- a/crates/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -68,7 +68,7 @@ pub fn optimize(
     #[allow(dead_code)]
     let verbose = verbose();
     // get toggle values
-    let cluster_with_columns = opt_state.predicate_pushdown;
+    let cluster_with_columns = opt_state.cluster_with_columns;
     let predicate_pushdown = opt_state.predicate_pushdown;
     let projection_pushdown = opt_state.projection_pushdown;
     let type_coercion = opt_state.type_coercion;

--- a/crates/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -1,6 +1,5 @@
 use polars_core::prelude::*;
 
-use crate::prelude::optimizer::cluster_with_columns::ClusterWithColumns;
 use crate::prelude::*;
 
 mod cache_states;
@@ -159,7 +158,7 @@ pub fn optimize(
     }
 
     if cluster_with_columns {
-        ClusterWithColumns::new(lp_arena, expr_arena).optimize(lp_top);
+        cluster_with_columns::optimize(lp_top, lp_arena, expr_arena)
     }
 
     // Make sure its before slice pushdown.

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -275,6 +275,16 @@ impl Default for ProjectionOptions {
     }
 }
 
+impl ProjectionOptions {
+    /// Conservatively merge the options of two [`ProjectionOptions`]
+    pub fn merge_options(&self, other: &Self) -> Self {
+        Self {
+            run_parallel: self.run_parallel & other.run_parallel,
+            duplicate_check: self.duplicate_check & other.duplicate_check,
+        }
+    }
+}
+
 // Arguments given to `concat`. Differs from `UnionOptions` as the latter is IR state.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/polars-plan/src/logical_plan/projection_expr.rs
+++ b/crates/polars-plan/src/logical_plan/projection_expr.rs
@@ -53,7 +53,6 @@ impl ProjectionExprs {
         debug_assert!(!self.has_sub_exprs(), "should not have sub-expressions yet");
     }
 
-    // @TODO: I don't think we can assume this
     pub(crate) fn exprs_mut(&mut self) -> &mut Vec<ExprIR> {
         self.dbg_assert_no_sub_exprs();
         &mut self.expr

--- a/crates/polars-plan/src/logical_plan/projection_expr.rs
+++ b/crates/polars-plan/src/logical_plan/projection_expr.rs
@@ -53,6 +53,18 @@ impl ProjectionExprs {
         debug_assert!(!self.has_sub_exprs(), "should not have sub-expressions yet");
     }
 
+    // @TODO: I don't think we can assume this
+    pub(crate) fn exprs_mut(&mut self) -> &mut Vec<ExprIR> {
+        self.dbg_assert_no_sub_exprs();
+        &mut self.expr
+    }
+
+    // @TODO: I don't think we can assume this
+    pub(crate) fn as_exprs(&self) -> &[ExprIR] {
+        self.dbg_assert_no_sub_exprs();
+        &self.expr
+    }
+
     pub(crate) fn exprs(self) -> Vec<ExprIR> {
         self.dbg_assert_no_sub_exprs();
         self.expr

--- a/crates/polars-plan/src/logical_plan/visitor/lp.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/lp.rs
@@ -24,7 +24,7 @@ impl IRNode {
     /// Replace the current `Node` with a new `IR`.
     pub fn replace(&mut self, ae: IR, arena: &mut Arena<IR>) {
         let node = self.node;
-        arena.replace(node, ae)
+        arena.replace(node, ae);
     }
 
     pub fn to_alp<'a>(&self, arena: &'a Arena<IR>) -> &'a IR {

--- a/crates/polars-utils/src/arena.rs
+++ b/crates/polars-utils/src/arena.rs
@@ -137,10 +137,11 @@ impl<T> Arena<T> {
     }
 
     #[inline]
-    pub fn replace(&mut self, idx: Node, val: T) {
+    pub fn replace(&mut self, idx: Node, val: T) -> T {
         let x = self.get_mut(idx);
-        *x = val;
+        std::mem::replace(x, val)
     }
+
     pub fn clear(&mut self) {
         self.items.clear()
     }

--- a/crates/polars-utils/src/arena.rs
+++ b/crates/polars-utils/src/arena.rs
@@ -95,6 +95,48 @@ impl<T> Arena<T> {
     }
 
     #[inline]
+    /// Get mutable references to several items of the Arena
+    ///
+    /// The `idxs` is asserted to contain unique `Node` elements which are preferably (not
+    /// necessarily) in order.
+    pub fn get_many_mut<const N: usize>(&mut self, indices: [Node; N]) -> [&mut T; N] {
+        // @NOTE: This implementation is adapted from the Rust Nightly Standard Library. When
+        // `get_many_mut` gets stabilized we should use that.
+
+        let len = self.items.len();
+
+        // NB: The optimizer should inline the loops into a sequence
+        // of instructions without additional branching.
+        let mut valid = true;
+        for (i, &idx) in indices.iter().enumerate() {
+            valid &= idx.0 < len;
+            for &idx2 in &indices[..i] {
+                valid &= idx != idx2;
+            }
+        }
+
+        assert!(valid, "Duplicate index or out-of-bounds index");
+
+        // NB: This implementation is written as it is because any variation of
+        // `indices.map(|i| self.get_unchecked_mut(i))` would make miri unhappy,
+        // or generate worse code otherwise. This is also why we need to go
+        // through a raw pointer here.
+        let slice: *mut [T] = &mut self.items[..] as *mut _;
+        let mut arr: std::mem::MaybeUninit<[&mut T; N]> = std::mem::MaybeUninit::uninit();
+        let arr_ptr = arr.as_mut_ptr();
+
+        // SAFETY: We expect `indices` to contain disjunct values that are
+        // in bounds of `self`.
+        unsafe {
+            for i in 0..N {
+                let idx = *indices.get_unchecked(i);
+                *(*arr_ptr).get_unchecked_mut(i) = (*slice).get_unchecked_mut(idx.0);
+            }
+            arr.assume_init()
+        }
+    }
+
+    #[inline]
     pub fn replace(&mut self, idx: Node, val: T) {
         let x = self.get_mut(idx);
         *x = val;

--- a/py-polars/tests/unit/test_cwc.py
+++ b/py-polars/tests/unit/test_cwc.py
@@ -3,7 +3,7 @@
 import polars as pl
 
 
-def test_basic_cwc():
+def test_basic_cwc() -> None:
     df = (
         pl.LazyFrame({"a": [1, 2]})
         .with_columns(pl.col("a").alias("b") * 2)
@@ -17,7 +17,7 @@ def test_basic_cwc():
     )
 
 
-def test_refuse_with_deps():
+def test_refuse_with_deps() -> None:
     df = (
         pl.LazyFrame({"a": [1, 2]})
         .with_columns(pl.col("a").alias("b") * 2)
@@ -32,7 +32,7 @@ def test_refuse_with_deps():
     assert """[[(col("c")) * (4)].alias("d")]""" in explain
 
 
-def test_partial_deps():
+def test_partial_deps() -> None:
     df = (
         pl.LazyFrame({"a": [1, 2]})
         .with_columns(pl.col("a").alias("b") * 2)
@@ -46,8 +46,6 @@ def test_partial_deps():
 
     explain = df.explain()
 
-    print(explain)
-
     assert (
         """[[(col("b")) * (4)].alias("d"), [(col("b")) * (6)].alias("f")]""" in explain
     )
@@ -57,7 +55,7 @@ def test_partial_deps():
     )
 
 
-def test_try_remove_simple_project():
+def test_try_remove_simple_project() -> None:
     df = (
         pl.LazyFrame({"a": [1, 2]})
         .with_columns(pl.col("a").alias("b") * 2)
@@ -87,7 +85,7 @@ def test_try_remove_simple_project():
     assert """simple π""" in explain
 
 
-def test_cwc_with_internal_aliases():
+def test_cwc_with_internal_aliases() -> None:
     df = (
         pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
         .with_columns(pl.any_horizontal((pl.col("a") == 2).alias("b")).alias("c"))

--- a/py-polars/tests/unit/test_cwc.py
+++ b/py-polars/tests/unit/test_cwc.py
@@ -1,0 +1,102 @@
+# Tests for the optimization pass cluster WITH_COLUMNS
+
+import polars as pl
+
+
+def test_basic_cwc():
+    df = (
+        pl.LazyFrame({"a": [1, 2]})
+        .with_columns(pl.col("a").alias("b") * 2)
+        .with_columns(pl.col("a").alias("c") * 3)
+        .with_columns(pl.col("a").alias("d") * 4)
+    )
+
+    assert (
+        """[[(col("a")) * (2)].alias("b"), [(col("a")) * (3)].alias("c"), [(col("a")) * (4)].alias("d")]"""
+        in df.explain()
+    )
+
+
+def test_refuse_with_deps():
+    df = (
+        pl.LazyFrame({"a": [1, 2]})
+        .with_columns(pl.col("a").alias("b") * 2)
+        .with_columns(pl.col("b").alias("c") * 3)
+        .with_columns(pl.col("c").alias("d") * 4)
+    )
+
+    explain = df.explain()
+
+    assert """[[(col("a")) * (2)].alias("b")]""" in explain
+    assert """[[(col("b")) * (3)].alias("c")]""" in explain
+    assert """[[(col("c")) * (4)].alias("d")]""" in explain
+
+
+def test_partial_deps():
+    df = (
+        pl.LazyFrame({"a": [1, 2]})
+        .with_columns(pl.col("a").alias("b") * 2)
+        .with_columns(
+            pl.col("a").alias("c") * 3,
+            pl.col("b").alias("d") * 4,
+            pl.col("a").alias("e") * 5,
+        )
+        .with_columns(pl.col("b").alias("f") * 6)
+    )
+
+    explain = df.explain()
+
+    print(explain)
+
+    assert (
+        """[[(col("b")) * (4)].alias("d"), [(col("b")) * (6)].alias("f")]""" in explain
+    )
+    assert (
+        """[[(col("a")) * (2)].alias("b"), [(col("a")) * (3)].alias("c"), [(col("a")) * (5)].alias("e")]"""
+        in explain
+    )
+
+
+def test_try_remove_simple_project():
+    df = (
+        pl.LazyFrame({"a": [1, 2]})
+        .with_columns(pl.col("a").alias("b") * 2)
+        .with_columns(pl.col("a").alias("d") * 4, pl.col("b").alias("c") * 3)
+    )
+
+    explain = df.explain()
+
+    assert (
+        """[[(col("a")) * (2)].alias("b"), [(col("a")) * (4)].alias("d")]""" in explain
+    )
+    assert """[[(col("b")) * (3)].alias("c")]""" in explain
+    assert """simple π""" not in explain
+
+    df = (
+        pl.LazyFrame({"a": [1, 2]})
+        .with_columns(pl.col("a").alias("b") * 2)
+        .with_columns(pl.col("b").alias("c") * 3, pl.col("a").alias("d") * 4)
+    )
+
+    explain = df.explain()
+
+    assert (
+        """[[(col("a")) * (2)].alias("b"), [(col("a")) * (4)].alias("d")]""" in explain
+    )
+    assert """[[(col("b")) * (3)].alias("c")]""" in explain
+    assert """simple π""" in explain
+
+
+def test_cwc_with_internal_aliases():
+    df = (
+        pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
+        .with_columns(pl.any_horizontal((pl.col("a") == 2).alias("b")).alias("c"))
+        .with_columns(pl.col("b").alias("d") * 3)
+    )
+
+    explain = df.explain()
+
+    assert (
+        """[[(col("a")) == (2)].cast(Boolean).alias("c"), [(col("b")) * (3)].alias("d")]"""
+        in explain
+    )


### PR DESCRIPTION
This adds a new optimization pass for the query engine that clusters several sequential `WITH COLUMNS` calls.

When the optimizer spots a chain of `WITH COLUMNS`, it tries to pull expressions as close to the source as possible. If all expressions can be pulled up closer to the source, the `WITH COLUMNS` node is removed entirely.