### PR TITLE
chore: Update version resolver for `1.0.0` release

### DIFF
--- a/.github/release-drafter-python.yml
+++ b/.github/release-drafter-python.yml
@@ -8,11 +8,14 @@ include-labels:
   - python
 
 version-resolver:
-  minor:
+  major:
     labels:
       - breaking
       - breaking python
-  default: patch
+  patch:
+    labels:
+      - fix
+  default: minor
 
 categories:
   - title: 🏆 Highlights


### PR DESCRIPTION
From now on, breaking changes will increment the major version:
- `1.0.0`
- `2.0.0`
- ...

Releases that _only_ include bug fixes will be patch releases:
- `1.0.1`
- `1.0.2`
- ...

Other releases will increase the minor version:
- `1.1.0`
- `1.2.0`
- ...

This adheres to [SemVer spec](https://semver.org/#summary):

> Given a version number MAJOR.MINOR.PATCH, increment the:
> 
> MAJOR version when you make incompatible API changes
> MINOR version when you add functionality in a backward compatible manner
> PATCH version when you make backward compatible bug fixes