### PR TITLE
docs(python): Add description and example of what happens when ignore_nulls=True on pl.concat_str

### DIFF
--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -609,7 +609,8 @@ def concat_str(
 
         If ``False``, null values will be propagated:
         if the row contains any null values, the output is null.
-        If ``True``, null values will be removed from the input list before concatenation.
+        If ``True``, null values will be removed from the
+        input list before concatenation.
 
     Examples
     --------

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -607,8 +607,9 @@ def concat_str(
     ignore_nulls
         Ignore null values (default is ``False``).
 
-        If set to ``False``, null values will be propagated.
+        If ``False``, null values will be propagated: 
         if the row contains any null values, the output is null.
+        If ``True``, null values will be propagated and will appear to be empty strings.
 
     Examples
     --------
@@ -639,6 +640,27 @@ def concat_str(
     │ 2   ┆ cats ┆ swim ┆ 4 cats swim   │
     │ 3   ┆ null ┆ walk ┆ null          │
     └─────┴──────┴──────┴───────────────┘
+    >>> df.with_columns(
+    ...     pl.concat_str(
+    ...         [
+    ...             pl.col("a") * 2,
+    ...             pl.col("b"),
+    ...             pl.col("c"),
+    ...         ],
+    ...         separator=" ",
+    ...         ignore_nulls=True,
+    ...     ).alias("full_sentence_ignore_nulls"),
+    ... )
+    shape: (3, 4)
+    ┌─────┬──────┬──────┬────────────────────────────┐
+    │ a   ┆ b    ┆ c    ┆ full_sentence_ignore_nulls │
+    │ --- ┆ ---  ┆ ---  ┆ ---                        │
+    │ i64 ┆ str  ┆ str  ┆ str                        │
+    ╞═════╪══════╪══════╪════════════════════════════╡
+    │ 1   ┆ dogs ┆ play ┆ 2 dogs play                │
+    │ 2   ┆ cats ┆ swim ┆ 4 cats swim                │
+    │ 3   ┆ null ┆ walk ┆ 6 walk                     │
+    └─────┴──────┴──────┴────────────────────────────┘
     """
     exprs = parse_as_list_of_expressions(exprs, *more_exprs)
     return wrap_expr(plr.concat_str(exprs, separator, ignore_nulls))

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -607,7 +607,7 @@ def concat_str(
     ignore_nulls
         Ignore null values (default is ``False``).
 
-        If ``False``, null values will be propagated: 
+        If ``False``, null values will be propagated:
         if the row contains any null values, the output is null.
         If ``True``, null values will be propagated and will appear to be empty strings.
 

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -609,7 +609,7 @@ def concat_str(
 
         If ``False``, null values will be propagated:
         if the row contains any null values, the output is null.
-        If ``True``, null values will be propagated and will appear to be empty strings.
+        If ``True``, null values will be removed from the input list before concatenation.
 
     Examples
     --------


### PR DESCRIPTION
Addresses #16814 on https://docs.pola.rs/py-polars/html/reference/expressions/api/polars.concat_str.html#polars.concat_str. (Other than changing the font, which is a larger decision.)