### PR TITLE
feat: Turn of coalescing and fix mutation of join on expressions

### DIFF
--- a/crates/polars-mem-engine/src/executors/join.rs
+++ b/crates/polars-mem-engine/src/executors/join.rs
@@ -68,8 +68,8 @@ impl Executor for JoinExec {
             (input_left.execute(state), input_right.execute(state))
         };
 
-        let mut df_left = df_left?;
-        let mut df_right = df_right?;
+        let df_left = df_left?;
+        let df_right = df_right?;
 
         let profile_name = if state.has_node_timer() {
             let by = self
@@ -96,14 +96,6 @@ impl Executor for JoinExec {
                 .iter()
                 .map(|e| e.evaluate(&df_right, state))
                 .collect::<PolarsResult<Vec<_>>>()?;
-
-            // make sure that we can join on evaluated expressions
-            for s in &left_on_series {
-                df_left.with_column(s.clone())?;
-            }
-            for s in &right_on_series {
-                df_right.with_column(s.clone())?;
-            }
 
             // prepare the tolerance
             // we must ensure that we use the right units

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -10,7 +10,7 @@ description = "More operations on Polars data structures"
 
 [dependencies]
 polars-compute = { workspace = true }
-polars-core = { workspace = true, features = ["algorithm_group_by", "zip_with", "fmt"] }
+polars-core = { workspace = true, features = ["algorithm_group_by", "zip_with"] }
 polars-error = { workspace = true }
 polars-json = { workspace = true, optional = true }
 polars-utils = { workspace = true }

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -10,7 +10,7 @@ description = "More operations on Polars data structures"
 
 [dependencies]
 polars-compute = { workspace = true }
-polars-core = { workspace = true, features = ["algorithm_group_by", "zip_with"] }
+polars-core = { workspace = true, features = ["algorithm_group_by", "zip_with", "fmt"] }
 polars-error = { workspace = true }
 polars-json = { workspace = true, optional = true }
 polars-utils = { workspace = true }

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -35,7 +35,7 @@ impl JoinArgs {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Hash, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum JoinCoalesce {
     #[default]
@@ -56,7 +56,7 @@ impl JoinCoalesce {
                 matches!(self, CoalesceColumns)
             },
             #[cfg(feature = "asof_join")]
-            AsOf(_) => false,
+            AsOf(_) => matches!(self, JoinSpecific | CoalesceColumns),
             Cross => false,
             #[cfg(feature = "semi_anti_join")]
             Semi | Anti => false,

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -587,14 +587,15 @@ pub trait AsofJoinBy: IntoDf {
     fn _join_asof_by(
         &self,
         other: &DataFrame,
-        left_on: &str,
-        right_on: &str,
+        left_on: &Series,
+        right_on: &Series,
         left_by: Vec<SmartString>,
         right_by: Vec<SmartString>,
         strategy: AsofStrategy,
         tolerance: Option<AnyValue<'static>>,
         suffix: Option<&str>,
         slice: Option<(i64, usize)>,
+        coalesce: bool,
     ) -> PolarsResult<DataFrame> {
         let (self_sliced_slot, other_sliced_slot); // Keeps temporaries alive.
         let (self_df, other_df);
@@ -608,8 +609,8 @@ pub trait AsofJoinBy: IntoDf {
             other_df = other;
         }
 
-        let left_asof = self_df.column(left_on)?.to_physical_repr();
-        let right_asof = other_df.column(right_on)?.to_physical_repr();
+        let left_asof = left_on.to_physical_repr();
+        let right_asof = right_on.to_physical_repr();
         let right_asof_name = right_asof.name();
         let left_asof_name = left_asof.name();
         check_asof_columns(
@@ -645,7 +646,7 @@ pub trait AsofJoinBy: IntoDf {
         )?;
 
         let mut drop_these = right_by.get_column_names();
-        if left_asof_name == right_asof_name {
+        if coalesce && left_asof_name == right_asof_name {
             drop_these.push(right_asof_name);
         }
 
@@ -688,8 +689,10 @@ pub trait AsofJoinBy: IntoDf {
         let self_df = self.to_df();
         let left_by = left_by.into_iter().map(|s| s.as_ref().into()).collect();
         let right_by = right_by.into_iter().map(|s| s.as_ref().into()).collect();
+        let left_key = self_df.column(left_on)?;
+        let right_key = other.column(right_on)?;
         self_df._join_asof_by(
-            other, left_on, right_on, left_by, right_by, strategy, tolerance, None, None,
+            other, right_key, left_key, left_by, right_by, strategy, tolerance, None, None, true,
         )
     }
 }

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -597,20 +597,26 @@ pub trait AsofJoinBy: IntoDf {
         slice: Option<(i64, usize)>,
         coalesce: bool,
     ) -> PolarsResult<DataFrame> {
-        let (self_sliced_slot, other_sliced_slot); // Keeps temporaries alive.
-        let (self_df, other_df);
+        let (self_sliced_slot, other_sliced_slot, left_slice_s, right_slice_s); // Keeps temporaries alive.
+        let (self_df, other_df, left_key, right_key);
         if let Some((offset, len)) = slice {
             self_sliced_slot = self.to_df().slice(offset, len);
             other_sliced_slot = other.slice(offset, len);
+            left_slice_s = left_on.slice(offset, len);
+            right_slice_s = right_on.slice(offset, len);
+            left_key = &left_slice_s;
+            right_key = &right_slice_s;
             self_df = &self_sliced_slot;
             other_df = &other_sliced_slot;
         } else {
             self_df = self.to_df();
             other_df = other;
+            left_key = left_on;
+            right_key = right_on;
         }
 
-        let left_asof = left_on.to_physical_repr();
-        let right_asof = right_on.to_physical_repr();
+        let left_asof = left_key.to_physical_repr();
+        let right_asof = right_key.to_physical_repr();
         let right_asof_name = right_asof.name();
         let left_asof_name = left_asof.name();
         check_asof_columns(
@@ -692,7 +698,7 @@ pub trait AsofJoinBy: IntoDf {
         let left_key = self_df.column(left_on)?;
         let right_key = other.column(right_on)?;
         self_df._join_asof_by(
-            other, right_key, left_key, left_by, right_by, strategy, tolerance, None, None, true,
+            other, left_key, right_key, left_by, right_by, strategy, tolerance, None, None, true,
         )
     }
 }

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -132,7 +132,7 @@ pub trait DataFrameJoinOps: IntoDf {
             clear(&mut selected_right);
         }
 
-        let should_coalesce = args.coalesce.coalesce(&args.how);
+        let should_coalesce = args.should_coalesce();
         assert_eq!(selected_left.len(), selected_right.len());
 
         #[cfg(feature = "chunked_ids")]
@@ -229,35 +229,32 @@ pub trait DataFrameJoinOps: IntoDf {
                     args.join_nulls,
                 ),
                 #[cfg(feature = "asof_join")]
-                JoinType::AsOf(options) => {
-                    let left_on = selected_left[0].name();
-                    let right_on = selected_right[0].name();
-
-                    match (options.left_by, options.right_by) {
-                        (Some(left_by), Some(right_by)) => left_df._join_asof_by(
-                            other,
-                            left_on,
-                            right_on,
-                            left_by,
-                            right_by,
-                            options.strategy,
-                            options.tolerance,
-                            args.suffix.as_deref(),
-                            args.slice,
-                        ),
-                        (None, None) => left_df._join_asof(
-                            other,
-                            left_on,
-                            right_on,
-                            options.strategy,
-                            options.tolerance,
-                            args.suffix,
-                            args.slice,
-                        ),
-                        _ => {
-                            panic!("expected by arguments on both sides")
-                        },
-                    }
+                JoinType::AsOf(options) => match (options.left_by, options.right_by) {
+                    (Some(left_by), Some(right_by)) => left_df._join_asof_by(
+                        other,
+                        s_left,
+                        s_right,
+                        left_by,
+                        right_by,
+                        options.strategy,
+                        options.tolerance,
+                        args.suffix.as_deref(),
+                        args.slice,
+                        should_coalesce,
+                    ),
+                    (None, None) => left_df._join_asof(
+                        other,
+                        s_left,
+                        s_right,
+                        options.strategy,
+                        options.tolerance,
+                        args.suffix,
+                        args.slice,
+                        should_coalesce,
+                    ),
+                    _ => {
+                        panic!("expected by arguments on both sides")
+                    },
                 },
                 JoinType::Cross => {
                     unreachable!()

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6584,7 +6584,8 @@ class DataFrame:
             - True: -> Always coalesce join columns.
             - False: -> Never coalesce join columns.
 
-            Note that joining on any other expressions than `col` will turn off coalescing.
+            Note that joining on any other expressions than `col`
+            will turn off coalescing.
 
         Returns
         -------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6584,6 +6584,8 @@ class DataFrame:
             - True: -> Always coalesce join columns.
             - False: -> Never coalesce join columns.
 
+            Note that joining on any other expressions than `col` will turn off coalescing.
+
         Returns
         -------
         DataFrame

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -15,6 +15,7 @@ from typing import (
     Collection,
     Iterable,
     Mapping,
+    NoReturn,
     Sequence,
     TypeVar,
     overload,
@@ -3975,7 +3976,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             - True: -> Always coalesce join columns.
             - False: -> Never coalesce join columns.
 
-            Note that joining on any other expressions than `col` will turn off coalescing.
+            Note that joining on any other expressions than `col`
+            will turn off coalescing.
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both
             DataFrames up to the join in parallel.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -15,7 +15,6 @@ from typing import (
     Collection,
     Iterable,
     Mapping,
-    NoReturn,
     Sequence,
     TypeVar,
     overload,
@@ -3975,6 +3974,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             - None: -> join specific.
             - True: -> Always coalesce join columns.
             - False: -> Never coalesce join columns.
+
+            Note that joining on any other expressions than `col` will turn off coalescing.
         allow_parallel
             Allow the physical plan to optionally evaluate the computation of both
             DataFrames up to the join in parallel.

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -571,6 +571,7 @@ def test_asof_join_tolerance_grouper() -> None:
         {
             "date": [date(2020, 1, 5), date(2020, 1, 10)],
             "by": [1, 1],
+            "date_right": [date(2020, 1, 5), None],
             "values": [100, None],
         }
     )

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -152,9 +152,9 @@ def test_join_on_expressions() -> None:
 
     df_b = pl.DataFrame({"b": [1, 4, 9, 9, 0]})
 
-    assert df_a.join(df_b, left_on=(pl.col("a") ** 2).cast(int), right_on=pl.col("b"))[
-        "a"
-    ].to_list() == [1, 4, 9, 9]
+    assert df_a.join(
+        df_b, left_on=(pl.col("a") ** 2).cast(int), right_on=pl.col("b")
+    ).to_dict(as_series=False) == {"a": [1, 2, 3, 3], "b": [1, 4, 9, 9]}
 
 
 def test_join() -> None:
@@ -249,12 +249,14 @@ def test_join_on_cast() -> None:
     assert df_a.join(df_b, on=pl.col("a").cast(pl.Int64)).to_dict(as_series=False) == {
         "index": [1, 2, 3, 5],
         "a": [-2, 3, 3, 10],
+        "a_right": [-2, 3, 3, 10],
     }
     assert df_a.lazy().join(
         df_b.lazy(), on=pl.col("a").cast(pl.Int64)
     ).collect().to_dict(as_series=False) == {
         "index": [1, 2, 3, 5],
         "a": [-2, 3, 3, 10],
+        "a_right": [-2, 3, 3, 10],
     }
 
 
@@ -365,7 +367,7 @@ def test_join_panic_on_binary_expr_5915() -> None:
     df_b = pl.DataFrame({"b": [1, 4, 9, 9, 0]}).lazy()
 
     z = df_a.join(df_b, left_on=[(pl.col("a") + 1).cast(int)], right_on=[pl.col("b")])
-    assert z.collect().to_dict(as_series=False) == {"a": [4]}
+    assert z.collect().to_dict(as_series=False) == {"a": [3], "b": [4]}
 
 
 def test_semi_join_projection_pushdown_6423() -> None:
@@ -970,9 +972,9 @@ def test_join_lit_panic_11410() -> None:
     df = pl.LazyFrame({"date": [1, 2, 3], "symbol": [4, 5, 6]})
     dates = df.select("date").unique(maintain_order=True)
     symbols = df.select("symbol").unique(maintain_order=True)
-    assert symbols.join(dates, left_on=pl.lit(1), right_on=pl.lit(1)).drop(
-        "literal"
-    ).collect().to_dict(as_series=False) == {"symbol": [4], "date": [1]}
+    assert symbols.join(dates, left_on=pl.lit(1), right_on=pl.lit(1)).collect().to_dict(
+        as_series=False
+    ) == {"symbol": [4], "date": [1]}
 
 
 def test_join_empty_literal_17027() -> None:

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -54,6 +54,12 @@ def test_asof_join_inline_cast_6438() -> None:
             datetime(2020, 1, 1, 9, 3),
             datetime(2020, 1, 1, 9, 6),
         ],
+        "time_right": [
+            datetime(2020, 1, 1, 9, 0),
+            None,
+            datetime(2020, 1, 1, 9, 2),
+            datetime(2020, 1, 1, 9, 3),
+        ],
         "stock": ["A", "B", "B", "C"],
         "trade": [101, 299, 301, 500],
         "quote": [100, None, 300, 501],
@@ -169,6 +175,7 @@ def test_join_asof_floats() -> None:
     expected = {
         "a": [1.0, 2.0, 3.0],
         "b": ["lrow1", "lrow2", "lrow3"],
+        "a_right": [0.59, 1.49, 2.89],
         "b_right": ["rrow1", "rrow2", "rrow3"],
     }
     assert result.to_dict(as_series=False) == expected
@@ -183,8 +190,8 @@ def test_join_asof_floats() -> None:
             "val": [0.0, 2.5, 2.6, 2.7, 3.4, 4.0, 5.0],
             "c": ["x", "x", "x", "y", "y", "y", "y"],
         }
-    ).with_columns(pl.col("val").alias("b"))
-    assert df1.join_asof(df2, on=pl.col("b").set_sorted(), by="c").to_dict(
+    ).with_columns(pl.col("val").alias("b").set_sorted())
+    assert df1.set_sorted("b").join_asof(df2, on=pl.col("b"), by="c").to_dict(
         as_series=False
     ) == {
         "b": [
@@ -394,6 +401,7 @@ def test_asof_join_by_logical_types() -> None:
         ],
         "b": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
         "c": ["1", "2", "3", "1", "2", "3", "1", "2", "3"],
+        "b_right": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
     }
     assert result.to_dict(as_series=False) == expected
 


### PR DESCRIPTION
Joining on any expression other than `col` will turn off coalescing behavior and will keep all columns of both tables. This also fixes several bugs with regard to accidentally mutating the underlying columns and adding literal expressions to the tables.

fixes #13220
fixes #9621