### PR TITLE
fix: Don't silently accept multi-table FROM clauses (implicit JOIN syntax)

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -596,7 +596,7 @@ impl SQLExprVisitor<'_> {
                 },
             },
             other => {
-                polars_bail!(SQLInterface: "SQL operator {:?} is not currently supported", other)
+                polars_bail!(SQLInterface: "operator {:?} is not currently supported", other)
             },
         })
     }
@@ -772,7 +772,7 @@ impl SQLExprVisitor<'_> {
                 bitstring_to_bytes_literal(b)?
             },
             SQLValue::SingleQuotedString(s) => lit(s.clone()),
-            other => polars_bail!(SQLInterface: "SQL value {:?} is not supported", other),
+            other => polars_bail!(SQLInterface: "value {:?} is not supported", other),
         })
     }
 
@@ -826,7 +826,7 @@ impl SQLExprVisitor<'_> {
             SQLValue::SingleQuotedString(s) | SQLValue::DoubleQuotedString(s) => {
                 AnyValue::StringOwned(s.into())
             },
-            other => polars_bail!(SQLInterface: "SQL value {:?} is not currently supported", other),
+            other => polars_bail!(SQLInterface: "value {:?} is not currently supported", other),
         })
     }
 
@@ -845,11 +845,11 @@ impl SQLExprVisitor<'_> {
 
         let low = self.convert_temporal_strings(&expr, &low);
         let high = self.convert_temporal_strings(&expr, &high);
-        if negated {
-            Ok(expr.clone().lt(low).or(expr.gt(high)))
+        Ok(if negated {
+            expr.clone().lt(low).or(expr.gt(high))
         } else {
-            Ok(expr.clone().gt_eq(low).and(expr.lt_eq(high)))
-        }
+            expr.clone().gt_eq(low).and(expr.lt_eq(high))
+        })
     }
 
     /// Visit a SQL `TRIM` function.
@@ -891,11 +891,11 @@ impl SQLExprVisitor<'_> {
     ) -> PolarsResult<Expr> {
         let subquery_result = self.visit_subquery(subquery, SubqueryRestriction::SingleColumn)?;
         let expr = self.visit_expr(expr)?;
-        if negated {
-            Ok(expr.is_in(subquery_result).not())
+        Ok(if negated {
+            expr.is_in(subquery_result).not()
         } else {
-            Ok(expr.is_in(subquery_result))
-        }
+            expr.is_in(subquery_result)
+        })
     }
 
     /// Visit `CASE` control flow expression.

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -306,3 +306,20 @@ def test_non_equi_joins(constraint: str) -> None:
             LEFT JOIN tbl ON {constraint}  -- not an equi-join
             """
         )
+
+
+def test_implicit_joins() -> None:
+    # no support for this yet; ensure we catch it
+    with pytest.raises(
+        SQLInterfaceError,
+        match=r"not currently supported .* use explicit JOIN syntax instead",
+    ), pl.SQLContext(
+        {"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2], "c": ["x", "y", "z"]})}
+    ) as ctx:
+        ctx.execute(
+            """
+            SELECT t1.*
+            FROM tbl AS t1, tbl AS t2
+            WHERE t1.a = t2.b
+            """
+        )


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/issues/16662.

* Catch use of old-school implicit JOIN syntax (multiple tables in the FROM clause, constraints in the WHERE) and raise an informative error; currently we require use of explicit JOIN constraints.
* A few minor renames/cleanups, eg: `process_set_expr` -> `process_query`.

Note that I do expect to have the implicit form working in the not-too-distant future, but at the moment anyone using this syntax may experience less useful errors or incorrect results, so we need to catch it until it is properly supported.