### PR TITLE
depr(python): Deprecate `use_pyarrow` parameter for `to_numpy` methods

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1784,7 +1784,7 @@ class DataFrame:
             if return_type == "array":
                 return jx.numpy.asarray(
                     # note: jax arrays are immutable, so can avoid a copy (vs torch)
-                    a=frame.to_numpy(writable=False, use_pyarrow=False, order=order),
+                    a=frame.to_numpy(writable=False, order=order),
                     order="K",
                 )
             elif return_type == "dict":
@@ -2001,7 +2001,7 @@ class DataFrame:
 
         if return_type == "tensor":
             # note: torch tensors are not immutable, so we must consider them writable
-            return torch.from_numpy(frame.to_numpy(writable=True, use_pyarrow=False))
+            return torch.from_numpy(frame.to_numpy(writable=True))
 
         elif return_type == "dict":
             if label is not None:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1500,7 +1500,7 @@ class DataFrame:
         order: IndexOrder = "fortran",
         allow_copy: bool = True,
         writable: bool = False,
-        use_pyarrow: bool = True,
+        use_pyarrow: bool | None = None,
     ) -> np.ndarray[Any, Any]:
         """
         Convert this DataFrame to a NumPy ndarray.
@@ -1528,11 +1528,15 @@ class DataFrame:
             Ensure the resulting array is writable. This will force a copy of the data
             if the array was created without copy, as the underlying Arrow data is
             immutable.
+
         use_pyarrow
             Use `pyarrow.Array.to_numpy
             <https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy>`_
 
-            function for the conversion to numpy if necessary.
+            function for the conversion to NumPy if necessary.
+
+            .. deprecated:: 0.20.28
+                Polars now uses its native engine by default for conversion to NumPy.
 
         Examples
         --------
@@ -1566,6 +1570,15 @@ class DataFrame:
         rec.array([(1, 6.5, 'a'), (2, 7. , 'b'), (3, 8.5, 'c')],
                   dtype=[('foo', 'u1'), ('bar', '<f4'), ('ham', '<U1')])
         """
+        if use_pyarrow is not None:
+            issue_deprecation_warning(
+                "The `use_pyarrow` parameter for `DataFrame.to_numpy` is deprecated."
+                " Polars now uses its native engine by default for conversion to NumPy.",
+                version="0.20.28",
+            )
+        else:
+            use_pyarrow = False
+
         if structured:
             if not allow_copy and not self.is_empty():
                 msg = "copy not allowed: cannot create structured array without copying data"

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1576,8 +1576,6 @@ class DataFrame:
                 " Polars now uses its native engine by default for conversion to NumPy.",
                 version="0.20.28",
             )
-        else:
-            use_pyarrow = False
 
         if structured:
             if not allow_copy and not self.is_empty():

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4421,7 +4421,7 @@ class Series:
         *,
         writable: bool = False,
         allow_copy: bool = True,
