### PR TITLE
refactor(rust): Make Series and ChunkedArray ops fallible

### DIFF
--- a/crates/polars-core/src/frame/arithmetic.rs
+++ b/crates/polars-core/src/frame/arithmetic.rs
@@ -15,21 +15,25 @@ fn get_supertype_all(df: &DataFrame, rhs: &Series) -> PolarsResult<DataType> {
 }
 
 macro_rules! impl_arithmetic {
-    ($self:expr, $rhs:expr, $operand: tt) => {{
+    ($self:expr, $rhs:expr, $operand:expr) => {{
         let st = get_supertype_all($self, $rhs)?;
         let rhs = $rhs.cast(&st)?;
-        let cols = POOL.install(|| {$self.columns.par_iter().map(|s| {
-            Ok(&s.cast(&st)? $operand &rhs)
-        }).collect::<PolarsResult<_>>()})?;
+        let cols = POOL.install(|| {
+            $self
+                .columns
+                .par_iter()
+                .map(|s| $operand(&s.cast(&st)?, &rhs))
+                .collect::<PolarsResult<_>>()
+        })?;
         Ok(unsafe { DataFrame::new_no_checks(cols) })
-    }}
+    }};
 }
 
 impl Add<&Series> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn add(self, rhs: &Series) -> Self::Output {
-        impl_arithmetic!(self, rhs, +)
+        impl_arithmetic!(self, rhs, std::ops::Add::add)
     }
 }
 
@@ -45,7 +49,7 @@ impl Sub<&Series> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn sub(self, rhs: &Series) -> Self::Output {
-        impl_arithmetic!(self, rhs, -)
+        impl_arithmetic!(self, rhs, std::ops::Sub::sub)
     }
 }
 
@@ -61,7 +65,7 @@ impl Mul<&Series> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn mul(self, rhs: &Series) -> Self::Output {
-        impl_arithmetic!(self, rhs, *)
+        impl_arithmetic!(self, rhs, std::ops::Mul::mul)
     }
 }
 
@@ -77,7 +81,7 @@ impl Div<&Series> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn div(self, rhs: &Series) -> Self::Output {
-        impl_arithmetic!(self, rhs, /)
+        impl_arithmetic!(self, rhs, std::ops::Div::div)
     }
 }
 
@@ -93,7 +97,7 @@ impl Rem<&Series> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn rem(self, rhs: &Series) -> Self::Output {
-        impl_arithmetic!(self, rhs, %)
+        impl_arithmetic!(self, rhs, std::ops::Rem::rem)
     }
 }
 
@@ -159,7 +163,7 @@ impl Add<&DataFrame> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn add(self, rhs: &DataFrame) -> Self::Output {
-        self.binary_aligned(rhs, &|a, b| Ok(a + b))
+        self.binary_aligned(rhs, &|a, b| a + b)
     }
 }
 
@@ -167,7 +171,7 @@ impl Sub<&DataFrame> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn sub(self, rhs: &DataFrame) -> Self::Output {
-        self.binary_aligned(rhs, &|a, b| Ok(a - b))
+        self.binary_aligned(rhs, &|a, b| a - b)
     }
 }
 
@@ -175,7 +179,7 @@ impl Div<&DataFrame> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn div(self, rhs: &DataFrame) -> Self::Output {
-        self.binary_aligned(rhs, &|a, b| Ok(a / b))
+        self.binary_aligned(rhs, &|a, b| a / b)
     }
 }
 
@@ -183,7 +187,7 @@ impl Mul<&DataFrame> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn mul(self, rhs: &DataFrame) -> Self::Output {
-        self.binary_aligned(rhs, &|a, b| Ok(a * b))
+        self.binary_aligned(rhs, &|a, b| a * b)
     }
 }
 
@@ -191,6 +195,6 @@ impl Rem<&DataFrame> for &DataFrame {
     type Output = PolarsResult<DataFrame>;
 
     fn rem(self, rhs: &DataFrame) -> Self::Output {
-        self.binary_aligned(rhs, &|a, b| Ok(a % b))
+        self.binary_aligned(rhs, &|a, b| a % b)
     }
 }

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -469,61 +469,6 @@ pub fn _struct_arithmetic<F: FnMut(&Series, &Series) -> PolarsResult<Series>>(
     }
 }
 
