### PR TITLE
feat: Add struct.field expansion (regex, wildcard, columns)

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/struct_.rs
+++ b/crates/polars-plan/src/dsl/function_expr/struct_.rs
@@ -14,6 +14,7 @@ pub enum StructFunction {
     #[cfg(feature = "json")]
     JsonEncode,
     WithFields,
+    MultipleFields(Arc<[ColumnName]>),
 }
 
 impl StructFunction {
@@ -109,6 +110,7 @@ impl StructFunction {
                     polars_bail!(op = "with_fields", got = dt, expected = "Struct")
                 }
             },
+            MultipleFields(_) => panic!("should be expanded"),
         }
     }
 }
@@ -125,6 +127,7 @@ impl Display for StructFunction {
             #[cfg(feature = "json")]
             JsonEncode => write!(f, "struct.to_json"),
             WithFields => write!(f, "with_fields"),
+            MultipleFields(_) => write!(f, "multiple_fields"),
         }
     }
 }
@@ -141,6 +144,7 @@ impl From<StructFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "json")]
             JsonEncode => map!(to_json),
             WithFields => map_as_slice!(with_fields),
+            MultipleFields(_) => unimplemented!(),
         }
     }
 }

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::logical_plan::expr_expansion::is_regex_projection;
 
 /// Specialized expressions for Struct dtypes.
 pub struct StructNameSpace(pub(crate) Expr);
@@ -15,8 +16,28 @@ impl StructNameSpace {
             })
     }
 
+    /// Retrieve one or multiple of the fields of this [`StructChunked`] as a new Series.
+    /// This expression also expands the `"*"` wildcard column.
+    pub fn field_by_names<S: AsRef<str>>(self, names: &[S]) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StructExpr(StructFunction::MultipleFields(
+                names
+                    .iter()
+                    .map(|name| ColumnName::from(name.as_ref()))
+                    .collect(),
+            )))
+            .with_function_options(|mut options| {
+                options.allow_rename = true;
+                options
+            })
+    }
+
     /// Retrieve one of the fields of this [`StructChunked`] as a new Series.
