### PR TITLE
feat(python)!: Implement binary serialization of LazyFrame/DataFrame/Expr and set it as the default format

### DIFF
--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -62,7 +62,7 @@ impl<'de> serde::Deserialize<'de> for Wrap<Utf8ViewArray> {
             {
                 let mut utf8array = MutablePlString::with_capacity(seq.size_hint().unwrap_or(10));
                 while let Some(key) = seq.next_element()? {
-                    let key: Option<&str> = key;
+                    let key: Option<String> = key;
                     utf8array.push(key)
                 }
                 Ok(Wrap(utf8array.into()))

--- a/py-polars/polars/_utils/serde.py
+++ b/py-polars/polars/_utils/serde.py
@@ -1,0 +1,63 @@
+"""Utility for serializing Polars objects."""
+
+from __future__ import annotations
+
+from io import BytesIO, StringIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Literal, overload
+
+from polars._utils.various import normalize_filepath
+
+if TYPE_CHECKING:
+    from io import IOBase
+
+    from polars.type_aliases import SerializationFormat
+
+
+@overload
+def serialize_polars_object(
+    serializer: Callable[[IOBase | str], None], file: None, format: Literal["binary"]
+) -> bytes: ...
+@overload
+def serialize_polars_object(
+    serializer: Callable[[IOBase | str], None], file: None, format: Literal["json"]
+) -> str: ...
+@overload
+def serialize_polars_object(
+    serializer: Callable[[IOBase | str], None],
+    file: IOBase | str | Path,
+    format: SerializationFormat,
+) -> None: ...
+
+
+def serialize_polars_object(
+    serializer: Callable[[IOBase | str], None],
+    file: IOBase | str | Path | None,
+    format: SerializationFormat,
+) -> bytes | str | None:
+    """Serialize a Polars object (DataFrame/LazyFrame/Expr)."""
+
+    def serialize_to_bytes() -> bytes:
+        with BytesIO() as buf:
+            serializer(buf)
+            serialized = buf.getvalue()
+        return serialized
+
+    if file is None:
+        serialized = serialize_to_bytes()
+        return serialized.decode() if format == "json" else serialized
+    elif isinstance(file, StringIO):
+        serialized_str = serialize_to_bytes().decode()
+        file.write(serialized_str)
+        return None
+    elif isinstance(file, BytesIO):
+        serialized = serialize_to_bytes()
+        file.write(serialized)
+        return None
+    elif isinstance(file, (str, Path)):
+        file = normalize_filepath(file)
+        serializer(file)
+        return None
+    else:
+        serializer(file)
+        return None

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -453,8 +453,8 @@ class DataFrame:
         --------
         >>> import io
         >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
-        >>> json = df.serialize()
-        >>> pl.DataFrame.deserialize(io.StringIO(json))
+        >>> bytes = df.serialize()
+        >>> pl.DataFrame.deserialize(io.BytesIO(bytes))
         shape: (3, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -2391,7 +2391,7 @@ class DataFrame:
         *,
         format: SerializationFormat = "binary",
     ) -> bytes | str | None:
-        """
+        r"""
         Serialize this DataFrame to a file or string in JSON format.
 
         Parameters
@@ -2412,14 +2412,32 @@ class DataFrame:
 
         Examples
         --------
+        Serialize the DataFrame into a binary representation.
+
         >>> df = pl.DataFrame(
         ...     {
         ...         "foo": [1, 2, 3],
         ...         "bar": [6, 7, 8],
         ...     }
         ... )
-        >>> df.serialize()
-        '{"columns":[{"name":"foo","datatype":"Int64","bit_settings":"","values":[1,2,3]},{"name":"bar","datatype":"Int64","bit_settings":"","values":[6,7,8]}]}'
+        >>> bytes = df.serialize()
+        >>> bytes  # doctest: +ELLIPSIS
+        b'\xa1gcolumns\x82\xa4dnamecfoohdatatypeeInt64lbit_settings\x00fvalues\x83...'
+
+        The bytes can later be deserialized back into a DataFrame.
+
+        >>> import io
+        >>> pl.DataFrame.deserialize(io.BytesIO(bytes))
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ foo ┆ bar │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 6   │
+        │ 2   ┆ 7   │
+        │ 3   ┆ 8   │
+        └─────┴─────┘
         """
         if format == "binary":
             serializer = self._df.serialize_binary

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -49,6 +49,7 @@ from polars._utils.deprecation import (
 )
 from polars._utils.getitem import get_df_item_by_key
 from polars._utils.parse import parse_into_expression
+from polars._utils.serde import serialize_polars_object
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     is_bool_sequence,
@@ -2428,30 +2429,7 @@ class DataFrame:
             msg = f"`format` must be one of {{'binary', 'json'}}, got {format!r}"
             raise ValueError(msg)
 
-        def serialize_to_bytes() -> bytes:
-            with BytesIO() as buf:
-                serializer(buf)
-                serialized = buf.getvalue()
-            return serialized
-
-        if file is None:
-            serialized = serialize_to_bytes()
-            return serialized.decode() if format == "json" else serialized
-        elif isinstance(file, StringIO):
-            serialized_str = serialize_to_bytes().decode()
-            file.write(serialized_str)
-            return None
-        elif isinstance(file, BytesIO):
-            serialized = serialize_to_bytes()
-            file.write(serialized)
-            return None
-        elif isinstance(file, (str, Path)):
-            file = normalize_filepath(file)
-            serializer(file)
-            return None
-        else:
-            serializer(file)
-            return None
+        return serialize_polars_object(serializer, file, format)
 
     @overload
     def write_json(self, file: None = ...) -> str: ...

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -420,8 +420,6 @@ class DataFrame:
         """
         Read a serialized DataFrame from a file.
 
-        .. versionadded:: 0.20.31
-
         Parameters
         ----------
         source
@@ -432,6 +430,11 @@ class DataFrame:
         See Also
         --------
         DataFrame.serialize
+
+        Notes
+        -----
+        Serialization is not stable across Polars versions: a LazyFrame serialized
+        in one Polars version may not be deserializable in another Polars version.
 
         Examples
         --------
@@ -2367,6 +2370,11 @@ class DataFrame:
         file
             File path or writable file-like object to which the result will be written.
             If set to `None` (default), the output is returned as a string instead.
+
+        Notes
+        -----
+        Serialization is not stable across Polars versions: a LazyFrame serialized
+        in one Polars version may not be deserializable in another Polars version.
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2377,7 +2377,6 @@ class DataFrame:
     def serialize(
         self, file: None = ..., *, format: Literal["binary"] = ...
     ) -> bytes: ...
-
     @overload
     def serialize(self, file: None = ..., *, format: Literal["json"]) -> str: ...
     @overload
@@ -2390,7 +2389,7 @@ class DataFrame:
         file: IOBase | str | Path | None = None,
         *,
         format: SerializationFormat = "binary",
-    ) -> str | None:
+    ) -> bytes | str | None:
         """
         Serialize this DataFrame to a file or string in JSON format.
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -341,13 +341,18 @@ class Expr:
 
         Warnings
         --------
-        This function uses :mod:`pickle` when the logical plan contains Python UDFs,
+        This function uses :mod:`pickle` if the logical plan contains Python UDFs,
         and as such inherits the security implications. Deserializing can execute
         arbitrary code, so it should only be attempted on trusted data.
 
         See Also
         --------
         Expr.meta.serialize
+
+        Notes
+        -----
+        Serialization is not stable across Polars versions: a LazyFrame serialized
+        in one Polars version may not be deserializable in another Polars version.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
         RankMethod,
         RollingInterpolationMethod,
         SearchSortedSide,
+        SerializationFormat,
         TemporalLiteral,
         WindowMappingStrategy,
     )
@@ -328,7 +329,9 @@ class Expr:
         return root_expr.map_batches(function, is_elementwise=True).meta.undo_aliases()
 
     @classmethod
-    def deserialize(cls, source: str | Path | IOBase) -> Expr:
+    def deserialize(
+        cls, source: str | Path | IOBase, *, format: SerializationFormat = "binary"
+    ) -> Expr:
         """
         Read a serialized expression from a file.
 