-impl Sub for &Series {
-    type Output = Series;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.try_sub(rhs).unwrap()
-    }
-}
-
-impl Add for &Series {
-    type Output = Series;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        self.try_add(rhs).unwrap()
-    }
-}
-
-impl Mul for &Series {
-    type Output = Series;
-
-    /// ```
-    /// # use polars_core::prelude::*;
-    /// let s: Series = [1, 2, 3].iter().collect();
-    /// let out = &s * &s;
-    /// ```
-    fn mul(self, rhs: Self) -> Self::Output {
-        self.try_mul(rhs).unwrap()
-    }
-}
-
-impl Div for &Series {
-    type Output = Series;
-
-    /// ```
-    /// # use polars_core::prelude::*;
-    /// let s: Series = [1, 2, 3].iter().collect();
-    /// let out = &s / &s;
-    /// ```
-    fn div(self, rhs: Self) -> Self::Output {
-        self.try_div(rhs).unwrap()
-    }
-}
-
-impl Rem for &Series {
-    type Output = Series;
-
-    /// ```
-    /// # use polars_core::prelude::*;
-    /// let s: Series = [1, 2, 3].iter().collect();
-    /// let out = &s / &s;
-    /// ```
-    fn rem(self, rhs: Self) -> Self::Output {
-        self.try_rem(rhs).unwrap()
-    }
-}
-
 fn check_lengths(a: &Series, b: &Series) -> PolarsResult<()> {
     match (a.len(), b.len()) {
         // broadcasting
@@ -537,27 +482,15 @@ fn check_lengths(a: &Series, b: &Series) -> PolarsResult<()> {
     }
 }
 
-impl Series {
-    pub fn try_sub(&self, rhs: &Self) -> PolarsResult<Self> {
-        check_lengths(self, rhs)?;
-        match (self.dtype(), rhs.dtype()) {
-            #[cfg(feature = "dtype-struct")]
-            (DataType::Struct(_), DataType::Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.try_sub(b))
-            },
-            _ => {
-                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
-                lhs.subtract(rhs.as_ref())
-            },
-        }
-    }
+impl Add for &Series {
+    type Output = PolarsResult<Series>;
 
-    pub fn try_add(&self, rhs: &Self) -> PolarsResult<Self> {
+    fn add(self, rhs: Self) -> Self::Output {
         check_lengths(self, rhs)?;
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.try_add(b))
+                _struct_arithmetic(self, rhs, |a, b| a.add(b))
             },
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
@@ -565,13 +498,41 @@ impl Series {
             },
         }
     }
+}
 
-    pub fn try_mul(&self, rhs: &Self) -> PolarsResult<Self> {
+impl Sub for &Series {
+    type Output = PolarsResult<Series>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
         check_lengths(self, rhs)?;
+        match (self.dtype(), rhs.dtype()) {
+            #[cfg(feature = "dtype-struct")]
+            (DataType::Struct(_), DataType::Struct(_)) => {
+                _struct_arithmetic(self, rhs, |a, b| a.sub(b))
+            },
+            _ => {
+                let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
+                lhs.subtract(rhs.as_ref())
+            },
+        }
+    }
+}
+
+impl Mul for &Series {
+    type Output = PolarsResult<Series>;
+
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// let s: Series = [1, 2, 3].iter().collect();
+    /// let out = (&s * &s).unwrap();
+    /// ```
+    fn mul(self, rhs: Self) -> Self::Output {
+        check_lengths(self, rhs)?;
+
         use DataType::*;
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
-            (Struct(_), Struct(_)) => _struct_arithmetic(self, rhs, |a, b| a.try_mul(b)),
+            (Struct(_), Struct(_)) => _struct_arithmetic(self, rhs, |a, b| a.mul(b)),
             // temporal lh
             (Duration(_), _) | (Date, _) | (Datetime(_, _), _) | (Time, _) => self.multiply(rhs),
             // temporal rhs
@@ -589,14 +550,23 @@ impl Series {
             },
         }
     }
+}
 
-    pub fn try_div(&self, rhs: &Self) -> PolarsResult<Self> {
+impl Div for &Series {
+    type Output = PolarsResult<Series>;
+
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// let s: Series = [1, 2, 3].iter().collect();
+    /// let out = (&s / &s).unwrap();
+    /// ```
+    fn div(self, rhs: Self) -> Self::Output {
         check_lengths(self, rhs)?;
         use DataType::*;
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (Struct(_), Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.try_div(b))
+                _struct_arithmetic(self, rhs, |a, b| a.div(b))
             },
             (Duration(_), _) => self.divide(rhs),
             | (Date, _)
@@ -614,13 +584,22 @@ impl Series {
             },
         }
     }
+}
 
