### PR TITLE
docs(python): Update version switcher for 1.0.0 prereleases

### DIFF
--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -5,6 +5,11 @@
     "url": "https://docs.pola.rs/api/python/dev/"
   },
   {
+    "name": "1",
+    "version": "1",
+    "url": "https://docs.pola.rs/api/python/version/1/"
+  },
+  {
     "name": "0.20 (stable)",
     "version": "0.20",
     "url": "https://docs.pola.rs/api/python/stable/",


### PR DESCRIPTION
**DO NOT MERGE**

This should be merged right before our first `1.0.0` pre-release.

It will make sure people can select version `1` from the version switcher.

The stable version remains at 0.20 until the definitive `1.0.0` version is released.