### PR TITLE
feat(python): Add `check_order` parameter to `assert_series_equal`

### DIFF
--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -37,10 +37,6 @@ def assert_frame_equal(
         The second DataFrame or LazyFrame to compare.
     check_row_order
         Require row order to match.
-
-        .. note::
-            Setting this to `False` requires sorting the data, which will fail on
-            frames that contain unsortable columns.
     check_column_order
         Require column order to match.
     check_dtypes
@@ -118,6 +114,7 @@ def assert_frame_equal(
             _assert_series_values_equal(
                 s_left,
                 s_right,
+                check_order=True,
                 check_exact=check_exact,
                 rtol=rtol,
                 atol=atol,
@@ -227,10 +224,6 @@ def assert_frame_not_equal(
         The second DataFrame or LazyFrame to compare.
     check_row_order
         Require row order to match.
-
-        .. note::
-            Setting this to `False` requires sorting the data, which will fail on
-            frames that contain unsortable columns.
     check_column_order
         Require column order to match.
     check_dtypes

--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -27,6 +27,7 @@ def assert_series_equal(
     *,
     check_dtypes: bool = True,
     check_names: bool = True,
+    check_order: bool = True,
     check_exact: bool = False,
     rtol: float = 1e-5,
     atol: float = 1e-8,
@@ -48,6 +49,8 @@ def assert_series_equal(
         Require data types to match.
     check_names
         Require names to match.
+    check_order
+        Require elements to appear in the same order.
     check_exact
         Require float values to match exactly. If set to `False`, values are considered
         equal when within tolerance of each other (see `rtol` and `atol`).
@@ -107,6 +110,7 @@ def assert_series_equal(
     _assert_series_values_equal(
         left,
         right,
+        check_order=check_order,
         check_exact=check_exact,
         rtol=rtol,
         atol=atol,
@@ -118,6 +122,7 @@ def _assert_series_values_equal(
     left: Series,
     right: Series,
     *,
+    check_order: bool,
     check_exact: bool,
     rtol: float,
     atol: float,
@@ -130,6 +135,10 @@ def _assert_series_values_equal(
     if categorical_as_str:
         left = _categorical_series_to_string(left)
         right = _categorical_series_to_string(right)
+
+    if not check_order:
+        left = left.sort()
+        right = right.sort()
 
     # Determine unequal elements
     try:
@@ -206,6 +215,7 @@ def _assert_series_nested_values_equal(
             _assert_series_values_equal(
                 s1,
                 s2,
+                check_order=True,
                 check_exact=check_exact,
                 rtol=rtol,
                 atol=atol,
@@ -219,6 +229,7 @@ def _assert_series_nested_values_equal(
             _assert_series_values_equal(
                 s1,
                 s2,
+                check_order=True,
                 check_exact=check_exact,
                 rtol=rtol,
                 atol=atol,
@@ -331,6 +342,7 @@ def assert_series_not_equal(
     *,
     check_dtypes: bool = True,
     check_names: bool = True,
+    check_order: bool = True,
     check_exact: bool = False,
     rtol: float = 1e-5,
     atol: float = 1e-8,
@@ -351,6 +363,8 @@ def assert_series_not_equal(
         Require data types to match.
     check_names
         Require names to match.
+    check_order
+        Require elements to appear in the same order.
     check_exact
         Require float values to match exactly. If set to `False`, values are considered
         equal when within tolerance of each other (see `rtol` and `atol`).
@@ -387,6 +401,7 @@ def assert_series_not_equal(
             right=right,
             check_dtypes=check_dtypes,
             check_names=check_names,
+            check_order=check_order,
             check_exact=check_exact,
             rtol=rtol,
             atol=atol,

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -6,12 +6,19 @@ from decimal import Decimal as D
 from typing import Any
 
 import pytest
+from hypothesis import given
 
 import polars as pl
 from polars.testing import assert_series_equal, assert_series_not_equal
+from polars.testing.parametric import series
 
 nan = float("nan")
 pytest_plugins = ["pytester"]
+
+
+@given(s=series())
+def test_assert_series_equal_parametric(s: pl.Series) -> None:
+    assert_series_equal(s, s)
 
 
 def test_compare_series_value_mismatch() -> None:
@@ -32,6 +39,15 @@ def test_compare_series_empty_equal() -> None:
     assert_series_equal(srs1, srs2)
     with pytest.raises(AssertionError):
         assert_series_not_equal(srs1, srs2)
+
+
+def test_assert_series_equal_check_order() -> None:
+    srs1 = pl.Series([1, 2, 3, None])
+    srs2 = pl.Series([2, None, 3, 1])
+
+    assert_series_equal(srs1, srs2, check_order=False)
+    with pytest.raises(AssertionError):
+        assert_series_not_equal(srs1, srs2, check_order=False)
 
 
 def test_compare_series_nans_assert_equal() -> None:


### PR DESCRIPTION
Similar to `assert_frame_equal`, this allows you to ignore the order in which elements appear.