### PR TITLE
feat: Initial SQL support for `INTERVAL` strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,6 +3203,7 @@ dependencies = [
  "polars-lazy",
  "polars-ops",
  "polars-plan",
+ "polars-time",
  "rand",
  "serde",
  "serde_json",

--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -410,6 +410,17 @@ impl Literal for ChronoDuration {
     }
 }
 
+#[cfg(feature = "dtype-duration")]
+impl Literal for Duration {
+    fn lit(self) -> Expr {
+        let ns = self.duration_ns();
+        Expr::Literal(LiteralValue::Duration(
+            if self.negative() { -ns } else { ns },
+            TimeUnit::Nanoseconds,
+        ))
+    }
+}
+
 #[cfg(feature = "dtype-datetime")]
 impl Literal for NaiveDate {
     fn lit(self) -> Expr {

--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -15,6 +15,7 @@ polars-error = { workspace = true }
 polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "dtype-decimal", "is_in", "list_eval", "log", "meta", "regex", "round_series", "sign", "string_reverse", "strings", "timezones", "trigonometry"] }
 polars-ops = { workspace = true }
 polars-plan = { workspace = true }
+polars-time = { workspace = true }
 
 hex = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -1,6 +1,7 @@
 use polars_core::prelude::*;
 use polars_lazy::prelude::*;
 use polars_sql::*;
+use polars_time::Duration;
 
 fn create_sample_df() -> PolarsResult<DataFrame> {
     let a = Series::new("a", (1..10000i64).map(|i| i / 100).collect::<Vec<_>>());
@@ -172,7 +173,8 @@ fn test_literal_exprs() {
             1.0 as float_lit,
             'foo' as string_lit,
             true as bool_lit,
-            null as null_lit
+            null as null_lit,
+            interval '1 quarter 2 weeks 1 day 50 seconds' as duration_lit
         FROM df"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let df_pl = df
@@ -183,6 +185,7 @@ fn test_literal_exprs() {
             lit("foo").alias("string_lit"),
             lit(true).alias("bool_lit"),
             lit(NULL).alias("null_lit"),
+            lit(Duration::parse("1q2w1d50s")).alias("duration_lit"),
         ])
         .collect()
         .unwrap();

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -14,7 +14,12 @@ if TYPE_CHECKING:
 
 
 def test_div() -> None:
-    df = pl.DataFrame({"a": [20.5, None, 10.0, 5.0, 2.5], "b": [6, 12, 24, None, 5]})
+    df = pl.DataFrame(
+        {
+            "a": [20.5, None, 10.0, 5.0, 2.5],
+            "b": [6, 12, 24, None, 5],
+        }
+    )
     res = df.sql("SELECT DIV(a, b) AS a_div_b, DIV(b, a) AS b_div_a FROM self")
     assert res.to_dict(as_series=False) == {
         "a_div_b": [3, None, 0, None, 0],


### PR DESCRIPTION
Closes #16702.

Adds initial `INTERVAL '...'` support to the SQL interface, covering typical uses (follow-ups listed below).

Handles all the typical units in verbose and abbreviated form, is case-insensitive and whitespace tolerant, and also ignores commas (all of which are valid for PostgreSQL interval literals).

* Extends our existing `Duration` object with a new `parse_interval` option.
* Also adds "Literal" and "Neg" trait implementations to `Duration`.

## Example

```python
import polars as pl

with pl.SQLContext(df=None, eager=True) as ctx:
    df = ctx.execute(
        """
        SELECT
          INTERVAL '1w2h3m4s' AS i1,
          INTERVAL '100ms, 100us' AS i2,
          INTERVAL '1 quarter 2 months 987 microseconds' AS i3,
        FROM df
        """
    )
    # shape: (1, 3)
    # ┌──────────────┬──────────────┬──────────────┐
    # │ i1           ┆ i2           ┆ i3           │
    # │ ---          ┆ ---          ┆ ---          │
    # │ duration[ns] ┆ duration[ns] ┆ duration[ns] │
    # ╞══════════════╪══════════════╪══════════════╡
    # │ 7d 2h 3m 4s  ┆ 100100µs     ┆ 140d 987µs   │
    # └──────────────┴──────────────┴──────────────┘
```

##  Follow-ups

* Parsing support for negative interval components, eg: `'7 days -1 hour 30 minutes -10 seconds'`.
* Parsing support for the alternative forms `INTERVAL 1 YEAR` and `'1y6m'::interval`.
* Parsing support for non-constant intervals, eg: `INTERVAL column_n YEAR`.
* Better `Duration` behaviour (generally, not SQL-specific) with ops and incorrect supertype conversions.