-    pub fn try_rem(&self, rhs: &Self) -> PolarsResult<Self> {
+impl Rem for &Series {
+    type Output = PolarsResult<Series>;
+
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// let s: Series = [1, 2, 3].iter().collect();
+    /// let out = (&s / &s).unwrap();
+    /// ```
+    fn rem(self, rhs: Self) -> Self::Output {
         check_lengths(self, rhs)?;
         match (self.dtype(), rhs.dtype()) {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
-                _struct_arithmetic(self, rhs, |a, b| a.try_rem(b))
+                _struct_arithmetic(self, rhs, |a, b| a.rem(b))
             },
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
@@ -905,23 +884,23 @@ mod test {
 
     #[test]
     #[allow(clippy::eq_op)]
-    fn test_arithmetic_series() {
+    fn test_arithmetic_series() -> PolarsResult<()> {
         // Series +-/* Series
         let s = Series::new("foo", [1, 2, 3]);
         assert_eq!(
-            Vec::from((&s * &s).i32().unwrap()),
+            Vec::from((&s * &s)?.i32().unwrap()),
             [Some(1), Some(4), Some(9)]
         );
         assert_eq!(
-            Vec::from((&s / &s).i32().unwrap()),
+            Vec::from((&s / &s)?.i32().unwrap()),
             [Some(1), Some(1), Some(1)]
         );
         assert_eq!(
-            Vec::from((&s - &s).i32().unwrap()),
+            Vec::from((&s - &s)?.i32().unwrap()),
             [Some(0), Some(0), Some(0)]
         );
         assert_eq!(
-            Vec::from((&s + &s).i32().unwrap()),
+            Vec::from((&s + &s)?.i32().unwrap()),
             [Some(2), Some(4), Some(6)]
         );
         // Series +-/* Number
@@ -964,9 +943,11 @@ mod test {
             [Some(0), Some(1), Some(1)]
         );
 
-        assert_eq!((&s * &s).name(), "foo");
+        assert_eq!((&s * &s)?.name(), "foo");
         assert_eq!((&s * 1).name(), "foo");
         assert_eq!((1.div(&s)).name(), "foo");
+
+        Ok(())
     }
 
     #[test]

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -88,28 +88,28 @@ impl private::PrivateSeries for SeriesWrap<DateChunked> {
                 let rhs = rhs.cast(&dt)?;
                 lhs.subtract(&rhs)
             },
-            DataType::Duration(_) => ((&self
-                .cast(
+            DataType::Duration(_) => std::ops::Sub::sub(
+                &self.cast(
                     &DataType::Datetime(TimeUnit::Milliseconds, None),
                     CastOptions::NonStrict,
-                )
-                .unwrap())
-                - rhs)
-                .cast(&DataType::Date),
+                )?,
+                rhs,
+            )?
+            .cast(&DataType::Date),
             dtr => polars_bail!(opq = sub, DataType::Date, dtr),
         }
     }
 
     fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {
         match rhs.dtype() {
-            DataType::Duration(_) => ((&self
-                .cast(
+            DataType::Duration(_) => std::ops::Add::add(
+                &self.cast(
                     &DataType::Datetime(TimeUnit::Milliseconds, None),
                     CastOptions::NonStrict,
-                )
-                .unwrap())
-                + rhs)
-                .cast(&DataType::Date),
+                )?,
+                rhs,
+            )?
+            .cast(&DataType::Date),
             dtr => polars_bail!(opq = add, DataType::Date, dtr),
         }
     }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -186,7 +186,9 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             dt if dt.is_float() => {
                 let phys = &self.0 .0;
                 let phys_float = phys.cast(dt).unwrap();
-                let out = (&phys_float * rhs).cast(&DataType::Int64).unwrap();
+                let out = std::ops::Mul::mul(&phys_float, rhs)?
+                    .cast(&DataType::Int64)
+                    .unwrap();
                 let phys = out.i64().unwrap().clone();
                 Ok(phys.into_duration(tul).into_series())
             },
@@ -201,9 +203,11 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             DataType::Duration(tur) => {
                 if tul == *tur {
                     // Returns a constant as f64.
-                    Ok((&self.0 .0.cast(&DataType::Float64).unwrap()
-                        / &rhs.duration().unwrap().0.cast(&DataType::Float64).unwrap())
-                        .into_series())
+                    Ok(std::ops::Div::div(
+                        &self.0 .0.cast(&DataType::Float64).unwrap(),
+                        &rhs.duration().unwrap().0.cast(&DataType::Float64).unwrap(),
+                    )?
+                    .into_series())
                 } else {
                     let rhs = rhs.cast(self.dtype())?;
                     self.divide(&rhs)
@@ -219,7 +223,9 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             dt if dt.is_float() => {
                 let phys = &self.0 .0;
                 let phys_float = phys.cast(dt).unwrap();
-                let out = (&phys_float / rhs).cast(&DataType::Int64).unwrap();
+                let out = std::ops::Div::div(&phys_float, rhs)?
+                    .cast(&DataType::Int64)
+                    .unwrap();
                 let phys = out.i64().unwrap().clone();
                 Ok(phys.into_duration(tul).into_series())
             },

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -634,7 +634,7 @@ impl Series {
 
     #[cfg(feature = "dot_product")]
     pub fn dot(&self, other: &Series) -> PolarsResult<f64> {
-        (self * other).sum::<f64>()
+        std::ops::Mul::mul(self, other)?.sum::<f64>()
     }
 
     /// Get the sum of the Series as a new Series of length 1.

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -565,7 +565,7 @@ impl PartitionedAggregation for AggregationExpr {
                         let (agg_count, agg_s) =
                             unsafe { POOL.join(|| count.agg_sum(groups), || sum.agg_sum(groups)) };
                         let agg_s = &agg_s / &agg_count;
-                        Ok(rename_series(agg_s, new_name))
+                        Ok(rename_series(agg_s?, new_name))
                     },
                     _ => Ok(Series::full_null(
                         new_name,

--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -55,25 +55,25 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
         Operator::LtEq => ChunkCompare::lt_eq(left, right).map(|ca| ca.into_series()),
         Operator::Eq => ChunkCompare::equal(left, right).map(|ca| ca.into_series()),
         Operator::NotEq => ChunkCompare::not_equal(left, right).map(|ca| ca.into_series()),
-        Operator::Plus => left.try_add(right),
-        Operator::Minus => left.try_sub(right),
-        Operator::Multiply => left.try_mul(right),
-        Operator::Divide => left.try_div(right),
+        Operator::Plus => left + right,
+        Operator::Minus => left - right,
+        Operator::Multiply => left * right,
+        Operator::Divide => left / right,
         Operator::TrueDivide => match left.dtype() {
             #[cfg(feature = "dtype-decimal")]
-            Decimal(_, _) => left.try_div(right),
-            Duration(_) | Date | Datetime(_, _) | Float32 | Float64 => left.try_div(right),
+            Decimal(_, _) => left / right,
+            Duration(_) | Date | Datetime(_, _) | Float32 | Float64 => left / right,
             #[cfg(feature = "dtype-array")]
             dt @ Array(_, _) => {
                 let left_dt = dt.cast_leaf(Float64);
                 let right_dt = right.dtype().cast_leaf(Float64);
-                left.cast(&left_dt)?.try_div(&right.cast(&right_dt)?)
+                left.cast(&left_dt)? / right.cast(&right_dt)?
             },
             _ => {
                 if right.dtype().is_temporal() {
-                    return left.try_div(right);
+                    return left / right;
                 }
-                left.cast(&Float64)?.try_div(&right.cast(&Float64)?)
+                left.cast(&Float64)? / right.cast(&Float64)?
             },
         },
         Operator::FloorDivide => {
@@ -95,7 +95,7 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
             .cast(&DataType::Boolean)?
             .bitand(&right.cast(&DataType::Boolean)?),
         Operator::Xor => left.bitxor(right),
-        Operator::Modulus => left.try_rem(right),
+        Operator::Modulus => left % right,
         Operator::EqValidity => left.equal_missing(right).map(|ca| ca.into_series()),
         Operator::NotEqValidity => left.not_equal_missing(right).map(|ca| ca.into_series()),
     }

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -256,7 +256,7 @@ fn test_lazy_query_3() {
 }
 
 #[test]
-fn test_lazy_query_4() {
+fn test_lazy_query_4() -> PolarsResult<()> {
     let df = df! {
         "uid" => [0, 0, 0, 1, 1, 1],
         "day" => [1, 2, 3, 1, 2, 3],
@@ -273,7 +273,7 @@ fn test_lazy_query_4() {
             col("day").alias("day"),
             col("cumcases")
                 .apply(
-                    |s: Series| Ok(Some(&s - &(s.shift(1)))),
+                    |s: Series| (&s - &(s.shift(1))).map(Some),
                     GetOutput::same_type(),
                 )
                 .alias("diff_cases"),
@@ -291,6 +291,8 @@ fn test_lazy_query_4() {
         Vec::from(out.column("diff_cases").unwrap().i32().unwrap()),
         &[None, Some(2), Some(3), None, Some(5), Some(11)]
     );
+
+    Ok(())
 }
 
 #[test]

--- a/crates/polars-ops/src/series/ops/business.rs
+++ b/crates/polars-ops/src/series/ops/business.rs
@@ -157,7 +157,10 @@ pub fn add_business_days(
             let start_time = start
                 .cast(&DataType::Time)?
                 .cast(&DataType::Duration(*time_unit))?;
-            return Ok(result_date.cast(&DataType::Datetime(*time_unit, None))? + start_time);
+            return std::ops::Add::add(
+                result_date.cast(&DataType::Datetime(*time_unit, None))?,
+                start_time,
+            );
         },
         #[cfg(feature = "timezones")]
         DataType::Datetime(time_unit, Some(time_zone)) => {
@@ -177,8 +180,10 @@ pub fn add_business_days(
             let start_time = start_naive
                 .cast(&DataType::Time)?
                 .cast(&DataType::Duration(*time_unit))?;
-            let result_naive =
-                result_date.cast(&DataType::Datetime(*time_unit, None))? + start_time;
+            let result_naive = std::ops::Add::add(
+                result_date.cast(&DataType::Datetime(*time_unit, None))?,
+                start_time,
+            )?;
             let result_tz_aware = replace_time_zone(
                 result_naive.datetime().unwrap(),
                 Some(time_zone),

--- a/crates/polars-ops/src/series/ops/diff.rs
+++ b/crates/polars-ops/src/series/ops/diff.rs
@@ -11,12 +11,12 @@ pub fn diff(s: &Series, n: i64, null_behavior: NullBehavior) -> PolarsResult<Ser
     };
 
     match null_behavior {
-        NullBehavior::Ignore => Ok(&s - &s.shift(n)),
+        NullBehavior::Ignore => &s - &s.shift(n),
         NullBehavior::Drop => {
             polars_ensure!(n > 0, InvalidOperation: "only positive integer allowed if nulls are dropped in 'diff' operation");
             let n = n as usize;
             let len = s.len() - n;
-            Ok(&s.slice(n as i64, len) - &s.slice(0, len))
+            &s.slice(n as i64, len) - &s.slice(0, len)
         },
     }
 }

--- a/crates/polars-ops/src/series/ops/fused.rs
+++ b/crates/polars-ops/src/series/ops/fused.rs
@@ -51,7 +51,7 @@ pub fn fma_series(a: &Series, b: &Series, c: &Series) -> Series {
             fma_ca(a, b, c).into_series()
         })
     } else {
-        a + &(b * c)
+        (a + &(b * c).unwrap()).unwrap()
     }
 }
 
@@ -102,7 +102,7 @@ pub fn fsm_series(a: &Series, b: &Series, c: &Series) -> Series {
             fsm_ca(a, b, c).into_series()
         })
     } else {
-        a - &(b * c)
+        (a - &(b * c).unwrap()).unwrap()
     }
 }
 
@@ -152,6 +152,6 @@ pub fn fms_series(a: &Series, b: &Series, c: &Series) -> Series {
             fms_ca(a, b, c).into_series()
         })
     } else {
-        &(a * b) - c
+        (&(a * b).unwrap() - c).unwrap()
     }
 }

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -95,7 +95,7 @@ pub trait LogSeries: SeriesSealed {
                     let sum = pk.sum_reduce().unwrap().into_series("");
 
                     if sum.get(0).unwrap().extract::<f64>().unwrap() != 1.0 {
-                        pk / &sum
+                        (pk / &sum)?
                     } else {
                         pk.clone()
                     }
@@ -104,7 +104,7 @@ pub trait LogSeries: SeriesSealed {
                 };
 
                 let log_pk = pk.log(base);
-                (&pk * &log_pk).sum::<f64>().map(|v| -v)
+                (&pk * &log_pk)?.sum::<f64>().map(|v| -v)
             },
             _ => s
                 .cast(&DataType::Float64)

--- a/crates/polars-ops/src/series/ops/moment.rs
+++ b/crates/polars-ops/src/series/ops/moment.rs
@@ -26,13 +26,13 @@ fn moment_precomputed_mean(s: &Series, moment: usize, mean: f64) -> PolarsResult
                 #[allow(clippy::redundant_clone)]
                 a_zero_mean.clone()
             } else {
-                &a_zero_mean * &a_zero_mean
+                (&a_zero_mean * &a_zero_mean)?
             };
 
             for n in n_list.iter().rev() {
-                s = &s * &s;
+                s = (&s * &s)?;
                 if n % 2 == 1 {
-                    s = &s * &a_zero_mean;
+                    s = (&s * &a_zero_mean)?;
                 }
             }
             s.mean()

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -531,10 +531,10 @@ pub(super) fn duration(s: &[Series], time_unit: TimeUnit) -> PolarsResult<Series
                 microseconds = microseconds.new_from_index(0, max_len);
             }
             if !is_zero_scalar(&nanoseconds) {
-                microseconds = microseconds + (nanoseconds.wrapping_trunc_div_scalar(1_000));
+                microseconds = (microseconds + (nanoseconds.wrapping_trunc_div_scalar(1_000)))?;
             }
             if !is_zero_scalar(&milliseconds) {
-                microseconds = microseconds + (milliseconds * 1_000);
+                microseconds = (microseconds + (milliseconds * 1_000))?;
             }
             microseconds
         },
