### PR TITLE
feat(rust): POC metadata reading and writing

### DIFF
--- a/crates/polars-core/src/chunked_array/metadata/collect.rs
+++ b/crates/polars-core/src/chunked_array/metadata/collect.rs
@@ -1,6 +1,16 @@
-use super::{Metadata, MetadataCollectable, MetadataEnv};
+use super::{Metadata, MetadataEnv};
 use crate::chunked_array::{ChunkAgg, ChunkedArray, PolarsDataType, PolarsNumericType};
 use crate::series::IsSorted;
+
+pub trait MetadataCollectable<T>: Sized {
+    fn collect_cheap_metadata(&mut self) {}
+
+    #[inline(always)]
+    fn with_cheap_metadata(mut self) -> Self {
+        self.collect_cheap_metadata();
+        self
+    }
+}
 
 impl<T> MetadataCollectable<T> for ChunkedArray<T>
 where

--- a/crates/polars-core/src/chunked_array/metadata/guard.rs
+++ b/crates/polars-core/src/chunked_array/metadata/guard.rs
@@ -1,0 +1,23 @@
+use std::ops::Deref;
+use std::sync::RwLockReadGuard;
+
+use super::Metadata;
+use crate::chunked_array::PolarsDataType;
+
+/// A read guard for [`Metadata`]
+pub enum MetadataReadGuard<'a, T: PolarsDataType + 'a> {
+    Unlocked(RwLockReadGuard<'a, Metadata<T>>),
+    Locked(&'a Metadata<T>),
+}
+
+impl<'a, T: PolarsDataType + 'a> Deref for MetadataReadGuard<'a, T> {
+    type Target = Metadata<T>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Unlocked(v) => v.deref(),
+            Self::Locked(v) => v,
+        }
+    }
+}

--- a/crates/polars-core/src/chunked_array/metadata/interior_mutable.rs
+++ b/crates/polars-core/src/chunked_array/metadata/interior_mutable.rs
@@ -1,0 +1,75 @@
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use super::{Metadata, MetadataTrait};
+use crate::chunked_array::PolarsDataType;
+
+// I have attempted multiple times to move this interior mutability to a per metadata field basis.
+// While this might allow the use of Atomics instead of RwLocks, it suffers several problems:
+//
+// 1. The amount of boilerplate explodes. For example, you want read, read_blocking, write,
+//    write_blocking, get_mut, set for each field.
+// 2. It is also very difficult to combine with the dynamic dispatch.
+// 3. It is difficult to combine with types that do not allow for atomics (e.g. Box<[u8]>).
+// 4. You actually have 2 fields per field: the Option and the Value. You run into critical section
+//    problems if you try to separate these.
+
+/// An interiorally mutable [`Metadata`]
+///
+/// This is essentially a more convenient API around `RwLock<Metadata>`. This also allows it to be
+/// `Clone`.
+pub struct IMMetadata<T: PolarsDataType>(RwLock<Metadata<T>>);
+
+impl<'a, T: PolarsDataType + 'a> IMMetadata<T>
+where
+    Metadata<T>: MetadataTrait + 'a,
+{
+    /// Cast the [`IMMetadata`] to a trait object of [`MetadataTrait`]
+    pub fn upcast(&'a self) -> &'a RwLock<dyn MetadataTrait + 'a> {
+        &self.0 as &RwLock<dyn MetadataTrait + 'a>
+    }
+}
+
+impl<T: PolarsDataType> IMMetadata<T> {
+    pub const fn new(md: Metadata<T>) -> Self {
+        Self(RwLock::new(md))
+    }
+
+    /// Try to grab a read guard to the [`Metadata`], this fails if this blocks.
+    pub fn try_read(&self) -> Option<RwLockReadGuard<Metadata<T>>> {
+        self.0.try_read().ok()
+    }
+    /// Block to grab a read guard the [`Metadata`]
+    pub fn read(&self) -> RwLockReadGuard<Metadata<T>> {
+        self.0.read().unwrap()
+    }
+
+    /// Try to grab a write guard to the [`Metadata`], this fails if this blocks.
+    pub fn try_write(&self) -> Option<RwLockWriteGuard<Metadata<T>>> {
+        self.0.try_write().ok()
+    }
+    /// Block to grab a write guard the [`Metadata`]
+    pub fn write(&self) -> RwLockWriteGuard<Metadata<T>> {
+        self.0.write().unwrap()
+    }
+
+    /// Take the internal [`Metadata`]
+    pub fn take(self) -> Metadata<T> {
+        self.0.into_inner().unwrap()
+    }
+    /// Get the mutable to the internal [`Metadata`]
+    pub fn get_mut(&mut self) -> &mut Metadata<T> {
+        self.0.get_mut().unwrap()
+    }
+}
+
+impl<T: PolarsDataType> Clone for IMMetadata<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.read().clone())
+    }
+}
+
+impl<T: PolarsDataType> Default for IMMetadata<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}

