### PR TITLE
feat!: Add `strict` parameter to `DataFrame/LazyFrame.drop` and fix behavior to default to True

### DIFF
--- a/crates/polars-plan/src/plans/builder_dsl.rs
+++ b/crates/polars-plan/src/plans/builder_dsl.rs
@@ -200,8 +200,8 @@ impl DslBuilder {
         .into()
     }
 
-    pub fn drop(self, to_drop: PlHashSet<String>) -> Self {
-        self.map_private(DslFunction::Drop(to_drop))
+    pub fn drop(self, to_drop: PlHashSet<String>, strict: bool) -> Self {
+        self.map_private(DslFunction::Drop(DropFunction { to_drop, strict }))
     }
 
     pub fn project(self, exprs: Vec<Expr>, options: ProjectionOptions) -> Self {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -472,7 +472,13 @@ pub fn to_alp_impl(
                     };
                     return run_conversion(lp, lp_arena, expr_arena, convert, "fill_nan");
                 },
-                DslFunction::Drop(to_drop) => {
+                DslFunction::Drop(DropFunction { to_drop, strict }) => {
+                    if strict {
+                        for col_name in to_drop.iter() {
+                            polars_ensure!(input_schema.contains(col_name), ColumnNotFound: "{col_name}");
+                        }
+                    }
+
                     let mut output_schema =
                         Schema::with_capacity(input_schema.len().saturating_sub(to_drop.len()));
 

--- a/crates/polars-plan/src/plans/functions/dsl.rs
+++ b/crates/polars-plan/src/plans/functions/dsl.rs
@@ -23,7 +23,17 @@ pub enum DslFunction {
     Stats(StatsFunction),
     /// FillValue
     FillNan(Expr),
-    Drop(PlHashSet<String>),
+    Drop(DropFunction),
+}
+
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DropFunction {
+    /// Columns that are going to be dropped
+    pub(crate) to_drop: PlHashSet<String>,
+    /// If `true`, performs a check for each item in `to_drop` against the schema. Returns an
+    /// `ColumnNotFound` error if the column does not exist in the schema.
+    pub(crate) strict: bool,
 }
 
 #[derive(Clone)]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6954,7 +6954,9 @@ class DataFrame:
         return self
 
     def drop(
-        self, *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector]
+        self,
+        *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector],
+        strict: bool = True,
     ) -> DataFrame:
         """
         Remove columns from the dataframe.
@@ -6964,6 +6966,9 @@ class DataFrame:
         *columns
             Names of the columns that should be removed from the dataframe.
             Accepts column selector input.
+        strict
+            Validate that all column names exist in the schema and throw an
+            exception if a column name does not exist in the schema.
 
         Examples
         --------
@@ -7031,7 +7036,7 @@ class DataFrame:
         │ 8.0 │
         └─────┘
         """
-        return self.lazy().drop(*columns).collect(_eager=True)
+        return self.lazy().drop(*columns, strict=strict).collect(_eager=True)
 
     def drop_in_place(self, name: str) -> Series:
         """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4371,7 +4371,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
     def drop(
-        self, *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector]
+        self,
+        *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector],
+        strict: bool = True,
     ) -> Self:
         """
         Remove columns from the DataFrame.
@@ -4381,6 +4383,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *columns
             Names of the columns that should be removed from the dataframe.
             Accepts column selector input.
+        strict
+            Validate that all column names exist in the schema and throw an
+            exception if a column name does not exist in the schema.
 
         Examples
         --------
@@ -4435,7 +4440,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┘
         """
         drop_cols = _expand_selectors(self, *columns)
-        return self._from_pyldf(self._ldf.drop(drop_cols))
+        return self._from_pyldf(self._ldf.drop(drop_cols, strict=strict))
 
     def rename(self, mapping: dict[str, str] | Callable[[str], str]) -> Self:
         """

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -1159,9 +1159,14 @@ impl PyLazyFrame {
             .into()
     }
 
-    fn drop(&self, columns: Vec<String>) -> Self {
+    fn drop(&self, columns: Vec<String>, strict: bool) -> Self {
         let ldf = self.ldf.clone();
-        ldf.drop(columns).into()
+        if strict {
+            ldf.drop(columns)
+        } else {
+            ldf.drop_no_validate(columns)
+        }
+        .into()
     }
 
     fn cast(&self, dtypes: HashMap<PyBackedStr, Wrap<DataType>>, strict: bool) -> Self {

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -125,3 +125,15 @@ def test_drop_without_parameters() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     assert_frame_equal(df.drop(), df)
     assert_frame_equal(df.lazy().drop(*[]), df.lazy())
+
+
+def test_drop_strict() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+
+    df.drop("a")
+
+    with pytest.raises(pl.exceptions.ColumnNotFoundError, match="b"):
+        df.drop("b")
+
+    df.drop("a", strict=False)
+    df.drop("b", strict=False)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/11913

This PR adds the `strict` flag on `LazyFrame::drop` that is set to `True` by default. When it is enabled, `drop` will validate the given column names against the schema and throw a `ColumnNotFound` error if the column is not defined instead of quietly ignore it. The flag can be set to `False` to re-enable the previous quiet ignoring behavior.

@stinodego