### PR TITLE
feat: Support `SQL` temporal functions `STRFTIME` and `STRPTIME`, and typed literal syntax

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1,5 +1,5 @@
 use polars_core::chunked_array::ops::{SortMultipleOptions, SortOptions};
-use polars_core::prelude::{polars_bail, polars_err, DataType, PolarsResult};
+use polars_core::prelude::{polars_bail, polars_err, DataType, PolarsResult, TimeUnit};
 use polars_lazy::dsl::Expr;
 #[cfg(feature = "list_eval")]
 use polars_lazy::dsl::ListNameSpaceExtension;
@@ -31,105 +31,105 @@ pub(crate) enum PolarsSQLFunctions {
     /// SQL 'abs' function
     /// Returns the absolute value of the input column.
     /// ```sql
-    /// SELECT ABS(column_1) from df;
+    /// SELECT ABS(column_1) FROM df;
     /// ```
     Abs,
     /// SQL 'ceil' function
     /// Returns the nearest integer closest from zero.
     /// ```sql
-    /// SELECT CEIL(column_1) from df;
+    /// SELECT CEIL(column_1) FROM df;
     /// ```
     Ceil,
     /// SQL 'div' function
     /// Returns the integer quotient of the division.
     /// ```sql
-    /// SELECT DIV(column_1, 2) from df;
+    /// SELECT DIV(column_1, 2) FROM df;
     /// ```
     Div,
     /// SQL 'exp' function
     /// Computes the exponential of the given value.
     /// ```sql
-    /// SELECT EXP(column_1) from df;
+    /// SELECT EXP(column_1) FROM df;
     /// ```
     Exp,
     /// SQL 'floor' function
     /// Returns the nearest integer away from zero.
     ///   0.5 will be rounded
     /// ```sql
-    /// SELECT FLOOR(column_1) from df;
+    /// SELECT FLOOR(column_1) FROM df;
     /// ```
     Floor,
     /// SQL 'pi' function
     /// Returns a (very good) approximation of 𝜋.
     /// ```sql
-    /// SELECT PI() from df;
+    /// SELECT PI() FROM df;
     /// ```
     Pi,
     /// SQL 'ln' function
     /// Computes the natural logarithm of the given value.
     /// ```sql
-    /// SELECT LN(column_1) from df;
+    /// SELECT LN(column_1) FROM df;
     /// ```
     Ln,
     /// SQL 'log2' function
     /// Computes the logarithm of the given value in base 2.
     /// ```sql
-    /// SELECT LOG2(column_1) from df;
+    /// SELECT LOG2(column_1) FROM df;
     /// ```
     Log2,
     /// SQL 'log10' function
     /// Computes the logarithm of the given value in base 10.
     /// ```sql
-    /// SELECT LOG10(column_1) from df;
+    /// SELECT LOG10(column_1) FROM df;
     /// ```
     Log10,
     /// SQL 'log' function
     /// Computes the `base` logarithm of the given value.
     /// ```sql
-    /// SELECT LOG(column_1, 10) from df;
+    /// SELECT LOG(column_1, 10) FROM df;
     /// ```
     Log,
     /// SQL 'log1p' function
     /// Computes the natural logarithm of "given value plus one".
     /// ```sql
-    /// SELECT LOG1P(column_1) from df;
+    /// SELECT LOG1P(column_1) FROM df;
     /// ```
     Log1p,
     /// SQL 'pow' function
     /// Returns the value to the power of the given exponent.
     /// ```sql
-    /// SELECT POW(column_1, 2) from df;
+    /// SELECT POW(column_1, 2) FROM df;
     /// ```
     Pow,
     /// SQL 'mod' function
     /// Returns the remainder of a numeric expression divided by another numeric expression.
     /// ```sql
-    /// SELECT MOD(column_1, 2) from df;
+    /// SELECT MOD(column_1, 2) FROM df;
     /// ```
     Mod,
     /// SQL 'sqrt' function
     /// Returns the square root (√) of a number.
     /// ```sql
-    /// SELECT SQRT(column_1) from df;
+    /// SELECT SQRT(column_1) FROM df;
     /// ```
     Sqrt,
     /// SQL 'cbrt' function
     /// Returns the cube root (∛) of a number.
     /// ```sql
-    /// SELECT CBRT(column_1) from df;
+    /// SELECT CBRT(column_1) FROM df;
     /// ```
     Cbrt,
     /// SQL 'round' function
     /// Round a number to `x` decimals (default: 0) away from zero.
     ///   .5 is rounded away from zero.
     /// ```sql
-    /// SELECT ROUND(column_1, 3) from df;
+    /// SELECT ROUND(column_1, 3) FROM df;
     /// ```
     Round,
     /// SQL 'sign' function
     /// Returns the sign of the argument as -1, 0, or +1.
     /// ```sql
-    /// SELECT SIGN(column_1) from df;
+    /// SELECT SIGN(column_1) FROM df;
     /// ```
     Sign,
 
@@ -139,103 +139,103 @@ pub(crate) enum PolarsSQLFunctions {
     /// SQL 'cos' function
     /// Compute the cosine sine of the input column (in radians).
     /// ```sql
-    /// SELECT COS(column_1) from df;
+    /// SELECT COS(column_1) FROM df;
     /// ```
     Cos,
     /// SQL 'cot' function
     /// Compute the cotangent of the input column (in radians).
     /// ```sql
-    /// SELECT COT(column_1) from df;
+    /// SELECT COT(column_1) FROM df;
     /// ```
     Cot,
     /// SQL 'sin' function
     /// Compute the sine of the input column (in radians).
     /// ```sql
-    /// SELECT SIN(column_1) from df;
+    /// SELECT SIN(column_1) FROM df;
     /// ```
     Sin,
     /// SQL 'tan' function
     /// Compute the tangent of the input column (in radians).
     /// ```sql
-    /// SELECT TAN(column_1) from df;
+    /// SELECT TAN(column_1) FROM df;
     /// ```
     Tan,
     /// SQL 'cosd' function
     /// Compute the cosine sine of the input column (in degrees).
     /// ```sql
-    /// SELECT COSD(column_1) from df;
+    /// SELECT COSD(column_1) FROM df;
     /// ```
     CosD,
     /// SQL 'cotd' function
     /// Compute cotangent of the input column (in degrees).
     /// ```sql
-    /// SELECT COTD(column_1) from df;
+    /// SELECT COTD(column_1) FROM df;
     /// ```
     CotD,
     /// SQL 'sind' function
     /// Compute the sine of the input column (in degrees).
     /// ```sql
-    /// SELECT SIND(column_1) from df;
+    /// SELECT SIND(column_1) FROM df;
     /// ```
     SinD,
     /// SQL 'tand' function
     /// Compute the tangent of the input column (in degrees).
     /// ```sql
-    /// SELECT TAND(column_1) from df;
+    /// SELECT TAND(column_1) FROM df;
     /// ```
     TanD,
     /// SQL 'acos' function
     /// Compute inverse cosinus of the input column (in radians).
     /// ```sql
-    /// SELECT ACOS(column_1) from df;
+    /// SELECT ACOS(column_1) FROM df;
     /// ```
     Acos,
     /// SQL 'asin' function
     /// Compute inverse sine of the input column (in radians).
     /// ```sql
-    /// SELECT ASIN(column_1) from df;
+    /// SELECT ASIN(column_1) FROM df;
     /// ```
     Asin,
     /// SQL 'atan' function
     /// Compute inverse tangent of the input column (in radians).
     /// ```sql
-    /// SELECT ATAN(column_1) from df;
+    /// SELECT ATAN(column_1) FROM df;
     /// ```
     Atan,
     /// SQL 'atan2' function
     /// Compute the inverse tangent of column_2/column_1 (in radians).
     /// ```sql
-    /// SELECT ATAN2(column_1, column_2) from df;
+    /// SELECT ATAN2(column_1, column_2) FROM df;
     /// ```
     Atan2,
     /// SQL 'acosd' function
     /// Compute inverse cosinus of the input column (in degrees).
     /// ```sql
-    /// SELECT ACOSD(column_1) from df;
+    /// SELECT ACOSD(column_1) FROM df;
     /// ```
     AcosD,
     /// SQL 'asind' function
     /// Compute inverse sine of the input column (in degrees).
     /// ```sql
-    /// SELECT ASIND(column_1) from df;
+    /// SELECT ASIND(column_1) FROM df;
     /// ```
     AsinD,
     /// SQL 'atand' function
     /// Compute inverse tangent of the input column (in degrees).
     /// ```sql
-    /// SELECT ATAND(column_1) from df;
+    /// SELECT ATAND(column_1) FROM df;
     /// ```
     AtanD,
     /// SQL 'atan2d' function
     /// Compute the inverse tangent of column_2/column_1 (in degrees).
     /// ```sql
-    /// SELECT ATAN2D(column_1) from df;
+    /// SELECT ATAN2D(column_1) FROM df;
     /// ```
     Atan2D,
     /// SQL 'degrees' function
     /// Convert between radians and degrees.
     /// ```sql
-    /// SELECT DEGREES(column_1) from df;
+    /// SELECT DEGREES(column_1) FROM df;
     /// ```
     ///
     ///
@@ -243,148 +243,178 @@ pub(crate) enum PolarsSQLFunctions {
     /// SQL 'RADIANS' function
     /// Convert between degrees and radians.
     /// ```sql
-    /// SELECT radians(column_1) from df;
+    /// SELECT RADIANS(column_1) FROM df;
     /// ```
     Radians,
 
     // ----
-    // Date Functions
+    // Temporal functions
     // ----
-    /// SQL 'date' function.
-    /// Converts a formatted string date to an actual Date type; ISO-8601 format is assumed
-    /// unless a strftime-compatible formatting string is provided as the second parameter.
-    /// ```sql
-    /// SELECT DATE('2021-03-15') from df;
-    /// SELECT DATE('2021-15-03', '%Y-d%-%m') from df;
-    /// SELECT DATE('2021-03', '%Y-%m') from df;
-    /// ```
-    Date,
     /// SQL 'date_part' function.
     /// Extracts a part of a date (or datetime) such as 'year', 'month', etc.
     /// ```sql
-    /// SELECT DATE_PART('year', column_1) from df;
-    /// SELECT DATE_PART('day', column_1) from df;
+    /// SELECT DATE_PART('year', column_1) FROM df;
+    /// SELECT DATE_PART('day', column_1) FROM df;
     DatePart,
+    /// SQL 'strftime' function.
+    /// Converts a datetime to a string using a format string.
+    /// ```sql
+    /// SELECT STRFTIME(column_1, '%d-%m-%Y %H:%M') FROM df;
+    /// ```
+    Strftime,
 
     // ----
     // String functions
     // ----
     /// SQL 'bit_length' function (bytes).
     /// ```sql
-    /// SELECT BIT_LENGTH(column_1) from df;
+    /// SELECT BIT_LENGTH(column_1) FROM df;
     /// ```
     BitLength,
     /// SQL 'concat' function
     /// Returns all input expressions concatenated together as a string.
     /// ```sql
-    /// SELECT CONCAT(column_1, column_2) from df;
+    /// SELECT CONCAT(column_1, column_2) FROM df;
     /// ```
     Concat,
     /// SQL 'concat_ws' function
     /// Returns all input expressions concatenated together
     /// (and interleaved with a separator) as a string.
     /// ```sql
-    /// SELECT CONCAT_WS(':', column_1, column_2, column_3) from df;
+    /// SELECT CONCAT_WS(':', column_1, column_2, column_3) FROM df;
     /// ```
     ConcatWS,
+    /// SQL 'date' function.
+    /// Converts a formatted string date to an actual Date type; ISO-8601 format is assumed
+    /// unless a strftime-compatible formatting string is provided as the second parameter.
+    /// ```sql
+    /// SELECT DATE('2021-03-15') FROM df;
+    /// SELECT DATE('2021-15-03', '%Y-d%-%m') FROM df;
+    /// SELECT DATE('2021-03', '%Y-%m') FROM df;
+    /// ```
+    Date,
+    /// SQL 'timestamp' function.
+    /// Converts a formatted string datetime to an actual Datetime type; ISO-8601 format is
+    /// assumed unless a strftime-compatible formatting string is provided as the second
+    /// parameter.
+    /// ```sql
+    /// SELECT TIMESTAMP('2021-03-15 10:30:45') FROM df;
+    /// SELECT TIMESTAMP('2021-15-03T00:01:02.333', '%Y-d%-%m %H:%M:%S') FROM df;
+    /// ```
+    Timestamp,
     /// SQL 'ends_with' function
     /// Returns True if the value ends with the second argument.
     /// ```sql
-    /// SELECT ENDS_WITH(column_1, 'a') from df;
+    /// SELECT ENDS_WITH(column_1, 'a') FROM df;
     /// SELECT column_2 from df WHERE ENDS_WITH(column_1, 'a');
     /// ```
     EndsWith,
     /// SQL 'initcap' function
     /// Returns the value with the first letter capitalized.
     /// ```sql
-    /// SELECT INITCAP(column_1) from df;
+    /// SELECT INITCAP(column_1) FROM df;
     /// ```
     #[cfg(feature = "nightly")]
     InitCap,
     /// SQL 'left' function
     /// Returns the first (leftmost) `n` characters.
     /// ```sql
-    /// SELECT LEFT(column_1, 3) from df;
+    /// SELECT LEFT(column_1, 3) FROM df;
     /// ```
     Left,
     /// SQL 'length' function (characters)
     /// Returns the character length of the string.
     /// ```sql
-    /// SELECT LENGTH(column_1) from df;
+    /// SELECT LENGTH(column_1) FROM df;
     /// ```
     Length,
     /// SQL 'lower' function
     /// Returns an lowercased column.
     /// ```sql
-    /// SELECT LOWER(column_1) from df;
+    /// SELECT LOWER(column_1) FROM df;
     /// ```
     Lower,
     /// SQL 'ltrim' function
     /// Strip whitespaces from the left.
     /// ```sql
-    /// SELECT LTRIM(column_1) from df;
+    /// SELECT LTRIM(column_1) FROM df;
     /// ```
     LTrim,
     /// SQL 'octet_length' function
     /// Returns the length of a given string in bytes.
     /// ```sql
-    /// SELECT OCTET_LENGTH(column_1) from df;
+    /// SELECT OCTET_LENGTH(column_1) FROM df;
     /// ```
     OctetLength,
     /// SQL 'regexp_like' function
     /// True if `pattern` matches the value (optional: `flags`).
     /// ```sql
-    /// SELECT REGEXP_LIKE(column_1, 'xyz', 'i') from df;
+    /// SELECT REGEXP_LIKE(column_1, 'xyz', 'i') FROM df;
     /// ```
     RegexpLike,
     /// SQL 'replace' function
     /// Replace a given substring with another string.
     /// ```sql
-    /// SELECT REPLACE(column_1,'old','new') from df;
+    /// SELECT REPLACE(column_1,'old','new') FROM df;
     /// ```
     Replace,
     /// SQL 'reverse' function
     /// Return the reversed string.
     /// ```sql
-    /// SELECT REVERSE(column_1) from df;
+    /// SELECT REVERSE(column_1) FROM df;
     /// ```
     Reverse,
     /// SQL 'right' function
     /// Returns the last (rightmost) `n` characters.
     /// ```sql
-    /// SELECT RIGHT(column_1, 3) from df;
+    /// SELECT RIGHT(column_1, 3) FROM df;
     /// ```
     Right,
     /// SQL 'rtrim' function
     /// Strip whitespaces from the right.
     /// ```sql
-    /// SELECT RTRIM(column_1) from df;
+    /// SELECT RTRIM(column_1) FROM df;
     /// ```
     RTrim,
     /// SQL 'starts_with' function
     /// Returns True if the value starts with the second argument.
     /// ```sql
-    /// SELECT STARTS_WITH(column_1, 'a') from df;
+    /// SELECT STARTS_WITH(column_1, 'a') FROM df;
     /// SELECT column_2 from df WHERE STARTS_WITH(column_1, 'a');
     /// ```
     StartsWith,
     /// SQL 'strpos' function
     /// Returns the index of the given substring in the target string.
     /// ```sql
-    /// SELECT STRPOS(column_1,'xyz') from df;
+    /// SELECT STRPOS(column_1,'xyz') FROM df;
     /// ```
     StrPos,
     /// SQL 'substr' function
     /// Returns a portion of the data (first character = 0) in the range.
     ///   \[start, start + length]
     /// ```sql
-    /// SELECT SUBSTR(column_1, 3, 5) from df;
+    /// SELECT SUBSTR(column_1, 3, 5) FROM df;
     /// ```
     Substring,
+    /// SQL 'strptime' function
+    /// Converts a string to a datetime using a format string.
+    /// ```sql
+    /// SELECT STRPTIME(column_1, '%d-%m-%Y %H:%M') FROM df;
+    /// ```
+    Strptime,
+    /// SQL 'time' function.
+    /// Converts a formatted string time to an actual Time type; ISO-8601 format is
+    /// assumed unless a strftime-compatible formatting string is provided as the second
+    /// parameter.
+    /// ```sql
+    /// SELECT TIME('10:30:45') FROM df;
+    /// SELECT TIME('20.30', '%H.%M') FROM df;
+    /// ```
+    Time,
     /// SQL 'upper' function
     /// Returns an uppercased column.
     /// ```sql
-    /// SELECT UPPER(column_1) from df;
+    /// SELECT UPPER(column_1) FROM df;
     /// ```
     Upper,
 
@@ -394,38 +424,38 @@ pub(crate) enum PolarsSQLFunctions {
     /// SQL 'coalesce' function
     /// Returns the first non-null value in the provided values/columns.
     /// ```sql
-    /// SELECT COALESCE(column_1, ...) from df;
+    /// SELECT COALESCE(column_1, ...) FROM df;
     /// ```
     Coalesce,
     /// SQL 'greatest' function
     /// Returns the greatest value in the list of expressions.
     /// ```sql
-    /// SELECT GREATEST(column_1, column_2, ...) from df;
+    /// SELECT GREATEST(column_1, column_2, ...) FROM df;
     /// ```
     Greatest,
     /// SQL 'if' function
     /// Returns expr1 if the boolean condition provided as the first
     /// parameter evaluates to true, and expr2 otherwise.
     /// ```sql
-    /// SELECT IF(column < 0, expr1, expr2) from df;
+    /// SELECT IF(column < 0, expr1, expr2) FROM df;
     /// ```
     If,
     /// SQL 'ifnull' function
     /// If an expression value is NULL, return an alternative value.
     /// ```sql
-    /// SELECT IFNULL(string_col, 'n/a') from df;
+    /// SELECT IFNULL(string_col, 'n/a') FROM df;
     /// ```
     IfNull,
     /// SQL 'least' function
     /// Returns the smallest value in the list of expressions.
     /// ```sql
-    /// SELECT LEAST(column_1, column_2, ...) from df;
+    /// SELECT LEAST(column_1, column_2, ...) FROM df;
     /// ```
     Least,
     /// SQL 'nullif' function
     /// Returns NULL if two expressions are equal, otherwise returns the first.
     /// ```sql
-    /// SELECT NULLIF(column_1, column_2) from df;
+    /// SELECT NULLIF(column_1, column_2) FROM df;
     /// ```
     NullIf,
 
@@ -435,64 +465,64 @@ pub(crate) enum PolarsSQLFunctions {
     /// SQL 'avg' function
     /// Returns the average (mean) of all the elements in the grouping.
     /// ```sql
-    /// SELECT AVG(column_1) from df;
+    /// SELECT AVG(column_1) FROM df;
     /// ```
     Avg,
     /// SQL 'count' function
     /// Returns the amount of elements in the grouping.
     /// ```sql
-    /// SELECT COUNT(column_1) from df;
-    /// SELECT COUNT(*) from df;
-    /// SELECT COUNT(DISTINCT column_1) from df;
-    /// SELECT COUNT(DISTINCT *) from df;
+    /// SELECT COUNT(column_1) FROM df;
+    /// SELECT COUNT(*) FROM df;
+    /// SELECT COUNT(DISTINCT column_1) FROM df;
+    /// SELECT COUNT(DISTINCT *) FROM df;
     /// ```
     Count,
     /// SQL 'first' function
     /// Returns the first element of the grouping.
     /// ```sql
-    /// SELECT FIRST(column_1) from df;
+    /// SELECT FIRST(column_1) FROM df;
     /// ```
     First,
     /// SQL 'last' function
     /// Returns the last element of the grouping.
     /// ```sql
-    /// SELECT LAST(column_1) from df;
+    /// SELECT LAST(column_1) FROM df;
     /// ```
     Last,
     /// SQL 'max' function
     /// Returns the greatest (maximum) of all the elements in the grouping.
     /// ```sql
-    /// SELECT MAX(column_1) from df;
+    /// SELECT MAX(column_1) FROM df;
     /// ```
     Max,
     /// SQL 'median' function
     /// Returns the median element from the grouping.
     /// ```sql
-    /// SELECT MEDIAN(column_1) from df;
+    /// SELECT MEDIAN(column_1) FROM df;
     /// ```
     Median,
     /// SQL 'min' function
     /// Returns the smallest (minimum) of all the elements in the grouping.
     /// ```sql
-    /// SELECT MIN(column_1) from df;
+    /// SELECT MIN(column_1) FROM df;
     /// ```
     Min,
     /// SQL 'stddev' function
     /// Returns the standard deviation of all the elements in the grouping.
     /// ```sql
-    /// SELECT STDDEV(column_1) from df;
+    /// SELECT STDDEV(column_1) FROM df;
     /// ```
     StdDev,
     /// SQL 'sum' function
     /// Returns the sum of all the elements in the grouping.
     /// ```sql
-    /// SELECT SUM(column_1) from df;
+    /// SELECT SUM(column_1) FROM df;
     /// ```
     Sum,
     /// SQL 'variance' function
     /// Returns the variance of all the elements in the grouping.
     /// ```sql
-    /// SELECT VARIANCE(column_1) from df;
+    /// SELECT VARIANCE(column_1) FROM df;
     /// ```
     Variance,
 
@@ -502,74 +532,74 @@ pub(crate) enum PolarsSQLFunctions {
     /// SQL 'array_length' function
     /// Returns the length of the array.
     /// ```sql
-    /// SELECT ARRAY_LENGTH(column_1) from df;
+    /// SELECT ARRAY_LENGTH(column_1) FROM df;
     /// ```
     ArrayLength,
     /// SQL 'array_lower' function
     /// Returns the minimum value in an array; equivalent to `array_min`.
     /// ```sql
-    /// SELECT ARRAY_LOWER(column_1) from df;
+    /// SELECT ARRAY_LOWER(column_1) FROM df;
     /// ```
     ArrayMin,
     /// SQL 'array_upper' function
     /// Returns the maximum value in an array; equivalent to `array_max`.
     /// ```sql
-    /// SELECT ARRAY_UPPER(column_1) from df;
+    /// SELECT ARRAY_UPPER(column_1) FROM df;
     /// ```
     ArrayMax,
     /// SQL 'array_sum' function
     /// Returns the sum of all values in an array.
     /// ```sql
-    /// SELECT ARRAY_SUM(column_1) from df;
+    /// SELECT ARRAY_SUM(column_1) FROM df;
     /// ```
     ArraySum,
     /// SQL 'array_mean' function
     /// Returns the mean of all values in an array.
     /// ```sql
-    /// SELECT ARRAY_MEAN(column_1) from df;
+    /// SELECT ARRAY_MEAN(column_1) FROM df;
     /// ```
     ArrayMean,
     /// SQL 'array_reverse' function
     /// Returns the array with the elements in reverse order.
     /// ```sql
-    /// SELECT ARRAY_REVERSE(column_1) from df;
+    /// SELECT ARRAY_REVERSE(column_1) FROM df;
     /// ```
     ArrayReverse,
     /// SQL 'array_unique' function
     /// Returns the array with the unique elements.
     /// ```sql
-    /// SELECT ARRAY_UNIQUE(column_1) from df;
+    /// SELECT ARRAY_UNIQUE(column_1) FROM df;
     /// ```
     ArrayUnique,
     /// SQL 'unnest' function
     /// Unnest/explodes an array column into multiple rows.
     /// ```sql
-    /// SELECT unnest(column_1) from df;
+    /// SELECT unnest(column_1) FROM df;
     /// ```
     Explode,
     /// SQL 'array_agg' function
     /// Concatenates the input expressions, including nulls, into an array.
     /// ```sql
-    /// SELECT ARRAY_AGG(column_1, column_2, ...) from df;
+    /// SELECT ARRAY_AGG(column_1, column_2, ...) FROM df;
     /// ```
     ArrayAgg,
     /// SQL 'array_to_string' function
     /// Takes all elements of the array and joins them into one string.
     /// ```sql
-    /// SELECT ARRAY_TO_STRING(column_1, ',') from df;
-    /// SELECT ARRAY_TO_STRING(column_1, ',', 'n/a') from df;
+    /// SELECT ARRAY_TO_STRING(column_1, ',') FROM df;
+    /// SELECT ARRAY_TO_STRING(column_1, ',', 'n/a') FROM df;
     /// ```
     ArrayToString,
     /// SQL 'array_get' function
     /// Returns the value at the given index in the array.
     /// ```sql
-    /// SELECT ARRAY_GET(column_1, 1) from df;
+    /// SELECT ARRAY_GET(column_1, 1) FROM df;
     /// ```
     ArrayGet,
     /// SQL 'array_contains' function
     /// Returns true if the array contains the value.
     /// ```sql
-    /// SELECT ARRAY_CONTAINS(column_1, 'foo') from df;
+    /// SELECT ARRAY_CONTAINS(column_1, 'foo') FROM df;
     /// ```
     ArrayContains,
     Udf(String),
@@ -733,8 +763,8 @@ impl PolarsSQLFunctions {
             // ----
             // Date functions
             // ----
-            "date" => Self::Date,
             "date_part" => Self::DatePart,
+            "strftime" => Self::Strftime,
 
             // ----
             // String functions
@@ -742,6 +772,8 @@ impl PolarsSQLFunctions {
             "bit_length" => Self::BitLength,
             "concat" => Self::Concat,
             "concat_ws" => Self::ConcatWS,
+            "date" => Self::Date,
+            "timestamp" | "datetime" => Self::Timestamp,
             "ends_with" => Self::EndsWith,
             #[cfg(feature = "nightly")]
             "initcap" => Self::InitCap,
@@ -757,7 +789,9 @@ impl PolarsSQLFunctions {
             "right" => Self::Right,
             "rtrim" => Self::RTrim,
             "starts_with" => Self::StartsWith,
+            "strptime" => Self::Strptime,
             "substr" => Self::Substring,
+            "time" => Self::Time,
             "upper" => Self::Upper,
 
             // ----
@@ -850,7 +884,7 @@ impl SQLFunctionVisitor<'_> {
                             _ => polars_bail!(SQLSyntax: "invalid value for ROUND decimals ({})", args[1]),
                         }))
                     }),
-                    _ => polars_bail!(SQLSyntax: "invalid number of arguments for ROUND (expected 1-2, found {})", args.len()),
+                    _ => polars_bail!(SQLSyntax: "ROUND expects 1-2 arguments (found {})", args.len()),
                 }
             },
             Sign => self.visit_unary(Expr::sign),
@@ -890,7 +924,7 @@ impl SQLFunctionVisitor<'_> {
                         Ok(when(cond).then(expr1).otherwise(expr2))
                     }),
                     _ => {
-                        polars_bail!(SQLSyntax: "invalid number of arguments for IF ({})", args.len()
+                        polars_bail!(SQLSyntax: "IF expects 3 arguments (found {})", args.len()
                         )
                     },
                 }
