### PR TITLE
feat(python)!: Read 2D numpy arrays as Array[dt, shape] instead of Listst[dt]

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -499,9 +499,7 @@ def numpy_to_pyseries(
         return constructor(
             name, values, nan_to_null if dtype in (np.float32, np.float64) else strict
         )
-    # TODO: remove this branch on 1.0.
-    # This returns a List whereas we should return an Array type
-    elif values.ndim == 2:
+    elif sum(values.shape) == 0:
         # Optimize by ingesting 1D and reshaping in Rust
         original_shape = values.shape
         values = values.reshape(-1)

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -541,15 +541,20 @@ def test_init_ndarray() -> None:
     assert np.array_equal(df.to_numpy(), np.arange(4).reshape(-1, 1).astype(np.int64))
 
     df = pl.DataFrame(np.arange(4).reshape(-1, 2).astype(np.int64), schema=["a"])
-    assert_frame_equal(df, pl.DataFrame({"a": [[0, 1], [2, 3]]}))
+    assert_frame_equal(
+        df,
+        pl.DataFrame(
+            {"a": [[0, 1], [2, 3]]}, schema={"a": pl.Array(pl.Int64, shape=2)}
+        ),
+    )
 
     # 2D numpy arrays
     df = pl.DataFrame({"a": np.arange(5, dtype=np.int64).reshape(1, -1)})
-    assert df.dtypes == [pl.List(pl.Int64)]
+    assert df.dtypes == [pl.Array(pl.Int64, shape=5)]
     assert df.shape == (1, 1)
 
     df = pl.DataFrame({"a": np.arange(10, dtype=np.int64).reshape(2, -1)})
-    assert df.dtypes == [pl.List(pl.Int64)]
+    assert df.dtypes == [pl.Array(pl.Int64, shape=5)]
     assert df.shape == (2, 1)
     assert df.rows() == [([0, 1, 2, 3, 4],), ([5, 6, 7, 8, 9],)]
 

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -466,7 +466,9 @@ def test_list_sliced_get_5186() -> None:
     df = pl.from_dict(
         {
             "ind": pl.arange(0, n, eager=True),
-            "inds": np.stack([np.arange(n), -np.arange(n)], axis=-1),
+            "inds": pl.Series(
+                np.stack([np.arange(n), -np.arange(n)], axis=-1), dtype=pl.List
+            ),
         }
     )
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -118,7 +118,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
             nan_to_null=True,
         ),
     ):
-        assert res.dtype == pl.List(pl.Float32)
+        assert res.dtype == pl.Array(pl.Float32, shape=2)
         assert res[0].to_list() == [1.0, 2.0]
         assert res[1].to_list() == [3.0, None]
 
@@ -134,7 +134,7 @@ def test_init_inputs(monkeypatch: Any) -> None:
 
     assert pl.Series(
         values=np.array([["foo", "bar"], ["foo2", "bar2"]])
-    ).dtype == pl.List(pl.String)
+    ).dtype == pl.Array(pl.String, shape=2)
 
     # lists
     assert pl.Series("a", [[1, 2], [3, 4]]).dtype == pl.List(pl.Int64)


### PR DESCRIPTION
closes #16512