### PR TITLE
feat(python)!: More removal of deprecated functionality

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5528,7 +5528,6 @@ class DataFrame:
         offset: str | timedelta | None = None,
         closed: ClosedInterval = "right",
         group_by: IntoExpr | Iterable[IntoExpr] | None = None,
-        check_sorted: bool | None = None,
     ) -> RollingGroupBy:
         """
         Create rolling groups based on a temporal or integer column.
@@ -5594,18 +5593,6 @@ class DataFrame:
             Define which sides of the temporal interval are closed (inclusive).
         group_by
             Also group by this column/these columns
-        check_sorted
-            Check whether `index_column` is sorted (or, if `group_by` is given,
-            check whether it's sorted within each group).
-            When the `group_by` argument is given, polars can not check sortedness
-            by the metadata and has to do a full scan on the index column to
-            verify data is sorted. This is expensive. If you are sure the
-            data within the groups is sorted, you can set this to `False`.
-            Doing so incorrectly will lead to incorrect output
-
-            .. deprecated:: 0.20.31
-                Sortedness is now verified in a quick manner, you can safely remove
-                this argument.
 
         Returns
         -------
@@ -5684,7 +5671,6 @@ class DataFrame:
             offset=offset,
             closed=closed,
             group_by=group_by,
-            check_sorted=check_sorted,
         )
 
     @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
@@ -5700,7 +5686,6 @@ class DataFrame:
         label: Label = "left",
         group_by: IntoExpr | Iterable[IntoExpr] | None = None,
         start_by: StartBy = "window",
-        check_sorted: bool | None = None,
     ) -> DynamicGroupBy:
         """
         Group based on a time value (or index value of type Int32, Int64).
@@ -5771,18 +5756,6 @@ class DataFrame:
 
               The resulting window is then shifted back until the earliest datapoint
               is in or in front of it.
-        check_sorted
-            Check whether `index_column` is sorted (or, if `group_by` is given,
-            check whether it's sorted within each group).
-            When the `group_by` argument is given, polars can not check sortedness
-            by the metadata and has to do a full scan on the index column to
-            verify data is sorted. This is expensive. If you are sure the
-            data within the groups is sorted, you can set this to `False`.
-            Doing so incorrectly will lead to incorrect output
-
-            .. deprecated:: 0.20.31
-                Sortedness is now verified in a quick manner, you can safely remove
-                this argument.
 
         Returns
         -------
@@ -6015,7 +5988,6 @@ class DataFrame:
             closed=closed,
             group_by=group_by,
             start_by=start_by,
-            check_sorted=check_sorted,
         )
 
     @deprecate_renamed_parameter("by", "group_by", version="0.20.14")

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -791,13 +791,7 @@ class RollingGroupBy:
         offset: str | timedelta | None,
         closed: ClosedInterval,
         group_by: IntoExpr | Iterable[IntoExpr] | None,
-        check_sorted: bool | None = None,
     ):
-        if check_sorted is not None:
-            issue_deprecation_warning(
-                "`check_sorted` is now deprecated in `rolling`, you can safely remove this argument.",
-                version="0.20.31",
-            )
         period = parse_as_duration_string(period)
         offset = parse_as_duration_string(offset)
 
@@ -945,13 +939,7 @@ class DynamicGroupBy:
         label: Label,
         group_by: IntoExpr | Iterable[IntoExpr] | None,
         start_by: StartBy,
-        check_sorted: bool | None = None,
     ):
-        if check_sorted is not None:
-            issue_deprecation_warning(
-                "`check_sorted` is now deprecated in `rolling`, you can safely remove this argument.",
-                version="0.20.31",
-            )
         every = parse_as_duration_string(every)
         period = parse_as_duration_string(period)
         offset = parse_as_duration_string(offset)

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-from datetime import timedelta
 from typing import TYPE_CHECKING, Iterable
 
 import polars._reexport as pl
@@ -151,7 +150,7 @@ class ExprDateTimeNameSpace:
             )
         )
 
-    def truncate(self, every: str | timedelta | Expr) -> Expr:
+    def truncate(self, every: str | dt.timedelta | Expr) -> Expr:
         """
         Divide the date/datetime range into buckets.
 
@@ -278,7 +277,7 @@ class ExprDateTimeNameSpace:
         return wrap_expr(self._pyexpr.dt_truncate(every))
 
     @unstable()
-    def round(self, every: str | timedelta | IntoExprColumn) -> Expr:
+    def round(self, every: str | dt.timedelta | IntoExprColumn) -> Expr:
         """
         Divide the date/datetime range into buckets.
 
