### PR TITLE
feat(rust): Add `split_at` method to arrow `Array`

### DIFF
--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -1,5 +1,5 @@
 use super::specification::try_check_offsets_bounds;
-use super::{new_empty_array, Array};
+use super::{new_empty_array, Array, Splitable};
 use crate::bitmap::Bitmap;
 use crate::datatypes::{ArrowDataType, Field};
 use crate::offset::OffsetsBuffer;
@@ -193,5 +193,31 @@ impl Array for MapArray {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+}
+
+impl Splitable for MapArray {
+    fn check_bound(&self, offset: usize) -> bool {
+        offset <= self.len()
+    }
+
+    unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {
+        let (lhs_offsets, rhs_offsets) = unsafe { self.offsets.split_at_unchecked(offset) };
+        let (lhs_validity, rhs_validity) = unsafe { self.validity.split_at_unchecked(offset) };
+
+        (
+            Self {
+                data_type: self.data_type.clone(),
+                offsets: lhs_offsets,
+                field: self.field.clone(),
+                validity: lhs_validity,
+            },
+            Self {
+                data_type: self.data_type.clone(),
+                offsets: rhs_offsets,
+                field: self.field.clone(),
+                validity: rhs_validity,
+            },
+        )
     }
 }

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 
 use polars_error::{polars_bail, PolarsResult};
 
+use super::Splitable;
 use crate::array::{Array, FromFfi, MutableArray, ToFfi};
 use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::datatypes::{ArrowDataType, PhysicalType};
@@ -168,6 +169,25 @@ unsafe impl ToFfi for NullArray {
 
     fn to_ffi_aligned(&self) -> Self {
         self.clone()
+    }
+}
+
+impl Splitable for NullArray {
+    fn check_bound(&self, offset: usize) -> bool {
+        offset <= self.len()
+    }
+
+    unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {
+        (
+            Self {
+                data_type: self.data_type.clone(),
+                length: offset,
+            },
+            Self {
+                data_type: self.data_type.clone(),
+                length: self.len() - offset,
+            },
+        )
     }
 }
 

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use either::Either;
 
-use super::Array;
+use super::{Array, Splitable};
 use crate::array::iterator::NonNullValuesIter;
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::Bitmap;
@@ -495,6 +495,31 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+}
+
+impl<T: NativeType> Splitable for PrimitiveArray<T> {
+    #[inline(always)]
+    fn check_bound(&self, offset: usize) -> bool {
+        offset <= self.len()
+    }
+
+    unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {
+        let (lhs_values, rhs_values) = unsafe { self.values.split_at_unchecked(offset) };
+        let (lhs_validity, rhs_validity) = unsafe { self.validity.split_at_unchecked(offset) };
+
+        (
+            Self {
+                data_type: self.data_type.clone(),
+                values: lhs_values,
+                validity: lhs_validity,
+            },
+            Self {
+                data_type: self.data_type.clone(),
+                values: rhs_values,
+                validity: rhs_validity,
+            },
+        )
     }
 }
 

--- a/crates/polars-arrow/src/array/struct_/mod.rs
+++ b/crates/polars-arrow/src/array/struct_/mod.rs
@@ -1,4 +1,4 @@
-use super::{new_empty_array, new_null_array, Array};
+use super::{new_empty_array, new_null_array, Array, Splitable};
 use crate::bitmap::Bitmap;
 use crate::datatypes::{ArrowDataType, Field};
 
@@ -250,5 +250,37 @@ impl Array for StructArray {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+}
+
+impl Splitable for StructArray {
+    fn check_bound(&self, offset: usize) -> bool {
+        offset <= self.len()
+    }
+
+    unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {
+        let (lhs_validity, rhs_validity) = unsafe { self.validity.split_at_unchecked(offset) };
+
+        let mut lhs_values = Vec::with_capacity(self.values.len());
+        let mut rhs_values = Vec::with_capacity(self.values.len());
+
+        for v in self.values.iter() {
+            let (lhs, rhs) = unsafe { v.split_at_boxed_unchecked(offset) };
+            lhs_values.push(lhs);
+            rhs_values.push(rhs);
+        }
+
+        (
+            Self {
+                data_type: self.data_type.clone(),
+                values: lhs_values,
+                validity: lhs_validity,
+            },
+            Self {
+                data_type: self.data_type.clone(),
+                values: rhs_values,
+                validity: rhs_validity,
+            },
+        )
     }
 }

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -1,7 +1,7 @@
 use either::Either;
 
 use super::specification::try_check_utf8;
