### PR TITLE
docs(python): Add missing word in `join` docstring

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6278,7 +6278,7 @@ class DataFrame:
             * *semi*
                  Filter rows that have a match in the right table.
             * *anti*
-                 Filter rows that not have a match in the right table.
+                 Filter rows that do not have a match in the right table.
 
             .. note::
                 A left join preserves the row order of the left DataFrame.


### PR DESCRIPTION
Missing word in docstring for ```polars.DataFrame.join```, param: ```how:anti```. "Filter rows that not have a match in the right table." ->Filter rows that do not have a match in the right table."