### PR TITLE
fix(rust): fix a printing issue in IR::Filter

### DIFF
--- a/crates/polars-plan/src/logical_plan/alp/format.rs
+++ b/crates/polars-plan/src/logical_plan/alp/format.rs
@@ -191,8 +191,8 @@ impl<'a> IRDisplay<'a> {
             Filter { predicate, input } => {
                 let predicate = self.display_expr(predicate);
                 // this one is writeln because we don't increase indent (which inserts a line)
-                writeln!(f, "{:indent$}FILTER {predicate} FROM", "")?;
-                self.with_root(*input)._format(f, indent)
+                write!(f, "{:indent$}FILTER {predicate} FROM", "")?;
+                self.with_root(*input)._format(f, sub_indent)
             },
             DataFrameScan {
                 schema,


### PR DESCRIPTION
This resolves a small issue introduced by #16191, where the `IR::Filter` is printed incorrectly.