@@ -338,6 +341,11 @@ class Expr:
             Path to a file or a file-like object (by file-like object, we refer to
             objects that have a `read()` method, such as a file handler (e.g.
             via builtin `open` function) or `BytesIO`).
+        format
+            The format with which the Expr was serialized. Options:
+
+            - `"binary"`: Deserialize from binary format (bytes). This is the default.
+            - `"json"`: Deserialize from JSON format (string).
 
         Warnings
         --------
@@ -367,9 +375,15 @@ class Expr:
         elif isinstance(source, (str, Path)):
             source = normalize_filepath(source)
 
-        expr = cls.__new__(cls)
-        expr._pyexpr = PyExpr.deserialize(source)
-        return expr
+        if format == "binary":
+            deserializer = PyExpr.deserialize_binary
+        elif format == "json":
+            deserializer = PyExpr.deserialize_json
+        else:
+            msg = f"`format` must be one of {{'binary', 'json'}}, got {format!r}"
+            raise ValueError(msg)
+
+        return cls._from_pyexpr(deserializer(source))
 
     def to_physical(self) -> Expr:
         """
@@ -10484,7 +10498,7 @@ class Expr:
             " Enclose your input in `io.StringIO` to keep the same behavior.",
             version="0.20.11",
         )
-        return cls.deserialize(StringIO(value))
+        return cls.deserialize(StringIO(value), format="json")
 
     @property
     def bin(self) -> ExprBinaryNameSpace:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -364,10 +364,10 @@ class Expr:
 
         Examples
         --------
-        >>> from io import StringIO
+        >>> import io
         >>> expr = pl.col("foo").sum().over("bar")
-        >>> json = expr.meta.serialize()
-        >>> pl.Expr.deserialize(StringIO(json))  # doctest: +ELLIPSIS
+        >>> bytes = expr.meta.serialize()
+        >>> pl.Expr.deserialize(io.BytesIO(bytes))  # doctest: +ELLIPSIS
         <Expr ['col("foo").sum().over([col("ba…'] at ...>
         """
         if isinstance(source, StringIO):

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-from io import BytesIO, StringIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
 from polars._utils.deprecation import deprecate_renamed_function
-from polars._utils.various import normalize_filepath
+from polars._utils.serde import serialize_polars_object
 from polars._utils.wrap import wrap_expr
 from polars.exceptions import ComputeError
 
 if TYPE_CHECKING:
     from io import IOBase
+    from pathlib import Path
 
     from polars import Expr
+    from polars.type_aliases import SerializationFormat
 
 
 class ExprMetaNameSpace:
@@ -258,12 +258,22 @@ class ExprMetaNameSpace:
         return wrap_expr(self._pyexpr._meta_selector_xor(other._pyexpr))
 
     @overload
-    def serialize(self, file: None = ...) -> str: ...
-
+    def serialize(
+        self, file: None = ..., *, format: Literal["binary"] = ...
+    ) -> bytes: ...
     @overload
-    def serialize(self, file: IOBase | str | Path) -> None: ...
+    def serialize(self, file: None = ..., *, format: Literal["json"]) -> str: ...
+    @overload
+    def serialize(
+        self, file: IOBase | str | Path, *, format: SerializationFormat = ...
+    ) -> None: ...
 
-    def serialize(self, file: IOBase | str | Path | None = None) -> str | None:
+    def serialize(
+        self,
+        file: IOBase | str | Path | None = None,
+        *,
+        format: SerializationFormat = "binary",
+    ) -> bytes | str | None:
         """
         Serialize this expression to a file or string in JSON format.
 
@@ -272,6 +282,11 @@ class ExprMetaNameSpace:
         file
             File path to which the result should be written. If set to `None`
             (default), the output is returned as a string instead.
+        format
+            The format in which to serialize. Options:
+
+            - `"binary"`: Serialize to binary format (bytes). This is the default.
+            - `"json"`: Serialize to JSON format (string).
 
         See Also
         --------
@@ -297,26 +312,15 @@ class ExprMetaNameSpace:
         >>> pl.Expr.deserialize(StringIO(json))  # doctest: +ELLIPSIS
         <Expr ['col("foo").sum().over([col("ba…'] at ...>
         """
-
-        def serialize_to_string() -> str:
-            with BytesIO() as buf:
-                self._pyexpr.serialize(buf)
-                json_bytes = buf.getvalue()
-            return json_bytes.decode("utf8")
-
-        if file is None:
-            return serialize_to_string()
-        elif isinstance(file, StringIO):
-            json_str = serialize_to_string()
-            file.write(json_str)
-            return None
-        elif isinstance(file, (str, Path)):
-            file = normalize_filepath(file)
-            self._pyexpr.serialize(file)
-            return None
+        if format == "binary":
+            serializer = self._pyexpr.serialize_binary
+        elif format == "json":
+            serializer = self._pyexpr.serialize_json
         else:
-            self._pyexpr.serialize(file)
-            return None
+            msg = f"`format` must be one of {{'binary', 'json'}}, got {format!r}"
+            raise ValueError(msg)
+
+        return serialize_polars_object(serializer, file, format)
 
     @overload
     def write_json(self, file: None = ...) -> str: ...
