### PR TITLE
fix(rust): bubble error when no available bitrepr

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -1,6 +1,7 @@
 use arrow::buffer::Buffer;
 
 use crate::prelude::*;
+use crate::series::BitRepr;
 
 /// Reinterprets the type of a [`ChunkedArray`]. T and U must have the same size
 /// and alignment.
@@ -103,41 +104,41 @@ impl<T> ToBitRepr for ChunkedArray<T>
 where
     T: PolarsNumericType,
 {
-    fn bit_repr_is_large() -> bool {
-        std::mem::size_of::<T::Native>() == 8
-    }
+    fn to_bit_repr(&self) -> BitRepr {
+        let is_large = std::mem::size_of::<T::Native>() == 8;
 
-    fn bit_repr_large(&self) -> UInt64Chunked {
-        if std::mem::size_of::<T::Native>() == 8 {
+        if is_large {
             if matches!(self.dtype(), DataType::UInt64) {
                 let ca = self.clone();
                 // Convince the compiler we are this type. This keeps flags.
-                return unsafe { std::mem::transmute::<ChunkedArray<T>, UInt64Chunked>(ca) };
+                return BitRepr::Large(unsafe {
+                    std::mem::transmute::<ChunkedArray<T>, UInt64Chunked>(ca)
+                });
             }
-            reinterpret_chunked_array(self)
-        } else {
-            unreachable!()
-        }
-    }
 
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        if std::mem::size_of::<T::Native>() == 4 {
-            if matches!(self.dtype(), DataType::UInt32) {
-                let ca = self.clone();
-                // Convince the compiler we are this type. This preserves flags.
-                return unsafe { std::mem::transmute::<ChunkedArray<T>, UInt32Chunked>(ca) };
-            }
-            reinterpret_chunked_array(self)
+            BitRepr::Large(reinterpret_chunked_array(self))
         } else {
-            // SAFETY: an unchecked cast to uint32 (which has no invariants) is
-            // always sound.
-            unsafe {
-                self.cast_unchecked(&DataType::UInt32)
-                    .unwrap()
-                    .u32()
-                    .unwrap()
-                    .clone()
-            }
+            BitRepr::Small(if std::mem::size_of::<T::Native>() == 4 {
+                if matches!(self.dtype(), DataType::UInt32) {
+                    let ca = self.clone();
+                    // Convince the compiler we are this type. This preserves flags.
+                    return BitRepr::Small(unsafe {
+                        std::mem::transmute::<ChunkedArray<T>, UInt32Chunked>(ca)
+                    });
+                }
+
+                reinterpret_chunked_array(self)
+            } else {
+                // SAFETY: an unchecked cast to uint32 (which has no invariants) is
+                // always sound.
+                unsafe {
+                    self.cast_unchecked(&DataType::UInt32)
+                        .unwrap()
+                        .u32()
+                        .unwrap()
+                        .clone()
+                }
+            })
         }
     }
 }
@@ -160,7 +161,10 @@ impl Reinterpret for Int64Chunked {
     }
 
     fn reinterpret_unsigned(&self) -> Series {
-        self.bit_repr_large().into_series()
+        let BitRepr::Large(b) = self.to_bit_repr() else {
+            unreachable!()
+        };
+        b.into_series()
     }
 }
 
@@ -183,7 +187,10 @@ impl Reinterpret for Int32Chunked {
     }
 
     fn reinterpret_unsigned(&self) -> Series {
-        self.bit_repr_small().into_series()
+        let BitRepr::Small(b) = self.to_bit_repr() else {
+            unreachable!()
+        };
+        b.into_series()
     }
 }
 
