### PR TITLE
fix(python): Casting and time unit handling for lists of temporal numpy types

### DIFF
--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
@@ -12,6 +12,21 @@ if TYPE_CHECKING:
     from polars.type_aliases import TimeUnit
 
 
+@pytest.mark.parametrize("time_unit", ["ns", "ms", "us"])
+def test_from_list_numpy_timedelta(time_unit: TimeUnit) -> None:
+    s = pl.Series(
+        "name",
+        [
+            np.timedelta64(timedelta(days=1), time_unit),
+            np.timedelta64(timedelta(seconds=1), time_unit),
+        ],
+    )
+    assert s.dtype == pl.Duration(time_unit)
+    assert s.name == "name"
+    assert s.dt[0] == timedelta(days=1)
+    assert s.dt[1] == timedelta(seconds=1)
+
+
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_from_numpy_timedelta(time_unit: TimeUnit) -> None:
     s = pl.Series(


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/16029

This should replicate the same logic for handling dimensions as for np.arrays with primitive numbers:

- 1 dimensional: pl.Series(PolarsType)
- 2 dimensional: pl.Series(pl.List(PolarsType))
- \=>3 dimensional: pl.Series(pl.Object)