### PR TITLE
test(python): Update exception imports in test suite

### DIFF
--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -16,6 +16,7 @@ import polars as pl
 from polars._utils.construction.utils import try_get_type_hints
 from polars.datatypes import PolarsDataType, numpy_char_code_to_dtype
 from polars.dependencies import dataclasses, pydantic
+from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -961,11 +962,11 @@ def test_init_pandas(monkeypatch: Any) -> None:
 
 def test_init_errors() -> None:
     # Length mismatch
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0, 4.0]})
 
     # Columns don't match data dimensions
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         pl.DataFrame([[1, 2], [3, 4]], schema=["a", "b", "c"])
 
     # Unmatched input

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -7,7 +7,7 @@ from typing import Any, Iterator, Mapping
 import pytest
 
 import polars as pl
-from polars.exceptions import DataOrientationWarning
+from polars.exceptions import DataOrientationWarning, InvalidOperationError
 
 
 def test_df_mixed_dtypes_string() -> None:
@@ -113,7 +113,7 @@ def test_df_init_strict() -> None:
 def test_df_init_from_series_strict() -> None:
     s = pl.Series("a", [-1, 0, 1])
     schema = {"a": pl.UInt8}
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         pl.DataFrame(s, schema=schema, strict=True)
 
     df = pl.DataFrame(s, schema=schema, strict=False)

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing.asserts.series import assert_series_equal
 
 
@@ -147,7 +148,7 @@ def test_series_init_np_temporal_with_nat_15518() -> None:
 def test_series_init_np_2d_zero_zero_shape() -> None:
     arr = np.array([]).reshape(0, 0)
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape("cannot reshape empty array into shape (0, 0)"),
     ):
         pl.Series(arr)

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -17,6 +17,7 @@ import polars as pl
 import polars.selectors as cs
 from polars._utils.construction import iterable_to_pydf
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, INTEGER_DTYPES
+from polars.exceptions import ComputeError
 from polars.testing import (
     assert_frame_equal,
     assert_frame_not_equal,
@@ -76,7 +77,7 @@ def test_comparisons() -> None:
     assert_frame_equal(df >= 2, pl.DataFrame({"a": [False, True], "b": [True, True]}))
     assert_frame_equal(df <= 2, pl.DataFrame({"a": [True, True], "b": [False, False]}))
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df > "2"  # noqa: B015
 
     # Series
@@ -115,7 +116,7 @@ def test_comparisons() -> None:
         df == pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})  # noqa: B015
 
     # Type mismatch
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df == pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})  # noqa: B015
 
 
@@ -490,7 +491,7 @@ def test_file_buffer() -> None:
     f.write(b"1,2,3,4,5,6\n7,8,9,10,11,12")
     f.seek(0)
     # check if not fails on TryClone and Length impl in file.rs
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.read_parquet(f)
 
 
@@ -1201,7 +1202,7 @@ def test_repeat_by_unequal_lengths_panic() -> None:
         }
     )
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="repeat_by argument and the Series should have equal length, "
         "or at least one of them should have length 1",
     ):
