### PR TITLE
feat(python)!: Remove deprecated functionality from rolling methods

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7198,7 +7198,7 @@ class Expr:
 
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
-        `weight` vector. The resulting values will be aggregated to their min.
+        `weights` vector. The resulting values will be aggregated to their min.
 
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
@@ -7214,7 +7214,7 @@ class Expr:
             The number of values in the window that should be non-null before computing
             a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Notes
         -----
@@ -7309,56 +7309,23 @@ class Expr:
 
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
-        `weight` vector. The resulting values will be aggregated to their max.
+        `weights` vector. The resulting values will be aggregated to their max.
 
-        If `by` has not been specified (the default), the window at a given row will
-        include the row itself, and the `window_size - 1` elements before it.
-
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
-        (the default) means the windows will be:
-
-            - (t_0 - window_size, t_0]
-            - (t_1 - window_size, t_1]
-            - ...
-            - (t_n - window_size, t_n]
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
         window_size
-            The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by a timedelta or the following string language:
-
-            - 1ns   (1 nanosecond)
-            - 1us   (1 microsecond)
-            - 1ms   (1 millisecond)
-            - 1s    (1 second)
-            - 1m    (1 minute)
-            - 1h    (1 hour)
-            - 1d    (1 calendar day)
-            - 1w    (1 calendar week)
-            - 1mo   (1 calendar month)
-            - 1q    (1 calendar quarter)
-            - 1y    (1 calendar year)
-            - 1i    (1 index count)
-
-            By "calendar day", we mean the corresponding time on the next day
-            (which may not be 24 hours, due to daylight savings). Similarly for
-            "calendar week", "calendar month", "calendar quarter", and
-            "calendar year".
-
-            If a timedelta or the dynamic string language is used, the `by`
-            and `closed` arguments must also be set.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Notes
         -----
@@ -7425,84 +7392,6 @@ class Expr:
         │ 5.0 ┆ 6.0         │
         │ 6.0 ┆ null        │
         └─────┴─────────────┘
