### PR TITLE
feat(python)!: Constrain access to globals from `df.sql` in favour of top-level `pl.sql`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4707,13 +4707,9 @@ class DataFrame:
         issue_unstable_warning(
             "`sql` is considered **unstable** (although it is close to being considered stable)."
         )
-        with SQLContext(
-            register_globals=True,
-            eager=True,
-        ) as ctx:
-            frames = {table_name: self} if table_name else {}
-            frames["self"] = self
-            ctx.register_many(frames)
+        with SQLContext(register_globals=False, eager=True) as ctx:
+            name = table_name if table_name else "self"
+            ctx.register(name=name, frame=self)
             return ctx.execute(query)  # type: ignore[return-value]
 
     def top_k(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1327,13 +1327,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         issue_unstable_warning(
             "`sql` is considered **unstable** (although it is close to being considered stable)."
         )
-        with SQLContext(
-            register_globals=True,
-            eager=False,
-        ) as ctx:
-            frames = {table_name: self} if table_name else {}
-            frames["self"] = self
-            ctx.register_many(frames)
+        with SQLContext(register_globals=False, eager=False) as ctx:
+            name = table_name if table_name else "self"
+            ctx.register(name=name, frame=self)
             return ctx.execute(query)  # type: ignore[return-value]
 
     def top_k(

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -86,6 +86,22 @@ def test_distinct() -> None:
         ctx.execute("SELECT * FROM df")
 
 
+def test_frame_sql_globals_error() -> None:
+    df1 = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df2 = pl.DataFrame({"a": [2, 3, 4], "b": [7, 6, 5]})  # noqa: F841
+
+    query = """
+        SELECT df1.a, df2.b
+        FROM df2 JOIN df1 ON df1.a = df2.a
+        ORDER BY b DESC
+    """
+    with pytest.raises(ComputeError, match=".*not found.*"):
+        df1.sql(query=query)
+
+    res = pl.sql(query=query, eager=True)
+    assert res.to_dict(as_series=False) == {"a": [2, 3], "b": [7, 6]}
+
+
 def test_in_no_ops_11946() -> None:
     lf = pl.LazyFrame(
         [


### PR DESCRIPTION
As discussed; updates `df.sql(query)` such that it can _only_ access "self", deferring to `pl.sql(query)` when access to frames in the current stack is required. 

This better-distinguishes the purpose of each function and allows for frame-level `df.sql` to be marginally optimised (as there is no longer any need to introspect globals).

## Example
```python
import python

df1 = pl.DataFrame({"id1": [1, 2]})
df2 = pl.DataFrame({"id2": [3, 4]})
```
Frame-level `df.sql` (has access to "self", but not globals):
```python
df1.sql("SELECT * FROM self WHERE id1 > 1")
# shape: (1, 1)
# ┌─────┐
# │ id1 │
# │ --- │
# │ i64 │
# ╞═════╡
# │ 2   │
# └─────┘
```
Top-level `pl.sql` (has access to globals):
```python
pl.sql("SELECT * FROM df1 CROSS JOIN df2", eager=True)
# shape: (4, 2)
# ┌─────┬─────┐
# │ id1 ┆ id2 │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 1   ┆ 3   │
# │ 1   ┆ 4   │
# │ 2   ┆ 3   │
# │ 2   ┆ 4   │
# └─────┴─────┘
```