### PR TITLE
refactor(python)!: Remove re-export of type aliases

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -236,7 +236,6 @@ from polars.string_cache import (
     enable_string_cache,
     using_string_cache,
 )
-from polars.type_aliases import PolarsDataType
 
 __version__: str = _get_polars_version()
 del _get_polars_version
@@ -325,8 +324,6 @@ __all__ = [
     "NESTED_DTYPES",
     "NUMERIC_DTYPES",
     "TEMPORAL_DTYPES",
-    # polars.type_aliases
-    "PolarsDataType",
     # polars.io
     "read_avro",
     "read_clipboard",

--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -63,14 +63,6 @@ from polars.datatypes.convert import (
     supported_numpy_char_code,
     unpack_dtypes,
 )
-from polars.type_aliases import (
-    OneOrMoreDataTypes,
-    PolarsDataType,
-    PolarsTemporalType,
-    PythonDataType,
-    SchemaDefinition,
-    SchemaDict,
-)
 
 __all__ = [
     # classes
@@ -134,11 +126,4 @@ __all__ = [
     "py_type_to_dtype",
     "supported_numpy_char_code",
     "unpack_dtypes",
-    # type_aliases
-    "OneOrMoreDataTypes",
-    "PolarsDataType",
-    "PolarsTemporalType",
-    "PythonDataType",
-    "SchemaDefinition",
-    "SchemaDict",
 ]

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -25,8 +25,8 @@ from polars.datatypes import (
 )
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType
     from polars.type_aliases import PolarsIntegerType, PolarsTemporalType, TimeUnit
+    from polars.typing import PolarsDataType
 
 
 DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -25,8 +25,12 @@ from polars.datatypes import (
 )
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsIntegerType, PolarsTemporalType, TimeUnit
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import (
+        PolarsDataType,
+        PolarsIntegerType,
+        PolarsTemporalType,
+        TimeUnit,
+    )
 
 
 DTYPE_TEMPORAL_UNITS: frozenset[TimeUnit] = frozenset(["ns", "us", "ms"])

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -42,8 +42,8 @@ if TYPE_CHECKING:
     import sys
 
     from polars import DataFrame, LazyFrame
-    from polars.datatypes import PolarsDataType
     from polars.type_aliases import SelectorType, TimeUnit
+    from polars.typing import PolarsDataType
 
     if sys.version_info >= (3, 11):
         from typing import Self

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -42,8 +42,7 @@ if TYPE_CHECKING:
     import sys
 
     from polars import DataFrame, LazyFrame
-    from polars.type_aliases import SelectorType, TimeUnit
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType, SelectorType, TimeUnit
 
     if sys.version_info >= (3, 11):
         from typing import Self

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
-from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -21,6 +19,8 @@ from typing import (
 
 if TYPE_CHECKING:
     import sys
+    from datetime import date, datetime, time, timedelta
+    from decimal import Decimal
 
     from sqlalchemy.engine import Connection, Engine
     from sqlalchemy.orm import Session
@@ -47,14 +47,14 @@ PythonDataType: TypeAlias = Union[
     Type[float],
     Type[bool],
     Type[str],
-    Type[date],
-    Type[time],
-    Type[datetime],
-    Type[timedelta],
+    Type["date"],
+    Type["time"],
+    Type["datetime"],
+    Type["timedelta"],
     Type[List[Any]],
     Type[Tuple[Any, ...]],
     Type[bytes],
-    Type[Decimal],
+    Type["Decimal"],
     Type[None],
 ]
 
@@ -64,8 +64,8 @@ SchemaDefinition: TypeAlias = Union[
 ]
 SchemaDict: TypeAlias = Mapping[str, PolarsDataType]
 
-NumericLiteral: TypeAlias = Union[int, float, Decimal]
-TemporalLiteral: TypeAlias = Union[date, time, datetime, timedelta]
+NumericLiteral: TypeAlias = Union[int, float, "Decimal"]
+TemporalLiteral: TypeAlias = Union["date", "time", "datetime", "timedelta"]
 NonNestedLiteral: TypeAlias = Union[NumericLiteral, TemporalLiteral, str, bool, bytes]
 # Python literal types (can convert into a `lit` expression)
 PythonLiteral: TypeAlias = Union[NonNestedLiteral, List[Any]]

--- a/py-polars/polars/typing.py
+++ b/py-polars/polars/typing.py
@@ -1,3 +1,0 @@
-from polars.type_aliases import PolarsDataType
-
-__all__ = ["PolarsDataType"]

--- a/py-polars/polars/typing.py
+++ b/py-polars/polars/typing.py
@@ -1,0 +1,3 @@
+from polars.type_aliases import PolarsDataType
+
+__all__ = ["PolarsDataType"]

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal as D
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars._utils.wrap import wrap_s
 from polars.polars import PySeries
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 @pytest.mark.parametrize(
@@ -36,7 +39,7 @@ from polars.polars import PySeries
 )
 @pytest.mark.parametrize("strict", [True, False])
 def test_fallback_with_dtype_strict(
-    dtype: pl.PolarsDataType, values: list[Any], strict: bool
+    dtype: PolarsDataType, values: list[Any], strict: bool
 ) -> None:
     result = wrap_s(
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=strict)
@@ -71,7 +74,7 @@ def test_fallback_with_dtype_strict(
     ],
 )
 def test_fallback_with_dtype_strict_failure(
-    dtype: pl.PolarsDataType, values: list[Any]
+    dtype: PolarsDataType, values: list[Any]
 ) -> None:
     with pytest.raises(TypeError, match="unexpected value"):
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
@@ -242,7 +245,7 @@ def test_fallback_with_dtype_strict_failure(
     ],
 )
 def test_fallback_with_dtype_nonstrict(
-    dtype: pl.PolarsDataType, values: list[Any], expected: list[Any]
+    dtype: PolarsDataType, values: list[Any], expected: list[Any]
 ) -> None:
     result = wrap_s(
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=False)
@@ -275,7 +278,7 @@ def test_fallback_with_dtype_nonstrict(
 )
 @pytest.mark.parametrize("strict", [True, False])
 def test_fallback_without_dtype(
-    expected_dtype: pl.PolarsDataType, values: list[Any], strict: bool
+    expected_dtype: PolarsDataType, values: list[Any], strict: bool
 ) -> None:
     result = wrap_s(PySeries.new_from_any_values("", values, strict=strict))
     assert result.to_list() == values
@@ -340,7 +343,7 @@ def test_fallback_without_dtype_strict_failure(values: list[Any]) -> None:
 )
 def test_fallback_without_dtype_nonstrict_mixed_types(
     values: list[Any],
-    expected_dtype: pl.PolarsDataType,
+    expected_dtype: PolarsDataType,
     expected: list[Any],
 ) -> None:
     result = wrap_s(PySeries.new_from_any_values("", values, strict=False))

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -13,7 +13,7 @@ from polars._utils.wrap import wrap_s
 from polars.polars import PySeries
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field, TypeAdapter
 
 import polars as pl
 from polars._utils.construction.utils import try_get_type_hints
