### PR TITLE
refactor(rust): make Parquet `Statistics` into `enum` instead of `trait`

### DIFF
--- a/crates/polars-parquet/src/arrow/read/statistics/binary.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/binary.rs
@@ -2,10 +2,10 @@ use arrow::array::{MutableArray, MutableBinaryArray};
 use arrow::offset::Offset;
 use polars_error::PolarsResult;
 
-use crate::parquet::statistics::{BinaryStatistics, Statistics as ParquetStatistics};
+use crate::parquet::statistics::BinaryStatistics;
 
 pub(super) fn push<O: Offset>(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&BinaryStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -17,8 +17,9 @@ pub(super) fn push<O: Offset>(
         .as_mut_any()
         .downcast_mut::<MutableBinaryArray<O>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<BinaryStatistics>().unwrap());
+
     min.push(from.and_then(|s| s.min_value.as_ref()));
     max.push(from.and_then(|s| s.max_value.as_ref()));
+
     Ok(())
 }

--- a/crates/polars-parquet/src/arrow/read/statistics/binview.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/binview.rs
@@ -1,10 +1,10 @@
 use arrow::array::{MutableArray, MutableBinaryViewArray, ViewType};
 use polars_error::PolarsResult;
 
-use crate::parquet::statistics::{BinaryStatistics, Statistics as ParquetStatistics};
+use crate::parquet::statistics::BinaryStatistics;
 
 pub(super) fn push<T: ViewType + ?Sized>(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&BinaryStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -16,7 +16,7 @@ pub(super) fn push<T: ViewType + ?Sized>(
         .as_mut_any()
         .downcast_mut::<MutableBinaryViewArray<T>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<BinaryStatistics>().unwrap());
+
     min.push(from.and_then(|s| {
         let opt_b = s.min_value.as_deref();
         unsafe { opt_b.map(|b| T::from_bytes_unchecked(b)) }
@@ -25,5 +25,6 @@ pub(super) fn push<T: ViewType + ?Sized>(
         let opt_b = s.max_value.as_deref();
         unsafe { opt_b.map(|b| T::from_bytes_unchecked(b)) }
     }));
+
     Ok(())
 }

--- a/crates/polars-parquet/src/arrow/read/statistics/boolean.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/boolean.rs
@@ -1,10 +1,10 @@
 use arrow::array::{MutableArray, MutableBooleanArray};
 use polars_error::PolarsResult;
 
-use crate::parquet::statistics::{BooleanStatistics, Statistics as ParquetStatistics};
+use crate::parquet::statistics::BooleanStatistics;
 
 pub(super) fn push(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&BooleanStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -16,8 +16,9 @@ pub(super) fn push(
         .as_mut_any()
         .downcast_mut::<MutableBooleanArray>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<BooleanStatistics>().unwrap());
+
     min.push(from.and_then(|s| s.min_value));
     max.push(from.and_then(|s| s.max_value));
+
     Ok(())
 }

--- a/crates/polars-parquet/src/arrow/read/statistics/fixlen.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/fixlen.rs
@@ -5,10 +5,10 @@ use polars_error::PolarsResult;
 
 use super::super::{convert_days_ms, convert_i128};
 use crate::arrow::read::convert_i256;
-use crate::parquet::statistics::{FixedLenStatistics, Statistics as ParquetStatistics};
+use crate::parquet::statistics::FixedLenStatistics;
 
 pub(super) fn push_i128(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&FixedLenStatistics>,
     n: usize,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
@@ -21,7 +21,6 @@ pub(super) fn push_i128(
         .as_mut_any()
         .downcast_mut::<MutablePrimitiveArray<i128>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
 
     min.push(from.and_then(|s| s.min_value.as_deref().map(|x| convert_i128(x, n))));
     max.push(from.and_then(|s| s.max_value.as_deref().map(|x| convert_i128(x, n))));
@@ -30,7 +29,7 @@ pub(super) fn push_i128(
 }
 
 pub(super) fn push_i256_with_i128(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&FixedLenStatistics>,
     n: usize,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
@@ -43,7 +42,6 @@ pub(super) fn push_i256_with_i128(
         .as_mut_any()
         .downcast_mut::<MutablePrimitiveArray<i256>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
 
     min.push(from.and_then(|s| {
         s.min_value
@@ -60,7 +58,7 @@ pub(super) fn push_i256_with_i128(
 }
 
 pub(super) fn push_i256(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&FixedLenStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -72,7 +70,6 @@ pub(super) fn push_i256(
         .as_mut_any()
         .downcast_mut::<MutablePrimitiveArray<i256>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
 
     min.push(from.and_then(|s| s.min_value.as_deref().map(convert_i256)));
     max.push(from.and_then(|s| s.max_value.as_deref().map(convert_i256)));
@@ -81,7 +78,7 @@ pub(super) fn push_i256(
 }
 
 pub(super) fn push(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&FixedLenStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -93,9 +90,10 @@ pub(super) fn push(
         .as_mut_any()
         .downcast_mut::<MutableFixedSizeBinaryArray>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
+
     min.push(from.and_then(|s| s.min_value.as_ref()));
     max.push(from.and_then(|s| s.max_value.as_ref()));
+
     Ok(())
 }
 
@@ -104,7 +102,7 @@ fn convert_year_month(value: &[u8]) -> i32 {
 }
 
 pub(super) fn push_year_month(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&FixedLenStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -116,7 +114,6 @@ pub(super) fn push_year_month(
         .as_mut_any()
         .downcast_mut::<MutablePrimitiveArray<i32>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
 
     min.push(from.and_then(|s| s.min_value.as_deref().map(convert_year_month)));
     max.push(from.and_then(|s| s.max_value.as_deref().map(convert_year_month)));
@@ -125,7 +122,7 @@ pub(super) fn push_year_month(
 }
 
 pub(super) fn push_days_ms(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&FixedLenStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -137,7 +134,6 @@ pub(super) fn push_days_ms(
         .as_mut_any()
         .downcast_mut::<MutablePrimitiveArray<days_ms>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
 
     min.push(from.and_then(|s| s.min_value.as_deref().map(convert_days_ms)));
     max.push(from.and_then(|s| s.max_value.as_deref().map(convert_days_ms)));

--- a/crates/polars-parquet/src/arrow/read/statistics/primitive.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/primitive.rs
@@ -4,7 +4,7 @@ use arrow::types::NativeType;
 use polars_error::PolarsResult;
 
 use crate::parquet::schema::types::{PrimitiveLogicalType, TimeUnit as ParquetTimeUnit};
-use crate::parquet::statistics::{PrimitiveStatistics, Statistics as ParquetStatistics};
+use crate::parquet::statistics::PrimitiveStatistics;
 use crate::parquet::types::NativeType as ParquetNativeType;
 
 pub fn timestamp(logical_type: Option<&PrimitiveLogicalType>, time_unit: TimeUnit, x: i64) -> i64 {
@@ -34,7 +34,7 @@ pub fn timestamp(logical_type: Option<&PrimitiveLogicalType>, time_unit: TimeUni
 }
 
 pub(super) fn push<P: ParquetNativeType, T: NativeType, F: Fn(P) -> PolarsResult<T> + Copy>(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&PrimitiveStatistics<P>>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
     map: F,
@@ -47,7 +47,7 @@ pub(super) fn push<P: ParquetNativeType, T: NativeType, F: Fn(P) -> PolarsResult
         .as_mut_any()
         .downcast_mut::<MutablePrimitiveArray<T>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<PrimitiveStatistics<P>>().unwrap());
+
     min.push(from.and_then(|s| s.min_value.map(map)).transpose()?);
     max.push(from.and_then(|s| s.max_value.map(map)).transpose()?);
 

--- a/crates/polars-parquet/src/arrow/read/statistics/utf8.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/utf8.rs
@@ -2,10 +2,10 @@ use arrow::array::{MutableArray, MutableUtf8Array};
 use arrow::offset::Offset;
 use polars_error::PolarsResult;
 
-use crate::parquet::statistics::{BinaryStatistics, Statistics as ParquetStatistics};
+use crate::parquet::statistics::BinaryStatistics;
 
 pub(super) fn push<O: Offset>(
-    from: Option<&dyn ParquetStatistics>,
+    from: Option<&BinaryStatistics>,
     min: &mut dyn MutableArray,
     max: &mut dyn MutableArray,
 ) -> PolarsResult<()> {
@@ -17,7 +17,6 @@ pub(super) fn push<O: Offset>(
         .as_mut_any()
         .downcast_mut::<MutableUtf8Array<O>>()
         .unwrap();
-    let from = from.map(|s| s.as_any().downcast_ref::<BinaryStatistics>().unwrap());
 
     min.push(
         from.and_then(|s| s.min_value.as_deref().map(simdutf8::basic::from_utf8))
@@ -27,5 +26,6 @@ pub(super) fn push<O: Offset>(
         from.and_then(|s| s.max_value.as_deref().map(simdutf8::basic::from_utf8))
             .transpose()?,
     );
+
     Ok(())
 }

--- a/crates/polars-parquet/src/arrow/write/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binary/basic.rs
@@ -7,9 +7,7 @@ use super::super::{utils, WriteOptions};
 use crate::arrow::read::schema::is_nullable;
 use crate::parquet::encoding::{delta_bitpacked, Encoding};
 use crate::parquet::schema::types::PrimitiveType;
-use crate::parquet::statistics::{
-    serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics,
-};
+use crate::parquet::statistics::{BinaryStatistics, ParquetStatistics};
 use crate::write::utils::invalid_encoding;
 use crate::write::Page;
 
@@ -92,7 +90,7 @@ pub(crate) fn build_statistics<O: Offset>(
     array: &BinaryArray<O>,
     primitive_type: PrimitiveType,
 ) -> ParquetStatistics {
-    let statistics = &BinaryStatistics {
+    BinaryStatistics {
         primitive_type,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
@@ -106,8 +104,8 @@ pub(crate) fn build_statistics<O: Offset>(
             .flatten()
             .min_by(|x, y| ord_binary(x, y))
             .map(|x| x.to_vec()),
-    } as &dyn Statistics;
-    serialize_statistics(statistics)
+    }
+    .serialize()
 }
 
 pub(crate) fn encode_delta<O: Offset>(

--- a/crates/polars-parquet/src/arrow/write/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binview/basic.rs
@@ -3,9 +3,7 @@ use polars_error::PolarsResult;
 
 use crate::parquet::encoding::delta_bitpacked;
 use crate::parquet::schema::types::PrimitiveType;
-use crate::parquet::statistics::{
-    serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics,
-};
+use crate::parquet::statistics::{BinaryStatistics, ParquetStatistics};
 use crate::read::schema::is_nullable;
 use crate::write::binary::{encode_non_null_values, ord_binary};
 use crate::write::utils::invalid_encoding;
@@ -84,7 +82,7 @@ pub(crate) fn build_statistics(
     array: &BinaryViewArray,
     primitive_type: PrimitiveType,
 ) -> ParquetStatistics {
-    let statistics = &BinaryStatistics {
+    BinaryStatistics {
         primitive_type,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
@@ -98,6 +96,6 @@ pub(crate) fn build_statistics(
             .flatten()
             .min_by(|x, y| ord_binary(x, y))
             .map(|x| x.to_vec()),
-    } as &dyn Statistics;
-    serialize_statistics(statistics)
+    }
+    .serialize()
 }

--- a/crates/polars-parquet/src/arrow/write/boolean/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/boolean/basic.rs
@@ -7,9 +7,7 @@ use crate::parquet::encoding::hybrid_rle::bitpacked_encode;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::DataPage;
 use crate::parquet::schema::types::PrimitiveType;
-use crate::parquet::statistics::{
-    serialize_statistics, BooleanStatistics, ParquetStatistics, Statistics,
-};
+use crate::parquet::statistics::{BooleanStatistics, ParquetStatistics};
 
 fn encode(iterator: impl Iterator<Item = bool>, buffer: &mut Vec<u8>) -> PolarsResult<()> {
     // encode values using bitpacking
@@ -82,11 +80,11 @@ pub fn array_to_page(
 }
 
 pub(super) fn build_statistics(array: &BooleanArray) -> ParquetStatistics {
-    let statistics = &BooleanStatistics {
+    BooleanStatistics {
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
         max_value: array.iter().flatten().max(),
         min_value: array.iter().flatten().min(),
-    } as &dyn Statistics;
-    serialize_statistics(statistics)
+    }
+    .serialize()
 }

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -19,7 +19,7 @@ use crate::parquet::encoding::hybrid_rle::encode;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::{DictPage, Page};
 use crate::parquet::schema::types::PrimitiveType;
-use crate::parquet::statistics::{serialize_statistics, ParquetStatistics};
+use crate::parquet::statistics::ParquetStatistics;
 use crate::write::DynIter;
 
 pub(crate) fn encode_as_dictionary_optional(
@@ -193,8 +193,7 @@ macro_rules! dyn_prim {
         let stats: Option<ParquetStatistics> = if $options.write_statistics {
             let mut stats = primitive_build_statistics::<$from, $to>(values, $type_.clone());
             stats.null_count = Some($array.null_count() as i64);
-            let stats = serialize_statistics(&stats);
-            Some(stats)
+            Some(stats.serialize())
         } else {
             None
         };
@@ -299,7 +298,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                         fixed_binary_encode_plain(array, false, &mut buffer);
                         let stats = if options.write_statistics {
                             let stats = fixed_binary_build_statistics(array, type_.clone());
-                            Some(serialize_statistics(&stats))
+                            Some(stats.serialize())
                         } else {
                             None
                         };

--- a/crates/polars-parquet/src/arrow/write/fixed_len_bytes.rs
+++ b/crates/polars-parquet/src/arrow/write/fixed_len_bytes.rs
@@ -8,7 +8,7 @@ use crate::arrow::read::schema::is_nullable;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::DataPage;
 use crate::parquet::schema::types::PrimitiveType;
-use crate::parquet::statistics::{serialize_statistics, FixedLenStatistics};
+use crate::parquet::statistics::FixedLenStatistics;
 
 pub(crate) fn encode_plain(array: &FixedSizeBinaryArray, is_optional: bool, buffer: &mut Vec<u8>) {
     // append the non-null values
@@ -52,7 +52,7 @@ pub fn array_to_page(
         array.null_count(),
         0,
         definition_levels_byte_length,
-        statistics.map(|x| serialize_statistics(&x)),
+        statistics.map(|x| x.serialize()),
         type_,
         options,
         Encoding::Plain,

--- a/crates/polars-parquet/src/arrow/write/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/basic.rs
@@ -9,7 +9,7 @@ use crate::parquet::encoding::delta_bitpacked::encode;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::DataPage;
 use crate::parquet::schema::types::PrimitiveType;
-use crate::parquet::statistics::{serialize_statistics, PrimitiveStatistics};
+use crate::parquet::statistics::PrimitiveStatistics;
 use crate::parquet::types::NativeType as ParquetNativeType;
 use crate::read::Page;
 
@@ -137,10 +137,7 @@ where
     let buffer = encode(array, is_optional, buffer);
 
     let statistics = if options.write_statistics {
-        Some(serialize_statistics(&build_statistics(
-            array,
-            type_.clone(),
-        )))
+        Some(build_statistics(array, type_.clone()).serialize())
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/primitive/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/nested.rs
@@ -9,7 +9,6 @@ use crate::arrow::write::Nested;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::DataPage;
 use crate::parquet::schema::types::PrimitiveType;
-use crate::parquet::statistics::serialize_statistics;
 use crate::parquet::types::NativeType;
 
 pub fn array_to_page<T, R>(
@@ -33,10 +32,7 @@ where
     let buffer = encode_plain(array, is_optional, buffer);
 
     let statistics = if options.write_statistics {
-        Some(serialize_statistics(&build_statistics(
-            array,
-            type_.clone(),
-        )))
+        Some(build_statistics(array, type_.clone()).serialize())
     } else {
         None
     };

--- a/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
+++ b/crates/polars-parquet/src/parquet/metadata/column_chunk_metadata.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-
 use parquet_format_safe::{ColumnChunk, ColumnMetaData, Encoding};
 
 use super::column_descriptor::ColumnDescriptor;
 use crate::parquet::compression::Compression;
 use crate::parquet::error::{Error, Result};
 use crate::parquet::schema::types::PhysicalType;
-use crate::parquet::statistics::{deserialize_statistics, Statistics};
+use crate::parquet::statistics::Statistics;
 
 #[cfg(feature = "serde_types")]
 mod serde_types {
@@ -113,11 +111,10 @@ impl ColumnChunkMetaData {
     }
 
     /// Decodes the raw statistics into [`Statistics`].
-    pub fn statistics(&self) -> Option<Result<Arc<dyn Statistics>>> {
-        self.metadata()
-            .statistics
-            .as_ref()
-            .map(|x| deserialize_statistics(x, self.column_descr.descriptor.primitive_type.clone()))
+    pub fn statistics(&self) -> Option<Result<Statistics>> {
+        self.metadata().statistics.as_ref().map(|x| {
+            Statistics::deserialize(x, self.column_descr.descriptor.primitive_type.clone())
+        })
     }
 
     /// Total number of values in this column chunk. Note that this is not necessarily the number

--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-
 use crate::parquet::compression::Compression;
 use crate::parquet::encoding::{get_length, Encoding};
 use crate::parquet::error::{Error, Result};
 use crate::parquet::indexes::Interval;
 use crate::parquet::metadata::Descriptor;
 pub use crate::parquet::parquet_bridge::{DataPageHeaderExt, PageType};
-use crate::parquet::statistics::{deserialize_statistics, Statistics};
+use crate::parquet::statistics::Statistics;
 pub use crate::parquet::thrift_format::{
     DataPageHeader as DataPageHeaderV1, DataPageHeaderV2, PageHeader as ParquetPageHeader,
 };
@@ -99,16 +97,16 @@ impl CompressedDataPage {
     }
 
     /// Decodes the raw statistics into a statistics
-    pub fn statistics(&self) -> Option<Result<Arc<dyn Statistics>>> {
+    pub fn statistics(&self) -> Option<Result<Statistics>> {
         match &self.header {
             DataPageHeader::V1(d) => d
                 .statistics
                 .as_ref()
-                .map(|x| deserialize_statistics(x, self.descriptor.primitive_type.clone())),
+                .map(|x| Statistics::deserialize(x, self.descriptor.primitive_type.clone())),
             DataPageHeader::V2(d) => d
                 .statistics
                 .as_ref()
-                .map(|x| deserialize_statistics(x, self.descriptor.primitive_type.clone())),
+                .map(|x| Statistics::deserialize(x, self.descriptor.primitive_type.clone())),
         }
     }
 
@@ -218,16 +216,16 @@ impl DataPage {
     }
 
     /// Decodes the raw statistics into a statistics
-    pub fn statistics(&self) -> Option<Result<Arc<dyn Statistics>>> {
+    pub fn statistics(&self) -> Option<Result<Statistics>> {
         match &self.header {
             DataPageHeader::V1(d) => d
                 .statistics
                 .as_ref()
-                .map(|x| deserialize_statistics(x, self.descriptor.primitive_type.clone())),
+                .map(|x| Statistics::deserialize(x, self.descriptor.primitive_type.clone())),
             DataPageHeader::V2(d) => d
                 .statistics
                 .as_ref()
-                .map(|x| deserialize_statistics(x, self.descriptor.primitive_type.clone())),
+                .map(|x| Statistics::deserialize(x, self.descriptor.primitive_type.clone())),
         }
     }
 }

--- a/crates/polars-parquet/src/parquet/statistics/binary.rs
+++ b/crates/polars-parquet/src/parquet/statistics/binary.rs
@@ -1,12 +1,9 @@
-use std::sync::Arc;
-
 use parquet_format_safe::Statistics as ParquetStatistics;
 
-use super::Statistics;
 use crate::parquet::error::Result;
-use crate::parquet::schema::types::{PhysicalType, PrimitiveType};
+use crate::parquet::schema::types::PrimitiveType;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BinaryStatistics {
     pub primitive_type: PrimitiveType,
     pub null_count: Option<i64>,
@@ -15,37 +12,25 @@ pub struct BinaryStatistics {
     pub min_value: Option<Vec<u8>>,
 }
 
-impl Statistics for BinaryStatistics {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
+impl BinaryStatistics {
+    pub fn deserialize(v: &ParquetStatistics, primitive_type: PrimitiveType) -> Result<Self> {
+        Ok(BinaryStatistics {
+            primitive_type,
+            null_count: v.null_count,
+            distinct_count: v.distinct_count,
+            max_value: v.max_value.clone(),
+            min_value: v.min_value.clone(),
+        })
     }
 
-    fn physical_type(&self) -> &PhysicalType {
-        &PhysicalType::ByteArray
-    }
-
-    fn null_count(&self) -> Option<i64> {
-        self.null_count
-    }
-}
-
-pub fn read(v: &ParquetStatistics, primitive_type: PrimitiveType) -> Result<Arc<dyn Statistics>> {
-    Ok(Arc::new(BinaryStatistics {
-        primitive_type,
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v.max_value.clone(),
-        min_value: v.min_value.clone(),
-    }))
-}
-
-pub fn write(v: &BinaryStatistics) -> ParquetStatistics {
-    ParquetStatistics {
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v.max_value.clone(),
-        min_value: v.min_value.clone(),
-        min: None,
-        max: None,
+    pub fn serialize(&self) -> ParquetStatistics {
+        ParquetStatistics {
+            null_count: self.null_count,
+            distinct_count: self.distinct_count,
+            max_value: self.max_value.clone(),
+            min_value: self.min_value.clone(),
+            min: None,
+            max: None,
+        }
     }
 }

--- a/crates/polars-parquet/src/parquet/statistics/boolean.rs
+++ b/crates/polars-parquet/src/parquet/statistics/boolean.rs
@@ -1,12 +1,8 @@
-use std::sync::Arc;
-
 use parquet_format_safe::Statistics as ParquetStatistics;
 
-use super::Statistics;
 use crate::parquet::error::{Error, Result};
-use crate::parquet::schema::types::PhysicalType;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BooleanStatistics {
     pub null_count: Option<i64>,
     pub distinct_count: Option<i64>,
@@ -14,59 +10,47 @@ pub struct BooleanStatistics {
     pub min_value: Option<bool>,
 }
 
-impl Statistics for BooleanStatistics {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
+impl BooleanStatistics {
+    pub fn deserialize(v: &ParquetStatistics) -> Result<Self> {
+        if let Some(ref v) = v.max_value {
+            if v.len() != std::mem::size_of::<bool>() {
+                return Err(Error::oos(
+                    "The max_value of statistics MUST be plain encoded",
+                ));
+            }
+        };
+        if let Some(ref v) = v.min_value {
+            if v.len() != std::mem::size_of::<bool>() {
+                return Err(Error::oos(
+                    "The min_value of statistics MUST be plain encoded",
+                ));
+            }
+        };
+
+        Ok(Self {
+            null_count: v.null_count,
+            distinct_count: v.distinct_count,
+            max_value: v
+                .max_value
+                .as_ref()
+                .and_then(|x| x.first())
+                .map(|x| *x != 0),
+            min_value: v
+                .min_value
+                .as_ref()
+                .and_then(|x| x.first())
+                .map(|x| *x != 0),
+        })
     }
 
-    fn physical_type(&self) -> &PhysicalType {
-        &PhysicalType::Boolean
-    }
-
-    fn null_count(&self) -> Option<i64> {
-        self.null_count
-    }
-}
-
-pub fn read(v: &ParquetStatistics) -> Result<Arc<dyn Statistics>> {
-    if let Some(ref v) = v.max_value {
-        if v.len() != std::mem::size_of::<bool>() {
-            return Err(Error::oos(
-                "The max_value of statistics MUST be plain encoded",
-            ));
+    pub fn serialize(&self) -> ParquetStatistics {
+        ParquetStatistics {
+            null_count: self.null_count,
+            distinct_count: self.distinct_count,
+            max_value: self.max_value.map(|x| vec![x as u8]),
+            min_value: self.min_value.map(|x| vec![x as u8]),
+            min: None,
+            max: None,
         }
-    };
-    if let Some(ref v) = v.min_value {
-        if v.len() != std::mem::size_of::<bool>() {
-            return Err(Error::oos(
-                "The min_value of statistics MUST be plain encoded",
-            ));
-        }
-    };
-
-    Ok(Arc::new(BooleanStatistics {
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v
-            .max_value
-            .as_ref()
-            .and_then(|x| x.first())
-            .map(|x| *x != 0),
-        min_value: v
-            .min_value
-            .as_ref()
-            .and_then(|x| x.first())
-            .map(|x| *x != 0),
-    }))
-}
-
-pub fn write(v: &BooleanStatistics) -> ParquetStatistics {
-    ParquetStatistics {
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v.max_value.map(|x| vec![x as u8]),
-        min_value: v.min_value.map(|x| vec![x as u8]),
-        min: None,
-        max: None,
     }
 }

--- a/crates/polars-parquet/src/parquet/statistics/fixed_len_binary.rs
+++ b/crates/polars-parquet/src/parquet/statistics/fixed_len_binary.rs
@@ -1,12 +1,9 @@
-use std::sync::Arc;
-
 use parquet_format_safe::Statistics as ParquetStatistics;
 
-use super::Statistics;
 use crate::parquet::error::{Error, Result};
-use crate::parquet::schema::types::{PhysicalType, PrimitiveType};
+use crate::parquet::schema::types::PrimitiveType;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FixedLenStatistics {
     pub primitive_type: PrimitiveType,
     pub null_count: Option<i64>,
@@ -15,62 +12,50 @@ pub struct FixedLenStatistics {
     pub min_value: Option<Vec<u8>>,
 }
 
-impl Statistics for FixedLenStatistics {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
+impl FixedLenStatistics {
+    pub fn deserialize(
+        v: &ParquetStatistics,
+        size: usize,
+        primitive_type: PrimitiveType,
+    ) -> Result<Self> {
+        if let Some(ref v) = v.max_value {
+            if v.len() != size {
+                return Err(Error::oos(
+                    "The max_value of statistics MUST be plain encoded",
+                ));
+            }
+        };
+        if let Some(ref v) = v.min_value {
+            if v.len() != size {
+                return Err(Error::oos(
+                    "The min_value of statistics MUST be plain encoded",
+                ));
+            }
+        };
+
+        Ok(Self {
+            primitive_type,
+            null_count: v.null_count,
+            distinct_count: v.distinct_count,
+            max_value: v.max_value.clone().map(|mut x| {
+                x.truncate(size);
+                x
+            }),
+            min_value: v.min_value.clone().map(|mut x| {
+                x.truncate(size);
+                x
+            }),
+        })
     }
 
-    fn physical_type(&self) -> &PhysicalType {
-        &self.primitive_type.physical_type
-    }
-
-    fn null_count(&self) -> Option<i64> {
-        self.null_count
-    }
-}
-
-pub fn read(
-    v: &ParquetStatistics,
-    size: usize,
-    primitive_type: PrimitiveType,
-) -> Result<Arc<dyn Statistics>> {
-    if let Some(ref v) = v.max_value {
-        if v.len() != size {
-            return Err(Error::oos(
-                "The max_value of statistics MUST be plain encoded",
-            ));
+    pub fn serialize(&self) -> ParquetStatistics {
+        ParquetStatistics {
+            null_count: self.null_count,
+            distinct_count: self.distinct_count,
+            max_value: self.max_value.clone(),
+            min_value: self.min_value.clone(),
+            min: None,
+            max: None,
         }
-    };
-    if let Some(ref v) = v.min_value {
-        if v.len() != size {
-            return Err(Error::oos(
-                "The min_value of statistics MUST be plain encoded",
-            ));
-        }
-    };
-
-    Ok(Arc::new(FixedLenStatistics {
-        primitive_type,
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v.max_value.clone().map(|mut x| {
-            x.truncate(size);
-            x
-        }),
-        min_value: v.min_value.clone().map(|mut x| {
-            x.truncate(size);
-            x
-        }),
-    }))
-}
-
-pub fn write(v: &FixedLenStatistics) -> ParquetStatistics {
-    ParquetStatistics {
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v.max_value.clone(),
-        min_value: v.min_value.clone(),
-        min: None,
-        max: None,
     }
 }

--- a/crates/polars-parquet/src/parquet/statistics/mod.rs
+++ b/crates/polars-parquet/src/parquet/statistics/mod.rs
@@ -3,9 +3,6 @@ mod boolean;
 mod fixed_len_binary;
 mod primitive;
 
-use std::any::Any;
-use std::sync::Arc;
-
 pub use binary::BinaryStatistics;
 pub use boolean::BooleanStatistics;
 pub use fixed_len_binary::FixedLenStatistics;
@@ -15,120 +12,150 @@ use crate::parquet::error::Result;
 use crate::parquet::schema::types::{PhysicalType, PrimitiveType};
 pub use crate::parquet::thrift_format::Statistics as ParquetStatistics;
 
-/// A trait used to describe specific statistics. Each physical type has its own struct.
-/// Match the [`Statistics::physical_type`] to each type and downcast accordingly.
-pub trait Statistics: Send + Sync + std::fmt::Debug {
-    fn as_any(&self) -> &dyn Any;
-
-    fn physical_type(&self) -> &PhysicalType;
-
-    fn null_count(&self) -> Option<i64>;
+#[derive(Debug, PartialEq)]
+pub enum Statistics {
+    Binary(BinaryStatistics),
+    Boolean(BooleanStatistics),
+    FixedLen(FixedLenStatistics),
+    Int32(PrimitiveStatistics<i32>),
+    Int64(PrimitiveStatistics<i64>),
+    Int96(PrimitiveStatistics<[u32; 3]>),
+    Float(PrimitiveStatistics<f32>),
+    Double(PrimitiveStatistics<f64>),
 }
 
-impl PartialEq for &dyn Statistics {
-    fn eq(&self, other: &Self) -> bool {
-        self.physical_type() == other.physical_type() && {
-            match self.physical_type() {
-                PhysicalType::Boolean => {
-                    self.as_any().downcast_ref::<BooleanStatistics>().unwrap()
-                        == other.as_any().downcast_ref::<BooleanStatistics>().unwrap()
-                },
-                PhysicalType::Int32 => {
-                    self.as_any()
-                        .downcast_ref::<PrimitiveStatistics<i32>>()
-                        .unwrap()
-                        == other
-                            .as_any()
-                            .downcast_ref::<PrimitiveStatistics<i32>>()
-                            .unwrap()
-                },
-                PhysicalType::Int64 => {
-                    self.as_any()
-                        .downcast_ref::<PrimitiveStatistics<i64>>()
-                        .unwrap()
-                        == other
-                            .as_any()
-                            .downcast_ref::<PrimitiveStatistics<i64>>()
-                            .unwrap()
-                },
-                PhysicalType::Int96 => {
-                    self.as_any()
-                        .downcast_ref::<PrimitiveStatistics<[u32; 3]>>()
-                        .unwrap()
-                        == other
-                            .as_any()
-                            .downcast_ref::<PrimitiveStatistics<[u32; 3]>>()
-                            .unwrap()
-                },
-                PhysicalType::Float => {
-                    self.as_any()
-                        .downcast_ref::<PrimitiveStatistics<f32>>()
-                        .unwrap()
-                        == other
-                            .as_any()
-                            .downcast_ref::<PrimitiveStatistics<f32>>()
-                            .unwrap()
-                },
-                PhysicalType::Double => {
-                    self.as_any()
-                        .downcast_ref::<PrimitiveStatistics<f64>>()
-                        .unwrap()
-                        == other
-                            .as_any()
-                            .downcast_ref::<PrimitiveStatistics<f64>>()
-                            .unwrap()
-                },
-                PhysicalType::ByteArray => {
-                    self.as_any().downcast_ref::<BinaryStatistics>().unwrap()
-                        == other.as_any().downcast_ref::<BinaryStatistics>().unwrap()
-                },
-                PhysicalType::FixedLenByteArray(_) => {
-                    self.as_any().downcast_ref::<FixedLenStatistics>().unwrap()
-                        == other.as_any().downcast_ref::<FixedLenStatistics>().unwrap()
-                },
-            }
+impl Statistics {
+    #[inline]
+    pub const fn physical_type(&self) -> &PhysicalType {
+        use Statistics as S;
+
+        match self {
+            S::Binary(_) => &PhysicalType::ByteArray,
+            S::Boolean(_) => &PhysicalType::Boolean,
+            S::FixedLen(s) => &s.primitive_type.physical_type,
+            S::Int32(_) => &PhysicalType::Int32,
+            S::Int64(_) => &PhysicalType::Int64,
+            S::Int96(_) => &PhysicalType::Int96,
+            S::Float(_) => &PhysicalType::Float,
+            S::Double(_) => &PhysicalType::Double,
         }
     }
-}
 
-/// Deserializes a raw parquet statistics into [`Statistics`].
-/// # Error
-/// This function errors if it is not possible to read the statistics to the
-/// corresponding `physical_type`.
-pub fn deserialize_statistics(
-    statistics: &ParquetStatistics,
-    primitive_type: PrimitiveType,
-) -> Result<Arc<dyn Statistics>> {
-    match primitive_type.physical_type {
-        PhysicalType::Boolean => boolean::read(statistics),
-        PhysicalType::Int32 => primitive::read::<i32>(statistics, primitive_type),
-        PhysicalType::Int64 => primitive::read::<i64>(statistics, primitive_type),
-        PhysicalType::Int96 => primitive::read::<[u32; 3]>(statistics, primitive_type),
-        PhysicalType::Float => primitive::read::<f32>(statistics, primitive_type),
-        PhysicalType::Double => primitive::read::<f64>(statistics, primitive_type),
-        PhysicalType::ByteArray => binary::read(statistics, primitive_type),
-        PhysicalType::FixedLenByteArray(size) => {
-            fixed_len_binary::read(statistics, size, primitive_type)
-        },
+    /// Deserializes a raw parquet statistics into [`Statistics`].
+    /// # Error
+    /// This function errors if it is not possible to read the statistics to the
+    /// corresponding `physical_type`.
+    #[inline]
+    pub fn deserialize(
+        statistics: &ParquetStatistics,
+        primitive_type: PrimitiveType,
+    ) -> Result<Self> {
+        use {PhysicalType as T, PrimitiveStatistics as PrimStat};
+        Ok(match primitive_type.physical_type {
+            T::ByteArray => BinaryStatistics::deserialize(statistics, primitive_type)?.into(),
+            T::Boolean => BooleanStatistics::deserialize(statistics)?.into(),
+            T::Int32 => PrimStat::<i32>::deserialize(statistics, primitive_type)?.into(),
+            T::Int64 => PrimStat::<i64>::deserialize(statistics, primitive_type)?.into(),
+            T::Int96 => PrimStat::<[u32; 3]>::deserialize(statistics, primitive_type)?.into(),
+            T::Float => PrimStat::<f32>::deserialize(statistics, primitive_type)?.into(),
+            T::Double => PrimStat::<f64>::deserialize(statistics, primitive_type)?.into(),
+            T::FixedLenByteArray(size) => {
+                FixedLenStatistics::deserialize(statistics, size, primitive_type)?.into()
+            },
+        })
     }
 }
 
-/// Serializes [`Statistics`] into a raw parquet statistics.
-pub fn serialize_statistics(statistics: &dyn Statistics) -> ParquetStatistics {
-    match statistics.physical_type() {
-        PhysicalType::Boolean => boolean::write(statistics.as_any().downcast_ref().unwrap()),
-        PhysicalType::Int32 => primitive::write::<i32>(statistics.as_any().downcast_ref().unwrap()),
-        PhysicalType::Int64 => primitive::write::<i64>(statistics.as_any().downcast_ref().unwrap()),
-        PhysicalType::Int96 => {
-            primitive::write::<[u32; 3]>(statistics.as_any().downcast_ref().unwrap())
-        },
-        PhysicalType::Float => primitive::write::<f32>(statistics.as_any().downcast_ref().unwrap()),
-        PhysicalType::Double => {
-            primitive::write::<f64>(statistics.as_any().downcast_ref().unwrap())
-        },
-        PhysicalType::ByteArray => binary::write(statistics.as_any().downcast_ref().unwrap()),
-        PhysicalType::FixedLenByteArray(_) => {
-            fixed_len_binary::write(statistics.as_any().downcast_ref().unwrap())
-        },
-    }
+macro_rules! statistics_from_as {
+    ($($variant:ident($struct:ty) => ($as_ident:ident, $into_ident:ident, $expect_ident:ident, $owned_expect_ident:ident),)+) => {
+        $(
+            impl From<$struct> for Statistics {
+                #[inline]
+                fn from(stats: $struct) -> Self {
+                    Self::$variant(stats)
+                }
+            }
+        )+
+
+        impl Statistics {
+            #[inline]
+            pub const fn null_count(&self) -> Option<i64> {
+                match self {
+                    $(Self::$variant(s) => s.null_count,)+
+                }
+            }
+
+            /// Serializes [`Statistics`] into a raw parquet statistics.
+            #[inline]
+            pub fn serialize(&self) -> ParquetStatistics {
+                match self {
+                    $(Self::$variant(s) => s.serialize(),)+
+                }
+            }
+
+            const fn variant_str(&self) -> &'static str {
+                match self {
+                    $(Self::$variant(_) => stringify!($struct),)+
+                }
+            }
+
+            $(
+                #[doc = concat!("Try to take [`Statistics`] as [`", stringify!($struct), "`]")]
+                #[inline]
+                pub fn $as_ident(&self) -> Option<&$struct> {
+                    match self {
+                        Self::$variant(s) => Some(s),
+                        _ => None,
+                    }
+                }
+
+                #[doc = concat!("Try to take [`Statistics`] as [`", stringify!($struct), "`]")]
+                #[inline]
+                pub fn $into_ident(self) -> Option<$struct> {
+                    match self {
+                        Self::$variant(s) => Some(s),
+                        _ => None,
+                    }
+                }
+
+                #[doc = concat!("Interpret [`Statistics`] to be [`", stringify!($struct), "`]")]
+                ///
+                /// Panics if it is not the correct variant.
+                #[track_caller]
+                #[inline]
+                pub fn $expect_ident(&self) -> &$struct {
+                    let Self::$variant(s) = self else {
+                        panic!("Expected Statistics to be {}, found {} instead", stringify!($struct), self.variant_str());
+                    };
+
+                    s
+                }
+
+                #[doc = concat!("Interpret [`Statistics`] to be [`", stringify!($struct), "`]")]
+                ///
+                /// Panics if it is not the correct variant.
+                #[track_caller]
+                #[inline]
+                pub fn $owned_expect_ident(self) -> $struct {
+                    let Self::$variant(s) = self else {
+                        panic!("Expected Statistics to be {}, found {} instead", stringify!($struct), self.variant_str());
+                    };
+
+                    s
+                }
+            )+
+
+        }
+    };
+}
+
+statistics_from_as! {
+    Binary    (BinaryStatistics             ) => (as_binary,   into_binary,   expect_as_binary,   expect_binary  ),
+    Boolean   (BooleanStatistics            ) => (as_boolean,  into_boolean,  expect_as_boolean,  expect_boolean ),
+    FixedLen  (FixedLenStatistics           ) => (as_fixedlen, into_fixedlen, expect_as_fixedlen, expect_fixedlen),
+    Int32     (PrimitiveStatistics<i32>     ) => (as_int32,    into_int32,    expect_as_int32,    expect_int32   ),
+    Int64     (PrimitiveStatistics<i64>     ) => (as_int64,    into_int64,    expect_as_int64,    expect_int64   ),
+    Int96     (PrimitiveStatistics<[u32; 3]>) => (as_int96,    into_int96,    expect_as_int96,    expect_int96   ),
+    Float     (PrimitiveStatistics<f32>     ) => (as_float,    into_float,    expect_as_float,    expect_float   ),
+    Double    (PrimitiveStatistics<f64>     ) => (as_double,   into_double,   expect_as_double,   expect_double  ),
 }

--- a/crates/polars-parquet/src/parquet/statistics/primitive.rs
+++ b/crates/polars-parquet/src/parquet/statistics/primitive.rs
@@ -1,13 +1,10 @@
-use std::sync::Arc;
-
 use parquet_format_safe::Statistics as ParquetStatistics;
 
-use super::Statistics;
 use crate::parquet::error::{Error, Result};
-use crate::parquet::schema::types::{PhysicalType, PrimitiveType};
+use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::types;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PrimitiveStatistics<T: types::NativeType> {
     pub primitive_type: PrimitiveType,
     pub null_count: Option<i64>,
@@ -16,55 +13,42 @@ pub struct PrimitiveStatistics<T: types::NativeType> {
     pub max_value: Option<T>,
 }
 
-impl<T: types::NativeType> Statistics for PrimitiveStatistics<T> {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn physical_type(&self) -> &PhysicalType {
-        &T::TYPE
-    }
-
-    fn null_count(&self) -> Option<i64> {
-        self.null_count
-    }
-}
-
-pub fn read<T: types::NativeType>(
-    v: &ParquetStatistics,
-    primitive_type: PrimitiveType,
-) -> Result<Arc<dyn Statistics>> {
-    if let Some(ref v) = v.max_value {
-        if v.len() != std::mem::size_of::<T>() {
+impl<T: types::NativeType> PrimitiveStatistics<T> {
+    pub fn deserialize(v: &ParquetStatistics, primitive_type: PrimitiveType) -> Result<Self> {
+        if v.max_value
+            .as_ref()
+            .is_some_and(|v| v.len() != std::mem::size_of::<T>())
+        {
             return Err(Error::oos(
                 "The max_value of statistics MUST be plain encoded",
             ));
-        }
-    };
-    if let Some(ref v) = v.min_value {
-        if v.len() != std::mem::size_of::<T>() {
+        };
+        if v.min_value
+            .as_ref()
+            .is_some_and(|v| v.len() != std::mem::size_of::<T>())
+        {
             return Err(Error::oos(
                 "The min_value of statistics MUST be plain encoded",
             ));
+        };
+
+        Ok(Self {
+            primitive_type,
+            null_count: v.null_count,
+            distinct_count: v.distinct_count,
+            max_value: v.max_value.as_ref().map(|x| types::decode(x)),
+            min_value: v.min_value.as_ref().map(|x| types::decode(x)),
+        })
+    }
+
+    pub fn serialize(&self) -> ParquetStatistics {
+        ParquetStatistics {
+            null_count: self.null_count,
+            distinct_count: self.distinct_count,
+            max_value: self.max_value.map(|x| x.to_le_bytes().as_ref().to_vec()),
+            min_value: self.min_value.map(|x| x.to_le_bytes().as_ref().to_vec()),
+            min: None,
+            max: None,
         }
-    };
-
-    Ok(Arc::new(PrimitiveStatistics::<T> {
-        primitive_type,
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v.max_value.as_ref().map(|x| types::decode(x)),
-        min_value: v.min_value.as_ref().map(|x| types::decode(x)),
-    }))
-}
-
-pub fn write<T: types::NativeType>(v: &PrimitiveStatistics<T>) -> ParquetStatistics {
-    ParquetStatistics {
-        null_count: v.null_count,
-        distinct_count: v.distinct_count,
-        max_value: v.max_value.map(|x| x.to_le_bytes().as_ref().to_vec()),
-        min_value: v.min_value.map(|x| x.to_le_bytes().as_ref().to_vec()),
-        min: None,
-        max: None,
     }
 }

--- a/crates/polars-parquet/src/parquet/write/column_chunk.rs
+++ b/crates/polars-parquet/src/parquet/write/column_chunk.rs
@@ -18,7 +18,6 @@ use crate::parquet::encoding::Encoding;
 use crate::parquet::error::{Error, Result};
 use crate::parquet::metadata::ColumnDescriptor;
 use crate::parquet::page::{CompressedPage, PageType};
-use crate::parquet::statistics::serialize_statistics;
 use crate::parquet::FallibleStreamingIterator;
 
 pub fn write_column_chunk<W, E>(
@@ -173,7 +172,7 @@ fn build_column_chunk(
 
     let statistics = specs.iter().map(|x| &x.statistics).collect::<Vec<_>>();
     let statistics = reduce(&statistics)?;
-    let statistics = statistics.map(|x| serialize_statistics(x.as_ref()));
+    let statistics = statistics.map(|x| x.serialize());
 
     let (type_, _): (Type, Option<i32>) = descriptor.descriptor.primitive_type.physical_type.into();
 

--- a/crates/polars-parquet/src/parquet/write/indexes/serialize.rs
+++ b/crates/polars-parquet/src/parquet/write/indexes/serialize.rs
@@ -1,7 +1,6 @@
 use parquet_format_safe::{BoundaryOrder, ColumnIndex, OffsetIndex, PageLocation};
 
 use crate::parquet::error::{Error, Result};
-use crate::parquet::statistics::serialize_statistics;
 use crate::parquet::write::page::{is_data_page, PageWriteSpec};
 
 pub fn serialize_column_index(pages: &[PageWriteSpec]) -> Result<ColumnIndex> {
@@ -15,7 +14,7 @@ pub fn serialize_column_index(pages: &[PageWriteSpec]) -> Result<ColumnIndex> {
         .filter(|x| is_data_page(x))
         .try_for_each(|spec| {
             if let Some(stats) = &spec.statistics {
-                let stats = serialize_statistics(stats.as_ref());
+                let stats = stats.serialize();
 
                 let null_count = stats
                     .null_count

--- a/crates/polars-parquet/src/parquet/write/page.rs
+++ b/crates/polars-parquet/src/parquet/write/page.rs
@@ -1,5 +1,4 @@
 use std::io::Write;
-use std::sync::Arc;
 
 #[cfg(feature = "async")]
 use futures::{AsyncWrite, AsyncWriteExt};
@@ -47,7 +46,7 @@ pub struct PageWriteSpec {
     pub offset: u64,
     pub bytes_written: u64,
     pub compression: Compression,
-    pub statistics: Option<Arc<dyn Statistics>>,
+    pub statistics: Option<Statistics>,
 }
 
 pub fn write_page<W: Write>(

--- a/crates/polars-parquet/src/parquet/write/statistics.rs
+++ b/crates/polars-parquet/src/parquet/write/statistics.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::parquet::error::{Error, Result};
 use crate::parquet::schema::types::PhysicalType;
 use crate::parquet::statistics::*;
@@ -25,15 +23,14 @@ fn reduce_vec8(lhs: Option<Vec<u8>>, rhs: &Option<Vec<u8>>, max: bool) -> Option
     }
 }
 
-pub fn reduce(stats: &[&Option<Arc<dyn Statistics>>]) -> Result<Option<Arc<dyn Statistics>>> {
+pub fn reduce(stats: &[&Option<Statistics>]) -> Result<Option<Statistics>> {
     if stats.is_empty() {
         return Ok(None);
     }
     let stats = stats
         .iter()
         .filter_map(|x| x.as_ref())
-        .map(|x| x.as_ref())
-        .collect::<Vec<&dyn Statistics>>();
+        .collect::<Vec<&Statistics>>();
     if stats.is_empty() {
         return Ok(None);
     };
@@ -45,37 +42,22 @@ pub fn reduce(stats: &[&Option<Arc<dyn Statistics>>]) -> Result<Option<Arc<dyn S
     if !same_type {
         return Err(Error::oos("The statistics do not have the same data_type"));
     };
-    Ok(match stats[0].physical_type() {
-        PhysicalType::Boolean => {
-            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
-            Some(Arc::new(reduce_boolean(stats)))
-        },
-        PhysicalType::Int32 => {
-            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
-            Some(Arc::new(reduce_primitive::<i32, _>(stats)))
-        },
-        PhysicalType::Int64 => {
-            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
-            Some(Arc::new(reduce_primitive::<i64, _>(stats)))
-        },
-        PhysicalType::Float => {
-            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
-            Some(Arc::new(reduce_primitive::<f32, _>(stats)))
-        },
-        PhysicalType::Double => {
-            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
-            Some(Arc::new(reduce_primitive::<f64, _>(stats)))
-        },
-        PhysicalType::ByteArray => {
-            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
-            Some(Arc::new(reduce_binary(stats)))
-        },
-        PhysicalType::FixedLenByteArray(_) => {
-            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
-            Some(Arc::new(reduce_fix_len_binary(stats)))
+
+    use PhysicalType as T;
+    let stats = match stats[0].physical_type() {
+        T::Boolean => reduce_boolean(stats.iter().map(|x| x.expect_as_boolean())).into(),
+        T::Int32 => reduce_primitive::<i32, _>(stats.iter().map(|x| x.expect_as_int32())).into(),
+        T::Int64 => reduce_primitive(stats.iter().map(|x| x.expect_as_int64())).into(),
+        T::Float => reduce_primitive(stats.iter().map(|x| x.expect_as_float())).into(),
+        T::Double => reduce_primitive(stats.iter().map(|x| x.expect_as_double())).into(),
+        T::ByteArray => reduce_binary(stats.iter().map(|x| x.expect_as_binary())).into(),
+        T::FixedLenByteArray(_) => {
+            reduce_fix_len_binary(stats.iter().map(|x| x.expect_as_fixedlen())).into()
         },
         _ => todo!(),
-    })
+    };
+
+    Ok(Some(stats))
 }
 
 fn reduce_binary<'a, I: Iterator<Item = &'a BinaryStatistics>>(mut stats: I) -> BinaryStatistics {

--- a/crates/polars/tests/it/io/parquet/mod.rs
+++ b/crates/polars/tests/it/io/parquet/mod.rs
@@ -25,8 +25,6 @@ pub enum Array {
     Struct(Vec<Array>, Vec<bool>),
 }
 
-use std::sync::Arc;
-
 use polars_parquet::parquet::schema::types::{PhysicalType, PrimitiveType};
 use polars_parquet::parquet::statistics::*;
 
@@ -112,57 +110,64 @@ pub fn alltypes_plain(column: &str) -> Array {
     }
 }
 
-pub fn alltypes_statistics(column: &str) -> Arc<dyn Statistics> {
+pub fn alltypes_statistics(column: &str) -> Statistics {
     match column {
-        "id" => Arc::new(PrimitiveStatistics::<i32> {
+        "id" => PrimitiveStatistics::<i32> {
             primitive_type: PrimitiveType::from_physical("col".to_string(), PhysicalType::Int32),
             null_count: Some(0),
             distinct_count: None,
             min_value: Some(0),
             max_value: Some(7),
-        }),
-        "id-short-array" => Arc::new(PrimitiveStatistics::<i32> {
+        }
+        .into(),
+        "id-short-array" => PrimitiveStatistics::<i32> {
             primitive_type: PrimitiveType::from_physical("col".to_string(), PhysicalType::Int32),
             null_count: Some(0),
             distinct_count: None,
             min_value: Some(4),
             max_value: Some(4),
-        }),
-        "bool_col" => Arc::new(BooleanStatistics {
+        }
+        .into(),
+        "bool_col" => BooleanStatistics {
             null_count: Some(0),
             distinct_count: None,
             min_value: Some(false),
             max_value: Some(true),
-        }),
-        "tinyint_col" | "smallint_col" | "int_col" => Arc::new(PrimitiveStatistics::<i32> {
+        }
+        .into(),
+        "tinyint_col" | "smallint_col" | "int_col" => PrimitiveStatistics::<i32> {
             primitive_type: PrimitiveType::from_physical("col".to_string(), PhysicalType::Int32),
             null_count: Some(0),
             distinct_count: None,
             min_value: Some(0),
             max_value: Some(1),
-        }),
-        "bigint_col" => Arc::new(PrimitiveStatistics::<i64> {
+        }
+        .into(),
+        "bigint_col" => PrimitiveStatistics::<i64> {
             primitive_type: PrimitiveType::from_physical("col".to_string(), PhysicalType::Int64),
             null_count: Some(0),
             distinct_count: None,
             min_value: Some(0),
             max_value: Some(10),
-        }),
-        "float_col" => Arc::new(PrimitiveStatistics::<f32> {
+        }
+        .into(),
+        "float_col" => PrimitiveStatistics::<f32> {
             primitive_type: PrimitiveType::from_physical("col".to_string(), PhysicalType::Float),
             null_count: Some(0),
             distinct_count: None,
             min_value: Some(0.0),
             max_value: Some(1.1),
-        }),
-        "double_col" => Arc::new(PrimitiveStatistics::<f64> {
+        }
+        .into(),
+        "double_col" => PrimitiveStatistics::<f64> {
             primitive_type: PrimitiveType::from_physical("col".to_string(), PhysicalType::Double),
             null_count: Some(0),
             distinct_count: None,
             min_value: Some(0.0),
             max_value: Some(10.1),
-        }),
-        "date_string_col" => Arc::new(BinaryStatistics {
+        }
+        .into(),
+        "date_string_col" => BinaryStatistics {
             primitive_type: PrimitiveType::from_physical(
                 "col".to_string(),
                 PhysicalType::ByteArray,
@@ -171,8 +176,9 @@ pub fn alltypes_statistics(column: &str) -> Arc<dyn Statistics> {
             distinct_count: None,
             min_value: Some(vec![48, 49, 47, 48, 49, 47, 48, 57]),
             max_value: Some(vec![48, 52, 47, 48, 49, 47, 48, 57]),
-        }),
-        "string_col" => Arc::new(BinaryStatistics {
+        }
+        .into(),
+        "string_col" => BinaryStatistics {
             primitive_type: PrimitiveType::from_physical(
                 "col".to_string(),
                 PhysicalType::ByteArray,
@@ -181,7 +187,8 @@ pub fn alltypes_statistics(column: &str) -> Arc<dyn Statistics> {
             distinct_count: None,
             min_value: Some(vec![48]),
             max_value: Some(vec![49]),
-        }),
+        }
+        .into(),
         "timestamp_col" => {
             todo!()
         },

--- a/crates/polars/tests/it/io/parquet/read/mod.rs
+++ b/crates/polars/tests/it/io/parquet/read/mod.rs
@@ -213,7 +213,7 @@ pub fn read_column<R: std::io::Read + std::io::Seek>(
     reader: &mut R,
     row_group: usize,
     field_name: &str,
-) -> Result<(Array, Option<std::sync::Arc<dyn Statistics>>)> {
+) -> Result<(Array, Option<Statistics>)> {
     let metadata = read_metadata(reader)?;
 
     let field = metadata
@@ -248,7 +248,7 @@ pub async fn read_column_async<
     reader: &mut R,
     row_group: usize,
     field_name: &str,
-) -> Result<(Array, Option<std::sync::Arc<dyn Statistics>>)> {
+) -> Result<(Array, Option<Statistics>)> {
     let metadata = read_metadata_async(reader).await?;
 
     let field = metadata
@@ -277,7 +277,7 @@ pub async fn read_column_async<
     Ok((arrays.pop().unwrap(), statistics.pop().unwrap()))
 }
 
-fn get_column(path: &str, column: &str) -> Result<(Array, Option<std::sync::Arc<dyn Statistics>>)> {
+fn get_column(path: &str, column: &str) -> Result<(Array, Option<Statistics>)> {
     let mut file = File::open(path).unwrap();
     read_column(&mut file, 0, column)
 }
@@ -288,7 +288,7 @@ fn test_column(column: &str) -> Result<()> {
     let path = path.to_str().unwrap();
     let (result, statistics) = get_column(path, column)?;
     // the file does not have statistics
-    assert_eq!(statistics.as_ref().map(|x| x.as_ref()), None);
+    assert_eq!(statistics.as_ref(), None);
     assert_eq!(result, alltypes_plain(column));
     Ok(())
 }

--- a/crates/polars/tests/it/io/parquet/write/binary.rs
+++ b/crates/polars/tests/it/io/parquet/write/binary.rs
@@ -3,7 +3,7 @@ use polars_parquet::parquet::encoding::Encoding;
 use polars_parquet::parquet::error::Result;
 use polars_parquet::parquet::metadata::Descriptor;
 use polars_parquet::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, Page};
-use polars_parquet::parquet::statistics::{serialize_statistics, BinaryStatistics, Statistics};
+use polars_parquet::parquet::statistics::BinaryStatistics;
 use polars_parquet::parquet::types::ord_binary;
 use polars_parquet::parquet::write::WriteOptions;
 
@@ -64,8 +64,8 @@ pub fn array_to_page_v1(
                 .flatten()
                 .min_by(|x, y| ord_binary(x, y))
                 .cloned(),
-        } as &dyn Statistics;
-        Some(serialize_statistics(statistics))
+        };
+        Some(statistics.serialize())
     } else {
         None
     };

--- a/crates/polars/tests/it/io/parquet/write/primitive.rs
+++ b/crates/polars/tests/it/io/parquet/write/primitive.rs
@@ -3,7 +3,7 @@ use polars_parquet::parquet::encoding::Encoding;
 use polars_parquet::parquet::error::Result;
 use polars_parquet::parquet::metadata::Descriptor;
 use polars_parquet::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, Page};
-use polars_parquet::parquet::statistics::{serialize_statistics, PrimitiveStatistics, Statistics};
+use polars_parquet::parquet::statistics::PrimitiveStatistics;
 use polars_parquet::parquet::types::NativeType;
 use polars_parquet::parquet::write::WriteOptions;
 
@@ -55,8 +55,8 @@ pub fn array_to_page_v1<T: NativeType>(
             distinct_count: None,
             max_value: array.iter().flatten().max_by(|x, y| x.ord(y)).copied(),
             min_value: array.iter().flatten().min_by(|x, y| x.ord(y)).copied(),
-        } as &dyn Statistics;
-        Some(serialize_statistics(statistics))
+        };
+        Some(statistics.serialize())
     } else {
         None
     };


### PR DESCRIPTION
This refactors the `polars-parquet` to provide an `enum` interface instead of a `trait` for `Statistics`. This makes the code a lot more debuggable and reduces the amount of `Arc` allocations needed. This does not really increase memory consumption as there are no long lived `Statistics` fields on `struct`s.

This should also:
- Reduce code-size and binary-size
- Allow for more inlining
- Improve error messages
- Improve the analysis by the rust compiler