### PR TITLE
docs(python): Add `interpolate_by` entry to rst files.

### DIFF
--- a/py-polars/docs/source/reference/expressions/modify_select.rst
+++ b/py-polars/docs/source/reference/expressions/modify_select.rst
@@ -34,6 +34,7 @@ Manipulation/selection
     Expr.head
     Expr.inspect
     Expr.interpolate
+    Expr.interpolate_by
     Expr.limit
     Expr.lower_bound
     Expr.map_dict

--- a/py-polars/docs/source/reference/series/modify_select.rst
+++ b/py-polars/docs/source/reference/series/modify_select.rst
@@ -31,6 +31,7 @@ Manipulation/selection
     Series.gather_every
     Series.head
     Series.interpolate
+    Series.interpolate_by
     Series.item
     Series.limit
     Series.new_from_index


### PR DESCRIPTION
Just noticed the new `interpolate_by` wasn't showing up in a docs search.