### PR TITLE
feat: Add circular shift via `circshift`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -556,7 +556,12 @@ pub trait ChunkShiftFill<T: PolarsDataType, V> {
 }
 
 pub trait ChunkShift<T: PolarsDataType> {
+    /// Shift the values by a given period and fill the parts that will be empty due to this operation
+    /// with null.
     fn shift(&self, periods: i64) -> ChunkedArray<T>;
+
+    /// Shift values circularly by a given period.
+    fn circshift(&self, periods: i64) -> ChunkedArray<T>;
 }
 
 /// Combine two [`ChunkedArray`] based on some predicate.

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2421,6 +2421,13 @@ impl DataFrame {
         unsafe { DataFrame::new_no_checks(col) }
     }
 
+    /// Shift values circularly by a given period.
+    pub fn circshift(&self, periods: i64) -> Self {
+        let col = self._apply_columns_par(&|s| s.circshift(periods));
+
+        unsafe { DataFrame::new_no_checks(col) }
+    }
+
     /// Replace None values with one of the following strategies:
     /// * Forward fill (replace None with the previous value)
     /// * Backward fill (replace None with the next value)

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -163,6 +163,10 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
         ChunkShift::shift(&self.0, periods).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        ChunkShift::circshift(&self.0, periods).into_series()
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -228,6 +228,10 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         ChunkShift::shift(&self.0, periods).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        ChunkShift::circshift(&self.0, periods).into_series()
+    }
+
     fn max_reduce(&self) -> PolarsResult<Scalar> {
         Ok(ChunkAggSeries::max_reduce(&self.0))
     }

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -179,6 +179,10 @@ impl SeriesTrait for SeriesWrap<BinaryOffsetChunked> {
         ChunkShift::shift(&self.0, periods).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        ChunkShift::circshift(&self.0, periods).into_series()
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -253,6 +253,10 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         ChunkShift::shift(&self.0, periods).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        ChunkShift::circshift(&self.0, periods).into_series()
+    }
+
     fn sum_reduce(&self) -> PolarsResult<Scalar> {
         Ok(ChunkAggSeries::sum_reduce(&self.0))
     }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -281,6 +281,11 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.with_state(false, |ca| ca.shift(periods)).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        self.with_state(false, |ca| ca.circshift(periods))
+            .into_series()
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -321,6 +321,10 @@ macro_rules! impl_dyn_series {
                 self.0.shift(periods).$into_logical().into_series()
             }
 
+            fn circshift(&self, periods: i64) -> Series {
+                self.0.circshift(periods).$into_logical().into_series()
+            }
+
             fn max_reduce(&self) -> PolarsResult<Scalar> {
                 let sc = self.0.max_reduce();
                 let av = sc.value().cast(self.dtype()).into_static().unwrap();

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -334,6 +334,13 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
             .into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        self.0
+            .circshift(periods)
+            .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
+            .into_series()
+    }
+
     fn max_reduce(&self) -> PolarsResult<Scalar> {
         let sc = self.0.max_reduce();
 

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -312,6 +312,10 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
         self.apply_physical_to_s(|ca| ca.shift(periods))
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        self.apply_physical_to_s(|ca| ca.circshift(periods))
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -393,6 +393,13 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        self.0
+            .circshift(periods)
+            .into_duration(self.0.time_unit())
+            .into_series()
+    }
+
     fn sum_reduce(&self) -> PolarsResult<Scalar> {
         let sc = self.0.sum_reduce();
         let v = sc.value().as_duration(self.0.time_unit());

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -284,6 +284,10 @@ macro_rules! impl_dyn_series {
                 ChunkShift::shift(&self.0, periods).into_series()
             }
 
+            fn circshift(&self, periods: i64) -> Series {
+                ChunkShift::circshift(&self.0, periods).into_series()
+            }
+
             fn sum_reduce(&self) -> PolarsResult<Scalar> {
                 Ok(ChunkAggSeries::sum_reduce(&self.0))
             }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -207,6 +207,10 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         ChunkShift::shift(&self.0, periods).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        ChunkShift::circshift(&self.0, periods).into_series()
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -387,6 +387,10 @@ macro_rules! impl_dyn_series {
                 ChunkShift::shift(&self.0, periods).into_series()
             }
 
+            fn circshift(&self, periods: i64) -> Series {
+                ChunkShift::circshift(&self.0, periods).into_series()
+            }
+
             fn sum_reduce(&self) -> PolarsResult<Scalar> {
                 Ok(ChunkAggSeries::sum_reduce(&self.0))
             }

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -260,6 +260,10 @@ impl SeriesTrait for NullChunked {
         self.clone().into_series()
     }
 
+    fn circshift(&self, _periods: i64) -> Series {
+        self.clone().into_series()
+    }
+
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(other.dtype() == &DataType::Null, ComputeError: "expected null dtype");
         // we don't create a new null array to keep probability of aligned chunks higher

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -200,6 +200,10 @@ where
         ChunkShift::shift(&self.0, periods).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        ChunkShift::circshift(&self.0, periods).into_series()
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -235,6 +235,10 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         ChunkShift::shift(&self.0, periods).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        ChunkShift::circshift(&self.0, periods).into_series()
+    }
+
     fn sum_reduce(&self) -> PolarsResult<Scalar> {
         Ok(ChunkAggSeries::sum_reduce(&self.0))
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -304,6 +304,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         self.0._apply_fields(|s| s.shift(periods)).into_series()
     }
 