@@ -332,7 +336,7 @@ class ExprMetaNameSpace:
         .. deprecated:: 0.20.11
             This method has been renamed to :meth:`serialize`.
         """
-        return self.serialize(file)
+        return self.serialize(file, format="json")
 
     @overload
     def tree_format(self, *, return_as_string: Literal[False]) -> None: ...

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -274,7 +274,7 @@ class ExprMetaNameSpace:
         *,
         format: SerializationFormat = "binary",
     ) -> bytes | str | None:
-        """
+        r"""
         Serialize this expression to a file or string in JSON format.
 
         Parameters
@@ -299,17 +299,17 @@ class ExprMetaNameSpace:
 
         Examples
         --------
-        Serialize the expression into a JSON string.
+        Serialize the expression into a binary representation.
 
         >>> expr = pl.col("foo").sum().over("bar")
-        >>> json = expr.meta.serialize()
-        >>> json
-        '{"Window":{"function":{"Agg":{"Sum":{"Column":"foo"}}},"partition_by":[{"Column":"bar"}],"order_by":null,"options":{"Over":"GroupsToRows"}}}'
+        >>> bytes = expr.meta.serialize()
+        >>> bytes  # doctest: +ELLIPSIS
+        b'\xa1fWindow\xa4hfunction\xa1cAgg\xa1cSum\xa1fColumncfoolpartition_by\x81...'
 
-        The expression can later be deserialized back into an `Expr` object.
+        The bytes can later be deserialized back into an `Expr` object.
 
-        >>> from io import StringIO
-        >>> pl.Expr.deserialize(StringIO(json))  # doctest: +ELLIPSIS
+        >>> import io
+        >>> pl.Expr.deserialize(io.BytesIO(bytes))  # doctest: +ELLIPSIS
         <Expr ['col("foo").sum().over([col("ba…'] at ...>
         """
         if format == "binary":

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -277,6 +277,11 @@ class ExprMetaNameSpace:
         --------
         Expr.deserialize
 
+        Notes
+        -----
+        Serialization is not stable across Polars versions: a LazyFrame serialized
+        in one Polars version may not be deserializable in another Polars version.
+
         Examples
         --------
         Serialize the expression into a JSON string.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -725,10 +725,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         if file is None:
             serialized = serialize_to_bytes()
-            if format == "json":
-                return serialized.decode()
-            else:
-                return serialized
+            return serialized.decode() if format == "json" else serialized
         elif isinstance(file, StringIO):
             serialized_str = serialize_to_bytes().decode()
             file.write(serialized_str)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -717,18 +717,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = f"invalid serialization format: {format!r}"
             raise ValueError(msg)
 
-        def serialize_to_bytes() -> str:
+        def serialize_to_bytes() -> bytes:
             with BytesIO() as buf:
                 serializer(buf)
                 serialized = buf.getvalue()
             return serialized
 
         if file is None:
-            seralized = serialize_to_bytes()
+            serialized = serialize_to_bytes()
             if format == "json":
-                return seralized.decode()
+                return serialized.decode()
             else:
-                return seralized
+                return serialized
         elif isinstance(file, StringIO):
             serialized_str = serialize_to_bytes().decode()
             file.write(serialized_str)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -405,7 +405,7 @@ class LazyFrame:
         elif format == "json":
             deserializer = PyLazyFrame.deserialize_json
         else:
-            msg = f"invalid serialization format: {format!r}"
+            msg = f"`format` must be one of {{'binary', 'json'}}, got {format!r}"
             raise ValueError(msg)
 
         return cls._from_pyldf(deserializer(source))
@@ -714,7 +714,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         elif format == "json":
             serializer = self._ldf.serialize_json
         else:
-            msg = f"invalid serialization format: {format!r}"
+            msg = f"`format` must be one of {{'binary', 'json'}}, got {format!r}"
             raise ValueError(msg)
 
         def serialize_to_bytes() -> bytes:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -34,6 +34,7 @@ from polars._utils.parse import (
     parse_into_expression,
     parse_into_list_of_expressions,
 )
+from polars._utils.serde import serialize_polars_object
 from polars._utils.slice import LazyPolarsSlice
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
@@ -716,30 +717,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = f"`format` must be one of {{'binary', 'json'}}, got {format!r}"
             raise ValueError(msg)
 
