### PR TITLE
chore(python): Skip latest deltalake release on macos

### DIFF
--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -4,6 +4,5 @@
 # -------------------------------------------------------
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch
-jax
-jaxlib
+jax[cpu]
 pyiceberg>=0.5.0

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -41,7 +41,10 @@ fastexcel>=0.9
 openpyxl
 xlsx2csv
 XlsxWriter
-deltalake>=0.15.0
+# Skip deltalake version 0.18.0 due to MacOS issues:
+# https://github.com/delta-io/delta-rs/issues/2577
+deltalake>=0.15.0; platform_system != 'darwin'
+deltalake>=0.15.0,!=0.18.0; platform_system == 'darwin'
 # Csv
 zstandard
 # Plotting


### PR DESCRIPTION
Ref https://github.com/delta-io/delta-rs/issues/2577