### PR TITLE
feat: Support SQL `VALUES` clause and inline renaming of columns in CTE & derived table definitions

### DIFF
--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -10,7 +10,7 @@ description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 
 [dependencies]
 arrow = { workspace = true }
-polars-core = { workspace = true }
+polars-core = { workspace = true, features = ["rows"] }
 polars-error = { workspace = true }
 polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "dtype-decimal", "is_in", "list_eval", "log", "meta", "regex", "round_series", "sign", "string_reverse", "strings", "timezones", "trigonometry"] }
 polars-ops = { workspace = true }
@@ -32,12 +32,12 @@ polars-core = { workspace = true, features = ["fmt"] }
 [features]
 default = []
 nightly = []
-csv = ["polars-lazy/csv"]
-ipc = ["polars-lazy/ipc"]
-json = ["polars-lazy/json", "polars-plan/extract_jsonpath"]
 binary_encoding = ["polars-lazy/binary_encoding"]
+csv = ["polars-lazy/csv"]
 diagonal_concat = ["polars-lazy/diagonal_concat"]
 dtype-decimal = ["polars-lazy/dtype-decimal"]
+ipc = ["polars-lazy/ipc"]
+json = ["polars-lazy/json", "polars-plan/extract_jsonpath"]
 list_eval = ["polars-lazy/list_eval"]
 parquet = ["polars-lazy/parquet"]
 semi_anti_join = ["polars-lazy/semi_anti_join"]

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -234,8 +234,10 @@ def test_values_clause_table_registration() -> None:
         assert ctx.tables() == []
 
         # confirm that VALUES clause derived table is registered, post-query
-        res = ctx.execute("SELECT * FROM (VALUES (-1,1)) AS tbl(x, y)")
+        res1 = ctx.execute("SELECT * FROM (VALUES (-1,1)) AS tbl(x, y)")
         assert ctx.tables() == ["tbl"]
 
-        # and confirm the data returned from the VALUES clause
-        assert res.to_dict(as_series=False) == {"x": [-1], "y": [1]}
+        # and confirm that we can select from it by the registered name
+        res2 = ctx.execute("SELECT x, y FROM tbl")
+        for res in (res1, res2):
+            assert res.to_dict(as_series=False) == {"x": [-1], "y": [1]}

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -14,14 +14,20 @@ if TYPE_CHECKING:
 
 
 def test_div() -> None:
-    df = pl.DataFrame(
-        {
-            "a": [20.5, None, 10.0, 5.0, 2.5],
-            "b": [6, 12, 24, None, 5],
-        },
-    )
-    res = df.sql("SELECT DIV(a, b) AS a_div_b, DIV(b, a) AS b_div_a FROM self")
+    res = pl.sql("""
+        SELECT label, DIV(a, b) AS a_div_b, DIV(tbl.b, tbl.a) AS b_div_a
+        FROM (
+          VALUES
+            ('a', 20.5, 6),
+            ('b', NULL, 12),
+            ('c', 10.0, 24),
+            ('d', 5.0, NULL),
+            ('e', 2.5, 5)
+        ) AS tbl(label, a, b)
+    """).collect()
+
     assert res.to_dict(as_series=False) == {
+        "label": ["a", "b", "c", "d", "e"],
         "a_div_b": [3, None, 0, None, 0],
         "b_div_a": [0, None, 2, None, 2],
     }


### PR DESCRIPTION
Adds new SQL interface support for...

* The `VALUES`[^1] clause (doesn't support inline literal casts yet).
* Column (re)naming in derived table aliases (eg: CTEs and VALUES clause).

## Example

Standalone `VALUES` clause:
```python
pl.sql("VALUES (1,2), (3,4)").collect()
# shape: (2, 2)
# ┌──────────┬──────────┐
# │ column_0 ┆ column_1 │
# │ ---      ┆ ---      │
# │ i32      ┆ i32      │
# ╞══════════╪══════════╡
# │ 1        ┆ 2        │
# │ 3        ┆ 4        │
# └──────────┴──────────┘
```
Select from `VALUES`, applying column names with the table alias:
```python
pl.sql("SELECT * FROM (VALUES(1,2), (3,4)) AS tbl(colx, coly)").collect()
# shape: (2, 2)
# ┌──────┬──────┐
# │ colx ┆ coly │
# │ ---  ┆ ---  │
# │ i32  ┆ i32  │
# ╞══════╪══════╡
# │ 1    ┆ 2    │
# │ 3    ┆ 4    │
# └──────┴──────┘
```
Demonstrate/stress-test name/alias resolution; select from inner `VALUES` and show that we successfully map column/table names through multiple levels of nested CTEs and derived table column aliasing.
```python
df = pl.sql(
  """
  WITH
    x AS (SELECT w.* FROM (VALUES(1,2), (3,4)) AS w(a, b)),
    y (m, n) AS (
      WITH z(c, d) AS (SELECT a, b FROM x)
        SELECT d*2 AS d2, c*3 AS c3 FROM z
  )
  SELECT n, m FROM y
  """,
  eager=True,
)
# shape: (2, 2)
# ┌─────┬─────┐
# │ n   ┆ m   │
# │ --- ┆ --- │
# │ i32 ┆ i32 │
# ╞═════╪═════╡
# │ 3   ┆ 4   │
# │ 9   ┆ 8   │
# └─────┴─────┘
```
[^1]: PostgreSQL VALUES clause: https://www.postgresql.org/docs/current/sql-values.html