-from polars.datatypes import PolarsDataType, numpy_char_code_to_dtype
+from polars.datatypes import numpy_char_code_to_dtype
 from polars.dependencies import dataclasses, pydantic
 from polars.testing import assert_frame_equal, assert_series_equal
 

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
 
     from zoneinfo import ZoneInfo
 
-    from polars.datatypes import PolarsDataType
+    from polars.typing import PolarsDataType
+
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
@@ -1299,7 +1300,7 @@ def test_from_records_nullable_structs() -> None:
         {"id": 1, "items": [{"item_id": 100, "description": "hi"}]},
     ]
 
-    schema: list[tuple[str, pl.PolarsDataType]] = [
+    schema: list[tuple[str, PolarsDataType]] = [
         ("id", pl.UInt16),
         (
             "items",
@@ -1311,7 +1312,7 @@ def test_from_records_nullable_structs() -> None:
         ),
     ]
 
-    schema_options: list[list[tuple[str, pl.PolarsDataType]] | None] = [schema, None]
+    schema_options: list[list[tuple[str, PolarsDataType]] | None] = [schema, None]
     for s in schema_options:
         result = pl.DataFrame(records, schema=s, orient="row")
         expected = {
@@ -1329,7 +1330,7 @@ def test_from_records_nullable_structs() -> None:
     assert df.to_dict(as_series=False) == {"id": [], "items": []}
     assert df.schema == dict_schema
 
-    dtype: pl.PolarsDataType = dict_schema["items"]
+    dtype: PolarsDataType = dict_schema["items"]
     series = pl.Series("items", dtype=dtype)
     assert series.to_frame().to_dict(as_series=False) == {"items": []}
     assert series.dtype == dict_schema["items"]

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
     from zoneinfo import ZoneInfo
 
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -11,7 +11,7 @@ import polars as pl
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_series_mixed_dtypes_list() -> None:

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import re
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 
 import polars as pl
 from polars.testing.asserts.series import assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_series_mixed_dtypes_list() -> None:
@@ -48,7 +51,7 @@ def test_series_mixed_dtypes_object() -> None:
 
 # https://github.com/pola-rs/polars/issues/15139
 @pytest.mark.parametrize("dtype", [pl.List(pl.Int64), None])
-def test_sequence_of_series_with_dtype(dtype: pl.PolarsDataType | None) -> None:
+def test_sequence_of_series_with_dtype(dtype: PolarsDataType | None) -> None:
     values = [1, 2, 3]
     int_series = pl.Series(values)
     list_series = pl.Series([int_series], dtype=dtype)
@@ -71,7 +74,7 @@ def test_sequence_of_series_with_dtype(dtype: pl.PolarsDataType | None) -> None:
     ],
 )
 def test_upcast_primitive_and_strings(
-    values: list[Any], dtype: pl.PolarsDataType, expected_dtype: pl.PolarsDataType
+    values: list[Any], dtype: PolarsDataType, expected_dtype: PolarsDataType
 ) -> None:
     with pytest.raises(TypeError):
         pl.Series(values, dtype=dtype, strict=True)

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -12,7 +12,7 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 def test_dtype() -> None:

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -12,7 +12,7 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_dtype() -> None:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -13,7 +13,7 @@ import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 def test_struct_to_list() -> None:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -13,7 +13,7 @@ import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_struct_to_list() -> None:

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -20,6 +20,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
+
+    from polars.typing import PolarsDataType
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
@@ -466,7 +468,7 @@ def test_logical_boolean() -> None:
 
 
 def test_lit_dtypes() -> None:
-    def lit_series(value: Any, dtype: pl.PolarsDataType | None) -> pl.Series:
+    def lit_series(value: Any, dtype: PolarsDataType | None) -> pl.Series:
         return pl.select(pl.lit(value, dtype=dtype)).to_series()
 
     d = datetime(2049, 10, 5, 1, 2, 3, 987654)

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -21,7 +21,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -12,8 +12,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import ClosedInterval, TimeUnit
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import ClosedInterval, PolarsDataType, TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -12,8 +12,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.datatypes import PolarsDataType
     from polars.type_aliases import ClosedInterval, TimeUnit
