### PR TITLE
refactor(rust): use RwLock for warnings

### DIFF
--- a/crates/polars-error/src/warning.rs
+++ b/crates/polars-error/src/warning.rs
@@ -5,10 +5,6 @@ static WARNING_FUNCTION: RwLock<Option<WarningFunction>> = RwLock::new(None);
 
 /// Set the function that will be called by the `polars_warn!` macro.
 /// You can use this to set logging in polars.
-///
-/// # Safety
-/// The caller must ensure there is no other thread accessing this function
-/// or calling `polars_warn!`.
 pub fn set_warning_function(function: WarningFunction) {
     let mut w = WARNING_FUNCTION.write().unwrap();
     *w = Some(function)

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -97,7 +97,7 @@ pub fn __register_startup_deps() {
         // register DATAFRAME UDF
         unsafe { python_udf::CALL_DF_UDF_PYTHON = Some(python_function_caller_df) }
         // register warning function for `polars_warn!`
-        unsafe { polars_error::set_warning_function(warning_function) };
+        polars_error::set_warning_function(warning_function);
         Python::with_gil(|py| {
             // init AnyValue LUT
             crate::conversion::any_value::LUT


### PR DESCRIPTION
This is more of a minor suggestion to address `The caller must ensure there is no other thread accessing this function
/// or calling polars_warn!`.

With RwLock, we can prevent this completely? And I don't think the performance impact will not be that noticeable, the warnings need to call Python and/or IO functions which dominate the call time.