### PR TITLE
feat(rust): Expose a few more expression nodes in the expression IR

### DIFF
--- a/py-polars/src/lazyframe/visitor/nodes.rs
+++ b/py-polars/src/lazyframe/visitor/nodes.rs
@@ -128,7 +128,7 @@ pub struct Select {
     #[pyo3(get)]
     expr: Vec<PyExprIR>,
     #[pyo3(get)]
-    options: (), //ProjectionOptions,
+    should_broadcast: bool,
 }
 
 #[pyclass]
@@ -195,7 +195,7 @@ pub struct HStack {
     #[pyo3(get)]
     exprs: Vec<PyExprIR>,
     #[pyo3(get)]
-    options: (), // ProjectionOptions,
+    should_broadcast: bool,
 }
 
 #[pyclass]
@@ -338,11 +338,11 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             input,
             expr,
             schema: _,
-            options: _,
+            options,
         } => Select {
             expr: expr.iter().map(|e| e.into()).collect(),
             input: input.0,
-            options: (),
+            should_broadcast: options.should_broadcast,
         }
         .into_py(py),
         IR::Sort {
@@ -428,11 +428,11 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             input,
             exprs,
             schema: _,
-            options: _,
+            options,
         } => HStack {
             input: input.0,
             exprs: exprs.iter().map(|e| e.into()).collect(),
-            options: (),
+            should_broadcast: options.should_broadcast,
         }
         .into_py(py),
         IR::Reduce {

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -103,6 +103,7 @@ fn _expr_nodes(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<Agg>().unwrap();
     m.add_class::<Ternary>().unwrap();
     m.add_class::<Function>().unwrap();
+    m.add_class::<Slice>().unwrap();
     m.add_class::<Len>().unwrap();
     m.add_class::<Window>().unwrap();
     m.add_class::<PyOperator>().unwrap();


### PR DESCRIPTION
A bunch of "easy" nodes that complete coverage for translation of some useful benchmark queries.

Also, sends through the `should_broadcast` projection option that was introduced in #16682