### PR TITLE
chore(python): Properly skip deltalake 0.18.0 for MacOS

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -43,8 +43,8 @@ xlsx2csv
 XlsxWriter
 # Skip deltalake version 0.18.0 due to MacOS issues:
 # https://github.com/delta-io/delta-rs/issues/2577
-deltalake>=0.15.0; platform_system != 'darwin'
-deltalake>=0.15.0,!=0.18.0; platform_system == 'darwin'
+deltalake>=0.15.0; platform_system != 'Darwin'
+deltalake>=0.15.0,!=0.18.0; platform_system == 'Darwin'
 # Csv
 zstandard
 # Plotting

--- a/py-polars/tests/unit/operations/test_value_counts.py
+++ b/py-polars/tests/unit/operations/test_value_counts.py
@@ -61,18 +61,18 @@ def test_value_counts_duplicate_name() -> None:
         s.value_counts()
 
     # ... but can customize that
-    assert_frame_equal(
-        pl.DataFrame({"count": [1, 0], "n": [2, 1]}, schema_overrides={"n": pl.UInt32}),
-        s.value_counts(name="n", sort=True),
+    result = s.value_counts(name="n", sort=True)
+    expected = pl.DataFrame(
+        {"count": [1, 0], "n": [2, 1]}, schema_overrides={"n": pl.UInt32}
     )
+    assert_frame_equal(result, expected)
 
     df = pl.DataFrame({"a": [None, 1, None, 2, 3]})
-    assert df.select(pl.col("a").count()).item() == 3
+    result = df.select(pl.col("a").count())
+    assert result.item() == 3
 
-    assert df.group_by(1).agg(pl.col("a").count()).to_dict(as_series=False) == {
-        "literal": [1],
-        "a": [3],
-    }
+    result = df.group_by(1).agg(pl.col("a").count())
+    assert result.to_dict(as_series=False) == {"literal": [1], "a": [3]}
 
 
 def test_count() -> None:


### PR DESCRIPTION
I messed up in https://github.com/pola-rs/polars/pull/16803. I verified now that this works.