### PR TITLE
feat: Update `DataFrame.pivot` to allow `index=None` when `values` is set

### DIFF
--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -33,7 +33,7 @@ impl PhysicalAggExpr for PivotExpr {
 pub fn pivot<I0, I1, I2, S0, S1, S2>(
     df: &DataFrame,
     on: I0,
-    index: I1,
+    index: Option<I1>,
     values: Option<I2>,
     sort_columns: bool,
     agg_expr: Option<Expr>,
@@ -59,7 +59,7 @@ where
 pub fn pivot_stable<I0, I1, I2, S0, S1, S2>(
     df: &DataFrame,
     on: I0,
-    index: I1,
+    index: Option<I1>,
     values: Option<I2>,
     sort_columns: bool,
     agg_expr: Option<Expr>,

--- a/crates/polars/tests/it/core/pivot.rs
+++ b/crates/polars/tests/it/core/pivot.rs
@@ -16,7 +16,7 @@ fn test_pivot_date_() -> PolarsResult<()> {
     let out = pivot(
         &df,
         ["values1"],
-        ["index"],
+        Some(["index"]),
         Some(["values2"]),
         true,
         Some(PivotAgg::Count),
@@ -34,7 +34,7 @@ fn test_pivot_date_() -> PolarsResult<()> {
     let mut out = pivot_stable(
         &df,
         ["values2"],
-        ["index"],
+        Some(["index"]),
         Some(["values1"]),
         true,
         Some(PivotAgg::First),
@@ -64,7 +64,7 @@ fn test_pivot_old() {
     let pvt = pivot(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         false,
         Some(PivotAgg::Sum),
@@ -79,7 +79,7 @@ fn test_pivot_old() {
     let pvt = pivot(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         false,
         Some(PivotAgg::Min),
@@ -93,7 +93,7 @@ fn test_pivot_old() {
     let pvt = pivot(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         false,
         Some(PivotAgg::Max),
@@ -107,7 +107,7 @@ fn test_pivot_old() {
     let pvt = pivot(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         false,
         Some(PivotAgg::Mean),
@@ -121,7 +121,7 @@ fn test_pivot_old() {
     let pvt = pivot(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         false,
         Some(PivotAgg::Count),
@@ -149,7 +149,7 @@ fn test_pivot_categorical() -> PolarsResult<()> {
     let out = pivot(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         true,
         Some(PivotAgg::Count),
@@ -174,7 +174,7 @@ fn test_pivot_new() -> PolarsResult<()> {
     let out = (pivot_stable(
         &df,
         ["cols1"],
-        ["index1", "index2"],
+        Some(["index1", "index2"]),
         Some(["values1"]),
         true,
         Some(PivotAgg::Sum),
@@ -191,7 +191,7 @@ fn test_pivot_new() -> PolarsResult<()> {
     let out = pivot_stable(
         &df,
         ["cols1", "cols2"],
-        ["index1", "index2"],
+        Some(["index1", "index2"]),
         Some(["values1"]),
         true,
         Some(PivotAgg::Sum),
@@ -222,7 +222,7 @@ fn test_pivot_2() -> PolarsResult<()> {
     let out = pivot_stable(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         false,
         Some(PivotAgg::First),
@@ -255,7 +255,7 @@ fn test_pivot_datetime() -> PolarsResult<()> {
     let out = pivot(
         &df,
         ["columns"],
-        ["index"],
+        Some(["index"]),
         Some(["values"]),
         false,
         Some(PivotAgg::Sum),

--- a/docs/releases/upgrade/1.md
+++ b/docs/releases/upgrade/1.md
@@ -393,7 +393,7 @@ After:
 ...         "test_2": [100, 100, 60, 60],
 ...     }
 ... )
->>> df.pivot(index='name', on='subject', values=['test_1', 'test_2'])
+>>> df.pivot('subject', index='name')
 ┌───────┬──────────────┬────────────────┬──────────────┬────────────────┐
 │ name  ┆ test_1_maths ┆ test_1_physics ┆ test_2_maths ┆ test_2_physics │
 │ ---   ┆ ---          ┆ ---            ┆ ---          ┆ ---            │
@@ -403,6 +403,13 @@ After:
 │ Karen ┆ 61           ┆ 58             ┆ 60           ┆ 60             │
 └───────┴──────────────┴────────────────┴──────────────┴────────────────┘
 ```
+
+Note that the function signature has also changed:
+
+- `columns` has been renamed to `on`, and is now the first positional argument.
+- `index` and `values` are both optional. If `index` is not specified, then it
+  will use all columns not specified in `on` and `values`. If `values` is
+  not specified, it will use all columns not specified in `on` and `index`.
 
 ### Support Decimal types by default when converting from Arrow
 

--- a/docs/src/rust/user-guide/transformations/pivot.rs
+++ b/docs/src/rust/user-guide/transformations/pivot.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:df]
 
     // --8<-- [start:eager]
-    let out = pivot(&df, ["foo"], ["bar"], Some(["N"]), false, None, None)?;
+    let out = pivot(&df, ["foo"], Some(["bar"]), Some(["N"]), false, None, None)?;
     println!("{}", &out);
     // --8<-- [end:eager]
 
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let q2 = pivot(
         &q.collect()?,
         ["foo"],
-        ["bar"],
+        Some(["bar"]),
         Some(["N"]),
         false,
         None,

--- a/py-polars/src/dataframe/general.rs
+++ b/py-polars/src/dataframe/general.rs
@@ -421,7 +421,7 @@ impl PyDataFrame {
     pub fn pivot_expr(
         &self,
         on: Vec<String>,
-        index: Vec<String>,
+        index: Option<Vec<String>>,
         values: Option<Vec<String>>,
         maintain_order: bool,
         sort_columns: bool,

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -22,7 +22,7 @@ def test_pivot() -> None:
             "N": [1, 2, 2, 4, 2],
         }
     )
-    result = df.pivot(index="foo", on="bar", values="N", aggregate_function=None)
+    result = df.pivot("bar", values="N", aggregate_function=None)
 
     expected = pl.DataFrame(
         [
@@ -45,7 +45,7 @@ def test_pivot_no_values() -> None:
             "N2": [1, 2, 2, 4, 2],
         }
     )
-    result = df.pivot(index="foo", on="bar", values=None, aggregate_function=None)
+    result = df.pivot(on="bar", index="foo", aggregate_function=None)
     expected = pl.DataFrame(
         {
             "foo": ["A", "B", "C"],
@@ -523,3 +523,11 @@ def test_pivot_string_17081() -> None:
         "5": [None, "8", None],
         "6": [None, None, "9"],
     }
+
+
+def test_pivot_invalid() -> None:
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="`index` and `values` cannot both be None in `pivot` operation",
+    ):
+        pl.DataFrame({"a": [1, 2], "b": [2, 3], "c": [3, 4]}).pivot("a")


### PR DESCRIPTION
closes https://github.com/pola-rs/polars/issues/11592, though using a different solution than suggested - here I'm implementing "if `index` is not specified, use all remaining columns", just as is already done for `values`, as well as for `unpivot`. Related discussion #17095 

I've also rewritten the `pivot` docstring examples, as I think they started off too complicated. It now starts with the simplest case, and then builds up