### PR TITLE
depr(python): Deprecate `tree_format` parameter for `LazyFrame.explain` in favor of `format`

### DIFF
--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -169,6 +169,7 @@ SearchSortedSide: TypeAlias = Literal["any", "left", "right"]
 TorchExportType: TypeAlias = Literal["tensor", "dataset", "dict"]
 TransferEncoding: TypeAlias = Literal["hex", "base64"]
 WindowMappingStrategy: TypeAlias = Literal["group_to_rows", "join", "explode"]
+ExplainFormat: TypeAlias = Literal["plain", "tree"]
 
 # type signature for allowed frame init
 FrameInitTypes: TypeAlias = Union[

--- a/py-polars/tests/unit/lazyframe/test_explain.py
+++ b/py-polars/tests/unit/lazyframe/test_explain.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+
+def test_lf_explain() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+    plan = lf.select("a").select(pl.col("a").sum() + pl.len())
+
+    result = plan.explain()
+
+    expected = """\
+ SELECT [[(col("a").sum()) + (len().cast(Int64))]] FROM
+  DF ["a", "b"]; PROJECT 1/2 COLUMNS; SELECTION: None\
+"""
+    assert result == expected
+
+
+def test_lf_explain_format_tree() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+    plan = lf.select("a").select(pl.col("a").sum() + pl.len())
+
+    result = plan.explain(format="tree")
+
+    expected = """\
+                0                        1
+   ┌─────────────────────────────────────────────────
+   │
+   │        ╭────────╮
+ 0 │        │ SELECT │
+   │        ╰───┬┬───╯
+   │            ││
+   │            │╰───────────────────────╮
+   │            │                        │
+   │  ╭─────────┴──────────╮             │
+   │  │ expression:        │  ╭──────────┴──────────╮
+   │  │ [(col("a")         │  │ FROM:               │
+ 1 │  │   .sum()) + (len() │  │ DF ["a", "b"]       │
+   │  │   .cast(Int64))]   │  │ PROJECT 1/2 COLUMNS │
+   │  ╰────────────────────╯  ╰─────────────────────╯
+\
+"""
+    assert result == expected
+
+
+def test_lf_explain_tree_format_deprecated() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+
+    with pytest.deprecated_call():
+        lf.explain(tree_format=True)


### PR DESCRIPTION
A `format` parameter is more appropriate here, to facilitate potential other formats like proposed here:
https://github.com/pola-rs/polars/issues/12075

Also added some tests because there were 0 tests for the tree format parameter.