### PR TITLE
feat(python)!: Remove default class variable values on DataTypes

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -434,23 +434,12 @@ class Datetime(TemporalType):
     epoch.
     """
 
-    time_unit: TimeUnit | None = None
-    time_zone: str | None = None
+    time_unit: TimeUnit
+    time_zone: str | None
 
     def __init__(
         self, time_unit: TimeUnit = "us", time_zone: str | timezone | None = None
     ):
-        if time_unit is None:
-            from polars._utils.deprecation import issue_deprecation_warning
-
-            issue_deprecation_warning(
-                "Passing `time_unit=None` to the Datetime constructor is deprecated."
-                " Either avoid passing a time unit to use the default value ('us'),"
-                " or pass a valid time unit instead ('ms', 'us', 'ns').",
-                version="0.20.11",
-            )
-            time_unit = "us"
-
         if time_unit not in ("ms", "us", "ns"):
             msg = (
                 "invalid `time_unit`"

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -501,7 +501,7 @@ class Duration(TemporalType):
     negative time offsets.
     """
 
-    time_unit: TimeUnit | None = None
+    time_unit: TimeUnit
 
     def __init__(self, time_unit: TimeUnit = "us"):
         if time_unit not in ("ms", "us", "ns"):

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -720,7 +720,7 @@ class Array(NestedType):
     ]
     """
 
-    inner: PolarsDataType | None = None
+    inner: PolarsDataType
     size: int
     shape: tuple[int, ...]
 
@@ -776,8 +776,6 @@ class Array(NestedType):
         elif isinstance(other, Array):
             if self.shape != other.shape:
                 return False
-            elif self.inner is None or other.inner is None:
-                return True
             else:
                 return self.inner == other.inner
         else:

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -669,7 +669,7 @@ class List(NestedType):
     └───────────────┴─────────────┘
     """
 
-    inner: PolarsDataType | None = None
+    inner: PolarsDataType
 
     def __init__(self, inner: PolarsDataType | PythonDataType):
         self.inner = polars.datatypes.py_type_to_dtype(inner)
@@ -685,10 +685,7 @@ class List(NestedType):
         if type(other) is DataTypeClass and issubclass(other, List):
             return True
         elif isinstance(other, List):
-            if self.inner is None or other.inner is None:
-                return True
-            else:
-                return self.inner == other.inner
+            return self.inner == other.inner
         else:
             return False
 

--- a/py-polars/polars/interchange/utils.py
+++ b/py-polars/polars/interchange/utils.py
@@ -72,14 +72,14 @@ def polars_dtype_to_dtype(dtype: PolarsDataType) -> Dtype:
 
 
 def _datetime_to_dtype(dtype: Datetime) -> Dtype:
-    tu = dtype.time_unit[0] if dtype.time_unit is not None else "u"
+    tu = dtype.time_unit[0]
     tz = dtype.time_zone if dtype.time_zone is not None else ""
     arrow_c_type = f"ts{tu}:{tz}"
     return DtypeKind.DATETIME, 64, arrow_c_type, NE
 
 
 def _duration_to_dtype(dtype: Duration) -> Dtype:
-    tu = dtype.time_unit[0] if dtype.time_unit is not None else "u"
+    tu = dtype.time_unit[0]
     arrow_c_type = f"tD{tu}"
     return DtypeKind.DATETIME, 64, arrow_c_type, NE
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2791,9 +2791,3 @@ def test_misc_precision_any_value_conversion(time_zone: Any, warn: bool) -> None
 def test_pytime_conversion(tm: time) -> None:
     s = pl.Series("tm", [tm])
     assert s.to_list() == [tm]
-
-
-def test_datetime_time_unit_none_deprecated() -> None:
-    with pytest.deprecated_call():
-        dtype = pl.Datetime(time_unit=None)  # type: ignore[arg-type]
-    assert dtype.time_unit == "us"


### PR DESCRIPTION
#### Changes

* Remove the default `None` value from some `DataType` attributes. These should be instance variables, not class variables.

#### Example

**Before**

```pycon
>>> dtype = pl.Datetime
>>> dtype.time_unit is None
True
```

**After**

```pycon
>>> dtype.time_unit is None
Traceback (most recent call last):
...
AttributeError: type object 'Datetime' has no attribute 'time_unit'
```

Use instead:

```pycon
>>> getattr(dtype, "time_unit", None) is None
True
```
