### PR TITLE
fix(rust, python): Correctly convert data frames to NumPy for C index order

### DIFF
--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -139,7 +139,8 @@ impl DataFrame {
                     match ordering {
                         IndexOrder::C => unsafe {
                             let num_cols = columns.len();
-                            let mut offset = (ptr as *mut N::Native).add(col_idx + chunk_offset);
+                            let mut offset =
+                                (ptr as *mut N::Native).add(col_idx + chunk_offset * num_cols);
                             for v in vals.iter() {
                                 *offset = *v;
                                 offset = offset.add(num_cols);

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -10,6 +10,7 @@ from hypothesis import given
 from numpy.testing import assert_array_equal, assert_equal
 
 import polars as pl
+from polars.testing import assert_frame_equal
 from polars.testing.parametric import series
 
 if TYPE_CHECKING:
@@ -274,3 +275,13 @@ def test_to_numpy_chunked_16375() -> None:
         ).to_numpy()
         == np.array([[1, 2], [1, 3], [2, 4], [1, 2], [1, 3], [2, 4]])
     ).all()
+
+
+def test_to_numpy_c_order_1700() -> None:
+    rng = np.random.default_rng()
+    df = pl.DataFrame({f"col_{i}": rng.normal(size=20) for i in range(3)})
+    df_chunked = pl.concat([df.slice(i * 10, 10) for i in range(3)])
+    assert_frame_equal(
+        df_chunked,
+        pl.from_numpy(df_chunked.to_numpy(order="c"), schema=df_chunked.schema),
+    )


### PR DESCRIPTION
# Motivation

https://github.com/pola-rs/polars/pull/16288 introduced a regression that caused `to_numpy(order="c")` calls to silently yield erroneous NumPy arrays whenever the data frame has more than one chunk. To reproduce with the latest release or polars `main`:

```python
import numpy as np
import polars as pl
from polars.testing import assert_frame_equal

rng = np.random.default_rng()
df = pl.DataFrame({
    f"col_{i}": rng.normal(size=100_000)
    for i in range(1000)
})
df_chunked = pl.concat([df.slice(i * 10_000, 10_000) for i in range(10)])
assert_frame_equal(
    df_chunked,
    pl.from_numpy(df_chunked.to_numpy(order="c"), schema=df_chunked.schema)
)
```

Currently, this results in an assertion failure. This PR fixes the issue.

---

I'm not sure if this is easily feasible but it would be great if this change could be released prior to a v1 release as it is quite a nasty bug 👀 
