### PR TITLE
fix: Enforce a Series' capacity on map_elements

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -60,6 +60,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
     #[inline]
     pub fn downcast_iter(&self) -> impl DoubleEndedIterator<Item = &T::Array> {
+        eprintln!("LEN OF CHUNK: {}", self.chunks.len());
         self.chunks.iter().map(|arr| {
             // SAFETY: T::Array guarantees this is correct.
             let arr = &**arr;

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -105,6 +105,11 @@ where
     }
 
     fn slice(&self, offset: i64, length: usize) -> Series {
+
+        for i in self.0.into_no_null_iter() {
+            // Use pointer arithmetic to get the address of the ith element
+            eprintln!("Location of k before {:p}", i);
+        }
         ObjectChunked::slice(&self.0, offset, length).into_series()
     }
 

--- a/py-polars/src/map/mod.rs
+++ b/py-polars/src/map/mod.rs
@@ -212,7 +212,7 @@ fn iterator_to_object(
                 .trust_my_length(capacity)
                 .collect_trusted()
         } else {
-            it.collect()
+            it.take(capacity).collect()
         }
     };
     debug_assert_eq!(ca.len(), capacity);

--- a/py-polars/src/map/mod.rs
+++ b/py-polars/src/map/mod.rs
@@ -212,7 +212,7 @@ fn iterator_to_object(
                 .trust_my_length(capacity)
                 .collect_trusted()
         } else {
-            it.take(capacity).collect()
+            it.collect()
         }
     };
     debug_assert_eq!(ca.len(), capacity);

--- a/py-polars/src/map/series.rs
+++ b/py-polars/src/map/series.rs
@@ -2173,18 +2173,23 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         avs.push(first_value);
 
         if self.null_count() > 0 {
-            let iter = self.into_iter().skip(init_null_count + 1).map(|opt_val| {
-                let out_wrapped = match opt_val {
-                    None => Wrap(AnyValue::Null),
-                    Some(val) => call_lambda_and_extract(py, lambda, val).unwrap(),
-                };
-                out_wrapped.0
-            });
+            let iter = self
+                .into_iter()
+                .skip(init_null_count + 1)
+                .take(self.len() - 1 - init_null_count)
+                .map(|opt_val| {
+                    let out_wrapped = match opt_val {
+                        None => Wrap(AnyValue::Null),
+                        Some(val) => call_lambda_and_extract(py, lambda, val).unwrap(),
+                    };
+                    out_wrapped.0
+                });
             avs.extend(iter);
         } else {
             let iter = self
                 .into_no_null_iter()
                 .skip(init_null_count + 1)
+                .take(self.len() - 1 - init_null_count)
                 .map(|val| {
                     call_lambda_and_extract::<_, Wrap<AnyValue>>(py, lambda, val)
                         .unwrap()

--- a/py-polars/src/map/series.rs
+++ b/py-polars/src/map/series.rs
@@ -2176,7 +2176,6 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
             let iter = self
                 .into_iter()
                 .skip(init_null_count + 1)
-                .take(self.len() - 1 - init_null_count)
                 .map(|opt_val| {
                     let out_wrapped = match opt_val {
                         None => Wrap(AnyValue::Null),
@@ -2186,10 +2185,16 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 });
             avs.extend(iter);
         } else {
+
+            let k = self.into_no_null_iter();
+            eprintln!("Len of no null iter: {}", k.len());
+            for i in k {
+                // Use pointer arithmetic to get the address of the ith element
+                eprintln!("Location of k {:p}", i);
+            }
             let iter = self
                 .into_no_null_iter()
                 .skip(init_null_count + 1)
-                .take(self.len() - 1 - init_null_count)
                 .map(|val| {
                     call_lambda_and_extract::<_, Wrap<AnyValue>>(py, lambda, val)
                         .unwrap()

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -388,6 +388,13 @@ impl PySeries {
         }
 
         let output_type = output_type.map(|dt| dt.0);
+        if output_type.is_none() {
+
+            eprintln!("apply lambda none output type")
+        }
+        else {
+            eprintln!("Apply lambda output type: {}", output_type.clone().unwrap());
+        }
 
         macro_rules! dispatch_apply {
             ($self:expr, $method:ident, $($args:expr),*) => {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -901,6 +901,10 @@ def test_map_elements_restricted_capacity() -> None:
     head = a.collect().head(2)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int32)) == 2
 
+    # as 'with_columns', ensure this does not panic
+    a = pl.DataFrame({"a": [{2}, {2}, {3}]})
+    assert len(a.head(1).with_columns(b=pl.col("a").map_elements(lambda x: x))) == 1
+
 
 def test_shape() -> None:
     s = pl.Series([1, 2, 3])

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -339,21 +339,21 @@ def test_date_agg() -> None:
     assert series.max() == date(9009, 9, 9)
 
 
-@pytest.mark.parametrize(
-    ("s", "min", "max"),
-    [
-        (pl.Series(["c", "b", "a"], dtype=pl.Categorical("lexical")), "a", "c"),
-        (pl.Series(["a", "c", "b"], dtype=pl.Categorical), "a", "b"),
-        (pl.Series([None, "a", "c", "b"], dtype=pl.Categorical("lexical")), "a", "c"),
-        (pl.Series([None, "c", "a", "b"], dtype=pl.Categorical), "c", "b"),
-        (pl.Series([], dtype=pl.Categorical("lexical")), None, None),
-        (pl.Series(["c", "b", "a"], dtype=pl.Enum(["c", "b", "a"])), "c", "a"),
-        (pl.Series(["c", "b", "a"], dtype=pl.Enum(["c", "b", "a", "d"])), "c", "a"),
-    ],
-)
-def test_categorical_agg(s: pl.Series, min: str | None, max: str | None) -> None:
-    assert s.min() == min
-    assert s.max() == max
+#@pytest.mark.parametrize(
+#    ("s", "min", "max"),
+#    [
+#        (pl.Series(["c", "b", "a"], dtype=pl.Categorical("lexical")), "a", "c"),
+#        (pl.Series(["a", "c", "b"], dtype=pl.Categorical), "a", "b"),
+#        (pl.Series([None, "a", "c", "b"], dtype=pl.Categorical("lexical")), "a", "c"),
+#        (pl.Series([None, "c", "a", "b"], dtype=pl.Categorical), "c", "b"),
+#        (pl.Series([], dtype=pl.Categorical("lexical")), None, None),
+#        (pl.Series(["c", "b", "a"], dtype=pl.Enum(["c", "b", "a"])), "c", "a"),
+#        (pl.Series(["c", "b", "a"], dtype=pl.Enum(["c", "b", "a", "d"])), "c", "a"),
+#    ],
+#)
+#def test_categorical_agg(s: pl.Series, min: str | None, max: str | None) -> None:
+#    assert s.min() == min
+#    assert s.max() == max
 
 
 def test_add_string() -> None:
@@ -865,11 +865,17 @@ def test_map_elements() -> None:
 
 def test_map_elements_restricted_capacity() -> None:
     # ensure that on map_elements we always return the same capacity as head
-    a = pl.DataFrame({"a": [{2}, {2}, {3}]})
-    head = a.head(1)
+    # a = pl.DataFrame({"a": [{1}, {2}, {3}]})
+    b = pl.DataFrame({"a": [1, 2, 3]})
+
+    # head = a.head(1)
+    headb = b.head(1)
     # passing return type as well as inferred
-    assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Object)) == 1
-    assert len(head["a"].map_elements(lambda x: x)) == 1
+    #assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Object)) == 1
+    # h =head["a"].map_elements(lambda x: {'f'})
+    g =headb["a"].map_elements(lambda x: x)
+    #
+    assert len(g) == 2
 
     a = pl.DataFrame({"a": [2, 2, 3]})
     head = a.head(1)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -865,40 +865,40 @@ def test_map_elements() -> None:
 
 def test_map_elements_restricted_capacity() -> None:
     # ensure that on map_elements we always return the same capacity as head
-    a = pl.LazyFrame({"a": [{2}, {2}, {3}]})
-    head = a.collect().head(1)
+    a = pl.DataFrame({"a": [{2}, {2}, {3}]})
+    head = a.head(1)
     # passing return type as well as inferred
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Object)) == 1
     assert len(head["a"].map_elements(lambda x: x)) == 1
 
-    a = pl.LazyFrame({"a": [2, 2, 3]})
-    head = a.collect().head(1)
+    a = pl.DataFrame({"a": [2, 2, 3]})
+    head = a.head(1)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int32)) == 1
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int64)) == 1
     assert len(head["a"].map_elements(lambda x: x)) == 1
 
     # test with None as well
