### PR TITLE
feat(python): Support zero-copy conversion for temporal types in `DataFrame.to_numpy`

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -641,7 +641,7 @@ impl<T> ChunkedArray<T>
 where
     T: PolarsNumericType,
 {
-    /// Contiguous slice
+    /// Returns the values of the array as a contiguous slice.
     pub fn cont_slice(&self) -> PolarsResult<&[T::Native]> {
         polars_ensure!(
             self.chunks.len() == 1 && self.chunks[0].null_count() == 0,
@@ -650,7 +650,7 @@ where
         Ok(self.downcast_iter().next().map(|arr| arr.values()).unwrap())
     }
 
-    /// Contiguous mutable slice
+    /// Returns the values of the array as a contiguous mutable slice.
     pub(crate) fn cont_slice_mut(&mut self) -> Option<&mut [T::Native]> {
         if self.chunks.len() == 1 && self.chunks[0].null_count() == 0 {
             // SAFETY, we will not swap the PrimitiveArray.

--- a/py-polars/src/interop/numpy/to_numpy_df.rs
+++ b/py-polars/src/interop/numpy/to_numpy_df.rs
@@ -188,7 +188,7 @@ fn df_columns_to_numpy(
         arr
     });
 
-    let numpy = PyModule::import_bound(py, "numpy")?;
+    let numpy = PyModule::import_bound(py, intern!(py, "numpy"))?;
     let np_array = match order {
         IndexOrder::C => numpy
             .getattr(intern!(py, "column_stack"))

--- a/py-polars/src/interop/numpy/to_numpy_series.rs
+++ b/py-polars/src/interop/numpy/to_numpy_series.rs
@@ -378,7 +378,7 @@ fn list_series_to_numpy(py: Python, s: &Series, writable: bool) -> PyObject {
         let slice = PySlice::new_bound(py, prev_offset, current_offset, 1);
         prev_offset = current_offset;
         np_array_flat
-            .call_method1(py, "__getitem__", (slice,))
+            .call_method1(py, intern!(py, "__getitem__"), (slice,))
             .unwrap()
     });
 

--- a/py-polars/src/interop/numpy/to_numpy_series.rs
+++ b/py-polars/src/interop/numpy/to_numpy_series.rs
@@ -11,7 +11,8 @@ use pyo3::types::PySlice;
 
 use super::to_numpy_df::df_to_numpy;
 use super::utils::{
-    create_borrowed_np_array, polars_dtype_to_np_temporal_dtype, reshape_numpy_array,
+    create_borrowed_np_array, dtype_supports_view, polars_dtype_to_np_temporal_dtype,
+    reshape_numpy_array, series_contains_null,
 };
 use crate::conversion::chunked_array::{decimal_to_pyobject_iter, time_to_pyobject_iter};
 use crate::conversion::ObjectValue;
@@ -79,39 +80,16 @@ fn try_series_to_numpy_view(
     allow_nulls: bool,
     allow_rechunk: bool,
 ) -> Option<(PyObject, bool)> {
-    if !supports_view(s.dtype()) {
+    if !dtype_supports_view(s.dtype()) {
         return None;
     }
-    if !allow_nulls && has_nulls(s) {
+    if !allow_nulls && series_contains_null(s) {
         return None;
     }
     let (s_owned, writable_flag) = handle_chunks(s, allow_rechunk)?;
 
     let array = series_to_numpy_view_recursive(py, s_owned, writable_flag);
     Some((array, writable_flag))
-}
-/// Returns whether the data type supports creating a NumPy view.
-fn supports_view(dtype: &DataType) -> bool {
-    match dtype {
-        dt if dt.is_numeric() => true,
-        DataType::Datetime(_, _) | DataType::Duration(_) => true,
-        DataType::Array(inner, _) => supports_view(inner.as_ref()),
-        _ => false,
-    }
-}
-/// Returns whether the Series contains nulls at any level of nesting.
-///
-/// Of the nested types, only Array types are handled since only those are relevant for NumPy views.
-fn has_nulls(s: &Series) -> bool {
-    if s.null_count() > 0 {
-        true
-    } else if s.dtype().is_array() {
-        let ca = s.array().unwrap();
-        let s_inner = ca.get_inner();
-        has_nulls(&s_inner)
-    } else {
-        false
-    }
 }
 /// Rechunk the Series if required.
 ///

--- a/py-polars/src/interop/numpy/to_numpy_series.rs
+++ b/py-polars/src/interop/numpy/to_numpy_series.rs
@@ -278,7 +278,6 @@ fn series_to_numpy_with_copy(py: Python, s: &Series, writable: bool) -> PyObject
         Struct(_) => {
             let ca = s.struct_().unwrap();
             let df = ca.clone().unnest();
-            // TODO: How should we determine the IndexOrder here?
             df_to_numpy(py, &df, IndexOrder::Fortran, writable, true).unwrap()
         },
         #[cfg(feature = "object")]


### PR DESCRIPTION
Ref #16415