### PR TITLE
fix(rust): `describe` / `explain` streaming plan

### DIFF
--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -212,7 +212,7 @@ pub(super) fn construct(
     };
     // keep the original around for formatting purposes
     let original_lp = if fmt {
-        let original_lp = node_to_lp_cloned(insertion_location, expr_arena, lp_arena);
+        let original_lp = IRPlan::new(insertion_location, lp_arena.clone(), expr_arena.clone());
         Some(original_lp)
     } else {
         None
@@ -233,7 +233,7 @@ fn get_pipeline_node(
     lp_arena: &mut Arena<IR>,
     mut pipelines: Vec<PipeLine>,
     schema: SchemaRef,
-    original_lp: Option<DslPlan>,
+    original_lp: Option<IRPlan>,
 ) -> IR {
     // create a dummy input as the map function will call the input
     // so we just create a scan that returns an empty df

--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -429,6 +429,7 @@ pub(crate) fn insert_streaming_nodes(
             },
         }
     }
+
     let mut inserted = false;
     for tree in pipeline_trees {
         if is_valid_tree(&tree)

--- a/crates/polars-plan/src/logical_plan/alp/format.rs
+++ b/crates/polars-plan/src/logical_plan/alp/format.rs
@@ -9,7 +9,10 @@ use recursive::recursive;
 
 use crate::prelude::*;
 
-pub struct IRDisplay<'a>(pub(crate) IRPlanRef<'a>);
+pub struct IRDisplay<'a> {
+    is_streaming: bool,
+    lp: IRPlanRef<'a>,
+}
 
 #[derive(Clone, Copy)]
 pub struct ExprIRDisplay<'a> {
