### PR TITLE
fix(python): Handle ambiguous/nonexistent datetimes in Series construction

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -205,7 +205,13 @@ def sequence_to_pyseries(
 
         if (values_dtype == Date) & (dtype == Datetime):
             return (
-                s.cast(Datetime(time_unit or "us")).dt.replace_time_zone(time_zone)._s
+                s.cast(Datetime(time_unit or "us"))
+                .dt.replace_time_zone(
+                    time_zone,
+                    ambiguous="raise" if strict else "null",
+                    non_existent="raise" if strict else "null",
+                )
+                ._s
             )
 
         if (dtype == Datetime) and (value.tzinfo is not None or time_zone is not None):
@@ -228,7 +234,11 @@ def sequence_to_pyseries(
                     TimeZoneAwareConstructorWarning,
                     stacklevel=find_stacklevel(),
                 )
-            return s.dt.replace_time_zone(dtype_tz or "UTC")._s
+            return s.dt.replace_time_zone(
+                dtype_tz or "UTC",
+                ambiguous="raise" if strict else "null",
+                non_existent="raise" if strict else "null",
+            )._s
         return s._s
 
     elif (


### PR DESCRIPTION
There is currently no way to construct a Series with a nonexistent/ambiguous datetime value, as the Series constructor has no `ambigous/nonexistent` argument, and the default is to raise.

This PR sets those values to null if `strict=False` was passed to the constructor.

@MarcoGorelli would love to get your input on this fix.