### PR TITLE
fix(rust): properly set schemas in cluster_with_columns when reassigning to columns

### DIFF
--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -81,6 +81,11 @@ impl Schema {
         Self { inner: map }
     }
 
+    /// Reserve `additional` memory spaces in the schema.
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional);
+    }
+
     /// The number of fields in the schema
     #[inline]
     pub fn len(&self) -> usize {
@@ -347,6 +352,21 @@ impl Schema {
     ///   index
     pub fn merge(&mut self, other: Self) {
         self.inner.extend(other.inner)
+    }
+
+    /// Merge borrowed `other` into `self`
+    ///
+    /// Merging logic:
+    /// - Fields that occur in `self` but not `other` are unmodified
+    /// - Fields that occur in `other` but not `self` are appended, in order, to the end of `self`
+    /// - Fields that occur in both `self` and `other` are updated with the dtype from `other`, but keep their original
+    ///   index
+    pub fn merge_from_ref(&mut self, other: &Self) {
+        self.inner.extend(
+            other
+                .iter()
+                .map(|(column, datatype)| (column.clone(), datatype.clone())),
+        )
     }
 
     /// Convert self to `ArrowSchema` by cloning the fields

--- a/py-polars/tests/unit/test_cwc.py
+++ b/py-polars/tests/unit/test_cwc.py
@@ -1,6 +1,5 @@
 # Tests for the optimization pass cluster WITH_COLUMNS
 
-
 import polars as pl
 
 
@@ -152,7 +151,7 @@ def test_cwc_with_internal_aliases() -> None:
     )
 
 
-def test_issue_16436() -> None:
+def test_read_of_pushed_column_16436() -> None:
     df = pl.DataFrame(
         {
             "x": [1.12, 2.21, 4.2, 3.21],
@@ -169,3 +168,29 @@ def test_issue_16436() -> None:
         .fill_nan(0)
         .collect()
     )
+
+
+def test_multiple_simple_projections_16435() -> None:
+    df = pl.DataFrame({"a": [1]}).lazy()
+
+    df = (
+        df.with_columns(b=pl.col("a"))
+        .with_columns(c=pl.col("b"))
+        .with_columns(l2a=pl.lit(2))
+        .with_columns(l2b=pl.col("l2a"))
+        .with_columns(m=pl.lit(3))
+    )
+
+    df.collect()
+
+
+def test_reverse_order() -> None:
+    df = pl.LazyFrame({"a": [1], "b": [2]})
+
+    df = (
+        df.with_columns(a=pl.col("a"), b=pl.col("b"), c=pl.col("a") * pl.col("b"))
+        .with_columns(x=pl.col("a"), y=pl.col("b"))
+        .with_columns(b=pl.col("a"), a=pl.col("b"))
+    )
+
+    df.collect()


### PR DESCRIPTION
Fixes #16435.

This PR focuses on cluster_with_columns (CWC) and resolves the issue where a schema was improperly handled when a simple projection needed to be inserted. This PR also removes several of the clones and allocations that came before with CWC.