### PR TITLE
depr(python): Deprecate `dt.mean`/`dt.median` in favor of `mean`/`median`

### DIFF
--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -154,12 +154,12 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s).max()  # type: ignore[return-value]
 
-    @deprecate_function("Use `Series.median` instead.", version="0.20.32")
+    @deprecate_function("Use `Series.median` instead.", version="1.0.0")
     def median(self) -> TemporalLiteral | None:
         """
         Return median as python DateTime.
 
-        .. deprecated:: 0.20.32
+        .. deprecated:: 1.0.0
             Use `Series.median` instead.
 
         Examples
@@ -184,12 +184,12 @@ class DateTimeNameSpace:
         """
         return self._s.median()
 
-    @deprecate_function("Use `Series.mean` instead.", version="0.20.32")
+    @deprecate_function("Use `Series.mean` instead.", version="1.0.0")
     def mean(self) -> TemporalLiteral | None:
         """
         Return mean as python DateTime.
 
-        .. deprecated:: 0.20.32
+        .. deprecated:: 1.0.0
             Use `Series.mean` instead.
 
         Examples

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -154,15 +154,19 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s).max()  # type: ignore[return-value]
 
+    @deprecate_function("Use `Series.median` instead.", version="0.20.32")
     def median(self) -> TemporalLiteral | None:
         """
         Return median as python DateTime.
+
+        .. deprecated:: 0.20.32
+            Use `Series.median` instead.
 
         Examples
         --------
         >>> from datetime import date, datetime
         >>> s = pl.Series([date(2001, 1, 1), date(2001, 1, 2)])
-        >>> s.dt.median()
+        >>> s.dt.median()  # doctest: +SKIP
         datetime.datetime(2001, 1, 1, 12, 0)
         >>> date = pl.datetime_range(
         ...     datetime(2001, 1, 1), datetime(2001, 1, 3), "1d", eager=True
@@ -175,25 +179,29 @@ class DateTimeNameSpace:
                 2001-01-02 00:00:00
                 2001-01-03 00:00:00
         ]
-        >>> date.dt.median()
+        >>> date.dt.median()  # doctest: +SKIP
         datetime.datetime(2001, 1, 2, 0, 0)
         """
         return self._s.median()
 
+    @deprecate_function("Use `Series.mean` instead.", version="0.20.32")
     def mean(self) -> TemporalLiteral | None:
         """
         Return mean as python DateTime.
+
+        .. deprecated:: 0.20.32
+            Use `Series.mean` instead.
 
         Examples
         --------
         >>> from datetime import date, datetime
         >>> s = pl.Series([date(2001, 1, 1), date(2001, 1, 2)])
-        >>> s.dt.mean()
+        >>> s.dt.mean()  # doctest: +SKIP
         datetime.datetime(2001, 1, 1, 12, 0)
         >>> s = pl.Series(
         ...     [datetime(2001, 1, 1), datetime(2001, 1, 2), datetime(2001, 1, 3)]
         ... )
