### PR TITLE
feat!: Do not parse hive partitions from user provided directory/glob path

### DIFF
--- a/crates/polars-lazy/src/scan/file_list_reader.rs
+++ b/crates/polars-lazy/src/scan/file_list_reader.rs
@@ -54,6 +54,7 @@ fn expand_paths(
                 } else if !path.ends_with("/")
                     && is_file_cloud(path.to_str().unwrap(), cloud_options)?
                 {
+                    expand_start_idx = 0;
                     out_paths.push(path.clone());
                     continue;
                 } else if !glob {
@@ -120,14 +121,11 @@ fn expand_paths(
                     out_paths.push(path.map_err(to_compute_err)?);
                 }
             } else {
+                expand_start_idx = 0;
                 out_paths.push(path.clone());
             }
         }
     }
-
-    // Todo:
-    // This maintains existing behavior - will remove very soon.
-    expand_start_idx = 0;
 
     Ok((
         out_paths.into_iter().collect::<Arc<[_]>>(),

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -326,33 +326,29 @@ def test_hive_partition_directory_scan(
     ).collect()
     assert_frame_equal(out, df)
 
-    out = scan(
-        tmp_path / append_glob, hive_partitioning=False, hive_schema=hive_schema
-    ).collect()
+    out = scan(tmp_path / append_glob, hive_partitioning=False).collect()
     assert_frame_equal(out, df.drop("a", "b"))
 
     out = scan(
         tmp_path / "a=1" / append_glob,
         hive_partitioning=True,
-        hive_schema=hive_schema,
     ).collect()
     assert_frame_equal(out, df.filter(a=1).drop("a"))
 
     out = scan(
         tmp_path / "a=1" / append_glob,
         hive_partitioning=False,
-        hive_schema=hive_schema,
     ).collect()
     assert_frame_equal(out, df.filter(a=1).drop("a", "b"))
 
     path = tmp_path / "a=1/b=1/data.bin"
 
     df = dfs[0]
-    out = scan(path, hive_partitioning=True, hive_schema=hive_schema).collect()
+    out = scan(path, hive_partitioning=True).collect()
 
     assert_frame_equal(out, df)
 
     df = dfs[0].drop("a", "b")
-    out = scan(path, hive_partitioning=False, hive_schema=hive_schema).collect()
+    out = scan(path, hive_partitioning=False).collect()
 
     assert_frame_equal(out, df)

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -283,7 +283,7 @@ def test_read_parquet_hive_schema_with_pyarrow() -> None:
     ],
 )
 @pytest.mark.parametrize(
-    ["append_glob", "glob"],
+    ("append_glob", "glob"),
     [
         ("**/*.bin", True),
         ("", True),

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -1,7 +1,8 @@
 import warnings
 from collections import OrderedDict
+from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import pyarrow.parquet as pq
 import pytest
@@ -275,7 +276,27 @@ def test_read_parquet_hive_schema_with_pyarrow() -> None:
         pl.read_parquet("test.parquet", hive_schema={"c": pl.Int32}, use_pyarrow=True)
 
 
-def test_hive_partition_directory_scan(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("scan_func", "write_func"),
+    [
+        (pl.scan_parquet, pl.DataFrame.write_parquet),
+    ],
+)
+@pytest.mark.parametrize(
+    ["append_glob", "glob"],
+    [
+        ("**/*.bin", True),
+        ("", True),
+        ("", False),
+    ],
+)
+def test_hive_partition_directory_scan(
+    tmp_path: Path,
+    append_glob: str,
+    scan_func: Callable[[Any], pl.LazyFrame],
+    write_func: Callable[[pl.DataFrame, Path], None],
+    glob: bool,
+) -> None:
     tmp_path.mkdir(exist_ok=True)
 
     dfs = [
@@ -290,30 +311,35 @@ def test_hive_partition_directory_scan(tmp_path: Path) -> None:
         b = df.item(0, "b")
         path = tmp_path / f"a={a}/b={b}/data.bin"
         path.parent.mkdir(exist_ok=True, parents=True)
-        df.drop("a", "b").write_parquet(path)
+        write_func(df.drop("a", "b"), path)
 
     df = pl.concat(dfs)
     hive_schema = df.lazy().select("a", "b").collect_schema()
 
-    out = pl.scan_parquet(
-        tmp_path, hive_partitioning=True, hive_schema=hive_schema
+    scan = scan_func
+    scan = partial(scan_func, hive_schema=hive_schema, glob=glob)
+
+    out = scan(
+        tmp_path / append_glob,
+        hive_partitioning=True,
+        hive_schema=hive_schema,
     ).collect()
     assert_frame_equal(out, df)
 
-    out = pl.scan_parquet(
-        tmp_path, hive_partitioning=False, hive_schema=hive_schema
+    out = scan(
+        tmp_path / append_glob, hive_partitioning=False, hive_schema=hive_schema
     ).collect()
     assert_frame_equal(out, df.drop("a", "b"))
 
-    out = pl.scan_parquet(
-        tmp_path / "a=1",
+    out = scan(
+        tmp_path / "a=1" / append_glob,
         hive_partitioning=True,
         hive_schema=hive_schema,
     ).collect()
     assert_frame_equal(out, df.filter(a=1).drop("a"))
 
-    out = pl.scan_parquet(
-        tmp_path / "a=1",
+    out = scan(
+        tmp_path / "a=1" / append_glob,
         hive_partitioning=False,
         hive_schema=hive_schema,
     ).collect()
@@ -322,15 +348,11 @@ def test_hive_partition_directory_scan(tmp_path: Path) -> None:
     path = tmp_path / "a=1/b=1/data.bin"
 
     df = dfs[0]
-    out = pl.scan_parquet(
-        path, hive_partitioning=True, hive_schema=hive_schema
-    ).collect()
+    out = scan(path, hive_partitioning=True, hive_schema=hive_schema).collect()
 
     assert_frame_equal(out, df)
 
     df = dfs[0].drop("a", "b")
-    out = pl.scan_parquet(
-        path, hive_partitioning=False, hive_schema=hive_schema
-    ).collect()
+    out = scan(path, hive_partitioning=False, hive_schema=hive_schema).collect()
 
     assert_frame_equal(out, df)


### PR DESCRIPTION
Before:

```python
scan_parquet("data/a=1/**/*.parquet")
shape: (5, 3)
┌─────┬───┬─────┐
│ a   ┆ … ┆ x   │
│ --- ┆   ┆ --- │
│ i64 ┆   ┆ i32 │
╞═════╪═══╪═════╡
│ 1   ┆ … ┆ 1   │
│ 1   ┆ … ┆ 1   │
│ 1   ┆ … ┆ 1   │
│ 1   ┆ … ┆ 1   │
│ 1   ┆ … ┆ 1   │
└─────┴───┴─────┘
```
After:

```python
scan_parquet("data/a=1/**/*.parquet")
┌───┬─────┐
│ … ┆ x   │
│   ┆ --- │
│   ┆ i32 │
╞═══╪═════╡
│ … ┆ 1   │
│ … ┆ 1   │
│ … ┆ 1   │
│ … ┆ 1   │
│ … ┆ 1   │
└───┴─────┘
```