### PR TITLE
refactor(python)!: Set `infer_schema_length` as keyword-only for `str.json_decode`

### DIFF
--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1185,6 +1185,7 @@ class ExprStringNameSpace:
     def json_decode(
         self,
         dtype: PolarsDataType | None = None,
+        *,
         infer_schema_length: int | None = N_INFER_DEFAULT,
     ) -> Expr:
         """

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -627,6 +627,7 @@ class StringNameSpace:
     def json_decode(
         self,
         dtype: PolarsDataType | None = None,
+        *,
         infer_schema_length: int | None = N_INFER_DEFAULT,
     ) -> Series:
         """


### PR DESCRIPTION
Closes #13698

This is a breaking change. If a deprecation is desired first, let me know.

Similar to #7860, the use of this argument is much more natural as a keyword argument, so impact should be limited.
Also stated there, these are hard to properly deprecate due to the Series -> Expr dispatch.



