### PR TITLE
feat: Add `quantile` support for `Time`, `Date`, and `Datetime` dtypes

### DIFF
--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -339,6 +339,15 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
         ))
     }
 
+    fn quantile_reduce(
+        &self,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
+    ) -> PolarsResult<Scalar> {
+        let v = self.0.quantile_reduce(quantile, interpol)?;
+        Ok(Scalar::new(self.dtype().clone(), v.value().clone()))
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -366,12 +366,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Scalar> {
         let v = self.0.quantile_reduce(quantile, interpol)?;
-        let to = self.dtype().to_physical();
-        let v = v.value().cast(&to);
-        Ok(Scalar::new(
-            self.dtype().clone(),
-            v.as_duration(self.0.time_unit()),
-        ))
+        Ok(Scalar::new(self.dtype().clone(), v.value().clone()))
     }
 
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -362,10 +362,16 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
 
     fn quantile_reduce(
         &self,
-        _quantile: f64,
-        _interpol: QuantileInterpolOptions,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Scalar> {
-        Ok(Scalar::new(self.dtype().clone(), AnyValue::Null))
+        let v = self.0.quantile_reduce(quantile, interpol)?;
+        let to = self.dtype().to_physical();
+        let v = v.value().cast(&to);
+        Ok(Scalar::new(
+            self.dtype().clone(),
+            v.as_duration(self.0.time_unit()),
+        ))
     }
 
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -304,6 +304,15 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
         Ok(Scalar::new(self.dtype().clone(), av))
     }
 
+    fn quantile_reduce(
+        &self,
+        quantile: f64,
+        interpol: QuantileInterpolOptions,
+    ) -> PolarsResult<Scalar> {
+        let v = self.0.quantile_reduce(quantile, interpol)?;
+        Ok(Scalar::new(self.dtype().clone(), v.value().clone()))
+    }
+
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1352,3 +1352,67 @@ def test_dt_mean_deprecated() -> None:
     with pytest.deprecated_call():
         result = s.dt.mean()
     assert result == s.mean()
+
+
+@pytest.mark.parametrize(
+    ("values", "quantile", "expected"),
+    [
+        ([date(2024, 1, x) for x in range(1, 6)], 0.0, date(2024, 1, 1)),
+        ([date(2024, 1, x) for x in range(1, 6)], 0.3, date(2024, 1, 1)),
+        ([date(2024, 1, x) for x in range(1, 6)], 0.5, date(2024, 1, 1)),
+        ([date(2024, 1, x) for x in range(1, 6)], 0.75, date(2024, 1, 1)),
+        ([date(2024, 1, x) for x in range(1, 6)], 1.0, date(2024, 1, 1)),
+    ],
+)
+def test_date_quantile(values, quantile, expected) -> None:
+    s = pl.Series("a", values)
+    assert s.quantile(quantile) == expected
+    assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "quantile", "expected"),
+    [
+        ([datetime(2024, 1, x) for x in range(1, 6)], 0.0, datetime(2024, 1, 1)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 0.3, datetime(2024, 1, 1)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 0.5, datetime(2024, 1, 1)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 0.75, datetime(2024, 1, 1)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 1.0, datetime(2024, 1, 1)),
+    ],
+)
+def test_datetime_quantile(values, quantile, expected) -> None:
+    s = pl.Series("a", values)
+    assert s.quantile(quantile) == expected
+    assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "quantile", "expected"),
+    [
+        ([timedelta(days=x) for x in range(1, 6)], 0.0, timedelta(days=1)),
+        ([timedelta(days=x) for x in range(1, 6)], 0.3, timedelta(days=2)),
+        ([timedelta(days=x) for x in range(1, 6)], 0.5, timedelta(days=3)),
+        ([timedelta(days=x) for x in range(1, 6)], 0.75, timedelta(days=4)),
+        ([timedelta(days=x) for x in range(1, 6)], 1.0, timedelta(days=5)),
+    ],
+)
+def test_duration_quantile(values, quantile, expected) -> None:
+    s = pl.Series("a", values)
+    assert s.quantile(quantile) == expected
+    assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "quantile", "expected"),
+    [
+        ([time(hour=x) for x in range(1, 6)], 0.0, time(hour=1)),
+        ([time(hour=x) for x in range(1, 6)], 0.3, time(hour=2)),
+        ([time(hour=x) for x in range(1, 6)], 0.5, time(hour=3)),
+        ([time(hour=x) for x in range(1, 6)], 0.75, time(hour=4)),
+        ([time(hour=x) for x in range(1, 6)], 1.0, time(hour=5)),
+    ],
+)
+def test_time_quantile(values, quantile, expected) -> None:
+    s = pl.Series("a", values)
+    assert s.quantile(quantile) == expected
+    assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1358,13 +1358,13 @@ def test_dt_mean_deprecated() -> None:
     ("values", "quantile", "expected"),
     [
         ([date(2024, 1, x) for x in range(1, 6)], 0.0, date(2024, 1, 1)),
-        ([date(2024, 1, x) for x in range(1, 6)], 0.3, date(2024, 1, 1)),
-        ([date(2024, 1, x) for x in range(1, 6)], 0.5, date(2024, 1, 1)),
-        ([date(2024, 1, x) for x in range(1, 6)], 0.75, date(2024, 1, 1)),
-        ([date(2024, 1, x) for x in range(1, 6)], 1.0, date(2024, 1, 1)),
+        ([date(2024, 1, x) for x in range(1, 6)], 0.3, date(2024, 1, 2)),
+        ([date(2024, 1, x) for x in range(1, 6)], 0.5, date(2024, 1, 3)),
+        ([date(2024, 1, x) for x in range(1, 6)], 0.75, date(2024, 1, 4)),
+        ([date(2024, 1, x) for x in range(1, 6)], 1.0, date(2024, 1, 5)),
     ],
 )
