### PR TITLE
feat: Allow wildcard and exclude before struct expansions

### DIFF
--- a/crates/polars-plan/src/logical_plan/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/expr_expansion.rs
@@ -712,7 +712,7 @@ fn replace_and_add_to_results(
 
                     // has both column and field expansion
                     // col('a', 'b').struct.field('*')
-                    if flags.multiple_columns {
+                    if flags.multiple_columns | flags.has_wildcard {
                         // First expand col('a', 'b') into an intermediate result.
                         let mut intermediate = vec![];
                         let mut flags = flags;
@@ -728,6 +728,7 @@ fn replace_and_add_to_results(
                         // Then expand the fields and add to the final result vec.
                         flags.expands_fields = true;
                         flags.multiple_columns = false;
+                        flags.has_wildcard = false;
                         for e in intermediate {
                             replace_and_add_to_results(e, flags, result, schema, keys)?;
                         }

--- a/py-polars/tests/unit/test_expansion.py
+++ b/py-polars/tests/unit/test_expansion.py
@@ -161,3 +161,20 @@ def test_field_and_column_expansion() -> None:
         "i": [3],
         "j": [4],
     }
+
+
+def test_struct_field_exclude_and_wildcard_expansion() -> None:
+    df = pl.DataFrame({"a": [{"x": 1, "y": 2}], "b": [{"i": 3, "j": 4}]})
+
+    assert df.select(pl.exclude("foo").struct.field("*")).to_dict(as_series=False) == {
+        "x": [1],
+        "y": [2],
+        "i": [3],
+        "j": [4],
+    }
+    assert df.select(pl.all().struct.field("*")).to_dict(as_series=False) == {
+        "x": [1],
+        "y": [2],
+        "i": [3],
+        "j": [4],
+    }


### PR DESCRIPTION
Wildcard and excludes are expanded first before we expand the struct's fields.

closes #16661