### PR TITLE
fix(rust): Ensure deduced join key names are unique

### DIFF
--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1014,3 +1014,13 @@ def test_left_join_coalesce_default_deprecation_message() -> None:
     right = pl.DataFrame({"a": [2, 3, 4], "c": [4, 5, 6]})
     with pytest.deprecated_call():
         left.join(right, on="a", how="left")
+
+
+@pytest.mark.parametrize("coalesce", [False, True])
+def test_join_raise_on_repeated_expression_key_names(coalesce: bool) -> None:
+    left = pl.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": [5, 6, 7]})
+    right = pl.DataFrame({"a": [2, 3, 4], "c": [4, 5, 6]})
+    with pytest.raises(pl.InvalidOperationError, match="already joined on"):
+        left.join(
+            right, on=[pl.col("a"), pl.col("a") % 2], how="full", coalesce=coalesce
+        )


### PR DESCRIPTION
The fix for #16289 checked for expression identity when validating the join keys, but if multiple expressions are not identical, they may still produce matching output key names. Since this is ambiguous, catch this more general case and raise.

- Fixes #16547