@@ -543,10 +543,10 @@ pub(super) fn duration(s: &[Series], time_unit: TimeUnit) -> PolarsResult<Series
                 nanoseconds = nanoseconds.new_from_index(0, max_len);
             }
             if !is_zero_scalar(&microseconds) {
-                nanoseconds = nanoseconds + (microseconds * 1_000);
+                nanoseconds = (nanoseconds + (microseconds * 1_000))?;
             }
             if !is_zero_scalar(&milliseconds) {
-                nanoseconds = nanoseconds + (milliseconds * 1_000_000);
+                nanoseconds = (nanoseconds + (milliseconds * 1_000_000))?;
             }
             nanoseconds
         },
@@ -555,10 +555,10 @@ pub(super) fn duration(s: &[Series], time_unit: TimeUnit) -> PolarsResult<Series
                 milliseconds = milliseconds.new_from_index(0, max_len);
             }
             if !is_zero_scalar(&nanoseconds) {
-                milliseconds = milliseconds + (nanoseconds.wrapping_trunc_div_scalar(1_000_000));
+                milliseconds = (milliseconds + (nanoseconds.wrapping_trunc_div_scalar(1_000_000)))?;
             }
             if !is_zero_scalar(&microseconds) {
-                milliseconds = milliseconds + (microseconds.wrapping_trunc_div_scalar(1_000));
+                milliseconds = (milliseconds + (microseconds.wrapping_trunc_div_scalar(1_000)))?;
             }
             milliseconds
         },