@@ -2108,7 +2109,7 @@ def test_lower_bound_upper_bound(fruits_cars: pl.DataFrame) -> None:
     res_expr = fruits_cars.select(pl.col("B").upper_bound())
     assert res_expr.item() == 9223372036854775807
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         fruits_cars.select(pl.col("fruits").upper_bound())
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -17,7 +17,7 @@ import polars as pl
 import polars.selectors as cs
 from polars._utils.construction import iterable_to_pydf
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, INTEGER_DTYPES
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import (
     assert_frame_equal,
     assert_frame_not_equal,
@@ -1359,12 +1359,12 @@ def test_dot_product() -> None:
     assert result == 32.0
 
     with pytest.raises(
-        pl.InvalidOperationError, match="`dot` operation not supported for dtype `bool`"
+        InvalidOperationError, match="`dot` operation not supported for dtype `bool`"
     ):
         pl.Series([True, False, False, True]) @ pl.Series([4, 5, 6, 7])
 
     with pytest.raises(
-        pl.InvalidOperationError, match="`dot` operation not supported for dtype `str`"
+        InvalidOperationError, match="`dot` operation not supported for dtype `str`"
     ):
         pl.Series([1, 2, 3, 4]) @ pl.Series(["True", "False", "False", "True"])
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -17,7 +17,12 @@ import polars as pl
 import polars.selectors as cs
 from polars._utils.construction import iterable_to_pydf
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, INTEGER_DTYPES
-from polars.exceptions import ComputeError, DuplicateError, InvalidOperationError
+from polars.exceptions import (
+    ComputeError,
+    DuplicateError,
+    InvalidOperationError,
+    OutOfBoundsError,
+)
 from polars.testing import (
     assert_frame_equal,
     assert_frame_not_equal,
@@ -386,7 +391,7 @@ def test_take_misc(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
 
     # Out of bounds error.
-    with pytest.raises(pl.OutOfBoundsError):
+    with pytest.raises(OutOfBoundsError):
         df.sort("fruits").select(
             pl.col("B").reverse().gather([1, 2]).implode().over("fruits"),
             "fruits",

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -17,7 +17,7 @@ import polars as pl
 import polars.selectors as cs
 from polars._utils.construction import iterable_to_pydf
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, INTEGER_DTYPES
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import ComputeError, DuplicateError, InvalidOperationError
 from polars.testing import (
     assert_frame_equal,
     assert_frame_not_equal,
@@ -1716,10 +1716,10 @@ def test_schema_equality() -> None:
 
 def test_df_schema_unique() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
-    with pytest.raises(pl.DuplicateError):
+    with pytest.raises(DuplicateError):
         df.columns = ["a", "a"]
 
-    with pytest.raises(pl.DuplicateError):
+    with pytest.raises(DuplicateError):
         df.rename({"b": "a"})
 
 

--- a/py-polars/tests/unit/dataframe/test_extend.py
+++ b/py-polars/tests/unit/dataframe/test_extend.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 import polars as pl
+from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal
 
 
@@ -73,7 +74,7 @@ def test_extend_column_number_mismatch() -> None:
     df1 = pl.DataFrame({"a": [1, 2], "b": [True, False]})
     df2 = df1.drop("a")
 
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         df1.extend(df2)
 
 
@@ -81,5 +82,5 @@ def test_extend_column_name_mismatch() -> None:
     df1 = pl.DataFrame({"a": [1, 2], "b": [True, False]})
     df2 = df1.with_columns(pl.col("a").alias("c"))
 
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         df1.extend(df2)

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -170,8 +171,5 @@ def test_serde_validation() -> None:
     }
     """
     )
-    with pytest.raises(
-        pl.ComputeError,
-        match=r"lengths don't match",
-    ):
+    with pytest.raises(ComputeError, match=r"lengths don't match"):
         pl.DataFrame.deserialize(f)

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -209,7 +210,7 @@ def test_upsample_index_invalid(
         }
     ).set_sorted("index")
 
-    with pytest.raises(pl.InvalidOperationError, match=r"must be a parsed integer"):
+    with pytest.raises(InvalidOperationError, match=r"must be a parsed integer"):
         df.upsample(
             time_column="index",
             every="1h",

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.exceptions import SchemaError, ShapeError
 from polars.testing import assert_frame_equal
 
 
@@ -49,14 +50,14 @@ def test_vstack_self_in_place(df1: pl.DataFrame) -> None:
 def test_vstack_column_number_mismatch(df1: pl.DataFrame) -> None:
     df2 = df1.drop("ham")
 
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         df1.vstack(df2)
 
 
 def test_vstack_column_name_mismatch(df1: pl.DataFrame) -> None:
     df2 = df1.with_columns(pl.col("foo").alias("oof"))
 
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         df1.vstack(df2)
 
 
@@ -69,7 +70,7 @@ def test_vstack_with_null_column() -> None:
 
     assert_frame_equal(result, expected)
 
-    with pytest.raises(pl.SchemaError):
+    with pytest.raises(SchemaError):
         df2.vstack(df1)
 
 

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import InvalidOperationError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -22,8 +22,7 @@ def test_cast_list_array() -> None:
 
     # width is incorrect
     with pytest.raises(
-        pl.ComputeError,
-        match=r"not all elements have the specified width",
+        ComputeError, match=r"not all elements have the specified width"
     ):
         s.cast(pl.Array(pl.Int64, 2))
 

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -11,6 +11,7 @@ import polars as pl
 from polars import StringCache
 from polars.exceptions import (
     CategoricalRemappingWarning,
+    ComputeError,
     StringCacheMismatchError,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
@@ -472,7 +473,7 @@ def test_cast_inner_categorical() -> None:
     assert out.to_list() == [["a"], ["a", "b"]]
 
     with pytest.raises(
-        pl.ComputeError, match=r"casting to categorical not allowed in `list.eval`"
+        ComputeError, match=r"casting to categorical not allowed in `list.eval`"
     ):
         pl.Series("foo", [["a", "b"], ["a", "b"]]).list.eval(
             pl.element().cast(pl.Categorical)

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import pytest
 
 import polars as pl
+from polars.exceptions import PolarsPanicError
 from polars.testing import assert_frame_equal
 
 
@@ -57,5 +58,5 @@ def test_series_duration_std_var() -> None:
 
 def test_series_duration_var_overflow() -> None:
     s = pl.Series([timedelta(days=10), timedelta(days=20), timedelta(days=40)])
-    with pytest.raises(pl.PolarsPanicError, match="OverflowError"):
+    with pytest.raises(PolarsPanicError, match="OverflowError"):
         s.var()

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -10,6 +10,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -239,7 +240,7 @@ def test_extend_to_an_enum() -> None:
 
 def test_series_init_uninstantiated_enum() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="can not cast / initialize Enum without categories present",
     ):
         pl.Series(["a", "b", "a"], dtype=pl.Enum)
@@ -382,7 +383,7 @@ def test_different_enum_comparison_order() -> None:
     )
     for op in [operator.gt, operator.ge, operator.lt, operator.le]:
         with pytest.raises(
-            pl.ComputeError,
+            ComputeError,
             match="can only compare categoricals of the same type",
         ):
             df_enum.filter(op(pl.col("a_cat"), pl.col("b_cat")))

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -10,7 +10,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -38,7 +38,7 @@ def test_enum_init_empty(categories: pl.Series | list[str] | None) -> None:
 
 def test_enum_non_existent() -> None:
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape(
             "conversion from `str` to `enum` failed in column '' for 1 out of 4 values: [\"c\"]"
         ),
@@ -166,7 +166,7 @@ def test_casting_to_an_enum_oob_from_integer() -> None:
 
 def test_casting_to_an_enum_from_categorical_nonexistent() -> None:
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=(
             r"conversion from `cat` to `enum` failed in column '' for 1 out of 4 values: \[\"c\"\]"
         ),
@@ -188,7 +188,7 @@ def test_casting_to_an_enum_from_global_categorical() -> None:
 @StringCache()
 def test_casting_to_an_enum_from_global_categorical_nonexistent() -> None:
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=(
             r"conversion from `cat` to `enum` failed in column '' for 1 out of 4 values: \[\"c\"\]"
         ),
@@ -348,7 +348,7 @@ def test_compare_enum_str_single_raise(
     s2 = "NOTEXIST"
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape(
             "conversion from `str` to `enum` failed in column '' for 1 out of 1 values: [\"NOTEXIST\"]"
         ),
@@ -364,7 +364,7 @@ def test_compare_enum_str_raise() -> None:
     for s_compare in [s2, s_broadcast]:
         for op in [operator.le, operator.gt, operator.ge, operator.lt]:
             with pytest.raises(
-                pl.InvalidOperationError,
+                InvalidOperationError,
                 match="conversion from `str` to `enum` failed in column",
             ):
                 op(s, s_compare)
@@ -440,13 +440,13 @@ def test_enum_cast_from_other_integer_dtype_oob() -> None:
     enum_dtype = pl.Enum(["a", "b", "c", "d"])
     series = pl.Series([-1, 2, 3, 3, 2, 1], dtype=pl.Int8)
     with pytest.raises(
-        pl.InvalidOperationError, match="conversion from `i8` to `u32` failed in column"
+        InvalidOperationError, match="conversion from `i8` to `u32` failed in column"
     ):
         series.cast(enum_dtype)
 
     series = pl.Series([2**34, 2, 3, 3, 2, 1], dtype=pl.UInt64)
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="conversion from `u64` to `u32` failed in column",
     ):
         series.cast(enum_dtype)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -10,7 +10,12 @@ import pytest
 
 import polars as pl
 from polars import StringCache
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import (
+    ComputeError,
+    InvalidOperationError,
+    OutOfBoundsError,
+    SchemaError,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -159,7 +164,7 @@ def test_casting_to_an_enum_oob_from_integer() -> None:
     dtype = pl.Enum(["a", "b", "c"])
     s = pl.Series([None, 1, 0, 5], dtype=pl.UInt32)
     with pytest.raises(
-        pl.OutOfBoundsError, match=("index 5 is bigger than the number of categories 3")
+        OutOfBoundsError, match=("index 5 is bigger than the number of categories 3")
     ):
         s.cast(dtype)
 
@@ -222,7 +227,7 @@ def test_append_to_an_enum() -> None:
 
 def test_append_to_an_enum_with_new_category() -> None:
     with pytest.raises(
-        pl.SchemaError,
+        SchemaError,
         match=("type Enum.*is incompatible with expected type Enum.*"),
     ):
         pl.Series([None, "a", "b", "c"], dtype=pl.Enum(["a", "b", "c"])).append(

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 
 
 def test_series_init_instantiated_object() -> None:
@@ -177,15 +178,15 @@ def test_object_raise_writers() -> None:
 
     buf = io.BytesIO()
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.write_parquet(buf)
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.write_ipc(buf)
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.write_json(buf)
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.write_csv(buf)
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.write_avro(buf)
 
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1351,7 +1351,7 @@ def test_replace_time_zone_ambiguous_with_ambiguous(
 def test_replace_time_zone_ambiguous_raises() -> None:
     ts = pl.Series(["2018-10-28 02:30:00"]).str.strptime(pl.Datetime)
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="Please use `ambiguous` to tell how it should be localized",
     ):
         ts.dt.replace_time_zone("Europe/Brussels")

--- a/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, DuplicateError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -298,7 +298,7 @@ def test_struct_with_lit() -> None:
 
 
 def test_eager_struct() -> None:
-    with pytest.raises(pl.DuplicateError, match="multiple fields with name '' found"):
+    with pytest.raises(DuplicateError, match="multiple fields with name '' found"):
         s = pl.struct([pl.Series([1, 2, 3]), pl.Series(["a", "b", "c"])], eager=True)
 
     s = pl.struct(

--- a/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -56,7 +57,7 @@ def test_datetime_time_zone(time_zone: str | None) -> None:
 def test_datetime_ambiguous_time_zone() -> None:
     expr = pl.datetime(2018, 10, 28, 2, 30, time_zone="Europe/Brussels")
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.select(expr)
 
 
@@ -128,7 +129,7 @@ def test_concat_list_with_lit() -> None:
 
 
 def test_concat_list_empty_raises() -> None:
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.DataFrame({"a": [1, 2, 3]}).with_columns(pl.concat_list([]))
 
 

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, PolarsPanicError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -21,7 +21,7 @@ def test_date_range() -> None:
 
 
 def test_date_range_invalid_time_unit() -> None:
-    with pytest.raises(pl.PolarsPanicError, match="'x' not supported"):
+    with pytest.raises(PolarsPanicError, match="'x' not supported"):
         pl.date_range(
             start=date(2021, 12, 16),
             end=date(2021, 12, 18),

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ def test_date_range_invalid_time_unit() -> None:
 
 
 def test_date_range_invalid_time() -> None:
-    with pytest.raises(pl.ComputeError, match="end is an out-of-range time"):
+    with pytest.raises(ComputeError, match="end is an out-of-range time"):
         pl.date_range(pl.date(2024, 1, 1), pl.date(2024, 2, 30), eager=True)
 
 
@@ -206,15 +207,15 @@ def test_date_range_input_shape_empty() -> None:
     single = pl.Series([datetime(2022, 1, 2)])
 
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+        ComputeError, match="`start` must contain exactly one value, got 0 values"
     ):
         pl.date_range(empty, single, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`end` must contain exactly one value, got 0 values"
+        ComputeError, match="`end` must contain exactly one value, got 0 values"
     ):
         pl.date_range(single, empty, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+        ComputeError, match="`start` must contain exactly one value, got 0 values"
     ):
         pl.date_range(empty, empty, eager=True)
 
@@ -224,15 +225,15 @@ def test_date_range_input_shape_multiple_values() -> None:
     multiple = pl.Series([datetime(2022, 1, 3), datetime(2022, 1, 4)])
 
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+        ComputeError, match="`start` must contain exactly one value, got 2 values"
     ):
         pl.date_range(multiple, single, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`end` must contain exactly one value, got 2 values"
+        ComputeError, match="`end` must contain exactly one value, got 2 values"
     ):
         pl.date_range(single, multiple, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+        ComputeError, match="`start` must contain exactly one value, got 2 values"
     ):
         pl.date_range(multiple, multiple, eager=True)
 
@@ -245,7 +246,7 @@ def test_date_range_start_later_than_end() -> None:
 
 def test_date_range_24h_interval_raises() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="`interval` input for `date_range` must consist of full days",
     ):
         pl.date_range(date(2022, 1, 1), date(2022, 1, 3), interval="24h", eager=True)
@@ -286,7 +287,7 @@ def test_date_ranges_broadcasting_fail() -> None:
     end = pl.Series([date(2021, 1, 2), date(2021, 1, 3)])
 
     with pytest.raises(
-        pl.ComputeError, match=r"lengths of `start` \(3\) and `end` \(2\) do not match"
+        ComputeError, match=r"lengths of `start` \(3\) and `end` \(2\) do not match"
     ):
         pl.date_ranges(start, end, eager=True)
 

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, PolarsPanicError, SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -95,7 +95,7 @@ def test_datetime_range_precision(
 
 
 def test_datetime_range_invalid_time_unit() -> None:
-    with pytest.raises(pl.PolarsPanicError, match="'x' not supported"):
+    with pytest.raises(PolarsPanicError, match="'x' not supported"):
         pl.datetime_range(
             start=datetime(2021, 12, 16),
             end=datetime(2021, 12, 16, 3),
@@ -185,7 +185,7 @@ def test_timezone_aware_datetime_range() -> None:
     ]
 
     with pytest.raises(
-        pl.SchemaError,
+        SchemaError,
         match="failed to determine supertype",
     ):
         pl.datetime_range(

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -7,6 +7,7 @@ import pytest
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -158,7 +159,7 @@ def test_datetime_range_lazy_with_expressions(
 
 
 def test_datetime_range_invalid_time_zone() -> None:
-    with pytest.raises(pl.ComputeError, match="unable to parse time zone: 'foo'"):
+    with pytest.raises(ComputeError, match="unable to parse time zone: 'foo'"):
         pl.datetime_range(
             datetime(2001, 1, 1),
             datetime(2001, 1, 3),
@@ -257,7 +258,7 @@ def test_tzaware_datetime_range_crossing_dst_monthly() -> None:
 
 def test_datetime_range_with_unsupported_datetimes() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match=r"datetime '2021-11-07 01:00:00' is ambiguous in time zone 'US/Central'",
     ):
         pl.datetime_range(
@@ -268,7 +269,7 @@ def test_datetime_range_with_unsupported_datetimes() -> None:
             eager=True,
         )
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match=r"datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Vienna'",
     ):
         pl.datetime_range(
@@ -491,7 +492,7 @@ def test_datetime_ranges_no_alias_schema_9037() -> None:
 
 @pytest.mark.parametrize("interval", [timedelta(0), timedelta(minutes=-10)])
 def test_datetime_range_invalid_interval(interval: timedelta) -> None:
-    with pytest.raises(pl.ComputeError, match="`interval` must be positive"):
+    with pytest.raises(ComputeError, match="`interval` must be positive"):
         pl.datetime_range(
             datetime(2000, 3, 20), datetime(2000, 3, 21), interval="-1h", eager=True
         )

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -204,7 +204,7 @@ def test_int_range_null_input() -> None:
 
 def test_int_range_invalid_conversion() -> None:
     with pytest.raises(
-        pl.InvalidOperationError, match="conversion from `i32` to `u32` failed"
+        InvalidOperationError, match="conversion from `i32` to `u32` failed"
     ):
         pl.select(pl.int_range(3, -1, -1, dtype=pl.UInt32))
 

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -158,15 +159,15 @@ def test_int_range_input_shape_empty() -> None:
     single = pl.Series([5])
 
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+        ComputeError, match="`start` must contain exactly one value, got 0 values"
     ):
         pl.int_range(empty, single, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`end` must contain exactly one value, got 0 values"
+        ComputeError, match="`end` must contain exactly one value, got 0 values"
     ):
         pl.int_range(single, empty, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+        ComputeError, match="`start` must contain exactly one value, got 0 values"
     ):
         pl.int_range(empty, empty, eager=True)
 
@@ -176,15 +177,15 @@ def test_int_range_input_shape_multiple_values() -> None:
     multiple = pl.Series([10, 15])
 
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+        ComputeError, match="`start` must contain exactly one value, got 2 values"
     ):
         pl.int_range(multiple, single, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`end` must contain exactly one value, got 2 values"
+        ComputeError, match="`end` must contain exactly one value, got 2 values"
     ):
         pl.int_range(single, multiple, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+        ComputeError, match="`start` must contain exactly one value, got 2 values"
     ):
         pl.int_range(multiple, multiple, eager=True)
 
@@ -197,7 +198,7 @@ def test_int_range_index_type_negative() -> None:
 
 
 def test_int_range_null_input() -> None:
-    with pytest.raises(pl.ComputeError, match="invalid null input for `int_range`"):
+    with pytest.raises(ComputeError, match="invalid null input for `int_range`"):
         pl.select(pl.int_range(3, pl.lit(None), -1, dtype=pl.UInt32))
 
 
@@ -210,7 +211,7 @@ def test_int_range_invalid_conversion() -> None:
 
 def test_int_range_non_integer_dtype() -> None:
     with pytest.raises(
-        pl.ComputeError, match="non-integer `dtype` passed to `int_range`: Float64"
+        ComputeError, match="non-integer `dtype` passed to `int_range`: Float64"
     ):
         pl.select(pl.int_range(3, -1, -1, dtype=pl.Float64))  # type: ignore[arg-type]
 
@@ -260,7 +261,7 @@ def test_int_ranges_broadcasting() -> None:
 # https://github.com/pola-rs/polars/issues/15307
 def test_int_range_non_int_dtype() -> None:
     with pytest.raises(
-        pl.ComputeError, match="non-integer `dtype` passed to `int_range`: String"
+        ComputeError, match="non-integer `dtype` passed to `int_range`: String"
     ):
         pl.int_range(0, 3, dtype=pl.String, eager=True)  # type: ignore[arg-type]
 
@@ -268,6 +269,6 @@ def test_int_range_non_int_dtype() -> None:
 # https://github.com/pola-rs/polars/issues/15307
 def test_int_ranges_non_int_dtype() -> None:
     with pytest.raises(
-        pl.ComputeError, match="non-integer `dtype` passed to `int_ranges`: String"
+        ComputeError, match="non-integer `dtype` passed to `int_ranges`: String"
     ):
         pl.int_ranges(0, 3, dtype=pl.String, eager=True)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -51,15 +52,15 @@ def test_time_range_input_shape_empty() -> None:
     single = pl.Series([time(12, 0)])
 
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+        ComputeError, match="`start` must contain exactly one value, got 0 values"
     ):
         pl.time_range(empty, single, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`end` must contain exactly one value, got 0 values"
+        ComputeError, match="`end` must contain exactly one value, got 0 values"
     ):
         pl.time_range(single, empty, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+        ComputeError, match="`start` must contain exactly one value, got 0 values"
     ):
         pl.time_range(empty, empty, eager=True)
 
@@ -69,15 +70,15 @@ def test_time_range_input_shape_multiple_values() -> None:
     multiple = pl.Series([time(11, 0), time(12, 0)])
 
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+        ComputeError, match="`start` must contain exactly one value, got 2 values"
     ):
         pl.time_range(multiple, single, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`end` must contain exactly one value, got 2 values"
+        ComputeError, match="`end` must contain exactly one value, got 2 values"
     ):
         pl.time_range(single, multiple, eager=True)
     with pytest.raises(
-        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+        ComputeError, match="`start` must contain exactly one value, got 2 values"
     ):
         pl.time_range(multiple, multiple, eager=True)
 
@@ -109,7 +110,7 @@ def test_time_range_start_later_than_end() -> None:
 
 @pytest.mark.parametrize("interval", [timedelta(0), timedelta(minutes=-10)])
 def test_time_range_invalid_step(interval: timedelta) -> None:
-    with pytest.raises(pl.ComputeError, match="`interval` must be positive"):
+    with pytest.raises(ComputeError, match="`interval` must be positive"):
         pl.time_range(time(11), time(12), interval=interval, eager=True)
 
 

--- a/py-polars/tests/unit/functions/test_business_day_count.py
+++ b/py-polars/tests/unit/functions/test_business_day_count.py
@@ -10,6 +10,7 @@ from hypothesis import assume, given, reject
 
 import polars as pl
 from polars._utils.various import parse_version
+from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 
@@ -93,7 +94,7 @@ def test_business_day_count_w_week_mask_invalid() -> None:
         }
     )
     with pytest.raises(
-        pl.ComputeError, match="`week_mask` must have at least one business day"
+        ComputeError, match="`week_mask` must have at least one business day"
     ):
         df.select(pl.business_day_count("start", "end", week_mask=[False] * 7))
 

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import InvalidOperationError
+from polars.exceptions import DuplicateError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -165,7 +165,7 @@ def test_concat_horizontal_duplicate_col() -> None:
     a = pl.LazyFrame({"a": ["a", "b"], "b": [1, 2]})
     b = pl.LazyFrame({"c": [5, 7, 8, 9], "d": [1, 2, 1, 2], "a": [1, 2, 1, 2]})
 
-    with pytest.raises(pl.DuplicateError):
+    with pytest.raises(DuplicateError):
         pl.concat([a, b], how="horizontal").collect()
 
 

--- a/py-polars/tests/unit/functions/test_nth.py
+++ b/py-polars/tests/unit/functions/test_nth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import DuplicateError
 from polars.testing import assert_frame_equal
 
 
@@ -24,5 +25,5 @@ def test_nth(expr: pl.Expr, expected_cols: list[str]) -> None:
 
 def test_nth_duplicate() -> None:
     df = pl.DataFrame({"a": [1, 2]})
-    with pytest.raises(pl.DuplicateError, match="a"):
+    with pytest.raises(DuplicateError, match="a"):
         df.select(pl.nth(0, 0))

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, OutOfBoundsError, SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -73,13 +73,13 @@ def test_repeat_n_zero() -> None:
     [1.5, 2.0, date(1971, 1, 2), "hello"],
 )
 def test_repeat_n_non_integer(n: Any) -> None:
-    with pytest.raises(pl.SchemaError, match="expected expression of dtype 'integer'"):
+    with pytest.raises(SchemaError, match="expected expression of dtype 'integer'"):
         pl.repeat(1, n=pl.lit(n), eager=True)
 
 
 def test_repeat_n_empty() -> None:
     df = pl.DataFrame(schema={"a": pl.Int32})
-    with pytest.raises(pl.OutOfBoundsError, match="index 0 is out of bounds"):
+    with pytest.raises(OutOfBoundsError, match="index 0 is out of bounds"):
         df.select(pl.repeat(1, n=pl.col("a")))
 
 

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -83,7 +84,7 @@ def test_repeat_n_empty() -> None:
 
 
 def test_repeat_n_negative() -> None:
-    with pytest.raises(pl.ComputeError, match="could not parse value '-1' as a size"):
+    with pytest.raises(ComputeError, match="could not parse value '-1' as a size"):
         pl.repeat(1, n=-1, eager=True)
 
 

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import InvalidOperationError
+from polars.exceptions import InvalidOperationError, ShapeError
 from polars.testing import assert_frame_equal
 
 
@@ -352,10 +352,10 @@ def test_single_element_broadcast(
 def test_mismatched_height_should_raise(
     df: pl.DataFrame, ternary_expr: pl.Expr
 ) -> None:
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         df.select(ternary_expr)
 
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         df.group_by(pl.lit(True).alias("key")).agg(ternary_expr)
 
 

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
 
 
@@ -249,7 +250,7 @@ def test_comp_incompatible_enum_dtype() -> None:
     df = pl.DataFrame({"a": pl.Series(["a", "b"], dtype=pl.Enum(["a", "b"]))})
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="conversion from `str` to `enum` failed in column 'literal'",
     ):
         df.with_columns(

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
@@ -5,6 +5,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 
@@ -154,7 +155,7 @@ def test_generalized_ufunc_missing_data() -> None:
     add_one = make_add_one()
     s_float = pl.Series("f", [1.0, 2.0, 3.0, None], dtype=pl.Float64)
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="Can't pass a Series with missing data to a generalized ufunc",
     ):
         add_one(s_float)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1804,7 +1804,7 @@ def test_ignore_errors_casting_dtypes() -> None:
         ignore_errors=True,
     ).to_dict(as_series=False) == {"inventory": [10, None, None, 90]}
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.read_csv(
             source=io.StringIO(csv),
             schema_overrides={"inventory": pl.Int8},
@@ -1814,7 +1814,7 @@ def test_ignore_errors_casting_dtypes() -> None:
 
 def test_ignore_errors_date_parser() -> None:
     data_invalid_date = "int,float,date\n3,3.4,X"
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.read_csv(
             source=io.StringIO(data_invalid_date),
             schema_overrides={"date": pl.Date},
@@ -1838,9 +1838,9 @@ def test_csv_ragged_lines() -> None:
     )
 
     for s in ["A\nB,ragged\nC", "A\nB\nC,ragged"]:
-        with pytest.raises(pl.ComputeError, match=r"found more fields than defined"):
+        with pytest.raises(ComputeError, match=r"found more fields than defined"):
             pl.read_csv(io.StringIO(s), has_header=False, truncate_ragged_lines=False)
-        with pytest.raises(pl.ComputeError, match=r"found more fields than defined"):
+        with pytest.raises(ComputeError, match=r"found more fields than defined"):
             pl.read_csv(io.StringIO(s), has_header=False, truncate_ragged_lines=False)
 
 
@@ -1936,7 +1936,7 @@ def test_csv_no_new_line_last() -> None:
 
 
 def test_invalid_csv_raise() -> None:
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.read_csv(
             b"""
     "WellCompletionCWI","FacilityID","ProductionMonth","ReportedHoursProdInj","ProdAccountingProductType","ReportedVolume","VolumetricActivityType"
@@ -1997,7 +1997,7 @@ def test_read_csv_single_column(columns: list[str] | str) -> None:
 
 
 def test_csv_invalid_escape_utf8_14960() -> None:
-    with pytest.raises(pl.ComputeError, match=r"field is not properly escaped"):
+    with pytest.raises(ComputeError, match=r"field is not properly escaped"):
         pl.read_csv('col1\n""•'.encode())
 
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -17,7 +17,7 @@ import zstandard
 
 import polars as pl
 from polars._utils.various import normalize_filepath
-from polars.exceptions import ComputeError, NoDataError
+from polars.exceptions import ComputeError, InvalidOperationError, NoDataError
 from polars.io.csv import BatchedCsvReader
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -2108,7 +2108,7 @@ def test_csv_float_decimal() -> None:
 
     floats = b"a;b\n12,239;1,233\n13,908;87,32"
     with pytest.raises(
-        pl.InvalidOperationError, match=r"'decimal_comma' argument cannot be combined"
+        InvalidOperationError, match=r"'decimal_comma' argument cannot be combined"
     ):
         pl.read_csv(floats, decimal_comma=True)
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1732,7 +1732,7 @@ def test_csv_9929() -> None:
     f = io.BytesIO()
     df.write_csv(f)
     f.seek(0)
-    with pytest.raises(pl.NoDataError):
+    with pytest.raises(NoDataError):
         pl.read_csv(f, skip_rows=10**6)
 
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -7,6 +7,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import polars as pl
+from polars.exceptions import DuplicateError
 from polars.testing import assert_frame_equal
 
 
@@ -185,7 +186,7 @@ def test_hive_partitioned_err(io_files_path: Path, tmp_path: Path) -> None:
     root.mkdir()
     df.write_parquet(root / "file.parquet")
 
-    with pytest.raises(pl.DuplicateError, match="invalid Hive partition schema"):
+    with pytest.raises(DuplicateError, match="invalid Hive partition schema"):
         pl.scan_parquet(root / "**/*.parquet", hive_partitioning=True).collect()
 
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -7,7 +7,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import polars as pl
-from polars.exceptions import DuplicateError
+from polars.exceptions import DuplicateError, SchemaFieldNotFoundError
 from polars.testing import assert_frame_equal
 
 
@@ -257,7 +257,7 @@ def test_scan_parquet_hive_schema(dataset_path: Path) -> None:
 @pytest.mark.write_disk()
 def test_read_parquet_invalid_hive_schema(dataset_path: Path) -> None:
     with pytest.raises(
-        pl.SchemaFieldNotFoundError,
+        SchemaFieldNotFoundError,
         match='path contains column not present in the given Hive schema: "c"',
     ):
         pl.read_parquet(

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -348,6 +349,6 @@ def test_ipc_raise_on_writing_mmap(tmp_path: Path) -> None:
     df = pl.read_ipc(p, memory_map=True)
 
     with pytest.raises(
-        pl.ComputeError, match="cannot write to file: already memory mapped"
+        ComputeError, match="cannot write to file: already memory mapped"
     ):
         df.write_ipc(p)

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 
@@ -355,7 +356,7 @@ def test_file_list_schema_mismatch(
         df.write_csv(path)
 
     lf = pl.scan_csv(paths)
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         lf.collect(streaming=streaming)
 
     if len({df.width for df in dfs}) == 1:

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, ShapeError
 from polars.testing import assert_frame_equal
 
 
@@ -160,7 +160,7 @@ def test_scan_csv_schema_new_columns_dtypes(
     assert df4.columns == ["category", "calories", "fats_g", "sugars_g"]
 
     # cannot have len(new_columns) > len(actual columns)
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         pl.scan_csv(
             file_path,
             schema_overrides=[pl.String, pl.String],

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -17,6 +17,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import dataframes
 
@@ -123,11 +124,11 @@ def test_read_parquet_respects_rechunk_16416(
 def test_to_from_buffer_lzo(df: pl.DataFrame) -> None:
     buf = io.BytesIO()
     # Writing lzo compressed parquet files is not supported for now.
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.write_parquet(buf, compression="lzo", use_pyarrow=False)
     buf.seek(0)
     # Invalid parquet file as writing failed.
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         _ = pl.read_parquet(buf)
 
     buf = io.BytesIO()
@@ -136,7 +137,7 @@ def test_to_from_buffer_lzo(df: pl.DataFrame) -> None:
         df.write_parquet(buf, compression="lzo", use_pyarrow=True)
     buf.seek(0)
     # Invalid parquet file as writing failed.
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         _ = pl.read_parquet(buf)
 
 
@@ -160,10 +161,10 @@ def test_to_from_file_lzo(df: pl.DataFrame, tmp_path: Path) -> None:
     file_path = tmp_path / "small.avro"
 
     # Writing lzo compressed parquet files is not supported for now.
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.write_parquet(file_path, compression="lzo", use_pyarrow=False)
     # Invalid parquet file as writing failed.
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         _ = pl.read_parquet(file_path)
 
     # Writing lzo compressed parquet files is not supported for now.

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -14,7 +14,11 @@ import polars as pl
 import polars.selectors as cs
 from polars import lit, when
 from polars.datatypes import FLOAT_DTYPES
-from polars.exceptions import PerformanceWarning, PolarsInefficientMapWarning
+from polars.exceptions import (
+    InvalidOperationError,
+    PerformanceWarning,
+    PolarsInefficientMapWarning,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -618,7 +622,7 @@ def test_cast_frame() -> None:
     # test 'strict' mode
     lf = pl.LazyFrame({"a": [1000, 2000, 3000]})
 
-    with pytest.raises(pl.InvalidOperationError, match="conversion .* failed"):
+    with pytest.raises(InvalidOperationError, match="conversion .* failed"):
         lf.cast(pl.UInt8).collect()
 
     assert lf.cast(pl.UInt8, strict=False).collect().rows() == [
@@ -1236,7 +1240,7 @@ def test_from_epoch_str() -> None:
         ]
     )
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         ldf.select(
             pl.from_epoch(pl.col("timestamp_ms"), time_unit="ms"),
             pl.from_epoch(pl.col("timestamp_us"), time_unit="us"),

--- a/py-polars/tests/unit/lazyframe/test_with_context.py
+++ b/py-polars/tests/unit/lazyframe/test_with_context.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 
@@ -18,7 +19,7 @@ def test_with_context() -> None:
 
     with pytest.deprecated_call():
         context = df_a.with_context(df_b.lazy())
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         context.select("a", "c").collect()
 
 

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -247,7 +248,7 @@ def test_err_on_implode_and_agg() -> None:
 
     # this would OOB
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"'implode' followed by an aggregation is not allowed",
     ):
         df.group_by("type").agg(pl.col("type").implode().first().alias("foo"))
@@ -262,7 +263,7 @@ def test_err_on_implode_and_agg() -> None:
 
     # but not during a window function as the groups cannot be mapped back
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"'implode' followed by an aggregation is not allowed",
     ):
         df.lazy().select(pl.col("type").implode().list.head(1).over("type")).collect()

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -121,13 +122,13 @@ def test_nested_min_max() -> None:
 
 def test_empty_inputs_raise() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="cannot return empty fold because the number of output rows is unknown",
     ):
         pl.select(pl.any_horizontal())
 
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="cannot return empty fold because the number of output rows is unknown",
     ):
         pl.select(pl.all_horizontal())
@@ -389,7 +390,7 @@ def test_mean_horizontal() -> None:
 def test_mean_horizontal_no_columns() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3], "b": [2.0, 4.0, 6.0], "c": [3, None, 9]})
 
-    with pytest.raises(pl.ComputeError, match="number of output rows is unknown"):
+    with pytest.raises(ComputeError, match="number of output rows is unknown"):
         lf.select(pl.mean_horizontal())
 
 

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -20,7 +20,7 @@ from polars import (
     UInt64,
 )
 from polars.datatypes import FLOAT_DTYPES, INTEGER_DTYPES
-from polars.exceptions import InvalidOperationError
+from polars.exceptions import ColumnNotFoundError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -535,7 +535,7 @@ def test_power_series() -> None:
     ):
         2**c
 
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         a ** "hi"  # type: ignore[operator]
 
     # Raising to UInt64: raises if can't be downcast safely to UInt32...
@@ -550,7 +550,7 @@ def test_power_series() -> None:
     assert_series_equal(2.0**a, pl.Series("literal", [2.0, 4.0], dtype=Float64))
     assert_series_equal(2**b, pl.Series("literal", [None, 4.0], dtype=Float64))
 
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         "hi" ** a
 
     # Series.pow() method

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -20,6 +20,7 @@ from polars import (
     UInt64,
 )
 from polars.datatypes import FLOAT_DTYPES, INTEGER_DTYPES
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -312,7 +313,7 @@ def test_bool_floordiv() -> None:
     df = pl.DataFrame({"x": [True]})
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="floor_div operation not supported for dtype `bool`",
     ):
         df.with_columns(pl.col("x").floordiv(2))
@@ -471,7 +472,7 @@ def test_arithmetic_datetime() -> None:
     with pytest.raises(TypeError):
         a % 2
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
     ):
         a**2
     with pytest.raises(TypeError):
