### PR TITLE
feat: Improve `read_csv` SQL table reading function defaults (better handle dates)

### DIFF
--- a/crates/polars-sql/src/table_functions.rs
+++ b/crates/polars-sql/src/table_functions.rs
@@ -79,17 +79,20 @@ impl PolarsTableFunctions {
 
     #[cfg(feature = "csv")]
     fn read_csv(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
-        polars_ensure!(!args.is_empty(), SQLSyntax: "`read_csv` expected a path");
+        polars_ensure!(args.len() == 1, SQLSyntax: "`read_csv` expects a single file path; found {:?} arguments", args.len());
 
         use polars_lazy::frame::LazyFileListReader;
         let path = self.get_file_path_from_arg(&args[0])?;
-        let lf = LazyCsvReader::new(&path).finish()?;
+        let lf = LazyCsvReader::new(&path)
+            .with_try_parse_dates(true)
+            .with_missing_is_null(true)
+            .finish()?;
         Ok((path, lf))
     }
 
     #[cfg(feature = "parquet")]
     fn read_parquet(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
-        polars_ensure!(!args.is_empty(), SQLSyntax: "`read_parquet` expected a path");
+        polars_ensure!(args.len() == 1, SQLSyntax: "`read_parquet` expects a single file path; found {:?} arguments", args.len());
 
         let path = self.get_file_path_from_arg(&args[0])?;
         let lf = LazyFrame::scan_parquet(&path, Default::default())?;
@@ -98,7 +101,7 @@ impl PolarsTableFunctions {
 
     #[cfg(feature = "ipc")]
     fn read_ipc(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
-        polars_ensure!(!args.is_empty(), SQLSyntax: "`read_ipc` expected a path");
+        polars_ensure!(args.len() == 1, SQLSyntax: "`read_ipc` expects a single file path; found {:?} arguments", args.len());
 
         let path = self.get_file_path_from_arg(&args[0])?;
         let lf = LazyFrame::scan_ipc(&path, Default::default())?;
@@ -106,7 +109,7 @@ impl PolarsTableFunctions {
     }
     #[cfg(feature = "json")]
     fn read_ndjson(&self, args: &[FunctionArg]) -> PolarsResult<(String, LazyFrame)> {
-        polars_ensure!(!args.is_empty(), SQLSyntax: "`read_json` expected a path");
+        polars_ensure!(args.len() == 1, SQLSyntax: "`read_ndjson` expects a single file path; found {:?} arguments", args.len());
 
         use polars_lazy::frame::LazyFileListReader;
         use polars_lazy::prelude::LazyJsonLineReader;
@@ -125,7 +128,7 @@ impl PolarsTableFunctions {
             ))) => Ok(s.to_string()),
             _ => polars_bail!(
                 SQLSyntax:
-                "only a single quoted string is accepted for the parameter; found: {}", arg,
+                "expected a valid file path as a single-quoted string; found: {}", arg,
             ),
         }
     }


### PR DESCRIPTION
Several modest improvements to SQL table-read function:

* Sets "try_parse_dates=True" by default for `read_csv`.
* Raises a `SQLSyntax` error if more than one argument is passed (all read funcs).
* Adds extra test coverage (null vs empty string, dates) for CSV reads from SQL.

## Example

```python
df = pl.sql(f"SELECT * FROM read_csv('some_file.csv')").collect()
```
