### PR TITLE
chore: Remove duplicate tag in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 *  @ritchie46 @stinodego @c-peters
 
-/crates/  @ritchie46 @stinodego @orlp @orlp @c-peters
+/crates/  @ritchie46 @stinodego @orlp @c-peters
 /crates/polars-sql/  @ritchie46 @stinodego @orlp @c-peters @universalmind303 @alexander-beedie
 /crates/polars-time/  @ritchie46 @stinodego @orlp @c-peters @MarcoGorelli
 /py-polars/  @ritchie46 @stinodego @c-peters @alexander-beedie @MarcoGorelli @reswqa


### PR DESCRIPTION
Fixes a duplicate tag in the CODEOWNERS.