### PR TITLE
feat: Streamline SQL `INTERVAL` handling and improve related error messages, update `sqlparser-rs` lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4162,9 +4162,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.39.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b4dc2cbde11890ccb254a8fc9d537fa41b36da00de2a1c5e9848c9bc42bd7"
+checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
 dependencies = [
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ serde_json = "1"
 simd-json = { version = "0.13", features = ["known-key"] }
 simdutf8 = "0.1.4"
 smartstring = "1"
-sqlparser = "0.39"
+sqlparser = "0.45"
 stacker = "0.1"
 streaming-iterator = "0.1.9"
 strength_reduce = "0.2"

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -119,7 +119,7 @@ impl SQLContext {
             .parse_statements()
             .map_err(to_compute_err)?;
 
-        polars_ensure!(ast.len() == 1, SQLInterface: "one (and only one) statement at a time please");
+        polars_ensure!(ast.len() == 1, SQLInterface: "one (and only one) statement can be parsed at a time");
         let res = self.execute_statement(ast.first().unwrap())?;
 
         // Ensure the result uses the proper arenas.
@@ -175,13 +175,11 @@ impl SQLContext {
 
     pub(crate) fn execute_query(&mut self, query: &Query) -> PolarsResult<LazyFrame> {
         self.register_ctes(query)?;
-
         self.execute_query_no_ctes(query)
     }
 
     pub(crate) fn execute_query_no_ctes(&mut self, query: &Query) -> PolarsResult<LazyFrame> {
         let lf = self.process_set_expr(&query.body, query)?;
-
         self.process_limit_offset(lf, &query.limit, &query.offset)
     }
 

--- a/crates/polars-sql/src/keywords.rs
+++ b/crates/polars-sql/src/keywords.rs
@@ -39,6 +39,7 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::IN,
         keywords::INNER,
         keywords::INT,
+        keywords::INTERVAL,
         keywords::JOIN,
         keywords::LEFT,
         keywords::LIMIT,

--- a/py-polars/tests/unit/sql/test_literals.py
+++ b/py-polars/tests/unit/sql/test_literals.py
@@ -103,7 +103,7 @@ def test_intervals() -> None:
               INTERVAL '100ms 100us' AS i2,
               -- long form with/without commas (case-insensitive)
               INTERVAL '1 week, 2 hours, 3 minutes, 4 seconds' AS i3,
-              INTERVAL '1 Quarter 2 Months 987 Microseconds' AS i4,
+              INTERVAL '1 QUARTER 2 Months 987 microseconds' AS i4,
             FROM df
             """
         )
@@ -124,3 +124,9 @@ def test_intervals() -> None:
             match="minus signs are not yet supported in interval strings; found '-7d'",
         ):
             ctx.execute("SELECT INTERVAL '-7d' AS one_week_ago FROM df")
+
+        with pytest.raises(
+            SQLSyntaxError,
+            match="unary ops are not valid on interval strings; found -'7d'",
+        ):
+            ctx.execute("SELECT INTERVAL -'7d' AS one_week_ago FROM df")


### PR DESCRIPTION
Double-checking against a PostgreSQL instance confirmed that unary ops are invalid when applied to interval strings (eg: `INTERVAL -'7d'` instead of `INTERVAL '-7d'`), so can simplify the parsing and raise a clear error here instead.

Also upgraded `sqlparser-rs` from 0.39 to 0.45; the very latest release (0.47) will require a bit more work to upgrade to so I'll tackle that later. Still pick up a few good additions/fixes with this jump.