-        use_pyarrow: bool = True,
+        use_pyarrow: bool | None = None,
         zero_copy_only: bool | None = None,
     ) -> np.ndarray[Any, Any]:
         """
@@ -4444,11 +4444,17 @@ class Series:
         allow_copy
             Allow memory to be copied to perform the conversion. If set to `False`,
             causes conversions that are not zero-copy to fail.
+
         use_pyarrow
             First convert to PyArrow, then call `pyarrow.Array.to_numpy
             <https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy>`_
             to convert to NumPy. If set to `False`, Polars' own conversion logic is
             used.
+
+            .. deprecated:: 0.20.28
+                Polars now uses its native engine by default for conversion to NumPy.
+                To use PyArrow's engine, call `.to_arrow().to_numpy()` instead.
+
         zero_copy_only
             Raise an exception if the conversion to a NumPy would require copying
             the underlying data. Data copy occurs, for example, when the Series contains
@@ -4474,6 +4480,16 @@ class Series:
                 version="0.20.10",
             )
             allow_copy = not zero_copy_only
+
+        if use_pyarrow is not None:
+            issue_deprecation_warning(
+                "The `use_pyarrow` parameter for `Series.to_numpy` is deprecated."
+                " Polars now uses its native engine for conversion to NumPy by default."
+                " To use PyArrow's engine, call `.to_arrow().to_numpy()` instead.",
+                version="0.20.28",
+            )
+        else:
+            use_pyarrow = False
 
         if (
             use_pyarrow

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4552,7 +4552,7 @@ class Series:
         with nullcontext() if device is None else jx.default_device(device):
             return jx.numpy.asarray(
                 # note: jax arrays are immutable, so can avoid a copy (vs torch)
-                a=srs.to_numpy(writable=False, use_pyarrow=False),
+                a=srs.to_numpy(writable=False),
                 order="K",
             )
 
@@ -4593,7 +4593,7 @@ class Series:
 
         # we have to build the tensor from a writable array or PyTorch will complain
         # about it (as writing to readonly array results in undefined behavior)
-        numpy_array = srs.to_numpy(writable=True, use_pyarrow=False)
+        numpy_array = srs.to_numpy(writable=True)
         tensor = torch.from_numpy(numpy_array)
 
         # note: named tensors are currently experimental

--- a/py-polars/tests/benchmark/interop/test_numpy.py
+++ b/py-polars/tests/benchmark/interop/test_numpy.py
@@ -42,12 +42,12 @@ def floats_chunked(floats_array: np.ndarray[Any, Any]) -> pl.Series:
 
 
 def test_to_numpy_series_zero_copy(floats: pl.Series) -> None:
-    floats.to_numpy(use_pyarrow=False)
+    floats.to_numpy()
 
 
 def test_to_numpy_series_with_nulls(floats_with_nulls: pl.Series) -> None:
-    floats_with_nulls.to_numpy(use_pyarrow=False)
+    floats_with_nulls.to_numpy()
 
 
 def test_to_numpy_series_chunked(floats_chunked: pl.Series) -> None:
-    floats_chunked.to_numpy(use_pyarrow=False)
+    floats_chunked.to_numpy()

--- a/py-polars/tests/unit/interop/numpy/test_numpy.py
+++ b/py-polars/tests/unit/interop/numpy/test_numpy.py
@@ -50,12 +50,9 @@ def test_asarray(numpy_interop_test_data: Any) -> None:
     assert_array_equal(pl_series_to_numpy_array, numpy_array)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_to_numpy(numpy_interop_test_data: Any, use_pyarrow: bool) -> None:
+def test_to_numpy(numpy_interop_test_data: Any) -> None:
     name, values, pl_dtype, np_dtype = numpy_interop_test_data
-    pl_series_to_numpy_array = pl.Series(name, values, pl_dtype).to_numpy(
-        use_pyarrow=use_pyarrow
-    )
+    pl_series_to_numpy_array = pl.Series(name, values, pl_dtype).to_numpy()
     numpy_array = np.asarray(values, dtype=np_dtype)
     assert_array_equal(pl_series_to_numpy_array, numpy_array)
 

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -112,12 +112,11 @@ def test_numpy_preserve_uint64_4112() -> None:
     assert df.to_numpy(structured=True).dtype == np.dtype([("a", "uint64")])
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_df_to_numpy_decimal(use_pyarrow: bool) -> None:
+def test_df_to_numpy_decimal() -> None:
     decimal_data = [D("1.234"), D("2.345"), D("-3.456")]
     df = pl.Series("n", decimal_data).to_frame()
 
-    result = df.to_numpy(use_pyarrow=use_pyarrow)
+    result = df.to_numpy()
 
     expected = np.array(decimal_data).reshape((-1, 1))
     assert_array_equal(result, expected)
@@ -191,7 +190,7 @@ def test_df_to_numpy_structured_nested() -> None:
             "c": [{"x": "a", "y": 1.0}, {"x": "b", "y": 2.0}],
         }
     )
-    result = df.to_numpy(structured=True, use_pyarrow=False)
+    result = df.to_numpy(structured=True)
 
     expected = np.array(
         [
@@ -212,7 +211,7 @@ def test_df_to_numpy_stacking_array() -> None:
         {"a": [[1, 2]], "b": 1},
         schema={"a": pl.Array(pl.Int64, 2), "b": pl.Int32},
     )
-    result = df.to_numpy(use_pyarrow=False)
+    result = df.to_numpy()
 
     expected = np.array([[np.array([1, 2]), 1]], dtype=np.object_)
 
@@ -223,7 +222,7 @@ def test_df_to_numpy_stacking_array() -> None:
 
 def test_df_to_numpy_stacking_string() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-    result = df.to_numpy(use_pyarrow=False)
+    result = df.to_numpy()
 
     expected = np.array([[1, "x"], [2, "y"], [3, "z"]], dtype=np.object_)
 


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

This is technically a breaking change, because our native engine behaves differently from PyArrow:
* Integer types with nulls become the smallest matching float (`float32` or `float64`) instead of always `float64`.
* Structs become a 2D array instead of a 1D object array of dicts.

Otherwise, behavior is identical.

I'll leave it up to @ritchie46 whether he wants to merge this or wait for a breaking release.