### PR TITLE
docs(python): Add example for index count in `DataFrame.rolling`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5720,8 +5720,8 @@ class DataFrame:
         │ 2020-01-08 23:16:43 ┆ 1     ┆ 1     ┆ 1     │
         └─────────────────────┴───────┴───────┴───────┘
 
-        The index count is based on actual values in a defined column and not on
-        consecutive rows as polars does not use indices:
+        If you use an index count in `period` or `offset`, then it's based on the
+        values in `index_column`:
 
         >>> df = pl.DataFrame({"int": [0, 4, 5, 6, 8], "value": [1, 4, 2, 4, 1]})
         >>> df.rolling("int", period="3i").agg(pl.col("int").alias("aggregated"))
@@ -5737,6 +5737,9 @@ class DataFrame:
         │ 6   ┆ [4, 5, 6]  │
         │ 8   ┆ [6, 8]     │
         └─────┴────────────┘
+
+        If you want the index count to be based on row number, then you may want to
+        combine `rolling` with :meth:`.with_row_index`.
         """
         period = deprecate_saturating(period)
         offset = deprecate_saturating(offset)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5719,6 +5719,24 @@ class DataFrame:
         │ 2020-01-03 19:45:32 ┆ 11    ┆ 2     ┆ 9     │
         │ 2020-01-08 23:16:43 ┆ 1     ┆ 1     ┆ 1     │
         └─────────────────────┴───────┴───────┴───────┘
+
+        The index count is based on actual values in a defined column and not on
+        consecutive rows as polars does not use indices:
+
+        >>> df = pl.DataFrame({"int": [0, 4, 5, 6, 8], "value": [1, 4, 2, 4, 1]})
+        >>> df.rolling("int", period="3i").agg(pl.col("int").alias("aggregated"))
+        shape: (5, 2)
+        ┌─────────┬────────────┐
+        │ integer ┆ aggregated │
+        │ ---     ┆ ---        │
+        │ i64     ┆ list[i64]  │
+        ╞═════════╪════════════╡
+        │ 0       ┆ [0]        │
+        │ 4       ┆ [4]        │
+        │ 5       ┆ [4, 5]     │
+        │ 6       ┆ [4, 5, 6]  │
+        │ 8       ┆ [6, 8]     │
+        └─────────┴────────────┘
         """
         period = deprecate_saturating(period)
         offset = deprecate_saturating(offset)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5726,17 +5726,17 @@ class DataFrame:
         >>> df = pl.DataFrame({"int": [0, 4, 5, 6, 8], "value": [1, 4, 2, 4, 1]})
         >>> df.rolling("int", period="3i").agg(pl.col("int").alias("aggregated"))
         shape: (5, 2)
-        ┌─────────┬────────────┐
-        │ integer ┆ aggregated │
-        │ ---     ┆ ---        │
-        │ i64     ┆ list[i64]  │
-        ╞═════════╪════════════╡
-        │ 0       ┆ [0]        │
-        │ 4       ┆ [4]        │
-        │ 5       ┆ [4, 5]     │
-        │ 6       ┆ [4, 5, 6]  │
-        │ 8       ┆ [6, 8]     │
-        └─────────┴────────────┘
+        ┌─────┬────────────┐
+        │ int ┆ aggregated │
+        │ --- ┆ ---        │
+        │ i64 ┆ list[i64]  │
+        ╞═════╪════════════╡
+        │ 0   ┆ [0]        │
+        │ 4   ┆ [4]        │
+        │ 5   ┆ [4, 5]     │
+        │ 6   ┆ [4, 5, 6]  │
+        │ 8   ┆ [6, 8]     │
+        └─────┴────────────┘
         """
         period = deprecate_saturating(period)
         offset = deprecate_saturating(offset)


### PR DESCRIPTION
towards #14781 

I added an example for using the index count in `DataFrame.rolling` as there has been unclarity about how exactly it works. 
