### PR TITLE
fix(python): Update implementation of Enum support in `lit` to address spurious test failure

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -130,7 +130,7 @@ def lit(
     elif isinstance(value, enum.Enum):
         lit_value = value.value
         if dtype is None and isinstance(value, str):
-            dtype = Enum(value.__class__.__members__.values())
+            dtype = Enum(m.value for m in type(value))
         return lit(lit_value, dtype=dtype)
 
     if dtype:


### PR DESCRIPTION
This is a bit of a weird one - I saw spurious failures on this Enum functionality which shouldn't have any randomness at all, e.g.:
https://github.com/pola-rs/polars/actions/runs/9661447486/job/26649165757?pr=17164

Hoping this new implementation takes care of it.