### PR TITLE
feat(python)!: Remove serde functionality from `pl.read_json` and `DataFrame.write_json`

### DIFF
--- a/docs/src/python/user-guide/io/json.py
+++ b/docs/src/python/user-guide/io/json.py
@@ -19,6 +19,9 @@ df = pl.DataFrame({"foo": [1, 2, 3], "bar": [None, "bak", "baz"]})
 df.write_json("docs/data/path.json")
 # --8<-- [end:write]
 
+"""
 # --8<-- [start:scan]
 df = pl.scan_ndjson("docs/data/path.json")
 # --8<-- [end:scan]
+
+"""

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2263,30 +2263,12 @@ class DataFrame:
             return None
 
     @overload
-    def write_json(
-        self,
-        file: None = ...,
-        *,
-        row_oriented: bool = ...,
-        pretty: bool | None = ...,
-    ) -> str: ...
+    def write_json(self, file: None = ...) -> str: ...
 
     @overload
-    def write_json(
-        self,
-        file: IOBase | str | Path,
-        *,
-        row_oriented: bool = ...,
-        pretty: bool | None = ...,
-    ) -> None: ...
+    def write_json(self, file: IOBase | str | Path) -> None: ...
 
-    def write_json(
-        self,
-        file: IOBase | str | Path | None = None,
-        *,
-        row_oriented: bool = False,
-        pretty: bool | None = None,
-    ) -> str | None:
+    def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
         """
         Serialize to JSON representation.
 
@@ -2295,17 +2277,6 @@ class DataFrame:
         file
             File path or writable file-like object to which the result will be written.
             If set to `None` (default), the output is returned as a string instead.
-        row_oriented
-            Write to row oriented json. This is slower, but more common.
-
-        pretty
-            Pretty serialize json.
-
-            .. deprecated:: 0.20.31
-                The `pretty` functionality for `write_json` will be removed in the next
-                breaking release. Use :meth:`serialize` to serialize the DataFrame in
-                the regular JSON format.
-
 
         See Also
         --------
@@ -2319,43 +2290,28 @@ class DataFrame:
         ...         "bar": [6, 7, 8],
         ...     }
         ... )
-        >>> df.write_json(row_oriented=True)
+        >>> df.write_json()
         '[{"foo":1,"bar":6},{"foo":2,"bar":7},{"foo":3,"bar":8}]'
         """
-        if pretty is not None:
-            issue_deprecation_warning(
-                "The `pretty` functionality for `write_json` will be removed in the next breaking release."
-                " Use `DataFrame.serialize` to serialize the DataFrame in the regular JSON format.",
-                version="0.20.31",
-            )
-        else:
-            pretty = False
 
-        if not row_oriented:
-            issue_deprecation_warning(
-                "`DataFrame.write_json` will only write row-oriented JSON in the next breaking release."
-                " Use `DataFrame.serialize` instead.",
-                version="0.20.31",
-            )
-
-        def write_json_to_string(*, pretty: bool, row_oriented: bool) -> str:
+        def write_json_to_string() -> str:
             with BytesIO() as buf:
-                self._df.write_json_old(buf, pretty=pretty, row_oriented=row_oriented)
+                self._df.write_json(buf)
                 json_bytes = buf.getvalue()
             return json_bytes.decode("utf8")
 
         if file is None:
-            return write_json_to_string(pretty=pretty, row_oriented=row_oriented)
+            return write_json_to_string()
         elif isinstance(file, StringIO):
-            json_str = write_json_to_string(pretty=pretty, row_oriented=row_oriented)
+            json_str = write_json_to_string()
             file.write(json_str)
             return None
         elif isinstance(file, (str, Path)):
             file = normalize_filepath(file)
-            self._df.write_json_old(file, pretty=pretty, row_oriented=row_oriented)
+            self._df.write_json(file)
             return None
         else:
-            self._df.write_json_old(file, pretty=pretty, row_oriented=row_oriented)
+            self._df.write_json(file)
             return None
 
     @overload

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -238,9 +238,6 @@ filterwarnings = [
   # TODO: Remove when behavior is updated
   # https://github.com/pola-rs/polars/issues/13441
   "ignore:.*default coalesce behavior of left join.*:DeprecationWarning",
-  # TODO: Remove when default is updated
-  # https://github.com/pola-rs/polars/issues/14526
-  "ignore:.*will only write row-oriented JSON.*:DeprecationWarning",
 ]
 xfail_strict = true
 

--- a/py-polars/src/dataframe/io.rs
+++ b/py-polars/src/dataframe/io.rs
@@ -491,27 +491,6 @@ impl PyDataFrame {
             .map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
     }
 
-    /// This method can be removed entirely in the next breaking release.
-    #[cfg(feature = "json")]
-    pub fn write_json_old(
-        &mut self,
-        py_f: PyObject,
-        pretty: bool,
-        row_oriented: bool,
-    ) -> PyResult<()> {
-        match (pretty, row_oriented) {
-            (_, true) => self.write_json(py_f),
-            (false, _) => self.serialize(py_f),
-            (true, _) => {
-                let file = BufWriter::new(get_file_like(py_f, true)?);
-
-                serde_json::to_writer_pretty(file, &self.df)
-                    .map_err(|e| polars_err!(ComputeError: "{e}"))
-                    .map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
-            },
-        }
-    }
-
     #[cfg(feature = "json")]
     pub fn write_ndjson(&mut self, py_f: PyObject) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -144,3 +144,34 @@ def test_json_deserialize_empty_list_10458() -> None:
     serialized_schema = pl.DataFrame(schema=schema).serialize()
     df = pl.DataFrame.deserialize(io.StringIO(serialized_schema))
     assert df.schema == schema
