### PR TITLE
feat(python): Start updating `BytecodeParser` for Python 3.13

### DIFF
--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -268,6 +268,7 @@ _MODULE_FUNC_TO_EXPR_NAME = {
     "json.loads": "str.json_decode",
 }
 _RE_IMPLICIT_BOOL = re.compile(r'pl\.col\("([^"]*)"\) & pl\.col\("\1"\)\.(.+)')
+_RE_STRIP_BOOL = re.compile(r"^bool\((.+)\)$")
 
 
 def _get_all_caller_variables() -> dict[str, Any]:
@@ -613,7 +614,7 @@ class InstructionTranslator:
     def _expr(self, value: StackEntry, col: str, param_name: str, depth: int) -> str:
         """Take stack entry value and convert to polars expression string."""
         if isinstance(value, StackValue):
-            op = value.operator
+            op = _RE_STRIP_BOOL.sub(r"\1", value.operator)
             e1 = self._expr(value.left_operand, col, param_name, depth + 1)
             if value.operator_arity == 1:
                 if op not in OpNames.UNARY_VALUES:
@@ -735,6 +736,7 @@ class RewrittenInstructions:
             "PUSH_NULL",
             "RESUME",
             "RETURN_VALUE",
+            "TO_BOOL",
         ]
     )
 


### PR DESCRIPTION
Looking to get ahead of this one early. Slightly painful to analyse in depth at the moment as the debugger promptly crashes on attach to the 3.13 beta, but there's always the good old "print" statement, so...😎  

## Updates

* Handle the new `bool(op)` wrapper.
* Handle the new `TO_BOOL` opcode 
  (See: https://github.com/python/cpython/pull/106003).

Can't test with `numpy` translation yet, but these two small updates alone take the related tests from _"almost 100% of them fail"_ to _"only four fail"_, which is a good sign that the changes are going to be minor. 

As the betas are released I'll make incremental adjustments so we don't have to scramble come October. 

## Example

```python
from polars._utils.udfs import BytecodeParser

bp = BytecodeParser(
    function = lambda x: not (x > 1) or x == 2,
    map_target = "expr",
)
bp.dis()
# 2         RESUME                0
#           LOAD_FAST             0 (x)
#           LOAD_CONST            1 (1)
#           COMPARE_OP          148 (bool(>))    <<< new to 3.13; 'bool' wrapper
#           UNARY_NOT
#           COPY                  1
#           TO_BOOL                              <<< new opcode
#           POP_JUMP_IF_TRUE      5 (to L1)
#           POP_TOP
#           LOAD_FAST             0 (x)
#           LOAD_CONST            2 (2)
#           COMPARE_OP           72 (==)
#    L1:    RETURN_VALUE

bp.to_expression("x")
# ~(pl.col("x") > 1) | (pl.col("x") == 2)
```

Previously:
```python
AssertionError: unrecognized opname
# Instruction(
#   opname='TO_BOOL', opcode=40, arg=None, argval=None, argrepr='', offset=14,
#   start_offset=14, starts_line=False, line_number=2, label=None,
#   positions=Positions(lineno=2, end_lineno=2, col_offset=15,
#   end_col_offset=36), cache_info=[('counter', 1, b'\x00\x00'),
#   ('version', 2, b'\x00\x00\x00\x00')],
# )
```