### PR TITLE
fix: Reduce needless panics in comparisons

### DIFF
--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -39,7 +39,8 @@ macro_rules! impl_compare {
             _ => (),
         };
 
-        let (lhs, rhs) = coerce_lhs_rhs(lhs, rhs).expect("cannot coerce datatypes");
+        let (lhs, rhs) = coerce_lhs_rhs(lhs, rhs).map_err(|_| polars_err!(SchemaMismatch: "could not evalulate comparison between series '{}' of dtype: {} and series '{}' of dtype: {}",
+        lhs.name(), lhs.dtype(), rhs.name(), rhs.dtype()))?;
         let lhs = lhs.to_physical_repr();
         let rhs = rhs.to_physical_repr();
         let mut out = match lhs.dtype() {
@@ -76,7 +77,7 @@ macro_rules! impl_compare {
                 lhs.0.$method(&rhs.0)
             },
 
-            _ => unimplemented!(),
+            dt => polars_bail!(InvalidOperation: "could apply comparison on series of dtype '{}; operand names: '{}', '{}'", dt, lhs.name(), rhs.name()),
         };
         out.rename(lhs.name());
         PolarsResult::Ok(out)

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -665,3 +665,17 @@ def test_raise_on_sorted_multi_args() -> None:
         pl.DataFrame({"a": [1], "b": [1]}).set_sorted(
             ["a", "b"]  # type: ignore[arg-type]
         )
+
+
+def test_err_invalid_comparison() -> None:
+    with pytest.raises(
+        pl.SchemaError,
+        match="could not evalulate comparison between series 'a' of dtype: date and series 'b' of dtype: bool",
+    ):
+        _ = pl.Series("a", [date(2020, 1, 1)]) == pl.Series("b", [True])
+
+    with pytest.raises(
+        pl.InvalidOperationError,
+        match="could apply comparison on series of dtype 'object; operand names: 'a', 'b'",
+    ):
+        _ = pl.Series("a", [object()]) == pl.Series("b", [object])


### PR DESCRIPTION
#16791 already removed most needless panics in arithmetic. Now also remove them in comparisons. I think these might hit users the most. They were also trivially fixed, so let's squash more of those.

Fixes #16824