### PR TITLE
feat(python): Allow vertical aggregation functions to accept `Expr`

### DIFF
--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -17,7 +17,7 @@ def vertical_parse_into_expr(*names: str | Expr) -> Expr:
         return wrap_expr(parse_into_expression(*names))
 
     if standard_all(isinstance(name, str) for name in names):
-        names = cast(tuple[str], names)
+        names = cast(tuple[str, ...], names)
         return F.col(*names)
 
     msg = "`names` input must be either a set of strings or a single expression"

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from builtins import any as standard_any
 
 import polars.functions as F
+from polars.expr import Expr
 
-if TYPE_CHECKING:
-    from polars import Expr
+
+def into_expr(*names: str | Expr) -> Expr:
+    """Process column name inputs into expressions."""
+    contains_expr = standard_any(isinstance(name, Expr) for name in names)
+    if len(names) > 1 and contains_expr:
+        msg = "`names` input must be either a set of strings or a single expression"
+        raise TypeError(msg)
+
+    return names[0] if contains_expr else F.col(*names)
 
 
 def all(*names: str, ignore_nulls: bool = True) -> Expr:
@@ -67,10 +75,10 @@ def all(*names: str, ignore_nulls: bool = True) -> Expr:
     if not names:
         return F.col("*")
 
-    return F.col(*names).all(ignore_nulls=ignore_nulls)
+    return into_expr(*names).all(ignore_nulls=ignore_nulls)
 
 
-def any(*names: str, ignore_nulls: bool = True) -> Expr | bool | None:
+def any(*names: str | Expr, ignore_nulls: bool = True) -> Expr | bool | None:
     """
     Evaluate a bitwise OR operation.
 
@@ -111,7 +119,7 @@ def any(*names: str, ignore_nulls: bool = True) -> Expr | bool | None:
     │ true │
     └──────┘
     """
-    return F.col(*names).any(ignore_nulls=ignore_nulls)
+    return into_expr(*names).any(ignore_nulls=ignore_nulls)
 
 
 def max(*names: str) -> Expr:
@@ -171,7 +179,7 @@ def max(*names: str) -> Expr:
     │ 8   ┆ 5   │
     └─────┴─────┘
     """
-    return F.col(*names).max()
+    return into_expr(*names).max()
 
 
 def min(*names: str) -> Expr:
@@ -231,7 +239,7 @@ def min(*names: str) -> Expr:
     │ 1   ┆ 2   │
     └─────┴─────┘
     """
-    return F.col(*names).min()
+    return into_expr(*names).min()
 
 
 def sum(*names: str) -> Expr:
@@ -291,7 +299,7 @@ def sum(*names: str) -> Expr:
     │ 7   ┆ 11  │
     └─────┴─────┘
     """
-    return F.col(*names).sum()
+    return into_expr(*names).sum()
 
 
 def cum_sum(*names: str) -> Expr:
@@ -329,4 +337,4 @@ def cum_sum(*names: str) -> Expr:
     │ 6   │
     └─────┘
     """
-    return F.col(*names).cum_sum()
+    return into_expr(*names).cum_sum()

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -34,7 +34,7 @@ def all(*names: str | Expr, ignore_nulls: bool = True) -> Expr:
     Parameters
     ----------
     *names
-        Name(s) of the columns to use in the aggregation.
+        Name(s) of the columns to use in the aggregation. Accepts expression input.
     ignore_nulls
         Ignore null values (default).
 
@@ -99,7 +99,7 @@ def any(*names: str | Expr, ignore_nulls: bool = True) -> Expr | bool | None:
     Parameters
     ----------
     *names
-        Name(s) of the columns to use in the aggregation.
+        Name(s) of the columns to use in the aggregation. Accepts expression input.
     ignore_nulls
         Ignore null values (default).
 
@@ -139,7 +139,7 @@ def max(*names: str | Expr) -> Expr:
     Parameters
     ----------
     *names
-        Name(s) of the columns to use in the aggregation.
+        Name(s) of the columns to use in the aggregation. Accepts expression input.
 
     See Also
     --------
@@ -199,7 +199,7 @@ def min(*names: str | Expr) -> Expr:
     Parameters
     ----------
     *names
-        Name(s) of the columns to use in the aggregation.
+        Name(s) of the columns to use in the aggregation. Accepts expression input.
 
     See Also
     --------
