### PR TITLE
chore: simplify interpolate code, add test for rolling_*_by with nulls

### DIFF
--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1231,3 +1231,15 @@ def test_rolling_aggs(
     )
     assert_frame_equal(result, expected)
     assert_frame_equal(result_from_unsorted, expected)
+
+
+def test_rolling_by_nulls() -> None:
+    df = pl.DataFrame({"a": [1, None], "b": [1, 2]})
+    with pytest.raises(
+        InvalidOperationError, match="not yet supported for series with null values"
+    ):
+        df.select(pl.col("a").rolling_min_by("b", "2i"))
+    with pytest.raises(
+        InvalidOperationError, match="not yet supported for series with null values"
+    ):
+        df.select(pl.col("b").rolling_min_by("a", "2i"))


### PR DESCRIPTION
applying some suggestions from https://github.com/pola-rs/polars/pull/16313 to some 'old' code

Removing so many levels of indentation was quite pleasing 😋 