@@ -900,7 +934,7 @@ impl SQLFunctionVisitor<'_> {
                 match args.len() {
                     2 => self.visit_variadic(coalesce),
                     _ => {
-                        polars_bail!(SQLSyntax:"Invalid number of arguments for IFNULL ({})", args.len())
+                        polars_bail!(SQLSyntax: "IFNULL expects 2 arguments (found {})", args.len())
                     },
                 }
             },
@@ -914,7 +948,7 @@ impl SQLFunctionVisitor<'_> {
                             .otherwise(l)
                     }),
                     _ => {
-                        polars_bail!(SQLSyntax:"Invalid number of arguments for NULLIF ({})", args.len())
+                        polars_bail!(SQLSyntax: "NULLIF expects 2 arguments (found {})", args.len())
                     },
                 }
             },
@@ -922,16 +956,6 @@ impl SQLFunctionVisitor<'_> {
             // ----
             // Date functions
             // ----
-            Date => {
-                let args = extract_args(function)?;
-                match args.len() {
-                    1 => self.visit_unary(|e| e.str().to_date(StrptimeOptions::default())),
-                    2 => self.visit_binary(|e, fmt| e.str().to_date(fmt)),
-                    _ => {
-                        polars_bail!(SQLSyntax: "invalid number of arguments for DATE ({})", args.len())
-                    },
-                }
-            },
             DatePart => self.try_visit_binary(|part, e| {
                 match part {
                     Expr::Literal(LiteralValue::String(p)) => {
@@ -950,6 +974,15 @@ impl SQLFunctionVisitor<'_> {
                     },
                 }
             }),
