### PR TITLE
perf: Optimize `is_sorted` for numeric data

### DIFF
--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -1,7 +1,10 @@
+use num_traits::Bounded;
 #[cfg(feature = "dtype-struct")]
 use polars_core::prelude::sort::arg_sort_multiple::_get_rows_encoded_ca;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
+use polars_core::with_match_physical_numeric_polars_type;
+use polars_utils::total_ord::TotalOrd;
 
 use crate::series::ops::SeriesSealed;
 
@@ -48,16 +51,9 @@ pub trait SeriesMethods: SeriesSealed {
         }
     }
 
+    /// Checks if a [`Series`] is sorted. Tries to fail fast.
     fn is_sorted(&self, options: SortOptions) -> PolarsResult<bool> {
         let s = self.as_series();
-
-        // for struct types we row-encode and recurse
-        #[cfg(feature = "dtype-struct")]
-        if matches!(s.dtype(), DataType::Struct(_)) {
-            let encoded =
-                _get_rows_encoded_ca("", &[s.clone()], &[options.descending], options.nulls_last)?;
-            return encoded.into_series().is_sorted(options);
-        }
 
         // fast paths
         if (options.descending
@@ -69,30 +65,120 @@ pub trait SeriesMethods: SeriesSealed {
         {
             return Ok(true);
         }
-        let nc = s.null_count();
-        let slen = s.len() - nc - 1; // Number of comparisons we might have to do
-        if nc == s.len() {
+
+        // for struct types we row-encode and recurse
+        #[cfg(feature = "dtype-struct")]
+        if matches!(s.dtype(), DataType::Struct(_)) {
+            let encoded =
+                _get_rows_encoded_ca("", &[s.clone()], &[options.descending], options.nulls_last)?;
+            return encoded.into_series().is_sorted(options);
+        }
+
+        let null_count = s.null_count();
+        let s_len = s.len();
+        if null_count == s_len {
             // All nulls is all equal
             return Ok(true);
         }
-        if nc > 0 {
-            let nulls = s.chunks().iter().flat_map(|c| c.validity().unwrap());
-            let mut npairs = nulls.clone().zip(nulls.skip(1));
-            // A null never precedes (follows) a non-null iff all nulls are at the end (beginning)
-            if (options.nulls_last && npairs.any(|(a, b)| !a && b)) || npairs.any(|(a, b)| a && !b)
-            {
+        // Check if nulls are in the right location.
+        if null_count > 0 {
+            // The slice triggers a fast null count
+            if options.nulls_last {
+                if s.slice((s_len - null_count) as i64, null_count)
+                    .null_count()
+                    != null_count
+                {
+                    return Ok(false);
+                }
+            } else if s.slice(0, null_count).null_count() != null_count {
                 return Ok(false);
             }
         }
-        // Compare adjacent elements with no-copy slices that don't include any nulls
-        let offset = !options.nulls_last as i64 * nc as i64;
-        let (s1, s2) = (s.slice(offset, slen), s.slice(offset + 1, slen));
+
+        if s.dtype().is_numeric() {
+            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                return Ok(is_sorted_ca_num::<$T>(ca, options))
+            })
+        }
+
+        let cmp_len = s_len - null_count - 1; // Number of comparisons we might have to do
+                                              // TODO! Change this, allocation of a full boolean series is too expensive and doesn't fail fast.
+                                              // Compare adjacent elements with no-copy slices that don't include any nulls
+        let offset = !options.nulls_last as i64 * null_count as i64;
+        let (s1, s2) = (s.slice(offset, cmp_len), s.slice(offset + 1, cmp_len));
         let cmp_op = if options.descending {
             Series::gt_eq
         } else {
             Series::lt_eq
         };
         Ok(cmp_op(&s1, &s2)?.all())
+    }
+}
+
+fn check_cmp<T: NumericNative, Cmp: Fn(&T, &T) -> bool>(
+    vals: &[T],
+    f: Cmp,
+    previous: &mut T,
+) -> bool {
+    let mut sorted = true;
+
+    // Outer loop so we can fail fast
+    // Inner loop will auto vectorize
+    for c in vals.chunks(1024) {
+        // don't early stop or branch
+        // so it autovectorizes
+        for v in c {
+            sorted &= f(previous, v);
+            *previous = *v;
+        }
+        if !sorted {
+            return false;
+        }
+    }
+    sorted
+}
+
+// Assumes nulls last/first is already checked.
+fn is_sorted_ca_num<T: PolarsNumericType>(ca: &ChunkedArray<T>, options: SortOptions) -> bool {
+    if let Ok(vals) = ca.cont_slice() {
+        let mut previous = vals[0];
+        return if options.descending {
+            check_cmp(vals, |prev, c| prev.tot_ge(c), &mut previous)
+        } else {
+            check_cmp(vals, |prev, c| prev.tot_le(c), &mut previous)
+        };
+    };
+
+    if ca.null_count() == 0 {
+        let mut previous = if options.descending {
+            T::Native::max_value()
+        } else {
+            T::Native::min_value()
+        };
+        for arr in ca.downcast_iter() {
+            let vals = arr.values();
+
+            let sorted = if options.descending {
+                check_cmp(vals, |prev, c| prev.tot_ge(c), &mut previous)
+            } else {
+                check_cmp(vals, |prev, c| prev.tot_le(c), &mut previous)
+            };
+            if !sorted {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // Slice off nulls and recurse.
+    let null_count = ca.null_count();
+    if options.nulls_last {
+        let ca = ca.slice(0, ca.len() - null_count);
+        is_sorted_ca_num(&ca, options)
+    } else {
+        let ca = ca.slice(null_count as i64, ca.len() - null_count);
+        is_sorted_ca_num(&ca, options)
     }
 }
 

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -1,5 +1,5 @@
-use polars_core::series::IsSorted;
 use polars_core::{with_match_physical_float_polars_type, with_match_physical_numeric_polars_type};
+use polars_ops::series::SeriesMethods;
 
 use super::*;
 use crate::prelude::*;
@@ -82,8 +82,9 @@ where
     if ca.is_empty() {
         return Ok(Series::new_empty(ca.name(), ca.dtype()));
     }
-    let ca = ca.rechunk();
-    let by = by.rechunk();
+    if by.null_count() > 0 {
+        polars_bail!(InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'")
+    }
     polars_ensure!(ca.len() == by.len(), InvalidOperation: "`by` column in `rolling_*_by` must be the same length as values column");
     ensure_duration_matches_data_type(options.window_size, by.dtype(), "window_size")?;
     polars_ensure!(!options.window_size.is_zero() && !options.window_size.negative, InvalidOperation: "`window_size` must be strictly positive");
@@ -98,15 +99,18 @@ where
             dt,
             "date/datetime"),
     };
+    let ca = ca.rechunk();
+    let by = by.rechunk();
+    let by_is_sorted = by.is_sorted(SortOptions {
+        descending: false,
+        ..Default::default()
+    })?;
     let by = by.datetime().unwrap();
     let tu = by.time_unit();
 
     let func = rolling_agg_fn_dynamic;
-    let out: ArrayRef = if matches!(by.is_sorted_flag(), IsSorted::Ascending) {
+    let out: ArrayRef = if by_is_sorted {
         let arr = ca.downcast_iter().next().unwrap();
-        if arr.null_count() > 0 {
-            polars_bail!(InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'")
-        }
         let by_values = by.cont_slice().map_err(|_| {
             polars_err!(
                 ComputeError:
@@ -130,9 +134,6 @@ where
         let ca = unsafe { ca.take_unchecked(&sorting_indices) };
         let by = unsafe { by.take_unchecked(&sorting_indices) };
         let arr = ca.downcast_iter().next().unwrap();
-        if arr.null_count() > 0 {
-            polars_bail!(InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'")
-        }
         let by_values = by.cont_slice().map_err(|_| {
             polars_err!(
                 ComputeError:

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -82,7 +82,7 @@ where
     if ca.is_empty() {
         return Ok(Series::new_empty(ca.name(), ca.dtype()));
     }
-    polars_ensure!( by.null_count() == 0 && ca.null_count() == 0, InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'");
+    polars_ensure!(by.null_count() == 0 && ca.null_count() == 0, InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'");
     polars_ensure!(ca.len() == by.len(), InvalidOperation: "`by` column in `rolling_*_by` must be the same length as values column");
     ensure_duration_matches_data_type(options.window_size, by.dtype(), "window_size")?;
     polars_ensure!(!options.window_size.is_zero() && !options.window_size.negative, InvalidOperation: "`window_size` must be strictly positive");
@@ -109,12 +109,7 @@ where
     let func = rolling_agg_fn_dynamic;
     let out: ArrayRef = if by_is_sorted {
         let arr = ca.downcast_iter().next().unwrap();
-        let by_values = by.cont_slice().map_err(|_| {
-            polars_err!(
-                ComputeError:
-                "`by` column should not have null values in 'rolling by' expression"
-            )
-        })?;
+        let by_values = by.cont_slice().unwrap();
         let values = arr.values().as_slice();
         func(
             values,
@@ -132,7 +127,7 @@ where
         let ca = unsafe { ca.take_unchecked(&sorting_indices) };
         let by = unsafe { by.take_unchecked(&sorting_indices) };
         let arr = ca.downcast_iter().next().unwrap();
-        let by_values = by.cont_slice().expect("checked already");
+        let by_values = by.cont_slice().unwrap();
         let values = arr.values().as_slice();
         func(
             values,

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -82,9 +82,7 @@ where
     if ca.is_empty() {
         return Ok(Series::new_empty(ca.name(), ca.dtype()));
     }
-    if by.null_count() > 0 {
-        polars_bail!(InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'")
-    }
+    polars_ensure!( by.null_count() == 0 && ca.null_count() == 0, InvalidOperation: "'Expr.rolling_*_by(...)' not yet supported for series with null values, consider using 'DataFrame.rolling' or 'Expr.rolling'");
     polars_ensure!(ca.len() == by.len(), InvalidOperation: "`by` column in `rolling_*_by` must be the same length as values column");
     ensure_duration_matches_data_type(options.window_size, by.dtype(), "window_size")?;
     polars_ensure!(!options.window_size.is_zero() && !options.window_size.negative, InvalidOperation: "`window_size` must be strictly positive");
@@ -134,12 +132,7 @@ where
         let ca = unsafe { ca.take_unchecked(&sorting_indices) };
         let by = unsafe { by.take_unchecked(&sorting_indices) };
         let arr = ca.downcast_iter().next().unwrap();
-        let by_values = by.cont_slice().map_err(|_| {
-            polars_err!(
-                ComputeError:
-                "`by` column should not have null values in 'rolling by' expression"
-            )
-        })?;
+        let by_values = by.cont_slice().expect("checked already");
         let values = arr.values().as_slice();
         func(
             values,

--- a/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -2,7 +2,7 @@ mod dispatch;
 #[cfg(feature = "rolling_window_by")]
 mod rolling_kernels;
 
-use arrow::array::{Array, ArrayRef, PrimitiveArray};
+use arrow::array::{ArrayRef, PrimitiveArray};
 use arrow::legacy::kernels::rolling;
 pub use dispatch::*;
 use polars_core::prelude::*;

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3744,7 +3744,7 @@ class Series:
         """
         return self.len() == 0
 
-    def is_sorted(self, *, descending: bool = False) -> bool:
+    def is_sorted(self, *, descending: bool = False, nulls_last: bool = False) -> bool:
         """
         Check if the Series is sorted.
 
@@ -3752,6 +3752,8 @@ class Series:
         ----------
         descending
             Check if the Series is sorted in descending order
+        nulls_last
+            Set nulls at the end of the Series in sorted check.
 
         Examples
         --------
@@ -3763,7 +3765,7 @@ class Series:
         >>> s.is_sorted(descending=True)
         True
         """
-        return self._s.is_sorted(descending)
+        return self._s.is_sorted(descending, nulls_last)
 
     def not_(self) -> Series:
         """

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -710,10 +710,10 @@ impl PySeries {
         })
     }
 
-    fn is_sorted(&self, descending: bool) -> PyResult<bool> {
+    fn is_sorted(&self, descending: bool, nulls_last: bool) -> PyResult<bool> {
         let options = SortOptions {
             descending,
-            nulls_last: descending,
+            nulls_last,
             multithreaded: true,
             maintain_order: false,
         };

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -1,0 +1,25 @@
+import polars as pl
+
+
+def test_is_sorted() -> None:
+    assert not pl.Series([1, 2, 5, None, 2, None]).is_sorted()
+    assert pl.Series([1, 2, 4, None, None]).is_sorted(nulls_last=True)
+    assert pl.Series([None, None, 1, 2, 4]).is_sorted(nulls_last=False)
+    assert not pl.Series([None, 1, None, 2, 4]).is_sorted()
+    assert not pl.Series([None, 1, 2, 3, -1, 4]).is_sorted(nulls_last=False)
+    assert not pl.Series([1, 2, 3, -1, 4, None, None]).is_sorted(nulls_last=True)
+    assert not pl.Series([1, 2, 3, -1, 4]).is_sorted()
+    assert pl.Series([1, 2, 3, 4]).is_sorted()
+    assert pl.Series([5, 2, 1, 1, -1]).is_sorted(descending=True)
+    assert pl.Series([None, None, 5, 2, 1, 1, -1]).is_sorted(
+        descending=True, nulls_last=False
+    )
+    assert pl.Series([5, 2, 1, 1, -1, None, None]).is_sorted(
+        descending=True, nulls_last=True
+    )
+    assert not pl.Series([5, None, 2, 1, 1, -1, None, None]).is_sorted(
+        descending=True, nulls_last=True
+    )
+    assert not pl.Series([5, 2, 1, 10, 1, -1, None, None]).is_sorted(
+        descending=True, nulls_last=True
+    )


### PR DESCRIPTION
Should be much faster and failing fast in case of non-sorted data.