### PR TITLE
feat: Add `struct.with_fields`

### DIFF
--- a/crates/polars-core/src/datatypes/field.rs
+++ b/crates/polars-core/src/datatypes/field.rs
@@ -3,7 +3,7 @@ use smartstring::alias::String as SmartString;
 use super::*;
 
 /// Characterizes the name and the [`DataType`] of a column.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
     any(feature = "serde", feature = "serde-lazy"),
     derive(Serialize, Deserialize)

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -336,6 +336,10 @@ impl<'a> FieldsMapper<'a> {
         Self { fields }
     }
 
+    pub fn args(&self) -> &[Field] {
+        self.fields
+    }
+
     /// Field with the same dtype.
     pub fn with_same_dtype(&self) -> PolarsResult<Field> {
         self.map_dtype(|dtype| dtype.clone())

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -40,4 +40,16 @@ impl StructNameSpace {
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::JsonEncode))
     }
+
+    pub fn with_fields(self, mut fields: Vec<Expr>) -> Expr {
+        fields.insert(0, self.0);
+        Expr::Function {
+            input: fields,
+            function: FunctionExpr::StructExpr(StructFunction::WithFields),
+            options: FunctionOptions {
+                collect_groups: ApplyOptions::ElementWise,
+                ..Default::default()
+            },
+        }
+    }
 }

--- a/py-polars/docs/source/reference/expressions/struct.rst
+++ b/py-polars/docs/source/reference/expressions/struct.rst
@@ -12,3 +12,4 @@ The following methods are available under the `expr.struct` attribute.
     Expr.struct.field
     Expr.struct.json_encode
     Expr.struct.rename_fields
+    Expr.struct.with_fields

--- a/py-polars/src/expr/struct.rs
+++ b/py-polars/src/expr/struct.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 
+use crate::expr::ToExprs;
 use crate::PyExpr;
 
 #[pymethods]
@@ -18,5 +19,10 @@ impl PyExpr {
 
     fn struct_json_encode(&self) -> Self {
         self.inner.clone().struct_().json_encode().into()
+    }
+
+    fn struct_with_fields(&self, fields: Vec<PyExpr>) -> Self {
+        let fields = fields.to_exprs();
+        self.inner.clone().struct_().with_fields(fields).into()
     }
 }


### PR DESCRIPTION
Akin to `DataFrame.with_columns`.

Will follow up with a `select_fields` as well.

```python
>>> df = pl.DataFrame(
...     {
...         "coords": [{"x": 1, "y": 4}, {"x": 4, "y": 9}, {"x": 9, "y": 16}],
...         "multiply": [10, 2, 3],
...     }
... )
>>> df
shape: (3, 2)
┌───────────┬──────────┐
│ coords    ┆ multiply │
│ ---       ┆ ---      │
│ struct[2] ┆ i64      │
╞═══════════╪══════════╡
│ {1,4}     ┆ 10       │
│ {4,9}     ┆ 2        │
│ {9,16}    ┆ 3        │
└───────────┴──────────┘
>>> df = df.with_columns(
...     pl.col("coords").struct.with_fields(
...         pl.col("coords").struct.field("x").sqrt(),
...         y_mul=pl.col("coords").struct.field("y") * pl.col("multiply"),
...     ),
... )
>>> df
shape: (3, 2)
┌─────────────┬──────────┐
│ coords      ┆ multiply │
│ ---         ┆ ---      │
│ struct[3]   ┆ i64      │
╞═════════════╪══════════╡
│ {1.0,4,40}  ┆ 10       │
│ {2.0,9,18}  ┆ 2        │
│ {3.0,16,48} ┆ 3        │
└─────────────┴──────────┘
>>> df.unnest("coords")
shape: (3, 4)
┌─────┬─────┬───────┬──────────┐
│ x   ┆ y   ┆ y_mul ┆ multiply │
│ --- ┆ --- ┆ ---   ┆ ---      │
│ f64 ┆ i64 ┆ i64   ┆ i64      │
╞═════╪═════╪═══════╪══════════╡
│ 1.0 ┆ 4   ┆ 40    ┆ 10       │
│ 2.0 ┆ 9   ┆ 18    ┆ 2        │
│ 3.0 ┆ 16  ┆ 48    ┆ 3        │
└─────┴─────┴───────┴──────────┘
```