### PR TITLE
chore: Add missing spaces in `cargo.toml`

### DIFF
--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -15,10 +15,10 @@ polars-lazy = { workspace = true, features = ["python"] }
 polars-ops = { workspace = true }
 polars-parquet = { workspace = true, optional = true }
 polars-plan = { workspace = true }
+# TODO! remove this once truly activated. This is required to make sdist building work
+polars-stream = { workspace = true }
 polars-time = { workspace = true }
 polars-utils = { workspace = true }
-# TODO! remove this once truly activated. This is required to make sdist building work
-polars-stream = {workspace = true}
 
 ahash = { workspace = true }
 arboard = { workspace = true, optional = true }

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -15,10 +15,11 @@ polars-lazy = { workspace = true, features = ["python"] }
 polars-ops = { workspace = true }
 polars-parquet = { workspace = true, optional = true }
 polars-plan = { workspace = true }
-# TODO! remove this once truly activated. This is required to make sdist building work
-polars-stream = { workspace = true }
 polars-time = { workspace = true }
 polars-utils = { workspace = true }
+
+# TODO! remove this once truly activated. This is required to make sdist building work
+polars-stream = { workspace = true }
 
 ahash = { workspace = true }
 arboard = { workspace = true, optional = true }


### PR DESCRIPTION
See https://github.com/pola-rs/polars/commit/5cad69e5d4af47e75ae0abbf88dc2bafbc8f66d2#r143437580, this is causing CI to fail. `dprint` didn't like the formatting, the following was fixed:

* spaces around `workspace = true`
* dependency sections, which can be separated by newlines must be in alphabetical order. `polars-stream` was listed after `polars-utils` which it didn't like.