### PR TITLE
docs(python): Add "coming from pandas" note to `DataFrame.unique` docstring

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9244,22 +9244,8 @@ class DataFrame:
 
         Notes
         -----
-        If you're coming from pandas, then
-
-        .. code-block:: python
-
-            # polars
-            df.unique(["a", "b"])
-
-        is equivalent to
-
-        .. code-block:: python
-
-            # pandas
-            df.drop_duplicates(["a", "b"])
-
-        though note that the output ordering is not stable unless
-        you also pass `maintain_order=True`.
+        If you're coming from pandas, this is similar to
+        `pandas.DataFrame.drop_duplicates`.
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9242,6 +9242,25 @@ class DataFrame:
         This method will fail if there is a column of type `List` in the DataFrame or
         subset.
 
+        Notes
+        -----
+        If you're coming from pandas, then
+
+        .. code-block:: python
+
+            # polars
+            df.unique(["a", "b"])
+
+        is equivalent to
+
+        .. code-block:: python
+
+            # pandas
+            df.drop_duplicates(["a", "b"])
+
+        though note that the output ordering is not stable unless
+        you also pass `maintain_order=True`.
+
         Examples
         --------
         >>> df = pl.DataFrame(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5567,6 +5567,25 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         This method will fail if there is a column of type `List` in the DataFrame or
         subset.
 
+        Notes
+        -----
+        If you're coming from pandas, then
+
+        .. code-block:: python
+
+            # polars
+            df.unique(["a", "b"])
+
+        is equivalent to
+
+        .. code-block:: python
+
+            # pandas
+            df.drop_duplicates(["a", "b"])
+
+        though note that the output ordering is not stable unless
+        you also pass `maintain_order=True`.
+
         Examples
         --------
         >>> lf = pl.LazyFrame(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5569,22 +5569,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Notes
         -----
-        If you're coming from pandas, then
-
-        .. code-block:: python
-
-            # polars
-            df.unique(["a", "b"])
-
-        is equivalent to
-
-        .. code-block:: python
-
-            # pandas
-            df.drop_duplicates(["a", "b"])
-
-        though note that the output ordering is not stable unless
-        you also pass `maintain_order=True`.
+        If you're coming from pandas, this is similar to
+        `pandas.DataFrame.drop_duplicates`.
 
         Examples
         --------


### PR DESCRIPTION
The most upvoted SO Polars question is about drop_duplicates: https://stackoverflow.com/questions/71196661/what-is-the-equivalent-of-dataframe-drop-duplicates-from-pandas-in-polars

Let's insert a cheeky `drop_duplicates` mention so that people can be directed to the Polars equivalent 😎 