### PR TITLE
test(python): Add some parametric tests for sort functionality

### DIFF
--- a/py-polars/docs/source/reference/exceptions.rst
+++ b/py-polars/docs/source/reference/exceptions.rst
@@ -11,7 +11,6 @@ Errors
     :nosignatures:
 
     PolarsError
-    ChronoFormatWarning
     ColumnNotFoundError
     ComputeError
     DuplicateError

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -247,7 +247,6 @@ __all__ = [
     "plugins",
     # exceptions - errors
     "PolarsError",
-    "ChronoFormatWarning",
     "ColumnNotFoundError",
     "ComputeError",
     "DuplicateError",

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -200,7 +200,6 @@ class UnstableWarning(PolarsWarning):  # type: ignore[misc]
 __all__ = [
     # Errors
     "PolarsError",
-    "ChronoFormatWarning",
     "ColumnNotFoundError",
     "ComputeError",
     "DuplicateError",

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -27,6 +27,7 @@ def test_series_sort_idempotent(s: pl.Series) -> None:
     df=dataframes(
         excluded_dtypes=[
             pl.Null,  # Bug, see: https://github.com/pola-rs/polars/issues/17007
+            pl.Decimal,  # Bug, see: https://github.com/pola-rs/polars/issues/17009
         ]
     )
 )

--- a/py-polars/tests/unit/testing/test_assert_frame_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_frame_equal.py
@@ -326,43 +326,32 @@ def test_assert_frame_equal_column_mismatch_order() -> None:
     assert_frame_equal(df1, df2, check_column_order=False)
 
 
-def test_assert_frame_equal_ignore_row_order() -> None:
+def test_assert_frame_equal_check_row_order() -> None:
     df1 = pl.DataFrame({"a": [1, 2], "b": [4, 3]})
     df2 = pl.DataFrame({"a": [2, 1], "b": [3, 4]})
-    df3 = pl.DataFrame({"b": [3, 4], "a": [2, 1]})
+
     with pytest.raises(AssertionError, match="value mismatch for column 'a'"):
         assert_frame_equal(df1, df2)
-
     assert_frame_equal(df1, df2, check_row_order=False)
-    # eg:
-    # ┌─────┬─────┐      ┌─────┬─────┐
-    # │ a   ┆ b   │      │ a   ┆ b   │
-    # │ --- ┆ --- │      │ --- ┆ --- │
-    # │ i64 ┆ i64 │ (eq) │ i64 ┆ i64 │
-    # ╞═════╪═════╡  ==  ╞═════╪═════╡
-    # │ 1   ┆ 4   │      │ 2   ┆ 3   │
-    # │ 2   ┆ 3   │      │ 1   ┆ 4   │
-    # └─────┴─────┘      └─────┴─────┘
+
+
+def test_assert_frame_equal_check_row_col_order() -> None:
+    df1 = pl.DataFrame({"a": [1, 2], "b": [4, 3]})
+    df3 = pl.DataFrame({"b": [3, 4], "a": [2, 1]})
 
     with pytest.raises(AssertionError, match="columns are not in the same order"):
         assert_frame_equal(df1, df3, check_row_order=False)
-
     assert_frame_equal(df1, df3, check_row_order=False, check_column_order=False)
 
-    class Foo:
-        def __init__(self) -> None:
-            pass
 
-    # note: not all column types support sorting
+def test_assert_frame_equal_check_row_order_unsortable() -> None:
+    df1 = pl.DataFrame({"a": [object(), object()], "b": [3, 4]})
+    df2 = pl.DataFrame({"a": [object(), object()], "b": [4, 3]})
     with pytest.raises(
         InvalidAssert,
         match="cannot set `check_row_order=False`.*unsortable columns",
     ):
-        assert_frame_equal(
-            left=pl.DataFrame({"a": [Foo(), Foo()], "b": [3, 4]}),
-            right=pl.DataFrame({"a": [Foo(), Foo()], "b": [4, 3]}),
-            check_row_order=False,
-        )
+        assert_frame_equal(df1, df2, check_row_order=False)
 
 
 def test_assert_frame_equal_dtypes_mismatch() -> None:


### PR DESCRIPTION
I caught two bugs, made separate issue for them:
https://github.com/pola-rs/polars/issues/17007
https://github.com/pola-rs/polars/issues/17009

Also an unrelated update to the docs - I had inadvertently added `ChronoFormatWarning` twice.