### PR TITLE
chore: Update dprint hook versions and enable JSON linting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,19 @@ version = "0.40.0"
 authors = ["Ritchie Vink <ritchie46@gmail.com>"]
 edition = "2021"
 homepage = "https://www.pola.rs/"
-repository = "https://github.com/pola-rs/polars"
 license = "MIT"
+repository = "https://github.com/pola-rs/polars"
 
 [workspace.dependencies]
-aho-corasick = "1.1"
 ahash = ">=0.8.5"
+aho-corasick = "1.1"
+arboard = { version = "3.4.0", default-features = false }
 arrow-array = { version = ">=41", default-features = false }
 arrow-buffer = { version = ">=41", default-features = false }
 arrow-data = { version = ">=41", default-features = false }
 arrow-schema = { version = ">=41", default-features = false }
 atoi = "2"
+atoi_simd = "0.15.5"
 avro-schema = { version = "0.3" }
 base64 = "0.22.0"
 bitflags = "2"
@@ -41,6 +43,7 @@ crossbeam-queue = "0.3"
 either = "1.11"
 ethnum = "1.3.2"
 fallible-streaming-iterator = "0.1.9"
+fast-float = { version = "0.2" }
 flate2 = { version = "1", default-features = false }
 futures = "0.3.25"
 hashbrown = { version = "0.14", features = ["rayon", "ahash", "serde"] }
@@ -48,8 +51,6 @@ hex = "0.4.3"
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
 itoap = { version = "1", features = ["simd"] }
-atoi_simd = "0.15.5"
-fast-float = { version = "0.2" }
 memchr = "2.6"
 multiversion = "0.7"
 ndarray = { version = "0.15", default-features = false }
@@ -62,10 +63,10 @@ rand = "0.8"
 rand_distr = "0.4"
 raw-cpuid = "11"
 rayon = "1.9"
+recursive = "0.1"
 regex = "1.9"
 reqwest = { version = "0.11", default-features = false }
 ryu = "1.0.13"
-recursive = "0.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1"
 simd-json = { version = "0.13", features = ["known-key"] }
@@ -81,16 +82,16 @@ tokio = "1.26"
 tokio-util = "0.7.8"
 unicode-reverse = "1.0.8"
 url = "2.4"
+uuid = { version = "1.7.0", features = ["v4"] }
 version_check = "0.9.4"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 zstd = "0.13"
-uuid = { version = "1.7.0", features = ["v4"] }
-arboard = { version = "3.4.0", default-features = false }
 
 polars = { version = "0.40.0", path = "crates/polars", default-features = false }
 polars-compute = { version = "0.40.0", path = "crates/polars-compute", default-features = false }
 polars-core = { version = "0.40.0", path = "crates/polars-core", default-features = false }
 polars-error = { version = "0.40.0", path = "crates/polars-error", default-features = false }
+polars-expr = { version = "0.40.0", path = "crates/polars-expr", default-features = false }
 polars-ffi = { version = "0.40.0", path = "crates/polars-ffi", default-features = false }
 polars-io = { version = "0.40.0", path = "crates/polars-io", default-features = false }
 polars-json = { version = "0.40.0", path = "crates/polars-json", default-features = false }
