### PR TITLE
feat(rust): Add general metadata structure to `ChunkedArray`

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/boolean.rs
+++ b/crates/polars-core/src/chunked_array/builder/boolean.rs
@@ -21,17 +21,7 @@ impl ChunkedBuilder<bool, BooleanType> for BooleanChunkedBuilder {
 
     fn finish(mut self) -> BooleanChunked {
         let arr = self.array_builder.as_box();
-
-        let mut ca = ChunkedArray {
-            field: Arc::new(self.field),
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: 0,
-            null_count: 0,
-        };
-        ca.compute_len();
-        ca
+        ChunkedArray::new_with_compute_len(Arc::new(self.field), vec![arr])
     }
 
     fn shrink_to_fit(&mut self) {

--- a/crates/polars-core/src/chunked_array/builder/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/mod.rs
@@ -47,13 +47,7 @@ pub trait ListBuilderTrait {
     fn finish(&mut self) -> ListChunked {
         let arr = self.inner_array();
 
-        let mut ca = ListChunked {
-            field: Arc::new(self.field().clone()),
-            chunks: vec![arr],
-            phantom: PhantomData,
-            ..Default::default()
-        };
-        ca.compute_len();
+        let mut ca = ListChunked::new_with_compute_len(Arc::new(self.field().clone()), vec![arr]);
         if self.fast_explode() {
             ca.set_fast_explode()
         }

--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -6,7 +6,6 @@ mod null;
 mod primitive;
 mod string;
 
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use arrow::array::*;

--- a/crates/polars-core/src/chunked_array/builder/primitive.rs
+++ b/crates/polars-core/src/chunked_array/builder/primitive.rs
@@ -27,16 +27,7 @@ where
 
     fn finish(mut self) -> ChunkedArray<T> {
         let arr = self.array_builder.as_box();
-        let mut ca = ChunkedArray {
-            field: Arc::new(self.field),
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: 0,
-            null_count: 0,
-        };
-        ca.compute_len();
-        ca
+        ChunkedArray::new_with_compute_len(Arc::new(self.field), vec![arr])
     }
 
     fn shrink_to_fit(&mut self) {

--- a/crates/polars-core/src/chunked_array/builder/string.rs
+++ b/crates/polars-core/src/chunked_array/builder/string.rs
@@ -52,32 +52,12 @@ impl<T: ViewType + ?Sized> BinViewChunkedBuilder<T> {
 impl StringChunkedBuilder {
     pub fn finish(mut self) -> StringChunked {
         let arr = self.chunk_builder.as_box();
-
-        let mut ca = ChunkedArray {
-            field: self.field,
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: 0,
-            null_count: 0,
-        };
-        ca.compute_len();
-        ca
+        ChunkedArray::new_with_compute_len(self.field, vec![arr])
     }
 }
 impl BinaryChunkedBuilder {
     pub fn finish(mut self) -> BinaryChunked {
         let arr = self.chunk_builder.as_box();
-
-        let mut ca = ChunkedArray {
-            field: self.field,
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: 0,
-            null_count: 0,
-        };
-        ca.compute_len();
-        ca
+        ChunkedArray::new_with_compute_len(self.field, vec![arr])
     }
 }

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -306,7 +306,13 @@ impl BinaryChunked {
             .map(|arr| arr.to_utf8view_unchecked().boxed())
             .collect();
         let field = Arc::new(Field::new(self.name(), DataType::String));
-        StringChunked::from_chunks_and_metadata(chunks, field, self.bit_settings, true, true)
+        StringChunked::from_chunks_and_metadata(
+            chunks,
+            field,
+            Arc::new(self.effective_metadata().cast()),
+            true,
+            true,
+        )
     }
 }
 
@@ -318,7 +324,13 @@ impl StringChunked {
             .collect();
         let field = Arc::new(Field::new(self.name(), DataType::Binary));
         unsafe {
-            BinaryChunked::from_chunks_and_metadata(chunks, field, self.bit_settings, true, true)
+            BinaryChunked::from_chunks_and_metadata(
+                chunks,
+                field,
+                Arc::new(self.effective_metadata().cast()),
+                true,
+                true,
+            )
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -1,7 +1,5 @@
 //! Implementations of upstream traits for [`ChunkedArray<T>`]
 use std::borrow::{Borrow, Cow};
-#[cfg(feature = "object")]
-use std::marker::PhantomData;
 
 #[cfg(feature = "object")]
 use arrow::bitmap::{Bitmap, MutableBitmap};
@@ -278,15 +276,9 @@ impl<T: PolarsObject> FromIterator<Option<T>> for ObjectChunked<T> {
             offset: 0,
             len,
         });
-        let mut out = ChunkedArray {
-            field: Arc::new(Field::new("", get_object_type::<T>())),
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: 0,
-            null_count: 0,
-        };
-        out.compute_len();
-        out
+        ChunkedArray::new_with_compute_len(
+            Arc::new(Field::new("", get_object_type::<T>())),
+            vec![arr],
+        )
     }
 }

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -69,7 +69,7 @@ impl<'a, I: Iterator<Item = Option<ArrayBox>>> Iterator for AmortizedListIter<'a
                 unsafe { *self.inner.as_mut() = array_ref };
 
                 // last iteration could have set the sorted flag (e.g. in compute_len)
-                self.series_container.clear_settings();
+                self.series_container.clear_flags();
                 // make sure that the length is correct
                 self.series_container._get_inner_mut().compute_len();
 
@@ -151,7 +151,7 @@ impl ListChunked {
                 vec![inner_values.clone()],
                 &iter_dtype,
             );
-            s.clear_settings();
+            s.clear_flags();
             Box::pin(s)
         };
 

--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -1,7 +1,6 @@
 //! Special list utility methods
 pub(super) mod iterator;
 
-use crate::chunked_array::Settings;
 use crate::prelude::*;
 
 impl ListChunked {
@@ -19,14 +18,14 @@ impl ListChunked {
         field.coerce(DataType::List(Box::new(dtype)));
     }
     pub fn set_fast_explode(&mut self) {
-        self.bit_settings.insert(Settings::FAST_EXPLODE_LIST)
+        Arc::make_mut(self.metadata_mut()).set_fast_explode_list(true);
     }
     pub(crate) fn unset_fast_explode(&mut self) {
-        self.bit_settings.remove(Settings::FAST_EXPLODE_LIST)
+        Arc::make_mut(self.metadata_mut()).set_fast_explode_list(false);
     }
 
     pub fn _can_fast_explode(&self) -> bool {
-        self.bit_settings.contains(Settings::FAST_EXPLODE_LIST)
+        self.effective_metadata().get_fast_explode_list()
     }
 
     /// Set the logical type of the [`ListChunked`].

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -13,7 +13,7 @@ use polars_utils::sync::SyncPtr;
 pub use revmap::*;
 
 use super::*;
-use crate::chunked_array::Settings;
+use crate::chunked_array::metadata::MetadataFlags;
 use crate::prelude::*;
 use crate::series::IsSorted;
 use crate::using_string_cache;
@@ -173,12 +173,12 @@ impl CategoricalChunked {
         }
     }
 
-    pub(crate) fn get_flags(&self) -> Settings {
+    pub(crate) fn get_flags(&self) -> MetadataFlags {
         self.physical().get_flags()
     }
 
     /// Set flags for the Chunked Array
-    pub(crate) fn set_flags(&mut self, mut flags: Settings) {
+    pub(crate) fn set_flags(&mut self, mut flags: MetadataFlags) {
         // We should not set the sorted flag if we are sorting in lexical order
         if self.uses_lexical_ordering() {
             flags.set_sorted_flag(IsSorted::Not)

--- a/crates/polars-core/src/chunked_array/metadata.rs
+++ b/crates/polars-core/src/chunked_array/metadata.rs
@@ -1,0 +1,182 @@
+use std::fmt;
+
+use bitflags::bitflags;
+use polars_utils::IdxSize;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::PolarsDataType;
+use crate::series::IsSorted;
+
+pub struct Metadata<T: PolarsDataType> {
+    flags: MetadataFlags,
+
+    min_value: Option<T::OwnedPhysical>,
+    max_value: Option<T::OwnedPhysical>,
+
+    distinct_count: Option<IdxSize>,
+}
+
+bitflags! {
+    #[derive(Default, Debug, Clone, Copy,PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(transparent))]
+    pub struct MetadataFlags: u8 {
+        const SORTED_ASC = 0x01;
+        const SORTED_DSC = 0x02;
+        const FAST_EXPLODE_LIST = 0x04;
+    }
+}
+
+impl MetadataFlags {
+    pub fn set_sorted_flag(&mut self, sorted: IsSorted) {
+        match sorted {
+            IsSorted::Not => {
+                self.remove(MetadataFlags::SORTED_ASC | MetadataFlags::SORTED_DSC);
+            },
+            IsSorted::Ascending => {
+                self.remove(MetadataFlags::SORTED_DSC);
+                self.insert(MetadataFlags::SORTED_ASC)
+            },
+            IsSorted::Descending => {
+                self.remove(MetadataFlags::SORTED_ASC);
+                self.insert(MetadataFlags::SORTED_DSC)
+            },
+        }
+    }
+
+    pub fn get_sorted_flag(&self) -> IsSorted {
+        if self.contains(MetadataFlags::SORTED_ASC) {
+            IsSorted::Ascending
+        } else if self.contains(MetadataFlags::SORTED_DSC) {
+            IsSorted::Descending
+        } else {
+            IsSorted::Not
+        }
+    }
+}
+
+impl<T: PolarsDataType> Default for Metadata<T> {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl<T: PolarsDataType> Clone for Metadata<T> {
+    fn clone(&self) -> Self {
+        Self {
+            flags: self.flags,
+            min_value: self.min_value.clone(),
+            max_value: self.max_value.clone(),
+            distinct_count: self.distinct_count,
+        }
+    }
+}
+
+impl<T: PolarsDataType> fmt::Debug for Metadata<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Metadata")
+            .field("flags", &self.flags)
+            .field("min_value", &self.min_value)
+            .field("max_value", &self.max_value)
+            .field("distinct_count", &self.distinct_count)
+            .finish()
+    }
+}
+
+impl<T: PolarsDataType> Metadata<T> {
+    pub const DEFAULT: Metadata<T> = Self {
+        flags: MetadataFlags::empty(),
+
+        min_value: None,
+        max_value: None,
+
+        distinct_count: None,
+    };
+
+    pub fn cast<R: PolarsDataType>(&self) -> Metadata<R> {
+        // @TODO: It might be possible to cast the min_value, max_value and distinct_values
+        Metadata {
+            flags: self.flags,
+            min_value: None,
+            max_value: None,
+            distinct_count: None,
+        }
+    }
+
+    pub fn is_sorted_ascending(&self) -> bool {
+        self.flags.contains(MetadataFlags::SORTED_ASC)
+    }
+
+    pub fn set_sorted_ascending(&mut self, value: bool) {
+        self.flags.set(MetadataFlags::SORTED_ASC, value);
+    }
+
+    pub fn is_sorted_descending(&self) -> bool {
+        self.flags.contains(MetadataFlags::SORTED_DSC)
+    }
+
+    pub fn set_sorted_descending(&mut self, value: bool) {
+        self.flags.set(MetadataFlags::SORTED_DSC, value);
+    }
+
+    pub fn get_fast_explode_list(&self) -> bool {
+        self.flags.contains(MetadataFlags::FAST_EXPLODE_LIST)
+    }
+
+    pub fn set_fast_explode_list(&mut self, value: bool) {
+        self.flags.set(MetadataFlags::FAST_EXPLODE_LIST, value);
+    }
+
+    pub fn is_sorted(&self) -> IsSorted {
+        let ascending = self.is_sorted_ascending();
+        let descending = self.is_sorted_descending();
+
+        match (ascending, descending) {
+            (true, false) => IsSorted::Ascending,
+            (false, true) => IsSorted::Descending,
+            (false, false) => IsSorted::Not,
+            (true, true) => unreachable!(),
+        }
+    }
+
+    pub fn set_sorted_flag(&mut self, is_sorted: IsSorted) {
+        let (ascending, descending) = match is_sorted {
+            IsSorted::Ascending => (true, false),
+            IsSorted::Descending => (false, true),
+            IsSorted::Not => (false, false),
+        };
+
+        self.set_sorted_ascending(ascending);
+        self.set_sorted_descending(descending);
+    }
+
+    pub fn set_distinct_count(&mut self, distinct_count: IdxSize) {
+        self.distinct_count = Some(distinct_count);
+    }
+    pub fn set_min_value(&mut self, min_value: T::OwnedPhysical) {
+        self.min_value = Some(min_value);
+    }
+    pub fn set_max_value(&mut self, max_value: T::OwnedPhysical) {
+        self.max_value = Some(max_value);
+    }
+
+    pub fn set_flags(&mut self, flags: MetadataFlags) {
+        self.flags = flags;
+    }
+
+    pub fn get_distinct_count(&self) -> Option<IdxSize> {
+        self.distinct_count
+    }
+
+    pub fn get_min_value(&self) -> Option<&T::OwnedPhysical> {
+        self.min_value.as_ref()
+    }
+
+    pub fn get_max_value(&self) -> Option<&T::OwnedPhysical> {
+        self.max_value.as_ref()
+    }
+
+    pub fn get_flags(&self) -> MetadataFlags {
+        self.flags
+    }
+}

--- a/crates/polars-core/src/chunked_array/object/builder.rs
+++ b/crates/polars-core/src/chunked_array/object/builder.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use super::*;
 use crate::chunked_array::object::registry::{AnonymousObjectBuilder, ObjectRegistry};
 use crate::utils::get_iter_capacity;
@@ -71,14 +69,7 @@ where
 
         self.field.dtype = get_object_type::<T>();
 
-        ChunkedArray {
-            field: Arc::new(self.field),
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: len as IdxSize,
-            null_count,
-        }
+        ChunkedArray::new_with_dims(Arc::new(self.field), vec![arr], len as IdxSize, null_count)
     }
 }
 
@@ -150,14 +141,7 @@ where
             len,
         });
 
-        ObjectChunked {
-            field,
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: len as IdxSize,
-            null_count: 0,
-        }
+        ObjectChunked::new_with_dims(field, vec![arr], len as IdxSize, 0)
     }
 
     pub fn new_from_vec_and_validity(name: &str, v: Vec<T>, validity: Bitmap) -> Self {
@@ -171,14 +155,7 @@ where
             len,
         });
 
