### PR TITLE
perf: Desugar `AND` filter into multiple nodes

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -11,6 +11,7 @@ ba = "ba"
 nd = "nd"
 opt_nd = "opt_nd"
 ser = "ser"
+ANDed = "ANDed"
 
 [default.extend-words]
 arange = "arange"

--- a/crates/polars-plan/src/logical_plan/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/stack_opt.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use super::*;
 
-/// Applies expression simplification and type coercion during converison to IR.
+/// Applies expression simplification and type coercion during conversion to IR.
 pub(super) struct ConversionOptimizer {
     scratch: Vec<Node>,
     simplify: Option<SimplifyExprRule>,

--- a/crates/polars-plan/src/logical_plan/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/logical_plan/conversion/stack_opt.rs
@@ -2,13 +2,14 @@ use std::borrow::Borrow;
 
 use super::*;
 
-pub(super) struct ConversionOpt {
+/// Applies expression simplification and type coercion during converison to IR.
+pub(super) struct ConversionOptimizer {
     scratch: Vec<Node>,
     simplify: Option<SimplifyExprRule>,
     coerce: Option<TypeCoercionRule>,
 }
 
-impl ConversionOpt {
+impl ConversionOptimizer {
     pub(super) fn new(simplify: bool, type_coercion: bool) -> Self {
         let simplify = if simplify {
             Some(SimplifyExprRule {})
@@ -22,7 +23,7 @@ impl ConversionOpt {
             None
         };
 
-        ConversionOpt {
+        ConversionOptimizer {
             scratch: Vec::with_capacity(8),
             simplify,
             coerce,


### PR DESCRIPTION
@alexander-beedie FYI. This should ensure the same performance as explicit nodes.