### PR TITLE
feat(python)!: Only accept a single column in `set_sorted`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10313,26 +10313,32 @@ class DataFrame:
 
     def set_sorted(
         self,
-        column: str | Iterable[str],
-        *more_columns: str,
+        column: str,
+        *,
         descending: bool = False,
     ) -> DataFrame:
         """
         Indicate that one or multiple columns are sorted.
 
+        This can speed up future operations.
+
         Parameters
         ----------
         column
-            Columns that are sorted
-        more_columns
-            Additional columns that are sorted, specified as positional arguments.
+            Column that are sorted
         descending
             Whether the columns are sorted in descending order.
+
+        Warnings
+        --------
+        This can lead to incorrect results if the data is NOT sorted!!
+        Use with care!
+
         """
+        # NOTE: Only accepts 1 column on purpose! User think they are sorted by
+        # the combined multicolumn values.
         return (
-            self.lazy()
-            .set_sorted(column, *more_columns, descending=descending)
-            .collect(_eager=True)
+            self.lazy().set_sorted(column, descending=descending).collect(_eager=True)
         )
 
     @unstable()

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9825,7 +9825,7 @@ class Expr:
 
         Warnings
         --------
-        This can lead to incorrect results if this `Series` is not sorted!!
+        This can lead to incorrect results if the data is NOT sorted!!
         Use with care!
 
         Examples

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -81,7 +81,7 @@ from polars.selectors import _expand_selectors, by_dtype, expand_selector
 from polars.slice import LazyPolarsSlice
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars.polars import PyLazyFrame, col
+    from polars.polars import PyLazyFrame
 
 if TYPE_CHECKING:
     import sys
@@ -5932,7 +5932,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if not isinstance(column, str):
             msg = "expected a 'str' for argument 'column' in 'set_sorted'"
             raise TypeError(msg)
-        return self.with_columns(col(column).set_sorted(descending=descending))
+        return self.with_columns(F.col(column).set_sorted(descending=descending))
 
     @unstable()
     def update(

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -658,3 +658,10 @@ def test_raise_invalid_arithmetic() -> None:
 
     with pytest.raises(pl.InvalidOperationError):
         df.select(pl.col("a") - pl.col("a"))
+
+
+def test_raise_on_sorted_multi_args() -> None:
+    with pytest.raises(TypeError):
+        pl.DataFrame({"a": [1], "b": [1]}).set_sorted(
+            ["a", "b"]  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
Put clear warnings on every `set_sorted` def and don't accept multiple columns. If you want to indicate that multiple columns are sorted individually, you'd have to do that manually. This makes it extra clear that the columns are sorted individually.