### PR TITLE
refactor(python): Move `DataFrame.to_numpy` implementation to Rust side

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1565,14 +1565,10 @@ class DataFrame:
         rec.array([(1, 6.5, 'a'), (2, 7. , 'b'), (3, 8.5, 'c')],
                   dtype=[('foo', 'u1'), ('bar', '<f4'), ('ham', '<U1')])
         """
-
-        def raise_on_copy(msg: str) -> None:
-            if not allow_copy and not self.is_empty():
-                msg = f"copy not allowed: {msg}"
-                raise RuntimeError(msg)
-
         if structured:
-            raise_on_copy("cannot create structured array without copying data")
+            if not allow_copy and not self.is_empty():
+                msg = "copy not allowed: cannot create structured array without copying data"
+                raise RuntimeError(msg)
 
             arrays = []
             struct_dtype = []
@@ -1588,19 +1584,7 @@ class DataFrame:
                 out[c] = arrays[idx]
             return out
 
-        if order == "fortran":
-            array = self._df.to_numpy_view()
-            if array is not None:
-                if writable and not array.flags.writeable:
-                    raise_on_copy("cannot create writable array without copying data")
-                    array = array.copy()
-                return array
-
-        raise_on_copy(
-            "only numeric data without nulls in Fortran-like order can be converted without copy"
-        )
-
-        out = self._df.to_numpy(order)
+        out = self._df.to_numpy(order, writable=writable, allow_copy=allow_copy)
 
         if out is None:
             return np.vstack(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1601,6 +1601,7 @@ class DataFrame:
         )
 
         out = self._df.to_numpy(order)
+
         if out is None:
             return np.vstack(
                 [

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1584,17 +1584,7 @@ class DataFrame:
                 out[c] = arrays[idx]
             return out
 
-        out = self._df.to_numpy(order, writable=writable, allow_copy=allow_copy)
-
-        if out is None:
-            return np.vstack(
-                [
-                    self.to_series(i).to_numpy(use_pyarrow=use_pyarrow)
-                    for i in range(self.width)
-                ]
-            ).T
-
-        return out
+        return self._df.to_numpy(order, writable=writable, allow_copy=allow_copy)
 
     @overload
     def to_jax(

--- a/py-polars/src/interop/numpy/to_numpy_df.rs
+++ b/py-polars/src/interop/numpy/to_numpy_df.rs
@@ -13,88 +13,95 @@ use crate::dataframe::PyDataFrame;
 #[pymethods]
 #[allow(clippy::wrong_self_convention)]
 impl PyDataFrame {
+    /// Convert this DataFrame to a NumPy ndarray.
+    fn to_numpy(&self, py: Python, order: Wrap<IndexOrder>) -> Option<PyObject> {
+        df_to_numpy(py, &self.df, order.0)
+    }
+
     /// Create a view of the data as a NumPy ndarray.
     ///
     /// WARNING: The resulting view will show the underlying value for nulls,
     /// which may be any value. The caller is responsible for handling nulls
     /// appropriately.
-    pub fn to_numpy_view(&self, py: Python) -> Option<PyObject> {
-        if self.df.is_empty() {
-            return None;
-        }
-        let first = self.df.get_columns().first().unwrap().dtype();
-        // TODO: Support Datetime/Duration types
-        if !first.is_numeric() {
-            return None;
-        }
-        if !self
-            .df
-            .get_columns()
-            .iter()
-            .all(|s| s.null_count() == 0 && s.dtype() == first && s.chunks().len() == 1)
-        {
-            return None;
-        }
+    fn to_numpy_view(&self, py: Python) -> Option<PyObject> {
+        try_df_to_numpy_view(py, &self.df)
+    }
+}
 
-        let owner = self.clone().into_py(py); // Keep the DataFrame memory alive.
+fn df_to_numpy(py: Python, df: &DataFrame, order: IndexOrder) -> Option<PyObject> {
+    let st = dtypes_to_supertype(df.iter().map(|s| s.dtype())).ok()?;
 
-        fn get_ptr<T>(py: Python, columns: &[Series], owner: PyObject) -> Option<PyObject>
-        where
-            T: PolarsNumericType,
-            T::Native: Element,
-        {
-            let slices = columns
-                .iter()
-                .map(|s| {
-                    let ca: &ChunkedArray<T> = s.unpack().unwrap();
-                    ca.cont_slice().unwrap()
-                })
-                .collect::<Vec<_>>();
+    let np_array = match st {
+        dt if dt.is_numeric() => with_match_physical_numeric_polars_type!(dt, |$T| {
+            df.to_ndarray::<$T>(order).ok()?.into_pyarray_bound(py).into_py(py)
+        }),
+        _ => return None,
+    };
+    Some(np_array)
+}
 
-            let first = slices.first().unwrap();
-            unsafe {
-                let mut end_ptr = first.as_ptr().add(first.len());
-                // Check if all arrays are from the same buffer
-                let all_contiguous = slices[1..].iter().all(|slice| {
-                    let valid = slice.as_ptr() == end_ptr;
-
-                    end_ptr = slice.as_ptr().add(slice.len());
-
-                    valid
-                });
-
-                if all_contiguous {
-                    let start_ptr = first.as_ptr();
-                    let dtype = T::Native::get_dtype_bound(py);
-                    let dims = [first.len(), columns.len()].into_dimension();
-                    Some(create_borrowed_np_array::<_>(
-                        py,
-                        dtype,
-                        dims,
-                        flags::NPY_ARRAY_FARRAY_RO,
-                        start_ptr as _,
-                        owner,
-                    ))
-                } else {
-                    None
-                }
-            }
-        }
-        with_match_physical_numeric_polars_type!(first, |$T| {
-            get_ptr::<$T>(py, self.df.get_columns(), owner)
-        })
+fn try_df_to_numpy_view(py: Python, df: &DataFrame) -> Option<PyObject> {
+    if df.is_empty() {
+        return None;
+    }
+    let first = df.get_columns().first().unwrap().dtype();
+    // TODO: Support Datetime/Duration types
+    if !first.is_numeric() {
+        return None;
+    }
+    if !df
+        .get_columns()
+        .iter()
+        .all(|s| s.null_count() == 0 && s.dtype() == first && s.chunks().len() == 1)
+    {
+        return None;
     }
 
-    /// Convert this DataFrame to a NumPy ndarray.
-    pub fn to_numpy(&self, py: Python, order: Wrap<IndexOrder>) -> Option<PyObject> {
-        let st = dtypes_to_supertype(self.df.iter().map(|s| s.dtype())).ok()?;
+    let owner = PyDataFrame::from(df.clone()).into_py(py); // Keep the DataFrame memory alive.
 
-        let pyarray = match st {
-            dt if dt.is_numeric() => with_match_physical_numeric_polars_type!(dt, |$T| {
-                self.df.to_ndarray::<$T>(order.0).ok()?.into_pyarray_bound(py).into_py(py)
-            }),
-            _ => return None,
-        };
-        Some(pyarray)
+    with_match_physical_numeric_polars_type!(first, |$T| {
+        get_ptr::<$T>(py, df.get_columns(), owner)
+    })
+}
+fn get_ptr<T>(py: Python, columns: &[Series], owner: PyObject) -> Option<PyObject>
+where
+    T: PolarsNumericType,
+    T::Native: Element,
+{
+    let slices = columns
+        .iter()
+        .map(|s| {
+            let ca: &ChunkedArray<T> = s.unpack().unwrap();
+            ca.cont_slice().unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    let first = slices.first().unwrap();
+    unsafe {
+        let mut end_ptr = first.as_ptr().add(first.len());
+        // Check if all arrays are from the same buffer
+        let all_contiguous = slices[1..].iter().all(|slice| {
+            let valid = slice.as_ptr() == end_ptr;
+
+            end_ptr = slice.as_ptr().add(slice.len());
+
+            valid
+        });
+
+        if all_contiguous {
+            let start_ptr = first.as_ptr();
+            let dtype = T::Native::get_dtype_bound(py);
+            let dims = [first.len(), columns.len()].into_dimension();
+            Some(create_borrowed_np_array::<_>(
+                py,
+                dtype,
+                dims,
+                flags::NPY_ARRAY_FARRAY_RO,
+                start_ptr as _,
+                owner,
+            ))
+        } else {
+            None
+        }
     }
 }

--- a/py-polars/src/interop/numpy/to_numpy_df.rs
+++ b/py-polars/src/interop/numpy/to_numpy_df.rs
@@ -169,16 +169,17 @@ fn try_df_to_numpy_numeric_supertype(
     Some(np_array)
 }
 fn df_columns_to_numpy(py: Python, df: &DataFrame, writable: bool) -> PyResult<PyObject> {
-    let series = df
+    let np_arrays = df
         .iter()
         .map(|s| series_to_numpy(py, s, writable, true).unwrap());
 
-    let list = PyList::new_bound(py, series);
+    // TODO: Handle multidimensional column arrays
+
     let numpy = PyModule::import_bound(py, "numpy")?;
     let arr = numpy
-        .getattr("vstack")
+        .getattr(intern!(py, "vstack"))
         .unwrap()
-        .call1((list,))?
-        .getattr("T")?;
+        .call1((PyList::new_bound(py, np_arrays),))?
+        .getattr(intern!(py, "T"))?;
     Ok(arr.into())
 }

--- a/py-polars/src/interop/numpy/to_numpy_df.rs
+++ b/py-polars/src/interop/numpy/to_numpy_df.rs
@@ -11,7 +11,6 @@ use crate::conversion::Wrap;
 use crate::dataframe::PyDataFrame;
 
 #[pymethods]
-#[allow(clippy::wrong_self_convention)]
 impl PyDataFrame {
     /// Convert this DataFrame to a NumPy ndarray.
     fn to_numpy(&self, py: Python, order: Wrap<IndexOrder>) -> Option<PyObject> {

--- a/py-polars/src/interop/numpy/to_numpy_series.rs
+++ b/py-polars/src/interop/numpy/to_numpy_series.rs
@@ -41,7 +41,12 @@ impl PySeries {
 }
 
 /// Convert a Series to a NumPy ndarray.
-fn series_to_numpy(py: Python, s: &Series, writable: bool, allow_copy: bool) -> PyResult<PyObject> {
+pub(super) fn series_to_numpy(
+    py: Python,
+    s: &Series,
+    writable: bool,
+    allow_copy: bool,
+) -> PyResult<PyObject> {
     if s.is_empty() {
         // Take this path to ensure a writable array.
         // This does not actually copy data for an empty Series.

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -152,7 +152,7 @@ def test_df_to_numpy_structured_not_zero_copy() -> None:
 
 def test_df_to_numpy_writable_not_zero_copy() -> None:
     df = pl.DataFrame({"a": [1, 2]})
-    msg = "cannot create writable array without copying data"
+    msg = "copy not allowed: cannot create a writable array without copying data"
     with pytest.raises(RuntimeError, match=msg):
         df.to_numpy(allow_copy=False, writable=True)
 

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -10,6 +10,8 @@ from numpy.testing import assert_array_equal, assert_equal
 import polars as pl
 
 if TYPE_CHECKING:
+    import numpy.typing as npt
+
     from polars.type_aliases import IndexOrder
 
 
@@ -161,3 +163,21 @@ def test_df_to_numpy_not_zero_copy() -> None:
     df = pl.DataFrame({"a": [1, 2, None]})
     with pytest.raises(RuntimeError):
         df.to_numpy(allow_copy=False)
+
+
+@pytest.mark.parametrize(
+    ("schema", "expected_dtype"),
+    [
+        ({"a": pl.Int8, "b": pl.Int8}, np.int8),
+        ({"a": pl.Int8, "b": pl.UInt16}, np.int32),
+        ({"a": pl.Int8, "b": pl.String}, np.object_),
+    ],
+)
+def test_df_to_numpy_empty_dtype_viewable(
+    schema: dict[str, pl.PolarsDataType], expected_dtype: npt.DTypeLike
+) -> None:
+    df = pl.DataFrame(schema=schema)
+    result = df.to_numpy(allow_copy=False)
+    assert result.shape == (0, 2)
+    assert result.dtype == expected_dtype
+    assert result.flags.writeable is True

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -26,7 +26,7 @@ def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:
 
 
 def assert_allow_copy_false_raises(s: pl.Series) -> None:
-    with pytest.raises(ValueError, match="cannot return a zero-copy array"):
+    with pytest.raises(RuntimeError, match="copy not allowed"):
         s.to_numpy(use_pyarrow=False, allow_copy=False)
 
 


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

This is required to facilitate recursive handling of Structs.