### PR TITLE
feat: improve error message when raising integers to negative integers, improve docs

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -158,7 +158,11 @@ fn pow_on_series(base: &Series, exponent: &Series) -> PolarsResult<Option<Series
                 }
             } else {
                 let ca = base.$native_type().unwrap();
-                let exponent = exponent.strict_cast(&DataType::UInt32)?;
+                let exponent = exponent.strict_cast(&DataType::UInt32).map_err(|err| polars_err!(
+                    InvalidOperation:
+                    "{}\n\nHint: if you were trying to raise an integer to a negative integer power, please cast your base or exponent to float first.",
+                    err
+                ))?;
                 pow_to_uint_dtype(ca, exponent.u32().unwrap())
             }
         })

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5540,6 +5540,9 @@ class Expr:
         """
         Method equivalent of exponentiation operator `expr ** exponent`.
 
+        If the exponent is float, the result follows the dtype of exponent.
+        Otherwise, it follows dtype of base.
+
         Parameters
         ----------
         exponent
@@ -5563,6 +5566,26 @@ class Expr:
         │ 4   ┆ 64   ┆ 16.0       │
         │ 8   ┆ 512  ┆ 512.0      │
         └─────┴──────┴────────────┘
+
+        Raising an integer to a positive integer results in an integer - in order
+        to raise to a negative integer, you can cast either the base or the exponent
+        to float first:
+
+        >>> df.with_columns(
+        ...     x_squared=pl.col("x").pow(2),
+        ...     x_inverse=pl.col("x").pow(-1.0),
+        ... )
+        shape: (4, 3)
+        ┌─────┬───────────┬───────────┐
+        │ x   ┆ x_squared ┆ x_inverse │
+        │ --- ┆ ---       ┆ ---       │
+        │ i64 ┆ i64       ┆ f64       │
+        ╞═════╪═══════════╪═══════════╡
+        │ 1   ┆ 1         ┆ 1.0       │
+        │ 2   ┆ 4         ┆ 0.5       │
+        │ 4   ┆ 16        ┆ 0.25      │
+        │ 8   ┆ 64        ┆ 0.125     │
+        └─────┴───────────┴───────────┘
         """
         return self.__pow__(exponent)
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1877,6 +1877,9 @@ class Series:
         """
         Raise to the power of the given exponent.
 
+        If the exponent is float, the result follows the dtype of exponent.
+        Otherwise, it follows dtype of base.
+
         Parameters
         ----------
         exponent
@@ -1884,6 +1887,8 @@ class Series:
 
         Examples
         --------
+        Raising integers to positive integers results in integers:
+
         >>> s = pl.Series("foo", [1, 2, 3, 4])
         >>> s.pow(3)
         shape: (4,)
@@ -1893,6 +1898,19 @@ class Series:
             8
             27
             64
+        ]
+
+        In order to raise integers to negative integers, you can cast either the
+        base or the exponent to float:
+
+        >>> s.pow(-3.0)
+        shape: (4,)
+        Series: 'foo' [f64]
+        [
+                1.0
+                0.125
+                0.037037
+                0.015625
         ]
         """
         if _check_for_numpy(exponent) and isinstance(exponent, np.ndarray):

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -537,7 +537,9 @@ def test_power_series() -> None:
         a ** "hi"  # type: ignore[operator]
 
     # Raising to UInt64: raises if can't be downcast safely to UInt32...
-    with pytest.raises(pl.ComputeError, match="conversion from `u64` to `u32` failed"):
+    with pytest.raises(
+        pl.InvalidOperationError, match="conversion from `u64` to `u32` failed"
+    ):
         a**m
     # ... but succeeds otherwise.
     assert_series_equal(a**j, pl.Series([1, 4], dtype=Int64))


### PR DESCRIPTION
closes #15897

I'll maintain that the change introduced in https://github.com/pola-rs/polars/pull/15506 is a net-positive, and that avoiding floating point imprecision for this operation is desirable - so I've just improved the error  message and docs

Demo:
```python
In [1]: import polars as pl
   ...: data = pl.DataFrame({"a": [1,2,3]})
   ...: data.select([pl.col("a").pow(-1)])
---------------------------------------------------------------------------
InvalidOperationError                     Traceback (most recent call last)
Cell In[1], line 3
      1 import polars as pl
      2 data = pl.DataFrame({"a": [1,2,3]})
----> 3 data.select([pl.col("a").pow(-1)])

File ~/polars-dev/py-polars/polars/dataframe/frame.py:8318, in DataFrame.select(self, *exprs, **named_exprs)
   8218 def select(
   8219     self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
   8220 ) -> DataFrame:
   8221     """
   8222     Select columns from this DataFrame.
   8223 
   (...)
   8316     └───────────┘
   8317     """
-> 8318     return self.lazy().select(*exprs, **named_exprs).collect(_eager=True)

File ~/polars-dev/py-polars/polars/lazyframe/frame.py:1846, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, cluster_with_columns, no_optimization, streaming, background, _eager, **_kwargs)
   1843 # Only for testing purposes atm.
   1844 callback = _kwargs.get("post_opt_callback")
-> 1846 return wrap_df(ldf.collect(callback))

InvalidOperationError: conversion from `i32` to `u32` failed in column 'literal' for 1 out of 1 values: [-1]

Hint: if you were trying to raise an integer to a negative integer power, please cast your base or exponent to float first.
```