+            Strftime => {
+                let args = extract_args(function)?;
+                match args.len() {
+                    2 => self.visit_binary(|e, fmt: String| e.dt().strftime(fmt.as_str())),
+                    _ => {
+                        polars_bail!(SQLSyntax: "STRFTIME expects 2 arguments (found {})", args.len())
+                    },
+                }
+            },
 
             // ----
             // String functions
@@ -958,7 +991,7 @@ impl SQLFunctionVisitor<'_> {
             Concat => {
                 let args = extract_args(function)?;
                 if args.is_empty() {
-                    polars_bail!(SQLSyntax: "invalid number of arguments for CONCAT (0)");
+                    polars_bail!(SQLSyntax: "CONCAT expects at least 1 argument (found 0)");
                 } else {
                     self.visit_variadic(|exprs: &[Expr]| concat_str(exprs, "", true))
                 }
@@ -966,7 +999,7 @@ impl SQLFunctionVisitor<'_> {
             ConcatWS => {
                 let args = extract_args(function)?;
                 if args.len() < 2 {
-                    polars_bail!(SQLSyntax: "invalid number of arguments for CONCAT_WS ({})", args.len());
+                    polars_bail!(SQLSyntax: "CONCAT_WS expects at least 2 arguments (found {})", args.len());
                 } else {
                     self.try_visit_variadic(|exprs: &[Expr]| {
                         match &exprs[0] {
@@ -974,6 +1007,16 @@ impl SQLFunctionVisitor<'_> {
                             _ => polars_bail!(SQLSyntax: "CONCAT_WS 'separator' must be a literal string (found {:?})", exprs[0]),
                         }
                     })
+                }
+            },
+            Date => {
+                let args = extract_args(function)?;
+                match args.len() {
+                    1 => self.visit_unary(|e| e.str().to_date(StrptimeOptions::default())),
+                    2 => self.visit_binary(|e, fmt| e.str().to_date(fmt)),
+                    _ => {
+                        polars_bail!(SQLSyntax: "DATE expects 1-2 arguments (found {})", args.len())
+                    },
                 }
             },
             EndsWith => self.visit_binary(|e, s| e.str().ends_with(s)),
@@ -1010,7 +1053,7 @@ impl SQLFunctionVisitor<'_> {
                     1 => self.visit_unary(|e| e.str().strip_chars_start(lit(Null))),
                     2 => self.visit_binary(|e, s| e.str().strip_chars_start(s)),
                     _ => {
-                        polars_bail!(SQLSyntax: "invalid number of arguments for LTRIM ({})", args.len())
+                        polars_bail!(SQLSyntax: "LTRIM expects 1-2 arguments (found {})", args.len())
                     },
                 }
             },
