### PR TITLE
fix(python): Fix `DataFrame.to_numpy` for Struct columns when `structured=True`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -78,6 +78,7 @@ from polars.datatypes import (
     Int64,
     Object,
     String,
+    Struct,
     UInt16,
     UInt32,
     UInt64,
@@ -1573,7 +1574,15 @@ class DataFrame:
             arrays = []
             struct_dtype = []
             for s in self.iter_columns():
-                arr = s.to_numpy(use_pyarrow=use_pyarrow)
+                if s.dtype == Struct:
+                    arr = s.struct.unnest().to_numpy(
+                        structured=True,
+                        allow_copy=True,
+                        use_pyarrow=use_pyarrow,
+                    )
+                else:
+                    arr = s.to_numpy(use_pyarrow=use_pyarrow)
+
                 if s.dtype == String and s.null_count() == 0:
                     arr = arr.astype(str, copy=False)
                 arrays.append(arr)

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -181,3 +181,27 @@ def test_df_to_numpy_empty_dtype_viewable(
     assert result.shape == (0, 2)
     assert result.dtype == expected_dtype
     assert result.flags.writeable is True
+
+
+def test_df_to_numpy_structured_nested() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [3.0, 4.0],
+            "c": [{"x": "a", "y": 1.0}, {"x": "b", "y": 2.0}],
+        }
+    )
+    result = df.to_numpy(structured=True, use_pyarrow=False)
+
+    expected = np.array(
+        [
+            (1, 3.0, ("a", 1.0)),
+            (2, 4.0, ("b", 2.0)),
+        ],
+        dtype=[
+            ("a", "<i8"),
+            ("b", "<f8"),
+            ("c", [("x", "<U1"), ("y", "<f8")]),
+        ],
+    )
+    assert_array_equal(result, expected)


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

Structs were just converted to an object type, but it makes much more sense for them to be nested structured arrays, which is supported by NumPy.