### PR TITLE
fix: Fix error reading lists of CSV files that contain comments

### DIFF
--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -136,7 +136,7 @@ impl<'a> CoreReader<'a> {
     pub(crate) fn new(
         reader_bytes: ReaderBytes<'a>,
         n_rows: Option<usize>,
-        mut skip_rows: usize,
+        skip_rows: usize,
         mut projection: Option<Vec<usize>>,
         max_records: Option<usize>,
         separator: Option<u8>,
@@ -201,7 +201,7 @@ impl<'a> CoreReader<'a> {
                     max_records,
                     has_header,
                     schema_overwrite.as_deref(),
-                    &mut skip_rows,
+                    skip_rows,
                     skip_rows_after_header,
                     comment_prefix.as_ref(),
                     quote_char,

--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -241,7 +241,7 @@ impl CsvReader<Box<dyn MmapBytesReader>> {
                     self.options.infer_schema_length,
                     self.options.has_header,
                     None,
-                    &mut self.options.skip_rows,
+                    self.options.skip_rows,
                     self.options.skip_rows_after_header,
                     parse_options.comment_prefix.as_ref(),
                     parse_options.quote_char,

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -220,7 +220,7 @@ impl LazyCsvReader {
             polars_utils::open_file(&self.path)
         }?;
         let reader_bytes = get_reader_bytes(&mut file).expect("could not mmap file");
-        let mut skip_rows = self.read_options.skip_rows;
+        let skip_rows = self.read_options.skip_rows;
         let parse_options = self.read_options.get_parse_options();
 
         let (schema, _, _) = infer_file_schema(
@@ -230,7 +230,7 @@ impl LazyCsvReader {
             self.read_options.has_header,
             // we set it to None and modify them after the schema is updated
             None,
-            &mut skip_rows,
+            skip_rows,
             self.read_options.skip_rows_after_header,
             parse_options.comment_prefix.as_ref(),
             parse_options.quote_char,


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/16327

Turns out I just had to remove the skip_rows overwrite to make it correct because this exists:
https://github.com/pola-rs/polars/blob/ceb895e0ab0d6ab3eb2e8eb1fccacb8d3fe14524/crates/polars-io/src/csv/read/read_impl.rs#L291-L294

was this your plan all along Ritchie 😂
