### PR TITLE
depr: Rename `SQLContext` "eager_execution" param to "eager", defer multi-frame `df.sql` SQL ops to top-level `pl.sql`

### DIFF
--- a/docs/src/python/user-guide/sql/create.py
+++ b/docs/src/python/user-guide/sql/create.py
@@ -7,7 +7,7 @@ import polars as pl
 data = {"name": ["Alice", "Bob", "Charlie", "David"], "age": [25, 30, 35, 40]}
 df = pl.LazyFrame(data)
 
-ctx = pl.SQLContext(my_table=df, eager_execution=True)
+ctx = pl.SQLContext(my_table=df, eager=True)
 
 result = ctx.execute(
     """

--- a/docs/src/python/user-guide/sql/intro.py
+++ b/docs/src/python/user-guide/sql/intro.py
@@ -33,7 +33,7 @@ ctx = pl.SQLContext(df_pandas=pl.from_pandas(df_pandas))
 pokemon = pl.read_csv(
     "https://gist.githubusercontent.com/ritchie46/cac6b337ea52281aa23c049250a4ff03/raw/89a957ff3919d90e6ef2d34235e6bf22304f3366/pokemon.csv"
 )
-with pl.SQLContext(register_globals=True, eager_execution=True) as ctx:
+with pl.SQLContext(register_globals=True, eager=True) as ctx:
     df_small = ctx.execute("SELECT * from pokemon LIMIT 5")
     print(df_small)
 # --8<-- [end:execute]
@@ -76,7 +76,7 @@ with pl.SQLContext(
     products_masterdata=pl.scan_csv("docs/data/products_masterdata.csv"),
     products_categories=pl.scan_ndjson("docs/data/products_categories.json"),
     sales_data=pl.from_pandas(sales_data),
-    eager_execution=True,
+    eager=True,
 ) as ctx:
     query = """
     SELECT

--- a/docs/src/python/user-guide/sql/select.py
+++ b/docs/src/python/user-guide/sql/select.py
@@ -20,7 +20,7 @@ df = pl.DataFrame(
     }
 )
 
-ctx = pl.SQLContext(population=df, eager_execution=True)
+ctx = pl.SQLContext(population=df, eager=True)
 
 print(ctx.execute("SELECT * FROM population"))
 # --8<-- [end:df]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1248,7 +1248,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             )
         )
 
-    def sql(self, query: str, *, table_name: str | None = None) -> Self:
+    def sql(self, query: str, *, table_name: str = "self") -> Self:
         """
         Execute a SQL query against the LazyFrame.
 
@@ -1265,13 +1265,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             SQL query to execute.
         table_name
             Optionally provide an explicit name for the table that represents the
-            calling frame (the alias "self" will always be registered/available).
+            calling frame (defaults to "self").
 
         Notes
         -----
         * The calling frame is automatically registered as a table in the SQL context
-          under the name "self". All DataFrames and LazyFrames found in the current
-          set of global variables are also registered, using their variable name.
+          under the name "self". If you want access to the DataFrames and LazyFrames
+          found in the current globals, use the top-level :meth:`pl.sql <polars.sql>`.
         * More control over registration and execution behaviour is available by
           using the :class:`SQLContext` object.
 
@@ -1297,27 +1297,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ x   ┆ 8   │
         └─────┴─────┘
 
-        Join two LazyFrames:
-
-        >>> lf1.sql(
-        ...     '''
-        ...     SELECT self.*, d
-        ...     FROM self
-        ...     INNER JOIN lf2 USING (a)
-        ...     WHERE a > 1 AND b < 8
-        ...     '''
-        ... ).collect()
-        shape: (1, 4)
-        ┌─────┬─────┬─────┬──────┐
-        │ a   ┆ b   ┆ c   ┆ d    │
-        │ --- ┆ --- ┆ --- ┆ ---  │
-        │ i64 ┆ i64 ┆ str ┆ i64  │
-        ╞═════╪═════╪═════╪══════╡
-        │ 2   ┆ 7   ┆ y   ┆ -654 │
-        └─────┴─────┴─────┴──────┘
-
-        Apply SQL transforms (aliasing "self" to "frame") and subsequently
-        filter natively (you can freely mix SQL and native operations):
+        Apply SQL transforms (aliasing "self" to "frame") then filter
+        natively (you can freely mix SQL and native operations):
 
         >>> lf1.sql(
         ...     query='''
@@ -1346,13 +1327,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         issue_unstable_warning(
             "`sql` is considered **unstable** (although it is close to being considered stable)."
         )
-        with SQLContext(
-            register_globals=True,
-            eager_execution=False,
-        ) as ctx:
-            frames = {table_name: self} if table_name else {}
-            frames["self"] = self
-            ctx.register_many(frames)
+        with SQLContext(register_globals=False, eager=False) as ctx:
+            name = table_name if table_name else "self"
+            ctx.register(name=name, frame=self)
             return ctx.execute(query)  # type: ignore[return-value]
 
     def top_k(

--- a/py-polars/polars/sql/functions.py
+++ b/py-polars/polars/sql/functions.py
@@ -105,10 +105,7 @@ def sql(query: str, *, eager: bool = False) -> DataFrame | LazyFrame:
     """
     from polars.sql import SQLContext
 