--- a/crates/polars-core/src/chunked_array/metadata/md_trait.rs
+++ b/crates/polars-core/src/chunked_array/metadata/md_trait.rs
@@ -1,0 +1,36 @@
+use polars_utils::IdxSize;
+
+use super::{Metadata, MetadataFlags};
+use crate::chunked_array::{IntoScalar, PolarsDataType, Scalar};
+
+pub trait MetadataTrait {
+    fn get_flags(&self) -> MetadataFlags;
+    fn min_value(&self) -> Option<Scalar>;
+    fn max_value(&self) -> Option<Scalar>;
+
+    /// Number of unique non-null values
+    fn distinct_count(&self) -> Option<IdxSize>;
+}
+
+impl<T: PolarsDataType> MetadataTrait for Metadata<T>
+where
+    T::OwnedPhysical: IntoScalar + Clone,
+{
+    fn get_flags(&self) -> MetadataFlags {
+        self.get_flags()
+    }
+
+    fn min_value(&self) -> Option<Scalar> {
+        self.get_min_value()
+            .map(|v| v.clone().into_scalar(T::get_dtype()).unwrap())
+    }
+
+    fn max_value(&self) -> Option<Scalar> {
+        self.get_max_value()
+            .map(|v| v.clone().into_scalar(T::get_dtype()).unwrap())
+    }
+
+    fn distinct_count(&self) -> Option<IdxSize> {
+        self.get_distinct_count()
+    }
+}

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -101,8 +101,8 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<BooleanChunked> {
-    fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
-        self.metadata().map(|v| v as &dyn MetadataTrait)
+    fn get_metadata(&self) -> Option<RwLockReadGuard<dyn MetadataTrait>> {
+        self.metadata_dyn()
     }
 
     fn bitxor(&self, other: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -165,8 +165,8 @@ macro_rules! impl_dyn_series {
                 ChunkRollApply::rolling_map(&self.0, _f, _options).map(|ca| ca.into_series())
             }
 
-            fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
-                self.metadata().map(|v| v as &dyn MetadataTrait)
+            fn get_metadata(&self) -> Option<RwLockReadGuard<dyn MetadataTrait>> {
+                self.metadata_dyn()
             }
 
             fn rename(&mut self, name: &str) {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -27,6 +27,7 @@ mod time;
 use std::any::Any;
 use std::borrow::Cow;
 use std::ops::{BitAnd, BitOr, BitXor};
+use std::sync::RwLockReadGuard;
 
 use ahash::RandomState;
 
@@ -69,7 +70,7 @@ where
 }
 
 macro_rules! impl_dyn_series {
-    ($ca: ident) => {
+    ($ca: ident, $pdt:ty) => {
         impl private::PrivateSeries for SeriesWrap<$ca> {
             fn compute_len(&mut self) {
                 self.0.compute_len()
@@ -240,8 +241,8 @@ macro_rules! impl_dyn_series {
                 ChunkRollApply::rolling_map(&self.0, _f, _options).map(|ca| ca.into_series())
             }
 
-            fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
-                self.metadata().map(|v| v as &dyn MetadataTrait)
+            fn get_metadata(&self) -> Option<RwLockReadGuard<dyn MetadataTrait>> {
+                self.metadata_dyn()
             }
 
             fn bitand(&self, other: &Series) -> PolarsResult<Series> {
@@ -471,17 +472,17 @@ macro_rules! impl_dyn_series {
 }
 
 #[cfg(feature = "dtype-u8")]
-impl_dyn_series!(UInt8Chunked);
+impl_dyn_series!(UInt8Chunked, UInt8Type);
 #[cfg(feature = "dtype-u16")]
-impl_dyn_series!(UInt16Chunked);
-impl_dyn_series!(UInt32Chunked);
-impl_dyn_series!(UInt64Chunked);
+impl_dyn_series!(UInt16Chunked, UInt16Type);
+impl_dyn_series!(UInt32Chunked, UInt32Type);
+impl_dyn_series!(UInt64Chunked, UInt64Type);
 #[cfg(feature = "dtype-i8")]
-impl_dyn_series!(Int8Chunked);
+impl_dyn_series!(Int8Chunked, Int8Type);
 #[cfg(feature = "dtype-i16")]
-impl_dyn_series!(Int16Chunked);
-impl_dyn_series!(Int32Chunked);
-impl_dyn_series!(Int64Chunked);
+impl_dyn_series!(Int16Chunked, Int16Type);
+impl_dyn_series!(Int32Chunked, Int32Type);
+impl_dyn_series!(Int64Chunked, Int64Type);
 
 impl<T: PolarsNumericType> private::PrivateSeriesNumeric for SeriesWrap<ChunkedArray<T>> {
     fn bit_repr_is_large(&self) -> bool {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -26,7 +26,7 @@ use num_traits::NumCast;
 pub use series_trait::{IsSorted, *};
 
 use crate::chunked_array::cast::CastOptions;
-use crate::chunked_array::metadata::{Metadata, MetadataFlags};
+use crate::chunked_array::metadata::{IMMetadata, Metadata, MetadataFlags};
 #[cfg(feature = "zip_with")]
 use crate::series::arithmetic::coerce_lhs_rhs;
 use crate::utils::{handle_casting_failures, materialize_dyn_int, Wrap};
@@ -280,7 +280,7 @@ impl Series {
             return false;
         }
 
-        inner.as_mut().md = Some(Arc::new(metadata));
+        inner.as_mut().md = Arc::new(IMMetadata::new(metadata));
         true
     }
 

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::borrow::Cow;
+use std::sync::RwLockReadGuard;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -194,7 +195,7 @@ pub trait SeriesTrait:
         polars_bail!(opq = bitxor, self._dtype());
     }
 
-    fn get_metadata(&self) -> Option<&dyn MetadataTrait> {
+    fn get_metadata(&self) -> Option<RwLockReadGuard<dyn MetadataTrait>> {
         None
     }
 


### PR DESCRIPTION
This PR illustrates a basic workflow for keeping track of and utilizing metadata. Currently, this is still all behind `POLARS_METADATA_USE=experimental`, but now we can start implementing a lot of places where metadata can be inferred or used.

In this PR, I implemented all the infrastructure necessary to write the metadata from `chunked_array::ops` and to read the metadata from `polars-expr`.

The writing is done using interior mutability. I attempted several approaches and this is the one that I settled on as being the easiest to work with and not providing to much overhead.

The reading is done through a trait object over the `MetadataTrait`, this makes all data available as `Scalar`s.

The follow snippet illustrates that it works.

```python
import polars as pl
import numpy as np
import os
from timeit import timeit

def many_mins():
    df = pl.DataFrame({ 'a': pl.Series(np.arange(500000)) })

    for i in range(10):
        df = df.with_columns(amin = pl.col.a.min())

os.environ["POLARS_METADATA_USE"] = "experimental"
with_md = timeit(many_mins, number=100)
os.environ["POLARS_METADATA_USE"] = "1"
without_md = timeit(many_mins, number=100)

print(f'without md = {without_md}')
print(f'with md    = {with_md}')
```

This outputs:

```
without md = 4.232960837998689
with md    = 0.6040126650004822
```