### PR TITLE
feat: Support '%' in pathnames for async scan

### DIFF
--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -108,9 +108,13 @@ impl CloudLocation {
             (bucket, key)
         };
 
-        let key = percent_encoding::percent_decode_str(key)
-            .decode_utf8()
-            .map_err(to_compute_err)?;
+        let key = if parsed.scheme().starts_with("http") {
+            percent_encoding::percent_decode_str(key)
+                .decode_utf8()
+                .map_err(to_compute_err)?
+        } else {
+            std::borrow::Cow::Borrowed(key)
+        };
         let (mut prefix, expansion) = extract_prefix_expansion(&key)?;
         if is_local && key.starts_with(DELIMITER) {
             prefix.insert(0, DELIMITER);

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -136,6 +136,7 @@ pub(crate) fn parse_url(input: &str) -> std::result::Result<url::Url, url::Parse
         } else {
             // Some paths may contain '%', we need to double-encode as it doesn't seem
             // possible to construct `Url` without having it decode the path.
+            // TODO: Maybe we can avoid using `Url`.
             const PERC: percent_encoding::AsciiSet = percent_encoding::CONTROLS.add(b'%');
             std::borrow::Cow::<str>::from(percent_encoding::percent_encode(input.as_bytes(), &PERC))
         };

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -130,20 +130,19 @@ impl CloudType {
 
 #[cfg(feature = "cloud")]
 pub(crate) fn parse_url(input: &str) -> std::result::Result<url::Url, url::ParseError> {
-    let input = if input.starts_with("https://") {
-        std::borrow::Cow::Borrowed(input)
-    } else {
-        // Some paths may contain '%', we need to double-encode as it doesn't seem
-        // possible to construct `Url` without having it decode the path.
-        const ASCII_SET: percent_encoding::AsciiSet = percent_encoding::CONTROLS.add(b'%');
-        std::borrow::Cow::<str>::from(percent_encoding::percent_encode(
-            input.as_bytes(),
-            &ASCII_SET,
-        ))
-    };
-    let input = input.as_ref();
-
     Ok(if input.contains("://") {
+        let input = if input.starts_with("https://") {
+            std::borrow::Cow::Borrowed(input)
+        } else {
+            // Some paths may contain '%', we need to double-encode as it doesn't seem
+            // possible to construct `Url` without having it decode the path.
+            const ASCII_SET: percent_encoding::AsciiSet = percent_encoding::CONTROLS.add(b'%');
+            std::borrow::Cow::<str>::from(percent_encoding::percent_encode(
+                input.as_bytes(),
+                &ASCII_SET,
+            ))
+        };
+        let input = input.as_ref();
         url::Url::parse(input)?
     } else {
         let path = std::path::Path::new(input);

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -136,11 +136,8 @@ pub(crate) fn parse_url(input: &str) -> std::result::Result<url::Url, url::Parse
         } else {
             // Some paths may contain '%', we need to double-encode as it doesn't seem
             // possible to construct `Url` without having it decode the path.
-            const ASCII_SET: percent_encoding::AsciiSet = percent_encoding::CONTROLS.add(b'%');
-            std::borrow::Cow::<str>::from(percent_encoding::percent_encode(
-                input.as_bytes(),
-                &ASCII_SET,
-            ))
+            const PERC: percent_encoding::AsciiSet = percent_encoding::CONTROLS.add(b'%');
+            std::borrow::Cow::<str>::from(percent_encoding::percent_encode(input.as_bytes(), &PERC))
         };
         let input = input.as_ref();
         url::Url::parse(input)?

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import urllib.parse
 import warnings
 from collections import OrderedDict
@@ -622,7 +623,7 @@ def test_hive_partition_dates(tmp_path: Path, monkeypatch: Any) -> None:
         ),
     )
 
-    for perc_escape in [True, False]:
+    for perc_escape in [True, False] if sys.platform != "win32" else [True]:
         root = tmp_path / f"includes_hive_cols_in_file_{perc_escape}"
         for (date1, date2), part_df in df.group_by(
             pl.col("date1").cast(pl.String).fill_null("__HIVE_DEFAULT_PARTITION__"),

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -580,9 +580,6 @@ def test_hive_partition_columns_contained_in_file(
 
 @pytest.mark.write_disk()
 def test_hive_partition_dates(tmp_path: Path, monkeypatch: Any) -> None:
-    # TODO: Path gets incorrectly un-escaped for async
-    monkeypatch.setenv("POLARS_FORCE_ASYNC", "0")
-
     df = pl.DataFrame(
         {
             "date1": [
@@ -636,6 +633,7 @@ def test_hive_partition_dates(tmp_path: Path, monkeypatch: Any) -> None:
     ):
         path = root / f"date1={date1}/date2={date2}/data.bin"
         path.parent.mkdir(exist_ok=True, parents=True)
+        print(path)
         part_df.write_parquet(path)
 
     # The schema for the hive columns is included in the file, so it should just work

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -633,7 +633,6 @@ def test_hive_partition_dates(tmp_path: Path, monkeypatch: Any) -> None:
     ):
         path = root / f"date1={date1}/date2={date2}/data.bin"
         path.parent.mkdir(exist_ok=True, parents=True)
-        print(path)
         part_df.write_parquet(path)
 
     # The schema for the hive columns is included in the file, so it should just work

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -629,7 +629,7 @@ def test_hive_partition_dates(tmp_path: Path, monkeypatch: Any) -> None:
             pl.col("date2").cast(pl.String).fill_null("__HIVE_DEFAULT_PARTITION__"),
         ):
             if perc_escape:
-                date2 = urllib.parse.quote(date2)
+                date2 = urllib.parse.quote(date2)  # type: ignore[call-overload]
 
             path = root / f"date1={date1}/date2={date2}/data.bin"
             path.parent.mkdir(exist_ok=True, parents=True)

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -636,7 +636,8 @@ def test_hive_partition_dates(tmp_path: Path, monkeypatch: Any) -> None:
             path.parent.mkdir(exist_ok=True, parents=True)
             part_df.write_parquet(path)
 
-        # The schema for the hive columns is included in the file, so it should just work
+        # The schema for the hive columns is included in the file, so it should
+        # just work
         lf = pl.scan_parquet(root)
         assert_frame_equal(lf.collect(), df)
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -622,9 +622,8 @@ def test_hive_partition_dates(tmp_path: Path, monkeypatch: Any) -> None:
         ),
     )
 
-    root = tmp_path / "includes_hive_cols_in_file"
-
-    for perc_escape in [True]:
+    for perc_escape in [True, False]:
+        root = tmp_path / f"includes_hive_cols_in_file_{perc_escape}"
         for (date1, date2), part_df in df.group_by(
             pl.col("date1").cast(pl.String).fill_null("__HIVE_DEFAULT_PARTITION__"),
             pl.col("date2").cast(pl.String).fill_null("__HIVE_DEFAULT_PARTITION__"),


### PR DESCRIPTION
This allows us to scan datasets written by pyarrow that are patitioned on datetime columns, as pyarrow `%`-encodes the colons

<img width="1121" alt="image" src="https://github.com/pola-rs/polars/assets/93244543/3eca2f9b-a230-47dc-bdef-617cf2e13c0d">