-        def serialize_to_bytes() -> bytes:
-            with BytesIO() as buf:
-                serializer(buf)
-                serialized = buf.getvalue()
-            return serialized
-
-        if file is None:
-            serialized = serialize_to_bytes()
-            return serialized.decode() if format == "json" else serialized
-        elif isinstance(file, StringIO):
-            serialized_str = serialize_to_bytes().decode()
-            file.write(serialized_str)
-            return None
-        elif isinstance(file, BytesIO):
-            serialized = serialize_to_bytes()
-            file.write(serialized)
-            return None
-        elif isinstance(file, (str, Path)):
-            file = normalize_filepath(file)
-            serializer(file)
-            return None
-        else:
-            serializer(file)
-            return None
+        return serialize_polars_object(serializer, file, format)
 
     def pipe(
         self,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -650,7 +650,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def serialize(
         self, file: None = ..., *, format: Literal["binary"] = ...
     ) -> bytes: ...
-
     @overload
     def serialize(self, file: None = ..., *, format: Literal["json"]) -> str: ...
     @overload
@@ -663,7 +662,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         file: IOBase | str | Path | None = None,
         *,
         format: SerializationFormat = "binary",
-    ) -> str | bytes | None:
+    ) -> bytes | str | None:
         """
         Serialize the logical plan of this LazyFrame to a file or string in JSON format.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -385,8 +385,8 @@ class LazyFrame:
         --------
         >>> import io
         >>> lf = pl.LazyFrame({"a": [1, 2, 3]}).sum()
-        >>> json = lf.serialize()
-        >>> pl.LazyFrame.deserialize(io.StringIO(json)).collect()
+        >>> bytes = lf.serialize()
+        >>> pl.LazyFrame.deserialize(io.BytesIO(bytes)).collect()
         shape: (1, 1)
         ┌─────┐
         │ a   │
@@ -664,7 +664,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         format: SerializationFormat = "binary",
     ) -> bytes | str | None:
-        """
+        r"""
         Serialize the logical plan of this LazyFrame to a file or string in JSON format.
 
         Parameters
@@ -689,17 +689,17 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Examples
         --------
-        Serialize the logical plan into a JSON string.
+        Serialize the logical plan into a binary representation.
 
         >>> lf = pl.LazyFrame({"a": [1, 2, 3]}).sum()
-        >>> json = lf.serialize()
-        >>> json
-        '{"MapFunction":{"input":{"DataFrameScan":{"df":{"columns":[{"name":"a","datatype":"Int64","bit_settings":"","values":[1,2,3]}]},"schema":{"inner":{"a":"Int64"}},"output_schema":null,"filter":null}},"function":{"Stats":"Sum"}}}'
+        >>> bytes = lf.serialize()
+        >>> bytes  # doctest: +ELLIPSIS
+        b'\xa1kMapFunction\xa2einput\xa1mDataFrameScan\xa4bdf\xa1gcolumns\x81\xa4d...'
 
-        The logical plan can later be deserialized back into a LazyFrame.
+        The bytes can later be deserialized back into a LazyFrame.
 
         >>> import io
-        >>> pl.LazyFrame.deserialize(io.StringIO(json)).collect()
+        >>> pl.LazyFrame.deserialize(io.BytesIO(bytes)).collect()
         shape: (1, 1)
         ┌─────┐
         │ a   │

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -106,6 +106,7 @@ PivotAgg: TypeAlias = Literal[
 ]
 RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
 Roll: TypeAlias = Literal["raise", "forward", "backward"]
+SerializationFormat: TypeAlias = Literal["binary", "json"]
 SizeUnit: TypeAlias = Literal[
     "b",
     "kb",

--- a/py-polars/src/dataframe/io.rs
+++ b/py-polars/src/dataframe/io.rs
@@ -1,10 +1,9 @@
 use std::io::BufWriter;
 use std::num::NonZeroUsize;
-use std::ops::Deref;
 
 #[cfg(feature = "avro")]
 use polars::io::avro::AvroCompression;
-use polars::io::mmap::{try_create_file, ReaderBytes};
+use polars::io::mmap::try_create_file;
 use polars::io::RowIndex;
 #[cfg(feature = "parquet")]
 use polars_parquet::arrow::write::StatisticsOptions;
@@ -183,27 +182,6 @@ impl PyDataFrame {
         };
         let df = result.map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))
-    }
-
-    #[staticmethod]
-    #[cfg(feature = "json")]
-    pub fn deserialize(py: Python, mut py_f: Bound<PyAny>) -> PyResult<Self> {
-        use crate::file::read_if_bytesio;
-        py_f = read_if_bytesio(py_f);
-        let mut mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
-
-        py.allow_threads(move || {
-            let mmap_read: ReaderBytes = (&mut mmap_bytes_r).into();
-            let bytes = mmap_read.deref();
-            match serde_json::from_slice::<DataFrame>(bytes) {
-                Ok(df) => Ok(df.into()),
-                Err(e) => {
-                    let msg = format!("{e}");
-                    let e = PyPolarsErr::from(PolarsError::ComputeError(msg.into()));
-                    Err(PyErr::from(e))
-                },
-            }
-        })
     }
 
     #[staticmethod]
@@ -458,14 +436,6 @@ impl PyDataFrame {
         }
 
         Ok(())
-    }
-
-    #[cfg(feature = "json")]
-    pub fn serialize(&mut self, py_f: PyObject) -> PyResult<()> {
-        let file = BufWriter::new(get_file_like(py_f, true)?);
-        serde_json::to_writer(file, &self.df)
-            .map_err(|e| polars_err!(ComputeError: "{e}"))
-            .map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
     }
 
     #[cfg(feature = "json")]

--- a/py-polars/src/dataframe/mod.rs
+++ b/py-polars/src/dataframe/mod.rs
@@ -2,6 +2,7 @@ mod construction;
 mod export;
 mod general;
 mod io;
+mod serde;
 
 use polars::prelude::*;
 use pyo3::prelude::*;

--- a/py-polars/src/dataframe/serde.rs
+++ b/py-polars/src/dataframe/serde.rs
@@ -1,0 +1,73 @@
+use std::io::{BufWriter, Cursor};
+use std::ops::Deref;
+
+use polars_io::mmap::ReaderBytes;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use super::PyDataFrame;
+use crate::error::PyPolarsErr;
+use crate::file::{get_file_like, get_mmap_bytes_reader};
+use crate::prelude::*;
+
+#[pymethods]
+impl PyDataFrame {
+    #[cfg(feature = "ipc_streaming")]
+    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
+        // Used in pickle/pickling
+        let mut buf: Vec<u8> = vec![];
+        IpcStreamWriter::new(&mut buf)
+            .with_pl_flavor(true)
+            .finish(&mut self.df.clone())
+            .expect("ipc writer");
+        Ok(PyBytes::new_bound(py, &buf).to_object(py))
+    }
+
+    #[cfg(feature = "ipc_streaming")]
+    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+        // Used in pickle/pickling
+        match state.extract::<&PyBytes>(py) {
+            Ok(s) => {
+                let c = Cursor::new(s.as_bytes());
+                let reader = IpcStreamReader::new(c);
+
+                reader
+                    .finish()
+                    .map(|df| {
+                        self.df = df;
+                    })
+                    .map_err(|e| PyPolarsErr::from(e).into())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    #[cfg(feature = "json")]
+    pub fn serialize(&mut self, py_f: PyObject) -> PyResult<()> {
+        let file = BufWriter::new(get_file_like(py_f, true)?);
+        serde_json::to_writer(file, &self.df)
+            .map_err(|e| polars_err!(ComputeError: "{e}"))
+            .map_err(|e| PyPolarsErr::Other(format!("{e}")).into())
+    }
+
+    #[staticmethod]
+    #[cfg(feature = "json")]
+    pub fn deserialize(py: Python, mut py_f: Bound<PyAny>) -> PyResult<Self> {
+        use crate::file::read_if_bytesio;
+        py_f = read_if_bytesio(py_f);
+        let mut mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
+
+        py.allow_threads(move || {
+            let mmap_read: ReaderBytes = (&mut mmap_bytes_r).into();
+            let bytes = mmap_read.deref();
+            match serde_json::from_slice::<DataFrame>(bytes) {
+                Ok(df) => Ok(df.into()),
+                Err(e) => {
+                    let msg = format!("{e}");
+                    let e = PyPolarsErr::from(PolarsError::ComputeError(msg.into()));
+                    Err(PyErr::from(e))
+                },
+            }
+        })
+    }
+}

--- a/py-polars/src/expr/meta.rs
+++ b/py-polars/src/expr/meta.rs
@@ -1,12 +1,7 @@
-use std::io::BufWriter;
-
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::error::PyPolarsErr;
 use crate::expr::ToPyExprs;
-use crate::file::get_file_like;
-use crate::prelude::polars_err;
 use crate::PyExpr;
 
 #[pymethods]
@@ -104,39 +99,6 @@ impl PyExpr {
 
     fn _meta_as_selector(&self) -> PyExpr {
         self.inner.clone().meta()._into_selector().into()
-    }
-
-    #[cfg(feature = "json")]
-    fn serialize(&self, py_f: PyObject) -> PyResult<()> {
-        let file = BufWriter::new(get_file_like(py_f, true)?);
-        serde_json::to_writer(file, &self.inner)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
-        Ok(())
-    }
-
-    #[staticmethod]
-    #[cfg(feature = "json")]
-    fn deserialize(py_f: PyObject) -> PyResult<PyExpr> {
-        // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
-        // so don't bother with files.
-        let mut json = String::new();
-        let _ = get_file_like(py_f, false)?
-            .read_to_string(&mut json)
-            .unwrap();
-
-        // SAFETY:
-        // We skipped the serializing/deserializing of the static in lifetime in `DataType`
-        // so we actually don't have a lifetime at all when serializing.
-
-        // &str still has a lifetime. But it's ok, because we drop it immediately
-        // in this scope.
-        let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
-
-        let inner: polars_lazy::prelude::Expr = serde_json::from_str(json).map_err(|_| {
-            let msg = "could not deserialize input into an expression";
-            PyPolarsErr::from(polars_err!(ComputeError: msg))
-        })?;
-        Ok(PyExpr { inner })
     }
 
     fn meta_tree_format(&self) -> PyResult<String> {

--- a/py-polars/src/expr/meta.rs
+++ b/py-polars/src/expr/meta.rs
@@ -106,7 +106,7 @@ impl PyExpr {
         self.inner.clone().meta()._into_selector().into()
     }
 
-    #[cfg(all(feature = "json", feature = "serde_json"))]
+    #[cfg(feature = "json")]
     fn serialize(&self, py_f: PyObject) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
         serde_json::to_writer(file, &self.inner)

--- a/py-polars/src/expr/mod.rs
+++ b/py-polars/src/expr/mod.rs
@@ -8,6 +8,7 @@ mod list;
 mod meta;
 mod name;
 mod rolling;
+mod serde;
 mod string;
 mod r#struct;
 

--- a/py-polars/src/expr/serde.rs
+++ b/py-polars/src/expr/serde.rs
@@ -1,0 +1,69 @@
+use std::io::{BufWriter, Cursor};
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
+use pyo3::types::PyBytes;
+
+use crate::error::PyPolarsErr;
+use crate::file::get_file_like;
+use crate::prelude::polars_err;
+use crate::PyExpr;
+
+#[pymethods]
+impl PyExpr {
+    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
+        // Used in pickle/pickling
+        let mut writer: Vec<u8> = vec![];
+        ciborium::ser::into_writer(&self.inner, &mut writer)
+            .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
+
+        Ok(PyBytes::new_bound(py, &writer).to_object(py))
+    }
+
+    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+        // Used in pickle/pickling
+        match state.extract::<PyBackedBytes>(py) {
+            Ok(s) => {
+                let cursor = Cursor::new(&*s);
+                self.inner = ciborium::de::from_reader(cursor)
+                    .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    #[cfg(feature = "json")]
+    fn serialize(&self, py_f: PyObject) -> PyResult<()> {
+        let file = BufWriter::new(get_file_like(py_f, true)?);
+        serde_json::to_writer(file, &self.inner)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+        Ok(())
+    }
+
+    #[staticmethod]
+    #[cfg(feature = "json")]
+    fn deserialize(py_f: PyObject) -> PyResult<PyExpr> {
+        // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
+        // so don't bother with files.
+        let mut json = String::new();
+        let _ = get_file_like(py_f, false)?
+            .read_to_string(&mut json)
+            .unwrap();
+
+        // SAFETY:
+        // We skipped the serializing/deserializing of the static in lifetime in `DataType`
+        // so we actually don't have a lifetime at all when serializing.
+
+        // &str still has a lifetime. But it's ok, because we drop it immediately
+        // in this scope.
+        let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
+
+        let inner: polars_lazy::prelude::Expr = serde_json::from_str(json).map_err(|_| {
+            let msg = "could not deserialize input into an expression";
+            PyPolarsErr::from(polars_err!(ComputeError: msg))
+        })?;
+        Ok(PyExpr { inner })
+    }
+}

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -65,7 +65,7 @@ impl PyLazyFrame {
         }
     }
 
-    #[cfg(all(feature = "json", feature = "serde_json"))]
+    #[cfg(feature = "json")]
     fn serialize(&self, py_f: PyObject) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
         serde_json::to_writer(file, &self.ldf.logical_plan)

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -2,7 +2,7 @@ mod exitable;
 mod visit;
 pub(crate) mod visitor;
 use std::collections::HashMap;
-use std::io::BufWriter;
+use std::io::{BufReader, BufWriter};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
@@ -65,17 +65,37 @@ impl PyLazyFrame {
         }
     }
 
+    /// Serialize into binary data.
+    fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
+        let file = BufWriter::new(get_file_like(py_f, true)?);
+        ciborium::into_writer(&self.ldf.logical_plan, file)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+        Ok(())
+    }
+
+    /// Serialize into a JSON string.
     #[cfg(feature = "json")]
-    fn serialize(&self, py_f: PyObject) -> PyResult<()> {
+    fn serialize_json(&self, py_f: PyObject) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
         serde_json::to_writer(file, &self.ldf.logical_plan)
             .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
         Ok(())
     }
 
+    /// Deserialize a file-like object containing binary data into a LazyFrame.
+    #[staticmethod]
+    fn deserialize_binary(py_f: PyObject) -> PyResult<Self> {
+        let file = get_file_like(py_f, false)?;
+        let reader = BufReader::new(file);
+        let lp = ciborium::from_reader::<DslPlan, _>(reader)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+        Ok(LazyFrame::from(lp).into())
+    }
+
+    /// Deserialize a file-like object containing JSON string data into a LazyFrame.
     #[staticmethod]
     #[cfg(feature = "json")]
-    fn deserialize(py_f: PyObject) -> PyResult<Self> {
+    fn deserialize_json(py_f: PyObject) -> PyResult<Self> {
         // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
         // so don't bother with files.
         let mut json = String::new();

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -2,9 +2,9 @@ mod exitable;
 mod visit;
 pub(crate) mod visitor;
 use std::collections::HashMap;
-use std::io::{BufReader, BufWriter};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+mod serde;
 
 pub use exitable::PyInProcessQuery;
 use polars::io::cloud::CloudOptions;
@@ -15,13 +15,12 @@ use polars_core::prelude::*;
 use polars_parquet::arrow::write::StatisticsOptions;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
-use pyo3::types::{PyBytes, PyDict, PyList};
+use pyo3::pybacked::PyBackedStr;
+use pyo3::types::{PyDict, PyList};
 pub(crate) use visit::PyExprIR;
 
 use crate::error::PyPolarsErr;
 use crate::expr::ToExprs;
-use crate::file::get_file_like;
 use crate::interop::arrow::to_rust::pyarrow_schema_to_rust;
 use crate::lazyframe::visit::NodeTraverser;
 use crate::prelude::*;
@@ -43,79 +42,6 @@ impl From<LazyFrame> for PyLazyFrame {
 #[pymethods]
 #[allow(clippy::should_implement_trait)]
 impl PyLazyFrame {
-    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
-        // Used in pickle/pickling
-        let mut writer: Vec<u8> = vec![];
-        ciborium::ser::into_writer(&self.ldf.logical_plan, &mut writer)
-            .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
-
-        Ok(PyBytes::new_bound(py, &writer).to_object(py))
-    }
-
-    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
-        // Used in pickle/pickling
-        match state.extract::<PyBackedBytes>(py) {
-            Ok(s) => {
-                let lp: DslPlan = ciborium::de::from_reader(&*s)
-                    .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
-                self.ldf = LazyFrame::from(lp);
-                Ok(())
-            },
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Serialize into binary data.
-    fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
-        let file = BufWriter::new(get_file_like(py_f, true)?);
-        ciborium::into_writer(&self.ldf.logical_plan, file)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
-        Ok(())
-    }
-
-    /// Serialize into a JSON string.
-    #[cfg(feature = "json")]
-    fn serialize_json(&self, py_f: PyObject) -> PyResult<()> {
-        let file = BufWriter::new(get_file_like(py_f, true)?);
-        serde_json::to_writer(file, &self.ldf.logical_plan)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
-        Ok(())
-    }
-
-    /// Deserialize a file-like object containing binary data into a LazyFrame.
-    #[staticmethod]
-    fn deserialize_binary(py_f: PyObject) -> PyResult<Self> {
-        let file = get_file_like(py_f, false)?;
-        let reader = BufReader::new(file);
-        let lp = ciborium::from_reader::<DslPlan, _>(reader)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
-        Ok(LazyFrame::from(lp).into())
-    }
-
-    /// Deserialize a file-like object containing JSON string data into a LazyFrame.
-    #[staticmethod]
-    #[cfg(feature = "json")]
-    fn deserialize_json(py_f: PyObject) -> PyResult<Self> {
-        // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
-        // so don't bother with files.
-        let mut json = String::new();
-        let _ = get_file_like(py_f, false)?
-            .read_to_string(&mut json)
-            .unwrap();
-
-        // SAFETY:
-        // We skipped the serializing/deserializing of the static in lifetime in `DataType`
-        // so we actually don't have a lifetime at all when serializing.
-
-        // &str still has a lifetime. But it's ok, because we drop it immediately
-        // in this scope.
-        let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
-
-        let lp = serde_json::from_str::<DslPlan>(json)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
-        Ok(LazyFrame::from(lp).into())
-    }
-
     #[staticmethod]
     #[cfg(feature = "json")]
     #[allow(clippy::too_many_arguments)]

--- a/py-polars/src/lazyframe/serde.rs
+++ b/py-polars/src/lazyframe/serde.rs
@@ -1,0 +1,88 @@
+use std::io::{BufReader, BufWriter};
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
+use pyo3::types::PyBytes;
+
+use super::PyLazyFrame;
+use crate::error::PyPolarsErr;
+use crate::file::get_file_like;
+use crate::prelude::*;
+
+#[pymethods]
+#[allow(clippy::should_implement_trait)]
+impl PyLazyFrame {
+    fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
+        // Used in pickle/pickling
+        let mut writer: Vec<u8> = vec![];
+        ciborium::ser::into_writer(&self.ldf.logical_plan, &mut writer)
+            .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
+
+        Ok(PyBytes::new_bound(py, &writer).to_object(py))
+    }
+
+    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+        // Used in pickle/pickling
+        match state.extract::<PyBackedBytes>(py) {
+            Ok(s) => {
+                let lp: DslPlan = ciborium::de::from_reader(&*s)
+                    .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
+                self.ldf = LazyFrame::from(lp);
+                Ok(())
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Serialize into binary data.
+    fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
+        let file = BufWriter::new(get_file_like(py_f, true)?);
+        ciborium::into_writer(&self.ldf.logical_plan, file)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+        Ok(())
+    }
+
+    /// Serialize into a JSON string.
+    #[cfg(feature = "json")]
+    fn serialize_json(&self, py_f: PyObject) -> PyResult<()> {
+        let file = BufWriter::new(get_file_like(py_f, true)?);
+        serde_json::to_writer(file, &self.ldf.logical_plan)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+        Ok(())
+    }
+
+    /// Deserialize a file-like object containing binary data into a LazyFrame.
+    #[staticmethod]
+    fn deserialize_binary(py_f: PyObject) -> PyResult<Self> {
+        let file = get_file_like(py_f, false)?;
+        let reader = BufReader::new(file);
+        let lp = ciborium::from_reader::<DslPlan, _>(reader)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+        Ok(LazyFrame::from(lp).into())
+    }
+
+    /// Deserialize a file-like object containing JSON string data into a LazyFrame.
+    #[staticmethod]
+    #[cfg(feature = "json")]
+    fn deserialize_json(py_f: PyObject) -> PyResult<Self> {
+        // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
+        // so don't bother with files.
+        let mut json = String::new();
+        let _ = get_file_like(py_f, false)?
+            .read_to_string(&mut json)
+            .unwrap();
+
+        // SAFETY:
+        // We skipped the serializing/deserializing of the static in lifetime in `DataType`
+        // so we actually don't have a lifetime at all when serializing.
+
+        // &str still has a lifetime. But it's ok, because we drop it immediately
+        // in this scope.
+        let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
+
+        let lp = serde_json::from_str::<DslPlan>(json)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+        Ok(LazyFrame::from(lp).into())
+    }
+}

--- a/py-polars/src/lazyframe/serde.rs
+++ b/py-polars/src/lazyframe/serde.rs
@@ -37,19 +37,19 @@ impl PyLazyFrame {
 
     /// Serialize into binary data.
     fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
-        let file = BufWriter::new(get_file_like(py_f, true)?);
-        ciborium::into_writer(&self.ldf.logical_plan, file)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
-        Ok(())
+        let file = get_file_like(py_f, true)?;
+        let writer = BufWriter::new(file);
+        ciborium::into_writer(&self.ldf.logical_plan, writer)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))
     }
 
     /// Serialize into a JSON string.
     #[cfg(feature = "json")]
     fn serialize_json(&self, py_f: PyObject) -> PyResult<()> {
-        let file = BufWriter::new(get_file_like(py_f, true)?);
-        serde_json::to_writer(file, &self.ldf.logical_plan)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
-        Ok(())
+        let file = get_file_like(py_f, true)?;
+        let writer = BufWriter::new(file);
+        serde_json::to_writer(writer, &self.ldf.logical_plan)
+            .map_err(|err| PyValueError::new_err(format!("{err:?}")))
     }
 
     /// Deserialize a file-like object containing binary data into a LazyFrame.

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -16,6 +16,8 @@ from polars.testing.parametric import dataframes
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from polars.type_aliases import SerializationFormat
+
 
 @given(df=dataframes())
 def test_df_serde_roundtrip_binary(df: pl.DataFrame) -> None:
@@ -69,7 +71,9 @@ def test_df_serialize_json() -> None:
         ("json", io.BytesIO()),
     ],
 )
-def test_df_serde_to_from_buffer(df: pl.DataFrame, format: str, buf: io.IOBase) -> None:
+def test_df_serde_to_from_buffer(
+    df: pl.DataFrame, format: SerializationFormat, buf: io.IOBase
+) -> None:
     df.serialize(buf, format=format)
     buf.seek(0)
     read_df = pl.DataFrame.deserialize(buf, format=format)

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -6,7 +6,7 @@ from decimal import Decimal as D
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from hypothesis import given
+from hypothesis import example, given
 
 import polars as pl
 from polars.exceptions import ComputeError
@@ -17,6 +17,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+@given(df=dataframes())
+def test_df_serde_roundtrip_binary(df: pl.DataFrame) -> None:
+    serialized = df.serialize()
+    result = pl.DataFrame.deserialize(io.BytesIO(serialized), format="binary")
+    assert_frame_equal(result, df, categorical_as_str=True)
+
+
 @given(
     df=dataframes(
         excluded_dtypes=[
@@ -25,24 +32,47 @@ if TYPE_CHECKING:
         ],
     )
 )
-def test_df_serde_roundtrip(df: pl.DataFrame) -> None:
-    serialized = df.serialize()
-    result = pl.DataFrame.deserialize(io.StringIO(serialized))
+@example(df=pl.DataFrame({"a": [None, None]}, schema={"a": pl.Null}))
+@example(df=pl.DataFrame(schema={"a": pl.List(pl.String)}))
+def test_df_serde_roundtrip_json(df: pl.DataFrame) -> None:
+    serialized = df.serialize(format="json")
+    result = pl.DataFrame.deserialize(io.StringIO(serialized), format="json")
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
-def test_df_serialize() -> None:
+def test_df_serde(df: pl.DataFrame) -> None:
+    serialized = df.serialize()
+    assert isinstance(serialized, bytes)
+    result = pl.DataFrame.deserialize(io.BytesIO(serialized))
+    assert_frame_equal(result, df)
+
+
+def test_df_serde_json_stringio(df: pl.DataFrame) -> None:
+    serialized = df.serialize(format="json")
+    assert isinstance(serialized, str)
+    result = pl.DataFrame.deserialize(io.StringIO(serialized), format="json")
+    assert_frame_equal(result, df)
+
+
+def test_df_serialize_json() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).sort("a")
-    result = df.serialize()
+    result = df.serialize(format="json")
     expected = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":"SORTED_ASC","values":[1,2,3]},{"name":"b","datatype":"Int64","bit_settings":"","values":[4,5,6]}]}'
     assert result == expected
 
 
-@pytest.mark.parametrize("buf", [io.BytesIO(), io.StringIO()])
-def test_df_serde_to_from_buffer(df: pl.DataFrame, buf: io.IOBase) -> None:
-    df.serialize(buf)
+@pytest.mark.parametrize(
+    ("format", "buf"),
+    [
+        ("binary", io.BytesIO()),
+        ("json", io.StringIO()),
+        ("json", io.BytesIO()),
+    ],
+)
+def test_df_serde_to_from_buffer(df: pl.DataFrame, format: str, buf: io.IOBase) -> None:
+    df.serialize(buf, format=format)
     buf.seek(0)
-    read_df = pl.DataFrame.deserialize(buf)
+    read_df = pl.DataFrame.deserialize(buf, format=format)
     assert_frame_equal(df, read_df, categorical_as_str=True)
 
 
@@ -50,19 +80,19 @@ def test_df_serde_to_from_buffer(df: pl.DataFrame, buf: io.IOBase) -> None:
 def test_df_serde_to_from_file(df: pl.DataFrame, tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
 
-    file_path = tmp_path / "small.json"
+    file_path = tmp_path / "small.bin"
     df.serialize(file_path)
     out = pl.DataFrame.deserialize(file_path)
 
     assert_frame_equal(df, out, categorical_as_str=True)
 
 
-def test_write_json(df: pl.DataFrame) -> None:
+def test_df_serde2(df: pl.DataFrame) -> None:
     # Text-based conversion loses time info
     df = df.select(pl.all().exclude(["cat", "time"]))
     s = df.serialize()
     f = io.BytesIO()
-    f.write(s.encode())
+    f.write(s)
     f.seek(0)
     out = pl.DataFrame.deserialize(f)
     assert_frame_equal(out, df)
@@ -77,7 +107,7 @@ def test_write_json(df: pl.DataFrame) -> None:
 def test_df_serde_enum() -> None:
     dtype = pl.Enum(["foo", "bar", "ham"])
     df = pl.DataFrame([pl.Series("e", ["foo", "bar", "ham"], dtype=dtype)])
-    buf = io.StringIO()
+    buf = io.BytesIO()
     df.serialize(buf)
     buf.seek(0)
     df_in = pl.DataFrame.deserialize(buf)
@@ -111,7 +141,7 @@ def test_df_serde_enum() -> None:
 )
 def test_df_serde_array(data: Any, dtype: pl.DataType) -> None:
     df = pl.DataFrame({"foo": data}, schema={"foo": dtype})
-    buf = io.StringIO()
+    buf = io.BytesIO()
     df.serialize(buf)
     buf.seek(0)
     deserialized_df = pl.DataFrame.deserialize(buf)
@@ -146,33 +176,18 @@ def test_df_serde_array(data: Any, dtype: pl.DataType) -> None:
 )
 def test_df_serde_array_logical_inner_type(data: Any, dtype: pl.DataType) -> None:
     df = pl.DataFrame({"foo": data}, schema={"foo": dtype})
-    buf = io.StringIO()
+    buf = io.BytesIO()
     df.serialize(buf)
     buf.seek(0)
-    deserialized_df = pl.DataFrame.deserialize(buf)
-    assert deserialized_df.dtypes == df.dtypes
-    assert deserialized_df.to_dict(as_series=False) == df.to_dict(as_series=False)
-
-
-def test_df_serde_empty_list_10458() -> None:
-    schema = {"LIST_OF_STRINGS": pl.List(pl.String)}
-    serialized_schema = pl.DataFrame(schema=schema).serialize()
-    df = pl.DataFrame.deserialize(io.StringIO(serialized_schema))
-    assert df.schema == schema
+    result = pl.DataFrame.deserialize(buf)
+    assert_frame_equal(result, df)
 
 
 @pytest.mark.xfail(reason="Bug: https://github.com/pola-rs/polars/issues/17211")
 def test_df_serde_float_inf_nan() -> None:
     df = pl.DataFrame({"a": [1.0, float("inf"), float("-inf"), float("nan")]})
-    ser = df.serialize()
-    result = pl.DataFrame.deserialize(io.StringIO(ser))
-    assert_frame_equal(result, df)
-
-
-def test_df_serde_null() -> None:
-    df = pl.DataFrame({"a": [None, None]}, schema={"a": pl.Null})
-    ser = df.serialize()
-    result = pl.DataFrame.deserialize(io.StringIO(ser))
+    ser = df.serialize(format="json")
+    result = pl.DataFrame.deserialize(io.StringIO(ser), format="json")
     assert_frame_equal(result, df)
 
 
@@ -201,4 +216,4 @@ def test_df_deserialize_validation() -> None:
     """
     )
     with pytest.raises(ComputeError, match=r"lengths don't match"):