+    fn circshift(&self, periods: i64) -> Series {
+        self.0._apply_fields(|s| s.circshift(periods)).into_series()
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -413,6 +413,9 @@ pub trait SeriesTrait:
     /// ```
     fn shift(&self, _periods: i64) -> Series;
 
+    /// Shift the values circularly by a given period.
+    fn circshift(&self, _periods: i64) -> Series;
+
     /// Get the sum of the Series as a new Scalar.
     ///
     /// If the [`DataType`] is one of `{Int8, UInt8, Int16, UInt16}` the `Series` is

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -428,6 +428,13 @@ impl LazyFrame {
         self.select(vec![col("*").shift(n.into())])
     }
 
+    /// Shift values circularly by a given period.
+    ///
+    /// See the method on [Series](polars_core::series::SeriesTrait::circshift) for more info on the `circshift` operation.
+    pub fn circshift<E: Into<Expr>>(self, n: E) -> Self {
+        self.select(vec![col("*").circshift(n.into())])
+    }
+
     /// Shift the values by a given period and fill the parts that will be empty due to this operation
     /// with the result of the `fill_value` expression.
     ///

--- a/crates/polars-ops/src/chunked_array/array/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/array/namespace.rs
@@ -170,6 +170,39 @@ pub trait ArrayNameSpace: AsArray {
         };
         Ok(out.into_series())
     }
+
+    fn array_circshift(&self, n: &Series) -> PolarsResult<Series> {
+        let ca = self.as_array();
+        let n_s = n.cast(&DataType::Int64)?;
+        let n = n_s.i64()?;
+        let out = match n.len() {
+            1 => {
+                if let Some(n) = n.get(0) {
+                    // SAFETY: Circshift does not change the dtype and number of elements of sub-array.
+                    unsafe { ca.apply_amortized_same_type(|s| s.as_ref().circshift(n)) }
+                } else {
+                    ArrayChunked::full_null_with_dtype(
+                        ca.name(),
+                        ca.len(),
+                        &ca.inner_dtype(),
+                        ca.width(),
+                    )
+                }
+            },
+            _ => {
+                // SAFETY: Circhift does not change the dtype and number of elements of sub-array.
+                unsafe {
+                    ca.zip_and_apply_amortized_same_type(n, |opt_s, opt_periods| {
+                        match (opt_s, opt_periods) {
+                            (Some(s), Some(n)) => Some(s.as_ref().circshift(n)),
+                            _ => None,
+                        }
+                    })
+                }
+            },
+        };
+        Ok(out.into_series())
+    }
 }
 
 impl ArrayNameSpace for ArrayChunked {}

