### PR TITLE
fix: Fix `split_chunks` for nested dtypes

### DIFF
--- a/crates/polars-arrow/src/record_batch.rs
+++ b/crates/polars-arrow/src/record_batch.rs
@@ -34,7 +34,7 @@ impl<A: AsRef<dyn Array>> RecordBatchT<A> {
                 .any(|array| array.len() != len)
             {
                 polars_bail!(ComputeError:
-                    "Chunk require all its arrays to have an equal number of rows".to_string(),
+                    "RecordBatch requires all its arrays to have an equal number of rows".to_string(),
                 );
             }
         }

--- a/crates/polars-core/src/frame/chunks.rs
+++ b/crates/polars-core/src/frame/chunks.rs
@@ -29,7 +29,13 @@ impl DataFrame {
             let columns = self
                 .get_columns()
                 .iter()
-                .map(|s| s.replace_with_chunk(s.chunks()[i].clone()))
+                .map(|s| {
+                    if s.n_chunks() == 1 {
+                        s.clone()
+                    } else {
+                        s.replace_with_chunk(s.chunks()[i].clone())
+                    }
+                })
                 .collect::<Vec<_>>();
 
             DataFrame::new_no_checks(columns)

--- a/crates/polars-core/src/frame/chunks.rs
+++ b/crates/polars-core/src/frame/chunks.rs
@@ -29,13 +29,7 @@ impl DataFrame {
             let columns = self
                 .get_columns()
                 .iter()
-                .map(|s| {
-                    Series::from_chunks_and_dtype_unchecked(
-                        s.name(),
-                        vec![s.chunks()[i].clone()],
-                        s.dtype(),
-                    )
-                })
+                .map(|s| s.replace_with_chunk(s.chunks()[i].clone()))
                 .collect::<Vec<_>>();
 
             DataFrame::new_no_checks(columns)

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -189,6 +189,24 @@ impl Series {
         ca.chunks_mut()
     }
 
+    /// Create a `Series` of the same data type with all chunks replaced.
+    /// # Safety
+    /// This chunks should align with the data-type
+    pub unsafe fn replace_chunks(&self, chunks: Vec<ArrayRef>) -> Self {
+        let mut new = self.clear();
+        *new.chunks_mut() = chunks;
+        new
+    }
+
+    /// Create a `Series` of the same data type with all chunks replaced.
+    /// # Safety
+    /// This chunks should align with the data-type
+    pub unsafe fn replace_with_chunk(&self, chunk: ArrayRef) -> Self {
+        let mut new = self.clear();
+        new.chunks_mut()[0] = chunk;
+        new
+    }
+
     pub fn is_sorted_flag(&self) -> IsSorted {
         if self.len() <= 1 {
             return IsSorted::Ascending;

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -191,19 +191,27 @@ impl Series {
 
     /// Create a `Series` of the same data type with all chunks replaced.
     /// # Safety
-    /// This chunks should align with the data-type
+    /// These chunks should align with the data-type
     pub unsafe fn replace_chunks(&self, chunks: Vec<ArrayRef>) -> Self {
         let mut new = self.clear();
-        *new.chunks_mut() = chunks;
+        // Assign mut so we go through arc only once.
+        let mut_new = new._get_inner_mut();
+        *mut_new.chunks_mut() = chunks;
+        mut_new.compute_len();
         new
     }
 
     /// Create a `Series` of the same data type with all chunks replaced.
     /// # Safety
-    /// This chunks should align with the data-type
+    /// This chunk should align with the data-type
     pub unsafe fn replace_with_chunk(&self, chunk: ArrayRef) -> Self {
         let mut new = self.clear();
-        new.chunks_mut()[0] = chunk;
+        // Assign mut so we go through arc only once.
+        let mut_new = new._get_inner_mut();
+        let chunks = mut_new.chunks_mut();
+        chunks.clear();
+        chunks.push(chunk);
+        mut_new.compute_len();
         new
     }
 


### PR DESCRIPTION
fixes #16478 