### PR TITLE
fix(python): `ChainedWhen` should not inherit `Expr`

### DIFF
--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -99,7 +99,7 @@ class Then(Expr):
         return wrap_expr(self._then.otherwise(statement_pyexpr))
 
 
-class ChainedWhen(Expr):
+class ChainedWhen:
     """
     Utility class for the `when-then-otherwise` expression.
 

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -622,3 +622,11 @@ def test_when_then_supertype_15975_comment() -> None:
     )
 
     assert q.collect()["val"].to_list() == [1.0, 1.5, 16.0]
+
+
+def test_chained_when_no_subclass_17142() -> None:
+    # https://github.com/pola-rs/polars/pull/17142
+    when = pl.when(True).then(1).when(True)
+
+    assert not isinstance(when, pl.Expr)
+    assert "<polars.expr.whenthen.ChainedWhen object at" in str(when)


### PR DESCRIPTION
Perhaps it was a miss copy that was confused with Then or ChainedThen.

```python
>>> import polars as pl
>>> pl.when(True).then(1).when(True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vscode/.local/lib/python3.9/site-packages/polars/expr/expr.py", line 137, in __repr__
    if len(expr_str := self._pyexpr.to_str()) > 30:
AttributeError: 'NoneType' object has no attribute 'to_str'
```