### PR TITLE
feat: Allow setting file cache TTL on a per-file basis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "polars",
  "polars-core",
  "polars-error",
+ "polars-io",
  "polars-lazy",
  "polars-ops",
  "polars-parquet",

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -34,6 +34,8 @@ use smartstring::alias::String as SmartString;
 #[cfg(feature = "cloud")]
 use url::Url;
 
+#[cfg(feature = "file_cache")]
+use crate::file_cache::get_env_file_cache_ttl;
 #[cfg(feature = "aws")]
 use crate::pl_async::with_concurrency_budget;
 #[cfg(feature = "aws")]
@@ -56,19 +58,23 @@ type Configs<T> = Vec<(T, String)>;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Options to connect to various cloud providers.
 pub struct CloudOptions {
+    pub max_retries: usize,
+    #[cfg(feature = "file_cache")]
+    pub file_cache_ttl: u64,
     #[cfg(feature = "aws")]
     aws: Option<Configs<AmazonS3ConfigKey>>,
     #[cfg(feature = "azure")]
     azure: Option<Configs<AzureConfigKey>>,
     #[cfg(feature = "gcp")]
     gcp: Option<Configs<GoogleConfigKey>>,
-    pub max_retries: usize,
 }
 
 impl Default for CloudOptions {
     fn default() -> Self {
         Self {
             max_retries: 2,
+            #[cfg(feature = "file_cache")]
+            file_cache_ttl: get_env_file_cache_ttl(),
             #[cfg(feature = "aws")]
             aws: Default::default(),
             #[cfg(feature = "azure")]

--- a/crates/polars-io/src/file_cache/cache.rs
+++ b/crates/polars-io/src/file_cache/cache.rs
@@ -50,19 +50,17 @@ pub static FILE_CACHE: Lazy<FileCache> = Lazy::new(|| {
         )
     }
 
-    // Safety: We have created the data and metadata directories.
-    unsafe {
-        EvictionManager {
-            data_dir,
-            metadata_dir,
-            files_to_remove: None,
-            min_ttl: min_ttl.clone(),
-            notify_ttl_updated: notify_ttl_updated.clone(),
-        }
-        .run_in_background();
-
-        FileCache::new_unchecked(prefix, min_ttl, notify_ttl_updated)
+    EvictionManager {
+        data_dir,
+        metadata_dir,
+        files_to_remove: None,
+        min_ttl: min_ttl.clone(),
+        notify_ttl_updated: notify_ttl_updated.clone(),
     }
+    .run_in_background();
+
+    // Safety: We have created the data and metadata directories.
+    unsafe { FileCache::new_unchecked(prefix, min_ttl, notify_ttl_updated) }
 });
 
 pub struct FileCache {

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -1,6 +1,6 @@
 use std::io::{Seek, SeekFrom};
-use std::ops::DerefMut;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 
 use fs4::FileExt;
@@ -29,12 +29,14 @@ struct Inner {
     path_prefix: Arc<Path>,
     metadata: FileLock<PathBuf>,
     cached_data: Option<CachedData>,
+    ttl: Arc<AtomicU64>,
     file_fetcher: Arc<dyn FileFetcher>,
 }
 
 struct EntryData {
     uri: Arc<str>,
     inner: Mutex<Inner>,
+    ttl: Arc<AtomicU64>,
 }
 
 pub struct FileCacheEntry(EntryData);
@@ -52,18 +54,21 @@ impl Inner {
 
         {
             let cache_guard = GLOBAL_FILE_CACHE_LOCK.lock_any();
-            let metadata_file = &mut self.metadata.acquire_shared().unwrap();
+            // We want to use an exclusive lock here to avoid an API call in the case where only the
+            // local TTL was updated.
+            let metadata_file = &mut self.metadata.acquire_exclusive().unwrap();
             update_last_accessed(metadata_file);
 
-            if let Ok(metadata) = self.try_get_metadata(metadata_file, &cache_guard) {
-                let data_file_path = self.get_cached_data_file_path();
+            let metadata = self
+                .try_get_maybe_init_metadata(metadata_file, &cache_guard)
+                .unwrap();
+            let data_file_path = self.get_cached_data_file_path();
 
-                if metadata.compare_local_state(data_file_path).is_ok() {
-                    if verbose {
-                        eprintln!("[file_cache::entry] try_open_assume_latest: opening already fetched file for uri = {}", self.uri.clone());
-                    }
-                    return Ok(finish_open(data_file_path, metadata_file));
+            if metadata.compare_local_state(data_file_path).is_ok() {
+                if verbose {
+                    eprintln!("[file_cache::entry] try_open_assume_latest: opening already fetched file for uri = {}", self.uri.clone());
                 }
+                return Ok(finish_open(data_file_path, metadata_file));
             }
         }
 
@@ -86,7 +91,7 @@ impl Inner {
             let metadata_file = &mut self.metadata.acquire_shared().unwrap();
             update_last_accessed(metadata_file);
 
-            if let Ok(metadata) = self.try_get_metadata(metadata_file, &cache_guard) {
+            if let Ok(metadata) = self.try_get_maybe_init_metadata(metadata_file, &cache_guard) {
                 if metadata.matches_remote_metadata(remote_metadata) {
                     let data_file_path = self.get_cached_data_file_path();
 
@@ -102,8 +107,9 @@ impl Inner {
 
         let metadata_file = &mut self.metadata.acquire_exclusive().unwrap();
         let metadata = self
-            .try_get_metadata(metadata_file, &cache_guard)
-            .unwrap_or_else(|_| Arc::new(EntryMetadata::new_with_uri(self.uri.clone())));
+            .try_get_maybe_init_metadata(metadata_file, &cache_guard)
+            // Safety: `metadata_file` is an exclusive guard.
+            .unwrap();
 
         if metadata.matches_remote_metadata(remote_metadata) {
             let data_file_path = self.get_cached_data_file_path();
@@ -172,7 +178,8 @@ impl Inner {
             polars_bail!(ComputeError: "downloaded file size ({}) does not match expected size ({})", local_size, remote_metadata.size);
         }
 
-        let mut metadata = Arc::unwrap_or_clone(metadata);
+        let mut metadata = metadata;
+        let metadata = Arc::make_mut(&mut metadata);
         metadata.local_last_modified = local_last_modified;
         metadata.local_size = local_size;
         metadata.remote_last_modified = remote_metadata.last_modified;
@@ -183,25 +190,37 @@ impl Inner {
 
         let data_file = finish_open(data_file_path, metadata_file);
 
+        metadata_file.set_len(0).unwrap();
         metadata_file.seek(SeekFrom::Start(0)).unwrap();
         metadata
-            .try_write(metadata_file.deref_mut())
+            .try_write(&mut **metadata_file)
             .map_err(to_compute_err)?;
 
         Ok(data_file)
     }
 
-    /// Try to read the metadata from disk.
-    fn try_get_metadata<F: FileLockAnyGuard>(
+    /// Try to read the metadata from disk. If `F` is an exclusive guard, this will
+    /// initialize the metadata if a valid one cannot be loaded from disk.
+    fn try_get_maybe_init_metadata<F: FileLockAnyGuard>(
         &mut self,
         metadata_file: &mut F,
         _cache_guard: &cache_lock::GlobalFileCacheGuardAny,
     ) -> PolarsResult<Arc<EntryMetadata>> {
-        let mut f = || {
-            let last_modified = super::utils::last_modified_u64(&metadata_file.metadata().unwrap());
+        let last_modified = super::utils::last_modified_u64(&metadata_file.metadata().unwrap());
+        let ttl = self.ttl.load(std::sync::atomic::Ordering::Relaxed);
 
+        for _ in 0..2 {
             if let Some(ref cached) = self.cached_data {
-                if cached.last_modified == last_modified {
+                if cached.last_modified == last_modified && cached.metadata.ttl == ttl {
+                    if cached.metadata.uri != self.uri {
+                        unimplemented!(
+                            "hash collision: uri1 = {}, uri2 = {}, hash = {}",
+                            cached.metadata.uri,
+                            self.uri,
+                            self.uri_hash,
+                        );
+                    }
+
                     return Ok(cached.metadata.clone());
                 }
             }
@@ -209,10 +228,36 @@ impl Inner {
             // Ensure cache is unset if read fails
             self.cached_data = None;
 
-            let metadata = Arc::new(
-                EntryMetadata::try_from_reader(metadata_file.deref_mut())
-                    .map_err(to_compute_err)?,
-            );
+            let mut metadata = match EntryMetadata::try_from_reader(&mut **metadata_file)
+                .map_err(to_compute_err)
+            {
+                Ok(v) => v,
+                Err(e) => {
+                    if F::IS_EXCLUSIVE {
+                        EntryMetadata::new(self.uri.clone(), ttl)
+                    } else {
+                        return Err(e);
+                    }
+                },
+            };
+
+            // Note this means if multiple processes on the same system set a
+            // different TTL for the same path, the metadata file will constantly
+            // get overwritten.
+            if metadata.ttl != ttl {
+                if F::IS_EXCLUSIVE {
+                    metadata.ttl = ttl;
+                    metadata_file.set_len(0).unwrap();
+                    metadata_file.seek(SeekFrom::Start(0)).unwrap();
+                    metadata
+                        .try_write(&mut **metadata_file)
+                        .map_err(to_compute_err)?;
+                } else {
+                    polars_bail!(ComputeError: "TTL mismatch");
+                }
+            }
+
+            let metadata = Arc::new(metadata);
             let data_file_path = get_data_file_path(
                 self.path_prefix.to_str().unwrap().as_bytes(),
                 self.uri_hash.as_bytes(),
@@ -223,23 +268,9 @@ impl Inner {
                 metadata,
                 data_file_path,
             });
+        }
 
-            Ok(self.cached_data.as_ref().unwrap().metadata.clone())
-        };
-
-        f().map(|v| {
-            // "just in case"
-            // but would be cool if we saw this one day :D
-            if v.uri != self.uri {
-                unimplemented!(
-                    "hash collision: uri1 = {}, uri2 = {}, hash = {}",
-                    v.uri,
-                    self.uri,
-                    self.uri_hash,
-                );
-            }
-            v
-        })
+        unreachable!();
     }
 
     /// # Panics
@@ -255,6 +286,7 @@ impl FileCacheEntry {
         uri_hash: String,
         path_prefix: Arc<Path>,
         file_fetcher: Arc<dyn FileFetcher>,
+        file_cache_ttl: u64,
     ) -> Self {
         let metadata = FileLock::from(get_metadata_file_path(
             path_prefix.to_str().unwrap().as_bytes(),
@@ -266,6 +298,8 @@ impl FileCacheEntry {
             "impl error: entry uri != file_fetcher uri"
         );
 
+        let ttl = Arc::new(AtomicU64::from(file_cache_ttl));
+
         Self(EntryData {
             uri: uri.clone(),
             inner: Mutex::new(Inner {
@@ -274,13 +308,15 @@ impl FileCacheEntry {
                 path_prefix,
                 metadata,
                 cached_data: None,
+                ttl: ttl.clone(),
                 file_fetcher,
             }),
+            ttl,
         })
     }
 
-    pub fn uri(&self) -> Arc<str> {
-        self.0.uri.clone()
+    pub fn uri(&self) -> &Arc<str> {
+        &self.0.uri
     }
 
     /// Directly returns the cached file if it finds one without checking if
@@ -294,6 +330,10 @@ impl FileCacheEntry {
     /// This will always perform at least 1 API call for fetching metadata.
     pub fn try_open_check_latest(&self) -> PolarsResult<std::fs::File> {
         self.0.inner.lock().unwrap().try_open_check_latest()
+    }
+
+    pub fn update_ttl(&self, ttl: u64) {
+        self.0.ttl.store(ttl, std::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/crates/polars-io/src/file_cache/eviction.rs
+++ b/crates/polars-io/src/file_cache/eviction.rs
@@ -149,7 +149,11 @@ impl EvictionCandidate {
 }
 
 impl EvictionManager {
-    pub(super) fn run_in_background(mut self) {
+    /// # Safety
+    /// The following directories exist:
+    /// * `self.data_dir`
+    /// * `self.metadata_dir`
+    pub(super) unsafe fn run_in_background(mut self) {
         let verbose = config::verbose();
 
         if verbose {

--- a/crates/polars-io/src/file_cache/eviction.rs
+++ b/crates/polars-io/src/file_cache/eviction.rs
@@ -1,60 +1,192 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use fs4::FileExt;
 use polars_core::config;
 use polars_error::PolarsResult;
 
 use super::cache_lock::{GlobalFileCacheGuardExclusive, GLOBAL_FILE_CACHE_LOCK};
+use super::metadata::EntryMetadata;
 use crate::pl_async;
 
+#[derive(Debug, Clone)]
+pub(super) struct EvictionCandidate {
+    path: PathBuf,
+    metadata_path: PathBuf,
+    metadata_last_modified: SystemTime,
+    ttl: u64,
+}
+
 pub(super) struct EvictionManager {
-    pub(super) prefix: Arc<Path>,
-    pub(super) files_to_remove: Option<(SystemTime, Vec<PathBuf>)>,
-    pub(super) limit_since_last_access: Duration,
+    pub(super) data_dir: Box<Path>,
+    pub(super) metadata_dir: Box<Path>,
+    pub(super) files_to_remove: Option<Vec<EvictionCandidate>>,
+    pub(super) min_ttl: Arc<AtomicU64>,
+    pub(super) notify_ttl_updated: Arc<tokio::sync::Notify>,
+}
+
+impl EvictionCandidate {
+    fn update_ttl(&mut self) {
+        let Ok(metadata_last_modified) =
+            std::fs::metadata(&self.metadata_path).map(|md| md.modified().unwrap())
+        else {
+            self.ttl = 0;
+            return;
+        };
+
+        if self.metadata_last_modified == metadata_last_modified {
+            return;
+        }
+
+        let Ok(ref mut file) = std::fs::OpenOptions::new()
+            .read(true)
+            .open(&self.metadata_path)
+        else {
+            self.ttl = 0;
+            return;
+        };
+
+        let ttl = EntryMetadata::try_from_reader(file)
+            .map(|x| x.ttl)
+            .unwrap_or(0);
+
+        self.metadata_last_modified = metadata_last_modified;
+        self.ttl = ttl;
+    }
+
+    fn should_remove(&self, now: &SystemTime) -> bool {
+        let Ok(metadata) = std::fs::metadata(&self.path) else {
+            return false;
+        };
+
+        if let Ok(duration) = now.duration_since(
+            metadata
+                .accessed()
+                .unwrap_or_else(|_| metadata.modified().unwrap()),
+        ) {
+            duration.as_secs() >= self.ttl
+        } else {
+            false
+        }
+    }
+
+    fn try_evict(
+        &mut self,
+        now: &SystemTime,
+        verbose: bool,
+        _guard: &GlobalFileCacheGuardExclusive,
+    ) {
+        self.update_ttl();
+        let path = &self.path;
+
+        if !path.exists() {
+            if verbose {
+                eprintln!(
+                    "[EvictionManager] evict_files: skipping {} (path no longer exists)",
+                    path.to_str().unwrap()
+                );
+            }
+            return;
+        }
+
+        let metadata = std::fs::metadata(path).unwrap();
+
+        let since_last_accessed = match now.duration_since(
+            metadata
+                .accessed()
+                .unwrap_or_else(|_| metadata.modified().unwrap()),
+        ) {
+            Ok(v) => v.as_secs(),
+            Err(_) => {
+                if verbose {
+                    eprintln!("[EvictionManager] evict_files: skipping {} (last accessed time was updated)", path.to_str().unwrap());
+                }
+                return;
+            },
+        };
+
+        if since_last_accessed < self.ttl {
+            if verbose {
+                eprintln!(
+                    "[EvictionManager] evict_files: skipping {} (last accessed time was updated)",
+                    path.to_str().unwrap()
+                );
+            }
+            return;
+        }
+
+        {
+            let file = std::fs::OpenOptions::new().read(true).open(path).unwrap();
+
+            if file.try_lock_exclusive().is_err() {
+                if verbose {
+                    eprintln!(
+                        "[EvictionManager] evict_files: skipping {} (file is locked)",
+                        self.path.to_str().unwrap()
+                    );
+                }
+                return;
+            }
+        }
+
+        if let Err(err) = std::fs::remove_file(path) {
+            if verbose {
+                eprintln!(
+                    "[EvictionManager] evict_files: error removing file: {} ({})",
+                    path.to_str().unwrap(),
+                    err
+                );
+            }
+        } else if verbose {
+            eprintln!(
+                "[EvictionManager] evict_files: removed file at {}",
+                path.to_str().unwrap()
+            );
+        }
+    }
 }
 
 impl EvictionManager {
     pub(super) fn run_in_background(mut self) {
         let verbose = config::verbose();
-        let sleep_interval = std::cmp::max(self.limit_since_last_access.as_secs() / 4, 60);
 
         if verbose {
             eprintln!(
-                "[EvictionManager] creating cache eviction background task with limit_since_last_accessed = {}, sleep_interval = {}",
-                self.limit_since_last_access.as_secs(),
-                sleep_interval,
+                "[EvictionManager] creating cache eviction background task, self.min_ttl = {}",
+                self.min_ttl.load(std::sync::atomic::Ordering::Relaxed)
             );
         }
 
         pl_async::get_runtime().spawn(async move {
             // Give some time at startup for other code to run.
             tokio::time::sleep(Duration::from_secs(3)).await;
+            let mut last_eviction_time;
 
             loop {
-                let mut sleep_interval = sleep_interval;
-
                 let this: &'static mut Self = unsafe { std::mem::transmute(&mut self) };
 
-                match tokio::task::spawn_blocking(|| this.update_file_list())
+                let result = tokio::task::spawn_blocking(|| this.update_file_list())
                     .await
-                    .unwrap()
-                {
-                    Ok(_) if self.files_to_remove.as_ref().unwrap().1.is_empty() => {},
+                    .unwrap();
+
+                last_eviction_time = Instant::now();
+
+                match result {
+                    Ok(_) if self.files_to_remove.as_ref().unwrap().is_empty() => {},
                     Ok(_) => loop {
                         if let Some(guard) = GLOBAL_FILE_CACHE_LOCK.try_lock_exclusive() {
                             if verbose {
                                 eprintln!(
                                     "[EvictionManager] got exclusive cache lock, evicting {} files",
-                                    self.files_to_remove.as_ref().unwrap().1.len()
+                                    self.files_to_remove.as_ref().unwrap().len()
                                 );
                             }
 
                             tokio::task::block_in_place(|| self.evict_files(&guard));
                             break;
                         }
-                        sleep_interval = sleep_interval.saturating_sub(7);
                         tokio::time::sleep(Duration::from_secs(7)).await;
                     },
                     Err(err) => {
@@ -64,17 +196,40 @@ impl EvictionManager {
                     },
                 }
 
-                tokio::time::sleep(Duration::from_secs(sleep_interval)).await;
+                loop {
+                    let min_ttl = self.min_ttl.load(std::sync::atomic::Ordering::Relaxed);
+                    let sleep_interval = std::cmp::max(min_ttl / 4, {
+                        #[cfg(debug_assertions)]
+                        {
+                            3
+                        }
+                        #[cfg(not(debug_assertions))]
+                        {
+                            60
+                        }
+                    });
+
+                    let since_last_eviction =
+                        Instant::now().duration_since(last_eviction_time).as_secs();
+                    let sleep_interval = sleep_interval.saturating_sub(since_last_eviction);
+                    let sleep_interval = Duration::from_secs(sleep_interval);
+
+                    tokio::select! {
+                        _ = self.notify_ttl_updated.notified() => {
+                            continue;
+                        }
+                        _ = tokio::time::sleep(sleep_interval) => {
+                            break;
+                        }
+                    }
+                }
             }
         });
     }
 
     fn update_file_list(&mut self) -> PolarsResult<()> {
-        let data_dir = &self.prefix.join("d/");
-        let metadata_dir = &self.prefix.join("m/");
-
-        let data_files_iter = std::fs::read_dir(data_dir).unwrap();
-        let metadata_files_iter = std::fs::read_dir(metadata_dir).unwrap();
+        let data_files_iter = std::fs::read_dir(self.data_dir.as_ref()).unwrap();
+        let metadata_files_iter = std::fs::read_dir(self.metadata_dir.as_ref()).unwrap();
         let mut files_to_remove = Vec::with_capacity(
             data_files_iter
                 .size_hint()
@@ -88,31 +243,52 @@ impl EvictionManager {
 
         let now = SystemTime::now();
 
-        let mut f = |file: std::fs::DirEntry| {
-            let metadata = file.metadata()?;
-
-            if let Ok(since_last_accessed) = now.duration_since(
-                metadata
-                    .accessed()
-                    .unwrap_or_else(|_| metadata.modified().unwrap()),
-            ) {
-                if since_last_accessed >= self.limit_since_last_access {
-                    files_to_remove.push(file.path());
-                }
-            }
-
-            std::io::Result::Ok(())
-        };
-
         for file in data_files_iter {
-            f(file?)?;
+            let file = file?;
+            let path = file.path();
+
+            let hash = path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .get(..32)
+                .unwrap();
+            let metadata_path = self.metadata_dir.join(hash);
+
+            let mut eviction_candidate = EvictionCandidate {
+                path,
+                metadata_path,
+                metadata_last_modified: UNIX_EPOCH,
+                ttl: 0,
+            };
+            eviction_candidate.update_ttl();
+
+            if eviction_candidate.should_remove(&now) {
+                files_to_remove.push(eviction_candidate);
+            }
         }
 
         for file in metadata_files_iter {
-            f(file?)?;
+            let file = file?;
+            let path = file.path();
+            let metadata_path = path.clone();
+
+            let mut eviction_candidate = EvictionCandidate {
+                path,
+                metadata_path,
+                metadata_last_modified: UNIX_EPOCH,
+                ttl: 0,
+            };
+
+            eviction_candidate.update_ttl();
+
+            if eviction_candidate.should_remove(&now) {
+                files_to_remove.push(eviction_candidate);
+            }
         }
 
-        self.files_to_remove = Some((now, files_to_remove));
+        self.files_to_remove = Some(files_to_remove);
 
         Ok(())
     }
@@ -121,74 +297,11 @@ impl EvictionManager {
     /// Panics if `self.files_to_remove` is `None`.
     fn evict_files(&mut self, _guard: &GlobalFileCacheGuardExclusive) {
         let verbose = config::verbose();
-        let files_to_remove = self.files_to_remove.take().unwrap().1;
-        let now = SystemTime::now();
+        let mut files_to_remove = self.files_to_remove.take().unwrap();
+        let now = &SystemTime::now();
 
-        for path in &files_to_remove {
-            if !path.exists() {
-                if verbose {
-                    eprintln!(
-                        "[EvictionManager] evict_files: skipping {} (path no longer exists)",
-                        path.to_str().unwrap()
-                    );
-                }
-                continue;
-            }
-
-            let metadata = std::fs::metadata(path).unwrap();
-
-            let since_last_accessed = match now.duration_since(
-                metadata
-                    .accessed()
-                    .unwrap_or_else(|_| metadata.modified().unwrap()),
-            ) {
-                Ok(v) => v,
-                Err(_) => {
-                    if verbose {
-                        eprintln!("[EvictionManager] evict_files: skipping {} (last accessed time was updated)", path.to_str().unwrap());
-                    }
-                    continue;
-                },
-            };
-
-            if since_last_accessed < self.limit_since_last_access {
-                if verbose {
-                    eprintln!(
-                        "[EvictionManager] evict_files: skipping {} (last accessed time was updated)",
-                        path.to_str().unwrap()
-                    );
-                }
-                continue;
-            }
-
-            let file = std::fs::OpenOptions::new().read(true).open(path).unwrap();
-
-            if file.try_lock_exclusive().is_err() {
-                if verbose {
-                    eprintln!(
-                        "[EvictionManager] evict_files: skipping {} (file is locked)",
-                        path.to_str().unwrap()
-                    );
-                }
-                continue;
-            }
-
-            drop(file);
-
-            if let Err(err) = std::fs::remove_file(path) {
-                if verbose {
-                    eprintln!(
-                        "[EvictionManager] evict_files: error removing file: {} ({})",
-                        path.to_str().unwrap(),
-                        err
-                    );
-                }
-            } else {
-                eprintln!(
-                    "[EvictionManager] evict_files: removed file at {}",
-                    path.to_str().unwrap()
-                );
-            }
+        for eviction_candidate in files_to_remove.iter_mut() {
+            eviction_candidate.try_evict(now, verbose, _guard);
         }
     }
 }

--- a/crates/polars-io/src/file_cache/file_lock.rs
+++ b/crates/polars-io/src/file_cache/file_lock.rs
@@ -5,9 +5,7 @@ use fs4::FileExt;
 
 /// Note: this creates the file if it does not exist when acquiring locks.
 pub(super) struct FileLock<T: AsRef<Path>>(T);
-#[repr(transparent)]
 pub(super) struct FileLockSharedGuard(File);
-#[repr(transparent)]
 pub(super) struct FileLockExclusiveGuard(File);
 
 /// Trait to specify a file is lock-guarded without needing a particular type of

--- a/crates/polars-io/src/file_cache/file_lock.rs
+++ b/crates/polars-io/src/file_cache/file_lock.rs
@@ -5,7 +5,9 @@ use fs4::FileExt;
 
 /// Note: this creates the file if it does not exist when acquiring locks.
 pub(super) struct FileLock<T: AsRef<Path>>(T);
+#[repr(transparent)]
 pub(super) struct FileLockSharedGuard(File);
+#[repr(transparent)]
 pub(super) struct FileLockExclusiveGuard(File);
 
 /// Trait to specify a file is lock-guarded without needing a particular type of
@@ -13,9 +15,14 @@ pub(super) struct FileLockExclusiveGuard(File);
 pub(super) trait FileLockAnyGuard:
     std::ops::Deref<Target = File> + std::ops::DerefMut<Target = File>
 {
+    const IS_EXCLUSIVE: bool;
 }
-impl FileLockAnyGuard for FileLockSharedGuard {}
-impl FileLockAnyGuard for FileLockExclusiveGuard {}
+impl FileLockAnyGuard for FileLockSharedGuard {
+    const IS_EXCLUSIVE: bool = false;
+}
+impl FileLockAnyGuard for FileLockExclusiveGuard {
+    const IS_EXCLUSIVE: bool = true;
+}
 
 impl<T: AsRef<Path>> From<T> for FileLock<T> {
     fn from(path: T) -> Self {

--- a/crates/polars-io/src/file_cache/metadata.rs
+++ b/crates/polars-io/src/file_cache/metadata.rs
@@ -19,6 +19,7 @@ pub(super) struct EntryMetadata {
     pub(super) local_last_modified: u64,
     pub(super) local_size: u64,
     pub(super) remote_last_modified: u64,
+    /// TTL since last access, in seconds.
     pub(super) ttl: u64,
 }
 

--- a/crates/polars-io/src/file_cache/metadata.rs
+++ b/crates/polars-io/src/file_cache/metadata.rs
@@ -19,6 +19,7 @@ pub(super) struct EntryMetadata {
     pub(super) local_last_modified: u64,
     pub(super) local_size: u64,
     pub(super) remote_last_modified: u64,
+    pub(super) ttl: u64,
 }
 
 impl std::fmt::Display for LocalCompareError {
@@ -40,12 +41,13 @@ impl std::fmt::Display for LocalCompareError {
 }
 
 impl EntryMetadata {
-    pub(super) fn new_with_uri(uri: Arc<str>) -> Self {
+    pub(super) fn new(uri: Arc<str>, ttl: u64) -> Self {
         Self {
             uri,
             local_last_modified: 0,
             local_size: 0,
             remote_last_modified: 0,
+            ttl,
         }
     }
 

--- a/crates/polars-io/src/file_cache/mod.rs
+++ b/crates/polars-io/src/file_cache/mod.rs
@@ -6,6 +6,6 @@ mod file_fetcher;
 mod file_lock;
 mod metadata;
 mod utils;
-pub use cache::FILE_CACHE;
+pub use cache::{get_env_file_cache_ttl, FILE_CACHE};
 pub use entry::FileCacheEntry;
-pub use utils::init_entries_from_uri_list;
+pub use utils::{init_entries_from_uri_list, FILE_CACHE_PREFIX};

--- a/crates/polars-io/src/file_cache/utils.rs
+++ b/crates/polars-io/src/file_cache/utils.rs
@@ -11,20 +11,19 @@ use super::file_fetcher::{CloudFileFetcher, LocalFileFetcher};
 use crate::cloud::{build_object_store, CloudLocation, CloudOptions, PolarsObjectStore};
 use crate::pl_async;
 use crate::prelude::{is_cloud_url, POLARS_TEMP_DIR_BASE_PATH};
+use crate::utils::ensure_directory_init;
 
 pub static FILE_CACHE_PREFIX: Lazy<Box<Path>> = Lazy::new(|| {
     let path = POLARS_TEMP_DIR_BASE_PATH
         .join("file-cache/")
         .into_boxed_path();
 
-    if let Err(err) = std::fs::create_dir_all(path.as_ref()) {
-        if !path.is_dir() {
-            panic!(
-                "failed to create file cache directory: path = {}, err = {}",
-                path.to_str().unwrap(),
-                err
-            );
-        }
+    if let Err(err) = ensure_directory_init(path.as_ref()) {
+        panic!(
+            "failed to create file cache directory: path = {}, err = {}",
+            path.to_str().unwrap(),
+            err
+        );
     }
 
     path

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -21,7 +21,11 @@ pub static POLARS_TEMP_DIR_BASE_PATH: Lazy<Box<Path>> = Lazy::new(|| {
 
     if let Err(err) = std::fs::create_dir_all(path.as_ref()) {
         if !path.is_dir() {
-            panic!("failed to create temporary directory: {}", err);
+            panic!(
+                "failed to create temporary directory: path = {}, err = {}",
+                path.to_str().unwrap(),
+                err
+            );
         }
     }
 

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -32,6 +32,18 @@ pub static POLARS_TEMP_DIR_BASE_PATH: Lazy<Box<Path>> = Lazy::new(|| {
     path
 });
 
+/// Ignores errors from `std::fs::create_dir_all` if the directory exists.
+#[cfg(feature = "file_cache")]
+pub(crate) fn ensure_directory_init(path: &Path) -> std::io::Result<()> {
+    let result = std::fs::create_dir_all(path);
+
+    if path.is_dir() {
+        Ok(())
+    } else {
+        result
+    }
+}
+
 pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
     reader: &'a mut R,
 ) -> PolarsResult<ReaderBytes<'a>> {

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 polars-core = { workspace = true, features = ["python"] }
 polars-error = { workspace = true }
+polars-io = { workspace = true }
 polars-lazy = { workspace = true, features = ["python"] }
 polars-ops = { workspace = true }
 polars-parquet = { workspace = true, optional = true }

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -13,7 +13,12 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     # we also set other function pointers needed
     # on the rust side. This function is highly
     # unsafe and should only be called once.
-    from polars.polars import __register_startup_deps
+    from polars.polars import (
+        __register_startup_deps,
+    )
+    from polars.polars import (
+        get_file_cache_prefix as _get_file_cache_prefix,
+    )
 
     __register_startup_deps()
 
@@ -435,6 +440,8 @@ __all__ = [
     # selectors
     "selectors",
     "sql_expr",
+    # internal
+    "_get_file_cache_prefix",
 ]
 
 os.environ["POLARS_ALLOW_EXTENSION"] = "true"

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -936,6 +936,7 @@ def scan_csv(
     glob: bool = True,
     storage_options: dict[str, Any] | None = None,
     retries: int = 0,
+    file_cache_ttl: int | None = None,
 ) -> LazyFrame:
     r"""
     Lazily read from a CSV file or multiple files via glob patterns.
@@ -1048,6 +1049,10 @@ def scan_csv(
         from environment variables.
     retries
         Number of retries if accessing a cloud instance fails.
+    file_cache_ttl
+        Amount of time to keep downloaded cloud files since their last access time,
+        in seconds. Uses the `POLARS_FILE_CACHE_TTL` environment variable
+        (which defaults to 1 hour) if not given.
 
     Returns
     -------
@@ -1170,6 +1175,7 @@ def scan_csv(
         glob=glob,
         retries=retries,
         storage_options=storage_options,
+        file_cache_ttl=file_cache_ttl,
     )
 
 
@@ -1204,6 +1210,7 @@ def _scan_csv_impl(
     glob: bool = True,
     storage_options: dict[str, Any] | None = None,
     retries: int = 0,
+    file_cache_ttl: int | None = None,
 ) -> LazyFrame:
     dtype_list: list[tuple[str, PolarsDataType]] | None = None
     if schema_overrides is not None:
@@ -1254,5 +1261,6 @@ def _scan_csv_impl(
         glob=glob,
         retries=retries,
         cloud_options=storage_options,
+        file_cache_ttl=file_cache_ttl,
     )
     return wrap_ldf(pylf)

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -312,6 +312,7 @@ def scan_ipc(
     storage_options: dict[str, Any] | None = None,
     memory_map: bool = True,
     retries: int = 0,
+    file_cache_ttl: int | None = None,
 ) -> LazyFrame:
     """
     Lazily read from an Arrow IPC (Feather v2) file or multiple files via glob patterns.
@@ -344,6 +345,10 @@ def scan_ipc(
         Only uncompressed IPC files can be memory mapped.
     retries
         Number of retries if accessing a cloud instance fails.
+    file_cache_ttl
+        Amount of time to keep downloaded cloud files since their last access time,
+        in seconds. Uses the `POLARS_FILE_CACHE_TTL` environment variable
+        (which defaults to 1 hour) if not given.
 
     """
     if isinstance(source, (str, Path)):
@@ -374,5 +379,6 @@ def scan_ipc(
         memory_map=memory_map,
         cloud_options=storage_options,
         retries=retries,
+        file_cache_ttl=file_cache_ttl,
     )
     return wrap_ldf(pylf)

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -53,6 +53,7 @@ matplotlib
 # Styling
 great-tables>=0.8.0; python_version >= '3.9'
 # Other
+blake3
 gevent
 nest_asyncio
 

--- a/py-polars/src/functions/io.rs
+++ b/py-polars/src/functions/io.rs
@@ -80,3 +80,12 @@ pub fn write_clipboard_string(s: &str) -> PyResult<()> {
         .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
     Ok(())
 }
+
+#[cfg(feature = "cloud")]
+#[pyfunction]
+pub fn get_file_cache_prefix() -> PyResult<String> {
+    Ok(polars_io::file_cache::FILE_CACHE_PREFIX
+        .to_str()
+        .unwrap()
+        .to_string())
+}

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -150,7 +150,8 @@ impl PyLazyFrame {
     #[pyo3(signature = (path, paths, separator, has_header, ignore_errors, skip_rows, n_rows, cache, overwrite_dtype,
         low_memory, comment_prefix, quote_char, null_values, missing_utf8_is_empty_string,
         infer_schema_length, with_schema_modify, rechunk, skip_rows_after_header,
-        encoding, row_index, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines, decimal_comma, glob, schema, cloud_options, retries
+        encoding, row_index, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines, decimal_comma, glob, schema,
+        cloud_options, retries, file_cache_ttl
     )
     )]
     fn new_from_csv(
@@ -183,6 +184,7 @@ impl PyLazyFrame {
         schema: Option<Wrap<Schema>>,
         cloud_options: Option<Vec<(String, String)>>,
         retries: usize,
+        file_cache_ttl: Option<u64>,
     ) -> PyResult<Self> {
         let null_values = null_values.map(|w| w.0);
         let quote_char = quote_char.map(|s| s.as_bytes()[0]);
@@ -211,19 +213,22 @@ impl PyLazyFrame {
             };
 
             let first_path_url = first_path.to_string_lossy();
-            let mut cloud_options = cloud_options
-                .map(|kv| parse_cloud_options(&first_path_url, kv))
-                .transpose()?;
+
+            let mut cloud_options = if let Some(opts) = cloud_options {
+                parse_cloud_options(&first_path_url, opts)?
+            } else {
+                Default::default()
+            };
+
             if retries > 0 {
-                cloud_options =
-                    cloud_options
-                        .or_else(|| Some(CloudOptions::default()))
-                        .map(|mut options| {
-                            options.max_retries = retries;
-                            options
-                        });
+                cloud_options.max_retries = retries;
             }
-            cloud_options
+
+            if let Some(file_cache_ttl) = file_cache_ttl {
+                cloud_options.file_cache_ttl = file_cache_ttl;
+            }
+
+            Some(cloud_options)
         };
 
         let r = if let Some(path) = path.as_ref() {
@@ -363,7 +368,7 @@ impl PyLazyFrame {
 
     #[cfg(feature = "ipc")]
     #[staticmethod]
-    #[pyo3(signature = (path, paths, n_rows, cache, rechunk, row_index, memory_map, cloud_options, retries))]
+    #[pyo3(signature = (path, paths, n_rows, cache, rechunk, row_index, memory_map, cloud_options, retries, file_cache_ttl))]
     fn new_from_ipc(
         path: Option<PathBuf>,
         paths: Vec<PathBuf>,
@@ -374,6 +379,7 @@ impl PyLazyFrame {
         memory_map: bool,
         cloud_options: Option<Vec<(String, String)>>,
         retries: usize,
+        file_cache_ttl: Option<u64>,
     ) -> PyResult<Self> {
         let row_index = row_index.map(|(name, offset)| RowIndex {
             name: Arc::from(name.as_str()),
@@ -391,19 +397,22 @@ impl PyLazyFrame {
             };
 
             let first_path_url = first_path.to_string_lossy();
-            let mut cloud_options = cloud_options
-                .map(|kv| parse_cloud_options(&first_path_url, kv))
-                .transpose()?;
+
+            let mut cloud_options = if let Some(opts) = cloud_options {
+                parse_cloud_options(&first_path_url, opts)?
+            } else {
+                Default::default()
+            };
+
             if retries > 0 {
-                cloud_options =
-                    cloud_options
-                        .or_else(|| Some(CloudOptions::default()))
-                        .map(|mut options| {
-                            options.max_retries = retries;
-                            options
-                        });
+                cloud_options.max_retries = retries;
             }
-            cloud_options
+
+            if let Some(file_cache_ttl) = file_cache_ttl {
+                cloud_options.file_cache_ttl = file_cache_ttl;
+            }
+
+            Some(cloud_options)
         };
 
         let args = ScanArgsIpc {

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -386,6 +386,10 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::register_plugin_function))
         .unwrap();
 
+    // Temporary storage
+    m.add_wrapped(wrap_pyfunction!(functions::get_file_cache_prefix))
+        .unwrap();
+
     Ok(())
 }
 

--- a/py-polars/tests/unit/io/test_file_cache.py
+++ b/py-polars/tests/unit/io/test_file_cache.py
@@ -39,7 +39,7 @@ def test_file_cache_ttl(
     assert all(x.exists() for x in metadata_file_paths)
     assert all(has_data_file)
 
-    sleep(5)
+    sleep(10)
 
     has_data_file = [False, False]
     for data_file in data_file_dir.iterdir():

--- a/py-polars/tests/unit/io/test_file_cache.py
+++ b/py-polars/tests/unit/io/test_file_cache.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+import polars as pl
+
+
+@pytest.mark.slow()
+@pytest.mark.skipif(sys.platform == "win32", reason="Paths differ on windows")
+def test_file_cache_ttl(
+    monkeypatch: pytest.MonkeyPatch, io_files_path: Path, tmp_path: Path
+) -> None:
+    file_cache_prefix = Path(pl._get_file_cache_prefix())
+    io_files_path = io_files_path.absolute()
+    monkeypatch.setenv("POLARS_FORCE_ASYNC", "1")
+
+    from time import sleep
+
+    from blake3 import blake3
+
+    paths = [
+        io_files_path / "foods1.csv",
+        io_files_path / "foods2.csv",
+    ]
+    hashes = [blake3(bytes(x)).hexdigest()[:32] for x in paths]
+    metadata_file_paths = [file_cache_prefix / f"m/{x}" for x in hashes]
+    data_file_dir = file_cache_prefix / "d/"
+    pl.scan_csv(paths).collect()
+    pl.scan_csv(paths[1], file_cache_ttl=0).collect()
+
+    has_data_file = [False, False]
+    for data_file in data_file_dir.iterdir():
+        for i, h in enumerate(hashes):
+            has_data_file[i] |= data_file.name.startswith(h)
+
+    assert all(x.exists() for x in metadata_file_paths)
+    assert all(has_data_file)
+
+    sleep(5)
+
+    has_data_file = [False, False]
+    for data_file in data_file_dir.iterdir():
+        for i, h in enumerate(hashes):
+            has_data_file[i] |= data_file.name.startswith(h)
+
+    assert [x.exists() for x in metadata_file_paths] == [True, False]
+    assert has_data_file == [True, False]


### PR DESCRIPTION
Note this means we need to pay the cost of needing to load every metadata file to check the TTL for eviction