+    from polars.typing import PolarsDataType
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -15,7 +15,7 @@ from polars.testing.parametric.strategies import series
 from polars.testing.parametric.strategies.data import datetimes
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -13,6 +13,9 @@ import polars as pl
 from polars.testing import assert_frame_equal
 from polars.testing.parametric.strategies import series
 from polars.testing.parametric.strategies.data import datetimes
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 @pytest.mark.parametrize(
@@ -90,7 +93,7 @@ def test_list_datetime_11571() -> None:
         pytest.param(2**63, pl.UInt64, id="above i64 max"),
     ],
 )
-def test_lit_int_return_type(input: int, dtype: pl.PolarsDataType) -> None:
+def test_lit_int_return_type(input: int, dtype: PolarsDataType) -> None:
     assert pl.select(pl.lit(input)).to_series().dtype == dtype
 
 

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 @pytest.mark.parametrize(
@@ -35,8 +38,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 def test_repeat(
     value: Any,
     n: int,
-    dtype: pl.PolarsDataType,
-    expected_dtype: pl.PolarsDataType,
+    dtype: PolarsDataType,
+    expected_dtype: PolarsDataType,
 ) -> None:
     expected = pl.Series("repeat", [value] * n).cast(expected_dtype)
 
@@ -105,7 +108,7 @@ def test_repeat_n_negative() -> None:
 def test_ones(
     n: int,
     value: Any,
-    dtype: pl.PolarsDataType,
+    dtype: PolarsDataType,
 ) -> None:
     expected = pl.Series("ones", [value] * n, dtype=dtype)
 
@@ -134,7 +137,7 @@ def test_ones(
 def test_zeros(
     n: int,
     value: Any,
-    dtype: pl.PolarsDataType,
+    dtype: PolarsDataType,
 ) -> None:
     expected = pl.Series("zeros", [value] * n, dtype=dtype)
 

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -15,7 +15,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 protocol_dtypes: list[PolarsDataType] = [
     pl.Int8,

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import pyarrow as pa
@@ -13,7 +14,10 @@ import polars as pl
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
-protocol_dtypes: list[pl.PolarsDataType] = [
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
+
+protocol_dtypes: list[PolarsDataType] = [
     pl.Int8,
     pl.Int16,
     pl.Int32,

--- a/py-polars/tests/unit/interchange/test_utils.py
+++ b/py-polars/tests/unit/interchange/test_utils.py
@@ -15,7 +15,7 @@ from polars.interchange.utils import (
 
 if TYPE_CHECKING:
     from polars.interchange.protocol import Dtype
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 NE = Endianness.NATIVE
 

--- a/py-polars/tests/unit/interchange/test_utils.py
+++ b/py-polars/tests/unit/interchange/test_utils.py
@@ -15,6 +15,7 @@ from polars.interchange.utils import (
 
 if TYPE_CHECKING:
     from polars.interchange.protocol import Dtype
+    from polars.typing import PolarsDataType
 
 NE = Endianness.NATIVE
 
@@ -50,7 +51,7 @@ NE = Endianness.NATIVE
         ),
     ],
 )
-def test_dtype_conversions(polars_dtype: pl.PolarsDataType, dtype: Dtype) -> None:
+def test_dtype_conversions(polars_dtype: PolarsDataType, dtype: Dtype) -> None:
     assert polars_dtype_to_dtype(polars_dtype) == dtype
     assert dtype_to_polars_dtype(dtype) == polars_dtype
 
@@ -75,7 +76,7 @@ def test_dtype_to_polars_dtype_categorical(dtype: Dtype) -> None:
         pl.Enum(["a", "b"]),
     ],
 )
-def test_polars_dtype_to_dtype_categorical(polars_dtype: pl.PolarsDataType) -> None:
+def test_polars_dtype_to_dtype_categorical(polars_dtype: PolarsDataType) -> None:
     assert polars_dtype_to_dtype(polars_dtype) == (DtypeKind.CATEGORICAL, 32, "I", NE)
 
 
@@ -134,7 +135,7 @@ def test_get_buffer_length_in_elements_unsupported_dtype() -> None:
     ],
 )
 def test_polars_dtype_to_data_buffer_dtype(
-    dtype: pl.PolarsDataType, expected: pl.PolarsDataType
+    dtype: PolarsDataType, expected: PolarsDataType
 ) -> None:
     assert polars_dtype_to_data_buffer_dtype(dtype) == expected
 

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -16,8 +16,7 @@ from polars.testing.parametric import series
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from polars.type_aliases import IndexOrder
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import IndexOrder, PolarsDataType
 
 
 def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from polars.type_aliases import IndexOrder
+    from polars.typing import PolarsDataType
 
 
 def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:
@@ -203,7 +204,7 @@ def test_df_to_numpy_not_zero_copy() -> None:
     ],
 )
 def test_df_to_numpy_empty_dtype_viewable(
-    schema: dict[str, pl.PolarsDataType], expected_dtype: npt.DTypeLike
+    schema: dict[str, PolarsDataType], expected_dtype: npt.DTypeLike
 ) -> None:
     df = pl.DataFrame(schema=schema)
     result = df.to_numpy(allow_copy=False)

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -16,7 +16,7 @@ from polars.testing.parametric import series
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -16,6 +16,8 @@ from polars.testing.parametric import series
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from polars.typing import PolarsDataType
+
 
 def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:
     if s.len() == 0:
