### PR TITLE
feat(rust,python): add `eq`/`ne` for more `FixedSizeList`s

### DIFF
--- a/crates/polars-compute/src/comparisons/array.rs
+++ b/crates/polars-compute/src/comparisons/array.rs
@@ -1,4 +1,7 @@
-use arrow::array::{Array, BinaryViewArray, FixedSizeListArray, PrimitiveArray, Utf8ViewArray};
+use arrow::array::{
+    Array, BinaryViewArray, BooleanArray, FixedSizeListArray, NullArray, PrimitiveArray,
+    StructArray, Utf8ViewArray,
+};
 use arrow::bitmap::utils::count_zeros;
 use arrow::bitmap::Bitmap;
 use arrow::datatypes::ArrowDataType;
@@ -48,27 +51,54 @@ macro_rules! compare {
             return Bitmap::new_with_value($wrong_width, lhs.len());
         }
 
-        use arrow::datatypes::PhysicalType::*;
-        use arrow::datatypes::PrimitiveType::*;
+        use arrow::datatypes::{PhysicalType as PH, PrimitiveType as PR};
         let lv = lhs.values();
         let rv = rhs.values();
         match lhs_type.data_type().to_physical_type() {
-            // Boolean => call_binary!(BooleanArray, lhs, rhs, $op),
-            Boolean => todo!(),
-            BinaryView => call_binary!(BinaryViewArray, lv, rv, $op),
-            Utf8View => call_binary!(Utf8ViewArray, lv, rv, $op),
-            Primitive(Int8) => call_binary!(PrimitiveArray<i8>, lv, rv, $op),
-            Primitive(Int16) => call_binary!(PrimitiveArray<i16>, lv, rv, $op),
-            Primitive(Int32) => call_binary!(PrimitiveArray<i32>, lv, rv, $op),
-            Primitive(Int64) => call_binary!(PrimitiveArray<i64>, lv, rv, $op),
-            Primitive(Int128) => call_binary!(PrimitiveArray<i128>, lv, rv, $op),
-            Primitive(UInt8) => call_binary!(PrimitiveArray<u8>, lv, rv, $op),
-            Primitive(UInt16) => call_binary!(PrimitiveArray<u16>, lv, rv, $op),
-            Primitive(UInt32) => call_binary!(PrimitiveArray<u32>, lv, rv, $op),
-            Primitive(UInt64) => call_binary!(PrimitiveArray<i64>, lv, rv, $op),
-            Primitive(Float32) => call_binary!(PrimitiveArray<f32>, lv, rv, $op),
-            Primitive(Float64) => call_binary!(PrimitiveArray<f64>, lv, rv, $op),
-            dt => todo!("Comparison of Arrays with {:?} are not yet supported", dt),
+            PH::Boolean => call_binary!(BooleanArray, lv, rv, $op),
+            PH::BinaryView => call_binary!(BinaryViewArray, lv, rv, $op),
+            PH::Utf8View => call_binary!(Utf8ViewArray, lv, rv, $op),
+            PH::Primitive(PR::Int8) => call_binary!(PrimitiveArray<i8>, lv, rv, $op),
+            PH::Primitive(PR::Int16) => call_binary!(PrimitiveArray<i16>, lv, rv, $op),
+            PH::Primitive(PR::Int32) => call_binary!(PrimitiveArray<i32>, lv, rv, $op),
+            PH::Primitive(PR::Int64) => call_binary!(PrimitiveArray<i64>, lv, rv, $op),
+            PH::Primitive(PR::Int128) => call_binary!(PrimitiveArray<i128>, lv, rv, $op),
+            PH::Primitive(PR::UInt8) => call_binary!(PrimitiveArray<u8>, lv, rv, $op),
+            PH::Primitive(PR::UInt16) => call_binary!(PrimitiveArray<u16>, lv, rv, $op),
+            PH::Primitive(PR::UInt32) => call_binary!(PrimitiveArray<u32>, lv, rv, $op),
+            PH::Primitive(PR::UInt64) => call_binary!(PrimitiveArray<u64>, lv, rv, $op),
+            PH::Primitive(PR::UInt128) => call_binary!(PrimitiveArray<u128>, lv, rv, $op),
+            PH::Primitive(PR::Float16) => {
+                todo!("Comparison of Arrays with Primitive(Float16) are not yet supported")
+            },
+            PH::Primitive(PR::Float32) => call_binary!(PrimitiveArray<f32>, lv, rv, $op),
+            PH::Primitive(PR::Float64) => call_binary!(PrimitiveArray<f64>, lv, rv, $op),
+            PH::Primitive(PR::Int256) => {
+                todo!("Comparison of Arrays with Primitive(Int256) are not yet supported")
+            },
+            PH::Primitive(PR::DaysMs) => {
+                todo!("Comparison of Arrays with Primitive(DaysMs) are not yet supported")
+            },
+            PH::Primitive(PR::MonthDayNano) => {
+                todo!("Comparison of Arrays with Primitive(MonthDayNano) are not yet supported")
+            },
+            PH::FixedSizeList => call_binary!(FixedSizeListArray, lv, rv, $op),
+            PH::Null => call_binary!(NullArray, lv, rv, $op),
+            PH::Binary => todo!("Comparison of Arrays with Binary are not yet supported"),
+            PH::FixedSizeBinary => {
+                todo!("Comparison of Arrays with FixedSizeBinary are not yet supported")
+            },
+            PH::LargeBinary => todo!("Comparison of Arrays with LargeBinary are not yet supported"),
+            PH::Utf8 => todo!("Comparison of Arrays with Utf8 are not yet supported"),
+            PH::LargeUtf8 => todo!("Comparison of Arrays with LargeUtf8 are not yet supported"),
+            PH::List => todo!("Comparison of Arrays with List are not yet supported"),
+            PH::LargeList => todo!("Comparison of Arrays with LargeList are not yet supported"),
+            PH::Struct => call_binary!(StructArray, lv, rv, $op),
+            PH::Union => todo!("Comparison of Arrays with Union are not yet supported"),
+            PH::Map => todo!("Comparison of Arrays with Map are not yet supported"),
+            PH::Dictionary(_) => {
+                todo!("Comparison of Arrays with Dictionary are not yet supported")
+            },
         }
     }};
 }

