### PR TITLE
feat!: change default of `offset` in group_by_dynamic from "negative `every`" to "zero"

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5815,7 +5815,7 @@ class DataFrame:
             length of the window, if None it will equal 'every'
         offset
             offset of the window, does not take effect if `start_by` is 'datapoint'.
-            Defaults to negative `every`.
+            Defaults to zero.
         truncate
             truncate the time value to the window lower bound
 
@@ -6006,13 +6006,12 @@ class DataFrame:
         When closed="both" the time values at the window boundaries belong to 2 groups.
 
         >>> df.group_by_dynamic("time", every="1h", closed="both").agg(pl.col("n"))
-        shape: (5, 2)
+        shape: (4, 2)
         ┌─────────────────────┬───────────┐
         │ time                ┆ n         │
         │ ---                 ┆ ---       │
         │ datetime[μs]        ┆ list[i64] │
         ╞═════════════════════╪═══════════╡
-        │ 2021-12-15 23:00:00 ┆ [0]       │
         │ 2021-12-16 00:00:00 ┆ [0, 1, 2] │
         │ 2021-12-16 01:00:00 ┆ [2, 3, 4] │
         │ 2021-12-16 02:00:00 ┆ [4, 5, 6] │
@@ -6044,13 +6043,12 @@ class DataFrame:
         ...     group_by="groups",
         ...     include_boundaries=True,
         ... ).agg(pl.col("n"))
-        shape: (7, 5)
+        shape: (6, 5)
         ┌────────┬─────────────────────┬─────────────────────┬─────────────────────┬───────────┐
         │ groups ┆ _lower_boundary     ┆ _upper_boundary     ┆ time                ┆ n         │
         │ ---    ┆ ---                 ┆ ---                 ┆ ---                 ┆ ---       │
         │ str    ┆ datetime[μs]        ┆ datetime[μs]        ┆ datetime[μs]        ┆ list[i64] │
         ╞════════╪═════════════════════╪═════════════════════╪═════════════════════╪═══════════╡
-        │ a      ┆ 2021-12-15 23:00:00 ┆ 2021-12-16 00:00:00 ┆ 2021-12-15 23:00:00 ┆ [0]       │
         │ a      ┆ 2021-12-16 00:00:00 ┆ 2021-12-16 01:00:00 ┆ 2021-12-16 00:00:00 ┆ [0, 1, 2] │
         │ a      ┆ 2021-12-16 01:00:00 ┆ 2021-12-16 02:00:00 ┆ 2021-12-16 01:00:00 ┆ [2]       │
         │ a      ┆ 2021-12-16 02:00:00 ┆ 2021-12-16 03:00:00 ┆ 2021-12-16 02:00:00 ┆ [5, 6]    │
@@ -11030,7 +11028,7 @@ class DataFrame:
             length of the window, if None it will equal 'every'
         offset
             offset of the window, only takes effect if `start_by` is `'window'`.
-            Defaults to negative `every`.
+            Defaults to zero.
         truncate
             truncate the time value to the window lower bound
         include_boundaries

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3476,7 +3476,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             length of the window, if None it will equal 'every'
         offset
             offset of the window, does not take effect if `start_by` is 'datapoint'.
-            Defaults to negative `every`.
+            Defaults to zero.
         truncate
             truncate the time value to the window lower bound
 
@@ -3673,13 +3673,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         >>> lf.group_by_dynamic("time", every="1h", closed="both").agg(
         ...     pl.col("n")
         ... ).collect()
-        shape: (5, 2)
+        shape: (4, 2)
         ┌─────────────────────┬───────────┐
         │ time                ┆ n         │
         │ ---                 ┆ ---       │
         │ datetime[μs]        ┆ list[i64] │
         ╞═════════════════════╪═══════════╡
-        │ 2021-12-15 23:00:00 ┆ [0]       │
         │ 2021-12-16 00:00:00 ┆ [0, 1, 2] │
         │ 2021-12-16 01:00:00 ┆ [2, 3, 4] │
         │ 2021-12-16 02:00:00 ┆ [4, 5, 6] │
