### PR TITLE
chore: Prepare update of API reference URLs

### DIFF
--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -103,7 +103,10 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: site
+          # docs/ and py-polars/ included for backwards compatibility
           clean-exclude: |
+            api/python/
+            api/rust/
             docs/
             py-polars/
           single-commit: true


### PR DESCRIPTION
The link to the API references will be updated. The old location will redirect to the new location.

Reasons the old URLs are not great:

* The `py-polars/html` path in our current stable docs doesn't make much sense - this is old and was kept for backwards compatibility.
* Now that our base domain is `docs.pola.rs`, it doesn't make sense for our dev references to start with `docs/...`.

Logic behind the new URLs:

* The links are set up like https://docs.pola.rs/api/{language}/{version}
* This matches nicely with the existing docs page for the API refs: https://docs.pola.rs/api/

This is not a super important issue, but it's just a nice professional touch if the URLs make sense. We have previously moved our user guide to a new path using redirects and it was easy and was picked up by search engines really quickly.

#### Links

Here is an overview of what the old/new links will be:

| What | Current | New |
| -- | -- | -- |
|  Python stable | https://docs.pola.rs/py-polars/html/ | https://docs.pola.rs/api/python/stable/ |
|  Python dev | https://docs.pola.rs/docs/python/dev/ | https://docs.pola.rs/api/python/dev/ |
|  Python versioned | https://docs.pola.rs/docs/python/version/0.20/ | https://docs.pola.rs/api/python/version/0.20/ |
|  Rust dev | https://docs.pola.rs/docs/rust/dev/ | https://docs.pola.rs/api/rust/dev/ |

#### This PR

This PR doesn't change anything yet, except that it will allow me to set up the API docs in the new locations without them being deleted when new commits are merged.

If this is merged, I can manually update the `gh-pages` branch and I will send a second PR to update the GitHub workflows and the hardcoded links in various locations.