### PR TITLE
chore: Fix incorrect debug assertion in `ChunkedArray::from_chunks_and_dtype`

### DIFF
--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -206,11 +206,8 @@ where
         // that check if the data types in the arrays are as expected
         #[cfg(debug_assertions)]
         {
-            if !chunks.is_empty() && dtype.is_primitive() {
-                assert_eq!(
-                    chunks[0].data_type().underlying_physical_type(),
-                    dtype.to_arrow(true)
-                )
+            if !chunks.is_empty() && !chunks[0].is_empty() && dtype.is_primitive() {
+                assert_eq!(chunks[0].data_type(), &dtype.to_arrow(true))
             }
         }
         let field = Arc::new(Field::new(name, dtype));

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -207,7 +207,10 @@ where
         #[cfg(debug_assertions)]
         {
             if !chunks.is_empty() && dtype.is_primitive() {
-                assert_eq!(chunks[0].data_type(), &dtype.to_physical().to_arrow(true))
+                assert_eq!(
+                    chunks[0].data_type().underlying_physical_type(),
+                    dtype.to_arrow(true)
+                )
             }
         }
         let field = Arc::new(Field::new(name, dtype));

--- a/py-polars/tests/unit/series/test_to_list.py
+++ b/py-polars/tests/unit/series/test_to_list.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from hypothesis import given
+from hypothesis import example, given
 
 import polars as pl
 from polars.testing import assert_series_equal
@@ -14,6 +14,7 @@ from polars.testing.parametric import series
         allow_time_zones=False,
     )
 )
+@example(s=pl.Series(dtype=pl.Array(pl.Date, 1)))
 def test_to_list(s: pl.Series) -> None:
     values = s.to_list()
     result = pl.Series(values, dtype=s.dtype)


### PR DESCRIPTION
Converting an empty Array-of-Dates type resulted in a panic due to a debug assert:

```python
pl.Series(dtype=pl.Array(pl.Date, 1)).to_list()
```
```
pyo3_runtime.PanicException: assertion `left == right` failed
  left: Date32
 right: Int32
```

Looks like empty arrays end up with the wrong data type here. I followed the trace but couldn't work out exactly why that happens. I did find this TODO comment which seems related:
https://github.com/pola-rs/polars/blob/9ea3bb6ed0cbebf49bdb908d444ee9e39626d1aa/crates/polars-core/src/chunked_array/array/iterator.rs#L41-L43

For now I have disabled the debug assertion for empty arrays. It resolves this issue.