### PR TITLE
ci(python): Do not update stable API reference on prerelease

### DIFF
--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -107,6 +107,7 @@ jobs:
           clean-exclude: |
             api/python/
             api/rust/
-            docs/
-            py-polars/
+            docs/python
+            docs/rust
+            py-polars/html
           single-commit: true

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
         run: |
           tag="${{ github.event.client_payload.tag }}"
-          regex="py-([0-9]+\.[0-9]+)\.[0-9]+.*"
+          regex="py-([0-9]+)\.[0-9]+\.[0-9]+.*"
           [[ $tag =~ $regex ]]
           version=${BASH_REMATCH[1]}
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -78,7 +78,7 @@ jobs:
           single-commit: true
 
       - name: Deploy Python docs for latest release version - stable
-        if: github.event_name == 'repository_dispatch'
+        if: github.event_name == 'repository_dispatch' && github.event.client_payload.is_prerelease == 'false'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -277,6 +277,7 @@ jobs:
           client-payload: >
             {
               "version": "${{ steps.version.outputs.version }}",
+              "is_prerelease": "${{ steps.version.outputs.is_prerelease }}",
               "tag": "${{ steps.github-release.outputs.tag_name }}",
               "sha": "${{ inputs.sha || github.sha }}"
             }

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -116,7 +116,7 @@ web_root = "https://docs.pola.rs"
 
 # Specify version for version switcher dropdown menu
 git_ref = os.environ.get("POLARS_VERSION", "main")
-version_match = re.fullmatch(r"py-(\d+\.\d+)\.\d+.*", git_ref)
+version_match = re.fullmatch(r"py-(\d+)\.\d+\.\d+.*", git_ref)
 switcher_version = version_match.group(1) if version_match is not None else "dev"
 
 html_js_files = [


### PR DESCRIPTION
This makes sure that the **stable** API reference remains at the latest full release (currently `0.20.31`) when we start publishing pre-releases of 1.0.0.

Also prepares to publish 1.0.0 versions to `api/python/version/1`.