### PR TITLE
feat(python): Mark `min_periods` as keyword-only for `rolling` methods

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7543,8 +7543,8 @@ class Expr:
         self,
         window_size: int | timedelta | str,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -7774,8 +7774,8 @@ class Expr:
         self,
         window_size: int | timedelta | str,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -8031,8 +8031,8 @@ class Expr:
         self,
         window_size: int | timedelta | str,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -8290,8 +8290,8 @@ class Expr:
         self,
         window_size: int | timedelta | str,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -8547,8 +8547,8 @@ class Expr:
         self,
         window_size: int | timedelta | str,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -8805,8 +8805,8 @@ class Expr:
         self,
         window_size: int | timedelta | str,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -9063,8 +9063,8 @@ class Expr:
         self,
         window_size: int | timedelta | str,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -9240,8 +9240,8 @@ class Expr:
         interpolation: RollingInterpolationMethod = "nearest",
         window_size: int | timedelta | str = 2,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval | None = None,
@@ -9493,8 +9493,8 @@ class Expr:
         function: Callable[[Series], Any],
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Self:
         """
@@ -11131,7 +11131,7 @@ class Expr:
 
     @unstable()
     def cumulative_eval(
-        self, expr: Expr, min_periods: int = 1, *, parallel: bool = False
+        self, expr: Expr, *, min_periods: int = 1, parallel: bool = False
     ) -> Self:
         """
         Run an expression over a sliding window that increases `1` slot every iteration.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2748,7 +2748,7 @@ class Series:
 
     @unstable()
     def cumulative_eval(
-        self, expr: Expr, min_periods: int = 1, *, parallel: bool = False
+        self, expr: Expr, *, min_periods: int = 1, parallel: bool = False
     ) -> Series:
         """
         Run an expression over a sliding window that increases `1` slot every iteration.
@@ -5587,8 +5587,8 @@ class Series:
         self,
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Series:
         """
@@ -5639,7 +5639,7 @@ class Series:
             self.to_frame()
             .select(
                 F.col(self.name).rolling_min(
-                    window_size, weights, min_periods, center=center
+                    window_size, weights, min_periods=min_periods, center=center
                 )
             )
             .to_series()
@@ -5650,8 +5650,8 @@ class Series:
         self,
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Series:
         """
@@ -5702,7 +5702,7 @@ class Series:
             self.to_frame()
             .select(
                 F.col(self.name).rolling_max(
-                    window_size, weights, min_periods, center=center
+                    window_size, weights, min_periods=min_periods, center=center
                 )
             )
             .to_series()
@@ -5713,8 +5713,8 @@ class Series:
         self,
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Series:
         """
@@ -5765,7 +5765,7 @@ class Series:
             self.to_frame()
             .select(
                 F.col(self.name).rolling_mean(
-                    window_size, weights, min_periods, center=center
+                    window_size, weights, min_periods=min_periods, center=center
                 )
             )
             .to_series()
@@ -5776,8 +5776,8 @@ class Series:
         self,
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Series:
         """
@@ -5828,7 +5828,7 @@ class Series:
             self.to_frame()
             .select(
                 F.col(self.name).rolling_sum(
-                    window_size, weights, min_periods, center=center
+                    window_size, weights, min_periods=min_periods, center=center
                 )
             )
             .to_series()
@@ -5839,8 +5839,8 @@ class Series:
         self,
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         ddof: int = 1,
     ) -> Series:
@@ -5895,7 +5895,11 @@ class Series:
             self.to_frame()
             .select(
                 F.col(self.name).rolling_std(
-                    window_size, weights, min_periods, center=center, ddof=ddof
+                    window_size,
+                    weights,
+                    min_periods=min_periods,
+                    center=center,
+                    ddof=ddof,
                 )
             )
             .to_series()
@@ -5906,8 +5910,8 @@ class Series:
         self,
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
         ddof: int = 1,
     ) -> Series:
@@ -5962,7 +5966,11 @@ class Series:
             self.to_frame()
             .select(
                 F.col(self.name).rolling_var(
-                    window_size, weights, min_periods, center=center, ddof=ddof
+                    window_size,
+                    weights,
+                    min_periods=min_periods,
+                    center=center,
+                    ddof=ddof,
                 )
             )
             .to_series()
@@ -5974,8 +5982,8 @@ class Series:
         function: Callable[[Series], Any],
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Series:
         """
@@ -6030,8 +6038,8 @@ class Series:
         self,
         window_size: int,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Series:
         """
@@ -6082,7 +6090,7 @@ class Series:
             self.to_frame()
             .select(
                 F.col(self.name).rolling_median(
-                    window_size, weights, min_periods, center=center
+                    window_size, weights, min_periods=min_periods, center=center
                 )
             )
             .to_series()
@@ -6095,8 +6103,8 @@ class Series:
         interpolation: RollingInterpolationMethod = "nearest",
         window_size: int = 2,
         weights: list[float] | None = None,
-        min_periods: int | None = None,
         *,
+        min_periods: int | None = None,
         center: bool = False,
     ) -> Series:
         """
@@ -6166,7 +6174,7 @@ class Series:
                     interpolation,
                     window_size,
                     weights,
-                    min_periods,
+                    min_periods=min_periods,
                     center=center,
                 )
             )


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/16684

This aligns the `rolling_*` and `rolling_*_by` methods. This is not breaking as the methods are marked as unstable.