### PR TITLE
feat!: Change casting failures from `ComputeError` to `InvalidOperationError`

### DIFF
--- a/crates/polars-core/src/utils/series.rs
+++ b/crates/polars-core/src/utils/series.rs
@@ -33,7 +33,7 @@ pub fn handle_casting_failures(input: &Series, output: &Series) -> PolarsResult<
     };
 
     polars_bail!(
-        ComputeError:
+        InvalidOperation:
         "conversion from `{}` to `{}` failed in column '{}' for {} out of {} values: {}{}",
         input.dtype(),
         output.dtype(),

--- a/crates/polars-plan/src/logical_plan/conversion/type_coercion/binary.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/type_coercion/binary.rs
@@ -187,13 +187,13 @@ fn process_struct_numeric_arithmetic(
 fn err_date_str_compare() -> PolarsResult<()> {
     if cfg!(feature = "python") {
         polars_bail!(
-            ComputeError:
+            InvalidOperation:
             "cannot compare 'date/datetime/time' to a string value \
             (create native python {{ 'date', 'datetime', 'time' }} or compare to a temporal column)"
         );
     } else {
         polars_bail!(
-            ComputeError: "cannot compare 'date/datetime/time' to a string value"
+            InvalidOperation: "cannot compare 'date/datetime/time' to a string value"
         );
     }
 }

--- a/py-polars/polars/interchange/from_dataframe.py
+++ b/py-polars/polars/interchange/from_dataframe.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import polars._reexport as pl
 import polars.functions as F
 from polars.datatypes import Boolean, Enum, Int64, String, UInt8, UInt32
-from polars.exceptions import ComputeError
+from polars.exceptions import InvalidOperationError
 from polars.interchange.dataframe import PolarsDataFrame
 from polars.interchange.protocol import ColumnNullType, CopyNotAllowedError, DtypeKind
 from polars.interchange.utils import (
@@ -278,7 +278,7 @@ def _construct_validity_buffer(
             if column_dtype.is_temporal():
                 sentinel = sentinel.cast(column_dtype)
             return data != sentinel  # noqa: TRY300
-        except ComputeError as e:
+        except InvalidOperationError as e:
             msg = f"invalid sentinel value for column of type {column_dtype}: {null_value!r}"
             raise TypeError(msg) from e
 

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -115,7 +115,7 @@ def test_df_init_strict() -> None:
 def test_df_init_from_series_strict() -> None:
     s = pl.Series("a", [-1, 0, 1])
     schema = {"a": pl.UInt8}
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         pl.DataFrame(s, schema=schema, strict=True)
 
     df = pl.DataFrame(s, schema=schema, strict=False)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -37,7 +37,7 @@ def test_enum_init_empty(categories: pl.Series | list[str] | None) -> None:
 
 def test_enum_non_existent() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        pl.InvalidOperationError,
         match=re.escape(
             "conversion from `str` to `enum` failed in column '' for 1 out of 4 values: [\"c\"]"
         ),
@@ -165,7 +165,7 @@ def test_casting_to_an_enum_oob_from_integer() -> None:
 
 def test_casting_to_an_enum_from_categorical_nonexistent() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        pl.InvalidOperationError,
         match=(
             r"conversion from `cat` to `enum` failed in column '' for 1 out of 4 values: \[\"c\"\]"
         ),
@@ -187,7 +187,7 @@ def test_casting_to_an_enum_from_global_categorical() -> None:
 @StringCache()
 def test_casting_to_an_enum_from_global_categorical_nonexistent() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        pl.InvalidOperationError,
         match=(
             r"conversion from `cat` to `enum` failed in column '' for 1 out of 4 values: \[\"c\"\]"
         ),
@@ -347,7 +347,7 @@ def test_compare_enum_str_single_raise(
     s2 = "NOTEXIST"
 
     with pytest.raises(
-        pl.ComputeError,
+        pl.InvalidOperationError,
         match=re.escape(
             "conversion from `str` to `enum` failed in column '' for 1 out of 1 values: [\"NOTEXIST\"]"
         ),
@@ -363,7 +363,7 @@ def test_compare_enum_str_raise() -> None:
     for s_compare in [s2, s_broadcast]:
         for op in [operator.le, operator.gt, operator.ge, operator.lt]:
             with pytest.raises(
-                pl.ComputeError,
+                pl.InvalidOperationError,
                 match="conversion from `str` to `enum` failed in column",
             ):
                 op(s, s_compare)
@@ -439,13 +439,14 @@ def test_enum_cast_from_other_integer_dtype_oob() -> None:
     enum_dtype = pl.Enum(["a", "b", "c", "d"])
     series = pl.Series([-1, 2, 3, 3, 2, 1], dtype=pl.Int8)
     with pytest.raises(
-        pl.ComputeError, match="conversion from `i8` to `u32` failed in column"
+        pl.InvalidOperationError, match="conversion from `i8` to `u32` failed in column"
     ):
         series.cast(enum_dtype)
 
     series = pl.Series([2**34, 2, 3, 3, 2, 1], dtype=pl.UInt64)
     with pytest.raises(
-        pl.ComputeError, match="conversion from `u64` to `u32` failed in column"
+        pl.InvalidOperationError,
+        match="conversion from `u64` to `u32` failed in column",
     ):
         series.cast(enum_dtype)
 

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -202,7 +202,9 @@ def test_int_range_null_input() -> None:
 
 
 def test_int_range_invalid_conversion() -> None:
-    with pytest.raises(pl.ComputeError, match="conversion from `i32` to `u32` failed"):
+    with pytest.raises(
+        pl.InvalidOperationError, match="conversion from `i32` to `u32` failed"
+    ):
         pl.select(pl.int_range(3, -1, -1, dtype=pl.UInt32))
 
 

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -249,7 +249,7 @@ def test_comp_incompatible_enum_dtype() -> None:
     df = pl.DataFrame({"a": pl.Series(["a", "b"], dtype=pl.Enum(["a", "b"]))})
 
     with pytest.raises(
-        pl.ComputeError,
+        pl.InvalidOperationError,
         match="conversion from `str` to `enum` failed in column 'literal'",
     ):
         df.with_columns(

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -42,7 +42,7 @@ def test_str_slice_expr() -> None:
     assert_frame_equal(out, expected)
 
     # negative length is not allowed
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         df.select(pl.col("a").str.slice(0, -1))
 
 

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -127,7 +127,7 @@ def test_to_date_non_exact_strptime() -> None:
     )
     assert_series_equal(result, expected)
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         s.str.to_date(format, strict=True, exact=True)
 
 
@@ -161,7 +161,7 @@ def test_to_date_all_inferred_date_patterns(time_string: str, expected: date) ->
     ],
 )
 def test_non_exact_short_elements_10223(value: str, attr: str) -> None:
-    with pytest.raises(pl.ComputeError, match="conversion .* failed"):
+    with pytest.raises(pl.InvalidOperationError, match="conversion .* failed"):
         getattr(pl.Series(["2019-01-01", value]).str, attr)(exact=False)
 
 
@@ -211,7 +211,7 @@ def test_to_datetime_non_exact_strptime(
     assert_series_equal(result, expected)
     assert result.dtype == pl.Datetime("us", time_zone)
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         s.str.to_datetime(format, strict=True, exact=True)
 
 
@@ -720,7 +720,7 @@ def test_strptime_ambiguous_earliest(exact: bool) -> None:
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_to_datetime_out_of_range_13401(time_unit: TimeUnit) -> None:
     s = pl.Series(["2020-January-01 12:34:66"])
-    with pytest.raises(pl.ComputeError, match="conversion .* failed"):
+    with pytest.raises(pl.InvalidOperationError, match="conversion .* failed"):
         s.str.to_datetime("%Y-%B-%d %H:%M:%S", time_unit=time_unit)
     assert (
         s.str.to_datetime("%Y-%B-%d %H:%M:%S", strict=False, time_unit=time_unit).item()

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -27,7 +27,7 @@ def test_string_date() -> None:
 def test_invalid_string_date() -> None:
     df = pl.DataFrame({"x1": ["2021-01-aa"]})
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         df.with_columns(**{"x1-date": pl.col("x1").cast(pl.Date)})
 
 
@@ -63,7 +63,7 @@ def test_string_datetime() -> None:
 
 def test_invalid_string_datetime() -> None:
     df = pl.DataFrame({"x1": ["2021-12-19 00:39:57", "2022-12-19 16:39:57"]})
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         df.with_columns(
             **{"x1-datetime-ns": pl.col("x1").cast(pl.Datetime(time_unit="ns"))}
         )
@@ -232,11 +232,11 @@ def test_strict_cast_int(
         assert _cast_expr(*args) == expected_value  # type: ignore[arg-type]
         assert _cast_lit(*args) == expected_value  # type: ignore[arg-type]
     else:
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_series(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_expr(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_lit(*args)  # type: ignore[arg-type]
 
 
@@ -371,11 +371,11 @@ def test_strict_cast_temporal(
         assert out.item() == expected_value
         assert out.dtype == to_dtype
     else:
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_series_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_expr_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_lit_t(*args)  # type: ignore[arg-type]
 
 
@@ -567,11 +567,11 @@ def test_strict_cast_string_and_binary(
         assert out.item() == expected_value
         assert out.dtype == to_dtype
     else:
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_series_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_expr_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(pl.InvalidOperationError):
             _cast_lit_t(*args)  # type: ignore[arg-type]
 
 

--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -133,5 +133,7 @@ def test_clip_string_input() -> None:
 
 def test_clip_bound_invalid_for_original_dtype() -> None:
     s = pl.Series([1, 2, 3, 4], dtype=pl.UInt32)
-    with pytest.raises(pl.ComputeError, match="conversion from `i32` to `u32` failed"):
+    with pytest.raises(
+        pl.InvalidOperationError, match="conversion from `i32` to `u32` failed"
+    ):
         s.clip(-1, 5)

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -123,7 +123,9 @@ def test_replace_cat_to_cat(str_mapping: dict[str | None, str]) -> None:
 def test_replace_invalid_old_dtype() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3]})
     mapping = {"a": 10, "b": 20}
-    with pytest.raises(pl.ComputeError, match="conversion from `str` to `i64` failed"):
+    with pytest.raises(
+        pl.InvalidOperationError, match="conversion from `str` to `i64` failed"
+    ):
         lf.select(pl.col("a").replace(mapping)).collect()
 
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -23,7 +23,7 @@ from polars.datatypes import (
     UInt64,
     Unknown,
 )
-from polars.exceptions import ComputeError, PolarsInefficientMapWarning, ShapeError
+from polars.exceptions import PolarsInefficientMapWarning, ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -498,7 +498,7 @@ def test_cast() -> None:
     assert a.cast(pl.Date).dtype == pl.Date
 
     # display failed values, GH#4706
-    with pytest.raises(ComputeError, match="foobar"):
+    with pytest.raises(pl.InvalidOperationError, match="foobar"):
         pl.Series(["1", "2", "3", "4", "foobar"]).cast(int)
 
 
@@ -1106,9 +1106,9 @@ def test_range() -> None:
 
 
 def test_strict_cast() -> None:
-    with pytest.raises(ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         pl.Series("a", [2**16]).cast(dtype=pl.Int16, strict=True)
-    with pytest.raises(ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         pl.DataFrame({"a": [2**16]}).select([pl.col("a").cast(pl.Int16, strict=True)])
 
 
@@ -2133,13 +2133,13 @@ def test_series_from_pandas_with_dtype() -> None:
     s = pl.Series("foo", pd.Series([1, 2, 3], dtype="Int16"), pl.Int8)
     assert_series_equal(s, expected)
 
-    with pytest.raises(pl.ComputeError, match="conversion from"):
+    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
         pl.Series("foo", pd.Series([-1, 2, 3]), pl.UInt8)
     s = pl.Series("foo", pd.Series([-1, 2, 3]), pl.UInt8, strict=False)
     assert s.to_list() == [None, 2, 3]
     assert s.dtype == pl.UInt8
 
-    with pytest.raises(pl.ComputeError, match="conversion from"):
+    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
         pl.Series("foo", pd.Series([-1, 2, 3], dtype="Int8"), pl.UInt8)
     s = pl.Series("foo", pd.Series([-1, 2, 3], dtype="Int8"), pl.UInt8, strict=False)
     assert s.to_list() == [None, 2, 3]
@@ -2150,7 +2150,7 @@ def test_series_from_pyarrow_with_dtype() -> None:
     s = pl.Series("foo", pa.array([-1, 2, 3]), pl.Int8)
     assert_series_equal(s, pl.Series("foo", [-1, 2, 3], dtype=pl.Int8))
 
-    with pytest.raises(pl.ComputeError, match="conversion from"):
+    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
         pl.Series("foo", pa.array([-1, 2, 3]), pl.UInt8)
 
     s = pl.Series("foo", pa.array([-1, 2, 3]), dtype=pl.UInt8, strict=False)
@@ -2162,7 +2162,7 @@ def test_series_from_numpy_with_dtye() -> None:
     s = pl.Series("foo", np.array([-1, 2, 3]), pl.Int8)
     assert_series_equal(s, pl.Series("foo", [-1, 2, 3], dtype=pl.Int8))
 
-    with pytest.raises(pl.ComputeError, match="conversion from"):
+    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
         pl.Series("foo", np.array([-1, 2, 3]), pl.UInt8)
 
     s = pl.Series("foo", np.array([-1, 2, 3]), dtype=pl.UInt8, strict=False)

--- a/py-polars/tests/unit/sql/test_cast.py
+++ b/py-polars/tests/unit/sql/test_cast.py
@@ -6,7 +6,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import ComputeError, SQLInterfaceError
+from polars.exceptions import SQLInterfaceError
 from polars.testing import assert_frame_equal
 
 
@@ -165,7 +165,7 @@ def test_cast_errors(values: Any, cast_op: str, error: str) -> None:
     df = pl.DataFrame({"values": values})
 
     # invalid CAST should raise an error...
-    with pytest.raises(ComputeError, match=error):
+    with pytest.raises(pl.InvalidOperationError, match=error):
         df.sql(f"SELECT {cast_op} FROM self")
 
     # ... or return `null` values if using TRY_CAST

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, SQLInterfaceError, SQLSyntaxError
+from polars.exceptions import SQLInterfaceError, SQLSyntaxError
 from polars.testing import assert_frame_equal
 
 
@@ -231,7 +231,7 @@ def test_implicit_temporal_string_errors(dtval: str) -> None:
     df = pl.DataFrame({"dt": [date(2020, 12, 30)]})
 
     with pytest.raises(
-        ComputeError,
+        pl.InvalidOperationError,
         match="(conversion.*failed)|(cannot compare.*string.*temporal)",
     ):
         df.sql(f"SELECT * FROM self WHERE dt = '{dtval}'")

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -403,7 +403,8 @@ def test_date_string_comparison(e: pl.Expr) -> None:
     ).with_columns(pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
 
     with pytest.raises(
-        pl.ComputeError, match=r"cannot compare 'date/datetime/time' to a string value"
+        pl.InvalidOperationError,
+        match=r"cannot compare 'date/datetime/time' to a string value",
     ):
         df.select(e)
 
@@ -493,7 +494,7 @@ def test_skip_nulls_err() -> None:
 def test_cast_err_column_value_highlighting(
     test_df: pl.DataFrame, type: pl.DataType, expected_message: str
 ) -> None:
-    with pytest.raises(pl.ComputeError, match=expected_message):
+    with pytest.raises(pl.InvalidOperationError, match=expected_message):
         test_df.with_columns(pl.all().cast(type))
 
 

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Iterator
 import pytest
 
 import polars as pl
-from polars import ComputeError
 
 if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType
@@ -291,7 +290,7 @@ def test_fmt_float_full() -> None:
 def test_fmt_list_12188() -> None:
     # set max_items to 1 < 4(size of failed list) to touch the testing branch.
     with pl.Config(fmt_table_cell_list_len=1), pytest.raises(
-        ComputeError, match="from `i64` to `u8` failed"
+        pl.InvalidOperationError, match="from `i64` to `u8` failed"
     ):
         pl.DataFrame(
             {

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -14,7 +14,7 @@ import polars as pl
 import polars.selectors as cs
 from polars import lit, when
 from polars.datatypes import FLOAT_DTYPES
-from polars.exceptions import ComputeError, PolarsInefficientMapWarning
+from polars.exceptions import PolarsInefficientMapWarning
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -613,7 +613,7 @@ def test_cast_frame() -> None:
     # test 'strict' mode
     lf = pl.LazyFrame({"a": [1000, 2000, 3000]})
 
-    with pytest.raises(ComputeError, match="conversion .* failed"):
+    with pytest.raises(pl.InvalidOperationError, match="conversion .* failed"):
         lf.cast(pl.UInt8).collect()
 
     assert lf.cast(pl.UInt8, strict=False).collect().rows() == [
@@ -1244,7 +1244,7 @@ def test_from_epoch_str() -> None:
         ]
     )
 
-    with pytest.raises(ComputeError):
+    with pytest.raises(pl.InvalidOperationError):
         ldf.select(
             pl.from_epoch(pl.col("timestamp_ms"), time_unit="ms"),
             pl.from_epoch(pl.col("timestamp_us"), time_unit="us"),


### PR DESCRIPTION
A lot of casting failures were already `InvalidOperationError`. Now a whole bunch of others are as well.