### PR TITLE
docs(python): Update version switcher for 1.0.0 final release

### DIFF
--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -5,15 +5,15 @@
     "url": "https://docs.pola.rs/api/python/dev/"
   },
   {
-    "name": "1",
+    "name": "1 (stable)",
     "version": "1",
-    "url": "https://docs.pola.rs/api/python/version/1/"
-  },
-  {
-    "name": "0.20 (stable)",
-    "version": "0.20",
     "url": "https://docs.pola.rs/api/python/stable/",
     "preferred": true
+  },
+  {
+    "name": "0.20",
+    "version": "0.20",
+    "url": "https://docs.pola.rs/api/python/version/0.20/"
   },
   {
     "name": "0.19",


### PR DESCRIPTION
**DO NOT MERGE**

This should be merged right before the final `1.0.0`.

It will set the `1.0.0` docs as the stable version in the version dropdown.