### PR TITLE
feat(rust): Expose some more information in translated expression IR to python

### DIFF
--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -1059,7 +1059,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 .to_object(py),
                 FunctionExpr::Atan2 => ("atan2",).to_object(py),
                 FunctionExpr::Sign => ("sign",).to_object(py),
-                FunctionExpr::FillNull => return Err(PyNotImplementedError::new_err("fill null")),
+                FunctionExpr::FillNull => ("fill_null",).to_object(py),
                 FunctionExpr::RollingExpr(rolling) => match rolling {
                     RollingFunction::Min(_) => {
                         return Err(PyNotImplementedError::new_err("rolling min"))
@@ -1123,7 +1123,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::Reshape(_, _) => {
                     return Err(PyNotImplementedError::new_err("reshape"))
                 },
-                FunctionExpr::RepeatBy => return Err(PyNotImplementedError::new_err("repeat by")),
+                FunctionExpr::RepeatBy => ("repeat_by",).to_object(py),
                 FunctionExpr::ArgUnique => ("argunique",).to_object(py),
                 FunctionExpr::Rank {
                     options: _,
@@ -1134,7 +1134,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                     has_max: _,
                 } => return Err(PyNotImplementedError::new_err("clip")),
                 FunctionExpr::AsStruct => return Err(PyNotImplementedError::new_err("as struct")),
-                FunctionExpr::TopK { .. } => return Err(PyNotImplementedError::new_err("top k")),
+                FunctionExpr::TopK { descending } => ("top_k", descending).to_object(py),
                 FunctionExpr::CumCount { reverse } => ("cumcount", reverse).to_object(py),
                 FunctionExpr::CumSum { reverse } => ("cumsum", reverse).to_object(py),
                 FunctionExpr::CumProd { reverse } => ("cumprod", reverse).to_object(py),
@@ -1257,9 +1257,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::Business(_) => {
                     return Err(PyNotImplementedError::new_err("business"))
                 },
-                FunctionExpr::TopKBy { .. } => {
-                    return Err(PyNotImplementedError::new_err("top_k_by"))
-                },
+                FunctionExpr::TopKBy { descending } => ("top_k_by", descending).to_object(py),
                 FunctionExpr::EwmMeanBy { half_life: _ } => {
                     return Err(PyNotImplementedError::new_err("ewm_mean_by"))
                 },

--- a/py-polars/src/lazyframe/visitor/nodes.rs
+++ b/py-polars/src/lazyframe/visitor/nodes.rs
@@ -292,6 +292,14 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
         }
         .into_py(py),
         IR::Scan {
+            hive_parts: Some(_),
+            ..
+        } => {
+            return Err(PyNotImplementedError::new_err(
+                "scan with hive partitioning",
+            ))
+        },
+        IR::Scan {
             paths,
             file_info: _,
             hive_parts: _,


### PR DESCRIPTION
Explicitly handle the options and hive partitioning in scans. I decided to use the serde-based serialization for the type-specific options in `Scan` rather than laboriously writing a translation for the options structs. 

Question: does this need to be gated behind `#[cfg(all(feature = "json", feature = "serde_json"))]`? I think it's reasonable to require those features for the IR translation to function, but if we don't think so, I do stuff by hand.

Additionally, build out a bit more of the expression translation. The major one is that `IRAggExprs` now hold a `Vec<Node>` rather than a single `Node` as arguments, since `Quantile` takes two expressions.