@@ -1040,7 +1083,7 @@ impl SQLFunctionVisitor<'_> {
                             },
                             true))
                     }),
-                    _ => polars_bail!(SQLSyntax: "invalid number of arguments for REGEXP_LIKE ({})",args.len()),
+                    _ => polars_bail!(SQLSyntax: "REGEXP_LIKE expects 2-3 arguments (found {})",args.len()),
                 }
             },
             Replace => {
@@ -1049,7 +1092,7 @@ impl SQLFunctionVisitor<'_> {
                     3 => self
                         .try_visit_ternary(|e, old, new| Ok(e.str().replace_all(old, new, true))),
                     _ => {
-                        polars_bail!(SQLSyntax: "invalid number of arguments for REPLACE ({})", args.len())
+                        polars_bail!(SQLSyntax: "REPLACE expects 3 arguments (found {})", args.len())
                     },
                 }
             },
@@ -1084,11 +1127,53 @@ impl SQLFunctionVisitor<'_> {
                     1 => self.visit_unary(|e| e.str().strip_chars_end(lit(Null))),
                     2 => self.visit_binary(|e, s| e.str().strip_chars_end(s)),
                     _ => {
-                        polars_bail!(SQLSyntax: "invalid number of arguments for RTRIM ({})", args.len())
+                        polars_bail!(SQLSyntax: "RTRIM expects 1-2 arguments (found {})", args.len())
                     },
                 }
             },
             StartsWith => self.visit_binary(|e, s| e.str().starts_with(s)),
