### PR TITLE
release(python): Python Polars 0.20.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.20.27"
+version = "0.20.28"
 dependencies = [
  "ahash",
  "arboard",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.20.27"
+version = "0.20.28"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
0.20.27 will be yanked due to a bug in the `to_numpy` conversion.