### PR TITLE
feat(python)!: Enforce deprecation of keyword arguments as positional

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -44,7 +44,6 @@ from polars._utils.construction import (
 from polars._utils.convert import parse_as_duration_string
 from polars._utils.deprecation import (
     deprecate_function,
-    deprecate_parameter_as_positional,
     deprecate_renamed_parameter,
     issue_deprecation_warning,
 )
@@ -5358,7 +5357,6 @@ class DataFrame:
         """
         return self.with_row_index(name, offset)
 
-    @deprecate_parameter_as_positional("by", version="0.20.7")
     def group_by(
         self,
         *by: IntoExpr | Iterable[IntoExpr],
@@ -6849,7 +6847,6 @@ class DataFrame:
                 raise
         return self
 
-    @deprecate_parameter_as_positional("columns", version="0.20.4")
     def drop(
         self, *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector]
     ) -> DataFrame:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
 import polars._reexport as pl
 import polars.functions as F
 from polars._utils.async_ import _AioDataFrameResult, _GeventDataFrameResult
-from polars._utils.deprecation import (
-    deprecate_parameter_as_positional,
-    issue_deprecation_warning,
-)
+from polars._utils.deprecation import issue_deprecation_warning
 from polars._utils.parse_expr_input import (
     parse_as_expression,
     parse_as_list_of_expressions,
@@ -100,7 +97,6 @@ def element() -> Expr:
     return F.col("")
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def count(*columns: str) -> Expr:
     """
     Return the number of non-null values in the column.
@@ -212,7 +208,6 @@ def cum_count(*columns: str, reverse: bool = False) -> Expr:
     return F.col(*columns).cum_count(reverse=reverse)
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def implode(*columns: str) -> Expr:
     """
     Aggregate all column values into a list.
@@ -334,7 +329,6 @@ def var(column: str, ddof: int = 1) -> Expr:
     return F.col(column).var(ddof)
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def mean(*columns: str) -> Expr:
     """
     Get the mean value.
@@ -382,7 +376,6 @@ def mean(*columns: str) -> Expr:
     return F.col(*columns).mean()
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def median(*columns: str) -> Expr:
     """
     Get the median value.
@@ -426,7 +419,6 @@ def median(*columns: str) -> Expr:
     return F.col(*columns).median()
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def n_unique(*columns: str) -> Expr:
     """
     Count unique values.
@@ -470,7 +462,6 @@ def n_unique(*columns: str) -> Expr:
     return F.col(*columns).n_unique()
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def approx_n_unique(*columns: str) -> Expr:
     """
     Approximate count of unique values.
@@ -515,7 +506,6 @@ def approx_n_unique(*columns: str) -> Expr:
     return F.col(*columns).approx_n_unique()
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def first(*columns: str) -> Expr:
     """
     Get the first column or value.
@@ -581,7 +571,6 @@ def first(*columns: str) -> Expr:
     return F.col(*columns).first()
 
 
-@deprecate_parameter_as_positional("column", version="0.20.4")
 def last(*columns: str) -> Expr:
     """
     Get the last column or value.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -28,7 +28,6 @@ from polars._utils.async_ import _AioDataFrameResult, _GeventDataFrameResult
 from polars._utils.convert import negate_duration_string, parse_as_duration_string
 from polars._utils.deprecation import (
     deprecate_function,
-    deprecate_parameter_as_positional,
     deprecate_renamed_parameter,
     issue_deprecation_warning,
 )
@@ -3052,7 +3051,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
         return self._from_pyldf(self._ldf.select_seq(pyexprs))
 
-    @deprecate_parameter_as_positional("by", version="0.20.7")
     def group_by(
         self,
         *by: IntoExpr | Iterable[IntoExpr],
@@ -4300,7 +4298,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
-    @deprecate_parameter_as_positional("columns", version="0.20.4")
     def drop(
         self, *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector]
     ) -> Self:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -434,7 +434,9 @@ def test_to_list() -> None:
 
 def test_rows() -> None:
     s0 = pl.Series("date", [123543, 283478, 1243]).cast(pl.Date)
-    with pytest.deprecated_call(match="`with_time_unit` is deprecated"):
+    with pytest.deprecated_call(
+        match="`ExprDateTimeNameSpace.with_time_unit` is deprecated"
+    ):
         s1 = (
             pl.Series("datetime", [a * 1_000_000 for a in [123543, 283478, 1243]])
             .cast(pl.Datetime)

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -125,15 +125,3 @@ def test_drop_without_parameters() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     assert_frame_equal(df.drop(), df)
     assert_frame_equal(df.lazy().drop(*[]), df.lazy())
-
-
-def test_drop_keyword_deprecated() -> None:
-    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
-    expected = df.select("b")
-    with pytest.deprecated_call():
-        result_df = df.drop(columns="a")
-    assert_frame_equal(result_df, expected)
-
-    with pytest.deprecated_call():
-        result_lf = df.lazy().drop(columns="a")
-    assert_frame_equal(result_lf, expected.lazy())

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -873,18 +873,6 @@ def test_group_by_named() -> None:
     assert_frame_equal(result, expected)
 
 
-def test_group_by_deprecated_by_arg() -> None:
-    df = pl.DataFrame({"a": [1, 1, 2, 2, 3, 3], "b": range(6)})
-    with pytest.deprecated_call():
-        result = df.group_by(by=(pl.col("a") * 2), maintain_order=True).agg(
-            pl.col("b").min()
-        )
-    expected = df.group_by((pl.col("a") * 2), maintain_order=True).agg(
-        pl.col("b").min()
-    )
-    assert_frame_equal(result, expected)
-
-
 def test_group_by_with_null() -> None:
     df = pl.DataFrame(
         {"a": [None, None, None, None], "b": [1, 1, 2, 2], "c": ["x", "y", "z", "u"]}

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -8,6 +8,7 @@ import pytest
 from polars._utils.deprecation import (
     deprecate_function,
     deprecate_nonkeyword_arguments,
+    deprecate_parameter_as_multi_positional,
     deprecate_renamed_function,
     deprecate_renamed_parameter,
     issue_deprecation_warning,
@@ -67,3 +68,31 @@ def test_deprecate_nonkeyword_arguments_method_warning() -> None:
     )
     with pytest.deprecated_call(match=msg):
         Foo().bar("qux", "quox")
+
+
+def test_deprecate_parameter_as_multi_positional(recwarn: Any) -> None:
+    @deprecate_parameter_as_multi_positional("foo", version="1.0.0")
+    def hello(*foo: str) -> tuple[str, ...]:
+        return foo
+
+    with pytest.deprecated_call():
+        result = hello(foo="x")
+    assert result == hello("x")
+
+    with pytest.deprecated_call():
+        result = hello(foo=["x", "y"])  # type: ignore[arg-type]
+    assert result == hello("x", "y")
+
+
+def test_deprecate_parameter_as_multi_positional_existing_arg(recwarn: Any) -> None:
+    @deprecate_parameter_as_multi_positional("foo", version="1.0.0")
+    def hello(bar: int, *foo: str) -> tuple[int, tuple[str, ...]]:
+        return bar, foo
+
+    with pytest.deprecated_call():
+        result = hello(5, foo="x")
+    assert result == hello(5, "x")
+
+    with pytest.deprecated_call():
+        result = hello(5, foo=["x", "y"])  # type: ignore[arg-type]
+    assert result == hello(5, "x", "y")


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/13525

These were deprecated in early 0.20, but I want to expedite the deprecation because:
* In the case of `group_by`, it blocks the semantics of using `by` as a column name in `**named_by`.
* In other cases, the deprecation was unlikely to impact many people so we might as well clean up the decorators now.

I kept the decorator implementation and added some tests, as I feel it may come in handy in the future.