### PR TITLE
feat(python): Add `rechunk` parameter to `read_delta`

### DIFF
--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -20,6 +20,7 @@ def read_delta(
     *,
     version: int | str | datetime | None = None,
     columns: list[str] | None = None,
+    rechunk: bool = False,
     storage_options: dict[str, Any] | None = None,
     delta_table_options: dict[str, Any] | None = None,
     pyarrow_options: dict[str, Any] | None = None,
@@ -41,6 +42,9 @@ def read_delta(
         table is read.
     columns
         Columns to select. Accepts a list of column names.
+    rechunk
+        Make sure that all columns are contiguous in memory by
+        aggregating the chunks into a single array.
     storage_options
         Extra options for the storage backends supported by `deltalake`.
         For cloud storages, this may include configurations for authentication etc.
@@ -143,7 +147,7 @@ def read_delta(
         delta_table_options=delta_table_options,
     )
 
-    return from_arrow(dl_tbl.to_pyarrow_table(columns=columns, **pyarrow_options))  # type: ignore[return-value]
+    return from_arrow(dl_tbl.to_pyarrow_table(columns=columns, **pyarrow_options), rechunk=rechunk)  # type: ignore[return-value]
 
 
 def scan_delta(

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -147,7 +147,9 @@ def read_delta(
         delta_table_options=delta_table_options,
     )
 
-    return from_arrow(dl_tbl.to_pyarrow_table(columns=columns, **pyarrow_options), rechunk=rechunk)  # type: ignore[return-value]
+    return from_arrow(
+        dl_tbl.to_pyarrow_table(columns=columns, **pyarrow_options), rechunk=rechunk
+    )  # type: ignore[return-value]
 
 
 def scan_delta(

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -501,3 +501,20 @@ def test_categorical_becomes_string(tmp_path: Path) -> None:
     df.write_delta(tmp_path)
     df2 = pl.read_delta(str(tmp_path))
     assert_frame_equal(df2, pl.DataFrame({"a": ["A", "B", "A"]}, schema={"a": pl.Utf8}))
+
+
+@pytest.mark.write_disk()
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.parametrize("rechunk_and_expected_chunks", [(True, 1), (False, 3)])
+def test_read_parquet_respects_rechunk_16982(
+    use_pyarrow: bool, rechunk_and_expected_chunks: tuple[bool, int], tmp_path: Path
+) -> None:
+    # Create a delta lake table with 3 chunks:
+    df = pl.DataFrame({"a": [1]})
+    df.write_delta(str(tmp_path))
+    df.write_delta(str(tmp_path), mode='append')
+    df.write_delta(str(tmp_path), mode='append')
+
+    rechunk, expected_chunks = rechunk_and_expected_chunks
+    result = pl.read_parquet(str(tmp_path), use_pyarrow=use_pyarrow, rechunk=rechunk)
+    assert result.n_chunks() == expected_chunks

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -504,10 +504,9 @@ def test_categorical_becomes_string(tmp_path: Path) -> None:
 
 
 @pytest.mark.write_disk()
-@pytest.mark.parametrize("use_pyarrow", [True, False])
 @pytest.mark.parametrize("rechunk_and_expected_chunks", [(True, 1), (False, 3)])
 def test_read_parquet_respects_rechunk_16982(
-    use_pyarrow: bool, rechunk_and_expected_chunks: tuple[bool, int], tmp_path: Path
+    rechunk_and_expected_chunks: tuple[bool, int], tmp_path: Path
 ) -> None:
     # Create a delta lake table with 3 chunks:
     df = pl.DataFrame({"a": [1]})
@@ -516,5 +515,5 @@ def test_read_parquet_respects_rechunk_16982(
     df.write_delta(str(tmp_path), mode='append')
 
     rechunk, expected_chunks = rechunk_and_expected_chunks
-    result = pl.read_delta(str(tmp_path), use_pyarrow=use_pyarrow, rechunk=rechunk)
+    result = pl.read_delta(str(tmp_path), rechunk=rechunk)
     assert result.n_chunks() == expected_chunks

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -511,8 +511,8 @@ def test_read_parquet_respects_rechunk_16982(
     # Create a delta lake table with 3 chunks:
     df = pl.DataFrame({"a": [1]})
     df.write_delta(str(tmp_path))
-    df.write_delta(str(tmp_path), mode='append')
-    df.write_delta(str(tmp_path), mode='append')
+    df.write_delta(str(tmp_path), mode="append")
+    df.write_delta(str(tmp_path), mode="append")
 
     rechunk, expected_chunks = rechunk_and_expected_chunks
     result = pl.read_delta(str(tmp_path), rechunk=rechunk)

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -516,5 +516,5 @@ def test_read_parquet_respects_rechunk_16982(
     df.write_delta(str(tmp_path), mode='append')
 
     rechunk, expected_chunks = rechunk_and_expected_chunks
-    result = pl.read_parquet(str(tmp_path), use_pyarrow=use_pyarrow, rechunk=rechunk)
+    result = pl.read_delta(str(tmp_path), use_pyarrow=use_pyarrow, rechunk=rechunk)
     assert result.n_chunks() == expected_chunks


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/16982

1. Add rechunk=False to polars.read_delta();
2. Add unit test for pl.read_delta(..., rechunk=False) with reference to [https://github.com/itamarst/polars/blob/616861217faf097f0568c8ede15d72b156d52561/py-polars/tests/unit/io/test_parquet.py#L109](#16416)