--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -192,4 +192,14 @@ impl ArrayNameSpace {
             false,
         )
     }
+
+    /// Circshift every sub-array.
+    pub fn circshift(self, n: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::ArrayExpr(ArrayFunction::CircShift),
+            &[n],
+            false,
+            false,
+        )
+    }
 }

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -30,6 +30,7 @@ pub enum ArrayFunction {
     #[cfg(feature = "array_count")]
     CountMatches,
     Shift,
+    CircShift,
 }
 
 impl ArrayFunction {
@@ -55,7 +56,7 @@ impl ArrayFunction {
             Contains => mapper.with_dtype(DataType::Boolean),
             #[cfg(feature = "array_count")]
             CountMatches => mapper.with_dtype(IDX_DTYPE),
-            Shift => mapper.with_same_dtype(),
+            Shift | CircShift => mapper.with_same_dtype(),
         }
     }
 }
@@ -96,6 +97,7 @@ impl Display for ArrayFunction {
             #[cfg(feature = "array_count")]
             CountMatches => "count_matches",
             Shift => "shift",
+            CircShift => "circshift",
         };
         write!(f, "arr.{name}")
     }
@@ -129,6 +131,7 @@ impl From<ArrayFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "array_count")]
             CountMatches => map_as_slice!(count_matches),
             Shift => map_as_slice!(shift),
+            CircShift => map_as_slice!(circshift),
         }
     }
 }
@@ -242,4 +245,11 @@ pub(super) fn shift(s: &[Series]) -> PolarsResult<Series> {
     let n = &s[1];
 
     ca.array_shift(n)
+}
+
+pub(super) fn circshift(s: &[Series]) -> PolarsResult<Series> {
+    let ca = s[0].array()?;
+    let n = &s[1];
+
+    ca.array_circshift(n)
 }

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -164,6 +164,7 @@ pub enum FunctionExpr {
     RollingExprBy(RollingFunctionBy),
     ShiftAndFill,
     Shift,
+    CircShift,
     DropNans,
     DropNulls,
     #[cfg(feature = "mode")]
@@ -402,7 +403,7 @@ impl Hash for FunctionExpr {
                 symbol.hash(state);
             },
             MaxHorizontal | MinHorizontal | SumHorizontal | MeanHorizontal | DropNans
-            | DropNulls | Reverse | ArgUnique | Shift | ShiftAndFill => {},
+            | DropNulls | Reverse | ArgUnique | Shift | ShiftAndFill | CircShift => {},
             #[cfg(feature = "mode")]
             Mode => {},
             #[cfg(feature = "abs")]
@@ -655,6 +656,7 @@ impl Display for FunctionExpr {
             #[cfg(feature = "top_k")]
             TopKBy { .. } => "top_k_by",
             Shift => "shift",
+            CircShift => "circshift",
             #[cfg(feature = "cum_agg")]
             CumCount { .. } => "cum_count",
             #[cfg(feature = "cum_agg")]
@@ -986,6 +988,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "top_k")]
             TopKBy { sort_options } => map_as_slice!(top_k_by, sort_options.clone()),
             Shift => map_as_slice!(shift_and_fill::shift),
+            CircShift => map_as_slice!(shift_and_fill::circshift),
             #[cfg(feature = "cum_agg")]
             CumCount { reverse } => map!(cum::cum_count, reverse),
             #[cfg(feature = "cum_agg")]

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -113,7 +113,7 @@ impl FunctionExpr {
             }),
             #[cfg(feature = "unique_counts")]
             UniqueCounts => mapper.with_dtype(IDX_DTYPE),
-            Shift | Reverse => mapper.with_same_dtype(),
+            Shift | CircShift | Reverse => mapper.with_same_dtype(),
             #[cfg(feature = "cum_agg")]
             CumCount { .. } => mapper.with_dtype(IDX_DTYPE),
             #[cfg(feature = "cum_agg")]