@@ -250,7 +257,10 @@ impl Float32Chunked {
     where
         F: Fn(&Series) -> Series,
     {
-        let s = self.bit_repr_small().into_series();
+        let BitRepr::Small(s) = self.to_bit_repr() else {
+            unreachable!()
+        };
+        let s = s.into_series();
         let out = f(&s);
         let out = out.u32().unwrap();
         out._reinterpret_float().into()
@@ -261,7 +271,10 @@ impl Float64Chunked {
     where
         F: Fn(&Series) -> Series,
     {
-        let s = self.bit_repr_large().into_series();
+        let BitRepr::Large(s) = self.to_bit_repr() else {
+            unreachable!()
+        };
+        let s = s.into_series();
         let out = f(&s);
         let out = out.u64().unwrap();
         out._reinterpret_float().into()

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 pub use sort::options::*;
 
 use crate::chunked_array::cast::CastOptions;
-use crate::series::IsSorted;
+use crate::series::{BitRepr, IsSorted};
 #[cfg(feature = "reinterpret")]
 pub trait Reinterpret {
     fn reinterpret_signed(&self) -> Series {
@@ -59,10 +59,7 @@ pub trait Reinterpret {
 /// This is useful in hashing context and reduces no.
 /// of compiled code paths.
 pub(crate) trait ToBitRepr {
-    fn bit_repr_is_large() -> bool;
-
-    fn bit_repr_large(&self) -> UInt64Chunked;
-    fn bit_repr_small(&self) -> UInt32Chunked;
+    fn to_bit_repr(&self) -> BitRepr;
 }
 
 pub trait ChunkAnyValue {

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::chunked_array::cast::CastOptions;
 use crate::config::verbose;
 use crate::prelude::sort::arg_sort_multiple::_get_rows_encoded_ca_unordered;
+use crate::series::BitRepr;
 use crate::utils::flatten::flatten_par;
 
 /// Used to create the tuples for a group_by operation.
@@ -163,11 +164,15 @@ where
                 num_groups_proxy(ca, multithreaded, sorted)
             },
             DataType::Int64 => {
-                let ca = self.bit_repr_large();
+                let BitRepr::Large(ca) = self.to_bit_repr() else {
+                    unreachable!()
+                };
                 num_groups_proxy(&ca, multithreaded, sorted)
             },
             DataType::Int32 => {
-                let ca = self.bit_repr_small();
+                let BitRepr::Small(ca) = self.to_bit_repr() else {
+                    unreachable!()
+                };
                 num_groups_proxy(&ca, multithreaded, sorted)
             },
             DataType::Float64 => {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -304,10 +304,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<CategoricalChunked> {
-    fn bit_repr_is_large(&self) -> bool {
-        false
-    }
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        self.0.physical().clone()
+    fn bit_repr(&self) -> Option<BitRepr> {
+        Some(BitRepr::Small(self.0.physical().clone()))
     }
 }

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -349,15 +349,7 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DateChunked> {
-    fn bit_repr_is_large(&self) -> bool {
-        false
-    }
-
-    fn bit_repr_large(&self) -> UInt64Chunked {
-        self.0.bit_repr_large()
-    }
-
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        self.0.bit_repr_small()
+    fn bit_repr(&self) -> Option<BitRepr> {
+        Some(self.0.to_bit_repr())
     }
 }

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -10,11 +10,8 @@ unsafe impl IntoSeries for DatetimeChunked {
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DatetimeChunked> {
-    fn bit_repr_is_large(&self) -> bool {
-        true
-    }
-    fn bit_repr_large(&self) -> UInt64Chunked {
-        self.0.bit_repr_large()
+    fn bit_repr(&self) -> Option<BitRepr> {
+        Some(self.0.to_bit_repr())
     }
 }
 

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -7,7 +7,11 @@ unsafe impl IntoSeries for DecimalChunked {
     }
 }
 
-impl private::PrivateSeriesNumeric for SeriesWrap<DecimalChunked> {}
+impl private::PrivateSeriesNumeric for SeriesWrap<DecimalChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
+    }
+}
 
 impl SeriesWrap<DecimalChunked> {
     fn apply_physical_to_s<F: Fn(&Int128Chunked) -> Int128Chunked>(&self, f: F) -> Series {

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -13,11 +13,8 @@ unsafe impl IntoSeries for DurationChunked {
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DurationChunked> {
-    fn bit_repr_is_large(&self) -> bool {
-        true
-    }
-    fn bit_repr_large(&self) -> UInt64Chunked {
-        self.0.bit_repr_large()
+    fn bit_repr(&self) -> Option<BitRepr> {
+        Some(self.0.to_bit_repr())
     }
 }
 

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -484,33 +484,47 @@ impl_dyn_series!(Int32Chunked);
 impl_dyn_series!(Int64Chunked);
 
 impl<T: PolarsNumericType> private::PrivateSeriesNumeric for SeriesWrap<ChunkedArray<T>> {
-    fn bit_repr_is_large(&self) -> bool {
-        ChunkedArray::<T>::bit_repr_is_large()
-    }
-    fn bit_repr_large(&self) -> UInt64Chunked {
-        self.0.bit_repr_large()
-    }
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        self.0.bit_repr_small()
+    fn bit_repr(&self) -> Option<BitRepr> {
+        Some(self.0.to_bit_repr())
     }
 }
 
-impl private::PrivateSeriesNumeric for SeriesWrap<StringChunked> {}
-impl private::PrivateSeriesNumeric for SeriesWrap<BinaryChunked> {}
-impl private::PrivateSeriesNumeric for SeriesWrap<BinaryOffsetChunked> {}
-impl private::PrivateSeriesNumeric for SeriesWrap<ListChunked> {}
-#[cfg(feature = "dtype-array")]
-impl private::PrivateSeriesNumeric for SeriesWrap<ArrayChunked> {}
-impl private::PrivateSeriesNumeric for SeriesWrap<BooleanChunked> {
-    fn bit_repr_is_large(&self) -> bool {
-        false
+impl private::PrivateSeriesNumeric for SeriesWrap<StringChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
     }
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        self.0
+}
+impl private::PrivateSeriesNumeric for SeriesWrap<BinaryChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
+    }
+}
+impl private::PrivateSeriesNumeric for SeriesWrap<BinaryOffsetChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
+    }
+}
+impl private::PrivateSeriesNumeric for SeriesWrap<ListChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
+    }
+}
+#[cfg(feature = "dtype-array")]
+impl private::PrivateSeriesNumeric for SeriesWrap<ArrayChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
+    }
+}
+impl private::PrivateSeriesNumeric for SeriesWrap<BooleanChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        let repr = self
+            .0
             .cast_with_options(&DataType::UInt32, CastOptions::NonStrict)
             .unwrap()
             .u32()
             .unwrap()
-            .clone()
+            .clone();
+
+        Some(BitRepr::Small(repr))
     }
 }

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -36,8 +36,11 @@ impl NullChunked {
     }
 }
 impl PrivateSeriesNumeric for NullChunked {
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        UInt32Chunked::full_null(self.name.as_ref(), self.len())
+    fn bit_repr(&self) -> Option<BitRepr> {
+        Some(BitRepr::Small(UInt32Chunked::full_null(
+            self.name.as_ref(),
+            self.len(),
+        )))
     }
 }
 

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 
 use ahash::RandomState;
 