+            Strptime => {
+                let args = extract_args(function)?;
+                match args.len() {
+                    2 => self.visit_binary(|e, fmt| {
+                        e.str().strptime(
+                            DataType::Datetime(TimeUnit::Microseconds, None),
+                            StrptimeOptions {
+                                format: Some(fmt),
+                                ..Default::default()
+                            },
+                            lit("latest"),
+                        )
+                    }),
+                    _ => {
+                        polars_bail!(SQLSyntax: "STRPTIME expects 2 arguments (found {})", args.len())
+                    },
+                }
+            },
+            Time => {
+                let args = extract_args(function)?;
+                match args.len() {
+                    1 => self.visit_unary(|e| e.str().to_time(StrptimeOptions::default())),
+                    2 => self.visit_binary(|e, fmt| e.str().to_time(fmt)),
+                    _ => {
+                        polars_bail!(SQLSyntax: "TIME expects 1-2 arguments (found {})", args.len())
+                    },
+                }
+            },
+            Timestamp => {
+                let args = extract_args(function)?;
+                match args.len() {
+                    1 => self.visit_unary(|e| {
+                        e.str()
+                            .to_datetime(None, None, StrptimeOptions::default(), lit("latest"))
+                    }),
+                    2 => self
+                        .visit_binary(|e, fmt| e.str().to_datetime(None, None, fmt, lit("latest"))),
+                    _ => {
+                        polars_bail!(SQLSyntax: "DATETIME expects 1-2 arguments (found {})", args.len())
+                    },
+                }
+            },
             Substring => {
                 let args = extract_args(function)?;
                 match args.len() {
@@ -1124,7 +1209,7 @@ impl SQLFunctionVisitor<'_> {
                             }
                         })
                     }),
-                    _ => polars_bail!(SQLSyntax: "invalid number of arguments for SUBSTR ({})", args.len()),
+                    _ => polars_bail!(SQLSyntax: "SUBSTR expects 2-3 arguments (found {})", args.len()),
                 }
             },
             Upper => self.visit_unary(|e| e.str().to_uppercase()),
@@ -1392,7 +1477,7 @@ impl SQLFunctionVisitor<'_> {
                 },
             }),
             _ => {
-                polars_bail!(SQLSyntax: "invalid number of arguments for ARRAY_TO_STRING ({})", args.len())
+                polars_bail!(SQLSyntax: "ARRAY_TO_STRING expects 2-3 arguments (found {})", args.len())
             },
         }
     }

