### PR TITLE
depr(python): Rename `dtypes` parameter to `schema_overrides` for `read_csv`/`scan_csv`/`read_csv_batched`

### DIFF
--- a/docs/src/python/user-guide/expressions/aggregation.py
+++ b/docs/src/python/user-guide/expressions/aggregation.py
@@ -6,7 +6,7 @@ import polars as pl
 # --8<-- [start:dataframe]
 url = "https://theunitedstates.io/congress-legislators/legislators-historical.csv"
 
-dtypes = {
+schema_overrides = {
     "first_name": pl.Categorical,
     "gender": pl.Categorical,
     "type": pl.Categorical,
@@ -14,7 +14,7 @@ dtypes = {
     "party": pl.Categorical,
 }
 
-dataset = pl.read_csv(url, dtypes=dtypes).with_columns(
+dataset = pl.read_csv(url, schema_overrides=schema_overrides).with_columns(
     pl.col("birthday").str.to_date(strict=False)
 )
 # --8<-- [end:dataframe]

--- a/py-polars/polars/_utils/deprecation.py
+++ b/py-polars/polars/_utils/deprecation.py
@@ -156,7 +156,7 @@ def _rename_keyword_argument(
             )
             raise TypeError(msg)
         issue_deprecation_warning(
-            f"`the argument {old_name}` for `{func_name}` is deprecated."
+            f"The argument `{old_name}` for `{func_name}` is deprecated."
             f" It has been renamed to `{new_name}`.",
             version=version,
         )

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -35,7 +35,7 @@ class BatchedCsvReader:
         comment_prefix: str | None = None,
         quote_char: str | None = '"',
         skip_rows: int = 0,
-        dtypes: None | (SchemaDict | Sequence[PolarsDataType]) = None,
+        schema_overrides: SchemaDict | Sequence[PolarsDataType] | None = None,
         null_values: str | Sequence[str] | dict[str, str] | None = None,
         missing_utf8_is_empty_string: bool = False,
         ignore_errors: bool = False,
@@ -61,15 +61,15 @@ class BatchedCsvReader:
 
         dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
         dtype_slice: Sequence[PolarsDataType] | None = None
-        if dtypes is not None:
-            if isinstance(dtypes, dict):
+        if schema_overrides is not None:
+            if isinstance(schema_overrides, dict):
                 dtype_list = []
-                for k, v in dtypes.items():
+                for k, v in schema_overrides.items():
                     dtype_list.append((k, py_type_to_dtype(v)))
-            elif isinstance(dtypes, Sequence):
-                dtype_slice = dtypes
+            elif isinstance(schema_overrides, Sequence):
+                dtype_slice = schema_overrides
             else:
-                msg = "`dtypes` arg should be list or dict"
+                msg = "`schema_overrides` arg should be list or dict"
                 raise TypeError(msg)
 
         processed_null_values = _process_null_values(null_values)

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -702,13 +702,22 @@ def _csv_buffer_to_frame(
     if read_options is None:
         read_options = {}
     if schema_overrides:
-        if (csv_dtypes := read_options.get("dtypes", {})) and set(
-            csv_dtypes
-        ).intersection(schema_overrides):
+        csv_dtypes = read_options.get("dtypes", {})
+        if csv_dtypes:
+            issue_deprecation_warning(
+                "The `dtypes` parameter for `read_csv` is deprecated. It has been renamed to `schema_overrides`.",
+                version="0.20.31",
+            )
+        csv_schema_overrides = read_options.get("schema_overrides", csv_dtypes)
+
+        if csv_schema_overrides and set(csv_schema_overrides).intersection(
+            schema_overrides
+        ):
             msg = "cannot specify columns in both `schema_overrides` and `read_options['dtypes']`"
             raise ParameterCollisionError(msg)
+
         read_options = read_options.copy()
-        read_options["dtypes"] = {**csv_dtypes, **schema_overrides}
+        read_options["schema_overrides"] = {**csv_schema_overrides, **schema_overrides}
 
     # otherwise rewind the buffer and parse as csv
     csv.seek(0)

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -75,7 +75,7 @@ def test_read_csv_categorical() -> None:
     f = io.BytesIO()
     f.write(b"col1,col2,col3,col4,col5,col6\n'foo',2,3,4,5,6\n'bar',8,9,10,11,12")
     f.seek(0)
-    df = pl.read_csv(f, has_header=True, dtypes={"col1": pl.Categorical})
+    df = pl.read_csv(f, has_header=True, schema_overrides={"col1": pl.Categorical})
     assert df["col1"].dtype == pl.Categorical
 
 

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -190,7 +190,7 @@ def test_read_csv_decimal(monkeypatch: Any) -> None:
 1.1,a
 0.01,a"""
 
-    df = pl.read_csv(csv.encode(), dtypes={"a": pl.Decimal(scale=2)})
+    df = pl.read_csv(csv.encode(), schema_overrides={"a": pl.Decimal(scale=2)})
     assert df.dtypes == [pl.Decimal(precision=None, scale=2), pl.String]
     assert df["a"].to_list() == [
         D("123.12"),

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -80,7 +80,7 @@ def test_scan_csv_schema_overwrite_and_dtypes_overwrite(
     file_path = io_files_path / file_name
     df = pl.scan_csv(
         file_path,
-        dtypes={"calories_foo": pl.String, "fats_g_foo": pl.Float32},
+        schema_overrides={"calories_foo": pl.String, "fats_g_foo": pl.Float32},
         with_column_names=lambda names: [f"{a}_foo" for a in names],
     ).collect()
     assert df.dtypes == [pl.String, pl.String, pl.Float32, pl.Int64]
@@ -100,7 +100,7 @@ def test_scan_csv_schema_overwrite_and_small_dtypes_overwrite(
     file_path = io_files_path / file_name
     df = pl.scan_csv(
         file_path,
-        dtypes={"calories_foo": pl.String, "sugars_g_foo": dtype},
+        schema_overrides={"calories_foo": pl.String, "sugars_g_foo": dtype},
         with_column_names=lambda names: [f"{a}_foo" for a in names],
     ).collect()
     assert df.dtypes == [pl.String, pl.String, pl.Float64, dtype]
@@ -122,7 +122,7 @@ def test_scan_csv_schema_new_columns_dtypes(
         # assign 'new_columns', providing partial dtype overrides
         df1 = pl.scan_csv(
             file_path,
-            dtypes={"calories": pl.String, "sugars": dtype},
+            schema_overrides={"calories": pl.String, "sugars": dtype},
             new_columns=["category", "calories", "fats", "sugars"],
         ).collect()
         assert df1.dtypes == [pl.String, pl.String, pl.Float64, dtype]
@@ -131,7 +131,7 @@ def test_scan_csv_schema_new_columns_dtypes(
         # assign 'new_columns' with 'dtypes' list
         df2 = pl.scan_csv(
             file_path,
-            dtypes=[pl.String, pl.String, pl.Float64, dtype],
+            schema_overrides=[pl.String, pl.String, pl.Float64, dtype],
             new_columns=["category", "calories", "fats", "sugars"],
         ).collect()
         assert df1.rows() == df2.rows()
@@ -151,7 +151,7 @@ def test_scan_csv_schema_new_columns_dtypes(
     # partially rename columns / overwrite dtypes
     df4 = pl.scan_csv(
         file_path,
-        dtypes=[pl.String, pl.String],
+        schema_overrides=[pl.String, pl.String],
         new_columns=["category", "calories"],
     ).collect()
     assert df4.dtypes == [pl.String, pl.String, pl.Float64, pl.Int64]
@@ -161,7 +161,7 @@ def test_scan_csv_schema_new_columns_dtypes(
     with pytest.raises(pl.ShapeError):
         pl.scan_csv(
             file_path,
-            dtypes=[pl.String, pl.String],
+            schema_overrides=[pl.String, pl.String],
             new_columns=["category", "calories", "c3", "c4", "c5"],
         ).collect()
 
@@ -169,7 +169,7 @@ def test_scan_csv_schema_new_columns_dtypes(
     with pytest.raises(ValueError, match="mutually.exclusive"):
         pl.scan_csv(
             file_path,
-            dtypes=[pl.String, pl.String],
+            schema_overrides=[pl.String, pl.String],
             new_columns=["category", "calories", "fats", "sugars"],
             with_column_names=lambda cols: [col.capitalize() for col in cols],
         ).collect()
@@ -248,7 +248,7 @@ def test_scan_csv_schema_overwrite_not_projected_8483(foods_file_path: Path) -> 
     df = (
         pl.scan_csv(
             foods_file_path,
-            dtypes={"calories": pl.String, "sugars_g": pl.Int8},
+            schema_overrides={"calories": pl.String, "sugars_g": pl.Int8},
         )
         .select(pl.len())
         .collect()

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -386,7 +386,7 @@ def test_schema_overrides(path_xlsx: Path, path_xlsb: Path, path_ods: Path) -> N
     df2 = pl.read_excel(
         path_xlsx,
         sheet_name="test4",
-        read_options={"dtypes": {"cardinality": pl.UInt16}},
+        read_options={"schema_overrides": {"cardinality": pl.UInt16}},
     ).drop_nulls()
 
     assert df2.schema["cardinality"] == pl.UInt16
@@ -398,7 +398,7 @@ def test_schema_overrides(path_xlsx: Path, path_xlsb: Path, path_ods: Path) -> N
         sheet_name="test4",
         schema_overrides={"cardinality": pl.UInt16},
         read_options={
-            "dtypes": {
+            "schema_overrides": {
                 "rows_by_key": pl.Float32,
                 "iter_groups": pl.Float32,
             },
@@ -439,7 +439,7 @@ def test_schema_overrides(path_xlsx: Path, path_xlsb: Path, path_ods: Path) -> N
             path_xlsx,
             sheet_name="test4",
             schema_overrides={"cardinality": pl.UInt16},
-            read_options={"dtypes": {"cardinality": pl.Int32}},
+            read_options={"schema_overrides": {"cardinality": pl.Int32}},
         )
 
     # read multiple sheets in conjunction with 'schema_overrides'

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -41,7 +41,9 @@ def test_scan_csv_overwrite_small_dtypes(
     io_files_path: Path, dtype: pl.DataType
 ) -> None:
     file_path = io_files_path / "foods1.csv"
-    df = pl.scan_csv(file_path, dtypes={"sugars_g": dtype}).collect(streaming=True)
+    df = pl.scan_csv(file_path, schema_overrides={"sugars_g": dtype}).collect(
+        streaming=True
+    )
     assert df.dtypes == [pl.String, pl.Int64, pl.Float64, dtype]
 
 


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/15431

This functionality is called `schema_overrides` everywhere except in the CSV reading functions. This improves the consistency.

The parameter for `csv` is slightly since it accepts a _list_ of data types, but I think that still qualifies as a schema override.