### PR TITLE
docs(python): Add missing deprecation entry for `str.concat`, API ref entry for `str.join`, build docs on pre-release

### DIFF
--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -58,7 +58,7 @@ jobs:
           target-folder: api/python/dev
           single-commit: true
 
-      - name: Parse the tag to find the major/minor version of Polars
+      - name: Parse the tag to find the major version of Polars
         id: version
         if: github.event_name == 'repository_dispatch'
         shell: bash

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -270,7 +270,7 @@ jobs:
           TAG: ${{ steps.github-release.outputs.tag_name }}
 
       - name: Trigger other workflows related to the release
-        if: inputs.dry-run == false && steps.version.outputs.is_prerelease == 'false'
+        if: inputs.dry-run == false
         uses: peter-evans/repository-dispatch@v3
         with:
           event-type: python-release

--- a/py-polars/docs/source/reference/expressions/string.rst
+++ b/py-polars/docs/source/reference/expressions/string.rst
@@ -22,6 +22,7 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.extract_groups
     Expr.str.find
     Expr.str.head
+    Expr.str.join
     Expr.str.json_decode
     Expr.str.json_path_match
     Expr.str.len_bytes

--- a/py-polars/docs/source/reference/series/string.rst
+++ b/py-polars/docs/source/reference/series/string.rst
@@ -22,6 +22,7 @@ The following methods are available under the `Series.str` attribute.
     Series.str.extract_groups
     Series.str.find
     Series.str.head
+    Series.str.join
     Series.str.json_decode
     Series.str.json_path_match
     Series.str.len_bytes

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2562,6 +2562,10 @@ class ExprStringNameSpace:
         """
         Vertically concatenate the string values in the column to a single string value.
 
+        .. deprecated:: 1.0.0
+            Use :meth:`join` instead. Note that the default `delimiter` for :meth:`join`
+            is an empty string instead of a hyphen.
+
         Parameters
         ----------
         delimiter

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1926,6 +1926,10 @@ class StringNameSpace:
         """
         Vertically concatenate the string values in the column to a single string value.
 
+        .. deprecated:: 1.0.0
+            Use :meth:`join` instead. Note that the default `delimiter` for :meth:`join`
+            is an empty string instead of a hyphen.
+
         Parameters
         ----------
         delimiter


### PR DESCRIPTION
Followup on https://github.com/pola-rs/polars/pull/16790 - I missed some things.

Also enabling publishing of docs on pre-releases. It's useful for people to have access to the migration guide and API reference when trying out a pre-release.