### PR TITLE
perf(python): Improve `Series.to_numpy` performance for chunked Series that would otherwise be zero-copy

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -236,17 +236,17 @@ impl DataType {
         self.is_float() || self.is_integer()
     }
 
-    /// Check if this [`DataType`] is a boolean
+    /// Check if this [`DataType`] is a boolean.
     pub fn is_bool(&self) -> bool {
         matches!(self, DataType::Boolean)
     }
 
-    /// Check if this [`DataType`] is a list
+    /// Check if this [`DataType`] is a list.
     pub fn is_list(&self) -> bool {
         matches!(self, DataType::List(_))
     }
 
-    /// Check if this [`DataType`] is a array
+    /// Check if this [`DataType`] is an array.
     pub fn is_array(&self) -> bool {
         #[cfg(feature = "dtype-array")]
         {

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -189,7 +189,7 @@ impl PySeries {
                         "cannot return a zero-copy writable array",
                     ));
                 }
-                arr = arr.call_method0(py, intern!(py, "copy")).unwrap();
+                arr = arr.call_method0(py, intern!(py, "copy"))?;
             }
             return Ok(arr);
         }

--- a/py-polars/src/to_numpy.rs
+++ b/py-polars/src/to_numpy.rs
@@ -59,25 +59,28 @@ impl PySeries {
     /// which may be any value. The caller is responsible for handling nulls
     /// appropriately.
     pub fn to_numpy_view(&self, py: Python) -> Option<PyObject> {
-        series_to_numpy_view(py, &self.series, true, false)
+        let (view, _) = try_series_to_numpy_view(py, &self.series, true, false)?;
+        Some(view)
     }
 }
 
