### PR TITLE
fix(python): Reduce scope of multi-threaded numpy conversion

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -113,6 +113,7 @@ def dict_to_pydf(
             # threads running python and release the gil in pyo3 (it will deadlock).
 
             # (note: 'dummy' is threaded)
+            # We catch FileNotFoundError: see 16675
             try:
                 import multiprocessing.dummy
 

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -79,6 +79,7 @@ def dict_to_pydf(
     schema_overrides: SchemaDict | None = None,
     strict: bool = True,
     nan_to_null: bool = False,
+    allow_multithreaded: bool = True,
 ) -> PyDataFrame:
     """Construct a PyDataFrame from a dictionary of sequences."""
     if isinstance(schema, Mapping) and data:
@@ -97,9 +98,13 @@ def dict_to_pydf(
         # if there are 3 or more numpy arrays of sufficient size, we multi-thread:
         count_numpy = sum(
             int(
-                _check_for_numpy(val)
+                allow_multithreaded
+                and _check_for_numpy(val)
                 and isinstance(val, np.ndarray)
                 and len(val) > _MIN_NUMPY_SIZE_FOR_MULTITHREADING
+                # integers and non-nan floats are zero-copy
+                and nan_to_null
+                and val.dtype in (np.float32, np.float64)
             )
             for val in data.values()
         )
@@ -108,20 +113,30 @@ def dict_to_pydf(
             # threads running python and release the gil in pyo3 (it will deadlock).
 
             # (note: 'dummy' is threaded)
-            import multiprocessing.dummy
+            try:
+                import multiprocessing.dummy
 
-            pool_size = thread_pool_size()
-            with multiprocessing.dummy.Pool(pool_size) as pool:
-                data = dict(
-                    zip(
-                        column_names,
-                        pool.map(
-                            lambda t: pl.Series(t[0], t[1], nan_to_null=nan_to_null)
-                            if isinstance(t[1], np.ndarray)
-                            else t[1],
-                            list(data.items()),
-                        ),
+                pool_size = thread_pool_size()
+                with multiprocessing.dummy.Pool(pool_size) as pool:
+                    data = dict(
+                        zip(
+                            column_names,
+                            pool.map(
+                                lambda t: pl.Series(t[0], t[1], nan_to_null=nan_to_null)
+                                if isinstance(t[1], np.ndarray)
+                                else t[1],
+                                list(data.items()),
+                            ),
+                        )
                     )
+            except FileNotFoundError:
+                return dict_to_pydf(
+                    data=data,
+                    schema=schema,
+                    schema_overrides=schema_overrides,
+                    strict=strict,
+                    nan_to_null=nan_to_null,
+                    allow_multithreaded=False,
                 )
 
     if not data and schema_overrides:


### PR DESCRIPTION
Only when we cannot move zero-copy. We catch the FileNotFound error and recurse without multithreading if failed.

fixes #16675