### PR TITLE
fix(python):  date/datetime predicates not pushed down into pyarrow.dataset

### DIFF
--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -378,7 +378,9 @@ impl Operator {
                 | Self::Gt
                 | Self::GtEq
                 | Self::And
+                | Self::LogicalAnd
                 | Self::Or
+                | Self::LogicalOr
                 | Self::Xor
                 | Self::EqValidity
                 | Self::NotEqValidity

--- a/crates/polars-plan/src/logical_plan/pyarrow.rs
+++ b/crates/polars-plan/src/logical_plan/pyarrow.rs
@@ -37,9 +37,11 @@ pub(super) fn predicate_to_pa(
                 None
             }
         },
-        AExpr::Cast {expr, data_type, strict } => {
-            predicate_to_pa(*expr, expr_arena, args)
-        },
+        AExpr::Cast {
+            expr,
+            data_type,
+            strict,
+        } => predicate_to_pa(*expr, expr_arena, args),
         AExpr::Column(name) => Some(format!("pa.compute.field('{}')", name.as_ref())),
         AExpr::Alias(input, _) => predicate_to_pa(*input, expr_arena, args),
         AExpr::Literal(LiteralValue::Series(s)) => {

--- a/crates/polars-plan/src/logical_plan/pyarrow.rs
+++ b/crates/polars-plan/src/logical_plan/pyarrow.rs
@@ -37,6 +37,9 @@ pub(super) fn predicate_to_pa(
                 None
             }
         },
+        AExpr::Cast {expr, data_type, strict } => {
+            predicate_to_pa(*expr, expr_arena, args)
+        },
         AExpr::Column(name) => Some(format!("pa.compute.field('{}')", name.as_ref())),
         AExpr::Alias(input, _) => predicate_to_pa(*input, expr_arena, args),
         AExpr::Literal(LiteralValue::Series(s)) => {


### PR DESCRIPTION
- Filters with LogicalAnd operators were not pushed down filter(expr, expr), even though it's same as filter(Expr & Expr)
- datetime.datetime(...) filters didn't work because it hit a branch with AExpr::Cast