### PR TITLE
feat: Support use of ordinal values in SQL `ORDER BY` clause

### DIFF
--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -223,13 +223,13 @@ def test_group_by_errors() -> None:
 
     with pytest.raises(
         SQLSyntaxError,
-        match=r"expected a positive integer or valid expression; got -99",
+        match=r"negative ordinals values are invalid for GROUP BY; found -99",
     ):
         df.sql("SELECT a, SUM(b) FROM self GROUP BY -99, a")
 
     with pytest.raises(
         SQLSyntaxError,
-        match=r"expected a positive integer or valid expression; got '!!!'",
+        match=r"GROUP BY requires a valid expression or positive ordinal; found '!!!'",
     ):
         df.sql("SELECT a, SUM(b) FROM self GROUP BY a, '!!!'")
 


### PR DESCRIPTION
Closes #15793.

Factored out the common code we're using to handle `GROUP BY`[^1] ordinals and used it to integrate support for the same capability in `ORDER BY`[^2] clauses.

## Example

```python
df = pl.DataFrame({
    "a": ["xx", "xx", "yy", "yy"],
    "b": [4000, 3000, 2000, 1000],
})
```
```python
df.sql("""
  SELECT * 
    FROM self 
    ORDER BY 1 DESC, 2 ASC
""")
# shape: (4, 2)
# ┌─────┬──────┐
# │ a   ┆ b    │
# │ --- ┆ ---  │
# │ str ┆ i64  │
# ╞═════╪══════╡
# │ yy  ┆ 1000 │
# │ yy  ┆ 2000 │
# │ xx  ┆ 3000 │
# │ xx  ┆ 4000 │
# └─────┴──────┘
```
```python
df.sql("""
  SELECT a, SUM(b) AS sum_b 
    FROM self 
    GROUP BY 1 
    ORDER BY 2 DESC
""")
# shape: (2, 2)
# ┌─────┬───────┐
# │ a   ┆ sum_b │
# │ --- ┆ ---   │
# │ str ┆ i64   │
# ╞═════╪═══════╡
# │ xx  ┆ 7000  │
# │ yy  ┆ 3000  │
# └─────┴───────┘
```
[^1]: https://github.com/pola-rs/polars/pull/15584
[^2]: _"A sort_expression can also be the column label **or number** of an output column"_ https://www.postgresql.org/docs/current/queries-order.html#QUERIES-ORDER