--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -20,9 +20,11 @@ fn time_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
 where
     F: Fn(&str, &str) -> chrono::ParseResult<K>,
 {
-    ["%T", "%T%.3f", "%T%.6f", "%T%.9f"]
-        .into_iter()
-        .find(|&fmt| convert(val, fmt).is_ok())
+    patterns::TIME_H_M_S
+        .iter()
+        .chain(patterns::TIME_H_M_S)
+        .find(|fmt| convert(val, fmt).is_ok())
+        .copied()
 }
 
 fn datetime_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>

--- a/crates/polars-time/src/chunkedarray/string/patterns.rs
+++ b/crates/polars-time/src/chunkedarray/string/patterns.rs
@@ -214,6 +214,8 @@ pub(super) static DATETIME_Y_M_D_Z: &[&str] = &[
     "%+", // ISO 8601; Same as %Y-%m-%dT%H:%M:%S%.f%:z; supports Z or UTC
 ];
 
+pub(super) static TIME_H_M_S: &[&str] = &["%T%.9f", "%T%.6f", "%T%.3f", "%T"];
+
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
 pub enum Pattern {
     DateDMY,

--- a/py-polars/docs/source/reference/sql/functions/aggregate.rst
+++ b/py-polars/docs/source/reference/sql/functions/aggregate.rst
@@ -204,7 +204,7 @@ STDDEV
 ------
 Returns the standard deviation of all the elements in the grouping.
 
-.. admonition:: Function aliases
+.. admonition:: Aliases
 
    `STDEV`, `STDEV_SAMP`, `STDDEV_SAMP`
 
@@ -265,7 +265,7 @@ VARIANCE
 --------
 Returns the variance of all the elements in the grouping.
 
-.. admonition:: Function aliases
+.. admonition:: Aliases
 
    `VAR`, `VAR_SAMP`
 

--- a/py-polars/docs/source/reference/sql/functions/math.rst
+++ b/py-polars/docs/source/reference/sql/functions/math.rst
@@ -99,7 +99,7 @@ CEIL
 ----
 Returns the nearest integer closest from zero.
 
-.. admonition:: Function aliases
+.. admonition:: Aliases
 
    `CEILING`
 
@@ -377,7 +377,7 @@ POW
 ---
 Returns the value to the power of the given exponent.
 
-.. admonition:: Function aliases
+.. admonition:: Aliases
 
    `POWER`
 

--- a/py-polars/docs/source/reference/sql/functions/string.rst
+++ b/py-polars/docs/source/reference/sql/functions/string.rst
@@ -5,12 +5,16 @@ String
    :header-rows: 1
    :widths: 20 60
 
+   * - Function
+     - Description
    * - :ref:`BIT_LENGTH <bit_length>`
      - Returns the length of the input string in bits.
    * - :ref:`CONCAT <concat>`
      - Returns all input expressions concatenated together as a string.
    * - :ref:`CONCAT_WS <concat_ws>`
      - Returns all input expressions concatenated together (and interleaved with a separator) as a string.
+   * - :ref:`DATE <date>`
+     - Converts a formatted date string to an actual Date value.
    * - :ref:`ENDS_WITH <ends_with>`
      - Returns True if the value ends with the second argument.
    * - :ref:`INITCAP <initcap>`
@@ -39,8 +43,12 @@ String
      - Returns True if the value starts with the second argument.
    * - :ref:`STRPOST <strpos>`
      - Returns the index of the given substring in the target string.
+   * - :ref:`STRPTIME <strptime>`
+     - Converts a string to a Datetime using a strftime-compatible formatting string.
    * - :ref:`SUBSTRING <substring>`
      - Returns a portion of the data (first character = 0) in the range [start, start + length].
+   * - :ref:`TIMESTAMP <timestamp>`
+     - Converts a formatted timestamp/datetime string to an actual Datetime value.
    * - :ref:`UPPER <upper>`
      - Returns an uppercased column.
 
@@ -131,6 +139,48 @@ Returns all input expressions concatenated together (and interleaved with a sepa
     # │ c:xx   │
     # │ dd:ww  │
     # └────────┘
+
+.. _date:
+
+DATE
+----
+Converts a formatted string date to an actual Date type; ISO-8601 format is assumed
+unless a strftime-compatible formatting string is provided as the second parameter.
+
+.. tip::
+
+  `DATE` is also supported as a typed literal (this form does not allow a format string).
+
+  .. code-block:: sql
+
+    SELECT DATE '2021-01-01' AS dt
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+      {
+        "s_dt1": ["1969-10-30", "2024-07-05", "2077-02-28"],
+        "s_dt2": ["10 February 1920", "5 July 2077", "28 April 2000"],
+      }
+    )
+    df.sql("""
+      SELECT
+        DATE(s_dt1) AS dt1,
+        DATE(s_dt2, '%d %B %Y') AS dt2
+      FROM self
+    """)
+    # shape: (3, 2)
+    # ┌────────────┬────────────┐
+    # │ dt1        ┆ dt2        │
+    # │ ---        ┆ ---        │
+    # │ date       ┆ date       │
+    # ╞════════════╪════════════╡
+    # │ 1969-10-30 ┆ 1920-02-10 │
+    # │ 2024-07-05 ┆ 2077-07-05 │
+    # │ 2077-02-28 ┆ 2000-04-28 │
+    # └────────────┴────────────┘
 
 .. _ends_with:
 
@@ -230,7 +280,7 @@ LENGTH
 ------
 Returns the character length of the string.
 
-.. admonition:: Function aliases
+.. admonition:: Aliases
 
    `CHAR_LENGTH`, `CHARACTER_LENGTH`
 
@@ -252,6 +302,7 @@ Returns the character length of the string.
         OCTET_LENGTH(color) AS n_bytes
       FROM self
     """)
+
     # shape: (3, 4)
     # ┌──────────┬──────────┬─────────┬─────────┐
     # │ iso_lang ┆ color    ┆ n_chars ┆ n_bytes │
@@ -531,6 +582,41 @@ Returns the index of the given substring in the target string.
     # │ grape  ┆ 3     │
     # └────────┴───────┘
 
+
+.. _strptime:
+
+STRPTIME
+--------
+Converts a string to a Datetime using a `chrono strftime <https://docs.rs/chrono/latest/chrono/format/strftime/>`_-compatible formatting string.
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+      {
+        "s_dt": ["1969 Oct 30", "2024 Jul 05", "2077 Feb 28"],
+        "s_tm": ["00.30.55", "12.40.15", "10.45.00"],
+      }
+    )
+    df.sql("""
+      SELECT
+        s_dt,
+        s_tm,
+        STRPTIME(s_dt || ' ' || s_tm, '%Y %b %d %H.%M.%S') AS dtm
+      FROM self
+    """)
+    # shape: (3, 3)
+    # ┌─────────────┬──────────┬─────────────────────┐
+    # │ s_dt        ┆ s_tm     ┆ dtm                 │
+    # │ ---         ┆ ---      ┆ ---                 │
+    # │ str         ┆ str      ┆ datetime[μs]        │
+    # ╞═════════════╪══════════╪═════════════════════╡
+    # │ 1969 Oct 30 ┆ 00.30.55 ┆ 1969-10-30 00:30:55 │
+    # │ 2024 Jul 05 ┆ 12.40.15 ┆ 2024-07-05 12:40:15 │
+    # │ 2077 Feb 28 ┆ 10.45.00 ┆ 2077-02-28 10:45:00 │
+    # └─────────────┴──────────┴─────────────────────┘
+
 .. _substring:
 
 SUBSTRING
@@ -556,6 +642,54 @@ Returns a slice of the string data (1-indexed) in the range [start, start + leng
     # │ orange ┆ ange    │
     # │ grape  ┆ ape     │
     # └────────┴─────────┘
+
+
+.. _timestamp:
+
+TIMESTAMP
+---------
+Converts a formatted string date to an actual Datetime type; ISO-8601 format is assumed
+unless a strftime-compatible formatting string is provided as the second parameter.
+
+.. admonition:: Aliases
+
+   `DATETIME`
+
+.. tip::
+
+  `TIMESTAMP` is also supported as a typed literal (this form does not allow a format string).
+
+  .. code-block:: sql
+
+    SELECT TIMESTAMP '2077-12-10 22:30:45' AS ts
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+      {
+        "str_timestamp": [
+          "1969 July 30, 00:30:55",
+          "2030-October-08, 12:40:15",
+          "2077 February 28, 10:45:00",
+        ]
+      }
+    )
+    df.sql("""
+      SELECT str_timestamp, TIMESTAMP(str_date, '%Y.%m.%d') AS date FROM self
+    """)
+    # shape: (3, 2)
+    # ┌────────────┬────────────┐
+    # │ str_date   ┆ date       │
+    # │ ---        ┆ ---        │
+    # │ str        ┆ date       │
+    # ╞════════════╪════════════╡
+    # │ 1969.10.30 ┆ 1969-10-30 │
+    # │ 2024.07.05 ┆ 2024-07-05 │
+    # │ 2077.02.28 ┆ 2077-02-28 │
+    # └────────────┴────────────┘
+
 
 .. _upper:
 

--- a/py-polars/docs/source/reference/sql/functions/temporal.rst
+++ b/py-polars/docs/source/reference/sql/functions/temporal.rst
@@ -7,38 +7,14 @@ Temporal
 
    * - Function
      - Description
-   * - :ref:`DATE <date>`
-     - Converts a formatted string date to an actual Date type.
+
    * - :ref:`DATE_PART <date_part>`
      - Extracts a part of a date (or datetime) such as 'year', 'month', etc.
    * - :ref:`EXTRACT <extract>`
      - Offers the same functionality as `DATE_PART` with slightly different syntax.
+   * - :ref:`STRFTIME <strftime>`
+     - Formats a temporal value (Datetime, Date, or Time) as a string.
 
-.. _date:
-
-DATE
-----
-Converts a formatted string date to an actual Date type; ISO-8601 format is assumed
-unless a strftime-compatible formatting string is provided as the second parameter.
-
-**Example:**
-
-.. code-block:: python
-
-    df = pl.DataFrame({"str_date": ["1969.10.30", "2024.07.05", "2077.02.28"]})
-    df.sql("""
-      SELECT str_date, DATE(str_date, '%Y.%m.%d') AS date FROM self
-    """)
-    # shape: (3, 2)
-    # ┌────────────┬────────────┐
-    # │ str_date   ┆ date       │
-    # │ ---        ┆ ---        │
-    # │ str        ┆ date       │
-    # ╞════════════╪════════════╡
-    # │ 1969.10.30 ┆ 1969-10-30 │
-    # │ 2024.07.05 ┆ 2024-07-05 │
-    # │ 2077.02.28 ┆ 2077-02-28 │
-    # └────────────┴────────────┘
 
 .. _date_part:
 
@@ -90,7 +66,6 @@ Extracts a part of a date (or datetime) such as 'year', 'month', etc.
         DATE_PART('day', dt) AS day
       FROM self
     """)