-use super::MetadataFlags;
+use super::{BitRepr, MetadataFlags};
 use crate::chunked_array::cast::CastOptions;
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::chunked_array::ops::compare_inner::{IntoTotalEqInner, TotalEqInner};
@@ -11,7 +11,11 @@ use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
 
-impl<T: PolarsObject> PrivateSeriesNumeric for SeriesWrap<ObjectChunked<T>> {}
+impl<T: PolarsObject> PrivateSeriesNumeric for SeriesWrap<ObjectChunked<T>> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
+    }
+}
 
 impl<T> PrivateSeries for SeriesWrap<ObjectChunked<T>>
 where

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -9,7 +9,11 @@ unsafe impl IntoSeries for StructChunked {
     }
 }
 
-impl PrivateSeriesNumeric for SeriesWrap<StructChunked> {}
+impl PrivateSeriesNumeric for SeriesWrap<StructChunked> {
+    fn bit_repr(&self) -> Option<BitRepr> {
+        None
+    }
+}
 
 impl private::PrivateSeries for SeriesWrap<StructChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -314,15 +314,7 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<TimeChunked> {
-    fn bit_repr_is_large(&self) -> bool {
-        true
-    }
-
-    fn bit_repr_large(&self) -> UInt64Chunked {
-        self.0.bit_repr_large()
-    }
-
-    fn bit_repr_small(&self) -> UInt32Chunked {
-        self.0.bit_repr_small()
+    fn bit_repr(&self) -> Option<BitRepr> {
+        Some(self.0.to_bit_repr())
     }
 }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -39,6 +39,11 @@ macro_rules! invalid_operation_panic {
     };
 }
 
