### PR TITLE
docs(python): Add docstring example for DataFrame.limit()

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5066,6 +5066,29 @@ class DataFrame:
         See Also
         --------
         head
+
+        Examples
+        --------
+        Get the first 3 rows of a DataFrame.
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2, 3, 4, 5],
+        ...         "bar": [6, 7, 8, 9, 10],
+        ...         "ham": ["a", "b", "c", "d", "e"],
+        ...     }
+        ... )
+        >>> df.limit(3)
+        shape: (3, 3)
+        ┌─────┬─────┬─────┐
+        │ foo ┆ bar ┆ ham │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ str │
+        ╞═════╪═════╪═════╡
+        │ 1   ┆ 6   ┆ a   │
+        │ 2   ┆ 7   ┆ b   │
+        │ 3   ┆ 8   ┆ c   │
+        └─────┴─────┴─────┘
         """
         return self.head(n)
 


### PR DESCRIPTION
Related to: Add missing docstring examples #13161

Add example for:
https://docs.pola.rs/py-polars/html/reference/dataframe/api/polars.DataFrame.limit.html