### PR TITLE
feat: Support `SQL` Struct/JSON field access operators

### DIFF
--- a/crates/polars-sql/src/keywords.rs
+++ b/crates/polars-sql/src/keywords.rs
@@ -13,6 +13,7 @@ pub fn all_keywords() -> Vec<&'static str> {
     let mut keywords = vec![];
     keywords.extend_from_slice(PolarsTableFunctions::keywords());
     keywords.extend_from_slice(PolarsSQLFunctions::keywords());
+
     use sqlparser::keywords;
     let sql_keywords = &[
         keywords::AND,
@@ -30,6 +31,7 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::DISTINCT,
         keywords::DOUBLE,
         keywords::DROP,
+        keywords::EXCEPT,
         keywords::EXCLUDE,
         keywords::FLOAT,
         keywords::FROM,
@@ -39,6 +41,7 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::IN,
         keywords::INNER,
         keywords::INT,
+        keywords::INTERSECT,
         keywords::INTERVAL,
         keywords::JOIN,
         keywords::LEFT,
@@ -51,6 +54,8 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::ORDER,
         keywords::OUTER,
         keywords::REGEXP,
+        keywords::RENAME,
+        keywords::REPLACE,
         keywords::RIGHT,
         keywords::RLIKE,
         keywords::SELECT,
@@ -60,6 +65,8 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::TABLES,
         keywords::THEN,
         keywords::TIME,
+        keywords::TRUNCATE,
+        keywords::UNION,
         keywords::USING,
         keywords::VARCHAR,
         keywords::WHEN,

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -703,16 +703,16 @@ impl SQLExprVisitor<'_> {
             // ----
             // JSON/Struct field access operators
             // ----
-            SQLBinaryOperator::Arrow | SQLBinaryOperator::LongArrow => match right {
+            SQLBinaryOperator::Arrow | SQLBinaryOperator::LongArrow => match rhs {
                 Expr::Literal(LiteralValue::String(path)) => {
-                    let mut expr = self.struct_field_access_expr(&left, &path, false)?;
+                    let mut expr = self.struct_field_access_expr(&lhs, &path, false)?;
                     if let SQLBinaryOperator::LongArrow = op {
                         expr = expr.cast(DataType::String);
                     }
                     expr
                 },
                 Expr::Literal(LiteralValue::Int(idx)) => {
-                    let mut expr = self.struct_field_access_expr(&left, &idx.to_string(), true)?;
+                    let mut expr = self.struct_field_access_expr(&lhs, &idx.to_string(), true)?;
                     if let SQLBinaryOperator::LongArrow = op {
                         expr = expr.cast(DataType::String);
                     }
@@ -723,14 +723,14 @@ impl SQLExprVisitor<'_> {
                 },
             },
             SQLBinaryOperator::HashArrow | SQLBinaryOperator::HashLongArrow => {
-                if let Expr::Literal(LiteralValue::String(path)) = right {
-                    let mut expr = self.struct_field_access_expr(&left, &path, true)?;
+                if let Expr::Literal(LiteralValue::String(path)) = rhs {
+                    let mut expr = self.struct_field_access_expr(&lhs, &path, true)?;
                     if let SQLBinaryOperator::HashLongArrow = op {
                         expr = expr.cast(DataType::String);
                     }
                     expr
                 } else {
-                    polars_bail!(SQLSyntax: "invalid json/struct path-extract definition: {:?}", right)
+                    polars_bail!(SQLSyntax: "invalid json/struct path-extract definition: {:?}", rhs)
                 }
             },
             other => {

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -582,6 +582,34 @@ impl SQLExprVisitor<'_> {
         }
     }
 
+    fn struct_field_access_expr(
+        &mut self,
+        expr: &Expr,
+        path: &str,
+        infer_index: bool,
+    ) -> PolarsResult<Expr> {
+        let path_elems = if path.starts_with('{') && path.ends_with('}') {
+            path.trim_matches(|c| c == '{' || c == '}')
+        } else {
+            path
+        }
+        .split(',');
+
+        let mut expr = expr.clone();
+        for p in path_elems {
+            let p = p.trim();
+            expr = if infer_index {
+                match p.parse::<i64>() {
+                    Ok(idx) => expr.list().get(lit(idx), true),
+                    Err(_) => expr.struct_().field_by_name(p),
+                }
+            } else {
+                expr.struct_().field_by_name(p)
+            }
+        }
+        Ok(expr)
+    }
+
     /// Visit a SQL binary operator.
     ///
     /// e.g. "column + 1", "column1 <= column2"
@@ -671,6 +699,39 @@ impl SQLExprVisitor<'_> {
                     }
                 };
                 self.visit_expr(&expr)?
