### PR TITLE
fix(python): make read_parquet() respect rechunk flag when using pyarrow

### DIFF
--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -160,6 +160,7 @@ def read_parquet(
             storage_options=storage_options,
             pyarrow_options=pyarrow_options,
             memory_map=memory_map,
+            rechunk=rechunk,
         )
 
     # Read file and bytes inputs using `read_parquet`
@@ -209,6 +210,7 @@ def _read_parquet_with_pyarrow(
     storage_options: dict[str, Any] | None = None,
     pyarrow_options: dict[str, Any] | None = None,
     memory_map: bool = True,
+    rechunk: bool = True,
 ) -> DataFrame:
     pyarrow_parquet = import_optional(
         "pyarrow.parquet",
@@ -228,7 +230,7 @@ def _read_parquet_with_pyarrow(
             columns=columns,
             **pyarrow_options,
         )
-    return from_arrow(pa_table)  # type: ignore[return-value]
+    return from_arrow(pa_table, rechunk=rechunk)  # type: ignore[return-value]
 
 
 def _read_parquet_binary(

--- a/py-polars/src/dataframe/general.rs
+++ b/py-polars/src/dataframe/general.rs
@@ -147,9 +147,9 @@ impl PyDataFrame {
         Ok(df.into())
     }
 
-    pub fn rechunk(&self) -> Self {
+    pub fn rechunk(&self, py: Python) -> Self {
         let mut df = self.df.clone();
-        df.as_single_chunk_par();
+        py.allow_threads(|| df.as_single_chunk_par());
         df.into()
     }
 


### PR DESCRIPTION
Fixes #16416 

While playing around with measuring memory I also discovered rechunk() doesn't release the GIL, so I fixed that too while I was at it.