### PR TITLE
perf: Default to writing binview data to IPC

### DIFF
--- a/crates/polars-io/src/ipc/write.rs
+++ b/crates/polars-io/src/ipc/write.rs
@@ -84,7 +84,7 @@ where
         IpcWriter {
             writer,
             compression: None,
-            pl_flavor: false,
+            pl_flavor: true,
         }
     }
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3240,26 +3240,26 @@ class DataFrame:
     def write_ipc(
         self,
         file: None,
-        compression: IpcCompression = "uncompressed",
         *,
-        future: bool = False,
+        compression: IpcCompression = "uncompressed",
+        future: bool | None = None,
     ) -> BytesIO: ...
 
     @overload
     def write_ipc(
         self,
         file: str | Path | IO[bytes],
-        compression: IpcCompression = "uncompressed",
         *,
-        future: bool = False,
+        compression: IpcCompression = "uncompressed",
+        future: bool | None = None,
     ) -> None: ...
 
     def write_ipc(
         self,
         file: str | Path | IO[bytes] | None,
-        compression: IpcCompression = "uncompressed",
         *,
-        future: bool = False,
+        compression: IpcCompression = "uncompressed",
+        future: bool | None = None,
     ) -> BytesIO | None:
         """
         Write to Arrow IPC binary stream or Feather file.
@@ -3308,6 +3308,8 @@ class DataFrame:
             issue_unstable_warning(
                 "The `future` parameter of `DataFrame.write_ipc` is considered unstable."
             )
+        if future is None:
+            future = True
 
         self._df.write_ipc(file, compression, future)
         return file if return_bytes else None  # type: ignore[return-value]
@@ -3316,20 +3318,26 @@ class DataFrame:
     def write_ipc_stream(
         self,
         file: None,
+        *,
         compression: IpcCompression = "uncompressed",
+        future: bool | None = None,
     ) -> BytesIO: ...
 
     @overload
     def write_ipc_stream(
         self,
         file: str | Path | IO[bytes],
+        *,
         compression: IpcCompression = "uncompressed",
+        future: bool | None = None,
     ) -> None: ...
 
     def write_ipc_stream(
         self,
         file: str | Path | IO[bytes] | None,
+        *,
         compression: IpcCompression = "uncompressed",
+        future: bool | None = None,
     ) -> BytesIO | None:
         """
         Write to Arrow IPC record batch stream.
@@ -3343,6 +3351,13 @@ class DataFrame:
             be written. If set to `None`, the output is returned as a BytesIO object.
         compression : {'uncompressed', 'lz4', 'zstd'}
             Compression method. Defaults to "uncompressed".
+        future
+            Setting this to `True` will write Polars' internal data structures that
+            might not be available by other Arrow implementations.
+
+            .. warning::
+                This functionality is considered **unstable**. It may be changed
+                at any point without it being considered a breaking change.
 
         Examples
         --------
@@ -3367,7 +3382,14 @@ class DataFrame:
         if compression is None:
             compression = "uncompressed"
 
-        self._df.write_ipc_stream(file, compression)
+        if future:
+            issue_unstable_warning(
+                "The `future` parameter of `DataFrame.write_ipc` is considered unstable."
+            )
+        if future is None:
+            future = True
+
+        self._df.write_ipc_stream(file, compression, future=future)
         return file if return_bytes else None  # type: ignore[return-value]
 
     def write_parquet(

--- a/py-polars/src/dataframe/io.rs
+++ b/py-polars/src/dataframe/io.rs
@@ -525,12 +525,14 @@ impl PyDataFrame {
         py: Python,
         py_f: PyObject,
         compression: Wrap<Option<IpcCompression>>,
+        future: bool,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
             let f = std::fs::File::create(&*s)?;
             py.allow_threads(|| {
                 IpcStreamWriter::new(f)
                     .with_compression(compression.0)
+                    .with_pl_flavor(future)
                     .finish(&mut self.df)
                     .map_err(PyPolarsErr::from)
             })?;
@@ -539,6 +541,7 @@ impl PyDataFrame {
 
             IpcStreamWriter::new(&mut buf)
                 .with_compression(compression.0)
+                .with_pl_flavor(future)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -131,7 +131,7 @@ def test_compressed_simple(compression: IpcCompression, stream: bool) -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [True, False, True], "c": ["a", "b", "c"]})
 
     f = io.BytesIO()
-    write_ipc(df, stream, f, compression)
+    write_ipc(df, stream, f, compression=compression)
     f.seek(0)
 
     df_read = read_ipc(stream, f, use_pyarrow=False)


### PR DESCRIPTION
Pyarrow 16 can now correctly read binview data, so let's write them. This allows us to memory map IPC again.

If users want to remain on an older pyarrow they can set  `future=False`.

breaking: `compression` is keyword only.