### PR TITLE
feat: Add SQL support for `TRY_CAST` function

### DIFF
--- a/py-polars/tests/unit/sql/test_cast.py
+++ b/py-polars/tests/unit/sql/test_cast.py
@@ -161,8 +161,14 @@ def test_cast() -> None:
 def test_cast_errors(values: Any, cast_op: str, error: str) -> None:
     df = pl.DataFrame({"values": values})
 
+    # invalid CAST should raise an error...
     with pytest.raises(ComputeError, match=error):
         df.sql(f"SELECT {cast_op} FROM df")
+
+    # ... or return `null` values if using TRY_CAST
+    target_type = cast_op.split("::")[1]
+    res = df.sql(f"SELECT TRY_CAST(values AS {target_type}) AS cast_values FROM df")
+    assert None in res.to_series()
 
 
 def test_cast_json() -> None:


### PR DESCRIPTION
Added SQL support for the `TRY_CAST` function (as implemented by various[^1] databases).

## Example

```python
import polars as pl
df = pl.DataFrame({"n": [-10, 0, 10, 20]})
```
Strict (default) `CAST` fails on invalid values ...
```python
df.sql("SELECT CAST(n AS uint1) FROM df")
# ComputeError: conversion from `i64` to `u8` failed in column 'n' for 1 out of 4 values: [-10]
```
... whereas `TRY_CAST` replace invalid values with `null`:
```python
df.sql("SELECT TRY_CAST(n AS uint1) FROM df")
# shape: (4, 1)
# ┌──────┐
# │ n    │
# │ ---  │
# │ u8   │
# ╞══════╡
# │ null │
# │ 0    │
# │ 10   │
# │ 20   │
# └──────┘
```

[^1]: TRY_CAST: [SQL Server](https://learn.microsoft.com/en-us/sql/t-sql/functions/try-cast-transact-sql?view=sql-server-ver16), [DuckDB](https://duckdb.org/docs/sql/expressions/cast#try_cast)