### PR TITLE
fix(rust,python): throw an invalid operation exception on performing a `sum` over a `list` of `str`s

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -448,9 +448,6 @@ impl StringChunked {
 }
 
 impl ChunkAggSeries for StringChunked {
-    fn sum_reduce(&self) -> Scalar {
-        Scalar::new(DataType::String, AnyValue::Null)
-    }
     fn max_reduce(&self) -> Scalar {
         let av: AnyValue = self.max_str().into();
         Scalar::new(DataType::String, av.into_static().unwrap())

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -71,6 +71,14 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         self.0.shrink_to_fit()
     }
 
+    fn sum_reduce(&self) -> PolarsResult<Scalar> {
+        polars_bail!(
+            op = "`sum`",
+            self.dtype(),
+            hint = "you may mean to call `concat_list`"
+        );
+    }
+
     fn slice(&self, offset: i64, length: usize) -> Series {
         self.0.slice(offset, length).into_series()
     }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -236,7 +236,11 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
     }
 
     fn sum_reduce(&self) -> PolarsResult<Scalar> {
-        Ok(ChunkAggSeries::sum_reduce(&self.0))
+        Err(polars_err!(
+            op = "`sum`",
+            DataType::String,
+            hint = "you may mean to call `str.concat` or `list.join`"
+        ))
     }
     fn max_reduce(&self) -> PolarsResult<Scalar> {
         Ok(ChunkAggSeries::max_reduce(&self.0))

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -265,6 +265,11 @@ macro_rules! polars_err {
             InvalidOperation: "{} operation not supported for dtype `{}`", $op, $arg
         )
     };
+    (op = $op:expr, $arg:expr, hint = $hint:literal) => {
+        $crate::polars_err!(
+            InvalidOperation: "{} operation not supported for dtype `{}`\n\nHint: {}", $op, $arg, $hint
+        )
+    };
     (op = $op:expr, $lhs:expr, $rhs:expr) => {
         $crate::polars_err!(
             InvalidOperation: "{} operation not supported for dtypes `{}` and `{}`", $op, $lhs, $rhs

--- a/docs/src/python/user-guide/concepts/expressions.py
+++ b/docs/src/python/user-guide/concepts/expressions.py
@@ -3,7 +3,7 @@ import polars as pl
 df = pl.DataFrame(
     {
         "foo": [1, 2, 3, None, 5],
-        "bar": ["foo", "ham", "spam", "egg", None],
+        "bar": [1.5, 0.9, 2.0, 0.0, None],
     }
 )
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -831,3 +831,13 @@ def test_take_list_15719() -> None:
     )
 
     assert_frame_equal(df, expected)
+
+
+def test_list_str_sum_exception_12935() -> None:
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        pl.Series(["foo", "bar"]).sum()
+
+
+def test_list_list_sum_exception_12935() -> None:
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        pl.Series([[1], [2]]).sum()

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -495,11 +495,11 @@ def test_lazy_functions() -> None:
         [
             pl.struct(pl.max("^a|b$")).alias("x"),
             pl.struct(pl.min("^.*[bc]$")).alias("y"),
-            pl.struct(pl.sum("^[^b]$")).alias("z"),
+            pl.struct(pl.sum("^[^a]$")).alias("z"),
         ]
     )
     assert out.rows() == [
-        ({"a": "foo", "b": 3}, {"b": 1, "c": -1.0}, {"a": None, "c": 5.0})
+        ({"a": "foo", "b": 3}, {"b": 1, "c": -1.0}, {"b": 6, "c": 5.0})
     ]
 
 


### PR DESCRIPTION
Fixes #12935.