@@ -571,19 +571,19 @@ pub(super) fn duration(s: &[Series], time_unit: TimeUnit) -> PolarsResult<Series
         TimeUnit::Milliseconds => MILLISECONDS,
     };
     if !is_zero_scalar(&seconds) {
-        duration = duration + seconds * multiplier;
+        duration = (duration + seconds * multiplier)?;
     }
     if !is_zero_scalar(&minutes) {
-        duration = duration + minutes * (multiplier * 60);
+        duration = (duration + minutes * (multiplier * 60))?;
     }
     if !is_zero_scalar(&hours) {
-        duration = duration + hours * (multiplier * 60 * 60);
+        duration = (duration + hours * (multiplier * 60 * 60))?;
     }
     if !is_zero_scalar(&days) {
-        duration = duration + days * (multiplier * SECONDS_IN_DAY);
+        duration = (duration + days * (multiplier * SECONDS_IN_DAY))?;
     }
     if !is_zero_scalar(&weeks) {
-        duration = duration + weeks * (multiplier * SECONDS_IN_DAY * 7);
+        duration = (duration + weeks * (multiplier * SECONDS_IN_DAY * 7))?;
     }
 
     duration.cast(&DataType::Duration(time_unit))

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -202,12 +202,12 @@ pub(super) fn combine(s: &[Series], tu: TimeUnit) -> PolarsResult<Series> {
     match tz {
         #[cfg(feature = "timezones")]
         Some(tz) => Ok(polars_ops::prelude::replace_time_zone(
-            result_naive.datetime().unwrap(),
+            result_naive?.datetime().unwrap(),
             Some(tz),
             &StringChunked::from_iter(std::iter::once("raise")),
             NonExistent::Raise,
         )?
         .into()),
-        _ => Ok(result_naive),
+        _ => result_naive,
     }
 }

