### PR TITLE
feat(python): Add `DataFrame.serialize/deserialize`

### DIFF
--- a/py-polars/docs/source/reference/dataframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/dataframe/miscellaneous.rst
@@ -12,3 +12,12 @@ Miscellaneous
     DataFrame.frame_equal
     DataFrame.lazy
     DataFrame.map_rows
+
+Serialization
+-------------
+
+.. autosummary::
+   :toctree: api/
+
+    DataFrame.deserialize
+    DataFrame.serialize

--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -16,8 +16,8 @@ Miscellaneous
     LazyFrame.pipe
     LazyFrame.profile
 
-Read/write logical plan
------------------------
+Serialization
+-------------
 
 .. autosummary::
    :toctree: api/

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2340,24 +2340,24 @@ class DataFrame:
                 version="0.20.31",
             )
 
-        def serialize_to_string(*, pretty: bool, row_oriented: bool) -> str:
+        def write_json_to_string(*, pretty: bool, row_oriented: bool) -> str:
             with BytesIO() as buf:
                 self._df.write_json_old(buf, pretty=pretty, row_oriented=row_oriented)
                 json_bytes = buf.getvalue()
             return json_bytes.decode("utf8")
 
         if file is None:
-            return serialize_to_string(pretty=pretty, row_oriented=row_oriented)
+            return write_json_to_string(pretty=pretty, row_oriented=row_oriented)
         elif isinstance(file, StringIO):
-            json_str = serialize_to_string(pretty=pretty, row_oriented=row_oriented)
+            json_str = write_json_to_string(pretty=pretty, row_oriented=row_oriented)
             file.write(json_str)
             return None
         elif isinstance(file, (str, Path)):
             file = normalize_filepath(file)
-            self._df.serialize(file, pretty=pretty, row_oriented=row_oriented)
+            self._df.write_json_old(file, pretty=pretty, row_oriented=row_oriented)
             return None
         else:
-            self._df.serialize(file, pretty=pretty, row_oriented=row_oriented)
+            self._df.write_json_old(file, pretty=pretty, row_oriented=row_oriented)
             return None
 
     @overload

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -98,11 +98,11 @@ from polars.exceptions import (
     TooManyRowsReturnedError,
 )
 from polars.functions import col, lit
-from polars.polars import PyDataFrame
 from polars.selectors import _expand_selector_dicts, _expand_selectors
 from polars.type_aliases import DbWriteMode, JaxExportType, TorchExportType
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyDataFrame
     from polars.polars import dtype_str_repr as _dtype_str_repr
     from polars.polars import write_clipboard_string as _write_clipboard_string
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2319,8 +2319,6 @@ class DataFrame:
         ...         "bar": [6, 7, 8],
         ...     }
         ... )
-        >>> df.write_json()
-        '{"columns":[{"name":"foo","datatype":"Int64","bit_settings":"","values":[1,2,3]},{"name":"bar","datatype":"Int64","bit_settings":"","values":[6,7,8]}]}'
         >>> df.write_json(row_oriented=True)
         '[{"foo":1,"bar":6},{"foo":2,"bar":7},{"foo":3,"bar":8}]'
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -340,7 +340,7 @@ class Expr:
     @classmethod
     def deserialize(cls, source: str | Path | IOBase) -> Self:
         """
-        Read an expression from a JSON file.
+        Read a serialized expression from a file.
 
         Parameters
         ----------
@@ -351,10 +351,9 @@ class Expr:
 
         Warnings
         --------
-            This function uses :mod:`pickle` under some circumstances, and as
-            such inherits the security implications. Deserializing can execute
-            arbitrary code so it should only be attempted on trusted data.
-            pickle is only used when the logical plan contains python UDFs.
+        This function uses :mod:`pickle` when the logical plan contains Python UDFs,
+        and as such inherits the security implications. Deserializing can execute
+        arbitrary code, so it should only be attempted on trusted data.
 
         See Also
         --------

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -291,22 +291,26 @@ class ExprMetaNameSpace:
         >>> pl.Expr.deserialize(StringIO(json))  # doctest: +ELLIPSIS
         <Expr ['col("foo").sum().over([col("ba…'] at ...>
         """
-        if isinstance(file, (str, Path)):
-            file = normalize_filepath(file)
-        to_string_io = (file is not None) and isinstance(file, StringIO)
-        if file is None or to_string_io:
+
+        def serialize_to_string() -> str:
             with BytesIO() as buf:
                 self._pyexpr.serialize(buf)
                 json_bytes = buf.getvalue()
+            return json_bytes.decode("utf8")
 
-            json_str = json_bytes.decode("utf8")
-            if to_string_io:
-                file.write(json_str)  # type: ignore[union-attr]
-            else:
-                return json_str
+        if file is None:
+            return serialize_to_string()
+        elif isinstance(file, StringIO):
+            json_str = serialize_to_string()
+            file.write(json_str)
+            return None
+        elif isinstance(file, (str, Path)):
+            file = normalize_filepath(file)
+            self._pyexpr.serialize(file)
+            return None
         else:
             self._pyexpr.serialize(file)
