### PR TITLE
feat: Support reading byte stream split encoded floats and doubles in parquet

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -12,7 +12,7 @@ use super::super::utils::{
 };
 use super::super::{utils, PagesIter};
 use crate::parquet::deserialize::SliceFilteredIter;
-use crate::parquet::encoding::{hybrid_rle, Encoding};
+use crate::parquet::encoding::{byte_stream_split, hybrid_rle, Encoding};
 use crate::parquet::page::{split_buffer, DataPage, DictPage};
 use crate::parquet::types::{decode, NativeType as ParquetNativeType};
 
@@ -97,6 +97,7 @@ where
     OptionalDictionary(OptionalPageValidity<'a>, ValuesDictionary<'a, T>),
     FilteredRequired(FilteredRequiredValues<'a>),
     FilteredOptional(FilteredOptionalPageValidity<'a>, Values<'a>),
+    RequiredByteStreamSplit(byte_stream_split::Decoder<'a>),
 }
 
 impl<'a, T> utils::PageState<'a> for State<'a, T>
@@ -111,6 +112,7 @@ where
             State::OptionalDictionary(optional, _) => optional.len(),
             State::FilteredRequired(values) => values.len(),
             State::FilteredOptional(optional, _) => optional.len(),
+            State::RequiredByteStreamSplit(decoder) => decoder.len(),
         }
     }
 }
@@ -191,6 +193,12 @@ where
                 FilteredOptionalPageValidity::try_new(page)?,
                 Values::try_new::<P>(page)?,
             )),
+            (Encoding::ByteStreamSplit, _, false, false) => {
+                let values = split_buffer(page)?.values;
+                Ok(State::RequiredByteStreamSplit(
+                    byte_stream_split::Decoder::try_new(values, std::mem::size_of::<P>())?,
+                ))
+            },
             _ => Err(utils::not_implemented(page)),
         }
     }
@@ -259,6 +267,9 @@ where
                     values,
                     page_values.values.by_ref().map(decode).map(self.op),
                 );
+            },
+            State::RequiredByteStreamSplit(decoder) => {
+                values.extend(decoder.iter_converted(decode).map(self.op).take(remaining));
             },
         }
         Ok(())

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/nested.rs
@@ -4,7 +4,7 @@ use arrow::array::PrimitiveArray;
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
-use polars_error::PolarsResult;
+use polars_error::{polars_err, PolarsResult};
 use polars_utils::iter::FallibleIterator;
 
 use super::super::nested_utils::*;
@@ -163,7 +163,7 @@ where
                     .iter_converted(decode)
                     .map(self.op)
                     .next()
-                    .unwrap_or_default();
+                    .ok_or_else(|| polars_err!(ComputeError: "No values left in page"))?;
                 values.push(value);
             },
             State::OptionalByteStreamSplit(decoder) => {
@@ -171,7 +171,7 @@ where
                     .iter_converted(decode)
                     .map(self.op)
                     .next()
-                    .unwrap_or_default();
+                    .ok_or_else(|| polars_err!(ComputeError: "No values left in page"))?;
                 values.push(value);
                 validity.push(true);
             },