--- a/crates/polars-sql/tests/udf.rs
+++ b/crates/polars-sql/tests/udf.rs
@@ -42,7 +42,7 @@ fn test_udfs() -> PolarsResult<()> {
         move |s: &mut [Series]| {
             let first = s[0].clone();
             let second = s[1].clone();
-            Ok(Some(first + second))
+            (first + second).map(Some)
         },
     );
 
@@ -77,7 +77,7 @@ fn test_udfs() -> PolarsResult<()> {
         move |s: &mut [Series]| {
             let first = s[0].clone();
             let second = s[1].clone();
-            Ok(Some(first / second))
+            (first / second).map(Some)
         },
     );
 

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -775,11 +775,11 @@ mod test {
             "",
             [0.0, 8.0, 4.000000000000002, 6.666666666666667, 24.5, 0.0],
         );
-        assert!(abs(&(var - expected)).unwrap().lt(1e-12).unwrap().all());
+        assert!(abs(&(var - expected)?).unwrap().lt(1e-12).unwrap().all());
 
         let var = unsafe { nulls.agg_var(&groups, 1) };
         let expected = Series::new("", [0.0, 8.0, 8.0, 9.333333333333343, 24.5, 0.0]);
-        assert!(abs(&(var - expected)).unwrap().lt(1e-12).unwrap().all());
+        assert!(abs(&(var - expected)?).unwrap().lt(1e-12).unwrap().all());
 
         let quantile = unsafe { a.agg_quantile(&groups, 0.5, QuantileInterpolOptions::Linear) };
         let expected = Series::new("", [3.0, 5.0, 5.0, 6.0, 5.5, 1.0]);

