### PR TITLE
perf: Always prune unused columns in semi/anti join

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/semi_anti_join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/semi_anti_join.rs
@@ -21,15 +21,18 @@ pub(super) fn process_semi_anti_join(
     let mut names_left = PlHashSet::with_capacity(n);
     let mut names_right = PlHashSet::with_capacity(n);
 
-    // if there are no projections we don't have to do anything (all columns are projected)
-    // otherwise we build local projections to sort out proper column names due to the
-    // join operation
-    //
-    // Joins on columns with different names, for example
-    // left_on = "a", right_on = "b
-    // will remove the name "b" (it is "a" now). That columns should therefore not
-    // be added to a local projection.
-    if !acc_projections.is_empty() {
+    if acc_projections.is_empty() {
+        // Only project the join columns.
+        for e in &right_on {
+            add_expr_to_accumulated(e.node(), &mut pushdown_right, &mut names_right, expr_arena);
+        }
+    } else {
+        // We build local projections to sort out proper column names due to the
+        // join operation.
+        // Joins on columns with different names, for example
+        // left_on = "a", right_on = "b
+        // will remove the name "b" (it is "a" now). That columns should therefore not
+        // be added to a local projection.
         let schema_left = lp_arena.get(input_left).schema(lp_arena);
         let schema_right = lp_arena.get(input_right).schema(lp_arena);
 

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -500,3 +500,16 @@ def test_non_coalesce_multi_key_join_projection_pushdown_16554(
     )
 
     assert_frame_equal(out.sort("a"), expect)
+
+
+@pytest.mark.parametrize("how", ["semi", "anti"])
+def test_projection_pushdown_semi_anti_no_selection(
+    how: Literal["semi", "anti"],
+) -> None:
+    q_a = pl.LazyFrame({"a": [1, 2, 3]})
+
+    q_b = pl.LazyFrame({"b": [1, 2, 3], "c": [1, 2, 3]})
+
+    assert "PROJECT 1/2" in (
+        q_a.join(q_b, left_on="a", right_on="b", how=how).explain()
+    )


### PR DESCRIPTION
If there were no projected columns, the rhs of the `semi`/`anti` join was fully loaded. 