### PR TITLE
refactor(rust): MinMaxKernel in primitive/binary parquet stats

### DIFF
--- a/crates/polars-compute/src/min_max/mod.rs
+++ b/crates/polars-compute/src/min_max/mod.rs
@@ -5,7 +5,7 @@ pub use self::dyn_array::{
     dyn_array_min_propagate_nan,
 };
 
-// Low-level min/max kernel.
+/// Low-level min/max kernel.
 pub trait MinMaxKernel {
     type Scalar<'a>: MinMax
     where

--- a/crates/polars-compute/src/min_max/scalar.rs
+++ b/crates/polars-compute/src/min_max/scalar.rs
@@ -1,5 +1,7 @@
-use arrow::array::{Array, BinaryViewArray, BooleanArray, PrimitiveArray, Utf8ViewArray};
-use arrow::types::NativeType;
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, BooleanArray, PrimitiveArray, Utf8Array, Utf8ViewArray,
+};
+use arrow::types::{NativeType, Offset};
 use polars_utils::min_max::MinMax;
 
 use super::MinMaxKernel;
@@ -133,6 +135,68 @@ impl MinMaxKernel for Utf8ViewArray {
     #[inline(always)]
     fn max_ignore_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
         self.to_binview().max_ignore_nan_kernel().map(|s| unsafe {
+            // SAFETY: the lifetime is the same, and it is valid UTF-8.
+            #[allow(clippy::transmute_bytes_to_str)]
+            std::mem::transmute::<&[u8], &str>(s)
+        })
+    }
+
+    #[inline(always)]
+    fn min_propagate_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        self.min_ignore_nan_kernel()
+    }
+
+    #[inline(always)]
+    fn max_propagate_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        self.max_ignore_nan_kernel()
+    }
+}
+
+impl<O: Offset> MinMaxKernel for BinaryArray<O> {
+    type Scalar<'a> = &'a [u8];
+
+    fn min_ignore_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        if self.null_count() == 0 {
+            self.values_iter().reduce(MinMax::min_ignore_nan)
+        } else {
+            self.non_null_values_iter().reduce(MinMax::min_ignore_nan)
+        }
+    }
+
+    fn max_ignore_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        if self.null_count() == 0 {
+            self.values_iter().reduce(MinMax::max_ignore_nan)
+        } else {
+            self.non_null_values_iter().reduce(MinMax::max_ignore_nan)
+        }
+    }
+
+    #[inline(always)]
+    fn min_propagate_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        self.min_ignore_nan_kernel()
+    }
+
+    #[inline(always)]
+    fn max_propagate_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        self.max_ignore_nan_kernel()
+    }
+}
+
+impl<O: Offset> MinMaxKernel for Utf8Array<O> {
+    type Scalar<'a> = &'a str;
+
+    #[inline(always)]
+    fn min_ignore_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        self.to_binary().min_ignore_nan_kernel().map(|s| unsafe {
+            // SAFETY: the lifetime is the same, and it is valid UTF-8.
+            #[allow(clippy::transmute_bytes_to_str)]
+            std::mem::transmute::<&[u8], &str>(s)
+        })
+    }
+
+    #[inline(always)]
+    fn max_ignore_nan_kernel(&self) -> Option<Self::Scalar<'_>> {
+        self.to_binary().max_ignore_nan_kernel().map(|s| unsafe {
             // SAFETY: the lifetime is the same, and it is valid UTF-8.
             #[allow(clippy::transmute_bytes_to_str)]
             std::mem::transmute::<&[u8], &str>(s)

--- a/crates/polars-compute/src/min_max/simd.rs
+++ b/crates/polars-compute/src/min_max/simd.rs
@@ -30,6 +30,10 @@ where
     F: FnMut(Simd<T, N>, Simd<T, N>) -> Simd<T, N>,
     LaneCount<N>: SupportedLaneCount,
 {
+    if arr.is_empty() {
+        return None;
+    }
+
     let mut arr_chunks = arr.chunks_exact(N);
 
     let identity = Simd::splat(scalar_identity);


### PR DESCRIPTION
Fixes #16687.

This PR now fully utilizes the MinMaxKernel to calculate the Parquet statistics. Specifically this PR adds this for `PrimitiveArray` and `BinaryArray` which is the majority of values.