### PR TITLE
fix: properly catch not found explode cols

### DIFF
--- a/crates/polars-plan/src/logical_plan/functions/dsl.rs
+++ b/crates/polars-plan/src/logical_plan/functions/dsl.rs
@@ -55,11 +55,13 @@ impl DslFunction {
                 let columns = columns
                     .iter()
                     .map(|e| {
-                        if let Expr::Column(name) = e {
-                            Ok(name.clone())
-                        } else {
+                        let Expr::Column(name) = e else {
                             polars_bail!(InvalidOperation: "expected column expression")
-                        }
+                        };
+
+                        polars_ensure!(input_schema.contains(name), ColumnNotFound: "{name}");
+
+                        Ok(name.clone())
                     })
                     .collect::<PolarsResult<Arc<[Arc<str>]>>>()?;
                 FunctionNode::Explode {

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -430,3 +430,10 @@ def test_expr_str_explode_deprecated() -> None:
 
     expected = pl.Series("a", ["H", "e", "l", "l", "o", "W", "o", "r", "l", "d"])
     assert_series_equal(result, expected)
+
+
+def test_undefined_col_15852() -> None:
+    lf = pl.LazyFrame({"foo": [1]})
+
+    with pytest.raises(pl.exceptions.ColumnNotFoundError):
+        lf.explode("bar").join(lf, on="foo").collect()


### PR DESCRIPTION
Fixes #15852.

This adds a check for whether a column is defined or not in `explode`.