### PR TITLE
fix: respect `nulls_last` parameter in aggregate `sort_by`

### DIFF
--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -138,6 +138,7 @@ fn sort_by_groups_multiple_by(
     indicator: GroupsIndicator,
     sort_by_s: &[Series],
     descending: &[bool],
+    nulls_last: &[bool],
     multithreaded: bool,
     maintain_order: bool,
 ) -> PolarsResult<(IdxSize, IdxVec)> {
@@ -151,7 +152,7 @@ fn sort_by_groups_multiple_by(
 
             let options = SortMultipleOptions {
                 descending: descending.to_owned(),
-                nulls_last: vec![false; descending.len()],
+                nulls_last: nulls_last.to_owned(),
                 multithreaded,
                 maintain_order,
             };
@@ -167,7 +168,7 @@ fn sort_by_groups_multiple_by(
 
             let options = SortMultipleOptions {
                 descending: descending.to_owned(),
-                nulls_last: vec![false; descending.len()],
+                nulls_last: nulls_last.to_owned(),
                 multithreaded,
                 maintain_order,
             };
@@ -251,6 +252,7 @@ impl PhysicalExpr for SortByExpr {
     ) -> PolarsResult<AggregationContext<'a>> {
         let mut ac_in = self.input.evaluate_on_groups(df, groups, state)?;
         let descending = prepare_bool_vec(&self.sort_options.descending, self.by.len());
+        let nulls_last = prepare_bool_vec(&self.sort_options.nulls_last, self.by.len());
 
         let mut ac_sort_by = self
             .by
@@ -307,6 +309,7 @@ impl PhysicalExpr for SortByExpr {
                         &sort_by_s,
                         &SortOptions {
                             descending: descending[0],
+                            nulls_last: nulls_last[0],
                             ..Default::default()
                         },
                     )
@@ -326,6 +329,7 @@ impl PhysicalExpr for SortByExpr {
                             indicator,
                             &sort_by_s,
                             &descending,
+                            &nulls_last,
                             self.sort_options.multithreaded,
                             self.sort_options.maintain_order,
                         )

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -658,3 +658,93 @@ def test_filter_aggregation_16642() -> None:
         "datetime": [date(2022, 1, 1), date(2022, 1, 2)],
         "num": [3, 3],
     }
+
+
+def test_sort_by_over_single_nulls_first() -> None:
+    key = [0, 0, 0, 0, 1, 1, 1, 1]
+    df = pl.DataFrame(
+        {
+            "key": key,
+            "value": [2, None, 1, 0, 2, None, 1, 0],
+        }
+    )
+    out = df.select(
+        pl.all().sort_by("value", nulls_last=False, maintain_order=True).over("key")
+    )
+    expected = pl.DataFrame(
+        {
+            "key": key,
+            "value": [None, 0, 1, 2, None, 0, 1, 2],
+        }
+    )
+    assert_frame_equal(out, expected)
+
+
+def test_sort_by_over_single_nulls_last() -> None:
+    key = [0, 0, 0, 0, 1, 1, 1, 1]
+    df = pl.DataFrame(
+        {
+            "key": key,
+            "value": [2, None, 1, 0, 2, None, 1, 0],
+        }
+    )
+    out = df.select(
+        pl.all().sort_by("value", nulls_last=True, maintain_order=True).over("key")
+    )
+    expected = pl.DataFrame(
+        {
+            "key": key,
+            "value": [0, 1, 2, None, 0, 1, 2, None],
+        }
+    )
+    assert_frame_equal(out, expected)
+
+
+def test_sort_by_over_multiple_nulls_first() -> None:
+    key1 = [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]
+    key2 = [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1]
+    df = pl.DataFrame(
+        {
+            "key1": key1,
+            "key2": key2,
+            "value": [1, None, 0, 1, None, 0, 1, None, 0, None, 1, 0],
+        }
+    )
+    out = df.select(
+        pl.all()
+        .sort_by("value", nulls_last=False, maintain_order=True)
+        .over("key1", "key2")
+    )
+    expected = pl.DataFrame(
+        {
+            "key1": key1,
+            "key2": key2,
+            "value": [None, 0, 1, None, 0, 1, None, 0, 1, None, 0, 1],
+        }
+    )
+    assert_frame_equal(out, expected)
+
+
+def test_sort_by_over_multiple_nulls_last() -> None:
+    key1 = [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]
+    key2 = [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1]
+    df = pl.DataFrame(
+        {
+            "key1": key1,
+            "key2": key2,
+            "value": [1, None, 0, 1, None, 0, 1, None, 0, None, 1, 0],
+        }
+    )
+    out = df.select(
+        pl.all()
+        .sort_by("value", nulls_last=True, maintain_order=True)
+        .over("key1", "key2")
+    )
+    expected = pl.DataFrame(
+        {
+            "key1": key1,
+            "key2": key2,
+            "value": [0, 1, None, 0, 1, None, 0, 1, None, 0, 1, None],
+        }
+    )
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
Fixes #17243.

From the issue example:

```python
df = pl.DataFrame({
    "a": [1, 10, 9, 3, 2, 4, 7, 5, 6, 8, None, None],
    "b": [1, 2, 3, 1, 4, 2, 3, 3, 2, 1, 1, 2],
})

pl.Config.set_tbl_rows(12)
print(df.select(pl.all().sort_by("a", nulls_last=True).over("b")))
```
```
shape: (12, 2)
┌──────┬─────┐
│ a    ┆ b   │
│ ---  ┆ --- │
│ i64  ┆ i64 │
╞══════╪═════╡
│ 1    ┆ 1   │
│ 4    ┆ 2   │
│ 5    ┆ 3   │
│ 3    ┆ 1   │
│ 2    ┆ 4   │
│ 6    ┆ 2   │
│ 7    ┆ 3   │
│ 9    ┆ 3   │
│ 10   ┆ 2   │
│ 8    ┆ 1   │
│ null ┆ 1   │
│ null ┆ 2   │
└──────┴─────┘
```