@@ -46,7 +48,7 @@ def assert_allow_copy_false_raises(s: pl.Series) -> None:
     ],
 )
 def test_series_to_numpy_numeric_zero_copy(
-    dtype: pl.PolarsDataType, expected_dtype: npt.DTypeLike
+    dtype: PolarsDataType, expected_dtype: npt.DTypeLike
 ) -> None:
     s = pl.Series([1, 2, 3]).cast(dtype)
     result = s.to_numpy(allow_copy=False)
@@ -72,7 +74,7 @@ def test_series_to_numpy_numeric_zero_copy(
     ],
 )
 def test_series_to_numpy_numeric_with_nulls(
-    dtype: pl.PolarsDataType, expected_dtype: npt.DTypeLike
+    dtype: PolarsDataType, expected_dtype: npt.DTypeLike
 ) -> None:
     s = pl.Series([1, 2, None], dtype=dtype, strict=False)
     result = s.to_numpy()
@@ -97,7 +99,7 @@ def test_series_to_numpy_numeric_with_nulls(
     ],
 )
 def test_series_to_numpy_temporal_zero_copy(
-    dtype: pl.PolarsDataType, expected_dtype: npt.DTypeLike
+    dtype: PolarsDataType, expected_dtype: npt.DTypeLike
 ) -> None:
     values = [0, 2_000, 1_000_000]
     s = pl.Series(values, dtype=dtype, strict=False)
@@ -148,7 +150,7 @@ def test_series_to_numpy_date() -> None:
     ],
 )
 def test_series_to_numpy_temporal_with_nulls(
-    dtype: pl.PolarsDataType, expected_dtype: npt.DTypeLike
+    dtype: PolarsDataType, expected_dtype: npt.DTypeLike
 ) -> None:
     values = [0, 2_000, 1_000_000, None]
     s = pl.Series(values, dtype=dtype, strict=False)
@@ -187,7 +189,7 @@ def test_series_to_numpy_datetime_with_tz_with_nulls() -> None:
 )
 @pytest.mark.parametrize("with_nulls", [False, True])
 def test_to_numpy_object_dtypes(
-    dtype: pl.PolarsDataType, values: list[Any], with_nulls: bool
+    dtype: PolarsDataType, values: list[Any], with_nulls: bool
 ) -> None:
     if with_nulls:
         values.append(None)

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import hypothesis.strategies as st
 import numpy as np
@@ -11,6 +11,9 @@ import pytest
 from hypothesis import given
 
 import polars as pl
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_df_to_pandas_empty() -> None:
@@ -180,7 +183,7 @@ def test_object_to_pandas_series(use_pyarrow_extension_array: bool) -> None:
 
 
 @pytest.mark.parametrize("polars_dtype", [pl.Categorical, pl.Enum(["a", "b"])])
-def test_series_to_pandas_categorical(polars_dtype: pl.PolarsDataType) -> None:
+def test_series_to_pandas_categorical(polars_dtype: PolarsDataType) -> None:
     s = pl.Series("x", ["a", "b", "a"], dtype=polars_dtype)
     result = s.to_pandas()
     expected = pd.Series(["a", "b", "a"], name="x", dtype="category")
@@ -188,7 +191,7 @@ def test_series_to_pandas_categorical(polars_dtype: pl.PolarsDataType) -> None:
 
 
 @pytest.mark.parametrize("polars_dtype", [pl.Categorical, pl.Enum(["a", "b"])])
-def test_series_to_pandas_categorical_pyarrow(polars_dtype: pl.PolarsDataType) -> None:
+def test_series_to_pandas_categorical_pyarrow(polars_dtype: PolarsDataType) -> None:
     s = pl.Series("x", ["a", "b", "a"], dtype=polars_dtype)
     result = s.to_pandas(use_pyarrow_extension_array=True)
     assert s.to_list() == result.to_list()

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -13,7 +13,7 @@ from hypothesis import given
 import polars as pl
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_df_to_pandas_empty() -> None:

--- a/py-polars/tests/unit/io/database/test_inference.py
+++ b/py-polars/tests/unit/io/database/test_inference.py
@@ -12,7 +12,7 @@ from polars.io.database._inference import _infer_dtype_from_database_typename
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/io/database/test_inference.py
+++ b/py-polars/tests/unit/io/database/test_inference.py
@@ -12,7 +12,7 @@ from polars.io.database._inference import _infer_dtype_from_database_typename
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.datatypes import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -20,7 +20,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_init_signature_match() -> None:

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -20,6 +20,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
+    from polars.typing import PolarsDataType
+
 
 def test_init_signature_match() -> None:
     # eager/lazy init signatures are expected to match; if this test fails, it
@@ -1191,7 +1193,7 @@ def test_quadratic_behavior_4736() -> None:
 
 
 @pytest.mark.parametrize("input_dtype", [pl.Int64, pl.Float64])
-def test_from_epoch(input_dtype: pl.PolarsDataType) -> None:
+def test_from_epoch(input_dtype: PolarsDataType) -> None:
     ldf = pl.LazyFrame(
         [
             pl.Series("timestamp_d", [13285]).cast(input_dtype),
@@ -1338,7 +1340,7 @@ def test_compare_schema_between_lazy_and_eager_6904() -> None:
     ],
 )
 def test_compare_aggregation_between_lazy_and_eager_6904(
-    dtype: pl.PolarsDataType, func: pl.Expr
+    dtype: PolarsDataType, func: pl.Expr
 ) -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/ml/test_to_jax.py
