### PR TITLE
chore(python): Add `polars.pyd` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ polars/vendor
 .venv*/
 __pycache__/
 .coverage
+*.pyd
 
 # Rust
 .cargo/


### PR DESCRIPTION
The file 'py-polars\polars\polars.pyd' is created on Windows. It is basically a DLL.

See [Python on Windows FAQ — Is a *.pyd file the same as a DLL?](https://docs.python.org/3/faq/windows.html#is-a-pyd-file-the-same-as-a-dll)