### PR TITLE
feat(python): Add `collect_schema` method to `LazyFrame` and `DataFrame`

### DIFF
--- a/docs/src/python/user-guide/lazy/schema.py
+++ b/docs/src/python/user-guide/lazy/schema.py
@@ -4,36 +4,33 @@ import polars as pl
 # --8<-- [end:setup]
 
 # --8<-- [start:schema]
-q3 = pl.DataFrame({"foo": ["a", "b", "c"], "bar": [0, 1, 2]}).lazy()
+lf = pl.LazyFrame({"foo": ["a", "b", "c"], "bar": [0, 1, 2]})
 
-print(q3.schema)
+print(lf.collect_schema())
 # --8<-- [end:schema]
 
 # --8<-- [start:lazyround]
-q4 = (
-    pl.DataFrame({"foo": ["a", "b", "c"], "bar": [0, 1, 2]})
-    .lazy()
-    .with_columns(pl.col("bar").round(0))
+lf = pl.LazyFrame({"foo": ["a", "b", "c"], "bar": [0, 1, 2]}).with_columns(
+    pl.col("bar").round(0)
 )
 # --8<-- [end:lazyround]
 
 # --8<-- [start:typecheck]
 try:
-    print(q4.collect())
+    print(lf.collect())
 except Exception as e:
     print(e)
 # --8<-- [end:typecheck]
 
 # --8<-- [start:lazyeager]
 lazy_eager_query = (
-    pl.DataFrame(
+    pl.LazyFrame(
         {
             "id": ["a", "b", "c"],
             "month": ["jan", "feb", "mar"],
             "values": [0, 1, 2],
         }
     )
-    .lazy()
     .with_columns((2 * pl.col("values")).alias("double_values"))
     .collect()
     .pivot(

--- a/docs/user-guide/lazy/schemas.md
+++ b/docs/user-guide/lazy/schemas.md
@@ -1,8 +1,8 @@
 # Schema
 
-The schema of a Polars `DataFrame` or `LazyFrame` sets out the names of the columns and their datatypes. You can see the schema with the `.schema` method on a `DataFrame` or `LazyFrame`
+The schema of a Polars `DataFrame` or `LazyFrame` sets out the names of the columns and their datatypes. You can see the schema with the `.collect_schema` method on a `DataFrame` or `LazyFrame`
 
-{{code_block('user-guide/lazy/schema','schema',['DataFrame','lazy'])}}
+{{code_block('user-guide/lazy/schema','schema',['LazyFrame'])}}
 
 ```python exec="on" result="text" session="user-guide/lazy/schemas"
 --8<-- "python/user-guide/lazy/schema.py:setup"
@@ -17,7 +17,7 @@ One advantage of the lazy API is that Polars will check the schema before any da
 
 We see how this works in the following simple example where we call the `.round` expression on the integer `bar` column.
 
-{{code_block('user-guide/lazy/schema','lazyround',['lazy','with_columns'])}}
+{{code_block('user-guide/lazy/schema','lazyround',['with_columns'])}}
 
 The `.round` expression is only valid for columns with a floating point dtype. Calling `.round` on an integer column means the operation will raise an `InvalidOperationError` when we evaluate the query with `collect`. This schema check happens before the data is processed when we call `collect`.
 
@@ -58,7 +58,7 @@ We show how to deal with a non-lazy operation in this example where we:
 - do a `.filter`
 - finish by executing the query with `.collect` to get a `DataFrame`
 
-{{code_block('user-guide/lazy/schema','lazyeager',['collect','pivot','filter'])}}
+{{code_block('user-guide/lazy/schema','lazyeager',['collect','lazy','pivot','filter'])}}
 
 ```python exec="on" result="text" session="user-guide/lazy/schemas"
 --8<-- "python/user-guide/lazy/schema.py:lazyeager"

--- a/py-polars/docs/source/reference/dataframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/dataframe/miscellaneous.rst
@@ -6,6 +6,7 @@ Miscellaneous
 .. autosummary::
    :toctree: api/
 
+    DataFrame.collect_schema
     DataFrame.corr
     DataFrame.equals
     DataFrame.lazy

--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -9,6 +9,7 @@ Miscellaneous
     LazyFrame.cache
     LazyFrame.collect
     LazyFrame.collect_async
+    LazyFrame.collect_schema
     LazyFrame.fetch
     LazyFrame.lazy
     LazyFrame.map_batches

--- a/py-polars/polars/api.py
+++ b/py-polars/polars/api.py
@@ -240,26 +240,25 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     --------
     >>> @pl.api.register_lazyframe_namespace("types")
     ... class DTypeOperations:
-    ...     def __init__(self, ldf: pl.LazyFrame):
-    ...         self._ldf = ldf
+    ...     def __init__(self, lf: pl.LazyFrame):
+    ...         self._lf = lf
     ...
     ...     def split_by_column_dtypes(self) -> list[pl.LazyFrame]:
     ...         return [
-    ...             self._ldf.select(pl.col(tp))
-    ...             for tp in dict.fromkeys(self._ldf.dtypes)
+    ...             self._lf.select(pl.col(tp))
+    ...             for tp in dict.fromkeys(self._lf.collect_schema().dtypes())
     ...         ]
     ...
     ...     def upcast_integer_types(self) -> pl.LazyFrame:
-    ...         return self._ldf.with_columns(
+    ...         return self._lf.with_columns(
     ...             pl.col(tp).cast(pl.Int64) for tp in (pl.Int8, pl.Int16, pl.Int32)
     ...         )
     >>>
-    >>> ldf = pl.DataFrame(
+    >>> lf = pl.LazyFrame(
     ...     data={"a": [1, 2], "b": [3, 4], "c": [5.6, 6.7]},
     ...     schema=[("a", pl.Int16), ("b", pl.Int32), ("c", pl.Float32)],
-    ... ).lazy()
-    >>>
-    >>> ldf.collect()
+    ... )
+    >>> lf.collect()
     shape: (2, 3)
     ┌─────┬─────┬─────┐
     │ a   ┆ b   ┆ c   │
@@ -269,7 +268,7 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     │ 1   ┆ 3   ┆ 5.6 │
     │ 2   ┆ 4   ┆ 6.7 │
     └─────┴─────┴─────┘
-    >>> ldf.types.upcast_integer_types().collect()
+    >>> lf.types.upcast_integer_types().collect()
     shape: (2, 3)
     ┌─────┬─────┬─────┐
     │ a   ┆ b   ┆ c   │
@@ -279,14 +278,13 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     │ 1   ┆ 3   ┆ 5.6 │
     │ 2   ┆ 4   ┆ 6.7 │
     └─────┴─────┴─────┘
-    >>>
-    >>> ldf = pl.DataFrame(
+
+    >>> lf = pl.LazyFrame(
     ...     data=[["xx", 2, 3, 4], ["xy", 4, 5, 6], ["yy", 5, 6, 7], ["yz", 6, 7, 8]],
     ...     schema=["a1", "a2", "b1", "b2"],
     ...     orient="row",
-    ... ).lazy()
-    >>>
-    >>> ldf.collect()
+    ... )
+    >>> lf.collect()
     shape: (4, 4)
     ┌─────┬─────┬─────┬─────┐
     │ a1  ┆ a2  ┆ b1  ┆ b2  │
@@ -298,7 +296,7 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     │ yy  ┆ 5   ┆ 6   ┆ 7   │
     │ yz  ┆ 6   ┆ 7   ┆ 8   │
     └─────┴─────┴─────┴─────┘
-    >>> pl.collect_all(ldf.types.split_by_column_dtypes())
+    >>> pl.collect_all(lf.types.split_by_column_dtypes())
     [shape: (4, 1)
     ┌─────┐
     │ a1  │

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1271,6 +1271,10 @@ class DataFrame:
 
         This is an alias for the :attr:`schema` property.
 
+        See Also
+        --------
+        schema
+
         Notes
         -----
         This method is included to facilitate writing code that is generic for both

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1265,6 +1265,45 @@ class DataFrame:
             ).render()
         )
 
+    def collect_schema(self) -> Schema:
+        """
+        Get an ordered mapping of column names to their data type.
+
+        This is an alias for the :attr:`schema` property.
+
+        Notes
+        -----
+        This method is included to facilitate writing code that is generic for both
+        DataFrame and LazyFrame.
+
+        Examples
+        --------
+        Determine the schema.
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2, 3],
+        ...         "bar": [6.0, 7.0, 8.0],
+        ...         "ham": ["a", "b", "c"],
+        ...     }
+        ... )
+        >>> df.collect_schema()
+        Schema({'foo': Int64, 'bar': Float64, 'ham': String})
+
+        Access various properties of the schema using the :class:`Schema` object.
+
+        >>> schema = df.collect_schema()
+        >>> schema["bar"]
+        Float64
+        >>> schema.names()
+        ['foo', 'bar', 'ham']
+        >>> schema.dtypes()
+        [Int64, Float64, String]
+        >>> schema.len()
+        3
+        """
+        return self.schema
+
     def item(self, row: int | None = None, column: int | str | None = None) -> Any:
         """
         Return the DataFrame as a scalar, or return the element at the given row/column.

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -5,6 +5,7 @@ import io
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Sequence
 
+import polars.functions as F
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import (
@@ -189,8 +190,9 @@ def read_parquet(
 
     if columns is not None:
         if is_int_sequence(columns):
-            columns = [lf.columns[i] for i in columns]
-        lf = lf.select(columns)
+            lf = lf.select(F.nth(columns))
+        else:
+            lf = lf.select(columns)
 
     return lf.collect()
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2784,7 +2784,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ null ┆ null ┆ null │
         └──────┴──────┴──────┘
         """
-        return pl.DataFrame(schema=self.schema).clear(n).lazy()
+        return pl.DataFrame(schema=self.collect_schema()).clear(n).lazy()
 
     def clone(self) -> Self:
         """
@@ -5081,7 +5081,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if value is not None:
 
             def infer_dtype(value: Any) -> PolarsDataType:
-                return next(iter(self.select(value).schema.values()))
+                return next(iter(self.select(value).collect_schema().values()))
 
             if isinstance(value, pl.Expr):
                 dtypes = [infer_dtype(value)]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -419,7 +419,6 @@ class LazyFrame:
         >>> lf.columns
         ['foo', 'bar']
         """
-        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema().names()
 
     @property
@@ -454,7 +453,6 @@ class LazyFrame:
         >>> lf.dtypes
         [Int64, Float64, String]
         """
-        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema().dtypes()
 
     @property
@@ -483,7 +481,6 @@ class LazyFrame:
         >>> lf.schema
         Schema({'foo': Int64, 'bar': Float64, 'ham': String})
         """
-        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema()
 
     @property
@@ -516,7 +513,6 @@ class LazyFrame:
         >>> lf.width
         2
         """
-        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema().len()
 
     def __bool__(self) -> NoReturn:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -195,9 +195,9 @@ class LazyFrame:
     │ 2   ┆ 4   │
     └─────┴─────┘
 
-    Notice that the dtypes are automatically inferred as polars Int64:
+    Notice that the dtypes are automatically inferred as Polars Int64:
 
-    >>> lf.dtypes
+    >>> lf.collect_schema().dtypes()
     [Int64, Int64]
 
     To specify a more detailed/specific frame schema you can supply the `schema`
@@ -419,7 +419,7 @@ class LazyFrame:
         >>> lf.columns
         ['foo', 'bar']
         """
-        # issue_deprecation_warning("noooo", version="1.0.0")
+        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema().names()
 
     @property
@@ -454,6 +454,7 @@ class LazyFrame:
         >>> lf.dtypes
         [Int64, Float64, String]
         """
+        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema().dtypes()
 
     @property
@@ -482,6 +483,7 @@ class LazyFrame:
         >>> lf.schema
         Schema({'foo': Int64, 'bar': Float64, 'ham': String})
         """
+        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema()
 
     @property
@@ -514,7 +516,7 @@ class LazyFrame:
         >>> lf.width
         2
         """
-        # issue_deprecation_warning("noooo", version="1.0.0")
+        issue_deprecation_warning("noooo", version="1.0.0")
         return self.collect_schema().len()
 
     def __bool__(self) -> NoReturn:
@@ -678,8 +680,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Examples
         --------
-        >>> def cast_str_to_int(data, col_name):
-        ...     return data.with_columns(pl.col(col_name).cast(pl.Int64))
+        >>> def cast_str_to_int(lf: pl.LazyFrame, col_name: str) -> pl.LazyFrame:
+        ...     return lf.with_columns(pl.col(col_name).cast(pl.Int64))
         >>> lf = pl.LazyFrame(
         ...     {
         ...         "a": [1, 2, 3, 4],
@@ -715,7 +717,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1   ┆ 3   │
         │ 2   ┆ 4   │
         └─────┴─────┘
-        >>> lf.pipe(lambda tdf: tdf.select(sorted(tdf.columns))).collect()
+        >>> lf.pipe(lambda lf: lf.select(sorted(lf.collect_schema()))).collect()
         shape: (2, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -153,7 +153,7 @@ def expand_selector(
         msg = f"expected a selector; found {selector!r} instead."
         raise TypeError(msg)
 
-    return tuple(target.select(selector).columns)
+    return tuple(target.select(selector).collect_schema())
 
 
 def _expand_selectors(frame: DataFrame | LazyFrame, *items: Any) -> list[Any]:

--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -158,7 +158,7 @@ def _assert_frame_schema_equal(
 ) -> None:
     __tracebackhide__ = True
 
-    left_schema, right_schema = left.schema, right.schema
+    left_schema, right_schema = left.collect_schema(), right.collect_schema()
 
     # Fast path for equal frames
     if left_schema == right_schema:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1708,7 +1708,7 @@ def test_schema_equality() -> None:
     lf = pl.LazyFrame({"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0]})
     lf_rev = lf.select("bar", "foo")
 
-    assert lf.schema != lf_rev.schema
+    assert lf.collect_schema() != lf_rev.collect_schema()
     assert lf.collect().schema != lf_rev.collect().schema
 
 

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -871,7 +871,7 @@ def test_struct_null_count_10130() -> None:
 def test_struct_arithmetic_schema() -> None:
     q = pl.LazyFrame({"A": [1], "B": [2]})
 
-    assert q.select(pl.struct("A") - pl.struct("B")).schema["A"] == pl.Struct(
+    assert q.select(pl.struct("A") - pl.struct("B")).collect_schema()["A"] == pl.Struct(
         {"A": pl.Int64}
     )
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1225,7 +1225,7 @@ def test_convert_time_zone_lazy_schema() -> None:
     result = ldf.with_columns(
         pl.col("ts_us").dt.convert_time_zone("America/New_York").alias("ts_us_ny"),
         pl.col("ts_ms").dt.convert_time_zone("America/New_York").alias("ts_us_kt"),
-    ).schema
+    ).collect_schema()
     expected = {
         "ts_us": pl.Datetime("us", "UTC"),
         "ts_ms": pl.Datetime("ms", "UTC"),

--- a/py-polars/tests/unit/functions/as_datatype/test_duration.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_duration.py
@@ -38,7 +38,7 @@ def test_duration_time_units(time_unit: TimeUnit, expected: timedelta) -> None:
             time_unit=time_unit,
         )
     )
-    assert result.schema["duration"] == pl.Duration(time_unit)
+    assert result.collect_schema()["duration"] == pl.Duration(time_unit)
     assert result.collect()["duration"].item() == expected
     if time_unit == "ns":
         assert (

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -338,7 +338,7 @@ def test_datetime_ranges_schema(
             pl.Datetime(time_unit=output_time_unit, time_zone=output_time_zone)
         ),
     }
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
     expected = pl.DataFrame(
@@ -442,7 +442,7 @@ def test_datetime_range_schema_upcasts_to_datetime(
         "end": pl.Date,
         "datetime_range": pl.List(output_dtype),
     }
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
     expected = pl.DataFrame(
@@ -485,7 +485,7 @@ def test_datetime_ranges_no_alias_schema_9037() -> None:
         "start": pl.List(pl.Datetime(time_unit="us", time_zone=None)),
         "end": pl.Datetime(time_unit="us", time_zone=None),
     }
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
 

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -73,7 +73,7 @@ def test_int_range_schema() -> None:
     result = pl.LazyFrame().select(int=pl.int_range(-3, 3))
 
     expected_schema = {"int": pl.Int64}
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
 
@@ -139,7 +139,7 @@ def test_int_ranges_schema_dtype_default() -> None:
     result = lf.select(pl.int_ranges("start", "end"))
 
     expected_schema = {"start": pl.List(pl.Int64)}
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
 
@@ -149,7 +149,7 @@ def test_int_ranges_schema_dtype_arg() -> None:
     result = lf.select(pl.int_ranges("start", "end", dtype=pl.UInt16))
 
     expected_schema = {"start": pl.List(pl.UInt16)}
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
 

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -16,7 +16,7 @@ def test_time_range_schema() -> None:
     df = pl.DataFrame({"start": [time(1)], "end": [time(1, 30)]}).lazy()
     result = df.with_columns(time_range=pl.time_ranges(pl.col("start"), pl.col("end")))
     expected_schema = {"start": pl.Time, "end": pl.Time, "time_range": pl.List(pl.Time)}
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
 

--- a/py-polars/tests/unit/functions/test_business_day_count.py
+++ b/py-polars/tests/unit/functions/test_business_day_count.py
@@ -108,7 +108,7 @@ def test_business_day_count_schema() -> None:
     result = lf.select(
         business_day_count=pl.business_day_count("start", "end"),
     )
-    assert result.schema["business_day_count"] == pl.Int32
+    assert result.collect_schema()["business_day_count"] == pl.Int32
     assert result.collect().schema["business_day_count"] == pl.Int32
     assert 'col("start").business_day_count([col("end")])' in result.explain()
 

--- a/py-polars/tests/unit/functions/test_col.py
+++ b/py-polars/tests/unit/functions/test_col.py
@@ -38,7 +38,7 @@ def test_col_series_selection() -> None:
     ldf = pl.LazyFrame({"a": [1], "b": [1], "c": [1]})
     srs = pl.Series(["b", "c"])
 
-    assert ldf.select(pl.col(srs)).columns == ["b", "c"]
+    assert ldf.select(pl.col(srs)).collect_schema().names() == ["b", "c"]
 
 
 def test_col_dot_style() -> None:

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -239,7 +239,9 @@ def dataset_path(tmp_path: Path) -> Path:
 @pytest.mark.write_disk()
 def test_scan_parquet_hive_schema(dataset_path: Path) -> None:
     result = pl.scan_parquet(dataset_path / "**/*.parquet", hive_partitioning=True)
-    assert result.schema == OrderedDict({"a": pl.Int64, "b": pl.Float64, "c": pl.Int64})
+    assert result.collect_schema() == OrderedDict(
+        {"a": pl.Int64, "b": pl.Float64, "c": pl.Int64}
+    )
 
     result = pl.scan_parquet(
         dataset_path / "**/*.parquet",
@@ -248,7 +250,7 @@ def test_scan_parquet_hive_schema(dataset_path: Path) -> None:
     )
 
     expected_schema = OrderedDict({"a": pl.Int64, "b": pl.Float64, "c": pl.Int32})
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
     assert result.collect().schema == expected_schema
 
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -33,12 +33,12 @@ def test_hive_partitioned_predicate_pushdown(
     )
     q = pl.scan_parquet(root / "**/*.parquet", hive_partitioning=False)
     # checks schema
-    assert q.columns == ["calories", "sugars_g"]
+    assert q.collect_schema().names() == ["calories", "sugars_g"]
     # checks materialization
     assert q.collect().columns == ["calories", "sugars_g"]
 
     q = pl.scan_parquet(root / "**/*.parquet", hive_partitioning=True)
-    assert q.columns == ["calories", "sugars_g", "category", "fats_g"]
+    assert q.collect_schema().names() == ["calories", "sugars_g", "category", "fats_g"]
 
     # Partitioning changes the order
     sort_by = ["fats_g", "category", "calories", "sugars_g"]

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -38,7 +38,7 @@ class TestIcebergScanIO:
     def test_scan_iceberg_plain(self, iceberg_path: str) -> None:
         df = pl.scan_iceberg(iceberg_path)
         assert len(df.collect()) == 3
-        assert df.schema == {
+        assert df.collect_schema() == {
             "id": pl.Int32,
             "str": pl.String,
             "ts": pl.Datetime(time_unit="us", time_zone=None),

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -137,15 +137,16 @@ def test_scan_csv_schema_new_columns_dtypes(
         assert df1.rows() == df2.rows()
 
     # rename existing columns, then lazy-select disjoint cols
-    df3 = pl.scan_csv(
+    lf = pl.scan_csv(
         file_path,
         new_columns=["colw", "colx", "coly", "colz"],
     )
-    assert df3.dtypes == [pl.String, pl.Int64, pl.Float64, pl.Int64]
-    assert df3.columns == ["colw", "colx", "coly", "colz"]
+    schema = lf.collect_schema()
+    assert schema.dtypes() == [pl.String, pl.Int64, pl.Float64, pl.Int64]
+    assert schema.names() == ["colw", "colx", "coly", "colz"]
     assert (
-        df3.select(["colz", "colx"]).collect().rows()
-        == df1.select(["sugars", pl.col("calories").cast(pl.Int64)]).rows()
+        lf.select("colz", "colx").collect().rows()
+        == df1.select("sugars", pl.col("calories").cast(pl.Int64)).rows()
     )
 
     # partially rename columns / overwrite dtypes

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -279,8 +279,10 @@ def test_lazy_self_join_file_cache_prop_3979(df: pl.DataFrame, tmp_path: Path) -
 
     a = pl.scan_parquet(file_path)
     b = pl.DataFrame({"a": [1]}).lazy()
-    assert a.join(b, how="cross").collect().shape == (3, df.width + b.width)
-    assert b.join(a, how="cross").collect().shape == (3, df.width + b.width)
+
+    expected_shape = (3, df.width + b.collect_schema().len())
+    assert a.join(b, how="cross").collect().shape == expected_shape
+    assert b.join(a, how="cross").collect().shape == expected_shape
 
 
 def test_recursive_logical_type() -> None:

--- a/py-polars/tests/unit/lazyframe/test_collect_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_collect_schema.py
@@ -1,4 +1,12 @@
+from hypothesis import given
+
 import polars as pl
+from polars.testing.parametric import dataframes
+
+
+@given(lf=dataframes(lazy=True))
+def test_collect_schema_parametric(lf: pl.LazyFrame) -> None:
+    assert lf.collect_schema() == lf.collect().schema
 
 
 def test_collect_schema() -> None:

--- a/py-polars/tests/unit/lazyframe/test_collect_schema.py
+++ b/py-polars/tests/unit/lazyframe/test_collect_schema.py
@@ -1,0 +1,14 @@
+import polars as pl
+
+
+def test_collect_schema() -> None:
+    lf = pl.LazyFrame(
+        {
+            "foo": [1, 2, 3],
+            "bar": [6.0, 7.0, 8.0],
+            "ham": ["a", "b", "c"],
+        }
+    )
+    result = lf.collect_schema()
+    expected = pl.Schema({"foo": pl.Int64(), "bar": pl.Float64(), "ham": pl.String()})
+    assert result == expected

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -576,7 +576,7 @@ def test_cast_frame() -> None:
     # cast via col:dtype map
     assert lf.cast(
         dtypes={"b": pl.Float32, "c": pl.String, "d": pl.Datetime("ms")}
-    ).schema == {
+    ).collect_schema() == {
         "a": pl.Float64,
         "b": pl.Float32,
         "c": pl.String,
@@ -591,7 +591,12 @@ def test_cast_frame() -> None:
             cs.temporal(): pl.String,
         }
     )
-    assert lfc.schema == {"a": pl.UInt8, "b": pl.Int32, "c": pl.Boolean, "d": pl.String}
+    assert lfc.collect_schema() == {
+        "a": pl.UInt8,
+        "b": pl.Int32,
+        "c": pl.Boolean,
+        "d": pl.String,
+    }
     assert lfc.collect().rows() == [
         (1, 4, True, "2020-01-02"),
         (2, 5, False, "2021-03-04"),
@@ -1245,22 +1250,22 @@ def test_cum_agg_types() -> None:
         pl.col("b").cum_sum(),
         pl.col("c").cum_sum(),
     )
-    assert cum_sum_lf.schema["a"] == pl.Int64
-    assert cum_sum_lf.schema["b"] == pl.UInt32
-    assert cum_sum_lf.schema["c"] == pl.Float64
+    assert cum_sum_lf.collect_schema()["a"] == pl.Int64
+    assert cum_sum_lf.collect_schema()["b"] == pl.UInt32
+    assert cum_sum_lf.collect_schema()["c"] == pl.Float64
     collected_cumsum_lf = cum_sum_lf.collect()
-    assert collected_cumsum_lf.schema == cum_sum_lf.schema
+    assert collected_cumsum_lf.schema == cum_sum_lf.collect_schema()
 
     cum_prod_lf = ldf.select(
         pl.col("a").cast(pl.UInt64).cum_prod(),
         pl.col("b").cum_prod(),
         pl.col("c").cum_prod(),
     )
-    assert cum_prod_lf.schema["a"] == pl.UInt64
-    assert cum_prod_lf.schema["b"] == pl.Int64
-    assert cum_prod_lf.schema["c"] == pl.Float64
+    assert cum_prod_lf.collect_schema()["a"] == pl.UInt64
+    assert cum_prod_lf.collect_schema()["b"] == pl.Int64
+    assert cum_prod_lf.collect_schema()["c"] == pl.Float64
     collected_cum_prod_lf = cum_prod_lf.collect()
-    assert collected_cum_prod_lf.schema == cum_prod_lf.schema
+    assert collected_cum_prod_lf.schema == cum_prod_lf.collect_schema()
 
 
 def test_compare_schema_between_lazy_and_eager_6904() -> None:

--- a/py-polars/tests/unit/lazyframe/test_rename.py
+++ b/py-polars/tests/unit/lazyframe/test_rename.py
@@ -10,6 +10,6 @@ def test_lazy_rename() -> None:
 
 def test_remove_redundant_mapping_4668() -> None:
     lf = pl.LazyFrame([["a"]] * 2, ["A", "B "]).lazy()
-    clean_name_dict = {x: " ".join(x.split()) for x in lf.columns}
+    clean_name_dict = {x: " ".join(x.split()) for x in lf.collect_schema()}
     lf = lf.rename(clean_name_dict)
-    assert lf.columns == ["A", "B"]
+    assert lf.collect_schema().names() == ["A", "B"]

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -434,12 +434,12 @@ def test_schema_mean_horizontal_single_column(
         pl.mean_horizontal(pl.all())
     )
 
-    assert lf.schema == OrderedDict([("a", out_dtype)])
+    assert lf.collect_schema() == OrderedDict([("a", out_dtype)])
 
 
 def test_schema_boolean_sum_horizontal() -> None:
     lf = pl.LazyFrame({"a": [True, False]}).select(pl.sum_horizontal("a"))
-    assert lf.schema == OrderedDict([("a", pl.UInt32)])
+    assert lf.collect_schema() == OrderedDict([("a", pl.UInt32)])
 
 
 def test_fold_all_schema() -> None:

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -609,7 +609,7 @@ def test_literal_subtract_schema_13284() -> None:
         .with_columns(pl.col("a") - pl.lit(1))
         .group_by("a")
         .len()
-    ).schema == OrderedDict([("a", pl.UInt8), ("len", pl.UInt32)])
+    ).collect_schema() == OrderedDict([("a", pl.UInt8), ("len", pl.UInt32)])
 
 
 def test_int_operator_stability() -> None:
@@ -630,5 +630,5 @@ def test_duration_division_schema() -> None:
         .select(pl.col("a") / pl.col("a"))
     )
 
-    assert q.schema == {"a": pl.Float64}
+    assert q.collect_schema() == {"a": pl.Float64}
     assert q.collect().to_dict(as_series=False) == {"a": [1.0]}

--- a/py-polars/tests/unit/operations/arithmetic/test_pow.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_pow.py
@@ -56,4 +56,4 @@ def test_pow_dtype() -> None:
         pl.UInt8,
     ]
     assert df.collect().dtypes == expected
-    assert df.dtypes == expected
+    assert df.collect_schema().dtypes() == expected

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -363,4 +363,4 @@ def test_unknown_map_elements() -> None:
         "Amount": [10, 1, 1, 5],
         "Flour": [10.0, 100.0, 100.0, 20.0],
     }
-    assert q.dtypes == [pl.Int64, pl.Unknown]
+    assert q.collect_schema().dtypes() == [pl.Int64, pl.Unknown]

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -32,7 +32,7 @@ def test_map_groups_lazy() -> None:
 
     expected = pl.LazyFrame({"a": [6.0, 2.0, 2.0], "b": [6.0, 2.0, 4.0]})
     assert_frame_equal(result, expected, check_row_order=False)
-    assert result.schema == expected.schema
+    assert result.collect_schema() == expected.collect_schema()
 
 
 def test_map_groups_rolling() -> None:

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -33,7 +33,7 @@ def test_array_min_max_dtype_12123() -> None:
         min=pl.col("a").arr.min().alias("min"),
     )
 
-    assert df.schema == {
+    assert df.collect_schema() == {
         "a": pl.Array(pl.Float64, 2),
         "b": pl.Float64,
         "max": pl.Float64,

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -900,7 +900,7 @@ def test_list_eval_err_raise_15653() -> None:
 
 def test_list_sum_bool_schema() -> None:
     q = pl.LazyFrame({"x": [[True, True, False]]})
-    assert q.select(pl.col("x").list.sum()).schema["x"] == pl.UInt32
+    assert q.select(pl.col("x").list.sum()).collect_schema()["x"] == pl.UInt32
 
 
 def test_list_eval_type_cast_11188() -> None:

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -337,7 +337,7 @@ def test_hex_decode_return_dtype() -> None:
     assert df.schema == {"a": pl.Binary}
 
     ldf = pl.LazyFrame(data).select(expr)
-    assert ldf.schema == {"a": pl.Binary}
+    assert ldf.collect_schema() == {"a": pl.Binary}
 
 
 def test_base64_decode_return_dtype() -> None:
@@ -348,7 +348,7 @@ def test_base64_decode_return_dtype() -> None:
     assert df.schema == {"a": pl.Binary}
 
     ldf = pl.LazyFrame(data).select(expr)
-    assert ldf.schema == {"a": pl.Binary}
+    assert ldf.collect_schema() == {"a": pl.Binary}
 
 
 def test_str_replace_str_replace_all() -> None:
@@ -628,7 +628,7 @@ def test_json_decode_lazy_expr() -> None:
     expected = pl.DataFrame(
         {"json": [{"a": 1, "b": True}, None, {"a": 2, "b": False}]}
     ).lazy()
-    assert ldf.schema == {"json": dtype}
+    assert ldf.collect_schema() == {"json": dtype}
     assert_frame_equal(ldf, expected)
 
 
@@ -1444,7 +1444,7 @@ def test_string_extract_groups_lazy_schema_10305() -> None:
         "captures"
     )
 
-    assert df.schema == {"candidate": pl.String, "ref": pl.String}
+    assert df.collect_schema() == {"candidate": pl.String, "ref": pl.String}
 
 
 def test_string_reverse() -> None:

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
@@ -106,7 +106,7 @@ def test_add_business_days_schema() -> None:
     result = lf.select(
         result=pl.col("start").dt.add_business_days("n"),
     )
-    assert result.schema["result"] == pl.Date
+    assert result.collect_schema()["result"] == pl.Date
     assert result.collect().schema["result"] == pl.Date
     assert 'col("start").add_business_days([col("n")])' in result.explain()
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -720,25 +720,21 @@ def test_combine_lazy_schema_datetime(
 ) -> None:
     df = pl.DataFrame({"ts": pl.Series([datetime(2020, 1, 1)])})
     df = df.with_columns(pl.col("ts").dt.replace_time_zone(time_zone))
-    result = (
-        df.lazy()
-        .select(pl.col("ts").dt.combine(time(1, 2, 3), time_unit=time_unit))
-        .dtypes
+    result = df.lazy().select(
+        pl.col("ts").dt.combine(time(1, 2, 3), time_unit=time_unit)
     )
-    expected = [pl.Datetime(time_unit, time_zone)]
-    assert result == expected
+    expected_dtypes = [pl.Datetime(time_unit, time_zone)]
+    assert result.collect_schema().dtypes() == expected_dtypes
 
 
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_combine_lazy_schema_date(time_unit: TimeUnit) -> None:
     df = pl.DataFrame({"ts": pl.Series([date(2020, 1, 1)])})
-    result = (
-        df.lazy()
-        .select(pl.col("ts").dt.combine(time(1, 2, 3), time_unit=time_unit))
-        .dtypes
+    result = df.lazy().select(
+        pl.col("ts").dt.combine(time(1, 2, 3), time_unit=time_unit)
     )
-    expected = [pl.Datetime(time_unit, None)]
-    assert result == expected
+    expected_dtypes = [pl.Datetime(time_unit, None)]
+    assert result.collect_schema().dtypes() == expected_dtypes
 
 
 def test_is_leap_year() -> None:

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -344,7 +344,9 @@ def test_base_utc_offset_lazy_schema() -> None:
         eager=True,
     )
     df = pl.DataFrame({"ts": ser}).lazy()
-    result = df.with_columns(base_utc_offset=pl.col("ts").dt.base_utc_offset()).schema
+    result = df.with_columns(
+        base_utc_offset=pl.col("ts").dt.base_utc_offset()
+    ).collect_schema()
     expected = {
         "ts": pl.Datetime(time_unit="us", time_zone="Europe/London"),
         "base_utc_offset": pl.Duration(time_unit="ms"),
@@ -382,7 +384,7 @@ def test_dst_offset_lazy_schema() -> None:
         eager=True,
     )
     df = pl.DataFrame({"ts": ser}).lazy()
-    result = df.with_columns(dst_offset=pl.col("ts").dt.dst_offset()).schema
+    result = df.with_columns(dst_offset=pl.col("ts").dt.dst_offset()).collect_schema()
     expected = {
         "ts": pl.Datetime(time_unit="us", time_zone="Europe/London"),
         "dst_offset": pl.Duration(time_unit="ms"),

--- a/py-polars/tests/unit/operations/test_bitwise.py
+++ b/py-polars/tests/unit/operations/test_bitwise.py
@@ -7,4 +7,4 @@ import polars as pl
 def test_bitwise_integral_schema(op: str) -> None:
     df = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
     q = df.select(getattr(pl.col("a"), op)(pl.col("b")))
-    assert q.schema["a"] == df.schema["a"]
+    assert q.collect_schema()["a"] == df.collect_schema()["a"]

--- a/py-polars/tests/unit/operations/test_clear.py
+++ b/py-polars/tests/unit/operations/test_clear.py
@@ -68,10 +68,10 @@ def test_clear_lf() -> None:
         }
     )
     ldfe = lf.clear()
-    assert ldfe.schema == lf.schema
+    assert ldfe.collect_schema() == lf.collect_schema()
 
     ldfe = lf.clear(2)
-    assert ldfe.schema == lf.schema
+    assert ldfe.collect_schema() == lf.collect_schema()
     assert ldfe.collect().rows() == [(None, None, None), (None, None, None)]
 
 

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -95,19 +95,19 @@ def test_drop_nulls_lazy() -> None:
 
 def test_drop_columns() -> None:
     out = pl.LazyFrame({"a": [1], "b": [2], "c": [3]}).drop(["a", "b"])
-    assert out.columns == ["c"]
+    assert out.collect_schema().names() == ["c"]
 
     out = pl.LazyFrame({"a": [1], "b": [2], "c": [3]}).drop(~cs.starts_with("c"))
-    assert out.columns == ["c"]
+    assert out.collect_schema().names() == ["c"]
 
-    out = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy().drop("a")
-    assert out.columns == ["b", "c"]
+    out = pl.LazyFrame({"a": [1], "b": [2], "c": [3]}).drop("a")
+    assert out.collect_schema().names() == ["b", "c"]
 
     out2 = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).drop("a", "b")
-    assert out2.columns == ["c"]
+    assert out2.collect_schema().names() == ["c"]
 
     out2 = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).drop({"a", "b", "c"})
-    assert out2.columns == []
+    assert out2.collect_schema().names() == []
 
 
 def test_drop_nan_ignore_null_3525() -> None:

--- a/py-polars/tests/unit/operations/test_ewm_by.py
+++ b/py-polars/tests/unit/operations/test_ewm_by.py
@@ -44,7 +44,7 @@ def test_ewma_by_date(sort: bool) -> None:
         {"values": [None, 1.0, 1.9116116523516815, None, 3.815410804703363]}
     )
     assert_frame_equal(result.collect(), expected)
-    assert result.schema["values"] == pl.Float64
+    assert result.collect_schema()["values"] == pl.Float64
     assert result.collect().schema["values"] == pl.Float64
 
 
@@ -88,7 +88,7 @@ def test_ewma_f32() -> None:
         schema_overrides={"values": pl.Float32},
     )
     assert_frame_equal(result.collect(), expected)
-    assert result.schema["values"] == pl.Float32
+    assert result.collect_schema()["values"] == pl.Float32
     assert result.collect().schema["values"] == pl.Float32
 
 
@@ -170,7 +170,7 @@ def test_ewma_by_index(data_type: PolarsIntegerType) -> None:
         {"values": [None, 1.0, 1.9116116523516815, None, 3.815410804703363]}
     )
     assert_frame_equal(result.collect(), expected)
-    assert result.schema["values"] == pl.Float64
+    assert result.collect_schema()["values"] == pl.Float64
     assert result.collect().schema["values"] == pl.Float64
 
 

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -28,7 +28,7 @@ def test_fill_null_static_schema_4843() -> None:
 
     df2 = df1.select([pl.col(pl.Int64).fill_null(0)])
     df3 = df2.select(pl.col(pl.Int64))
-    assert df3.schema == {"a": pl.Int64, "b": pl.Int64}
+    assert df3.collect_schema() == {"a": pl.Int64, "b": pl.Int64}
 
 
 def test_fill_null_f32_with_lit() -> None:

--- a/py-polars/tests/unit/operations/test_gather.py
+++ b/py-polars/tests/unit/operations/test_gather.py
@@ -29,7 +29,7 @@ def test_gather_agg_schema() -> None:
         df.lazy()
         .group_by("group", maintain_order=True)
         .agg(pl.col("value").get(1))
-        .schema["value"]
+        .collect_schema()["value"]
         == pl.Int64
     )
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1022,13 +1022,15 @@ def test_schema_on_agg() -> None:
         "first": pl.Int64,
         "last": pl.Int64,
     }
-    assert result.schema == expected_schema
+    assert result.collect_schema() == expected_schema
 
 
 def test_group_by_schema_err() -> None:
     lf = pl.LazyFrame({"foo": [None, 1, 2], "bar": [1, 2, 3]})
     with pytest.raises(pl.ColumnNotFoundError):
-        lf.group_by("not-existent").agg(pl.col("bar").max().alias("max_bar")).schema
+        lf.group_by("not-existent").agg(
+            pl.col("bar").max().alias("max_bar")
+        ).collect_schema()
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -860,7 +860,7 @@ def test_group_by_dynamic_lazy_schema(include_boundaries: bool) -> None:
         "dt", every="2d", closed="right", include_boundaries=include_boundaries
     ).agg(pl.col("dt").min().alias("dt_min"))
 
-    assert result.schema == result.collect().schema
+    assert result.collect_schema() == result.collect().schema
 
 
 def test_group_by_dynamic_12414() -> None:

--- a/py-polars/tests/unit/operations/test_interpolate.py
+++ b/py-polars/tests/unit/operations/test_interpolate.py
@@ -41,7 +41,7 @@ def test_interpolate_linear(
 ) -> None:
     df = pl.LazyFrame({"a": [1, None, 2, None, 3]}, schema={"a": input_dtype})
     result = df.with_columns(pl.all().interpolate(method="linear"))
-    assert result.schema["a"] == output_dtype
+    assert result.collect_schema()["a"] == output_dtype
     expected = pl.DataFrame(
         {"a": [1.0, 1.5, 2.0, 2.5, 3.0]}, schema={"a": output_dtype}
     )
@@ -87,7 +87,7 @@ def test_interpolate_temporal_linear(
 ) -> None:
     df = pl.LazyFrame({"a": input}, schema={"a": input_dtype})
     result = df.with_columns(pl.all().interpolate(method="linear"))
-    assert result.schema["a"] == input_dtype
+    assert result.collect_schema()["a"] == input_dtype
     expected = pl.DataFrame({"a": output}, schema={"a": input_dtype})
     assert_frame_equal(result.collect(), expected)
 
@@ -110,7 +110,7 @@ def test_interpolate_temporal_linear(
 def test_interpolate_nearest(input_dtype: PolarsDataType) -> None:
     df = pl.LazyFrame({"a": [1, None, 2, None, 3]}, schema={"a": input_dtype})
     result = df.with_columns(pl.all().interpolate(method="nearest"))
-    assert result.schema["a"] == input_dtype
+    assert result.collect_schema()["a"] == input_dtype
     expected = pl.DataFrame({"a": [1, 2, 2, 3, 3]}, schema={"a": input_dtype})
     assert_frame_equal(result.collect(), expected)
 
@@ -154,6 +154,6 @@ def test_interpolate_temporal_nearest(
 ) -> None:
     df = pl.LazyFrame({"a": input}, schema={"a": input_dtype})
     result = df.with_columns(pl.all().interpolate(method="nearest"))
-    assert result.schema["a"] == input_dtype
+    assert result.collect_schema()["a"] == input_dtype
     expected = pl.DataFrame({"a": output}, schema={"a": input_dtype})
     assert_frame_equal(result.collect(), expected)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -923,17 +923,17 @@ def test_join_coalesce(how: JoinStrategy) -> None:
     how = "inner"
     q = a.join(b, on="a", coalesce=False, how=how)
     out = q.collect()
-    assert q.schema == out.schema
+    assert q.collect_schema() == out.schema
     assert out.columns == ["a", "b", "a_right", "b_right", "c"]
 
     q = a.join(b, on=["a", "b"], coalesce=False, how=how)
     out = q.collect()
-    assert q.schema == out.schema
+    assert q.collect_schema() == out.schema
     assert out.columns == ["a", "b", "a_right", "b_right", "c"]
 
     q = a.join(b, on=["a", "b"], coalesce=True, how=how)
     out = q.collect()
-    assert q.schema == out.schema
+    assert q.collect_schema() == out.schema
     assert out.columns == ["a", "b", "c"]
 
 

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1171,4 +1171,4 @@ def test_join_as_of_by_schema() -> None:
     a = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy()
     b = pl.DataFrame({"a": [1], "b": [2], "d": [4]}).lazy()
     q = a.join_asof(b, on=pl.col("a").set_sorted(), by="b")
-    assert q.collect().columns == q.columns
+    assert q.collect_schema().names() == q.collect().columns

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -79,7 +79,7 @@ def test_asof_join_schema_5211() -> None:
         .join_asof(
             df2.lazy(), left_on="today", right_on="next_friday", strategy="forward"
         )
-        .schema
+        .collect_schema()
     ) == {"today": pl.Int64, "next_friday": pl.Int64}
 
 
@@ -119,7 +119,7 @@ def test_asof_join_schema_5684() -> None:
 
     assert_frame_equal(projected_result, result)
     assert (
-        q.schema
+        q.collect_schema()
         == projected_result.schema
         == {"id": pl.Int64, "a": pl.Int64, "b_right": pl.Int64}
     )

--- a/py-polars/tests/unit/operations/test_rename.py
+++ b/py-polars/tests/unit/operations/test_rename.py
@@ -147,5 +147,5 @@ def test_rename_schema_order_6660() -> None:
 
     computed = renamed.select([pl.all(), pl.col("4").alias("computed")])
 
-    assert renamed.schema == renamed.collect().schema
-    assert computed.schema == computed.collect().schema
+    assert renamed.collect_schema() == renamed.collect().schema
+    assert computed.collect_schema() == computed.collect().schema

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -302,7 +302,10 @@ def test_arg_sort_rank_nans() -> None:
 
 def test_set_sorted_schema() -> None:
     assert (
-        pl.DataFrame({"A": [0, 1]}).lazy().with_columns(pl.col("A").set_sorted()).schema
+        pl.DataFrame({"A": [0, 1]})
+        .lazy()
+        .with_columns(pl.col("A").set_sorted())
+        .collect_schema()
     ) == {"A": pl.Int64}
 
 

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -209,7 +209,7 @@ def test_group_by_ordinal_position() -> None:
             )
             SELECT c, total_b FROM grp ORDER BY c"""
         )
-        assert_frame_equal(res2, expected.select(expected.columns[:2]))
+        assert_frame_equal(res2, expected.select(pl.nth(0, 1)))
 
 
 def test_group_by_errors() -> None:

--- a/py-polars/tests/unit/sql/test_table_operations.py
+++ b/py-polars/tests/unit/sql/test_table_operations.py
@@ -73,7 +73,7 @@ def test_show_tables(test_frame: pl.LazyFrame) -> None:
 )
 def test_truncate_table(truncate_sql: str, test_frame: pl.LazyFrame) -> None:
     # 'truncate' preserves the table, but optimally drops all rows within it
-    expected = pl.DataFrame(schema=test_frame.schema)
+    expected = pl.DataFrame(schema=test_frame.collect_schema())
 
     with pl.SQLContext(frame=test_frame, eager=True) as ctx:
         res = ctx.execute(truncate_sql)

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -279,7 +279,7 @@ def test_boolean_agg_schema() -> None:
     for streaming in [True, False]:
         assert (
             agg_df.collect(streaming=streaming).schema
-            == agg_df.schema
+            == agg_df.collect_schema()
             == {"x": pl.Int64, "max_y": pl.Boolean}
         )
 

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -287,7 +287,7 @@ def test_streaming_outer_join_partial_flush(tmp_path: Path) -> None:
     lf1 = pl.scan_parquet(other_parquet_path)
     lf2 = pl.scan_parquet(parquet_path)
 
-    join_cols = set(lf1.columns).intersection(set(lf2.columns))
+    join_cols = set(lf1.collect_schema()).intersection(set(lf2.collect_schema()))
     final_lf = lf1.join(lf2, on=list(join_cols), how="full", coalesce=True)
 
     assert final_lf.collect(streaming=True).to_dict(as_series=False) == {

--- a/py-polars/tests/unit/streaming/test_streaming_sort.py
+++ b/py-polars/tests/unit/streaming/test_streaming_sort.py
@@ -138,7 +138,7 @@ def test_out_of_core_sort_9503(
     # ensure we create many chunks
     # this will ensure we create more files
     # and that creates contention while dumping
-    q = pl.concat(
+    df = pl.concat(
         [
             pl.DataFrame(
                 [
@@ -149,12 +149,14 @@ def test_out_of_core_sort_9503(
             for _ in range(num_tables)
         ],
         rechunk=False,
-    ).lazy()
-    q = q.sort(q.columns)
-    df = q.collect(streaming=True)
-    assert df.shape == (1_000_000, 2)
-    assert df["column_0"].flags["SORTED_ASC"]
-    assert df.head(20).to_dict(as_series=False) == {
+    )
+    lf = df.lazy()
+
+    result = lf.sort(df.columns).collect(streaming=True)
+
+    assert result.shape == (1_000_000, 2)
+    assert result["column_0"].flags["SORTED_ASC"]
+    assert result.head(20).to_dict(as_series=False) == {
         "column_0": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         "column_1": [
             242,

--- a/py-polars/tests/unit/test_api.py
+++ b/py-polars/tests/unit/test_api.py
@@ -81,7 +81,8 @@ def test_custom_lazy_namespace() -> None:
 
         def by_column_dtypes(self) -> list[pl.LazyFrame]:
             return [
-                self._lf.select(pl.col(dt)) for dt in self._lf.collect_schema().dtypes()
+                self._lf.select(pl.col(tp))
+                for tp in dict.fromkeys(self._lf.collect_schema().dtypes())
             ]
 
     ldf = pl.DataFrame(

--- a/py-polars/tests/unit/test_api.py
+++ b/py-polars/tests/unit/test_api.py
@@ -76,12 +76,12 @@ def test_custom_expr_namespace() -> None:
 def test_custom_lazy_namespace() -> None:
     @pl.api.register_lazyframe_namespace("split")
     class SplitFrame:
-        def __init__(self, ldf: pl.LazyFrame):
-            self._ldf = ldf
+        def __init__(self, lf: pl.LazyFrame):
+            self._lf = lf
 
         def by_column_dtypes(self) -> list[pl.LazyFrame]:
             return [
-                self._ldf.select(pl.col(tp)) for tp in dict.fromkeys(self._ldf.dtypes)
+                self._lf.select(pl.col(dt)) for dt in self._lf.collect_schema().dtypes()
             ]
 
     ldf = pl.DataFrame(

--- a/py-polars/tests/unit/test_expansion.py
+++ b/py-polars/tests/unit/test_expansion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 import pytest
@@ -37,7 +39,7 @@ def test_regex_in_filter() -> None:
 
 
 def test_regex_selection() -> None:
-    ldf = pl.LazyFrame(
+    lf = pl.LazyFrame(
         {
             "foo": [1],
             "fooey": [1],
@@ -45,16 +47,23 @@ def test_regex_selection() -> None:
             "bar": [1],
         }
     )
-    assert ldf.select([pl.col("^foo.*$")]).columns == ["foo", "fooey", "foobar"]
+    result = lf.select([pl.col("^foo.*$")])
+    assert result.collect_schema().names() == ["foo", "fooey", "foobar"]
 
 
-def test_exclude_selection() -> None:
-    ldf = pl.LazyFrame({"a": [1], "b": [1], "c": [True]})
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        (pl.exclude("a"), ["b", "c"]),
+        (pl.all().exclude(pl.Boolean), ["a", "b"]),
+        (pl.all().exclude([pl.Boolean]), ["a", "b"]),
+        (pl.all().exclude(NUMERIC_DTYPES), ["c"]),
+    ],
+)
+def test_exclude_selection(expr: pl.Expr, expected: list[str]) -> None:
+    lf = pl.LazyFrame({"a": [1], "b": [1], "c": [True]})
 
-    assert ldf.select([pl.exclude("a")]).columns == ["b", "c"]
-    assert ldf.select(pl.all().exclude(pl.Boolean)).columns == ["a", "b"]
-    assert ldf.select(pl.all().exclude([pl.Boolean])).columns == ["a", "b"]
-    assert ldf.select(pl.all().exclude(NUMERIC_DTYPES)).columns == ["c"]
+    assert lf.select(expr).collect_schema().names() == expected
 
 
 def test_struct_name_resolving_15430() -> None:
@@ -77,24 +86,20 @@ def test_struct_name_resolving_15430() -> None:
     assert b.columns == ["b"]
 
 
-def test_exclude_keys_in_aggregation_16170() -> None:
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        (pl.all().name.prefix("agg_"), ["A", "agg_B", "agg_C"]),
+        (pl.col("B", "C").name.prefix("agg_"), ["A", "agg_B", "agg_C"]),
+        (pl.col("A", "C").name.prefix("agg_"), ["A", "agg_A", "agg_C"]),
+    ],
+)
+def test_exclude_keys_in_aggregation_16170(expr: pl.Expr, expected: list[str]) -> None:
     df = pl.DataFrame({"A": [4, 4, 3], "B": [1, 2, 3], "C": [5, 6, 7]})
 
     # wildcard excludes aggregation column
-    assert df.lazy().group_by("A").agg(pl.all().name.prefix("agg_")).columns == [
-        "A",
-        "agg_B",
-        "agg_C",
-    ]
-
-    # specifically named columns are not excluded
-    assert df.lazy().group_by("A").agg(
-        pl.col("B", "C").name.prefix("agg_")
-    ).columns == ["A", "agg_B", "agg_C"]
-
-    assert df.lazy().group_by("A").agg(
-        pl.col("A", "C").name.prefix("agg_")
-    ).columns == ["A", "agg_A", "agg_C"]
+    result = df.lazy().group_by("A").agg(expr)
+    assert result.collect_schema().names() == expected
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -315,21 +315,21 @@ def test_join_suffix_collision_9562() -> None:
 
 
 def test_projection_join_names_9955() -> None:
-    batting = pl.DataFrame(
+    batting = pl.LazyFrame(
         {
             "playerID": ["abercda01"],
             "yearID": [1871],
             "lgID": ["NA"],
         }
-    ).lazy()
+    )
 
-    awards_players = pl.DataFrame(
+    awards_players = pl.LazyFrame(
         {
             "playerID": ["bondto01"],
             "yearID": [1877],
             "lgID": ["NL"],
         }
-    ).lazy()
+    )
 
     right = awards_players.filter(pl.col("lgID") == "NL").select("playerID")
 
@@ -340,7 +340,7 @@ def test_projection_join_names_9955() -> None:
         how="inner",
     )
 
-    q = q.select(batting.columns)
+    q = q.select(batting.collect_schema())
 
     assert q.collect().schema == {
         "playerID": pl.String,
@@ -419,7 +419,7 @@ def test_cached_schema_15651() -> None:
     _ = q.select(pl.len()).collect(projection_pushdown=True)
 
     # ensure that q's "cached" columns are still correct
-    assert q.columns == q.collect().columns
+    assert q.collect_schema().names() == q.collect().columns
 
 
 def test_double_projection_pushdown_15895() -> None:

--- a/py-polars/tests/unit/testing/parametric/strategies/test_core.py
+++ b/py-polars/tests/unit/testing/parametric/strategies/test_core.py
@@ -142,8 +142,13 @@ def test_dataframes_allow_null_override(df: pl.DataFrame) -> None:
     )
 )
 def test_dataframes_columns(lf: pl.LazyFrame) -> None:
-    assert lf.schema == {"a": pl.UInt8, "b": pl.UInt8, "c": pl.Boolean, "d": pl.String}
-    assert lf.columns == ["a", "b", "c", "d"]
+    assert lf.collect_schema() == {
+        "a": pl.UInt8,
+        "b": pl.UInt8,
+        "c": pl.Boolean,
+        "d": pl.String,
+    }
+    assert lf.collect_schema().names() == ["a", "b", "c", "d"]
     df = lf.collect()
 
     # confirm uint cols bounds
@@ -237,7 +242,7 @@ def test_strategy_dtypes(
 ) -> None:
     # dataframe, lazyframe
     assert all(tp.is_temporal() for tp in df.dtypes)
-    assert all(not tp.is_temporal() for tp in lf.dtypes)
+    assert all(not tp.is_temporal() for tp in lf.collect_schema().dtypes())
 
     # series
     assert s1.dtype.is_temporal()


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/16328

#### Changes

* Add `collect_schema` method to `LazyFrame` and `DataFrame`. This method is the same as the `.schema` property now. For `LazyFrame`, this is the idiomatic way to resolve the schema.
* Update references to the `LazyFrame` properties `.schema`, `.dtypes`, `.columns`, and `.width` to use `.collect_schema()` instead.

This includes some performance improvements for methods that were abusing LazyFrame properties internally (`LazyFrame.describe/fill_null`). That convinces me this is a good move.

I did not yet add any warnings to the LazyFrame properties. This will be done separately.