### PR TITLE
fix(python): Fix `DataFrame.to_numpy` for Array/Struct types

### DIFF
--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -205,3 +205,17 @@ def test_df_to_numpy_structured_nested() -> None:
         ],
     )
     assert_array_equal(result, expected)
+
+
+def test_df_to_numpy_stacking_array() -> None:
+    df = pl.DataFrame(
+        {"A": [[1, 2]], "B": 1},
+        schema={"A": pl.Array(pl.Int64, 2), "B": pl.Int32},
+    )
+    result = df.to_numpy(use_pyarrow=False)
+
+    expected = np.array([[np.array([1, 2]), 1]], dtype=np.object_)
+
+    assert result.shape == (1, 2)
+    assert result[0].shape == (2,)
+    assert_array_equal(result[0][0], expected[0][0])

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -209,8 +209,8 @@ def test_df_to_numpy_structured_nested() -> None:
 
 def test_df_to_numpy_stacking_array() -> None:
     df = pl.DataFrame(
-        {"A": [[1, 2]], "B": 1},
-        schema={"A": pl.Array(pl.Int64, 2), "B": pl.Int32},
+        {"a": [[1, 2]], "b": 1},
+        schema={"a": pl.Array(pl.Int64, 2), "b": pl.Int32},
     )
     result = df.to_numpy(use_pyarrow=False)
 
@@ -219,3 +219,12 @@ def test_df_to_numpy_stacking_array() -> None:
     assert result.shape == (1, 2)
     assert result[0].shape == (2,)
     assert_array_equal(result[0][0], expected[0][0])
+
+
+def test_df_to_numpy_stacking_string() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    result = df.to_numpy(use_pyarrow=False)
+
+    expected = np.array([[1, "x"], [2, "y"], [3, "z"]], dtype=np.object_)
+
+    assert_array_equal(result, expected)


### PR DESCRIPTION
The vstack operation would lead to errors / incorrect results because the numpy array representing these columns has more than 1 dimension. The arrays are now converted to 1D object arrays before stacking.

See https://github.com/pola-rs/polars/issues/14334#issuecomment-2070955932