### PR TITLE
depr(python): Deprecate selecting rows using `DataFrame.__getitem__` with a single input

### DIFF
--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Iterable, NoReturn, Sequence, overload
 import polars._reexport as pl
 import polars.functions as F
 from polars._utils.constants import U32_MAX
+from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.various import range_to_slice
 from polars.datatypes.classes import (
     Boolean,
@@ -151,9 +152,18 @@ def get_df_item_by_key(
         # https://github.com/pola-rs/polars/issues/4924
         return df.__class__()
     try:
-        return _select_rows(df, key)  # type: ignore[arg-type]
+        item = _select_rows(df, key)  # type: ignore[arg-type]
     except TypeError:
-        return _select_columns(df, key)  # type: ignore[arg-type]
+        item = _select_columns(df, key)  # type: ignore[arg-type]
+    else:
+        issue_deprecation_warning(
+            "Selecting rows using `DataFrame.__getitem__` with a single input is deprecated."
+            " This will select columns instead of rows in a future version of Polars."
+            " Add an explicit column specifier to silence this warning."
+            " For example, use `df[x, :]` instead of `df[x]`.",
+            version="0.20.30",
+        )
+    return item
 
 
 # `str` overlaps with `Sequence[str]`

--- a/py-polars/polars/testing/parametric/strategies/core.py
+++ b/py-polars/polars/testing/parametric/strategies/core.py
@@ -458,7 +458,7 @@ def dataframes(  # noqa: D417
     # Apply chunking
     if allow_chunks and size > 1 and not allow_series_chunks and draw(st.booleans()):
         split_at = size // 2
-        df = df[:split_at].vstack(df[split_at:])
+        df = df[:split_at, :].vstack(df[split_at:, :])
 
     if lazy:
         return df.lazy()

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -131,77 +131,6 @@ def test_selection() -> None:
     assert_series_equal(df.to_series(1), pl.Series("b", [1.0, 2.0, 3.0]))
     assert_series_equal(df.to_series(-1), pl.Series("c", ["a", "b", "c"]))
 
-    # select columns by mask
-    assert df[:2, :1].rows() == [(1,), (2,)]
-    assert df[:2, ["a"]].rows() == [(1,), (2,)]
-
-    # column selection by string(s) in first dimension
-    assert df["a"].to_list() == [1, 2, 3]
-    assert df["b"].to_list() == [1.0, 2.0, 3.0]
-    assert df["c"].to_list() == ["a", "b", "c"]
-
-    # row selection by integers(s) in first dimension
-    assert_frame_equal(df[0], pl.DataFrame({"a": [1], "b": [1.0], "c": ["a"]}))
-    assert_frame_equal(df[-1], pl.DataFrame({"a": [3], "b": [3.0], "c": ["c"]}))
-
-    # row, column selection when using two dimensions
-    assert df[:, "a"].to_list() == [1, 2, 3]
-    assert df[:, 1].to_list() == [1.0, 2.0, 3.0]
-    assert df[:2, 2].to_list() == ["a", "b"]
-
-    assert_frame_equal(
-        df[[1, 2]], pl.DataFrame({"a": [2, 3], "b": [2.0, 3.0], "c": ["b", "c"]})
-    )
-    assert_frame_equal(
-        df[[-1, -2]], pl.DataFrame({"a": [3, 2], "b": [3.0, 2.0], "c": ["c", "b"]})
-    )
-
-    assert df[["a", "b"]].columns == ["a", "b"]
-    assert_frame_equal(
-        df[[1, 2], [1, 2]], pl.DataFrame({"b": [2.0, 3.0], "c": ["b", "c"]})
-    )
-    assert typing.cast(str, df[1, 2]) == "b"
-    assert typing.cast(float, df[1, 1]) == 2.0
-    assert typing.cast(int, df[2, 0]) == 3
-
-    assert df[[2], ["a", "b"]].rows() == [(3, 3.0)]
-    assert df.to_series(0).name == "a"
-    assert (df["a"] == df["a"]).sum() == 3
-    assert (df["c"] == df["a"].cast(str)).sum() == 0
-    assert df[:, "a":"b"].rows() == [(1, 1.0), (2, 2.0), (3, 3.0)]  # type: ignore[index, misc]
-    assert df[:, "a":"c"].columns == ["a", "b", "c"]  # type: ignore[index, misc]
-    assert df[:, []].shape == (0, 0)
-    expect = pl.DataFrame({"c": ["b"]})
-    assert_frame_equal(df[1, [2]], expect)
-    expect = pl.DataFrame({"b": [1.0, 3.0]})
-    assert_frame_equal(df[[0, 2], [1]], expect)
-    assert typing.cast(str, df[0, "c"]) == "a"
-    assert typing.cast(str, df[1, "c"]) == "b"
-    assert typing.cast(str, df[2, "c"]) == "c"
-    assert typing.cast(int, df[0, "a"]) == 1
-
-    # more slicing
-    expect = pl.DataFrame({"a": [3, 2, 1], "b": [3.0, 2.0, 1.0], "c": ["c", "b", "a"]})
-    assert_frame_equal(df[::-1], expect)
-    expect = pl.DataFrame({"a": [1, 2], "b": [1.0, 2.0], "c": ["a", "b"]})
-    assert_frame_equal(df[:-1], expect)
-
-    expect = pl.DataFrame({"a": [1, 3], "b": [1.0, 3.0], "c": ["a", "c"]})
-    assert_frame_equal(df[::2], expect)
-
-    # only allow boolean values in column position
-    df = pl.DataFrame(
-        {
-            "a": [1, 2],
-            "b": [2, 3],
-            "c": [3, 4],
-        }
-    )
-
-    assert df[:, [False, True, True]].columns == ["b", "c"]
-    assert df[:, pl.Series([False, True, True])].columns == ["b", "c"]
-    assert df[:, pl.Series([False, False, False])].columns == []
-
 
 def test_mixed_sequence_selection() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
@@ -1173,7 +1102,7 @@ def test_from_generator_or_iterable() -> None:
         infer_schema_length=1001,
     )
     assert df.schema == {"col": pl.List(pl.String)}
-    assert df[-2:]["col"].to_list() == [None, ["a", "b", "c"]]
+    assert df[-2:, :]["col"].to_list() == [None, ["a", "b", "c"]]
 
     # empty iterator
     assert_frame_equal(
@@ -2756,7 +2685,7 @@ def test_iter_slices() -> None:
 
     assert len(batches[0]) == 50
     assert len(batches[1]) == 45
-    assert batches[1].rows() == df[50:].rows()
+    assert batches[1].rows() == df[50:, :].rows()
 
 
 def test_format_empty_df() -> None:

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -52,7 +52,7 @@ def test_extend_various_dtypes() -> None:
 def test_extend_slice_offset_8745() -> None:
     df = pl.DataFrame([{"age": 1}, {"age": 2}, {"age": 3}])
 
-    df = df[:-1]
+    df = df[:-1, :]
     tail = pl.DataFrame([{"age": 8}])
     result = df.extend(tail)
 

--- a/py-polars/tests/unit/dataframe/test_from_dict.py
+++ b/py-polars/tests/unit/dataframe/test_from_dict.py
@@ -125,7 +125,7 @@ def test_from_dict_with_scalars() -> None:
         },
         schema_overrides={"z": pl.UInt8},
     )
-    assert df7[999:].rows() == [(0, 1, 0, 1), (0, 1, 0, 1)]
+    assert df7[999:, :].rows() == [(0, 1, 0, 1), (0, 1, 0, 1)]
     assert df7.schema == {
         "w": pl.UInt8,
         "x": pl.UInt8,

--- a/py-polars/tests/unit/datatypes/test_null.py
+++ b/py-polars/tests/unit/datatypes/test_null.py
@@ -11,7 +11,7 @@ from polars.testing import assert_frame_equal
 def test_null_index() -> None:
     df = pl.DataFrame({"a": [[1, 2], [3, 4], [5, 6]], "b": [[1, 2], [1, 2], [4, 5]]})
 
-    result = df.with_columns(pl.lit(None).alias("null_col"))[-1]
+    result = df.with_columns(pl.lit(None).alias("null_col"))[-1, :]
 
     expected = pl.DataFrame(
         {"a": [[5, 6]], "b": [[4, 5]], "null_col": [None]},

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -65,7 +65,7 @@ def test_lit_ambiguous_datetimes_11379() -> None:
     )
     for i in range(len(df)):
         result = df.filter(pl.col("ts") >= df["ts"][i])
-        expected = df[i:]
+        expected = df[i:, :]
         assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -140,7 +140,7 @@ def test_from_dataframe_pyarrow_boolean() -> None:
 
 def test_from_dataframe_chunked() -> None:
     df = pl.Series("a", [0, 1], dtype=pl.Int8).to_frame()
-    df_chunked = pl.concat([df[:1], df[1:]], rechunk=False)
+    df_chunked = pl.concat([df[:1, :], df[1:, :]], rechunk=False)
 
     df_pa = df_chunked.to_arrow()
     result = pl.from_dataframe(df_pa)
@@ -151,7 +151,7 @@ def test_from_dataframe_chunked() -> None:
 
 def test_from_dataframe_chunked_string() -> None:
     df = pl.Series("a", ["a", None, "bc", "d", None, "efg"]).to_frame()
-    df_chunked = pl.concat([df[:1], df[1:3], df[3:]], rechunk=False)
+    df_chunked = pl.concat([df[:1, :], df[1:3, :], df[3:, :]], rechunk=False)
 
     df_pa = df_chunked.to_arrow()
     result = pl.from_dataframe(df_pa)

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -76,7 +76,7 @@ def test_to_numpy(order: IndexOrder, f_contiguous: bool, c_contiguous: bool) -> 
     )
     assert not df["s"][:2].has_nulls()
     assert_array_equal(
-        df[:2].to_numpy(structured=True),
+        df[:2, :].to_numpy(structured=True),
         np.array([("x",), ("y",)], dtype=[("s", "<U1")]),
     )
 

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -160,6 +160,6 @@ def test_surrealdb_fetchall(batch_size: int | None) -> None:
         frames = list(res)  # type: ignore[call-overload]
         n_mock_rows = len(SURREAL_MOCK_DATA)
         assert len(frames) == ceil(n_mock_rows / batch_size)
-        assert_frame_equal(df_expected[:batch_size], frames[0])
+        assert_frame_equal(df_expected[:batch_size, :], frames[0])
     else:
         assert_frame_equal(df_expected, res)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -236,7 +236,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(as_series=False) == {
+    assert df[[0, 39], :].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -70,7 +70,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(as_series=False) == {
+    assert df[[0, 39], :].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -112,7 +112,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(as_series=False) == {
+    assert df[[0, 39], :].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -311,7 +311,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(as_series=False) == {
+    assert df[[0, 39], :].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -475,8 +475,8 @@ def test_list_sliced_get_5186() -> None:
         pl.col("inds").list.first().alias("first_element"),
         pl.col("inds").list.last().alias("last_element"),
     ]
-    out1 = df.select(exprs)[10:20]
-    out2 = df[10:20].select(exprs)
+    out1 = df.select(exprs)[10:20, :]
+    out2 = df[10:20, :].select(exprs)
     assert_frame_equal(out1, out2)
 
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -966,7 +966,7 @@ def test_offset_by_expressions() -> None:
 
     # Check single-row cases
     for i in range(len(df)):
-        df_slice = df[i : i + 1]
+        df_slice = df[i : i + 1, :]
         result = df_slice.select(
             c=pl.col("a").dt.offset_by(pl.col("b")),
             d=pl.col("a").dt.cast_time_unit("ms").dt.offset_by(pl.col("b")),
@@ -975,7 +975,7 @@ def test_offset_by_expressions() -> None:
             .dt.offset_by(pl.col("b")),
             f=pl.col("a").dt.date().dt.offset_by(pl.col("b")),
         )
-        assert_frame_equal(result, expected[i : i + 1])
+        assert_frame_equal(result, expected[i : i + 1, :])
         # single-row Series are always sorted
         assert result.flags == {
             "c": {"SORTED_ASC": True, "SORTED_DESC": False},

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -235,7 +235,7 @@ def verify_total_ordering(
         ans_correct_dict, schema={c: pl.Boolean for c in ans_correct_dict}
     )
 
-    assert_frame_equal(ans[:1], ans_correct)
+    assert_frame_equal(ans.head(1), ans_correct)
 
 
 def verify_total_ordering_broadcast(
@@ -286,8 +286,8 @@ def verify_total_ordering_broadcast(
         ans_correct_dict, schema={c: pl.Boolean for c in ans_correct_dict}
     )
 
-    assert_frame_equal(ans_first[:1], ans_correct)
-    assert_frame_equal(ans_scalar[:1], ans_correct)
+    assert_frame_equal(ans_first.head(1), ans_correct)
+    assert_frame_equal(ans_scalar.head(1), ans_correct)
 
 
 INTERESTING_FLOAT_VALUES = [

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -43,7 +43,7 @@ def test_python_slicing_data_frame() -> None:
         slice(-3, None, -3),
     ):
         # confirm frame slice matches python slice
-        assert df[py_slice].rows() == df.rows()[py_slice]
+        assert df[py_slice, :].rows() == df.rows()[py_slice]
 
 
 def test_python_slicing_series() -> None:

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1291,7 +1291,7 @@ def test_range() -> None:
     assert s3.dtype == pl.List(pl.List(pl.Int64))
 
     df = pl.DataFrame([s1])
-    assert_frame_equal(df[2:5], df[range(2, 5)])
+    assert_frame_equal(df[2:5, :], df[range(2, 5), :])
 
 
 def test_strict_cast() -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -360,7 +360,7 @@ def test_inspect(capsys: CaptureFixture[str]) -> None:
 
 def test_fetch(fruits_cars: pl.DataFrame) -> None:
     res = fruits_cars.lazy().select("*").fetch(2)
-    assert_frame_equal(res, res[:2])
+    assert_frame_equal(res, res.head(2))
 
 
 def test_fold_filter() -> None:


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/4924

_I am not 100% convinced with this one, but I am making the PR to spark the discussion..._

* Old syntax: `df[:2]`
* Use instead: `df[:2, :]`

The old syntax will be repurposed to select columns instead of rows.

If this gets the final go-head I'll finish updating the tests.