--- a/crates/polars/tests/it/core/date_like.rs
+++ b/crates/polars/tests/it/core/date_like.rs
@@ -141,11 +141,12 @@ fn test_duration() -> PolarsResult<()> {
 
 #[test]
 #[cfg(feature = "dtype-duration")]
-fn test_duration_date_arithmetic() {
+fn test_duration_date_arithmetic() -> PolarsResult<()> {
     let date1 = Int32Chunked::new("", &[1, 1, 1]).into_date().into_series();
     let date2 = Int32Chunked::new("", &[2, 3, 4]).into_date().into_series();
 
     let diff_ms = &date2 - &date1;
+    let diff_ms = diff_ms?;
     let diff_us = diff_ms
         .cast(&DataType::Duration(TimeUnit::Microseconds))
         .unwrap();
@@ -154,14 +155,16 @@ fn test_duration_date_arithmetic() {
         .unwrap();
 
     // `+` is commutative for date and duration
-    assert_series_eq(&(&diff_ms + &date1), &(&date1 + &diff_ms));
-    assert_series_eq(&(&diff_us + &date1), &(&date1 + &diff_us));
-    assert_series_eq(&(&diff_ns + &date1), &(&date1 + &diff_ns));
+    assert_series_eq(&(&diff_ms + &date1)?, &(&date1 + &diff_ms)?);
+    assert_series_eq(&(&diff_us + &date1)?, &(&date1 + &diff_us)?);
+    assert_series_eq(&(&diff_ns + &date1)?, &(&date1 + &diff_ns)?);
 
     // `+` is correct date and duration
-    assert_series_eq(&(&diff_ms + &date1), &date2);
-    assert_series_eq(&(&diff_us + &date1), &date2);
-    assert_series_eq(&(&diff_ns + &date1), &date2);
+    assert_series_eq(&(&diff_ms + &date1)?, &date2);
+    assert_series_eq(&(&diff_us + &date1)?, &date2);
+    assert_series_eq(&(&diff_ns + &date1)?, &date2);
+
+    Ok(())
 }
 
 fn assert_series_eq(s1: &Series, s2: &Series) {

--- a/crates/polars/tests/it/core/series.rs
+++ b/crates/polars/tests/it/core/series.rs
@@ -2,13 +2,15 @@ use polars::prelude::*;
 use polars::series::*;
 
 #[test]
-fn test_series_arithmetic() {
+fn test_series_arithmetic() -> PolarsResult<()> {
     let a = &Series::new("a", &[1, 100, 6, 40]);
     let b = &Series::new("b", &[-1, 2, 3, 4]);
-    assert_eq!(a + b, Series::new("a", &[0, 102, 9, 44]));
-    assert_eq!(a - b, Series::new("a", &[2, 98, 3, 36]));
-    assert_eq!(a * b, Series::new("a", &[-1, 200, 18, 160]));
-    assert_eq!(a / b, Series::new("a", &[-1, 50, 2, 10]));
+    assert_eq!((a + b)?, Series::new("a", &[0, 102, 9, 44]));
+    assert_eq!((a - b)?, Series::new("a", &[2, 98, 3, 36]));
+    assert_eq!((a * b)?, Series::new("a", &[-1, 200, 18, 160]));
+    assert_eq!((a / b)?, Series::new("a", &[-1, 50, 2, 10]));
+
+    Ok(())
 }
 
 #[test]

--- a/crates/polars/tests/it/lazy/folds.rs
+++ b/crates/polars/tests/it/lazy/folds.rs
@@ -10,7 +10,7 @@ fn test_fold_wildcard() -> PolarsResult<()> {
     let out = df1
         .clone()
         .lazy()
-        .select([fold_exprs(lit(0), |a, b| Ok(Some(&a + &b)), [col("*")]).alias("foo")])
+        .select([fold_exprs(lit(0), |a, b| (&a + &b).map(Some), [col("*")]).alias("foo")])
         .collect()?;
 
     assert_eq!(

--- a/crates/polars/tests/it/lazy/queries.rs
+++ b/crates/polars/tests/it/lazy/queries.rs
@@ -195,7 +195,7 @@ fn test_unknown_supertype_ignore() -> PolarsResult<()> {
 fn test_apply_multiple_columns() -> PolarsResult<()> {
     let df = fruits_cars();
 
-    let multiply = |s: &mut [Series]| Ok(Some(&(&s[0] * &s[0]) * &s[1]));
+    let multiply = |s: &mut [Series]| (&(&s[0] * &s[0])? * &s[1]).map(Some);
 
     let out = df
         .clone()

--- a/docs/src/rust/user-guide/expressions/folds.rs
+++ b/docs/src/rust/user-guide/expressions/folds.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let out = df
         .lazy()
-        .select([fold_exprs(lit(0), |acc, x| Ok(Some(acc + x)), [col("*")]).alias("sum")])
+        .select([fold_exprs(lit(0), |acc, x| (acc + x).map(Some), [col("*")]).alias("sum")])
         .collect()?;
     println!("{}", out);
     // --8<-- [end:mansum]

--- a/py-polars/src/series/arithmetic.rs
+++ b/py-polars/src/series/arithmetic.rs
@@ -7,23 +7,29 @@ use crate::PySeries;
 #[pymethods]
 impl PySeries {
     fn add(&self, other: &PySeries) -> PyResult<Self> {
-        let out = self
-            .series
-            .try_add(&other.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        Ok((&self.series + &other.series)
+            .map(Into::into)
+            .map_err(PyPolarsErr::from)?)
     }
-    fn sub(&self, other: &PySeries) -> Self {
-        (&self.series - &other.series).into()
+    fn sub(&self, other: &PySeries) -> PyResult<Self> {
+        Ok((&self.series - &other.series)
+            .map(Into::into)
+            .map_err(PyPolarsErr::from)?)
     }
-    fn div(&self, other: &PySeries) -> Self {
-        (&self.series / &other.series).into()
+    fn div(&self, other: &PySeries) -> PyResult<Self> {
+        Ok((&self.series / &other.series)
+            .map(Into::into)
+            .map_err(PyPolarsErr::from)?)
     }
-    fn mul(&self, other: &PySeries) -> Self {
-        (&self.series * &other.series).into()
+    fn mul(&self, other: &PySeries) -> PyResult<Self> {
+        Ok((&self.series * &other.series)
+            .map(Into::into)
+            .map_err(PyPolarsErr::from)?)
     }
-    fn rem(&self, other: &PySeries) -> Self {
-        (&self.series % &other.series).into()
+    fn rem(&self, other: &PySeries) -> PyResult<Self> {
+        Ok((&self.series % &other.series)
+            .map(Into::into)
+            .map_err(PyPolarsErr::from)?)
     }
 }
 

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -643,11 +643,13 @@ impl PySeries {
 
         let result: AnyValue = if lhs_dtype.is_float() || rhs_dtype.is_float() {
             (&self.series * &other.series)
+                .map_err(PyPolarsErr::from)?
                 .sum::<f64>()
                 .map_err(PyPolarsErr::from)?
                 .into()
         } else {
             (&self.series * &other.series)
+                .map_err(PyPolarsErr::from)?
                 .sum::<i64>()
                 .map_err(PyPolarsErr::from)?
                 .into()


### PR DESCRIPTION
This PR makes the ops for `Series` and `ChunkedArray` completely fallible, which allows us to more strictly enforce propagating the error or ignoring it.

This is the first part of #16958.