-use super::{Array, GenericBinaryArray};
+use super::{Array, GenericBinaryArray, Splitable};
 use crate::array::iterator::NonNullValuesIter;
 use crate::array::BinaryArray;
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
@@ -503,6 +503,33 @@ impl<O: Offset> Utf8Array<O> {
                 self.validity.clone(),
             )
         }
+    }
+}
+
+impl<O: Offset> Splitable for Utf8Array<O> {
+    #[inline(always)]
+    fn check_bound(&self, offset: usize) -> bool {
+        offset <= self.len()
+    }
+
+    unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {
+        let (lhs_validity, rhs_validity) = unsafe { self.validity.split_at_unchecked(offset) };
+        let (lhs_offsets, rhs_offsets) = unsafe { self.offsets.split_at_unchecked(offset) };
+
+        (
+            Self {
+                data_type: self.data_type.clone(),
+                offsets: lhs_offsets,
+                values: self.values.clone(),
+                validity: lhs_validity,
+            },
+            Self {
+                data_type: self.data_type.clone(),
+                offsets: rhs_offsets,
+                values: self.values.clone(),
+                validity: rhs_validity,
+            },
+        )
     }
 }
 

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -7,6 +7,7 @@ use polars_error::{polars_bail, PolarsResult};
 
 use super::utils::{count_zeros, fmt, get_bit, get_bit_unchecked, BitChunk, BitChunks, BitmapIter};
 use super::{chunk_iter_to_vec, intersects_with, IntoIter, MutableBitmap};
