### PR TITLE
docs(python): Bump docs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,9 +10,9 @@ numba
 # https://github.com/pola-rs/polars/issues/16998
 numpy<2
 
-mkdocs-material==9.5.2
-mkdocs-macros-plugin==1.0.4
+mkdocs-material==9.5.27
+mkdocs-macros-plugin==1.0.5
 mkdocs-redirects==1.2.1
 material-plausible-plugin==0.2.0
-markdown-exec[ansi]==1.8.0
-PyGithub==2.3.0
+markdown-exec[ansi]==1.9.3
+pygithub==2.3.0

--- a/docs/src/python/user-guide/expressions/structs.py
+++ b/docs/src/python/user-guide/expressions/structs.py
@@ -70,7 +70,7 @@ df = pl.DataFrame({"keys": ["a", "a", "b"], "values": [10, 7, 1]})
 
 out = df.select(
     pl.struct(["keys", "values"])
-    .map_elements(lambda x: len(x["keys"]) + x["values"])
+    .map_elements(lambda x: len(x["keys"]) + x["values"], return_dtype=pl.Int64)
     .alias("solution_map_elements"),
     (pl.col("keys").str.len_bytes() + pl.col("values")).alias("solution_expr"),
 )

--- a/docs/src/python/user-guide/expressions/user-defined-functions.py
+++ b/docs/src/python/user-guide/expressions/user-defined-functions.py
@@ -1,7 +1,11 @@
 # --8<-- [start:setup]
 
-import polars as pl
+import warnings
 
+import polars as pl
+from polars.exceptions import PolarsInefficientMapWarning
+
+warnings.simplefilter("ignore", PolarsInefficientMapWarning)
 # --8<-- [end:setup]
 
 # --8<-- [start:dataframe]
@@ -57,7 +61,7 @@ print(out)
 # --8<-- [end:np_log]
 
 # --8<-- [start:diff_from_mean_numba]
-from numba import guvectorize, int64, float64
+from numba import float64, guvectorize, int64
 
 
 # This will be compiled to machine code, so it will be fast. The Series is

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -6,17 +6,17 @@ pyarrow
 
 hypothesis==6.103.0
 
-sphinx==7.2.4
+sphinx==7.3.7
 
 # Third-party Sphinx extensions
-autodocsumm==0.2.11
+autodocsumm==0.2.12
 numpydoc==1.7.0
-pydata-sphinx-theme==0.14.1
+pydata-sphinx-theme==0.15.4
 sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.0
 sphinx-favicon==1.0.1
-sphinx_reredirects==0.1.3
-sphinx-toolbox==3.5.0
+sphinx-reredirects==0.1.4
+sphinx-toolbox==3.6.0
 
-livereload==2.6.3
+livereload==2.7.0

--- a/py-polars/tests/docs/test_user_guide.py
+++ b/py-polars/tests/docs/test_user_guide.py
@@ -32,8 +32,5 @@ def _change_test_dir() -> Iterator[None]:
 @pytest.mark.docs()
 @pytest.mark.parametrize("path", snippet_paths)
 @pytest.mark.usefixtures("_change_test_dir")
-@pytest.mark.filterwarnings(
-    r"ignore:\nExpr\.map_elements:polars.exceptions.PolarsInefficientMapWarning"
-)
 def test_run_python_snippets(path: Path) -> None:
     runpy.run_path(str(path))


### PR DESCRIPTION
New pydata theme version is out, which solves an issue that blocked us from upgrading for a long time. So, time for an update!

Also fixes a warning during doc build.