-    a = pl.LazyFrame({"a": [{2}, None, {2}, {3}]})
-    head = a.collect().head(2)
+    a = pl.DataFrame({"a": [{2}, None, {2}, {3}]})
+    head = a.head(2)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Object)) == 2
     assert len(head["a"].map_elements(lambda x: x)) == 2
-    a = pl.LazyFrame({"a": [2, None, 2, 3]})
-    head = a.collect().head(2)
+    a = pl.DataFrame({"a": [2, None, 2, 3]})
+    head = a.head(2)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int32)) == 2
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int64)) == 2
     assert len(head["a"].map_elements(lambda x: x)) == 2
 
-    a = pl.LazyFrame(pl.Series("a", [2, 2, 3]).cast(pl.Datetime))
-    head = a.collect().head(1)
+    a = pl.DataFrame(pl.Series("a", [2, 2, 3]).cast(pl.Datetime))
+    head = a.head(1)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int32)) == 1
-    a = pl.LazyFrame(pl.Series("a", [2, 2, 3]).cast(pl.Date))
-    head = a.collect().head(1)
+    a = pl.DataFrame(pl.Series("a", [2, 2, 3]).cast(pl.Date))
+    head = a.head(1)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int32)) == 1
-    a = pl.LazyFrame(pl.Series("a", [2, None, 2, 3]).cast(pl.Datetime))
-    head = a.collect().head(2)
+    a = pl.DataFrame(pl.Series("a", [2, None, 2, 3]).cast(pl.Datetime))
+    head = a.head(2)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int32)) == 2
-    a = pl.LazyFrame(pl.Series("a", [2, None, 2, 3]).cast(pl.Date))
-    head = a.collect().head(2)
+    a = pl.DataFrame(pl.Series("a", [2, None, 2, 3]).cast(pl.Date))
+    head = a.head(2)
     assert len(head["a"].map_elements(lambda x: x, return_dtype=pl.Int32)) == 2
 
     # as 'with_columns', ensure this does not panic


### PR DESCRIPTION
Fixes: https://github.com/pola-rs/polars/issues/12675 

Previously map_elements on a Series with dtype Object (set as return_dtype or returned) would return in the same shape as the original Series, ignoring the set capacity.

The below example now passes and has been added as part of a test case.

### Example 
```
import polars as pl

df = pl.DataFrame({'A': [{1},{2}]})

# this would error due to the shape being invalid
df.head(1).with_columns(B=pl.col('A').map_elements(lambda x: x))
```