@@ -483,7 +484,7 @@ def test_arithmetic_datetime() -> None:
     with pytest.raises(TypeError):
         2 % a
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
     ):
         2**a
 
@@ -518,18 +519,18 @@ def test_power_series() -> None:
     assert_series_equal(k**d, pl.Series([1, 4], dtype=Int64))
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="`pow` operation not supported for dtype `null` as exponent",
     ):
         a ** pl.lit(None)
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="`pow` operation not supported for dtype `date` as base",
     ):
         c**2
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="`pow` operation not supported for dtype `date` as exponent",
     ):
         2**c
@@ -539,7 +540,7 @@ def test_power_series() -> None:
 
     # Raising to UInt64: raises if can't be downcast safely to UInt32...
     with pytest.raises(
-        pl.InvalidOperationError, match="conversion from `u64` to `u32` failed"
+        InvalidOperationError, match="conversion from `u64` to `u32` failed"
     ):
         a**m
     # ... but succeeds otherwise.
@@ -656,7 +657,7 @@ def test_raise_invalid_temporal(a: pl.DataType, b: pl.DataType, op: str) -> None
     b = pl.Series("b", [], dtype=b)  # type: ignore[assignment]
     _df = pl.DataFrame([a, b])
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         eval(f"_df.select(pl.col('a') {op} pl.col('b'))")
 
 
@@ -743,7 +744,7 @@ def test_arithmetic_duration_div_multiply() -> None:
 
 def test_invalid_shapes_err() -> None:
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"cannot do arithmetic operation on series of different lengths: got 2 and 3",
     ):
         pl.Series([1, 2]) + pl.Series([1, 2, 3])