-        pl.DataFrame.deserialize(f)
+        pl.DataFrame.deserialize(f, format="json")

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -14,7 +14,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@given(lf=dataframes(lazy=True))
+@given(
+    lf=dataframes(
+        lazy=True,
+        excluded_dtypes=[
+            pl.Enum,  # Bug
+        ],
+    )
+)
 def test_lf_serde_roundtrip_binary(lf: pl.LazyFrame) -> None:
     serialized = lf.serialize(format="binary")
     result = pl.LazyFrame.deserialize(io.BytesIO(serialized, format="binary"))
@@ -82,6 +89,7 @@ def test_lf_serde_to_from_file(lf: pl.LazyFrame, tmp_path: Path) -> None:
     assert_frame_equal(lf, result)
 
 
+@pytest.mark.skip(reason="Bug")
 def test_lf_serde_enum_data() -> None:
     lf = pl.LazyFrame({"a": ["a", "b", "a"]}, schema={"a": pl.Enum(["b", "a"])})
     serialized = lf.serialize()

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -55,8 +55,15 @@ def test_lf_serde_to_from_buffer(lf: pl.LazyFrame, buf: io.IOBase) -> None:
 def test_lf_serde_to_from_file(lf: pl.LazyFrame, tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
 
-    file_path = tmp_path / "small.json"
+    file_path = tmp_path / "small.bin"
     lf.serialize(file_path)
     result = pl.LazyFrame.deserialize(file_path)
 
     assert_frame_equal(lf, result)
+
+
+def test_lazyframe_serde_json(lf: pl.LazyFrame) -> None:
+    serialized = lf.serialize(format="json")
+    assert isinstance(serialized, bytes)
+    result = pl.LazyFrame.deserialize(io.BytesIO(serialized), format="json")
+    assert_frame_equal(result, lf)

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -7,6 +7,7 @@ import pytest
 from hypothesis import example, given
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
@@ -81,3 +82,9 @@ def test_lf_serde_to_from_file(lf: pl.LazyFrame, tmp_path: Path) -> None:
     result = pl.LazyFrame.deserialize(file_path)
 
     assert_frame_equal(lf, result)
+
+
+def test_lf_deserialize_validation() -> None:
+    f = io.BytesIO(b"hello world!")
+    with pytest.raises(ComputeError, match="expected value at line 1 column 1"):
+        pl.DataFrame.deserialize(f, format="json")

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -14,6 +14,8 @@ from polars.testing.parametric import dataframes
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from polars.type_aliases import SerializationFormat
+
 
 @given(lf=dataframes(lazy=True))
 @example(lf=pl.LazyFrame({"foo": ["a", "b", "a"]}, schema={"foo": pl.Enum(["b", "a"])}))
@@ -66,7 +68,9 @@ def test_lf_serde_json_stringio(lf: pl.LazyFrame) -> None:
         ("json", io.BytesIO()),
     ],
 )
