### PR TITLE
feat(python): Respect index order in `DataFrame.to_numpy` also for non-numeric frames

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1518,9 +1518,7 @@ class DataFrame:
             Fortran-like. In general, using the Fortran-like index order is faster.
             However, the C-like order might be more appropriate to use for downstream
             applications to prevent cloning data, e.g. when reshaping into a
-            one-dimensional array. Note that this option only takes effect if
-            `structured` is set to `False` and the DataFrame dtypes allow a
-            global dtype for all columns.
+            one-dimensional array.
         allow_copy
             Allow memory to be copied to perform the conversion. If set to `False`,
             causes conversions that are not zero-copy to fail.

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -220,13 +220,18 @@ def test_df_to_numpy_stacking_array() -> None:
     assert_array_equal(result[0][0], expected[0][0])
 
 
-def test_df_to_numpy_stacking_string() -> None:
+@pytest.mark.parametrize("order", ["c", "fortran"])
+def test_df_to_numpy_stacking_string(order: IndexOrder) -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-    result = df.to_numpy()
+    result = df.to_numpy(order=order)
 
     expected = np.array([[1, "x"], [2, "y"], [3, "z"]], dtype=np.object_)
 
     assert_array_equal(result, expected)
+    if order == "c":
+        assert result.flags.c_contiguous is True
+    else:
+        assert result.flags.f_contiguous is True
 
 
 def test_to_numpy_chunked_16375() -> None:


### PR DESCRIPTION
`vstack` followed by a transpose will result in an F-contiguous array. `column_stack` creates a C-contiguous array. So we can use one or the other depending on the order requested by the user.

Structured arrays are both C and F contiguous since they are 1-dimensional.