### PR TITLE
fix: Use of SQL `ORDER BY` should not cause reordering of `SELECT` cols

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -565,14 +565,11 @@ impl SQLContext {
                         retained_names.insert(ColumnName::from(field.name.as_str()));
                     },
                 });
+                let retained_columns: Vec<_> =
+                    retained_names.into_iter().map(|name| col(&name)).collect();
                 lf = lf.with_columns(projections);
                 lf = self.process_order_by(lf, &query.order_by)?;
-                lf.select(
-                    retained_names
-                        .iter()
-                        .map(|name| col(name))
-                        .collect::<Vec<_>>(),
-                )
+                lf.select(&retained_columns)
             } else if contains_wildcard_exclude {
                 let mut dropped_names = Vec::with_capacity(projections.len());
                 let exclude_expr = projections.iter().find(|expr| {

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -257,8 +257,15 @@ def test_join_misc_13618() -> None:
         }
     )
     res = (
-        pl.SQLContext(t=df, t1=df, eager=True)
-        .execute("SELECT t.A, t.fruits, t1.B, t1.cars FROM t JOIN t1 ON t.A=t1.B")
+        pl.SQLContext(t=df, t1=df, eager_execution=True)
+        .execute(
+            """
+            SELECT t.A, t.fruits, t1.B, t1.cars
+            FROM t
+            JOIN t1 ON t.A = t1.B
+            ORDER BY t.A DESC
+            """
+        )
         .to_dict(as_series=False)
     )
     assert res == {

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -257,7 +257,7 @@ def test_join_misc_13618() -> None:
         }
     )
     res = (
-        pl.SQLContext(t=df, t1=df, eager_execution=True)
+        pl.SQLContext(t=df, t1=df, eager=True)
         .execute(
             """
             SELECT t.A, t.fruits, t1.B, t1.cars

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -34,7 +34,7 @@ def test_any_all() -> None:
           x <= ANY(df.y) AS "Any Leq",
           x == ANY(df.y) AS "Any eq",
           x != ANY(df.y) AS "Any Neq",
-        FROM self
+        FROM df
         """,
     ).collect()
 

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -34,7 +34,7 @@ def test_any_all() -> None:
           x <= ANY(df.y) AS "Any Leq",
           x == ANY(df.y) AS "Any eq",
           x != ANY(df.y) AS "Any Neq",
-        FROM df
+        FROM self
         """,
     ).collect()
 
@@ -257,6 +257,27 @@ def test_order_by(foods_ipc_path: Path) -> None:
     )
     assert order_by_expression_res.to_dict(as_series=False) == {
         "modded": [1, 1, 2],
+    }
+
+
+def test_order_by_misc() -> None:
+    res = pl.DataFrame(
+        {
+            "x": ["apple", "orange"],
+            "y": ["sheep", "alligator"],
+            "z": ["hello", "world"],
+        }
+    ).sql(
+        """
+        SELECT z, y, x
+        FROM self ORDER BY y DESC
+        """
+    )
+    assert res.columns == ["z", "y", "x"]
+    assert res.to_dict(as_series=False) == {
+        "z": ["hello", "world"],
+        "y": ["sheep", "alligator"],
+        "x": ["apple", "orange"],
     }
 
 


### PR DESCRIPTION
It was possible for use of an `ORDER BY` clause to indirectly cause reordering of `SELECT` cols when using the SQL interface. Fixed, and added some test coverage.