### PR TITLE
feat(python): Support Python `Enum` values in `lit`

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import enum
 from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -12,7 +13,7 @@ from polars._utils.convert import (
     timedelta_to_int,
 )
 from polars._utils.wrap import wrap_expr
-from polars.datatypes import Date, Datetime, Duration, Time
+from polars.datatypes import Date, Datetime, Duration, Enum, Time
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 
@@ -125,6 +126,12 @@ def lit(
 
     elif isinstance(value, (list, tuple)):
         return lit(pl.Series("literal", [value], dtype=dtype))
+
+    elif isinstance(value, enum.Enum):
+        lit_value = value.value
+        if dtype is None and isinstance(value, str):
+            dtype = Enum(value.__class__.__members__.values())
+        return lit(lit_value, dtype=dtype)
 
     if dtype:
         return wrap_expr(plr.lit(value, allow_object)).cast(dtype)


### PR DESCRIPTION
Closes #16668

We now take the Enum value as a literal. If it's a string Enum, and dtype is not set, we set the dtype to a Polars `Enum`.