### PR TITLE
fix: Remove unwrap in `extend()`

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -987,7 +987,7 @@ impl DataFrame {
             .zip(other.columns.iter())
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(left, right)?;
-                left.extend(right).unwrap();
+                left.extend(right)?;
                 Ok(())
             })
     }

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -184,7 +184,7 @@ def test_concat_vertical() -> None:
 
 
 def test_extend_ints() -> None:
-    a = pl.DataFrame({"a": [1 for _ in range(1)]})
+    a = pl.DataFrame({"a": [1 for _ in range(1)]}, schema={"a": pl.Int64})
     with pytest.raises(pl.exceptions.SchemaError):
         # This is current behavior. It would be nice to have
         # DataFrame and lit treat ints consistently

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -183,6 +183,14 @@ def test_concat_vertical() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_extend_ints() -> None:
+    a = pl.DataFrame({"a": [1 for _ in range(1)]})
+    with pytest.raises(pl.exceptions.SchemaError):
+        # This is current behavior. It would be nice to have
+        # DataFrame and lit treat ints consistently
+        a.extend(a.select(pl.lit(0).alias("a")))
+
+
 def test_null_handling_correlation() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, None, 4], "b": [1, 2, 3, 10, 4]})
 

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -188,7 +188,7 @@ def test_extend_ints() -> None:
     with pytest.raises(pl.exceptions.SchemaError):
         # This is current behavior. It would be nice to have
         # DataFrame and lit treat ints consistently
-        a.extend(a.select(pl.lit(0).alias("a")))
+        a.extend(a.select(pl.lit(0, dtype=pl.Int32).alias("a")))
 
 
 def test_null_handling_correlation() -> None:

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -186,8 +186,6 @@ def test_concat_vertical() -> None:
 def test_extend_ints() -> None:
     a = pl.DataFrame({"a": [1 for _ in range(1)]}, schema={"a": pl.Int64})
     with pytest.raises(pl.exceptions.SchemaError):
-        # This is current behavior. It would be nice to have
-        # DataFrame and lit treat ints consistently
         a.extend(a.select(pl.lit(0, dtype=pl.Int32).alias("a")))
 
 


### PR DESCRIPTION
Closes #16882 by replacing the unwrap with proper error propagation. This still leaves open the other aspect, where the pl.DataFrame() constructor and pl.lit() treat literal ints inconsistently.