### PR TITLE
refactor(python): Explicitly mark `dependencies` module as private

### DIFF
--- a/py-polars/polars/_dependencies.py
+++ b/py-polars/polars/_dependencies.py
@@ -256,7 +256,7 @@ def import_optional(
 
     Examples
     --------
-    >>> from polars.dependencies import import_optional
+    >>> from polars._dependencies import import_optional
     >>> import_optional(
     ...     "definitely_a_real_module",
     ...     err_prefix="super-important package",

--- a/py-polars/polars/_utils/async_.py
+++ b/py-polars/polars/_utils/async_.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Awaitable, Generator, Generic, TypeVar
 
+from polars._dependencies import _GEVENT_AVAILABLE
 from polars._utils.wrap import wrap_df
-from polars.dependencies import _GEVENT_AVAILABLE
 
 if TYPE_CHECKING:
     from asyncio.futures import Future

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -19,6 +19,16 @@ from typing import (
 import polars._reexport as pl
 import polars._utils.construction as plc
 from polars import functions as F
+from polars._dependencies import (
+    _NUMPY_AVAILABLE,
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    _check_for_pandas,
+    dataclasses,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.utils import (
     contains_nested,
     is_namedtuple,
@@ -45,16 +55,6 @@ from polars.datatypes import (
     parse_into_dtype,
     try_parse_into_dtype,
 )
-from polars.dependencies import (
-    _NUMPY_AVAILABLE,
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    _check_for_pandas,
-    dataclasses,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import DataOrientationWarning, ShapeError
 from polars.meta import thread_pool_size
 

--- a/py-polars/polars/_utils/construction/other.py
+++ b/py-polars/polars/_utils/construction/other.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.utils import get_first_non_none
-from polars.dependencies import pyarrow as pa
 
 if TYPE_CHECKING:
-    from polars.dependencies import pandas as pd
+    from polars._dependencies import pandas as pd
 
 
 def pandas_series_to_arrow(

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -15,6 +15,14 @@ from typing import (
 
 import polars._reexport as pl
 import polars._utils.construction as plc
+from polars._dependencies import (
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    dataclasses,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.utils import (
     get_first_non_none,
     is_namedtuple,
@@ -52,21 +60,13 @@ from polars.datatypes.constructor import (
     polars_type_to_constructor,
     py_type_to_constructor,
 )
-from polars.dependencies import (
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    dataclasses,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PySeries
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
-    from polars.dependencies import pandas as pd
+    from polars._dependencies import pandas as pd
     from polars.type_aliases import PolarsDataType
 
 

--- a/py-polars/polars/_utils/construction/utils.py
+++ b/py-polars/polars/_utils/construction/utils.py
@@ -4,7 +4,7 @@ import sys
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, Sequence, get_type_hints
 
-from polars.dependencies import _check_for_pydantic, pydantic
+from polars._dependencies import _check_for_pydantic, pydantic
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/py-polars/polars/_utils/convert.py
+++ b/py-polars/polars/_utils/convert.py
@@ -13,6 +13,7 @@ from typing import (
     overload,
 )
 
+from polars._dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 from polars._utils.constants import (
     EPOCH,
     EPOCH_DATE,
@@ -23,7 +24,6 @@ from polars._utils.constants import (
     SECONDS_PER_HOUR,
     US_PER_SECOND,
 )
-from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
 if TYPE_CHECKING:
     from datetime import date, tzinfo

--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Iterable, NoReturn, Sequence, overload
 
 import polars._reexport as pl
 import polars.functions as F
+from polars._dependencies import _check_for_numpy
+from polars._dependencies import numpy as np
 from polars._utils.constants import U32_MAX
 from polars._utils.slice import PolarsSlice
 from polars._utils.various import range_to_slice
@@ -17,8 +19,6 @@ from polars.datatypes.classes import (
     UInt32,
     UInt64,
 )
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 from polars.meta.index_type import get_index_type
 
 if TYPE_CHECKING:

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -22,6 +22,8 @@ from typing import (
 
 import polars as pl
 from polars import functions as F
+from polars._dependencies import _check_for_numpy
+from polars._dependencies import numpy as np
 from polars.datatypes import (
     Boolean,
     Date,
@@ -33,8 +35,6 @@ from polars.datatypes import (
     Time,
 )
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Reversible

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -5,8 +5,8 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
+from polars._dependencies import json
 from polars._utils.various import normalize_filepath
-from polars.dependencies import json
 
 if TYPE_CHECKING:
     import sys

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, overload
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction.dataframe import (
     arrow_to_pydf,
     dict_to_pydf,
@@ -19,13 +21,11 @@ from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import _cast_repr_strings_with_schema
 from polars._utils.wrap import wrap_df, wrap_s
 from polars.datatypes import N_INFER_DEFAULT, Categorical, List, Object, String, Struct
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
-    from polars.dependencies import numpy as np
+    from polars._dependencies import numpy as np
     from polars.interchange.protocol import SupportsInterchange
     from polars.type_aliases import Orientation, SchemaDefinition, SchemaDict
 

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -6,7 +6,7 @@ import os
 from textwrap import dedent
 from typing import TYPE_CHECKING, Iterable
 
-from polars.dependencies import html
+from polars._dependencies import html
 
 if TYPE_CHECKING:
     from types import TracebackType

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -31,6 +31,21 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import (
+    _GREAT_TABLES_AVAILABLE,
+    _HVPLOT_AVAILABLE,
+    _PANDAS_AVAILABLE,
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    _check_for_pandas,
+    _check_for_pyarrow,
+    great_tables,
+    hvplot,
+    import_optional,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction import (
     arrow_to_pydf,
     dataframe_to_pydf,
@@ -77,21 +92,6 @@ from polars.datatypes import (
     UInt64,
 )
 from polars.datatypes.group import INTEGER_DTYPES
-from polars.dependencies import (
-    _GREAT_TABLES_AVAILABLE,
-    _HVPLOT_AVAILABLE,
-    _PANDAS_AVAILABLE,
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    _check_for_pandas,
-    _check_for_pyarrow,
-    great_tables,
-    hvplot,
-    import_optional,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import (
     ColumnNotFoundError,
     ModuleUpgradeRequiredError,

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -5,7 +5,7 @@ from decimal import Decimal as PyDecimal
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from polars import datatypes as dt
-from polars.dependencies import numpy as np
+from polars._dependencies import numpy as np
 
 # Module not available when building docs
 try:

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -8,6 +8,8 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
 from typing import TYPE_CHECKING, Any, Collection, Optional, Union
 
+from polars._dependencies import numpy as np
+from polars._dependencies import pyarrow as pa
 from polars.datatypes.classes import (
     Array,
     Binary,
@@ -38,8 +40,6 @@ from polars.datatypes.classes import (
     UInt64,
     Unknown,
 )
-from polars.dependencies import numpy as np
-from polars.dependencies import pyarrow as pa
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import dtype_str_repr as _dtype_str_repr

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -25,6 +25,8 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import _check_for_numpy
+from polars._dependencies import numpy as np
 from polars._utils.convert import negate_duration_string, parse_as_duration_string
 from polars._utils.deprecation import (
     deprecate_function,
@@ -47,8 +49,6 @@ from polars._utils.various import (
     warn_null_comparison,
 )
 from polars.datatypes import Int64, is_polars_dtype, parse_into_dtype
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 from polars.exceptions import CustomUFuncWarning, PolarsInefficientMapWarning
 from polars.expr.array import ExprArrayNameSpace
 from polars.expr.binary import ExprBinaryNameSpace

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -6,6 +6,8 @@ from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
+from polars._dependencies import _check_for_numpy
+from polars._dependencies import numpy as np
 from polars._utils.convert import (
     date_to_int,
     datetime_to_int,
@@ -14,8 +16,6 @@ from polars._utils.convert import (
 )
 from polars._utils.wrap import wrap_expr
 from polars.datatypes import Date, Datetime, Duration, Enum, Time
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -7,8 +7,8 @@ from io import BytesIO, StringIO
 from pathlib import Path
 from typing import IO, Any, ContextManager, Iterator, Sequence, overload
 
+from polars._dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars._utils.various import is_int_sequence, is_str_sequence, normalize_filepath
-from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
 
 

--- a/py-polars/polars/io/database/_utils.py
+++ b/py-polars/polars/io/database/_utils.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from polars._dependencies import import_optional
 from polars.convert import from_arrow
-from polars.dependencies import import_optional
 
 if TYPE_CHECKING:
     import sys
@@ -28,8 +28,8 @@ def _run_async(co: Coroutine[Any, Any, Any]) -> Any:
     """Run asynchronous code as if it was synchronous."""
     import asyncio
 
+    from polars._dependencies import import_optional
     from polars._utils.unstable import issue_unstable_warning
-    from polars.dependencies import import_optional
 
     issue_unstable_warning(
         "Use of asynchronous connections is currently considered unstable "

--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Iterable, Literal, overload
 
+from polars._dependencies import import_optional
 from polars.datatypes import N_INFER_DEFAULT
-from polars.dependencies import import_optional
 from polars.io.database._cursor_proxies import ODBCCursorProxy
 from polars.io.database._executor import ConnectionExecutor
 

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+from polars._dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.convert import from_arrow
 from polars.datatypes import Null, Time
 from polars.datatypes.convert import unpack_dtypes
-from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/iceberg.py
+++ b/py-polars/polars/io/iceberg.py
@@ -21,8 +21,8 @@ from functools import partial, singledispatch
 from typing import TYPE_CHECKING, Any, Callable
 
 import polars._reexport as pl
+from polars._dependencies import pyiceberg
 from polars._utils.convert import to_py_date, to_py_datetime
-from polars.dependencies import pyiceberg
 
 if TYPE_CHECKING:
     from datetime import date, datetime

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -5,13 +5,13 @@ from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Sequence
 
 import polars._reexport as pl
+from polars._dependencies import import_optional
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import (
     is_str_sequence,
     normalize_filepath,
 )
 from polars._utils.wrap import wrap_df, wrap_ldf
-from polars.dependencies import import_optional
 from polars.io._utils import (
     is_glob_pattern,
     is_local_file,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Sequence
 
 import polars.functions as F
+from polars._dependencies import import_optional
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import (
@@ -14,7 +15,6 @@ from polars._utils.various import (
 )
 from polars._utils.wrap import wrap_df, wrap_ldf
 from polars.convert import from_arrow
-from polars.dependencies import import_optional
 from polars.io._utils import (
     parse_columns_arg,
     parse_row_index_args,

--- a/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
+++ b/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
-from polars.dependencies import pyarrow as pa
+from polars._dependencies import pyarrow as pa
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame

--- a/py-polars/polars/io/pyarrow_dataset/functions.py
+++ b/py-polars/polars/io/pyarrow_dataset/functions.py
@@ -7,7 +7,7 @@ from polars.io.pyarrow_dataset.anonymous_scan import _scan_pyarrow_dataset
 
 if TYPE_CHECKING:
     from polars import LazyFrame
-    from polars.dependencies import pyarrow as pa
+    from polars._dependencies import pyarrow as pa
 
 
 @unstable()

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Sequence, overload
 
 from polars import functions as F
+from polars._dependencies import json
 from polars.datatypes import (
     Date,
     Datetime,
@@ -15,7 +16,6 @@ from polars.datatypes import (
     Time,
 )
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES
-from polars.dependencies import json
 from polars.exceptions import DuplicateError
 from polars.selectors import _expand_selector_dicts, _expand_selectors
 

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -8,6 +8,7 @@ from typing import IO, TYPE_CHECKING, Any, Callable, NoReturn, Sequence, overloa
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import import_optional
 from polars._utils.deprecation import (
     deprecate_renamed_parameter,
     issue_deprecation_warning,
@@ -24,7 +25,6 @@ from polars.datatypes import (
     String,
 )
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES, NUMERIC_DTYPES
-from polars.dependencies import import_optional
 from polars.exceptions import (
     ModuleUpgradeRequiredError,
     NoDataError,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -23,6 +23,7 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import import_optional, subprocess
 from polars._utils.async_ import _AioDataFrameResult, _GeventDataFrameResult
 from polars._utils.convert import negate_duration_string, parse_as_duration_string
 from polars._utils.deprecation import (
@@ -76,7 +77,6 @@ from polars.datatypes import (
     parse_into_dtype,
 )
 from polars.datatypes.group import DataTypeGroup
-from polars.dependencies import import_optional, subprocess
 from polars.exceptions import PerformanceWarning
 from polars.lazyframe.group_by import LazyGroupBy
 from polars.lazyframe.in_process import InProcessQuery
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     from polars import DataFrame, DataType, Expr
-    from polars.dependencies import numpy as np
+    from polars._dependencies import numpy as np
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -24,6 +24,18 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
+from polars._dependencies import (
+    _HVPLOT_AVAILABLE,
+    _PYARROW_AVAILABLE,
+    _check_for_numpy,
+    _check_for_pandas,
+    _check_for_pyarrow,
+    hvplot,
+    import_optional,
+)
+from polars._dependencies import numpy as np
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.construction import (
     arrow_to_pyseries,
     dataframe_to_pyseries,
@@ -85,18 +97,6 @@ from polars.datatypes import (
     supported_numpy_char_code,
 )
 from polars.datatypes._utils import dtype_to_init_repr
-from polars.dependencies import (
-    _HVPLOT_AVAILABLE,
-    _PYARROW_AVAILABLE,
-    _check_for_numpy,
-    _check_for_pandas,
-    _check_for_pyarrow,
-    hvplot,
-    import_optional,
-)
-from polars.dependencies import numpy as np
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.exceptions import ComputeError, ModuleUpgradeRequiredError, ShapeError
 from polars.series.array import ArrayNameSpace
 from polars.series.binary import BinaryNameSpace

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -12,15 +12,15 @@ from typing import (
     overload,
 )
 
+from polars._dependencies import _check_for_pandas, _check_for_pyarrow
+from polars._dependencies import pandas as pd
+from polars._dependencies import pyarrow as pa
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import _get_stack_locals
 from polars._utils.wrap import wrap_ldf
 from polars.convert import from_arrow, from_pandas
 from polars.dataframe import DataFrame
-from polars.dependencies import _check_for_pandas, _check_for_pyarrow
-from polars.dependencies import pandas as pd
-from polars.dependencies import pyarrow as pa
 from polars.lazyframe import LazyFrame
 from polars.series import Series
 from polars.type_aliases import FrameType

--- a/py-polars/polars/testing/parametric/__init__.py
+++ b/py-polars/polars/testing/parametric/__init__.py
@@ -1,4 +1,4 @@
-from polars.dependencies import _HYPOTHESIS_AVAILABLE
+from polars._dependencies import _HYPOTHESIS_AVAILABLE
 
 if not _HYPOTHESIS_AVAILABLE:
     msg = (

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -26,10 +26,10 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from polars import DataFrame, Expr, LazyFrame, Series
+    from polars._dependencies import numpy as np
+    from polars._dependencies import pandas as pd
+    from polars._dependencies import pyarrow as pa
     from polars.datatypes import DataType, DataTypeClass, IntegerType, TemporalType
-    from polars.dependencies import numpy as np
-    from polars.dependencies import pandas as pd
-    from polars.dependencies import pyarrow as pa
     from polars.selectors import _selector_proxy_
 
     if sys.version_info >= (3, 10):

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -13,9 +13,9 @@ import pytest
 from pydantic import BaseModel, Field, TypeAdapter
 
 import polars as pl
+from polars._dependencies import dataclasses, pydantic
 from polars._utils.construction.utils import try_get_type_hints
 from polars.datatypes import numpy_char_code_to_dtype
-from polars.dependencies import dataclasses, pydantic
 from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -427,10 +427,10 @@ def test_from_pandas_series() -> None:
 
 
 def test_from_optional_not_available() -> None:
-    from polars.dependencies import _LazyModule
+    from polars._dependencies import _LazyModule
 
     # proxy module is created dynamically if the required module is not available
-    # (see the polars.dependencies source code for additional detail/comments)
+    # (see the polars._dependencies source code for additional detail/comments)
 
     np = _LazyModule("numpy", module_available=False)
     with pytest.raises(ImportError, match=r"np\.array requires 'numpy'"):

--- a/py-polars/tests/unit/ml/test_to_jax.py
+++ b/py-polars/tests/unit/ml/test_to_jax.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.dependencies import _lazy_import
+from polars._dependencies import _lazy_import
 
 # don't import jax until an actual test is triggered (the decorator already
 # ensures the tests aren't run locally; this avoids premature local import)

--- a/py-polars/tests/unit/ml/test_to_torch.py
+++ b/py-polars/tests/unit/ml/test_to_torch.py
@@ -6,7 +6,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.dependencies import _lazy_import
+from polars._dependencies import _lazy_import
 
 # don't import torch until an actual test is triggered (the decorator already
 # ensures the tests aren't run locally; this avoids premature local import)

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
@@ -11,7 +11,7 @@ import pytest
 from hypothesis import assume, given
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars._dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -9,7 +9,7 @@ import pytest
 from hypothesis import given
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars._dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 

--- a/py-polars/tests/unit/operations/test_cross_join.py
+++ b/py-polars/tests/unit/operations/test_cross_join.py
@@ -1,7 +1,7 @@
 import sys
 from datetime import datetime
 
-from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars._dependencies import _ZONEINFO_AVAILABLE
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/py-polars/tests/unit/operations/test_ewm_by.py
+++ b/py-polars/tests/unit/operations/test_ewm_by.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars._dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 

--- a/py-polars/tests/unit/operations/test_interpolate.py
+++ b/py-polars/tests/unit/operations/test_interpolate.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars._dependencies import _ZONEINFO_AVAILABLE
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -180,7 +180,7 @@ def test_init_structured_objects() -> None:
     # validate init from dataclass, namedtuple, and pydantic model objects
     from typing import NamedTuple
 
-    from polars.dependencies import dataclasses, pydantic
+    from polars._dependencies import dataclasses, pydantic
 
     @dataclasses.dataclass
     class TeaShipmentDC:

--- a/py-polars/tests/unit/test_async.py
+++ b/py-polars/tests/unit/test_async.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 import pytest
 
 import polars as pl
-from polars.dependencies import gevent
+from polars._dependencies import gevent
 from polars.exceptions import ColumnNotFoundError
 
 pytestmark = pytest.mark.slow()

--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -85,7 +85,7 @@ def test_polars_import() -> None:
     ):
         # ensure that we have not broken lazy-loading (numpy, pandas, pyarrow, etc).
         lazy_modules = [
-            dep for dep in pl.dependencies.__all__ if not dep.startswith("_")
+            dep for dep in pl._dependencies.__all__ if not dep.startswith("_")
         ]
         for mod in lazy_modules:
             not_imported = not df_import["import"].str.starts_with(mod).any()

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.dependencies import _ZONEINFO_AVAILABLE
+from polars._dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ColumnNotFoundError
 from polars.selectors import expand_selector, is_selector
 from polars.testing import assert_frame_equal


### PR DESCRIPTION
This module is purely for our own use. It's not relevant for users, so let's explicitly mark that boundary.