-
     # shape: (3, 4)
     # ┌────────────┬──────┬───────┬─────┐
     # │ dt         ┆ year ┆ month ┆ day │
@@ -136,11 +111,11 @@ Extracts a part of a date (or datetime) such as 'year', 'month', etc.
 
     df = pl.DataFrame(
       {
-          "dt": [
-              date(1969, 12, 31),
-              date(2026, 8, 22),
-              date(2077, 2, 10),
-          ]
+        "dt": [
+          date(1969, 12, 31),
+          date(2026, 8, 22),
+          date(2077, 2, 10),
+        ],
       }
     )
     df.sql("""
@@ -151,7 +126,6 @@ Extracts a part of a date (or datetime) such as 'year', 'month', etc.
         EXTRACT(quarter FROM dt) AS quarter,
       FROM self
     """)
-
     # shape: (3, 4)
     # ┌────────────┬────────┬──────┬─────────┐
     # │ dt         ┆ decade ┆ year ┆ quarter │
@@ -162,3 +136,34 @@ Extracts a part of a date (or datetime) such as 'year', 'month', etc.
     # │ 2026-08-22 ┆ 202    ┆ 2026 ┆ 3       │
     # │ 2077-02-10 ┆ 207    ┆ 2077 ┆ 1       │
     # └────────────┴────────┴──────┴─────────┘
+
+.. _strftime:
+
+STRFTIME
+--------
+Formats a temporal value (Datetime, Date, or Time) as a string using a `chrono strftime <https://docs.rs/chrono/latest/chrono/format/strftime/>`_-compatible formatting string.
+
+.. code-block:: python
+
+    df = pl.DataFrame(
+      {
+        "dt": [date(1978, 7, 5), None, date(2020, 4, 10)],
+        "tm": [time(10, 10, 10), time(22, 33, 55), None],
+      }
+    )
+    df.sql("""
+      SELECT
+        STRFTIME(dt, '%B %d, %Y') AS s_dt,
+        STRFTIME(tm, '%H.%M.%S') AS s_tm,
+      FROM self
+    """)
+    # shape: (3, 2)
+    # ┌────────────────┬──────────┐
+    # │ s_dt           ┆ s_tm     │
+    # │ ---            ┆ ---      │
+    # │ str            ┆ str      │
+    # ╞════════════════╪══════════╡
+    # │ July 05, 1978  ┆ 10.10.10 │
+    # │ null           ┆ 22.33.55 │
+    # │ April 10, 2020 ┆ null     │
+    # └────────────────┴──────────┘

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -644,8 +644,11 @@ def test_strptime_complete_formats(string: str, fmt: str, expected: datetime) ->
 )
 def test_to_time_subseconds(data: str, format: str, expected: time) -> None:
     s = pl.Series([data])
-    result = s.str.to_time(format).item()
-    assert result == expected
+    for res in (
+        s.str.to_time().item(),
+        s.str.to_time(format).item(),
+    ):
+        assert res == expected
 
 
 def test_to_time_format_warning() -> None:

--- a/py-polars/tests/unit/sql/test_array.py
+++ b/py-polars/tests/unit/sql/test_array.py
@@ -166,6 +166,11 @@ def test_array_to_string() -> None:
             }
         ),
     )
+    with pytest.raises(
+        SQLSyntaxError,
+        match=r"ARRAY_TO_STRING expects 2-3 arguments \(found 1\)",
+    ):
+        pl.sql_expr("ARRAY_TO_STRING(arr)")
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/sql/test_conditional.py
+++ b/py-polars/tests/unit/sql/test_conditional.py
@@ -69,7 +69,10 @@ def test_control_flow(foods_ipc_path: Path) -> None:
     }
 
     for null_func in ("IFNULL", "NULLIF"):