+use crate::array::Splitable;
 use crate::bitmap::aligned::AlignedBitmapSlice;
 use crate::bitmap::iterator::{
     FastU32BitmapIter, FastU56BitmapIter, FastU64BitmapIter, TrueIdxIter,
@@ -63,6 +64,11 @@ pub struct Bitmap {
     unset_bit_count_cache: AtomicU64,
 }
 
+#[inline(always)]
+fn has_cached_unset_bit_count(ubcc: u64) -> bool {
+    ubcc >> 63 == 0
+}
+
 impl Clone for Bitmap {
     fn clone(&self) -> Self {
         Self {
@@ -117,7 +123,7 @@ impl Bitmap {
             length,
             offset: 0,
             bytes: Arc::new(bytes.into()),
-            unset_bit_count_cache: AtomicU64::new(UNKNOWN_BIT_COUNT),
+            unset_bit_count_cache: AtomicU64::new(if length == 0 { 0 } else { UNKNOWN_BIT_COUNT }),
         })
     }
 
@@ -216,15 +222,12 @@ impl Bitmap {
     /// This function counts the number of unset bits if it is not already
     /// computed. Repeated calls use the cached bitcount.
     pub fn unset_bits(&self) -> usize {
-        let cache = self.unset_bit_count_cache.load(Ordering::Relaxed);
-        if cache >> 63 != 0 {
+        self.lazy_unset_bits().unwrap_or_else(|| {
             let zeros = count_zeros(&self.bytes, self.offset, self.length);
             self.unset_bit_count_cache
                 .store(zeros as u64, Ordering::Relaxed);
             zeros
-        } else {
-            cache as usize
-        }
+        })
     }
 
     /// Returns the number of unset bits on this [`Bitmap`] if it is known.
@@ -232,11 +235,7 @@ impl Bitmap {
     /// Guaranteed to be `<= self.len()`.
     pub fn lazy_unset_bits(&self) -> Option<usize> {
         let cache = self.unset_bit_count_cache.load(Ordering::Relaxed);
-        if cache >> 63 != 0 {
-            None
-        } else {
-            Some(cache as usize)
-        }
+        has_cached_unset_bit_count(cache).then_some(cache as usize)
     }
 
     /// Updates the count of the number of set bits on this [`Bitmap`].
@@ -286,7 +285,7 @@ impl Bitmap {
             return;
         }
 
-        if *unset_bit_count_cache >> 63 == 0 {
+        if has_cached_unset_bit_count(*unset_bit_count_cache) {
             // If we keep all but a small portion of the array it is worth
             // doing an eager re-count since we can reuse the old count via the
             // inclusion-exclusion principle.
@@ -588,5 +587,76 @@ impl From<Bitmap> for arrow_buffer::buffer::NullBuffer {
         let buffer = arrow_buffer::buffer::BooleanBuffer::new(buffer, value.offset, value.length);
         // SAFETY: null count is accurate
         unsafe { arrow_buffer::buffer::NullBuffer::new_unchecked(buffer, null_count) }
+    }
+}
+
+impl Splitable for Bitmap {
+    #[inline(always)]
+    fn check_bound(&self, offset: usize) -> bool {
+        offset <= self.len()
+    }
+
+    unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {
+        let bytes = &self.bytes;
+
+        if offset == 0 {
+            return (Self::new(), self.clone());
+        }
+        if offset == self.len() {
+            return (self.clone(), Self::new());
+        }
+
+        let ubcc = self.unset_bit_count_cache.load(Ordering::Relaxed);
+
+        let lhs_length = offset;
+        let rhs_length = self.length - offset;
+
+        let mut lhs_ubcc = UNKNOWN_BIT_COUNT;
+        let mut rhs_ubcc = UNKNOWN_BIT_COUNT;
+
+        if has_cached_unset_bit_count(ubcc) {
+            if ubcc == 0 {
+                lhs_ubcc = 0;
+                rhs_ubcc = 0;
+            } else if ubcc == self.length as u64 {
+                lhs_ubcc = offset as u64;
+                rhs_ubcc = (self.length - offset) as u64;
+            } else {
+                // If we keep all but a small portion of the array it is worth
+                // doing an eager re-count since we can reuse the old count via the
+                // inclusion-exclusion principle.
+                let small_portion = (self.length / 4).max(32);
+
+                if lhs_length <= rhs_length {
+                    if rhs_length + small_portion >= self.length {
+                        let count = count_zeros(&self.bytes, self.offset, lhs_length) as u64;
+                        lhs_ubcc = count;
+                        rhs_ubcc = ubcc - count;
+                    }
+                } else if lhs_length + small_portion >= self.length {
+                    let count = count_zeros(&self.bytes, self.offset + offset, rhs_length) as u64;
+                    lhs_ubcc = ubcc - count;
+                    rhs_ubcc = count;
+                }
+            }
+        }
+
+        debug_assert!(lhs_ubcc == UNKNOWN_BIT_COUNT || lhs_ubcc <= ubcc);
+        debug_assert!(rhs_ubcc == UNKNOWN_BIT_COUNT || rhs_ubcc <= ubcc);
+
+        (
+            Self {
+                bytes: bytes.clone(),
+                offset: self.offset,
+                length: lhs_length,
+                unset_bit_count_cache: AtomicU64::new(lhs_ubcc),
+            },
+            Self {
+                bytes: bytes.clone(),
+                offset: self.offset + offset,
+                length: rhs_length,
+                unset_bit_count_cache: AtomicU64::new(rhs_ubcc),
+            },
+        )
     }
 }

--- a/crates/polars/tests/it/arrow/array/binview/mod.rs
+++ b/crates/polars/tests/it/arrow/array/binview/mod.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::buffer::Buffer;
+use arrow::datatypes::ArrowDataType;
+
+fn array() -> BinaryViewArrayGeneric<str> {
+    let datatype = ArrowDataType::Utf8View;
+
+    let hello = View::new_from_bytes(b"hello", 0, 0);
+    let there = View::new_from_bytes(b"there", 0, 6);
+    let bye = View::new_from_bytes(b"bye", 1, 0);
+    let excl = View::new_from_bytes(b"!!!", 1, 3);
+    let hello_there = View::new_from_bytes(b"hello there", 1, 0);
+
+    let views = Buffer::from(vec![hello, there, bye, excl, hello_there]);
+    let buffers = Arc::new([
+        Buffer::from(b"hello there".to_vec()),
+        Buffer::from(b"bye!!!".to_vec()),
+    ]);
+    let validity = None;
+
+    BinaryViewArrayGeneric::try_new(datatype, views, buffers, validity).unwrap()
+}
+
+#[test]
+fn split_at() {
+    let (lhs, rhs) = array().split_at(2);
+
+    assert_eq!(lhs.value(0), "hello");
+    assert_eq!(lhs.value(1), "there");
+    assert_eq!(rhs.value(0), "bye");
+    assert_eq!(rhs.value(1), "!!!");
+    assert_eq!(rhs.value(2), "hello there");
+}

--- a/crates/polars/tests/it/arrow/array/boolean/mod.rs
+++ b/crates/polars/tests/it/arrow/array/boolean/mod.rs
@@ -1,15 +1,17 @@
-use arrow::array::{Array, BooleanArray};
+use arrow::array::{Array, BooleanArray, Splitable};
 use arrow::bitmap::Bitmap;
 use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 mod mutable;
 
+fn array() -> BooleanArray {
+    vec![Some(true), None, Some(false)].into_iter().collect()
+}
+
 #[test]
 fn basics() {
-    let data = vec![Some(true), None, Some(false)];
-
-    let array: BooleanArray = data.into_iter().collect();
+    let array = array();
 
     assert_eq!(array.data_type(), &ArrowDataType::Boolean);
 
@@ -36,6 +38,19 @@ fn basics() {
     let array = array.sliced(1, 2);
     assert!(!array.value(0));
     assert!(!array.value(1));
+}
+
+#[test]
+fn split_at() {
+    let (lhs, rhs) = array().split_at(1);
+
+    assert!(lhs.is_valid(0));
+    assert!(!rhs.is_valid(0));
+    assert!(rhs.is_valid(1));
+
+    assert!(lhs.value(0));
+    assert!(!rhs.value(0));
+    assert!(!rhs.value(1));
 }
 
 #[test]

--- a/crates/polars/tests/it/arrow/array/dictionary/mod.rs
+++ b/crates/polars/tests/it/arrow/array/dictionary/mod.rs
@@ -26,6 +26,24 @@ fn try_new_ok() {
 }
 
 #[test]
+fn split_at() {
+    let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
+    let data_type =
+        ArrowDataType::Dictionary(i32::KEY_TYPE, Box::new(values.data_type().clone()), false);
+    let array = DictionaryArray::try_new(
+        data_type,
+        PrimitiveArray::from_vec(vec![1, 0]),
+        values.boxed(),
+    )
+    .unwrap();
+
+    let (lhs, rhs) = array.split_at(1);
+
+    assert_eq!(format!("{lhs:?}"), "DictionaryArray[aa]");
+    assert_eq!(format!("{rhs:?}"), "DictionaryArray[a]");
+}
+
+#[test]
 fn try_new_incorrect_key() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
     let data_type =

--- a/crates/polars/tests/it/arrow/array/fixed_size_list/mod.rs
+++ b/crates/polars/tests/it/arrow/array/fixed_size_list/mod.rs
@@ -34,6 +34,14 @@ fn basics() {
 }
 
 #[test]
+fn split_at() {
+    let (lhs, rhs) = data().split_at(1);
+
+    assert_eq!(lhs.value(0).as_ref(), Int32Array::from_slice([10, 20]));
+    assert_eq!(rhs.value(0).as_ref(), Int32Array::from_slice([0, 0]));
+}
+
+#[test]
 fn with_validity() {
     let array = data();
 

--- a/crates/polars/tests/it/arrow/array/list/mod.rs
+++ b/crates/polars/tests/it/arrow/array/list/mod.rs
@@ -21,6 +21,25 @@ fn debug() {
 }
 
 #[test]
+fn split_at() {
+    let values = Buffer::from(vec![1, 2, 3, 4, 5]);
+    let values = PrimitiveArray::<i32>::new(ArrowDataType::Int32, values, None);
+
+    let data_type = ListArray::<i32>::default_datatype(ArrowDataType::Int32);
+    let array = ListArray::<i32>::new(
+        data_type,
+        vec![0, 2, 2, 3, 5].try_into().unwrap(),
+        Box::new(values),
+        None,
+    );
+
+    let (lhs, rhs) = array.split_at(2);
+
+    assert_eq!(format!("{lhs:?}"), "ListArray[[1, 2], []]");
+    assert_eq!(format!("{rhs:?}"), "ListArray[[3], [4, 5]]");
+}
+
+#[test]
 #[should_panic]
 fn test_nested_panic() {
     let values = Buffer::from(vec![1, 2, 3, 4, 5]);

--- a/crates/polars/tests/it/arrow/array/mod.rs
+++ b/crates/polars/tests/it/arrow/array/mod.rs
@@ -1,4 +1,5 @@
 mod binary;
+mod binview;
 mod boolean;
 mod dictionary;
 mod equal;

--- a/crates/polars/tests/it/arrow/array/primitive/mod.rs
+++ b/crates/polars/tests/it/arrow/array/primitive/mod.rs
@@ -8,11 +8,13 @@ mod fmt;
 mod mutable;
 mod to_mutable;
 
+fn array() -> Int32Array {
+    vec![Some(1), None, Some(10)].into_iter().collect()
+}
+
 #[test]
 fn basics() {
-    let data = vec![Some(1), None, Some(10)];
-
-    let array = Int32Array::from_iter(data);
+    let array = array();
 
     assert_eq!(array.value(0), 1);
     assert_eq!(array.value(1), 0);
@@ -42,6 +44,19 @@ fn basics() {
         assert_eq!(array.value_unchecked(0), 0);
         assert_eq!(array.value_unchecked(1), 10);
     }
+}
+
+#[test]
+fn split_at() {
+    let (lhs, rhs) = array().split_at(1);
+
+    assert!(lhs.is_valid(0));
+    assert!(!rhs.is_valid(0));
+    assert!(rhs.is_valid(1));
+
+    assert_eq!(lhs.value(0), 1);
+    assert_eq!(rhs.value(0), 0);
+    assert_eq!(rhs.value(1), 10);
 }
 
 #[test]

--- a/crates/polars/tests/it/arrow/array/struct_/mod.rs
+++ b/crates/polars/tests/it/arrow/array/struct_/mod.rs
@@ -5,8 +5,7 @@ use arrow::array::*;
 use arrow::bitmap::Bitmap;
 use arrow::datatypes::*;
 
-#[test]
-fn debug() {
+fn array() -> StructArray {
     let boolean = BooleanArray::from_slice([false, false, true, true]).boxed();
     let int = Int32Array::from_slice([42, 28, 19, 31]).boxed();
 
@@ -15,13 +14,31 @@ fn debug() {
         Field::new("c", ArrowDataType::Int32, false),
     ];
 
-    let array = StructArray::new(
+    StructArray::new(
         ArrowDataType::Struct(fields),
         vec![boolean.clone(), int.clone()],
         Some(Bitmap::from([true, true, false, true])),
-    );
+    )
+}
+
+#[test]
+fn debug() {
+    let array = array();
+
     assert_eq!(
         format!("{array:?}"),
         "StructArray[{b: false, c: 42}, {b: false, c: 28}, None, {b: true, c: 31}]"
+    );
+}
+
+#[test]
+fn split_at() {
+    let array = array();
+
+    let (lhs, rhs) = array.split_at(1);
+    assert_eq!(format!("{lhs:?}"), "StructArray[{b: false, c: 42}]");
+    assert_eq!(
+        format!("{rhs:?}"),
+        "StructArray[{b: false, c: 28}, None, {b: true, c: 31}]"
     );
 }

--- a/crates/polars/tests/it/arrow/array/utf8/mod.rs
+++ b/crates/polars/tests/it/arrow/array/utf8/mod.rs
@@ -9,11 +9,15 @@ mod mutable;
 mod mutable_values;
 mod to_mutable;
 
+fn array() -> Utf8Array<i32> {
+    vec![Some("hello"), None, Some("hello2")]
+        .into_iter()
+        .collect()
+}
+
 #[test]
 fn basics() {
-    let data = vec![Some("hello"), None, Some("hello2")];
-
-    let array: Utf8Array<i32> = data.into_iter().collect();
+    let array = array();
 
     assert_eq!(array.value(0), "hello");
     assert_eq!(array.value(1), "");
@@ -43,6 +47,20 @@ fn basics() {
     // note how this keeps everything: the offsets were sliced
     assert_eq!(array.values().as_slice(), b"hellohello2");
     assert_eq!(array.offsets().as_slice(), &[5, 5, 11]);
+}
+
+#[test]
+fn split_at() {
+    let (lhs, rhs) = array().split_at(1);
+
+    assert_eq!(lhs.value(0), "hello");
+    assert_eq!(rhs.value(0), "");
+    assert_eq!(rhs.value(1), "hello2");
+    // note how this keeps everything: the offsets were sliced
+    assert_eq!(lhs.values().as_slice(), b"hellohello2");
+    assert_eq!(rhs.values().as_slice(), b"hellohello2");
+    assert_eq!(lhs.offsets().as_slice(), &[0, 5]);
+    assert_eq!(rhs.offsets().as_slice(), &[5, 5, 11]);
 }
 
 #[test]

--- a/crates/polars/tests/it/arrow/bitmap/mod.rs
+++ b/crates/polars/tests/it/arrow/bitmap/mod.rs
@@ -4,6 +4,7 @@ mod immutable;
 mod mutable;
 mod utils;
 
+use arrow::array::Splitable;
 use arrow::bitmap::Bitmap;
 use proptest::prelude::*;
 
@@ -121,4 +122,16 @@ fn subslicing_gives_correct_null_count() {
 
     let view3 = view2.sliced(0, 1);
     assert_eq!(view3.unset_bits(), 0);
+}
+
+#[test]
+fn split_at() {
+    let bm = create_bitmap([0b01101010], 8);
+
+    let (lhs, rhs) = bm.split_at(5);
+    assert_eq!(
+        &lhs.iter().collect::<Vec<bool>>(),
+        &[false, true, false, true, false]
+    );
+    assert_eq!(&rhs.iter().collect::<Vec<bool>>(), &[true, true, false]);
 }


### PR DESCRIPTION
This adds a `split_at` and `split_at_unchecked` method to each type that implements the `Array` trait. This is done under the `Splitable` trait.