### PR TITLE
feat(python): Support Decimal inputs for `lit`

### DIFF
--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -37,6 +37,10 @@ impl PhysicalExpr for LiteralExpr {
             UInt64(v) => UInt64Chunked::full(LITERAL_NAME, *v, 1).into_series(),
             Float32(v) => Float32Chunked::full(LITERAL_NAME, *v, 1).into_series(),
             Float64(v) => Float64Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(v, scale) => Int128Chunked::full(LITERAL_NAME, *v, 1)
+                .into_decimal_unchecked(None, *scale)
+                .into_series(),
             Boolean(v) => BooleanChunked::full(LITERAL_NAME, *v, 1).into_series(),
             Null => polars_core::prelude::Series::new_null(LITERAL_NAME, 1),
             Range {

--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -45,6 +45,9 @@ pub enum LiteralValue {
     Float32(f32),
     /// A 64-bit floating point number.
     Float64(f64),
+    /// A 128-bit decimal number with a maximum scale of 38.
+    #[cfg(feature = "dtype-decimal")]
+    Decimal(i128, usize),
     Range {
         low: i64,
         high: i64,
@@ -121,6 +124,8 @@ impl LiteralValue {
             Int64(v) => AnyValue::Int64(*v),
             Float32(v) => AnyValue::Float32(*v),
             Float64(v) => AnyValue::Float64(*v),
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(v, scale) => AnyValue::Decimal(*v, *scale),
             String(v) => AnyValue::String(v),
             #[cfg(feature = "dtype-duration")]
             Duration(v, tu) => AnyValue::Duration(*v, *tu),
@@ -192,6 +197,8 @@ impl LiteralValue {
             LiteralValue::Int64(_) => DataType::Int64,
             LiteralValue::Float32(_) => DataType::Float32,
             LiteralValue::Float64(_) => DataType::Float64,
+            #[cfg(feature = "dtype-decimal")]
+            LiteralValue::Decimal(_, scale) => DataType::Decimal(None, Some(*scale)),
             LiteralValue::String(_) => DataType::String,
             LiteralValue::Binary(_) => DataType::Binary,
             LiteralValue::Range { data_type, .. } => data_type.clone(),
@@ -276,6 +283,8 @@ impl TryFrom<AnyValue<'_>> for LiteralValue {
             AnyValue::Int64(i) => Ok(Self::Int64(i)),
             AnyValue::Float32(f) => Ok(Self::Float32(f)),
             AnyValue::Float64(f) => Ok(Self::Float64(f)),
+            #[cfg(feature = "dtype-decimal")]
+            AnyValue::Decimal(v, scale) => Ok(Self::Decimal(v, scale)),
             #[cfg(feature = "dtype-date")]
             AnyValue::Date(v) => Ok(LiteralValue::Date(v)),
             #[cfg(feature = "dtype-datetime")]

--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -556,7 +556,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 },
                 Binary(_) => return Err(PyNotImplementedError::new_err("binary literal")),
                 Range { .. } => return Err(PyNotImplementedError::new_err("range literal")),
-                Date(..) | DateTime(..) => Literal {
+                Date(..) | DateTime(..) | Decimal(..) => Literal {
                     value: Wrap(lit.to_any_value().unwrap()).to_object(py),
                     dtype,
                 },


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/13341

Previously, passing Python Decimal objects to `lit` was unsupported. Now it works:

```python
from decimal import Decimal
import polars as pl

expr = pl.lit(Decimal("0.1"))
print(pl.select(expr))
```
```
shape: (1, 1)
┌──────────────┐
│ literal      │
│ ---          │
│ decimal[*,1] │
╞══════════════╡
│ 0.1          │
└──────────────┘
```