### PR TITLE
feat(python)!: Update function signature of `nth` to allow positional input of indices, remove `columns` parameter

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2789,7 +2789,7 @@ class Expr:
         │ two   ┆ [4, 99]   │
         └───────┴───────────┘
         """
-        if isinstance(indices, list) or (
+        if isinstance(indices, Sequence) or (
             _check_for_numpy(indices) and isinstance(indices, np.ndarray)
         ):
             indices_lit = F.lit(pl.Series("", indices, dtype=Int64))._pyexpr

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -741,7 +741,10 @@ def nth(*indices: int | Sequence[int], columns: Sequence[str] | None = None) -> 
         return wrap_expr(plr.index_cols(indices))
 
     cols = F.col(columns)
-    return cols.get(indices[0]) if len(indices) == 1 else cols.gather(indices)  # type: ignore[arg-type]
+    if len(indices) == 1:
+        return cols.get(indices[0])  # type: ignore[arg-type]
+    else:
+        return cols.gather(indices)  # type: ignore[arg-type]
 
 
 def head(column: str, n: int = 10) -> Expr:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -658,22 +658,14 @@ def last(*columns: str) -> Expr:
     return F.col(*columns).last()
 
 
-def nth(*indices: int | Sequence[int], columns: Sequence[str] | None = None) -> Expr:
+def nth(*indices: int | Sequence[int]) -> Expr:
     """
-    Get the nth column(s) or value(s).
-
-    This function has different behavior depending on the presence of `columns`
-    values. If none given (the default), returns an expression that takes the nth
-    column of the context; otherwise, takes the nth value of the given column(s).
+    Get the nth column(s) of the context.
 
     Parameters
     ----------
     indices
         One or more indices representing the columns to retrieve.
-    columns
-        One or more column names. If omitted (the default), returns an
-        expression that takes the nth column of the context; otherwise,
-        takes the nth value of the given column(s).
 
     Examples
     --------
@@ -684,9 +676,6 @@ def nth(*indices: int | Sequence[int], columns: Sequence[str] | None = None) -> 
     ...         "c": ["foo", "bar", "baz"],
     ...     }
     ... )
-
-    Return the "nth" column(s):
-
     >>> df.select(pl.nth(1))
     shape: (3, 1)
     ┌─────┐
@@ -698,7 +687,6 @@ def nth(*indices: int | Sequence[int], columns: Sequence[str] | None = None) -> 
     │ 5   │
     │ 2   │
     └─────┘
-
     >>> df.select(pl.nth(2, 0))
     shape: (3, 2)
     ┌─────┬─────┐
@@ -710,41 +698,11 @@ def nth(*indices: int | Sequence[int], columns: Sequence[str] | None = None) -> 
     │ bar ┆ 8   │
     │ baz ┆ 3   │
     └─────┴─────┘