--- a/py-polars/tests/unit/operations/arithmetic/test_neg.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_neg.py
@@ -6,6 +6,7 @@ from decimal import Decimal as D
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
@@ -50,7 +51,7 @@ def test_neg_overflow_wrapping() -> None:
 def test_neg_unsigned_int() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]}, schema={"a": pl.UInt8})
     with pytest.raises(
-        pl.InvalidOperationError, match="`neg` operation not supported for dtype `u8`"
+        InvalidOperationError, match="`neg` operation not supported for dtype `u8`"
     ):
         df.select(-pl.col("a"))
 
@@ -58,7 +59,7 @@ def test_neg_unsigned_int() -> None:
 def test_neg_non_numeric() -> None:
     df = pl.DataFrame({"a": ["p", "q", "r"]})
     with pytest.raises(
-        pl.InvalidOperationError, match="`neg` operation not supported for dtype `str`"
+        InvalidOperationError, match="`neg` operation not supported for dtype `str`"
     ):
         df.select(-pl.col("a"))
 

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal
 
 
@@ -35,7 +35,7 @@ def test_error_on_reducing_map() -> None:
         {"id": [0, 0, 0, 1, 1, 1], "t": [2, 4, 5, 10, 11, 14], "y": [0, 1, 1, 2, 3, 4]}
     )
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=(
             r"output length of `map` \(1\) must be equal to "
             r"the input length \(6\); consider using `apply` instead"
@@ -46,7 +46,7 @@ def test_error_on_reducing_map() -> None:
     df = pl.DataFrame({"x": [1, 2, 3, 4], "group": [1, 2, 1, 2]})
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=(
             r"output length of `map` \(1\) must be equal to "
             r"the input length \(4\); consider using `apply` instead"

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 
@@ -96,7 +97,7 @@ def test_lazy_map_schema() -> None:
         return df["a"]
 
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="Expected 'LazyFrame.map' to return a 'DataFrame', got a",
     ):
         df.lazy().map_batches(custom).collect()  # type: ignore[arg-type]
@@ -108,7 +109,7 @@ def test_lazy_map_schema() -> None:
         return df.select(pl.all().cast(pl.String))
 
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="The output schema of 'LazyFrame.map' is incorrect. Expected",
     ):
         df.lazy().map_batches(custom2).collect()

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 
@@ -63,7 +64,7 @@ def test_map_groups_rolling() -> None:
 def test_map_groups_empty() -> None:
     df = pl.DataFrame(schema={"x": pl.Int64})
     with pytest.raises(
-        pl.ComputeError, match=r"cannot group_by \+ apply on empty 'DataFrame'"
+        ComputeError, match=r"cannot group_by \+ apply on empty 'DataFrame'"
     ):
         df.group_by("x").map_groups(lambda x: x)
 

--- a/py-polars/tests/unit/operations/map/test_map_rows.py
+++ b/py-polars/tests/unit/operations/map/test_map_rows.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 
@@ -49,7 +50,7 @@ def test_map_rows_error_return_type() -> None:
         res = [x + y for x, y in zip(row[0], row[1])]
         return [res]
 
-    with pytest.raises(pl.ComputeError, match="expected tuple, got list"):
+    with pytest.raises(ComputeError, match="expected tuple, got list"):
         df.map_rows(combine)
 
 

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -149,7 +149,7 @@ def test_array_get() -> None:
     assert_frame_equal(out_df, expected_df)
 
     # Out-of-bounds index literal.
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         out = s.arr.get(100, null_on_oob=False)
 
     # Negative index literal.
@@ -158,7 +158,7 @@ def test_array_get() -> None:
     assert_series_equal(out, expected)
 
     # Test index expr.
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         out = s.arr.get(pl.Series([1, -2, 100]), null_on_oob=False)
 
     out = s.arr.get(pl.Series([1, -2, 0]), null_on_oob=False)
@@ -175,7 +175,7 @@ def test_array_get() -> None:
         ],
         dtype=pl.Array(pl.Date, 2),
     )
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         out = s.arr.get(pl.Series([1, -2, 4]), null_on_oob=False)
 
 

--- a/py-polars/tests/unit/operations/namespaces/array/test_contains.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_contains.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import SchemaError
 from polars.testing import assert_series_equal
 
 
@@ -68,5 +69,5 @@ def test_array_contains_literal(
 
 def test_array_contains_invalid_datatype() -> None:
     df = pl.DataFrame({"a": [[1, 2], [3, 4]]}, schema={"a": pl.List(pl.Int8)})
-    with pytest.raises(pl.SchemaError, match="invalid series dtype: expected `Array`"):
+    with pytest.raises(SchemaError, match="invalid series dtype: expected `Array`"):
         df.select(pl.col("a").arr.contains(2))

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -30,7 +31,7 @@ def test_list_arr_get() -> None:
     out = pl.select(pl.lit(a).list.last()).to_series()
     assert_series_equal(out, expected)
 
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         a.list.get(3, null_on_oob=False)
 
     # Null index.
@@ -40,10 +41,10 @@ def test_list_arr_get() -> None:
 
     a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
 
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         a.list.get(-3, null_on_oob=False)
 
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         pl.DataFrame(
             {"a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]]}
         ).with_columns(
@@ -54,7 +55,7 @@ def test_list_arr_get() -> None:
     # get by indexes where some are out of bounds
     df = pl.DataFrame({"cars": [[1, 2, 3], [2, 3], [4], []], "indexes": [-2, 1, -3, 0]})
 
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         df.select([pl.col("cars").list.get("indexes", null_on_oob=False)]).to_dict(
             as_series=False
         )
@@ -67,10 +68,10 @@ def test_list_arr_get() -> None:
         }
     )
 
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         df.select(pl.col("lists").list.get(3, null_on_oob=False))
 
-    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
         df.select(pl.col("lists").list.get(pl.col("index"), null_on_oob=False))
 
 
@@ -750,15 +751,13 @@ def test_list_to_array() -> None:
 
 def test_list_to_array_wrong_lengths() -> None:
     s = pl.Series([[1.0, 2.0], [3.0, 4.0]], dtype=pl.List(pl.Float32))
-    with pytest.raises(
-        pl.ComputeError, match="not all elements have the specified width"
-    ):
+    with pytest.raises(ComputeError, match="not all elements have the specified width"):
         s.list.to_array(3)
 
 
 def test_list_to_array_wrong_dtype() -> None:
     s = pl.Series([1.0, 2.0])
-    with pytest.raises(pl.ComputeError, match="expected List dtype"):
+    with pytest.raises(ComputeError, match="expected List dtype"):
         s.list.to_array(2)
 
 

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -4,7 +4,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -43,7 +43,7 @@ def test_str_slice_expr() -> None:
     assert_frame_equal(out, expected)
 
     # negative length is not allowed
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         df.select(pl.col("a").str.slice(0, -1))
 
 

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -4,6 +4,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -237,9 +238,9 @@ def test_str_decode() -> None:
 
 def test_str_decode_exception() -> None:
     s = pl.Series(["not a valid", "626172", None])
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         s.str.decode(encoding="hex")
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         s.str.decode(encoding="base64")
     with pytest.raises(ValueError):
         s.str.decode("utf8")  # type: ignore[arg-type]
@@ -291,7 +292,7 @@ def test_str_find_invalid_regex() -> None:
     df = pl.DataFrame({"txt": ["AbCdEfG"]})
     rx_invalid = "(?i)AB.))"
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.with_columns(pl.col("txt").str.find(rx_invalid, strict=True))
 
     res = df.with_columns(pl.col("txt").str.find(rx_invalid, strict=False))
@@ -408,7 +409,7 @@ def test_str_to_integer() -> None:
         check_exact=True,
     )
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         hex.str.to_integer(base=16)
 
 
@@ -423,7 +424,7 @@ def test_str_to_integer_base_expr() -> None:
     # test strict raise
     df = pl.DataFrame({"str": ["110", "ff00", "cafe", None], "base": [2, 10, 10, 8]})
 
-    with pytest.raises(pl.ComputeError, match="failed for 2 value"):
+    with pytest.raises(ComputeError, match="failed for 2 value"):
         df.select(pl.col("str").str.to_integer(base="base"))
 
 
@@ -447,7 +448,7 @@ def test_str_to_integer_base_literal() -> None:
     )
     assert_frame_equal(result, expected)
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.with_columns(
             pl.col("bin").str.to_integer(base=2),
             pl.col("hex").str.to_integer(base=16),
@@ -782,7 +783,7 @@ def test_contains() -> None:
         pl.Series([None, None, None]).cast(pl.Boolean).to_list()
         == s_txt.str.contains("(not_valid_regex", literal=False, strict=False).to_list()
     )
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         s_txt.str.contains("(not_valid_regex", literal=False, strict=True)
     assert (
         pl.Series([True, False, False]).cast(pl.Boolean).to_list()
@@ -850,7 +851,7 @@ def test_contains_expr() -> None:
         "contains_lit": [False, True, False, None, None, False],
     }
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.select(
             pl.col("text").str.contains(pl.col("pattern"), literal=False, strict=True)
         )
@@ -941,7 +942,7 @@ def test_replace_all() -> None:
             )["text"].to_list()
         )
         # invalid regex (but valid literal - requires "literal=True")
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(ComputeError):
             df["text"].str.replace_all("*", "")
 
     assert (
@@ -1134,7 +1135,7 @@ def test_decode_strict() -> None:
     expected = {"strings": [b"\xd0\x86\xd0\xbd77", None, None]}
     assert result.to_dict(as_series=False) == expected
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         df.select(pl.col("strings").str.decode("base64", strict=True))
 
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
@@ -12,6 +12,7 @@ from hypothesis import assume, given
 
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
@@ -91,7 +92,7 @@ def test_add_business_day_w_week_mask_invalid() -> None:
         }
     )
     with pytest.raises(
-        pl.ComputeError, match="`week_mask` must have at least one business day"
+        ComputeError, match="`week_mask` must have at least one business day"
     ):
         df.select(pl.col("start").dt.add_business_days("n", week_mask=[False] * 7))
 
@@ -161,7 +162,7 @@ def test_add_business_days_w_roll() -> None:
             "n": [1, 5, 7],
         }
     )
-    with pytest.raises(pl.ComputeError, match="is not a business date"):
+    with pytest.raises(ComputeError, match="is not a business date"):
         df.select(result=pl.col("start").dt.add_business_days("n"))
     result = df.select(
         result=pl.col("start").dt.add_business_days("n", roll="forward")
@@ -202,7 +203,7 @@ def test_add_business_days_datetime(time_zone: str | None, time_unit: TimeUnit) 
     ).dt.replace_time_zone(time_zone)
     assert_series_equal(result, expected)
 
-    with pytest.raises(pl.ComputeError, match="is not a business date"):
+    with pytest.raises(ComputeError, match="is not a business date"):
         df.select(result=pl.col("start").dt.add_business_days(2))
 
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
@@ -12,7 +12,7 @@ from hypothesis import assume, given
 
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
@@ -209,11 +209,11 @@ def test_add_business_days_datetime(time_zone: str | None, time_unit: TimeUnit) 
 
 def test_add_business_days_invalid() -> None:
     df = pl.DataFrame({"start": [timedelta(1)]})
-    with pytest.raises(pl.InvalidOperationError, match="expected date or datetime"):
+    with pytest.raises(InvalidOperationError, match="expected date or datetime"):
         df.select(result=pl.col("start").dt.add_business_days(2, week_mask=[True] * 7))
     df = pl.DataFrame({"start": [date(2020, 1, 1)]})
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="expected Int64, Int32, UInt64, or UInt32, got f64",
     ):
         df.select(

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -10,7 +10,7 @@ from hypothesis import given
 
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 
 if sys.version_info >= (3, 9):
@@ -118,7 +118,7 @@ def test_to_datetime(datetimes: datetime, fmt: str) -> None:
     # If there's an exception, check that it's either:
     # - something which polars can't parse at all: missing day or month
     # - something on which polars intentionally raises
-    except pl.InvalidOperationError as exc:
+    except InvalidOperationError as exc:
         assert "failed in column" in str(exc)  # noqa: PT017
         assert not any(day in fmt for day in ("%d", "%j")) or not any(
             month in fmt for month in ("%b", "%B", "%m")

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -10,6 +10,7 @@ from hypothesis import given
 
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 if sys.version_info >= (3, 9):
@@ -122,7 +123,7 @@ def test_to_datetime(datetimes: datetime, fmt: str) -> None:
         assert not any(day in fmt for day in ("%d", "%j")) or not any(
             month in fmt for month in ("%b", "%B", "%m")
         )
-    except pl.ComputeError as exc:
+    except ComputeError as exc:
         assert "Invalid format string" in str(exc)  # noqa: PT017
         assert (
             (("%H" in fmt) ^ ("%M" in fmt))

--- a/py-polars/tests/unit/operations/namespaces/test_meta.py
+++ b/py-polars/tests/unit/operations/namespaces/test_meta.py
@@ -6,6 +6,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars.exceptions import ComputeError
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,7 +44,7 @@ def test_root_and_output_names() -> None:
     assert e.meta.output_name() == "len"
 
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="cannot determine output column without a context for this expression",
     ):
         pl.all().name.suffix("_").meta.output_name()

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
@@ -127,7 +127,7 @@ def test_to_date_non_exact_strptime() -> None:
     )
     assert_series_equal(result, expected)
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         s.str.to_date(format, strict=True, exact=True)
 
 
@@ -161,7 +161,7 @@ def test_to_date_all_inferred_date_patterns(time_string: str, expected: date) ->
     ],
 )
 def test_non_exact_short_elements_10223(value: str, attr: str) -> None:
