### PR TITLE
feat: follow-up optimization for ndjson projection pushdown

### DIFF
--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -26,7 +26,7 @@ pub(crate) struct Buffer<'a> {
     buf: AnyValueBuffer<'a>,
 }
 
-impl Buffer<'_> {
+impl<'a> Buffer<'a> {
     pub fn into_series(self) -> Series {
         let mut s = self.buf.into_series();
         s.rename(self.name);
@@ -126,6 +126,10 @@ impl Buffer<'_> {
     }
     pub fn add_null(&mut self) {
         self.buf.add(AnyValue::Null).expect("should not fail");
+    }
+
+    pub fn name(&self) -> &'a str {
+        self.name
     }
 }
 pub(crate) fn init_buffers(


### PR DESCRIPTION
This removes the need for allocation of buffers that are going to be pruned anyway.