--- a/crates/polars-parquet/src/parquet/encoding/byte_stream_split/decoder.rs
+++ b/crates/polars-parquet/src/parquet/encoding/byte_stream_split/decoder.rs
@@ -1,0 +1,103 @@
+use crate::parquet::error::ParquetError;
+
+/// Decodes using the [Byte Stream Split](https://github.com/apache/parquet-format/blob/master/Encodings.md#byte-stream-split-byte_stream_split--9) encoding.
+/// # Implementation
+/// A fixed size buffer is stored inline to support reading types of up to 8 bytes in size.
+#[derive(Debug)]
+pub struct Decoder<'a> {
+    values: &'a [u8],
+    buffer: [u8; 8],
+    num_elements: usize,
+    position: usize,
+    element_size: usize,
+}
+
+impl<'a> Decoder<'a> {
+    pub fn try_new(values: &'a [u8], element_size: usize) -> Result<Self, ParquetError> {
+        if element_size > 8 {
+            // Since Parquet format version 2.11 it's valid to use byte stream split for fixed-length byte array data,
+            // which could be larger than 8 bytes, but Polars doesn't yet support reading byte stream split encoded FLBA data.
+            return Err(ParquetError::oos(
+                "Byte stream split decoding only supports up to 8 byte element sizes",
+            ));
+        }
+
+        let values_size = values.len();
+        if values_size % element_size != 0 {
+            return Err(ParquetError::oos(
+                "Values array length is not a multiple of the element size",
+            ));
+        }
+        let num_elements = values.len() / element_size;
+
+        Ok(Self {
+            values,
+            buffer: [0; 8],
+            num_elements,
+            position: 0,
+            element_size,
+        })
+    }
+
+    pub fn move_next(&mut self) -> bool {
+        if self.position >= self.num_elements {
+            return false;
+        }
+
+        for n in 0..self.element_size {
+            self.buffer[n] = self.values[(self.num_elements * n) + self.position]
+        }
+
+        self.position += 1;
+        true
+    }
+
+    /// The number of remaining values
+    pub fn len(&self) -> usize {
+        self.num_elements - self.position
+    }
+
+    pub fn current_value(&self) -> &[u8] {
+        &self.buffer[0..self.element_size]
+    }
+
+    pub fn iter_converted<'b, T, F>(&'b mut self, converter: F) -> DecoderIterator<'a, 'b, T, F>
+    where
+        F: Copy + Fn(&[u8]) -> T,
+    {
+        DecoderIterator {
+            decoder: self,
+            converter,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DecoderIterator<'a, 'b, T, F>
+where
+    F: Copy + Fn(&[u8]) -> T,
+{
+    decoder: &'b mut Decoder<'a>,
+    converter: F,
+}
+
+impl<'a, 'b, T, F> Iterator for DecoderIterator<'a, 'b, T, F>
+where
+    F: Copy + Fn(&[u8]) -> T,
+{
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.decoder.move_next() {
+            Some((self.converter)(self.decoder.current_value()))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.decoder.len(), Some(self.decoder.len()))
+    }
+}

--- a/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
@@ -1,0 +1,67 @@
+mod decoder;
+
+pub use decoder::Decoder;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parquet::error::ParquetError;
+    use crate::parquet::types::NativeType;
+
+    #[test]
+    fn round_trip_f32() -> Result<(), ParquetError> {
+        let data = vec![1.0e-2_f32, 2.5_f32, 3.0e2_f32];
+        let mut buffer = vec![];
+        encode(&data, &mut buffer);
+
+        let mut decoder = Decoder::try_new(&buffer, std::mem::size_of::<f32>())?;
+        let values = decoder
+            .iter_converted(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(data, values);
+
+        Ok(())
+    }
+
+    #[test]
+    fn round_trip_f64() -> Result<(), ParquetError> {
+        let data = vec![1.0e-2_f64, 2.5_f64, 3.0e2_f64];
+        let mut buffer = vec![];
+        encode(&data, &mut buffer);
+
+        let mut decoder = Decoder::try_new(&buffer, std::mem::size_of::<f64>())?;
+        let values = decoder
+            .iter_converted(|bytes| f64::from_le_bytes(bytes.try_into().unwrap()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(data, values);
+
+        Ok(())
+    }
+
+    #[test]
+    fn fails_for_bad_size() -> Result<(), ParquetError> {
+        let buffer = vec![0; 12];
+
+        let result = Decoder::try_new(&buffer, 8);
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    fn encode<T: NativeType>(data: &[T], buffer: &mut Vec<u8>) {
+        let element_size = std::mem::size_of::<T>();
+        let num_elements = data.len();
+        let total_length = std::mem::size_of_val(data);
+        buffer.resize(total_length, 0);
+
+        for (i, v) in data.iter().enumerate() {
+            let value_bytes = v.to_le_bytes();
+            let value_bytes_ref = value_bytes.as_ref();
+            for n in 0..element_size {
+                buffer[(num_elements * n) + i] = value_bytes_ref[n];
+            }
+        }
+    }
+}

--- a/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
@@ -41,10 +41,20 @@ mod tests {
     }
 
     #[test]
-    fn fails_for_bad_size() -> Result<(), ParquetError> {
+    fn fails_for_invalid_values_size() -> Result<(), ParquetError> {
         let buffer = vec![0; 12];
 
         let result = Decoder::try_new(&buffer, 8);
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn fails_for_invalid_element_size() -> Result<(), ParquetError> {
+        let buffer = vec![0; 16];
+
+        let result = Decoder::try_new(&buffer, 16);
         assert!(result.is_err());
 
         Ok(())

--- a/crates/polars-parquet/src/parquet/encoding/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/mod.rs
@@ -1,4 +1,5 @@
 pub mod bitpacked;
+pub mod byte_stream_split;
 pub mod delta_bitpacked;
 pub mod delta_byte_array;
 pub mod delta_length_byte_array;

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1117,6 +1117,7 @@ def test_parquet_statistics_uint64_16683() -> None:
     assert statistics.max == u64_max
 
 
+@pytest.mark.slow()
 @pytest.mark.parametrize("nullable", [True, False])
 def test_read_byte_stream_split(nullable: bool) -> None:
     rng = np.random.default_rng(123)
@@ -1148,6 +1149,7 @@ def test_read_byte_stream_split(nullable: bool) -> None:
     assert_frame_equal(read, df)
 
 
+@pytest.mark.slow()
 @pytest.mark.parametrize("rows_nullable", [True, False])
 @pytest.mark.parametrize("item_nullable", [True, False])
 def test_read_byte_stream_split_arrays(

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1146,3 +1146,65 @@ def test_read_byte_stream_split(nullable: bool) -> None:
     read = pl.read_parquet(f)
 
     assert_frame_equal(read, df)
+
+
+@pytest.mark.parametrize("rows_nullable", [True, False])
+@pytest.mark.parametrize("item_nullable", [True, False])
+def test_read_byte_stream_split_arrays(
+    item_nullable: bool, rows_nullable: bool
+) -> None:
+    rng = np.random.default_rng(123)
+    num_rows = 1_000
+    max_array_len = 10
+    array_lengths = rng.integers(0, max_array_len + 1, num_rows)
+    if rows_nullable:
+        row_validity_mask = rng.integers(0, 2, num_rows).astype(np.bool_)
+        array_lengths[row_validity_mask] = 0
+        row_validity_mask = pa.array(row_validity_mask)
+    else:
+        row_validity_mask = None
+
+    offsets = np.zeros(num_rows + 1, dtype=np.int64)
+    np.cumsum(array_lengths, out=offsets[1:])
+    num_values = offsets[-1]
+    values = rng.uniform(-1.0e6, 1.0e6, num_values)
+
+    if item_nullable:
+        element_validity_mask = rng.integers(0, 2, num_values).astype(np.bool_)
+    else:
+        element_validity_mask = None
+
+    schema = pa.schema(
+        [
+            pa.field(
+                "floats",
+                type=pa.list_(pa.field("", pa.float32(), nullable=item_nullable)),
+                nullable=rows_nullable,
+            ),
+            pa.field(
+                "doubles",
+                type=pa.list_(pa.field("", pa.float64(), nullable=item_nullable)),
+                nullable=rows_nullable,
+            ),
+        ]
+    )
+    arrays = [
+        pa.ListArray.from_arrays(
+            pa.array(offsets),
+            pa.array(values, type=field.type.field(0).type, mask=element_validity_mask),
+            mask=row_validity_mask,
+        )
+        for field in schema
+    ]
+    table = pa.Table.from_arrays(arrays, schema=schema)
+    df = pl.from_arrow(table)
+
+    f = io.BytesIO()
+    pq.write_table(
+        table, f, compression="snappy", use_dictionary=False, use_byte_stream_split=True
+    )
+
+    f.seek(0)
+    read = pl.read_parquet(f)
+
+    assert_frame_equal(read, df)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1135,7 +1135,7 @@ def test_read_byte_stream_split(nullable: bool) -> None:
     )
     arrays = [pa.array(values, type=field.type, mask=validity_mask) for field in schema]
     table = pa.Table.from_arrays(arrays, schema=schema)
-    df = pl.from_arrow(table)
+    df = cast(pl.DataFrame, pl.from_arrow(table))
 
     f = io.BytesIO()
     pq.write_table(
@@ -1197,7 +1197,7 @@ def test_read_byte_stream_split_arrays(
         for field in schema
     ]
     table = pa.Table.from_arrays(arrays, schema=schema)
-    df = pl.from_arrow(table)
+    df = cast(pl.DataFrame, pl.from_arrow(table))
 
     f = io.BytesIO()
     pq.write_table(


### PR DESCRIPTION
Fixes #17042 

This PR adds support for reading Parquet files with float or double values that are encoded with the byte stream split encoding. I started out using the changes in https://github.com/jorgecarleitao/parquet2/pull/221, but refactored the way the decoder worked to avoid needing to change the State enums for the basic and nested PrimitiveDecoder structs too much (I think these would have at least needed extra type parameters for the ParqueNativeType and converter function).

Version 2.11 of the Parquet format extended the byte stream split encoding to be valid for integer types and fixed length byte arrays, motivated by the addition of the float16 logical type which uses a 2-byte fixed length byte array physical type. But it looks like Polars doesn't support reading float16 data so I think for now it's fine to only handle floats and doubles.

This code doesn't handle when `is_filtered` is true in `build_state`, but I couldn't find any code path where that is used by Polars, and `is_filtered == true` also seems to be unimplemented for dictionary encoded data, so I assume this isn't necessary?