@@ -380,7 +379,7 @@ class ExprDateTimeNameSpace:
         │ 2001-01-01 01:00:00 ┆ 2001-01-01 01:00:00 │
         └─────────────────────┴─────────────────────┘
         """
-        if isinstance(every, timedelta):
+        if isinstance(every, dt.timedelta):
             every = parse_as_duration_string(every)
         every = parse_as_expression(every, str_as_lit=True)
         return wrap_expr(self._pyexpr.dt_round(every))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3481,7 +3481,6 @@ class Expr:
         period: str | timedelta,
         offset: str | timedelta | None = None,
         closed: ClosedInterval = "right",
-        check_sorted: bool | None = None,
     ) -> Self:
         """
         Create rolling groups based on a temporal or integer column.
@@ -3539,10 +3538,6 @@ class Expr:
             Offset of the window. Default is `-period`.
         closed : {'right', 'left', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
-        check_sorted
-            Whether to check that `index_column` is sorted.
-            If you are sure the data is sorted, you can set this to `False`.
-            Doing so incorrectly will lead to incorrect output.
 
         Examples
         --------
@@ -9258,7 +9253,6 @@ class Expr:
         by: str | IntoExpr,
         *,
         half_life: str | timedelta,
-        check_sorted: bool | None = None,
     ) -> Self:
         r"""
         Calculate time-based exponentially weighted moving average.
@@ -9304,13 +9298,6 @@ class Expr:
             durations such as months (or even days in the time-zone-aware case)
             are not supported, please express your duration in an approximately
             equivalent number of hours (e.g. '370h' instead of '1mo').
-        check_sorted
-            Check whether `by` column is sorted.
-            Incorrectly setting this to `False` will lead to incorrect output.
-
-            .. deprecated:: 0.20.27
-                Sortedness is now verified in a quick manner, you can safely remove
-                this argument.
 
         Returns
         -------
@@ -9350,11 +9337,6 @@ class Expr:
         """
         by = parse_as_expression(by)
         half_life = parse_as_duration_string(half_life)
-        if check_sorted is not None:
-            issue_deprecation_warning(
-                "`check_sorted` is now deprecated in `ewm_mean_by`, you can safely remove this argument.",
-                version="0.20.27",
-            )
         return self._from_pyexpr(self._pyexpr.ewm_mean_by(by, half_life))
 
     def ewm_std(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3158,7 +3158,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset: str | timedelta | None = None,
         closed: ClosedInterval = "right",
         group_by: IntoExpr | Iterable[IntoExpr] | None = None,
-        check_sorted: bool | None = None,
     ) -> LazyGroupBy:
         """
         Create rolling groups based on a temporal or integer column.
@@ -3224,18 +3223,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Define which sides of the temporal interval are closed (inclusive).
         group_by
             Also group by this column/these columns
-        check_sorted
-            Check whether `index_column` is sorted (or, if `group_by` is given,
-            check whether it's sorted within each group).
-            When the `group_by` argument is given, polars can not check sortedness
-            by the metadata and has to do a full scan on the index column to
-            verify data is sorted. This is expensive. If you are sure the
-            data within the groups is sorted, you can set this to `False`.
-            Doing so incorrectly will lead to incorrect output
-
-            .. deprecated:: 0.20.31
-                Sortedness is now verified in a quick manner, you can safely remove
-                this argument.
 
         Returns
         -------
@@ -3311,7 +3298,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         label: Label = "left",
         group_by: IntoExpr | Iterable[IntoExpr] | None = None,
         start_by: StartBy = "window",
-        check_sorted: bool | None = None,
     ) -> LazyGroupBy:
         """
         Group based on a time value (or index value of type Int32, Int64).
@@ -3382,18 +3368,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
               The resulting window is then shifted back until the earliest datapoint
               is in or in front of it.
