### PR TITLE
fix: make `GetOutput::get_field` fallible

### DIFF
--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -118,7 +118,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
 
         this.apply(
             func,
-            GetOutput::map_field(move |f| eval_field_to_dtype(f, &expr2, false)),
+            GetOutput::map_field(move |f| Ok(eval_field_to_dtype(f, &expr2, false))),
         )
         .with_fmt("expanding_eval")
     }

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -196,7 +196,7 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
         this.0
             .map(
                 func,
-                GetOutput::map_field(move |f| eval_field_to_dtype(f, &expr2, true)),
+                GetOutput::map_field(move |f| Ok(eval_field_to_dtype(f, &expr2, true))),
             )
             .with_fmt("eval")
     }

--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -177,7 +177,7 @@ impl ArrayNameSpace {
                             Field::from_owned(name, inner.as_ref().clone())
                         })
                         .collect();
-                    DataType::Struct(fields)
+                    Ok(DataType::Struct(fields))
                 }),
             )
             .with_fmt("arr.to_struct")

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -7,7 +7,7 @@ fn cum_fold_dtype() -> GetOutput {
         for fld in &fields[1..] {
             st = get_supertype(&st, &fld.dtype).unwrap();
         }
-        Field::new(
+        Ok(Field::new(
             &fields[0].name,
             DataType::Struct(
                 fields
@@ -15,7 +15,7 @@ fn cum_fold_dtype() -> GetOutput {
                     .map(|fld| Field::new(fld.name(), st.clone()))
                     .collect(),
             ),
-        )
+        ))
     })
 }
 

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -298,7 +298,7 @@ impl ListNameSpace {
                     let out = out_dtype.read().unwrap();
                     match out.as_ref() {
                         // dtype already set
-                        Some(dt) => dt.clone(),
+                        Some(dt) => Ok(dt.clone()),
                         // dtype still unknown, set it
                         None => {
                             drop(out);
@@ -314,7 +314,7 @@ impl ListNameSpace {
                             let dt = DataType::Struct(fields);
 
                             *lock = Some(dt.clone());
-                            dt
+                            Ok(dt)
                         },
                     }
                 }),

--- a/crates/polars-plan/src/dsl/name.rs
+++ b/crates/polars-plan/src/dsl/name.rs
@@ -83,7 +83,7 @@ impl ExprNameNameSpace {
                         .iter()
                         .map(|fd| Field::new(&f(fd.name()), fd.data_type().clone()))
                         .collect();
-                    DataType::Struct(fields)
+                    Ok(DataType::Struct(fields))
                 },
                 _ => panic!("Only struct dtype is supported for `map_fields`."),
             }),

--- a/crates/polars-plan/src/dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_udf.rs
@@ -216,13 +216,15 @@ impl SeriesUdf for PythonUdfExpression {
 
     fn get_output(&self) -> Option<GetOutput> {
         let output_type = self.output_type.clone();
-        Some(GetOutput::map_field(move |fld| match output_type {
-            Some(ref dt) => Field::new(fld.name(), dt.clone()),
-            None => {
-                let mut fld = fld.clone();
-                fld.coerce(DataType::Unknown(Default::default()));
-                fld
-            },
+        Some(GetOutput::map_field(move |fld| {
+            Ok(match output_type {
+                Some(ref dt) => Field::new(fld.name(), dt.clone()),
+                None => {
+                    let mut fld = fld.clone();
+                    fld.coerce(DataType::Unknown(Default::default()));
+                    fld
+                },
+            })
         }))
     }
 }
@@ -239,13 +241,15 @@ impl Expr {
 
         let returns_scalar = func.returns_scalar;
         let return_dtype = func.output_type.clone();
-        let output_type = GetOutput::map_field(move |fld| match return_dtype {
-            Some(ref dt) => Field::new(fld.name(), dt.clone()),
-            None => {
-                let mut fld = fld.clone();
-                fld.coerce(DataType::Unknown(Default::default()));
-                fld
-            },
+        let output_type = GetOutput::map_field(move |fld| {
+            Ok(match return_dtype {
+                Some(ref dt) => Field::new(fld.name(), dt.clone()),
+                None => {
+                    let mut fld = fld.clone();
+                    fld.coerce(DataType::Unknown(Default::default()));
+                    fld
+                },
+            })
         });
 
         Expr::AnonymousFunction {

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -250,7 +250,7 @@ impl AExpr {
                 let output_type = tmp.as_ref().unwrap_or(output_type);
                 let fields = func_args_to_fields(input, schema, arena, nested)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", options.fmt_str);
-                Ok(output_type.get_field(schema, Context::Default, &fields))
+                output_type.get_field(schema, Context::Default, &fields)
             },
             Function {
                 function, input, ..

--- a/py-polars/src/map/lazy.rs
+++ b/py-polars/src/map/lazy.rs
@@ -192,9 +192,11 @@ pub fn map_mul(
 
     let exprs = pyexpr.iter().map(|pe| pe.clone().inner).collect::<Vec<_>>();
 
-    let output_map = GetOutput::map_field(move |fld| match output_type {
-        Some(ref dt) => Field::new(fld.name(), dt.0.clone()),
-        None => fld.clone(),
+    let output_map = GetOutput::map_field(move |fld| {
+        Ok(match output_type {
+            Some(ref dt) => Field::new(fld.name(), dt.0.clone()),
+            None => fld.clone(),
+        })
     });
     if map_groups {
         polars::lazy::dsl::apply_multiple(function, exprs, output_map, returns_scalar).into()


### PR DESCRIPTION
Fixes #15444.

This PR makes the `get_field` method of `GetOutput` fallible. Consequently, we can bubble up a lot more errors related to super typing instead of panicking.

Although, I would normally add a test case here. I don't think this PR warrants one as the exact super typing behavior might be changed later.