### PR TITLE
fix(rust): Expand i128 primitive type match

### DIFF
--- a/crates/polars-arrow/src/array/equal/mod.rs
+++ b/crates/polars-arrow/src/array/equal/mod.rs
@@ -217,7 +217,7 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             let rhs = rhs.as_any().downcast_ref().unwrap();
             boolean::equal(lhs, rhs)
         },
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             let lhs = lhs.as_any().downcast_ref().unwrap();
             let rhs = rhs.as_any().downcast_ref().unwrap();
             primitive::equal::<$T>(lhs, rhs)

--- a/crates/polars-arrow/src/array/fmt.rs
+++ b/crates/polars-arrow/src/array/fmt.rs
@@ -2,7 +2,7 @@ use std::fmt::{Result, Write};
 
 use super::Array;
 use crate::bitmap::Bitmap;
-use crate::{match_integer_type, with_match_primitive_type};
+use crate::{match_integer_type, with_match_primitive_type_full};
 
 /// Returns a function that writes the value of the element of `array`
 /// at position `index` to a [`Write`],
@@ -17,7 +17,7 @@ pub fn get_value_display<'a, F: Write + 'a>(
         Boolean => Box::new(|f, index| {
             super::boolean::fmt::write_value(array.as_any().downcast_ref().unwrap(), index, f)
         }),
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             let writer = super::primitive::fmt::get_write_value::<$T, _>(
                 array.as_any().downcast_ref().unwrap(),
             );

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -456,7 +456,7 @@ pub fn to_data(array: &dyn Array) -> arrow_data::ArrayData {
     match array.data_type().to_physical_type() {
         Null => to_data_dyn!(array, NullArray),
         Boolean => to_data_dyn!(array, BooleanArray),
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             to_data_dyn!(array, PrimitiveArray<$T>)
         }),
         Binary => to_data_dyn!(array, BinaryArray<i32>),
@@ -487,7 +487,7 @@ pub fn from_data(data: &arrow_data::ArrayData) -> Box<dyn Array> {
     match data_type.to_physical_type() {
         Null => Box::new(NullArray::from_data(data)),
         Boolean => Box::new(BooleanArray::from_data(data)),
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             Box::new(PrimitiveArray::<$T>::from_data(data))
         }),
         Binary => Box::new(BinaryArray::<i32>::from_data(data)),
@@ -786,7 +786,7 @@ pub use utf8::{MutableUtf8Array, MutableUtf8ValuesArray, Utf8Array, Utf8ValuesIt
 pub use values::ValueSize;
 
 pub(crate) use self::ffi::{offset_buffers_children_dictionary, FromFfi, ToFfi};
-use crate::{match_integer_type, with_match_primitive_type, with_match_primitive_type_full};
+use crate::{match_integer_type, with_match_primitive_type_full};
 
 /// A trait describing the ability of a struct to create itself from a iterator.
 /// This is similar to [`Extend`], but accepted the creation to error.

--- a/crates/polars-arrow/src/io/avro/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/avro/read/deserialize.rs
@@ -8,7 +8,7 @@ use crate::array::*;
 use crate::datatypes::*;
 use crate::record_batch::RecordBatchT;
 use crate::types::months_days_ns;
-use crate::with_match_primitive_type;
+use crate::with_match_primitive_type_full;
 
 fn make_mutable(
     data_type: &ArrowDataType,
@@ -19,7 +19,7 @@ fn make_mutable(
         PhysicalType::Boolean => {
             Box::new(MutableBooleanArray::with_capacity(capacity)) as Box<dyn MutableArray>
         },
-        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        PhysicalType::Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             Box::new(MutablePrimitiveArray::<$T>::with_capacity(capacity).to(data_type.clone()))
                 as Box<dyn MutableArray>
         }),

--- a/crates/polars-arrow/src/scalar/equal.rs
+++ b/crates/polars-arrow/src/scalar/equal.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::*;
-use crate::{match_integer_type, with_match_primitive_type};
+use crate::{match_integer_type, with_match_primitive_type_full};
 
 impl PartialEq for dyn Scalar + '_ {
     fn eq(&self, that: &dyn Scalar) -> bool {
@@ -38,7 +38,7 @@ fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
     match lhs.data_type().to_physical_type() {
         Null => dyn_eq!(NullScalar, lhs, rhs),
         Boolean => dyn_eq!(BooleanScalar, lhs, rhs),
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             dyn_eq!(PrimitiveScalar<$T>, lhs, rhs)
         }),
         LargeUtf8 => dyn_eq!(Utf8Scalar<i64>, lhs, rhs),

--- a/crates/polars-arrow/src/scalar/mod.rs
+++ b/crates/polars-arrow/src/scalar/mod.rs
@@ -34,7 +34,7 @@ mod union;
 
 pub use union::UnionScalar;
 
-use crate::{match_integer_type, with_match_primitive_type};
+use crate::{match_integer_type, with_match_primitive_type_full};
 
 /// Trait object declaring an optional value with a [`ArrowDataType`].
 /// This strait is often used in APIs that accept multiple scalar types.
@@ -119,7 +119,7 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
             };
             Box::new(BooleanScalar::new(value))
         },
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<$T>>()


### PR DESCRIPTION
Closes #16111 

Update primitive match to use ```with_match_primitive_type_full!``` macro instead.

The original ```with_match_primitive_type!``` macro now only remains for the ```polars_arrow::compute::aggregate::sum``` function. This is due to not being able to implement simd_sum for f16 types: https://github.com/rust-lang/rust/issues/116909.