+
+
+def test_serde_validation() -> None:
+    f = io.StringIO(
+        """
+    {
+      "columns": [
+        {
+          "name": "a",
+          "datatype": "Int64",
+          "values": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "b",
+          "datatype": "Int64",
+          "values": [
+            1
+          ]
+        }
+      ]
+    }
+    """
+    )
+    with pytest.raises(
+        pl.ComputeError,
+        match=r"lengths don't match",
+    ):
+        pl.DataFrame.deserialize(f)

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -144,17 +144,3 @@ def test_json_deserialize_empty_list_10458() -> None:
     serialized_schema = pl.DataFrame(schema=schema).serialize()
     df = pl.DataFrame.deserialize(io.StringIO(serialized_schema))
     assert df.schema == schema
-
-
-def test_df_write_json_deprecated() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    with pytest.deprecated_call():
-        result = df.write_json()
-    assert result == df.serialize()
-
-
-def test_df_write_json_pretty_deprecated() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    with pytest.deprecated_call():
-        result = df.write_json(pretty=True)
-    assert isinstance(result, str)

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -11,9 +11,9 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 
-def test_write_json_row_oriented() -> None:
+def test_write_json() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", None]})
-    out = df.write_json(row_oriented=True)
+    out = df.write_json()
     assert out == '[{"a":1,"b":"a"},{"a":2,"b":"b"},{"a":3,"b":null}]'
 
     # Test round trip
@@ -27,11 +27,10 @@ def test_write_json_row_oriented() -> None:
 def test_write_json_categoricals() -> None:
     data = {"column": ["test1", "test2", "test3", "test4"]}
     df = pl.DataFrame(data).with_columns(pl.col("column").cast(pl.Categorical))
-
-    assert (
-        df.write_json(row_oriented=True, file=None)
-        == '[{"column":"test1"},{"column":"test2"},{"column":"test3"},{"column":"test4"}]'
+    expected = (
+        '[{"column":"test1"},{"column":"test2"},{"column":"test3"},{"column":"test4"}]'
     )
+    assert df.write_json() == expected
 
 
 def test_write_json_duration() -> None:
@@ -44,8 +43,9 @@ def test_write_json_duration() -> None:
     )
 
     # we don't guarantee a format, just round-circling
-    value = str(df.write_json(row_oriented=True))
-    assert value == """[{"a":"PT91762.939S"},{"a":"PT91762.89S"},{"a":"PT6020.836S"}]"""
+    value = df.write_json()
+    expected = '[{"a":"PT91762.939S"},{"a":"PT91762.89S"},{"a":"PT6020.836S"}]'
+    assert value == expected
 
 
 def test_json_infer_schema_length_11148() -> None:

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -538,37 +538,6 @@ def test_invalid_group_by_arg() -> None:
         df.group_by(1).agg({"a": "sum"})
 
 
-def test_serde_validation() -> None:
-    f = io.StringIO(
-        """
-    {
-      "columns": [
-        {
-          "name": "a",
-          "datatype": "Int64",
-          "values": [
-            1,
-            2
-          ]
-        },
-        {
-          "name": "b",
-          "datatype": "Int64",
-          "values": [
-            1
-          ]
-        }
-      ]
-    }
-    """
-    )
-    with pytest.raises(
-        pl.ComputeError,
-        match=r"lengths don't match",
-    ):
-        pl.read_json(f)
-
-
 def test_overflow_msg() -> None:
     with pytest.raises(
         pl.ComputeError,


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/14526

#### Changes

* `pl.read_json` no longer supports reading JSON files produced by `DataFrame.serialize`. Users should use `pl.DataFrame.deserialize` instead.
* `DataFrame.write_json` now only writes row-oriented JSON. The parameters `row_oriented` and `pretty` have been removed. Users should use `DataFrame.serialize` to serialize a DataFrame.

#### Examples



**Before - `write_json`**

```pycon
>>> df = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
>>> df.write_json()
'{"columns":[{"name":"a","datatype":"Int64","bit_settings":"","values":[1,2]},{"name":"b","datatype":"Float64","bit_settings":"","values":[3.0,4.0]}]}'
```

**After - `write_json`**

```pycon
>>> df.write_json()  # Same behavior as previously `df.write_json(row_oriented=True)`
'[{"a":1,"b":3.0},{"a":2,"b":4.0}]'
```

**Before - `read_json`**

```pycon
>>> import io
>>> df_ser = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":"","values":[1,2]},{"name":"b","datatype":"Float64","bit_settings":"","values":[3.0,4.0]}]}'
>>> pl.read_json(io.StringIO(df_ser))
shape: (2, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ i64 ┆ f64 │
╞═════╪═════╡
│ 1   ┆ 3.0 │
│ 2   ┆ 4.0 │
└─────┴─────┘
```

**After - `read_json`**

```pycon
>>> pl.read_json(io.StringIO(df_ser))  # Format no longer supported: data is treated as a single row
shape: (1, 1)
┌─────────────────────────────────┐
│ columns                         │
│ ---                             │
│ list[struct[4]]                 │
╞═════════════════════════════════╡
│ [{"a","Int64","",[1.0, 2.0]}, … │
└─────────────────────────────────┘
```

Use instead:

```pycon
>>> pl.DataFrame.deserialize(io.StringIO(df_ser))
shape: (2, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ i64 ┆ f64 │
╞═════╪═════╡
│ 1   ┆ 3.0 │
│ 2   ┆ 4.0 │
└─────┴─────┘
```