### PR TITLE
feat(python): Add "ignore_spaces" to `alpha` and `alphanumeric` selectors, add "ascii_only" to `digit`

### DIFF
--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -57,17 +57,43 @@ def test_selector_all(df: pl.DataFrame) -> None:
 
 def test_selector_alpha() -> None:
     df = pl.DataFrame(
-        schema=["Hello123", "こんにちは (^_^)", "مرحبا", "你好!", "World"],
+        schema=["Hello 123", "こんにちは (^_^)", "مرحبا", "你好!", "World"],
     )
     # alphabetical-only (across all languages)
     assert expand_selector(df, cs.alpha()) == ("مرحبا", "World")
     assert expand_selector(df, cs.alpha(ascii_only=True)) == ("World",)
-    assert expand_selector(df, ~cs.alpha()) == ("Hello123", "こんにちは (^_^)", "你好!")
+    assert expand_selector(df, ~cs.alpha()) == (
+        "Hello 123",
+        "こんにちは (^_^)",
+        "你好!",
+    )
+    assert expand_selector(df, ~cs.alpha(ignore_spaces=True)) == (
+        "Hello 123",
+        "こんにちは (^_^)",
+        "你好!",
+    )
 
     # alphanumeric-only (across all languages)
-    assert expand_selector(df, cs.alphanumeric()) == ("Hello123", "مرحبا", "World")
-    assert expand_selector(df, cs.alphanumeric(True)) == ("Hello123", "World")
-    assert expand_selector(df, ~cs.alphanumeric()) == ("こんにちは (^_^)", "你好!")
+    assert expand_selector(df, cs.alphanumeric(True)) == ("World",)
+    assert expand_selector(df, ~cs.alphanumeric()) == (
+        "Hello 123",
+        "こんにちは (^_^)",
+        "你好!",
+    )
+    assert expand_selector(df, ~cs.alphanumeric(True, ignore_spaces=True)) == (
+        "こんにちは (^_^)",
+        "مرحبا",
+        "你好!",
+    )
+    assert expand_selector(df, cs.alphanumeric(ignore_spaces=True)) == (
+        "Hello 123",
+        "مرحبا",
+        "World",
+    )
+    assert expand_selector(df, ~cs.alphanumeric(ignore_spaces=True)) == (
+        "こんにちは (^_^)",
+        "你好!",
+    )
 
 
 def test_selector_by_dtype(df: pl.DataFrame) -> None:
@@ -298,6 +324,10 @@ def test_selector_digit() -> None:
     df = pl.DataFrame(schema=["Portfolio", "Year", "2000", "2010", "2020", "✌️"])
     assert expand_selector(df, cs.digit()) == ("2000", "2010", "2020")
     assert expand_selector(df, ~cs.digit()) == ("Portfolio", "Year", "✌️")
+
+    df = pl.DataFrame({"১৯৯৯": [1999], "২০৭৭": [2077], "3000": [3000]})
+    assert expand_selector(df, cs.digit()) == tuple(df.columns)
+    assert expand_selector(df, cs.digit(ascii_only=True)) == ("3000",)
 
 
 def test_selector_drop(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -328,6 +328,7 @@ def test_selector_digit() -> None:
     df = pl.DataFrame({"১৯৯৯": [1999], "২০৭৭": [2077], "3000": [3000]})
     assert expand_selector(df, cs.digit()) == tuple(df.columns)
     assert expand_selector(df, cs.digit(ascii_only=True)) == ("3000",)
+    assert expand_selector(df, (cs.digit() - cs.digit(True))) == ("১৯৯৯", "২০৭৭")
 
 
 def test_selector_drop(df: pl.DataFrame) -> None:


### PR DESCRIPTION
## Update

Builds on https://github.com/pola-rs/polars/pull/16310.

#### Improvements:

* Allows alpha/alphanumeric matches to be determined independent of the presence of spaces (eg: _"This Is A Column"_ can optionally still be considered alphanumeric).
* Can distinguish between unicode digits (matched by default) and ascii-only digits.

#### Also: 

* Improved selector typing (able to remove some `type: ignore` directives).

## Examples
```python
import polars.selectors as cs
import polars as pl

df = pl.DataFrame({
    "FirstCol": [100, 200, 300],
    "2ndCol": [400, 500, 600],
    "Last Col": [700, 800, 900],
})
```
Alpha/alphanumeric matches with/without spaces:
```python
df.select(cs.alpha())
# ┌──────────┐
# │ FirstCol │
# │ ---      │
# │ i64      │
# ╞══════════╡
# │ 100      │
# │ 200      │
# │ 300      │
# └──────────┘

df.select(cs.alpha(ignore_spaces=True))
# ┌──────────┬──────────┐
# │ FirstCol ┆ Last Col │
# │ ---      ┆ ---      │
# │ i64      ┆ i64      │
# ╞══════════╪══════════╡
# │ 100      ┆ 700      │
# │ 200      ┆ 800      │
# │ 300      ┆ 900      │
# └──────────┴──────────┘

df.select(cs.alphanumeric())
# ┌──────────┬────────┐
# │ FirstCol ┆ 2ndCol │
# │ ---      ┆ ---    │
# │ i64      ┆ i64    │
# ╞══════════╪════════╡
# │ 100      ┆ 400    │
# │ 200      ┆ 500    │
# │ 300      ┆ 600    │
# └──────────┴────────┘

df.select(cs.alphanumeric(ignore_spaces=True))
# ┌──────────┬────────┬──────────┐
# │ FirstCol ┆ 2ndCol ┆ Last Col │
# │ ---      ┆ ---    ┆ ---      │
# │ i64      ┆ i64    ┆ i64      │
# ╞══════════╪════════╪══════════╡
# │ 100      ┆ 400    ┆ 700      │
# │ 200      ┆ 500    ┆ 800      │
# │ 300      ┆ 600    ┆ 900      │
# └──────────┴────────┴──────────┘
```
Digit matches, unicode/ascii-only:
```python
df = pl.DataFrame({
    "१९९९": [1999],
    "२०७७": [2077],
    "3000": [3000],
})

df.select(cs.digit()).columns
# ['१९९९', '२०७७', '3000']

df.select(cs.digit(ascii_only=True)).columns
# ['3000']
```