+++ b/py-polars/tests/unit/ml/test_to_jax.py
@@ -17,7 +17,7 @@ jxn, _ = _lazy_import("jax.numpy")
 pytestmark = pytest.mark.ci_only
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/ml/test_to_jax.py
+++ b/py-polars/tests/unit/ml/test_to_jax.py
@@ -17,7 +17,7 @@ jxn, _ = _lazy_import("jax.numpy")
 pytestmark = pytest.mark.ci_only
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -12,7 +12,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from polars.type_aliases import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 def test_quantile_expr_input() -> None:
@@ -405,7 +405,7 @@ def test_nan_inf_aggregation() -> None:
 
 
 @pytest.mark.parametrize("dtype", [pl.Int16, pl.UInt16])
-def test_int16_max_12904(dtype: pl.PolarsDataType) -> None:
+def test_int16_max_12904(dtype: PolarsDataType) -> None:
     s = pl.Series([None, 1], dtype=dtype)
 
     assert s.min() == 1

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -12,7 +12,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_quantile_expr_input() -> None:

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -10,7 +10,7 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_any_expr(fruits_cars: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import datetime
 from collections import OrderedDict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_any_expr(fruits_cars: pl.DataFrame) -> None:
@@ -428,8 +431,8 @@ def test_mean_horizontal_all_null() -> None:
     ],
 )
 def test_schema_mean_horizontal_single_column(
-    in_dtype: pl.PolarsDataType,
-    out_dtype: pl.PolarsDataType,
+    in_dtype: PolarsDataType,
+    out_dtype: PolarsDataType,
 ) -> None:
     lf = pl.LazyFrame({"a": pl.Series([1, 0]).cast(in_dtype)}).select(
         pl.mean_horizontal(pl.all())

--- a/py-polars/tests/unit/operations/arithmetic/test_neg.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_neg.py
@@ -11,7 +11,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/arithmetic/test_neg.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_neg.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from decimal import Decimal as D
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -9,11 +10,14 @@ import polars as pl
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
+
 
 @pytest.mark.parametrize(
     "dtype", [pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64]
 )
-def test_neg_operator(dtype: pl.PolarsDataType) -> None:
+def test_neg_operator(dtype: PolarsDataType) -> None:
     lf = pl.LazyFrame({"a": [-1, 0, 1, None]}, schema={"a": dtype})
     result = lf.select(-pl.col("a"))
     expected = pl.LazyFrame({"a": [1, 0, -1, None]}, schema={"a": dtype})

--- a/py-polars/tests/unit/operations/rolling/test_map.py
+++ b/py-polars/tests/unit/operations/rolling/test_map.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
 import polars as pl
 from polars.testing import assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 @pytest.mark.parametrize(
@@ -57,7 +62,7 @@ def test_rolling_map_np_nansum() -> None:
 
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
-def test_rolling_map_std(dtype: pl.PolarsDataType) -> None:
+def test_rolling_map_std(dtype: PolarsDataType) -> None:
     s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=dtype)
     result = s.rolling_map(function=lambda s: s.std(), window_size=3)
 
@@ -66,7 +71,7 @@ def test_rolling_map_std(dtype: pl.PolarsDataType) -> None:
 
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
-def test_rolling_map_std_weights(dtype: pl.PolarsDataType) -> None:
+def test_rolling_map_std_weights(dtype: PolarsDataType) -> None:
     s = pl.Series("A", [1.0, 2.0, 9.0, 2.0, 13.0], dtype=dtype)
 
     result = s.rolling_map(

--- a/py-polars/tests/unit/operations/rolling/test_map.py
+++ b/py-polars/tests/unit/operations/rolling/test_map.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 from decimal import Decimal as D
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_abs() -> None:
@@ -46,7 +49,7 @@ def test_builtin_abs() -> None:
 @pytest.mark.parametrize(
     "dtype", [pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64]
 )
-def test_abs_builtin(dtype: pl.PolarsDataType) -> None:
+def test_abs_builtin(dtype: PolarsDataType) -> None:
     lf = pl.LazyFrame({"a": [-1, 0, 1, None]}, schema={"a": dtype})
     result = lf.select(abs(pl.col("a")))
     expected = pl.LazyFrame({"a": [1, 0, 1, None]}, schema={"a": dtype})

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -11,7 +11,7 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_abs() -> None:

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -12,7 +12,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 def test_string_date() -> None:
@@ -172,8 +172,8 @@ def test_leading_plus_zero_float(dtype: pl.DataType) -> None:
 
 def _cast_series(
     val: int | datetime | date | time | timedelta,
-    dtype_in: pl.PolarsDataType,
-    dtype_out: pl.PolarsDataType,
+    dtype_in: PolarsDataType,
+    dtype_out: PolarsDataType,
     strict: bool,
 ) -> int | datetime | date | time | timedelta | None:
     return pl.Series("a", [val], dtype=dtype_in).cast(dtype_out, strict=strict).item()  # type: ignore[no-any-return]
@@ -181,8 +181,8 @@ def _cast_series(
 
 def _cast_expr(
     val: int | datetime | date | time | timedelta,
-    dtype_in: pl.PolarsDataType,
-    dtype_out: pl.PolarsDataType,
+    dtype_in: PolarsDataType,
+    dtype_out: PolarsDataType,
     strict: bool,
 ) -> int | datetime | date | time | timedelta | None:
     return (  # type: ignore[no-any-return]
@@ -195,8 +195,8 @@ def _cast_expr(
 
 def _cast_lit(
     val: int | datetime | date | time | timedelta,
-    dtype_in: pl.PolarsDataType,
-    dtype_out: pl.PolarsDataType,
+    dtype_in: PolarsDataType,
+    dtype_out: PolarsDataType,
     strict: bool,
 ) -> int | datetime | date | time | timedelta | None:
     return pl.select(pl.lit(val, dtype=dtype_in).cast(dtype_out, strict=strict)).item()  # type: ignore[no-any-return]
@@ -221,8 +221,8 @@ def _cast_lit(
 )
 def test_strict_cast_int(
     value: int,
-    from_dtype: pl.PolarsDataType,
-    to_dtype: pl.PolarsDataType,
+    from_dtype: PolarsDataType,
+    to_dtype: PolarsDataType,
     should_succeed: bool,
     expected_value: Any,
 ) -> None:
@@ -259,8 +259,8 @@ def test_strict_cast_int(
 )
 def test_cast_int(
     value: int,
-    from_dtype: pl.PolarsDataType,
-    to_dtype: pl.PolarsDataType,
+    from_dtype: PolarsDataType,
+    to_dtype: PolarsDataType,
     expected_value: Any,
 ) -> None:
     args = [value, from_dtype, to_dtype, False]
@@ -271,8 +271,8 @@ def test_cast_int(
 
 def _cast_series_t(
     val: int | datetime | date | time | timedelta,
-    dtype_in: pl.PolarsDataType,
-    dtype_out: pl.PolarsDataType,
+    dtype_in: PolarsDataType,
+    dtype_out: PolarsDataType,
     strict: bool,
 ) -> pl.Series:
     return pl.Series("a", [val], dtype=dtype_in).cast(dtype_out, strict=strict)
@@ -280,8 +280,8 @@ def _cast_series_t(
 
 def _cast_expr_t(
     val: int | datetime | date | time | timedelta,
-    dtype_in: pl.PolarsDataType,
-    dtype_out: pl.PolarsDataType,
+    dtype_in: PolarsDataType,
+    dtype_out: PolarsDataType,
     strict: bool,
 ) -> pl.Series:
     return (
@@ -294,8 +294,8 @@ def _cast_expr_t(
 
 def _cast_lit_t(
     val: int | datetime | date | time | timedelta,
-    dtype_in: pl.PolarsDataType,
-    dtype_out: pl.PolarsDataType,
+    dtype_in: PolarsDataType,
+    dtype_out: PolarsDataType,
     strict: bool,
 ) -> pl.Series:
     return pl.select(
@@ -354,8 +354,8 @@ def _cast_lit_t(
 )
 def test_strict_cast_temporal(
     value: int,
-    from_dtype: pl.PolarsDataType,
-    to_dtype: pl.PolarsDataType,
+    from_dtype: PolarsDataType,
+    to_dtype: PolarsDataType,
     should_succeed: bool,
     expected_value: Any,
 ) -> None:
@@ -429,8 +429,8 @@ def test_strict_cast_temporal(
 )
 def test_cast_temporal(
     value: int,
-    from_dtype: pl.PolarsDataType,
-    to_dtype: pl.PolarsDataType,
+    from_dtype: PolarsDataType,
+    to_dtype: PolarsDataType,
     expected_value: Any,
 ) -> None:
     args = [value, from_dtype, to_dtype, False]
@@ -489,8 +489,8 @@ def test_cast_temporal(
 )
 def test_cast_string_and_binary(
     value: int,
-    from_dtype: pl.PolarsDataType,
-    to_dtype: pl.PolarsDataType,
+    from_dtype: PolarsDataType,
+    to_dtype: PolarsDataType,
     expected_value: Any,
 ) -> None:
     args = [value, from_dtype, to_dtype, False]
@@ -550,8 +550,8 @@ def test_cast_string_and_binary(
 )
 def test_strict_cast_string_and_binary(
     value: int,
-    from_dtype: pl.PolarsDataType,
-    to_dtype: pl.PolarsDataType,
+    from_dtype: PolarsDataType,
+    to_dtype: PolarsDataType,
     should_succeed: bool,
     expected_value: Any,
 ) -> None:
@@ -685,7 +685,7 @@ def test_all_null_cast_5826() -> None:
     "dtype",
     [pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64, pl.Int8, pl.Int16, pl.Int32, pl.Int64],
 )
-def test_bool_numeric_supertype(dtype: pl.PolarsDataType) -> None:
+def test_bool_numeric_supertype(dtype: PolarsDataType) -> None:
     df = pl.DataFrame({"v": [1, 2, 3, 4, 5, 6]})
     result = df.select((pl.col("v") < 3).sum().cast(dtype) / pl.len())
     assert result.item() - 0.3333333 <= 0.00001

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -12,7 +12,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_string_date() -> None:

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -10,7 +10,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_comparison_order_null_broadcasting() -> None:

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import math
 from contextlib import nullcontext
-from typing import Any, ContextManager
+from typing import TYPE_CHECKING, Any, ContextManager
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_comparison_order_null_broadcasting() -> None:
@@ -199,7 +202,7 @@ def reference_ordering_missing(lhs: Any, rhs: Any) -> str:
 
 
 def verify_total_ordering(
-    lhs: Any, rhs: Any, dummy: Any, dtype: pl.PolarsDataType
+    lhs: Any, rhs: Any, dummy: Any, dtype: PolarsDataType
 ) -> None:
     ref = reference_ordering_propagating(lhs, rhs)
     refmiss = reference_ordering_missing(lhs, rhs)
@@ -239,7 +242,7 @@ def verify_total_ordering(
 
 
 def verify_total_ordering_broadcast(
-    lhs: Any, rhs: Any, dummy: Any, dtype: pl.PolarsDataType
+    lhs: Any, rhs: Any, dummy: Any, dtype: PolarsDataType
 ) -> None:
     ref = reference_ordering_propagating(lhs, rhs)
     refmiss = reference_ordering_missing(lhs, rhs)

--- a/py-polars/tests/unit/operations/test_extend_constant.py
+++ b/py-polars/tests/unit/operations/test_extend_constant.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 @pytest.mark.parametrize(
@@ -23,7 +26,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
         (timedelta(hours=7, seconds=123), pl.Duration("ms")),
     ],
 )
-def test_extend_constant(const: Any, dtype: pl.PolarsDataType) -> None:
+def test_extend_constant(const: Any, dtype: PolarsDataType) -> None:
     df = pl.DataFrame({"a": pl.Series("s", [None], dtype=dtype)})
 
     expected_df = pl.DataFrame(
@@ -59,7 +62,7 @@ def test_extend_constant(const: Any, dtype: pl.PolarsDataType) -> None:
         (timedelta(hours=7, seconds=123), pl.Duration("ms")),
     ],
 )
-def test_extend_constant_arr(const: Any, dtype: pl.PolarsDataType) -> None:
+def test_extend_constant_arr(const: Any, dtype: PolarsDataType) -> None:
     """
     Test extend_constant in pl.List array.
 

--- a/py-polars/tests/unit/operations/test_extend_constant.py
+++ b/py-polars/tests/unit/operations/test_extend_constant.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars import PolarsDataType
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_simplify_expression_lit_true_4376() -> None:

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -11,7 +11,7 @@ import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_simplify_expression_lit_true_4376() -> None:

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -12,7 +12,7 @@ import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_group_by() -> None:

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -12,7 +12,7 @@ import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 def test_group_by() -> None:
@@ -643,7 +643,7 @@ def test_group_by_binary_agg_with_literal() -> None:
 
 @pytest.mark.slow()
 @pytest.mark.parametrize("dtype", [pl.Int32, pl.UInt32])
-def test_overflow_mean_partitioned_group_by_5194(dtype: pl.PolarsDataType) -> None:
+def test_overflow_mean_partitioned_group_by_5194(dtype: PolarsDataType) -> None:
     df = pl.DataFrame(
         [
             pl.Series("data", [10_00_00_00] * 100_000, dtype=dtype),
@@ -1059,8 +1059,8 @@ def test_group_by_schema_err() -> None:
 def test_schemas(
     data: dict[str, list[Any]],
     expr: pl.Expr,
-    expected_select: dict[str, pl.PolarsDataType],
-    expected_gb: dict[str, pl.PolarsDataType],
+    expected_select: dict[str, PolarsDataType],
+    expected_gb: dict[str, PolarsDataType],
 ) -> None:
     df = pl.DataFrame(data)
 

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_is_first_distinct() -> None:

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_is_first_distinct() -> None:
@@ -148,7 +151,7 @@ def test_is_last_distinct() -> None:
 
 
 @pytest.mark.parametrize("dtypes", [pl.Int32, pl.String, pl.Boolean, pl.List(pl.Int32)])
-def test_is_first_last_distinct_all_null(dtypes: pl.PolarsDataType) -> None:
+def test_is_first_last_distinct_all_null(dtypes: PolarsDataType) -> None:
     s = pl.Series([None, None, None], dtype=dtypes)
     assert s.is_first_distinct().to_list() == [True, False, False]
     assert s.is_last_distinct().to_list() == [False, False, True]

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -10,7 +10,7 @@ from polars import StringCache
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_struct_logical_is_in() -> None:

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from datetime import date
+from typing import TYPE_CHECKING
 
 import pytest
 
 import polars as pl
 from polars import StringCache
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 def test_struct_logical_is_in() -> None:
@@ -166,7 +170,7 @@ def test_is_in_invalid_shape() -> None:
 
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
-def test_is_in_float(dtype: pl.PolarsDataType) -> None:
+def test_is_in_float(dtype: PolarsDataType) -> None:
     s = pl.Series([float("nan"), 0.0], dtype=dtype)
     result = s.is_in([-0.0, -float("nan")])
     expected = pl.Series([True, True], dtype=pl.Boolean)

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from hypothesis import given
@@ -9,6 +9,9 @@ from hypothesis import given
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import dataframes, series
+
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
 
 
 @given(
@@ -276,7 +279,7 @@ def test_sort_aggregation_fast_paths() -> None:
 
 
 @pytest.mark.parametrize("dtype", [pl.Int8, pl.Int16, pl.Int32, pl.Int64])
-def test_sorted_join_and_dtypes(dtype: pl.PolarsDataType) -> None:
+def test_sorted_join_and_dtypes(dtype: PolarsDataType) -> None:
     df_a = (
         pl.DataFrame({"a": [-5, -2, 3, 3, 9, 10]})
         .with_row_index()

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -11,7 +11,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import dataframes, series
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @given(

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -11,7 +11,7 @@ from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 # TODO: Define data type groups centrally somewhere in the test suite
 DATETIME_DTYPES: set[PolarsDataType] = {

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -10,14 +10,17 @@ import polars as pl
 from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 
+if TYPE_CHECKING:
+    from polars.typing import PolarsDataType
+
 # TODO: Define data type groups centrally somewhere in the test suite
-DATETIME_DTYPES: set[pl.PolarsDataType] = {
+DATETIME_DTYPES: set[PolarsDataType] = {
     pl.Datetime,
     pl.Datetime("ms"),
     pl.Datetime("us"),
     pl.Datetime("ns"),
 }
-TEMPORAL_DTYPES: set[pl.PolarsDataType] = (
+TEMPORAL_DTYPES: set[PolarsDataType] = (
     {pl.Date, pl.Time} | pl.DURATION_DTYPES | DATETIME_DTYPES
 )
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -29,7 +29,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import EpochTimeUnit, PolarsDataType, TimeUnit
+    from polars.type_aliases import EpochTimeUnit, TimeUnit
+    from polars.typing import PolarsDataType
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
@@ -1486,7 +1487,7 @@ def test_is_finite_is_infinite() -> None:
 
 
 @pytest.mark.parametrize("float_type", [pl.Float32, pl.Float64])
-def test_is_nan_is_not_nan(float_type: pl.PolarsDataType) -> None:
+def test_is_nan_is_not_nan(float_type: PolarsDataType) -> None:
     s = pl.Series([1.0, np.nan, None], dtype=float_type)
 
     assert_series_equal(s.is_nan(), pl.Series([False, True, None]))
@@ -1875,7 +1876,7 @@ def test_from_epoch_expr(
     value: int,
     time_unit: EpochTimeUnit,
     exp: date | datetime,
-    exp_type: pl.PolarsDataType,
+    exp_type: PolarsDataType,
 ) -> None:
     s = pl.Series("timestamp", [value, None])
     result = pl.from_epoch(s, time_unit=time_unit)
@@ -1966,7 +1967,7 @@ def test_is_between() -> None:
     ],
 )
 def test_upper_lower_bounds(
-    dtype: pl.PolarsDataType, upper: int | float, lower: int | float
+    dtype: PolarsDataType, upper: int | float, lower: int | float
 ) -> None:
     s = pl.Series("s", dtype=dtype)
     assert s.lower_bound().item() == lower

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -29,8 +29,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import EpochTimeUnit, TimeUnit
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import EpochTimeUnit, PolarsDataType, TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -10,7 +10,7 @@ from polars.exceptions import SQLInterfaceError, SQLSyntaxError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 def test_div() -> None:

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -10,7 +10,7 @@ from polars.exceptions import SQLInterfaceError, SQLSyntaxError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.datatypes import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 def test_div() -> None:

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -20,7 +20,7 @@ from polars.datatypes import (
 
 if TYPE_CHECKING:
     from polars.datatypes import DataTypeClass
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 SIMPLE_DTYPES: list[DataTypeClass] = list(
     pl.INTEGER_DTYPES  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -20,6 +20,7 @@ from polars.datatypes import (
 
 if TYPE_CHECKING:
     from polars.datatypes import DataTypeClass
+    from polars.typing import PolarsDataType
 
 SIMPLE_DTYPES: list[DataTypeClass] = list(
     pl.INTEGER_DTYPES  # type: ignore[arg-type]
@@ -135,7 +136,7 @@ def test_dtypes_hashable() -> None:
         ),
     ],
 )
-def test_repr(dtype: pl.PolarsDataType, representation: str) -> None:
+def test_repr(dtype: PolarsDataType, representation: str) -> None:
     assert repr(dtype) == representation
 
 

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -9,7 +9,7 @@ import pytest
 import polars as pl
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars.typing import PolarsDataType
 
 
 @pytest.fixture(autouse=True)
@@ -108,7 +108,7 @@ Series: 'foo' [str]
     "dtype", [pl.String, pl.Categorical, pl.Enum(["abc", "abcd", "abcde"])]
 )
 def test_fmt_series_string_truncate_cat(
-    dtype: pl.PolarsDataType, capfd: pytest.CaptureFixture[str]
+    dtype: PolarsDataType, capfd: pytest.CaptureFixture[str]
 ) -> None:
     s = pl.Series(name="foo", values=["abc", "abcd", "abcde"], dtype=dtype)
     with pl.Config(fmt_str_lengths=4):

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -9,7 +9,7 @@ import pytest
 import polars as pl
 
 if TYPE_CHECKING:
-    from polars.typing import PolarsDataType
+    from polars.type_aliases import PolarsDataType
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
#### Changes

- Remove re-export of `PolarsDataType` at the top-level
- Remove the following re-exports in the `datatypes` module:
    - `OneOrMoreDataTypes`
    - `PolarsDataType`
    - `PolarsTemporalType`
    - `PythonDataType`
    - `SchemaDefinition`
    - `SchemaDict`

We do not want to re-export type aliases for a few reasons:
- Re-exporting these means we need to load them on every import, when they are only useful during type checking.
- So far, these aren't really meant to be public. They are meant for our own use. We haven't really vetted these to be suitable for public use.

I want to set up a proper `polars.typing` module [like NumPy has](https://numpy.org/devdocs/reference/typing.html#), with a few 'blessed' type aliases. Until then, people can use the `polars.type_aliases` module (which is not really intended to be public) or define their own type aliases.

This is _technically_ not breaking because we do not document the type aliases in the API reference, but all the same, there will probably be some people who were using these re-exports. So now with the 1.0.0 release it's a good opportunity to make this change.

**Example**

Before:

```python
def foo(dtype: pl.PolarsDataType) -> None: ...
```

After:

```python
from polars.type_aliases import PolarsDataType

def foo(dtype: PolarsDataType) -> None: ...
```