### PR TITLE
fix(python): Fix boolean trap issue in `top_k`/`bottom_k`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2096,7 +2096,14 @@ class Expr:
         └───────┴──────────┘
         """
         k = parse_as_expression(k)
-        return self._from_pyexpr(self._pyexpr.top_k(k, nulls_last, multithreaded))
+        return self._from_pyexpr(
+            self._pyexpr.top_k(
+                k,
+                nulls_last=nulls_last,
+                maintain_order=maintain_order,
+                multithreaded=multithreaded,
+            )
+        )
 
     def top_k_by(
         self,
@@ -2228,7 +2235,12 @@ class Expr:
             raise ValueError(msg)
         return self._from_pyexpr(
             self._pyexpr.top_k_by(
-                k, by, descending, nulls_last, maintain_order, multithreaded
+                k,
+                by,
+                descending=descending,
+                nulls_last=nulls_last,
+                maintain_order=maintain_order,
+                multithreaded=multithreaded,
             )
         )
 
@@ -2291,7 +2303,14 @@ class Expr:
         └───────┴──────────┘
         """
         k = parse_as_expression(k)
-        return self._from_pyexpr(self._pyexpr.bottom_k(k, nulls_last, multithreaded))
+        return self._from_pyexpr(
+            self._pyexpr.bottom_k(
+                k,
+                nulls_last=nulls_last,
+                maintain_order=maintain_order,
+                multithreaded=multithreaded,
+            )
+        )
 
     def bottom_k_by(
         self,
@@ -2423,7 +2442,12 @@ class Expr:
             raise ValueError(msg)
         return self._from_pyexpr(
             self._pyexpr.bottom_k_by(
-                k, by, descending, nulls_last, maintain_order, multithreaded
+                k,
+                by,
+                descending=descending,
+                nulls_last=nulls_last,
+                maintain_order=maintain_order,
+                multithreaded=multithreaded,
             )
         )
 

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -293,14 +293,15 @@ impl PyExpr {
     }
 
     #[cfg(feature = "top_k")]
-    fn top_k(&self, k: Self, nulls_last: bool, multithreaded: bool) -> Self {
+    fn top_k(&self, k: Self, nulls_last: bool, maintain_order: bool, multithreaded: bool) -> Self {
         self.inner
             .clone()
             .top_k(
                 k.inner,
                 SortOptions::default()
                     .with_nulls_last(nulls_last)
-                    .with_maintain_order(multithreaded),
+                    .with_maintain_order(maintain_order)
+                    .with_multithreaded(multithreaded),
             )
             .into()
     }
@@ -324,22 +325,29 @@ impl PyExpr {
                 SortMultipleOptions {
                     descending,
                     nulls_last,
-                    multithreaded,
                     maintain_order,
+                    multithreaded,
                 },
             )
             .into()
     }
 
     #[cfg(feature = "top_k")]
-    fn bottom_k(&self, k: Self, nulls_last: bool, multithreaded: bool) -> Self {
+    fn bottom_k(
+        &self,
+        k: Self,
+        nulls_last: bool,
+        maintain_order: bool,
+        multithreaded: bool,
+    ) -> Self {
         self.inner
             .clone()
             .bottom_k(
                 k.inner,
                 SortOptions::default()
                     .with_nulls_last(nulls_last)
-                    .with_maintain_order(multithreaded),
+                    .with_maintain_order(maintain_order)
+                    .with_multithreaded(multithreaded),
             )
             .into()
     }
@@ -363,8 +371,8 @@ impl PyExpr {
                 SortMultipleOptions {
                     descending,
                     nulls_last,
-                    multithreaded,
                     maintain_order,
+                    multithreaded,
                 },
             )
             .into()


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/15238#issuecomment-2127119299

The `multithreaded` parameter was passed to `maintain_order`.

We should use keyword arguments to deal with booleans - also when passing it to the PyO3 bindings.