+pub enum BitRepr {
+    Small(UInt32Chunked),
+    Large(UInt64Chunked),
+}
+
 pub(crate) mod private {
     use ahash::RandomState;
 
@@ -47,15 +52,10 @@ pub(crate) mod private {
     use crate::chunked_array::ops::compare_inner::{TotalEqInner, TotalOrdInner};
 
     pub trait PrivateSeriesNumeric {
-        fn bit_repr_is_large(&self) -> bool {
-            false
-        }
-        fn bit_repr_large(&self) -> UInt64Chunked {
-            unimplemented!()
-        }
-        fn bit_repr_small(&self) -> UInt32Chunked {
-            unimplemented!()
-        }
+        /// Return a bit representation
+        ///
+        /// If there is no available bit representation this returns `None`.
+        fn bit_repr(&self) -> Option<BitRepr>;
     }
 
     pub trait PrivateSeries {

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -237,7 +237,7 @@ pub trait JoinDispatch: IntoDf {
         #[cfg(feature = "dtype-categorical")]
         _check_categorical_src(s_left.dtype(), s_right.dtype())?;
 
-        let idx = s_left.hash_join_semi_anti(s_right, anti, join_nulls);
+        let idx = s_left.hash_join_semi_anti(s_right, anti, join_nulls)?;
         // SAFETY:
         // indices are in bounds
         Ok(unsafe { ca_self._finish_anti_semi_join(&idx, slice) })

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -1,4 +1,5 @@
 use arrow::array::PrimitiveArray;
+use polars_core::series::BitRepr;
 use polars_core::utils::split;
 use polars_core::with_match_physical_float_polars_type;
 use polars_utils::hashing::DirtyHash;
@@ -20,12 +21,14 @@ pub trait SeriesJoin: SeriesSealed + Sized {
         let (lhs, rhs) = (s_self.to_physical_repr(), other.to_physical_repr());
         validate.validate_probe(&lhs, &rhs, false)?;
 
-        use DataType::*;
+        let lhs_dtype = lhs.dtype();
+        let rhs_dtype = rhs.dtype();
 
-        match lhs.dtype() {
-            String | Binary => {
-                let lhs = lhs.cast(&Binary).unwrap();
-                let rhs = rhs.cast(&Binary).unwrap();
+        use DataType as T;
+        match lhs_dtype {
+            T::String | T::Binary => {
+                let lhs = lhs.cast(&T::Binary).unwrap();
+                let rhs = rhs.cast(&T::Binary).unwrap();
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 let (lhs, rhs, _, _) = prepare_binary::<BinaryType>(lhs, rhs, false);
@@ -33,7 +36,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 let rhs = rhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
                 hash_join_tuples_left(lhs, rhs, None, None, validate, join_nulls)
             },
-            BinaryOffset => {
+            T::BinaryOffset => {
                 let lhs = lhs.binary_offset().unwrap();
                 let rhs = rhs.binary_offset().unwrap();
                 let (lhs, rhs, _, _) = prepare_binary::<BinaryOffsetType>(lhs, rhs, false);
@@ -42,37 +45,57 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 let rhs = rhs.iter().map(|k| k.as_slice()).collect::<Vec<_>>();
                 hash_join_tuples_left(lhs, rhs, None, None, validate, join_nulls)
             },
+            x if x.is_float() => {
+                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
+                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+                    num_group_join_left(lhs, rhs, validate, join_nulls)
+                })
+            },
             _ => {
-                if lhs.dtype().is_float() {
-                    with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                        let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                        let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
-                        num_group_join_left(lhs, rhs, validate, join_nulls)
-                    })
-                } else if s_self.bit_repr_is_large() {
-                    let lhs = lhs.bit_repr_large();
-                    let rhs = rhs.bit_repr_large();
-                    num_group_join_left(&lhs, &rhs, validate, join_nulls)
-                } else {
-                    let lhs = lhs.bit_repr_small();
-                    let rhs = rhs.bit_repr_small();
-                    num_group_join_left(&lhs, &rhs, validate, join_nulls)
+                let lhs = s_self.bit_repr();
+                let rhs = other.bit_repr();
+
+                let (Some(lhs), Some(rhs)) = (lhs, rhs) else {
+                    polars_bail!(nyi = "Hash Left Join between {lhs_dtype} and {rhs_dtype}");
+                };
+
+                use BitRepr as B;
+                match (lhs, rhs) {
+                    (B::Small(lhs), B::Small(rhs)) => {
+                        num_group_join_left(&lhs, &rhs, validate, join_nulls)
+                    },
+                    (B::Large(lhs), B::Large(rhs)) => {
+                        num_group_join_left(&lhs, &rhs, validate, join_nulls)
+                    },
+                    _ => {
+                        polars_bail!(
+                        nyi = "Mismatch bit repr Hash Left Join between {lhs_dtype} and {rhs_dtype}",
+                    );
+                    },
                 }
             },
         }
     }
 
     #[cfg(feature = "semi_anti_join")]
-    fn hash_join_semi_anti(&self, other: &Series, anti: bool, join_nulls: bool) -> Vec<IdxSize> {
+    fn hash_join_semi_anti(
+        &self,
+        other: &Series,
+        anti: bool,
+        join_nulls: bool,
+    ) -> PolarsResult<Vec<IdxSize>> {
         let s_self = self.as_series();
         let (lhs, rhs) = (s_self.to_physical_repr(), other.to_physical_repr());
 
-        use DataType::*;
+        let lhs_dtype = lhs.dtype();
+        let rhs_dtype = rhs.dtype();
 
-        match lhs.dtype() {
-            String | Binary => {
-                let lhs = lhs.cast(&Binary).unwrap();
-                let rhs = rhs.cast(&Binary).unwrap();
+        use DataType as T;
+        Ok(match lhs_dtype {
+            T::String | T::Binary => {
+                let lhs = lhs.cast(&T::Binary).unwrap();
+                let rhs = rhs.cast(&T::Binary).unwrap();
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 let (lhs, rhs, _, _) = prepare_binary::<BinaryType>(lhs, rhs, false);
@@ -85,7 +108,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                     hash_join_tuples_left_semi(lhs, rhs, join_nulls)
                 }
             },
-            BinaryOffset => {
+            T::BinaryOffset => {
                 let lhs = lhs.binary_offset().unwrap();
                 let rhs = rhs.binary_offset().unwrap();
                 let (lhs, rhs, _, _) = prepare_binary::<BinaryOffsetType>(lhs, rhs, false);
@@ -98,24 +121,37 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                     hash_join_tuples_left_semi(lhs, rhs, join_nulls)
                 }
             },
+            x if x.is_float() => {
+                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
+                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+                    num_group_join_anti_semi(lhs, rhs, anti, join_nulls)
+                })
+            },
             _ => {
-                if lhs.dtype().is_float() {
-                    with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                        let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                        let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
-                        num_group_join_anti_semi(lhs, rhs, anti, join_nulls)
-                    })
-                } else if s_self.bit_repr_is_large() {
-                    let lhs = lhs.bit_repr_large();
-                    let rhs = rhs.bit_repr_large();
-                    num_group_join_anti_semi(&lhs, &rhs, anti, join_nulls)
-                } else {
-                    let lhs = lhs.bit_repr_small();
-                    let rhs = rhs.bit_repr_small();
-                    num_group_join_anti_semi(&lhs, &rhs, anti, join_nulls)
+                let lhs = s_self.bit_repr();
+                let rhs = other.bit_repr();
+
+                let (Some(lhs), Some(rhs)) = (lhs, rhs) else {
+                    polars_bail!(nyi = "Hash Semi-Anti Join between {lhs_dtype} and {rhs_dtype}");
+                };
+
+                use BitRepr as B;
+                match (lhs, rhs) {
+                    (B::Small(lhs), B::Small(rhs)) => {
+                        num_group_join_anti_semi(&lhs, &rhs, anti, join_nulls)
+                    },
+                    (B::Large(lhs), B::Large(rhs)) => {
+                        num_group_join_anti_semi(&lhs, &rhs, anti, join_nulls)
+                    },
+                    _ => {
+                        polars_bail!(
+                            nyi = "Mismatch bit repr Hash Semi-Anti Join between {lhs_dtype} and {rhs_dtype}",
+                        );
+                    },
                 }
             },
-        }
+        })
     }
 
     // returns the join tuples and whether or not the lhs tuples are sorted
@@ -129,11 +165,14 @@ pub trait SeriesJoin: SeriesSealed + Sized {
         let (lhs, rhs) = (s_self.to_physical_repr(), other.to_physical_repr());
         validate.validate_probe(&lhs, &rhs, true)?;
 
-        use DataType::*;
-        match lhs.dtype() {
-            String | Binary => {
-                let lhs = lhs.cast(&Binary).unwrap();
-                let rhs = rhs.cast(&Binary).unwrap();
+        let lhs_dtype = lhs.dtype();
+        let rhs_dtype = rhs.dtype();
+
+        use DataType as T;
+        match lhs_dtype {
+            T::String | T::Binary => {
+                let lhs = lhs.cast(&T::Binary).unwrap();
+                let rhs = rhs.cast(&T::Binary).unwrap();
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 let (lhs, rhs, swapped, _) = prepare_binary::<BinaryType>(lhs, rhs, true);
@@ -145,7 +184,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                     !swapped,
                 ))
             },
-            BinaryOffset => {
+            T::BinaryOffset => {
                 let lhs = lhs.binary_offset().unwrap();
                 let rhs = rhs.binary_offset()?;
                 let (lhs, rhs, swapped, _) = prepare_binary::<BinaryOffsetType>(lhs, rhs, true);
@@ -157,21 +196,34 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                     !swapped,
                 ))
             },
+            x if x.is_float() => {
+                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
+                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+                    group_join_inner::<$T>(lhs, rhs, validate, join_nulls)
+                })
+            },
             _ => {
-                if lhs.dtype().is_float() {
-                    with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                        let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                        let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
-                        group_join_inner::<$T>(lhs, rhs, validate, join_nulls)
-                    })
-                } else if s_self.bit_repr_is_large() {
-                    let lhs = s_self.bit_repr_large();
-                    let rhs = other.bit_repr_large();
-                    group_join_inner::<UInt64Type>(&lhs, &rhs, validate, join_nulls)
-                } else {
-                    let lhs = s_self.bit_repr_small();
-                    let rhs = other.bit_repr_small();
-                    group_join_inner::<UInt32Type>(&lhs, &rhs, validate, join_nulls)
+                let lhs = s_self.bit_repr();
+                let rhs = other.bit_repr();
+
+                let (Some(lhs), Some(rhs)) = (lhs, rhs) else {
+                    polars_bail!(nyi = "Hash Inner Join between {lhs_dtype} and {rhs_dtype}");
+                };
+
+                use BitRepr as B;
+                match (lhs, rhs) {
+                    (B::Small(lhs), B::Small(rhs)) => {
+                        group_join_inner(&lhs, &rhs, validate, join_nulls)
+                    },
+                    (B::Large(lhs), BitRepr::Large(rhs)) => {
+                        group_join_inner(&lhs, &rhs, validate, join_nulls)
+                    },
+                    _ => {
+                        polars_bail!(
+                            nyi = "Mismatch bit repr Hash Inner Join between {lhs_dtype} and {rhs_dtype}"
+                        );
+                    },
                 }
             },
         }
