### PR TITLE
fix(python): Update `apply` call in `str_duration_` util.

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -307,7 +307,7 @@ def _cast_repr_strings_with_schema(
             elif tp == Duration:
                 cast_cols[c] = (
                     F.col(c)
-                    .apply(str_duration_, return_dtype=Int64)
+                    .map_elements(str_duration_, return_dtype=Int64)
                     .cast(Duration("ns"))
                     .cast(tp)
                 )


### PR DESCRIPTION
Closes #16411

Just an old call to `apply` that was generating a warning.

Updated to use `map_elements` instead.