### PR TITLE
docs(python): Clarify explanation and examples for `.eq_missing`

### DIFF
--- a/py-polars/docs/source/reference/series/index.rst
+++ b/py-polars/docs/source/reference/series/index.rst
@@ -20,6 +20,7 @@ This page gives an overview of all public Series methods.
    list
    modify_select
    miscellaneous
+   operators
    plot
    string
    struct

--- a/py-polars/docs/source/reference/series/operators.rst
+++ b/py-polars/docs/source/reference/series/operators.rst
@@ -1,0 +1,27 @@
+=========
+Operators
+=========
+
+Comparison
+~~~~~~~~~~
+
+.. currentmodule:: polars
+.. autosummary::
+   :toctree: api/
+
+   Series.eq
+   Series.eq_missing
+   Series.ge
+   Series.gt
+   Series.le
+   Series.lt
+   Series.ne
+   Series.ne_missing
+
+Numeric
+~~~~~~~
+
+.. autosummary::
+   :toctree: api/
+
+   Series.pow

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5008,8 +5008,10 @@ class Expr:
         Equality operator where null is treated as a distinct value.
 
         This differs from default `eq` where null values are propagated.
-        With this method, `None == None` returns `True` instead of `None`,
-        and `x == None` returns `False` instead of `None` where `x` is not `None`.
+        Equality operator where null is treated as a distinct value.
+        With this method, null is equal to null and is not equal to any other value.
+
+
 
         Parameters
         ----------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5005,7 +5005,7 @@ class Expr:
 
     def eq_missing(self, other: Any) -> Self:
         """
-        Equality operator where `None` is treated as a distinct value.
+        Equality operator where null is treated as a distinct value.
 
         This differs from default `eq` where null values are propagated.
         With this method, `None == None` returns `True` instead of `None`,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5005,9 +5005,11 @@ class Expr:
 
     def eq_missing(self, other: Any) -> Self:
         """
-        Method equivalent of equality operator `expr == other` where `None == None`.
+        Equality operator where `None` is treated as a distinct value.
 
         This differs from default `eq` where null values are propagated.
+        With this method, `None == None` returns `True` instead of `None`,
+        and `x == None` returns `False` instead of `None` where `x` is not `None`.
 
         Parameters
         ----------
@@ -5018,8 +5020,8 @@ class Expr:
         --------
         >>> df = pl.DataFrame(
         ...     data={
-        ...         "x": [1.0, 2.0, float("nan"), 4.0, None, None],
-        ...         "y": [2.0, 2.0, float("nan"), 4.0, 5.0, None],
+        ...         "x": [1.0, 2.0, float("nan"), None, None, 5.0],
+        ...         "y": [2.0, 2.0, float("nan"), None, 5.0, None],
         ...     }
         ... )
         >>> df.with_columns(
@@ -5035,9 +5037,9 @@ class Expr:
         │ 1.0  ┆ 2.0  ┆ false  ┆ false          │
         │ 2.0  ┆ 2.0  ┆ true   ┆ true           │
         │ NaN  ┆ NaN  ┆ true   ┆ true           │
-        │ 4.0  ┆ 4.0  ┆ true   ┆ true           │
-        │ null ┆ 5.0  ┆ null   ┆ false          │
         │ null ┆ null ┆ null   ┆ true           │
+        │ null ┆ 5.0  ┆ null   ┆ false          │
+        │ 5.0  ┆ null ┆ null   ┆ false          │
         └──────┴──────┴────────┴────────────────┘
         """
         other = parse_into_expression(other, str_as_lit=True)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5008,7 +5008,6 @@ class Expr:
         Equality operator where null is treated as a distinct value.
 
         This differs from default `eq` where null values are propagated.
-        Equality operator where null is treated as a distinct value.
         With this method, null is equal to null and is not equal to any other value.
 
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -820,9 +820,9 @@ class Series:
 
     def eq_missing(self, other: Any) -> Series | Expr:
         """
-        Method equivalent of equality operator `series == other` where `None == None`.
-
-        This differs from the standard `ne` where null values are propagated.
+        This differs from default `eq` where null values are propagated.
+        Equality operator where null is treated as a distinct value.
+        With this method, null is equal to null and is not equal to any other value.
 
         Parameters
         ----------
@@ -836,14 +836,16 @@ class Series:
 
         Examples
         --------
-        >>> s1 = pl.Series("a", [333, 200, None])
-        >>> s2 = pl.Series("a", [100, 200, None])
+        >>> s1 = pl.Series("a", [333, 200, None, 100, None])
+        >>> s2 = pl.Series("a", [100, 200, None, None, 100])
         >>> s1.eq(s2)
         shape: (3,)
         Series: 'a' [bool]
         [
             false
             true
+            null
+            null
             null
         ]
         >>> s1.eq_missing(s2)
@@ -853,6 +855,8 @@ class Series:
             false
             true
             true
+            false
+            false
         ]
         """
         if isinstance(other, pl.Expr):

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -820,6 +820,8 @@ class Series:
 
     def eq_missing(self, other: Any) -> Series | Expr:
         """
+        Equality operator where null is treated as a distinct value.
+
         This differs from default `eq` where null values are propagated.
         Equality operator where null is treated as a distinct value.
         With this method, null is equal to null and is not equal to any other value.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -841,7 +841,7 @@ class Series:
         >>> s1 = pl.Series("a", [333, 200, None, 100, None])
         >>> s2 = pl.Series("a", [100, 200, None, None, 100])
         >>> s1.eq(s2)
-        shape: (3,)
+        shape: (5,)
         Series: 'a' [bool]
         [
             false
@@ -851,7 +851,7 @@ class Series:
             null
         ]
         >>> s1.eq_missing(s2)
-        shape: (3,)
+        shape: (5,)
         Series: 'a' [bool]
         [
             false


### PR DESCRIPTION
Fixes #16867 with explanation proposed by @mcrumiller. Provides examples that `.eq_missing()` will return `False` whether the number is on the left (the Expr) or right (the `other` parameter) when the other value is `None`. For documentation page https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.eq_missing.html.