### PR TITLE
perf: speed up offset_by 2x for constant durations

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -197,16 +197,15 @@ fn apply_offsets_to_datetime(
                 let offset = &Duration::parse(offset);
                 if offset.is_constant_duration(datetime.time_zone().as_deref()) {
                     // fastpath!
-                    let duration = match datetime.time_unit() {
+                    let mut duration = match datetime.time_unit() {
                         TimeUnit::Milliseconds => offset.duration_ms(),
                         TimeUnit::Microseconds => offset.duration_us(),
                         TimeUnit::Nanoseconds => offset.duration_ns(),
                     };
                     if offset.negative() {
-                        Ok(datetime.0.apply_values(|v| v - duration))
-                    } else {
-                        Ok(datetime.0.apply_values(|v| v + duration))
+                        duration = -duration;
                     }
+                    Ok(datetime.0.apply_values(|v| v + duration))
                 } else {
                     let offset_fn = match datetime.time_unit() {
                         TimeUnit::Milliseconds => Duration::add_ms,

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -205,7 +205,7 @@ fn apply_offsets_to_datetime(
                     if offset.negative() {
                         duration = -duration;
                     }
-                    Ok(datetime.0.apply_values(|v| v + duration))
+                    Ok(datetime.0.clone().wrapping_add_scalar(duration))
                 } else {
                     let offset_fn = match datetime.time_unit() {
                         TimeUnit::Milliseconds => Duration::add_ms,

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_offset_by.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_offset_by.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
             "2d24h",
             [date(2020, 1, 4), date(2020, 1, 5)],
         ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "-2mo",
+            [date(2019, 11, 1), date(2019, 11, 2)],
+        ),
     ],
 )
 def test_date_offset_by(inputs: list[date], offset: str, outputs: list[date]) -> None:
@@ -85,6 +90,11 @@ def test_date_offset_by(inputs: list[date], offset: str, outputs: list[date]) ->
             [date(2020, 1, 1), date(2020, 1, 2)],
             "-3m",
             [datetime(2019, 12, 31, 23, 57), datetime(2020, 1, 1, 23, 57)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "2mo",
+            [datetime(2020, 3, 1), datetime(2020, 3, 2)],
         ),
     ],
 )

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_offset_by.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_offset_by.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.type_aliases import TimeUnit
+
+
+@pytest.mark.parametrize(
+    ("inputs", "offset", "outputs"),
+    [
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "1d",
+            [date(2020, 1, 2), date(2020, 1, 3)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "-1d",
+            [date(2019, 12, 31), date(2020, 1, 1)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "3d",
+            [date(2020, 1, 4), date(2020, 1, 5)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "72h",
+            [date(2020, 1, 4), date(2020, 1, 5)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "2d24h",
+            [date(2020, 1, 4), date(2020, 1, 5)],
+        ),
+    ],
+)
+def test_date_offset_by(inputs: list[date], offset: str, outputs: list[date]) -> None:
+    result = pl.Series(inputs).dt.offset_by(offset)
+    expected = pl.Series(outputs)
+    assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "offset", "outputs"),
+    [
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "1d",
+            [date(2020, 1, 2), date(2020, 1, 3)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "-1d",
+            [date(2019, 12, 31), date(2020, 1, 1)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "3d",
+            [date(2020, 1, 4), date(2020, 1, 5)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "72h",
+            [date(2020, 1, 4), date(2020, 1, 5)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "2d24h",
+            [date(2020, 1, 4), date(2020, 1, 5)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "7m",
+            [datetime(2020, 1, 1, 0, 7), datetime(2020, 1, 2, 0, 7)],
+        ),
+        (
+            [date(2020, 1, 1), date(2020, 1, 2)],
+            "-3m",
+            [datetime(2019, 12, 31, 23, 57), datetime(2020, 1, 1, 23, 57)],
+        ),
+    ],
+)
+@pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
+@pytest.mark.parametrize("time_zone", ["Europe/London", "Asia/Kathmandu", None])
+def test_datetime_offset_by(
+    inputs: list[date],
+    offset: str,
+    outputs: list[datetime],
+    time_unit: TimeUnit,
+    time_zone: str | None,
+) -> None:
+    result = pl.Series(inputs, dtype=pl.Datetime(time_unit, time_zone)).dt.offset_by(
+        offset
+    )
+    expected = pl.Series(outputs, dtype=pl.Datetime(time_unit, time_zone))
+    assert_series_equal(result, expected)


### PR DESCRIPTION
closes #16722  (timing becomes in line with the alternative method presented - I couldn't reproduce the 10x difference reported)

timing results available here https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=181508652

---

~~I think this is fine but I didn't sleep too well so I'll check over it again tomorrow before marking as 'ready for review'~~

---

The gist of the change is: in the simple case, keep things simple and use `apply_values`