### PR TITLE
fix(rust): correct AExpr.to_field for bitwise and logical and/or

### DIFF
--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -75,12 +75,12 @@ impl AExpr {
                     | Operator::Gt
                     | Operator::Eq
                     | Operator::NotEq
-                    | Operator::And
+                    | Operator::LogicalAnd
                     | Operator::LtEq
                     | Operator::GtEq
                     | Operator::NotEqValidity
                     | Operator::EqValidity
-                    | Operator::Or => {
+                    | Operator::LogicalOr => {
                         let out_field;
                         let out_name = {
                             out_field = arena.get(*left).to_field(schema, ctxt, arena)?;

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -695,3 +695,10 @@ def test_resolved_names_15442() -> None:
 def test_list_sum_bool_schema() -> None:
     q = pl.LazyFrame({"x": [[True, True, False]]})
     assert q.select(pl.col("x").list.sum()).schema["x"] == pl.UInt32
+
+
+@pytest.mark.parametrize("op", ["and_", "or_"])
+def test_bitwise_integral_schema(op: str) -> None:
+    df = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
+    q = df.select(getattr(pl.col("a"), op)(pl.col("b")))
+    assert q.schema["a"] == df.schema["a"]


### PR DESCRIPTION
AExpr.to_field would incorrectly state that the bitwise and/or of integral columns was boolean, and conversely that the logical and/or was the common supertype. Fix this by matching on the correct operator names.

- Closes #16359