### PR TITLE
fix: Don't exclude explicitly named columns in group-by context' expr expansion

### DIFF
--- a/crates/polars-lazy/src/tests/mod.rs
+++ b/crates/polars-lazy/src/tests/mod.rs
@@ -186,3 +186,21 @@ pub(crate) fn get_df() -> DataFrame {
         .finish()
         .unwrap()
 }
+
+#[test]
+fn test_foo() -> PolarsResult<()> {
+    let df = df![
+        "A" => [1],
+        "B" => [1],
+    ]?;
+
+    let q = df.lazy();
+
+    let out = q
+        .group_by([col("A")])
+        .agg([cols(["A", "B"]).name().prefix("_agg")])
+        .explain(false)?;
+
+    println!("{out}");
+    Ok(())
+}

--- a/crates/polars-plan/src/logical_plan/expr_expansion.rs
+++ b/crates/polars-plan/src/logical_plan/expr_expansion.rs
@@ -37,7 +37,9 @@ fn rewrite_special_aliases(expr: Expr) -> PolarsResult<Expr> {
                 let name = function.call(&name)?;
                 Ok(Expr::Alias(expr, ColumnName::from(name)))
             },
-            _ => panic!("`keep`, `suffix`, `prefix` should be last expression"),
+            _ => {
+                polars_bail!(InvalidOperation: "`keep`, `suffix`, `prefix` should be last expression")
+            },
         }
     } else {
         Ok(expr)
@@ -526,7 +528,8 @@ fn replace_and_add_to_results(
         }) {
             match &e {
                 Expr::Columns(names) => {
-                    let exclude = prepare_excluded(&expr, schema, keys, flags.has_exclude)?;
+                    // Don't exclude grouping keys if columns are explicitly specified.
+                    let exclude = prepare_excluded(&expr, schema, &[], flags.has_exclude)?;
                     expand_columns(&expr, result, names, schema, &exclude)?;
                 },
                 Expr::DtypeColumn(dtypes) => {


### PR DESCRIPTION
Fixes #16170