### PR TITLE
test(python): Skip intermittently failing AWS test

### DIFF
--- a/py-polars/tests/unit/io/cloud/test_aws.py
+++ b/py-polars/tests/unit/io/cloud/test_aws.py
@@ -59,7 +59,17 @@ def s3(s3_base: str, io_files_path: Path) -> str:
 
 @pytest.mark.parametrize(
     ("function", "extension"),
-    [(pl.read_csv, "csv"), (pl.read_ipc, "ipc")],
+    [
+        pytest.param(
+            pl.read_csv,
+            "csv",
+            marks=pytest.mark.skip(
+                reason="Causes intermittent failures in CI. See: "
+                "https://github.com/pola-rs/polars/issues/16910"
+            ),
+        ),
+        (pl.read_ipc, "ipc"),
+    ],
 )
 def test_read_s3(s3: str, function: Callable[..., Any], extension: str) -> None:
     storage_options = {"endpoint_url": s3}


### PR DESCRIPTION
Ref #16910

I've seen this fail more often, for example:
https://github.com/pola-rs/polars/actions/runs/9486777587/job/26141912223?pr=16906

Failure seems to be in the test rather than in the functionality, so skipping for now.