### PR TITLE
refactor(rust): start further use of polars-compute in polars-parquet

### DIFF
--- a/crates/polars-parquet/src/arrow/write/primitive/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/nested.rs
@@ -11,13 +11,14 @@ use crate::parquet::page::DataPage;
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::types::NativeType;
 
-pub fn array_to_page<T, R>(
-    array: &PrimitiveArray<T>,
+pub fn array_to_page<'a, T, R>(
+    array: &'a PrimitiveArray<T>,
     options: WriteOptions,
     type_: PrimitiveType,
     nested: &[Nested],
 ) -> PolarsResult<DataPage>
 where
+    PrimitiveArray<T>: polars_compute::min_max::MinMaxKernel<Scalar<'a> = T>,
     T: ArrowNativeType,
     R: NativeType,
     T: num_traits::AsPrimitive<R>,


### PR DESCRIPTION
This adds further usage of `polars-compute` in `polars-parquet`. I cannot get it to work for Primitives since there is a very, very annoying trait bound I cannot really circumvent without changing `polars-compute`.