-        ObjectChunked {
-            field,
-            chunks: vec![arr],
-            phantom: PhantomData,
-            bit_settings: Default::default(),
-            length: len as IdxSize,
-            null_count: null_count as IdxSize,
-        }
+        ObjectChunked::new_with_dims(field, vec![arr], len as IdxSize, null_count as IdxSize)
     }
 
     pub fn new_empty(name: &str) -> Self {

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -91,8 +91,16 @@ where
         if self.null_count() == self.len() {
             return None;
         }
+
         // There is at least one non-null value.
-        match self.is_sorted_flag() {
+
+        let md = self.effective_metadata();
+
+        if let Some(min) = md.get_min_value() {
+            return Some(*min);
+        }
+
+        match md.is_sorted() {
             IsSorted::Ascending => {
                 let idx = self.first_non_null().unwrap();
                 unsafe { self.get_unchecked(idx) }
@@ -113,7 +121,14 @@ where
             return None;
         }
         // There is at least one non-null value.
-        match self.is_sorted_flag() {
+
+        let md = self.effective_metadata();
+
+        if let Some(max) = md.get_max_value() {
+            return Some(*max);
+        }
+
+        match md.is_sorted() {
             IsSorted::Ascending => {
                 let idx = if T::get_dtype().is_float() {
                     float_arg_max_sorted_ascending(self)
@@ -144,44 +159,54 @@ where
             return None;
         }
         // There is at least one non-null value.
-        match self.is_sorted_flag() {
-            IsSorted::Ascending => {
-                let min = unsafe { self.get_unchecked(self.first_non_null().unwrap()) };
-                let max = {
-                    let idx = if T::get_dtype().is_float() {
-                        float_arg_max_sorted_ascending(self)
-                    } else {
-                        self.last_non_null().unwrap()
+
+        let md = self.effective_metadata();
+
+        let (min, max) = match (md.get_min_value(), md.get_max_value()) {
+            (Some(min), Some(max)) => (*min, *max),
+            (Some(min), None) => (*min, self.max()?),
+            (None, Some(max)) => (self.min()?, *max),
+            (None, None) => match md.is_sorted() {
+                IsSorted::Ascending => {
+                    let min = unsafe { self.get_unchecked(self.first_non_null().unwrap()) };
+                    let max = {
+                        let idx = if T::get_dtype().is_float() {
+                            float_arg_max_sorted_ascending(self)
+                        } else {
+                            self.last_non_null().unwrap()
+                        };
+
+                        unsafe { self.get_unchecked(idx) }
+                    };
+                    min.zip(max)
+                },
+                IsSorted::Descending => {
+                    let min = unsafe { self.get_unchecked(self.last_non_null().unwrap()) };
+                    let max = {
+                        let idx = if T::get_dtype().is_float() {
+                            float_arg_max_sorted_descending(self)
+                        } else {
+                            self.first_non_null().unwrap()
+                        };
+
+                        unsafe { self.get_unchecked(idx) }
                     };
 
-                    unsafe { self.get_unchecked(idx) }
-                };
-                min.zip(max)
-            },
-            IsSorted::Descending => {
-                let min = unsafe { self.get_unchecked(self.last_non_null().unwrap()) };
-                let max = {
-                    let idx = if T::get_dtype().is_float() {
-                        float_arg_max_sorted_descending(self)
-                    } else {
-                        self.first_non_null().unwrap()
-                    };
+                    min.zip(max)
+                },
+                IsSorted::Not => self
+                    .downcast_iter()
+                    .filter_map(MinMaxKernel::min_max_ignore_nan_kernel)
+                    .reduce(|(min1, max1), (min2, max2)| {
+                        (
+                            MinMax::min_ignore_nan(min1, min2),
+                            MinMax::max_ignore_nan(max1, max2),
+                        )
+                    }),
+            }?,
+        };
 
-                    unsafe { self.get_unchecked(idx) }
-                };
-
-                min.zip(max)
-            },
-            IsSorted::Not => self
-                .downcast_iter()
-                .filter_map(MinMaxKernel::min_max_ignore_nan_kernel)
-                .reduce(|(min1, max1), (min2, max2)| {
-                    (
-                        MinMax::min_ignore_nan(min1, min2),
-                        MinMax::max_ignore_nan(max1, max2),
-                    )
-                }),
-        }
+        Some((min, max))
     }
 
     fn mean(&self) -> Option<f64> {

--- a/crates/polars-core/src/chunked_array/ops/append.rs
+++ b/crates/polars-core/src/chunked_array/ops/append.rs
@@ -171,8 +171,10 @@ impl ArrayChunked {
         self.field = Arc::new(Field::new(self.name(), dtype));
 
         let len = self.len();
+
         self.length += other.length;
         self.null_count += other.null_count;
+
         new_chunks(&mut self.chunks, &other.chunks, len);
         self.set_sorted_flag(IsSorted::Not);
         Ok(())

--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -69,7 +69,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
     #[inline]
     pub fn downcast_slices(&self) -> Option<impl DoubleEndedIterator<Item = &[T::Physical<'_>]>> {
-        if self.null_count != 0 {
+        if self.null_count() != 0 {
             return None;
         }
         let arr = self.downcast_iter().next().unwrap();

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -140,7 +140,7 @@ mod inner_mod {
                             *ptr = arr_window;
                         }
                         // reset flags as we reuse this container
-                        series_container.clear_settings();
+                        series_container.clear_flags();
                         // ensure the length is correct
                         series_container._get_inner_mut().compute_len();
                         let s = if size == options.window_size {
@@ -194,7 +194,7 @@ mod inner_mod {
                             *ptr = arr_window;
                         }
                         // reset flags as we reuse this container
-                        series_container.clear_settings();
+                        series_container.clear_flags();
                         // ensure the length is correct
                         series_container._get_inner_mut().compute_len();
                         let s = f(&series_container);

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -63,7 +63,7 @@ pub struct FalseT;
 /// The StaticArray and dtype return must be correct.
 pub unsafe trait PolarsDataType: Send + Sync + Sized {
     type Physical<'a>: std::fmt::Debug + Clone;
-    type OwnedPhysical: std::fmt::Debug;
+    type OwnedPhysical: std::fmt::Debug + Send + Sync + Clone;
     type ZeroablePhysical<'a>: Zeroable + From<Self::Physical<'a>>;
     type Array: for<'a> StaticArray<
         ValueT<'a> = Self::Physical<'a>,
@@ -80,6 +80,7 @@ pub unsafe trait PolarsDataType: Send + Sync + Sized {
 pub trait PolarsNumericType: 'static
 where
     Self: for<'a> PolarsDataType<
+        OwnedPhysical = Self::Native,
         Physical<'a> = Self::Native,
         ZeroablePhysical<'a> = Self::Native,
         Array = PrimitiveArray<Self::Native>,

--- a/crates/polars-core/src/serde/chunked_array.rs
+++ b/crates/polars-core/src/serde/chunked_array.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 
-use crate::chunked_array::Settings;
+use crate::chunked_array::metadata::MetadataFlags;
 use crate::prelude::*;
 
 pub struct IterSer<I>
@@ -47,7 +47,7 @@ fn serialize_impl<T, S>(
     serializer: S,
     name: &str,
     dtype: &DataType,
-    bit_settings: Settings,
+    bit_settings: MetadataFlags,
     ca: &ChunkedArray<T>,
 ) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
 where

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -4,7 +4,7 @@ pub mod series;
 
 #[cfg(test)]
 mod test {
-    use crate::chunked_array::Settings;
+    use crate::chunked_array::metadata::MetadataFlags;
     use crate::prelude::*;
     use crate::series::IsSorted;
 
@@ -56,7 +56,7 @@ mod test {
             let json = serde_json::to_string(&column).unwrap();
             let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap();
             let f = out.get_flags();
-            assert_ne!(f, Settings::empty());
+            assert_ne!(f, MetadataFlags::empty());
             assert_eq!(column.get_flags(), out.get_flags());
         }
     }

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -7,7 +7,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "dtype-array")]
 use crate::chunked_array::builder::get_fixed_size_list_builder;
 use crate::chunked_array::builder::AnonymousListBuilder;
-use crate::chunked_array::Settings;
+use crate::chunked_array::metadata::MetadataFlags;
 use crate::prelude::*;
 
 impl Serialize for Series {
@@ -103,7 +103,7 @@ impl<'de> Deserialize<'de> for Series {
             {
                 let mut name: Option<Cow<'de, str>> = None;
                 let mut dtype = None;
-                let mut bit_settings: Option<Settings> = None;
+                let mut bit_settings: Option<MetadataFlags> = None;
                 let mut values_set = false;
                 while let Some(key) = map.next_key::<Cow<str>>().unwrap() {
                     match key.as_ref() {

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -1,10 +1,10 @@
 use std::any::Any;
 use std::borrow::Cow;
 
-use super::private;
+use super::{private, MetadataFlags};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::{AsSinglePtr, Settings};
+use crate::chunked_array::AsSinglePtr;
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;
@@ -21,11 +21,11 @@ impl private::PrivateSeries for SeriesWrap<ArrayChunked> {
         self.0.ref_field().data_type()
     }
 
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
 
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -14,10 +14,10 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -15,10 +15,10 @@ impl private::PrivateSeries for SeriesWrap<BinaryOffsetChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -14,10 +14,10 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -55,10 +55,10 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -30,10 +30,10 @@ macro_rules! impl_dyn_series {
             fn _dtype(&self) -> &DataType {
                 self.0.dtype()
             }
-            fn _get_flags(&self) -> Settings {
+            fn _get_flags(&self) -> MetadataFlags {
                 self.0.get_flags()
             }
-            fn _set_flags(&mut self, flags: Settings) {
+            fn _set_flags(&mut self, flags: MetadataFlags) {
                 self.0.set_flags(flags)
             }
 

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -28,10 +28,10 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -85,10 +85,10 @@ impl private::PrivateSeries for SeriesWrap<DecimalChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -39,10 +39,10 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.deref_mut().set_flags(flags)
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.deref().get_flags()
     }
 

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -17,10 +17,10 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
-            fn _set_flags(&mut self, flags: Settings) {
+            fn _set_flags(&mut self, flags: MetadataFlags) {
                 self.0.set_flags(flags)
             }
-            fn _get_flags(&self) -> Settings {
+            fn _get_flags(&self) -> MetadataFlags {
                 self.0.get_flags()
             }
             fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -14,10 +14,10 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -84,11 +84,11 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
-            fn _get_flags(&self) -> Settings {
+            fn _get_flags(&self) -> MetadataFlags {
                 self.0.get_flags()
             }
 
-            fn _set_flags(&mut self, flags: Settings) {
+            fn _set_flags(&mut self, flags: MetadataFlags) {
                 self.0.set_flags(flags)
             }
 

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -57,7 +57,7 @@ impl PrivateSeries for NullChunked {
     }
 
     #[allow(unused)]
-    fn _set_flags(&mut self, flags: Settings) {}
+    fn _set_flags(&mut self, flags: MetadataFlags) {}
 
     fn _dtype(&self) -> &DataType {
         &DataType::Null
@@ -115,8 +115,8 @@ impl PrivateSeries for NullChunked {
         AggList::agg_list(self, groups)
     }
 
-    fn _get_flags(&self) -> Settings {
-        Settings::empty()
+    fn _get_flags(&self) -> MetadataFlags {
+        MetadataFlags::empty()
     }
 
     fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) -> PolarsResult<()> {

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -3,9 +3,9 @@ use std::borrow::Cow;
 
 use ahash::RandomState;
 
+use super::MetadataFlags;
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::chunked_array::ops::compare_inner::{IntoTotalEqInner, TotalEqInner};
-use crate::chunked_array::Settings;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
@@ -37,10 +37,10 @@ where
         self.0.dtype()
     }
 
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -15,10 +15,10 @@ impl private::PrivateSeries for SeriesWrap<StringChunked> {
         self.0.ref_field().data_type()
     }
 
-    fn _set_flags(&mut self, flags: Settings) {
+    fn _set_flags(&mut self, flags: MetadataFlags) {
         self.0.set_flags(flags)
     }
-    fn _get_flags(&self) -> Settings {
+    fn _get_flags(&self) -> MetadataFlags {
         self.0.get_flags()
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -24,9 +24,9 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
         self.0.ref_field().data_type()
     }
     #[allow(unused)]
-    fn _set_flags(&mut self, flags: Settings) {}
-    fn _get_flags(&self) -> Settings {
-        Settings::empty()
+    fn _set_flags(&mut self, flags: MetadataFlags) {}
+    fn _get_flags(&self) -> MetadataFlags {
+        MetadataFlags::empty()
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -26,7 +26,7 @@ use num_traits::NumCast;
 use rayon::prelude::*;
 pub use series_trait::{IsSorted, *};
 
-use crate::chunked_array::Settings;
+use crate::chunked_array::metadata::MetadataFlags;
 #[cfg(feature = "zip_with")]
 use crate::series::arithmetic::coerce_lhs_rhs;
 use crate::utils::{
@@ -220,9 +220,9 @@ impl Series {
             return IsSorted::Ascending;
         }
         let flags = self.get_flags();
-        if flags.contains(Settings::SORTED_DSC) {
+        if flags.contains(MetadataFlags::SORTED_DSC) {
             IsSorted::Descending
-        } else if flags.contains(Settings::SORTED_ASC) {
+        } else if flags.contains(MetadataFlags::SORTED_ASC) {
             IsSorted::Ascending
         } else {
             IsSorted::Not
@@ -235,15 +235,15 @@ impl Series {
         self.set_flags(flags);
     }
 
-    pub(crate) fn clear_settings(&mut self) {
-        self.set_flags(Settings::empty());
+    pub(crate) fn clear_flags(&mut self) {
+        self.set_flags(MetadataFlags::empty());
     }
     #[allow(dead_code)]
-    pub fn get_flags(&self) -> Settings {
+    pub fn get_flags(&self) -> MetadataFlags {
         self.0._get_flags()
     }
 
-    pub(crate) fn set_flags(&mut self, flags: Settings) {
+    pub(crate) fn set_flags(&mut self, flags: MetadataFlags) {
         self._get_inner_mut()._set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -41,8 +41,8 @@ pub(crate) mod private {
     use ahash::RandomState;
 
     use super::*;
+    use crate::chunked_array::metadata::MetadataFlags;
     use crate::chunked_array::ops::compare_inner::{TotalEqInner, TotalOrdInner};
-    use crate::chunked_array::Settings;
 
     pub trait PrivateSeriesNumeric {
         fn bit_repr_is_large(&self) -> bool {
@@ -74,9 +74,9 @@ pub(crate) mod private {
 
         fn compute_len(&mut self);
 
-        fn _get_flags(&self) -> Settings;
+        fn _get_flags(&self) -> MetadataFlags;
 
-        fn _set_flags(&mut self, flags: Settings);
+        fn _set_flags(&mut self, flags: MetadataFlags);
 
         fn explode_by_offsets(&self, _offsets: &[i64]) -> Series {
             invalid_operation_panic!(explode_by_offsets, self)

--- a/crates/polars-io/src/parquet/read/mod.rs
+++ b/crates/polars-io/src/parquet/read/mod.rs
@@ -21,6 +21,7 @@ mod options;
 mod predicates;
 mod read_impl;
 mod reader;
+mod to_metadata;
 mod utils;
 
 pub use options::{ParallelStrategy, ParquetOptions};

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -7,14 +7,14 @@ use arrow::datatypes::ArrowSchemaRef;
 use polars_core::prelude::*;
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
 use polars_core::POOL;
-use polars_parquet::read;
-use polars_parquet::read::{ArrayIter, FileMetaData, RowGroupMetaData};
+use polars_parquet::read::{self, ArrayIter, FileMetaData, PhysicalType, RowGroupMetaData};
 use rayon::prelude::*;
 
 #[cfg(feature = "cloud")]
 use super::async_impl::FetchRowGroupsFromObjectStore;
 use super::mmap::{mmap_columns, ColumnStore};
 use super::predicates::read_this_row_group;
+use super::to_metadata::ToMetadata;
 use super::utils::materialize_empty_df;
 use super::{mmap, ParallelStrategy};
 use crate::mmap::{MmapBytesReader, ReaderBytes};
@@ -67,11 +67,54 @@ fn column_idx_to_series(
     let columns = mmap_columns(store, md.columns(), &field.name);
     let iter = mmap::to_deserializer(columns, field.clone(), remaining_rows, Some(chunk_size))?;
 
-    if remaining_rows < md.num_rows() {
+    let mut series = if remaining_rows < md.num_rows() {
         array_iter_to_series(iter, field, Some(remaining_rows))
     } else {
         array_iter_to_series(iter, field, None)
+    }?;
+
+    // See if we can find some statistics for this series. If we cannot find anything just return
+    // the series as is.
+    let Some(Ok(stats)) = md.columns()[column_i].statistics() else {
+        return Ok(series);
+    };
+
+    let series_trait = series.as_ref();
+
+    macro_rules! match_dtypes_into_metadata {
+        ($(($dtype:pat, $phystype:pat) => ($stats:ident, $pldtype:ty),)+) => {
+            match (series_trait.dtype(), stats.physical_type()) {
+                $(
+                ($dtype, $phystype) => {
+                    series.try_set_metadata(
+                        ToMetadata::<$pldtype>::to_metadata(stats.$stats())
+                    );
+                })+
+                _ => {},
+            }
+        };
     }
+
+    // Match the data types used by the Series and by the Statistics. If we find a match, set some
+    // Metadata for the underlying ChunkedArray.
+    use {DataType as D, PhysicalType as P};
+    match_dtypes_into_metadata! {
+        (D::Boolean, P::Boolean  ) => (expect_as_boolean, BooleanType),
+        (D::UInt8,   P::Int32    ) => (expect_as_int32,   UInt8Type  ),
+        (D::UInt16,  P::Int32    ) => (expect_as_int32,   UInt16Type ),
+        (D::UInt32,  P::Int32    ) => (expect_as_int32,   UInt32Type ),
+        (D::UInt64,  P::Int64    ) => (expect_as_int64,   UInt64Type ),
+        (D::Int8,    P::Int32    ) => (expect_as_int32,   Int8Type   ),
+        (D::Int16,   P::Int32    ) => (expect_as_int32,   Int16Type  ),
+        (D::Int32,   P::Int32    ) => (expect_as_int32,   Int32Type  ),
+        (D::Int64,   P::Int64    ) => (expect_as_int64,   Int64Type  ),
+        (D::Float32, P::Float    ) => (expect_as_float,   Float32Type),
+        (D::Float64, P::Double   ) => (expect_as_double,  Float64Type),
+        (D::String,  P::ByteArray) => (expect_as_binary,  StringType ),
+        (D::Binary,  P::ByteArray) => (expect_as_binary,  BinaryType ),
+    }
+
+    Ok(series)
 }
 
 pub(super) fn array_iter_to_series(

--- a/crates/polars-io/src/parquet/read/to_metadata.rs
+++ b/crates/polars-io/src/parquet/read/to_metadata.rs
@@ -1,0 +1,114 @@
+use polars_core::chunked_array::metadata::Metadata;
+use polars_core::datatypes::{
+    BinaryType, BooleanType, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+    PolarsDataType, StringType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+};
+use polars_parquet::parquet::statistics::{
+    BinaryStatistics, BooleanStatistics, PrimitiveStatistics,
+};
+
+pub trait ToMetadata<D: PolarsDataType + 'static>: Sized + 'static {
+    fn to_metadata(&self) -> Metadata<D>;
+}
+
+impl ToMetadata<BooleanType> for BooleanStatistics {
+    fn to_metadata(&self) -> Metadata<BooleanType> {
+        let mut md = Metadata::default();
+
+        if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok()) {
+            md.set_distinct_count(distinct_count);
+        }
+        if let Some(min_value) = self.min_value {
+            md.set_min_value(min_value);
+        }
+        if let Some(max_value) = self.max_value {
+            md.set_max_value(max_value);
+        }
+
+        md
+    }
+}
+
+impl ToMetadata<BinaryType> for BinaryStatistics {
+    fn to_metadata(&self) -> Metadata<BinaryType> {
+        let mut md = Metadata::default();
+
+        if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok()) {
+            md.set_distinct_count(distinct_count);
+        }
+        if let Some(min_value) = self.min_value.as_ref() {
+            md.set_min_value(min_value.clone().into_boxed_slice());
+        }
+        if let Some(max_value) = self.max_value.as_ref() {
+            md.set_max_value(max_value.clone().into_boxed_slice());
+        }
+
+        md
+    }
+}
+
+impl ToMetadata<StringType> for BinaryStatistics {
+    fn to_metadata(&self) -> Metadata<StringType> {
+        let mut md = Metadata::default();
+
+        if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok()) {
+            md.set_distinct_count(distinct_count);
+        }
+        if let Some(min_value) = self
+            .min_value
+            .as_ref()
+            .and_then(|s| String::from_utf8(s.clone()).ok())
+        {
+            md.set_min_value(min_value);
+        }
+        if let Some(max_value) = self
+            .max_value
+            .as_ref()
+            .and_then(|s| String::from_utf8(s.clone()).ok())
+        {
+            md.set_max_value(max_value);
+        }
+
+        md
+    }
+}
+
+macro_rules! prim_statistics {
+    ($(($bstore:ty, $pltype:ty),)+) => {
+        $(
+        impl ToMetadata<$pltype> for PrimitiveStatistics<$bstore> {
+            fn to_metadata(&self) -> Metadata<$pltype> {
+                let mut md = Metadata::default();
+
+                if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok())
+                {
+                    md.set_distinct_count(distinct_count);
+                }
+                if let Some(min_value) = self.min_value {
+                    md.set_min_value(min_value as <$pltype as PolarsDataType>::OwnedPhysical);
+                }
+                if let Some(max_value) = self.max_value {
+                    md.set_max_value(max_value as <$pltype as PolarsDataType>::OwnedPhysical);
+                }
+
+                md
+            }
+        }
+        )+
+    }
+}
+
+prim_statistics! {
+    (i32, Int8Type),
+    (i32, Int16Type),
+    (i32, Int32Type),
+    (i64, Int64Type),
+
+    (i32, UInt8Type),
+    (i32, UInt16Type),
+    (i32, UInt32Type),
+    (i64, UInt64Type),
+
+    (f32, Float32Type),
+    (f64, Float64Type),
+}


### PR DESCRIPTION
This PR adds a general `Metadata` structure to the `ChunkedArray`, which can be used to be better informed decisions during the runtime of the query. Currently, it is not always set or used perfectly, but it can be slowly incorperated.