### PR TITLE
fix(python): from_arrow_fixed_size_list

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -465,7 +465,9 @@ def arrow_to_pyseries(
         if array.num_chunks > 1:
             # somehow going through ffi with a structarray
             # returns the first chunk every time
-            if isinstance(array.type, pa.StructType):
+            # somehow going through ffi with a FixedSizeList
+            # returns the whole array x times
+            if isinstance(array.type, (pa.StructType, pa.FixedSizeListType)):
                 pys = PySeries.from_arrow(name, array.combine_chunks())
             else:
                 it = array.iterchunks()


### PR DESCRIPTION
In the process of putting this fix in I noticed that we'd have a bug if there were both structs and dictionaries because when it's adding those columns back, it doesn't merge them between the dictionary_cols and struct_cols. There isn't any reason to separate the special cases so I put them in a single dict along with fixed_size_list.