-pub(crate) fn series_to_numpy_view(
+/// Create a NumPy view of the given Series.
+pub(crate) fn try_series_to_numpy_view(
     py: Python,
     s: &Series,
     allow_nulls: bool,
     allow_rechunk: bool,
-) -> Option<PyObject> {
+) -> Option<(PyObject, bool)> {
     if !supports_view(s.dtype()) {
         return None;
     }
     if !allow_nulls && has_nulls(s) {
         return None;
     }
-    let (s_owned, writable) = handle_chunks(s, allow_rechunk)?;
+    let (s_owned, writable_flag) = handle_chunks(s, allow_rechunk)?;
 
-    Some(series_to_numpy_view_recursive(py, s_owned, writable))
+    let array = series_to_numpy_view_recursive(py, s_owned, writable_flag);
+    Some((array, writable_flag))
 }
 /// Returns whether the data type supports creating a NumPy view.
 fn supports_view(dtype: &DataType) -> bool {
@@ -115,9 +118,7 @@ fn handle_chunks(s: &Series, allow_rechunk: bool) -> Option<(Series, bool)> {
     }
 }
 
-/// Create a NumPy view of the given Series.
-///
-/// This function is called after verifying that the Series consists of a single chunk.
+/// Create a NumPy view of the given Series without checking for data types, chunks, or nulls.
 fn series_to_numpy_view_recursive(py: Python, s: Series, writable: bool) -> PyObject {
     debug_assert!(s.n_chunks() == 1);
     match s.dtype() {

--- a/py-polars/src/to_numpy.rs
+++ b/py-polars/src/to_numpy.rs
@@ -58,34 +58,56 @@ impl PySeries {
     /// WARNING: The resulting view will show the underlying value for nulls,
     /// which may be any value. The caller is responsible for handling nulls
     /// appropriately.
-    #[allow(clippy::wrong_self_convention)]
     pub fn to_numpy_view(&self, py: Python) -> Option<PyObject> {
-        series_to_numpy_view(py, &self.series, true)
+        series_to_numpy_view(py, &self.series, true, false)
     }
 }
 
-pub(crate) fn series_to_numpy_view(py: Python, s: &Series, allow_nulls: bool) -> Option<PyObject> {
-    // NumPy arrays are always contiguous
-    if s.n_chunks() > 1 {
-        return None;
-    }
+pub(crate) fn series_to_numpy_view(
+    py: Python,
+    s: &Series,
+    allow_nulls: bool,
+    allow_rechunk: bool,
+) -> Option<PyObject> {
     if !allow_nulls && s.null_count() > 0 {
         return None;
     }
+
+    let is_chunked = s.n_chunks() > 1;
+    let s_owned = if is_chunked {
+        // NumPy arrays are always contiguous
+        if !allow_rechunk {
+            return None;
+        } else {
+            s.rechunk()
+        }
+    } else {
+        s.clone()
+    };
+
     let view = match s.dtype() {
-        dt if dt.is_numeric() => numeric_series_to_numpy_view(py, s),
-        DataType::Datetime(_, _) | DataType::Duration(_) => temporal_series_to_numpy_view(py, s),
-        DataType::Array(_, _) => array_series_to_numpy_view(py, s, allow_nulls)?,
+        dt if dt.is_numeric() => numeric_series_to_numpy_view(py, s_owned, is_chunked),
+        DataType::Datetime(_, _) | DataType::Duration(_) => {
+            temporal_series_to_numpy_view(py, s_owned, is_chunked)
+        },
+        DataType::Array(_, _) => {
+            array_series_to_numpy_view(py, &s_owned, allow_nulls, allow_rechunk)?
+        },
         _ => return None,
     };
     Some(view)
 }
-fn numeric_series_to_numpy_view(py: Python, s: &Series) -> PyObject {
+fn numeric_series_to_numpy_view(py: Python, s: Series, writable: bool) -> PyObject {
     let dims = [s.len()].into_dimension();
-    let owner = PySeries::from(s.clone()).into_py(py); // Keep the Series memory alive.
     with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
         let np_dtype = <$T as PolarsNumericType>::Native::get_dtype_bound(py);
         let ca: &ChunkedArray<$T> = s.unpack::<$T>().unwrap();
+        let flags = if writable {
+            flags::NPY_ARRAY_FARRAY
+        } else {
+            flags::NPY_ARRAY_FARRAY_RO
+        };
+
         let slice = ca.data_views().next().unwrap();
 
         unsafe {
@@ -93,30 +115,34 @@ fn numeric_series_to_numpy_view(py: Python, s: &Series) -> PyObject {
                 py,
                 np_dtype,
                 dims,
-                flags::NPY_ARRAY_FARRAY_RO,
+                flags,
                 slice.as_ptr() as _,
-                owner,
+                PySeries::from(s).into_py(py), // Keep the Series memory alive.,
             )
         }
     })
 }
-fn temporal_series_to_numpy_view(py: Python, s: &Series) -> PyObject {
+fn temporal_series_to_numpy_view(py: Python, s: Series, writable: bool) -> PyObject {
     let np_dtype = polars_dtype_to_np_temporal_dtype(py, s.dtype());
 
     let phys = s.to_physical_repr();
     let ca = phys.i64().unwrap();
     let slice = ca.data_views().next().unwrap();
     let dims = [s.len()].into_dimension();
-    let owner = PySeries::from(s.clone()).into_py(py); // Keep the Series memory alive.
+    let flags = if writable {
+        flags::NPY_ARRAY_FARRAY
+    } else {
+        flags::NPY_ARRAY_FARRAY_RO
+    };
 
     unsafe {
         create_borrowed_np_array::<_>(
             py,
             np_dtype,
             dims,
-            flags::NPY_ARRAY_FARRAY_RO,
+            flags,
             slice.as_ptr() as _,
-            owner,
+            PySeries::from(s).into_py(py), // Keep the Series memory alive.,
         )
     }
 }
@@ -148,10 +174,15 @@ fn polars_dtype_to_np_temporal_dtype<'a>(
         _ => panic!("only Datetime/Duration inputs supported, got {}", dtype),
     }
 }
-fn array_series_to_numpy_view(py: Python, s: &Series, allow_nulls: bool) -> Option<PyObject> {
+fn array_series_to_numpy_view(
+    py: Python,
+    s: &Series,
+    allow_nulls: bool,
+    allow_rechunk: bool,
+) -> Option<PyObject> {
     let ca = s.array().unwrap();
     let s_inner = ca.get_inner();
-    let np_array_flat = series_to_numpy_view(py, &s_inner, allow_nulls)?;
+    let np_array_flat = series_to_numpy_view(py, &s_inner, allow_nulls, allow_rechunk)?;
 
     // Reshape to the original shape.
     let DataType::Array(_, width) = s.dtype() else {

--- a/py-polars/tests/benchmark/interop/__init__.py
+++ b/py-polars/tests/benchmark/interop/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark tests for conversions from/to other data formats."""

--- a/py-polars/tests/benchmark/interop/test_numpy.py
+++ b/py-polars/tests/benchmark/interop/test_numpy.py
@@ -1,5 +1,7 @@
 """Benchmark tests for conversions from/to NumPy."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/py-polars/tests/benchmark/interop/test_numpy.py
+++ b/py-polars/tests/benchmark/interop/test_numpy.py
@@ -1,0 +1,51 @@
+"""Benchmark tests for conversions from/to NumPy."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import polars as pl
+
+pytestmark = pytest.mark.benchmark()
+
+
+@pytest.fixture(scope="module")
+def floats_array() -> np.ndarray[Any, Any]:
+    n_rows = 10_000
+    return np.random.randn(n_rows)
+
+
+@pytest.fixture()
+def floats(floats_array: np.ndarray[Any, Any]) -> pl.Series:
+    return pl.Series(floats_array)
+
+
+@pytest.fixture()
+def floats_with_nulls(floats: pl.Series) -> pl.Series:
+    null_probability = 0.1
+    validity = pl.Series(np.random.uniform(size=floats.len())) > null_probability
+    return pl.select(pl.when(validity).then(floats)).to_series()
+
+
+@pytest.fixture()
+def floats_chunked(floats_array: np.ndarray[Any, Any]) -> pl.Series:
+    n_chunks = 5
+    chunk_len = len(floats_array) // n_chunks
+    chunks = [
+        floats_array[i * chunk_len : (i + 1) * chunk_len] for i in range(n_chunks)
+    ]
+    chunks_copy = [pl.Series(c.copy()) for c in chunks]
+    return pl.concat(chunks_copy, rechunk=False)
+
+
+def test_to_numpy_series_zero_copy(floats: pl.Series) -> None:
+    floats.to_numpy(use_pyarrow=False)
+
+
+def test_to_numpy_series_with_nulls(floats_with_nulls: pl.Series) -> None:
+    floats_with_nulls.to_numpy(use_pyarrow=False)
+
+
+def test_to_numpy_series_chunked(floats_chunked: pl.Series) -> None:
+    floats_chunked.to_numpy(use_pyarrow=False)

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -308,7 +308,13 @@ def test_to_numpy_chunked() -> None:
 
     assert result.tolist() == s.to_list()
     assert result.dtype == np.int64
+    assert result.flags.writeable is True
     assert_allow_copy_false_raises(s)
+
+    # Check that writing to the array doesn't change the original data
+    result[0] = 10
+    assert result.tolist() == [10, 2, 3, 4]
+    assert s.to_list() == [1, 2, 3, 4]
 
 
 def test_zero_copy_only_deprecated() -> None:

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -317,6 +317,19 @@ def test_to_numpy_chunked() -> None:
     assert s.to_list() == [1, 2, 3, 4]
 
 
+def test_to_numpy_chunked_temporal() -> None:
+    s1 = pl.Series([datetime(2020, 1, 1), datetime(2021, 1, 1)])
+    s2 = pl.Series([datetime(2022, 1, 1), datetime(2023, 1, 1)])
+    s = pl.concat([s1, s2], rechunk=False)
+
+    result = s.to_numpy(use_pyarrow=False)
+
+    assert result.tolist() == s.to_list()
+    assert result.dtype == np.dtype("datetime64[us]")
+    assert result.flags.writeable is True
+    assert_allow_copy_false_raises(s)
+
+
 def test_zero_copy_only_deprecated() -> None:
     values = [1, 2]
     s = pl.Series([1, 2])

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -317,15 +317,17 @@ def test_to_numpy_chunked() -> None:
     assert s.to_list() == [1, 2, 3, 4]
 
 
-def test_to_numpy_chunked_temporal() -> None:
-    s1 = pl.Series([datetime(2020, 1, 1), datetime(2021, 1, 1)])
-    s2 = pl.Series([datetime(2022, 1, 1), datetime(2023, 1, 1)])
+def test_to_numpy_chunked_temporal_nested() -> None:
+    dtype = pl.Array(pl.Datetime("us"), 1)
+    s1 = pl.Series([[datetime(2020, 1, 1)], [datetime(2021, 1, 1)]], dtype=dtype)
+    s2 = pl.Series([[datetime(2022, 1, 1)], [datetime(2023, 1, 1)]], dtype=dtype)
     s = pl.concat([s1, s2], rechunk=False)
 
     result = s.to_numpy(use_pyarrow=False)
 
     assert result.tolist() == s.to_list()
     assert result.dtype == np.dtype("datetime64[us]")
+    assert result.shape == (4, 1)
     assert result.flags.writeable is True
     assert_allow_copy_false_raises(s)
 


### PR DESCRIPTION
Ref #16267

Instead of iterating over the values, we rechunk and create a writable view.

This regressed in https://github.com/pola-rs/polars/pull/16178 - now we get the best of both worlds with a writable array _and_ only a single, fast copy.

Performance of converting a chunked Series of 50 million float32s:
* Before: ~60ms
* After: ~25ms

I added some benchmark tests so that we may catch regressions here in the future.