-    with pytest.raises(pl.InvalidOperationError, match="conversion .* failed"):
+    with pytest.raises(InvalidOperationError, match="conversion .* failed"):
         getattr(pl.Series(["2019-01-01", value]).str, attr)(exact=False)
 
 
@@ -211,7 +211,7 @@ def test_to_datetime_non_exact_strptime(
     assert_series_equal(result, expected)
     assert result.dtype == pl.Datetime("us", time_zone)
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         s.str.to_datetime(format, strict=True, exact=True)
 
 
@@ -720,7 +720,7 @@ def test_strptime_ambiguous_earliest(exact: bool) -> None:
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
 def test_to_datetime_out_of_range_13401(time_unit: TimeUnit) -> None:
     s = pl.Series(["2020-January-01 12:34:66"])
-    with pytest.raises(pl.InvalidOperationError, match="conversion .* failed"):
+    with pytest.raises(InvalidOperationError, match="conversion .* failed"):
         s.str.to_datetime("%Y-%B-%d %H:%M:%S", time_unit=time_unit)
     assert (
         s.str.to_datetime("%Y-%B-%d %H:%M:%S", strict=False, time_unit=time_unit).item()

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -469,21 +469,21 @@ def test_strptime_invalid_timezone() -> None:
 
 def test_to_datetime_ambiguous_or_non_existent() -> None:
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="datetime '2021-11-07 01:00:00' is ambiguous in time zone 'US/Central'",
     ):
         pl.Series(["2021-11-07 01:00"]).str.to_datetime(
             time_unit="us", time_zone="US/Central"
         )
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
     ):
         pl.Series(["2021-03-28 02:30"]).str.to_datetime(
             time_unit="us", time_zone="Europe/Warsaw"
         )
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
     ):
         pl.Series(["2021-03-28 02:30"]).str.to_datetime(
@@ -492,7 +492,7 @@ def test_to_datetime_ambiguous_or_non_existent() -> None:
             ambiguous="null",
         )
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
     ):
         pl.Series(["2021-03-28 02:30"] * 2).str.to_datetime(
@@ -671,7 +671,7 @@ def test_to_datetime_ambiguous_earliest(exact: bool) -> None:
     )
     expected = datetime(2020, 10, 25, 1, fold=1, tzinfo=ZoneInfo("Europe/London"))
     assert result == expected
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.Series(["2020-10-25 01:00"]).str.to_datetime(
             time_zone="Europe/London",
             exact=exact,
@@ -710,7 +710,7 @@ def test_strptime_ambiguous_earliest(exact: bool) -> None:
     )
     expected = datetime(2020, 10, 25, 1, fold=1, tzinfo=ZoneInfo("Europe/London"))
     assert result == expected
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.Series(["2020-10-25 01:00"]).str.strptime(
             pl.Datetime("us", "Europe/London"),
             exact=exact,

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -972,7 +972,7 @@ def test_rolling_invalid() -> None:
         },
     )
     with pytest.raises(
-        pl.InvalidOperationError, match="duration may not be a parsed integer"
+        InvalidOperationError, match="duration may not be a parsed integer"
     ):
         (
             df.sort("times")
@@ -980,7 +980,7 @@ def test_rolling_invalid() -> None:
             .agg(pl.col("values").sum().alias("sum"))
         )
     with pytest.raises(
-        pl.InvalidOperationError, match="duration must be a parsed integer"
+        InvalidOperationError, match="duration must be a parsed integer"
     ):
         (
             df.with_row_index()

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -89,7 +90,7 @@ def test_abs_unsigned_int() -> None:
 def test_abs_non_numeric() -> None:
     df = pl.DataFrame({"a": ["p", "q", "r"]})
     with pytest.raises(
-        pl.InvalidOperationError, match="`abs` operation not supported for dtype `str`"
+        InvalidOperationError, match="`abs` operation not supported for dtype `str`"
     ):
         df.select(pl.col("a").abs())
 
@@ -98,7 +99,7 @@ def test_abs_date() -> None:
     df = pl.DataFrame({"date": [date(1960, 1, 1), date(1970, 1, 1), date(1980, 1, 1)]})
 
     with pytest.raises(
-        pl.InvalidOperationError, match="`abs` operation not supported for dtype `date`"
+        InvalidOperationError, match="`abs` operation not supported for dtype `date`"
     ):
         df.select(pl.col("date").abs())
 

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -8,7 +8,7 @@ import pytest
 
 import polars as pl
 from polars._utils.constants import MS_PER_SECOND, NS_PER_SECOND, US_PER_SECOND
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
@@ -28,7 +28,7 @@ def test_string_date() -> None:
 def test_invalid_string_date() -> None:
     df = pl.DataFrame({"x1": ["2021-01-aa"]})
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         df.with_columns(**{"x1-date": pl.col("x1").cast(pl.Date)})
 
 
@@ -64,7 +64,7 @@ def test_string_datetime() -> None:
 
 def test_invalid_string_datetime() -> None:
     df = pl.DataFrame({"x1": ["2021-12-19 00:39:57", "2022-12-19 16:39:57"]})
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         df.with_columns(
             **{"x1-datetime-ns": pl.col("x1").cast(pl.Datetime(time_unit="ns"))}
         )
@@ -233,11 +233,11 @@ def test_strict_cast_int(
         assert _cast_expr(*args) == expected_value  # type: ignore[arg-type]
         assert _cast_lit(*args) == expected_value  # type: ignore[arg-type]
     else:
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_series(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_expr(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_lit(*args)  # type: ignore[arg-type]
 
 
@@ -372,11 +372,11 @@ def test_strict_cast_temporal(
         assert out.item() == expected_value
         assert out.dtype == to_dtype
     else:
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_series_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_expr_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_lit_t(*args)  # type: ignore[arg-type]
 
 
@@ -568,11 +568,11 @@ def test_strict_cast_string_and_binary(
         assert out.item() == expected_value
         assert out.dtype == to_dtype
     else:
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_series_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_expr_t(*args)  # type: ignore[arg-type]
-        with pytest.raises(pl.InvalidOperationError):
+        with pytest.raises(InvalidOperationError):
             _cast_lit_t(*args)  # type: ignore[arg-type]
 
 
@@ -609,14 +609,14 @@ def test_cast_categorical_name_retention(
 def test_cast_date_to_time() -> None:
     s = pl.Series([date(1970, 1, 1), date(2000, 12, 31)])
     msg = "casting from Date to Time not supported"
-    with pytest.raises(pl.InvalidOperationError, match=msg):
+    with pytest.raises(InvalidOperationError, match=msg):
         s.cast(pl.Time)
 
 
 def test_cast_time_to_date() -> None:
     s = pl.Series([time(0, 0), time(20, 00)])
     msg = "casting from Time to Date not supported"
-    with pytest.raises(pl.InvalidOperationError, match=msg):
+    with pytest.raises(InvalidOperationError, match=msg):
         s.cast(pl.Date)
 
 
@@ -634,7 +634,7 @@ def test_cast_decimal_to_boolean() -> None:
 def test_cast_array_to_different_width() -> None:
     s = pl.Series([[1, 2], [3, 4]], dtype=pl.Array(pl.Int8, 2))
     with pytest.raises(
-        pl.InvalidOperationError, match="cannot cast Array to a different width"
+        InvalidOperationError, match="cannot cast Array to a different width"
     ):
         s.cast(pl.Array(pl.Int16, 3))
 
@@ -654,7 +654,7 @@ def test_cast_decimal_to_decimal_high_precision() -> None:
 def test_err_on_time_datetime_cast() -> None:
     s = pl.Series([time(10, 0, 0), time(11, 30, 59)])
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="casting from Time to Datetime\\(Microseconds, None\\) not supported; consider using `dt.combine`",
     ):
         s.cast(pl.Datetime)
@@ -669,7 +669,7 @@ def test_err_on_invalid_time_zone_cast() -> None:
 def test_invalid_inner_type_cast_list() -> None:
     s = pl.Series([[-1, 1]])
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"cannot cast List inner type: 'Int64' to Categorical",
     ):
         s.cast(pl.List(pl.Categorical))

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -8,6 +8,7 @@ import pytest
 
 import polars as pl
 from polars._utils.constants import MS_PER_SECOND, NS_PER_SECOND, US_PER_SECOND
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
@@ -661,7 +662,7 @@ def test_err_on_time_datetime_cast() -> None:
 
 def test_err_on_invalid_time_zone_cast() -> None:
     s = pl.Series([datetime(2021, 1, 1)])
-    with pytest.raises(pl.ComputeError, match=r"unable to parse time zone: 'qwerty'"):
+    with pytest.raises(ComputeError, match=r"unable to parse time zone: 'qwerty'"):
         s.cast(pl.Datetime("us", "qwerty"))
 
 

--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
 
 
@@ -120,7 +121,7 @@ def test_clip_non_numeric_dtype_fails() -> None:
     msg = "`clip` only supports physical numeric types"
 
     s = pl.Series(["a", "b", "c"])
-    with pytest.raises(pl.InvalidOperationError, match=msg):
+    with pytest.raises(InvalidOperationError, match=msg):
         s.clip(pl.lit("b"), pl.lit("z"))
 
 
@@ -134,6 +135,6 @@ def test_clip_string_input() -> None:
 def test_clip_bound_invalid_for_original_dtype() -> None:
     s = pl.Series([1, 2, 3, 4], dtype=pl.UInt32)
     with pytest.raises(
-        pl.InvalidOperationError, match="conversion from `i32` to `u32` failed"
+        InvalidOperationError, match="conversion from `i32` to `u32` failed"
     ):
         s.clip(-1, 5)

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -7,6 +7,7 @@ from typing import Any, ContextManager
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 
@@ -371,7 +372,7 @@ def test_total_ordering_bool_series(lhs: bool | None, rhs: bool | None) -> None:
 def test_cat_compare_with_bool() -> None:
     data = pl.DataFrame([pl.Series("col1", ["a", "b"], dtype=pl.Categorical)])
 
-    with pytest.raises(pl.ComputeError, match="cannot compare categorical with bool"):
+    with pytest.raises(ComputeError, match="cannot compare categorical with bool"):
         data.filter(pl.col("col1") == True)  # noqa: E712
 
 

--- a/py-polars/tests/unit/operations/test_ewm_by.py
+++ b/py-polars/tests/unit/operations/test_ewm_by.py
@@ -8,6 +8,7 @@ import pytest
 
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -134,7 +135,7 @@ def test_ewma_by_datetime_tz_aware(time_unit: TimeUnit) -> None:
         schema_overrides={"times": pl.Datetime(time_unit, "Asia/Kathmandu")},
     )
     msg = "expected `half_life` to be a constant duration"
-    with pytest.raises(pl.InvalidOperationError, match=msg):
+    with pytest.raises(InvalidOperationError, match=msg):
         df.select(
             pl.col("values").ewm_mean_by("times", half_life="2d"),
         )
@@ -204,13 +205,13 @@ def test_ewma_by_if_unsorted() -> None:
 
 def test_ewma_by_invalid() -> None:
     df = pl.DataFrame({"values": [1, 2]})
-    with pytest.raises(pl.InvalidOperationError, match="half_life cannot be negative"):
+    with pytest.raises(InvalidOperationError, match="half_life cannot be negative"):
         df.with_row_index().select(
             pl.col("values").ewm_mean_by("index", half_life="-2i"),
         )
     df = pl.DataFrame({"values": [[1, 2], [3, 4]]})
     with pytest.raises(
-        pl.InvalidOperationError, match=r"expected series to be Float64, Float32, .*"
+        InvalidOperationError, match=r"expected series to be Float64, Float32, .*"
     ):
         df.with_row_index().select(
             pl.col("values").ewm_mean_by("index", half_life="2i"),

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -5,6 +5,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -196,7 +197,7 @@ def test_explode_invalid_element_count() -> None:
         }
     ).with_row_index()
     with pytest.raises(
-        pl.ShapeError, match=r"exploded columns must have matching element counts"
+        ShapeError, match=r"exploded columns must have matching element counts"
     ):
         df.explode(["col1", "col2"])
 

--- a/py-polars/tests/unit/operations/test_extend_constant.py
+++ b/py-polars/tests/unit/operations/test_extend_constant.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -75,7 +76,7 @@ def test_extend_constant_arr(const: Any, dtype: pl.PolarsDataType) -> None:
 
 def test_extend_by_not_uint_expr() -> None:
     s = pl.Series("s", [1])
-    with pytest.raises(pl.ComputeError, match="value and n should have unit length"):
+    with pytest.raises(ComputeError, match="value and n should have unit length"):
         s.extend_constant(pl.Series([2, 3]), 3)
-    with pytest.raises(pl.ComputeError, match="value and n should have unit length"):
+    with pytest.raises(ComputeError, match="value and n should have unit length"):
         s.extend_constant(2, pl.Series([3, 4]))

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -9,6 +9,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars.exceptions import ColumnNotFoundError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -1027,7 +1028,7 @@ def test_schema_on_agg() -> None:
 
 def test_group_by_schema_err() -> None:
     lf = pl.LazyFrame({"foo": [None, 1, 2], "bar": [1, 2, 3]})
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         lf.group_by("not-existent").agg(
             pl.col("bar").max().alias("max_bar")
         ).collect_schema()

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -340,7 +341,7 @@ def test_rolling_dynamic_sortedness_check() -> None:
         }
     )
 
-    with pytest.raises(pl.ComputeError, match=r"input data is not sorted"):
+    with pytest.raises(ComputeError, match=r"input data is not sorted"):
         df.group_by_dynamic("idx", every="2i", group_by="group").agg(
             pl.col("idx").alias("idx1")
         )
@@ -437,7 +438,7 @@ def test_group_by_dynamic_validation() -> None:
         }
     )
 