-
-        Create a DataFrame with a datetime column and a row number column
-
-        >>> from datetime import timedelta, datetime
-        >>> start = datetime(2001, 1, 1)
-        >>> stop = datetime(2001, 1, 2)
-        >>> df_temporal = pl.DataFrame(
-        ...     {"date": pl.datetime_range(start, stop, "1h", eager=True)}
-        ... ).with_row_index()
-        >>> df_temporal
-        shape: (25, 2)
-        ┌───────┬─────────────────────┐
-        │ index ┆ date                │
-        │ ---   ┆ ---                 │
-        │ u32   ┆ datetime[μs]        │
-        ╞═══════╪═════════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 │
-        │ 1     ┆ 2001-01-01 01:00:00 │
-        │ 2     ┆ 2001-01-01 02:00:00 │
-        │ 3     ┆ 2001-01-01 03:00:00 │
-        │ 4     ┆ 2001-01-01 04:00:00 │
-        │ …     ┆ …                   │
-        │ 20    ┆ 2001-01-01 20:00:00 │
-        │ 21    ┆ 2001-01-01 21:00:00 │
-        │ 22    ┆ 2001-01-01 22:00:00 │
-        │ 23    ┆ 2001-01-01 23:00:00 │
-        │ 24    ┆ 2001-01-02 00:00:00 │
-        └───────┴─────────────────────┘
-
-        Compute the rolling max with the temporal windows closed on the right (default)
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_max=pl.col("index").rolling_max(window_size="2h", by="date")
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_max │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ u32             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ 0               │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 1               │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 2               │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 3               │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 4               │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 20              │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 21              │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 22              │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 23              │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 24              │
-        └───────┴─────────────────────┴─────────────────┘
-
-        Compute the rolling max with the closure of windows on both sides
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_max=pl.col("index").rolling_max(
-        ...         window_size="2h", by="date", closed="both"
-        ...     )
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_max │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ u32             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ 0               │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 1               │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 2               │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 3               │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 4               │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 20              │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 21              │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 22              │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 23              │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 24              │
-        └───────┴─────────────────────┴─────────────────┘
         """
         return self._from_pyexpr(
             self._pyexpr.rolling_max(
@@ -7531,56 +7420,23 @@ class Expr:
 
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
-        `weight` vector. The resulting values will be aggregated to their mean.
+        `weights` vector. The resulting values will be aggregated to their mean.
 
-        If `by` has not been specified (the default), the window at a given row will
-        include the row itself, and the `window_size - 1` elements before it.
-
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
-        (the default) means the windows will be:
-
-            - (t_0 - window_size, t_0]
-            - (t_1 - window_size, t_1]
-            - ...
-            - (t_n - window_size, t_n]
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
         window_size
-            The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by a timedelta or the following string language:
-
-            - 1ns   (1 nanosecond)
-            - 1us   (1 microsecond)
-            - 1ms   (1 millisecond)
-            - 1s    (1 second)
-            - 1m    (1 minute)
-            - 1h    (1 hour)
-            - 1d    (1 calendar day)
-            - 1w    (1 calendar week)
-            - 1mo   (1 calendar month)
-            - 1q    (1 calendar quarter)
-            - 1y    (1 calendar year)
-            - 1i    (1 index count)
-
-            By "calendar day", we mean the corresponding time on the next day
-            (which may not be 24 hours, due to daylight savings). Similarly for
-            "calendar week", "calendar month", "calendar quarter", and
-            "calendar year".
-
-            If a timedelta or the dynamic string language is used, the `by`
-            and `closed` arguments must also be set.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Notes
         -----
@@ -7647,86 +7503,6 @@ class Expr:
         │ 5.0 ┆ 5.0          │
         │ 6.0 ┆ null         │
         └─────┴──────────────┘
-
-        Create a DataFrame with a datetime column and a row number column
-
-        >>> from datetime import timedelta, datetime
-        >>> start = datetime(2001, 1, 1)
-        >>> stop = datetime(2001, 1, 2)
-        >>> df_temporal = pl.DataFrame(
-        ...     {"date": pl.datetime_range(start, stop, "1h", eager=True)}
-        ... ).with_row_index()
-        >>> df_temporal
-        shape: (25, 2)
-        ┌───────┬─────────────────────┐
-        │ index ┆ date                │
-        │ ---   ┆ ---                 │
-        │ u32   ┆ datetime[μs]        │
-        ╞═══════╪═════════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 │
-        │ 1     ┆ 2001-01-01 01:00:00 │
-        │ 2     ┆ 2001-01-01 02:00:00 │
-        │ 3     ┆ 2001-01-01 03:00:00 │
-        │ 4     ┆ 2001-01-01 04:00:00 │
-        │ …     ┆ …                   │
-        │ 20    ┆ 2001-01-01 20:00:00 │
-        │ 21    ┆ 2001-01-01 21:00:00 │
-        │ 22    ┆ 2001-01-01 22:00:00 │
-        │ 23    ┆ 2001-01-01 23:00:00 │
-        │ 24    ┆ 2001-01-02 00:00:00 │
-        └───────┴─────────────────────┘
-
-        Compute the rolling mean with the temporal windows closed on the right (default)
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_mean=pl.col("index").rolling_mean(
-        ...         window_size="2h", by="date"
-        ...     )
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬──────────────────┐
-        │ index ┆ date                ┆ rolling_row_mean │
-        │ ---   ┆ ---                 ┆ ---              │
-        │ u32   ┆ datetime[μs]        ┆ f64              │
-        ╞═══════╪═════════════════════╪══════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ 0.0              │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 0.5              │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 1.5              │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 2.5              │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 3.5              │
-        │ …     ┆ …                   ┆ …                │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 19.5             │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 20.5             │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 21.5             │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 22.5             │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 23.5             │
-        └───────┴─────────────────────┴──────────────────┘
-
-        Compute the rolling mean with the closure of windows on both sides
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_mean=pl.col("index").rolling_mean(
-        ...         window_size="2h", by="date", closed="both"
-        ...     )
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬──────────────────┐
-        │ index ┆ date                ┆ rolling_row_mean │
-        │ ---   ┆ ---                 ┆ ---              │
-        │ u32   ┆ datetime[μs]        ┆ f64              │
-        ╞═══════╪═════════════════════╪══════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ 0.0              │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 0.5              │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 1.0              │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 2.0              │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 3.0              │
-        │ …     ┆ …                   ┆ …                │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 19.0             │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 20.0             │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 21.0             │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 22.0             │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 23.0             │
-        └───────┴─────────────────────┴──────────────────┘
         """
         return self._from_pyexpr(
             self._pyexpr.rolling_mean(
@@ -7755,56 +7531,23 @@ class Expr:
 
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
-        `weight` vector. The resulting values will be aggregated to their sum.
+        `weights` vector. The resulting values will be aggregated to their sum.
 
-        If `by` has not been specified (the default), the window at a given row will
-        include the row itself, and the `window_size - 1` elements before it.
-
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
-        (the default) means the windows will be:
-
-            - (t_0 - window_size, t_0]
-            - (t_1 - window_size, t_1]
-            - ...
-            - (t_n - window_size, t_n]
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
         window_size
-            The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by a timedelta or the following string language:
-
-            - 1ns   (1 nanosecond)
-            - 1us   (1 microsecond)
-            - 1ms   (1 millisecond)
-            - 1s    (1 second)
-            - 1m    (1 minute)
-            - 1h    (1 hour)
-            - 1d    (1 calendar day)
-            - 1w    (1 calendar week)
-            - 1mo   (1 calendar month)
-            - 1q    (1 calendar quarter)
-            - 1y    (1 calendar year)
-            - 1i    (1 index count)
-
-            By "calendar day", we mean the corresponding time on the next day
-            (which may not be 24 hours, due to daylight savings). Similarly for
-            "calendar week", "calendar month", "calendar quarter", and
-            "calendar year".
-
-            If a timedelta or the dynamic string language is used, the `by`
-            and `closed` arguments must also be set.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Notes
         -----
@@ -7871,84 +7614,6 @@ class Expr:
         │ 5.0 ┆ 15.0        │
         │ 6.0 ┆ null        │
         └─────┴─────────────┘
-
-        Create a DataFrame with a datetime column and a row number column
-
-        >>> from datetime import timedelta, datetime
-        >>> start = datetime(2001, 1, 1)
-        >>> stop = datetime(2001, 1, 2)
-        >>> df_temporal = pl.DataFrame(
-        ...     {"date": pl.datetime_range(start, stop, "1h", eager=True)}
-        ... ).with_row_index()
-        >>> df_temporal
-        shape: (25, 2)
-        ┌───────┬─────────────────────┐
-        │ index ┆ date                │
-        │ ---   ┆ ---                 │
-        │ u32   ┆ datetime[μs]        │
-        ╞═══════╪═════════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 │
-        │ 1     ┆ 2001-01-01 01:00:00 │
-        │ 2     ┆ 2001-01-01 02:00:00 │
-        │ 3     ┆ 2001-01-01 03:00:00 │
-        │ 4     ┆ 2001-01-01 04:00:00 │
-        │ …     ┆ …                   │
-        │ 20    ┆ 2001-01-01 20:00:00 │
-        │ 21    ┆ 2001-01-01 21:00:00 │
-        │ 22    ┆ 2001-01-01 22:00:00 │
-        │ 23    ┆ 2001-01-01 23:00:00 │
-        │ 24    ┆ 2001-01-02 00:00:00 │
-        └───────┴─────────────────────┘
-
-        Compute the rolling sum with the temporal windows closed on the right (default)
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_sum=pl.col("index").rolling_sum(window_size="2h", by="date")
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_sum │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ u32             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ 0               │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 1               │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 3               │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 5               │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 7               │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 39              │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 41              │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 43              │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 45              │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 47              │
-        └───────┴─────────────────────┴─────────────────┘
-
-        Compute the rolling sum with the closure of windows on both sides
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_sum=pl.col("index").rolling_sum(
-        ...         window_size="2h", by="date", closed="both"
-        ...     )
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_sum │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ u32             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ 0               │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 1               │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 3               │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 6               │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 9               │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 57              │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 60              │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 63              │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 66              │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 69              │
-        └───────┴─────────────────────┴─────────────────┘
         """
         return self._from_pyexpr(
             self._pyexpr.rolling_sum(
@@ -7976,54 +7641,25 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        If `by` has not been specified (the default), the window at a given row will
-        include the row itself, and the `window_size - 1` elements before it.
+        A window of length `window_size` will traverse the array. The values that fill
+        this window will (optionally) be multiplied with the weights given by the
+        `weights` vector. The resulting values will be aggregated to their std.
 
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
-        (the default) means the windows will be:
-
-            - (t_0 - window_size, t_0]
-            - (t_1 - window_size, t_1]
-            - ...
-            - (t_n - window_size, t_n]
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
         window_size
-            The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by a timedelta or the following string language:
-
-            - 1ns   (1 nanosecond)
-            - 1us   (1 microsecond)
-            - 1ms   (1 millisecond)
-            - 1s    (1 second)
-            - 1m    (1 minute)
-            - 1h    (1 hour)
-            - 1d    (1 calendar day)
-            - 1w    (1 calendar week)
-            - 1mo   (1 calendar month)
-            - 1q    (1 calendar quarter)
-            - 1y    (1 calendar year)
-            - 1i    (1 index count)
-
-            By "calendar day", we mean the corresponding time on the next day
-            (which may not be 24 hours, due to daylight savings). Similarly for
-            "calendar week", "calendar month", "calendar quarter", and
-            "calendar year".
-
-            If a timedelta or the dynamic string language is used, the `by`
-            and `closed` arguments must also be set.
+            The length of the window in number of elements.
         weights
-            An optional slice with the same length as the window that determines the
-            relative contribution of each value in a window to the output.
+            An optional slice with the same length as the window that will be multiplied
+            elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
 
@@ -8092,84 +7728,6 @@ class Expr:
         │ 5.0 ┆ 1.0         │
         │ 6.0 ┆ null        │
         └─────┴─────────────┘
-
-        Create a DataFrame with a datetime column and a row number column
-
-        >>> from datetime import timedelta, datetime
-        >>> start = datetime(2001, 1, 1)
-        >>> stop = datetime(2001, 1, 2)
-        >>> df_temporal = pl.DataFrame(
-        ...     {"date": pl.datetime_range(start, stop, "1h", eager=True)}
-        ... ).with_row_index()
-        >>> df_temporal
-        shape: (25, 2)
-        ┌───────┬─────────────────────┐
-        │ index ┆ date                │
-        │ ---   ┆ ---                 │
-        │ u32   ┆ datetime[μs]        │
-        ╞═══════╪═════════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 │
-        │ 1     ┆ 2001-01-01 01:00:00 │
-        │ 2     ┆ 2001-01-01 02:00:00 │
-        │ 3     ┆ 2001-01-01 03:00:00 │
-        │ 4     ┆ 2001-01-01 04:00:00 │
-        │ …     ┆ …                   │
-        │ 20    ┆ 2001-01-01 20:00:00 │
-        │ 21    ┆ 2001-01-01 21:00:00 │
-        │ 22    ┆ 2001-01-01 22:00:00 │
-        │ 23    ┆ 2001-01-01 23:00:00 │
-        │ 24    ┆ 2001-01-02 00:00:00 │
-        └───────┴─────────────────────┘
-
-        Compute the rolling std with the temporal windows closed on the right (default)
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_std=pl.col("index").rolling_std(window_size="2h", by="date")
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_std │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ f64             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ null            │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 0.707107        │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 0.707107        │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 0.707107        │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 0.707107        │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 0.707107        │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 0.707107        │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 0.707107        │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 0.707107        │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 0.707107        │
-        └───────┴─────────────────────┴─────────────────┘
-
-        Compute the rolling std with the closure of windows on both sides
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_std=pl.col("index").rolling_std(
-        ...         window_size="2h", by="date", closed="both"
-        ...     )
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_std │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ f64             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ null            │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 0.707107        │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 1.0             │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 1.0             │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 1.0             │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 1.0             │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 1.0             │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 1.0             │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 1.0             │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 1.0             │
-        └───────┴─────────────────────┴─────────────────┘
         """
         return self._from_pyexpr(
             self._pyexpr.rolling_std(
@@ -8198,54 +7756,25 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        If `by` has not been specified (the default), the window at a given row will
-        include the row itself, and the `window_size - 1` elements before it.
+        A window of length `window_size` will traverse the array. The values that fill
+        this window will (optionally) be multiplied with the weights given by the
+        `weights` vector. The resulting values will be aggregated to their var.
 
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
-        (the default) means the windows will be:
-
-            - (t_0 - window_size, t_0]
-            - (t_1 - window_size, t_1]
-            - ...
-            - (t_n - window_size, t_n]
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
         window_size
-            The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by a timedelta or the following string language:
-
-            - 1ns   (1 nanosecond)
-            - 1us   (1 microsecond)
-            - 1ms   (1 millisecond)
-            - 1s    (1 second)
-            - 1m    (1 minute)
-            - 1h    (1 hour)
-            - 1d    (1 calendar day)
-            - 1w    (1 calendar week)
-            - 1mo   (1 calendar month)
-            - 1q    (1 calendar quarter)
-            - 1y    (1 calendar year)
-            - 1i    (1 index count)
-
-            By "calendar day", we mean the corresponding time on the next day
-            (which may not be 24 hours, due to daylight savings). Similarly for
-            "calendar week", "calendar month", "calendar quarter", and
-            "calendar year".
-
-            If a timedelta or the dynamic string language is used, the `by`
-            and `closed` arguments must also be set.
+            The length of the window in number of elements.
         weights
-            An optional slice with the same length as the window that determines the
-            relative contribution of each value in a window to the output.
+            An optional slice with the same length as the window that will be multiplied
+            elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
 
@@ -8314,84 +7843,6 @@ class Expr:
         │ 5.0 ┆ 1.0         │
         │ 6.0 ┆ null        │
         └─────┴─────────────┘
-
-        Create a DataFrame with a datetime column and a row number column
-
-        >>> from datetime import timedelta, datetime
-        >>> start = datetime(2001, 1, 1)
-        >>> stop = datetime(2001, 1, 2)
-        >>> df_temporal = pl.DataFrame(
-        ...     {"date": pl.datetime_range(start, stop, "1h", eager=True)}
-        ... ).with_row_index()
-        >>> df_temporal
-        shape: (25, 2)
-        ┌───────┬─────────────────────┐
-        │ index ┆ date                │
-        │ ---   ┆ ---                 │
-        │ u32   ┆ datetime[μs]        │
-        ╞═══════╪═════════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 │
-        │ 1     ┆ 2001-01-01 01:00:00 │
-        │ 2     ┆ 2001-01-01 02:00:00 │
-        │ 3     ┆ 2001-01-01 03:00:00 │
-        │ 4     ┆ 2001-01-01 04:00:00 │
-        │ …     ┆ …                   │
-        │ 20    ┆ 2001-01-01 20:00:00 │
-        │ 21    ┆ 2001-01-01 21:00:00 │
-        │ 22    ┆ 2001-01-01 22:00:00 │
-        │ 23    ┆ 2001-01-01 23:00:00 │
-        │ 24    ┆ 2001-01-02 00:00:00 │
-        └───────┴─────────────────────┘
-
-        Compute the rolling var with the temporal windows closed on the right (default)
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_var=pl.col("index").rolling_var(window_size="2h", by="date")
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_var │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ f64             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ null            │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 0.5             │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 0.5             │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 0.5             │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 0.5             │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 0.5             │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 0.5             │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 0.5             │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 0.5             │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 0.5             │
-        └───────┴─────────────────────┴─────────────────┘
-
-        Compute the rolling var with the closure of windows on both sides
-
-        >>> df_temporal.with_columns(
-        ...     rolling_row_var=pl.col("index").rolling_var(
-        ...         window_size="2h", by="date", closed="both"
-        ...     )
-        ... )  # doctest:+SKIP
-        shape: (25, 3)
-        ┌───────┬─────────────────────┬─────────────────┐
-        │ index ┆ date                ┆ rolling_row_var │
-        │ ---   ┆ ---                 ┆ ---             │
-        │ u32   ┆ datetime[μs]        ┆ f64             │
-        ╞═══════╪═════════════════════╪═════════════════╡
-        │ 0     ┆ 2001-01-01 00:00:00 ┆ null            │
-        │ 1     ┆ 2001-01-01 01:00:00 ┆ 0.5             │
-        │ 2     ┆ 2001-01-01 02:00:00 ┆ 1.0             │
-        │ 3     ┆ 2001-01-01 03:00:00 ┆ 1.0             │
-        │ 4     ┆ 2001-01-01 04:00:00 ┆ 1.0             │
-        │ …     ┆ …                   ┆ …               │
-        │ 20    ┆ 2001-01-01 20:00:00 ┆ 1.0             │
-        │ 21    ┆ 2001-01-01 21:00:00 ┆ 1.0             │
-        │ 22    ┆ 2001-01-01 22:00:00 ┆ 1.0             │
-        │ 23    ┆ 2001-01-01 23:00:00 ┆ 1.0             │
-        │ 24    ┆ 2001-01-02 00:00:00 ┆ 1.0             │
-        └───────┴─────────────────────┴─────────────────┘
         """
         return self._from_pyexpr(
             self._pyexpr.rolling_var(
@@ -8419,54 +7870,25 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        If `by` has not been specified (the default), the window at a given row will
-        include the row itself, and the `window_size - 1` elements before it.
+        A window of length `window_size` will traverse the array. The values that fill
+        this window will (optionally) be multiplied with the weights given by the
+        `weights` vector. The resulting values will be aggregated to their median.
 
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
-        (the default) means the windows will be:
-
-            - (t_0 - window_size, t_0]
-            - (t_1 - window_size, t_1]
-            - ...
-            - (t_n - window_size, t_n]
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
         window_size
-            The length of the window. Can be a fixed integer size, or a dynamic temporal
-            size indicated by a timedelta or the following string language:
-
-            - 1ns   (1 nanosecond)
-            - 1us   (1 microsecond)
-            - 1ms   (1 millisecond)
-            - 1s    (1 second)
-            - 1m    (1 minute)
-            - 1h    (1 hour)
-            - 1d    (1 calendar day)
-            - 1w    (1 calendar week)
-            - 1mo   (1 calendar month)
-            - 1q    (1 calendar quarter)
-            - 1y    (1 calendar year)
-            - 1i    (1 index count)
-
-            By "calendar day", we mean the corresponding time on the next day
-            (which may not be 24 hours, due to daylight savings). Similarly for
-            "calendar week", "calendar month", "calendar quarter", and
-            "calendar year".
-
-            If a timedelta or the dynamic string language is used, the `by`
-            and `closed` arguments must also be set.
+            The length of the window in number of elements.
         weights
-            An optional slice with the same length as the window that determines the
-            relative contribution of each value in a window to the output.
+            An optional slice with the same length as the window that will be multiplied
+            elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Notes
         -----
@@ -8561,16 +7983,12 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        If `by` has not been specified (the default), the window at a given row will
-        include the row itself, and the `window_size - 1` elements before it.
+        A window of length `window_size` will traverse the array. The values that fill
+        this window will (optionally) be multiplied with the weights given by the
+        `weights` vector. The resulting values will be aggregated to their quantile.
 
-        If you pass a `by` column `<t_0, t_1, ..., t_n>`, then `closed="right"`
-        (the default) means the windows will be:
-
-            - (t_0 - window_size, t_0]
-            - (t_1 - window_size, t_1]
-            - ...
-            - (t_n - window_size, t_n]
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -8579,40 +7997,15 @@ class Expr:
         interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
             Interpolation method.
         window_size
-            The length of the window. Can be a fixed integer size, or a dynamic
-            temporal size indicated by a timedelta or the following string language:
-
-            - 1ns   (1 nanosecond)
-            - 1us   (1 microsecond)
-            - 1ms   (1 millisecond)
-            - 1s    (1 second)
-            - 1m    (1 minute)
-            - 1h    (1 hour)
-            - 1d    (1 calendar day)
-            - 1w    (1 calendar week)
-            - 1mo   (1 calendar month)
-            - 1q    (1 calendar quarter)
-            - 1y    (1 calendar year)
-            - 1i    (1 index count)
-
-            By "calendar day", we mean the corresponding time on the next day
-            (which may not be 24 hours, due to daylight savings). Similarly for
-            "calendar week", "calendar month", "calendar quarter", and
-            "calendar year".
-
-            If a timedelta or the dynamic string language is used, the `by`
-            and `closed` arguments must also be set.
+            The length of the window in number of elements.
         weights
-            An optional slice with the same length as the window that determines the
-            relative contribution of each value in a window to the output.
+            An optional slice with the same length as the window that will be multiplied
+            elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Notes
         -----
@@ -8728,8 +8121,8 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        The window at a given row includes the row itself and the
-        `window_size - 1` elements before it.
+        The window at a given row will include the row itself, and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -8783,17 +8176,13 @@ class Expr:
         function
             Custom aggregation function.
         window_size
-            Size of the window. The window at a given row will include the row
-            itself and the `window_size - 1` elements before it.
+            The length of the window in number of elements.
         weights
-            A list of weights with the same length as the window that will be multiplied
+            An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
             Set the labels at the center of the window.
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6048,7 +6048,6 @@ class Expr:
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling min based on another column.
@@ -6095,12 +6094,6 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive),
             defaults to `'right'`.
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6163,12 +6156,6 @@ class Expr:
         └───────┴─────────────────────┴─────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_min_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_min_by(by, window_size, min_periods, closed)
@@ -6182,7 +6169,6 @@ class Expr:
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling max based on another column.
@@ -6229,12 +6215,6 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive),
             defaults to `'right'`.
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6323,12 +6303,6 @@ class Expr:
         └───────┴─────────────────────┴─────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_max_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_max_by(by, window_size, min_periods, closed)
@@ -6342,7 +6316,6 @@ class Expr:
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling mean based on another column.
@@ -6389,12 +6362,6 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive),
             defaults to `'right'`.
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6485,12 +6452,6 @@ class Expr:
         └───────┴─────────────────────┴──────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_mean_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_mean_by(
@@ -6509,7 +6470,6 @@ class Expr:
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Apply a rolling sum based on another column.
@@ -6556,12 +6516,6 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive),
             defaults to `'right'`.
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6650,12 +6604,6 @@ class Expr:
         └───────┴─────────────────────┴─────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_sum_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_sum_by(by, window_size, min_periods, closed)
@@ -6670,7 +6618,6 @@ class Expr:
         min_periods: int = 1,
         closed: ClosedInterval = "right",
         ddof: int = 1,
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling standard deviation based on another column.
@@ -6719,12 +6666,6 @@ class Expr:
             defaults to `'right'`.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6813,12 +6754,6 @@ class Expr:
         └───────┴─────────────────────┴─────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_std_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_std_by(
@@ -6839,7 +6774,6 @@ class Expr:
         min_periods: int = 1,
         closed: ClosedInterval = "right",
         ddof: int = 1,
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling variance based on another column.
@@ -6888,12 +6822,6 @@ class Expr:
             defaults to `'right'`.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -6982,12 +6910,6 @@ class Expr:
         └───────┴─────────────────────┴─────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_var_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_var_by(
@@ -7007,7 +6929,6 @@ class Expr:
         *,
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling median based on another column.
@@ -7054,12 +6975,6 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive),
             defaults to `'right'`.
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -7124,12 +7039,6 @@ class Expr:
         └───────┴─────────────────────┴────────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_median_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_median_by(by, window_size, min_periods, closed)
@@ -7145,7 +7054,6 @@ class Expr:
         interpolation: RollingInterpolationMethod = "nearest",
         min_periods: int = 1,
         closed: ClosedInterval = "right",
-        warn_if_unsorted: bool | None = None,
     ) -> Self:
         """
         Compute a rolling quantile based on another column.
@@ -7196,12 +7104,6 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive),
             defaults to `'right'`.
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column.
-
-            .. deprecated:: 0.20.27
-                This operation no longer requires sorted data, you can safely remove
-                the `warn_if_unsorted` argument.
 
         Notes
         -----
@@ -7266,12 +7168,6 @@ class Expr:
         └───────┴─────────────────────┴──────────────────────┘
         """
         window_size = _prepare_rolling_by_window_args(window_size)
-        if warn_if_unsorted is not None:
-            issue_deprecation_warning(
-                "`warn_if_unsorted` is deprecated in `rolling_quantile_by` because it "
-                "no longer requires sorted data - you can safely remove this argument.",
-                version="0.20.27",
-            )
         by = parse_as_expression(by)
         return self._from_pyexpr(
             self._pyexpr.rolling_quantile_by(
@@ -7463,19 +7359,6 @@ class Expr:
             - 1, if `window_size` is a dynamic temporal size
         center
             Set the labels at the center of the window
-        by
-            If the `window_size` is temporal, for instance `"5h"` or `"3s"`, you must
-            set the column that will be used to determine the windows. This column must
-            be of dtype Datetime or Date.
-
-            .. deprecated:: 0.20.24
-                Passing `by` to `rolling_max` is deprecated - please use
-                :meth:`.rolling_max_by` instead.
-        closed : {'left', 'right', 'both', 'none'}
-            Define which sides of the temporal interval are closed (inclusive); only
-            applicable if `by` has been set (in which case, it defaults to `'right'`).
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
 
         Notes
         -----
@@ -7698,19 +7581,6 @@ class Expr:
             - 1, if `window_size` is a dynamic temporal size
         center
             Set the labels at the center of the window
-        by
-            If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
-            set the column that will be used to determine the windows. This column must
-            be of dtype Datetime or Date.
-
-            .. deprecated:: 0.20.24
-                Passing `by` to `rolling_mean` is deprecated - please use
-                :meth:`.rolling_mean_by` instead.
-        closed : {'left', 'right', 'both', 'none'}
-            Define which sides of the temporal interval are closed (inclusive); only
-            applicable if `by` has been set (in which case, it defaults to `'right'`).
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
 
         Notes
         -----
@@ -7935,19 +7805,6 @@ class Expr:
             - 1, if `window_size` is a dynamic temporal size
         center
             Set the labels at the center of the window
-        by
-            If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
-            set the column that will be used to determine the windows. This column must
-            of dtype `{Date, Datetime}`
-
-            .. deprecated:: 0.20.24
-                Passing `by` to `rolling_sum` is deprecated - please use
-                :meth:`.rolling_sum_by` instead.
-        closed : {'left', 'right', 'both', 'none'}
-            Define which sides of the temporal interval are closed (inclusive); only
-            applicable if `by` has been set (in which case, it defaults to `'right'`).
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
 
         Notes
         -----
@@ -8167,21 +8024,8 @@ class Expr:
             - 1, if `window_size` is a dynamic temporal size
         center
             Set the labels at the center of the window
-        by
-            If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
-            set the column that will be used to determine the windows. This column must
-            be of dtype Datetime or Date.
-
-            .. deprecated:: 0.20.24
-                Passing `by` to `rolling_std` is deprecated - please use
-                :meth:`.rolling_std_by` instead.
-        closed : {'left', 'right', 'both', 'none'}
-            Define which sides of the temporal interval are closed (inclusive); only
-            applicable if `by` has been set (in which case, it defaults to `'right'`).
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
 
         Notes
         -----
@@ -8402,21 +8246,8 @@ class Expr:
             - 1, if `window_size` is a dynamic temporal size
         center
             Set the labels at the center of the window
-        by
-            If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
-            set the column that will be used to determine the windows. This column must
-            be of dtype Datetime or Date.
-
-            .. deprecated:: 0.20.24
-                Passing `by` to `rolling_var` is deprecated - please use
-                :meth:`.rolling_var_by` instead.
-        closed : {'left', 'right', 'both', 'none'}
-            Define which sides of the temporal interval are closed (inclusive); only
-            applicable if `by` has been set (in which case, it defaults to `'right'`).
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
 
         Notes
         -----
@@ -8636,19 +8467,6 @@ class Expr:
             - 1, if `window_size` is a dynamic temporal size
         center
             Set the labels at the center of the window
-        by
-            If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
-            set the column that will be used to determine the windows. This column must
-            be of dtype Datetime or Date.
-
-            .. deprecated:: 0.20.24
-                Passing `by` to `rolling_median` is deprecated - please use
-                :meth:`.rolling_median_by` instead.
-        closed : {'left', 'right', 'both', 'none'}
-            Define which sides of the temporal interval are closed (inclusive); only
-            applicable if `by` has been set (in which case, it defaults to `'right'`).
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
 
         Notes
         -----
@@ -8795,19 +8613,6 @@ class Expr:
             - 1, if `window_size` is a dynamic temporal size
         center
             Set the labels at the center of the window
-        by
-            If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
-            set the column that will be used to determine the windows. This column must
-            be of dtype Datetime or Date.
-
-            .. deprecated:: 0.20.24
-                Passing `by` to `rolling_quantile` is deprecated - please use
-                :meth:`.rolling_quantile_by` instead.
-        closed : {'left', 'right', 'both', 'none'}
-            Define which sides of the temporal interval are closed (inclusive); only
-            applicable if `by` has been set (in which case, it defaults to `'right'`).
-        warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
 
         Notes
         -----
@@ -11252,9 +11057,7 @@ def _prepare_alpha(
     return alpha
 
 
-def _prepare_rolling_by_window_args(
-    window_size: timedelta | str,
-) -> str:
+def _prepare_rolling_by_window_args(window_size: timedelta | str) -> str:
     if isinstance(window_size, timedelta):
         window_size = parse_as_duration_string(window_size)
     return window_size

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5635,15 +5635,6 @@ class Series:
             300
         ]
         """
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_min(
-                    window_size, weights, min_periods=min_periods, center=center
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_max(
@@ -5698,15 +5689,6 @@ class Series:
             500
         ]
         """
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_max(
-                    window_size, weights, min_periods=min_periods, center=center
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_mean(
@@ -5761,15 +5743,6 @@ class Series:
             450.0
         ]
         """
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_mean(
-                    window_size, weights, min_periods=min_periods, center=center
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_sum(
@@ -5824,15 +5797,6 @@ class Series:
                 9
         ]
         """
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_sum(
-                    window_size, weights, min_periods=min_periods, center=center
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_std(
@@ -5891,19 +5855,6 @@ class Series:
                 2.0
         ]
         """
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_std(
-                    window_size,
-                    weights,
-                    min_periods=min_periods,
-                    center=center,
-                    ddof=ddof,
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_var(
@@ -5962,19 +5913,6 @@ class Series:
                 4.0
         ]
         """
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_var(
-                    window_size,
-                    weights,
-                    min_periods=min_periods,
-                    center=center,
-                    ddof=ddof,
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_map(
@@ -6083,18 +6021,6 @@ class Series:
                 6.0
         ]
         """
-        if min_periods is None:
-            min_periods = window_size
-
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_median(
-                    window_size, weights, min_periods=min_periods, center=center
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_quantile(
@@ -6163,23 +6089,6 @@ class Series:
                 5.32
         ]
         """
-        if min_periods is None:
-            min_periods = window_size
-
-        return (
-            self.to_frame()
-            .select(
-                F.col(self.name).rolling_quantile(
-                    quantile,
-                    interpolation,
-                    window_size,
-                    weights,
-                    min_periods=min_periods,
-                    center=center,
-                )
-            )
-            .to_series()
-        )
 
     @unstable()
     def rolling_skew(self, window_size: int, *, bias: bool = True) -> Series:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5608,18 +5608,15 @@ class Series:
         Parameters
         ----------
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Examples
         --------
@@ -5662,18 +5659,15 @@ class Series:
         Parameters
         ----------
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Examples
         --------
@@ -5716,18 +5710,15 @@ class Series:
         Parameters
         ----------
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Examples
         --------
@@ -5770,18 +5761,15 @@ class Series:
         Parameters
         ----------
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
-            An optional slice with the same length of the window that will be multiplied
+            An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Examples
         --------
@@ -5825,18 +5813,15 @@ class Series:
         Parameters
         ----------
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
 
@@ -5883,18 +5868,15 @@ class Series:
         Parameters
         ----------
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
 
@@ -5936,17 +5918,13 @@ class Series:
         function
             Custom aggregation function.
         window_size
-            Size of the window. The window at a given row will include the row
-            itself and the `window_size - 1` elements before it.
+            The length of the window in number of elements.
         weights
-            A list of weights with the same length as the window that will be multiplied
+            An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
             Set the labels at the center of the window.
 
@@ -5987,24 +5965,21 @@ class Series:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
+        The window at a given row will include the row itself and the `window_size - 1`
+        elements before it.
+
         Parameters
         ----------
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
-
-        The window at a given row will include the row itself and the `window_size - 1`
-        elements before it.
+            Set the labels at the center of the window.
 
         Examples
         --------
@@ -6050,18 +6025,15 @@ class Series:
         interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
             Interpolation method.
         window_size
-            The length of the window.
+            The length of the window in number of elements.
         weights
             An optional slice with the same length as the window that will be multiplied
             elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
-            a result. If None, it will be set equal to:
-
-            - the window size, if `window_size` is a fixed integer
-            - 1, if `window_size` is a dynamic temporal size
+            a result. If set to `None` (default), it will be set equal to `window_size`.
         center
-            Set the labels at the center of the window
+            Set the labels at the center of the window.
 
         Examples
         --------

--- a/py-polars/src/expr/rolling.rs
+++ b/py-polars/src/expr/rolling.rs
@@ -15,9 +15,10 @@ impl PyExpr {
         &self,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,
@@ -50,9 +51,10 @@ impl PyExpr {
         &self,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,
@@ -85,9 +87,10 @@ impl PyExpr {
         &self,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,
@@ -119,9 +122,10 @@ impl PyExpr {
         &self,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,
@@ -156,10 +160,11 @@ impl PyExpr {
         &self,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
         ddof: u8,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,
@@ -195,10 +200,11 @@ impl PyExpr {
         &self,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
         ddof: u8,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,
@@ -234,9 +240,10 @@ impl PyExpr {
         &self,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             min_periods,
@@ -274,9 +281,10 @@ impl PyExpr {
         interpolation: Wrap<QuantileInterpolOptions>,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,
@@ -324,9 +332,10 @@ impl PyExpr {
         lambda: PyObject,
         window_size: usize,
         weights: Option<Vec<f64>>,
-        min_periods: usize,
+        min_periods: Option<usize>,
         center: bool,
     ) -> Self {
+        let min_periods = min_periods.unwrap_or(window_size);
         let options = RollingOptionsFixedWindow {
             window_size,
             weights,

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -688,17 +688,15 @@ def test_rolling_aggregations_with_over_11225() -> None:
 
     df_temporal = df_temporal.sort("group", "date")
 
-    with pytest.deprecated_call(match="you can safely remove this argument"):
-        result = df_temporal.with_columns(
-            rolling_row_mean=pl.col("index")
-            .rolling_mean_by(
-                by="date",
-                window_size="2d",
-                closed="left",
-                warn_if_unsorted=False,
-            )
-            .over("group")
+    result = df_temporal.with_columns(
+        rolling_row_mean=pl.col("index")
+        .rolling_mean_by(
+            by="date",
+            window_size="2d",
+            closed="left",
         )
+        .over("group")
+    )
     expected = pl.DataFrame(
         {
             "index": [0, 1, 2, 3, 4],

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -502,13 +502,6 @@ def test_lit_agg_err() -> None:
         pl.DataFrame({"y": [1]}).with_columns(pl.lit(1).sum().over("y"))
 
 
-def test_window_size_validation() -> None:
-    df = pl.DataFrame({"x": [1.0]})
-
-    with pytest.raises(ValueError, match=r"`window_size` must be positive"):
-        df.with_columns(trailing_min=pl.col("x").rolling_min(window_size=-3))
-
-
 def test_invalid_group_by_arg() -> None:
     df = pl.DataFrame({"a": [1]})
     with pytest.raises(


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/13525

The rolling methods are unstable, so we can expedite this deprecation. Let's get these in good shape for 1.0.0!