### PR TITLE
fix(python): Fix handling NaT values when creating Series from NumPy ndarray

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -339,7 +339,7 @@ class Series:
                     self._s = (
                         # `values.dtype` has already been validated in
                         # `numpy_to_pyseries`, so `input_dtype` can't be `None`
-                        self.cast(input_dtype)  # type: ignore[arg-type]
+                        self.cast(input_dtype, strict=False)  # type: ignore[arg-type]
                         .cast(dtype)
                         .scatter(np.argwhere(np.isnat(values)).flatten(), None)
                         ._s

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -121,4 +122,15 @@ def test_series_init_nonexistent_datetime() -> None:
 
     result = pl.Series([value], dtype=dtype, strict=False)
     expected = pl.Series([None], dtype=dtype)
+    assert_series_equal(result, expected)
+
+
+# https://github.com/pola-rs/polars/issues/15518
+def test_series_init_np_temporal_with_nat_15518() -> None:
+    arr = np.array(["2020-01-01", "2020-01-02", "2020-01-03"], "datetime64[D]")
+    arr[1] = np.datetime64("NaT")
+
+    result = pl.Series(arr)
+
+    expected = pl.Series([date(2020, 1, 1), None, date(2020, 1, 3)])
     assert_series_equal(result, expected)


### PR DESCRIPTION
Closes #15518

Not too happy with this fix, but this code needs to be revised anyway. It does the trick for now!