-    with pytest.raises(pl.ComputeError, match="'every' argument must be positive"):
+    with pytest.raises(ComputeError, match="'every' argument must be positive"):
         df.group_by_dynamic("index", group_by="group", every="-1i", period="2i").agg(
             pl.col("weight")
         )

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -348,7 +348,7 @@ def test_rolling_dynamic_sortedness_check() -> None:
 
     # no `by` argument
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"argument in operation 'group_by_dynamic' is not sorted",
     ):
         df.group_by_dynamic("idx", every="2i").agg(pl.col("idx").alias("idx1"))
@@ -976,7 +976,7 @@ def test_group_by_dynamic_invalid() -> None:
         },
     )
     with pytest.raises(
-        pl.InvalidOperationError, match="duration may not be a parsed integer"
+        InvalidOperationError, match="duration may not be a parsed integer"
     ):
         (
             df.sort("times")
@@ -984,7 +984,7 @@ def test_group_by_dynamic_invalid() -> None:
             .agg(pl.col("values").sum().alias("sum"))
         )
     with pytest.raises(
-        pl.InvalidOperationError, match="duration must be a parsed integer"
+        InvalidOperationError, match="duration must be a parsed integer"
     ):
         (
             df.with_row_index()

--- a/py-polars/tests/unit/operations/test_interpolate_by.py
+++ b/py-polars/tests/unit/operations/test_interpolate_by.py
@@ -9,6 +9,7 @@ import pytest
 from hypothesis import assume, given
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import column, dataframes
 
@@ -195,12 +196,12 @@ def test_interpolate_vs_numpy(data: st.DataObject) -> None:
 def test_interpolate_by_invalid() -> None:
     s = pl.Series([1, None, 3])
     by = pl.Series([1, 2])
-    with pytest.raises(pl.InvalidOperationError, match=r"\(3\), got 2"):
+    with pytest.raises(InvalidOperationError, match=r"\(3\), got 2"):
         s.interpolate_by(by)
 
     by = pl.Series([1, None, 3])
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="null values in `by` column are not yet supported in 'interpolate_by'",
     ):
         s.interpolate_by(by)

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -79,9 +80,9 @@ def test_is_first_last_distinct_list(data: list[list[Any] | None]) -> None:
 def test_is_first_last_distinct_list_inner_nested() -> None:
     df = pl.DataFrame({"a": [[[1, 2]], [[1, 2]]]})
     err_msg = "only allowed if the inner type is not nested"
-    with pytest.raises(pl.InvalidOperationError, match=err_msg):
+    with pytest.raises(InvalidOperationError, match=err_msg):
         df.select(pl.col("a").is_first_distinct())
-    with pytest.raises(pl.InvalidOperationError, match=err_msg):
+    with pytest.raises(InvalidOperationError, match=err_msg):
         df.select(pl.col("a").is_last_distinct())
 
 

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -6,7 +6,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -85,7 +85,7 @@ def test_is_in_null_prop() -> None:
         is None
     )
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="`is_in` cannot check for Int64 values in Boolean data",
     ):
         _res = pl.Series([None], dtype=pl.Boolean).is_in(pl.Series([42])).item()
@@ -141,7 +141,7 @@ def test_is_in_series() -> None:
     assert df.select(pl.col("b").is_in([])).to_series().to_list() == [False] * df.height
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"`is_in` cannot check for String values in Int64 data",
     ):
         df.select(pl.col("b").is_in(["x", "x"]))
@@ -214,7 +214,7 @@ def test_is_in_expr_list_series(
     if matches:
         assert df.select(expr_is_in).to_series().to_list() == matches
     else:
-        with pytest.raises(pl.InvalidOperationError, match=expected_error):
+        with pytest.raises(InvalidOperationError, match=expected_error):
             df.select(expr_is_in)
 
 

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -6,6 +6,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -161,7 +162,7 @@ def test_is_in_null() -> None:
 
 
 def test_is_in_invalid_shape() -> None:
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         pl.Series("a", [1, 2, 3]).is_in([[]])
 
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -947,7 +947,7 @@ def test_join_empties(how: JoinStrategy) -> None:
 def test_join_raise_on_redundant_keys() -> None:
     left = pl.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": [5, 6, 7]})
     right = pl.DataFrame({"a": [2, 3, 4], "c": [4, 5, 6]})
-    with pytest.raises(pl.InvalidOperationError, match="already joined on"):
+    with pytest.raises(InvalidOperationError, match="already joined on"):
         left.join(right, on=["a", "a"], how="full", coalesce=True)
 
 
@@ -955,7 +955,7 @@ def test_join_raise_on_redundant_keys() -> None:
 def test_join_raise_on_repeated_expression_key_names(coalesce: bool) -> None:
     left = pl.DataFrame({"a": [1, 2, 3], "b": [3, 4, 5], "c": [5, 6, 7]})
     right = pl.DataFrame({"a": [2, 3, 4], "c": [4, 5, 6]})
-    with pytest.raises(pl.InvalidOperationError, match="already joined on"):
+    with pytest.raises(InvalidOperationError, match="already joined on"):
         left.join(
             right, on=[pl.col("a"), pl.col("a") % 2], how="full", coalesce=coalesce
         )

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import ColumnNotFoundError, ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -818,7 +818,7 @@ def test_join_projection_invalid_name_contains_suffix_15243() -> None:
     df1 = pl.DataFrame({"a": [1, 2, 3]}).lazy()
     df2 = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).lazy()
 
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         (
             df1.join(df2, on="a")
             .select(pl.col("b").filter(pl.col("b") == pl.col("foo_right")))

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -9,7 +9,12 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.exceptions import ColumnNotFoundError, ComputeError, InvalidOperationError
+from polars.exceptions import (
+    ColumnNotFoundError,
+    ComputeError,
+    DuplicateError,
+    InvalidOperationError,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -810,7 +815,7 @@ def test_join_results_in_duplicate_names() -> None:
         }
     )
     rhs = lhs.clone()
-    with pytest.raises(pl.DuplicateError, match="'c_right' already exists"):
+    with pytest.raises(DuplicateError, match="'c_right' already exists"):
         lhs.join(rhs, on=["a", "b"], how="left")
 
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -623,24 +624,24 @@ def test_join_validation() -> None:
             duplicate, on=on, how=how, validate="1:m"
         )
 
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(ComputeError):
             _one_to_many_fail_inner = duplicate.join(
                 unique, on=on, how=how, validate="1:m"
             )
 
         # one to one
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(ComputeError):
             _one_to_one_fail_1_inner = unique.join(
                 duplicate, on=on, how=how, validate="1:1"
             )
 
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(ComputeError):
             _one_to_one_fail_2_inner = duplicate.join(
                 unique, on=on, how=how, validate="1:1"
             )
 
         # many to one
-        with pytest.raises(pl.ComputeError):
+        with pytest.raises(ComputeError):
             _many_to_one_fail_inner = unique.join(
                 duplicate, on=on, how=how, validate="m:1"
             )
@@ -727,7 +728,7 @@ def test_join_validation_many_keys() -> None:
 
     for join_type in ["inner", "left", "full"]:
         for val in ["1:1", "1:m"]:
-            with pytest.raises(pl.ComputeError):
+            with pytest.raises(ComputeError):
                 df1.join(df2, on=["val1", "val2"], how=join_type, validate=val)
 
     # many in rhs
@@ -746,7 +747,7 @@ def test_join_validation_many_keys() -> None:
 
     for join_type in ["inner", "left", "full"]:
         for val in ["m:1", "1:1"]:
-            with pytest.raises(pl.ComputeError):
+            with pytest.raises(ComputeError):
                 df1.join(df2, on=["val1", "val2"], how=join_type, validate=val)
 
 
@@ -783,7 +784,7 @@ def test_join_on_wildcard_error() -> None:
     df = pl.DataFrame({"x": [1]})
     df2 = pl.DataFrame({"x": [1], "y": [2]})
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="wildcard column selection not supported at this point",
     ):
         df.join(df2, on=pl.all())
@@ -793,7 +794,7 @@ def test_join_on_nth_error() -> None:
     df = pl.DataFrame({"x": [1]})
     df2 = pl.DataFrame({"x": [1], "y": [2]})
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match=r"nth column selection not supported at this point \(n=0\)",
     ):
         df.join(df2, on=pl.first())

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, DuplicateError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -470,7 +470,7 @@ def test_pivot_struct() -> None:
 
 def test_duplicate_column_names_which_should_raise_14305() -> None:
     df = pl.DataFrame({"a": [1, 3, 2], "c": ["a", "a", "a"], "d": [7, 8, 9]})
-    with pytest.raises(pl.DuplicateError, match="has more than one occurrences"):
+    with pytest.raises(DuplicateError, match="has more than one occurrences"):
         df.pivot(index="a", columns="c", values="d")
 
 

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -416,9 +416,7 @@ def test_pivot_negative_duration() -> None:
 
 def test_aggregate_function_default() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["foo", "foo"], "c": ["x", "x"]})
-    with pytest.raises(
-        pl.ComputeError, match="found multiple elements in the same group"
-    ):
+    with pytest.raises(ComputeError, match="found multiple elements in the same group"):
         df.pivot(index="b", columns="c", values="a")
 
 

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import DuplicateError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 inf = float("inf")
@@ -102,7 +103,7 @@ def test_qcut_full_null() -> None:
 def test_qcut_allow_duplicates() -> None:
     s = pl.Series([1, 2, 2, 3])
 
-    with pytest.raises(pl.DuplicateError):
+    with pytest.raises(DuplicateError):
         s.qcut([0.50, 0.51])
 
     result = s.qcut([0.50, 0.51], allow_duplicates=True)

--- a/py-polars/tests/unit/operations/test_random.py
+++ b/py-polars/tests/unit/operations/test_random.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -95,7 +96,7 @@ def test_sample_empty_df() -> None:
     assert df.sample(fraction=0.4, with_replacement=True).shape == (0, 1)
 
     # // If without replacement, then expect shape mismatch on sample_n not sample_frac
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         df.sample(n=3, with_replacement=False)
     assert df.sample(fraction=0.4, with_replacement=False).shape == (0, 1)
 
@@ -109,7 +110,7 @@ def test_sample_series() -> None:
     assert len(s.sample(n=2, with_replacement=True, seed=0)) == 2
 
     # on a series of length 5, you cannot sample more than 5 items
-    with pytest.raises(pl.ShapeError):
+    with pytest.raises(ShapeError):
         s.sample(n=10, with_replacement=False, seed=0)
     # unless you use with_replacement=True
     assert len(s.sample(n=10, with_replacement=True, seed=0)) == 10

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -6,7 +6,11 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import CategoricalRemappingWarning, ComputeError
+from polars.exceptions import (
+    CategoricalRemappingWarning,
+    ComputeError,
+    InvalidOperationError,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -124,7 +128,7 @@ def test_replace_invalid_old_dtype() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3]})
     mapping = {"a": 10, "b": 20}
     with pytest.raises(
-        pl.InvalidOperationError, match="conversion from `str` to `i64` failed"
+        InvalidOperationError, match="conversion from `str` to `i64` failed"
     ):
         lf.select(pl.col("a").replace(mapping)).collect()
 

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.exceptions import CategoricalRemappingWarning
+from polars.exceptions import CategoricalRemappingWarning, ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -438,7 +438,7 @@ def test_replace_old_new_many_to_one() -> None:
 
 def test_replace_old_new_mismatched_lengths() -> None:
     s = pl.Series([1, 2, 2, 3, 4])
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         s.replace([2, 3, 4], [8, 9])
 
 
@@ -496,7 +496,7 @@ def test_replace_fast_path_many_to_one_null() -> None:
 def test_replace_duplicates_old(old: list[int], new: int | list[int]) -> None:
     s = pl.Series([1, 2, 3, 2, 3])
     with pytest.raises(
-        pl.ComputeError,
+        ComputeError,
         match="`old` input for `replace` must not contain duplicates",
     ):
         s.replace(old, new)

--- a/py-polars/tests/unit/operations/test_reshape.py
+++ b/py-polars/tests/unit/operations/test_reshape.py
@@ -5,6 +5,7 @@ import re
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_series_equal
 
 
@@ -38,7 +39,7 @@ def test_reshape() -> None:
 
     # invalid (empty) dimensions
     with pytest.raises(
-        pl.InvalidOperationError, match="at least one dimension must be specified"
+        InvalidOperationError, match="at least one dimension must be specified"
     ):
         s.reshape(())
 
@@ -48,7 +49,7 @@ def test_reshape_invalid_dimension_size(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     print(shape)
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape(f"cannot reshape array of size 4 into shape {shape}"),
     ):
         s.reshape(shape)
@@ -58,7 +59,7 @@ def test_reshape_invalid_zero_dimension() -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     shape = (-1, 0)
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape(
             f"cannot reshape array into shape containing a zero dimension after the first: {shape}"
         ),
@@ -70,7 +71,7 @@ def test_reshape_invalid_zero_dimension() -> None:
 def test_reshape_invalid_zero_dimension2(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape(
             f"cannot reshape non-empty array into shape containing a zero dimension: {shape}"
         ),
@@ -82,7 +83,7 @@ def test_reshape_invalid_zero_dimension2(shape: tuple[int, ...]) -> None:
 def test_reshape_invalid_multiple_unknown_dims(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     with pytest.raises(
-        pl.InvalidOperationError, match="can only specify one unknown dimension"
+        InvalidOperationError, match="can only specify one unknown dimension"
     ):
         s.reshape(shape)
 
@@ -98,7 +99,7 @@ def test_reshape_empty_valid_1d(shape: tuple[int, ...]) -> None:
 def test_reshape_empty_invalid_2d(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [], dtype=pl.Int64)
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape(f"cannot reshape empty array into shape {shape}"),
     ):
         s.reshape(shape)
@@ -108,7 +109,7 @@ def test_reshape_empty_invalid_2d(shape: tuple[int, ...]) -> None:
 def test_reshape_empty_invalid_1d(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [], dtype=pl.Int64)
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=re.escape(f"cannot reshape empty array into shape ({shape[0]})"),
     ):
         s.reshape(shape)

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -221,7 +222,7 @@ def test_rolling_dynamic_sortedness_check() -> None:
         }
     )
 
