### PR TITLE
fix(python): Eager group by iterators had unclear behaviour

### DIFF
--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -825,7 +825,7 @@ class RollingGroupBy:
         self.closed = closed
         self.group_by = group_by
         self.check_sorted = check_sorted
-        self._groups_ready = True
+        self._groups_ready = False
 
     def _collect_groups(self) -> None:
         """Group and collect the dataframe for iteration."""

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -10,25 +10,18 @@ from polars._utils.deprecation import (
 )
 
 if TYPE_CHECKING:
-    import sys
     from datetime import timedelta
 
     from polars import DataFrame, Series
     from polars.type_aliases import (
         ClosedInterval,
+        GroupByIterator,
         IntoExpr,
         Label,
         RollingInterpolationMethod,
         SchemaDict,
         StartBy,
     )
-
-    if sys.version_info >= (3, 11):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
-
-    GroupByIterator: TypeAlias = Iterator[tuple[object | tuple[object, ...], DataFrame]]
 
 
 class GroupBy:

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -24,15 +24,11 @@ if TYPE_CHECKING:
     )
 
     if sys.version_info >= (3, 11):
-        from typing import Generator, TypeAlias
+        from typing import TypeAlias
     else:
-        from typing import Generator
-
         from typing_extensions import TypeAlias
 
-    GroupByIterator: TypeAlias = Generator[
-        tuple[object | tuple[object, ...], DataFrame], None, None
-    ]
+    GroupByIterator: TypeAlias = Iterator[tuple[object | tuple[object, ...], DataFrame]]
 
 
 class GroupBy:

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -279,4 +279,6 @@ BooleanMask: TypeAlias = Union[
 ]
 SingleColSelector: TypeAlias = Union[SingleIndexSelector, SingleNameSelector]
 MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, BooleanMask]
-GroupByIterator: TypeAlias = Iterator[Tuple[object | Tuple[object, ...], "DataFrame"]]
+GroupByIterator: TypeAlias = Iterator[
+    Tuple[Union[object, Tuple[object, ...]], "DataFrame"]
+]

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Collection,
     Iterable,
+    Iterator,
     List,
     Literal,
     Mapping,
@@ -278,3 +279,4 @@ BooleanMask: TypeAlias = Union[
 ]
 SingleColSelector: TypeAlias = Union[SingleIndexSelector, SingleNameSelector]
 MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, BooleanMask]
+GroupByIterator: TypeAlias = Iterator[Tuple[object | Tuple[object, ...], "DataFrame"]]

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -992,6 +992,23 @@ def test_group_by_multiple_null_cols_15623() -> None:
     assert df.is_empty()
 
 
+def test_group_by_repeated_iteration() -> None:
+    df = pl.DataFrame({"a": ["A", "B", "A", "A", "C"], "b": [1, 2, 3, 4, 5]})
+    group_by = df.group_by(pl.col("a"), maintain_order=True)
+    it_1 = []
+    it_2 = []
+    # Interleaved, repeated iteration
+    for item in group_by:
+        it_2 = list(group_by)
+        it_1.append(item)
+    assert len(it_1) == len(it_2) == 3
+
+    # Check if they actually produce the same results
+    for (n1, d1), (n3, d3) in zip(it_1, group_by):
+        assert n1 == n3
+        assert_frame_equal(d1, d3)
+
+
 @pytest.mark.release()
 def test_categorical_vs_str_group_by() -> None:
     # this triggers the perfect hash table

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1009,6 +1009,13 @@ def test_group_by_repeated_iteration() -> None:
         assert_frame_equal(d1, d3)
 
 
+def test_group_by_not_iterator() -> None:
+    df = pl.DataFrame({"a": ["A", "B", "A", "A", "C"], "b": [1, 2, 3, 4, 5]})
+    group_by = df.group_by(pl.col("a"), maintain_order=True)
+    with pytest.raises(TypeError):
+        next(group_by)  # type: ignore[call-overload]
+
+
 @pytest.mark.release()
 def test_categorical_vs_str_group_by() -> None:
     # this triggers the perfect hash table


### PR DESCRIPTION
Closes #12868

Edit: Implementation is now the other way around (`GroupBy` and co. are now Iterables)

As mentioned in #12868, it was unclear how `next()` was supposed to interact with a `df.group_by` directly.
It seemed to me that having it as an Iterator would be logical, but the alternative isn't hard to implement either (and this way there's progress).

As such, the initialisation code was moved so a separate function, which is invoked on the first `iter()` or `next()` call (not in `__init__`, so that users don't have to pay the grouping price if they don't want to iterate)

Additionally, this fixes the problem with the current implementation where calling `iter()` on a `GroupBy` resets its internal state: previously, the `iter()` call in the loop would keep resetting the iteration progress, which may be unintuitive
```python
from itertools import islice

import polars as pl

df = pl.DataFrame({"a": ["A", "B", "A", "A", "C"], "b": [1, 2, 3, 4, 5]})
group_by = df.group_by(pl.col("a"), maintain_order=True)

# This would loop infinitely (if not for islice), printing A, A, A, ...
for (name,), _group in islice(group_by, 20):
    print(name, end=", ")
    iter(group_by)  # this resets the iterator above! not according to Iterator spec
```

This may, however, break code that stored a `GroupBy` and then tried to iterate over it twice, separately. I'm not sure if this is problematic (as this use case does not seem intended), but it might be worth mentioning

```python
group_by = df.group_by(pl.col("a"), maintain_order=True)

# Produces A, B, C,
for (name,), _group in group_by:
    print(name, end=", ")
    
# Previously, also produced A, B, C,
# Now, it would produce nothing (empty iterator)
for (name,), _group in group_by:
    print(name, end=", ")
```
The alternative to this PR would be to create a new class (i.e. `GroupByIterator`) which is returned from the `__iter__` methods, meaning that the `GroupBy` classes would themselves be Iterables. In that case, `next()` would error when called directly on a `GroupBy`, but the above code would continue to work. I'm open to changing it to that, if preferred.