### PR TITLE
feat(rust): use min/max metadata on debug builds with `POLARS_METADATA_FLAGS=extensive`

### DIFF
--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -101,6 +101,16 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<BooleanChunked> {
+    fn get_metadata_min_value(&self) -> Option<Scalar> {
+        let v = self.metadata()?.get_min_value()?;
+        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
+    }
+
+    fn get_metadata_max_value(&self) -> Option<Scalar> {
+        let v = self.metadata()?.get_max_value()?;
+        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
+    }
+
     fn bitxor(&self, other: &Series) -> PolarsResult<Series> {
         let other = self.0.unpack_series_matching_type(other)?;
         Ok((&self.0).bitxor(other).into_series())

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -140,6 +140,16 @@ impl private::PrivateSeries for SeriesWrap<DateChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<DateChunked> {
+    fn get_metadata_min_value(&self) -> Option<Scalar> {
+        let v = self.0.metadata()?.get_min_value()?;
+        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
+    }
+
+    fn get_metadata_max_value(&self) -> Option<Scalar> {
+        let v = self.0.metadata()?.get_max_value()?;
+        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
+    }
+
     fn rename(&mut self, name: &str) {
         self.0.rename(name);
     }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -165,6 +165,22 @@ macro_rules! impl_dyn_series {
                 ChunkRollApply::rolling_map(&self.0, _f, _options).map(|ca| ca.into_series())
             }
 
+            fn get_metadata_min_value(&self) -> Option<Scalar> {
+                let v = self.metadata()?.get_min_value()?;
+                Some(Scalar::new(
+                    private::PrivateSeries::_dtype(self).clone(),
+                    AnyValue::from(*v),
+                ))
+            }
+
+            fn get_metadata_max_value(&self) -> Option<Scalar> {
+                let v = self.metadata()?.get_max_value()?;
+                Some(Scalar::new(
+                    private::PrivateSeries::_dtype(self).clone(),
+                    AnyValue::from(*v),
+                ))
+            }
+
             fn rename(&mut self, name: &str) {
                 self.0.rename(name);
             }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -239,6 +239,22 @@ macro_rules! impl_dyn_series {
                 ChunkRollApply::rolling_map(&self.0, _f, _options).map(|ca| ca.into_series())
             }
 
+            fn get_metadata_min_value(&self) -> Option<Scalar> {
+                let v = self.metadata()?.get_min_value()?;
+                Some(Scalar::new(
+                    private::PrivateSeries::_dtype(self).clone(),
+                    AnyValue::from(*v),
+                ))
+            }
+
+            fn get_metadata_max_value(&self) -> Option<Scalar> {
+                let v = self.metadata()?.get_max_value()?;
+                Some(Scalar::new(
+                    private::PrivateSeries::_dtype(self).clone(),
+                    AnyValue::from(*v),
+                ))
+            }
+
             fn bitand(&self, other: &Series) -> PolarsResult<Series> {
                 let other = if other.len() == 1 {
                     Cow::Owned(other.cast(self.dtype())?)

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -505,6 +505,7 @@ impl Series {
     where
         T: NumCast,
     {
+        // @TODO: Add parameter for this
         let min = self.min_reduce()?;
         let min = min.value().extract::<T>();
         Ok(min)
@@ -516,6 +517,7 @@ impl Series {
     where
         T: NumCast,
     {
+        // @TODO: Add parameter for this
         let max = self.max_reduce()?;
         let max = max.value().extract::<T>();
         Ok(max)

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -505,7 +505,6 @@ impl Series {
     where
         T: NumCast,
     {
-        // @TODO: Add parameter for this
         let min = self.min_reduce()?;
         let min = min.value().extract::<T>();
         Ok(min)
@@ -517,7 +516,6 @@ impl Series {
     where
         T: NumCast,
     {
-        // @TODO: Add parameter for this
         let max = self.max_reduce()?;
         let max = max.value().extract::<T>();
         Ok(max)

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -193,6 +193,14 @@ pub trait SeriesTrait:
         polars_bail!(opq = bitxor, self._dtype());
     }
 
+    fn get_metadata_min_value(&self) -> Option<Scalar> {
+        None
+    }
+
+    fn get_metadata_max_value(&self) -> Option<Scalar> {
+        None
+    }
+
     /// Get the lengths of the underlying chunks
     fn chunk_lengths(&self) -> ChunkLenIter;
 


### PR DESCRIPTION
This introduces the use of the `min_value` and `max_value` metadata for the aggregation expressions. Currently, this is only enabled for `POLARS_METADATA_FLAGS=extensive` under debug builds, but after some testing, we can try to enable it for more people.

For large parquet data sets with statistics, where the metadata is already loaded. This massively speeds up the computation.

As an example.

```python
import polars as pl

yellow_tripdata = pl.read_parquet("yellow_tripdata_2024-01.parquet")
yellow_tripdata.write_parquet("a.parquet", statistics='full')

df = pl.read_parquet("a.parquet")
for _ in range(1000):
    _ = df.select(pl.col.total_amount.min())
```

Enabling `POLARS_METADATA_FLAGS=extensive`, speeds up 20+ seconds to basically instantly.