### PR TITLE
fix(python): Fix deprecated call to Array.width in assertion util

### DIFF
--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -313,7 +313,7 @@ def _categorical_dtype_to_string_dtype(dtype: DataType) -> DataType:
         return List(inner_cast)
     elif isinstance(dtype, Array):
         inner_cast = _categorical_dtype_to_string_dtype(dtype.inner)  # type: ignore[arg-type]
-        return Array(inner_cast, dtype.width)
+        return Array(inner_cast, dtype.size)
     elif isinstance(dtype, Struct):
         fields = {
             f.name: _categorical_dtype_to_string_dtype(f.dtype)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -651,7 +651,7 @@ def test_assert_series_equal_check_dtype_deprecated() -> None:
         assert_series_not_equal(s1, s3, check_dtype=False)  # type: ignore[call-arg]
 
 
-def test_assert_series_equal_nested_categorical_as_str() -> None:
+def test_assert_series_equal_nested_categorical_as_str_global() -> None:
     # https://github.com/pola-rs/polars/issues/16196
 
     # Global
@@ -667,6 +667,23 @@ def test_assert_series_equal_nested_categorical_as_str() -> None:
 
     assert_series_equal(s_global, s_local, categorical_as_str=True)
     assert_series_not_equal(s_global, s_local, categorical_as_str=False)
+
+
+@pytest.mark.parametrize(
+    "s",
+    [
+        pl.Series([["a", "b"], ["a"]], dtype=pl.List(pl.Categorical)),
+        pytest.param(
+            pl.Series([["a", "b"], ["a", "c"]], dtype=pl.Array(pl.Categorical, 2)),
+            marks=pytest.mark.xfail(
+                reason="Currently bugged: https://github.com/pola-rs/polars/issues/16706"
+            ),
+        ),
+        pl.Series([{"a": "x"}, {"a": "y"}], dtype=pl.Struct({"a": pl.Categorical})),
+    ],
+)
+def test_assert_series_equal_nested_categorical_as_str(s: pl.Series) -> None:
+    assert_series_equal(s, s, categorical_as_str=True)
 
 
 def test_tracebackhide(testdir: pytest.Testdir) -> None:


### PR DESCRIPTION
Minor issue with https://github.com/pola-rs/polars/pull/16700 which I didn't cover in unit tests (sorry). Testing it uncovered another bug, so it's still not covered, but at least it should be fixed.