### PR TITLE
fix(python): Throw exception with '+' on selectors

### DIFF
--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -376,6 +376,23 @@ class _selector_proxy_(Expr):
         raise TypeError(msg)
 
     @overload
+    def __add__(self, other: SelectorType) -> SelectorType: ...
+
+    @overload
+    def __add__(self, other: Any) -> Expr: ...
+
+    def __add__(self, other: Any) -> Expr:
+        if is_selector(other):
+            msg = """
+unsupported operand type(s) for op: ('Selector' + 'Selector')
+
+Hint: utilize the OR `|` operator for a selection union or the AND `&` operator for a selection intersection.
+            """.strip()
+            raise TypeError(msg)
+        else:
+            return self.as_expr().__add__(other)
+
+    @overload
     def __and__(self, other: SelectorType) -> SelectorType: ...
 
     @overload


### PR DESCRIPTION
Fixes #13986.

This PR adds an exception and hint when using the add operator between two selectors. It shows the following error:

```
unsupported operand type(s) for op: ('Selector' + 'Selector')

Hint: utilize the OR `|` operator for a selection union or the AND `&` operator for a selection intersection.
```

@stinodego can you take a look at this?