### PR TITLE
perf: do not use pyo3-built

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,7 +3286,6 @@ dependencies = [
  "polars-time",
  "polars-utils",
  "pyo3",
- "pyo3-built",
  "recursive",
  "serde_json",
  "smartstring",
@@ -3322,12 +3321,6 @@ dependencies = [
  "once_cell",
  "target-lexicon",
 ]
-
-[[package]]
-name = "pyo3-built"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ee655adc94166665a1d714b439e27857dd199b947076891d6a17d32d396cde"
 
 [[package]]
 name = "pyo3-ffi"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -28,7 +28,6 @@ num-traits = { workspace = true }
 numpy = { version = "0.21", default-features = false }
 once_cell = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3-py38", "chrono", "extension-module", "multiple-pymethods"] }
-pyo3-built = { version = "0.5", optional = true }
 recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }
 smartstring = { workspace = true }
@@ -136,7 +135,7 @@ pivot = ["polars/pivot"]
 top_k = ["polars/top_k"]
 propagate_nans = ["polars/propagate_nans"]
 sql = ["polars/sql"]
-build_info = ["dep:pyo3-built", "dep:built"]
+build_info = ["dep:built"]
 performant = ["polars/performant"]
 timezones = ["polars/timezones"]
 cse = ["polars/cse"]

--- a/py-polars/polars/meta/build.py
+++ b/py-polars/polars/meta/build.py
@@ -18,8 +18,8 @@ def build_info() -> dict[str, Any]:
 
     The dictionary with build information contains the following keys:
 
-    - `"build"`
-    - `"info-time"`
+    - `"compiler"`
+    - `"time"`
     - `"dependencies"`
     - `"features"`
     - `"host"`
@@ -29,11 +29,5 @@ def build_info() -> dict[str, Any]:
 
     If Polars was compiled without the `build_info` feature flag, only the `"version"`
     key is included.
-
-    Notes
-    -----
-    `pyo3-built`_ is used to generate the build information.
-
-    .. _pyo3-built: https://github.com/PyO3/pyo3-built
     """
     return __build__

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -5,10 +5,6 @@
 #![allow(clippy::too_many_arguments)] // Python functions can have many arguments due to default arguments
 
 #[cfg(feature = "build_info")]
-#[macro_use]
-extern crate pyo3_built;
-
-#[cfg(feature = "build_info")]
 #[allow(dead_code)]
 mod build {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -376,14 +372,63 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     // Build info
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     #[cfg(feature = "build_info")]
-    m.add(
-        "__build__",
-        pyo3_built!(py, build, "build", "time", "deps", "features", "host", "target", "git"),
-    )?;
+    add_build_info(py, m)?;
 
     // Plugins
     m.add_wrapped(wrap_pyfunction!(functions::register_plugin_function))
         .unwrap();
 
+    Ok(())
+}
+
+#[cfg(feature = "build_info")]
+fn add_build_info<'a>(py: Python, m: &'a Bound<PyModule>) -> PyResult<()> {
+    use pyo3::types::{PyDict, PyString};
+    let info = PyDict::new_bound(py);
+
+    let build = PyDict::new_bound(py);
+    build.set_item("rustc", build::RUSTC)?;
+    build.set_item("rustc-version", build::RUSTC_VERSION)?;
+    build.set_item("opt-level", build::OPT_LEVEL)?;
+    build.set_item("debug", build::DEBUG)?;
+    build.set_item("jobs", build::NUM_JOBS)?;
+    info.set_item("compiler", build)?;
+
+    info.set_item("time", build::BUILT_TIME_UTC)?;
+
+    let deps = PyDict::new_bound(py);
+    for (name, version) in build::DEPENDENCIES.iter() {
+        deps.set_item(name, version)?;
+    }
+    info.set_item("dependencies", deps)?;
+
+    let features = build::FEATURES
+        .iter()
+        .map(|feat| PyString::new_bound(py, feat))
+        .collect::<Vec<_>>();
+    info.set_item("features", features)?;
+
+    let host = PyDict::new_bound(py);
+    host.set_item("triple", build::HOST)?;
+    info.set_item("host", host)?;
+
+    let target = PyDict::new_bound(py);
+    target.set_item("arch", build::CFG_TARGET_ARCH)?;
+    target.set_item("os", build::CFG_OS)?;
+    target.set_item("family", build::CFG_FAMILY)?;
+    target.set_item("env", build::CFG_ENV)?;
+    target.set_item("triple", build::TARGET)?;
+    target.set_item("endianness", build::CFG_ENDIAN)?;
+    target.set_item("pointer-width", build::CFG_POINTER_WIDTH)?;
+    target.set_item("profile", build::PROFILE)?;
+    info.set_item("target", target)?;
+
+    let git = PyDict::new_bound(py);
+    git.set_item("version", build::GIT_VERSION)?;
+    git.set_item("dirty", build::GIT_DIRTY)?;
+    git.set_item("hash", build::GIT_COMMIT_HASH)?;
+    git.set_item("head", build::GIT_HEAD_REF)?;
+    info.set_item("git", git)?;
+    m.add("__build__", info)?;
     Ok(())
 }

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -382,7 +382,7 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
 }
 
 #[cfg(feature = "build_info")]
-fn add_build_info<'a>(py: Python, m: &'a Bound<PyModule>) -> PyResult<()> {
+fn add_build_info(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     use pyo3::types::{PyDict, PyString};
     let info = PyDict::new_bound(py);
 

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -198,7 +198,7 @@ def memory_usage_without_pyarrow() -> Generator[MemoryUsage, Any, Any]:
 
     Memory usage from PyArrow is not tracked.
     """
-    if not pl.build_info()["build"]["debug"]:
+    if not pl.build_info()["compiler"]["debug"]:
         pytest.skip("Memory usage only available in debug/dev builds.")
 
     if sys.platform == "win32":

--- a/py-polars/tests/unit/meta/test_build.py
+++ b/py-polars/tests/unit/meta/test_build.py
@@ -9,8 +9,8 @@ def test_build_info_version() -> None:
 def test_build_info_keys() -> None:
     build_info = pl.build_info()
     expected_keys = [
-        "build",
-        "info-time",
+        "compiler",
+        "time",
         "dependencies",
         "features",
         "host",


### PR DESCRIPTION
This crate only saved us ~50 LOC and included a hidden dependency on `email.utils` increasing our import times.

While in the process I also renamed the awkwardly named `pl.build_info()["build"]` to `pl.build_info()["compiler"]` and `pl.build_info()["info-time"]` is now a RFC2822 string `pl.build_info()["time"]`.