### PR TITLE
refactor: Remove inner `Arc` from `FileCacheEntry`

### DIFF
--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -37,8 +37,7 @@ struct EntryData {
     inner: Mutex<Inner>,
 }
 
-#[derive(Clone)]
-pub struct FileCacheEntry(Arc<EntryData>);
+pub struct FileCacheEntry(EntryData);
 
 impl EntryMetadata {
     fn matches_remote_metadata(&self, remote_metadata: &RemoteMetadata) -> bool {
@@ -267,7 +266,7 @@ impl FileCacheEntry {
             "impl error: entry uri != file_fetcher uri"
         );
 
-        Self(Arc::new(EntryData {
+        Self(EntryData {
             uri: uri.clone(),
             inner: Mutex::new(Inner {
                 uri,
@@ -277,7 +276,7 @@ impl FileCacheEntry {
                 cached_data: None,
                 file_fetcher,
             }),
-        }))
+        })
     }
 
     pub fn uri(&self) -> Arc<str> {


### PR DESCRIPTION
We already always wrap it in an `Arc` on the outside (`Arc<FileCacheEntry>`)