### PR TITLE
test: Fix file cache verbose logging leakage during pytest

### DIFF
--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -32,23 +32,22 @@ pub(super) static GLOBAL_FILE_CACHE_LOCK: Lazy<GlobalLock> = Lazy::new(|| {
     pl_async::get_runtime().spawn(async move {
         let access_tracker = at_bool;
         let notify_lock_acquired = notify_lock_acquired_2;
-        let verbose = config::verbose();
 
         loop {
-            if verbose {
+            if config::verbose() {
                 eprintln!("file cache background unlock: waiting for acquisition notification");
             }
 
             notify_lock_acquired.notified().await;
 
-            if verbose {
+            if config::verbose() {
                 eprintln!("file cache background unlock: got acquisition notification");
             }
 
             loop {
                 if !access_tracker.swap(false, std::sync::atomic::Ordering::Relaxed) {
                     if let Some(unlocked_by_this_call) = GLOBAL_FILE_CACHE_LOCK.try_unlock() {
-                        if unlocked_by_this_call && verbose {
+                        if unlocked_by_this_call && config::verbose() {
                             eprintln!(
                                 "file cache background unlock: unlocked global file cache lockfile"
                             );

--- a/crates/polars-io/src/file_cache/eviction.rs
+++ b/crates/polars-io/src/file_cache/eviction.rs
@@ -154,9 +154,7 @@ impl EvictionManager {
     /// * `self.data_dir`
     /// * `self.metadata_dir`
     pub(super) fn run_in_background(mut self) {
-        let verbose = config::verbose();
-
-        if verbose {
+        if config::verbose() {
             eprintln!(
                 "[EvictionManager] creating cache eviction background task, self.min_ttl = {}",
                 self.min_ttl.load(std::sync::atomic::Ordering::Relaxed)
@@ -181,7 +179,7 @@ impl EvictionManager {
                     Ok(_) if self.files_to_remove.as_ref().unwrap().is_empty() => {},
                     Ok(_) => loop {
                         if let Some(guard) = GLOBAL_FILE_CACHE_LOCK.try_lock_exclusive() {
-                            if verbose {
+                            if config::verbose() {
                                 eprintln!(
                                     "[EvictionManager] got exclusive cache lock, evicting {} files",
                                     self.files_to_remove.as_ref().unwrap().len()
@@ -194,7 +192,7 @@ impl EvictionManager {
                         tokio::time::sleep(Duration::from_secs(7)).await;
                     },
                     Err(err) => {
-                        if verbose {
+                        if config::verbose() {
                             eprintln!("[EvictionManager] error updating file list: {}", err);
                         }
                     },


### PR DESCRIPTION
I played around a bit, I think what happens is pytest joins on the N workers it spawns together at the end, and some workers finish running tests earlier. This and combined with that pytest I think only silences test output during execution of a test, so the workers that have finished (and are getting joined on) no longer have silenced stdout/stderr, the printing from the background task then gets displayed after the background task runs, as POLARS_VERBOSE was set to true during the test execution 

I can seemingly confirm because the more I increase the worker count, the more messages get logged.

This is fixed by not caching the `config::verbose` value, as it gets unset after the test finishes.