### PR TITLE
feat: Support SQL `ORDER BY ALL` syntax

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1002,33 +1002,42 @@ impl SQLContext {
         order_by: &[OrderByExpr],
         selected: Option<&[Expr]>,
     ) -> PolarsResult<LazyFrame> {
-        let mut by = Vec::with_capacity(order_by.len());
+        let schema = lf.schema_with_arenas(&mut self.lp_arena, &mut self.expr_arena)?;
+        let columns_iter = schema.iter_names().map(|e| col(e));
+
         let mut descending = Vec::with_capacity(order_by.len());
         let mut nulls_last = Vec::with_capacity(order_by.len());
+        let mut by: Vec<Expr> = Vec::with_capacity(order_by.len());
 
-        let schema = Some(lf.schema_with_arenas(&mut self.lp_arena, &mut self.expr_arena)?);
-        let columns = schema
-            .clone()
-            .unwrap()
-            .iter_names()
-            .map(|e| col(e))
-            .collect::<Vec<_>>();
+        if order_by.len() == 1  // support `ORDER BY ALL` (iff there is no column named 'ALL' in the schema)
+            && matches!(&order_by[0].expr, SQLExpr::Identifier(ident) if ident.value.to_uppercase() == "ALL" && !schema.iter_names().any(|name| name.to_uppercase() == "ALL"))
+        {
+            if let Some(selected) = selected {
+                by.extend(selected.iter().cloned());
+            } else {
+                by.extend(columns_iter);
+            };
+            let desc_order = !order_by[0].asc.unwrap_or(true);
+            nulls_last.resize(by.len(), !order_by[0].nulls_first.unwrap_or(desc_order));
+            descending.resize(by.len(), desc_order);
+        } else {
+            let columns = &columns_iter.collect::<Vec<_>>();
+            for ob in order_by {
+                // note: if not specified 'NULLS FIRST' is default for DESC, 'NULLS LAST' otherwise
+                // https://www.postgresql.org/docs/current/queries-order.html
+                let desc_order = !ob.asc.unwrap_or(true);
+                nulls_last.push(!ob.nulls_first.unwrap_or(desc_order));
+                descending.push(desc_order);
 
-        for ob in order_by {
-            // note: if not specified 'NULLS FIRST' is default for DESC, 'NULLS LAST' otherwise
-            // https://www.postgresql.org/docs/current/queries-order.html
-            let desc_order = !ob.asc.unwrap_or(true);
-            nulls_last.push(!ob.nulls_first.unwrap_or(desc_order));
-            descending.push(desc_order);
-
-            // translate order expression, allowing ordinal values
-            by.push(self.expr_or_ordinal(
-                &ob.expr,
-                &columns,
-                selected,
-                schema.as_deref(),
-                "ORDER BY",
-            )?)
+                // translate order expression, allowing ordinal values
+                by.push(self.expr_or_ordinal(
+                    &ob.expr,
+                    columns,
+                    selected,
+                    Some(&schema),
+                    "ORDER BY",
+                )?)
+            }
         }
         Ok(lf.sort_by_exprs(
             &by,

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -86,7 +86,7 @@ def test_group_by_all() -> None:
             COUNT(*) AS n
         FROM self
         GROUP BY ALL
-        ORDER BY a
+        ORDER BY ALL
         """
     )
     expected = pl.DataFrame(

--- a/py-polars/tests/unit/sql/test_order_by.py
+++ b/py-polars/tests/unit/sql/test_order_by.py
@@ -116,6 +116,14 @@ def test_order_by_misc_selection() -> None:
     res = df.sql("SELECT (x % y) AS xmy FROM self ORDER BY x % y NULLS FIRST")
     assert res.to_dict(as_series=False) == {"xmy": [None, None, 1, 3]}
 
+    # confirm that 'order by all' syntax prioritises cols
+    df = pl.DataFrame({"SOME": [0, 1], "ALL": [1, 0]})
+    res = df.sql("SELECT * FROM self ORDER BY ALL")
+    assert res.to_dict(as_series=False) == {"SOME": [1, 0], "ALL": [0, 1]}
+
+    res = df.sql("SELECT * FROM self ORDER BY ALL DESC")
+    assert res.to_dict(as_series=False) == {"SOME": [0, 1], "ALL": [1, 0]}
+
 
 def test_order_by_misc_16579() -> None:
     res = pl.DataFrame(
@@ -151,11 +159,13 @@ def test_order_by_multi_nulls_first_last() -> None:
     # │ 3    ┆ 1    │
     # └──────┴──────┘
 
-    res = df.sql("SELECT * FROM self ORDER BY x, y")
-    assert res.to_dict(as_series=False) == {
-        "x": [1, 3, None, None],
-        "y": [2, 1, 3, None],
-    }
+    res1 = df.sql("SELECT * FROM self ORDER BY x, y")
+    res2 = df.sql("SELECT * FROM self ORDER BY ALL")
+    for res in (res1, res2):
+        assert res.to_dict(as_series=False) == {
+            "x": [1, 3, None, None],
+            "y": [2, 1, 3, None],
+        }
 
     res = df.sql("SELECT * FROM self ORDER BY x NULLS FIRST, y")
     assert res.to_dict(as_series=False) == {
@@ -169,17 +179,21 @@ def test_order_by_multi_nulls_first_last() -> None:
         "y": [2, 1, None, 3],
     }
 
-    res = df.sql("SELECT * FROM self ORDER BY x NULLS FIRST, y NULLS FIRST")
-    assert res.to_dict(as_series=False) == {
-        "x": [None, None, 1, 3],
-        "y": [None, 3, 2, 1],
-    }
+    res1 = df.sql("SELECT * FROM self ORDER BY x NULLS FIRST, y NULLS FIRST")
+    res2 = df.sql("SELECT * FROM self ORDER BY ALL NULLS FIRST")
+    for res in (res1, res2):
+        assert res.to_dict(as_series=False) == {
+            "x": [None, None, 1, 3],
+            "y": [None, 3, 2, 1],
+        }
 
-    res = df.sql("SELECT * FROM self ORDER BY x DESC NULLS FIRST, y DESC NULLS FIRST")
-    assert res.to_dict(as_series=False) == {
-        "x": [None, None, 3, 1],
-        "y": [None, 3, 1, 2],
-    }
+    res1 = df.sql("SELECT * FROM self ORDER BY x DESC NULLS FIRST, y DESC NULLS FIRST")
+    res2 = df.sql("SELECT * FROM self ORDER BY ALL DESC NULLS FIRST")
+    for res in (res1, res2):
+        assert res.to_dict(as_series=False) == {
+            "x": [None, None, 3, 1],
+            "y": [None, 3, 1, 2],
+        }
 
     res = df.sql("SELECT * FROM self ORDER BY x DESC NULLS FIRST, y DESC NULLS LAST")
     assert res.to_dict(as_series=False) == {

--- a/py-polars/tests/unit/sql/test_order_by.py
+++ b/py-polars/tests/unit/sql/test_order_by.py
@@ -180,7 +180,7 @@ def test_order_by_multi_nulls_first_last() -> None:
     }
 
     res1 = df.sql("SELECT * FROM self ORDER BY x NULLS FIRST, y NULLS FIRST")
-    res2 = df.sql("SELECT * FROM self ORDER BY ALL NULLS FIRST")
+    res2 = df.sql("SELECT * FROM self ORDER BY All NULLS FIRST")
     for res in (res1, res2):
         assert res.to_dict(as_series=False) == {
             "x": [None, None, 1, 3],
@@ -188,7 +188,7 @@ def test_order_by_multi_nulls_first_last() -> None:
         }
 
     res1 = df.sql("SELECT * FROM self ORDER BY x DESC NULLS FIRST, y DESC NULLS FIRST")
-    res2 = df.sql("SELECT * FROM self ORDER BY ALL DESC NULLS FIRST")
+    res2 = df.sql("SELECT * FROM self ORDER BY all DESC NULLS FIRST")
     for res in (res1, res2):
         assert res.to_dict(as_series=False) == {
             "x": [None, None, 3, 1],


### PR DESCRIPTION
Continuing the recent onslaught of modern/friendly SQL syntax support...

* `SELECT * FROM df ORDER BY ALL`

This syntax automatically orders by _all_ columns found in the final selection[^1]. 
Can also apply `DESC` and `NULLS FIRST/LAST` modifiers, which get broadcast to all columns in the sort.

## Example

This query...
```python
pl.sql("""
  SELECT a, b, c, d, e, f, g FROM df
  ORDER BY 
    a DESC NULLS LAST, 
    b DESC NULLS LAST, 
    c DESC NULLS LAST,
    d DESC NULLS LAST, 
    e DESC NULLS LAST, 
    f DESC NULLS LAST,
    g DESC NULLS LAST
""")
```
...can now be written much more succinctly as:
```python
pl.sql("""
  SELECT a, b, c, d, e, f, g FROM df 
  ORDER BY ALL DESC NULLS LAST
""")
```

[^1]: **Note:** if an actual column called "ALL" (irrespective of case) is present, that is prioritised.