@@ -3711,13 +3710,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     group_by="groups",
         ...     include_boundaries=True,
         ... ).agg(pl.col("n")).collect()
-        shape: (7, 5)
+        shape: (6, 5)
         ┌────────┬─────────────────────┬─────────────────────┬─────────────────────┬───────────┐
         │ groups ┆ _lower_boundary     ┆ _upper_boundary     ┆ time                ┆ n         │
         │ ---    ┆ ---                 ┆ ---                 ┆ ---                 ┆ ---       │
         │ str    ┆ datetime[μs]        ┆ datetime[μs]        ┆ datetime[μs]        ┆ list[i64] │
         ╞════════╪═════════════════════╪═════════════════════╪═════════════════════╪═══════════╡
-        │ a      ┆ 2021-12-15 23:00:00 ┆ 2021-12-16 00:00:00 ┆ 2021-12-15 23:00:00 ┆ [0]       │
         │ a      ┆ 2021-12-16 00:00:00 ┆ 2021-12-16 01:00:00 ┆ 2021-12-16 00:00:00 ┆ [0, 1, 2] │
         │ a      ┆ 2021-12-16 01:00:00 ┆ 2021-12-16 02:00:00 ┆ 2021-12-16 01:00:00 ┆ [2]       │
         │ a      ┆ 2021-12-16 02:00:00 ┆ 2021-12-16 03:00:00 ┆ 2021-12-16 02:00:00 ┆ [5, 6]    │
@@ -3769,7 +3767,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         index_column = parse_as_expression(index_column)
         if offset is None:
-            offset = negate_duration_string(parse_as_duration_string(every))
+            offset = "0ns"
 
         if period is None:
             period = every
@@ -6542,7 +6540,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             length of the window, if None it will equal 'every'
         offset
             offset of the window, does not take effect if `start_by` is 'datapoint'.
-            Defaults to negative `every`.
+            Defaults to zero.
         truncate
             truncate the time value to the window lower bound
         include_boundaries

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -503,10 +503,10 @@ def test_group_by_dynamic_flat_agg_4814() -> None:
             (pl.col("b") / pl.col("a")).last().alias("last_ratio_2"),
         ]
     ).to_dict(as_series=False) == {
-        "a": [0, 1, 2],
-        "sum_ratio_1": [1.0, 4.2, 5.0],
-        "last_ratio_1": [1.0, 6.0, 6.0],
-        "last_ratio_2": [1.0, 6.0, 6.0],
+        "a": [1, 2],
+        "sum_ratio_1": [4.2, 5.0],
+        "last_ratio_1": [6.0, 6.0],
+        "last_ratio_2": [6.0, 6.0],
     }
 
 
@@ -543,7 +543,7 @@ def test_group_by_dynamic_overlapping_groups_flat_apply_multiple_5038(
         .to_dict(as_series=False)
     )
 
-    assert res["corr"] == pytest.approx([9.148920923684765])
+    assert res["corr"] == pytest.approx([6.988674024215477])
     assert res["a"] == [None]
 
 

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -333,11 +333,11 @@ def test_rolling_kernels_group_by_dynamic_7548() -> None:
         pl.col("value").max().alias("max_value"),
         pl.col("value").sum().alias("sum_value"),
     ).to_dict(as_series=False) == {
-        "time": [-1, 0, 1, 2, 3],
-        "value": [[0, 1], [0, 1, 2], [1, 2, 3], [2, 3], [3]],
-        "min_value": [0, 0, 1, 2, 3],
-        "max_value": [1, 2, 3, 3, 3],
-        "sum_value": [1, 3, 6, 5, 3],
+        "time": [0, 1, 2, 3],
+        "value": [[0, 1, 2], [1, 2, 3], [2, 3], [3]],
+        "min_value": [0, 1, 2, 3],
+        "max_value": [2, 3, 3, 3],
+        "sum_value": [3, 6, 5, 3],
     }
 
 
