### PR TITLE
fix: deal with sliced PyArrow record batches

### DIFF
--- a/crates/polars-arrow/src/array/fixed_size_list/ffi.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/ffi.rs
@@ -35,6 +35,8 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for FixedSizeListArray {
         let child = unsafe { array.child(0)? };
         let values = ffi::try_from(child)?;
 
-        Self::try_new(data_type, values, validity)
+        let mut fsl = Self::try_new(data_type, values, validity)?;
+        fsl.slice(array.offset(), array.length());
+        Ok(fsl)
     }
 }

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -544,6 +544,9 @@ pub trait ArrowArrayRef: std::fmt::Debug {
 
     fn n_buffers(&self) -> usize;
 
+    fn offset(&self) -> usize;
+    fn length(&self) -> usize;
+
     fn parent(&self) -> &InternalArrowArray;
     fn array(&self) -> &ArrowArray;
     fn data_type(&self) -> &ArrowDataType;
@@ -602,6 +605,14 @@ impl ArrowArrayRef for InternalArrowArray {
     fn n_buffers(&self) -> usize {
         self.array.n_buffers as usize
     }
+
+    fn offset(&self) -> usize {
+        self.array.offset as usize
+    }
+
+    fn length(&self) -> usize {
+        self.array.length as usize
+    }
 }
 
 #[derive(Debug)]
@@ -627,6 +638,14 @@ impl<'a> ArrowArrayRef for ArrowArrayChild<'a> {
 
     fn n_buffers(&self) -> usize {
         self.array.n_buffers as usize
+    }
+
+    fn offset(&self) -> usize {
+        self.array.offset as usize
+    }
+
+    fn length(&self) -> usize {
+        self.array.length as usize
     }
 }
 


### PR DESCRIPTION
This fixes the slicing behavior of FixedSizeLists when loaded with PyArrow. I am not sure if this behavior is also faulty at other places (I especially suspect structs), but as long as there are no reported problems there I think this fix is okay for now.

Fixes #16614.