### PR TITLE
docs(python): Fix stated value of include_nulls in DataFrame.update

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10726,10 +10726,6 @@ class DataFrame:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        By default, null values in the right frame are ignored. Use
-        `include_nulls=True` to overwrite values in this frame with
-        null values in the other frame.
-
         Parameters
         ----------
         other
@@ -10748,8 +10744,8 @@ class DataFrame:
         right_on
            Join column(s) of the right DataFrame.
         include_nulls
-            If True, null values from the right dataframe will be used to update the
-            left dataframe.
+            Overwrite values in the left frame with null values from the right frame.
+            If set to `False` (default), null values in the right frame are ignored.
 
         Notes
         -----

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10727,7 +10727,7 @@ class DataFrame:
             at any point without it being considered a breaking change.
 
         By default, null values in the right frame are ignored. Use
-        `include_nulls=False` to overwrite values in this frame with
+        `include_nulls=True` to overwrite values in this frame with
         null values in the other frame.
 
         Parameters

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -6142,7 +6142,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         include_nulls: bool = False,
     ) -> Self:
         """
-        Update the values in this `LazyFrame` with the non-null values in `other`.
+        Update the values in this `LazyFrame` with the values in `other`.
 
         .. warning::
             This functionality is considered **unstable**. It may be changed
@@ -6166,8 +6166,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         right_on
            Join column(s) of the right DataFrame.
         include_nulls
-            If True, null values from the right DataFrame will be used to update the
-            left DataFrame.
+            Overwrite values in the left frame with null values from the right frame.
+            If set to `False` (default), null values in the right frame are ignored.
 
         Notes
         -----


### PR DESCRIPTION
Change from `False` to `True` in 

> Use `include_nulls=True` to overwrite values in this frame with null values in the other frame.

Fixes #16379. Documentation is at https://docs.pola.rs/py-polars/html/reference/dataframe/api/polars.DataFrame.update.html#polars.DataFrame.update.