### PR TITLE
refactor(rust): defensively invalidate metadata and start on copying of `min_value`, `max_value` and `distinct_count`

### DIFF
--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -214,33 +214,6 @@ where
         ChunkedArray::new_with_compute_len(field, chunks)
     }
 
-    /// Create a new ChunkedArray from self, where the chunks are replaced.
-    ///
-    /// # Safety
-    /// The caller must ensure the dtypes of the chunks are correct
-    pub(crate) unsafe fn from_chunks_and_metadata(
-        chunks: Vec<ArrayRef>,
-        field: Arc<Field>,
-        metadata: Arc<Metadata<T>>,
-        keep_sorted: bool,
-        keep_fast_explode: bool,
-    ) -> Self {
-        let mut out = ChunkedArray::new_with_compute_len(field, chunks);
-
-        let mut md = metadata;
-        if !keep_sorted {
-            let inner = Arc::make_mut(&mut md);
-            inner.set_sorted_flag(IsSorted::Not);
-        }
-        if !keep_fast_explode {
-            let inner = Arc::make_mut(&mut md);
-            inner.set_fast_explode_list(false);
-        }
-        out.md = Some(md);
-
-        out
-    }
-
     pub(crate) unsafe fn from_chunks_and_dtype_unchecked(
         name: &str,
         chunks: Vec<ArrayRef>,

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -2,6 +2,7 @@ use arrow::legacy::kernels::concatenate::concatenate_owned_unchecked;
 use polars_error::constants::LENGTH_LIMIT_MSG;
 
 use super::*;
+use crate::chunked_array::metadata::MetadataProperties;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::builder::ObjectChunkedBuilder;
 use crate::utils::slice_offsets;
@@ -116,7 +117,20 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                     self.clone()
                 } else {
                     let chunks = inner_rechunk(&self.chunks);
-                    unsafe { self.copy_with_chunks(chunks, true, true) }
+
+                    let mut ca = unsafe { self.copy_with_chunks(chunks) };
+
+                    use MetadataProperties as P;
+                    ca.copy_metadata(
+                        self,
+                        P::SORTED
+                            | P::FAST_EXPLODE_LIST
+                            | P::MIN_VALUE
+                            | P::MAX_VALUE
+                            | P::DISTINCT_COUNT,
+                    );
+
+                    ca
                 }
             },
         }
@@ -133,8 +147,57 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         // A normal slice, slice the buffers and thus keep the whole memory allocated.
         let exec = || {
             let (chunks, len) = slice(&self.chunks, offset, length, self.len());
-            let mut out = unsafe { self.copy_with_chunks(chunks, true, true) };
+            let mut out = unsafe { self.copy_with_chunks(chunks) };
+
+            use MetadataProperties as P;
+            let mut properties = P::SORTED | P::FAST_EXPLODE_LIST;
+
+            let is_ascending = self.is_sorted_ascending_flag();
+            let is_descending = self.is_sorted_descending_flag();
+
+            if length != 0 && (is_ascending || is_descending) {
+                let (raw_offset, slice_len) = slice_offsets(offset, length, self.len());
+
+                let mut can_copy_min_value = false;
+                let mut can_copy_max_value = false;
+
+                let is_at_start = raw_offset == 0;
+                if is_at_start {
+                    let has_nulls_at_start = self.null_count() != 0
+                        && self
+                            .chunks()
+                            .first()
+                            .unwrap()
+                            .as_ref()
+                            .validity()
+                            .map_or(false, |bm| bm.get(0).unwrap());
+
+                    can_copy_min_value |= !has_nulls_at_start && is_ascending;
+                    can_copy_max_value |= !has_nulls_at_start && is_descending;
+                }
+
+                let is_until_end = raw_offset + slice_len == self.len();
+                if is_until_end {
+                    let has_nulls_at_end = self.null_count() != 0
+                        && self
+                            .chunks()
+                            .last()
+                            .unwrap()
+                            .as_ref()
+                            .validity()
+                            .map_or(false, |bm| bm.get(bm.len() - 1).unwrap());
+
+                    can_copy_min_value |= !has_nulls_at_end && is_descending;
+                    can_copy_max_value |= !has_nulls_at_end && is_ascending;
+                }
+
+                properties.set(P::MIN_VALUE, can_copy_min_value);
+                properties.set(P::MAX_VALUE, can_copy_max_value);
+            }
+
+            out.copy_metadata(self, properties);
             out.length = len as IdxSize;
+
             out
         };
 

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -9,6 +9,7 @@ use arrow::legacy::trusted_len::TrustedLenPush;
 
 #[cfg(feature = "dtype-array")]
 use crate::chunked_array::builder::get_fixed_size_list_builder;
+use crate::chunked_array::metadata::MetadataProperties;
 use crate::prelude::*;
 use crate::series::implementations::null::NullChunked;
 
@@ -272,7 +273,12 @@ impl ExplodeByOffsets for ListChunked {
         }
         process_range(start, last, &mut builder);
         let arr = builder.finish(Some(&inner_type.to_arrow(true))).unwrap();
-        unsafe { self.copy_with_chunks(vec![Box::new(arr)], true, true) }.into_series()
+        let mut ca = unsafe { self.copy_with_chunks(vec![Box::new(arr)]) };
+
+        use MetadataProperties as P;
+        ca.copy_metadata(self, P::SORTED | P::FAST_EXPLODE_LIST);
+
+        ca.into_series()
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/nulls.rs
+++ b/crates/polars-core/src/chunked_array/ops/nulls.rs
@@ -1,6 +1,7 @@
 use arrow::bitmap::Bitmap;
 
 use super::*;
