### PR TITLE
Projection pushdown not working for AnonymousScan

### DIFF
--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -663,6 +663,27 @@ fn scan_anonymous_fn() -> PolarsResult<()> {
 }
 
 #[test]
+fn scan_anonymous_fn_with_options() -> PolarsResult<()> {
+    let function = Arc::new(|scan_opts: AnonymousScanArgs| {
+        assert_eq!(scan_opts.n_rows, Some(3));
+        assert_ne!(scan_opts.with_columns, None);
+        Ok(fruits_cars())
+    });
+
+    let args = ScanArgsAnonymous {
+        schema: Some(Arc::new(fruits_cars().schema())),
+        ..ScanArgsAnonymous::default()
+    };
+
+    let df = LazyFrame::anonymous_scan(function, args)?
+        .select([col("A"), col("fruits")])
+        .fetch(3)?;
+
+    assert_eq!(df.shape(), (3, 2));
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "dtype-full")]
 fn scan_small_dtypes() -> PolarsResult<()> {
     let small_dt = vec![


### PR DESCRIPTION
(Just providing the failing test here for now, until it's confirmed the test should be working and this is indeed a bug.)

Not sure if I'm missing something, but looks like projection pushdown is not working for `AnonymousScan`.

Besides the provided failing test, I tried implementing a struct with the `AnonymousScan` trait, and specifying:

```rust
fn allows_projection_pushdown(&self) -> bool {
    true
}
```

But when the `scan` function is called by Polars, I'd expect `AnonymousScanArgs.with_columns` to contain the needed columns from `select`, but I receive `None` instead.

`AnonymousScanArgs.n_rows` seems to be correctly receiving the value from `.fetch()`, so the problem seems specific to `with_columns`.