--- a/crates/polars-plan/src/dsl/function_expr/shift_and_fill.rs
+++ b/crates/polars-plan/src/dsl/function_expr/shift_and_fill.rs
@@ -126,3 +126,20 @@ pub fn shift(args: &[Series]) -> PolarsResult<Series> {
         None => Ok(Series::full_null(s.name(), s.len(), s.dtype())),
     }
 }
+
+pub fn circshift(args: &[Series]) -> PolarsResult<Series> {
+    let s = &args[0];
+    let n_s = &args[1];
+    polars_ensure!(
+        n_s.len() == 1,
+        ComputeError: "n must be a single value."
+    );
+
+    let n_s = n_s.cast(&DataType::Int64)?;
+    let n = n_s.i64()?;
+
+    match n.get(0) {
+        Some(n) => Ok(s.circshift(n)),
+        None => Ok(Series::full_null(s.name(), s.len(), s.dtype())),
+    }
+}

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -239,6 +239,16 @@ impl ListNameSpace {
         )
     }
 
+    /// Circshift every sublist.
+    pub fn circshift(self, periods: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::ListExpr(ListFunction::CircShift),
+            &[periods],
+            false,
+            false,
+        )
+    }
+
     /// Slice every sublist.
     pub fn slice(self, offset: Expr, length: Expr) -> Expr {
         self.0.map_many_private(

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -759,6 +759,11 @@ impl Expr {
         )
     }
 
+    /// Shift the values in the array circularly by some period. See [the eager implementation](polars_core::series::SeriesTrait::circshift).
+    pub fn circshift(self, n: Expr) -> Self {
+        self.apply_many_private(FunctionExpr::CircShift, &[n], false, false)
+    }
+
     /// Cumulatively count values from 0 to len.
     #[cfg(feature = "cum_agg")]
     pub fn cum_count(self, reverse: bool) -> Self {

--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -8,6 +8,7 @@ Manipulation/selection
 
     DataFrame.bottom_k
     DataFrame.cast
+    DataFrame.circshift
     DataFrame.clear
     DataFrame.clone
     DataFrame.drop

--- a/py-polars/docs/source/reference/expressions/modify_select.rst
+++ b/py-polars/docs/source/reference/expressions/modify_select.rst
@@ -14,6 +14,7 @@ Manipulation/selection
     Expr.bottom_k_by
     Expr.cast
     Expr.ceil
+    Expr.circshift
     Expr.clip
     Expr.clip_max
     Expr.clip_min

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -9,6 +9,7 @@ Manipulation/selection
     LazyFrame.approx_n_unique
     LazyFrame.bottom_k
     LazyFrame.cast
+    LazyFrame.circshift
     LazyFrame.clear
     LazyFrame.clone
     LazyFrame.drop

--- a/py-polars/docs/source/reference/series/modify_select.rst
+++ b/py-polars/docs/source/reference/series/modify_select.rst
@@ -12,6 +12,7 @@ Manipulation/selection
     Series.bottom_k
     Series.cast
     Series.ceil
+    Series.circshift
     Series.clear
     Series.clip
     Series.clip_max

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8197,6 +8197,56 @@ class DataFrame:
         """
         return self.lazy().shift(n, fill_value=fill_value).collect(_eager=True)
 
+    def circshift(self, n: int = 1) -> DataFrame:
+        """
+        Circularly shift values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Examples
+        --------
+        By default, values are shifted forward by one index.
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1, 2, 3, 4],
+        ...         "b": [5, 6, 7, 8],
+        ...     }
+        ... )
+        >>> df.circshift()
+        shape: (4, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 4   ┆ 8   │
+        │ 1   ┆ 5   │
+        │ 2   ┆ 6   │
+        │ 3   ┆ 7   │
+        └─────┴─────┘
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> df.circshift(-2)
+        shape: (4, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 3   ┆ 7   │
+        │ 4   ┆ 8   │
+        │ 1   ┆ 5   │
+        │ 2   ┆ 6   │
+        └─────┴─────┘
+        """
+        return self.lazy().circshift(n).collect(_eager=True)
+
     def is_duplicated(self) -> Series:
         """
         Get a mask of all duplicated rows in this DataFrame.

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -779,3 +779,47 @@ class ExprArrayNameSpace:
         """
         n = parse_as_expression(n)
         return wrap_expr(self._pyexpr.arr_shift(n))
+
+    def circshift(self, n: int | IntoExprColumn = 1) -> Expr:
+        """
+        Circularly shift array values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Examples
+        --------
+        By default, array values are shifted forward by one index.
+
+        >>> df = pl.DataFrame(
+        ...     {"a": [[1, 2, 3], [4, 5, 6]]}, schema={"a": pl.Array(pl.Int64, 3)}
+        ... )
+        >>> df.with_columns(shift=pl.col("a").arr.circshift())
+        shape: (2, 2)
+        ┌───────────────┬───────────────┐
+        │ a             ┆ shift         │
+        │ ---           ┆ ---           │
+        │ array[i64, 3] ┆ array[i64, 3] │
+        ╞═══════════════╪═══════════════╡
+        │ [1, 2, 3]     ┆ [3, 1, 2]     │
+        │ [4, 5, 6]     ┆ [6, 4, 5]     │
+        └───────────────┴───────────────┘
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> df.with_columns(shift=pl.col("a").arr.circshift(-2))
+        shape: (2, 2)
+        ┌───────────────┬───────────────┐
+        │ a             ┆ shift         │
+        │ ---           ┆ ---           │
+        │ array[i64, 3] ┆ array[i64, 3] │
+        ╞═══════════════╪═══════════════╡
+        │ [1, 2, 3]     ┆ [3, 1, 2]     │
+        │ [4, 5, 6]     ┆ [6, 4, 5]     │
+        └───────────────┴───────────────┘
+        """
+        n = parse_as_expression(n)
+        return wrap_expr(self._pyexpr.arr_circshift(n))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2892,6 +2892,57 @@ class Expr:
         n = parse_as_expression(n)
         return self._from_pyexpr(self._pyexpr.shift(n, fill_value))
 
+    def circshift(self, n: int | IntoExprColumn = 1) -> Self:
+        """
+        Circularly shift values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        See Also
+        --------
+        shift
+        shift_and_fill
+
+        Examples
+        --------
+        By default, values are shifted forward by one index.
+
+        >>> df = pl.DataFrame({"a": [1, 2, 3, 4]})
+        >>> df.with_columns(shift=pl.col("a").circshift())
+        shape: (4, 2)
+        ┌─────┬───────┐
+        │ a   ┆ shift │
+        │ --- ┆ ---   │
+        │ i64 ┆ i64   │
+        ╞═════╪═══════╡
+        │ 1   ┆ 4     │
+        │ 2   ┆ 1     │
+        │ 3   ┆ 2     │
+        │ 4   ┆ 3     │
+        └─────┴───────┘
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> df.with_columns(shift=pl.col("a").circshift(-2))
+        shape: (4, 2)
+        ┌─────┬───────┐
+        │ a   ┆ shift │
+        │ --- ┆ ---   │
+        │ i64 ┆ i64   │
+        ╞═════╪═══════╡
+        │ 1   ┆ 3     │
+        │ 2   ┆ 4     │
+        │ 3   ┆ 1     │
+        │ 4   ┆ 2     │
+        └─────┴───────┘
+        """
+        n = parse_as_expression(n)
+        return self._from_pyexpr(self._pyexpr.circshift(n))
+
     def fill_null(
         self,
         value: Any | Expr | None = None,

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -916,6 +916,48 @@ class ExprListNameSpace:
         n = parse_as_expression(n)
         return wrap_expr(self._pyexpr.list_shift(n))
 
+    def circshift(self, n: int | IntoExprColumn = 1) -> Expr:
+        """
+        Circularly shift list values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Examples
+        --------
+        By default, list values are shifted forward by one index.
+
+        >>> df = pl.DataFrame({"a": [[1, 2, 3], [4, 5]]})
+        >>> df.with_columns(shift=pl.col("a").list.circshift())
+        shape: (2, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ shift     │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ list[i64] │
+        ╞═══════════╪═══════════╡
+        │ [1, 2, 3] ┆ [3, 1, 2] │
+        │ [4, 5]    ┆ [5, 4]    │
+        └───────────┴───────────┘
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> df.with_columns(shift=pl.col("a").list.circshift(-2))
+        shape: (2, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ shift     │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ list[i64] │
+        ╞═══════════╪═══════════╡
+        │ [1, 2, 3] ┆ [3, 1, 2] │
+        │ [4, 5]    ┆ [4, 5]    │
+        └───────────┴───────────┘
+        """
+        n = parse_as_expression(n)
+        return wrap_expr(self._pyexpr.list_circshift(n))
+
     def slice(
         self, offset: int | str | Expr, length: int | str | Expr | None = None
     ) -> Expr:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4483,6 +4483,57 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         n = parse_as_expression(n)
         return self._from_pyldf(self._ldf.shift(n, fill_value))
 
+    def circshift(self, n: int | IntoExprColumn = 1) -> Self:
+        """
+        Circularly shift values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Examples
+        --------
+        By default, values are shifted forward by one index.
+
+        >>> lf = pl.LazyFrame(
+        ...     {
+        ...         "a": [1, 2, 3, 4],
+        ...         "b": [5, 6, 7, 8],
+        ...     }
+        ... )
+        >>> lf.circshift().collect()
+        shape: (4, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 4   ┆ 8   │
+        │ 1   ┆ 5   │
+        │ 2   ┆ 6   │
+        │ 3   ┆ 7   │
+        └─────┴─────┘
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> lf.circshift(-2).collect()
+        shape: (4, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 3   ┆ 7   │
+        │ 4   ┆ 8   │
+        │ 1   ┆ 5   │
+        │ 2   ┆ 6   │
+        └─────┴─────┘
+        """
+        n = parse_as_expression(n)
+        return self._from_pyldf(self._ldf.circshift(n))
+
     def slice(self, offset: int, length: int | None = None) -> Self:
         """
         Get a slice of this DataFrame.

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -621,3 +621,37 @@ class ArrayNameSpace:
             [6, null, null]
         ]
         """
+
+    def circshift(self, n: int | IntoExprColumn = 1) -> Series:
+        """
+        Circularly shift array values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Examples
+        --------
+        By default, array values are shifted forward by one index.
+
+        >>> s = pl.Series([[1, 2, 3], [4, 5, 6]], dtype=pl.Array(pl.Int64, 3))
+        >>> s.arr.circshift()
+        shape: (2,)
+        Series: '' [array[i64, 3]]
+        [
+            [3, 1, 2]
+            [6, 4, 5]
+        ]
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> s.arr.circshift(-2)
+        shape: (2,)
+        Series: '' [array[i64, 3]]
+        [
+            [3, 1, 2]
+            [6, 4, 5]
+        ]
+        """

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -712,6 +712,40 @@ class ListNameSpace:
         ]
         """
 
+    def circshift(self, n: int | IntoExprColumn = 1) -> Series:
+        """
+        Circularly shift list values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Examples
+        --------
+        By default, list values are shifted forward by one index.
+
+        >>> s = pl.Series([[1, 2, 3], [4, 5]])
+        >>> s.list.circshift()
+        shape: (2,)
+        Series: '' [list[i64]]
+        [
+                [3, 1, 2]
+                [5, 4]
+        ]
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> s.list.circshift(-2)
+        shape: (2,)
+        Series: '' [list[i64]]
+        [
+                [3, 1, 2]
+                [4, 5]
+        ]
+        """
+
     def slice(self, offset: int | Expr, length: int | Expr | None = None) -> Series:
         """
         Slice every sublist.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5546,6 +5546,45 @@ class Series:
         ]
         """
 
+    def circshift(self, n: int = 1) -> Series:
+        """
+        Circularly shift values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Examples
+        --------
+        By default, values are shifted forward by one index, and the last value is
+        moved to the first index.
+
+        >>> s = pl.Series([1, 2, 3, 4])
+        >>> s.circshift()
+        shape: (4,)
+        Series: '' [i64]
+        [
+                4
+                1
+                2
+                3
+        ]
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> s.circshift(-2)
+        shape: (4,)
+        Series: '' [i64]
+        [
+                3
+                4
+                1
+                2
+        ]
+        """
+
     def zip_with(self, mask: Series, other: Series) -> Self:
         """
         Take values from self or other based on the given mask.

--- a/py-polars/src/expr/array.rs
+++ b/py-polars/src/expr/array.rs
@@ -126,4 +126,8 @@ impl PyExpr {
     fn arr_shift(&self, n: PyExpr) -> Self {
         self.inner.clone().arr().shift(n.inner).into()
     }
+
+    fn arr_circshift(&self, n: PyExpr) -> Self {
+        self.inner.clone().arr().circshift(n.inner).into()
+    }
 }

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -443,6 +443,12 @@ impl PyExpr {
         out.into()
     }
 
+    fn circshift(&self, n: Self) -> Self {
+        let expr = self.inner.clone();
+        let out = expr.circshift(n.inner);
+        out.into()
+    }
+
     fn fill_null(&self, expr: Self) -> Self {
         self.inner.clone().fill_null(expr.inner).into()
     }

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -118,6 +118,10 @@ impl PyExpr {
         self.inner.clone().list().shift(periods.inner).into()
     }
 
+    fn list_circshift(&self, periods: PyExpr) -> Self {
+        self.inner.clone().list().circshift(periods.inner).into()
+    }
+
     fn list_slice(&self, offset: PyExpr, length: Option<PyExpr>) -> Self {
         let length = match length {
             Some(i) => i.inner,

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -997,6 +997,12 @@ impl PyLazyFrame {
         out.into()
     }
 
+    fn circshift(&self, n: PyExpr) -> Self {
+        let lf = self.ldf.clone();
+        let out = lf.circshift(n.inner);
+        out.into()
+    }
+
     fn fill_nan(&self, fill_value: PyExpr) -> Self {
         let ldf = self.ldf.clone();
         ldf.fill_nan(fill_value.inner).into()

--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -869,6 +869,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                     return Err(PyNotImplementedError::new_err("shift and fill"))
                 },
                 FunctionExpr::Shift => ("shift",).to_object(py),
+                FunctionExpr::CircShift => ("circshift",).to_object(py),
                 FunctionExpr::DropNans => ("dropnan",).to_object(py),
                 FunctionExpr::DropNulls => ("dropnull",).to_object(py),
                 FunctionExpr::Mode => ("mode",).to_object(py),

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -769,6 +769,21 @@ def test_shift_over_13041() -> None:
     }
 
 
+def test_circshift_over() -> None:
+    df = pl.DataFrame(
+        {
+            "id": [0, 0, 0, 1, 1, 1],
+            "cat_col": pl.Series(["a", "b", "c", "d", "e", "f"], dtype=pl.Categorical),
+        }
+    )
+    result = df.with_columns(pl.col("cat_col").circshift(2).over("id"))
+
+    assert result.to_dict(as_series=False) == {
+        "id": [0, 0, 0, 1, 1, 1],
+        "cat_col": ["b", "c", "a", "e", "f", "d"],
+    }
+
+
 @pytest.mark.parametrize("context", [pl.StringCache(), contextlib.nullcontext()])
 @pytest.mark.parametrize("ordering", ["physical", "lexical"])
 def test_sort_categorical_retain_none(

--- a/py-polars/tests/unit/operations/test_shift.py
+++ b/py-polars/tests/unit/operations/test_shift.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 import pytest
 
 import polars as pl
+from polars import StringCache
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from polars.type_aliases import PolarsDataType
 
 
 def test_shift() -> None:
@@ -137,3 +144,98 @@ def test_shift_and_fill_frame_deprecated() -> None:
 
     expected = pl.LazyFrame({"a": [100, 1, 2], "b": [100, 4, 5]})
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("shift_amt", "idx_out"),
+    [
+        (0, [0, 1, 2]),
+        (1, [2, 0, 1]),
+        (2, [1, 2, 0]),
+        (3, [0, 1, 2]),
+        (-1, [1, 2, 0]),
+        (-2, [2, 0, 1]),
+        (-3, [0, 1, 2]),
+    ],
+)
+@pytest.mark.parametrize(
+    ("values", "dtype"),
+    [
+        ([1, 2, 3], pl.Int32),
+        (["a", "b", "c"], pl.String),
+        (["a", "b", "c"], pl.Categorical),
+        ([[1], [2, 2], [3, 3, 3]], pl.List),
+        ([[1, 1], [2, 2], [3, 3]], pl.Array(pl.Int32, 2)),
+        ([b"0", b"1", b"2"], pl.Binary),
+        ([date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3)], pl.Date),
+        (
+            [datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 3)],
+            pl.Datetime,
+        ),
+    ],
+)
+@StringCache()
+def test_circshift(
+    values: list[Any], dtype: PolarsDataType, shift_amt: int, idx_out: list[int]
+) -> None:
+    a = pl.Series("a", values, dtype=dtype)
+    values_out = [values[i] for i in idx_out]
+    expected = pl.Series("a", values_out, dtype=dtype)
+    assert_series_equal(a.circshift(shift_amt), expected)
+
+
+def test_circshift_frame(fruits_cars: pl.DataFrame) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
+    out = df.select(pl.col("a").circshift(1))
+    assert_series_equal(out["a"], pl.Series("a", [5, 1, 2, 3, 4]))
+
+    res = fruits_cars.lazy().circshift(2).collect()
+    expected = pl.DataFrame(
+        {
+            "A": [4, 5, 1, 2, 3],
+            "fruits": ["apple", "banana", "banana", "banana", "apple"],
+            "B": [2, 1, 5, 4, 3],
+            "cars": ["beetle", "beetle", "beetle", "audi", "beetle"],
+        }
+    )
+    assert_frame_equal(res, expected)
+
+    # negative value
+    res = fruits_cars.lazy().circshift(-2).collect()
+    expected = pl.DataFrame(
+        {
+            "A": [3, 4, 5, 1, 2],
+            "fruits": ["apple", "apple", "banana", "banana", "banana"],
+            "B": [3, 2, 1, 5, 4],
+            "cars": ["beetle", "beetle", "beetle", "beetle", "audi"],
+        }
+    )
+    assert_frame_equal(res, expected)
+
+
+def test_circshift_expr() -> None:
+    ldf = pl.LazyFrame({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]})
+
+    # use exprs
+    out = ldf.select(pl.col("a").circshift(n=pl.col("b").min())).collect()
+    assert out.to_dict(as_series=False) == {"a": [5, 1, 2, 3, 4]}
+
+    out = ldf.select(pl.col("a").circshift(pl.col("b").min())).collect()
+    assert out.to_dict(as_series=False) == {"a": [5, 1, 2, 3, 4]}
+
+    # use df method
+    out = ldf.circshift(pl.lit(3)).collect()
+    assert out.to_dict(as_series=False) == {
+        "a": [3, 4, 5, 1, 2],
+        "b": [3, 4, 5, 1, 2],
+    }
+    out = ldf.circshift(pl.lit(2)).collect()
+    assert out.to_dict(as_series=False) == {"a": [4, 5, 1, 2, 3], "b": [4, 5, 1, 2, 3]}
+
+
+def test_circshift_categorical() -> None:
+    df = pl.Series("a", ["a", "b"], dtype=pl.Categorical).to_frame()
+
+    s = df.with_columns(pl.col("a").circshift())["a"]
+    assert s.dtype == pl.Categorical
+    assert s.to_list() == ["b", "a"]


### PR DESCRIPTION
Implements #16322.

```python
pl.Series([1, 2, 3, 4]).circshift(-2)
# shape: (4,)
# Series: '' [i64]
# [
#         3
#         4
#         1
#         2
# ]

pl.Series([[1], [1, 2], [1, 2, 3]]).list.circshift()
# shape: (3,)
# Series: '' [list[i64]]
# [
#         [1]
#         [2, 1]
#         [3, 1, 2]
# ]
```
etc.