-    with SQLContext(
-        eager_execution=eager,
-        register_globals=True,
-    ) as ctx:
+    with SQLContext(eager=eager, register_globals=True) as ctx:
         return ctx.execute(query)
 
 

--- a/py-polars/tests/unit/sql/test_cast.py
+++ b/py-polars/tests/unit/sql/test_cast.py
@@ -22,7 +22,7 @@ def test_cast() -> None:
     )
     # test various dtype casts, using standard ("CAST <col> AS <dtype>")
     # and postgres-specific ("<col>::<dtype>") cast syntax
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         res = ctx.execute(
             """
             SELECT
@@ -142,7 +142,7 @@ def test_cast() -> None:
     ]
 
     with pytest.raises(ComputeError, match="unsupported use of FORMAT in CAST"):
-        pl.SQLContext(df=df, eager_execution=True).execute(
+        pl.SQLContext(df=df, eager=True).execute(
             "SELECT CAST(a AS STRING FORMAT 'HEX') FROM df"
         )
 
@@ -163,18 +163,18 @@ def test_cast_errors(values: Any, cast_op: str, error: str) -> None:
 
     # invalid CAST should raise an error...
     with pytest.raises(ComputeError, match=error):
-        df.sql(f"SELECT {cast_op} FROM df")
+        df.sql(f"SELECT {cast_op} FROM self")
 
     # ... or return `null` values if using TRY_CAST
     target_type = cast_op.split("::")[1]
-    res = df.sql(f"SELECT TRY_CAST(values AS {target_type}) AS cast_values FROM df")
+    res = df.sql(f"SELECT TRY_CAST(values AS {target_type}) AS cast_values FROM self")
     assert None in res.to_series()
 
 
 def test_cast_json() -> None:
     df = pl.DataFrame({"txt": ['{"a":[1,2,3],"b":["x","y","z"],"c":5.0}']})
 
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         for json_cast in ("txt::json", "CAST(txt AS JSON)"):
             res = ctx.execute(f"SELECT {json_cast} AS j FROM df")
 

--- a/py-polars/tests/unit/sql/test_conditional.py
+++ b/py-polars/tests/unit/sql/test_conditional.py
@@ -22,7 +22,7 @@ def test_case_when() -> None:
             "v2": [101, 202, 303, 404],
         }
     )
-    with pl.SQLContext(test_data=lf, eager_execution=True) as ctx:
+    with pl.SQLContext(test_data=lf, eager=True) as ctx:
         out = ctx.execute(
             """
             SELECT *, CASE WHEN COALESCE(v1, v2) % 2 != 0 THEN 'odd' ELSE 'even' END as "v3"

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -18,7 +18,7 @@ def foods_ipc_path() -> Path:
 def test_group_by(foods_ipc_path: Path) -> None:
     lf = pl.scan_ipc(foods_ipc_path)
 
-    ctx = pl.SQLContext(eager_execution=True)
+    ctx = pl.SQLContext(eager=True)
     ctx.register("foods", lf)
 
     out = ctx.execute(

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -58,7 +58,7 @@ def test_join_anti_semi(sql: str, expected: pl.DataFrame) -> None:
         "tbl_b": pl.DataFrame({"a": [3, 2, 1], "b": [6, 5, 4], "c": ["x", "y", "z"]}),
         "tbl_c": pl.DataFrame({"c": ["w", "y", "z"], "d": [10.5, -50.0, 25.5]}),
     }
-    ctx = pl.SQLContext(frames, eager_execution=True)
+    ctx = pl.SQLContext(frames, eager=True)
     assert_frame_equal(expected, ctx.execute(sql))
 
 
@@ -67,7 +67,7 @@ def test_join_cross() -> None:
         "tbl_a": pl.DataFrame({"a": [1, 2, 3], "b": [4, 0, 6], "c": ["w", "y", "z"]}),
         "tbl_b": pl.DataFrame({"a": [3, 2, 1], "b": [6, 5, 4], "c": ["x", "y", "z"]}),
     }
