### PR TITLE
feat: Support directory paths in scans for Parquet, IPC and CSV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,6 +3182,7 @@ dependencies = [
  "bitflags 2.5.0",
  "futures",
  "glob",
+ "memchr",
  "once_cell",
  "polars-arrow",
  "polars-core",

--- a/crates/polars-io/src/options.rs
+++ b/crates/polars-io/src/options.rs
@@ -17,6 +17,7 @@ pub struct RowIndex {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HiveOptions {
     pub enabled: bool,
+    pub hive_start_idx: usize,
     pub schema: Option<SchemaRef>,
 }
 
@@ -24,6 +25,7 @@ impl Default for HiveOptions {
     fn default() -> Self {
         Self {
             enabled: true,
+            hive_start_idx: 0,
             schema: None,
         }
     }

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -26,6 +26,7 @@ polars-utils = { workspace = true }
 ahash = { workspace = true }
 bitflags = { workspace = true }
 glob = { version = "0.3" }
+memchr = { workspace = true }
 once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 rayon = { workspace = true }

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -13,7 +13,6 @@ use crate::prelude::*;
 #[derive(Clone)]
 #[cfg(feature = "csv")]
 pub struct LazyCsvReader {
-    path: PathBuf,
     paths: Arc<[PathBuf]>,
     glob: bool,
     cache: bool,
@@ -35,8 +34,7 @@ impl LazyCsvReader {
 
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyCsvReader {
-            path: path.as_ref().to_owned(),
-            paths: Arc::new([]),
+            paths: Arc::new([path.as_ref().to_path_buf()]),
             glob: true,
             cache: true,
             read_options: Default::default(),
@@ -218,15 +216,13 @@ impl LazyCsvReader {
     where
         F: Fn(Schema) -> PolarsResult<Schema>,
     {
-        let mut file = if let Some(mut paths) = self.iter_paths()? {
-            let path = match paths.next() {
-                Some(globresult) => globresult?,
-                None => polars_bail!(ComputeError: "globbing pattern did not match any files"),
-            };
-            polars_utils::open_file(path)
-        } else {
-            polars_utils::open_file(&self.path)
-        }?;
+        let paths = self.expand_paths()?.0;
+        let Some(path) = paths.first() else {
+            polars_bail!(ComputeError: "no paths specified for this reader");
+        };
+
+        let mut file = polars_utils::open_file(path)?;
+
         let reader_bytes = get_reader_bytes(&mut file).expect("could not mmap file");
         let skip_rows = self.read_options.skip_rows;
         let parse_options = self.read_options.get_parse_options();
@@ -264,25 +260,9 @@ impl LazyCsvReader {
 
 impl LazyFileListReader for LazyCsvReader {
     /// Get the final [LazyFrame].
-    fn finish(mut self) -> PolarsResult<LazyFrame> {
-        if !self.glob {
-            return self.finish_no_glob();
-        }
-        if let Some(paths) = self.iter_paths()? {
-            let paths = paths
-                .into_iter()
-                .collect::<PolarsResult<Arc<[PathBuf]>>>()?;
-            self.paths = paths;
-        }
-        self.finish_no_glob()
-    }
-
-    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
-        let paths = if self.paths.is_empty() {
-            Arc::new([self.path])
-        } else {
-            self.paths
-        };
+    fn finish(self) -> PolarsResult<LazyFrame> {
+        // `expand_paths` respects globs
+        let paths = self.expand_paths()?.0;
 
         let mut lf: LazyFrame =
             DslBuilder::scan_csv(paths, self.read_options, self.cache, self.cloud_options)?
@@ -292,21 +272,16 @@ impl LazyFileListReader for LazyCsvReader {
         Ok(lf)
     }
 
+    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
+        unreachable!();
+    }
+
     fn glob(&self) -> bool {
         self.glob
     }
 
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
     fn paths(&self) -> &[PathBuf] {
         &self.paths
-    }
-
-    fn with_path(mut self, path: PathBuf) -> Self {
-        self.path = path;
-        self
     }
 
     fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {

--- a/crates/polars-lazy/src/scan/file_list_reader.rs
+++ b/crates/polars-lazy/src/scan/file_list_reader.rs
@@ -1,4 +1,5 @@
-use std::path::{Path, PathBuf};
+use std::collections::VecDeque;
+use std::path::PathBuf;
 
 use polars_core::error::to_compute_err;
 use polars_core::prelude::*;
@@ -11,23 +12,124 @@ use crate::prelude::*;
 
 pub type PathIterator = Box<dyn Iterator<Item = PolarsResult<PathBuf>>>;
 
-// cloud_options is used only with async feature
-#[allow(unused_variables)]
-fn polars_glob(pattern: &str, cloud_options: Option<&CloudOptions>) -> PolarsResult<PathIterator> {
-    if is_cloud_url(pattern) {
+fn expand_paths(
+    paths: &[PathBuf],
+    #[allow(unused_variables)] cloud_options: Option<&CloudOptions>,
+    glob: bool,
+) -> PolarsResult<(Arc<[PathBuf]>, usize)> {
+    let Some(first_path) = paths.first() else {
+        return Ok((vec![].into(), 0));
+    };
+
+    let is_cloud = is_cloud_url(first_path);
+    let mut expand_start_idx = usize::MAX;
+    let mut out_paths = vec![];
+
+    if is_cloud {
         #[cfg(feature = "async")]
         {
-            let paths = polars_io::async_glob(pattern, cloud_options)?;
-            Ok(Box::new(paths.into_iter().map(|a| Ok(PathBuf::from(&a)))))
+            use polars_io::cloud::{CloudLocation, PolarsObjectStore};
+
+            fn is_file_cloud(
+                path: &str,
+                cloud_options: Option<&CloudOptions>,
+            ) -> PolarsResult<bool> {
+                polars_io::pl_async::get_runtime().block_on_potential_spawn(async {
+                    let (CloudLocation { prefix, .. }, store) =
+                        polars_io::cloud::build_object_store(path, cloud_options).await?;
+                    let store = PolarsObjectStore::new(store);
+                    PolarsResult::Ok(store.head(&prefix.into()).await.is_ok())
+                })
+            }
+
+            for path in paths {
+                let glob_start_idx =
+                    memchr::memchr3(b'*', b'?', b'[', path.to_str().unwrap().as_bytes());
+
+                let (path, glob_start_idx) = if let Some(glob_start_idx) = glob_start_idx {
+                    (path.clone(), glob_start_idx)
+                } else if !path.ends_with("/")
+                    && is_file_cloud(path.to_str().unwrap(), cloud_options)?
+                {
+                    out_paths.push(path.clone());
+                    continue;
+                } else if !glob {
+                    polars_bail!(ComputeError: "not implemented: did not find cloud file at path = {} and `glob` was set to false", path.to_str().unwrap());
+                } else {
+                    (path.join("**/*"), path.to_str().unwrap().len())
+                };
+
+                expand_start_idx = std::cmp::min(expand_start_idx, glob_start_idx);
+
+                out_paths.extend(
+                    polars_io::async_glob(path.to_str().unwrap(), cloud_options)?
+                        .into_iter()
+                        .map(PathBuf::from),
+                );
+            }
         }
         #[cfg(not(feature = "async"))]
         panic!("Feature `async` must be enabled to use globbing patterns with cloud urls.")
     } else {
-        let paths = glob::glob(pattern)
-            .map_err(|_| polars_err!(ComputeError: "invalid glob pattern given"))?;
-        let paths = paths.map(|v| v.map_err(to_compute_err));
-        Ok(Box::new(paths))
+        let mut stack = VecDeque::new();
+
+        for path in paths {
+            stack.clear();
+
+            if path.is_dir() {
+                let i = path.to_str().unwrap().len();
+
+                expand_start_idx = std::cmp::min(expand_start_idx, i);
+
+                stack.push_back(path.clone());
+
+                while let Some(dir) = stack.pop_front() {
+                    let mut paths = std::fs::read_dir(dir)
+                        .map_err(PolarsError::from)?
+                        .map(|x| x.map(|x| x.path()))
+                        .collect::<std::io::Result<Vec<_>>>()
+                        .map_err(PolarsError::from)?;
+                    paths.sort_unstable();
+
+                    for path in paths {
+                        if path.is_dir() {
+                            stack.push_back(path);
+                        } else {
+                            out_paths.push(path);
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            let i = memchr::memchr3(b'*', b'?', b'[', path.to_str().unwrap().as_bytes());
+
+            if glob && i.is_some() {
+                let i = i.unwrap();
+                expand_start_idx = std::cmp::min(expand_start_idx, i);
+
+                let Ok(paths) = glob::glob(path.to_str().unwrap()) else {
+                    polars_bail!(ComputeError: "invalid glob pattern given")
+                };
+
+                for path in paths {
+                    out_paths.push(path.map_err(to_compute_err)?);
+                }
+            } else {
+                out_paths.push(path.clone());
+            }
+        }
     }
+
+    // Todo:
+    // This maintains existing behavior - will remove very soon.
+    expand_start_idx = 0;
+
+    Ok((
+        out_paths.into_iter().collect::<Arc<[_]>>(),
+        expand_start_idx,
+    ))
 }
 
 /// Reads [LazyFrame] from a filesystem or a cloud storage.
@@ -40,43 +142,42 @@ pub trait LazyFileListReader: Clone {
         if !self.glob() {
             return self.finish_no_glob();
         }
-        if let Some(paths) = self.iter_paths()? {
-            let lfs = paths
-                .map(|r| {
-                    let path = r?;
-                    self.clone()
-                        // Each individual reader should not apply a row limit.
-                        .with_n_rows(None)
-                        // Each individual reader should not apply a row index.
-                        .with_row_index(None)
-                        .with_path(path.clone())
-                        .with_rechunk(false)
-                        .finish_no_glob()
-                        .map_err(|e| {
-                            polars_err!(
-                                ComputeError: "error while reading {}: {}", path.display(), e
-                            )
-                        })
-                })
-                .collect::<PolarsResult<Vec<_>>>()?;
 
-            polars_ensure!(
-                !lfs.is_empty(),
-                ComputeError: "no matching files found in {}", self.path().display()
-            );
+        let paths = self.expand_paths()?.0;
 
-            let mut lf = self.concat_impl(lfs)?;
-            if let Some(n_rows) = self.n_rows() {
-                lf = lf.slice(0, n_rows as IdxSize)
-            };
-            if let Some(rc) = self.row_index() {
-                lf = lf.with_row_index(&rc.name, Some(rc.offset))
-            };
+        let lfs = paths
+            .iter()
+            .map(|path| {
+                self.clone()
+                    // Each individual reader should not apply a row limit.
+                    .with_n_rows(None)
+                    // Each individual reader should not apply a row index.
+                    .with_row_index(None)
+                    .with_paths(Arc::new([path.clone()]))
+                    .with_rechunk(false)
+                    .finish_no_glob()
+                    .map_err(|e| {
+                        polars_err!(
+                            ComputeError: "error while reading {}: {}", path.display(), e
+                        )
+                    })
+            })
+            .collect::<PolarsResult<Vec<_>>>()?;
 
-            Ok(lf)
-        } else {
-            self.finish_no_glob()
-        }
+        polars_ensure!(
+            !lfs.is_empty(),
+            ComputeError: "no matching files found in {:?}", self.paths().iter().map(|x| x.to_str().unwrap()).collect::<Vec<_>>()
+        );
+
+        let mut lf = self.concat_impl(lfs)?;
+        if let Some(n_rows) = self.n_rows() {
+            lf = lf.slice(0, n_rows as IdxSize)
+        };
+        if let Some(rc) = self.row_index() {
+            lf = lf.with_row_index(&rc.name, Some(rc.offset))
+        };
+
+        Ok(lf)
     }
 
     /// Recommended concatenation of [LazyFrame]s from many input files.
@@ -104,19 +205,9 @@ pub trait LazyFileListReader: Clone {
         true
     }
 
-    /// Path of the scanned file.
-    /// It can be potentially a glob pattern.
-    fn path(&self) -> &Path;
-
     fn paths(&self) -> &[PathBuf];
 
-    /// Set path of the scanned file.
-    /// Support glob patterns.
-    #[must_use]
-    fn with_path(self, path: PathBuf) -> Self;
-
     /// Set paths of the scanned files.
-    /// Doesn't glob patterns.
     #[must_use]
     fn with_paths(self, paths: Arc<[PathBuf]>) -> Self;
 
@@ -145,23 +236,9 @@ pub trait LazyFileListReader: Clone {
         None
     }
 
-    /// Get list of files referenced by this reader.
-    ///
-    /// Returns [None] if path is not a glob pattern.
-    fn iter_paths(&self) -> PolarsResult<Option<PathIterator>> {
-        let paths = self.paths();
-        if paths.is_empty() {
-            let path_str = self.path().to_string_lossy();
-            if path_str.contains('*') || path_str.contains('?') || path_str.contains('[') {
-                polars_glob(&path_str, self.cloud_options()).map(Some)
-            } else {
-                Ok(None)
-            }
-        } else {
-            polars_ensure!(self.path().to_string_lossy() == "", InvalidOperation: "expected only a single path argument");
-            // Lint is incorrect as we need static lifetime.
-            #[allow(clippy::unnecessary_to_owned)]
-            Ok(Some(Box::new(paths.to_vec().into_iter().map(Ok))))
-        }
+    /// Returns a list of paths after resolving globs and directories, as well as
+    /// the hive start index.
+    fn expand_paths(&self) -> PolarsResult<(Arc<[PathBuf]>, usize)> {
+        expand_paths(self.paths(), self.cloud_options(), self.glob())
     }
 }

--- a/crates/polars-lazy/src/scan/file_list_reader.rs
+++ b/crates/polars-lazy/src/scan/file_list_reader.rs
@@ -12,6 +12,9 @@ use crate::prelude::*;
 
 pub type PathIterator = Box<dyn Iterator<Item = PolarsResult<PathBuf>>>;
 
+/// Recursively traverses directories and expands globs if `glob` is `true`.
+/// Returns the expanded paths and the index at which to start parsing hive
+/// partitions from the path.
 fn expand_paths(
     paths: &[PathBuf],
     #[allow(unused_variables)] cloud_options: Option<&CloudOptions>,
@@ -237,7 +240,7 @@ pub trait LazyFileListReader: Clone {
     }
 
     /// Returns a list of paths after resolving globs and directories, as well as
-    /// the hive start index.
+    /// the string index at which to start parsing hive partitions.
     fn expand_paths(&self) -> PolarsResult<(Arc<[PathBuf]>, usize)> {
         expand_paths(self.paths(), self.cloud_options(), self.glob())
     }

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -33,39 +33,22 @@ impl Default for ScanArgsIpc {
 #[derive(Clone)]
 struct LazyIpcReader {
     args: ScanArgsIpc,
-    path: PathBuf,
     paths: Arc<[PathBuf]>,
 }
 
 impl LazyIpcReader {
-    fn new(path: PathBuf, args: ScanArgsIpc) -> Self {
+    fn new(args: ScanArgsIpc) -> Self {
         Self {
             args,
-            path,
             paths: Arc::new([]),
         }
     }
 }
 
 impl LazyFileListReader for LazyIpcReader {
-    fn finish(mut self) -> PolarsResult<LazyFrame> {
-        if let Some(paths) = self.iter_paths()? {
-            let paths = paths
-                .into_iter()
-                .collect::<PolarsResult<Arc<[PathBuf]>>>()?;
-            self.paths = paths;
-        }
-        self.finish_no_glob()
-    }
-
-    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
+    fn finish(self) -> PolarsResult<LazyFrame> {
+        let paths = self.expand_paths()?.0;
         let args = self.args;
-
-        let paths = if self.paths.is_empty() {
-            Arc::new([self.path]) as Arc<[PathBuf]>
-        } else {
-            self.paths
-        };
 
         let options = IpcScanOptions {
             memory_map: args.memory_map,
@@ -87,17 +70,12 @@ impl LazyFileListReader for LazyIpcReader {
         Ok(lf)
     }
 
-    fn path(&self) -> &Path {
-        self.path.as_path()
+    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
+        unreachable!()
     }
 
     fn paths(&self) -> &[PathBuf] {
         &self.paths
-    }
-
-    fn with_path(mut self, path: PathBuf) -> Self {
-        self.path = path;
-        self
     }
 
     fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
@@ -136,12 +114,12 @@ impl LazyFileListReader for LazyIpcReader {
 impl LazyFrame {
     /// Create a LazyFrame directly from a ipc scan.
     pub fn scan_ipc(path: impl AsRef<Path>, args: ScanArgsIpc) -> PolarsResult<Self> {
-        LazyIpcReader::new(path.as_ref().to_owned(), args).finish()
+        LazyIpcReader::new(args)
+            .with_paths(Arc::new([path.as_ref().to_path_buf()]))
+            .finish()
     }
 
     pub fn scan_ipc_files(paths: Arc<[PathBuf]>, args: ScanArgsIpc) -> PolarsResult<Self> {
-        LazyIpcReader::new(PathBuf::new(), args)
-            .with_paths(paths)
-            .finish()
+        LazyIpcReader::new(args).with_paths(paths).finish()
     }
 }

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -114,8 +114,9 @@ impl LazyFileListReader for LazyJsonLineReader {
         let scan_type = FileScan::NDJson { options };
 
         Ok(LazyFrame::from(DslPlan::Scan {
-            paths: Arc::from([self.path.clone()]),
+            paths: self.paths,
             file_info: None,
+            hive_parts: None,
             predicate: None,
             file_options,
             scan_type,

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -11,8 +11,7 @@ use crate::prelude::LazyFrame;
 
 #[derive(Clone)]
 pub struct LazyJsonLineReader {
-    pub(crate) path: PathBuf,
-    paths: Arc<[PathBuf]>,
+    pub(crate) paths: Arc<[PathBuf]>,
     pub(crate) batch_size: Option<NonZeroUsize>,
     pub(crate) low_memory: bool,
     pub(crate) rechunk: bool,
@@ -30,8 +29,7 @@ impl LazyJsonLineReader {
 
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyJsonLineReader {
-            path: path.as_ref().to_path_buf(),
-            paths: Arc::new([]),
+            paths: Arc::new([path.as_ref().to_path_buf()]),
             batch_size: None,
             low_memory: false,
             rechunk: false,
@@ -124,17 +122,8 @@ impl LazyFileListReader for LazyJsonLineReader {
         }))
     }
 
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
     fn paths(&self) -> &[PathBuf] {
         &self.paths
-    }
-
-    fn with_path(mut self, path: PathBuf) -> Self {
-        self.path = path;
-        self
     }
 
     fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -42,15 +42,13 @@ impl Default for ScanArgsParquet {
 #[derive(Clone)]
 struct LazyParquetReader {
     args: ScanArgsParquet,
-    path: PathBuf,
     paths: Arc<[PathBuf]>,
 }
 
 impl LazyParquetReader {
-    fn new(path: PathBuf, args: ScanArgsParquet) -> Self {
+    fn new(args: ScanArgsParquet) -> Self {
         Self {
             args,
-            path,
             paths: Arc::new([]),
         }
     }
@@ -59,26 +57,11 @@ impl LazyParquetReader {
 impl LazyFileListReader for LazyParquetReader {
     /// Get the final [LazyFrame].
     fn finish(mut self) -> PolarsResult<LazyFrame> {
-        if !self.args.glob {
-            return self.finish_no_glob();
-        }
-        if let Some(paths) = self.iter_paths()? {
-            let paths = paths
-                .into_iter()
-                .collect::<PolarsResult<Arc<[PathBuf]>>>()?;
-            self.paths = paths;
-        }
-        self.finish_no_glob()
-    }
+        let (paths, hive_start_idx) = self.expand_paths()?;
+        self.args.hive_options.hive_start_idx = hive_start_idx;
 
-    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
         let row_index = self.args.row_index;
 
-        let paths = if self.paths.is_empty() {
-            Arc::new([self.path]) as Arc<[PathBuf]>
-        } else {
-            self.paths
-        };
         let mut lf: LazyFrame = DslBuilder::scan_parquet(
             paths,
             self.args.n_rows,
@@ -103,17 +86,16 @@ impl LazyFileListReader for LazyParquetReader {
         Ok(lf)
     }
 
-    fn path(&self) -> &Path {
-        self.path.as_path()
+    fn glob(&self) -> bool {
+        self.args.glob
+    }
+
+    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
+        unreachable!();
     }
 
     fn paths(&self) -> &[PathBuf] {
         &self.paths
-    }
-
-    fn with_path(mut self, path: PathBuf) -> Self {
-        self.path = path;
-        self
     }
 
     fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
@@ -156,13 +138,13 @@ impl LazyFileListReader for LazyParquetReader {
 impl LazyFrame {
     /// Create a LazyFrame directly from a parquet scan.
     pub fn scan_parquet(path: impl AsRef<Path>, args: ScanArgsParquet) -> PolarsResult<Self> {
-        LazyParquetReader::new(path.as_ref().to_owned(), args).finish()
+        LazyParquetReader::new(args)
+            .with_paths(Arc::new([path.as_ref().to_path_buf()]))
+            .finish()
     }
 
     /// Create a LazyFrame directly from a parquet scan.
     pub fn scan_parquet_files(paths: Arc<[PathBuf]>, args: ScanArgsParquet) -> PolarsResult<Self> {
-        LazyParquetReader::new(PathBuf::new(), args)
-            .with_paths(paths)
-            .finish()
+        LazyParquetReader::new(args).with_paths(paths).finish()
     }
 }

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -233,6 +233,7 @@ fn create_physical_plan_impl(
         Scan {
             paths,
             file_info,
+            hive_parts,
             output_schema,
             scan_type,
             predicate,
@@ -283,6 +284,7 @@ fn create_physical_plan_impl(
                 } => Ok(Box::new(executors::ParquetExec::new(
                     paths,
                     file_info,
+                    hive_parts,
                     predicate,
                     options,
                     cloud_options,

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -19,6 +19,7 @@ use polars_io::prelude::ParquetAsyncReader;
 use polars_io::utils::{check_projected_arrow_schema, is_cloud_url};
 use polars_io::SerReader;
 use polars_plan::plans::FileInfo;
+use polars_plan::prelude::hive::HivePartitions;
 use polars_plan::prelude::FileScanOptions;
 use polars_utils::iter::EnumerateIdxTrait;
 use polars_utils::IdxSize;
@@ -39,6 +40,7 @@ pub struct ParquetSource {
     cloud_options: Option<CloudOptions>,
     metadata: Option<FileMetaDataRef>,
     file_info: FileInfo,
+    hive_parts: Option<Vec<Arc<HivePartitions>>>,
     verbose: bool,
     run_async: bool,
     prefetch_size: usize,
@@ -78,12 +80,10 @@ impl ParquetSource {
         let file_options = self.file_options.clone();
         let schema = self.file_info.schema.clone();
 
-        let mut file_info = self.file_info.clone();
-        file_info.update_hive_partitions(path)?;
-        let hive_partitions = file_info
+        let hive_partitions = self
             .hive_parts
             .as_ref()
-            .map(|hive| hive.materialize_partition_columns());
+            .map(|x| x[index].materialize_partition_columns());
 
         let projection = materialize_projection(
             file_options.with_columns.as_deref(),
@@ -192,6 +192,7 @@ impl ParquetSource {
         metadata: Option<FileMetaDataRef>,
         file_options: FileScanOptions,
         file_info: FileInfo,
+        hive_parts: Option<Vec<Arc<HivePartitions>>>,
         verbose: bool,
         predicate: Option<Arc<dyn PhysicalIoExpr>>,
     ) -> PolarsResult<Self> {
@@ -216,6 +217,7 @@ impl ParquetSource {
             cloud_options,
             metadata,
             file_info,
+            hive_parts,
             verbose,
             run_async,
             prefetch_size,

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -76,6 +76,7 @@ where
         Scan {
             paths,
             file_info,
+            hive_parts,
             file_options,
             predicate,
             output_schema,
@@ -144,6 +145,7 @@ where
                         metadata,
                         file_options,
                         file_info,
+                        hive_parts,
                         verbose,
                         predicate,
                     )?;

--- a/crates/polars-plan/src/plans/builder_dsl.rs
+++ b/crates/polars-plan/src/plans/builder_dsl.rs
@@ -56,6 +56,7 @@ impl DslBuilder {
         Ok(DslPlan::Scan {
             paths: Arc::new([]),
             file_info: Some(file_info),
+            hive_parts: None,
             predicate: None,
             file_options,
             scan_type: FileScan::Anonymous {
@@ -97,6 +98,7 @@ impl DslBuilder {
         Ok(DslPlan::Scan {
             paths,
             file_info: None,
+            hive_parts: None,
             file_options: options,
             predicate: None,
             scan_type: FileScan::Parquet {
@@ -127,6 +129,7 @@ impl DslBuilder {
         Ok(DslPlan::Scan {
             paths,
             file_info: None,
+            hive_parts: None,
             file_options: FileScanOptions {
                 with_columns: None,
                 cache,
@@ -179,6 +182,7 @@ impl DslBuilder {
         Ok(DslPlan::Scan {
             paths,
             file_info: None,
+            hive_parts: None,
             file_options: options,
             predicate: None,
             scan_type: FileScan::Csv {

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -45,6 +45,7 @@ impl IR {
             IR::Scan {
                 paths,
                 file_info,
+                hive_parts,
                 predicate,
                 scan_type,
                 output_schema: _,
@@ -52,6 +53,7 @@ impl IR {
             } => DslPlan::Scan {
                 paths,
                 file_info: Some(file_info),
+                hive_parts,
                 predicate: predicate.map(|e| e.to_expr(expr_arena)),
                 scan_type,
                 file_options: options,

--- a/crates/polars-plan/src/plans/conversion/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/scans.rs
@@ -77,15 +77,11 @@ pub(super) fn parquet_file_info(
         )
     };
 
-    let mut file_info = FileInfo::new(
+    let file_info = FileInfo::new(
         schema,
         Some(Either::Left(reader_schema)),
         (num_rows, num_rows.unwrap_or(0)),
     );
-
-    if file_options.hive_options.enabled {
-        file_info.init_hive_partitions(path.as_path(), file_options.hive_options.schema.clone())?
-    }
 
     Ok((file_info, metadata))
 }

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -245,6 +245,7 @@ impl<'a> IRDotDisplay<'a> {
             Scan {
                 paths,
                 file_info,
+                hive_parts: _,
                 predicate,
                 scan_type,
                 file_options: options,

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -104,6 +104,7 @@ impl IR {
             Scan {
                 paths,
                 file_info,
+                hive_parts,
                 output_schema,
                 predicate,
                 file_options: options,
@@ -116,6 +117,7 @@ impl IR {
                 Scan {
                     paths: paths.clone(),
                     file_info: file_info.clone(),
+                    hive_parts: hive_parts.clone(),
                     output_schema: output_schema.clone(),
                     file_options: options.clone(),
                     predicate: new_predicate,

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 
 pub use dot::IRDotDisplay;
 pub use format::{ExprIRDisplay, IRDisplay};
+use hive::HivePartitions;
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::unitvec;
@@ -50,6 +51,7 @@ pub enum IR {
     Scan {
         paths: Arc<[PathBuf]>,
         file_info: FileInfo,
+        hive_parts: Option<Vec<Arc<HivePartitions>>>,
         predicate: Option<ExprIR>,
         /// schema of the projected file
         output_schema: Option<SchemaRef>,

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use hive::HivePartitions;
 use polars_core::prelude::*;
 use recursive::recursive;
 
@@ -22,7 +23,7 @@ pub mod expr_ir;
 mod file_scan;
 mod format;
 mod functions;
-pub(super) mod hive;
+pub mod hive;
 pub(crate) mod iterator;
 mod lit;
 pub(crate) mod optimizer;
@@ -80,6 +81,7 @@ pub enum DslPlan {
         paths: Arc<[PathBuf]>,
         // Option as this is mostly materialized on the IR phase.
         file_info: Option<FileInfo>,
+        hive_parts: Option<Vec<Arc<HivePartitions>>>,
         predicate: Option<Expr>,
         file_options: FileScanOptions,
         scan_type: FileScan,
@@ -186,7 +188,7 @@ impl Clone for DslPlan {
             Self::PythonScan { options } => Self::PythonScan { options: options.clone() },
             Self::Filter { input, predicate } => Self::Filter { input: input.clone(), predicate: predicate.clone() },
             Self::Cache { input, id, cache_hits } => Self::Cache { input: input.clone(), id: id.clone(), cache_hits: cache_hits.clone() },
-            Self::Scan { paths, file_info, predicate, file_options, scan_type } => Self::Scan { paths: paths.clone(), file_info: file_info.clone(), predicate: predicate.clone(), file_options: file_options.clone(), scan_type: scan_type.clone() },
+            Self::Scan { paths, file_info, hive_parts, predicate, file_options, scan_type } => Self::Scan { paths: paths.clone(), file_info: file_info.clone(), hive_parts: hive_parts.clone(), predicate: predicate.clone(), file_options: file_options.clone(), scan_type: scan_type.clone() },
             Self::DataFrameScan { df, schema, output_schema, filter: selection } => Self::DataFrameScan { df: df.clone(), schema: schema.clone(), output_schema: output_schema.clone(), filter: selection.clone() },
             Self::Select { expr, input, options } => Self::Select { expr: expr.clone(), input: input.clone(), options: options.clone() },
             Self::GroupBy { input, keys, aggs,  apply, maintain_order, options } => Self::GroupBy { input: input.clone(), keys: keys.clone(), aggs: aggs.clone(), apply: apply.clone(), maintain_order: maintain_order.clone(), options: options.clone() },

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -395,6 +395,7 @@ impl ProjectionPushDown {
             Scan {
                 paths,
                 file_info,
+                hive_parts,
                 scan_type,
                 predicate,
                 mut file_options,
@@ -433,8 +434,9 @@ impl ProjectionPushDown {
                         // Hive partitions are created AFTER the projection, so the output
                         // schema is incorrect. Here we ensure the columns that are projected and hive
                         // parts are added at the proper place in the schema, which is at the end.
-                        if let Some(parts) = file_info.hive_parts.as_deref() {
-                            let partition_schema = parts.schema();
+                        if let Some(ref hive_parts) = hive_parts {
+                            let partition_schema = hive_parts.first().unwrap().schema();
+
                             for (name, _) in partition_schema.iter() {
                                 if let Some(dt) = schema.shift_remove(name) {
                                     schema.with_column(name.clone(), dt);
@@ -448,6 +450,7 @@ impl ProjectionPushDown {
                 let lp = Scan {
                     paths,
                     file_info,
+                    hive_parts,
                     output_schema,
                     scan_type,
                     predicate,

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -165,6 +165,7 @@ impl SlicePushDown {
             (Scan {
                 paths,
                 file_info,
+                hive_parts,
                 output_schema,
                 mut file_options,
                 predicate,
@@ -175,6 +176,7 @@ impl SlicePushDown {
                 let lp = Scan {
                     paths,
                     file_info,
+                    hive_parts,
                     output_schema,
                     scan_type: FileScan::Csv { options, cloud_options },
                     file_options,
@@ -187,6 +189,7 @@ impl SlicePushDown {
             (Scan {
                 paths,
                 file_info,
+                hive_parts,
                 output_schema,
                 file_options: mut options,
                 predicate,
@@ -196,6 +199,7 @@ impl SlicePushDown {
                 let lp = Scan {
                     paths,
                     file_info,
+                    hive_parts,
                     output_schema,
                     predicate,
                     file_options: options,

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -76,6 +76,7 @@ impl Hash for HashableEqLP<'_> {
             IR::Scan {
                 paths,
                 file_info: _,
+                hive_parts: _,
                 predicate,
                 output_schema: _,
                 scan_type,
@@ -255,6 +256,7 @@ impl HashableEqLP<'_> {
                 IR::Scan {
                     paths: pl,
                     file_info: _,
+                    hive_parts: _,
                     predicate: pred_l,
                     output_schema: _,
                     scan_type: stl,
@@ -263,6 +265,7 @@ impl HashableEqLP<'_> {
                 IR::Scan {
                     paths: pr,
                     file_info: _,
+                    hive_parts: _,
                     predicate: pred_r,
                     output_schema: _,
                     scan_type: str,

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -57,7 +57,7 @@ class BatchedCsvReader:
         truncate_ragged_lines: bool = False,
         decimal_comma: bool = False,
     ):
-        path = normalize_filepath(source)
+        path = normalize_filepath(source, check_not_directory=False)
 
         dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
         dtype_slice: Sequence[PolarsDataType] | None = None

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -487,7 +487,7 @@ def _read_csv_impl(
 ) -> DataFrame:
     path: str | None
     if isinstance(source, (str, Path)):
-        path = normalize_filepath(source)
+        path = normalize_filepath(source, check_not_directory=False)
     else:
         path = None
         if isinstance(source, BytesIO):
@@ -1141,9 +1141,11 @@ def scan_csv(
     _check_arg_is_1byte("quote_char", quote_char, can_be_empty=True)
 
     if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
+        source = normalize_filepath(source, check_not_directory=False)
     else:
-        source = [normalize_filepath(source) for source in source]
+        source = [
+            normalize_filepath(source, check_not_directory=False) for source in source
+        ]
 
     return _scan_csv_impl(
         source,

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -137,7 +137,7 @@ def _read_ipc_impl(
     memory_map: bool = True,
 ) -> DataFrame:
     if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
+        source = normalize_filepath(source, check_not_directory=False)
     if isinstance(columns, str):
         columns = [columns]
 
@@ -261,7 +261,7 @@ def _read_ipc_stream_impl(
     rechunk: bool = True,
 ) -> DataFrame:
     if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
+        source = normalize_filepath(source, check_not_directory=False)
     if isinstance(columns, str):
         columns = [columns]
 
@@ -294,7 +294,7 @@ def read_ipc_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, DataTyp
         Dictionary mapping column names to datatypes
     """
     if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
+        source = normalize_filepath(source, check_not_directory=False)
 
     return _read_ipc_schema(source)
 
@@ -353,11 +353,13 @@ def scan_ipc(
     """
     if isinstance(source, (str, Path)):
         can_use_fsspec = True
-        source = normalize_filepath(source)
+        source = normalize_filepath(source, check_not_directory=False)
         sources = []
     else:
         can_use_fsspec = False
-        sources = [normalize_filepath(source) for source in source]
+        sources = [
+            normalize_filepath(source, check_not_directory=False) for source in source
+        ]
         source = None  # type: ignore[assignment]
 
     # try fsspec scanner

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -274,7 +274,7 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
         Dictionary mapping column names to datatypes
     """
     if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
+        source = normalize_filepath(source, check_not_directory=False)
 
     return _read_parquet_schema(source)
 
@@ -383,9 +383,11 @@ def scan_parquet(
         issue_unstable_warning(msg)
 
     if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
+        source = normalize_filepath(source, check_not_directory=False)
     else:
-        source = [normalize_filepath(source) for source in source]
+        source = [
+            normalize_filepath(source, check_not_directory=False) for source in source
+        ]
 
     return _scan_parquet_impl(
         source,

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -334,6 +334,7 @@ impl PyLazyFrame {
         });
         let hive_options = HiveOptions {
             enabled: hive_partitioning,
+            hive_start_idx: 0,
             schema: hive_schema,
         };
 

--- a/py-polars/src/lazyframe/visitor/nodes.rs
+++ b/py-polars/src/lazyframe/visitor/nodes.rs
@@ -294,6 +294,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
         IR::Scan {
             paths,
             file_info: _,
+            hive_parts: _,
             predicate,
             output_schema: _,
             scan_type,


### PR DESCRIPTION
This PR enables passing directory paths to `scan_(parquet|ipc|csv)`, which will be recursively traversed to load all files.

There is also some refactoring around hive partition logic to prepare for future behavior changes.