### PR TITLE
feat(python): `DataFrame.assert_schema`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10683,6 +10683,26 @@ class DataFrame:
         )
 
     @unstable()
+    def assert_schema(self, schema: SchemaDict) -> DataFrame:
+        """
+        Assert that the schema conforms to expectations.
+
+        Return the original frame on success, raise AssertionError on failure.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+        """
+        if self.schema != schema:
+            msg = (
+                "Wrong dataframe schema:\n"
+                f"• expected: '{schema}',\n"
+                f"• observed: '{dict(self.schema)}'."
+            )
+            raise AssertionError(msg)
+        return self
+
+    @unstable()
     def update(
         self,
         other: DataFrame,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5925,6 +5925,26 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
 
     @unstable()
+    def assert_schema(self, schema: SchemaDict) -> LazyFrame:
+        """
+        Assert that the schema conforms to expectations.
+
+        Return the original frame on success, raise AssertionError on failure.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+        """
+        if self.schema != schema:
+            msg = (
+                "Wrong dataframe schema:\n"
+                f"• expected: '{schema}',\n"
+                f"• observed: '{dict(self.schema)}'."
+            )
+            raise AssertionError(msg)
+        return self
+
+    @unstable()
     def update(
         self,
         other: LazyFrame,


### PR DESCRIPTION
Closes #14620

A companion PR to #14620.

Note that there exists another suggestion by @JulianCologne in #11064 about checking **contents** of DataFrames.
This suggestion is only about checking **schemas**.

----
Minor questions:
- should it be `AssertionError` or `SchemaError`?
- what is the correct order of methods in 'frame.py' (e.g. stable methods, then unstable methods, with alphabetical order within groups)?