### PR TITLE
fix: Fix use of `COUNT(*)` in SQL `GROUP BY` operations

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1235,16 +1235,14 @@ impl SQLFunctionVisitor<'_> {
     fn visit_count(&mut self) -> PolarsResult<Expr> {
         let args = extract_args(self.func);
         match (self.func.distinct, args.as_slice()) {
-            // count()
-            (false, []) => Ok(len()),
+            // count(*), count()
+            (false, [FunctionArgExpr::Wildcard] | []) => Ok(len()),
             // count(column_name)
             (false, [FunctionArgExpr::Expr(sql_expr)]) => {
                 let expr = parse_sql_expr(sql_expr, self.ctx, None)?;
                 let expr = self.apply_window_spec(expr, &self.func.over)?;
                 Ok(expr.count())
             },
-            // count(*)
-            (false, [FunctionArgExpr::Wildcard]) => Ok(len()),
             // count(distinct column_name)
             (true, [FunctionArgExpr::Expr(sql_expr)]) => {
                 let expr = parse_sql_expr(sql_expr, self.ctx, None)?;

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -66,7 +66,8 @@ fn test_group_by_simple() -> PolarsResult<()> {
           a          AS "aa",
           SUM(b)     AS "bb",
           SUM(a + b) AS "cc",
-          COUNT(a)   AS "total_count"
+          COUNT(a)   AS "count_a",
+          COUNT(*)   AS "count_star"
         FROM df
         GROUP BY a
         LIMIT 100
@@ -81,7 +82,8 @@ fn test_group_by_simple() -> PolarsResult<()> {
         .agg(&[
             col("b").sum().alias("bb"),
             (col("a") + col("b")).sum().alias("cc"),
-            col("a").count().alias("total_count"),
+            col("a").count().alias("count_a"),
+            col("a").len().alias("count_star"),
         ])
         .limit(100)
         .sort(["aa"], Default::default())

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3485,6 +3485,10 @@ class DataFrame:
         """
         Write the data in a Polars DataFrame to a database.
 
+        .. versionadded:: 0.20.26
+            Support for instantiated connection objects in addition to URI strings, and
+            a new `engine_options` parameter.
+
         Parameters
         ----------
         table_name

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -890,6 +890,11 @@ def by_index(*indices: int | range | Sequence[int | range]) -> SelectorType:
         One or more column indices (or range objects).
         Negative indexing is supported.
 
+    Notes
+    -----
+    Matching columns are returned in the order in which their indexes
+    appear in the selector, not the underlying schema order.
+
     See Also
     --------
     by_dtype : Select all columns matching the given dtypes.


### PR DESCRIPTION
The difference between `len`/`count` caused the aggregate expression check in "GROUP BY" to miss `len` (it's not an AggExpr), as used by "COUNT(*)" in the SQL interface. Fixed, and added the missing coverage.

(Also includes two minor unrelated docstring updates).

## Example
```python
df = pl.DataFrame({
    "a": ["xx", "yy", "xx", "yy", "xx", "zz"],
    "b": [1, None, 3, 4, None, 6],
    "c": [99, 99, 66, 66, 66, 66],
})

df.sql("""
  SELECT
    a,
    COUNT(b) AS count_b,
    COUNT(*) AS count_star
  FROM self
  GROUP BY a
  ORDER BY a
""")

# shape: (3, 3)
# ┌─────┬─────────┬────────────┐
# │ a   ┆ count_b ┆ count_star │
# │ --- ┆ ---     ┆ ---        │
# │ str ┆ u32     ┆ u32        │
# ╞═════╪═════════╪════════════╡
# │ xx  ┆ 2       ┆ 3          │
# │ yy  ┆ 1       ┆ 2          │
# │ zz  ┆ 1       ┆ 1          │
# └─────┴─────────┴────────────┘
```