-        >>> s.dt.mean()
+        >>> s.dt.mean()  # doctest: +SKIP
         datetime.datetime(2001, 1, 2, 0, 0)
         """
         return self._s.mean()

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1043,10 +1043,11 @@ def test_median(
     values: list[TemporalLiteral | None], expected_median: TemporalLiteral | None
 ) -> None:
     s = pl.Series(values)
-    assert s.dt.median() == expected_median
 
-    if s.dtype in (pl.Datetime, pl.Duration, pl.Time):
-        assert s.median() == expected_median
+    assert s.median() == expected_median
+
+    with pytest.deprecated_call():
+        assert s.dt.median() == expected_median
 
 
 @pytest.mark.parametrize(
@@ -1100,10 +1101,11 @@ def test_mean(
     values: list[TemporalLiteral | None], expected_mean: TemporalLiteral | None
 ) -> None:
     s = pl.Series(values)
-    assert s.dt.mean() == expected_mean
 
-    if s.dtype in (pl.Datetime, pl.Duration, pl.Time):
-        assert s.mean() == expected_mean
+    assert s.mean() == expected_mean
+
+    with pytest.deprecated_call():
+        assert s.dt.mean() == expected_mean
 
 
 @pytest.mark.parametrize(
@@ -1122,7 +1124,10 @@ def test_datetime_mean_with_tu(
     values: list[datetime], expected_mean: datetime, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).mean() == expected_mean
-    assert pl.Series(values, dtype=pl.Duration(time_unit)).dt.mean() == expected_mean
+    with pytest.deprecated_call():
+        assert (
+            pl.Series(values, dtype=pl.Duration(time_unit)).dt.mean() == expected_mean
+        )
 
 
 @pytest.mark.parametrize(
@@ -1141,9 +1146,11 @@ def test_datetime_median_with_tu(
     values: list[datetime], expected_median: datetime, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).median() == expected_median
-    assert (
-        pl.Series(values, dtype=pl.Duration(time_unit)).dt.median() == expected_median
-    )
+    with pytest.deprecated_call():
+        assert (
+            pl.Series(values, dtype=pl.Duration(time_unit)).dt.median()
+            == expected_median
+        )
 
 
 @pytest.mark.parametrize(
@@ -1162,7 +1169,10 @@ def test_duration_mean_with_tu(
     values: list[timedelta], expected_mean: timedelta, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).mean() == expected_mean
-    assert pl.Series(values, dtype=pl.Duration(time_unit)).dt.mean() == expected_mean
+    with pytest.deprecated_call():
+        assert (
+            pl.Series(values, dtype=pl.Duration(time_unit)).dt.mean() == expected_mean
+        )
 
 
 @pytest.mark.parametrize(
@@ -1181,9 +1191,11 @@ def test_duration_median_with_tu(
     values: list[timedelta], expected_median: timedelta, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).median() == expected_median
-    assert (
-        pl.Series(values, dtype=pl.Duration(time_unit)).dt.median() == expected_median
-    )
+    with pytest.deprecated_call():
+        assert (
+            pl.Series(values, dtype=pl.Duration(time_unit)).dt.median()
+            == expected_median
+        )
 
 
 def test_agg_mean_expr() -> None:

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1042,12 +1042,7 @@ def test_weekday(time_unit: TimeUnit) -> None:
 def test_median(
     values: list[TemporalLiteral | None], expected_median: TemporalLiteral | None
 ) -> None:
-    s = pl.Series(values)
-
-    assert s.median() == expected_median
-
-    with pytest.deprecated_call():
-        assert s.dt.median() == expected_median
+    assert pl.Series(values).median() == expected_median
 
 
 @pytest.mark.parametrize(
@@ -1100,12 +1095,7 @@ def test_median(
 def test_mean(
     values: list[TemporalLiteral | None], expected_mean: TemporalLiteral | None
 ) -> None:
-    s = pl.Series(values)
-
-    assert s.mean() == expected_mean
-
-    with pytest.deprecated_call():
-        assert s.dt.mean() == expected_mean
+    assert pl.Series(values).mean() == expected_mean
 
 
 @pytest.mark.parametrize(
@@ -1124,10 +1114,6 @@ def test_datetime_mean_with_tu(
     values: list[datetime], expected_mean: datetime, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).mean() == expected_mean
-    with pytest.deprecated_call():
-        assert (
-            pl.Series(values, dtype=pl.Duration(time_unit)).dt.mean() == expected_mean
-        )
 
 
 @pytest.mark.parametrize(
@@ -1146,11 +1132,6 @@ def test_datetime_median_with_tu(
     values: list[datetime], expected_median: datetime, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).median() == expected_median
-    with pytest.deprecated_call():
-        assert (
-            pl.Series(values, dtype=pl.Duration(time_unit)).dt.median()
-            == expected_median
-        )
 
 
 @pytest.mark.parametrize(
@@ -1169,10 +1150,6 @@ def test_duration_mean_with_tu(
     values: list[timedelta], expected_mean: timedelta, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).mean() == expected_mean
-    with pytest.deprecated_call():
-        assert (
-            pl.Series(values, dtype=pl.Duration(time_unit)).dt.mean() == expected_mean
-        )
 
 
 @pytest.mark.parametrize(
@@ -1191,11 +1168,6 @@ def test_duration_median_with_tu(
     values: list[timedelta], expected_median: timedelta, time_unit: TimeUnit
 ) -> None:
     assert pl.Series(values, dtype=pl.Duration(time_unit)).median() == expected_median
-    with pytest.deprecated_call():
-        assert (
-            pl.Series(values, dtype=pl.Duration(time_unit)).dt.median()
-            == expected_median
-        )
 
 
 def test_agg_mean_expr() -> None:
@@ -1364,3 +1336,49 @@ def test_series_datetime_timeunits(
     assert list(s.dt.millisecond()) == [v.microsecond // 1000 for v in s]
     assert list(s.dt.nanosecond()) == [v.microsecond * 1000 for v in s]
     assert list(s.dt.microsecond()) == [v.microsecond for v in s]
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_median"),
+    [
+        ([], None),
+        ([None, None], None),
+        ([date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)], datetime(2022, 1, 2)),
+        (
+            [datetime(2022, 1, 1), datetime(2022, 1, 2), datetime(2024, 5, 15)],
+            datetime(2022, 1, 2),
+        ),
+        ([timedelta(days=1), timedelta(days=2), timedelta(days=15)], timedelta(days=2)),
+        ([time(hour=1), time(hour=2), time(hour=15)], time(hour=2)),
+    ],
+)
+def test_deprecate_median(
+    values: list[TemporalLiteral | None], expected_median: TemporalLiteral | None
+) -> None:
+    with pytest.deprecated_call():
+        assert pl.Series(values).dt.median() == expected_median
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_mean"),
+    [
+        ([], None),
+        ([None, None], None),
+        (
+            [date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)],
+            datetime(2022, 10, 16, 16, 0),
+        ),
+        ([datetime(2022, 1, 1)], datetime(2022, 1, 1)),
+        (
+            [datetime(2022, 1, 1), datetime(2022, 1, 2), datetime(2024, 5, 15)],
+            datetime(2022, 10, 16, 16, 0, 0),
+        ),
+        ([timedelta(days=1), timedelta(days=2), timedelta(days=15)], timedelta(days=6)),
+        ([time(hour=1), time(hour=2), time(hour=15)], time(hour=6)),
+    ],
+)
+def test_deprecate_mean(
+    values: list[TemporalLiteral | None], expected_mean: TemporalLiteral | None
+) -> None:
+    with pytest.deprecated_call():
+        assert pl.Series(values).dt.mean() == expected_mean

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1338,47 +1338,17 @@ def test_series_datetime_timeunits(
     assert list(s.dt.microsecond()) == [v.microsecond for v in s]
 
 
-@pytest.mark.parametrize(
-    ("values", "expected_median"),
-    [
-        ([], None),
-        ([None, None], None),
-        ([date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)], datetime(2022, 1, 2)),
-        (
-            [datetime(2022, 1, 1), datetime(2022, 1, 2), datetime(2024, 5, 15)],
-            datetime(2022, 1, 2),
-        ),
-        ([timedelta(days=1), timedelta(days=2), timedelta(days=15)], timedelta(days=2)),
-        ([time(hour=1), time(hour=2), time(hour=15)], time(hour=2)),
-    ],
-)
-def test_deprecate_median(
-    values: list[TemporalLiteral | None], expected_median: TemporalLiteral | None
-) -> None:
+def test_dt_median_deprecated() -> None:
+    values = [date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)]
+    s = pl.Series(values)
     with pytest.deprecated_call():
-        assert pl.Series(values).dt.median() == expected_median
+        result = s.dt.median()
+    assert result == s.median()
 
 
-@pytest.mark.parametrize(
-    ("values", "expected_mean"),
-    [
-        ([], None),
-        ([None, None], None),
-        (
-            [date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)],
-            datetime(2022, 10, 16, 16, 0),
-        ),
-        ([datetime(2022, 1, 1)], datetime(2022, 1, 1)),
-        (
-            [datetime(2022, 1, 1), datetime(2022, 1, 2), datetime(2024, 5, 15)],
-            datetime(2022, 10, 16, 16, 0, 0),
-        ),
-        ([timedelta(days=1), timedelta(days=2), timedelta(days=15)], timedelta(days=6)),
-        ([time(hour=1), time(hour=2), time(hour=15)], time(hour=6)),
-    ],
-)
-def test_deprecate_mean(
-    values: list[TemporalLiteral | None], expected_mean: TemporalLiteral | None
-) -> None:
+def test_dt_mean_deprecated() -> None:
+    values = [date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15)]
+    s = pl.Series(values)
     with pytest.deprecated_call():
-        assert pl.Series(values).dt.mean() == expected_mean
+        result = s.dt.mean()
+    assert result == s.mean()


### PR DESCRIPTION
We can now use `Series.mean` and `Series.median` for all temporal dtypes.