### PR TITLE
perf(python): Further optimise initial `polars` import

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -22,7 +22,6 @@ from polars.datatypes import N_INFER_DEFAULT, Categorical, List, Object, String,
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
-from polars.io import read_csv
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
@@ -738,6 +737,8 @@ def _from_dataframe_repr(m: re.Match[str]) -> DataFrame:
         else:
             # otherwise, take a trip through our CSV inference logic
             if all(tp == String for tp in df.schema.values()):
+                from polars.io import read_csv
+
                 buf = io.BytesIO()
                 df.write_csv(file=buf)
                 df = read_csv(buf, new_columns=df.columns, try_parse_dates=True)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -100,17 +100,6 @@ from polars.exceptions import (
     TooManyRowsReturnedError,
 )
 from polars.functions import col, lit
-from polars.io.csv._utils import _check_arg_is_1byte
-from polars.io.spreadsheet._write_utils import (
-    _unpack_multi_column_dict,
-    _xl_apply_conditional_formats,
-    _xl_inject_sparklines,
-    _xl_setup_table_columns,
-    _xl_setup_table_options,
-    _xl_setup_workbook,
-    _xl_unique_table_name,
-    _XLFormatCache,
-)
 from polars.selectors import _expand_selector_dicts, _expand_selectors
 from polars.slice import PolarsSlice
 from polars.type_aliases import DbWriteMode, TorchExportType
@@ -2295,6 +2284,8 @@ class DataFrame:
         >>> path: pathlib.Path = dirpath / "new_file.csv"
         >>> df.write_csv(path, separator=",")
         """
+        from polars.io.csv._utils import _check_arg_is_1byte
+
         _check_arg_is_1byte("separator", separator, can_be_empty=False)
         _check_arg_is_1byte("quote_char", quote_char, can_be_empty=True)
         if not null_value:
@@ -2750,6 +2741,17 @@ class DataFrame:
         ...     sheet_zoom=125,
         ... )
         """  # noqa: W505
+        from polars.io.spreadsheet._write_utils import (
+            _unpack_multi_column_dict,
+            _xl_apply_conditional_formats,
+            _xl_inject_sparklines,
+            _xl_setup_table_columns,
+            _xl_setup_table_options,
+            _xl_setup_workbook,
+            _xl_unique_table_name,
+            _XLFormatCache,
+        )
+
         xlsxwriter = import_optional("xlsxwriter", err_prefix="Excel export requires")
         from xlsxwriter.utility import xl_cell_to_rowcol
 

--- a/py-polars/polars/io/spreadsheet/_utils.py
+++ b/py-polars/polars/io/spreadsheet/_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from typing import Any, Iterator, cast
 
 
@@ -24,6 +23,8 @@ def PortableTemporaryFile(
 
     Plays better with Windows when using the 'delete' option.
     """
+    from tempfile import NamedTemporaryFile
+
     params = cast(
         Any,
         {

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -47,7 +47,6 @@ from polars._utils.various import (
     parse_percentiles,
 )
 from polars._utils.wrap import wrap_df, wrap_expr
-from polars.convert import from_dict
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
     N_INFER_DEFAULT,
@@ -77,7 +76,6 @@ from polars.datatypes import (
     py_type_to_dtype,
 )
 from polars.dependencies import import_optional, subprocess
-from polars.io.csv._utils import _check_arg_is_1byte
 from polars.lazyframe.group_by import LazyGroupBy
 from polars.lazyframe.in_process import InProcessQuery
 from polars.selectors import _expand_selectors, by_dtype, expand_selector
@@ -772,6 +770,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ max        ┆ 3.0      ┆ 50.0     ┆ 1.0      ┆ zz   ┆ 2022-12-31 ┆ 23:15:10 │
         └────────────┴──────────┴──────────┴──────────┴──────┴────────────┴──────────┘
         """
+        from polars.convert import from_dict
+
         if not self.columns:
             msg = "cannot describe a LazyFrame that has no columns"
             raise TypeError(msg)
@@ -2260,6 +2260,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         >>> lf = pl.scan_csv("/path/to/my_larger_than_ram_file.csv")  # doctest: +SKIP
         >>> lf.sink_csv("out.csv")  # doctest: +SKIP
         """
+        from polars.io.csv._utils import _check_arg_is_1byte
+
         _check_arg_is_1byte("separator", separator, can_be_empty=False)
         _check_arg_is_1byte("quote_char", quote_char, can_be_empty=False)
         if not null_value:


### PR DESCRIPTION
Shaves another few `ms` off the initial `polars` import; definitely don't need Excel utility functions in the top-level DataFrame imports, and can avoid a premature `io` utils import too.