-        return None
+            return None
 
     @overload
     def write_json(self, file: None = ...) -> str: ...

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -348,7 +348,7 @@ class LazyFrame:
     @classmethod
     def deserialize(cls, source: str | Path | IOBase) -> Self:
         """
-        Read a logical plan from a JSON file to construct a LazyFrame.
+        Read a logical plan from a file to construct a LazyFrame.
 
         Parameters
         ----------
@@ -359,11 +359,9 @@ class LazyFrame:
 
         Warnings
         --------
-            This function uses :mod:`pickle` under some circumstances, and as
-            such inherits the security implications. Deserializing can execute
-            arbitrary code so it should only be attempted on trusted data.
-            pickle is only used when the logical plan contains python UDFs.
-
+        This function uses :mod:`pickle` when the logical plan contains Python UDFs,
+        and as such inherits the security implications. Deserializing can execute
+        arbitrary code, so it should only be attempted on trusted data.
 
         See Also
         --------

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -238,6 +238,9 @@ filterwarnings = [
   # TODO: Remove when behavior is updated
   # https://github.com/pola-rs/polars/issues/13441
   "ignore:.*default coalesce behavior of left join.*:DeprecationWarning",
+  # TODO: Remove when default is updated
+  # https://github.com/pola-rs/polars/issues/14526
+  "ignore:.*will only write row-oriented JSON.*:DeprecationWarning",
 ]
 xfail_strict = true
 

--- a/py-polars/src/dataframe/io.rs
+++ b/py-polars/src/dataframe/io.rs
@@ -453,21 +453,42 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "json")]
-    pub fn write_json(&mut self, py_f: PyObject, pretty: bool, row_oriented: bool) -> PyResult<()> {
+    pub fn serialize(&mut self, py_f: PyObject) -> PyResult<()> {
+        let file = BufWriter::new(get_file_like(py_f, true)?);
+        serde_json::to_writer(file, &self.df)
+            .map_err(|e| polars_err!(ComputeError: "{e}"))
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
+    }
+
+    #[cfg(feature = "json")]
+    pub fn write_json(&mut self, py_f: PyObject) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
 
-        let r = match (pretty, row_oriented) {
-            (_, true) => JsonWriter::new(file)
-                .with_json_format(JsonFormat::Json)
-                .finish(&mut self.df),
-            (true, _) => serde_json::to_writer_pretty(file, &self.df)
-                .map_err(|e| polars_err!(ComputeError: "{e}")),
-            (false, _) => {
-                serde_json::to_writer(file, &self.df).map_err(|e| polars_err!(ComputeError: "{e}"))
+        JsonWriter::new(file)
+            .with_json_format(JsonFormat::Json)
+            .finish(&mut self.df)
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
+    }
+
+    /// This method can be removed entirely in the next breaking release.
+    #[cfg(feature = "json")]
+    pub fn write_json_old(
+        &mut self,
+        py_f: PyObject,
+        pretty: bool,
+        row_oriented: bool,
+    ) -> PyResult<()> {
+        match (pretty, row_oriented) {
+            (_, true) => self.write_json(py_f),
+            (false, _) => self.serialize(py_f),
+            (true, _) => {
+                let file = BufWriter::new(get_file_like(py_f, true)?);
+
+                serde_json::to_writer_pretty(file, &self.df)
+                    .map_err(|e| polars_err!(ComputeError: "{e}"))
+                    .map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
             },
-        };
-        r.map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
-        Ok(())
+        }
     }
 
     #[cfg(feature = "json")]
@@ -478,8 +499,7 @@ impl PyDataFrame {
             .with_json_format(JsonFormat::JsonLines)
             .finish(&mut self.df);
 
-        r.map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
-        Ok(())
+        r.map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
     }
 
     #[cfg(feature = "ipc")]

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -1,0 +1,24 @@
+import pytest
+
+import polars as pl
+
+
+def test_df_serialize() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).sort("a")
+    result = df.serialize()
+    expected = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":"SORTED_ASC","values":[1,2,3]},{"name":"b","datatype":"Int64","bit_settings":"","values":[4,5,6]}]}'
+    assert result == expected
+
+
+def test_df_write_json_deprecated() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    with pytest.deprecated_call():
+        result = df.write_json()
+    assert result == df.serialize()
+
+
+def test_df_write_json_pretty_deprecated() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    with pytest.deprecated_call():
+        result = df.write_json(pretty=True)
+    assert isinstance(result, str)

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -1,6 +1,16 @@
+from __future__ import annotations
+
+import io
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_df_serialize() -> None:
@@ -8,6 +18,132 @@ def test_df_serialize() -> None:
     result = df.serialize()
     expected = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":"SORTED_ASC","values":[1,2,3]},{"name":"b","datatype":"Int64","bit_settings":"","values":[4,5,6]}]}'
     assert result == expected
+
+
+@pytest.mark.parametrize("buf", [io.BytesIO(), io.StringIO()])
+def test_to_from_buffer(df: pl.DataFrame, buf: io.IOBase) -> None:
+    df.serialize(buf)
+    buf.seek(0)
+    read_df = pl.DataFrame.deserialize(buf)
+    assert_frame_equal(df, read_df, categorical_as_str=True)
+
+
+@pytest.mark.write_disk()
+def test_to_from_file(df: pl.DataFrame, tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    file_path = tmp_path / "small.json"
+    df.serialize(file_path)
+    out = pl.DataFrame.deserialize(file_path)
+
+    assert_frame_equal(df, out, categorical_as_str=True)
+
+
+def test_write_json_to_string() -> None:
+    # Tests if it runs if no arg given
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    expected_str = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":"","values":[1,2,3]}]}'
+    assert df.serialize() == expected_str
+
+
+def test_write_json(df: pl.DataFrame) -> None:
+    # Text-based conversion loses time info
+    df = df.select(pl.all().exclude(["cat", "time"]))
+    s = df.serialize()
+    f = io.BytesIO()
+    f.write(s.encode())
+    f.seek(0)
+    out = pl.DataFrame.deserialize(f)
+    assert_frame_equal(out, df)
+
+    file = io.BytesIO()
+    df.serialize(file)
+    file.seek(0)
+    out = pl.DataFrame.deserialize(file)
+    assert_frame_equal(out, df)
+
+
+def test_df_serde_enum() -> None:
+    dtype = pl.Enum(["foo", "bar", "ham"])
+    df = pl.DataFrame([pl.Series("e", ["foo", "bar", "ham"], dtype=dtype)])
+    buf = io.StringIO()
+    df.serialize(buf)
+    buf.seek(0)
+    df_in = pl.DataFrame.deserialize(buf)
+    assert df_in.schema["e"] == dtype
+
+
+@pytest.mark.parametrize(
+    ("data", "dtype"),
+    [
+        ([[1, 2, 3], [None, None, None], [1, None, 3]], pl.Array(pl.Int32(), width=3)),
+        ([["a", "b"], [None, None]], pl.Array(pl.Utf8, width=2)),
+        ([[True, False, None], [None, None, None]], pl.Array(pl.Utf8, width=3)),
+        (
+            [[[1, 2, 3], [4, None, 5]], None, [[None, None, 2]]],
+            pl.List(pl.Array(pl.Int32(), width=3)),
+        ),
+        (
+            [
+                [datetime(1991, 1, 1), datetime(1991, 1, 1), None],
+                [None, None, None],
+            ],
+            pl.Array(pl.Datetime, width=3),
+        ),
+    ],
+)
+def test_write_read_json_array(data: Any, dtype: pl.DataType) -> None:
+    df = pl.DataFrame({"foo": data}, schema={"foo": dtype})
+    buf = io.StringIO()
+    df.serialize(buf)
+    buf.seek(0)
+    deserialized_df = pl.DataFrame.deserialize(buf)
+    assert_frame_equal(deserialized_df, df)
+
+
+@pytest.mark.parametrize(
+    ("data", "dtype"),
+    [
+        (
+            [
+                [
+                    datetime(1997, 10, 1),
+                    datetime(2000, 1, 2, 10, 30, 1),
+                ],
+                [None, None],
+            ],
+            pl.Array(pl.Datetime, width=2),
+        ),
+        (
+            [[date(1997, 10, 1), date(2000, 1, 1)], [None, None]],
+            pl.Array(pl.Date, width=2),
+        ),
+        (
+            [
+                [timedelta(seconds=1), timedelta(seconds=10)],
+                [None, None],
+            ],
+            pl.Array(pl.Duration, width=2),
+        ),
+    ],
+)
+def test_write_read_json_array_logical_inner_type(
+    data: Any, dtype: pl.DataType
+) -> None:
+    df = pl.DataFrame({"foo": data}, schema={"foo": dtype})
+    buf = io.StringIO()
+    df.serialize(buf)
+    buf.seek(0)
+    deserialized_df = pl.DataFrame.deserialize(buf)
+    assert deserialized_df.dtypes == df.dtypes
+    assert deserialized_df.to_dict(as_series=False) == df.to_dict(as_series=False)
+
+
+def test_json_deserialize_empty_list_10458() -> None:
+    schema = {"LIST_OF_STRINGS": pl.List(pl.String)}
+    serialized_schema = pl.DataFrame(schema=schema).serialize()
+    df = pl.DataFrame.deserialize(io.StringIO(serialized_schema))
+    assert df.schema == schema
 
 
 def test_df_write_json_deprecated() -> None:


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14526

This introduces `DataFrame.serialize/deserialize`. This functionality already existed as part of `pl.read_json/DataFrame.write_json`, but is now split off for clarity.

This will be followed up with a breaking change to `pl.read_json/DataFrame.write_json` that removes the serde functionality from those functions.