### PR TITLE
fix: Crash using empty `Series` in `LazyFrame.select()`

### DIFF
--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -456,7 +456,7 @@ impl Hash for LiteralValue {
                 s.null_count().hash(state);
                 const RANDOM: u64 = 0x2c194fa5df32a367;
                 let mut rng = (len as u64) ^ RANDOM;
-                for _ in 0..5 {
+                for _ in 0..std::cmp::min(5, len) {
                     let idx = hash_to_partition(rng, len);
                     s.get(idx).unwrap().hash(state);
                     rng = rng.rotate_right(17).wrapping_add(RANDOM);

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -774,3 +774,9 @@ def test_nested_cache_no_panic_16553() -> None:
     assert pl.LazyFrame().select(a=[[[1]]]).collect(comm_subexpr_elim=True).to_dict(
         as_series=False
     ) == {"a": [[[[1]]]]}
+
+
+def test_hash_empty_series_16577() -> None:
+    s = pl.Series(values=None)
+    out = pl.LazyFrame().select(s).collect()
+    assert out.equals(s.to_frame())


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/16577