### PR TITLE
feat: allow experimental metadata use on release

### DIFF
--- a/crates/polars-core/src/chunked_array/metadata/collect.rs
+++ b/crates/polars-core/src/chunked_array/metadata/collect.rs
@@ -9,7 +9,7 @@ where
     ChunkedArray<T>: ChunkAgg<T::Native>,
 {
     fn collect_cheap_metadata(&mut self) {
-        if !MetadataEnv::extensive_use() {
+        if !MetadataEnv::experimental_enabled() {
             return;
         }
 

--- a/crates/polars-core/src/chunked_array/metadata/env.rs
+++ b/crates/polars-core/src/chunked_array/metadata/env.rs
@@ -1,50 +1,67 @@
 #[derive(Debug, Clone, Copy)]
-pub struct MetadataEnv(#[cfg(debug_assertions)] u32);
+pub struct MetadataEnv(u32);
 
-#[cfg(debug_assertions)]
 impl MetadataEnv {
-    pub const ENABLED: u32 = 0x1;
-    pub const EXTENSIVE_USE: u32 = 0x2;
-    pub const LOG: u32 = 0x4;
+    const ENV_VAR: &'static str = "POLARS_METADATA_USE";
 
-    #[inline(always)]
+    const ENABLED: u32 = 0x1;
+    const EXPERIMENTAL: u32 = 0x2;
+    const LOG: u32 = 0x4;
+
+    #[inline]
     fn get_cached() -> Self {
-        static CACHED: std::sync::OnceLock<MetadataEnv> = std::sync::OnceLock::new();
-        *CACHED.get_or_init(Self::get)
+        if cfg!(debug_assertions) {
+            let Ok(env) = std::env::var(Self::ENV_VAR) else {
+                return Self(Self::ENABLED);
+            };
+
+            // @NOTE
+            // We use a RwLock here so that we can mutate it for specific runs or sections of runs
+            // when we perform A/B tests.
+            static CACHED: std::sync::RwLock<Option<(String, MetadataEnv)>> =
+                std::sync::RwLock::new(None);
+
+            if let Some((cached_str, cached_value)) = CACHED.read().unwrap().as_ref() {
+                if cached_str == &env[..] {
+                    return *cached_value;
+                }
+            }
+
+            let v = Self::get();
+            *CACHED.write().unwrap() = Some((env.to_string(), v));
+            v
+        } else {
+            static CACHED: std::sync::OnceLock<MetadataEnv> = std::sync::OnceLock::new();
+            *CACHED.get_or_init(Self::get)
+        }
     }
 
-    #[inline(always)]
+    #[inline(never)]
     fn get() -> Self {
-        let Ok(env) = std::env::var("POLARS_METADATA_FLAGS") else {
+        let Ok(env) = std::env::var(Self::ENV_VAR) else {
             return Self(Self::ENABLED);
         };
 
-        if env == "0" {
-            return Self(0);
+        match &env[..] {
+            "0" => Self(0),
+            "1" => Self(Self::ENABLED),
+            "experimental" => Self(Self::ENABLED | Self::EXPERIMENTAL),
+            "experimental,log" => Self(Self::ENABLED | Self::EXPERIMENTAL | Self::LOG),
+            "log" => Self(Self::ENABLED | Self::LOG),
+            _ => {
+                eprintln!("Invalid `{}` environment variable", Self::ENV_VAR);
+                eprintln!("Possible values:");
+                eprintln!("  - 0                = Turn off all usage of metadata");
+                eprintln!("  - 1                = Turn on usage of metadata (default)");
+                eprintln!(
+                    "  - experimental     = Turn on normal and experimental usage of metadata"
+                );
+                eprintln!("  - experimental,log = Turn on normal, experimental usage and logging of metadata usage");
+                eprintln!("  - log              = Turn on normal and logging of metadata usage");
+                eprintln!();
+                panic!("Invalid environment variable")
+            },
         }
-
-        // @NOTE
-        // We use a RwLock here so that we can mutate it for specific runs or sections of runs when
-        // we perform A/B tests.
-        static CACHED: std::sync::RwLock<Option<(String, MetadataEnv)>> =
-            std::sync::RwLock::new(None);
-
-        if let Some((cached_str, cached_value)) = CACHED.read().unwrap().as_ref() {
-            if cached_str == &env {
-                return *cached_value;
-            }
-        };
-
-        let mut mdenv = Self(Self::ENABLED);
-        for arg in env.split(',') {
-            match &arg.trim().to_lowercase()[..] {
-                "extensive" => mdenv.0 |= Self::EXTENSIVE_USE,
-                "log" => mdenv.0 |= Self::LOG,
-                _ => panic!("Invalid `POLARS_METADATA_FLAGS` environment variable"),
-            }
-        }
-
-        mdenv
     }
 
     #[inline(always)]
@@ -54,48 +71,34 @@ impl MetadataEnv {
 
     #[inline(always)]
     pub fn enabled() -> bool {
-        Self::get().0 & Self::ENABLED != 0
+        if cfg!(debug_assertions) {
+            Self::get_cached().0 & Self::ENABLED != 0
+        } else {
+            true
+        }
     }
 
     #[inline(always)]
     pub fn log() -> bool {
-        Self::get_cached().0 & Self::LOG != 0
+        if cfg!(debug_assertions) {
+            Self::get_cached().0 & Self::LOG != 0
+        } else {
+            false
+        }
     }
 
     #[inline(always)]
-    pub fn extensive_use() -> bool {
-        Self::get().0 & Self::EXTENSIVE_USE != 0
+    pub fn experimental_enabled() -> bool {
+        Self::get_cached().0 & Self::EXPERIMENTAL != 0
     }
 
+    #[cfg(debug_assertions)]
     pub fn logfile() -> &'static std::sync::Mutex<std::fs::File> {
         static CACHED: std::sync::OnceLock<std::sync::Mutex<std::fs::File>> =
             std::sync::OnceLock::new();
         CACHED.get_or_init(|| {
             std::sync::Mutex::new(std::fs::File::create(".polars-metadata.log").unwrap())
         })
-    }
-}
-
-#[cfg(not(debug_assertions))]
-impl MetadataEnv {
-    #[inline(always)]
-    pub const fn disabled() -> bool {
-        false
-    }
-
-    #[inline(always)]
-    pub const fn enabled() -> bool {
-        true
-    }
-
-    #[inline(always)]
-    pub const fn log() -> bool {
-        false
-    }
-
-    #[inline(always)]
-    pub const fn extensive_use() -> bool {
-        false
     }
 }
 

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -67,9 +67,7 @@ impl PhysicalExpr for AggregationExpr {
 
         match group_by {
             GroupByMethod::Min => {
-                let extensive_use = MetadataEnv::extensive_use();
-
-                if extensive_use {
+                if MetadataEnv::experimental_enabled() {
                     if let Some(sc) = s.get_metadata_min_value() {
                         return Ok(sc.into_series(s.name()));
                     }
@@ -102,9 +100,7 @@ impl PhysicalExpr for AggregationExpr {
                 panic!("activate 'propagate_nans' feature")
             },
             GroupByMethod::Max => {
-                let extensive_use = MetadataEnv::extensive_use();
-
-                if extensive_use {
+                if MetadataEnv::experimental_enabled() {
                     if let Some(sc) = s.get_metadata_max_value() {
                         return Ok(sc.into_series(s.name()));
                     }


### PR DESCRIPTION
This renames the metadata flag from `POLARS_METADATA_FLAGS` to `POLARS_METADATA_USE`. I also renamed `extensive` to `experimental`. There are 3 settings that can be controlled.

| Setting      | Debug Build                        | Release Build                      |
|--------------|------------------------------------|------------------------------------|
| Enabled      | `POLARS_METADATA_USE=1` (default)  | `true`                             |
| Experimental | `POLARS_METADATA_USE=experimental` | `POLARS_METADATA_USE=experimental` |
| Logging      | `POLARS_METADATA_USE=log`          | `false`                            |

In the debug-mode, the value can be changed during runs to make A/B testing possible. For release-mode builds, the value is cached and cannot be changed after it is set initially.

There are 5 accepted values.

* `0`: Turn off all usage of metadata
* `1`: Turn on usage of metadata (default)
* `experimental`: Turn on normal and experimental usage of metadata
* `experimental,log`: Turn on normal, experimental usage and logging of metadata usage
* `log`: Turn on normal and logging of metadata usage

In general, the runtime overhead should be negligible since the value is cached and branch prediction should do it work on here.