@@ -259,7 +259,7 @@ def sum(*names: str | Expr) -> Expr:
     Parameters
     ----------
     *names
-        Name(s) of the columns to use in the aggregation.
+        Name(s) of the columns to use in the aggregation. Accepts expression input.
 
     See Also
     --------
@@ -319,7 +319,7 @@ def cum_sum(*names: str | Expr) -> Expr:
     Parameters
     ----------
     *names
-        Name(s) of the columns to use in the aggregation.
+        Name(s) of the columns to use in the aggregation. Accepts expression input.
 
     See Also
     --------

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -19,7 +19,7 @@ def vertical_parse_into_expr(*names: str | Expr) -> Expr:
     if standard_all(isinstance(name, str) for name in names):
         names = cast(tuple[str], names)
         return F.col(*names)
-    
+
     msg = "`names` input must be either a set of strings or a single expression"
     raise TypeError(msg)
 

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from builtins import any as standard_any
+from typing import cast
 
 import polars.functions as F
 from polars.expr import Expr
@@ -13,7 +14,7 @@ def into_expr(*names: str | Expr) -> Expr:
         msg = "`names` input must be either a set of strings or a single expression"
         raise TypeError(msg)
 
-    return names[0] if contains_expr else F.col(*names)
+    return cast(Expr, names[0]) if contains_expr else F.col(cast(tuple[str], names))
 
 
 def all(*names: str | Expr, ignore_nulls: bool = True) -> Expr:

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -16,7 +16,7 @@ def into_expr(*names: str | Expr) -> Expr:
     return names[0] if contains_expr else F.col(*names)
 
 
-def all(*names: str, ignore_nulls: bool = True) -> Expr:
+def all(*names: str | Expr, ignore_nulls: bool = True) -> Expr:
     """
     Either return an expression representing all columns, or evaluate a bitwise AND operation.
 
@@ -122,7 +122,7 @@ def any(*names: str | Expr, ignore_nulls: bool = True) -> Expr | bool | None:
     return into_expr(*names).any(ignore_nulls=ignore_nulls)
 
 
-def max(*names: str) -> Expr:
+def max(*names: str | Expr) -> Expr:
     """
     Get the maximum value.
 
@@ -182,7 +182,7 @@ def max(*names: str) -> Expr:
     return into_expr(*names).max()
 
 
-def min(*names: str) -> Expr:
+def min(*names: str | Expr) -> Expr:
     """
     Get the minimum value.
 
@@ -242,7 +242,7 @@ def min(*names: str) -> Expr:
     return into_expr(*names).min()
 
 
-def sum(*names: str) -> Expr:
+def sum(*names: str | Expr) -> Expr:
     """
     Sum all values.
 
@@ -302,7 +302,7 @@ def sum(*names: str) -> Expr:
     return into_expr(*names).sum()
 
 
-def cum_sum(*names: str) -> Expr:
+def cum_sum(*names: str | Expr) -> Expr:
     """
     Cumulatively sum all values.
 

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from builtins import all as standard_all
-from typing import TYPE_CHECKING, cast, Iterable
+from typing import TYPE_CHECKING, Tuple, cast
 
 import polars.functions as F
 from polars._utils.parse import parse_into_expression
@@ -17,7 +17,7 @@ def vertical_parse_into_expr(*names: str | Expr) -> Expr:
         return wrap_expr(parse_into_expression(*names))
 
     if standard_all(isinstance(name, str) for name in names):
-        names = cast(Iterable[str], names)
+        names = cast(Tuple[str], names)
         return F.col(*names)
 
     msg = "`names` input must be either a set of strings or a single expression"

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from builtins import all as standard_all
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, Iterable
 
 import polars.functions as F
 from polars._utils.parse import parse_into_expression
@@ -17,7 +17,7 @@ def vertical_parse_into_expr(*names: str | Expr) -> Expr:
         return wrap_expr(parse_into_expression(*names))
 
     if standard_all(isinstance(name, str) for name in names):
-        names = cast(tuple[str, ...], names)
+        names = cast(Iterable[str], names)
         return F.col(*names)
 
     msg = "`names` input must be either a set of strings or a single expression"


### PR DESCRIPTION
Resolves #11516 (only `any` is mentioned but the same applied for all vertical aggregations)