### PR TITLE
fix(rust): bail on bool `floordiv`

### DIFF
--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -29,6 +29,10 @@ pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {
         _ => {},
     }
 
+    if !a.dtype().is_numeric() {
+        polars_bail!(op = "floor_div", a.dtype());
+    }
+
     let logical_type = a.dtype();
 
     let a = a.to_physical_repr();

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -293,3 +293,13 @@ def test_null_column_arithmetic(op: Any) -> None:
     # test broadcast left
     output_df = df.select(op(pl.Series("a", [None]), pl.col("a")))
     assert_frame_equal(expected_df, output_df)
+
+
+def test_bool_floordiv() -> None:
+    df = pl.DataFrame({"x": [True]})
+
+    with pytest.raises(
+        pl.InvalidOperationError,
+        match="floor_div operation not supported for dtype `bool`",
+    ):
+        df.with_columns(pl.col("x").floordiv(2))


### PR DESCRIPTION
This adds an error message for a `floordiv` on a `bool`.