### PR TITLE
feat(python)!: Change default engine for `read_excel` to `"calamine"`

### DIFF
--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -48,6 +48,7 @@ def read_excel(
     engine: ExcelSpreadsheetEngine = ...,
     engine_options: dict[str, Any] | None = ...,
     read_options: dict[str, Any] | None = ...,
+    columns: Sequence[int] | Sequence[str] | None = ...,
     schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
@@ -63,6 +64,7 @@ def read_excel(
     engine: ExcelSpreadsheetEngine = ...,
     engine_options: dict[str, Any] | None = ...,
     read_options: dict[str, Any] | None = ...,
+    columns: Sequence[int] | Sequence[str] | None = ...,
     schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
@@ -78,6 +80,7 @@ def read_excel(
     engine: ExcelSpreadsheetEngine = ...,
     engine_options: dict[str, Any] | None = ...,
     read_options: dict[str, Any] | None = ...,
+    columns: Sequence[int] | Sequence[str] | None = ...,
     schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
@@ -95,6 +98,7 @@ def read_excel(
     engine: ExcelSpreadsheetEngine = ...,
     engine_options: dict[str, Any] | None = ...,
     read_options: dict[str, Any] | None = ...,
+    columns: Sequence[int] | Sequence[str] | None = ...,
     schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
@@ -110,6 +114,7 @@ def read_excel(
     engine: ExcelSpreadsheetEngine = ...,
     engine_options: dict[str, Any] | None = ...,
     read_options: dict[str, Any] | None = ...,
+    columns: Sequence[int] | Sequence[str] | None = ...,
     schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
@@ -125,6 +130,7 @@ def read_excel(
     engine: ExcelSpreadsheetEngine = ...,
     engine_options: dict[str, Any] | None = ...,
     read_options: dict[str, Any] | None = ...,
+    columns: Sequence[int] | Sequence[str] | None = ...,
     schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
@@ -141,6 +147,7 @@ def read_excel(
     engine: ExcelSpreadsheetEngine = "calamine",
     engine_options: dict[str, Any] | None = None,
     read_options: dict[str, Any] | None = None,
+    columns: Sequence[int] | Sequence[str] | None = None,
     schema_overrides: SchemaDict | None = None,
     infer_schema_length: int | None = N_INFER_DEFAULT,
     raise_if_empty: bool = True,
@@ -194,6 +201,9 @@ def read_excel(
         * "calamine": `ExcelReader.load_sheet_by_name`
         * "xlsx2csv": `pl.read_csv`
         * "openpyxl": n/a (can only provide `engine_options`)
+    columns
+        Columns to read from the sheet; if not specified, all columns are read. Can
+        be given as a sequence of column names or indices.
     schema_overrides
         Support type specification or override of one or more columns.
     infer_schema_length
@@ -269,6 +279,7 @@ def read_excel(
         schema_overrides=schema_overrides,
         infer_schema_length=infer_schema_length,
         raise_if_empty=raise_if_empty,
+        columns=columns,
     )
 
 
@@ -278,7 +289,8 @@ def read_ods(
     *,
     sheet_id: None = ...,
     sheet_name: str,
-    schema_overrides: SchemaDict | None = None,
+    columns: Sequence[int] | Sequence[str] | None = ...,
+    schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
 ) -> pl.DataFrame: ...
@@ -290,7 +302,8 @@ def read_ods(
     *,
     sheet_id: None = ...,
     sheet_name: None = ...,
-    schema_overrides: SchemaDict | None = None,
+    columns: Sequence[int] | Sequence[str] | None = ...,
+    schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
 ) -> pl.DataFrame: ...
@@ -302,7 +315,8 @@ def read_ods(
     *,
     sheet_id: int,
     sheet_name: str,
-    schema_overrides: SchemaDict | None = None,
+    columns: Sequence[int] | Sequence[str] | None = ...,
+    schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
 ) -> NoReturn: ...
@@ -314,7 +328,8 @@ def read_ods(
     *,
     sheet_id: Literal[0] | Sequence[int],
     sheet_name: None = ...,
-    schema_overrides: SchemaDict | None = None,
+    columns: Sequence[int] | Sequence[str] | None = ...,
+    schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
 ) -> dict[str, pl.DataFrame]: ...
@@ -326,7 +341,8 @@ def read_ods(
     *,
     sheet_id: int,
     sheet_name: None = ...,
-    schema_overrides: SchemaDict | None = None,
+    columns: Sequence[int] | Sequence[str] | None = ...,
+    schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
 ) -> pl.DataFrame: ...
@@ -338,7 +354,8 @@ def read_ods(
     *,
     sheet_id: None,
     sheet_name: list[str] | tuple[str],
-    schema_overrides: SchemaDict | None = None,
+    columns: Sequence[int] | Sequence[str] | None = ...,
+    schema_overrides: SchemaDict | None = ...,
     infer_schema_length: int | None = ...,
     raise_if_empty: bool = ...,
 ) -> dict[str, pl.DataFrame]: ...
@@ -349,6 +366,7 @@ def read_ods(
     *,
     sheet_id: int | Sequence[int] | None = None,
     sheet_name: str | list[str] | tuple[str] | None = None,
+    columns: Sequence[int] | Sequence[str] | None = None,
     schema_overrides: SchemaDict | None = None,
     infer_schema_length: int | None = N_INFER_DEFAULT,
     raise_if_empty: bool = True,
@@ -370,6 +388,9 @@ def read_ods(
     sheet_name
         Sheet name(s) to convert; cannot be used in conjunction with `sheet_id`. If
         more than one is given then a `{sheetname:frame,}` dict is returned.
+    columns
+        Columns to read from the sheet; if not specified, all columns are read. Can
+        be given as a sequence of column names or indices.
     schema_overrides
         Support type specification or override of one or more columns.
     infer_schema_length
@@ -417,6 +438,7 @@ def read_ods(
         schema_overrides=schema_overrides,
         infer_schema_length=infer_schema_length,
         raise_if_empty=raise_if_empty,
+        columns=columns,
     )
 
 
@@ -471,6 +493,7 @@ def _read_spreadsheet(
     read_options: dict[str, Any] | None = None,
     schema_overrides: SchemaDict | None = None,
     infer_schema_length: int | None = N_INFER_DEFAULT,
+    columns: Sequence[int] | Sequence[str] | None = None,
     *,
     raise_if_empty: bool = True,
 ) -> pl.DataFrame | dict[str, pl.DataFrame]:
@@ -484,19 +507,27 @@ def _read_spreadsheet(
 
     # normalise some top-level parameters to 'read_options' entries
     if engine == "calamine":
-        if ("schema_sample_rows" in read_options) and (
+        if ("use_columns" in read_options) and columns:
+            msg = 'cannot specify both `columns` and `read_options["use_columns"]`'
+            raise ParameterCollisionError(msg)
+        elif ("schema_sample_rows" in read_options) and (
             infer_schema_length != N_INFER_DEFAULT
         ):
             msg = 'cannot specify both `infer_schema_length` and `read_options["schema_sample_rows"]`'
             raise ParameterCollisionError(msg)
+
         read_options["schema_sample_rows"] = infer_schema_length
 
     elif engine == "xlsx2csv":
-        if ("infer_schema_length" in read_options) and (
+        if ("columns" in read_options) and columns:
+            msg = 'cannot specify both `columns` and `read_options["columns"]`'
+            raise ParameterCollisionError(msg)
+        elif ("infer_schema_length" in read_options) and (
             infer_schema_length != N_INFER_DEFAULT
         ):
             msg = 'cannot specify both `infer_schema_length` and `read_options["infer_schema_length"]`'
             raise ParameterCollisionError(msg)
+
         read_options["infer_schema_length"] = infer_schema_length
     else:
         read_options["infer_schema_length"] = infer_schema_length
@@ -515,6 +546,7 @@ def _read_spreadsheet(
                 schema_overrides=schema_overrides,
                 read_options=read_options,
                 raise_if_empty=raise_if_empty,
+                columns=columns,
             )
             for name in sheet_names
         }
@@ -645,10 +677,10 @@ def _initialise_spreadsheet_parser(
 
 def _csv_buffer_to_frame(
     csv: StringIO,
+    *,
     separator: str,
     read_options: dict[str, Any],
     schema_overrides: SchemaDict | None,
-    *,
     raise_if_empty: bool,
 ) -> pl.DataFrame:
     """Translate StringIO buffer containing delimited data as a DataFrame."""
@@ -725,12 +757,24 @@ def _drop_null_data(df: pl.DataFrame, *, raise_if_empty: bool) -> pl.DataFrame:
     return df.filter(~F.all_horizontal(F.all().is_null()))
 
 
+def _reorder_columns(
+    df: pl.DataFrame, columns: Sequence[int] | Sequence[str] | None
+) -> pl.DataFrame:
+    if columns:
+        from polars.selectors import by_index, by_name
+
+        cols = by_index(*columns) if isinstance(columns[0], int) else by_name(*columns)
+        df = df.select(cols)
+    return df
+
+
 def _read_spreadsheet_openpyxl(
     parser: Any,
+    *,
     sheet_name: str | None,
     read_options: dict[str, Any],
     schema_overrides: SchemaDict | None,
-    *,
+    columns: Sequence[int] | Sequence[str] | None,
     raise_if_empty: bool,
 ) -> pl.DataFrame:
     """Use the 'openpyxl' library to read data from the given worksheet."""
@@ -775,24 +819,35 @@ def _read_spreadsheet_openpyxl(
         infer_schema_length=infer_schema_length,
         strict=False,
     )
-    return _drop_null_data(df, raise_if_empty=raise_if_empty)
+
+    df = _drop_null_data(df, raise_if_empty=raise_if_empty)
+    df = _reorder_columns(df, columns)
+    return df
 
 
 def _read_spreadsheet_calamine(
     parser: Any,
+    *,
     sheet_name: str | None,
     read_options: dict[str, Any],
     schema_overrides: SchemaDict | None,
-    *,
+    columns: Sequence[int] | Sequence[str] | None,
     raise_if_empty: bool,
 ) -> pl.DataFrame:
     # if we have 'schema_overrides' and a more recent version of `fastexcel`
     # we can pass translated dtypes to the engine to refine the initial parse
     fastexcel = import_optional("fastexcel")
-    fastexcel_version = parse_version(fastexcel.__version__)
+    fastexcel_version = parse_version(original_version := fastexcel.__version__)
+
     if fastexcel_version < (0, 9) and "schema_sample_rows" in read_options:
-        msg = f"a more recent version of `fastexcel` is required (>= 0.9; found {fastexcel.__version__})"
+        msg = f"a more recent version of `fastexcel` is required (>= 0.9; found {original_version})"
         raise ModuleUpgradeRequiredError(msg)
+    if fastexcel_version < (0, 10, 2) and "use_columns" in read_options:
+        msg = f"a more recent version of `fastexcel` is required (>= 0.10.2; found {original_version})"
+        raise ModuleUpgradeRequiredError(msg)
+
+    if columns:
+        read_options["use_columns"] = columns
 
     schema_overrides = schema_overrides or {}
     if read_options.get("schema_sample_rows") == 0:
@@ -864,10 +919,11 @@ def _read_spreadsheet_calamine(
 
 def _read_spreadsheet_xlsx2csv(
     parser: Any,
+    *,
     sheet_name: str | None,
     read_options: dict[str, Any],
     schema_overrides: SchemaDict | None,
-    *,
+    columns: Sequence[int] | Sequence[str] | None,
     raise_if_empty: bool,
 ) -> pl.DataFrame:
     """Use the 'xlsx2csv' library to read data from the given worksheet."""
@@ -875,11 +931,14 @@ def _read_spreadsheet_xlsx2csv(
 
     parser.convert(outfile=csv_buffer, sheetname=sheet_name)
     read_options.setdefault("truncate_ragged_lines", True)
+    if columns:
+        read_options["columns"] = columns
 
-    return _csv_buffer_to_frame(
+    df = _csv_buffer_to_frame(
         csv_buffer,
         separator=",",
         read_options=read_options,
         schema_overrides=schema_overrides,
         raise_if_empty=raise_if_empty,
     )
+    return _reorder_columns(df, columns)

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -148,6 +148,8 @@ def read_excel(
     """
     Read Excel spreadsheet data into a DataFrame.
 
+    .. versionchanged:: 1.0
+        Default engine is now "calamine" (was "xlsx2csv").
     .. versionadded:: 0.20.6
         Added "calamine" fastexcel engine for Excel Workbooks (.xlsx, .xlsb, .xls).
     .. versionadded:: 0.19.3
@@ -167,12 +169,9 @@ def read_excel(
         Sheet name(s) to convert; cannot be used in conjunction with `sheet_id`. If more
         than one is given then a `{sheetname:frame,}` dict is returned.
     engine : {'calamine', 'xlsx2csv', 'openpyxl'}
-        Library used to parse the spreadsheet file; defaults to "xlsx2csv"
-        if not explicitly set.
-
         * "calamine": this engine can be used for reading all major types of Excel
           Workbook (`.xlsx`, `.xlsb`, `.xls`) and is *dramatically* faster than the
-          other options, using the `fastexcel` module to bind the calamine reader.
+          other options, using the `fastexcel` module to bind the Calamine parser.
         * "xlsx2csv": converts the data to an in-memory CSV before using the native
           polars `read_csv` method to parse the result. You can pass `engine_options`
           and `read_options` to refine the conversion.

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -176,6 +176,8 @@ def read_excel(
         Sheet name(s) to convert; cannot be used in conjunction with `sheet_id`. If more
         than one is given then a `{sheetname:frame,}` dict is returned.
     engine : {'calamine', 'xlsx2csv', 'openpyxl'}
+        Library used to parse the spreadsheet file; defaults to "calamine".
+
         * "calamine": this engine can be used for reading all major types of Excel
           Workbook (`.xlsx`, `.xlsb`, `.xls`) and is *dramatically* faster than the
           other options, using the `fastexcel` module to bind the Calamine parser.

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -1047,8 +1047,11 @@ def by_index(*indices: int | range | Sequence[int | range]) -> SelectorType:
     for idx in indices:
         if isinstance(idx, (range, Sequence)):
             all_indices.extend(idx)  # type: ignore[arg-type]
-        else:
+        elif isinstance(idx, int):
             all_indices.append(idx)
+        else:
+            msg = f"invalid index value: {idx!r}"
+            raise TypeError(msg)
 
     return _selector_proxy_(
         F.nth(*all_indices), name="by_index", parameters={"*indices": indices}

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -86,10 +86,8 @@ def path_ods_mixed(io_files_path: Path) -> Path:
     [
         # xls file
         (pl.read_excel, "path_xls", {"engine": "calamine"}),
-        (pl.read_excel, "path_xls", {"engine": None}),  # << autodetect
         # xlsx file
         (pl.read_excel, "path_xlsx", {"engine": "xlsx2csv"}),
-        (pl.read_excel, "path_xlsx", {"engine": None}),  # << autodetect
         (pl.read_excel, "path_xlsx", {"engine": "openpyxl"}),
         (pl.read_excel, "path_xlsx", {"engine": "calamine"}),
         # xlsb file (binary)
@@ -392,6 +390,7 @@ def test_schema_overrides(path_xlsx: Path, path_xlsb: Path, path_ods: Path) -> N
     df2 = pl.read_excel(
         path_xlsx,
         sheet_name="test4",
+        engine="xlsx2csv",
         read_options={"schema_overrides": {"cardinality": pl.UInt16}},
     ).drop_nulls()
 
@@ -402,6 +401,7 @@ def test_schema_overrides(path_xlsx: Path, path_xlsb: Path, path_ods: Path) -> N
     df3 = pl.read_excel(
         path_xlsx,
         sheet_name="test4",
+        engine="xlsx2csv",
         schema_overrides={"cardinality": pl.UInt16},
         read_options={
             "schema_overrides": {
@@ -444,6 +444,7 @@ def test_schema_overrides(path_xlsx: Path, path_xlsb: Path, path_ods: Path) -> N
         pl.read_excel(
             path_xlsx,
             sheet_name="test4",
+            engine="xlsx2csv",
             schema_overrides={"cardinality": pl.UInt16},
             read_options={"schema_overrides": {"cardinality": pl.Int32}},
         )
@@ -834,9 +835,9 @@ def test_excel_empty_sheet(
     with pytest.raises(NoDataError, match="empty Excel sheet"):
         read_spreadsheet(empty_spreadsheet_path)
 
-    engine_params = [{}] if ods else [{"engine": None}, {"engine": "calamine"}]
+    engine_params = [{}] if ods else [{"engine": "calamine"}]
     for params in engine_params:
-        df = read_spreadsheet(  # type: ignore[arg-type]
+        df = read_spreadsheet(
             empty_spreadsheet_path,
             sheet_name="no_data",
             raise_if_empty=False,
@@ -845,7 +846,7 @@ def test_excel_empty_sheet(
         expected = pl.DataFrame()
         assert_frame_equal(df, expected)
 
-        df = read_spreadsheet(  # type: ignore[arg-type]
+        df = read_spreadsheet(
             empty_spreadsheet_path,
             sheet_name="no_rows",
             raise_if_empty=False,

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import pytest
 
@@ -474,7 +474,7 @@ def test_schema_overrides(path_xlsx: Path, path_xlsb: Path, path_ods: Path) -> N
         ("calamine", "schema_sample_rows"),
     ],
 )
-def test_invalid_parameter_combinations(
+def test_invalid_parameter_combinations_infer_schema_len(
     path_xlsx: Path, engine: str, read_opts_param: str
 ) -> None:
     with pytest.raises(
@@ -487,6 +487,29 @@ def test_invalid_parameter_combinations(
             engine=engine,
             read_options={read_opts_param: 512},
             infer_schema_length=1024,
+        )
+
+
+@pytest.mark.parametrize(
+    ("engine", "read_opts_param"),
+    [
+        ("xlsx2csv", "columns"),
+        ("calamine", "use_columns"),
+    ],
+)
+def test_invalid_parameter_combinations_columns(
+    path_xlsx: Path, engine: str, read_opts_param: str
+) -> None:
+    with pytest.raises(
+        ParameterCollisionError,
+        match=f"cannot specify both `columns`.*{read_opts_param}",
+    ):
+        pl.read_excel(  # type: ignore[call-overload]
+            path_xlsx,
+            sheet_id=1,
+            engine=engine,
+            read_options={read_opts_param: ["B", "C", "D"]},
+            columns=["A", "B", "C"],
         )
 
 
@@ -649,8 +672,10 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
             engine=engine,
             read_options=read_options,
         )[:3].select(df.columns[:3])
+
         if engine == "xlsx2csv":
             xldf = xldf.with_columns(pl.col("dtm").str.strptime(pl.Date, fmt_strptime))
+
         assert_frame_equal(df, xldf)
 
 
@@ -907,15 +932,22 @@ def test_excel_type_inference_with_nulls(engine: ExcelSpreadsheetEngine) -> None
     xls = BytesIO()
     df.write_excel(xls)
 
-    read_df = pl.read_excel(
-        xls,
-        engine=engine,
-        schema_overrides={
-            "e": pl.Date,
-            "f": pl.Datetime("us"),
-        },
-    )
-    assert_frame_equal(df, read_df)
+    reversed_cols = list(reversed(df.columns))
+    read_cols: Sequence[str] | Sequence[int]
+    for read_cols in (  # type: ignore[assignment]
+        reversed_cols,
+        [5, 4, 3, 2, 1, 0],
+    ):
+        read_df = pl.read_excel(
+            xls,
+            engine=engine,
+            columns=read_cols,
+            schema_overrides={
+                "e": pl.Date,
+                "f": pl.Datetime("us"),
+            },
+        )
+        assert_frame_equal(df.select(reversed_cols), read_df)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17177

### Changes

* Set `"calamine"` as the default engine for `read_excel` for all file types, instead of only for `.xlsb` and `.xls`.
* Added a common `columns` parameter that can constrain _which_ columns are returned (ref: #17265).

### Example

```python
# new param works consistently with all engines
pl.read_excel(file_path, columns=["ColA","ColC","ColE"])
```