### PR TITLE
chore(rust): Use `PolarsResult` more, instead of Result<..., E>

### DIFF
--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -138,13 +138,13 @@ where
         unsafe { Self::from_chunks_and_dtype_unchecked(ca.name(), chunks, ca.dtype().clone()) }
     }
 
-    pub fn try_from_chunk_iter<I, A, E>(name: &str, iter: I) -> Result<Self, E>
+    pub fn try_from_chunk_iter<I, A>(name: &str, iter: I) -> PolarsResult<Self>
     where
-        I: IntoIterator<Item = Result<A, E>>,
+        I: IntoIterator<Item = PolarsResult<A>>,
         T: PolarsDataType<Array = A>,
         A: Array,
     {
-        let chunks: Result<_, _> = iter
+        let chunks: PolarsResult<_> = iter
             .into_iter()
             .map(|x| Ok(Box::new(x?) as Box<dyn Array>))
             .collect();

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -57,13 +57,13 @@ where
     }
 
     /// Applies a function only to the non-null elements, propagating nulls.
-    pub fn try_apply_nonnull_values_generic<'a, U, K, F, E>(
+    pub fn try_apply_nonnull_values_generic<'a, U, K, F>(
         &'a self,
         mut op: F,
-    ) -> Result<ChunkedArray<U>, E>
+    ) -> PolarsResult<ChunkedArray<U>>
     where
         U: PolarsDataType,
-        F: FnMut(T::Physical<'a>) -> Result<K, E>,
+        F: FnMut(T::Physical<'a>) -> PolarsResult<K>,
         U::Array: ArrayFromIter<K> + ArrayFromIter<Option<K>>,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -102,10 +102,10 @@ where
         }
     }
 
-    pub fn try_apply_generic<'a, U, K, F, E>(&'a self, op: F) -> Result<ChunkedArray<U>, E>
+    pub fn try_apply_generic<'a, U, K, F>(&'a self, op: F) -> PolarsResult<ChunkedArray<U>>
     where
         U: PolarsDataType,
-        F: FnMut(Option<T::Physical<'a>>) -> Result<Option<K>, E> + Copy,
+        F: FnMut(Option<T::Physical<'a>>) -> PolarsResult<Option<K>> + Copy,
         U::Array: ArrayFromIter<Option<K>>,
     {
         let iter = self.downcast_iter().map(|arr| {


### PR DESCRIPTION
I was trying to understand why `Result<..., E>` is used in some places, so I tried using `PolarsResult` instead

By the looks of it, everything passes, and it gets a little simpler?