### PR TITLE
Allow passing custom HTTP headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,6 +3111,7 @@ dependencies = [
  "futures",
  "glob",
  "home",
+ "http 1.1.0",
  "itoa",
  "memchr",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ flate2 = { version = "1", default-features = false }
 futures = "0.3.25"
 hashbrown = { version = "0.14", features = ["rayon", "ahash", "serde"] }
 hex = "0.4.3"
+http = { version = "1.1", default-features = false }
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
 itoap = { version = "1", features = ["simd"] }

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -28,6 +28,7 @@ fast-float = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 glob = { version = "0.3" }
+http = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }
 memchr = { workspace = true }
 memmap = { package = "memmap2", version = "0.7" }
@@ -116,7 +117,7 @@ file_cache = ["async", "dep:blake3", "dep:fs4"]
 aws = ["object_store/aws", "cloud", "reqwest"]
 azure = ["object_store/azure", "cloud"]
 gcp = ["object_store/gcp", "cloud"]
-http = ["object_store/http", "cloud"]
+http = ["object_store/http", "cloud", "dep:http"]
 partition = ["polars-core/partition_by"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
 simd = []

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -113,7 +113,7 @@ pub async fn build_object_store(
                 {
                     let store = object_store::http::HttpBuilder::new()
                         .with_url(url)
-                        .with_client_options(super::get_client_options())
+                        .with_client_options(super::get_client_options(&options)?)
                         .build()?;
                     Ok::<_, PolarsError>(Arc::new(store) as Arc<dyn ObjectStore>)
                 }


### PR DESCRIPTION
Enables passing custom HTTP headers to cloud functions, e.g.:

```python
pl.scan_parquet('http://foobar.com/a/file.parquet', storage_options={'headers': ...})
```

Fixes #17197

TODO: The ConfigKey system used to parse storage options does not seem to have support for a mapping value. For now, the code takes `<value>` in  `'headers': <value>'` and passes it as the value of a "Foobar" header as PoC. Any idea on how best to support an actual `Dict[HeaderName, HeaderValue]` is welcome.