-    with pl.SQLContext(frames, eager_execution=True) as ctx:
+    with pl.SQLContext(frames, eager=True) as ctx:
         out = ctx.execute(
             """
             SELECT *
@@ -90,14 +90,14 @@ def test_join_cross() -> None:
 
 
 def test_join_cross_11927() -> None:
-    df1 = pl.DataFrame({"id": [1, 2, 3]})
+    df1 = pl.DataFrame({"id": [1, 2, 3]})  # noqa: F841
     df2 = pl.DataFrame({"id": [3, 4, 5]})  # noqa: F841
     df3 = pl.DataFrame({"id": [4, 5, 6]})  # noqa: F841
 
-    res = df1.sql("SELECT df2.id FROM self CROSS JOIN df2 WHERE self.id = df2.id")
+    res = pl.sql("SELECT df1.id FROM df1 CROSS JOIN df2 WHERE df1.id = df2.id")
     assert_frame_equal(res, pl.DataFrame({"id": [3]}))
 
-    res = df1.sql("SELECT * FROM self CROSS JOIN df3 WHERE self.id = df3.id")
+    res = pl.sql("SELECT * FROM df1 CROSS JOIN df3 WHERE df1.id = df3.id")
     assert res.is_empty()
 
 
@@ -173,7 +173,7 @@ def test_join_inner_15663() -> None:
             "VALUE_B": [25.6, 53.4, 12.7],
         }
     )
-    with pl.SQLContext(register_globals=True, eager_execution=True) as ctx:
+    with pl.SQLContext(register_globals=True, eager=True) as ctx:
         query = """
         SELECT
             a.LOCID,
@@ -257,7 +257,7 @@ def test_join_misc_13618() -> None:
         }
     )
     res = (
-        pl.SQLContext(t=df, t1=df, eager_execution=True)
+        pl.SQLContext(t=df, t1=df, eager=True)
         .execute("SELECT t.A, t.fruits, t1.B, t1.cars FROM t JOIN t1 ON t.A=t1.B")
         .to_dict(as_series=False)
     )
@@ -270,9 +270,9 @@ def test_join_misc_13618() -> None:
 
 
 def test_join_misc_16255() -> None:
-    df1 = pl.read_csv(BytesIO(b"id,data\n1,open"))
+    df1 = pl.read_csv(BytesIO(b"id,data\n1,open"))  # noqa: F841
     df2 = pl.read_csv(BytesIO(b"id,data\n1,closed"))  # noqa: F841