-
-    Return the "nth" value(s) for the given columns:
-
-    >>> df.select(pl.nth(-2, columns=["b", "c"]))
-    shape: (1, 2)
-    ┌─────┬─────┐
-    │ b   ┆ c   │
-    │ --- ┆ --- │
-    │ i64 ┆ str │
-    ╞═════╪═════╡
-    │ 5   ┆ bar │
-    └─────┴─────┘
-
-    >>> df.select(pl.nth(0, 2, columns=["c", "a"]))
-    shape: (2, 2)
-    ┌─────┬─────┐
-    │ c   ┆ a   │
-    │ --- ┆ --- │
-    │ str ┆ i64 │
-    ╞═════╪═════╡
-    │ foo ┆ 1   │
-    │ baz ┆ 3   │
-    └─────┴─────┘
     """
     if len(indices) == 1 and isinstance(indices[0], Sequence):
         indices = indices[0]  # type: ignore[assignment]
 
-    if columns is None:
-        return wrap_expr(plr.index_cols(indices))
-
-    cols = F.col(columns)
-    if len(indices) == 1:
-        return cols.get(indices[0])  # type: ignore[arg-type]
-    else:
-        return cols.gather(indices)  # type: ignore[arg-type]
+    return wrap_expr(plr.index_cols(indices))
 
 
 def head(column: str, n: int = 10) -> Expr:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -994,7 +994,7 @@ def by_index(*indices: int | range | Sequence[int | range]) -> SelectorType:
             all_indices.append(idx)
 
     return _selector_proxy_(
-        F.nth(all_indices), name="by_index", parameters={"*indices": indices}
+        F.nth(*all_indices), name="by_index", parameters={"*indices": indices}
     )
 
 

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -447,7 +447,7 @@ def test_lazy_functions() -> None:
         pl.first("a").name.suffix("_first"),
         pl.first("b", "c").name.suffix("_first"),
         pl.last("c", "b", "a").name.suffix("_last"),
-        pl.nth(1, "c", "a").name.suffix("_nth1"),
+        pl.nth(1, columns=["c", "a"]).name.suffix("_nth1"),
     )
     expected: dict[str, list[Any]] = {
         "b_var": [1.0],

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -447,7 +447,6 @@ def test_lazy_functions() -> None:
         pl.first("a").name.suffix("_first"),
         pl.first("b", "c").name.suffix("_first"),
         pl.last("c", "b", "a").name.suffix("_last"),
-        pl.nth(1, columns=["c", "a"]).name.suffix("_nth1"),
     )
     expected: dict[str, list[Any]] = {
         "b_var": [1.0],
@@ -470,8 +469,6 @@ def test_lazy_functions() -> None:
         "c_last": [4.0],
         "b_last": [3],
         "a_last": ["foo"],
-        "c_nth1": [2.0],
-        "a_nth1": ["bar"],
     }
     assert_frame_equal(
         out,

--- a/py-polars/tests/unit/functions/test_nth.py
+++ b/py-polars/tests/unit/functions/test_nth.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_cols"),
+    [
+        (pl.nth(0), "a"),
+        (pl.nth(-1), "c"),
+        (pl.nth(2, 1), ["c", "b"]),
+        (pl.nth([2, -2, 0]), ["c", "b", "a"]),
+    ],
+)
+def test_nth(expr: pl.Expr, expected_cols: list[str]) -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    result = df.select(expr)
+    expected = df.select(expected_cols)
+    assert_frame_equal(result, expected)
+
+
+def test_nth_duplicate() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    with pytest.raises(pl.DuplicateError, match="a"):
+        df.select(pl.nth(0, 0))

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -120,7 +120,7 @@ def test_selector_by_dtype(df: pl.DataFrame) -> None:
 def test_selector_by_index(df: pl.DataFrame) -> None:
     # one or more +ve indexes
     assert df.select(cs.by_index(0)).columns == ["abc"]
-    assert df.select(pl.nth([0, 1, 2])).columns == ["abc", "bbb", "cde"]
+    assert df.select(pl.nth(0, 1, 2)).columns == ["abc", "bbb", "cde"]
     assert df.select(cs.by_index(0, 1, 2)).columns == ["abc", "bbb", "cde"]
 
     # one or more -ve indexes


### PR DESCRIPTION
Closes #16511

#### Changes

* Update `nth` to remove the overloaded capability to select `values` from given columns at the specified indices.
* Now positional parameters are parsed as additional column indices to select.

#### Example

**Before**

```pycon
>>> df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
>>> df.select(pl.nth(1, "a"))
shape: (1, 1)
┌─────┐
│ a   │
│ --- │
│ i64 │
╞═════╡
│ 2   │
└─────┘
```

**After**

```pycon
>>> df.select(pl.nth(1, "a"))
...
TypeError: argument 'indices': 'str' object cannot be interpreted as an integer
```

Use instead:


```pycon
>>> df.select(pl.col("a").get(1))
shape: (1, 1)
┌─────┐
│ a   │
│ --- │
│ i64 │
╞═════╡
│ 2   │
└─────┘
```
