### PR TITLE
fix(rust): Fix panic when computing min() of Duration series.

### DIFF
--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -407,10 +407,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
     fn min_reduce(&self) -> PolarsResult<Scalar> {
         let sc = self.0.min_reduce();
         let v = sc.value().as_duration(self.0.time_unit());
-        Ok(Scalar::new(
-            self.dtype().clone(),
-            v.as_duration(self.0.time_unit()),
-        ))
+        Ok(Scalar::new(self.dtype().clone(), v))
     }
     fn std_reduce(&self, ddof: u8) -> PolarsResult<Scalar> {
         let sc = self.0.std_reduce(ddof);

--- a/py-polars/tests/unit/dataframe/test_describe.py
+++ b/py-polars/tests/unit/dataframe/test_describe.py
@@ -24,8 +24,9 @@ def test_df_describe(lazy: bool) -> None:
             ],
             "g": [date(2020, 1, 1), date(2021, 7, 5), date(2022, 12, 31)],
             "h": [time(10, 30), time(15, 0), time(20, 30)],
+            "i": [1_000_000, 2_000_000, 3_000_000],
         },
-        schema_overrides={"e": pl.Categorical},
+        schema_overrides={"e": pl.Categorical, "i": pl.Duration},
     )
 
     frame: pl.DataFrame | pl.LazyFrame = df.lazy() if lazy else df
@@ -92,6 +93,17 @@ def test_df_describe(lazy: bool) -> None:
                 "15:00:00",
                 "20:30:00",
                 "20:30:00",
+            ],
+            "i": [
+                "3",
+                "0",
+                "0:00:02",
+                None,
+                "0:00:01",
+                "0:00:02",
+                "0:00:02",
+                "0:00:03",
+                "0:00:03",
             ],
         }
     )


### PR DESCRIPTION
The implementation of min_reduce accidentally called `.as_duration()` twice. The second one panicked because the `AnyType` was no longer `Int64`.

Fixes #16382 