+use crate::chunked_array::metadata::MetadataProperties;
 
 impl<T: PolarsDataType> ChunkedArray<T> {
     /// Get a mask of the null values.
@@ -23,7 +24,9 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
     pub(crate) fn coalesce_nulls(&self, other: &[ArrayRef]) -> Self {
         let chunks = coalesce_nulls(&self.chunks, other);
-        unsafe { self.copy_with_chunks(chunks, true, false) }
+        let mut ca = unsafe { self.copy_with_chunks(chunks) };
+        ca.copy_metadata(self, MetadataProperties::SORTED);
+        ca
     }
 }
 

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -63,7 +63,7 @@ pub struct FalseT;
 /// The StaticArray and dtype return must be correct.
 pub unsafe trait PolarsDataType: Send + Sync + Sized {
     type Physical<'a>: std::fmt::Debug + Clone;
-    type OwnedPhysical: std::fmt::Debug + Send + Sync + Clone;
+    type OwnedPhysical: std::fmt::Debug + Send + Sync + Clone + PartialEq;
     type ZeroablePhysical<'a>: Zeroable + From<Self::Physical<'a>>;
     type Array: for<'a> StaticArray<
         ValueT<'a> = Self::Physical<'a>,

--- a/crates/polars-io/src/parquet/read/to_metadata.rs
+++ b/crates/polars-io/src/parquet/read/to_metadata.rs
@@ -15,15 +15,9 @@ impl ToMetadata<BooleanType> for BooleanStatistics {
     fn to_metadata(&self) -> Metadata<BooleanType> {
         let mut md = Metadata::default();
 
-        if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok()) {
-            md.set_distinct_count(distinct_count);
-        }
-        if let Some(min_value) = self.min_value {
-            md.set_min_value(min_value);
-        }
-        if let Some(max_value) = self.max_value {
-            md.set_max_value(max_value);
-        }
+        md.set_distinct_count(self.distinct_count.and_then(|v| v.try_into().ok()));
+        md.set_min_value(self.min_value);
+        md.set_max_value(self.max_value);
 
         md
     }
@@ -33,15 +27,17 @@ impl ToMetadata<BinaryType> for BinaryStatistics {
     fn to_metadata(&self) -> Metadata<BinaryType> {
         let mut md = Metadata::default();
 
-        if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok()) {
-            md.set_distinct_count(distinct_count);
-        }
-        if let Some(min_value) = self.min_value.as_ref() {
-            md.set_min_value(min_value.clone().into_boxed_slice());
-        }
-        if let Some(max_value) = self.max_value.as_ref() {
-            md.set_max_value(max_value.clone().into_boxed_slice());
-        }
+        md.set_distinct_count(self.distinct_count.and_then(|v| v.try_into().ok()));
+        md.set_min_value(
+            self.min_value
+                .as_ref()
+                .map(|v| v.clone().into_boxed_slice()),
+        );
+        md.set_max_value(
+            self.max_value
+                .as_ref()
+                .map(|v| v.clone().into_boxed_slice()),
+        );
 
         md
     }
@@ -51,23 +47,17 @@ impl ToMetadata<StringType> for BinaryStatistics {
     fn to_metadata(&self) -> Metadata<StringType> {
         let mut md = Metadata::default();
 
-        if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok()) {
-            md.set_distinct_count(distinct_count);
-        }
-        if let Some(min_value) = self
-            .min_value
-            .as_ref()
-            .and_then(|s| String::from_utf8(s.clone()).ok())
-        {
-            md.set_min_value(min_value);
-        }
-        if let Some(max_value) = self
-            .max_value
-            .as_ref()
-            .and_then(|s| String::from_utf8(s.clone()).ok())
-        {
-            md.set_max_value(max_value);
-        }
+        md.set_distinct_count(self.distinct_count.and_then(|v| v.try_into().ok()));
+        md.set_min_value(
+            self.min_value
+                .as_ref()
+                .and_then(|s| String::from_utf8(s.clone()).ok()),
+        );
+        md.set_max_value(
+            self.max_value
+                .as_ref()
+                .and_then(|s| String::from_utf8(s.clone()).ok()),
+        );
 
         md
     }
@@ -80,16 +70,9 @@ macro_rules! prim_statistics {
             fn to_metadata(&self) -> Metadata<$pltype> {
                 let mut md = Metadata::default();
 
-                if let Some(distinct_count) = self.distinct_count.and_then(|v| v.try_into().ok())
-                {
-                    md.set_distinct_count(distinct_count);
-                }
-                if let Some(min_value) = self.min_value {
-                    md.set_min_value(min_value as <$pltype as PolarsDataType>::OwnedPhysical);
-                }
-                if let Some(max_value) = self.max_value {
-                    md.set_max_value(max_value as <$pltype as PolarsDataType>::OwnedPhysical);
-                }
+                md.set_distinct_count(self.distinct_count.and_then(|v| v.try_into().ok()));
+                md.set_min_value(self.min_value.map(|v| v as <$pltype as PolarsDataType>::OwnedPhysical));
+                md.set_max_value(self.max_value.map(|v| v as <$pltype as PolarsDataType>::OwnedPhysical));
 
                 md
             }


### PR DESCRIPTION
With this PR, I change the way we clone `ChunkedArray`s. Now, we have to explicitly state after the clone that it is okay to copy over some metadata properties. This clears the way to properly handle other kinds metadata and I implemented such handling for `slice` and `rechunk`.