### PR TITLE
feat: Support cloud storage in `scan_csv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "arrow-array"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +750,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1015,6 +1040,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation"
@@ -1437,6 +1468,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73969b81e8bc90a3828d913dd3973d80771bfb9d7fbe1a78a79122aad456af15"
+dependencies = [
+ "rustix",
+ "tokio",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2973,11 +3015,13 @@ dependencies = [
  "ahash",
  "async-trait",
  "atoi_simd",
+ "blake3",
  "bytes",
  "chrono",
  "chrono-tz",
  "fast-float",
  "flate2",
+ "fs4",
  "futures",
  "home",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73969b81e8bc90a3828d913dd3973d80771bfb9d7fbe1a78a79122aad456af15"
 dependencies = [
  "rustix",
- "tokio",
  "windows-sys 0.52.0",
 ]
 

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
 fast-float = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
-fs4 = { version = "0.8.3", features = ["sync", "tokio"] }
+fs4 = { version = "0.8.3", features = ["sync"] }
 futures = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }
 memchr = { workspace = true }

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -40,11 +40,11 @@ regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"], optional = true }
-serde_json = { version = "1", default-features = false, features = ["std", "alloc", "raw_value"], optional = true }
+serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"], optional = true }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
 smartstring = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt-multi-thread", "time", "sync"], optional = true }
+tokio = { workspace = true, features = ["fs", "net", "rt-multi-thread", "time", "sync"], optional = true }
 tokio-util = { workspace = true, features = ["io", "io-util"], optional = true }
 url = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -20,11 +20,13 @@ ahash = { workspace = true }
 arrow = { workspace = true }
 async-trait = { version = "0.1.59", optional = true }
 atoi_simd = { workspace = true, optional = true }
+blake3 = "1.5.1"
 bytes = { version = "1.3" }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
 fast-float = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
+fs4 = { version = "0.8.3", features = ["sync", "tokio"] }
 futures = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }
 memchr = { workspace = true }
@@ -37,8 +39,8 @@ rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
-serde = { workspace = true, features = ["rc"], optional = true }
-serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"], optional = true }
+serde = { workspace = true, features = ["rc"] }
+serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"] }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
 smartstring = { workspace = true }
@@ -60,11 +62,10 @@ json = [
   "polars-json",
   "simd-json",
   "atoi_simd",
-  "serde_json",
   "dtype-struct",
   "csv",
 ]
-serde = ["dep:serde", "polars-core/serde-lazy", "polars-parquet/serde"]
+serde = ["polars-core/serde-lazy"]
 # support for arrows ipc file parsing
 ipc = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrows streaming ipc file parsing
@@ -107,7 +108,7 @@ async = [
   "polars-error/regex",
   "polars-parquet?/async",
 ]
-cloud = ["object_store", "async", "polars-error/object_store", "url", "serde_json", "serde"]
+cloud = ["object_store", "async", "polars-error/object_store", "url"]
 aws = ["object_store/aws", "cloud", "reqwest"]
 azure = ["object_store/azure", "cloud"]
 gcp = ["object_store/gcp", "cloud"]

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -65,7 +65,7 @@ json = [
   "dtype-struct",
   "csv",
 ]
-serde = ["polars-core/serde-lazy"]
+serde = ["polars-core/serde-lazy", "polars-parquet/serde"]
 # support for arrows ipc file parsing
 ipc = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrows streaming ipc file parsing

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -26,7 +26,6 @@ chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
 fast-float = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
-fs4 = { version = "0.8.3", features = ["sync"] }
 futures = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }
 memchr = { workspace = true }
@@ -51,6 +50,7 @@ zstd = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 home = "0.5.4"
+fs4 = { version = "0.8.3", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -39,8 +39,8 @@ rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
-serde = { workspace = true, features = ["rc"] }
-serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"] }
+serde = { workspace = true, features = ["rc"], optional = true }
+serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"], optional = true }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
 smartstring = { workspace = true }
@@ -62,10 +62,11 @@ json = [
   "polars-json",
   "simd-json",
   "atoi_simd",
+  "serde_json",
   "dtype-struct",
   "csv",
 ]
-serde = ["polars-core/serde-lazy", "polars-parquet/serde"]
+serde = ["dep:serde", "polars-core/serde-lazy", "polars-parquet/serde"]
 # support for arrows ipc file parsing
 ipc = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrows streaming ipc file parsing
@@ -108,7 +109,7 @@ async = [
   "polars-error/regex",
   "polars-parquet?/async",
 ]
-cloud = ["object_store", "async", "polars-error/object_store", "url"]
+cloud = ["object_store", "async", "polars-error/object_store", "url", "serde_json", "serde"]
 aws = ["object_store/aws", "cloud", "reqwest"]
 azure = ["object_store/azure", "cloud"]
 gcp = ["object_store/gcp", "cloud"]

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -40,7 +40,7 @@ regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"], optional = true }
-serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"], optional = true }
+serde_json = { version = "1", default-features = false, features = ["std", "alloc", "raw_value"], optional = true }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
 smartstring = { workspace = true }

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -20,7 +20,7 @@ ahash = { workspace = true }
 arrow = { workspace = true }
 async-trait = { version = "0.1.59", optional = true }
 atoi_simd = { workspace = true, optional = true }
-blake3 = "1.5.1"
+blake3 = { version = "1.5.1", optional = true }
 bytes = { version = "1.3" }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
@@ -49,8 +49,8 @@ url = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+fs4 = { version = "0.8.3", features = ["sync"], optional = true }
 home = "0.5.4"
-fs4 = { version = "0.8.3", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"
@@ -109,7 +109,8 @@ async = [
   "polars-error/regex",
   "polars-parquet?/async",
 ]
-cloud = ["object_store", "async", "polars-error/object_store", "url", "serde_json", "serde"]
+cloud = ["object_store", "async", "polars-error/object_store", "url", "serde_json", "serde", "file_cache"]
+file_cache = ["async", "dep:blake3", "dep:fs4"]
 aws = ["object_store/aws", "cloud", "reqwest"]
 azure = ["object_store/azure", "cloud"]
 gcp = ["object_store/gcp", "cloud"]

--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -28,7 +28,7 @@ pub fn count_rows(
     has_header: bool,
 ) -> PolarsResult<usize> {
     let mut reader = if is_cloud_url(path) || config::force_async() {
-        #[cfg(feature = "async")]
+        #[cfg(feature = "cloud")]
         {
             FILE_CACHE
                 .get_entry(path.to_str().unwrap())
@@ -36,9 +36,9 @@ pub fn count_rows(
                 .unwrap()
                 .try_open_assume_latest()?
         }
-        #[cfg(not(feature = "async"))]
+        #[cfg(not(feature = "cloud"))]
         {
-            panic!("required feature `async` is not enabled")
+            panic!("required feature `cloud` is not enabled")
         }
     } else {
         polars_utils::open_file(path)?
@@ -62,7 +62,7 @@ pub fn count_rows(
     })
     .unwrap_or(1);
 
-    let file_chunks = get_file_chunks(
+    let file_chunks: Vec<(usize, usize)> = get_file_chunks(
         &reader_bytes,
         n_threads,
         None,

--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use memchr::memchr2_iter;
 use num_traits::Pow;
 use polars_core::prelude::*;
-use polars_core::POOL;
+use polars_core::{config, POOL};
 use polars_utils::index::Bounded;
 use polars_utils::slice::GetSaferUnchecked;
 use rayon::prelude::*;
@@ -12,6 +12,9 @@ use super::buffer::Buffer;
 use super::options::{CommentPrefix, NullValuesCompiled};
 use super::splitfields::SplitFields;
 use super::utils::get_file_chunks;
+#[cfg(feature = "async")]
+use crate::file_cache::FILE_CACHE;
+use crate::prelude::is_cloud_url;
 use crate::utils::get_reader_bytes;
 
 /// Read the number of rows without parsing columns
@@ -24,7 +27,22 @@ pub fn count_rows(
     eol_char: u8,
     has_header: bool,
 ) -> PolarsResult<usize> {
-    let mut reader = polars_utils::open_file(path)?;
+    let mut reader = if is_cloud_url(path) || config::force_async() {
+        #[cfg(feature = "async")]
+        {
+            FILE_CACHE
+                .get_entry(path.to_str().unwrap())
+                // Safety: This was initialized by schema inference.
+                .unwrap()
+                .try_open_assume_latest()?
+        }
+        #[cfg(not(feature = "async"))]
+        {
+            panic!("required feature `async` is not enabled")
+        }
+    } else {
+        polars_utils::open_file(path)?
+    };
     let reader_bytes = get_reader_bytes(&mut reader)?;
     const MIN_ROWS_PER_THREAD: usize = 1024;
     let max_threads = POOL.current_num_threads();

--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -12,8 +12,6 @@ use super::buffer::Buffer;
 use super::options::{CommentPrefix, NullValuesCompiled};
 use super::splitfields::SplitFields;
 use super::utils::get_file_chunks;
-#[cfg(feature = "cloud")]
-use crate::file_cache::FILE_CACHE;
 use crate::prelude::is_cloud_url;
 use crate::utils::get_reader_bytes;
 
@@ -30,7 +28,7 @@ pub fn count_rows(
     let mut reader = if is_cloud_url(path) || config::force_async() {
         #[cfg(feature = "cloud")]
         {
-            FILE_CACHE
+            crate::file_cache::FILE_CACHE
                 .get_entry(path.to_str().unwrap())
                 // Safety: This was initialized by schema inference.
                 .unwrap()

--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -12,7 +12,7 @@ use super::buffer::Buffer;
 use super::options::{CommentPrefix, NullValuesCompiled};
 use super::splitfields::SplitFields;
 use super::utils::get_file_chunks;
-#[cfg(feature = "async")]
+#[cfg(feature = "cloud")]
 use crate::file_cache::FILE_CACHE;
 use crate::prelude::is_cloud_url;
 use crate::utils::get_reader_bytes;

--- a/crates/polars-io/src/file_cache/cache.rs
+++ b/crates/polars-io/src/file_cache/cache.rs
@@ -1,0 +1,140 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use once_cell::sync::Lazy;
+use polars_core::config;
+use polars_error::PolarsResult;
+use polars_utils::aliases::PlHashMap;
+
+use super::entry::FileCacheEntry;
+use super::file_fetcher::FileFetcher;
+use crate::file_cache::entry::{DATA_PREFIX, METADATA_PREFIX};
+use crate::prelude::is_cloud_url;
+
+pub static FILE_CACHE: Lazy<FileCache> = Lazy::new(|| {
+    let prefix = std::env::var("POLARS_TEMP_DIR")
+        .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into_owned());
+    let prefix = PathBuf::from(prefix).join("polars/file-cache/");
+    let prefix = Arc::<Path>::from(prefix.as_path());
+
+    if config::verbose() {
+        eprintln!("file cache prefix: {}", prefix.to_str().unwrap());
+    }
+
+    FileCache::new(prefix)
+});
+
+pub struct FileCache {
+    prefix: Arc<Path>,
+    entries: Arc<RwLock<PlHashMap<Arc<str>, Arc<FileCacheEntry>>>>,
+}
+
+impl FileCache {
+    fn new(prefix: Arc<Path>) -> Self {
+        let path = &prefix
+            .as_ref()
+            .join(std::str::from_utf8(&[METADATA_PREFIX]).unwrap());
+        let _ = std::fs::create_dir_all(path);
+        assert!(
+            path.is_dir(),
+            "failed to create file cache metadata directory: {}",
+            path.to_str().unwrap(),
+        );
+
+        let path = &prefix
+            .as_ref()
+            .join(std::str::from_utf8(&[DATA_PREFIX]).unwrap());
+        let _ = std::fs::create_dir_all(path);
+        assert!(
+            path.is_dir(),
+            "failed to create file cache data directory: {}",
+            path.to_str().unwrap(),
+        );
+
+        Self {
+            prefix,
+            entries: Default::default(),
+        }
+    }
+
+    /// If `uri` is a local path, it must be an absolute path.
+    pub fn init_entry<F: Fn() -> PolarsResult<Arc<dyn FileFetcher>>>(
+        &self,
+        uri: Arc<str>,
+        get_file_fetcher: F,
+    ) -> PolarsResult<Arc<FileCacheEntry>> {
+        let verbose = config::verbose();
+
+        #[cfg(debug_assertions)]
+        {
+            // Local paths must be absolute or else the cache would be wrong.
+            if !crate::utils::is_cloud_url(uri.as_ref()) {
+                let path = Path::new(uri.as_ref());
+                assert_eq!(path, std::fs::canonicalize(path).unwrap().as_path());
+            }
+        }
+
+        {
+            let entries = self.entries.read().unwrap();
+
+            if let Some(entry) = entries.get(uri.as_ref()) {
+                if verbose {
+                    eprintln!(
+                        "[file_cache] init_entry: return existing entry for uri = {}",
+                        uri.clone()
+                    );
+                }
+                return Ok(entry.clone());
+            }
+        }
+
+        let uri_hash = blake3::hash(uri.as_bytes())
+            .to_hex()
+            .get(..32)
+            .unwrap()
+            .to_string();
+
+        {
+            let mut entries = self.entries.write().unwrap();
+
+            // May have been raced
+            if let Some(entry) = entries.get(uri.as_ref()) {
+                if verbose {
+                    eprintln!("[file_cache] init_entry: return existing entry for uri = {} (lost init race)", uri.clone());
+                }
+                return Ok(entry.clone());
+            }
+
+            if verbose {
+                eprintln!(
+                    "[file_cache] init_entry: creating new entry for uri = {}, hash = {}",
+                    uri.clone(),
+                    uri_hash.clone()
+                );
+            }
+
+            let entry = Arc::new(FileCacheEntry::new(
+                uri.clone(),
+                uri_hash,
+                self.prefix.clone(),
+                get_file_fetcher()?,
+            ));
+            entries.insert_unique_unchecked(uri, entry.clone());
+            Ok(entry.clone())
+        }
+    }
+
+    /// This function can accept relative local paths.
+    pub fn get_entry(&self, uri: &str) -> Option<Arc<FileCacheEntry>> {
+        if is_cloud_url(uri) {
+            self.entries.read().unwrap().get(uri).map(Arc::clone)
+        } else {
+            let uri = std::fs::canonicalize(uri).unwrap();
+            self.entries
+                .read()
+                .unwrap()
+                .get(uri.to_str().unwrap())
+                .map(Arc::clone)
+        }
+    }
+}

--- a/crates/polars-io/src/file_cache/cache.rs
+++ b/crates/polars-io/src/file_cache/cache.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -7,16 +7,13 @@ use polars_core::config;
 use polars_error::PolarsResult;
 use polars_utils::aliases::PlHashMap;
 
-use super::entry::FileCacheEntry;
+use super::entry::{FileCacheEntry, DATA_PREFIX, METADATA_PREFIX};
 use super::eviction::EvictionManager;
 use super::file_fetcher::FileFetcher;
-use crate::file_cache::entry::{DATA_PREFIX, METADATA_PREFIX};
-use crate::prelude::is_cloud_url;
+use crate::prelude::{is_cloud_url, POLARS_TEMP_DIR_BASE_PATH};
 
 pub static FILE_CACHE: Lazy<FileCache> = Lazy::new(|| {
-    let prefix = std::env::var("POLARS_TEMP_DIR")
-        .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into_owned());
-    let prefix = PathBuf::from(prefix).join("polars/file-cache/");
+    let prefix = POLARS_TEMP_DIR_BASE_PATH.join("polars/file-cache/");
     let prefix = Arc::<Path>::from(prefix.as_path());
 
     if config::verbose() {

--- a/crates/polars-io/src/file_cache/cache.rs
+++ b/crates/polars-io/src/file_cache/cache.rs
@@ -10,11 +10,12 @@ use polars_utils::aliases::PlHashMap;
 use super::entry::{FileCacheEntry, DATA_PREFIX, METADATA_PREFIX};
 use super::eviction::EvictionManager;
 use super::file_fetcher::FileFetcher;
-use crate::prelude::{is_cloud_url, POLARS_TEMP_DIR_BASE_PATH};
+use super::utils::FILE_CACHE_PREFIX;
+use crate::prelude::is_cloud_url;
 
 pub static FILE_CACHE: Lazy<FileCache> = Lazy::new(|| {
-    let prefix = POLARS_TEMP_DIR_BASE_PATH.join("polars/file-cache/");
-    let prefix = Arc::<Path>::from(prefix.as_path());
+    let prefix = FILE_CACHE_PREFIX.as_ref();
+    let prefix = Arc::<Path>::from(prefix);
 
     if config::verbose() {
         eprintln!("file cache prefix: {}", prefix.to_str().unwrap());

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 
-#[cfg(not(target_family = "wasm"))]
 use fs4::FileExt;
 use once_cell::sync::Lazy;
 use polars_core::config;

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 
+#[cfg(not(target_family = "wasm"))]
 use fs4::FileExt;
 use once_cell::sync::Lazy;
 use polars_core::config;

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -1,0 +1,173 @@
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::time::Duration;
+
+use fs4::FileExt;
+use once_cell::sync::Lazy;
+use polars_core::config;
+
+use crate::pl_async;
+
+pub(super) static GLOBAL_FILE_CACHE_LOCK: Lazy<GlobalLock> = Lazy::new(|| {
+    let path = std::env::var("POLARS_TEMP_DIR")
+        .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into_owned());
+    let path = PathBuf::from(path).join("polars/file-cache/");
+    let _ = std::fs::create_dir_all(&path);
+    let path = path.join(".process-lock");
+
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|err| {
+            panic!("failed to open/create global file cache lockfile: {}", err);
+        })
+        .unwrap();
+
+    let at_bool = Arc::new(AtomicBool::new(false));
+    // Holding this access tracker prevents the background task from
+    // unlocking the lock.
+    let access_tracker = AccessTracker(at_bool.clone());
+
+    pl_async::get_runtime().spawn(async move {
+        let access_tracker = at_bool;
+        let verbose = config::verbose();
+
+        loop {
+            if !access_tracker.swap(false, std::sync::atomic::Ordering::Relaxed)
+                && GLOBAL_FILE_CACHE_LOCK.try_unlock()
+                && verbose
+            {
+                eprintln!("unlocked global file cache lockfile");
+            }
+            tokio::time::sleep(Duration::from_secs(3)).await;
+        }
+    });
+
+    GlobalLock {
+        inner: RwLock::new(GlobalLockData { file, state: None }),
+        access_tracker,
+    }
+});
+
+pub(super) enum LockedState {
+    Shared,
+    #[allow(dead_code)]
+    Exclusive,
+}
+
+#[allow(dead_code)]
+pub(super) type GlobalFileCacheGuardAny<'a> = RwLockReadGuard<'a, GlobalLockData>;
+pub(super) type GlobalFileCacheGuardExclusive<'a> = RwLockWriteGuard<'a, GlobalLockData>;
+
+#[derive(Clone)]
+struct AccessTracker(Arc<AtomicBool>);
+
+pub(super) struct GlobalLockData {
+    file: std::fs::File,
+    state: Option<LockedState>,
+}
+
+pub(super) struct GlobalLock {
+    inner: RwLock<GlobalLockData>,
+    access_tracker: AccessTracker,
+}
+
+impl Drop for AccessTracker {
+    fn drop(&mut self) {
+        self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+impl GlobalLock {
+    fn get_access_tracker(&self) -> AccessTracker {
+        let at = self.access_tracker.clone();
+        at.0.store(true, std::sync::atomic::Ordering::Relaxed);
+        at
+    }
+
+    fn try_unlock(&self) -> bool {
+        if let Ok(mut this) = self.inner.try_write() {
+            if Arc::strong_count(&self.access_tracker.0) <= 2 && this.state.take().is_some() {
+                this.file.unlock().unwrap();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Acquire either a shared or exclusive lock. This always returns a read-guard
+    /// to allow for better parallelism within the current process. The tradeoff
+    /// is that we may hold an exclusive lock on the global lockfile for longer
+    /// than we need to (since we don't transition to a shared lock state),
+    /// which blocks other processes.
+    pub(super) fn lock_any(&self) -> GlobalFileCacheGuardAny {
+        let access_tracker = self.get_access_tracker();
+
+        {
+            let this = self.inner.read().unwrap();
+
+            if this.state.is_some() {
+                return this;
+            }
+        }
+
+        {
+            let mut this = self.inner.write().unwrap();
+
+            if this.state.is_none() {
+                this.file.lock_shared().unwrap();
+                this.state = Some(LockedState::Shared);
+            }
+        }
+
+        // Safety: Holding the access tracker guard maintains an Arc refcount
+        // > 2, which prevents automatic unlock.
+        debug_assert!(Arc::strong_count(&access_tracker.0) > 2);
+
+        {
+            let this = self.inner.read().unwrap();
+            assert!(
+                this.state.is_some(),
+                "impl error: global file cache lock was unlocked"
+            );
+            this
+        }
+    }
+
+    /// Acquire an exclusive lock on the cache directory. Holding this lock freezes
+    /// all cache operations except for reading from already-opened data files.
+    #[allow(dead_code)]
+    pub(super) fn try_lock_exclusive(&self) -> Option<GlobalFileCacheGuardExclusive> {
+        let access_tracker = self.get_access_tracker();
+
+        if let Ok(mut this) = self.inner.try_write() {
+            if
+            // 3:
+            // * the Lazy<GlobalLock>
+            // * the global unlock background task
+            // * this function
+            Arc::strong_count(&access_tracker.0) > 3 {
+                return None;
+            }
+
+            if let Some(ref state) = this.state {
+                if matches!(state, LockedState::Exclusive) {
+                    return Some(this);
+                }
+            }
+
+            if this.state.take().is_some() {
+                this.file.unlock().unwrap();
+            }
+
+            if this.file.try_lock_exclusive().is_ok() {
+                this.state = Some(LockedState::Exclusive);
+                return Some(this);
+            }
+        }
+        None
+    }
+}

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -121,7 +121,7 @@ impl GlobalLock {
     /// Returns
     /// * `None` - Could be locked (ambiguous)
     /// * `Some(true)` - Unlocked (by this function call)
-    /// * `Some(false)` - Unlocked (already previously unlocked)
+    /// * `Some(false)` - Unlocked (was not locked)
     fn try_unlock(&self) -> Option<bool> {
         if let Ok(mut this) = self.inner.try_write() {
             if Arc::strong_count(&self.access_tracker.0) <= 2 {

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
@@ -7,14 +6,13 @@ use fs4::FileExt;
 use once_cell::sync::Lazy;
 use polars_core::config;
 
+use super::utils::FILE_CACHE_PREFIX;
 use crate::pl_async;
 
 pub(super) static GLOBAL_FILE_CACHE_LOCK: Lazy<GlobalLock> = Lazy::new(|| {
-    let path = std::env::var("POLARS_TEMP_DIR")
-        .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into_owned());
-    let path = PathBuf::from(path).join("polars/file-cache/");
-    let _ = std::fs::create_dir_all(&path);
-    let path = path.join(".process-lock");
+    let path = FILE_CACHE_PREFIX.as_ref();
+    let _ = std::fs::create_dir_all(path);
+    let path = FILE_CACHE_PREFIX.join(".process-lock");
 
     let file = std::fs::OpenOptions::new()
         .write(true)

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -10,8 +10,6 @@ use super::utils::FILE_CACHE_PREFIX;
 use crate::pl_async;
 
 pub(super) static GLOBAL_FILE_CACHE_LOCK: Lazy<GlobalLock> = Lazy::new(|| {
-    let path = FILE_CACHE_PREFIX.as_ref();
-    let _ = std::fs::create_dir_all(path);
     let path = FILE_CACHE_PREFIX.join(".process-lock");
 
     let file = std::fs::OpenOptions::new()

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -124,12 +124,14 @@ impl GlobalLock {
     /// * `Some(false)` - Unlocked (already previously unlocked)
     fn try_unlock(&self) -> Option<bool> {
         if let Ok(mut this) = self.inner.try_write() {
-            if Arc::strong_count(&self.access_tracker.0) <= 2 && this.state.take().is_some() {
-                this.file.unlock().unwrap();
-                return Some(true);
+            if Arc::strong_count(&self.access_tracker.0) <= 2 {
+                return if this.state.take().is_some() {
+                    this.file.unlock().unwrap();
+                    Some(true)
+                } else {
+                    Some(false)
+                };
             }
-
-            return this.state.is_none().then_some(false);
         }
         None
     }

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -1,0 +1,351 @@
+use std::io::{Seek, SeekFrom};
+use std::ops::DerefMut;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use fs4::FileExt;
+use polars_core::config;
+use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};
+use polars_utils::flatten;
+
+use super::cache_lock::{self, GLOBAL_FILE_CACHE_LOCK};
+use super::file_fetcher::FileFetcher;
+use super::file_lock::{FileLock, FileLockAnyGuard};
+use super::metadata::EntryMetadata;
+use super::utils::update_last_accessed;
+
+pub(super) const DATA_PREFIX: u8 = b'd';
+pub(super) const METADATA_PREFIX: u8 = b'm';
+
+struct CachedData {
+    last_modified: u64,
+    metadata: Arc<EntryMetadata>,
+    data_file_path: PathBuf,
+}
+
+struct Inner {
+    uri: Arc<str>,
+    uri_hash: String,
+    path_prefix: Arc<Path>,
+    metadata: FileLock<PathBuf>,
+    cached_data: Option<CachedData>,
+    file_fetcher: Arc<dyn FileFetcher>,
+}
+
+struct EntryData {
+    uri: Arc<str>,
+    inner: Mutex<Inner>,
+}
+
+#[derive(Clone)]
+pub struct FileCacheEntry(Arc<EntryData>);
+
+impl Inner {
+    fn try_open_assume_latest(&mut self) -> PolarsResult<std::fs::File> {
+        let verbose = config::verbose();
+
+        {
+            let cache_guard = GLOBAL_FILE_CACHE_LOCK.lock_any();
+            let metadata_file = &mut self.metadata.acquire_shared().unwrap();
+            update_last_accessed(metadata_file);
+
+            if let Ok(metadata) = self.try_get_metadata(metadata_file, &cache_guard) {
+                let data_file_path = self.get_cached_data_file_path();
+                let cmp_result = metadata.compare_local_state(data_file_path);
+
+                if cmp_result.is_ok() {
+                    if verbose {
+                        eprintln!("[file_cache::entry] try_open_assume_latest: opening already fetched file for uri = {}", self.uri.clone());
+                    }
+                    return Ok(finish_open(data_file_path, metadata_file));
+                }
+            }
+        }
+
+        if verbose {
+            eprintln!(
+                "[file_cache::entry] try_open_assume_latest: did not find cached file for uri = {}",
+                self.uri.clone()
+            );
+        }
+
+        self.try_open_check_latest()
+    }
+
+    fn try_open_check_latest(&mut self) -> PolarsResult<std::fs::File> {
+        let verbose = config::verbose();
+        let remote_metadata = self.file_fetcher.fetch_metadata()?;
+        let cache_guard = GLOBAL_FILE_CACHE_LOCK.lock_any();
+
+        {
+            let metadata_file = &mut self.metadata.acquire_shared().unwrap();
+            update_last_accessed(metadata_file);
+
+            if let Ok(metadata) = self.try_get_metadata(metadata_file, &cache_guard) {
+                if metadata.remote_last_modified == remote_metadata.last_modified
+                    && metadata.local_size == remote_metadata.size
+                {
+                    let data_file_path = self.get_cached_data_file_path();
+                    let cmp_result = metadata.compare_local_state(data_file_path);
+
+                    if cmp_result.is_ok() {
+                        if verbose {
+                            eprintln!("[file_cache::entry] try_open_check_latest: opening already fetched file for uri = {}", self.uri.clone());
+                        }
+                        return Ok(finish_open(data_file_path, metadata_file));
+                    }
+                }
+            }
+        }
+
+        let metadata_file = &mut self.metadata.acquire_exclusive().unwrap();
+        let metadata = self
+            .try_get_metadata(metadata_file, &cache_guard)
+            .unwrap_or_else(|_| Arc::new(EntryMetadata::new_with_uri(self.uri.clone())));
+
+        if metadata.remote_last_modified == remote_metadata.last_modified
+            && metadata.local_size == remote_metadata.size
+        {
+            let data_file_path = self.get_cached_data_file_path();
+            let cmp_result = metadata.compare_local_state(data_file_path);
+
+            if cmp_result.is_ok() {
+                if verbose {
+                    eprintln!(
+                        "[file_cache::entry] try_open_check_latest: opening already fetched file (lost race) for uri = {}",
+                        self.uri.clone()
+                    );
+                }
+                return Ok(finish_open(data_file_path, metadata_file));
+            }
+        }
+
+        if verbose {
+            eprintln!(
+                "[file_cache::entry] try_open_check_latest: fetching new data file for uri = {}, remote_last_modified = {}, remote_size = {}",
+                self.uri.clone(),
+                remote_metadata.last_modified,
+                remote_metadata.size
+            );
+        }
+
+        let data_file_path = &get_data_file_path(
+            self.path_prefix.to_str().unwrap().as_bytes(),
+            self.uri_hash.as_bytes(),
+            remote_metadata.last_modified,
+        );
+        let _ = std::fs::remove_file(data_file_path);
+        if !self.file_fetcher.fetches_as_symlink() {
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(data_file_path)
+                .map_err(PolarsError::from)?;
+            file.lock_exclusive().unwrap();
+            if file.allocate(remote_metadata.size).is_err() {
+                polars_bail!(
+                    ComputeError: "failed to allocate {} bytes to download uri = {}",
+                    remote_metadata.size,
+                    self.uri.as_ref()
+                );
+            }
+        }
+        self.file_fetcher.fetch(data_file_path)?;
+
+        // Don't do this on windows as it will break setting last accessed times.
+        #[cfg(target_family = "unix")]
+        if !self.file_fetcher.fetches_as_symlink() {
+            let mut perms = std::fs::metadata(data_file_path.clone())
+                .unwrap()
+                .permissions();
+            perms.set_readonly(true);
+            std::fs::set_permissions(data_file_path, perms).unwrap();
+        }
+
+        let data_file_metadata = std::fs::metadata(data_file_path).unwrap();
+        let local_last_modified = super::utils::last_modified_u64(&data_file_metadata);
+        let local_size = data_file_metadata.len();
+
+        if local_size != remote_metadata.size {
+            polars_bail!(ComputeError: "downloaded file size ({}) does not match expected size ({})", local_size, remote_metadata.size);
+        }
+
+        let mut metadata = Arc::unwrap_or_clone(metadata);
+        metadata.local_last_modified = local_last_modified;
+        metadata.local_size = local_size;
+        metadata.remote_last_modified = remote_metadata.last_modified;
+
+        let cmp_result = metadata.compare_local_state(data_file_path);
+        if let Err(e) = cmp_result {
+            panic!("metadata mismatch after file fetch: {}", e);
+        }
+
+        let data_file = finish_open(data_file_path, metadata_file);
+
+        metadata_file.seek(SeekFrom::Start(0)).unwrap();
+        metadata
+            .try_write(metadata_file.deref_mut())
+            .map_err(to_compute_err)?;
+
+        Ok(data_file)
+    }
+
+    /// Try to read the metadata from disk.
+    fn try_get_metadata<F: FileLockAnyGuard>(
+        &mut self,
+        metadata_file: &mut F,
+        _cache_guard: &cache_lock::GlobalFileCacheGuardAny,
+    ) -> PolarsResult<Arc<EntryMetadata>> {
+        let mut f = || {
+            let last_modified = super::utils::last_modified_u64(&metadata_file.metadata().unwrap());
+
+            if let Some(ref cached) = self.cached_data {
+                if cached.last_modified == last_modified {
+                    return Ok(cached.metadata.clone());
+                }
+            }
+
+            // Ensure cache is unset if read fails
+            self.cached_data = None;
+
+            let metadata = Arc::new(
+                EntryMetadata::try_from_reader(metadata_file.deref_mut())
+                    .map_err(to_compute_err)?,
+            );
+            let data_file_path = get_data_file_path(
+                self.path_prefix.to_str().unwrap().as_bytes(),
+                self.uri_hash.as_bytes(),
+                metadata.remote_last_modified,
+            );
+            self.cached_data = Some(CachedData {
+                last_modified,
+                metadata,
+                data_file_path,
+            });
+
+            Ok(self.cached_data.as_ref().unwrap().metadata.clone())
+        };
+
+        f().map(|v| {
+            // "just in case"
+            // but would be cool if we saw this one day :D
+            if v.uri != self.uri {
+                unimplemented!(
+                    "hash collision: uri1 = {}, uri2 = {}, hash = {}",
+                    v.uri,
+                    self.uri,
+                    self.uri_hash,
+                );
+            }
+            v
+        })
+    }
+
+    /// # Panics
+    /// Panics if `self.cached_data` is `None`.
+    fn get_cached_data_file_path(&self) -> &Path {
+        &self.cached_data.as_ref().unwrap().data_file_path
+    }
+}
+
+impl FileCacheEntry {
+    pub(crate) fn new(
+        uri: Arc<str>,
+        uri_hash: String,
+        path_prefix: Arc<Path>,
+        file_fetcher: Arc<dyn FileFetcher>,
+    ) -> Self {
+        let metadata = FileLock::from(get_metadata_file_path(
+            path_prefix.to_str().unwrap().as_bytes(),
+            uri_hash.as_bytes(),
+        ));
+
+        debug_assert!(
+            Arc::ptr_eq(&uri, &file_fetcher.get_uri()),
+            "impl error: entry uri != file_fetcher uri"
+        );
+
+        Self(Arc::new(EntryData {
+            uri: uri.clone(),
+            inner: Mutex::new(Inner {
+                uri,
+                uri_hash,
+                path_prefix,
+                metadata,
+                cached_data: None,
+                file_fetcher,
+            }),
+        }))
+    }
+
+    pub fn uri(&self) -> Arc<str> {
+        self.0.uri.clone()
+    }
+
+    /// Directly returns the cached file if it finds one without checking if
+    /// there is a newer version on the remote. This does not make any API calls
+    /// if it finds a cached file, otherwise it simply downloads the file.
+    pub fn try_open_assume_latest(&self) -> PolarsResult<std::fs::File> {
+        self.0.inner.lock().unwrap().try_open_assume_latest()
+    }
+
+    /// Returns the cached file after ensuring it is up to date against the remote
+    /// This will always perform at least 1 API call for fetching metadata.
+    pub fn try_open_check_latest(&self) -> PolarsResult<std::fs::File> {
+        self.0.inner.lock().unwrap().try_open_check_latest()
+    }
+}
+
+fn finish_open<F: FileLockAnyGuard>(data_file_path: &Path, _metadata_guard: &F) -> std::fs::File {
+    let file = {
+        #[cfg(not(target_family = "windows"))]
+        {
+            std::fs::OpenOptions::new()
+                .read(true)
+                .open(data_file_path)
+                .unwrap()
+        }
+        // windows requires write access to update the last accessed time
+        #[cfg(target_family = "windows")]
+        {
+            std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(data_file_path)
+                .unwrap()
+        }
+    };
+    update_last_accessed(&file);
+    if file.try_lock_shared().is_err() {
+        panic!(
+            "finish_open: could not acquire shared lock on data file at {}",
+            data_file_path.to_str().unwrap()
+        );
+    }
+    file
+}
+
+/// `[prefix]/d/[uri hash][last modified]`
+fn get_data_file_path(path_prefix: &[u8], uri_hash: &[u8], remote_last_modified: u64) -> PathBuf {
+    let path = flatten(
+        &[
+            path_prefix,
+            &[b'/', DATA_PREFIX, b'/'],
+            uri_hash,
+            format!("{:013x}", remote_last_modified).as_bytes(),
+        ],
+        None,
+    );
+    PathBuf::from(std::str::from_utf8(&path).unwrap())
+}
+
+/// `[prefix]/m/[uri hash]`
+fn get_metadata_file_path(path_prefix: &[u8], uri_hash: &[u8]) -> PathBuf {
+    let bytes = flatten(
+        &[path_prefix, &[b'/', METADATA_PREFIX, b'/'], uri_hash],
+        None,
+    );
+    let s = std::str::from_utf8(bytes.as_slice()).unwrap();
+    PathBuf::from(s)
+}

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -3,7 +3,6 @@ use std::ops::DerefMut;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-#[cfg(not(target_family = "wasm"))]
 use fs4::FileExt;
 use polars_core::config;
 use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -3,6 +3,7 @@ use std::ops::DerefMut;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+#[cfg(not(target_family = "wasm"))]
 use fs4::FileExt;
 use polars_core::config;
 use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -262,7 +262,7 @@ impl FileCacheEntry {
         ));
 
         debug_assert!(
-            Arc::ptr_eq(&uri, &file_fetcher.get_uri()),
+            Arc::ptr_eq(&uri, file_fetcher.get_uri()),
             "impl error: entry uri != file_fetcher uri"
         );
 

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -51,9 +51,8 @@ impl Inner {
 
             if let Ok(metadata) = self.try_get_metadata(metadata_file, &cache_guard) {
                 let data_file_path = self.get_cached_data_file_path();
-                let cmp_result = metadata.compare_local_state(data_file_path);
 
-                if cmp_result.is_ok() {
+                if metadata.compare_local_state(data_file_path).is_ok() {
                     if verbose {
                         eprintln!("[file_cache::entry] try_open_assume_latest: opening already fetched file for uri = {}", self.uri.clone());
                     }
@@ -86,9 +85,8 @@ impl Inner {
                     && metadata.local_size == remote_metadata.size
                 {
                     let data_file_path = self.get_cached_data_file_path();
-                    let cmp_result = metadata.compare_local_state(data_file_path);
 
-                    if cmp_result.is_ok() {
+                    if metadata.compare_local_state(data_file_path).is_ok() {
                         if verbose {
                             eprintln!("[file_cache::entry] try_open_check_latest: opening already fetched file for uri = {}", self.uri.clone());
                         }
@@ -107,9 +105,8 @@ impl Inner {
             && metadata.local_size == remote_metadata.size
         {
             let data_file_path = self.get_cached_data_file_path();
-            let cmp_result = metadata.compare_local_state(data_file_path);
 
-            if cmp_result.is_ok() {
+            if metadata.compare_local_state(data_file_path).is_ok() {
                 if verbose {
                     eprintln!(
                         "[file_cache::entry] try_open_check_latest: opening already fetched file (lost race) for uri = {}",
@@ -176,8 +173,7 @@ impl Inner {
         metadata.local_size = local_size;
         metadata.remote_last_modified = remote_metadata.last_modified;
 
-        let cmp_result = metadata.compare_local_state(data_file_path);
-        if let Err(e) = cmp_result {
+        if let Err(e) = metadata.compare_local_state(data_file_path) {
             panic!("metadata mismatch after file fetch: {}", e);
         }
 

--- a/crates/polars-io/src/file_cache/eviction.rs
+++ b/crates/polars-io/src/file_cache/eviction.rs
@@ -1,0 +1,194 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use fs4::FileExt;
+use polars_core::config;
+use polars_error::PolarsResult;
+
+use super::cache_lock::{GlobalFileCacheGuardExclusive, GLOBAL_FILE_CACHE_LOCK};
+use crate::pl_async;
+
+pub(super) struct EvictionManager {
+    pub(super) prefix: Arc<Path>,
+    pub(super) files_to_remove: Option<(SystemTime, Vec<PathBuf>)>,
+    pub(super) limit_since_last_access: Duration,
+}
+
+impl EvictionManager {
+    pub(super) fn run_in_background(mut self) {
+        let verbose = config::verbose();
+        let sleep_interval = std::cmp::max(self.limit_since_last_access.as_secs() / 4, 7);
+
+        if verbose {
+            eprintln!(
+                "[EvictionManager] creating cache eviction background task with limit_since_last_accessed = {}, sleep_interval = {}",
+                self.limit_since_last_access.as_secs(),
+                sleep_interval,
+            );
+        }
+
+        pl_async::get_runtime().spawn(async move {
+            // Give some time at startup for other code to run.
+            tokio::time::sleep(Duration::from_secs(3)).await;
+
+            loop {
+                let mut sleep_interval = sleep_interval;
+
+                let this: &'static mut Self = unsafe { std::mem::transmute(&mut self) };
+
+                match tokio::task::spawn_blocking(|| this.update_file_list())
+                    .await
+                    .unwrap()
+                {
+                    Ok(_) if self.files_to_remove.as_ref().unwrap().1.is_empty() => {},
+                    Ok(_) => loop {
+                        if let Some(guard) = GLOBAL_FILE_CACHE_LOCK.try_lock_exclusive() {
+                            if verbose {
+                                eprintln!(
+                                    "[EvictionManager] got exclusive cache lock, evicting {} files",
+                                    self.files_to_remove.as_ref().unwrap().1.len()
+                                );
+                            }
+
+                            tokio::task::block_in_place(|| self.evict_files(&guard));
+                            break;
+                        }
+                        sleep_interval = sleep_interval.saturating_sub(7);
+                        tokio::time::sleep(Duration::from_secs(7)).await;
+                    },
+                    Err(err) => {
+                        if verbose {
+                            eprintln!("[EvictionManager] error updating file list: {}", err);
+                        }
+                    },
+                }
+
+                tokio::time::sleep(Duration::from_secs(sleep_interval)).await;
+            }
+        });
+    }
+
+    fn update_file_list(&mut self) -> PolarsResult<()> {
+        let data_dir = &self.prefix.join("d/");
+        let metadata_dir = &self.prefix.join("m/");
+
+        let data_files_iter = std::fs::read_dir(data_dir).unwrap();
+        let metadata_files_iter = std::fs::read_dir(metadata_dir).unwrap();
+        let mut files_to_remove = Vec::with_capacity(
+            data_files_iter
+                .size_hint()
+                .1
+                .unwrap_or(data_files_iter.size_hint().0)
+                + metadata_files_iter
+                    .size_hint()
+                    .1
+                    .unwrap_or(metadata_files_iter.size_hint().0),
+        );
+
+        let now = SystemTime::now();
+
+        let mut f = |file: std::fs::DirEntry| {
+            let metadata = file.metadata()?;
+
+            if let Ok(since_last_accessed) = now.duration_since(
+                metadata
+                    .accessed()
+                    .unwrap_or_else(|_| metadata.modified().unwrap()),
+            ) {
+                if since_last_accessed >= self.limit_since_last_access {
+                    files_to_remove.push(file.path());
+                }
+            }
+
+            std::io::Result::Ok(())
+        };
+
+        for file in data_files_iter {
+            f(file?)?;
+        }
+
+        for file in metadata_files_iter {
+            f(file?)?;
+        }
+
+        self.files_to_remove = Some((now, files_to_remove));
+
+        Ok(())
+    }
+
+    /// # Panics
+    /// Panics if `self.files_to_remove` is `None`.
+    fn evict_files(&mut self, _guard: &GlobalFileCacheGuardExclusive) {
+        let verbose = config::verbose();
+        let files_to_remove = self.files_to_remove.take().unwrap().1;
+        let now = SystemTime::now();
+
+        for path in &files_to_remove {
+            if !path.exists() {
+                if verbose {
+                    eprintln!(
+                        "[EvictionManager] evict_files: skipping {} (path no longer exists)",
+                        path.to_str().unwrap()
+                    );
+                }
+                continue;
+            }
+
+            let metadata = std::fs::metadata(path).unwrap();
+
+            let since_last_accessed = match now.duration_since(
+                metadata
+                    .accessed()
+                    .unwrap_or_else(|_| metadata.modified().unwrap()),
+            ) {
+                Ok(v) => v,
+                Err(_) => {
+                    if verbose {
+                        eprintln!("[EvictionManager] evict_files: skipping {} (last accessed time was updated)", path.to_str().unwrap());
+                    }
+                    continue;
+                },
+            };
+
+            if since_last_accessed < self.limit_since_last_access {
+                if verbose {
+                    eprintln!(
+                        "[EvictionManager] evict_files: skipping {} (last accessed time was updated)",
+                        path.to_str().unwrap()
+                    );
+                }
+                continue;
+            }
+
+            let file = std::fs::OpenOptions::new().read(true).open(path).unwrap();
+
+            if file.try_lock_exclusive().is_err() {
+                if verbose {
+                    eprintln!(
+                        "[EvictionManager] evict_files: skipping {} (file is locked)",
+                        path.to_str().unwrap()
+                    );
+                }
+                continue;
+            }
+
+            drop(file);
+
+            if let Err(err) = std::fs::remove_file(path) {
+                if verbose {
+                    eprintln!(
+                        "[EvictionManager] evict_files: error removing file: {} ({})",
+                        path.to_str().unwrap(),
+                        err
+                    );
+                }
+            } else {
+                eprintln!(
+                    "[EvictionManager] evict_files: removed file at {}",
+                    path.to_str().unwrap()
+                );
+            }
+        }
+    }
+}

--- a/crates/polars-io/src/file_cache/eviction.rs
+++ b/crates/polars-io/src/file_cache/eviction.rs
@@ -18,7 +18,7 @@ pub(super) struct EvictionManager {
 impl EvictionManager {
     pub(super) fn run_in_background(mut self) {
         let verbose = config::verbose();
-        let sleep_interval = std::cmp::max(self.limit_since_last_access.as_secs() / 4, 7);
+        let sleep_interval = std::cmp::max(self.limit_since_last_access.as_secs() / 4, 60);
 
         if verbose {
             eprintln!(

--- a/crates/polars-io/src/file_cache/file_fetcher.rs
+++ b/crates/polars-io/src/file_cache/file_fetcher.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use polars_error::{PolarsError, PolarsResult};
+
+use super::utils::last_modified_u64;
+use crate::cloud::PolarsObjectStore;
+use crate::pl_async;
+
+pub trait FileFetcher: Send + Sync {
+    fn get_uri(&self) -> Arc<str>;
+    fn fetch_metadata(&self) -> PolarsResult<RemoteMetadata>;
+    /// Fetches the object to a `local_path`.
+    fn fetch(&self, local_path: &std::path::Path) -> PolarsResult<()>;
+    fn fetches_as_symlink(&self) -> bool;
+}
+
+pub struct RemoteMetadata {
+    pub size: u64,
+    pub last_modified: u64,
+}
+
+pub(super) struct LocalFileFetcher {
+    uri: Arc<str>,
+    path: Box<std::path::Path>,
+}
+
+impl LocalFileFetcher {
+    pub(super) fn from_uri(uri: Arc<str>) -> Self {
+        let path = std::path::PathBuf::from(uri.as_ref()).into_boxed_path();
+        debug_assert_eq!(
+            path,
+            std::fs::canonicalize(&path).unwrap().into_boxed_path()
+        );
+
+        Self { uri, path }
+    }
+}
+
+impl FileFetcher for LocalFileFetcher {
+    fn get_uri(&self) -> Arc<str> {
+        self.uri.clone()
+    }
+
+    fn fetches_as_symlink(&self) -> bool {
+        #[cfg(target_family = "unix")]
+        {
+            true
+        }
+        #[cfg(not(target_family = "unix"))]
+        {
+            false
+        }
+    }
+
+    fn fetch_metadata(&self) -> PolarsResult<RemoteMetadata> {
+        let metadata = std::fs::metadata(&self.path).map_err(PolarsError::from)?;
+
+        Ok(RemoteMetadata {
+            size: metadata.len(),
+            last_modified: last_modified_u64(&metadata),
+        })
+    }
+
+    fn fetch(&self, local_path: &std::path::Path) -> PolarsResult<()> {
+        #[cfg(target_family = "unix")]
+        {
+            std::os::unix::fs::symlink(&self.path, local_path).map_err(PolarsError::from)
+        }
+        #[cfg(not(target_family = "unix"))]
+        {
+            std::fs::copy(&self.path, local_path).map_err(PolarsError::from)?;
+            Ok(())
+        }
+    }
+}
+
+pub(super) struct CloudFileFetcher {
+    pub(super) uri: Arc<str>,
+    pub(super) cloud_path: object_store::path::Path,
+    pub(super) object_store: PolarsObjectStore,
+}
+
+impl FileFetcher for CloudFileFetcher {
+    fn get_uri(&self) -> Arc<str> {
+        self.uri.clone()
+    }
+
+    fn fetches_as_symlink(&self) -> bool {
+        false
+    }
+
+    fn fetch_metadata(&self) -> PolarsResult<RemoteMetadata> {
+        let metadata = pl_async::get_runtime()
+            .block_on_potential_spawn(self.object_store.head(&self.cloud_path))?;
+
+        Ok(RemoteMetadata {
+            size: metadata.size as u64,
+            last_modified: metadata.last_modified.timestamp_millis() as u64,
+        })
+    }
+
+    fn fetch(&self, local_path: &std::path::Path) -> PolarsResult<()> {
+        pl_async::get_runtime().block_on_potential_spawn(async {
+            let file = &mut tokio::fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(local_path)
+                .await
+                .map_err(PolarsError::from)?;
+
+            self.object_store.download(&self.cloud_path, file).await?;
+            file.sync_all().await.map_err(PolarsError::from)?;
+            PolarsResult::Ok(())
+        })?;
+        Ok(())
+    }
+}

--- a/crates/polars-io/src/file_cache/file_lock.rs
+++ b/crates/polars-io/src/file_cache/file_lock.rs
@@ -1,0 +1,86 @@
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+
+use fs4::FileExt;
+
+/// Note: this creates the file if it does not exist when acquiring locks.
+pub(super) struct FileLock<T: AsRef<Path>>(T);
+pub(super) struct FileLockSharedGuard(File);
+pub(super) struct FileLockExclusiveGuard(File);
+
+/// Trait to specify a file is lock-guarded without needing a particular type of
+/// guard (i.e. shared/exclusive).
+pub(super) trait FileLockAnyGuard:
+    std::ops::Deref<Target = File> + std::ops::DerefMut<Target = File>
+{
+}
+impl FileLockAnyGuard for FileLockSharedGuard {}
+impl FileLockAnyGuard for FileLockExclusiveGuard {}
+
+impl<T: AsRef<Path>> From<T> for FileLock<T> {
+    fn from(path: T) -> Self {
+        Self(path)
+    }
+}
+
+impl<T: AsRef<Path>> FileLock<T> {
+    pub(super) fn acquire_shared(&self) -> Result<FileLockSharedGuard, std::io::Error> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(self.0.as_ref())?;
+        file.lock_shared().map(|_| FileLockSharedGuard(file))
+    }
+
+    pub(super) fn acquire_exclusive(&self) -> Result<FileLockExclusiveGuard, std::io::Error> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(self.0.as_ref())?;
+        file.lock_exclusive().map(|_| FileLockExclusiveGuard(file))
+    }
+}
+
+impl std::ops::Deref for FileLockSharedGuard {
+    type Target = File;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for FileLockSharedGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for FileLockSharedGuard {
+    fn drop(&mut self) {
+        self.0.unlock().unwrap();
+    }
+}
+
+impl std::ops::Deref for FileLockExclusiveGuard {
+    type Target = File;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for FileLockExclusiveGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for FileLockExclusiveGuard {
+    fn drop(&mut self) {
+        self.0.unlock().unwrap();
+    }
+}

--- a/crates/polars-io/src/file_cache/file_lock.rs
+++ b/crates/polars-io/src/file_cache/file_lock.rs
@@ -1,7 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 
-#[cfg(not(target_family = "wasm"))]
 use fs4::FileExt;
 
 /// Note: this creates the file if it does not exist when acquiring locks.

--- a/crates/polars-io/src/file_cache/file_lock.rs
+++ b/crates/polars-io/src/file_cache/file_lock.rs
@@ -1,6 +1,7 @@
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 
+#[cfg(not(target_family = "wasm"))]
 use fs4::FileExt;
 
 /// Note: this creates the file if it does not exist when acquiring locks.

--- a/crates/polars-io/src/file_cache/metadata.rs
+++ b/crates/polars-io/src/file_cache/metadata.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub enum LocalCompareError {
+    LastModifiedMismatch { expected: u64, actual: u64 },
+    SizeMismatch { expected: u64, actual: u64 },
+    DataFileReadError(std::io::Error),
+}
+
+pub type LocalCompareResult = Result<(), LocalCompareError>;
+
+/// Metadata written to a file used to track state / synchronize across processes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(super) struct EntryMetadata {
+    pub(super) uri: Arc<str>,
+    pub(super) local_last_modified: u64,
+    pub(super) local_size: u64,
+    pub(super) remote_last_modified: u64,
+}
+
+impl std::fmt::Display for LocalCompareError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LastModifiedMismatch { expected, actual } => write!(
+                f,
+                "last modified time mismatch: expected {}, found {}",
+                expected, actual
+            ),
+            Self::SizeMismatch { expected, actual } => {
+                write!(f, "size mismatch: expected {}, found {}", expected, actual)
+            },
+            Self::DataFileReadError(err) => {
+                write!(f, "failed to read local file metadata: {}", err)
+            },
+        }
+    }
+}
+
+impl EntryMetadata {
+    pub(super) fn new_with_uri(uri: Arc<str>) -> Self {
+        Self {
+            uri,
+            local_last_modified: 0,
+            local_size: 0,
+            remote_last_modified: 0,
+        }
+    }
+
+    pub(super) fn compare_local_state(&self, data_file_path: &Path) -> LocalCompareResult {
+        let metadata = match std::fs::metadata(data_file_path) {
+            Ok(v) => v,
+            Err(e) => return Err(LocalCompareError::DataFileReadError(e)),
+        };
+
+        let local_last_modified = super::utils::last_modified_u64(&metadata);
+        let local_size = metadata.len();
+
+        if local_last_modified != self.local_last_modified {
+            Err(LocalCompareError::LastModifiedMismatch {
+                expected: self.local_last_modified,
+                actual: local_last_modified,
+            })
+        } else if local_size != self.local_size {
+            Err(LocalCompareError::SizeMismatch {
+                expected: self.local_size,
+                actual: local_size,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) fn try_write<W: std::io::Write>(&self, writer: &mut W) -> serde_json::Result<()> {
+        serde_json::to_writer(writer, self)
+    }
+
+    pub(super) fn try_from_reader<R: std::io::Read>(reader: &mut R) -> serde_json::Result<Self> {
+        serde_json::from_reader(reader)
+    }
+}

--- a/crates/polars-io/src/file_cache/mod.rs
+++ b/crates/polars-io/src/file_cache/mod.rs
@@ -1,0 +1,10 @@
+mod cache;
+mod cache_lock;
+mod entry;
+mod file_fetcher;
+mod file_lock;
+mod metadata;
+mod utils;
+pub use cache::FILE_CACHE;
+pub use entry::FileCacheEntry;
+pub use utils::init_entries_from_uri_list;

--- a/crates/polars-io/src/file_cache/mod.rs
+++ b/crates/polars-io/src/file_cache/mod.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod cache_lock;
 mod entry;
+mod eviction;
 mod file_fetcher;
 mod file_lock;
 mod metadata;

--- a/crates/polars-io/src/file_cache/utils.rs
+++ b/crates/polars-io/src/file_cache/utils.rs
@@ -1,0 +1,88 @@
+use std::sync::Arc;
+use std::time::UNIX_EPOCH;
+
+use polars_error::{to_compute_err, PolarsError, PolarsResult};
+
+use super::cache::FILE_CACHE;
+use super::entry::FileCacheEntry;
+use super::file_fetcher::{CloudFileFetcher, LocalFileFetcher};
+use crate::cloud::{build_object_store, CloudLocation, CloudOptions, PolarsObjectStore};
+use crate::pl_async;
+use crate::prelude::is_cloud_url;
+
+pub(super) fn last_modified_u64(metadata: &std::fs::Metadata) -> u64 {
+    metadata
+        .modified()
+        .unwrap()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+pub(super) fn update_last_accessed(file: &std::fs::File) {
+    let file_metadata = file.metadata().unwrap();
+
+    if let Err(e) = file.set_times(
+        std::fs::FileTimes::new()
+            .set_modified(file_metadata.modified().unwrap())
+            .set_accessed(std::time::SystemTime::now()),
+    ) {
+        panic!("failed to update file last accessed time: {}", e);
+    }
+}
+
+pub fn init_entries_from_uri_list<A: AsRef<[Arc<str>]>>(
+    uri_list: A,
+    cloud_options: Option<&CloudOptions>,
+) -> PolarsResult<Vec<Arc<FileCacheEntry>>> {
+    let uri_list = uri_list.as_ref();
+
+    if uri_list.is_empty() {
+        return Ok(Default::default());
+    }
+
+    let first_uri = uri_list.first().unwrap().as_ref();
+
+    if is_cloud_url(first_uri) {
+        let (_, object_store) = pl_async::get_runtime()
+            .block_on_potential_spawn(build_object_store(first_uri, cloud_options))?;
+        let object_store = PolarsObjectStore::new(object_store);
+
+        uri_list
+            .iter()
+            .map(|uri| {
+                FILE_CACHE.init_entry(uri.clone(), || {
+                    let CloudLocation {
+                        prefix, expansion, ..
+                    } = CloudLocation::new(uri.as_ref()).unwrap();
+
+                    let cloud_path = {
+                        assert!(expansion.is_none(), "path should not contain wildcards");
+                        object_store::path::Path::from_url_path(prefix).map_err(to_compute_err)?
+                    };
+
+                    let object_store = object_store.clone();
+                    let uri = uri.clone();
+
+                    Ok(Arc::new(CloudFileFetcher {
+                        uri,
+                        object_store,
+                        cloud_path,
+                    }))
+                })
+            })
+            .collect::<PolarsResult<Vec<_>>>()
+    } else {
+        uri_list
+            .iter()
+            .map(|uri| {
+                let uri = std::fs::canonicalize(uri.as_ref()).map_err(PolarsError::from)?;
+                let uri = Arc::<str>::from(uri.to_str().unwrap());
+
+                FILE_CACHE.init_entry(uri.clone(), || {
+                    Ok(Arc::new(LocalFileFetcher::from_uri(uri.clone())))
+                })
+            })
+            .collect::<PolarsResult<Vec<_>>>()
+    }
+}

--- a/crates/polars-io/src/file_cache/utils.rs
+++ b/crates/polars-io/src/file_cache/utils.rs
@@ -76,7 +76,13 @@ pub fn init_entries_from_uri_list<A: AsRef<[Arc<str>]>>(
         uri_list
             .iter()
             .map(|uri| {
-                let uri = std::fs::canonicalize(uri.as_ref()).map_err(PolarsError::from)?;
+                let uri = std::fs::canonicalize(uri.as_ref()).map_err(|err| {
+                    let msg = Some(format!("{}: {}", err, uri.as_ref()).into());
+                    PolarsError::IO {
+                        error: err.into(),
+                        msg,
+                    }
+                })?;
                 let uri = Arc::<str>::from(uri.to_str().unwrap());
 
                 FILE_CACHE.init_entry(uri.clone(), || {

--- a/crates/polars-io/src/file_cache/utils.rs
+++ b/crates/polars-io/src/file_cache/utils.rs
@@ -13,9 +13,17 @@ use crate::pl_async;
 use crate::prelude::{is_cloud_url, POLARS_TEMP_DIR_BASE_PATH};
 
 pub(super) static FILE_CACHE_PREFIX: Lazy<Box<Path>> = Lazy::new(|| {
-    POLARS_TEMP_DIR_BASE_PATH
-        .join("/file-cache/")
-        .into_boxed_path()
+    let path = POLARS_TEMP_DIR_BASE_PATH
+        .join("file-cache/")
+        .into_boxed_path();
+
+    if let Err(err) = std::fs::create_dir_all(path.as_ref()) {
+        if !path.is_dir() {
+            panic!("failed to create file cache directory: {}", err);
+        }
+    }
+
+    path
 });
 
 pub(super) fn last_modified_u64(metadata: &std::fs::Metadata) -> u64 {

--- a/crates/polars-io/src/file_cache/utils.rs
+++ b/crates/polars-io/src/file_cache/utils.rs
@@ -1,6 +1,8 @@
+use std::path::Path;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
+use once_cell::sync::Lazy;
 use polars_error::{to_compute_err, PolarsError, PolarsResult};
 
 use super::cache::FILE_CACHE;
@@ -8,7 +10,13 @@ use super::entry::FileCacheEntry;
 use super::file_fetcher::{CloudFileFetcher, LocalFileFetcher};
 use crate::cloud::{build_object_store, CloudLocation, CloudOptions, PolarsObjectStore};
 use crate::pl_async;
-use crate::prelude::is_cloud_url;
+use crate::prelude::{is_cloud_url, POLARS_TEMP_DIR_BASE_PATH};
+
+pub(super) static FILE_CACHE_PREFIX: Lazy<Box<Path>> = Lazy::new(|| {
+    POLARS_TEMP_DIR_BASE_PATH
+        .join("/file-cache/")
+        .into_boxed_path()
+});
 
 pub(super) fn last_modified_u64(metadata: &std::fs::Metadata) -> u64 {
     metadata

--- a/crates/polars-io/src/lib.rs
+++ b/crates/polars-io/src/lib.rs
@@ -7,6 +7,8 @@ pub mod avro;
 pub mod cloud;
 #[cfg(any(feature = "csv", feature = "json"))]
 pub mod csv;
+#[cfg(feature = "async")]
+pub mod file_cache;
 #[cfg(any(feature = "ipc", feature = "ipc_streaming"))]
 pub mod ipc;
 #[cfg(feature = "json")]

--- a/crates/polars-io/src/lib.rs
+++ b/crates/polars-io/src/lib.rs
@@ -7,7 +7,7 @@ pub mod avro;
 pub mod cloud;
 #[cfg(any(feature = "csv", feature = "json"))]
 pub mod csv;
-#[cfg(feature = "async")]
+#[cfg(feature = "cloud")]
 pub mod file_cache;
 #[cfg(any(feature = "ipc", feature = "ipc_streaming"))]
 pub mod ipc;

--- a/crates/polars-io/src/lib.rs
+++ b/crates/polars-io/src/lib.rs
@@ -7,7 +7,7 @@ pub mod avro;
 pub mod cloud;
 #[cfg(any(feature = "csv", feature = "json"))]
 pub mod csv;
-#[cfg(feature = "cloud")]
+#[cfg(feature = "file_cache")]
 pub mod file_cache;
 #[cfg(any(feature = "ipc", feature = "ipc_streaming"))]
 pub mod ipc;

--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -37,6 +37,20 @@ impl<T: GetSize, E: Error> GetSize for Result<T, E> {
     }
 }
 
+pub(crate) struct Size(u64);
+
+impl GetSize for Size {
+    fn size(&self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for Size {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
 enum Optimization {
     Step,
     Accept,

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -11,6 +11,15 @@ use regex::{Regex, RegexBuilder};
 
 use crate::mmap::{MmapBytesReader, ReaderBytes};
 
+pub static POLARS_TEMP_DIR_BASE_PATH: Lazy<Box<Path>> = Lazy::new(|| {
+    std::env::var("POLARS_TEMP_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(std::env::temp_dir().to_string_lossy().as_ref()).join("polars/")
+        })
+        .into_boxed_path()
+});
+
 pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
     reader: &'a mut R,
 ) -> PolarsResult<ReaderBytes<'a>> {

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -12,12 +12,20 @@ use regex::{Regex, RegexBuilder};
 use crate::mmap::{MmapBytesReader, ReaderBytes};
 
 pub static POLARS_TEMP_DIR_BASE_PATH: Lazy<Box<Path>> = Lazy::new(|| {
-    std::env::var("POLARS_TEMP_DIR")
+    let path = std::env::var("POLARS_TEMP_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
             PathBuf::from(std::env::temp_dir().to_string_lossy().as_ref()).join("polars/")
         })
-        .into_boxed_path()
+        .into_boxed_path();
+
+    if let Err(err) = std::fs::create_dir_all(path.as_ref()) {
+        if !path.is_dir() {
+            panic!("failed to create temporary directory: {}", err);
+        }
+    }
+
+    path
 });
 
 pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(

--- a/crates/polars-lazy/src/physical_plan/executors/scan/csv.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/csv.rs
@@ -62,7 +62,7 @@ impl CsvExec {
         let finish_read =
             |i: usize, options: CsvReadOptions, predicate: Option<Arc<dyn PhysicalIoExpr>>| {
                 if run_async {
-                    #[cfg(feature = "async")]
+                    #[cfg(feature = "cloud")]
                     {
                         options
                             .into_reader_with_file_handle(
@@ -75,9 +75,9 @@ impl CsvExec {
                             ._with_predicate(predicate.clone())
                             .finish()
                     }
-                    #[cfg(not(feature = "async"))]
+                    #[cfg(not(feature = "cloud"))]
                     {
-                        panic!("required feature `async` is not enabled")
+                        panic!("required feature `cloud` is not enabled")
                     }
                 } else {
                     options

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -254,7 +254,7 @@ fn create_physical_plan_impl(
 
             match scan_type {
                 #[cfg(feature = "csv")]
-                FileScan::Csv { options } => Ok(Box::new(executors::CsvExec {
+                FileScan::Csv { options, .. } => Ok(Box::new(executors::CsvExec {
                     paths,
                     file_info,
                     options,

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -31,7 +31,7 @@ streaming-decompression = "0.1"
 
 async-stream = { version = "0.3.3", optional = true }
 
-brotli = { version = "^6.0", optional = true }
+brotli = { version = "^5.0", optional = true }
 flate2 = { workspace = true, optional = true }
 lz4 = { version = "1.24", optional = true }
 lz4_flex = { version = "0.11", optional = true }

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -1,8 +1,10 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-use polars_core::POOL;
+use polars_core::{config, POOL};
 use polars_io::csv::read::{BatchedCsvReader, CsvReadOptions, CsvReader};
+use polars_io::file_cache::FILE_CACHE;
+use polars_io::utils::is_cloud_url;
 use polars_plan::global::_set_n_rows_for_scan;
 use polars_plan::prelude::FileScanOptions;
 use polars_utils::iter::EnumerateIdxTrait;
@@ -44,6 +46,14 @@ impl CsvSource {
             return Ok(());
         }
         let path = &self.paths[self.current_path_idx];
+
+        let force_async = config::force_async();
+        let run_async = force_async || is_cloud_url(path);
+
+        if self.current_path_idx == 0 && force_async && self.verbose {
+            eprintln!("ASYNC READING FORCED");
+        }
+
         self.current_path_idx += 1;
 
         let options = self.options.clone().unwrap();
@@ -80,14 +90,33 @@ impl CsvSource {
             eprintln!("STREAMING CHUNK SIZE: {chunk_size} rows")
         }
 
-        let reader: CsvReader<File> = options
+        let options = options
             .with_schema(Some(self.schema.clone()))
             .with_n_rows(n_rows)
             .with_columns(with_columns)
             .with_rechunk(false)
-            .with_row_index(row_index)
-            .with_path(Some(path))
-            .try_into_reader_with_file_path(None)?;
+            .with_row_index(row_index);
+
+        let reader: CsvReader<File> = if run_async {
+            #[cfg(feature = "async")]
+            {
+                options.into_reader_with_file_handle(
+                    FILE_CACHE
+                        .get_entry(path.to_str().unwrap())
+                        // Safety: This was initialized by schema inference.
+                        .unwrap()
+                        .try_open_assume_latest()?,
+                )
+            }
+            #[cfg(not(feature = "async"))]
+            {
+                panic!("required feature `async` is not enabled")
+            }
+        } else {
+            options
+                .with_path(Some(path))
+                .try_into_reader_with_file_path(None)?
+        };
 
         self.reader = Some(reader);
         let reader = self.reader.as_mut().unwrap();

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -98,7 +98,7 @@ impl CsvSource {
             .with_row_index(row_index);
 
         let reader: CsvReader<File> = if run_async {
-            #[cfg(feature = "async")]
+            #[cfg(feature = "cloud")]
             {
                 options.into_reader_with_file_handle(
                     FILE_CACHE
@@ -108,9 +108,9 @@ impl CsvSource {
                         .try_open_assume_latest()?,
                 )
             }
-            #[cfg(not(feature = "async"))]
+            #[cfg(not(feature = "cloud"))]
             {
-                panic!("required feature `async` is not enabled")
+                panic!("required feature `cloud` is not enabled")
             }
         } else {
             options

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use polars_core::{config, POOL};
 use polars_io::csv::read::{BatchedCsvReader, CsvReadOptions, CsvReader};
-use polars_io::file_cache::FILE_CACHE;
 use polars_io::utils::is_cloud_url;
 use polars_plan::global::_set_n_rows_for_scan;
 use polars_plan::prelude::FileScanOptions;
@@ -101,7 +100,7 @@ impl CsvSource {
             #[cfg(feature = "cloud")]
             {
                 options.into_reader_with_file_handle(
-                    FILE_CACHE
+                    polars_io::file_cache::FILE_CACHE
                         .get_entry(path.to_str().unwrap())
                         // Safety: This was initialized by schema inference.
                         .unwrap()

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -99,7 +99,7 @@ where
             }
             match scan_type {
                 #[cfg(feature = "csv")]
-                FileScan::Csv { options } => {
+                FileScan::Csv { options, .. } => {
                     let src = sources::CsvSource::new(
                         paths,
                         file_info.schema,

--- a/crates/polars-plan/src/logical_plan/builder_dsl.rs
+++ b/crates/polars-plan/src/logical_plan/builder_dsl.rs
@@ -156,6 +156,7 @@ impl DslBuilder {
         paths: P,
         read_options: CsvReadOptions,
         cache: bool,
+        cloud_options: Option<CloudOptions>,
     ) -> PolarsResult<Self> {
         let paths = paths.into();
 
@@ -182,6 +183,7 @@ impl DslBuilder {
             predicate: None,
             scan_type: FileScan::Csv {
                 options: read_options,
+                cloud_options,
             },
         }
         .into())

--- a/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/dsl_to_ir.rs
@@ -116,8 +116,11 @@ pub fn to_alp_impl(
                         file_info
                     },
                     #[cfg(feature = "csv")]
-                    FileScan::Csv { options, .. } => {
-                        scans::csv_file_info(&paths, &file_options, options)
+                    FileScan::Csv {
+                        options,
+                        cloud_options,
+                    } => {
+                        scans::csv_file_info(&paths, &file_options, options, cloud_options.as_ref())
                             .map_err(|e| e.context(failed_here!(csv scan)))?
                     },
                     // FileInfo should be set.

--- a/crates/polars-plan/src/logical_plan/conversion/scans.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/scans.rs
@@ -161,9 +161,16 @@ pub(super) fn csv_file_info(
 
     let infer_schema_func = |i| {
         let mut file = if run_async {
-            let entry: &Arc<polars_io::file_cache::FileCacheEntry> =
-                cache_entries.as_ref().unwrap().get(i).unwrap();
-            entry.try_open_check_latest()?
+            #[cfg(feature = "async")]
+            {
+                let entry: &Arc<polars_io::file_cache::FileCacheEntry> =
+                    cache_entries.as_ref().unwrap().get(i).unwrap();
+                entry.try_open_check_latest()?
+            }
+            #[cfg(not(feature = "async"))]
+            {
+                panic!("required feature `async` is not enabled")
+            }
         } else {
             polars_utils::open_file(paths.get(i).unwrap())?
         };

--- a/crates/polars-plan/src/logical_plan/functions/count.rs
+++ b/crates/polars-plan/src/logical_plan/functions/count.rs
@@ -21,7 +21,10 @@ use super::*;
 pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<DataFrame> {
     match scan_type {
         #[cfg(feature = "csv")]
-        FileScan::Csv { options } => {
+        FileScan::Csv {
+            options,
+            cloud_options,
+        } => {
             let parse_options = options.get_parse_options();
             let n_rows: PolarsResult<usize> = paths
                 .iter()

--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -168,7 +168,7 @@ impl SlicePushDown {
                 output_schema,
                 mut file_options,
                 predicate,
-                scan_type: FileScan::Csv { options },
+                scan_type: FileScan::Csv { options, cloud_options },
             }, Some(state)) if predicate.is_none() && state.offset >= 0 =>  {
                 file_options.n_rows = Some(state.offset as usize + state.len as usize);
 
@@ -176,7 +176,7 @@ impl SlicePushDown {
                     paths,
                     file_info,
                     output_schema,
-                    scan_type: FileScan::Csv { options },
+                    scan_type: FileScan::Csv { options, cloud_options },
                     file_options,
                     predicate,
                 };


### PR DESCRIPTION
This adds support for cloud storage in `scan_csv`, using a local cache to avoid duplicates downloads. Cached files are removed if they are not accessed within an hour (configurable with `POLARS_FILE_CACHE_TTL`).