### PR TITLE
refactor(rust): expose all metadata to polars-expr

### DIFF
--- a/crates/polars-core/src/datatypes/into_scalar.rs
+++ b/crates/polars-core/src/datatypes/into_scalar.rs
@@ -1,0 +1,57 @@
+use polars_error::{polars_bail, PolarsResult};
+
+use super::{AnyValue, DataType, Scalar};
+
+pub trait IntoScalar {
+    fn into_scalar(self, dtype: DataType) -> PolarsResult<Scalar>;
+}
+
+macro_rules! impl_into_scalar {
+    ($(
+        $ty:ty: ($($dt:pat),+ $(,)?),
+    )+) => {
+        $(
+        impl IntoScalar for $ty {
+            fn into_scalar(self, dtype: DataType) -> PolarsResult<Scalar> {
+                Ok(match &dtype {
+                    T::Null => Scalar::new(dtype, AnyValue::Null),
+                    $($dt => Scalar::new(dtype, self.into()),)+
+                    _ => polars_bail!(InvalidOperation: "Cannot cast `{}` to `Scalar` with dtype={dtype}", stringify!($ty)),
+                })
+            }
+        }
+        )+
+    };
+}
+
+use DataType as T;
+impl_into_scalar! {
+    bool: (T::Boolean),
+    u8: (T::UInt8),
+    u16: (T::UInt16),
+    u32: (T::UInt32), // T::Categorical, T::Enum
+    u64: (T::UInt64),
+    i8: (T::Int8),
+    i16: (T::Int16),
+    i32: (T::Int32), // T::Date
+    i64: (T::Int64), // T::Datetime, T::Duration, T::Time
+    // i128: (T::Decimal),
+    f32: (T::Float32),
+    f64: (T::Float64),
+    // Vec<u8>: (T::Binary),
+    // String: (T::String),
+    // Series: (T::List, T::Array),
+    // /// Can be used to fmt and implements Any, so can be downcasted to the proper value type.
+    // #[cfg(feature = "object")]
+    // Object(&'a dyn PolarsObjectSafe),
+    // #[cfg(feature = "object")]
+    // ObjectOwned(OwnedObject),
+    // #[cfg(feature = "dtype-struct")]
+    // // 3 pointers and thus not larger than string/vec
+    // // - idx in the `&StructArray`
+    // // - The array itself
+    // // - The fields
+    // Struct(usize, &'a StructArray, &'a [Field]),
+    // #[cfg(feature = "dtype-struct")]
+    // StructOwned(Box<(Vec<AnyValue<'a>>, Vec<Field>)>),
+}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -12,6 +12,7 @@ mod aliases;
 mod any_value;
 mod dtype;
 mod field;
+mod into_scalar;
 #[cfg(feature = "object")]
 mod static_array_collect;
 mod time_unit;
@@ -32,6 +33,7 @@ use arrow::types::NativeType;
 use bytemuck::Zeroable;
 pub use dtype::*;
 pub use field::*;
+pub use into_scalar::*;
 use num_traits::{Bounded, FromPrimitive, Num, NumCast, One, Zero};
 use polars_compute::arithmetic::HasPrimitiveArithmeticKernel;
 use polars_compute::float_sum::FloatSum;

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -101,14 +101,8 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<BooleanChunked> {
-    fn get_metadata_min_value(&self) -> Option<Scalar> {
-        let v = self.metadata()?.get_min_value()?;
-        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
-    }
-
-    fn get_metadata_max_value(&self) -> Option<Scalar> {
-        let v = self.metadata()?.get_max_value()?;
-        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
+    fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
+        self.metadata().map(|v| v as &dyn MetadataTrait)
     }
 
     fn bitxor(&self, other: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -140,16 +140,6 @@ impl private::PrivateSeries for SeriesWrap<DateChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<DateChunked> {
-    fn get_metadata_min_value(&self) -> Option<Scalar> {
-        let v = self.0.metadata()?.get_min_value()?;
-        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
-    }
-
-    fn get_metadata_max_value(&self) -> Option<Scalar> {
-        let v = self.0.metadata()?.get_max_value()?;
-        Some(Scalar::new(DataType::Boolean, AnyValue::from(*v)))
-    }
-
     fn rename(&mut self, name: &str) {
         self.0.rename(name);
     }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -165,20 +165,8 @@ macro_rules! impl_dyn_series {
                 ChunkRollApply::rolling_map(&self.0, _f, _options).map(|ca| ca.into_series())
             }
 
-            fn get_metadata_min_value(&self) -> Option<Scalar> {
-                let v = self.metadata()?.get_min_value()?;
-                Some(Scalar::new(
-                    private::PrivateSeries::_dtype(self).clone(),
-                    AnyValue::from(*v),
-                ))
-            }
-
-            fn get_metadata_max_value(&self) -> Option<Scalar> {
-                let v = self.metadata()?.get_max_value()?;
-                Some(Scalar::new(
-                    private::PrivateSeries::_dtype(self).clone(),
-                    AnyValue::from(*v),
-                ))
+            fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
+                self.metadata().map(|v| v as &dyn MetadataTrait)
             }
 
             fn rename(&mut self, name: &str) {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -32,6 +32,7 @@ use ahash::RandomState;
 
 use super::*;
 use crate::chunked_array::comparison::*;
+use crate::chunked_array::metadata::MetadataTrait;
 use crate::chunked_array::ops::compare_inner::{
     IntoTotalEqInner, IntoTotalOrdInner, TotalEqInner, TotalOrdInner,
 };
@@ -239,20 +240,8 @@ macro_rules! impl_dyn_series {
                 ChunkRollApply::rolling_map(&self.0, _f, _options).map(|ca| ca.into_series())
             }
 
-            fn get_metadata_min_value(&self) -> Option<Scalar> {
-                let v = self.metadata()?.get_min_value()?;
-                Some(Scalar::new(
-                    private::PrivateSeries::_dtype(self).clone(),
-                    AnyValue::from(*v),
-                ))
-            }
-
-            fn get_metadata_max_value(&self) -> Option<Scalar> {
-                let v = self.metadata()?.get_max_value()?;
-                Some(Scalar::new(
-                    private::PrivateSeries::_dtype(self).clone(),
-                    AnyValue::from(*v),
-                ))
+            fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
+                self.metadata().map(|v| v as &dyn MetadataTrait)
             }
 
             fn bitand(&self, other: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use serde::{Deserialize, Serialize};
 
 use crate::chunked_array::cast::CastOptions;
+use crate::chunked_array::metadata::MetadataTrait;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::prelude::*;
@@ -193,11 +194,7 @@ pub trait SeriesTrait:
         polars_bail!(opq = bitxor, self._dtype());
     }
 
-    fn get_metadata_min_value(&self) -> Option<Scalar> {
-        None
-    }
-
-    fn get_metadata_max_value(&self) -> Option<Scalar> {
+    fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
         None
     }
 
@@ -376,6 +373,8 @@ pub trait SeriesTrait:
     }
 
     /// Get unique values in the Series.
+    ///
+    /// A `null` value also counts as a unique value.
     fn n_unique(&self) -> PolarsResult<usize> {
         polars_bail!(opq = n_unique, self._dtype());
     }


### PR DESCRIPTION
This adds a `MetadataTrait` with which `polars-expr` can freely access the metadata. This does require multiple instances of dynamic dispatch, but this seems like the proper solution and should be on a cold path in the code.

This is reliant on #17005.