@@ -103,7 +104,6 @@ polars-row = { version = "0.40.0", path = "crates/polars-row", default-features 
 polars-sql = { version = "0.40.0", path = "crates/polars-sql", default-features = false }
 polars-time = { version = "0.40.0", path = "crates/polars-time", default-features = false }
 polars-utils = { version = "0.40.0", path = "crates/polars-utils", default-features = false }
-polars-expr = { version = "0.40.0", path = "crates/polars-expr", default-features = false }
 
 [workspace.dependencies.arrow-format]
 package = "polars-arrow-format"

--- a/docs/development/contributing/ide.md
+++ b/docs/development/contributing/ide.md
@@ -19,7 +19,7 @@ For it to work well for the Polars code base, add the following settings to your
 
 ```json
 {
-    "rust-analyzer.cargo.features": "all",
+  "rust-analyzer.cargo.features": "all"
 }
 ```
 
@@ -32,7 +32,7 @@ This will make it use the correct Ruff version and configuration.
 
 ```json
 {
-    "ruff.importStrategy": "fromEnvironment",
+  "ruff.importStrategy": "fromEnvironment"
 }
 ```
 
@@ -57,38 +57,38 @@ See the [official VSCode documentation](https://code.visualstudio.com/docs/edito
 
 ```json
 {
-    "configurations": [
-        {
-            "name": "Debug Rust/Python",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "${workspaceFolder}/py-polars/debug/launch.py",
-            "args": [
-                "${file}"
-            ],
-            "console": "internalConsole",
-            "justMyCode": true,
-            "serverReadyAction": {
-                "pattern": "pID = ([0-9]+)",
-                "action": "startDebugging",
-                "name": "Rust LLDB"
-            }
-        },
-        {
-            "name": "Rust LLDB",
-            "pid": "0",
-            "type": "lldb",
-            "request": "attach",
-            "program": "${workspaceFolder}/py-polars/.venv/bin/python",
-            "stopOnEntry": false,
-            "sourceLanguages": [
-                "rust"
-            ],
-            "presentation": {
-                "hidden": true
-            }
-        }
-    ]
+  "configurations": [
+    {
+      "name": "Debug Rust/Python",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/py-polars/debug/launch.py",
+      "args": [
+        "${file}"
+      ],
+      "console": "internalConsole",
+      "justMyCode": true,
+      "serverReadyAction": {
+        "pattern": "pID = ([0-9]+)",
+        "action": "startDebugging",
+        "name": "Rust LLDB"
+      }
+    },
+    {
+      "name": "Rust LLDB",
+      "pid": "0",
+      "type": "lldb",
+      "request": "attach",
+      "program": "${workspaceFolder}/py-polars/.venv/bin/python",
+      "stopOnEntry": false,
+      "sourceLanguages": [
+        "rust"
+      ],
+      "presentation": {
+        "hidden": true
+      }
+    }
+  ]
 }
 ```
 

--- a/docs/mlc-config.json
+++ b/docs/mlc-config.json
@@ -1,9 +1,10 @@
 {
-    "ignorePatterns": [
-        {
-            "pattern": "^https://crates.io/"
-        },{
-            "pattern": "^https://stackoverflow.com/"
-        }
-    ]
+  "ignorePatterns": [
+    {
+      "pattern": "^https://crates.io/"
+    },
+    {
+      "pattern": "^https://stackoverflow.com/"
+    }
+  ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -1,6 +1,6 @@
 {
   "includes": [
-    "**/*.{md,toml}"
+    "**/*.{md,toml,json}"
   ],
   "excludes": [
     ".venv/",
@@ -8,9 +8,11 @@
     "py-polars/.hypothesis/",
     "py-polars/.mypy_cache/",
     "py-polars/.pytest_cache/",
-    "py-polars/.ruff_cache/"
+    "py-polars/.ruff_cache/",
+    "py-polars/tests/unit/io/files/"
   ],
   "plugins": [
+    "https://plugins.dprint.dev/json-0.19.3.wasm",
     "https://plugins.dprint.dev/markdown-0.17.1.wasm",
     "https://plugins.dprint.dev/toml-0.6.2.wasm"
   ]

--- a/dprint.json
+++ b/dprint.json
@@ -1,17 +1,17 @@
 {
-    "includes": [
-        "**/*.{md,toml}"
-    ],
-    "excludes": [
-        ".venv/",
-        "**/target/",
-        "py-polars/.hypothesis/",
-        "py-polars/.mypy_cache/",
-        "py-polars/.pytest_cache/",
-        "py-polars/.ruff_cache/"
-    ],
-    "plugins": [
-        "https://plugins.dprint.dev/markdown-0.16.2.wasm",
-        "https://plugins.dprint.dev/toml-0.5.4.wasm"
-    ]
+  "includes": [
+    "**/*.{md,toml}"
+  ],
+  "excludes": [
+    ".venv/",
+    "**/target/",
+    "py-polars/.hypothesis/",
+    "py-polars/.mypy_cache/",
+    "py-polars/.pytest_cache/",
+    "py-polars/.ruff_cache/"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.17.1.wasm",
+    "https://plugins.dprint.dev/toml-0.6.2.wasm"
+  ]
 }

--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -1,23 +1,23 @@
 [
-    {
-        "name": "dev",
-        "version": "dev",
-        "url": "https://docs.pola.rs/docs/python/dev/"
-    },
-    {
-        "name": "0.20 (stable)",
-        "version": "0.20",
-        "url": "https://docs.pola.rs/py-polars/html/",
-        "preferred": true
-    },
-    {
-        "name": "0.19",
-        "version": "0.19",
-        "url": "https://docs.pola.rs/docs/python/version/0.19/"
-    },
-    {
-        "name": "0.18",
-        "version": "0.18",
-        "url": "https://docs.pola.rs/docs/python/version/0.18/"
-    }
+  {
+    "name": "dev",
+    "version": "dev",
+    "url": "https://docs.pola.rs/docs/python/dev/"
+  },
+  {
+    "name": "0.20 (stable)",
+    "version": "0.20",
+    "url": "https://docs.pola.rs/py-polars/html/",
+    "preferred": true
+  },
+  {
+    "name": "0.19",
+    "version": "0.19",
+    "url": "https://docs.pola.rs/docs/python/version/0.19/"
+  },
+  {
+    "name": "0.18",
+    "version": "0.18",
+    "url": "https://docs.pola.rs/docs/python/version/0.18/"
+  }
 ]


### PR DESCRIPTION
Apparently the new TOML formatter does some sorting within Cargo.toml files, which is nice.

I enabled JSON formatting - we don't have a lot of JSON files but it can't hurt.