### PR TITLE
docs: Lots of additions to the SQL reference docs

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -851,7 +851,7 @@ impl SQLContext {
                 let lf = self.execute_query(query)?;
                 self.register(tbl_name, lf);
                 let out = df! {
-                    "Response" => ["Create Table"]
+                    "Response" => ["CREATE TABLE"]
                 }
                 .unwrap()
                 .lazy();

--- a/crates/polars-sql/tests/functions_io.rs
+++ b/crates/polars-sql/tests/functions_io.rs
@@ -15,7 +15,7 @@ fn read_csv_tbl_func() {
             FROM read_csv('../../examples/datasets/foods1.csv')"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let create_tbl_res = df! {
-        "Response" => ["Create Table"]
+        "Response" => ["CREATE TABLE"]
     }
     .unwrap();
     assert!(df_sql.equals(&create_tbl_res));
@@ -74,7 +74,7 @@ fn read_parquet_tbl() {
             FROM read_parquet('../../examples/datasets/foods1.parquet')"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let create_tbl_res = df! {
-        "Response" => ["Create Table"]
+        "Response" => ["CREATE TABLE"]
     }
     .unwrap();
     assert!(df_sql.equals(&create_tbl_res));
@@ -97,7 +97,7 @@ fn read_ipc_tbl() {
             FROM read_ipc('../../examples/datasets/foods1.ipc')"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let create_tbl_res = df! {
-        "Response" => ["Create Table"]
+        "Response" => ["CREATE TABLE"]
     }
     .unwrap();
     assert!(df_sql.equals(&create_tbl_res));

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -420,7 +420,7 @@ fn test_create_table() {
         FROM df"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let create_tbl_res = df! {
-        "Response" => ["Create Table"]
+        "Response" => ["CREATE TABLE"]
     }
     .unwrap();
     assert!(df_sql.equals(&create_tbl_res));

--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -1,5 +1,5 @@
 /* To have blue background of width of the block (instead of width of content) */
-dl.class>dt:first-of-type {
+dl.class > dt:first-of-type {
     display: block !important;
 }
 
@@ -28,6 +28,7 @@ html[data-theme="dark"] {
 div.bd-sidebar-primary {
     background-image: linear-gradient(90deg, var(--pst-gradient-sidebar-left) 0%, var(--pst-gradient-sidebar-right) 100%);
 }
+
 div.sd-card {
     background-image: linear-gradient(0deg, var(--pst-gradient-sidebar-left) 0%, var(--pst-gradient-sidebar-right) 100%);
 }
@@ -44,6 +45,7 @@ footer.bd-footer {
 div.bd-sidebar-secondary {
     display: none;
 }
+
 label.sidebar-toggle.secondary-toggle {
     display: none !important;
 }
@@ -56,4 +58,9 @@ a:visited {
 /* fix ugly navbar scrollbar display */
 .sidebar-primary-items__end {
     margin: 0 !important;
+}
+
+/* give code examples the same faint drop-shadow as admonitions */
+pre {
+    box-shadow: 0 .2rem .5rem var(--pst-color-shadow), 0 0 .0625rem var(--pst-color-shadow) !important;
 }

--- a/py-polars/docs/source/reference/dataframe/index.rst
+++ b/py-polars/docs/source/reference/dataframe/index.rst
@@ -19,6 +19,8 @@ This page gives an overview of all public DataFrame methods.
    plot
    style
 
+.. _dataframe:
+
 .. currentmodule:: polars
 
 .. autoclass:: DataFrame

--- a/py-polars/docs/source/reference/lazyframe/index.rst
+++ b/py-polars/docs/source/reference/lazyframe/index.rst
@@ -15,6 +15,8 @@ This page gives an overview of all public LazyFrame methods.
    modify_select
    miscellaneous
 
+.. _lazyframe:
+
 .. currentmodule:: polars
 
 .. autoclass:: LazyFrame

--- a/py-polars/docs/source/reference/series/index.rst
+++ b/py-polars/docs/source/reference/series/index.rst
@@ -25,6 +25,8 @@ This page gives an overview of all public Series methods.
    struct
    temporal
 
+.. _series:
+
 .. currentmodule:: polars
 
 .. autoclass:: Series

--- a/py-polars/docs/source/reference/sql/clauses.rst
+++ b/py-polars/docs/source/reference/sql/clauses.rst
@@ -9,16 +9,18 @@ SQL Clauses
      - Description
    * - :ref:`SELECT <select>`
      - Retrieves specific column data from one or more tables.
+   * - :ref:`DISTINCT <distinct>`
+     - Returns unique values from a query.
    * - :ref:`FROM <from>`
      - Specify the table(s) from which to retrieve or delete data.
    * - :ref:`JOIN <join>`
      - Combine rows from two or more tables based on a related column.
    * - :ref:`WHERE <where>`
-     - Filter rows returned from the query based on specific condition(s).
+     - Filter rows returned from the query based on the given conditions.
    * - :ref:`GROUP BY <group_by>`
      - Aggregate row values based based on one or more key columns.
    * - :ref:`HAVING <having>`
-     - Filter groups in a `GROUP BY` based on specific condition(s).
+     - Filter groups in a `GROUP BY` based on the given conditions.
    * - :ref:`ORDER BY <order_by>`
      - Sort the query result based on one or more specified columns.
    * - :ref:`LIMIT <limit>`
@@ -55,6 +57,35 @@ Select the columns to be returned by the query.
     # │ 1   ┆ zz  │
     # │ 2   ┆ yy  │
     # │ 3   ┆ xx  │
+    # └─────┴─────┘
+
+.. _distinct:
+
+DISTINCT
+--------
+Returns unique values from a query.
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+      {
+        "a": [1, 2, 2, 1],
+        "b": ["xx", "yy", "yy", "xx"],
+      }
+    )
+    df.sql("""
+      SELECT DISTINCT * FROM self
+    """)
+    # shape: (2, 2)
+    # ┌─────┬─────┐
+    # │ a   ┆ b   │
+    # │ --- ┆ --- │
+    # │ i64 ┆ str │
+    # ╞═════╪═════╡
+    # │ 1   ┆ xx  │
+    # │ 2   ┆ yy  │
     # └─────┴─────┘
 
 .. _from:

--- a/py-polars/docs/source/reference/sql/clauses.rst
+++ b/py-polars/docs/source/reference/sql/clauses.rst
@@ -174,7 +174,7 @@ Combines rows from two or more tables based on a related column.
 WHERE
 -----
 
-Filter rows returned from the query based on specific condition(s).
+Filter rows returned from the query based on the given conditions.
 
 .. code-block:: python
 
@@ -229,7 +229,7 @@ Group rows that have the same values in specified columns into summary rows.
 
 HAVING
 ------
-Filter groups in a `GROUP BY` based on specific condition(s).
+Filter groups in a `GROUP BY` based on the given conditions.
 
 .. code-block:: python
 

--- a/py-polars/docs/source/reference/sql/functions/aggregate.rst
+++ b/py-polars/docs/source/reference/sql/functions/aggregate.rst
@@ -204,6 +204,10 @@ STDDEV
 ------
 Returns the standard deviation of all the elements in the grouping.
 
+.. admonition:: Function aliases
+
+   `STDEV`, `STDEV_SAMP`, `STDDEV_SAMP`
+
 **Example:**
 
 .. code-block:: python
@@ -260,6 +264,10 @@ Returns the sum of all the elements in the grouping.
 VARIANCE
 --------
 Returns the variance of all the elements in the grouping.
+
+.. admonition:: Function aliases
+
+   `VAR`, `VAR_SAMP`
 
 **Example:**
 

--- a/py-polars/docs/source/reference/sql/functions/math.rst
+++ b/py-polars/docs/source/reference/sql/functions/math.rst
@@ -95,9 +95,13 @@ Returns the cube root (∛) of a number.
 
 .. _ceil:
 
-CEIL 
+CEIL
 ----
 Returns the nearest integer closest from zero.
+
+.. admonition:: Function aliases
+
+   `CEILING`
 
 **Example:**
 
@@ -145,7 +149,7 @@ Returns the integer quotient of the division.
 
 .. _exp:
 
-EXP 
+EXP
 ---
 Computes the exponential of the given value.
 
@@ -170,7 +174,7 @@ Computes the exponential of the given value.
 
 .. _floor_function:
 
-FLOOR 
+FLOOR
 -----
 Returns the nearest integer away from zero.
 
@@ -245,7 +249,7 @@ Computes the `base` logarithm of the given value.
 
 .. _log2:
 
-LOG2 
+LOG2
 ----
 Computes the logarithm of the given value in base 2.
 
@@ -372,6 +376,10 @@ Returns a (good) approximation of 𝜋.
 POW
 ---
 Returns the value to the power of the given exponent.
+
+.. admonition:: Function aliases
+
+   `POWER`
 
 **Example:**
 

--- a/py-polars/docs/source/reference/sql/functions/string.rst
+++ b/py-polars/docs/source/reference/sql/functions/string.rst
@@ -230,6 +230,10 @@ LENGTH
 ------
 Returns the character length of the string.
 
+.. admonition:: Function aliases
+
+   `CHAR_LENGTH`, `CHARACTER_LENGTH`
+
 **Example:**
 
 .. code-block:: python

--- a/py-polars/docs/source/reference/sql/index.rst
+++ b/py-polars/docs/source/reference/sql/index.rst
@@ -21,7 +21,7 @@ and operations supported by Polars.
         ^^^^^^^^^^^^^^
 
         .. toctree::
-           :maxdepth: 2
+           :maxdepth: 3
 
            python_api
 

--- a/py-polars/docs/source/reference/sql/python_api.rst
+++ b/py-polars/docs/source/reference/sql/python_api.rst
@@ -2,14 +2,112 @@
 Python API
 ==========
 
-SQLContext
-----------
 .. currentmodule:: polars
 
-Polars provides a SQL interface to query frame data; this is available through
-the :class:`SQLContext` object, detailed below, as well as the DataFrame
-:meth:`~polars.DataFrame.sql` and LazyFrame :meth:`~polars.LazyFrame.sql`
-methods (which make use of SQLContext internally).
+There are three primary entry points to the Polars SQL interface, each operating at a
+different level of granularity. There is the :class:`~polars.sql.SQLContext` object,
+a top-level :func:`polars.sql` function that operates on the global context, and
+frame-level :meth:`DataFrame.sql` and :meth:`LazyFrame.sql` methods.
+
+Global SQL
+----------
+
+Both :class:`~polars.sql.SQLContext` and the :func:`polars.sql` function can be used
+to execute SQL queries mediated by the Polars execution engine against Polars
+:ref:`DataFrame <dataframe>`, :ref:`LazyFrame <lazyframe>`, and :ref:`Series <series>`
+data, as well as `Pandas <https://pandas.pydata.org/>`_ DataFrame and Series, and
+`PyArrow <https://arrow.apache.org/docs/python/>`_ Table and RecordBatch objects.
+Non-Polars objects are implicitly converted to DataFrame when used in a SQL query; for
+PyArrow, and Pandas data that uses PyArrow dtypes, this conversion can be zero-copy if
+the underlying data maps to a type supported by Polars.
+
+**Example:**
+
+.. code-block:: python
+
+    import polars as pl
+    import pandas as pd
+
+    polars_df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [4, 5, 6, 7]})
+    pandas_df = pd.DataFrame({"a": [3, 4, 5, 6], "b": [6, 7, 8, 9]})
+    pyarrow_table = polars_df.to_arrow()
+    polars_series = (polars_df["a"] * 2).rename("c")
+
+    pl.sql(
+        """
+        SELECT a, b, SUM(c) AS c_total FROM (
+          SELECT * FROM polars_df                  -- polars frame
+            UNION ALL SELECT * FROM pandas_df      -- pandas frame
+            UNION ALL SELECT * FROM pyarrow_table  -- pyarrow table
+        ) all_data
+        INNER JOIN polars_series
+          ON polars_series.c == all_data.b         -- join on series
+        GROUP BY "a", "b"
+        ORDER BY "a", "b"
+        """
+    ).collect()
+
+    # shape: (3, 3)
+    # ┌─────┬─────┬─────────┐
+    # │ a   ┆ b   ┆ c_total │
+    # │ --- ┆ --- ┆ ---     │
+    # │ i64 ┆ i64 ┆ i64     │
+    # ╞═════╪═════╪═════════╡
+    # │ 1   ┆ 4   ┆ 8       │
+    # │ 3   ┆ 6   ┆ 18      │
+    # │ 5   ┆ 8   ┆ 8       │
+    # └─────┴─────┴─────────┘
+
+.. topic:: Documentation
+
+  * :meth:`polars.sql`
+
+
+Frame-level SQL
+---------------
+
+Executes SQL directly against the specific underlying eager/lazy frame, referencing
+it as "self"; returns a new frame representing the query result.
+
+**Example:**
+
+.. code-block:: python
+
+    import polars as pl
+
+    df = pl.DataFrame({
+        "a": [1, 2, 3],
+        "b": [4, 5, 6],
+    })
+    df.sql("""
+      SELECT a::uint4, (b * b) AS bb
+      FROM self WHERE a != 2
+    """)
+
+    # shape: (2, 2)
+    # ┌─────┬─────┐
+    # │ a   ┆ bb  │
+    # │ --- ┆ --- │
+    # │ u32 ┆ i64 │
+    # ╞═════╪═════╡
+    # │ 1   ┆ 16  │
+    # │ 3   ┆ 36  │
+    # └─────┴─────┘
+
+.. topic:: Documentation
+
+  * :meth:`DataFrame.sql`
+  * :meth:`LazyFrame.sql`
+
+
+SQLContext
+----------
+
+Polars provides a dedicated class for querying frame data that offers additional
+control over table registration and management of state, and can also be used as
+a context manager. This is the :class:`SQLContext` object, and it provides all of
+the core functionality used by the other SQL functions.
+
 
 .. py:class:: SQLContext
     :canonical: polars.sql.SQLContext
@@ -18,7 +116,7 @@ methods (which make use of SQLContext internally).
 
     .. automethod:: __init__
 
-    **Note:** can be used as a context manager.
+    **Note:** can also be used as a context manager.
 
     .. automethod:: __enter__
     .. automethod:: __exit__
@@ -30,8 +128,9 @@ Methods
    :toctree: api/
 
     SQLContext.execute
+    SQLContext.execute_global
     SQLContext.register
     SQLContext.register_globals
     SQLContext.register_many
-    SQLContext.unregister
     SQLContext.tables
+    SQLContext.unregister

--- a/py-polars/docs/source/reference/sql/python_api.rst
+++ b/py-polars/docs/source/reference/sql/python_api.rst
@@ -14,8 +14,17 @@ frame-level :meth:`DataFrame.sql` and :meth:`LazyFrame.sql` methods, and the
 :func:`polars.sql_expr` function that creates native expressions from SQL.
 
 
+Querying
+--------
+
+SQL queries can be issued against compatible data structures in the current globals,
+against specific frames, or incorporated into expressions.
+
+
+.. _global_sql:
+
 Global SQL
-----------
+~~~~~~~~~~
 
 Both :class:`~polars.sql.SQLContext` and the :func:`polars.sql` function can be used
 to execute SQL queries mediated by the Polars execution engine against Polars
@@ -35,8 +44,8 @@ zero-copy if the underlying data maps cleanly to a natively-supported dtype.
 
     polars_df = pl.DataFrame({"a": [1, 2, 3, 4], "b": [4, 5, 6, 7]})
     pandas_df = pd.DataFrame({"a": [3, 4, 5, 6], "b": [6, 7, 8, 9]})
-    pyarrow_table = polars_df.to_arrow()
     polars_series = (polars_df["a"] * 2).rename("c")
+    pyarrow_table = polars_df.to_arrow()
 
     pl.sql(
         """
@@ -46,7 +55,7 @@ zero-copy if the underlying data maps cleanly to a natively-supported dtype.
             UNION ALL SELECT * FROM pyarrow_table  -- pyarrow table
         ) all_data
         INNER JOIN polars_series
-          ON polars_series.c == all_data.b         -- join on series
+          ON polars_series.c = all_data.b          -- polars series
         GROUP BY "a", "b"
         ORDER BY "a", "b"
         """
@@ -67,9 +76,15 @@ zero-copy if the underlying data maps cleanly to a natively-supported dtype.
 
   * :meth:`polars.sql`
 
+.. seealso::
 
-Frame-level SQL
----------------
+  :ref:`SQLContext <sql_context>`
+
+
+.. _frame_sql:
+
+Frame SQL
+~~~~~~~~~
 
 Executes SQL directly against the specific underlying eager/lazy frame, referencing
 it as "self"; returns a new frame representing the query result.
@@ -105,8 +120,10 @@ it as "self"; returns a new frame representing the query result.
   * :meth:`LazyFrame.sql`
 
 
-Expressions
------------
+.. _expression_sql:
+
+Expression SQL
+~~~~~~~~~~~~~~
 
 The :func:`polars.sql_expr` function can be used to create native Polars expressions
 from SQL fragments.
@@ -142,8 +159,10 @@ from SQL fragments.
   * :meth:`polars.sql_expr`
 
 
+.. _sql_context:
+
 SQLContext
-----------
+~~~~~~~~~~
 
 Polars provides a dedicated class for querying frame data that offers additional
 control over table registration and management of state, and can also be used as
@@ -164,7 +183,7 @@ the core functionality used by the other SQL functions.
     .. automethod:: __exit__
 
 Methods
-~~~~~~~
+^^^^^^^
 
 .. autosummary::
    :toctree: api/
@@ -207,3 +226,7 @@ Methods
         # │ 2   ┆ 0.2     ┆ 53.4    │
         # │ 3   ┆ 0.3     ┆ 12.7    │
         # └─────┴─────────┴─────────┘
+
+.. seealso::
+
+  :ref:`pl.sql <global_sql>`

--- a/py-polars/docs/source/reference/sql/table_operations.rst
+++ b/py-polars/docs/source/reference/sql/table_operations.rst
@@ -8,35 +8,37 @@ Table Operations
    * - Function
      - Description
    * - :ref:`CREATE TABLE <create_table>`
-     - Create a new table and its columns from a SQL query against an existing table.
+     - Create a new table and its columns from a SQL query executed against an existing table.
    * - :ref:`DROP TABLES <drop_tables>`
-     - Delete a specified table and related data.
+     - Deletes the specified table, unregistering it.
    * - :ref:`EXPLAIN <explain>`
-     - Returns logical plan of the query.
+     - Returns the Polars execution plan for a given SQL query.
    * - :ref:`SHOW TABLES <show_tables>`
-     - Returns a list of all tables in the context.
+     - Returns a list of all tables registered in the given context.
    * - :ref:`UNNEST <unnest_table_func>`
-     - Unnest one or more arrays as columns in a new table.
+     - Unnest one or more arrays as columns in a new table object.
    * - :ref:`TRUNCATE <truncate>`
-     - Remove rows from table without deleting the table from context.
+     - Remove all data from a table without actually deleting it.
+
 
 .. _create_table:
 
 CREATE TABLE
 ------------
-Create a new table and its columns from a SQL query against an existing table.
+Create a new table and its columns from a SQL query executed against an existing table.
 
 **Example:**
 
 .. code-block:: sql
 
-    CREATE TABLE new_table AS SELECT * FROM df WHERE value > 42
+    CREATE TABLE new_table AS
+    SELECT * FROM existing_table WHERE value > 42
 
 .. _drop_tables:
 
 DROP TABLES
 -----------
-Delete a specified table and related data.
+Deletes the specified table, unregistering it.
 
 **Example:**
 
@@ -48,19 +50,19 @@ Delete a specified table and related data.
 
 EXPLAIN
 -------
-Returns Logical Plan of the query.
+Returns the Polars execution plan for a given SQL query.
 
 **Example:**
 
 .. code-block:: sql
 
-    EXPLAIN SELECT * FROM df
+    EXPLAIN SELECT * FROM some_table
 
 .. _show_tables:
 
 SHOW TABLES
 -----------
-Display the list of tables in the context.
+Returns a list of all tables registered in the given context.
 
 **Example:**
 
@@ -72,7 +74,7 @@ Display the list of tables in the context.
 
 UNNEST
 ------
-Unnest one or more arrays as columns in a new table.
+Unnest one or more arrays as columns in a new table object.
 
 **Example:**
 
@@ -89,10 +91,10 @@ Unnest one or more arrays as columns in a new table.
 
 TRUNCATE
 --------
-Removes all rows from the specified table, but keeps the table.
+Remove all data from a table without actually deleting it.
 
 **Example:**
 
 .. code-block:: sql
 
-    TRUNCATE TABLE df
+    TRUNCATE TABLE some_table

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -171,16 +171,16 @@ def test_sql_on_compatible_frame_types() -> None:
     ):
         res = pl.sql(
             """
-                        SELECT a, b, SUM(c) AS cc FROM (
-                          SELECT * FROM df               -- polars frame
-                            UNION ALL SELECT * FROM dfp  -- pandas frame
-                            UNION ALL SELECT * FROM dfa  -- pyarrow table
-                            UNION ALL SELECT * FROM dfb  -- pyarrow record batch
-                        ) tbl
-                        INNER JOIN dfs ON dfs.c == tbl.b -- join on pandas/polars series
-                        GROUP BY "a", "b"
-                        ORDER BY "a", "b"
-                    """
+            SELECT a, b, SUM(c) AS cc FROM (
+              SELECT * FROM df               -- polars frame
+                UNION ALL SELECT * FROM dfp  -- pandas frame
+                UNION ALL SELECT * FROM dfa  -- pyarrow table
+                UNION ALL SELECT * FROM dfb  -- pyarrow record batch
+            ) tbl
+            INNER JOIN dfs ON dfs.c == tbl.b -- join on pandas/polars series
+            GROUP BY "a", "b"
+            ORDER BY "a", "b"
+            """
         ).collect()
 
         expected = pl.DataFrame({"a": [1, 3], "b": [4, 6], "cc": [16, 24]})


### PR DESCRIPTION
* Extends the Python API section of the SQL docs with frame-level (`DataFrame.sql`, `LazyFrame.sql`) and top-level (`pl.sql` and `pl.sql_expr`) entries, with details/examples (including executing Polars SQL against pyarrow/pandas).
* Minor enhancement to code blocks; applies a small/faint drop-shadow that exactly matches admonitions. Looks slightly nicer and more visually consistent, especially when admonitions are found immediately adjacent.
* Added supported function aliases to several SQL functions (eg: `CEIL` can also be `CEILING`).
* Added `DISTINCT` to "clauses" docs.

More to come...