### PR TITLE
feat(rust,py): add additional control to `write_parquet::statistics` parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,6 +3068,7 @@ dependencies = [
  "num-traits",
  "parquet-format-safe",
  "polars-arrow",
+ "polars-compute",
  "polars-error",
  "polars-utils",
  "rand",

--- a/crates/polars-compute/src/distinct_count.rs
+++ b/crates/polars-compute/src/distinct_count.rs
@@ -1,0 +1,18 @@
+use arrow::array::{Array, BooleanArray};
+
+/// Kernel to calculate the number of unique non-null elements
+pub trait DistinctCountKernel {
+    /// Calculate the number of unique non-null elements in [`Self`]
+    fn distinct_count(&self) -> usize;
+}
+
+impl DistinctCountKernel for BooleanArray {
+    fn distinct_count(&self) -> usize {
+        if self.len() - self.null_count() == 0 {
+            return 0;
+        }
+
+        let unset_bits = self.values().unset_bits();
+        2 - usize::from(unset_bits == 0 || unset_bits == self.values().len())
+    }
+}

--- a/crates/polars-compute/src/lib.rs
+++ b/crates/polars-compute/src/lib.rs
@@ -9,6 +9,7 @@ use arrow::types::NativeType;
 
 pub mod arithmetic;
 pub mod comparisons;
+pub mod distinct_count;
 pub mod filter;
 pub mod float_sum;
 pub mod if_then_else;

--- a/crates/polars-core/src/chunked_array/metadata.rs
+++ b/crates/polars-core/src/chunked_array/metadata.rs
@@ -14,6 +14,7 @@ pub struct Metadata<T: PolarsDataType> {
     min_value: Option<T::OwnedPhysical>,
     max_value: Option<T::OwnedPhysical>,
 
+    /// Number of unique non-null values
     distinct_count: Option<IdxSize>,
 }
 

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -79,7 +79,7 @@ macro_rules! impl_compare {
             _ => unimplemented!(),
         };
         out.rename(lhs.name());
-        Ok(out) as PolarsResult<BooleanChunked>
+        PolarsResult::Ok(out)
     }};
 }
 

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -64,7 +64,7 @@ json = [
   "dtype-struct",
   "csv",
 ]
-serde = ["dep:serde", "polars-core/serde-lazy"]
+serde = ["dep:serde", "polars-core/serde-lazy", "polars-parquet/serde"]
 # support for arrows ipc file parsing
 ipc = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrows streaming ipc file parsing

--- a/crates/polars-io/src/parquet/write/mod.rs
+++ b/crates/polars-io/src/parquet/write/mod.rs
@@ -6,5 +6,5 @@ mod writer;
 
 pub use batched_writer::BatchedWriter;
 pub use options::{BrotliLevel, GzipLevel, ParquetCompression, ParquetWriteOptions, ZstdLevel};
-pub use polars_parquet::write::RowGroupIterColumns;
+pub use polars_parquet::write::{RowGroupIterColumns, StatisticsOptions};
 pub use writer::ParquetWriter;

