### PR TITLE
refactor(python): Rename `type_aliases` module to `_typing`

### DIFF
--- a/docs/user-guide/expressions/plugins.md
+++ b/docs/user-guide/expressions/plugins.md
@@ -97,7 +97,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 from polars.plugins import register_plugin_function
-from polars.type_aliases import IntoExpr
+from polars._typing import IntoExpr
 
 
 def pig_latinnify(expr: IntoExpr) -> pl.Expr:

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -229,17 +229,17 @@ class SeriesBuffers(TypedDict):
 
 # minimal protocol definitions that can reasonably represent
 # an executable connection, cursor, or equivalent object
-class BasicConnection(Protocol):  # noqa: D101
+class BasicConnection(Protocol):
     def cursor(self, *args: Any, **kwargs: Any) -> Any:
         """Return a cursor object."""
 
 
-class BasicCursor(Protocol):  # noqa: D101
+class BasicCursor(Protocol):
     def execute(self, *args: Any, **kwargs: Any) -> Any:
         """Execute a query."""
 
 
-class Cursor(BasicCursor):  # noqa: D101
+class Cursor(BasicCursor):
     def fetchall(self, *args: Any, **kwargs: Any) -> Any:
         """Fetch all results."""
 

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -63,13 +63,13 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
-    from polars.polars import PySeries
-    from polars.type_aliases import (
+    from polars._typing import (
         Orientation,
         PolarsDataType,
         SchemaDefinition,
         SchemaDict,
     )
+    from polars.polars import PySeries
 
 _MIN_NUMPY_SIZE_FOR_MULTITHREADING = 1000
 

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -66,8 +66,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
+    from polars._typing import PolarsDataType
     from polars.dependencies import pandas as pd
-    from polars.type_aliases import PolarsDataType
 
 
 def sequence_to_pyseries(

--- a/py-polars/polars/_utils/convert.py
+++ b/py-polars/polars/_utils/convert.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from datetime import date, tzinfo
     from decimal import Decimal
 
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 
 
 @overload

--- a/py-polars/polars/_utils/deprecation.py
+++ b/py-polars/polars/_utils/deprecation.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import sys
     from typing import Mapping
 
-    from polars.type_aliases import Ambiguous
+    from polars._typing import Ambiguous
 
     if sys.version_info >= (3, 10):
         from typing import ParamSpec

--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -23,7 +23,7 @@ from polars.meta.index_type import get_index_type
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
-    from polars.type_aliases import (
+    from polars._typing import (
         MultiColSelector,
         MultiIndexSelector,
         SingleColSelector,

--- a/py-polars/polars/_utils/parse/expr.py
+++ b/py-polars/polars/_utils/parse/expr.py
@@ -12,8 +12,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import Expr
+    from polars._typing import IntoExpr, PolarsDataType
     from polars.polars import PyExpr
-    from polars.type_aliases import IntoExpr, PolarsDataType
 
 
 def parse_into_expression(

--- a/py-polars/polars/_utils/serde.py
+++ b/py-polars/polars/_utils/serde.py
@@ -11,7 +11,7 @@ from polars._utils.various import normalize_filepath
 if TYPE_CHECKING:
     from io import IOBase
 
-    from polars.type_aliases import SerializationFormat
+    from polars._typing import SerializationFormat
 
 
 @overload

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Reversible
 
     from polars import DataFrame
-    from polars.type_aliases import PolarsDataType, SizeUnit
+    from polars._typing import PolarsDataType, SizeUnit
 
     if sys.version_info >= (3, 13):
         from typing import TypeIs

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     import sys
     from types import TracebackType
 
-    from polars.type_aliases import FloatFmt
+    from polars._typing import FloatFmt
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -25,9 +25,9 @@ from polars.exceptions import NoDataError
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
+    from polars._typing import Orientation, SchemaDefinition, SchemaDict
     from polars.dependencies import numpy as np
     from polars.interchange.protocol import SupportsInterchange
-    from polars.type_aliases import Orientation, SchemaDefinition, SchemaDict
 
 
 def from_dict(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -31,6 +31,11 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._typing import (
+    DbWriteMode,
+    JaxExportType,
+    TorchExportType,
+)
 from polars._utils.construction import (
     arrow_to_pydf,
     dataframe_to_pydf,
@@ -101,11 +106,6 @@ from polars.exceptions import (
 from polars.functions import col, lit
 from polars.schema import Schema
 from polars.selectors import _expand_selector_dicts, _expand_selectors
-from polars.type_aliases import (
-    DbWriteMode,
-    JaxExportType,
-    TorchExportType,
-)
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame
@@ -127,10 +127,7 @@ if TYPE_CHECKING:
     from xlsxwriter import Workbook
 
     from polars import DataType, Expr, LazyFrame, Series
-    from polars._utils.various import NoDefault
-    from polars.interchange.dataframe import PolarsDataFrame
-    from polars.ml.torch import PolarsDataset
-    from polars.type_aliases import (
+    from polars._typing import (
         AsofJoinStrategy,
         AvroCompression,
         ClosedInterval,
@@ -172,6 +169,9 @@ if TYPE_CHECKING:
         UniqueKeepStrategy,
         UnstackDirection,
     )
+    from polars._utils.various import NoDefault
+    from polars.interchange.dataframe import PolarsDataFrame
+    from polars.ml.torch import PolarsDataset
 
     if sys.version_info >= (3, 10):
         from typing import Concatenate, ParamSpec

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from polars import DataFrame
-    from polars.type_aliases import (
+    from polars._typing import (
         ClosedInterval,
         IntoExpr,
         Label,

--- a/py-polars/polars/datatypes/_parse.py
+++ b/py-polars/polars/datatypes/_parse.py
@@ -25,7 +25,7 @@ from polars.datatypes.classes import (
 from polars.datatypes.convert import is_polars_dtype
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType, PythonDataType, SchemaDict
+    from polars._typing import PolarsDataType, PythonDataType, SchemaDict
 
 
 UnionTypeOld = type(Union[int, str])

--- a/py-polars/polars/datatypes/_utils.py
+++ b/py-polars/polars/datatypes/_utils.py
@@ -1,7 +1,7 @@
 """Utility functions for handling and processing of datatypes."""
 
+from polars._typing import PolarsDataType
 from polars.datatypes.classes import Array, List, Struct
-from polars.type_aliases import PolarsDataType
 
 
 def dtype_to_init_repr(dtype: PolarsDataType, prefix: str = "pl.") -> str:

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -15,7 +15,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import Series
-    from polars.type_aliases import (
+    from polars._typing import (
         CategoricalOrdering,
         PolarsDataType,
         PythonDataType,

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 
 # Number of rows to scan by default when inferring datatypes
 N_INFER_DEFAULT = 100

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -16,7 +16,7 @@ except ImportError:
     _DOCUMENTING = True
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 if not _DOCUMENTING:
     _POLARS_TYPE_TO_CONSTRUCTOR: dict[

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -54,7 +54,7 @@ else:
     UnionType = type(Union[int, float])
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType, PythonDataType, TimeUnit
+    from polars._typing import PolarsDataType, PythonDataType, TimeUnit
 
     if sys.version_info >= (3, 10):
         from typing import TypeGuard

--- a/py-polars/polars/datatypes/group.py
+++ b/py-polars/polars/datatypes/group.py
@@ -26,7 +26,7 @@ from polars.datatypes.classes import (
 )
 
 if TYPE_CHECKING:
-    from polars.type_aliases import (
+    from polars._typing import (
         PolarsDataType,
         PolarsIntegerType,
         PolarsTemporalType,

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from datetime import date, datetime, time
 
     from polars import Expr
-    from polars.type_aliases import IntoExpr, IntoExprColumn
+    from polars._typing import IntoExpr, IntoExprColumn
 
 
 class ExprArrayNameSpace:

--- a/py-polars/polars/expr/binary.py
+++ b/py-polars/polars/expr/binary.py
@@ -7,7 +7,7 @@ from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import IntoExpr, TransferEncoding
+    from polars._typing import IntoExpr, TransferEncoding
 
 
 class ExprBinaryNameSpace:

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -14,7 +14,7 @@ from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import (
+    from polars._typing import (
         Ambiguous,
         EpochTimeUnit,
         IntoExpr,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -72,10 +72,7 @@ if TYPE_CHECKING:
     from io import IOBase
 
     from polars import DataFrame, LazyFrame, Series
-    from polars._utils.various import (
-        NoDefault,
-    )
-    from polars.type_aliases import (
+    from polars._typing import (
         ClosedInterval,
         FillNullStrategy,
         InterpolationMethod,
@@ -91,6 +88,9 @@ if TYPE_CHECKING:
         SerializationFormat,
         TemporalLiteral,
         WindowMappingStrategy,
+    )
+    from polars._utils.various import (
+        NoDefault,
     )
 
     if sys.version_info >= (3, 11):

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from datetime import date, datetime, time
 
     from polars import Expr, Series
-    from polars.type_aliases import (
+    from polars._typing import (
         IntoExpr,
         IntoExprColumn,
         NullBehavior,

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from polars import Expr
-    from polars.type_aliases import SerializationFormat
+    from polars._typing import SerializationFormat
 
 
 class ExprMetaNameSpace:

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -18,7 +18,7 @@ from polars.exceptions import ChronoFormatWarning
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import (
+    from polars._typing import (
         Ambiguous,
         IntoExpr,
         IntoExprColumn,

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -8,7 +8,7 @@ from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import IntoExpr
+    from polars._typing import IntoExpr
 
 
 class ExprStructNameSpace:

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -11,8 +11,8 @@ from polars._utils.wrap import wrap_expr
 from polars.expr.expr import Expr
 
 if TYPE_CHECKING:
+    from polars._typing import IntoExpr
     from polars.polars import PyExpr
-    from polars.type_aliases import IntoExpr
 
 
 class When:

--- a/py-polars/polars/functions/aggregation/horizontal.py
+++ b/py-polars/polars/functions/aggregation/horizontal.py
@@ -13,7 +13,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import IntoExpr
+    from polars._typing import IntoExpr
 
 
 def all_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import Ambiguous, IntoExpr, SchemaDict, TimeUnit
+    from polars._typing import Ambiguous, IntoExpr, SchemaDict, TimeUnit
 
 
 def datetime_(

--- a/py-polars/polars/functions/business.py
+++ b/py-polars/polars/functions/business.py
@@ -12,7 +12,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import IntoExprColumn
+    from polars._typing import IntoExprColumn
 
 
 def business_day_count(

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -11,8 +11,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
+    from polars._typing import PolarsDataType
     from polars.expr.expr import Expr
-    from polars.type_aliases import PolarsDataType
 
 __all__ = ["col"]
 

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -7,17 +7,17 @@ from typing import TYPE_CHECKING, Iterable, Sequence, get_args
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._typing import ConcatMethod
 from polars._utils.various import ordered_unique
 from polars._utils.wrap import wrap_df, wrap_expr, wrap_ldf, wrap_s
 from polars.exceptions import InvalidOperationError
-from polars.type_aliases import ConcatMethod
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
 
 if TYPE_CHECKING:
     from polars import DataFrame, Expr, LazyFrame, Series
-    from polars.type_aliases import FrameType, JoinStrategy, PolarsType
+    from polars._typing import FrameType, JoinStrategy, PolarsType
 
 
 def concat(

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from typing import Awaitable, Collection, Literal
 
     from polars import DataFrame, Expr, LazyFrame, Series
-    from polars.type_aliases import (
+    from polars._typing import (
         CorrelationMethod,
         EpochTimeUnit,
         IntoExpr,

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -23,7 +23,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import PolarsDataType, TimeUnit
+    from polars._typing import PolarsDataType, TimeUnit
 
 
 def lit(

--- a/py-polars/polars/functions/range/date_range.py
+++ b/py-polars/polars/functions/range/date_range.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import ClosedInterval, IntoExprColumn
+    from polars._typing import ClosedInterval, IntoExprColumn
 
 
 @overload

--- a/py-polars/polars/functions/range/datetime_range.py
+++ b/py-polars/polars/functions/range/datetime_range.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import ClosedInterval, IntoExprColumn, TimeUnit
+    from polars._typing import ClosedInterval, IntoExprColumn, TimeUnit
 
 
 @overload

--- a/py-polars/polars/functions/range/int_range.py
+++ b/py-polars/polars/functions/range/int_range.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import IntoExprColumn, PolarsIntegerType
+    from polars._typing import IntoExprColumn, PolarsIntegerType
 
 
 @overload

--- a/py-polars/polars/functions/range/time_range.py
+++ b/py-polars/polars/functions/range/time_range.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import ClosedInterval, IntoExprColumn
+    from polars._typing import ClosedInterval, IntoExprColumn
 
 
 @overload

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import IntoExpr, PolarsDataType
+    from polars._typing import IntoExpr, PolarsDataType
 
 
 # create a lookup of dtypes that have a reasonable one/zero mapping; for

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -10,7 +10,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
-    from polars.type_aliases import IntoExprColumn
+    from polars._typing import IntoExprColumn
 
 
 def when(

--- a/py-polars/polars/interchange/from_dataframe.py
+++ b/py-polars/polars/interchange/from_dataframe.py
@@ -16,9 +16,9 @@ from polars.interchange.utils import (
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
+    from polars._typing import PolarsDataType
     from polars.interchange.protocol import Buffer, Column, Dtype, SupportsInterchange
     from polars.interchange.protocol import DataFrame as InterchangeDataFrame
-    from polars.type_aliases import PolarsDataType
 
 
 def from_dataframe(df: SupportsInterchange, *, allow_copy: bool = True) -> DataFrame:

--- a/py-polars/polars/interchange/utils.py
+++ b/py-polars/polars/interchange/utils.py
@@ -26,9 +26,9 @@ from polars.datatypes import (
 from polars.interchange.protocol import DtypeKind, Endianness
 
 if TYPE_CHECKING:
+    from polars._typing import PolarsDataType
     from polars.datatypes import DataTypeClass
     from polars.interchange.protocol import Dtype
-    from polars.type_aliases import PolarsDataType
 
 NE = Endianness.NATIVE
 

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from polars import DataFrame
-    from polars.type_aliases import CsvEncoding, PolarsDataType, SchemaDict
+    from polars._typing import CsvEncoding, PolarsDataType, SchemaDict
 
 
 class BatchedCsvReader:

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -28,7 +28,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame
-    from polars.type_aliases import CsvEncoding, PolarsDataType, SchemaDict
+    from polars._typing import CsvEncoding, PolarsDataType, SchemaDict
 
 
 @deprecate_renamed_parameter("dtypes", "schema_overrides", version="0.20.31")

--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
     from polars import DataFrame
-    from polars.type_aliases import ConnectionOrCursor, Cursor, SchemaDict
+    from polars._typing import ConnectionOrCursor, Cursor, SchemaDict
 
     try:
         from sqlalchemy.sql.expression import Selectable

--- a/py-polars/polars/io/database/_inference.py
+++ b/py-polars/polars/io/database/_inference.py
@@ -35,7 +35,7 @@ from polars.datatypes.group import (
 )
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def _infer_dtype_from_database_typename(

--- a/py-polars/polars/io/database/_utils.py
+++ b/py-polars/polars/io/database/_utils.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
         from typing_extensions import TypeAlias
 
     from polars import DataFrame
-    from polars.type_aliases import SchemaDict
+    from polars._typing import SchemaDict
 
     try:
         from sqlalchemy.sql.expression import Selectable

--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
         from typing_extensions import TypeAlias
 
     from polars import DataFrame
-    from polars.type_aliases import ConnectionOrCursor, DbReadEngine, SchemaDict
+    from polars._typing import ConnectionOrCursor, DbReadEngine, SchemaDict
 
     try:
         from sqlalchemy.sql.expression import Selectable

--- a/py-polars/polars/io/json/read.py
+++ b/py-polars/polars/io/json/read.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from io import IOBase
 
     from polars import DataFrame
-    from polars.type_aliases import SchemaDefinition
+    from polars._typing import SchemaDefinition
 
 
 def read_json(

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from io import IOBase
 
     from polars import DataFrame, LazyFrame
-    from polars.type_aliases import SchemaDefinition
+    from polars._typing import SchemaDefinition
 
 
 def read_ndjson(

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -27,7 +27,7 @@ with contextlib.suppress(ImportError):
 
 if TYPE_CHECKING:
     from polars import DataFrame, DataType, LazyFrame
-    from polars.type_aliases import ParallelStrategy, SchemaDict
+    from polars._typing import ParallelStrategy, SchemaDict
 
 
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from xlsxwriter.worksheet import Worksheet
 
     from polars import DataFrame, Series
-    from polars.type_aliases import (
+    from polars._typing import (
         ColumnFormatDict,
         ColumnTotalsDefinition,
         ConditionalFormatDict,

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -36,7 +36,7 @@ from polars.io.csv.functions import read_csv
 if TYPE_CHECKING:
     from typing import Literal
 
-    from polars.type_aliases import ExcelSpreadsheetEngine, SchemaDict
+    from polars._typing import ExcelSpreadsheetEngine, SchemaDict
 
 
 @overload

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -94,8 +94,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     from polars import DataFrame, DataType, Expr
-    from polars.dependencies import numpy as np
-    from polars.type_aliases import (
+    from polars._typing import (
         AsofJoinStrategy,
         ClosedInterval,
         ColumnNameOrSelector,
@@ -117,6 +116,7 @@ if TYPE_CHECKING:
         StartBy,
         UniqueKeepStrategy,
     )
+    from polars.dependencies import numpy as np
 
     if sys.version_info >= (3, 10):
         from typing import Concatenate, ParamSpec

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -9,8 +9,8 @@ from polars._utils.wrap import wrap_ldf
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame
+    from polars._typing import IntoExpr, RollingInterpolationMethod, SchemaDict
     from polars.polars import PyLazyGroupBy
-    from polars.type_aliases import IntoExpr, RollingInterpolationMethod, SchemaDict
 
 
 class LazyGroupBy:

--- a/py-polars/polars/plugins.py
+++ b/py-polars/polars/plugins.py
@@ -12,7 +12,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import IntoExpr
+    from polars._typing import IntoExpr
 
 __all__ = ["register_plugin_function"]
 

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     import sys
 
     from polars import DataFrame, LazyFrame
-    from polars.type_aliases import PolarsDataType, SelectorType, TimeUnit
+    from polars._typing import PolarsDataType, SelectorType, TimeUnit
 
     if sys.version_info >= (3, 11):
         from typing import Self

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
     from datetime import date, datetime, time
 
     from polars import Series
+    from polars._typing import IntoExpr, IntoExprColumn
     from polars.polars import PySeries
-    from polars.type_aliases import IntoExpr, IntoExprColumn
 
 
 @expr_dispatch

--- a/py-polars/polars/series/binary.py
+++ b/py-polars/polars/series/binary.py
@@ -6,8 +6,8 @@ from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
     from polars import Series
+    from polars._typing import IntoExpr, TransferEncoding
     from polars.polars import PySeries
-    from polars.type_aliases import IntoExpr, TransferEncoding
 
 
 @expr_dispatch

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
     import datetime as dt
 
     from polars import Expr, Series
-    from polars.polars import PySeries
-    from polars.type_aliases import (
+    from polars._typing import (
         Ambiguous,
         EpochTimeUnit,
         IntoExpr,
@@ -22,6 +21,7 @@ if TYPE_CHECKING:
         TemporalLiteral,
         TimeUnit,
     )
+    from polars.polars import PySeries
 
 
 @expr_dispatch

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -10,13 +10,13 @@ if TYPE_CHECKING:
     from datetime import date, datetime, time
 
     from polars import Expr, Series
-    from polars.polars import PySeries
-    from polars.type_aliases import (
+    from polars._typing import (
         IntoExpr,
         IntoExprColumn,
         NullBehavior,
         ToStructStrategy,
     )
+    from polars.polars import PySeries
 
 
 @expr_dispatch

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -119,10 +119,7 @@ if TYPE_CHECKING:
     from hvplot.plotting.core import hvPlotTabularPolars
 
     from polars import DataFrame, DataType, Expr
-    from polars._utils.various import (
-        NoDefault,
-    )
-    from polars.type_aliases import (
+    from polars._typing import (
         BufferInfo,
         ClosedInterval,
         ComparisonOperator,
@@ -143,6 +140,9 @@ if TYPE_CHECKING:
         SingleIndexSelector,
         SizeUnit,
         TemporalLiteral,
+    )
+    from polars._utils.various import (
+        NoDefault,
     )
 
     if sys.version_info >= (3, 11):

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -8,8 +8,7 @@ from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
     from polars import Expr, Series
-    from polars.polars import PySeries
-    from polars.type_aliases import (
+    from polars._typing import (
         Ambiguous,
         IntoExpr,
         IntoExprColumn,
@@ -18,6 +17,7 @@ if TYPE_CHECKING:
         TimeUnit,
         TransferEncoding,
     )
+    from polars.polars import PySeries
 
 
 @expr_dispatch

--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -12,8 +12,8 @@ from polars.datatypes import dtype_to_ffiname
 
 if TYPE_CHECKING:
     from polars import Series
+    from polars._typing import PolarsDataType
     from polars.polars import PySeries
-    from polars.type_aliases import PolarsDataType
 
     if sys.version_info >= (3, 10):
         from typing import ParamSpec

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -12,6 +12,7 @@ from typing import (
     overload,
 )
 
+from polars._typing import FrameType
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import _get_stack_locals
@@ -23,7 +24,6 @@ from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.lazyframe import LazyFrame
 from polars.series import Series
-from polars.type_aliases import FrameType
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PySQLContext

--- a/py-polars/polars/testing/parametric/profiles.py
+++ b/py-polars/polars/testing/parametric/profiles.py
@@ -5,7 +5,7 @@ import re
 
 from hypothesis import settings
 
-from polars.type_aliases import ParametricProfileNames
+from polars._typing import ParametricProfileNames
 
 
 def load_profile(

--- a/py-polars/polars/testing/parametric/strategies/core.py
+++ b/py-polars/polars/testing/parametric/strategies/core.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from hypothesis.strategies import DrawFn, SearchStrategy
 
     from polars import LazyFrame
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 _ROW_LIMIT = 5  # max generated frame/series length

--- a/py-polars/polars/testing/parametric/strategies/data.py
+++ b/py-polars/polars/testing/parametric/strategies/data.py
@@ -64,8 +64,8 @@ if TYPE_CHECKING:
 
     from hypothesis.strategies import SearchStrategy
 
+    from polars._typing import PolarsDataType, SchemaDict, TimeUnit
     from polars.datatypes import DataType, DataTypeClass
-    from polars.type_aliases import PolarsDataType, SchemaDict, TimeUnit
 
 _DEFAULT_LIST_LEN_LIMIT = 3
 _DEFAULT_N_CATEGORIES = 10

--- a/py-polars/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/polars/testing/parametric/strategies/dtype.py
@@ -37,8 +37,8 @@ from polars.datatypes import (
 if TYPE_CHECKING:
     from hypothesis.strategies import DrawFn, SearchStrategy
 
+    from polars._typing import CategoricalOrdering, PolarsDataType, TimeUnit
     from polars.datatypes import DataTypeClass
-    from polars.type_aliases import CategoricalOrdering, PolarsDataType, TimeUnit
 
 
 # Supported data type classes which do not take any arguments

--- a/py-polars/polars/testing/parametric/strategies/legacy.py
+++ b/py-polars/polars/testing/parametric/strategies/legacy.py
@@ -14,7 +14,7 @@ from polars.testing.parametric.strategies.dtype import _instantiate_dtype, dtype
 if TYPE_CHECKING:
     from hypothesis.strategies import SearchStrategy
 
-    from polars.type_aliases import OneOrMoreDataTypes, PolarsDataType
+    from polars._typing import OneOrMoreDataTypes, PolarsDataType
 
 
 @deprecate_function(

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -1,0 +1,25 @@
+"""
+Deprecated module - do not use.
+
+Used to contain private type aliases. These are now in the `polars._typing` module.
+"""
+
+from typing import Any
+
+import polars._typing as plt
+from polars._utils.deprecation import issue_deprecation_warning
+
+
+def __getattr__(name: str) -> Any:
+    if name in dir(plt):
+        issue_deprecation_warning(
+            "The `polars.type_aliases` module is deprecated."
+            " The type aliases have moved to the `polars._typing` module to explicitly mark them as private."
+            " Please define your own type aliases, or temporarily import from the `polars._typing` module."
+            " A public `polars.typing` module will be added in the future.",
+            version="1.0.0",
+        )
+        return getattr(plt, name)
+
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -13,7 +13,7 @@ from polars._utils.wrap import wrap_s
 from polars.polars import PySeries
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -12,7 +12,7 @@ from polars.exceptions import InvalidOperationError
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_series_mixed_dtypes_list() -> None:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -34,7 +34,7 @@ from tests.unit.conftest import INTEGER_DTYPES
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import JoinStrategy, UniqueKeepStrategy
+    from polars._typing import JoinStrategy, UniqueKeepStrategy
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -16,7 +16,7 @@ from polars.testing.parametric import dataframes
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import SerializationFormat
+    from polars._typing import SerializationFormat
 
 
 @given(df=dataframes())

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import FillNullStrategy, PolarsIntegerType
+    from polars._typing import FillNullStrategy, PolarsIntegerType
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -17,7 +17,7 @@ from polars.exceptions import (
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @StringCache()

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.conftest import NUMERIC_DTYPES
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_dtype() -> None:

--- a/py-polars/tests/unit/datatypes/test_parse.py
+++ b/py-polars/tests/unit/datatypes/test_parse.py
@@ -25,7 +25,7 @@ from polars.datatypes._parse import (
 )
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def assert_dtype_equal(left: PolarsDataType, right: PolarsDataType) -> None:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -13,7 +13,7 @@ import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_struct_to_list() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -26,7 +26,7 @@ from tests.unit.conftest import DATETIME_DTYPES, TEMPORAL_DTYPES
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import (
+    from polars._typing import (
         Ambiguous,
         PolarsTemporalType,
         TimeUnit,

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -21,7 +21,7 @@ from tests.unit.conftest import (
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -12,7 +12,7 @@ from polars.testing import assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/functions/as_datatype/test_duration.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_duration.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 
 
 def test_empty_duration() -> None:

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -11,7 +11,7 @@ from polars.exceptions import ComputeError, PanicException
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ClosedInterval
+    from polars._typing import ClosedInterval
 
 
 def test_date_range() -> None:

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import ClosedInterval, PolarsDataType, TimeUnit
+    from polars._typing import ClosedInterval, PolarsDataType, TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -10,7 +10,7 @@ from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ClosedInterval
+    from polars._typing import ClosedInterval
 
 
 def test_time_range_schema() -> None:

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -10,7 +10,7 @@ from polars.exceptions import DuplicateError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ConcatMethod
+    from polars._typing import ConcatMethod
 
 
 def test_concat_align() -> None:

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -15,7 +15,7 @@ from polars.testing.parametric.strategies import series
 from polars.testing.parametric.strategies.data import datetimes
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -10,7 +10,7 @@ from polars.exceptions import ComputeError, OutOfBoundsError, SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -15,7 +15,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 protocol_dtypes: list[PolarsDataType] = [
     pl.Int8,

--- a/py-polars/tests/unit/interchange/test_utils.py
+++ b/py-polars/tests/unit/interchange/test_utils.py
@@ -14,8 +14,8 @@ from polars.interchange.utils import (
 )
 
 if TYPE_CHECKING:
+    from polars._typing import PolarsDataType
     from polars.interchange.protocol import Dtype
-    from polars.type_aliases import PolarsDataType
 
 NE = Endianness.NATIVE
 

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
@@ -10,7 +10,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsTemporalType
+    from polars._typing import PolarsTemporalType
 
 
 def test_from_numpy() -> None:

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
@@ -9,7 +9,7 @@ import pytest
 import polars as pl
 
 if TYPE_CHECKING:
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 
 
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -16,7 +16,7 @@ from polars.testing.parametric import series
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from polars.type_aliases import IndexOrder, PolarsDataType
+    from polars._typing import IndexOrder, PolarsDataType
 
 
 def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -16,7 +16,7 @@ from polars.testing.parametric import series
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -13,7 +13,7 @@ from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_from_pandas() -> None:

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -13,7 +13,7 @@ from hypothesis import given
 import polars as pl
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_df_to_pandas_empty() -> None:

--- a/py-polars/tests/unit/io/database/test_inference.py
+++ b/py-polars/tests/unit/io/database/test_inference.py
@@ -12,7 +12,7 @@ from polars.io.database._inference import _infer_dtype_from_database_typename
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -21,7 +21,7 @@ from polars.io.database._arrow_registry import ARROW_DRIVER_REGISTRY
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import (
+    from polars._typing import (
         ConnectionOrCursor,
         DbReadEngine,
         SchemaDefinition,

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import DbWriteEngine
+    from polars._typing import DbWriteEngine
 
 
 @pytest.mark.write_disk()

--- a/py-polars/tests/unit/io/test_avro.py
+++ b/py-polars/tests/unit/io/test_avro.py
@@ -11,7 +11,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import AvroCompression
+    from polars._typing import AvroCompression
 
 
 COMPRESSIONS = ["uncompressed", "snappy", "deflate"]

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -25,7 +25,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
     from tests.unit.conftest import MemoryUsage
 
 

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -14,7 +14,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import IpcCompression
+    from polars._typing import IpcCompression
     from tests.unit.conftest import MemoryUsage
 
 COMPRESSIONS = ["uncompressed", "lz4", "zstd"]

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -12,7 +12,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ParallelStrategy
+    from polars._typing import ParallelStrategy
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -24,7 +24,7 @@ from polars.testing.parametric import dataframes
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import ParquetCompression
+    from polars._typing import ParquetCompression
     from tests.unit.conftest import MemoryUsage
 
 

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -13,7 +13,7 @@ from polars.testing.asserts.frame import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import SchemaDict
+    from polars._typing import SchemaDict
 
 
 @dataclass

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -17,7 +17,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.conftest import FLOAT_DTYPES, NUMERIC_DTYPES
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ExcelSpreadsheetEngine, SchemaDict, SelectorType
+    from polars._typing import ExcelSpreadsheetEngine, SchemaDict, SelectorType
 
 pytestmark = pytest.mark.slow()
 

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -24,7 +24,7 @@ from tests.unit.conftest import FLOAT_DTYPES
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_init_signature_match() -> None:

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -14,7 +14,7 @@ from polars.testing.parametric import dataframes
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import SerializationFormat
+    from polars._typing import SerializationFormat
 
 
 @given(lf=dataframes(lazy=True))

--- a/py-polars/tests/unit/ml/test_to_jax.py
+++ b/py-polars/tests/unit/ml/test_to_jax.py
@@ -17,7 +17,7 @@ jxn, _ = _lazy_import("jax.numpy")
 pytestmark = pytest.mark.ci_only
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     import numpy.typing as npt
 
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_quantile_expr_input() -> None:

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -11,7 +11,7 @@ from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_any_expr(fruits_cars: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/operations/arithmetic/test_neg.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_neg.py
@@ -12,7 +12,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
@@ -16,7 +16,7 @@ from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import Roll, TimeUnit
+    from polars._typing import Roll, TimeUnit
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -15,7 +15,7 @@ from polars.testing.parametric import series
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import TemporalLiteral, TimeUnit
+    from polars._typing import TemporalLiteral, TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_offset_by.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_offset_by.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -23,7 +23,7 @@ elif _ZONEINFO_AVAILABLE:
 if TYPE_CHECKING:
     from hypothesis.strategies import DrawFn
 
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 
 
 DATE_FORMATS = ["%Y{}%m{}%d", "%d{}%m{}%Y"]

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
@@ -11,7 +11,7 @@ import polars as pl
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 
 
 @given(

--- a/py-polars/tests/unit/operations/namespaces/test_binary.py
+++ b/py-polars/tests/unit/operations/namespaces/test_binary.py
@@ -1,8 +1,8 @@
 import pytest
 
 import polars as pl
+from polars._typing import TransferEncoding
 from polars.testing import assert_frame_equal
-from polars.type_aliases import TransferEncoding
 
 
 def test_binary_conversions() -> None:

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -18,7 +18,7 @@ from polars.testing import assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import PolarsTemporalType, TimeUnit
+    from polars._typing import PolarsTemporalType, TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/operations/rolling/test_map.py
+++ b/py-polars/tests/unit/operations/rolling/test_map.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -19,7 +19,7 @@ from polars.testing.parametric.strategies.dtype import _time_units
 if TYPE_CHECKING:
     from hypothesis.strategies import SearchStrategy
 
-    from polars.type_aliases import ClosedInterval, PolarsDataType, TimeUnit
+    from polars._typing import ClosedInterval, PolarsDataType, TimeUnit
 
 
 @pytest.fixture()

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -12,7 +12,7 @@ from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_abs() -> None:

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_string_date() -> None:

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -11,7 +11,7 @@ from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_comparison_order_null_broadcasting() -> None:

--- a/py-polars/tests/unit/operations/test_ewm_by.py
+++ b/py-polars/tests/unit/operations/test_ewm_by.py
@@ -12,7 +12,7 @@ from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsIntegerType, TimeUnit
+    from polars._typing import PolarsIntegerType, TimeUnit
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/py-polars/tests/unit/operations/test_extend_constant.py
+++ b/py-polars/tests/unit/operations/test_extend_constant.py
@@ -10,7 +10,7 @@ from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -11,7 +11,7 @@ import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_simplify_expression_lit_true_4376() -> None:

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -13,7 +13,7 @@ from polars.exceptions import ColumnNotFoundError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_group_by() -> None:

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import Label, StartBy
+    from polars._typing import Label, StartBy
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/operations/test_interpolate.py
+++ b/py-polars/tests/unit/operations/test_interpolate.py
@@ -11,7 +11,7 @@ from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType, PolarsTemporalType
+    from polars._typing import PolarsDataType, PolarsTemporalType
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/py-polars/tests/unit/operations/test_interpolate_by.py
+++ b/py-polars/tests/unit/operations/test_interpolate_by.py
@@ -14,7 +14,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import column, dataframes
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -10,7 +10,7 @@ from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_is_first_distinct() -> None:

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -11,7 +11,7 @@ from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_struct_logical_is_in() -> None:

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -18,7 +18,7 @@ from polars.exceptions import (
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import JoinStrategy
+    from polars._typing import JoinStrategy
 
 
 def test_semi_anti_join() -> None:

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -11,7 +11,7 @@ from polars.exceptions import ComputeError, DuplicateError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PivotAgg
+    from polars._typing import PivotAgg
 
 
 def test_pivot() -> None:

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -10,7 +10,7 @@ from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ClosedInterval, PolarsIntegerType
+    from polars._typing import ClosedInterval, PolarsIntegerType
 
 
 def test_rolling() -> None:

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -11,7 +11,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import dataframes, series
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @given(

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -33,7 +33,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import EpochTimeUnit, PolarsDataType, TimeUnit
+    from polars._typing import EpochTimeUnit, PolarsDataType, TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -10,7 +10,7 @@ from polars.exceptions import SQLInterfaceError, SQLSyntaxError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 def test_div() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -14,7 +14,7 @@ from polars.exceptions import PolarsInefficientMapWarning
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import JoinStrategy
+    from polars._typing import JoinStrategy
 
 pytestmark = pytest.mark.xdist_group("streaming")
 

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -13,7 +13,7 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.type_aliases import JoinStrategy
+    from polars._typing import JoinStrategy
 
 pytestmark = pytest.mark.xdist_group("streaming")
 

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -20,8 +20,8 @@ from polars.datatypes.group import DataTypeGroup
 from tests.unit.conftest import DATETIME_DTYPES, NUMERIC_DTYPES
 
 if TYPE_CHECKING:
+    from polars._typing import PolarsDataType
     from polars.datatypes.classes import DataTypeClass
-    from polars.type_aliases import PolarsDataType
 
 SIMPLE_DTYPES: list[DataTypeClass] = [
     *[dt.base_type() for dt in NUMERIC_DTYPES],

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -24,7 +24,7 @@ from polars.exceptions import (
 from tests.unit.conftest import TEMPORAL_DTYPES
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ConcatMethod
+    from polars._typing import ConcatMethod
 
 
 def test_error_on_empty_group_by() -> None:

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -10,7 +10,7 @@ import polars as pl
 from polars.exceptions import InvalidOperationError
 
 if TYPE_CHECKING:
-    from polars.type_aliases import PolarsDataType
+    from polars._typing import PolarsDataType
 
 
 @pytest.fixture(autouse=True)

--- a/py-polars/tests/unit/test_init.py
+++ b/py-polars/tests/unit/test_init.py
@@ -27,3 +27,11 @@ def test_dtype_groups_deprecated() -> None:
         dtypes = pl.INTEGER_DTYPES
 
     assert pl.Int8 in dtypes
+
+
+def test_type_aliases_deprecated() -> None:
+    with pytest.deprecated_call(
+        match="The `polars.type_aliases` module is deprecated."
+    ):
+        from polars.type_aliases import PolarsDataType
+    assert str(PolarsDataType).startswith("typing.Union")

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -7,11 +7,11 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars._typing import SelectorType
 from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ColumnNotFoundError
 from polars.selectors import expand_selector, is_selector
 from polars.testing import assert_frame_equal
-from polars.type_aliases import SelectorType
 from tests.unit.conftest import INTEGER_DTYPES, TEMPORAL_DTYPES
 
 if sys.version_info >= (3, 9):

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -27,7 +27,7 @@ from polars._utils.various import (
 if TYPE_CHECKING:
     from zoneinfo import ZoneInfo
 
-    from polars.type_aliases import TimeUnit
+    from polars._typing import TimeUnit
 else:
     from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 


### PR DESCRIPTION
The `type_aliases` module was not technically public, i.e. it is not documented in the API reference and it is not explicitly re-exported at the top-level. However, it was also not explicitly marked private (it did not have a leading underscore).

For clarity, I renamed the module to `_typing`. This makes it clear that the module is private and importing from it is 'at own risk'.

I plan on adding a public `typing` module in the near future which re-exports some curated type aliases from `_typing`. Until then, people can (continue to) abuse our private typing module, or define their own.

I kept the `type_aliases` module for now with a deprecation message, as I expect quite a lot of users will be using it regardless of it not being public.