### PR TITLE
feat: Support SQL `SELECT * ILIKE` wildcard syntax

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -729,7 +729,7 @@ impl SQLContext {
             let have_order_by = !query.order_by.is_empty();
 
             // Note: if there is an 'order by' then we project everything (original cols
-            // and new projections), and *then* select the final cols; the retained cols
+            // and new projections) and *then* select the final cols; the retained cols
             // are used to ensure a correct final projection. If there's no 'order by',
             // clause then we can project the final column *expressions* directly.
             for p in projections.iter() {
@@ -752,11 +752,9 @@ impl SQLContext {
                 if !select_modifiers.rename.is_empty() {
                     lf = lf.with_columns(select_modifiers.renamed_cols());
                 }
-                self.process_order_by(lf, &query.order_by, Some(&retained_cols))?
-                    .select(retained_cols)
-            } else {
-                lf.select(retained_cols)
+                lf = self.process_order_by(lf, &query.order_by, Some(&retained_cols))?
             }
+            lf.select(retained_cols)
         } else {
             lf = self.process_group_by(lf, &group_by_keys, &projections)?;
             lf = self.process_order_by(lf, &query.order_by, None)?;

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::ops::Deref;
 
+use polars_core::export::regex::{escape, Regex};
 use polars_core::frame::row::Row;
 use polars_core::prelude::*;
 use polars_lazy::prelude::*;
@@ -22,6 +23,18 @@ use crate::sql_expr::{
     to_sql_interface_err,
 };
 use crate::table_functions::PolarsTableFunctions;
+
+struct RenameColumns {
+    before: Vec<String>,
+    after: Vec<String>,
+}
+
+struct SelectModifiers {
+    exclude: PlHashSet<String>, // SELECT * EXCLUDE
+    ilike: Option<Regex>,       // SELECT * ILIKE
+    rename: RenameColumns,      // SELECT * RENAME
+    replace: Vec<Expr>,         // SELECT * REPLACE
+}
 
 /// The SQLContext is the main entry point for executing SQL queries.
 #[derive(Clone)]
@@ -607,9 +620,15 @@ impl SQLContext {
         lf = self.process_where(lf, &select_stmt.selection)?;
 
         // 'SELECT *' modifiers
-        let mut excluded_cols = vec![];
-        let mut replace_exprs = vec![];
-        let mut rename_cols = (&mut vec![], &mut vec![]);
+        let mut select_modifiers = SelectModifiers {
+            ilike: None,
+            exclude: PlHashSet::new(),
+            rename: RenameColumns {
+                before: vec![],
+                after: vec![],
+            },
+            replace: vec![],
+        };
 
         // Column projections (SELECT clause)
         let projections: Vec<Expr> = select_stmt
@@ -628,9 +647,7 @@ impl SQLContext {
                         .process_qualified_wildcard(
                             obj_name,
                             wildcard_options,
-                            &mut excluded_cols,
-                            &mut rename_cols,
-                            &mut replace_exprs,
+                            &mut select_modifiers,
                             Some(schema.deref()),
                         )?,
                     SelectItem::Wildcard(wildcard_options) => {
@@ -642,9 +659,7 @@ impl SQLContext {
                         self.process_wildcard_additional_options(
                             cols,
                             wildcard_options,
-                            &mut excluded_cols,
-                            &mut rename_cols,
-                            &mut replace_exprs,
+                            &mut select_modifiers,
                             Some(schema.deref()),
                         )?
                     },
@@ -703,34 +718,36 @@ impl SQLContext {
         };
 
         lf = if group_by_keys.is_empty() {
-            lf = if query.order_by.is_empty() {
-                // No sort, select cols as given
-                lf.select(projections)
+            // Establish final/selected cols, accounting for 'SELECT *' modifiers
+            let retained_cols: Vec<_> = projections
+                .iter()
+                .filter_map(|e| {
+                    let field = e.to_field(schema.deref(), Context::Default).ok()?;
+                    let name = field.name.to_string();
+                    if select_modifiers
+                        .ilike
+                        .as_ref()
+                        .map_or(true, |rx| rx.is_match(&name))
+                        && !select_modifiers.exclude.contains(&name)
+                    {
+                        Some(col(name.as_str()))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            if query.order_by.is_empty() {
+                if select_modifiers.ilike.is_some() || !select_modifiers.exclude.is_empty() {
+                    lf.select(projections).select(retained_cols)
+                } else {
+                    lf.select(projections)
+                }
             } else {
-                // Add projections to the base frame as any of the
-                // original columns may be required for the sort
+                // Include projections as any of the original columns may be required for the sort
                 lf = lf.with_columns(projections.clone());
-
-                // Final/selected cols (also ensures accurate ordinal position refs)
-                let retained_cols = projections
-                    .iter()
-                    .map(|e| {
-                        col(e
-                            .to_field(schema.deref(), Context::Default)
-                            .unwrap()
-                            .name
-                            .as_str())
-                    })
-                    .collect::<Vec<_>>();
-
-                lf = self.process_order_by(lf, &query.order_by, Some(&retained_cols))?;
-                lf.select(retained_cols)
-            };
-            // Discard any excluded cols
-            if !excluded_cols.is_empty() {
-                lf.drop(excluded_cols)
-            } else {
-                lf
+                self.process_order_by(lf, &query.order_by, Some(&retained_cols))?
+                    .select(retained_cols)
             }
         } else {
             lf = self.process_group_by(lf, &group_by_keys, &projections)?;
@@ -771,12 +788,15 @@ impl SQLContext {
             None => lf,
         };
 
-        // Apply final 'SELECT *' modifiers
-        if !replace_exprs.is_empty() {
-            lf = lf.with_columns(replace_exprs);
+        // Apply final 'SELECT *' REPLACE/RENAME modifiers
+        if !select_modifiers.replace.is_empty() {
+            lf = lf.with_columns(select_modifiers.replace);
         }
-        if !rename_cols.0.is_empty() {
-            lf = lf.rename(rename_cols.0, rename_cols.1);
+        if !select_modifiers.rename.before.is_empty() {
+            lf = lf.rename(
+                select_modifiers.rename.before,
+                select_modifiers.rename.after,
+            );
         }
         Ok(lf)
     }
@@ -1173,70 +1193,73 @@ impl SQLContext {
         &mut self,
         ObjectName(idents): &ObjectName,
         options: &WildcardAdditionalOptions,
-        excluded_cols: &mut Vec<String>,
-        rename_cols: &mut (&mut Vec<String>, &mut Vec<String>),
-        replace_exprs: &mut Vec<Expr>,
+        modifiers: &mut SelectModifiers,
         schema: Option<&Schema>,
     ) -> PolarsResult<Vec<Expr>> {
         let mut new_idents = idents.clone();
         new_idents.push(Ident::new("*"));
 
         let expr = resolve_compound_identifier(self, new_idents.deref(), schema);
-        self.process_wildcard_additional_options(
-            expr?,
-            options,
-            excluded_cols,
-            rename_cols,
-            replace_exprs,
-            schema,
-        )
+        self.process_wildcard_additional_options(expr?, options, modifiers, schema)
     }
 
     fn process_wildcard_additional_options(
         &mut self,
         exprs: Vec<Expr>,
         options: &WildcardAdditionalOptions,
-        excluded_cols: &mut Vec<String>,
-        rename_cols: &mut (&mut Vec<String>, &mut Vec<String>),
-        replace_exprs: &mut Vec<Expr>,
+        modifiers: &mut SelectModifiers,
         schema: Option<&Schema>,
     ) -> PolarsResult<Vec<Expr>> {
         // bail on (currently) unsupported wildcard options
         if options.opt_except.is_some() {
-            polars_bail!(SQLInterface: "EXCEPT wildcard option is unsupported (use EXCLUDE instead)")
-        } else if options.opt_ilike.is_some() {
-            polars_bail!(SQLInterface: "ILIKE wildcard option is currently unsupported")
+            polars_bail!(SQLInterface: "EXCEPT wildcard option is not supported (use EXCLUDE instead)")
+        } else if options.opt_exclude.is_some() && options.opt_ilike.is_some() {
+            polars_bail!(SQLInterface: "EXCLUDE and ILIKE wildcard options cannot be used together")
         } else if options.opt_rename.is_some() && options.opt_replace.is_some() {
             // pending an upstream fix: https://github.com/sqlparser-rs/sqlparser-rs/pull/1321
-            polars_bail!(SQLInterface: "RENAME and REPLACE wildcard options cannot (yet) be used simultaneously")
+            polars_bail!(SQLInterface: "RENAME and REPLACE wildcard options cannot (yet) be used together")
         }
 
         if let Some(items) = &options.opt_exclude {
-            *excluded_cols = match items {
-                ExcludeSelectItem::Single(ident) => vec![ident.value.clone()],
+            match items {
+                ExcludeSelectItem::Single(ident) => {
+                    modifiers.exclude.insert(ident.value.clone());
+                },
                 ExcludeSelectItem::Multiple(idents) => {
-                    idents.iter().map(|i| i.value.clone()).collect()
+                    modifiers
+                        .exclude
+                        .extend(idents.iter().map(|i| i.value.clone()));
                 },
             };
+        } else if let Some(item) = &options.opt_ilike {
+            let rx = escape(item.pattern.as_str())
+                .replace('%', ".*")
+                .replace('_', ".");
+
+            modifiers.ilike = Some(Regex::new(format!("^(?i){}$", rx).as_str()).unwrap());
         }
+
         if let Some(items) = &options.opt_rename {
             match items {
                 RenameSelectItem::Single(rename) => {
-                    rename_cols.0.push(rename.ident.value.clone());
-                    rename_cols.1.push(rename.alias.value.clone());
+                    modifiers.rename.before.push(rename.ident.value.clone());
+                    modifiers.rename.after.push(rename.alias.value.clone());
                 },
                 RenameSelectItem::Multiple(renames) => {
                     for rn in renames {
-                        rename_cols.0.push(rn.ident.value.clone());
-                        rename_cols.1.push(rn.alias.value.clone());
+                        modifiers.rename.before.push(rn.ident.value.clone());
+                        modifiers.rename.after.push(rn.alias.value.clone());
                     }
                 },
             }
         }
+
         if let Some(replacements) = &options.opt_replace {
             for rp in &replacements.items {
                 let replacement_expr = parse_sql_expr(&rp.expr, self, schema);
-                replace_exprs.push(replacement_expr?.alias(rp.column_name.value.as_str()));
+                modifiers
+                    .replace
+                    .push(replacement_expr?.alias(rp.column_name.value.as_str()));
             }
         }
         Ok(exprs)

--- a/py-polars/tests/unit/sql/test_wildcard_opts.py
+++ b/py-polars/tests/unit/sql/test_wildcard_opts.py
@@ -36,7 +36,11 @@ def test_select_exclude(
     expected: list[str],
     df: pl.DataFrame,
 ) -> None:
-    assert df.sql(f"SELECT * EXCLUDE {excluded} FROM self").columns == expected
+    for exclude_keyword in ("EXCLUDE", "EXCEPT"):
+        assert (
+            df.sql(f"SELECT * {exclude_keyword} {excluded} FROM self").columns
+            == expected
+        )
 
 
 def test_select_exclude_order_by(

--- a/py-polars/tests/unit/sql/test_wildcard_opts.py
+++ b/py-polars/tests/unit/sql/test_wildcard_opts.py
@@ -121,34 +121,31 @@ def test_select_rename_exclude_sort(order_by: str, df: pl.DataFrame) -> None:
 
 
 @pytest.mark.parametrize(
-    ("replacements", "order_by", "check_cols", "expected"),
+    ("replacements", "check_cols", "expected"),
     [
         (
             "(ID // 3 AS ID)",
-            "",
             ["ID"],
-            [(111,), (222,), (333,)],
+            [(333,), (222,), (111,)],
         ),
         (
-            "((City || ':' || City) AS City, ID // 3 AS ID)",
-            "ORDER BY ID DESC",
+            "((City || ':' || City) AS City, ID // -3 AS ID)",
             ["City", "ID"],
             [
-                ("Metropolis:Metropolis", 333),
-                ("Themyscira:Themyscira", 222),
-                ("Gotham:Gotham", 111),
+                ("Gotham:Gotham", -111),
+                ("Themyscira:Themyscira", -222),
+                ("Metropolis:Metropolis", -333),
             ],
         ),
     ],
 )
 def test_select_replace(
     replacements: str,
-    order_by: str,
     check_cols: list[str],
     expected: list[tuple[Any]],
     df: pl.DataFrame,
 ) -> None:
-    res = df.sql(f"SELECT * REPLACE {replacements} FROM self {order_by}")
+    res = df.sql(f"SELECT * REPLACE {replacements} FROM self ORDER BY ID DESC")
 
     assert res.select(check_cols).rows() == expected
     assert res.columns == df.columns

--- a/py-polars/tests/unit/sql/test_wildcard_opts.py
+++ b/py-polars/tests/unit/sql/test_wildcard_opts.py
@@ -62,8 +62,18 @@ def test_select_exclude_error(df: pl.DataFrame) -> None:
     with pytest.raises(SQLInterfaceError, match="ILIKE"):
         assert df.sql("SELECT * EXCLUDE Address ILIKE '%o%' FROM self")
 
+    # these two options are aliases, with EXCLUDE being preferred
+    with pytest.raises(
+        SQLInterfaceError,
+        match="EXCLUDE and EXCEPT wildcard options cannot be used together",
+    ):
+        assert df.sql("SELECT * EXCLUDE Address EXCEPT City FROM self")
+
     # note: missing "()" around the exclude option results in dupe col
-    with pytest.raises(DuplicateError, match="the name 'City' is duplicate"):
+    with pytest.raises(
+        DuplicateError,
+        match="the name 'City' is duplicate",
+    ):
         assert df.sql("SELECT * EXCLUDE Address, City FROM self")
 
 


### PR DESCRIPTION
Following on from #17109, which added `RENAME` and `REPLACE` modifiers:

## New

* Added support for the `SELECT * ILIKE …`  wildcard select-modifier[^1]. 
  This is a pattern-match on column names, using SQL "%" and "_" glob chars. 

## Also

* Fixed interaction of `ORDER BY` and `REPLACE` modifier (should sort on post-replace values).
* Fixed use of ordinal values with `ORDER BY` clause if _also_ using `SELECT * EXCLUDE`.
* Improved use of `ORDER BY` on columns targeted by `RENAME` modifier.
* Some code refactoring/consolidation to improve clarity around select-modifiers.
* Extended select-modifier unit tests to cover additional permutations/combinations of modifiers.

## Note

With this final addition, we will support _all_ `SELECT *` wildcard modifiers for the 1.0 🎉 
```
SELECT * EXCLUDE …
SELECT * ILIKE …
SELECT * RENAME …
SELECT * REPLACE …
```

## Examples

```python
import polars as pl

df = pl.DataFrame({
    "ID": [333, 666, 999],
    "FirstName": ["Bruce", "Diana", "Clark"],
    "LastName": ["Wayne", "Prince", "Kent"],
    "Address": ["The Batcave", "Paradise Island", "Fortress of Solitude"],
    "City": ["Gotham", "Themyscira", "Metropolis"],
})
```
Demonstrate use of `SELECT * ILIKE`:
```python
df.sql("""
  SELECT * ILIKE '%a%e%'
  FROM self
  ORDER BY FirstName
""")
# shape: (3, 3)
# ┌───────────┬──────────┬──────────────────────┐
# │ FirstName ┆ LastName ┆ Address              │
# │ ---       ┆ ---      ┆ ---                  │
# │ str       ┆ str      ┆ str                  │
# ╞═══════════╪══════════╪══════════════════════╡
# │ Bruce     ┆ Wayne    ┆ The Batcave          │
# │ Clark     ┆ Kent     ┆ Fortress of Solitude │
# │ Diana     ┆ Prince   ┆ Paradise Island      │
# └───────────┴──────────┴──────────────────────┘
```
Combine `ILIKE` with `RENAME`, sort with ordinal-based `ORDER BY`:
```python
df.sql("""
  SELECT * ILIKE '%I%' RENAME (FirstName AS Name) 
  FROM self
  ORDER BY 3 DESC
""")
# shape: (3, 3)
# ┌─────┬───────┬────────────┐
# │ ID  ┆ Name  ┆ City       │
# │ --- ┆ ---   ┆ ---        │
# │ i64 ┆ str   ┆ str        │
# ╞═════╪═══════╪════════════╡
# │ 666 ┆ Diana ┆ Themyscira │
# │ 999 ┆ Clark ┆ Metropolis │
# │ 333 ┆ Bruce ┆ Gotham     │
# └─────┴───────┴────────────┘
```
Correctly apply `ORDER BY` on a column targeted by the `RENAME` modifier:
```python
df.sql("""
  SELECT * EXCLUDE (ID, City, LastName) RENAME FirstName AS Name
  FROM self
  ORDER BY Name
""")
# shape: (3, 2)
# ┌───────┬──────────────────────┐
# │ Name  ┆ Address              │
# │ ---   ┆ ---                  │
# │ str   ┆ str                  │
# ╞═══════╪══════════════════════╡
# │ Bruce ┆ The Batcave          │
# │ Clark ┆ Fortress of Solitude │
# │ Diana ┆ Paradise Island      │
# └───────┴──────────────────────┘
```
[^1]: Note that these `SELECT *` wildcard options have become very popular in the last couple of years, with DuckDB, Snowflake, Databricks, and other vendors jumping on to the syntax, but PostgreSQL (our usual syntax target) actually has yet to implement it. However, given its popularity I think it's important that we have it (and it's purely additive; we lose nothing by supporting it) ✌️