+    /// This expression also supports wildcard "*" and regex expansion.
     pub fn field_by_name(self, name: &str) -> Expr {
+        if name == "*" || is_regex_projection(name) {
+            return self.field_by_names(&[name]);
+        }
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::FieldByName(
                 ColumnName::from(name),

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -28,7 +28,7 @@ class ExprStructNameSpace:
             msg = f"expected type 'int | str', got {type(item).__name__!r} ({item!r})"
             raise TypeError(msg)
 
-    def field(self, name: str | list[str]) -> Expr:
+    def field(self, name: str | list[str], *more_names: str) -> Expr:
         """
         Retrieve one or multiple `Struct` field(s) as a new Series.
 
@@ -36,6 +36,8 @@ class ExprStructNameSpace:
         ----------
         name
             Name of the struct field to retrieve.
+        *more_names
+            Additional struct field names.
 
         Examples
         --------
@@ -100,7 +102,7 @@ class ExprStructNameSpace:
 
         Retrieve multiple fields by name:
 
-        >>> df.select(pl.col("struct_col").struct.field(["aaa", "bbb"]))
+        >>> df.select(pl.col("struct_col").struct.field("aaa", "bbb"))
         shape: (2, 2)
         ┌─────┬─────┐
         │ aaa ┆ bbb │
@@ -125,6 +127,8 @@ class ExprStructNameSpace:
         └─────┴─────┘
 
         """
+        if more_names:
+            name = [*([name] if isinstance(name, str) else name), *more_names]
         if isinstance(name, list):
             return wrap_expr(self._pyexpr.struct_multiple_fields(name))
 

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -28,9 +28,9 @@ class ExprStructNameSpace:
             msg = f"expected type 'int | str', got {type(item).__name__!r} ({item!r})"
             raise TypeError(msg)
 
-    def field(self, name: str) -> Expr:
+    def field(self, name: str | list[str]) -> Expr:
         """
-        Retrieve a `Struct` field as a new Series.
+        Retrieve one or multiple `Struct` field(s) as a new Series.
 
         Parameters
         ----------
@@ -84,7 +84,50 @@ class ExprStructNameSpace:
         │ ab  ┆ [1, 2]    │
         │ cd  ┆ [3]       │
         └─────┴───────────┘
+
+        Use wildcard expansion:
+
+        >>> df.select(pl.col("struct_col").struct.field("*"))
+        shape: (2, 4)
+        ┌─────┬─────┬──────┬───────────┐
+        │ aaa ┆ bbb ┆ ccc  ┆ ddd       │
+        │ --- ┆ --- ┆ ---  ┆ ---       │
+        │ i64 ┆ str ┆ bool ┆ list[i64] │
+        ╞═════╪═════╪══════╪═══════════╡
+        │ 1   ┆ ab  ┆ true ┆ [1, 2]    │
+        │ 2   ┆ cd  ┆ null ┆ [3]       │
+        └─────┴─────┴──────┴───────────┘
+
+        Retrieve multiple fields by name:
+
+        >>> df.select(pl.col("struct_col").struct.field(["aaa", "bbb"]))
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ aaa ┆ bbb │
+        │ --- ┆ --- │
+        │ i64 ┆ str │
+        ╞═════╪═════╡
+        │ 1   ┆ ab  │
+        │ 2   ┆ cd  │
+        └─────┴─────┘
+
+        Retrieve multiple fields by regex expansion:
+
+        >>> df.select(pl.col("struct_col").struct.field("^a.*|b.*$"))
+        shape: (2, 2)
+        ┌─────┬─────┐
+        │ aaa ┆ bbb │
+        │ --- ┆ --- │
+        │ i64 ┆ str │
+        ╞═════╪═════╡
+        │ 1   ┆ ab  │
+        │ 2   ┆ cd  │
+        └─────┴─────┘
+
         """
+        if isinstance(name, list):
+            return wrap_expr(self._pyexpr.struct_multiple_fields(name))
+
         return wrap_expr(self._pyexpr.struct_field_by_name(name))
 
     def rename_fields(self, names: Sequence[str]) -> Expr:

--- a/py-polars/src/expr/struct.rs
+++ b/py-polars/src/expr/struct.rs
@@ -13,6 +13,10 @@ impl PyExpr {
         self.inner.clone().struct_().field_by_name(name).into()
     }
 
+    fn struct_multiple_fields(&self, names: Vec<String>) -> Self {
+        self.inner.clone().struct_().field_by_names(&names).into()
+    }
+
     fn struct_rename_fields(&self, names: Vec<String>) -> Self {
         self.inner.clone().struct_().rename_fields(names).into()
     }

--- a/py-polars/tests/unit/test_expansion.py
+++ b/py-polars/tests/unit/test_expansion.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+import pytest
+
 import polars as pl
 from polars import NUMERIC_DTYPES
 from polars.testing import assert_frame_equal
@@ -93,7 +97,16 @@ def test_exclude_keys_in_aggregation_16170() -> None:
     ).columns == ["A", "agg_A", "agg_C"]
 
 
-def test_struct_field_expansion() -> None:
+@pytest.mark.parametrize(
+    "field",
+    [
+        ["aaa", "ccc"],
+        [["aaa", "ccc"]],
+        [["aaa"], "ccc"],
+        [["^aa.+|cc.+$"]],
+    ],
+)
+def test_struct_field_expand(field: Any) -> None:
     df = pl.DataFrame(
         {
             "aaa": [1, 2],
@@ -102,15 +115,19 @@ def test_struct_field_expansion() -> None:
             "ddd": [[1, 2], [3]],
         }
     )
-
     struct_df = df.select(pl.struct(["aaa", "bbb", "ccc", "ddd"]).alias("struct_col"))
+    res_df = struct_df.select(pl.col("struct_col").struct.field(*field))
+    assert_frame_equal(res_df, df.select("aaa", "ccc"))
 
+
+def test_struct_field_expand_star() -> None:
+    df = pl.DataFrame(
+        {
+            "aaa": [1, 2],
+            "bbb": ["ab", "cd"],
+            "ccc": [True, None],
+            "ddd": [[1, 2], [3]],
+        }
+    )
+    struct_df = df.select(pl.struct(["aaa", "bbb", "ccc", "ddd"]).alias("struct_col"))
     assert_frame_equal(struct_df.select(pl.col("struct_col").struct.field("*")), df)
-    assert struct_df.select(
-        pl.col("struct_col").struct.field(["aaa", "ccc"])
-    ).columns == ["aaa", "ccc"]
-
-    assert struct_df.select(pl.col("struct_col").struct.field("^a.+|b.+$")).columns == [
-        "aaa",
-        "bbb",
-    ]


### PR DESCRIPTION
```python
>>> df = pl.DataFrame(
...     {
...         "aaa": [1, 2],
...         "bbb": ["ab", "cd"],
...         "ccc": [True, None],
...         "ddd": [[1, 2], [3]],
...     }
... ).select(pl.struct(["aaa", "bbb", "ccc", "ddd"]).alias("struct_col"))
>>> df
shape: (2, 1)
┌──────────────────────┐
│ struct_col           │
│ ---                  │
│ struct[4]            │
╞══════════════════════╡
│ {1,"ab",true,[1, 2]} │
│ {2,"cd",null,[3]}    │
└──────────────────────┘
Use wildcard expansion:

>>> df.select(pl.col("struct_col").struct.field("*"))
shape: (2, 4)
┌─────┬─────┬──────┬───────────┐
│ aaa ┆ bbb ┆ ccc  ┆ ddd       │
│ --- ┆ --- ┆ ---  ┆ ---       │
│ i64 ┆ str ┆ bool ┆ list[i64] │
╞═════╪═════╪══════╪═══════════╡
│ 1   ┆ ab  ┆ true ┆ [1, 2]    │
│ 2   ┆ cd  ┆ null ┆ [3]       │
└─────┴─────┴──────┴───────────┘

Retrieve multiple fields by name:

>>> df.select(pl.col("struct_col").struct.field(["aaa", "bbb"]))
shape: (2, 2)
┌─────┬─────┐
│ aaa ┆ bbb │
│ --- ┆ --- │
│ i64 ┆ str │
╞═════╪═════╡
│ 1   ┆ ab  │
│ 2   ┆ cd  │
└─────┴─────┘

Retrieve multiple fields by regex expansion:

>>> df.select(pl.col("struct_col").struct.field("^a.*|b.*$"))
shape: (2, 2)
┌─────┬─────┐
│ aaa ┆ bbb │
│ --- ┆ --- │
│ i64 ┆ str │
╞═════╪═════╡
│ 1   ┆ ab  │
│ 2   ┆ cd  │
└─────┴─────┘
```

@alexander-beedie can you do the multiple columns without passing a list?

closes #3859