@@ -187,11 +239,14 @@ pub trait SeriesJoin: SeriesSealed + Sized {
         let (lhs, rhs) = (s_self.to_physical_repr(), other.to_physical_repr());
         validate.validate_probe(&lhs, &rhs, true)?;
 
-        use DataType::*;
-        match lhs.dtype() {
-            String | Binary => {
-                let lhs = lhs.cast(&Binary).unwrap();
-                let rhs = rhs.cast(&Binary).unwrap();
+        let lhs_dtype = lhs.dtype();
+        let rhs_dtype = rhs.dtype();
+
+        use DataType as T;
+        match lhs_dtype {
+            T::String | T::Binary => {
+                let lhs = lhs.cast(&T::Binary).unwrap();
+                let rhs = rhs.cast(&T::Binary).unwrap();
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 let (lhs, rhs, swapped, _) = prepare_binary::<BinaryType>(lhs, rhs, true);
@@ -200,7 +255,7 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 let rhs = rhs.iter().map(|k| k.as_slice()).collect::<Vec<_>>();
                 hash_join_tuples_outer(lhs, rhs, swapped, validate, join_nulls)
             },
-            BinaryOffset => {
+            T::BinaryOffset => {
                 let lhs = lhs.binary_offset().unwrap();
                 let rhs = rhs.binary_offset()?;
                 let (lhs, rhs, swapped, _) = prepare_binary::<BinaryOffsetType>(lhs, rhs, true);
@@ -209,21 +264,29 @@ pub trait SeriesJoin: SeriesSealed + Sized {
                 let rhs = rhs.iter().map(|k| k.as_slice()).collect::<Vec<_>>();
                 hash_join_tuples_outer(lhs, rhs, swapped, validate, join_nulls)
             },
+            x if x.is_float() => {
+                with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
+                    let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
+                    let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
+                    hash_join_outer(lhs, rhs, validate, join_nulls)
+                })
+            },
             _ => {
-                if lhs.dtype().is_float() {
-                    with_match_physical_float_polars_type!(lhs.dtype(), |$T| {
-                        let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
-                        let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
-                        hash_join_outer(lhs, rhs, validate, join_nulls)
-                    })
-                } else if s_self.bit_repr_is_large() {
-                    let lhs = s_self.bit_repr_large();
-                    let rhs = other.bit_repr_large();
-                    hash_join_outer(&lhs, &rhs, validate, join_nulls)
-                } else {
-                    let lhs = s_self.bit_repr_small();
-                    let rhs = other.bit_repr_small();
-                    hash_join_outer(&lhs, &rhs, validate, join_nulls)
+                let (Some(lhs), Some(rhs)) = (s_self.bit_repr(), other.bit_repr()) else {
+                    polars_bail!(nyi = "Hash Join Outer between {lhs_dtype} and {rhs_dtype}");
+                };
+
+                use BitRepr as B;
+                match (lhs, rhs) {
+                    (B::Small(lhs), B::Small(rhs)) => {
+                        hash_join_outer(&lhs, &rhs, validate, join_nulls)
+                    },
+                    (B::Large(lhs), B::Large(rhs)) => {
+                        hash_join_outer(&lhs, &rhs, validate, join_nulls)
+                    },
+                    _ => {
+                        polars_bail!(nyi = "Mismatch bit repr Hash Join Outer between {lhs_dtype} and {rhs_dtype}");
+                    },
                 }
             },
         }


### PR DESCRIPTION
This PR refactors the code surrounding bit representations and properly bubbles errors up if no bit representation is defined.

This resolves the panic in #14826, but does not implement the wanted behavior.

I am not sure a test case is useful here as the behavior should be added in the end.