-    with pytest.raises(pl.ComputeError, match=r"input data is not sorted"):
+    with pytest.raises(ComputeError, match=r"input data is not sorted"):
         df.rolling("idx", period="2i", group_by="group").agg(
             pl.col("idx").alias("idx1")
         )

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -229,7 +229,7 @@ def test_rolling_dynamic_sortedness_check() -> None:
 
     # no `group_by` argument
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="argument in operation 'rolling' is not sorted",
     ):
         df.rolling("idx", period="2i").agg(pl.col("idx").alias("idx1"))

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -3,6 +3,7 @@ from hypothesis import given
 from hypothesis.strategies import booleans
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import series
 
@@ -56,14 +57,12 @@ def test_top_k() -> None:
         check_row_order=False,
     )
 
-    with pytest.raises(pl.ComputeError, match="`k` must be set for `top_k`"):
+    with pytest.raises(ComputeError, match="`k` must be set for `top_k`"):
         df.select(
             pl.col("bool_val").top_k(pl.lit(None)),
         )
 
-    with pytest.raises(
-        pl.ComputeError, match="`k` must be a single value for `top_k`."
-    ):
+    with pytest.raises(ComputeError, match="`k` must be a single value for `top_k`."):
         df.select(pl.col("test").top_k(pl.lit(pl.Series("s", [1, 2]))))
 
     # dataframe

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -5,7 +5,7 @@ from typing import Iterator
 import pytest
 
 import polars as pl
-from polars.exceptions import StringCacheMismatchError
+from polars.exceptions import InvalidOperationError, StringCacheMismatchError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -192,7 +192,7 @@ def test_err_transpose_object() -> None:
     class CustomObject:
         pass
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         pl.DataFrame([CustomObject()]).transpose()
 
 

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -5,7 +5,11 @@ from typing import Iterator
 import pytest
 
 import polars as pl
-from polars.exceptions import InvalidOperationError, StringCacheMismatchError
+from polars.exceptions import (
+    InvalidOperationError,
+    SchemaError,
+    StringCacheMismatchError,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -31,7 +35,7 @@ def test_transpose_tz_naive_and_tz_aware() -> None:
     )
     df = df.with_columns(pl.col("b").dt.replace_time_zone("Asia/Kathmandu"))
     with pytest.raises(
-        pl.SchemaError,
+        SchemaError,
         match=r"failed to determine supertype of datetime\[μs\] and datetime\[μs, Asia/Kathmandu\]",
     ):
         df.transpose()

--- a/py-polars/tests/unit/operations/test_value_counts.py
+++ b/py-polars/tests/unit/operations/test_value_counts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import DuplicateError
 from polars.testing import assert_frame_equal
 
 
@@ -64,7 +65,7 @@ def test_value_counts_duplicate_name() -> None:
 
     # default name is 'count' ...
     with pytest.raises(
-        pl.DuplicateError,
+        DuplicateError,
         match="duplicate column names; change `name` to fix",
     ):
         s.value_counts()

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -7,6 +7,7 @@ import pytest
 from hypothesis import given
 
 import polars as pl
+from polars.exceptions import PolarsPanicError
 from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 
@@ -178,7 +179,7 @@ def test_series_from_buffers_offsets_do_not_match_data() -> None:
     offsets = pl.Series([0, 1, 3, 3, 9, 11], dtype=pl.Int64)
 
     msg = "offsets must not exceed the values length"
-    with pytest.raises(pl.PolarsPanicError, match=msg):
+    with pytest.raises(PolarsPanicError, match=msg):
         pl.Series._from_buffers(pl.String, data=[data, offsets])
 
 

--- a/py-polars/tests/unit/series/buffers/test_get_buffer_info.py
+++ b/py-polars/tests/unit/series/buffers/test_get_buffer_info.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 
 
 def test_get_buffer_info_numeric() -> None:
@@ -38,5 +39,5 @@ def test_get_buffer_info_chunked() -> None:
     s2 = pl.Series([3, 4])
     s = pl.concat([s1, s2], rechunk=False)
 
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(ComputeError):
         s._get_buffer_info()

--- a/py-polars/tests/unit/series/test_all_any.py
+++ b/py-polars/tests/unit/series/test_all_any.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import SchemaError
 
 
 @pytest.mark.parametrize(
@@ -36,7 +37,7 @@ def test_any_kleene(data: list[bool | None], expected: bool | None) -> None:
 
 
 def test_any_wrong_dtype() -> None:
-    with pytest.raises(pl.SchemaError, match="expected `Boolean`"):
+    with pytest.raises(SchemaError, match="expected `Boolean`"):
         pl.Series([0, 1, 0]).any()
 
 
@@ -71,5 +72,5 @@ def test_all_kleene(data: list[bool | None], expected: bool | None) -> None:
 
 
 def test_all_wrong_dtype() -> None:
-    with pytest.raises(pl.SchemaError, match="expected `Boolean`"):
+    with pytest.raises(SchemaError, match="expected `Boolean`"):
         pl.Series([0, 1, 0]).all()

--- a/py-polars/tests/unit/series/test_append.py
+++ b/py-polars/tests/unit/series/test_append.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.exceptions import SchemaError
 from polars.testing import assert_series_equal
 
 
@@ -66,7 +67,7 @@ def test_struct_schema_on_append_extend_3452() -> None:
     ]
     housing1, housing2 = pl.Series(housing1_data), pl.Series(housing2_data)
     with pytest.raises(
-        pl.SchemaError,
+        SchemaError,
         match=(
             'cannot append field with name "address" '
             'to struct with field name "city"'
@@ -75,7 +76,7 @@ def test_struct_schema_on_append_extend_3452() -> None:
         housing1.append(housing2)
 
     with pytest.raises(
-        pl.SchemaError,
+        SchemaError,
         match=(
             'cannot extend field with name "address" '
             'to struct with field name "city"'

--- a/py-polars/tests/unit/series/test_scatter.py
+++ b/py-polars/tests/unit/series/test_scatter.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 
@@ -56,7 +57,7 @@ def test_scatter() -> None:
 
 def test_index_with_None_errors_16905() -> None:
     s = pl.Series("s", [1, 2, 3])
-    with pytest.raises(pl.ComputeError, match="index values should not be null"):
+    with pytest.raises(ComputeError, match="index values should not be null"):
         s[[1, None]] = 5
     # The error doesn't trash the series, as it used to:
     assert_series_equal(s, pl.Series("s", [1, 2, 3]))

--- a/py-polars/tests/unit/series/test_scatter.py
+++ b/py-polars/tests/unit/series/test_scatter.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 
 
@@ -68,7 +68,7 @@ def test_object_dtype_16905() -> None:
     s = pl.Series("s", [obj, 27], dtype=pl.Object)
     # This operation is not semantically wrong, it might be supported in the
     # future, but for now it isn't.
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         s[0] = 5
     # The error doesn't trash the series, as it used to:
     assert s.dtype == pl.Object

--- a/py-polars/tests/unit/series/test_scatter.py
+++ b/py-polars/tests/unit/series/test_scatter.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import ComputeError, InvalidOperationError, OutOfBoundsError
 from polars.testing import assert_series_equal
 
 
@@ -50,7 +50,7 @@ def test_scatter() -> None:
     assert a.to_list() == [None, 1, 2, None, 4]
 
     a = pl.Series("x", [1, 2])
-    with pytest.raises(pl.OutOfBoundsError):
+    with pytest.raises(OutOfBoundsError):
         a[-100] = None
     assert_series_equal(a, pl.Series("x", [1, 2]))
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -23,7 +23,11 @@ from polars.datatypes import (
     UInt64,
     Unknown,
 )
-from polars.exceptions import PolarsInefficientMapWarning, ShapeError
+from polars.exceptions import (
+    InvalidOperationError,
+    PolarsInefficientMapWarning,
+    ShapeError,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -295,7 +299,7 @@ def test_bitwise_ops() -> None:
 def test_bitwise_floats_invert() -> None:
     s = pl.Series([2.0, 3.0, 0.0])
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         ~s
 
 
@@ -489,7 +493,7 @@ def test_cast() -> None:
     assert a.cast(pl.Date).dtype == pl.Date
 
     # display failed values, GH#4706
-    with pytest.raises(pl.InvalidOperationError, match="foobar"):
+    with pytest.raises(InvalidOperationError, match="foobar"):
         pl.Series(["1", "2", "3", "4", "foobar"]).cast(int)
 
 
@@ -1097,9 +1101,9 @@ def test_range() -> None:
 
 
 def test_strict_cast() -> None:
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         pl.Series("a", [2**16]).cast(dtype=pl.Int16, strict=True)
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         pl.DataFrame({"a": [2**16]}).select([pl.col("a").cast(pl.Int16, strict=True)])
 
 
@@ -1695,12 +1699,12 @@ def test_trigonometric_cot() -> None:
 def test_trigonometric_invalid_input() -> None:
     # String
     s = pl.Series("a", ["1", "2", "3"])
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         s.sin()
 
     # Date
     s = pl.Series("a", [date(1990, 2, 28), date(2022, 7, 26)])
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         s.cosh()
 
 
@@ -1766,7 +1770,7 @@ def test_sign() -> None:
 
     # Invalid input
     a = pl.Series("a", [date(1950, 2, 1), date(1970, 1, 1), date(2022, 12, 12), None])
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         a.sign()
 
 
@@ -2124,13 +2128,13 @@ def test_series_from_pandas_with_dtype() -> None:
     s = pl.Series("foo", pd.Series([1, 2, 3], dtype="Int16"), pl.Int8)
     assert_series_equal(s, expected)
 
-    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
+    with pytest.raises(InvalidOperationError, match="conversion from"):
         pl.Series("foo", pd.Series([-1, 2, 3]), pl.UInt8)
     s = pl.Series("foo", pd.Series([-1, 2, 3]), pl.UInt8, strict=False)
     assert s.to_list() == [None, 2, 3]
     assert s.dtype == pl.UInt8
 
-    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
+    with pytest.raises(InvalidOperationError, match="conversion from"):
         pl.Series("foo", pd.Series([-1, 2, 3], dtype="Int8"), pl.UInt8)
     s = pl.Series("foo", pd.Series([-1, 2, 3], dtype="Int8"), pl.UInt8, strict=False)
     assert s.to_list() == [None, 2, 3]
@@ -2141,7 +2145,7 @@ def test_series_from_pyarrow_with_dtype() -> None:
     s = pl.Series("foo", pa.array([-1, 2, 3]), pl.Int8)
     assert_series_equal(s, pl.Series("foo", [-1, 2, 3], dtype=pl.Int8))
 
-    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
+    with pytest.raises(InvalidOperationError, match="conversion from"):
         pl.Series("foo", pa.array([-1, 2, 3]), pl.UInt8)
 
     s = pl.Series("foo", pa.array([-1, 2, 3]), dtype=pl.UInt8, strict=False)
@@ -2153,7 +2157,7 @@ def test_series_from_numpy_with_dtye() -> None:
     s = pl.Series("foo", np.array([-1, 2, 3]), pl.Int8)
     assert_series_equal(s, pl.Series("foo", [-1, 2, 3], dtype=pl.Int8))
 
-    with pytest.raises(pl.InvalidOperationError, match="conversion from"):
+    with pytest.raises(InvalidOperationError, match="conversion from"):
         pl.Series("foo", np.array([-1, 2, 3]), pl.UInt8)
 
     s = pl.Series("foo", np.array([-1, 2, 3]), dtype=pl.UInt8, strict=False)

--- a/py-polars/tests/unit/sql/test_cast.py
+++ b/py-polars/tests/unit/sql/test_cast.py
@@ -6,7 +6,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import SQLInterfaceError
+from polars.exceptions import InvalidOperationError, SQLInterfaceError
 from polars.testing import assert_frame_equal
 
 
@@ -165,7 +165,7 @@ def test_cast_errors(values: Any, cast_op: str, error: str) -> None:
     df = pl.DataFrame({"values": values})
 
     # invalid CAST should raise an error...
-    with pytest.raises(pl.InvalidOperationError, match=error):
+    with pytest.raises(InvalidOperationError, match=error):
         df.sql(f"SELECT {cast_op} FROM self")
 
     # ... or return `null` values if using TRY_CAST

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.exceptions import SQLSyntaxError
 from polars.testing import assert_frame_equal
 
 
@@ -133,7 +134,7 @@ def test_in_subquery() -> None:
     )
 
     with pytest.raises(
-        pl.SQLSyntaxError,
+        SQLSyntaxError,
         match="SQL subquery returns more than one column",
     ):
         sql.execute(

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 import pytest
 
 import polars as pl
-from polars.exceptions import SQLInterfaceError, SQLSyntaxError
+from polars.exceptions import InvalidOperationError, SQLInterfaceError, SQLSyntaxError
 from polars.testing import assert_frame_equal
 
 
@@ -232,7 +232,7 @@ def test_implicit_temporal_string_errors(dtval: str) -> None:
     df = pl.DataFrame({"dt": [date(2020, 12, 30)]})
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="(conversion.*failed)|(cannot compare.*string.*temporal)",
     ):
         df.sql(f"SELECT * FROM self WHERE dt = '{dtval}'")

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import DuplicateError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -112,7 +113,7 @@ def test_streaming_group_by_types() -> None:
             "date_max": [date(2022, 1, 1)],
         }
 
-    with pytest.raises(pl.DuplicateError):
+    with pytest.raises(DuplicateError):
         (
             df.lazy()
             .group_by("person_id")

--- a/py-polars/tests/unit/test_async.py
+++ b/py-polars/tests/unit/test_async.py
@@ -10,6 +10,7 @@ import pytest
 
 import polars as pl
 from polars.dependencies import gevent
+from polars.exceptions import ColumnNotFoundError
 
 pytestmark = pytest.mark.slow()
 
@@ -56,8 +57,8 @@ _aio_collect = pytest.mark.parametrize(
     [
         (_aio_collect_async, None),
         (_aio_collect_all_async, None),
-        (partial(_aio_collect_async, True), pl.ColumnNotFoundError),
-        (partial(_aio_collect_all_async, True), pl.ColumnNotFoundError),
+        (partial(_aio_collect_async, True), ColumnNotFoundError),
+        (partial(_aio_collect_all_async, True), ColumnNotFoundError),
     ],
 )
 
@@ -134,8 +135,8 @@ _gevent_collect = pytest.mark.parametrize(
     [
         (_gevent_collect_async, None),
         (_gevent_collect_all_async, None),
-        (partial(_gevent_collect_async, True), pl.ColumnNotFoundError),
-        (partial(_gevent_collect_all_async, True), pl.ColumnNotFoundError),
+        (partial(_gevent_collect_async, True), ColumnNotFoundError),
+        (partial(_gevent_collect_all_async, True), ColumnNotFoundError),
     ],
 )
 

--- a/py-polars/tests/unit/test_convert.py
+++ b/py-polars/tests/unit/test_convert.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, NoDataError
 
 
 def test_from_records_schema_inference() -> None:
@@ -34,7 +34,7 @@ def test_from_dicts_nested_nulls() -> None:
 
 
 def test_from_dicts_empty() -> None:
-    with pytest.raises(pl.NoDataError, match="no data, cannot infer schema"):
+    with pytest.raises(NoDataError, match="no data, cannot infer schema"):
         pl.from_dicts([])
 
 

--- a/py-polars/tests/unit/test_convert.py
+++ b/py-polars/tests/unit/test_convert.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 
 
 def test_from_records_schema_inference() -> None:
@@ -41,7 +42,7 @@ def test_from_dicts_all_cols_6716() -> None:
     dicts = [{"a": None} for _ in range(20)] + [{"a": "crash"}]
 
     with pytest.raises(
-        pl.ComputeError, match="make sure that all rows have the same schema"
+        ComputeError, match="make sure that all rows have the same schema"
     ):
         pl.from_dicts(dicts, infer_schema_length=20)
     assert pl.from_dicts(dicts, infer_schema_length=None).dtypes == [pl.String]

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -52,7 +53,7 @@ def test_empty_count_window() -> None:
 
 def test_empty_sort_by_args() -> None:
     df = pl.DataFrame([1, 2, 3])
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         df.select(pl.all().sort_by([]))
 
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -29,7 +29,7 @@ def test_error_on_reducing_map() -> None:
         {"id": [0, 0, 0, 1, 1, 1], "t": [2, 4, 5, 10, 11, 14], "y": [0, 1, 1, 2, 3, 4]}
     )
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=(
             r"output length of `map` \(1\) must be equal to "
             r"the input length \(6\); consider using `apply` instead"
@@ -39,7 +39,7 @@ def test_error_on_reducing_map() -> None:
 
     df = pl.DataFrame({"x": [1, 2, 3, 4], "group": [1, 2, 1, 2]})
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=(
             r"output length of `map` \(1\) must be equal to "
             r"the input length \(4\); consider using `apply` instead"
@@ -227,7 +227,7 @@ def test_filter_not_of_type_bool() -> None:
 
 
 def test_is_nan_on_non_boolean() -> None:
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         pl.Series(["1", "2", "3"]).fill_nan("2")  # type: ignore[arg-type]
 
 
@@ -290,7 +290,7 @@ def test_invalid_sort_by() -> None:
 
 def test_epoch_time_type() -> None:
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="`timestamp` operation not supported for dtype `time`",
     ):
         pl.Series([time(0, 0, 1)]).dt.epoch("s")
@@ -400,7 +400,7 @@ def test_date_string_comparison(e: pl.Expr) -> None:
     ).with_columns(pl.col("date").str.strptime(pl.Date, "%Y-%m-%d"))
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"cannot compare 'date/datetime/time' to a string value",
     ):
         df.select(e)
@@ -444,7 +444,7 @@ def test_take_negative_index_is_oob() -> None:
 def test_string_numeric_arithmetic_err() -> None:
     df = pl.DataFrame({"s": ["x"]})
     with pytest.raises(
-        pl.InvalidOperationError, match=r"arithmetic on string and numeric not allowed"
+        InvalidOperationError, match=r"arithmetic on string and numeric not allowed"
     ):
         df.select(pl.col("s") + 1)
 
@@ -491,7 +491,7 @@ def test_skip_nulls_err() -> None:
 def test_cast_err_column_value_highlighting(
     test_df: pl.DataFrame, type: pl.DataType, expected_message: str
 ) -> None:
-    with pytest.raises(pl.InvalidOperationError, match=expected_message):
+    with pytest.raises(InvalidOperationError, match=expected_message):
         test_df.with_columns(pl.all().cast(type))
 
 
@@ -630,7 +630,7 @@ def test_raise_not_found_in_simplify_14974() -> None:
 
 def test_invalid_product_type() -> None:
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="`product` operation not supported for dtype",
     ):
         pl.Series([[1, 2, 3]]).product()
@@ -638,21 +638,19 @@ def test_invalid_product_type() -> None:
 
 def test_fill_null_invalid_supertype() -> None:
     df = pl.DataFrame({"date": [date(2022, 1, 1), None]})
-    with pytest.raises(
-        pl.InvalidOperationError, match="could not determine supertype of"
-    ):
+    with pytest.raises(InvalidOperationError, match="could not determine supertype of"):
         df.select(pl.col("date").fill_null(1.0))
 
 
 def test_raise_array_of_cats() -> None:
-    with pytest.raises(pl.InvalidOperationError, match="is not yet supported"):
+    with pytest.raises(InvalidOperationError, match="is not yet supported"):
         pl.Series([["a", "b"], ["a", "c"]], dtype=pl.Array(pl.Categorical, 2))
 
 
 def test_raise_invalid_arithmetic() -> None:
     df = pl.Series("a", [object()]).to_frame()
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(InvalidOperationError):
         df.select(pl.col("a") - pl.col("a"))
 
 
@@ -671,7 +669,7 @@ def test_err_invalid_comparison() -> None:
         _ = pl.Series("a", [date(2020, 1, 1)]) == pl.Series("b", [True])
 
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="could not apply comparison on series of dtype 'object; operand names: 'a', 'b'",
     ):
         _ = pl.Series("a", [object()]) == pl.Series("b", [object])

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -11,7 +11,16 @@ import pytest
 
 import polars as pl
 from polars.datatypes.convert import dtype_to_py_type
