### PR TITLE
fix(rust,python): Handle NamedTuples in any_value

### DIFF
--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -337,18 +337,17 @@ pub(crate) fn py_object_to_any_value<'py>(
 
     fn get_struct<'py>(ob: &Bound<'py, PyAny>, strict: bool) -> PyResult<AnyValue<'py>> {
         let convert = ob.hasattr("_asdict")?;
-        let dict: &Bound<'py, PyDict>;
         let cmd: Bound<'py, PyDict>;
         let cm: Bound<'py, PyAny>;
         let list: Bound<'py, PySequence>;
-        if convert {
+        let dict = if convert {
             list = ob.downcast::<PySequence>()?.clone();
             cm = list.call_method0("_asdict")?;
             cmd = cm.downcast::<PyDict>()?.clone();
-            dict = &cmd
+            &cmd
         } else {
-            dict = ob.downcast::<PyDict>()?;
-        }
+            ob.downcast::<PyDict>()?
+        };
         let len = dict.len();
         let mut keys = Vec::with_capacity(len);
         let mut vals = Vec::with_capacity(len);

--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -336,7 +336,7 @@ pub(crate) fn py_object_to_any_value<'py>(
     }
 
     fn get_struct<'py>(ob: &Bound<'py, PyAny>, strict: bool) -> PyResult<AnyValue<'py>> {
-        let convert = ob.hasattr( "_asdict")?;
+        let convert = ob.hasattr("_asdict")?;
         let dict: &Bound<'py, PyDict>;
         let cmd: Bound<'py, PyDict>;
         let cm: Bound<'py, PyAny>;
@@ -361,8 +361,6 @@ pub(crate) fn py_object_to_any_value<'py>(
         }
         Ok(AnyValue::StructOwned(Box::new((vals, keys))))
     }
-
-
 
     fn get_object(ob: &Bound<'_, PyAny>, _strict: bool) -> PyResult<AnyValue<'static>> {
         #[cfg(feature = "object")]

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from io import BytesIO
 from operator import floordiv, truediv
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterator, NamedTuple, Sequence, cast
 
 import numpy as np
 import pyarrow as pa
@@ -2887,3 +2887,36 @@ def test_iter_columns() -> None:
     iter_columns = df.iter_columns()
     assert_series_equal(next(iter_columns), pl.Series("a", [1, 1, 2]))
     assert_series_equal(next(iter_columns), pl.Series("b", [4, 5, 6]))
+
+
+def test_named_tuples() -> None:
+    class Event(NamedTuple):
+        name: str
+        description: str
+
+    this_dtype = pl.List(pl.Struct({"name": pl.String, "description": pl.String}))
+    data = {"events": [0, 1, 2]}
+    df = pl.DataFrame(data).select(
+        events=pl.col("events").map_elements(
+            lambda num: [Event("name", "desc") for _ in range(num)],
+            return_dtype=this_dtype,
+        )
+    )
+    expected = pl.DataFrame(
+        [
+            pl.Series(
+                "events",
+                [
+                    [],
+                    [{"name": "name", "description": "desc"}],
+                    [
+                        {"name": "name", "description": "desc"},
+                        {"name": "name", "description": "desc"},
+                    ],
+                ],
+                dtype=this_dtype,
+            ),
+        ]
+    )
+
+    assert_frame_equal(df, expected)


### PR DESCRIPTION
addresses https://github.com/pola-rs/polars/issues/15425

The issue is that their input is a nested NamedTuple which gets checked as a Tuple by rust and then treated as a list. I saw there was already python code that checks for NamedTuples but in this case it's nested so the python code doesn't see it and is handled by rust.