### PR TITLE
docs(python): Remove erroneous `implode` reference from the user guide section on window functions

### DIFF
--- a/docs/user-guide/expressions/window.md
+++ b/docs/user-guide/expressions/window.md
@@ -84,7 +84,7 @@ For more exercise, below are some window functions for us to compute:
 - sort the pokemon within a type by attack in descending order and select the first `3` as `"strongest/group"`
 - sort the pokemon within a type by name and select the first `3` as `"sorted_by_alphabet"`
 
-{{code_block('user-guide/expressions/window','examples',['over','implode'])}}
+{{code_block('user-guide/expressions/window','examples',['over'])}}
 
 ```python exec="on" result="text" session="user-guide/window"
 --8<-- "python/user-guide/expressions/window.py:examples"


### PR DESCRIPTION
The existing documentation for window functions in the user guide page included `implode` in the list of API, but there was no actual usage or example provided for `implode`. This led to potential confusion for users following the documentation.

