### PR TITLE
refactor(rust): remove seqmacro and u8,u16 bitpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3282,7 +3282,6 @@ dependencies = [
  "polars-error",
  "polars-utils",
  "rand",
- "seq-macro",
  "serde",
  "simdutf8",
  "snap",
@@ -4265,12 +4264,6 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "seq-macro"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -26,7 +26,6 @@ polars-utils = { workspace = true }
 simdutf8 = { workspace = true }
 
 parquet-format-safe = "0.2"
-seq-macro = { version = "0.3", default-features = false }
 streaming-decompression = "0.1"
 
 async-stream = { version = "0.3.3", optional = true }

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/mod.rs
@@ -1,3 +1,57 @@
+macro_rules! seq_macro {
+    ($i:ident in 1..31 $block:block) => {
+        seq_macro!($i in [
+                 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+        ] $block)
+    };
+    ($i:ident in 0..32 $block:block) => {
+        seq_macro!($i in [
+             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+        ] $block)
+    };
+    ($i:ident in 0..=32 $block:block) => {
+        seq_macro!($i in [
+             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+            32,
+        ] $block)
+    };
+    ($i:ident in 1..63 $block:block) => {
+        seq_macro!($i in [
+                 1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+            32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+            48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+        ] $block)
+    };
+    ($i:ident in 0..64 $block:block) => {
+        seq_macro!($i in [
+             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+            32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+            48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ] $block)
+    };
+    ($i:ident in 0..=64 $block:block) => {
+        seq_macro!($i in [
+             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+            32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+            48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+            64,
+        ] $block)
+    };
+    ($i:ident in [$($value:literal),+ $(,)?] $block:block) => {
+        $({
+            #[allow(non_upper_case_globals)]
+            const $i: usize = $value;
+            { $block }
+        })+
+    };
+}
+
 mod decode;
 mod encode;
 mod pack;
@@ -103,36 +157,6 @@ pub trait Unpackable: Copy + Sized + Default {
     type Unpacked: Unpacked<Self>;
     fn unpack(packed: &[u8], num_bits: usize, unpacked: &mut Self::Unpacked);
     fn pack(unpacked: &Self::Unpacked, num_bits: usize, packed: &mut [u8]);
-}
-
-impl Unpackable for u8 {
-    type Packed = [u8; 8];
-    type Unpacked = [u8; 8];
-
-    #[inline]
-    fn unpack(packed: &[u8], num_bits: usize, unpacked: &mut Self::Unpacked) {
-        unpack::unpack8(packed, unpacked, num_bits)
-    }
-
-    #[inline]
-    fn pack(packed: &Self::Unpacked, num_bits: usize, unpacked: &mut [u8]) {
-        pack::pack8(packed, unpacked, num_bits)
-    }
-}
-
-impl Unpackable for u16 {
-    type Packed = [u8; 16 * 2];
-    type Unpacked = [u16; 16];
-
-    #[inline]
-    fn unpack(packed: &[u8], num_bits: usize, unpacked: &mut Self::Unpacked) {
-        unpack::unpack16(packed, unpacked, num_bits)
-    }
-
-    #[inline]
-    fn pack(packed: &Self::Unpacked, num_bits: usize, unpacked: &mut [u8]) {
-        pack::pack16(packed, unpacked, num_bits)
-    }
 }
 
 impl Unpackable for u32 {

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/unpack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/unpack.rs
@@ -14,8 +14,26 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
+//
 // Copied from https://github.com/apache/arrow-rs/blob/6859efa690d4c9530cf8a24053bc6ed81025a164/parquet/src/util/bit_pack.rs
+
+// This implements bit unpacking. For example, for `u8` and `num_bits=3`.
+// 0b001_101_110  -> 0b0000_0001, 0b0000_0101, 0b0000_0110
+//
+// This file is a bit insane. It unrolls all the possible num_bits vs. combinations. These are very
+// highly used functions in Parquet and therefore this that been extensively unrolled and
+// optimized. Attempts have been done to introduce SIMD here, but those attempts have not paid off
+// in comparison to auto-vectorization.
+//
+// Generally, there are two code-size vs. runtime tradeoffs taken here in favor of
+// runtime.
+//
+// 1. Each individual function unrolled to a point where all constants are known to
+// the compiler. In microbenchmarks, this increases the performance by around 4.5
+// to 5 times.
+// 2. All functions are compiled seperately and dispatch is done using a
+// jumptable. In microbenchmarks, this increases the performance by around 2 to 2.5
+// times.
 
 /// Macro that generates an unpack function taking the number of bits as a const generic
 macro_rules! unpack_impl {
@@ -50,7 +68,7 @@ macro_rules! unpack_impl {
             // performance in a microbenchmark. Although the code it generates is completely
             // insane. There should be something we can do here to make this less code, sane code
             // and faster code.
-            seq_macro::seq!(i in 0..$bits {
+            seq_macro!(i in 0..$bits {
                 let start_bit = i * NUM_BITS;
                 let end_bit = start_bit + NUM_BITS;
 
@@ -88,7 +106,7 @@ macro_rules! unpack {
             // @NOTE
             // This jumptable appoach saves around 2 - 2.5x on performance over no jumptable and no
             // generics.
-            seq_macro::seq!(i in 0..=$bits {
+            seq_macro!(i in 0..=$bits {
                 if i == num_bits {
                     return $name::unpack::<i>(input, output);
                 }
@@ -98,8 +116,6 @@ macro_rules! unpack {
     };
 }
 
-unpack!(unpack8, u8, 1, 8);
-unpack!(unpack16, u16, 2, 16);
 unpack!(unpack32, u32, 4, 32);
 unpack!(unpack64, u64, 8, 64);
 
@@ -110,22 +126,6 @@ mod tests {
     #[test]
     fn test_basic() {
         let input = [0xFF; 4096];
-
-        for i in 0..=8 {
-            let mut output = [0; 8];
-            unpack8(&input, &mut output, i);
-            for (idx, out) in output.iter().enumerate() {
-                assert_eq!(out.trailing_ones() as usize, i, "out[{}] = {}", idx, out);
-            }
-        }
-
-        for i in 0..=16 {
-            let mut output = [0; 16];
-            unpack16(&input, &mut output, i);
-            for (idx, out) in output.iter().enumerate() {
-                assert_eq!(out.trailing_ones() as usize, i, "out[{}] = {}", idx, out);
-            }
-        }
 
         for i in 0..=32 {
             let mut output = [0; 32];

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/unpack.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/unpack.rs
@@ -31,7 +31,7 @@
 // 1. Each individual function unrolled to a point where all constants are known to
 // the compiler. In microbenchmarks, this increases the performance by around 4.5
 // to 5 times.
-// 2. All functions are compiled seperately and dispatch is done using a
+// 2. All functions are compiled separately and dispatch is done using a
 // jumptable. In microbenchmarks, this increases the performance by around 2 to 2.5
 // times.
 


### PR DESCRIPTION
After looking for a long time at how to SIMD this bitpacking, I am pausing for a bit to work on something else. There are some code deletions, namely removing the unused u8 and u16 implementations of bit(un)packing. This also removes the `seq_macro` crate.

Maybe, I will look at this again in the future.