@@ -423,11 +423,10 @@ def test_group_by_dynamic_elementwise_following_mean_agg_6904(
         pl.DataFrame(
             {
                 "a": [
-                    datetime(2020, 12, 31, 23, 59, 50),
                     datetime(2021, 1, 1, 0, 0),
                     datetime(2021, 1, 1, 0, 0, 10),
                 ],
-                "c": [0.9092974268256817, 0.9092974268256817, -0.7568024953079282],
+                "c": [0.9092974268256817, -0.7568024953079282],
             }
         ).with_columns(pl.col("a").dt.replace_time_zone(time_zone)),
     )
@@ -585,9 +584,8 @@ def test_truncate_negative_offset(tzinfo: ZoneInfo | None) -> None:
             "idx", every="2i", period="3i", include_boundaries=True
         ).agg(pl.col("A"))
 
-        assert out.shape == (4, 4)
+        assert out.shape == (3, 4)
         assert out["A"].to_list() == [
-            ["A"],
             ["A", "A", "B"],
             ["B", "B", "B"],
             ["B", "C"],
@@ -613,14 +611,13 @@ def test_groupy_by_dynamic_median_10695() -> None:
         period="3m",
     ).agg(pl.col("foo").median()).to_dict(as_series=False) == {
         "timestamp": [
-            datetime(2023, 8, 22, 15, 43),
             datetime(2023, 8, 22, 15, 44),
             datetime(2023, 8, 22, 15, 45),
             datetime(2023, 8, 22, 15, 46),
             datetime(2023, 8, 22, 15, 47),
             datetime(2023, 8, 22, 15, 48),
         ],
-        "foo": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+        "foo": [1.0, 1.0, 1.0, 1.0, 1.0],
     }
 
 


### PR DESCRIPTION
This may be a 2.0 or 3.0 change, just wanted to get something started anyway and see the impact

## Background

Currently, the start of the first window in `group_by_dynamic` is determined as follows:
1) take the earliest datapoint
2) truncate it by `every`
3) apply `offset`
4) shift the window backwards by `offset` until the earliest datapoint is in or in front of it
5) empty windows are skipped

The for typical case (where `every == period`), steps 5 and 3 cancel each other out, and the "offset defaults to negative every" just makes the logic harder to teach and understand. I think that the "negative every" default was originally introduced because at first there was no step 4). Now that step 4) exists, then defaulting to `-every` is no longer necessary to ensure that the earliest datapoint is included in at least one window.

## Impact

**For the "base case" (where period == every), this makes no difference**

The only case when changing the default of `offset` makes a difference is if `period` is greater than `every`, or if `closed='both'`. And in that case, I'd say that the difference is for the better. I'll show an example - suppose you start with
```python
import polars as pl
from datetime import date
df = pl.DataFrame({'ts': [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 3)], 'value': [1,2,3]})
df.group_by_dynamic('ts', every='1d', period='2d').agg('value')
```
You might expect that the windows will be:
- [2020-01-01, 2020-01-03)
- [2020-01-02, 2020-01-04)
- [2020-01-03, 2020-01-05)

But actually, because `offset` defaults to "negative every", the result includes an extra
- [2020-12-31, 2020-01-02)
at the front, and it doesn't get skipped because `period` > `every` and so it contains the first datapoint.

Furthermore, if we look at the failing tests, then the new output matches the originally-reported expected output (when provided):
-  https://github.com/pola-rs/polars/issues/10695: the new output (from this PR) matches the OP's expected output
- https://github.com/pola-rs/polars/issues/7548: same, the new output matches the OP's expected output
- https://github.com/pola-rs/polars/issues/6904: no expected output provided
- test_truncate_negative_offset: no linked issue
- https://github.com/pola-rs/polars/issues/5038: no expected output provided
- https://github.com/pola-rs/polars/issues/4814: new output matches original expected output

## Summary

- for most users, this PR changes nothing
- for those affected, the change in this PR aligns things with users' original expectations