### PR TITLE
perf: add RangedUniqueKernel for primitive array

### DIFF
--- a/crates/polars-compute/src/unique/mod.rs
+++ b/crates/polars-compute/src/unique/mod.rs
@@ -1,7 +1,7 @@
 use arrow::array::Array;
 
-/// Kernel to calculate the number of unique elements
-pub trait UniqueKernel: Array {
+/// Kernel to calculate the number of unique elements where the elements are already sorted.
+pub trait SortedUniqueKernel: Array {
     /// Calculate the set of unique elements in `fst` and `others` and fold the result into one
     /// array.
     fn unique_fold<'a>(fst: &'a Self, others: impl Iterator<Item = &'a Self>) -> Self;
@@ -9,9 +9,6 @@ pub trait UniqueKernel: Array {
     /// Calculate the set of unique elements in [`Self`] where we have no further information about
     /// `self`.
     fn unique(&self) -> Self;
-
-    /// Calculate the set of unique elements in [`Self`] where `self` is sorted.
-    fn unique_sorted(&self) -> Self;
 
     /// Calculate the number of unique elements in [`Self`]
     ///
@@ -22,4 +19,46 @@ pub trait UniqueKernel: Array {
     fn n_unique_non_null(&self) -> usize;
 }
 
+/// Optimized kernel to calculate the unique elements of an array.
+///
+/// This kernel is a specialized for where all values are known to be in some small range of
+/// values. In this case, you can usually get by with a bitset and bit-arithmetic instead of using
+/// vectors and hashsets. Consequently, this kernel is usually called when further information is
+/// known about the underlying array.
+///
+/// This trait is not implemented directly on the `Array` as with many other kernels. Rather, it is
+/// implemented on a `State` struct to which `Array`s can be appended. This allows for sharing of
+/// `State` between many chunks and allows for different implementations for the same array (e.g. a
+/// maintain order and no maintain-order variant).
+pub trait RangedUniqueKernel {
+    type Array: Array;
+
+    /// Returns whether all the values in the whole range are in the state
+    fn has_seen_all(&self) -> bool;
+
+    /// Append an `Array`'s values to the `State`
+    fn append(&mut self, array: &Self::Array);
+
+    /// Consume the state to get the unique elements
+    fn finalize_unique(self) -> Self::Array;
+    /// Consume the state to get the number of unique elements including null
+    fn finalize_n_unique(self) -> usize;
+    /// Consume the state to get the number of unique elements excluding null
+    fn finalize_n_unique_non_null(self) -> usize;
+}
+
+/// A generic unique kernel that selects the generally applicable unique kernel for an `Array`.
+pub trait GenericUniqueKernel {
+    /// Calculate the set of unique elements
+    fn unique(&self) -> Self;
+    /// Calculate the number of unique elements including null
+    fn n_unique(&self) -> usize;
+    /// Calculate the number of unique elements excluding null
+    fn n_unique_non_null(&self) -> usize;
+}
+
 mod boolean;
+mod primitive;
+
+pub use boolean::BooleanUniqueKernelState;
+pub use primitive::PrimitiveRangedUniqueState;

--- a/crates/polars-compute/src/unique/primitive.rs
+++ b/crates/polars-compute/src/unique/primitive.rs
@@ -1,0 +1,176 @@
+use std::ops::{Add, RangeInclusive, Sub};
+
+use arrow::array::PrimitiveArray;
+use arrow::bitmap::MutableBitmap;
+use arrow::datatypes::ArrowDataType;
+use arrow::types::NativeType;
+use num_traits::FromPrimitive;
+use polars_utils::float::IsFloat;
+use polars_utils::total_ord::TotalOrd;
+
+use super::RangedUniqueKernel;
+
+/// A specialized unique kernel for [`PrimitiveArray`] for when all values are in a small known
+/// range.
+pub struct PrimitiveRangedUniqueState<T: NativeType> {
+    seen: u128,
+    range: RangeInclusive<T>,
+    has_null: bool,
+    data_type: ArrowDataType,
+}
+
+impl<T: NativeType> PrimitiveRangedUniqueState<T>
+where
+    T: Add<T, Output = T> + Sub<T, Output = T> + FromPrimitive + IsFloat,
+{
+    pub fn new(
+        min_value: T,
+        max_value: T,
+        has_null: bool,
+        data_type: ArrowDataType,
+    ) -> Option<Self> {
+        // We cannot really do this for floating point number as these are not as discrete as
+        // integers.
+        if T::is_float() {
+            return None;
+        }
+
+        if TotalOrd::tot_gt(
+            &(max_value - min_value),
+            &T::from_u8(128 - u8::from(has_null)).unwrap(),
+        ) {
+            return None;
+        }
+
+        Some(Self {
+            seen: 0,
+            range: min_value..=max_value,
+            has_null,
+            data_type,
+        })
+    }
+
+    fn len(&self) -> u8 {
+        (*self.range.end() - *self.range.start()).to_le_bytes()[0]
+    }
+
+    fn has_seen_null(&self) -> bool {
+        self.has_null && self.seen & 1 != 0
+    }
+
+    #[inline(always)]
+    fn to_value(&self, scalar: Option<T>) -> u8 {
+        match scalar {
+            None => {
+                debug_assert!(self.has_null);
+                0
+            },
+            Some(v) => {
+                debug_assert!(<T as TotalOrd>::tot_le(&v, self.range.end()));
+                debug_assert!(<T as TotalOrd>::tot_ge(&v, self.range.start()));
+
+                (v - *self.range.start()).to_le_bytes()[0] + u8::from(self.has_null)
+            },
+        }
+    }
+}
+
+impl<T: NativeType> RangedUniqueKernel for PrimitiveRangedUniqueState<T>
+where
+    T: Add<T, Output = T> + Sub<T, Output = T> + FromPrimitive + IsFloat,
+{
+    type Array = PrimitiveArray<T>;
+
+    fn has_seen_all(&self) -> bool {
+        let len = self.len();
+        let bit_length = len + u8::from(self.has_null);
+
+        debug_assert!(bit_length > 0);
+        debug_assert!(bit_length <= 128);
+
+        self.seen == (1u128 << len).wrapping_sub(1)
+    }
+
+    fn append(&mut self, array: &Self::Array) {
+        const STEP_SIZE: usize = 128;
+
+        if !self.has_null {
+            let mut i = 0;
+            let values = array.values().as_slice();
+
+            while !self.has_seen_all() && i < values.len() {
+                for v in values[i..].iter().take(STEP_SIZE) {
+                    self.seen |= 1 << self.to_value(Some(*v));
+                }
+
+                i += STEP_SIZE;
+            }
+        } else {
+            let mut i = 0;
+            let mut values = array.iter();
+
+            while !self.has_seen_all() && i < values.len() {
+                for _ in 0..STEP_SIZE {
+                    let Some(v) = values.next() else {
+                        break;
+                    };
+                    self.seen |= 1 << self.to_value(v.copied());
+                }
+
+                i += STEP_SIZE;
+            }
+        }
+    }
+
+    fn finalize_unique(self) -> Self::Array {
+        let mut seen = self.seen;
+
+        let num_values = seen.count_ones() as usize;
+        let mut values = Vec::with_capacity(num_values);
+
+        let (values, validity) = if self.has_seen_null() {
+            let mut validity = MutableBitmap::with_capacity(num_values);
+
+            values.push(T::zeroed());
+            validity.push(false);
+            seen >>= 1;
+
+            let mut offset = 0u8;
+            while seen != 0 {
+                let shift = self.seen.trailing_zeros();
+                offset += shift as u8;
+                values.push(*self.range.start() + T::from_u8(offset).unwrap());
+                validity.push(true);
+
+                seen >>= shift + 1;
+                offset += 1;
+            }
+
+            (values, Some(validity.freeze()))
+        } else {
+            seen >>= u8::from(self.has_null);
+
+            let mut offset = 0u8;
+            while seen != 0 {
+                let shift = seen.trailing_zeros();
+                offset += shift as u8;
+                values.push(*self.range.start() + T::from_u8(offset).unwrap());
+
+                seen >>= shift + 1;
+                offset += 1;
+            }
+
+            (values, None)
+        };
+
+        PrimitiveArray::new(self.data_type, values.into(), validity)
+    }
+
+    fn finalize_n_unique(self) -> usize {
+        self.seen.count_ones() as usize
+    }
+
+    fn finalize_n_unique_non_null(self) -> usize {
+        (self.seen & !1).count_ones() as usize
+    }
+}

--- a/crates/polars-parquet/src/arrow/write/boolean/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/boolean/basic.rs
@@ -85,7 +85,7 @@ pub(super) fn build_statistics(
     options: &StatisticsOptions,
 ) -> ParquetStatistics {
     use polars_compute::min_max::MinMaxKernel;
-    use polars_compute::unique::UniqueKernel;
+    use polars_compute::unique::GenericUniqueKernel;
 
     BooleanStatistics {
         null_count: options.null_count.then(|| array.null_count() as i64),


### PR DESCRIPTION
This PR adds a unique value kernel that is selected based on the metadata for `PrimitiveArray`. When the difference between the metadata min and max value is small enough a different kernel is used that does not require sorting the data first.

This is mostly to show how the new metadata can be used to select a different kernel.

For a microbenchmark on release mode, we see the following results:

```python
import polars as pl
import numpy as np
from timeit import timeit

xs = list(np.random.randint(5, 100, size = 500000))
df = pl.DataFrame({ "x": xs, }, schema = { "x": pl.Int32 })

def rand_unique():
    df.select(pl.col.x.unique())

t = timeit(rand_unique, number = 10000)
print(f'Before Time = {t}')
df.select(xmin = pl.col.x.min(), xmax = pl.col.x.max())
t = timeit(rand_unique, number = 10000)
print(f'After Time = {t}')
```

```
Before Time = 22.795969667999998
After Time = 4.657802337999783
```

This is a ~4.9x improvement. I feel like this can also be further improved if needed.