### PR TITLE
docs(python): Add docstring examples for various functions

### DIFF
--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -39,6 +39,22 @@ def read_avro(
     Returns
     -------
     DataFrame
+
+    Examples
+    --------
+    Read a DataFrame from an Apache Avro file, with columns
+
+    >>> pl.read_avro("data.avro")
+    ... shape: (3, 3)
+    ... ┌─────┬────────┬──────┐
+    ... │ id  ┆ name   ┆ age  │
+    ... │ --- ┆ ---    ┆ ---  │
+    ... │ i64 ┆ str    ┆ i64  │
+    ... ├─────┼────────┼──────┤
+    ... │ 1   ┆ Alice  ┆ 20   │
+    ... │ 2   ┆ Bob    ┆ 30   │
+    ... │ 3   ┆ Alex   ┆ 40   │
+    ... └─────┴────────┴──────┘
     """
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source)

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -44,7 +44,7 @@ def read_avro(
     --------
     Read a DataFrame from an Apache Avro file, with columns
 
-    >>> pl.read_avro("data.avro")
+    >>> pl.read_avro("data.avro") # doctest: +SKIP
     ... shape: (3, 3)
     ... ┌─────┬────────┬──────┐
     ... │ id  ┆ name   ┆ age  │

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -55,6 +55,8 @@ def read_ndjson(
 
     Examples
     --------
+    Read from a njdson string.
+
     >>> from io import StringIO
     >>> json_str = '{"foo":1,"bar":6}\n{"foo":2,"bar":7}\n{"foo":3,"bar":8}\n'
     >>> pl.read_ndjson(StringIO(json_str))
@@ -141,7 +143,7 @@ def scan_ndjson(
     --------
     >>> from io import StringIO
     >>> json_str = '{"foo":1,"bar":6}\n{"foo":2,"bar":7}\n{"foo":3,"bar":8}\n'
-    >>> pl.scan_ndjson(StringIO(json_str)).collect()
+    >>> pl.scan_ndjson(StringIO(json_str)).collect()  # doctest: +SKIP
     shape: (3, 2)
     ┌─────┬─────┐
     │ foo ┆ bar │

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -98,7 +98,7 @@ def scan_ndjson(
     row_index_offset: int = 0,
     ignore_errors: bool = False,
 ) -> LazyFrame:
-    """
+    r"""
     Lazily read from a newline delimited JSON file or multiple files via glob patterns.
 
     This allows the query optimizer to push down predicates and projections to the scan
@@ -136,6 +136,22 @@ def scan_ndjson(
         Offset to start the row index column (only use if the name is set)
     ignore_errors
         Return `Null` if parsing fails because of schema mismatches.
+
+    Examples
+    --------
+    >>> from io import StringIO
+    >>> json_str = '{"foo":1,"bar":6}\n{"foo":2,"bar":7}\n{"foo":3,"bar":8}\n'
+    >>> pl.scan_ndjson(StringIO(json_str)).collect()
+    shape: (3, 2)
+    ┌─────┬─────┐
+    │ foo ┆ bar │
+    │ --- ┆ --- │
+    │ i64 ┆ i64 │
+    ╞═════╪═════╡
+    │ 1   ┆ 6   │
+    │ 2   ┆ 7   │
+    │ 3   ┆ 8   │
+    └─────┴─────┘
     """
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source)

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -135,7 +135,7 @@ def read_parquet(
     --------
     Read a local Parquet file.
 
-    >>> pl.read_parquet("path/to/file.parquet")
+    >>> pl.read_parquet("path/to/file.parquet")  # doctest: +SKIP
 
     Read a file on Azure Blob Storage
 
@@ -144,7 +144,7 @@ def read_parquet(
     ...     "AZURE_STORAGE_ACCOUNT_NAME": "AZURE_STORAGE_ACCOUNT_NAME",
     ...     "AZURE_STORAGE_ACCOUNT_KEY": "AZURE_STORAGE_ACCOUNT_KEY",
     ... }
-    >>> pl.read_parquet(source, storage_options=storage_options)
+    >>> pl.read_parquet(source, storage_options=storage_options)  # doctest: +SKIP
     """
     if hive_schema is not None:
         msg = "The `hive_schema` parameter of `read_parquet` is considered unstable."
@@ -289,7 +289,8 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
     Examples
     --------
     Read a parquet file.
-    >>> pl.read_parquet("path/to/file.parquet")
+
+    >>> pl.read_parquet("path/to/file.parquet")  # doctest: +SKIP
     shape: (3, 3)
     ┌──────┬─────────┬──────────┐
     │ year ┆ name    ┆ country  │
@@ -302,7 +303,8 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
     └──────┴─────────┴──────────┘
 
     Get the schema of the parquet file.
-    >>> pl.read_parquet_schema("path/to/file.parquet")
+
+    >>> pl.read_parquet_schema("path/to/file.parquet")  # doctest: +SKIP
     {'year': Int64, 'name': String, 'country': String}
     """
     if isinstance(source, (str, Path)):

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -130,6 +130,21 @@ def read_parquet(
     --------
     scan_parquet
     scan_pyarrow_dataset
+
+    Examples
+    --------
+    Read a local Parquet file.
+
+    >>> pl.read_parquet("path/to/file.parquet")
+
+    Read a file on Azure Blob Storage
+
+    >>> source = "az://path/to/file.parquet"
+    >>> storage_options = {
+    ...     "AZURE_STORAGE_ACCOUNT_NAME": "AZURE_STORAGE_ACCOUNT_NAME",
+    ...     "AZURE_STORAGE_ACCOUNT_KEY": "AZURE_STORAGE_ACCOUNT_KEY",
+    ... }
+    >>> pl.read_parquet(source, storage_options=storage_options)
     """
     if hive_schema is not None:
         msg = "The `hive_schema` parameter of `read_parquet` is considered unstable."
@@ -270,6 +285,25 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
     -------
     dict
         Dictionary mapping column names to datatypes
+
+    Examples
+    --------
+    Read a parquet file.
+    >>> pl.read_parquet("path/to/file.parquet")
+    shape: (3, 3)
+    ┌──────┬─────────┬──────────┐
+    │ year ┆ name    ┆ country  │
+    │ ---  ┆ ---     ┆ ---      │
+    │ i64  ┆ str     ┆ str      │
+    ├──────┼─────────┼──────────┤
+    │ 2020 ┆ Alice   ┆ USA      │
+    │ 2021 ┆ Bob     ┆ Canada   │
+    │ 2022 ┆ Charlie ┆ UK       │
+    └──────┴─────────┴──────────┘
+
+    Get the schema of the parquet file.
+    >>> pl.read_parquet_schema("path/to/file.parquet")
+    {'year': Int64, 'name': String, 'country': String}
     """
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source)

--- a/py-polars/polars/meta/build.py
+++ b/py-polars/polars/meta/build.py
@@ -29,5 +29,15 @@ def build_info() -> dict[str, Any]:
 
     If Polars was compiled without the `build_info` feature flag, only the `"version"`
     key is included.
+
+    Returns
+    -------
+    dict
+        A dictionary with Polars build information.
+
+    Examples
+    --------
+    Return detailed Polars build information.
+    >>> pl.build_info()
     """
     return __build__

--- a/py-polars/polars/meta/build.py
+++ b/py-polars/polars/meta/build.py
@@ -38,6 +38,7 @@ def build_info() -> dict[str, Any]:
     Examples
     --------
     Return detailed Polars build information.
-    >>> pl.build_info()
+
+    >>> pl.build_info()  # doctest: +SKIP
     """
     return __build__


### PR DESCRIPTION
Related to: Add missing docstring examples #13161

Add example for:
- https://docs.pola.rs/py-polars/html/reference/api/polars.read_parquet_schema.html
- https://docs.pola.rs/py-polars/html/reference/api/polars.read_avro.html
- https://docs.pola.rs/py-polars/html/reference/api/polars.read_parquet_schema.html
- https://docs.pola.rs/py-polars/html/reference/api/polars.scan_ndjson.html
- https://docs.pola.rs/py-polars/html/reference/api/polars.build_info.html