-from polars.exceptions import ColumnNotFoundError, ComputeError, InvalidOperationError
+from polars.exceptions import (
+    ColumnNotFoundError,
+    ComputeError,
+    InvalidOperationError,
+    OutOfBoundsError,
+    PolarsPanicError,
+    SchemaError,
+    SchemaFieldNotFoundError,
+    StructFieldNotFoundError,
+)
 
 if TYPE_CHECKING:
     from polars.type_aliases import ConcatMethod
@@ -83,7 +92,7 @@ def test_error_on_invalid_series_init() -> None:
 
 
 def test_error_on_invalid_struct_field() -> None:
-    with pytest.raises(pl.StructFieldNotFoundError):
+    with pytest.raises(StructFieldNotFoundError):
         pl.struct(
             [pl.Series("a", [1, 2]), pl.Series("b", ["a", "b"])], eager=True
         ).struct.field("z")
@@ -103,7 +112,7 @@ def test_string_numeric_comp_err() -> None:
 
 def test_panic_error() -> None:
     with pytest.raises(
-        pl.PolarsPanicError,
+        PolarsPanicError,
         match="unit: 'k' not supported",
     ):
         pl.datetime_range(
@@ -154,7 +163,7 @@ def test_projection_update_schema_missing_column() -> None:
 def test_not_found_on_rename() -> None:
     df = pl.DataFrame({"exists": [1, 2, 3]})
 
-    err_type = (pl.SchemaFieldNotFoundError, ColumnNotFoundError)
+    err_type = (SchemaFieldNotFoundError, ColumnNotFoundError)
     with pytest.raises(err_type):
         df.rename({"does_not_exist": "exists"})
 
@@ -307,7 +316,7 @@ def test_duplicate_columns_arg_csv() -> None:
 
 
 def test_datetime_time_add_err() -> None:
-    with pytest.raises(pl.SchemaError, match="failed to determine supertype"):
+    with pytest.raises(SchemaError, match="failed to determine supertype"):
         pl.Series([datetime(1970, 1, 1, 0, 0, 1)]) + pl.Series([time(0, 0, 2)])
 
 
@@ -437,7 +446,7 @@ def test_compare_different_len() -> None:
 
 def test_take_negative_index_is_oob() -> None:
     df = pl.DataFrame({"value": [1, 2, 3]})
-    with pytest.raises(pl.OutOfBoundsError):
+    with pytest.raises(OutOfBoundsError):
         df["value"].gather(-4)
 
 
@@ -663,7 +672,7 @@ def test_raise_on_sorted_multi_args() -> None:
 
 def test_err_invalid_comparison() -> None:
     with pytest.raises(
-        pl.SchemaError,
+        SchemaError,
         match="could not evalulate comparison between series 'a' of dtype: date and series 'b' of dtype: bool",
     ):
         _ = pl.Series("a", [date(2020, 1, 1)]) == pl.Series("b", [True])

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -11,7 +11,7 @@ import pytest
 
 import polars as pl
 from polars.datatypes.convert import dtype_to_py_type
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import ColumnNotFoundError, ComputeError, InvalidOperationError
 
 if TYPE_CHECKING:
     from polars.type_aliases import ConcatMethod
@@ -92,7 +92,7 @@ def test_error_on_invalid_struct_field() -> None:
 def test_not_found_error() -> None:
     csv = "a,b,c\n2,1,1"
     df = pl.read_csv(io.StringIO(csv))
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         df.select("d")
 
 
@@ -138,7 +138,7 @@ def test_join_lazy_on_df() -> None:
 
 def test_projection_update_schema_missing_column() -> None:
     with pytest.raises(
-        pl.ColumnNotFoundError,
+        ColumnNotFoundError,
         match='unable to find column "colC"',
     ):
         (
@@ -154,7 +154,7 @@ def test_projection_update_schema_missing_column() -> None:
 def test_not_found_on_rename() -> None:
     df = pl.DataFrame({"exists": [1, 2, 3]})
 
-    err_type = (pl.SchemaFieldNotFoundError, pl.ColumnNotFoundError)
+    err_type = (pl.SchemaFieldNotFoundError, ColumnNotFoundError)
     with pytest.raises(err_type):
         df.rename({"does_not_exist": "exists"})
 
@@ -602,12 +602,12 @@ def test_sort_by_error() -> None:
 
 
 def test_non_existent_expr_inputs_in_lazy() -> None:
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         pl.LazyFrame().filter(pl.col("x") == 1).explain()  # tests: 12074
 
     lf = pl.LazyFrame({"foo": [1, 1, -2, 3]})
 
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         (
             lf.select(pl.col("foo").cum_sum().alias("bar"))
             .filter(pl.col("bar") == pl.col("foo"))
@@ -624,7 +624,7 @@ def test_error_list_to_array() -> None:
 
 def test_raise_not_found_in_simplify_14974() -> None:
     df = pl.DataFrame()
-    with pytest.raises(pl.ColumnNotFoundError):
+    with pytest.raises(ColumnNotFoundError):
         df.select(1 / (1 + pl.col("a")))
 
 

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Iterator
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 
 if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType
@@ -290,7 +291,7 @@ def test_fmt_float_full() -> None:
 def test_fmt_list_12188() -> None:
     # set max_items to 1 < 4(size of failed list) to touch the testing branch.
     with pl.Config(fmt_table_cell_list_len=1), pytest.raises(
-        pl.InvalidOperationError, match="from `i64` to `u8` failed"
+        InvalidOperationError, match="from `i64` to `u8` failed"
     ):
         pl.DataFrame(
             {

--- a/py-polars/tests/unit/test_plugins.py
+++ b/py-polars/tests/unit/test_plugins.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.plugins import (
     _is_dynamic_lib,
     _resolve_plugin_path,
@@ -24,7 +25,7 @@ def test_register_plugin_function_invalid_plugin_path(tmp_path: Path) -> None:
         plugin_path=plugin_path, function_name="hello", args=5
     )
 
-    with pytest.raises(pl.ComputeError, match="error loading dynamic library"):
+    with pytest.raises(ComputeError, match="error loading dynamic library"):
         pl.select(expr)
 
 

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -8,6 +8,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -208,7 +209,7 @@ def test_expr_deserialize_file_not_found() -> None:
 
 def test_expr_deserialize_invalid_json() -> None:
     with pytest.raises(
-        pl.ComputeError, match="could not deserialize input into an expression"
+        ComputeError, match="could not deserialize input into an expression"
     ):
         pl.Expr.deserialize(io.StringIO("abcdef"))
 

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -8,7 +8,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -122,7 +122,7 @@ def test_pickle_udf_expression() -> None:
 
     # tests that 'GetOutput' is also deserialized
     with pytest.raises(
-        pl.SchemaError,
+        SchemaError,
         match=r"expected output type 'String', got 'Int64'; set `return_dtype` to the proper datatype",
     ):
         df.select(e)


### PR DESCRIPTION
In a lot of cases, exceptions were already imported from the `exceptions` module directly. Now we do this consistently across the test suite, instead of using the top-level re-exports (I want to get rid of those - more info in later PR).