### PR TITLE
perf: Faster bitpacking for Parquet writer

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -63,6 +63,7 @@ jobs:
           -p polars-io
           -p polars-lazy
           -p polars-ops
+          -p polars-parquet
           -p polars-plan
           -p polars-row
           -p polars-sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,6 +3050,7 @@ dependencies = [
  "polars-arrow",
  "polars-error",
  "polars-utils",
+ "rand",
  "seq-macro",
  "serde",
  "simdutf8",

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -27,6 +27,7 @@ simdutf8 = { workspace = true }
 parquet-format-safe = "0.2"
 seq-macro = { version = "0.3", default-features = false }
 streaming-decompression = "0.1"
+rand = "0.8"
 
 async-stream = { version = "0.3.3", optional = true }
 

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -25,9 +25,9 @@ polars-utils = { workspace = true }
 simdutf8 = { workspace = true }
 
 parquet-format-safe = "0.2"
+rand = "0.8"
 seq-macro = { version = "0.3", default-features = false }
 streaming-decompression = "0.1"
-rand = "0.8"
 
 async-stream = { version = "0.3.3", optional = true }
 

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -25,7 +25,6 @@ polars-utils = { workspace = true }
 simdutf8 = { workspace = true }
 
 parquet-format-safe = "0.2"
-rand = "0.8"
 seq-macro = { version = "0.3", default-features = false }
 streaming-decompression = "0.1"
 
@@ -40,6 +39,9 @@ snap = { version = "^1.1", optional = true }
 zstd = { version = "^0.13", optional = true, default-features = false }
 
 xxhash-rust = { version = "0.8", optional = true, features = ["xxh64"] }
+
+[dev-dependencies]
+rand = "0.8"
 
 [features]
 compression = [

--- a/crates/polars-parquet/src/lib.rs
+++ b/crates/polars-parquet/src/lib.rs
@@ -1,4 +1,6 @@
+#![feature(test)]
 #![allow(clippy::len_without_is_empty)]
 pub mod arrow;
 pub use crate::arrow::{read, write};
 pub mod parquet;
+extern crate test;

--- a/crates/polars-parquet/src/lib.rs
+++ b/crates/polars-parquet/src/lib.rs
@@ -1,6 +1,4 @@
-#![feature(test)]
 #![allow(clippy::len_without_is_empty)]
 pub mod arrow;
 pub use crate::arrow::{read, write};
 pub mod parquet;
-extern crate test;

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/encode.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/encode.rs
@@ -1,4 +1,4 @@
-use super::{Packed, Unpackable, Unpacked};
+use super::{Unpackable, Unpacked};
 
 /// Encodes (packs) a slice of [`Unpackable`] into bitpacked bytes `packed`, using `num_bits` per value.
 ///
@@ -42,7 +42,7 @@ pub fn encode<T: Unpackable>(unpacked: &[T], num_bits: usize, packed: &mut [u8])
 /// Only the first `ceil8(unpacked.len() * num_bits)` of `packed` are populated.
 #[inline]
 pub fn encode_pack<T: Unpackable>(unpacked: &[T], num_bits: usize, packed: &mut [u8]) {
-    if unpacked.len() < T::Packed::LENGTH {
+    if unpacked.len() < T::Unpacked::LENGTH {
         let mut complete_unpacked = T::Unpacked::zero();
         complete_unpacked.as_mut()[..unpacked.len()].copy_from_slice(unpacked);
         T::pack(&complete_unpacked, num_bits, packed)

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/mod.rs
@@ -43,11 +43,11 @@ impl Packed for [u8; 32 * 4] {
     }
 }
 
-impl Packed for [u8; 64 * 64] {
-    const LENGTH: usize = 64 * 64;
+impl Packed for [u8; 64 * 8] {
+    const LENGTH: usize = 64 * 8;
     #[inline]
     fn zero() -> Self {
-        [0; 64 * 64]
+        [0; 64 * 8]
     }
 }
 
@@ -151,7 +151,7 @@ impl Unpackable for u32 {
 }
 
 impl Unpackable for u64 {
-    type Packed = [u8; 64 * 64];
+    type Packed = [u8; 64 * 8];
     type Unpacked = [u64; 64];
 
     #[inline]

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
@@ -14,7 +14,7 @@ macro_rules! pack_impl {
             let input_ptr = input.as_ptr();
             let mut output_ptr = output.as_mut_ptr() as *mut $t;
             let mut out_register: $t = read_unaligned(input_ptr);
-            
+
             seq_macro::seq!(i in 1..$bits_minus_one {
                 let bits_filled: usize = i * NUM_BITS;
                 let inner_cursor: usize = bits_filled % $bits;
@@ -81,7 +81,6 @@ pack!(pack64, u64, 8, 64, 63);
 #[cfg(test)]
 mod tests {
     use rand::distributions::{Distribution, Uniform};
-    use test::Bencher;
 
     use super::super::unpack::*;
     use super::*;
@@ -119,8 +118,8 @@ mod tests {
         let mut random_array = [0u8; 8];
         let between = Uniform::from(0..6);
         for num_bits in 3..8 {
-            for i in 0..8 {
-                random_array[i] = between.sample(&mut rng);
+            for i in &mut random_array {
+                *i = between.sample(&mut rng);
             }
             let mut output = [0u8; 8];
             pack8(&random_array, &mut output, num_bits);
@@ -136,8 +135,8 @@ mod tests {
         let mut random_array = [0u16; 16];
         let between = Uniform::from(0..128);
         for num_bits in 7..16 {
-            for i in 0..16 {
-                random_array[i] = between.sample(&mut rng);
+            for i in &mut random_array {
+                *i = between.sample(&mut rng);
             }
             let mut output = [0u8; 16 * 2];
             pack16(&random_array, &mut output, num_bits);
@@ -153,8 +152,8 @@ mod tests {
         let mut random_array = [0u32; 32];
         let between = Uniform::from(0..131_072);
         for num_bits in 17..32 {
-            for i in 0..32 {
-                random_array[i] = between.sample(&mut rng);
+            for i in &mut random_array {
+                *i = between.sample(&mut rng);
             }
             let mut output = [0u8; 32 * 4];
             pack32(&random_array, &mut output, num_bits);
@@ -170,8 +169,8 @@ mod tests {
         let mut random_array = [0u64; 64];
         let between = Uniform::from(0..131_072);
         for num_bits in 17..64 {
-            for i in 0..64 {
-                random_array[i] = between.sample(&mut rng);
+            for i in &mut random_array {
+                *i = between.sample(&mut rng);
             }
             let mut output = [0u8; 64 * 8];
             pack64(&random_array, &mut output, num_bits);
@@ -179,20 +178,5 @@ mod tests {
             unpack64(&output, &mut other, num_bits);
             assert_eq!(other, random_array);
         }
-    }
-
-    #[bench]
-    fn bench_u32_17_bit(b: &mut Bencher) {
-        let mut rng = rand::thread_rng();
-        let mut random_array = [0u32; 32];
-        let between = Uniform::from(0..131_072);
-        for i in 0..32 {
-            random_array[i] = between.sample(&mut rng);
-        }
-        let mut output = [0u8; 32 * 4];
-        b.iter(|| pack32(&random_array, &mut output, 17));
-        let mut other = [0u32; 32];
-        unpack32(&output, &mut other, 17);
-        assert_eq!(other, random_array);
     }
 }

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
@@ -1,59 +1,61 @@
 /// Macro that generates a packing function taking the number of bits as a const generic
 macro_rules! pack_impl {
-    ($t:ty, $bytes:literal, $bits:tt) => {
-        pub fn pack<const NUM_BITS: usize>(input: &[$t; $bits], output: &mut [u8]) {
+    ($t:ty, $bytes:literal, $bits:tt, $bits_minus_one:tt) => {
+        pub unsafe fn pack<const NUM_BITS: usize>(input: &[$t; $bits], output: &mut [u8]) {
             if NUM_BITS == 0 {
                 for out in output {
                     *out = 0;
                 }
                 return;
             }
-            assert!(NUM_BITS <= $bytes * 8);
+            assert!(NUM_BITS <= $bits);
             assert!(output.len() >= NUM_BITS * $bytes);
 
-            let mask = match NUM_BITS {
-                $bits => <$t>::MAX,
-                _ => ((1 << NUM_BITS) - 1),
-            };
+            let input_ptr = input.as_ptr();
+            let mut output_ptr = output.as_mut_ptr() as *mut $t;
+            let mut out_register: $t = read_unaligned(input_ptr);
+            
+            seq_macro::seq!(i in 1..$bits_minus_one {
+                let bits_filled: usize = i * NUM_BITS;
+                let inner_cursor: usize = bits_filled % $bits;
+                let remaining: usize = $bits - inner_cursor;
 
-            for i in 0..$bits {
-                let start_bit = i * NUM_BITS;
-                let end_bit = start_bit + NUM_BITS;
+                let offset_ptr = input_ptr.add(i);
+                let in_register: $t = read_unaligned(offset_ptr);
 
-                let start_bit_offset = start_bit % $bits;
-                let end_bit_offset = end_bit % $bits;
-                let start_byte = start_bit / $bits;
-                let end_byte = end_bit / $bits;
-                if start_byte != end_byte && end_bit_offset != 0 {
-                    let a = input[i] << start_bit_offset;
-                    let val_a = <$t>::to_le_bytes(a);
-                    for i in 0..$bytes {
-                        output[start_byte * $bytes + i] |= val_a[i]
-                    }
+                out_register =
+                    if inner_cursor > 0 {
+                        out_register | (in_register << inner_cursor)
+                    } else {
+                        in_register
+                    };
 
-                    let b = (input[i] >> (NUM_BITS - end_bit_offset)) & mask;
-                    let val_b = <$t>::to_le_bytes(b);
-                    for i in 0..$bytes {
-                        output[end_byte * $bytes + i] |= val_b[i]
-                    }
-                } else {
-                    let val = (input[i] & mask) << start_bit_offset;
-                    let val = <$t>::to_le_bytes(val);
-
-                    for i in 0..$bytes {
-                        output[start_byte * $bytes + i] |= val[i]
+                if remaining <= NUM_BITS {
+                    write_unaligned(output_ptr, out_register);
+                    output_ptr = output_ptr.offset(1);
+                    if 0 < remaining && remaining < NUM_BITS {
+                        out_register = in_register >> remaining
                     }
                 }
-            }
+            });
+
+            let in_register: $t = read_unaligned(input_ptr.add($bits - 1));
+            out_register = if $bits - NUM_BITS > 0 {
+                out_register | (in_register << ($bits - NUM_BITS))
+            } else {
+                out_register | in_register
+            };
+            write_unaligned(output_ptr, out_register)
         }
     };
 }
 
 /// Macro that generates pack functions that accept num_bits as a parameter
 macro_rules! pack {
-    ($name:ident, $t:ty, $bytes:literal, $bits:tt) => {
+    ($name:ident, $t:ty, $bytes:literal, $bits:tt, $bits_minus_one:tt) => {
         mod $name {
-            pack_impl!($t, $bytes, $bits);
+            use std::ptr::{read_unaligned, write_unaligned};
+            pack_impl!($t, $bytes, $bits, $bits_minus_one);
         }
 
         /// Pack unpacked `input` into `output` with a bit width of `num_bits`
@@ -61,7 +63,9 @@ macro_rules! pack {
             // This will get optimised into a jump table
             seq_macro::seq!(i in 0..=$bits {
                 if i == num_bits {
-                    return $name::pack::<i>(input, output);
+                    unsafe {
+                        return $name::pack::<i>(input, output);
+                    }
                 }
             });
             unreachable!("invalid num_bits {}", num_bits);
@@ -69,10 +73,10 @@ macro_rules! pack {
     };
 }
 
-pack!(pack8, u8, 1, 8);
-pack!(pack16, u16, 2, 16);
-pack!(pack32, u32, 4, 32);
-pack!(pack64, u64, 8, 64);
+pack!(pack8, u8, 1, 8, 7);
+pack!(pack16, u16, 2, 16, 15);
+pack!(pack32, u32, 4, 32, 31);
+pack!(pack64, u64, 8, 64, 63);
 
 #[cfg(test)]
 mod tests {
@@ -106,6 +110,74 @@ mod tests {
             let mut other = [0u32; 32];
             unpack32(&output, &mut other, num_bits);
             assert_eq!(other, input);
+        }
+    }
+
+    #[test]
+    fn test_u8_random() {
+        let mut rng = rand::thread_rng();
+        let mut random_array = [0u8; 8];
+        let between = Uniform::from(0..6);
+        for num_bits in 3..8 {
+            for i in 0..8 {
+                random_array[i] = between.sample(&mut rng);
+            }
+            let mut output = [0u8; 8];
+            pack8(&random_array, &mut output, num_bits);
+            let mut other = [0u8; 8];
+            unpack8(&output, &mut other, num_bits);
+            assert_eq!(other, random_array);
+        }
+    }
+
+    #[test]
+    fn test_u16_random() {
+        let mut rng = rand::thread_rng();
+        let mut random_array = [0u16; 16];
+        let between = Uniform::from(0..128);
+        for num_bits in 7..16 {
+            for i in 0..16 {
+                random_array[i] = between.sample(&mut rng);
+            }
+            let mut output = [0u8; 16 * 2];
+            pack16(&random_array, &mut output, num_bits);
+            let mut other = [0u16; 16];
+            unpack16(&output, &mut other, num_bits);
+            assert_eq!(other, random_array);
+        }
+    }
+
+    #[test]
+    fn test_u32_random() {
+        let mut rng = rand::thread_rng();
+        let mut random_array = [0u32; 32];
+        let between = Uniform::from(0..131_072);
+        for num_bits in 17..32 {
+            for i in 0..32 {
+                random_array[i] = between.sample(&mut rng);
+            }
+            let mut output = [0u8; 32 * 4];
+            pack32(&random_array, &mut output, num_bits);
+            let mut other = [0u32; 32];
+            unpack32(&output, &mut other, num_bits);
+            assert_eq!(other, random_array);
+        }
+    }
+
+    #[test]
+    fn test_u64_random() {
+        let mut rng = rand::thread_rng();
+        let mut random_array = [0u64; 64];
+        let between = Uniform::from(0..131_072);
+        for num_bits in 17..64 {
+            for i in 0..64 {
+                random_array[i] = between.sample(&mut rng);
+            }
+            let mut output = [0u8; 64 * 8];
+            pack64(&random_array, &mut output, num_bits);
+            let mut other = [0u64; 64];
+            unpack64(&output, &mut other, num_bits);
+            assert_eq!(other, random_array);
         }
     }
 

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
@@ -16,6 +16,11 @@ macro_rules! pack_impl {
             let mut output_ptr = output.as_mut_ptr() as *mut $t;
             let mut out_register: $t = read_unaligned(input_ptr);
 
+            if $bits == NUM_BITS {
+                write_unaligned(output_ptr, out_register);
+                output_ptr = output_ptr.offset(1);
+            }
+
             // Using microbenchmark (79d1fff), unrolling this loop is over 10x
             // faster than not (>20x faster than old algorithm)
             seq_macro::seq!(i in 1..$bits_minus_one {
@@ -46,7 +51,7 @@ macro_rules! pack_impl {
             out_register = if $bits - NUM_BITS > 0 {
                 out_register | (in_register << ($bits - NUM_BITS))
             } else {
-                out_register | in_register
+                in_register
             };
             write_unaligned(output_ptr, out_register)
         }
@@ -120,7 +125,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut random_array = [0u8; 8];
         let between = Uniform::from(0..6);
-        for num_bits in 3..8 {
+        for num_bits in 3..=8 {
             for i in &mut random_array {
                 *i = between.sample(&mut rng);
             }
@@ -137,7 +142,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut random_array = [0u16; 16];
         let between = Uniform::from(0..128);
-        for num_bits in 7..16 {
+        for num_bits in 7..=16 {
             for i in &mut random_array {
                 *i = between.sample(&mut rng);
             }
@@ -154,7 +159,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut random_array = [0u32; 32];
         let between = Uniform::from(0..131_072);
-        for num_bits in 17..32 {
+        for num_bits in 17..=32 {
             for i in &mut random_array {
                 *i = between.sample(&mut rng);
             }
@@ -171,7 +176,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut random_array = [0u64; 64];
         let between = Uniform::from(0..131_072);
-        for num_bits in 17..64 {
+        for num_bits in 17..=64 {
             for i in &mut random_array {
                 *i = between.sample(&mut rng);
             }

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
@@ -76,6 +76,9 @@ pack!(pack64, u64, 8, 64);
 
 #[cfg(test)]
 mod tests {
+    use rand::distributions::{Distribution, Uniform};
+    use test::Bencher;
+
     use super::super::unpack::*;
     use super::*;
 
@@ -104,5 +107,20 @@ mod tests {
             unpack32(&output, &mut other, num_bits);
             assert_eq!(other, input);
         }
+    }
+
+    #[bench]
+    fn bench_u32_17_bit(b: &mut Bencher) {
+        let mut rng = rand::thread_rng();
+        let mut random_array = [0u32; 32];
+        let between = Uniform::from(0..131_072);
+        for i in 0..32 {
+            random_array[i] = between.sample(&mut rng);
+        }
+        let mut output = [0u8; 32 * 4];
+        b.iter(|| pack32(&random_array, &mut output, 17));
+        let mut other = [0u32; 32];
+        unpack32(&output, &mut other, 17);
+        assert_eq!(other, random_array);
     }
 }

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
@@ -1,6 +1,7 @@
 /// Macro that generates a packing function taking the number of bits as a const generic
 macro_rules! pack_impl {
     ($t:ty, $bytes:literal, $bits:tt, $bits_minus_one:tt) => {
+        // Adapted from https://github.com/quickwit-oss/bitpacking
         pub unsafe fn pack<const NUM_BITS: usize>(input: &[$t; $bits], output: &mut [u8]) {
             if NUM_BITS == 0 {
                 for out in output {

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/pack.rs
@@ -16,6 +16,8 @@ macro_rules! pack_impl {
             let mut output_ptr = output.as_mut_ptr() as *mut $t;
             let mut out_register: $t = read_unaligned(input_ptr);
 
+            // Using microbenchmark (79d1fff), unrolling this loop is over 10x
+            // faster than not (>20x faster than old algorithm)
             seq_macro::seq!(i in 1..$bits_minus_one {
                 let bits_filled: usize = i * NUM_BITS;
                 let inner_cursor: usize = bits_filled % $bits;


### PR DESCRIPTION
I replaced the Parquet bit-packing algorithm with a modified version of the scalar algorithm from https://github.com/quickwit-oss/bitpacking (unsure where/how to give credit). I ensured the new algorithm works by adding unit tests that encode/decode random data.

I added a microbenchmark in my first commit to help measure the performance gain.

|| Before  | After |
|-| ------------- | ------------- |
|Avg. (ns/iter)|93.75 | 4.25 |
|Std. (ns/iter)| 1.57 | 0.04 |

I removed the microbenchmark in a later commit because it requires nightly Rust and is probably not useful outside of this PR.

Other miscellaneous fixes:
- Packed array of 64 u64's should have a maximum length of 64 * 8 u8's (second commit)
- Input array length should be compared to expected unpacked length instead of expected packed length to avoid unnecessary allocations/copies (third commit)