+            },
+            // ----
+            // JSON/Struct field access operators
+            // ----
+            SQLBinaryOperator::Arrow | SQLBinaryOperator::LongArrow => match right {
+                Expr::Literal(LiteralValue::String(path)) => {
+                    let mut expr = self.struct_field_access_expr(&left, &path, false)?;
+                    if let SQLBinaryOperator::LongArrow = op {
+                        expr = expr.cast(DataType::String);
+                    }
+                    expr
+                },
+                Expr::Literal(LiteralValue::Int(idx)) => {
+                    let mut expr = self.struct_field_access_expr(&left, &idx.to_string(), true)?;
+                    if let SQLBinaryOperator::LongArrow = op {
+                        expr = expr.cast(DataType::String);
+                    }
+                    expr
+                },
+                _ => {
+                    polars_bail!(SQLSyntax: "invalid json/struct path-extract definition: {:?}", right)
+                },
+            },
+            SQLBinaryOperator::HashArrow | SQLBinaryOperator::HashLongArrow => {
+                if let Expr::Literal(LiteralValue::String(path)) = right {
+                    let mut expr = self.struct_field_access_expr(&left, &path, true)?;
+                    if let SQLBinaryOperator::HashLongArrow = op {
+                        expr = expr.cast(DataType::String);
+                    }
+                    expr
+                } else {
+                    polars_bail!(SQLSyntax: "invalid json/struct path-extract definition: {:?}", right)
+                }
             },
             other => {
                 polars_bail!(SQLInterface: "operator {:?} is not currently supported", other)

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -733,7 +733,7 @@ fn test_struct_field_selection() {
     let sql = r#"
       SELECT
         json_msg.str AS id,
-        SUM(json_msg.num) AS sum_n
+        SUM(json_msg -> 'num') AS sum_n
       FROM df
       GROUP BY json_msg.str
       ORDER BY 1

--- a/py-polars/tests/unit/sql/test_structs.py
+++ b/py-polars/tests/unit/sql/test_structs.py
@@ -86,6 +86,30 @@ def test_struct_field_group_by_errors(df_struct: pl.DataFrame) -> None:
 
 
 @pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ("nested #> '{c,1}'", 2),
+        ("nested #> '{c,-1}'", 1),
+        ("nested #>> '{c,0}'", "3"),
+        ("nested -> '0' -> 0", "baz"),
+        ("nested -> 'c' -> -1", 1),
+        ("nested -> 'c' ->> 2", "1"),
+    ],
+)
+def test_struct_field_operator_access(expr: str, expected: int | str) -> None:
+    df = pl.DataFrame(
+        {
+            "nested": {
+                "0": ["baz"],
+                "b": ["foo", "bar"],
+                "c": [3, 2, 1],
+            },
+        },
+    )
+    assert df.sql(f"SELECT {expr} FROM self").item() == expected
+
+
+@pytest.mark.parametrize(
     ("fields", "excluding", "rename"),
     [
         ("json_msg.*", "age", {}),


### PR DESCRIPTION
Builds on #17109, which added support for querying into Struct fields using dot-notation.

In addition to that, this PR adds the PostgreSQL operator versions[^1].
Can use for both array and field indexing.

* `-> ` Extract value at key/index.
* `->>` Extract value at key/index, as a string.
* `#> ` Extract value at specified path, where path elements can be keys or indexes.
* `#>>` Extract value at specified path, where path elements can be keys or indexes, as a string.

## Note

Unlike standard array-indexing in PostgreSQL, which is 1-indexed, these operators expect 0-indexing as they follow JSON conventions, so the following two queries are equivalent (and both now parse):

* `df.sql('SELECT nested."0"[1] FROM self')`
* `df.sql("SELECT nested -> '0' -> 0 FROM self")`

_"Yay for consistency"_ 🙄

## Examples

```python
import polars as pl

df = pl.DataFrame({
    "nested": {
        "0": ["baz"],
        "b": ["foo", "bar"],
        "c": [3, 2, 1],
    },
})
# shape: (1, 1)
# ┌────────────────────────────────────┐
# │ nested                             │
# │ ---                                │
# │ struct[3]                          │
# ╞════════════════════════════════════╡
# │ {["baz"],["foo", "bar"],[3, 2, 1]} │
# └────────────────────────────────────┘
```
Index into struct fields with operators:
```python
df.sql("SELECT nested -> 'c' -> 1 FROM self").item()
# 2

df.sql("SELECT nested -> 'c' ->> 1 FROM self").item()
# "2"

df.sql("SELECT nested -> '0' -> 0 FROM self").item()
# "baz"

df.sql("SELECT nested #> '{b,-1}' FROM self").item()
# "bar"

df.sql("SELECT nested #>> '{c,2}' FROM self").item()
# "1"
```

[^1]: See: https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSON-PROCESSING.