-        with pytest.raises(SQLSyntaxError):  # both functions expect TWO arguments
+        with pytest.raises(
+            SQLSyntaxError,
+            match=r"(IFNULL|NULLIF) expects 2 arguments \(found 3\)",
+        ):
             pl.SQLContext(df=nums).execute(f"SELECT {null_func}(x,y,z) FROM df")
 
 

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
 
 
 def test_div() -> None:
-    res = pl.sql("""
+    res = pl.sql(
+        """
         SELECT label, DIV(a, b) AS a_div_b, DIV(tbl.b, tbl.a) AS b_div_a
         FROM (
           VALUES
@@ -24,7 +25,8 @@ def test_div() -> None:
             ('d', 5.0, NULL),
             ('e', 2.5, 5)
         ) AS tbl(label, a, b)
-    """).collect()
+        """
+    ).collect()
 
     assert res.to_dict(as_series=False) == {
         "label": ["a", "b", "c", "d", "e"],
@@ -127,10 +129,16 @@ def test_round_ndigits_errors() -> None:
             SQLSyntaxError, match=r"invalid value for ROUND decimals \('!!'\)"
         ):
             ctx.execute("SELECT ROUND(n,'!!') AS n FROM df")
+
         with pytest.raises(
             SQLInterfaceError, match=r"ROUND .* negative decimals value \(-1\)"
         ):
             ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
+
+        with pytest.raises(
+            SQLSyntaxError, match=r"ROUND expects 1-2 arguments \(found 4\)"
+        ):
+            ctx.execute("SELECT ROUND(1.2345,6,7,8) AS n FROM df")
 
 
 def test_stddev_variance() -> None:

--- a/py-polars/tests/unit/sql/test_regex.py
+++ b/py-polars/tests/unit/sql/test_regex.py
@@ -139,6 +139,6 @@ def test_regexp_like_errors() -> None:
 
         with pytest.raises(
             SQLSyntaxError,
-            match="invalid number of arguments for REGEXP_LIKE",
+            match=r"REGEXP_LIKE expects 2-3 arguments \(found 1\)",
         ):
             ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol)")

--- a/py-polars/tests/unit/sql/test_strings.py
+++ b/py-polars/tests/unit/sql/test_strings.py
@@ -76,7 +76,10 @@ def test_string_concat() -> None:
 )
 def test_string_concat_errors(invalid_concat: str) -> None:
     lf = pl.LazyFrame({"x": ["a", "b", "c"]})
-    with pytest.raises(SQLSyntaxError, match="invalid number of arguments"):
+    with pytest.raises(
+        SQLSyntaxError,
+        match=r"CONCAT.*expects at least \d argument[s]? \(found \d\)",
+    ):
         pl.SQLContext(data=lf).execute(f"SELECT {invalid_concat} FROM data")
 
 
@@ -320,7 +323,9 @@ def test_string_replace() -> None:
         res = out["words"].to_list()
         assert res == ["English breakfast tea is the best tea", "", None]
 
-        with pytest.raises(SQLSyntaxError, match="invalid number of arguments"):
+        with pytest.raises(
+            SQLSyntaxError, match=r"REPLACE expects 3 arguments \(found 2\)"
+        ):
             ctx.execute("SELECT REPLACE(words,'coffee') FROM df")
 
 
@@ -355,6 +360,12 @@ def test_string_substr() -> None:
             match=r"SUBSTR does not support negative length \(-99\)",
         ):
             ctx.execute("SELECT SUBSTR(scol,2,-99) FROM df")
+
+        with pytest.raises(
+            SQLSyntaxError,
+            match=r"SUBSTR expects 2-3 arguments \(found 1\)",
+        ):
+            pl.sql_expr("SUBSTR(s)")
 
     assert res.to_dict(as_series=False) == {
         "s1": ["abcdefg", "abcde", "abc", None],


### PR DESCRIPTION
Improves the slightly sparse temporal SQL support with some key functions.

## Updates

* Added support for `STRFTIME` (temporal → string)
* Added support for `STRPTIME` (string → temporal)
* Added support for temporal "typed literal" syntax for, eg: 
   `SELECT DATETIME '2077-07-05 10:30:45'`
   `SELECT DATE '2077-07-05'`
   `SELECT TIME '10:30:45'`
* New SQL doc entries and test coverage for all of the above.

## Also

* Closes #17093 (introducing `TIMESTAMP` and `DATETIME` to join the existing `DATE`).
* Improved our default `Time` inference patterns to account for fractional seconds.
* Improved SQL _"invalid number of argument"_ error messages by additionally including how many arguments were actually expected.

## Examples

`STRFTIME`:
```python
pl.DataFrame({
    "dtm": [None, datetime(1980, 9, 30, 1, 25, 50)],
    "dt": [date(1978, 7, 5), date(1969, 12, 31)],
    "tm": [time(10, 10, 10), time(22, 33, 55)],
}).sql(
    """
    SELECT
      STRFTIME(dtm,'%m.%d.%Y/%T') AS s_dtm,
      STRFTIME(dt,'%B %d, %Y') AS s_dt,
      STRFTIME(tm,'%S.%M.%H') AS s_tm,
    FROM self
    """
)
# shape: (2, 3)
# ┌─────────────────────┬───────────────────┬──────────┐
# │ s_dtm               ┆ s_dt              ┆ s_tm     │
# │ ---                 ┆ ---               ┆ ---      │
# │ str                 ┆ str               ┆ str      │
# ╞═════════════════════╪═══════════════════╪══════════╡
# │ null                ┆ July 05, 1978     ┆ 10.10.10 │
# │ 09.30.1980/01:25:50 ┆ December 31, 1969 ┆ 55.33.22 │
# └─────────────────────┴───────────────────┴──────────┘
```
`STRPTIME`:
```python
pl.DataFrame({
    "s_dtm": [None, "09.30.1980/01:25:50", "07.17.2077/11:30:55"],
    "s_dt": ["July 5, 1978", "December 31, 1969", "April 10, 2020"],
    "s_tm": ["10.10.10", "55.33.22", None],
}).sql(
    """
    SELECT
      STRPTIME(s_dtm,'%m.%d.%Y/%T') AS dtm,
      STRPTIME(s_dt,'%B %d, %Y')::date AS dt,
      STRPTIME(s_tm,'%S.%M.%H')::time AS tm
    FROM self
    """
)
# shape: (3, 3)
# ┌─────────────┬──────────┬─────────────────────┐
# │ s_dt        ┆ s_tm     ┆ dtm                 │
# │ ---         ┆ ---      ┆ ---                 │
# │ str         ┆ str      ┆ datetime[μs]        │
# ╞═════════════╪══════════╪═════════════════════╡
# │ 1969 Oct 30 ┆ 00.30.55 ┆ 1969-10-30 00:30:55 │
# │ 2024 Jul 05 ┆ 12.40.15 ┆ 2024-07-05 12:40:15 │
# │ 2077 Feb 28 ┆ 10.45.00 ┆ 2077-02-28 10:45:00 │
# └─────────────┴──────────┴─────────────────────┘
```