-    res = df1.sql(
+    res = pl.sql(
         """
         SELECT a.id, a.data AS d1, b.data AS d2
         FROM self AS a JOIN df2 AS b

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -95,10 +95,10 @@ def test_join_cross_11927() -> None:
     df3 = pl.DataFrame({"id": [4, 5, 6]})  # noqa: F841
 
     res = pl.sql("SELECT df1.id FROM df1 CROSS JOIN df2 WHERE df1.id = df2.id")
-    assert_frame_equal(res, pl.DataFrame({"id": [3]}))
+    assert_frame_equal(res.collect(), pl.DataFrame({"id": [3]}))
 
     res = pl.sql("SELECT * FROM df1 CROSS JOIN df3 WHERE df1.id = df3.id")
-    assert res.is_empty()
+    assert res.collect().is_empty()
 
 
 @pytest.mark.parametrize(
@@ -275,9 +275,10 @@ def test_join_misc_16255() -> None:
     res = pl.sql(
         """
         SELECT a.id, a.data AS d1, b.data AS d2
-        FROM self AS a JOIN df2 AS b
+        FROM df1 AS a JOIN df2 AS b
         ON a.id = b.id
-        """
+        """,
+        eager=True,
     )
     assert res.rows() == [(1, "open", "closed")]
 

--- a/py-polars/tests/unit/sql/test_literals.py
+++ b/py-polars/tests/unit/sql/test_literals.py
@@ -7,7 +7,7 @@ from polars.exceptions import ComputeError
 
 
 def test_bit_hex_literals() -> None:
-    with pl.SQLContext(df=None, eager_execution=True) as ctx:
+    with pl.SQLContext(df=None, eager=True) as ctx:
         out = ctx.execute(
             """
             SELECT *,

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -58,7 +58,7 @@ def test_distinct() -> None:
             "b": [1, 2, 3, 4, 5, 6],
         }
     )
-    ctx = pl.SQLContext(register_globals=True, eager_execution=True)
+    ctx = pl.SQLContext(register_globals=True, eager=True)
     res1 = ctx.execute("SELECT DISTINCT a FROM df ORDER BY a DESC")
     assert_frame_equal(
         left=df.select("a").unique().sort(by="a", descending=True),

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -15,13 +15,13 @@ def foods_ipc_path() -> Path:
 
 
 def test_any_all() -> None:
-    df = pl.DataFrame(
+    df = pl.DataFrame(  # noqa: F841
         {
             "x": [-1, 0, 1, 2, 3, 4],
             "y": [1, 0, 0, 1, 2, 3],
         }
     )
-    res = df.sql(
+    res = pl.sql(
         """
         SELECT
           x >= ALL(df.y) AS "All Geq",
@@ -36,7 +36,8 @@ def test_any_all() -> None:
           x != ANY(df.y) AS "Any Neq",
         FROM df
         """,
-    )
+    ).collect()
+
     assert res.to_dict(as_series=False) == {
         "All Geq": [0, 0, 0, 0, 1, 1],
         "All G": [0, 0, 0, 0, 0, 1],

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -93,7 +93,7 @@ def test_round_ndigits(decimals: int, expected: list[float]) -> None:
     df = pl.DataFrame(
         {"n": [-8192.499, -3.9550, -1.54321, 2.45678, 3.59901, 8192.5001]},
     )
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         if decimals == 0:
             out = ctx.execute("SELECT ROUND(n) AS n FROM df")
             assert_series_equal(out["n"], pl.Series("n", values=expected))
@@ -104,7 +104,7 @@ def test_round_ndigits(decimals: int, expected: list[float]) -> None:
 
 def test_round_ndigits_errors() -> None:
     df = pl.DataFrame({"n": [99.999]})
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         with pytest.raises(
             InvalidOperationError, match="invalid 'decimals' for Round: ??"
         ):

--- a/py-polars/tests/unit/sql/test_operators.py
+++ b/py-polars/tests/unit/sql/test_operators.py
@@ -21,7 +21,7 @@ def test_div() -> None:
             "b": [-100.5, 7.0, 2.5, None, -3.14],
         }
     )
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         res = ctx.execute(
             """
             SELECT
@@ -81,7 +81,7 @@ def test_equal_not_equal() -> None:
 def test_is_between(foods_ipc_path: Path) -> None:
     lf = pl.scan_ipc(foods_ipc_path)
 
-    ctx = pl.SQLContext(foods1=lf, eager_execution=True)
+    ctx = pl.SQLContext(foods1=lf, eager=True)
     out = ctx.execute(
         """
         SELECT *

--- a/py-polars/tests/unit/sql/test_regex.py
+++ b/py-polars/tests/unit/sql/test_regex.py
@@ -32,7 +32,7 @@ def test_regex_expr_match(regex_op: str, expected: list[int]) -> None:
             "pat": ["^A", "^A", "^A", r"[AB]\d.*$", ".*xxx$"],
         }
     )
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         out = ctx.execute(f"SELECT idx, str FROM df WHERE str {regex_op} pat")
         assert out.to_series().to_list() == expected
 
@@ -68,7 +68,7 @@ def test_regex_operators(
 ) -> None:
     lf = pl.scan_ipc(foods_ipc_path)
 
-    with pl.SQLContext(foods=lf, eager_execution=True) as ctx:
+    with pl.SQLContext(foods=lf, eager=True) as ctx:
         out = ctx.execute(
             f"""
             SELECT DISTINCT category FROM foods
@@ -80,7 +80,7 @@ def test_regex_operators(
 
 def test_regex_operators_error() -> None:
     df = pl.LazyFrame({"sval": ["ABC", "abc", "000", "A0C", "a0c"]})
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         with pytest.raises(
             ComputeError, match="invalid pattern for '~' operator: dyn .*12345"
         ):
@@ -113,7 +113,7 @@ def test_regexp_like(
 ) -> None:
     lf = pl.scan_ipc(foods_ipc_path)
     flags = "" if flags is None else f",'{flags}'"
-    with pl.SQLContext(foods=lf, eager_execution=True) as ctx:
+    with pl.SQLContext(foods=lf, eager=True) as ctx:
         out = ctx.execute(
             f"""
             SELECT DISTINCT category FROM foods

--- a/py-polars/tests/unit/sql/test_strings.py
+++ b/py-polars/tests/unit/sql/test_strings.py
@@ -109,7 +109,7 @@ def test_string_left_right_reverse() -> None:
 def test_string_left_negative_expr() -> None:
     # negative values and expressions
     df = pl.DataFrame({"s": ["alphabet", "alphabet"], "n": [-6, 6]})
-    with pl.SQLContext(df=df, eager_execution=True) as sql:
+    with pl.SQLContext(df=df, eager=True) as sql:
         res = sql.execute(
             """
             SELECT
@@ -143,7 +143,7 @@ def test_string_left_negative_expr() -> None:
 def test_string_right_negative_expr() -> None:
     # negative values and expressions
     df = pl.DataFrame({"s": ["alphabet", "alphabet"], "n": [-6, 6]})
-    with pl.SQLContext(df=df, eager_execution=True) as sql:
+    with pl.SQLContext(df=df, eager=True) as sql:
         res = sql.execute(
             """
             SELECT
@@ -249,7 +249,7 @@ def test_string_position() -> None:
         values=["Dubai", "Abu Dhabi", "Sharjah", "Al Ain", "Ajman", "Ras Al Khaimah"],
     ).to_frame()
 
-    with pl.SQLContext(cities=df, eager_execution=True) as ctx:
+    with pl.SQLContext(cities=df, eager=True) as ctx:
         res = ctx.execute(
             """
             SELECT

--- a/py-polars/tests/unit/sql/test_table_operations.py
+++ b/py-polars/tests/unit/sql/test_table_operations.py
@@ -26,7 +26,7 @@ def test_drop_table(test_frame: pl.LazyFrame) -> None:
     # 'drop' completely removes the table from sql context
     expected = pl.DataFrame()
 
-    with pl.SQLContext(frame=test_frame, eager_execution=True) as ctx:
+    with pl.SQLContext(frame=test_frame, eager=True) as ctx:
         res = ctx.execute("DROP TABLE frame")
         assert_frame_equal(res, expected)
 
@@ -75,7 +75,7 @@ def test_truncate_table(truncate_sql: str, test_frame: pl.LazyFrame) -> None:
     # 'truncate' preserves the table, but optimally drops all rows within it
     expected = pl.DataFrame(schema=test_frame.schema)
 
-    with pl.SQLContext(frame=test_frame, eager_execution=True) as ctx:
+    with pl.SQLContext(frame=test_frame, eager=True) as ctx:
         res = ctx.execute(truncate_sql)
         assert_frame_equal(res, expected)
 

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -21,7 +21,7 @@ def test_date() -> None:
             "version": ["0.0.1", "0.7.3", "0.7.4"],
         }
     )
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+    with pl.SQLContext(df=df, eager=True) as ctx:
         result = ctx.execute("SELECT date < DATE('2021-03-20') from df")
 
     expected = pl.DataFrame({"date": [True, False, False]})
@@ -99,7 +99,7 @@ def test_extract(part: str, dtype: pl.DataType, expected: list[Any]) -> None:
             ],
         }
     )
-    with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
+    with pl.SQLContext(frame_data=df, eager=True) as ctx:
         for func in (f"EXTRACT({part} FROM dt)", f"DATE_PART(dt,'{part}')"):
             res = ctx.execute(f"SELECT {func} AS {part} FROM frame_data").to_series()
 
@@ -125,9 +125,7 @@ def test_extract(part: str, dtype: pl.DataType, expected: list[Any]) -> None:
     ],
 )
 def test_extract_century_millennium(dt: date, expected: list[int]) -> None:
-    with pl.SQLContext(
-        frame_data=pl.DataFrame({"dt": [dt]}), eager_execution=True
-    ) as ctx:
+    with pl.SQLContext(frame_data=pl.DataFrame({"dt": [dt]}), eager=True) as ctx:
         res = ctx.execute(
             """
             SELECT
@@ -226,7 +224,7 @@ def test_timestamp_time_unit(unit: str | None, expected: list[int]) -> None:
     )
     precision = {"ms": 3, "us": 6, "ns": 9}
 
-    with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
+    with pl.SQLContext(frame_data=df, eager=True) as ctx:
         prec = f"({precision[unit]})" if unit else ""
         res = ctx.execute(f"SELECT ts::timestamp{prec} FROM frame_data").to_series()
 
@@ -237,7 +235,7 @@ def test_timestamp_time_unit(unit: str | None, expected: list[int]) -> None:
 def test_timestamp_time_unit_errors() -> None:
     df = pl.DataFrame({"ts": [datetime(2024, 1, 7, 1, 2, 3, 123456)]})
 
-    with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
+    with pl.SQLContext(frame_data=df, eager=True) as ctx:
         for prec in (0, 15):
             with pytest.raises(
                 ComputeError,

--- a/py-polars/tests/unit/sql/test_union.py
+++ b/py-polars/tests/unit/sql/test_union.py
@@ -55,7 +55,7 @@ def test_union(
     with pl.SQLContext(
         frame1=pl.DataFrame({"c1": [1, 2], "c2": ["zz", "yy"]}),
         frame2=pl.DataFrame({"c1": [2, 3], "c2": ["yy", "xx"]}),
-        eager_execution=True,
+        eager=True,
     ) as ctx:
         query = f"""
             SELECT {', '.join(cols1)} FROM frame1


### PR DESCRIPTION
Everywhere else where we allow a choice between returning a `DataFrame` or `LazyFrame` we use an "eager" parameter; this updates `SQLContext` to follow the same convention, deprecating "eager_execution" in favour of just "eager".

```python
with SQLContext(…, eager=True) as sql:
    sql.execute(query)
```

@stinodego: also, as discussed last night, `df.sql(query)` now _only_ allows queries against "self", deferring to `pl.sql(query)` when access to frames in the globals is required. This better-distinguishes the purpose of each function and allows for frame-level `df.sql` to be marginally optimised (no need to introspect globals).

## Example
```python
df1 = pl.DataFrame({"id1": [1, 2]})
df2 = pl.DataFrame({"id2": [3, 4]})
```
Frame-level SQL (access to "self"):
```python
df1.sql("SELECT * FROM self WHERE id1 > 1")
# shape: (1, 1)
# ┌─────┐
# │ id1 │
# │ --- │
# │ i64 │
# ╞═════╡
# │ 2   │
# └─────┘
```
Top-level SQL (access to globals):
```python
pl.sql("SELECT * FROM df1 CROSS JOIN df2", eager=True)
# shape: (4, 2)
# ┌─────┬─────┐
# │ id1 ┆ id2 │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 1   ┆ 3   │
# │ 1   ┆ 4   │
# │ 2   ┆ 3   │
# │ 2   ┆ 4   │
# └─────┴─────┘
```