### PR TITLE
fix(rust): boolean array distinct count

### DIFF
--- a/crates/polars-compute/src/distinct_count.rs
+++ b/crates/polars-compute/src/distinct_count.rs
@@ -30,6 +30,7 @@ mod test {
     #[test]
     fn test_distinct_count() {
         let test_cases = vec![
+            (BooleanArray::from(vec![]), 0),
             (BooleanArray::from(vec![None, None]), 0),
             (BooleanArray::from(vec![Some(true), Some(true)]), 1),
             (BooleanArray::from(vec![Some(false), Some(false)]), 1),

--- a/crates/polars-compute/src/distinct_count.rs
+++ b/crates/polars-compute/src/distinct_count.rs
@@ -8,17 +8,39 @@ pub trait DistinctCountKernel {
 
 impl DistinctCountKernel for BooleanArray {
     fn distinct_count(&self) -> usize {
-        if self.len() - self.null_count() == 0 {
+        let null_count = self.null_count();
+        if self.len() - null_count == 0 {
             return 0;
         }
 
-        if self.null_count() == 0 {
+        if null_count == 0 {
             let unset_bits = self.values().unset_bits();
             2 - usize::from(unset_bits == 0 || unset_bits == self.values().len())
         } else {
-            let values = self.values() & self.validity().unwrap();
-            let unset_bits = self.values().unset_bits();
-            3 - usize::from(unset_bits == 0 || unset_bits == values.len())
+            let set_bits = (self.values() & self.validity().unwrap()).set_bits();
+            2 - usize::from(set_bits == 0 || set_bits == self.values().len() - null_count)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_distinct_count() {
+        let test_cases = vec![
+            (BooleanArray::from(vec![None, None]), 0),
+            (BooleanArray::from(vec![Some(true), Some(true)]), 1),
+            (BooleanArray::from(vec![Some(false), Some(false)]), 1),
+            (BooleanArray::from(vec![Some(true), Some(false)]), 2),
+            (BooleanArray::from(vec![Some(true), None]), 1),
+            (BooleanArray::from(vec![Some(false), None]), 1),
+            (BooleanArray::from(vec![Some(true), Some(false), None]), 2),
+        ];
+
+        for (input, expected) in test_cases {
+            assert_eq!(input.distinct_count(), expected);
         }
     }
 }

--- a/crates/polars-parquet/src/arrow/write/boolean/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/boolean/basic.rs
@@ -91,11 +91,7 @@ pub(super) fn build_statistics(
         null_count: options.null_count.then(|| array.null_count() as i64),
         distinct_count: options
             .distinct_count
-            .then(|| {
-                (array.distinct_count() - ((array.null_count() > 0) as usize))
-                    .try_into()
-                    .ok()
-            })
+            .then(|| array.distinct_count().try_into().ok())
             .flatten(),
         max_value: options
             .max_value


### PR DESCRIPTION
I'm not getting the numbers I'm expecting after #16765. See https://github.com/pola-rs/polars/pull/16765#discussion_r1629426159 for details. Added some tests as well to be sure we get expected behavior.

EDIT: Not sure if the plan in #16765 was to actually include counting nulls or not. Depending on that, I see that there now is a PR (#16782) that fixes this if counting nulls as well is the purpose.