### PR TITLE
fix(python): respect `nan_to_null` when using multi-thread in `pl.from_pandas`

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -114,7 +114,7 @@ def dict_to_pydf(
                     zip(
                         column_names,
                         pool.map(
-                            lambda t: pl.Series(t[0], t[1])
+                            lambda t: pl.Series(t[0], t[1], nan_to_null=nan_to_null)
                             if isinstance(t[1], np.ndarray)
                             else t[1],
                             list(data.items()),

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -69,6 +69,8 @@ if TYPE_CHECKING:
         SchemaDict,
     )
 
+_MIN_NUMPY_SIZE_FOR_MULTITHREADING = 1000
+
 
 def dict_to_pydf(
     data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
@@ -97,7 +99,7 @@ def dict_to_pydf(
             int(
                 _check_for_numpy(val)
                 and isinstance(val, np.ndarray)
-                and len(val) > 1000
+                and len(val) > _MIN_NUMPY_SIZE_FOR_MULTITHREADING
             )
             for val in data.values()
         )

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -1051,3 +1051,17 @@ def test_from_numpy_different_resolution_invalid() -> None:
         pl.Series(
             np.array(["2020-01-01"], dtype="datetime64[s]"), dtype=pl.Datetime("us")
         )
+
+
+def test_from_pandas_nan_to_null_16453(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "polars._utils.construction.dataframe._MIN_NUMPY_SIZE_FOR_MULTITHREADING", 2
+    )
+    df = pd.DataFrame(
+        {"a": [np.nan, 1.0, 2], "b": [1.0, 2.0, 3.0], "c": [4.0, 5.0, 6.0]}
+    )
+    result = pl.from_pandas(df, nan_to_null=True)
+    expected = pl.DataFrame(
+        {"a": [None, 1.0, 2], "b": [1.0, 2.0, 3.0], "c": [4.0, 5.0, 6.0]}
+    )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Sorry I don't have the time to write a test case at the moment.

Closes #16453