### PR TITLE
docs(rust): Fix polars-plan docs.rs build

### DIFF
--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -184,7 +184,6 @@ panic_on_schema = []
 
 [package.metadata.docs.rs]
 features = [
-  "approx_n_unique",
   "temporal",
   "serde",
   "rolling_window",


### PR DESCRIPTION
Closes #17204

The feature `approx_n_unique` doesn't exist, I guess it was removed.