### PR TITLE
refactor(rust): use binary `try_{add, mul, ...}` ops in borrowed dispatch

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -274,7 +274,7 @@ impl StructChunked {
 
     pub(crate) fn try_apply_fields<F>(&self, func: F) -> PolarsResult<Self>
     where
-        F: Fn(&Series) -> PolarsResult<Series>,
+        F: FnMut(&Series) -> PolarsResult<Series>,
     {
         let fields = self
             .fields

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -381,11 +381,11 @@ fn coerce_time_units<'a>(
 }
 
 #[cfg(feature = "dtype-struct")]
-pub fn _struct_arithmetic<F: FnMut(&Series, &Series) -> Series>(
+pub fn _struct_arithmetic<F: FnMut(&Series, &Series) -> PolarsResult<Series>>(
     s: &Series,
     rhs: &Series,
     mut func: F,
-) -> Series {
+) -> PolarsResult<Series> {
     let s = s.struct_().unwrap();
     let rhs = rhs.struct_().unwrap();
     let s_fields = s.fields();
@@ -394,20 +394,20 @@ pub fn _struct_arithmetic<F: FnMut(&Series, &Series) -> Series>(
     match (s_fields.len(), rhs_fields.len()) {
         (_, 1) => {
             let rhs = &rhs.fields()[0];
-            s._apply_fields(|s| func(s, rhs)).into_series()
+            Ok(s.try_apply_fields(|s| func(s, rhs))?.into_series())
         },
         (1, _) => {
             let s = &s.fields()[0];
-            rhs._apply_fields(|rhs| func(s, rhs)).into_series()
+            Ok(rhs.try_apply_fields(|rhs| func(s, rhs))?.into_series())
         },
         _ => {
             let mut rhs_iter = rhs.fields().iter();
 
-            s._apply_fields(|s| match rhs_iter.next() {
+            Ok(s.try_apply_fields(|s| match rhs_iter.next() {
                 Some(rhs) => func(s, rhs),
-                None => s.clone(),
-            })
-            .into_series()
+                None => Ok(s.clone()),
+            })?
+            .into_series())
         },
     }
 }
@@ -416,33 +416,10 @@ impl Sub for &Series {
     type Output = Series;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        match (self.dtype(), rhs.dtype()) {
-            #[cfg(feature = "dtype-struct")]
-            (DataType::Struct(_), DataType::Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.sub(b))
-            },
-            _ => {
-                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-                lhs.subtract(rhs.as_ref()).expect("data types don't match")
-            },
-        }
+        self.try_sub(rhs).unwrap()
     }
 }
 
-impl Series {
-    pub fn try_add(&self, rhs: &Series) -> PolarsResult<Series> {
-        match (self.dtype(), rhs.dtype()) {
-            #[cfg(feature = "dtype-struct")]
-            (DataType::Struct(_), DataType::Struct(_)) => {
-                Ok(_struct_arithmetic(self, rhs, |a, b| a.add(b)))
-            },
-            _ => {
-                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
-                lhs.add_to(rhs.as_ref())
-            },
-        }
-    }
-}
 impl Add for &Series {
     type Output = Series;
 
@@ -460,16 +437,7 @@ impl Mul for &Series {
     /// let out = &s * &s;
     /// ```
     fn mul(self, rhs: Self) -> Self::Output {
-        match (self.dtype(), rhs.dtype()) {
-            #[cfg(feature = "dtype-struct")]
-            (DataType::Struct(_), DataType::Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.mul(b))
-            },
-            _ => {
-                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-                lhs.multiply(rhs.as_ref()).expect("data types don't match")
-            },
-        }
+        self.try_mul(rhs).unwrap()
     }
 }
 
@@ -482,16 +450,7 @@ impl Div for &Series {
     /// let out = &s / &s;
     /// ```
     fn div(self, rhs: Self) -> Self::Output {
-        match (self.dtype(), rhs.dtype()) {
-            #[cfg(feature = "dtype-struct")]
-            (DataType::Struct(_), DataType::Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.div(b))
-            },
-            _ => {
-                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-                lhs.divide(rhs.as_ref()).expect("data types don't match")
-            },
-        }
+        self.try_div(rhs).unwrap()
     }
 }
 
@@ -504,14 +463,72 @@ impl Rem for &Series {
     /// let out = &s / &s;
     /// ```
     fn rem(self, rhs: Self) -> Self::Output {
+        self.try_rem(rhs).unwrap()
+    }
+}
+
+impl Series {
+    pub fn try_sub(&self, rhs: &Self) -> PolarsResult<Self> {
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.rem(b))
+                _struct_arithmetic(self, rhs, |a, b| a.try_sub(b))
             },
             _ => {
-                let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
-                lhs.remainder(rhs.as_ref()).expect("data types don't match")
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
+                lhs.subtract(rhs.as_ref())
+            },
+        }
+    }
+
+    pub fn try_add(&self, rhs: &Self) -> PolarsResult<Self> {
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                _struct_arithmetic(self, rhs, |a, b| a.try_add(b))
+            },
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
+                lhs.add_to(rhs.as_ref())
+            },
+        }
+    }
+
+    pub fn try_mul(&self, rhs: &Self) -> PolarsResult<Self> {
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                _struct_arithmetic(self, rhs, |a, b| a.try_mul(b))
+            },
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
+                lhs.multiply(rhs.as_ref())
+            },
+        }
+    }
+
+    pub fn try_div(&self, rhs: &Self) -> PolarsResult<Self> {
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                _struct_arithmetic(self, rhs, |a, b| a.try_div(b))
+            },
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
+                lhs.divide(rhs.as_ref())
+            },
+        }
+    }
+
+    pub fn try_rem(&self, rhs: &Self) -> PolarsResult<Self> {
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                _struct_arithmetic(self, rhs, |a, b| a.try_rem(b))
+            },
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
+                lhs.remainder(rhs.as_ref())
             },
         }
     }

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -22,9 +22,7 @@ pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {
     match (a.dtype(), b.dtype()) {
         #[cfg(feature = "dtype-struct")]
         (DataType::Struct(_), DataType::Struct(_)) => {
-            return Ok(_struct_arithmetic(a, b, |a, b| {
-                floor_div_series(a, b).unwrap()
-            }))
+            return _struct_arithmetic(a, b, floor_div_series);
         },
         _ => {},
     }


### PR DESCRIPTION
This PR removes many of the panics that happen when performing binary operations with invalid types. This is achieved by dividing the operation functions into a `try_{add, mul, ...}` and an `{add, mul, ...}` as was already done from some operations. We can then call these functions from the dispatcher.