### PR TITLE
docs(python): Fix bullet points not rendering correctly in `DataFrame.join` docstring

### DIFF
--- a/docs/src/python/user-guide/expressions/window.py
+++ b/docs/src/python/user-guide/expressions/window.py
@@ -34,7 +34,7 @@ print(filtered)
 
 # --8<-- [start:sort]
 out = filtered.with_columns(
-    pl.col(["Name", "Speed"]).sort_by("Speed", descending=True).over("Type 1"),
+    pl.col("Name", "Speed").sort_by("Speed", descending=True).over("Type 1"),
 )
 print(out)
 # --8<-- [end:sort]

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -19,6 +19,7 @@ Computation
     Series.cos
     Series.cosh
     Series.cot
+    Series.cum_count
     Series.cum_max
     Series.cum_min
     Series.cum_prod

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6569,6 +6569,7 @@ class DataFrame:
             Join on null values. By default null values will never produce matches.
         coalesce
             Coalescing behavior (merging of join columns).
+
             - None: -> join specific.
             - True: -> Always coalesce join columns.
             - False: -> Never coalesce join columns.
@@ -9447,7 +9448,7 @@ class DataFrame:
         This method operates at the `DataFrame` level; to operate on subsets at the
         expression level you can make use of struct-packing instead, for example:
 
-        >>> expr_unique_subset = pl.struct(["a", "b"]).n_unique()
+        >>> expr_unique_subset = pl.struct("a", "b").n_unique()
 
         If instead you want to count the number of unique values per-column, you can
         also use expression-level syntax to return a new frame containing that result:
@@ -9458,7 +9459,7 @@ class DataFrame:
         In aggregate context there is also an equivalent method for returning the
         unique values per-group:
 
-        >>> df_agg_nunique = df.group_by(["a"]).n_unique()
+        >>> df_agg_nunique = df.group_by("a").n_unique()
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6563,8 +6563,8 @@ class DataFrame:
                     “m:1”: check if join keys are unique in right dataset
 
             .. note::
+                This is currently not supported by the streaming engine.
 
-                - This is currently not supported the streaming engine.
         join_nulls
             Join on null values. By default null values will never produce matches.
         coalesce

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3936,6 +3936,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Join on null values. By default null values will never produce matches.
         coalesce
             Coalescing behavior (merging of join columns).
+
             - None: -> join specific.
             - True: -> Always coalesce join columns.
             - False: -> Never coalesce join columns.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3930,8 +3930,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                     “m:1”: check if join keys are unique in right dataset
 
             .. note::
+                This is currently not supported by the streaming engine.
 
-                - This is currently not supported the streaming engine.
         join_nulls
             Join on null values. By default null values will never produce matches.
         coalesce


### PR DESCRIPTION
once again, fixing up docstring bullet points which don't render properly 😄 check the "coalesce" arg description in https://docs.pola.rs/py-polars/html/reference/dataframe/api/polars.DataFrame.join.html

bonus drive-bys:
- some ergonomic syntax
- Series.cum_count was left out of the docs
