### PR TITLE
feat: Support per-column `nulls_last` on sort operations

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
@@ -35,8 +35,14 @@ pub fn _arg_bottom_k(
     sort_options: &mut SortMultipleOptions,
 ) -> PolarsResult<NoNull<IdxCa>> {
     let from_n_rows = by_column[0].len();
-    _broadcast_descending(by_column.len(), &mut sort_options.descending);
-    let encoded = _get_rows_encoded(by_column, &sort_options.descending, sort_options.nulls_last)?;
+    _broadcast_bools(by_column.len(), &mut sort_options.descending);
+    _broadcast_bools(by_column.len(), &mut sort_options.nulls_last);
+
+    let encoded = _get_rows_encoded(
+        by_column,
+        &sort_options.descending,
+        &sort_options.nulls_last,
+    )?;
     let arr = encoded.into_array();
     let mut rows = arr
         .values_iter()

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -177,7 +177,7 @@ mod test {
 
             let out = df.sort(
                 ["cat", "vals"],
-                SortMultipleOptions::default().with_order_descendings([false, false]),
+                SortMultipleOptions::default().with_order_descending_multi([false, false]),
             )?;
             let out = out.column("cat")?;
             let cat = out.categorical()?;
@@ -185,7 +185,7 @@ mod test {
 
             let out = df.sort(
                 ["vals", "cat"],
-                SortMultipleOptions::default().with_order_descendings([false, false]),
+                SortMultipleOptions::default().with_order_descending_multi([false, false]),
             )?;
             let out = out.column("cat")?;
             let cat = out.categorical()?;

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1773,8 +1773,8 @@ impl DataFrame {
         mut sort_options: SortMultipleOptions,
         slice: Option<(i64, usize)>,
     ) -> PolarsResult<Self> {
-        // note that the by_column argument also contains evaluated expression from polars-lazy
-        // that may not even be present in this dataframe.
+        // note that the by_column argument also contains evaluated expression from
+        // polars-lazy that may not even be present in this dataframe.
 
         // therefore when we try to set the first columns as sorted, we ignore the error
         // as expressions are not present (they are renamed to _POLARS_SORT_COLUMN_i.
@@ -1782,9 +1782,8 @@ impl DataFrame {
         let first_by_column = by_column[0].name().to_string();
 
         let set_sorted = |df: &mut DataFrame| {
-            // Mark the first sort column as sorted
-            // if the column did not exists it is ok, because we sorted by an expression
-            // not present in the dataframe
+            // Mark the first sort column as sorted; if the column does not exist it
+            // is ok, because we sorted by an expression not present in the dataframe
             let _ = df.apply(&first_by_column, |s| {
                 let mut s = s.clone();
                 if first_descending {
@@ -1795,14 +1794,11 @@ impl DataFrame {
                 s
             });
         };
-
         if self.is_empty() {
             let mut out = self.clone();
             set_sorted(&mut out);
-
             return Ok(out);
         }
-
         if let Some((0, k)) = slice {
             return self.bottom_k_impl(k, by_column, sort_options);
         }
@@ -1824,7 +1820,7 @@ impl DataFrame {
                 let s = &by_column[0];
                 let options = SortOptions {
                     descending: sort_options.descending[0],
-                    nulls_last: sort_options.nulls_last,
+                    nulls_last: sort_options.nulls_last[0],
                     multithreaded: sort_options.multithreaded,
                     maintain_order: sort_options.maintain_order,
                 };
@@ -1836,13 +1832,12 @@ impl DataFrame {
                     if let Some((offset, len)) = slice {
                         out = out.slice(offset, len);
                     }
-
                     return Ok(out.into_frame());
                 }
                 s.arg_sort(options)
             },
             _ => {
-                if sort_options.nulls_last
+                if sort_options.nulls_last.iter().all(|&x| x)
                     || has_struct
                     || std::env::var("POLARS_ROW_FMT_SORT").is_ok()
                 {
@@ -1899,7 +1894,7 @@ impl DataFrame {
     ///     df.sort(
     ///         &["sepal_width", "sepal_length"],
     ///         SortMultipleOptions::new()
-    ///             .with_order_descendings([false, true])
+    ///             .with_order_descending_multi([false, true])
     ///     )
     /// }
     /// ```

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -315,13 +315,13 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
         let df = self.0.clone().unnest();
 
-        let desc = if options.descending {
-            vec![true; df.width()]
-        } else {
-            vec![false; df.width()]
-        };
+        let n_cols = df.width();
+        let desc = vec![options.descending; n_cols];
+        let last = vec![options.nulls_last; n_cols];
 
-        let multi_options = SortMultipleOptions::from(&options).with_order_descendings(desc);
+        let multi_options = SortMultipleOptions::from(&options)
+            .with_order_descending_multi(desc)
+            .with_nulls_last_multi(last);
 
         let out = df.sort_impl(df.columns.clone(), multi_options, None)?;
         Ok(StructChunked::new_unchecked(self.name(), &out.columns).into_series())

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -292,7 +292,7 @@ impl LazyFrame {
     ///     df.lazy().sort(
     ///         &["sepal_width", "sepal_length"],
     ///         SortMultipleOptions::new()
-    ///             .with_order_descendings([false, true])
+    ///             .with_order_descending_multi([false, true])
     ///     )
     /// }
     /// ```

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1036,7 +1036,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
         .lazy()
         .select([arg_sort_by(
             [col("int"), col("flt")],
-            SortMultipleOptions::default().with_order_descendings([true, false]),
+            SortMultipleOptions::default().with_order_descending_multi([true, false]),
         )])
         .collect()?;
 
@@ -1054,7 +1054,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
         .lazy()
         .select([arg_sort_by(
             [col("str"), col("flt")],
-            SortMultipleOptions::default().with_order_descendings([true, false]),
+            SortMultipleOptions::default().with_order_descending_multi([true, false]),
         )])
         .collect()?;
     Ok(())

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -104,7 +104,7 @@ fn test_streaming_multiple_keys_aggregate() -> PolarsResult<()> {
         ])
         .sort_by_exprs(
             [col("sugars_g"), col("calories")],
-            SortMultipleOptions::default().with_order_descendings([false, false]),
+            SortMultipleOptions::default().with_order_descending_multi([false, false]),
         );
 
     assert_streaming_with_default(q, true, false);

--- a/crates/polars-lazy/src/tests/tpch.rs
+++ b/crates/polars-lazy/src/tests/tpch.rs
@@ -79,7 +79,7 @@ fn test_q2() -> PolarsResult<()> {
         .sort_by_exprs(
             [cols(["s_acctbal", "n_name", "s_name", "p_partkey"])],
             SortMultipleOptions::default()
-                .with_order_descendings([true, false, false, false])
+                .with_order_descending_multi([true, false, false, false])
                 .with_maintain_order(true),
         )
         .limit(100)

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -75,8 +75,12 @@ pub trait SeriesMethods: SeriesSealed {
         // for struct types we row-encode and recurse
         #[cfg(feature = "dtype-struct")]
         if matches!(s.dtype(), DataType::Struct(_)) {
-            let encoded =
-                _get_rows_encoded_ca("", &[s.clone()], &[options.descending], options.nulls_last)?;
+            let encoded = _get_rows_encoded_ca(
+                "",
+                &[s.clone()],
+                &[options.descending],
+                &[options.nulls_last],
+            )?;
             return encoded.into_series().is_sorted(options);
         }
 

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -207,7 +207,7 @@ impl Sink for SortSink {
                 dist,
                 self.sort_idx,
                 self.sort_options.descending[0],
-                self.sort_options.nulls_last,
+                self.sort_options.nulls_last[0],
                 self.slice,
                 context.verbose,
                 self.mem_track.clone(),

--- a/crates/polars-plan/src/logical_plan/alp/tree_format.rs
+++ b/crates/polars-plan/src/logical_plan/alp/tree_format.rs
@@ -52,11 +52,10 @@ impl fmt::Display for TreeFmtAExpr<'_> {
                 for i in &sort_options.descending {
                     write!(f, "{}", *i as u8)?;
                 }
-                write!(
-                    f,
-                    "{}{}",
-                    sort_options.nulls_last as u8, sort_options.multithreaded as u8
-                )?;
+                for i in &sort_options.nulls_last {
+                    write!(f, "{}", *i as u8)?;
+                }
+                write!(f, "{}", sort_options.multithreaded as u8)?;
                 return Ok(());
             },
             AExpr::Filter { .. } => "filter",

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -865,7 +865,7 @@ impl SQLContext {
         Ok(lf.sort_by_exprs(
             &by,
             SortMultipleOptions::default()
-                .with_order_descendings(descending)
+                .with_order_descending_multi(descending)
                 .with_maintain_order(true),
         ))
     }

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1143,7 +1143,7 @@ impl SQLFunctionVisitor<'_> {
                 cumulative_f(
                     e.sort_by(
                         &order_by,
-                        SortMultipleOptions::default().with_order_descendings(desc.clone()),
+                        SortMultipleOptions::default().with_order_descending_multi(desc.clone()),
                     ),
                     false,
                 )

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -851,7 +851,7 @@ impl SQLExprVisitor<'_> {
             let (order_by, descending) = self.visit_order_by(order_by)?;
             base = base.sort_by(
                 order_by,
-                SortMultipleOptions::default().with_order_descendings(descending),
+                SortMultipleOptions::default().with_order_descending_multi(descending),
             );
         }
         if let Some(limit) = &expr.limit {

--- a/crates/polars-sql/tests/ops_distinct_on.rs
+++ b/crates/polars-sql/tests/ops_distinct_on.rs
@@ -16,22 +16,22 @@ fn test_distinct_on() {
 
     ctx.register("df", df.clone());
     let sql = r#"
-  SELECT DISTINCT ON ("Name")
-      "Name",
-      "Record Date",
-      "Score"
-  FROM
-      df
-  ORDER BY
-      "Name",
-      "Record Date" DESC;"#;
+      SELECT DISTINCT ON ("Name")
+          "Name",
+          "Record Date",
+          "Score"
+      FROM
+          df
+      ORDER BY
+          "Name",
+          "Record Date" DESC;"#;
     let lf = ctx.execute(sql).unwrap();
     let actual = lf.collect().unwrap();
     let expected = df
         .sort_by_exprs(
             vec![col("Name"), col("Record Date")],
             SortMultipleOptions::default()
-                .with_order_descendings([false, true])
+                .with_order_descending_multi([false, true])
                 .with_maintain_order(true),
         )
         .group_by_stable(vec![col("Name")])

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -560,7 +560,7 @@ fn test_group_by_2() -> PolarsResult<()> {
         ])
         .sort_by_exprs(
             vec![col("count"), col("category")],
-            SortMultipleOptions::default().with_order_descendings([false, true]),
+            SortMultipleOptions::default().with_order_descending_multi([false, true]),
         )
         .limit(2);
     let expected = expected.collect()?;

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -485,6 +485,23 @@ def _polars_warn(msg: str, category: type[Warning] = UserWarning) -> None:
     )
 
 
+def extend_bool(
+    value: bool | Sequence[bool],
+    n_match: int,
+    value_name: str,
+    match_name: str,
+) -> Sequence[bool]:
+    """Ensure the given bool or sequence of bools is the correct length."""
+    values = [value] * n_match if isinstance(value, bool) else value
+    if n_match != len(values):
+        msg = (
+            f"the length of `{value_name}` ({len(values)}) "
+            f"does not match the length of `{match_name}` ({n_match})"
+        )
+        raise ValueError(msg)
+    return values
+
+
 def in_terminal_that_supports_colour() -> bool:
     """
     Determine (within reason) if we are in an interactive terminal that supports color.

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4546,7 +4546,7 @@ class DataFrame:
         by: IntoExpr | Iterable[IntoExpr],
         *more_by: IntoExpr,
         descending: bool | Sequence[bool] = False,
-        nulls_last: bool = False,
+        nulls_last: bool | Sequence[bool] = False,
         multithreaded: bool = True,
         maintain_order: bool = False,
     ) -> DataFrame:
@@ -4564,7 +4564,8 @@ class DataFrame:
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
         nulls_last
-            Place null values last.
+            Place null values last; can specify a single boolean applying to all columns
+            or a sequence of booleans for per-column control.
         multithreaded
             Sort using multiple threads.
         maintain_order
@@ -4750,7 +4751,7 @@ class DataFrame:
         *,
         by: IntoExpr | Iterable[IntoExpr],
         descending: bool | Sequence[bool] = False,
-        nulls_last: bool | None = None,
+        nulls_last: bool | Sequence[bool] | None = None,
         maintain_order: bool | None = None,
     ) -> DataFrame:
         """
@@ -4851,7 +4852,7 @@ class DataFrame:
         *,
         by: IntoExpr | Iterable[IntoExpr],
         descending: bool | Sequence[bool] = False,
-        nulls_last: bool | None = None,
+        nulls_last: bool | Sequence[bool] | None = None,
         maintain_order: bool | None = None,
     ) -> DataFrame:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -44,6 +44,7 @@ from polars._utils.parse_expr_input import (
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     BUILDING_SPHINX_DOCS,
+    extend_bool,
     find_stacklevel,
     no_default,
     normalize_filepath,
@@ -2155,7 +2156,7 @@ class Expr:
         k: int | IntoExprColumn = 5,
         *,
         descending: bool | Sequence[bool] = False,
-        nulls_last: bool | None = None,
+        nulls_last: bool | Sequence[bool] | None = None,
         maintain_order: bool | None = None,
         multithreaded: bool | None = None,
     ) -> Self:
@@ -2319,11 +2320,8 @@ class Expr:
 
         k = parse_as_expression(k)
         by = parse_as_list_of_expressions(by)
-        if isinstance(descending, bool):
-            descending = [descending]
-        elif len(by) != len(descending):
-            msg = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
-            raise ValueError(msg)
+        descending = extend_bool(descending, len(by), "descending", "by")
+        nulls_last = extend_bool(nulls_last, len(by), "nulls_last", "by")
         return self._from_pyexpr(
             self._pyexpr.top_k_by(
                 k,
@@ -2454,7 +2452,7 @@ class Expr:
         k: int | IntoExprColumn = 5,
         *,
         descending: bool | Sequence[bool] = False,
-        nulls_last: bool | None = None,
+        nulls_last: bool | Sequence[bool] | None = None,
         maintain_order: bool | None = None,
         multithreaded: bool | None = None,
     ) -> Self:
@@ -2613,11 +2611,8 @@ class Expr:
 
         k = parse_as_expression(k)
         by = parse_as_list_of_expressions(by)
-        if isinstance(descending, bool):
-            descending = [descending]
-        elif len(by) != len(descending):
-            msg = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
-            raise ValueError(msg)
+        descending = extend_bool(descending, len(by), "descending", "by")
+        nulls_last = extend_bool(nulls_last, len(by), "nulls_last", "by")
         return self._from_pyexpr(
             self._pyexpr.bottom_k_by(
                 k,
@@ -2780,7 +2775,7 @@ class Expr:
         by: IntoExpr | Iterable[IntoExpr],
         *more_by: IntoExpr,
         descending: bool | Sequence[bool] = False,
-        nulls_last: bool = False,
+        nulls_last: bool | Sequence[bool] = False,
         multithreaded: bool = True,
         maintain_order: bool = False,
     ) -> Self:
@@ -2801,7 +2796,8 @@ class Expr:
             Sort in descending order. When sorting by multiple columns, can be specified
             per column by passing a sequence of booleans.
         nulls_last
-            Place null values last.
+            Place null values last; can specify a single boolean applying to all columns
+            or a sequence of booleans for per-column control.
         multithreaded
             Sort using multiple threads.
         maintain_order
@@ -2908,11 +2904,8 @@ class Expr:
         └───────┴────────┴────────┘
         """
         by = parse_as_list_of_expressions(by, *more_by)
-        if isinstance(descending, bool):
-            descending = [descending]
-        elif len(by) != len(descending):
-            msg = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
-            raise ValueError(msg)
+        descending = extend_bool(descending, len(by), "descending", "by")
+        nulls_last = extend_bool(nulls_last, len(by), "nulls_last", "by")
         return self._from_pyexpr(
             self._pyexpr.sort_by(
                 by, descending, nulls_last, multithreaded, maintain_order

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -16,6 +16,7 @@ from polars._utils.parse_expr_input import (
     parse_as_list_of_expressions,
 )
 from polars._utils.unstable import issue_unstable_warning, unstable
+from polars._utils.various import extend_bool
 from polars._utils.wrap import wrap_df, wrap_expr
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Datetime, Int64, UInt32
 
@@ -1640,7 +1641,7 @@ def arg_sort_by(
     exprs: IntoExpr | Iterable[IntoExpr],
     *more_exprs: IntoExpr,
     descending: bool | Sequence[bool] = False,
-    nulls_last: bool = False,
+    nulls_last: bool | Sequence[bool] = False,
     multithreaded: bool = True,
     maintain_order: bool = False,
 ) -> Expr:
@@ -1725,12 +1726,8 @@ def arg_sort_by(
     └─────┘
     """
     exprs = parse_as_list_of_expressions(exprs, *more_exprs)
-
-    if isinstance(descending, bool):
-        descending = [descending] * len(exprs)
-    elif len(exprs) != len(descending):
-        msg = f"the length of `descending` ({len(descending)}) does not match the length of `exprs` ({len(exprs)})"
-        raise ValueError(msg)
+    descending = extend_bool(descending, len(exprs), "descending", "exprs")
+    nulls_last = extend_bool(nulls_last, len(exprs), "nulls_last", "exprs")
     return wrap_expr(
         plr.arg_sort_by(exprs, descending, nulls_last, multithreaded, maintain_order)
     )

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -312,7 +312,7 @@ impl PyExpr {
         k: Self,
         by: Vec<Self>,
         descending: Vec<bool>,
-        nulls_last: bool,
+        nulls_last: Vec<bool>,
         maintain_order: bool,
         multithreaded: bool,
     ) -> Self {
@@ -358,7 +358,7 @@ impl PyExpr {
         k: Self,
         by: Vec<Self>,
         descending: Vec<bool>,
-        nulls_last: bool,
+        nulls_last: Vec<bool>,
         maintain_order: bool,
         multithreaded: bool,
     ) -> Self {
@@ -415,7 +415,7 @@ impl PyExpr {
         &self,
         by: Vec<Self>,
         descending: Vec<bool>,
-        nulls_last: bool,
+        nulls_last: Vec<bool>,
         multithreaded: bool,
         maintain_order: bool,
     ) -> Self {

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -61,7 +61,7 @@ pub fn rolling_cov(
 pub fn arg_sort_by(
     by: Vec<PyExpr>,
     descending: Vec<bool>,
-    nulls_last: bool,
+    nulls_last: Vec<bool>,
     multithreaded: bool,
     maintain_order: bool,
 ) -> PyExpr {

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -494,7 +494,7 @@ impl PyLazyFrame {
             [by_column],
             SortMultipleOptions {
                 descending: vec![descending],
-                nulls_last,
+                nulls_last: vec![nulls_last],
                 multithreaded,
                 maintain_order,
             },
@@ -506,7 +506,7 @@ impl PyLazyFrame {
         &self,
         by: Vec<PyExpr>,
         descending: Vec<bool>,
-        nulls_last: bool,
+        nulls_last: Vec<bool>,
         maintain_order: bool,
         multithreaded: bool,
     ) -> Self {
@@ -529,7 +529,7 @@ impl PyLazyFrame {
         k: IdxSize,
         by: Vec<PyExpr>,
         descending: Vec<bool>,
-        nulls_last: bool,
+        nulls_last: Vec<bool>,
         maintain_order: bool,
         multithreaded: bool,
     ) -> Self {
@@ -553,7 +553,7 @@ impl PyLazyFrame {
         k: IdxSize,
         by: Vec<PyExpr>,
         descending: Vec<bool>,
-        nulls_last: bool,
+        nulls_last: Vec<bool>,
         maintain_order: bool,
         multithreaded: bool,
     ) -> Self {

--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -308,7 +308,7 @@ pub struct SortBy {
     by: Vec<usize>,
     #[pyo3(get)]
     /// maintain_order, nulls_last, descending
-    sort_options: (bool, bool, Vec<bool>),
+    sort_options: (bool, Vec<bool>, Vec<bool>),
 }
 
 #[pyclass]
@@ -594,7 +594,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
             by: by.iter().map(|n| n.0).collect(),
             sort_options: (
                 sort_options.maintain_order,
-                sort_options.nulls_last,
+                sort_options.nulls_last.clone(),
                 sort_options.descending.clone(),
             ),
         }

--- a/py-polars/src/lazyframe/visitor/nodes.rs
+++ b/py-polars/src/lazyframe/visitor/nodes.rs
@@ -141,7 +141,7 @@ pub struct Sort {
     #[pyo3(get)]
     by_column: Vec<PyExprIR>,
     #[pyo3(get)]
-    sort_options: (bool, bool, Vec<bool>),
+    sort_options: (bool, Vec<bool>, Vec<bool>),
     #[pyo3(get)]
     slice: Option<(i64, usize)>,
 }
@@ -360,7 +360,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             by_column: by_column.iter().map(|e| e.into()).collect(),
             sort_options: (
                 sort_options.maintain_order,
-                sort_options.nulls_last,
+                sort_options.nulls_last.clone(),
                 sort_options.descending.clone(),
             ),
             slice: *slice,

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -735,13 +735,19 @@ def test_struct_concat_self_no_rechunk() -> None:
 
 
 def test_sort_structs() -> None:
-    assert pl.DataFrame(
-        {"sex": ["male", "female", "female"], "age": [22, 38, 26]}
-    ).select(pl.struct(["sex", "age"]).sort()).unnest("sex").to_dict(
-        as_series=False
-    ) == {
-        "sex": ["female", "female", "male"],
-        "age": [26, 38, 22],
+    df = pl.DataFrame(
+        {
+            "sex": ["m", "f", "f", "f", "m", "m", "f"],
+            "age": [22, 38, 26, 24, 21, 46, 22],
+        },
+    )
+    df_sorted_as_struct = df.select(pl.struct(["sex", "age"]).sort()).unnest("sex")
+    df_expected = df.sort(by=["sex", "age"])
+
+    assert_frame_equal(df_expected, df_sorted_as_struct)
+    assert df_sorted_as_struct.to_dict(as_series=False) == {
+        "sex": ["f", "f", "f", "f", "m", "m", "m"],
+        "age": [22, 24, 26, 38, 21, 22, 46],
     }
 
 


### PR DESCRIPTION
Fun one... started looking at implementing `NULLS FIRST` and `NULLS LAST` for the SQL interface, and needed to extend the core `sort` "nulls_last" parameter so that (like "descending") it can take per-column values.

* This PR updates `SortMultipleOptions` and all related sort functions to handle multi-value "nulls_last". 
* Once #16635 merges I'll add the SQL implementation.

## Examples

```python
import polars

df = pl.DataFrame({"x": [None, 1, None, 3], "y": [3, 2, None, 1]})
# shape: (4, 2)
# ┌──────┬──────┐
# │ x    ┆ y    │
# │ ---  ┆ ---  │
# │ i64  ┆ i64  │
# ╞══════╪══════╡
# │ null ┆ 3    │
# │ 1    ┆ 2    │
# │ null ┆ null │
# │ 3    ┆ 1    │
# └──────┴──────┘

df.sort("x", "y", nulls_last=True)
# shape: (4, 2)
# ┌──────┬──────┐
# │ x    ┆ y    │
# │ ---  ┆ ---  │
# │ i64  ┆ i64  │
# ╞══════╪══════╡
# │ 1    ┆ 2    │
# │ 3    ┆ 1    │
# │ null ┆ 3    │
# │ null ┆ null │
# └──────┴──────┘

df.sort("x", "y", nulls_last=False)
# shape: (4, 2)
# ┌──────┬──────┐
# │ x    ┆ y    │
# │ ---  ┆ ---  │
# │ i64  ┆ i64  │
# ╞══════╪══════╡
# │ null ┆ null │
# │ null ┆ 3    │
# │ 1    ┆ 2    │
# │ 3    ┆ 1    │
# └──────┴──────┘

df.sort("x", "y", nulls_last=[False,True])
# shape: (4, 2)
# ┌──────┬──────┐
# │ x    ┆ y    │
# │ ---  ┆ ---  │
# │ i64  ┆ i64  │
# ╞══════╪══════╡
# │ null ┆ 3    │
# │ null ┆ null │
# │ 1    ┆ 2    │
# │ 3    ┆ 1    │
# └──────┴──────┘

df.sort("x", "y", nulls_last=[True,False])
# shape: (4, 2)
# ┌──────┬──────┐
# │ x    ┆ y    │
# │ ---  ┆ ---  │
# │ i64  ┆ i64  │
# ╞══════╪══════╡
# │ 1    ┆ 2    │
# │ 3    ┆ 1    │
# │ null ┆ null │
# │ null ┆ 3    │
# └──────┴──────┘
```