### PR TITLE
fix: properly set `FAST_EXPLODE_LIST` metadata

### DIFF
--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -17,15 +17,13 @@ impl ListChunked {
         let field = Arc::make_mut(&mut self.field);
         field.coerce(DataType::List(Box::new(dtype)));
     }
+
     pub fn set_fast_explode(&mut self) {
-        Arc::make_mut(self.metadata_mut()).set_fast_explode_list(true);
-    }
-    pub(crate) fn unset_fast_explode(&mut self) {
-        Arc::make_mut(self.metadata_mut()).set_fast_explode_list(false);
+        self.set_fast_explode_list(true)
     }
 
     pub fn _can_fast_explode(&self) -> bool {
-        self.effective_metadata().get_fast_explode_list()
+        self.get_fast_explode_list()
     }
 
     /// Set the logical type of the [`ListChunked`].

--- a/crates/polars-core/src/chunked_array/metadata/mod.rs
+++ b/crates/polars-core/src/chunked_array/metadata/mod.rs
@@ -116,7 +116,7 @@ impl MetadataFlags {
 
     pub fn set_fast_explode_list(&mut self, fast_explode_list: bool) {
         mdenv_may_bail!(set: "fast_explode_list", fast_explode_list);
-        self.insert(Self::FAST_EXPLODE_LIST)
+        self.set(Self::FAST_EXPLODE_LIST, fast_explode_list)
     }
 
     pub fn get_fast_explode_list(&self) -> bool {

--- a/crates/polars-core/src/chunked_array/ops/append.rs
+++ b/crates/polars-core/src/chunked_array/ops/append.rs
@@ -156,8 +156,8 @@ impl ListChunked {
         self.null_count += other.null_count;
         new_chunks(&mut self.chunks, &other.chunks, len);
         self.set_sorted_flag(IsSorted::Not);
-        if !other._can_fast_explode() {
-            self.unset_fast_explode()
+        if !other.get_fast_explode_list() {
+            self.unset_fast_explode_list()
         }
         Ok(())
     }

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -375,6 +375,32 @@ def test_group_by_flatten_string() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_fast_explode_merge_right_16923() -> None:
+    df = pl.concat(
+        [
+            pl.DataFrame({"foo": [["a", "b"], ["c"]]}),
+            pl.DataFrame({"foo": [None]}, schema={"foo": pl.List(pl.Utf8)}),
+        ],
+        how="diagonal",
+        rechunk=True,
+    ).explode("foo")
+
+    assert len(df) == 4
+
+
+def test_fast_explode_merge_left_16923() -> None:
+    df = pl.concat(
+        [
+            pl.DataFrame({"foo": [None]}, schema={"foo": pl.List(pl.Utf8)}),
+            pl.DataFrame({"foo": [["a", "b"], ["c"]]}),
+        ],
+        how="diagonal",
+        rechunk=True,
+    ).explode("foo")
+
+    assert len(df) == 4
+
+
 @pytest.mark.parametrize(
     ("values", "exploded"),
     [


### PR DESCRIPTION
Fixes #16923.

This resolves very dumb mistake (I made), where the `FAST_EXPLODE_LIST` was only ever set to `true` when calling `set_fast_explode_list`.

We now use `set` instead of `insert`.