@@ -58,9 +61,6 @@ fn write_scan(
     predicate: &Option<ExprIRDisplay<'_>>,
     n_rows: Option<usize>,
 ) -> fmt::Result {
-    if indent != 0 {
-        writeln!(f)?;
-    }
     let path_fmt = match path.len() {
         1 => path[0].to_string_lossy(),
         0 => "".into(),
@@ -91,13 +91,66 @@ fn write_scan(
 }
 
 impl<'a> IRDisplay<'a> {
+    pub fn new(lp: IRPlanRef<'a>) -> Self {
+        if let Some(streaming_lp) = lp.extract_streaming_plan() {
+            return Self::new_streaming(streaming_lp);
+        }
+
+        Self {
+            is_streaming: false,
+            lp,
+        }
+    }
+
+    fn new_streaming(lp: IRPlanRef<'a>) -> Self {
+        Self {
+            is_streaming: true,
+            lp,
+        }
+    }
+
+    fn root(&self) -> &IR {
+        self.lp.root()
+    }
+
+    fn with_root(&self, root: Node) -> Self {
+        Self {
+            is_streaming: false,
+            lp: self.lp.with_root(root),
+        }
+    }
+
+    fn display_expr(&self, root: &'a ExprIR) -> ExprIRDisplay<'a> {
+        ExprIRDisplay {
+            node: root.node(),
+            output_name: root.output_name_inner(),
+            expr_arena: self.lp.expr_arena,
+        }
+    }
+
+    fn display_expr_slice(&self, exprs: &'a [ExprIR]) -> ExprIRSliceDisplay<'a, ExprIR> {
+        ExprIRSliceDisplay {
+            exprs,
+            expr_arena: self.lp.expr_arena,
+        }
+    }
+
     #[recursive]
     fn _format(&self, f: &mut Formatter, indent: usize) -> fmt::Result {
-        if indent != 0 {
-            writeln!(f)?;
-        }
+        let indent = if self.is_streaming {
+            writeln!(f, "{:indent$}STREAMING:", "")?;
+            indent + 2
+        } else {
+            if indent != 0 {
+                writeln!(f)?;
+            }
+
+            indent
+        };
+
         let sub_indent = indent + 2;
         use IR::*;
+
         match self.root() {
             #[cfg(feature = "python")]
             PythonScan { options, predicate } => {
@@ -293,9 +346,12 @@ impl<'a> IRDisplay<'a> {
             MapFunction {
                 input, function, ..
             } => {
-                let function_fmt = format!("{function}");
-                write!(f, "{:indent$}{function_fmt}", "")?;
-                self.with_root(*input)._format(f, sub_indent)
+                if let Some(streaming_lp) = function.to_streaming_lp() {
+                    IRDisplay::new_streaming(streaming_lp)._format(f, indent)
+                } else {
+                    write!(f, "{:indent$}{function}", "")?;
+                    self.with_root(*input)._format(f, sub_indent)
+                }
             },
             ExtContext { input, .. } => {
                 write!(f, "{:indent$}EXTERNAL_CONTEXT", "")?;
@@ -313,7 +369,7 @@ impl<'a> IRDisplay<'a> {
             },
             SimpleProjection { input, columns } => {
                 let num_columns = columns.as_ref().len();
-                let total_columns = self.0.lp_arena.get(*input).schema(self.0.lp_arena).len();
+                let total_columns = self.lp.lp_arena.get(*input).schema(self.lp.lp_arena).len();
 
                 let columns = ColumnsDisplay(columns.as_ref());
                 write!(
@@ -325,31 +381,6 @@ impl<'a> IRDisplay<'a> {
                 self.with_root(*input)._format(f, sub_indent)
             },
             Invalid => write!(f, "{:indent$}INVALID", ""),
-        }
-    }
-}
-
-impl<'a> IRDisplay<'a> {
-    fn root(&self) -> &IR {
-        self.0.root()
-    }
-
-    fn with_root(&self, root: Node) -> Self {
-        Self(self.0.with_root(root))
-    }
-
-    fn display_expr(&self, root: &'a ExprIR) -> ExprIRDisplay<'a> {
-        ExprIRDisplay {
-            node: root.node(),
-            output_name: root.output_name_inner(),
-            expr_arena: self.0.expr_arena,
-        }
-    }
-
-    fn display_expr_slice(&self, exprs: &'a [ExprIR]) -> ExprIRSliceDisplay<'a, ExprIR> {
-        ExprIRSliceDisplay {
-            exprs,
-            expr_arena: self.0.expr_arena,
         }
     }
 }

--- a/crates/polars-plan/src/logical_plan/alp/tree_format.rs
+++ b/crates/polars-plan/src/logical_plan/alp/tree_format.rs
@@ -102,8 +102,21 @@ fn multiline_expression(expr: &str) -> std::borrow::Cow<'_, str> {
 
 impl<'a> TreeFmtNode<'a> {
     pub fn root_logical_plan(lp: IRPlanRef<'a>) -> Self {
+        if let Some(streaming_lp) = lp.extract_streaming_plan() {
+            return Self::streaming_root_logical_plan(streaming_lp);
+        }
+
         Self {
             h: None,
+            content: TreeFmtNodeContent::LogicalPlan(lp.lp_top),
+
+            lp,
+        }
+    }
+
+    fn streaming_root_logical_plan(lp: IRPlanRef<'a>) -> Self {
+        Self {
+            h: Some("Streaming".to_string()),
             content: TreeFmtNodeContent::LogicalPlan(lp.lp_top),
 
             lp,
@@ -325,10 +338,19 @@ impl<'a> TreeFmtNode<'a> {
                         wh(h, &format!("SLICE[offset: {offset}, len: {len}]")),
                         vec![self.lp_node(None, *input)],
                     ),
-                    MapFunction { input, function } => ND(
-                        wh(h, &format!("{function}")),
-                        vec![self.lp_node(None, *input)],
-                    ),
+                    MapFunction { input, function } => {
+                        if let Some(streaming_lp) = function.to_streaming_lp() {
+                            ND(
+                                String::default(),
+                                vec![TreeFmtNode::streaming_root_logical_plan(streaming_lp)],
+                            )
+                        } else {
+                            ND(
+                                wh(h, &format!("{function}")),
+                                vec![self.lp_node(None, *input)],
+                            )
+                        }
+                    },
                     ExtContext { input, .. } => {
                         ND(wh(h, "EXTERNAL_CONTEXT"), vec![self.lp_node(None, *input)])
                     },

--- a/crates/polars-utils/src/arena.rs
+++ b/crates/polars-utils/src/arena.rs
@@ -31,7 +31,7 @@ impl Default for Node {
 
 static ARENA_VERSION: AtomicU32 = AtomicU32::new(0);
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Arena<T> {
     version: u32,
     items: Vec<T>,


### PR DESCRIPTION
This PR adds back the possibility to `describe` / `explain` streaming engine plans. As these plans are not stored in the main `IRPlan`, there need to be special cases for that in each `describe` format.

This specifically addresses it for:
- Base format: Adds streaming header, prints the underlying plan
- Tree format: Adds streaming header into top node, prints the underlying plan
- Dot format: Prints the underlying plan

Fixes #16762