### PR TITLE
fix(python): Fix edge case in DataFrame constructor data orientation inference

### DIFF
--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -13,6 +13,7 @@ import pytest
 from pydantic import BaseModel, Field, TypeAdapter
 
 import polars as pl
+from polars._utils.construction.dataframe import _infer_data_orientation
 from polars._utils.construction.utils import try_get_type_hints
 from polars.datatypes import PolarsDataType, numpy_char_code_to_dtype
 from polars.dependencies import dataclasses, pydantic
@@ -1622,3 +1623,13 @@ def test_array_construction() -> None:
     df = pl.from_dicts(rows, schema=schema)
     assert df.schema == schema
     assert df.rows() == [("a", [1, 2, 3]), ("b", [2, 3, 4])]
+
+
+def test_infer_data_orientation() -> None:
+    assert _infer_data_orientation([1], 1) == "col"
+    assert _infer_data_orientation([1, 2], 2) == "col"
+    assert _infer_data_orientation([1, 2], 2, 2) == "col"
+    assert _infer_data_orientation([1, 2, 3], 2) == "col"
+    assert _infer_data_orientation([1, 2, 3], 2, 2) == "col"
+    assert _infer_data_orientation([1, 2, 3], 2, 3) == "row"
+    assert _infer_data_orientation([1, "x"], 2) == "row"


### PR DESCRIPTION
I found an edge case where the input `[[1]]` would be interpreted row-wise when it could be interpreted column-wise.

We'll get rid of this logic anyway, but I have to fix this to properly deprecate it, otherwise we get false positives.