--- a/crates/polars-compute/src/comparisons/mod.rs
+++ b/crates/polars-compute/src/comparisons/mod.rs
@@ -72,7 +72,9 @@ pub trait TotalOrdKernel: Sized + Array {
     }
 }
 
+mod null;
 mod scalar;
+mod struct_;
 mod view;
 
 #[cfg(feature = "simd")]

--- a/crates/polars-compute/src/comparisons/null.rs
+++ b/crates/polars-compute/src/comparisons/null.rs
@@ -1,0 +1,50 @@
+use arrow::array::{Array, NullArray};
+use arrow::bitmap::Bitmap;
+
+use super::TotalOrdKernel;
+
+impl TotalOrdKernel for NullArray {
+    type Scalar = Box<dyn Array>;
+
+    fn tot_eq_kernel(&self, other: &Self) -> Bitmap {
+        assert!(self.len() == other.len());
+        Bitmap::new_with_value(true, self.len())
+    }
+
+    fn tot_ne_kernel(&self, other: &Self) -> Bitmap {
+        assert!(self.len() == other.len());
+        Bitmap::new_zeroed(self.len())
+    }
+
+    fn tot_lt_kernel(&self, _other: &Self) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_le_kernel(&self, _other: &Self) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_eq_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        todo!()
+    }
+
+    fn tot_ne_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        todo!()
+    }
+
+    fn tot_lt_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_le_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_gt_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_ge_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+}

