### PR TITLE
docs(python): Mark hypothesis testing functionality as unstable

### DIFF
--- a/py-polars/polars/testing/parametric/profiles.py
+++ b/py-polars/polars/testing/parametric/profiles.py
@@ -14,6 +14,10 @@ def load_profile(
     """
     Load a named (or custom) hypothesis profile for use with the parametric tests.
 
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
+
     Parameters
     ----------
     profile : {str, int}, optional
@@ -70,6 +74,10 @@ def load_profile(
 def set_profile(profile: ParametricProfileNames | int) -> None:
     """
     Set the env var `POLARS_HYPOTHESIS_PROFILE` to the given profile name/value.
+
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
 
     Parameters
     ----------

--- a/py-polars/polars/testing/parametric/strategies/core.py
+++ b/py-polars/polars/testing/parametric/strategies/core.py
@@ -49,6 +49,10 @@ def series(  # noqa: D417
     """
     Hypothesis strategy for producing Polars Series.
 
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
+
     Parameters
     ----------
     name : {str, strategy}, optional
@@ -284,6 +288,10 @@ def dataframes(  # noqa: D417
     """
     Hypothesis strategy for producing Polars DataFrames or LazyFrames.
 
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
+
     Parameters
     ----------
     cols : {int, columns}, optional
@@ -492,6 +500,10 @@ def dataframes(  # noqa: D417
 class column:
     """
     Define a column for use with the `dataframes` strategy.
+
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
 
     Parameters
     ----------

--- a/py-polars/polars/testing/parametric/strategies/data.py
+++ b/py-polars/polars/testing/parametric/strategies/data.py
@@ -256,6 +256,10 @@ def lists(
     """
     Create a strategy for generating lists of the given data type.
 
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
+
     Parameters
     ----------
     inner_dtype

--- a/py-polars/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/polars/testing/parametric/strategies/dtype.py
@@ -95,6 +95,10 @@ def dtypes(
     """
     Create a strategy for generating Polars :class:`DataType` objects.
 
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
+
     Parameters
     ----------
     allowed_dtypes

--- a/py-polars/polars/testing/parametric/strategies/legacy.py
+++ b/py-polars/polars/testing/parametric/strategies/legacy.py
@@ -34,6 +34,10 @@ def columns(
     .. deprecated:: 0.20.26
         Use :class:`column` instead in conjunction with a list comprehension.
 
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
+
     Generate a fixed sequence of `column` objects suitable for passing to the
     @dataframes strategy, or using standalone (note that this function is not itself
     a strategy).


### PR DESCRIPTION
There is quite some fine-tuning needed still - I don't want to be constrained by the existing API.

I don't think there are a _lot_ of people out there using this functionality. Plus, it's purely for testing code, so changes here are not going to break production pipelines.

So let's mark these as unstable for now to make improvements easier.

Note: I did not make these raise an `UnstableWarning` on use because it's testing functionality and raising warnings from testing utils might disturb the testing suite.