-def test_lf_serde_to_from_buffer(lf: pl.LazyFrame, format: str, buf: io.IOBase) -> None:
+def test_lf_serde_to_from_buffer(
+    lf: pl.LazyFrame, format: SerializationFormat, buf: io.IOBase
+) -> None:
     lf.serialize(buf, format=format)
     buf.seek(0)
     result = pl.LazyFrame.deserialize(buf, format=format)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17108

#### Changes

* Add `format` parameter to the `serialize/deserialize` methods on `DataFrame/LazyFrame/Expr` with the options `"json"` (existing) and `"binary"` (new).
* Set `"binary"` as the default format. This is a breaking change. You can retain the previous behavior by specifying `format="json"`

**Example**

Before:

```pycon
>>> lf = pl.LazyFrame({"a": [1, 2, 3]}).sum()
>>> serialized = lf.serialize()
>>> serialized
'{"MapFunction":{"input":{"DataFrameScan":{"df":{"columns":[{"name":...'
>>> from io import StringIO
>>> pl.LazyFrame.deserialize(StringIO(serialized)).collect()
shape: (1, 1)
┌─────┐
│ a   │
│ --- │
│ i64 │
╞═════╡
│ 6   │
└─────┘
```

After:

```pycon
>>> lf = pl.LazyFrame({"a": [1, 2, 3]}).sum()
>>> serialized = lf.serialize()
>>> serialized
b'\xa1kMapFunction\xa2einput\xa1mDataFrameScan\xa4bdf...'
>>> from io import BytesIO  # Note: using BytesIO instead of StringIO
>>> pl.LazyFrame.deserialize(BytesIO(serialized)).collect()
shape: (1, 1)
┌─────┐
│ a   │
│ --- │
│ i64 │
╞═════╡
│ 6   │
└─────┘
```