--- a/crates/polars-compute/src/comparisons/struct_.rs
+++ b/crates/polars-compute/src/comparisons/struct_.rs
@@ -1,0 +1,152 @@
+use arrow::array::{
+    Array, BinaryViewArray, BooleanArray, NullArray, PrimitiveArray, StructArray, Utf8ViewArray,
+};
+use arrow::bitmap::Bitmap;
+use arrow::datatypes::ArrowDataType;
+
+use super::TotalOrdKernel;
+
+macro_rules! call_binary {
+    ($T:ty, $lhs:expr, $rhs:expr, $op:path) => {{
+        let lhs: &$T = $lhs.as_any().downcast_ref().unwrap();
+        let rhs: &$T = $rhs.as_any().downcast_ref().unwrap();
+
+        $op(lhs, rhs)
+    }};
+}
+
+macro_rules! compare {
+    ($lhs:expr, $rhs:expr, $op:path, $fold:expr) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+        assert_eq!(lhs.len(), rhs.len());
+        let ArrowDataType::Struct(lhs_type) = lhs.data_type().to_logical_type()
+        else {
+            panic!("array comparison called with non-array type");
+        };
+        let ArrowDataType::Struct(rhs_type) = rhs.data_type().to_logical_type()
+        else {
+            panic!("array comparison called with non-array type");
+        };
+        assert_eq!(lhs_type.len(), rhs_type.len());
+
+        let lv = lhs.values();
+        let rv = rhs.values();
+
+        let mut fold = None;
+
+        for i in 0..lhs_type.len() {
+            assert_eq!(lhs_type[i].data_type(), rhs_type[i].data_type());
+
+            use arrow::datatypes::PhysicalType as PH;
+            use arrow::datatypes::PrimitiveType as PR;
+
+            let lv = &lv[i];
+            let rv = &rv[i];
+
+            let new = match lhs_type[i].data_type().to_physical_type() {
+                PH::Boolean => call_binary!(BooleanArray, lv, rv, $op),
+                PH::BinaryView => call_binary!(BinaryViewArray, lv, rv, $op),
+                PH::Utf8View => call_binary!(Utf8ViewArray, lv, rv, $op),
+                PH::Primitive(PR::Int8) => call_binary!(PrimitiveArray<i8>, lv, rv, $op),
+                PH::Primitive(PR::Int16) => call_binary!(PrimitiveArray<i16>, lv, rv, $op),
+                PH::Primitive(PR::Int32) => call_binary!(PrimitiveArray<i32>, lv, rv, $op),
+                PH::Primitive(PR::Int64) => call_binary!(PrimitiveArray<i64>, lv, rv, $op),
+                PH::Primitive(PR::Int128) => call_binary!(PrimitiveArray<i128>, lv, rv, $op),
+                PH::Primitive(PR::UInt8) => call_binary!(PrimitiveArray<u8>, lv, rv, $op),
+                PH::Primitive(PR::UInt16) => call_binary!(PrimitiveArray<u16>, lv, rv, $op),
+                PH::Primitive(PR::UInt32) => call_binary!(PrimitiveArray<u32>, lv, rv, $op),
+                PH::Primitive(PR::UInt64) => call_binary!(PrimitiveArray<i64>, lv, rv, $op),
+                PH::Primitive(PR::UInt128) => call_binary!(PrimitiveArray<u128>, lv, rv, $op),
+                PH::Primitive(PR::Float16) => todo!("Comparison of Struct with Primitive(Float16) are not yet supported"),
+                PH::Primitive(PR::Float32) => call_binary!(PrimitiveArray<f32>, lv, rv, $op),
+                PH::Primitive(PR::Float64) => call_binary!(PrimitiveArray<f64>, lv, rv, $op),
+                PH::Primitive(PR::Int256) => todo!("Comparison of Struct with Primitive(Int256) are not yet supported"),
+                PH::Primitive(PR::DaysMs) => todo!("Comparison of Struct with Primitive(DaysMs) are not yet supported"),
+                PH::Primitive(PR::MonthDayNano) => todo!("Comparison of Struct with Primitive(MonthDayNano) are not yet supported"),
+
+                #[cfg(feature = "dtype-array")]
+                PH::FixedSizeList => call_binary!(arrow::array::FixedSizeListArray, lv, rv, $op),
+                #[cfg(not(feature = "dtype-array"))]
+                PH::FixedSizeList => todo!("Comparison of Struct with FixedSizeList are not supported without the `dtype-array` feature"),
+
+                PH::Null => call_binary!(NullArray, lv, rv, $op),
+                PH::Binary => todo!("Comparison of Struct with Binary are not yet supported"),
+                PH::FixedSizeBinary => todo!("Comparison of Struct with FixedSizeBinary are not yet supported"),
+                PH::LargeBinary => todo!("Comparison of Struct with LargeBinary are not yet supported"),
+                PH::Utf8 => todo!("Comparison of Struct with Utf8 are not yet supported"),
+                PH::LargeUtf8 => todo!("Comparison of Struct with LargeUtf8 are not yet supported"),
+                PH::List => todo!("Comparison of Struct with List are not yet supported"),
+                PH::LargeList => todo!("Comparison of Struct with LargeList are not yet supported"),
+                PH::Struct => call_binary!(StructArray, lv, rv, $op),
+                PH::Union => todo!("Comparison of Struct with Union are not yet supported"),
+                PH::Map => todo!("Comparison of Struct with Map are not yet supported"),
+                PH::Dictionary(_) => todo!("Comparison of Struct with Dictionary are not yet supported"),
+            };
+
+            fold = if let Some(fold) = fold {
+                Some($fold(fold, new))
+            } else {
+                Some(new)
+            };
+        }
+
+        fold.unwrap()
+    }};
+}
+
+impl TotalOrdKernel for StructArray {
+    type Scalar = Box<dyn Array>;
+
+    fn tot_eq_kernel(&self, other: &Self) -> Bitmap {
+        use std::ops::BitAnd;
+        compare!(
+            self,
+            other,
+            TotalOrdKernel::tot_eq_missing_kernel,
+            |a: Bitmap, b: Bitmap| a.bitand(&b)
+        )
+    }
+
+    fn tot_ne_kernel(&self, other: &Self) -> Bitmap {
+        use std::ops::BitOr;
+        compare!(
+            self,
+            other,
+            TotalOrdKernel::tot_ne_missing_kernel,
+            |a: Bitmap, b: Bitmap| a.bitor(&b)
+        )
+    }
+
+    fn tot_lt_kernel(&self, _other: &Self) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_le_kernel(&self, _other: &Self) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_eq_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        todo!()
+    }
+
+    fn tot_ne_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        todo!()
+    }
+
+    fn tot_lt_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_le_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_gt_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+
+    fn tot_ge_kernel_broadcast(&self, _other: &Self::Scalar) -> Bitmap {
+        unimplemented!()
+    }
+}

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -5,12 +5,13 @@ from datetime import datetime, time, timedelta
 from decimal import Decimal as D
 from typing import Any
 
+import hypothesis.strategies as st
 import pytest
 from hypothesis import given
 
 import polars as pl
 from polars.testing import assert_series_equal, assert_series_not_equal
-from polars.testing.parametric import series
+from polars.testing.parametric import dtypes, series
 
 nan = float("nan")
 pytest_plugins = ["pytester"]
@@ -18,6 +19,16 @@ pytest_plugins = ["pytester"]
 
 @given(s=series())
 def test_assert_series_equal_parametric(s: pl.Series) -> None:
+    assert_series_equal(s, s)
+
+
+@given(data=st.data())
+def test_assert_series_equal_parametric_array(data: st.DataObject) -> None:
+    inner = data.draw(dtypes(excluded_dtypes=[pl.Struct, pl.Categorical]))
+    shape = data.draw(st.integers(min_value=1, max_value=3))
+    dtype = pl.Array(inner, shape=shape)
+    s = data.draw(series(dtype=dtype))
+
     assert_series_equal(s, s)
 
 


### PR DESCRIPTION
This PR adds more types of equality checks for different types of `FixedSizeList`s. There are two many areas remaining which are the `Offset` based arrays and the `DictionaryArray`.