### PR TITLE
fix(python): Update some `Series` dunder method type signatures

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -596,32 +596,32 @@ class Series:
     def __len__(self) -> int:
         return self.len()
 
-    def __and__(self, other: Series) -> Self:
+    def __and__(self, other: Any) -> Self:
         if not isinstance(other, Series):
             other = Series([other])
         return self._from_pyseries(self._s.bitand(other._s))
 
-    def __rand__(self, other: Series) -> Series:
+    def __rand__(self, other: Any) -> Series:
         if not isinstance(other, Series):
             other = Series([other])
         return other & self
 
-    def __or__(self, other: Series) -> Self:
+    def __or__(self, other: Any) -> Self:
         if not isinstance(other, Series):
             other = Series([other])
         return self._from_pyseries(self._s.bitor(other._s))
 
-    def __ror__(self, other: Series) -> Series:
+    def __ror__(self, other: Any) -> Series:
         if not isinstance(other, Series):
             other = Series([other])
         return other | self
 
-    def __xor__(self, other: Series) -> Self:
+    def __xor__(self, other: Any) -> Self:
         if not isinstance(other, Series):
             other = Series([other])
         return self._from_pyseries(self._s.bitxor(other._s))
 
-    def __rxor__(self, other: Series) -> Series:
+    def __rxor__(self, other: Any) -> Series:
         if not isinstance(other, Series):
             other = Series([other])
         return other ^ self

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -277,21 +277,15 @@ def test_bitwise_ops() -> None:
     # Note that the type annotations only allow Series to be passed in, but there is
     # specific code to deal with non-Series inputs.
     assert_series_equal(
-        (
-            True & a  # type: ignore[operator]
-        ),
+        (True & a),
         pl.Series([True, False, True]),
     )
     assert_series_equal(
-        (
-            True | a  # type: ignore[operator]
-        ),
+        (True | a),
         pl.Series([True, True, True]),
     )
     assert_series_equal(
-        (
-            True ^ a  # type: ignore[operator]
-        ),
+        (True ^ a),
         pl.Series([False, True, False]),
     )
 


### PR DESCRIPTION
Closes #17048.

The correct typing for "other" here is `Any` (it can legitimately be almost anything, and we handle the case that it is not a Series internally; fixing this also lets us ditch a few "type: ignore" directives in the unit tests).