### PR TITLE
feat: predicate + projection pushdown in NDJson

### DIFF
--- a/crates/polars-io/src/json/mod.rs
+++ b/crates/polars-io/src/json/mod.rs
@@ -327,6 +327,9 @@ where
                     false,
                     self.infer_schema_len,
                     self.ignore_errors,
+                    None,
+                    None,
+                    None,
                 )?;
                 let mut df: DataFrame = json_reader.as_df()?;
                 if self.rechunk {

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -166,6 +166,26 @@ pub(crate) fn update_row_counts2(dfs: &mut [DataFrame], offset: IdxSize) {
     }
 }
 
+/// Because of threading every row starts from `0` or from `offset`.
+/// We must correct that so that they are monotonically increasing.
+#[cfg(feature = "json")]
+pub(crate) fn update_row_counts3(dfs: &mut [DataFrame], heights: &[IdxSize], offset: IdxSize) {
+    assert_eq!(dfs.len(), heights.len());
+    if !dfs.is_empty() {
+        let mut previous = heights[0] + offset;
+        for i in 1..dfs.len() {
+            let df = &mut dfs[i];
+            let n_read = heights[i];
+
+            if let Some(s) = unsafe { df.get_columns_mut() }.get_mut(0) {
+                *s = &*s + previous;
+            }
+
+            previous += n_read;
+        }
+    }
+}
+
 /// Compute `remaining_rows_to_read` to be taken per file up front, so we can actually read
 /// concurrently/parallel
 ///

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -297,6 +297,7 @@ fn create_physical_plan_impl(
                     options,
                     file_options,
                     file_info,
+                    predicate,
                 ))),
                 FileScan::Anonymous { function, .. } => {
                     Ok(Box::new(executors::AnonymousScanExec {

--- a/crates/polars-plan/src/plans/conversion/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/scans.rs
@@ -299,6 +299,7 @@ pub(super) fn ndjson_file_info(
             polars_io::ndjson::infer_schema(&mut reader, ndjson_options.infer_schema_length)?;
         prepare_schemas(schema, file_options.row_index.as_ref())
     };
+
     Ok(FileInfo::new(
         schema,
         Some(Either::Right(reader_schema)),

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -401,7 +401,7 @@ impl<'a> PredicatePushDown<'a> {
                     FileScan::Csv { .. } => options.n_rows.is_none(),
                     FileScan::Anonymous { function, .. } => function.allows_predicate_pushdown(),
                     #[cfg(feature = "json")]
-                    FileScan::NDJson { .. } => false,
+                    FileScan::NDJson { .. } => true,
                     #[allow(unreachable_patterns)]
                     _ => true,
                 };

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -406,7 +406,7 @@ impl ProjectionPushDown {
                         function.allows_projection_pushdown()
                     },
                     #[cfg(feature = "json")]
-                    FileScan::NDJson { .. } => false,
+                    FileScan::NDJson { .. } => true,
                     #[cfg(feature = "ipc")]
                     FileScan::Ipc { .. } => true,
                     #[cfg(feature = "csv")]


### PR DESCRIPTION
This PR adds predicate and projection pushdown in NDJson in a similar fashion as is done in CSV. This currently just filters after each chunk is deserialized, which is not perfectly efficient. It would probably be a good idea to do the projection during the `into_series` call and the predicate during the `...ChunkedBuilder` append value.