### PR TITLE
build(python): Pin optional NumPy dependency to `< 2.0.0` for now

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -49,7 +49,9 @@ fsspec = ["fsspec"]
 gevent = ["gevent"]
 iceberg = ["pyiceberg >= 0.5.0"]
 matplotlib = ["matplotlib"]
-numpy = ["numpy >= 1.16.0"]
+# TODO: Remove upper bound when we support 2.0
+# https://github.com/pola-rs/polars/issues/16998
+numpy = ["numpy >= 1.16.0, < 2.0.0"]
 openpyxl = ["openpyxl >= 3.0.0"]
 pandas = ["pyarrow >= 7.0.0", "pandas"]
 plot = ["hvplot >= 0.9.1"]


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/16998

I should have done this earlier - apologies. I had misjudged the implications here.

To be clear: 
* This will make sure `pip install polars[numpy]` gets you a compatible version.
* If you have NumPy 2.0 installed, you can still `pip install polars` without problems. Polars works with NumPy 2.0 with certain limitations (see linked issue).