-        check_sorted
-            Check whether `index_column` is sorted (or, if `group_by` is given,
-            check whether it's sorted within each group).
-            When the `group_by` argument is given, polars can not check sortedness
-            by the metadata and has to do a full scan on the index column to
-            verify data is sorted. This is expensive. If you are sure the
-            data within the groups is sorted, you can set this to `False`.
-            Doing so incorrectly will lead to incorrect output
-
-            .. deprecated:: 0.20.31
-                Sortedness is now verified in a quick manner, you can safely remove
-                this argument.
 
         Returns
         -------

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1762,12 +1762,7 @@ class DateTimeNameSpace:
         """
 
     @unstable()
-    def round(
-        self,
-        every: str | dt.timedelta | IntoExprColumn,
-        *,
-        ambiguous: Ambiguous | Series | None = None,
-    ) -> Series:
+    def round(self, every: str | dt.timedelta | IntoExprColumn) -> Series:
         """
         Divide the date/ datetime range into buckets.
 
@@ -1788,15 +1783,6 @@ class DateTimeNameSpace:
         ----------
         every
             Every interval start and period length
-        ambiguous
-            Determine how to deal with ambiguous datetimes:
-
-            - `'raise'` (default): raise
-            - `'earliest'`: use the earliest datetime
-            - `'latest'`: use the latest datetime
-
-            .. deprecated:: 0.19.3
-                This is now automatically inferred; you can safely omit this argument.
 
         Returns
         -------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6757,9 +6757,6 @@ class Series:
             durations such as months (or even days in the time-zone-aware case)
             are not supported, please express your duration in an approximately
             equivalent number of hours (e.g. '370h' instead of '1mo').
-        check_sorted
-            Check whether `by` column is sorted.
-            Incorrectly setting this to `False` will lead to incorrect output.
 
         Returns
         -------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -81,7 +81,6 @@ class StringNameSpace:
         strict: bool = True,
         exact: bool = True,
         cache: bool = True,
-        utc: bool | None = None,
         ambiguous: Ambiguous | Series = "raise",
     ) -> Series:
         """
@@ -112,15 +111,6 @@ class StringNameSpace:
                 data beforehand will almost certainly be more performant.
         cache
             Use a cache of unique, converted datetimes to apply the conversion.
-        utc
-            Parse time zone aware datetimes as UTC. This may be useful if you have data
-            with mixed offsets.
-
-            .. deprecated:: 0.18.0
-                This is now a no-op, you can safely remove it.
-                Offset-naive strings are parsed as `pl.Datetime(time_unit)`,
-                and offset-aware strings are converted to
-                `pl.Datetime(time_unit, "UTC")`.
         ambiguous
             Determine how to deal with ambiguous datetimes:
 

--- a/py-polars/tests/unit/operations/test_ewm_by.py
+++ b/py-polars/tests/unit/operations/test_ewm_by.py
@@ -181,10 +181,9 @@ def test_ewma_by_if_unsorted() -> None:
     expected = pl.DataFrame({"values": [2.5, 2.0], "by": [3, 1]})
     assert_frame_equal(result, expected)
 
-    with pytest.deprecated_call(match="you can safely remove this argument"):
-        result = df.with_columns(
-            pl.col("values").ewm_mean_by("by", half_life="2i", check_sorted=False),
-        )
+    result = df.with_columns(
+        pl.col("values").ewm_mean_by("by", half_life="2i"),
+    )
     assert_frame_equal(result, expected)
 
     result = df.sort("by").with_columns(

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -929,7 +929,7 @@ def test_group_by_dynamic_agg_bad_input_types(input: Any) -> None:
         ).agg(input)
 
 
-def test_group_by_dynamic_check_sorted_15225() -> None:
+def test_group_by_dynamic_15225() -> None:
     df = pl.DataFrame(
         {
             "a": [1, 2, 3],
@@ -937,10 +937,7 @@ def test_group_by_dynamic_check_sorted_15225() -> None:
             "c": [1, 1, 2],
         }
     )
-    with pytest.deprecated_call(match="`check_sorted` is now deprecated"):
-        result = df.group_by_dynamic("b", every="2d", check_sorted=False).agg(
-            pl.sum("a")
-        )
+    result = df.group_by_dynamic("b", every="2d").agg(pl.sum("a"))
     expected = pl.DataFrame({"b": [date(2020, 1, 1), date(2020, 1, 3)], "a": [3, 3]})
     assert_frame_equal(result, expected)
     result = df.group_by_dynamic("b", every="2d", group_by="c").agg(pl.sum("a"))

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -261,15 +261,13 @@ def test_rolling_empty_groups_9973() -> None:
         }
     )
 
-    with pytest.deprecated_call(match="`check_sorted` is now deprecated"):
-        out = data.rolling(
-            index_column="date",
-            group_by="id",
-            period="2d",
-            offset="1d",
-            closed="left",
-            check_sorted=True,
-        ).agg(pl.col("value"))
+    out = data.rolling(
+        index_column="date",
+        group_by="id",
+        period="2d",
+        offset="1d",
+        closed="left",
+    ).agg(pl.col("value"))
 
     assert_frame_equal(out, expected)
 
@@ -293,7 +291,9 @@ def test_rolling_duplicates_11281() -> None:
     assert_frame_equal(result, expected)
 
 
-def test_rolling_check_sorted_15225() -> None:
+def test_rolling_15225() -> None:
+    # https://github.com/pola-rs/polars/issues/15225
+
     df = pl.DataFrame(
         {
             "a": [1, 2, 3],


### PR DESCRIPTION
Ref #13525

#### Changes

* Remove deprecated `check_sorted` parameter from `ewm_by` and `rolling`. This was only deprecated recently, but I'd rather not leave this useless parameter laying around. We made the same update for the other rolling functions.
* Remove deprecated `utc` parameter from `str.to_datetime`.
* Remove deprecated `ambiguous` parameter in `dt.round`.