-def test_date_quantile(values, quantile, expected) -> None:
+def test_date_quantile(values: list[date], quantile: float, expected: date) -> None:
     s = pl.Series("a", values)
     assert s.quantile(quantile) == expected
     assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected
@@ -1374,13 +1374,15 @@ def test_date_quantile(values, quantile, expected) -> None:
     ("values", "quantile", "expected"),
     [
         ([datetime(2024, 1, x) for x in range(1, 6)], 0.0, datetime(2024, 1, 1)),
-        ([datetime(2024, 1, x) for x in range(1, 6)], 0.3, datetime(2024, 1, 1)),
-        ([datetime(2024, 1, x) for x in range(1, 6)], 0.5, datetime(2024, 1, 1)),
-        ([datetime(2024, 1, x) for x in range(1, 6)], 0.75, datetime(2024, 1, 1)),
-        ([datetime(2024, 1, x) for x in range(1, 6)], 1.0, datetime(2024, 1, 1)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 0.3, datetime(2024, 1, 2)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 0.5, datetime(2024, 1, 3)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 0.75, datetime(2024, 1, 4)),
+        ([datetime(2024, 1, x) for x in range(1, 6)], 1.0, datetime(2024, 1, 5)),
     ],
 )
-def test_datetime_quantile(values, quantile, expected) -> None:
+def test_datetime_quantile(
+    values: list[datetime], quantile: float, expected: datetime
+) -> None:
     s = pl.Series("a", values)
     assert s.quantile(quantile) == expected
     assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected
@@ -1396,7 +1398,9 @@ def test_datetime_quantile(values, quantile, expected) -> None:
         ([timedelta(days=x) for x in range(1, 6)], 1.0, timedelta(days=5)),
     ],
 )
-def test_duration_quantile(values, quantile, expected) -> None:
+def test_duration_quantile(
+    values: list[timedelta], quantile: float, expected: timedelta
+) -> None:
     s = pl.Series("a", values)
     assert s.quantile(quantile) == expected
     assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected
@@ -1412,7 +1416,7 @@ def test_duration_quantile(values, quantile, expected) -> None:
         ([time(hour=x) for x in range(1, 6)], 1.0, time(hour=5)),
     ],
 )
-def test_time_quantile(values, quantile, expected) -> None:
+def test_time_quantile(values: list[time], quantile: float, expected: time) -> None:
     s = pl.Series("a", values)
     assert s.quantile(quantile) == expected
     assert s.to_frame().select(pl.col("a").quantile(quantile)).item() == expected

--- a/py-polars/tests/unit/operations/test_quantile.py
+++ b/py-polars/tests/unit/operations/test_quantile.py
@@ -1,0 +1,60 @@
+from statistics import quantiles
+
+import numpy as np
+import pytest
+from hypothesis import given, reproduce_failure
+from hypothesis.strategies import booleans, floats
+
+import polars as pl
+from polars.datatypes import FLOAT_DTYPES, INTEGER_DTYPES
+from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing.parametric import series, dtypes, series
+
+TEMPORAL_DTYPES = [pl.Duration]
+
+
+# default parameters for testing quantile
+default = series(
+    name="a",
+    allowed_dtypes=[*FLOAT_DTYPES, *INTEGER_DTYPES],
+    min_size=1,
+    allow_null=True,
+    allow_infinity=False,
+)
+
+
+@given(
+    s=default,
+    quantile=floats(min_value=0.0, max_value=1.0),
+)
+@pytest.mark.parametrize("method", ["nearest", "higher", "lower", "midpoint", "linear"])
+def test_quantile_df_numeric(s: pl.Series, quantile: float, method: str):
+    # test Series
+    result = s.quantile(quantile, interpolation=method)
+
+    # we must remove nulls prior to passing to numpy
+    s_no_null = s.drop_nulls()
+    if s_no_null.is_empty():
+        assert result is None
+        return
+
+    expected = np.quantile(s_no_null.to_list(), quantile, method=method)
+
+    # Series
+    assert result == expected
+
+    # Expr
+    assert (
+        s.to_frame().select(pl.col("a").quantile(quantile, interpolation=method)).item()
+        == expected
+    )
+
+    # Lazy
+    assert (
+        s.to_frame()
+        .lazy()
+        .select(pl.col("a").quantile(quantile, interpolation=method))
+        .collect()
+        .item()
+        == expected
+    )


### PR DESCRIPTION
`quantile` is implemented for `Duration` but not for the other three temporal types. I have added unit tests for all four temporal types.