### PR TITLE
feat(rust): Use AsRef<Path> instead of PathBuf in sink_ methods

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -15,7 +15,7 @@ pub mod pivot;
     feature = "csv",
     feature = "json"
 ))]
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 pub use anonymous_scan::*;
@@ -752,10 +752,10 @@ impl LazyFrame {
     /// into memory. This methods will return an error if the query cannot be completely done in a
     /// streaming fashion.
     #[cfg(feature = "parquet")]
-    pub fn sink_parquet(self, path: PathBuf, options: ParquetWriteOptions) -> PolarsResult<()> {
+    pub fn sink_parquet(self, path: impl AsRef<Path>, options: ParquetWriteOptions) -> PolarsResult<()> {
         self.sink(
             SinkType::File {
-                path: Arc::new(path),
+                path: Arc::new(path.as_ref().to_path_buf()),
                 file_type: FileType::Parquet(options),
             },
             "collect().write_parquet()",
@@ -787,10 +787,10 @@ impl LazyFrame {
     /// into memory. This methods will return an error if the query cannot be completely done in a
     /// streaming fashion.
     #[cfg(feature = "ipc")]
-    pub fn sink_ipc(self, path: PathBuf, options: IpcWriterOptions) -> PolarsResult<()> {
+    pub fn sink_ipc(self, path: impl AsRef<Path>, options: IpcWriterOptions) -> PolarsResult<()> {
         self.sink(
             SinkType::File {
-                path: Arc::new(path),
+                path: Arc::new(path.as_ref().to_path_buf()),
                 file_type: FileType::Ipc(options),
             },
             "collect().write_ipc()",
@@ -832,10 +832,10 @@ impl LazyFrame {
     /// into memory. This methods will return an error if the query cannot be completely done in a
     /// streaming fashion.
     #[cfg(feature = "csv")]
-    pub fn sink_csv(self, path: PathBuf, options: CsvWriterOptions) -> PolarsResult<()> {
+    pub fn sink_csv(self, path: impl AsRef<Path>, options: CsvWriterOptions) -> PolarsResult<()> {
         self.sink(
             SinkType::File {
-                path: Arc::new(path),
+                path: Arc::new(path.as_ref().to_path_buf()),
                 file_type: FileType::Csv(options),
             },
             "collect().write_csv()",
@@ -846,10 +846,10 @@ impl LazyFrame {
     /// into memory. This methods will return an error if the query cannot be completely done in a
     /// streaming fashion.
     #[cfg(feature = "json")]
-    pub fn sink_json(self, path: PathBuf, options: JsonWriterOptions) -> PolarsResult<()> {
+    pub fn sink_json(self, path: impl AsRef<Path>, options: JsonWriterOptions) -> PolarsResult<()> {
         self.sink(
             SinkType::File {
-                path: Arc::new(path),
+                path: Arc::new(path.as_ref().to_path_buf()),
                 file_type: FileType::Json(options),
             },
             "collect().write_ndjson()` or `collect().write_json()",

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -752,7 +752,11 @@ impl LazyFrame {
     /// into memory. This methods will return an error if the query cannot be completely done in a
     /// streaming fashion.
     #[cfg(feature = "parquet")]
-    pub fn sink_parquet(self, path: impl AsRef<Path>, options: ParquetWriteOptions) -> PolarsResult<()> {
+    pub fn sink_parquet(
+        self,
+        path: impl AsRef<Path>,
+        options: ParquetWriteOptions,
+    ) -> PolarsResult<()> {
         self.sink(
             SinkType::File {
                 path: Arc::new(path.as_ref().to_path_buf()),


### PR DESCRIPTION
I guess there is no reason why something like shouldn't work:

```rust
ldf.sink_parquet("foo.parquet");
```