### PR TITLE
feat(python): Add optional "default" to `get_column` DataFrame method

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7358,7 +7358,15 @@ class DataFrame:
         """
         return [wrap_s(s) for s in self._df.get_columns()]
 
-    def get_column(self, name: str, *, default: Any | NoDefault = no_default) -> Series:
+    @overload
+    def get_column(self, name: str, *, default: Series | NoDefault = ...) -> Series: ...
+
+    @overload
+    def get_column(self, name: str, *, default: Any) -> Any: ...
+
+    def get_column(
+        self, name: str, *, default: Any | NoDefault = no_default
+    ) -> Series | Any:
         """
         Get a single column by name.
 
@@ -7372,7 +7380,7 @@ class DataFrame:
 
         Returns
         -------
-        Series (or arbitrary default value)
+        Series (or arbitrary default value, if specified).
 
         See Also
         --------

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -18,6 +18,7 @@ import polars.selectors as cs
 from polars._utils.construction import iterable_to_pydf
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
 from polars.exceptions import (
+    ColumnNotFoundError,
     ComputeError,
     DuplicateError,
     InvalidOperationError,
@@ -126,11 +127,21 @@ def test_comparisons() -> None:
         df == pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})  # noqa: B015
 
 
-def test_selection() -> None:
+def test_column_selection() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]})
 
     # get column by name
-    assert_series_equal(df.get_column("b"), pl.Series("b", [1.0, 2.0, 3.0]))
+    b = pl.Series("b", [1.0, 2.0, 3.0])
+    assert_series_equal(df["b"], b)
+    assert_series_equal(df.get_column("b"), b)
+
+    with pytest.raises(ColumnNotFoundError, match="x"):
+        df.get_column("x")
+
+    default_series = pl.Series("x", ["?", "?", "?"])
+    assert_series_equal(df.get_column("x", default=default_series), default_series)
+
+    assert df.get_column("x", default=None) is None
 
     # get column by index
     assert_series_equal(df.to_series(1), pl.Series("b", [1.0, 2.0, 3.0]))


### PR DESCRIPTION
Closes #17170.

* Adds an optional "default" param to `DataFrame.get_column`; provides some additional usability in a few cases.
* This method is analogous to `dict.get`, which allows for the same sort of behaviour, but instead of returning None if no default is actively specified we will continue to raise.

Note: existing behaviour is entirely unchanged _unless_ the new parameter is invoked.

## Example
```python
import polars as pl

df = pl.DataFrame({
  "foo": [1, 2, 3],
  "bar": [4, 5, 6],
})
```
Without `default` (existing/standard behaviour):
```python
res = df.get_column("baz")
# ColumnNotFoundError: baz
```
With (optional) use of `default`:
```python
if (srs := df.get_column("baz", default=None)) is not None:
    do_some_stuff(srs)
```
```python
default_baz = pl.Series("baz",["?","?","?"])
df.get_column("baz", default=default_baz)
# shape: (3,)
# Series: 'baz' [str]
# [
#     "?"
#     "?"
#     "?"
# ]

```