--- a/crates/polars-io/src/parquet/write/options.rs
+++ b/crates/polars-io/src/parquet/write/options.rs
@@ -1,7 +1,7 @@
 use polars_error::PolarsResult;
 use polars_parquet::write::{
     BrotliLevel as BrotliLevelParquet, CompressionOptions, GzipLevel as GzipLevelParquet,
-    ZstdLevel as ZstdLevelParquet,
+    StatisticsOptions, ZstdLevel as ZstdLevelParquet,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ pub struct ParquetWriteOptions {
     /// Data page compression
     pub compression: ParquetCompression,
     /// Compute and write column statistics.
-    pub statistics: bool,
+    pub statistics: StatisticsOptions,
     /// If `None` will be all written to a single row group.
     pub row_group_size: Option<usize>,
     /// if `None` will be 1024^2 bytes

--- a/crates/polars-io/src/parquet/write/writer.rs
+++ b/crates/polars-io/src/parquet/write/writer.rs
@@ -4,7 +4,8 @@ use std::sync::Mutex;
 use arrow::datatypes::PhysicalType;
 use polars_core::prelude::*;
 use polars_parquet::write::{
-    to_parquet_schema, transverse, CompressionOptions, Encoding, FileWriter, Version, WriteOptions,
+    to_parquet_schema, transverse, CompressionOptions, Encoding, FileWriter, StatisticsOptions,
+    Version, WriteOptions,
 };
 
 use super::batched_writer::BatchedWriter;
@@ -18,7 +19,7 @@ pub struct ParquetWriter<W> {
     /// Data page compression
     compression: CompressionOptions,
     /// Compute and write column statistics.
-    statistics: bool,
+    statistics: StatisticsOptions,
     /// if `None` will be 512^2 rows
     row_group_size: Option<usize>,
     /// if `None` will be 1024^2 bytes
@@ -39,7 +40,7 @@ where
         ParquetWriter {
             writer,
             compression: ParquetCompression::default().into(),
-            statistics: true,
+            statistics: StatisticsOptions::default(),
             row_group_size: None,
             data_page_size: None,
             parallel: true,
@@ -56,7 +57,7 @@ where
     }
 
     /// Compute and write statistic
-    pub fn with_statistics(mut self, statistics: bool) -> Self {
+    pub fn with_statistics(mut self, statistics: StatisticsOptions) -> Self {
         self.statistics = statistics;
         self
     }
@@ -100,7 +101,7 @@ where
 
     fn materialize_options(&self) -> WriteOptions {
         WriteOptions {
-            write_statistics: self.statistics,
+            statistics: self.statistics,
             compression: self.compression,
             version: Version::V1,
             data_pagesize_limit: self.data_page_size,

--- a/crates/polars-lazy/src/tests/mod.rs
+++ b/crates/polars-lazy/src/tests/mod.rs
@@ -94,7 +94,7 @@ fn init_files() {
                         #[cfg(feature = "parquet")]
                         {
                             ParquetWriter::new(f)
-                                .with_statistics(true)
+                                .with_statistics(StatisticsOptions::full())
                                 .finish(&mut df)
                                 .unwrap();
                         }

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -20,6 +20,7 @@ ethnum = { workspace = true }
 fallible-streaming-iterator = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 num-traits = { workspace = true }
+polars-compute = { workspace = true }
 polars-error = { workspace = true }
 polars-utils = { workspace = true }
 simdutf8 = { workspace = true }

--- a/crates/polars-parquet/src/arrow/write/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binary/basic.rs
@@ -9,7 +9,7 @@ use crate::parquet::encoding::{delta_bitpacked, Encoding};
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::statistics::{BinaryStatistics, ParquetStatistics};
 use crate::write::utils::invalid_encoding;
-use crate::write::Page;
+use crate::write::{Page, StatisticsOptions};
 
 pub(crate) fn encode_non_null_values<'a, I: Iterator<Item = &'a [u8]>>(
     iter: I,
@@ -65,8 +65,8 @@ pub fn array_to_page<O: Offset>(
         _ => return Err(invalid_encoding(encoding, array.data_type())),
     }
 
-    let statistics = if options.write_statistics {
-        Some(build_statistics(array, type_.clone()))
+    let statistics = if options.has_statistics() {
+        Some(build_statistics(array, type_.clone(), &options.statistics))
     } else {
         None
     };
@@ -89,21 +89,32 @@ pub fn array_to_page<O: Offset>(
 pub(crate) fn build_statistics<O: Offset>(
     array: &BinaryArray<O>,
     primitive_type: PrimitiveType,
+    options: &StatisticsOptions,
 ) -> ParquetStatistics {
     BinaryStatistics {
         primitive_type,
-        null_count: Some(array.null_count() as i64),
+        null_count: options.null_count.then_some(array.null_count() as i64),
         distinct_count: None,
-        max_value: array
-            .iter()
-            .flatten()
-            .max_by(|x, y| ord_binary(x, y))
-            .map(|x| x.to_vec()),
-        min_value: array
-            .iter()
-            .flatten()
-            .min_by(|x, y| ord_binary(x, y))
-            .map(|x| x.to_vec()),
+        max_value: options
+            .max_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .max_by(|x, y| ord_binary(x, y))
+                    .map(|x| x.to_vec())
+            })
+            .flatten(),
+        min_value: options
+            .min_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .min_by(|x, y| ord_binary(x, y))
+                    .map(|x| x.to_vec())
+            })
+            .flatten(),
     }
     .serialize()
 }

--- a/crates/polars-parquet/src/arrow/write/binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/binary/nested.rs
@@ -24,8 +24,8 @@ where
 
     encode_plain(array, &mut buffer);
 
-    let statistics = if options.write_statistics {
-        Some(build_statistics(array, type_.clone()))
+    let statistics = if options.has_statistics() {
+        Some(build_statistics(array, type_.clone(), &options.statistics))
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binview/basic.rs
@@ -7,7 +7,7 @@ use crate::parquet::statistics::{BinaryStatistics, ParquetStatistics};
 use crate::read::schema::is_nullable;
 use crate::write::binary::{encode_non_null_values, ord_binary};
 use crate::write::utils::invalid_encoding;
-use crate::write::{utils, Encoding, Page, WriteOptions};
+use crate::write::{utils, Encoding, Page, StatisticsOptions, WriteOptions};
 
 pub(crate) fn encode_plain(array: &BinaryViewArray, buffer: &mut Vec<u8>) {
     let capacity =
@@ -56,8 +56,8 @@ pub fn array_to_page(
         _ => return Err(invalid_encoding(encoding, array.data_type())),
     }
 
-    let statistics = if options.write_statistics {
-        Some(build_statistics(array, type_.clone()))
+    let statistics = if options.has_statistics() {
+        Some(build_statistics(array, type_.clone(), &options.statistics))
     } else {
         None
     };
@@ -81,21 +81,32 @@ pub fn array_to_page(
 pub(crate) fn build_statistics(
     array: &BinaryViewArray,
     primitive_type: PrimitiveType,
+    options: &StatisticsOptions,
 ) -> ParquetStatistics {
     BinaryStatistics {
         primitive_type,
-        null_count: Some(array.null_count() as i64),
+        null_count: options.null_count.then_some(array.null_count() as i64),
         distinct_count: None,
-        max_value: array
-            .iter()
-            .flatten()
-            .max_by(|x, y| ord_binary(x, y))
-            .map(|x| x.to_vec()),
-        min_value: array
-            .iter()
-            .flatten()
-            .min_by(|x, y| ord_binary(x, y))
-            .map(|x| x.to_vec()),
+        max_value: options
+            .max_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .max_by(|x, y| ord_binary(x, y))
+                    .map(|x| x.to_vec())
+            })
+            .flatten(),
+        min_value: options
+            .min_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .min_by(|x, y| ord_binary(x, y))
+                    .map(|x| x.to_vec())
+            })
+            .flatten(),
     }
     .serialize()
 }

--- a/crates/polars-parquet/src/arrow/write/binview/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/binview/nested.rs
@@ -20,8 +20,8 @@ pub fn array_to_page(
 
     encode_plain(array, &mut buffer);
 
-    let statistics = if options.write_statistics {
-        Some(build_statistics(array, type_.clone()))
+    let statistics = if options.has_statistics() {
+        Some(build_statistics(array, type_.clone(), &options.statistics))
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/boolean/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/boolean/nested.rs
@@ -23,8 +23,8 @@ pub fn array_to_page(
 
     encode_plain(array, is_optional, &mut buffer)?;
 
-    let statistics = if options.write_statistics {
-        Some(build_statistics(array))
+    let statistics = if options.has_statistics() {
+        Some(build_statistics(array, &options.statistics))
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -190,8 +190,12 @@ macro_rules! dyn_prim {
 
         let buffer = primitive_encode_plain::<$from, $to>(values, false, vec![]);
 
-        let stats: Option<ParquetStatistics> = if $options.write_statistics {
-            let mut stats = primitive_build_statistics::<$from, $to>(values, $type_.clone());
+        let stats: Option<ParquetStatistics> = if !$options.statistics.is_empty() {
+            let mut stats = primitive_build_statistics::<$from, $to>(
+                values,
+                $type_.clone(),
+                &$options.statistics,
+            );
             stats.null_count = Some($array.null_count() as i64);
             Some(stats.serialize())
         } else {
@@ -240,8 +244,12 @@ pub fn array_to_pages<K: DictionaryKey>(
 
                         let mut buffer = vec![];
                         binary_encode_plain::<i64>(array, &mut buffer);
-                        let stats = if options.write_statistics {
-                            Some(binary_build_statistics(array, type_.clone()))
+                        let stats = if options.has_statistics() {
+                            Some(binary_build_statistics(
+                                array,
+                                type_.clone(),
+                                &options.statistics,
+                            ))
                         } else {
                             None
                         };
@@ -256,8 +264,12 @@ pub fn array_to_pages<K: DictionaryKey>(
                         let mut buffer = vec![];
                         binview::encode_plain(array, &mut buffer);
 
-                        let stats = if options.write_statistics {
-                            Some(binview::build_statistics(array, type_.clone()))
+                        let stats = if options.has_statistics() {
+                            Some(binview::build_statistics(
+                                array,
+                                type_.clone(),
+                                &options.statistics,
+                            ))
                         } else {
                             None
                         };
@@ -273,8 +285,12 @@ pub fn array_to_pages<K: DictionaryKey>(
                         let mut buffer = vec![];
                         binview::encode_plain(&array, &mut buffer);
 
-                        let stats = if options.write_statistics {
-                            Some(binview::build_statistics(&array, type_.clone()))
+                        let stats = if options.has_statistics() {
+                            Some(binview::build_statistics(
+                                &array,
+                                type_.clone(),
+                                &options.statistics,
+                            ))
                         } else {
                             None
                         };
@@ -285,8 +301,12 @@ pub fn array_to_pages<K: DictionaryKey>(
 
                         let mut buffer = vec![];
                         binary_encode_plain::<i64>(values, &mut buffer);
-                        let stats = if options.write_statistics {
-                            Some(binary_build_statistics(values, type_.clone()))
+                        let stats = if options.has_statistics() {
+                            Some(binary_build_statistics(
+                                values,
+                                type_.clone(),
+                                &options.statistics,
+                            ))
                         } else {
                             None
                         };
@@ -296,8 +316,12 @@ pub fn array_to_pages<K: DictionaryKey>(
                         let mut buffer = vec![];
                         let array = array.values().as_any().downcast_ref().unwrap();
                         fixed_binary_encode_plain(array, false, &mut buffer);
-                        let stats = if options.write_statistics {
-                            let stats = fixed_binary_build_statistics(array, type_.clone());
+                        let stats = if options.has_statistics() {
+                            let stats = fixed_binary_build_statistics(
+                                array,
+                                type_.clone(),
+                                &options.statistics,
+                            );
                             Some(stats.serialize())
                         } else {
                             None

--- a/crates/polars-parquet/src/arrow/write/file.rs
+++ b/crates/polars-parquet/src/arrow/write/file.rs
@@ -61,7 +61,7 @@ impl<W: Write> FileWriter<W> {
                 parquet_schema,
                 FileWriteOptions {
                     version: options.version,
-                    write_statistics: options.write_statistics,
+                    write_statistics: options.has_statistics(),
                 },
                 created_by,
             ),

--- a/crates/polars-parquet/src/arrow/write/fixed_len_bytes.rs
+++ b/crates/polars-parquet/src/arrow/write/fixed_len_bytes.rs
@@ -3,7 +3,7 @@ use arrow::types::i256;
 use polars_error::PolarsResult;
 
 use super::binary::ord_binary;
-use super::{utils, WriteOptions};
+use super::{utils, StatisticsOptions, WriteOptions};
 use crate::arrow::read::schema::is_nullable;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::DataPage;
@@ -62,21 +62,32 @@ pub fn array_to_page(
 pub(super) fn build_statistics(
     array: &FixedSizeBinaryArray,
     primitive_type: PrimitiveType,
+    options: &StatisticsOptions,
 ) -> FixedLenStatistics {
     FixedLenStatistics {
         primitive_type,
-        null_count: Some(array.null_count() as i64),
+        null_count: options.null_count.then_some(array.null_count() as i64),
         distinct_count: None,
-        max_value: array
-            .iter()
-            .flatten()
-            .max_by(|x, y| ord_binary(x, y))
-            .map(|x| x.to_vec()),
-        min_value: array
-            .iter()
-            .flatten()
-            .min_by(|x, y| ord_binary(x, y))
-            .map(|x| x.to_vec()),
+        max_value: options
+            .max_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .max_by(|x, y| ord_binary(x, y))
+                    .map(|x| x.to_vec())
+            })
+            .flatten(),
+        min_value: options
+            .min_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .min_by(|x, y| ord_binary(x, y))
+                    .map(|x| x.to_vec())
+            })
+            .flatten(),
     }
 }
 
@@ -84,21 +95,32 @@ pub(super) fn build_statistics_decimal(
     array: &PrimitiveArray<i128>,
     primitive_type: PrimitiveType,
     size: usize,
+    options: &StatisticsOptions,
 ) -> FixedLenStatistics {
     FixedLenStatistics {
         primitive_type,
-        null_count: Some(array.null_count() as i64),
+        null_count: options.null_count.then_some(array.null_count() as i64),
         distinct_count: None,
-        max_value: array
-            .iter()
-            .flatten()
-            .max()
-            .map(|x| x.to_be_bytes()[16 - size..].to_vec()),
-        min_value: array
-            .iter()
-            .flatten()
-            .min()
-            .map(|x| x.to_be_bytes()[16 - size..].to_vec()),
+        max_value: options
+            .max_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .max()
+                    .map(|x| x.to_be_bytes()[16 - size..].to_vec())
+            })
+            .flatten(),
+        min_value: options
+            .min_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .min()
+                    .map(|x| x.to_be_bytes()[16 - size..].to_vec())
+            })
+            .flatten(),
     }
 }
 
@@ -106,21 +128,32 @@ pub(super) fn build_statistics_decimal256_with_i128(
     array: &PrimitiveArray<i256>,
     primitive_type: PrimitiveType,
     size: usize,
+    options: &StatisticsOptions,
 ) -> FixedLenStatistics {
     FixedLenStatistics {
         primitive_type,
-        null_count: Some(array.null_count() as i64),
+        null_count: options.null_count.then_some(array.null_count() as i64),
         distinct_count: None,
-        max_value: array
-            .iter()
-            .flatten()
-            .max()
-            .map(|x| x.0.low().to_be_bytes()[16 - size..].to_vec()),
-        min_value: array
-            .iter()
-            .flatten()
-            .min()
-            .map(|x| x.0.low().to_be_bytes()[16 - size..].to_vec()),
+        max_value: options
+            .max_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .max()
+                    .map(|x| x.0.low().to_be_bytes()[16 - size..].to_vec())
+            })
+            .flatten(),
+        min_value: options
+            .min_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .min()
+                    .map(|x| x.0.low().to_be_bytes()[16 - size..].to_vec())
+            })
+            .flatten(),
     }
 }
 
@@ -128,20 +161,31 @@ pub(super) fn build_statistics_decimal256(
     array: &PrimitiveArray<i256>,
     primitive_type: PrimitiveType,
     size: usize,
+    options: &StatisticsOptions,
 ) -> FixedLenStatistics {
     FixedLenStatistics {
         primitive_type,
-        null_count: Some(array.null_count() as i64),
+        null_count: options.null_count.then_some(array.null_count() as i64),
         distinct_count: None,
-        max_value: array
-            .iter()
-            .flatten()
-            .max()
-            .map(|x| x.0.to_be_bytes()[32 - size..].to_vec()),
-        min_value: array
-            .iter()
-            .flatten()
-            .min()
-            .map(|x| x.0.to_be_bytes()[32 - size..].to_vec()),
+        max_value: options
+            .max_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .max()
+                    .map(|x| x.0.to_be_bytes()[32 - size..].to_vec())
+            })
+            .flatten(),
+        min_value: options
+            .min_value
+            .then(|| {
+                array
+                    .iter()
+                    .flatten()
+                    .min()
+                    .map(|x| x.0.to_be_bytes()[32 - size..].to_vec())
+            })
+            .flatten(),
     }
 }

--- a/crates/polars-parquet/src/arrow/write/primitive/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/nested.rs
@@ -31,8 +31,8 @@ where
 
     let buffer = encode_plain(array, is_optional, buffer);
 
-    let statistics = if options.write_statistics {
-        Some(build_statistics(array, type_.clone()).serialize())
+    let statistics = if options.has_statistics() {
+        Some(build_statistics(array, type_.clone(), &options.statistics).serialize())
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/sink.rs
+++ b/crates/polars-parquet/src/arrow/write/sink.rs
@@ -58,7 +58,7 @@ where
             parquet_schema.clone(),
             ParquetWriteOptions {
                 version: options.version,
-                write_statistics: options.write_statistics,
+                write_statistics: options.has_statistics(),
             },
             created_by,
         );

--- a/crates/polars/tests/it/io/parquet/arrow/mod.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/mod.rs
@@ -564,7 +564,7 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             max_value: Box::new(Utf8ViewArray::from_slice([Some("def")])),
         },
         "bool" => Statistics {
-            distinct_count: UInt64Array::from([None]).boxed(),
+            distinct_count: UInt64Array::from([Some(2)]).boxed(),
             null_count: UInt64Array::from([Some(4)]).boxed(),
             min_value: Box::new(BooleanArray::from_slice([false])),
             max_value: Box::new(BooleanArray::from_slice([true])),
@@ -701,7 +701,7 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
             max_value: new_list(Box::new(Int16Array::from_slice([10])), true).boxed(),
         },
         "list_bool" => Statistics {
-            distinct_count: new_list(UInt64Array::from([None]).boxed(), true).boxed(),
+            distinct_count: new_list(UInt64Array::from([Some(2)]).boxed(), true).boxed(),
             null_count: new_list(UInt64Array::from([Some(1)]).boxed(), true).boxed(),
             min_value: new_list(Box::new(BooleanArray::from_slice([false])), true).boxed(),
             max_value: new_list(Box::new(BooleanArray::from_slice([true])), true).boxed(),
@@ -1096,7 +1096,7 @@ pub fn pyarrow_struct_statistics(column: &str) -> Statistics {
             distinct_count: new_struct(
                 vec![
                     Box::new(UInt64Array::from([None])),
-                    Box::new(UInt64Array::from([None])),
+                    Box::new(UInt64Array::from([Some(2)])),
                 ],
                 names.clone(),
             )
@@ -1130,7 +1130,7 @@ pub fn pyarrow_struct_statistics(column: &str) -> Statistics {
                     new_struct(
                         vec![
                             Box::new(UInt64Array::from([None])),
-                            Box::new(UInt64Array::from([None])),
+                            Box::new(UInt64Array::from([Some(2)])),
                         ],
                         names.clone(),
                     )
@@ -1257,7 +1257,7 @@ fn integration_write(
     chunks: &[RecordBatchT<Box<dyn Array>>],
 ) -> PolarsResult<Vec<u8>> {
     let options = WriteOptions {
-        write_statistics: true,
+        statistics: StatisticsOptions::full(),
         compression: CompressionOptions::Uncompressed,
         version: Version::V1,
         data_pagesize_limit: None,

--- a/crates/polars/tests/it/io/parquet/arrow/read_indexes.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/read_indexes.rs
@@ -29,7 +29,7 @@ fn pages(
     let parquet_schema = to_parquet_schema(&schema)?;
 
     let options = WriteOptions {
-        write_statistics: true,
+        statistics: StatisticsOptions::full(),
         compression: CompressionOptions::Uncompressed,
         version: Version::V1,
         data_pagesize_limit: None,
@@ -79,7 +79,7 @@ fn read_with_indexes(
     expected: Box<dyn Array>,
 ) -> PolarsResult<()> {
     let options = WriteOptions {
-        write_statistics: true,
+        statistics: StatisticsOptions::full(),
         compression: CompressionOptions::Uncompressed,
         version: Version::V1,
         data_pagesize_limit: None,

--- a/crates/polars/tests/it/io/parquet/arrow/write.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/write.rs
@@ -45,7 +45,7 @@ fn round_trip_opt_stats(
     let schema = ArrowSchema::from(vec![field]);
 
     let options = WriteOptions {
-        write_statistics: true,
+        statistics: StatisticsOptions::full(),
         compression,
         version,
         data_pagesize_limit: None,

--- a/crates/polars/tests/it/io/parquet/roundtrip.rs
+++ b/crates/polars/tests/it/io/parquet/roundtrip.rs
@@ -6,7 +6,9 @@ use arrow::record_batch::RecordBatchT;
 use polars_error::PolarsResult;
 use polars_parquet::arrow::write::{FileWriter, WriteOptions};
 use polars_parquet::read::read_metadata;
-use polars_parquet::write::{CompressionOptions, Encoding, RowGroupIterator, Version};
+use polars_parquet::write::{
+    CompressionOptions, Encoding, RowGroupIterator, StatisticsOptions, Version,
+};
 
 fn round_trip(
     array: &ArrayRef,
@@ -18,7 +20,7 @@ fn round_trip(
     let schema = ArrowSchema::from(vec![field]);
 
     let options = WriteOptions {
-        write_statistics: true,
+        statistics: StatisticsOptions::full(),
         compression,
         version,
         data_pagesize_limit: None,

--- a/py-polars/src/dataframe/io.rs
+++ b/py-polars/src/dataframe/io.rs
@@ -6,6 +6,8 @@ use std::ops::Deref;
 use polars::io::avro::AvroCompression;
 use polars::io::mmap::{try_create_file, ReaderBytes};
 use polars::io::RowIndex;
+#[cfg(feature = "parquet")]
+use polars_parquet::arrow::write::StatisticsOptions;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 
@@ -442,7 +444,7 @@ impl PyDataFrame {
         py_f: PyObject,
         compression: &str,
         compression_level: Option<i32>,
-        statistics: bool,
+        statistics: Wrap<StatisticsOptions>,
         row_group_size: Option<usize>,
         data_page_size: Option<usize>,
     ) -> PyResult<()> {
@@ -453,7 +455,7 @@ impl PyDataFrame {
             py.allow_threads(|| {
                 ParquetWriter::new(f)
                     .with_compression(compression)
-                    .with_statistics(statistics)
+                    .with_statistics(statistics.0)
                     .with_row_group_size(row_group_size)
                     .with_data_page_size(data_page_size)
                     .finish(&mut self.df)
@@ -463,7 +465,7 @@ impl PyDataFrame {
             let buf = get_file_like(py_f, true)?;
             ParquetWriter::new(buf)
                 .with_compression(compression)
-                .with_statistics(statistics)
+                .with_statistics(statistics.0)
                 .with_row_group_size(row_group_size)
                 .with_data_page_size(data_page_size)
                 .finish(&mut self.df)

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -11,6 +11,8 @@ use polars::io::cloud::CloudOptions;
 use polars::io::{HiveOptions, RowIndex};
 use polars::time::*;
 use polars_core::prelude::*;
+#[cfg(feature = "parquet")]
+use polars_parquet::arrow::write::StatisticsOptions;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
@@ -659,7 +661,7 @@ impl PyLazyFrame {
         path: PathBuf,
         compression: &str,
         compression_level: Option<i32>,
-        statistics: bool,
+        statistics: Wrap<StatisticsOptions>,
         row_group_size: Option<usize>,
         data_pagesize_limit: Option<usize>,
         maintain_order: bool,
@@ -668,7 +670,7 @@ impl PyLazyFrame {
 
         let options = ParquetWriteOptions {
             compression,
-            statistics,
+            statistics: statistics.0,
             row_group_size,
             data_pagesize_limit,
             maintain_order,


### PR DESCRIPTION
Adds additional control over which statistics are written into Parquet files through the `write_parquet` parameter `statistics`.

It is now possible to specify `"full"` to also attempt to add the `distinct_count` statistic (currently only added for `Booleans`). It is also possible to give a `dict[str, bool]` to specify individual statistics `min`, `max`, `distinct_count` and `null_count`.

Fixes #16441