### PR TITLE
feat: Add SQL support for `NATURAL` joins and the `COLUMNS` function

### DIFF
--- a/py-polars/docs/source/reference/sql/clauses.rst
+++ b/py-polars/docs/source/reference/sql/clauses.rst
@@ -127,13 +127,11 @@ Combines rows from two or more tables based on a related column.
 **Join Types**
 
 * `CROSS JOIN`
-* `FULL JOIN`
-* `INNER JOIN`
-* `LEFT JOIN`
-* `[LEFT] ANTI JOIN`
-* `[LEFT] SEMI JOIN`
-* `RIGHT ANTI JOIN`
-* `RIGHT SEMI JOIN`
+* `[NATURAL] FULL JOIN`
+* `[NATURAL] INNER JOIN`
+* `[NATURAL] LEFT JOIN`
+* `[LEFT | RIGHT] ANTI JOIN`
+* `[LEFT | RIGHT] SEMI JOIN`
 
 **Example:**
 
@@ -156,7 +154,6 @@ Combines rows from two or more tables based on a related column.
       FROM df1 FULL JOIN df2
       USING (ham)
     """).collect()
-
     # shape: (4, 3)
     # ┌──────┬───────┬─────┐
     # │ foo  ┆ apple ┆ ham │
@@ -168,6 +165,20 @@ Combines rows from two or more tables based on a related column.
     # │ null ┆ z     ┆ d   │
     # │ 3    ┆ null  ┆ c   │
     # └──────┴───────┴─────┘
+
+    pl.sql("""
+      SELECT COLUMNS('^\w+$')
+      FROM df1 NATURAL INNER JOIN df2
+    """).collect()
+    # shape: (2, 3)
+    # ┌─────┬───────┬─────┐
+    # │ foo ┆ apple ┆ ham │
+    # │ --- ┆ ---   ┆ --- │
+    # │ i64 ┆ str   ┆ str │
+    # ╞═════╪═══════╪═════╡
+    # │ 1   ┆ x     ┆ a   │
+    # │ 2   ┆ y     ┆ b   │
+    # └─────┴───────┴─────┘
 
 .. _where:
 

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -323,3 +323,138 @@ def test_implicit_joins() -> None:
             WHERE t1.a = t2.b
             """
         )
+
+
+def test_natural_joins_01() -> None:
+    df1 = pl.DataFrame(
+        {
+            "CharacterID": [1, 2, 3, 4],
+            "FirstName": ["Jernau Morat", "Cheradenine", "Byr", "Diziet"],
+            "LastName": ["Gurgeh", "Zakalwe", "Genar-Hofoen", "Sma"],
+        }
+    )
+    df2 = pl.DataFrame(
+        {
+            "CharacterID": [1, 2, 3, 5],
+            "Role": ["Protagonist", "Protagonist", "Protagonist", "Antagonist"],
+            "Book": [
+                "Player of Games",
+                "Use of Weapons",
+                "Excession",
+                "Consider Phlebas",
+            ],
+        }
+    )
+    df3 = pl.DataFrame(
+        {
+            "CharacterID": [1, 2, 3, 4],
+            "Affiliation": ["Culture", "Culture", "Culture", "Shellworld"],
+            "Species": ["Pan-human", "Human", "Human", "Oct"],
+        }
+    )
+    df4 = pl.DataFrame(
+        {
+            "CharacterID": [1, 2, 3, 6],
+            "Ship": [
+                "Limiting Factor",
+                "Xenophobe",
+                "Grey Area",
+                "Falling Outside The Normal Moral Constraints",
+            ],
+            "Drone": ["Flere-Imsaho", "Skaffen-Amtiskaw", "Eccentric", "Psychopath"],
+        }
+    )
+    with pl.SQLContext(
+        {"df1": df1, "df2": df2, "df3": df3, "df4": df4}, eager=True
+    ) as ctx:
+        # note: use of 'COLUMNS' is a neat way to drop
+        # all non-coalesced "<name>:<suffix>" cols
+        res = ctx.execute(
+            """
+            SELECT COLUMNS('^[^:]*$')
+            FROM df1
+            NATURAL LEFT JOIN df2
+            NATURAL INNER JOIN df3
+            NATURAL LEFT JOIN df4
+            ORDER BY ALL
+            """
+        )
+        assert res.rows(named=True) == [
+            {
+                "CharacterID": 1,
+                "FirstName": "Jernau Morat",
+                "LastName": "Gurgeh",
+                "Role": "Protagonist",
+                "Book": "Player of Games",
+                "Affiliation": "Culture",
+                "Species": "Pan-human",
+                "Ship": "Limiting Factor",
+                "Drone": "Flere-Imsaho",
+            },
+            {
+                "CharacterID": 2,
+                "FirstName": "Cheradenine",
+                "LastName": "Zakalwe",
+                "Role": "Protagonist",
+                "Book": "Use of Weapons",
+                "Affiliation": "Culture",
+                "Species": "Human",
+                "Ship": "Xenophobe",
+                "Drone": "Skaffen-Amtiskaw",
+            },
+            {
+                "CharacterID": 3,
+                "FirstName": "Byr",
+                "LastName": "Genar-Hofoen",
+                "Role": "Protagonist",
+                "Book": "Excession",
+                "Affiliation": "Culture",
+                "Species": "Human",
+                "Ship": "Grey Area",
+                "Drone": "Eccentric",
+            },
+            {
+                "CharacterID": 4,
+                "FirstName": "Diziet",
+                "LastName": "Sma",
+                "Role": None,
+                "Book": None,
+                "Affiliation": "Shellworld",
+                "Species": "Oct",
+                "Ship": None,
+                "Drone": None,
+            },
+        ]
+
+
+@pytest.mark.parametrize(
+    ("cols_constraint", "expected"),
+    [
+        (">= 5", [(8, 8, 6)]),
+        ("< 7", [(5, 4, 4)]),
+        ("< 8", [(5, 4, 4), (7, 4, 4), (0, 7, 2)]),
+        ("!= 4", [(8, 8, 6), (2, 8, 6), (0, 7, 2)]),
+    ],
+)
+def test_natural_joins_02(cols_constraint: str, expected: list[tuple[int]]) -> None:
+    df1 = pl.DataFrame(  # noqa: F841
+        {
+            "x": [1, 5, 3, 8, 6, 7, 4, 0, 2],
+            "y": [3, 4, 6, 8, 3, 4, 1, 7, 8],
+        }
+    )
+    df2 = pl.DataFrame(  # noqa: F841
+        {
+            "y": [0, 4, 0, 8, 0, 4, 0, 7, None],
+            "z": [9, 8, 7, 6, 5, 4, 3, 2, 1],
+        },
+    )
+    actual = pl.sql(
+        f"""
+        SELECT * EXCLUDE "y:df2"
+        FROM df1 NATURAL JOIN df2
+        WHERE COLUMNS(*) {cols_constraint}
+        """
+    ).collect()
+
+    assert actual.rows() == expected

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 import polars as pl
-from polars.exceptions import SQLInterfaceError
+from polars.exceptions import SQLInterfaceError, SQLSyntaxError
 from polars.testing import assert_frame_equal
 
 
@@ -425,6 +425,13 @@ def test_natural_joins_01() -> None:
                 "Drone": None,
             },
         ]
+
+    # misc errors
+    with pytest.raises(SQLSyntaxError, match=r"did you mean COLUMNS\(\*\)\?"):
+        pl.sql("SELECT * FROM df1 NATURAL JOIN df2 WHERE COLUMNS('*') >= 5")
+
+    with pytest.raises(SQLSyntaxError, match=r"COLUMNS expects a regex"):
+        pl.sql("SELECT COLUMNS(1234) FROM df1 NATURAL JOIN df2")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## New

* Adds `NATURAL [INNER|LEFT|FULL] JOIN`[^1] support for the SQL interface (this flavour of join automatically uses the common cols between the two tables as the join-key), and the associated SQL docs entries/examples.
* Partial implementation of the useful DuckDB `COLUMNS`[^2] function; this maps almost 1:1 onto Polars' `col` expression, enabling use of regular expressions to select multiple columns. Also offers some (currently limited) broadcasting capabilities; at the moment broadcasting support only works in the `WHERE` clause.

## Also

* Ensure `SQLFunctionVisitor` translations also have access to the current/active schema.
* Some refactoring, with more to come later. Some of the logic is getting quite involved, and could do with more inline comments, explanations and additional cleanups.

## Examples

Establish test data:
```python
import polars as pl

df1 = pl.DataFrame({
    "CharacterID": [1, 2, 3],
    "FirstName": ["Jernau Morat", "Cheradenine", "Byr"],
    "LastName": ["Gurgeh", "Zakalwe", "Genar-Hofoen"],
})
df2 = pl.DataFrame({
    "CharacterID": [1, 2, 3],
    "Book": ["Player of Games", "Use of Weapons", "Excession"],
})
df3 = pl.DataFrame({
    "CharacterID": [1, 2, 3],
    "Ship": ["Limiting Factor", "Xenophobe", "Grey Area"],
})
```
Apply `NATURAL` joins, use a `COLUMNS` regex to avoid selecting `<col>:<suffix>` cols:
```python
pl.sql("""
  SELECT COLUMNS('^[^:]+$')
  FROM df1
    NATURAL JOIN df2
    NATURAL JOIN df3
  ORDER BY CharacterID
""").collect()

# shape: (3, 5)
# ┌─────────────┬──────────────┬──────────────┬─────────────────┬─────────────────┐
# │ CharacterID ┆ FirstName    ┆ LastName     ┆ Book            ┆ Ship            │
# │ ---         ┆ ---          ┆ ---          ┆ ---             ┆ ---             │
# │ i64         ┆ str          ┆ str          ┆ str             ┆ str             │
# ╞═════════════╪══════════════╪══════════════╪═════════════════╪═════════════════╡
# │ 1           ┆ Jernau Morat ┆ Gurgeh       ┆ Player of Games ┆ Limiting Factor │
# │ 2           ┆ Cheradenine  ┆ Zakalwe      ┆ Use of Weapons  ┆ Xenophobe       │
# │ 3           ┆ Byr          ┆ Genar-Hofoen ┆ Excession       ┆ Grey Area       │
# └─────────────┴──────────────┴──────────────┴─────────────────┴─────────────────┘
```
Use `COLUMNS` to broadcast constraints in `WHERE` clause; filter for value `>= 4` across _all_ columns:
```python
df1 = pl.DataFrame({
    "x": [1, 5, 3, 8, 6, 7, 4, 0, 2],
    "y": [3, 4, 6, 8, 3, 4, 1, 7, 8],
})
df2 = pl.DataFrame({
    "y": [0, 4, 0, 8, 0, 4, 0, 7, 0],
    "z": [9, 8, 7, 6, 5, 4, 3, 2, 1],
})

pl.sql(f"""
  SELECT * EXCLUDE "y:df2"
  FROM df1 NATURAL JOIN df2
  WHERE COLUMNS(*) >= 4
""").collect()

# shape: (5, 3)
# ┌─────┬─────┬─────┐
# │ x   ┆ y   ┆ z   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 5   ┆ 4   ┆ 8   │
# │ 7   ┆ 4   ┆ 8   │
# │ 8   ┆ 8   ┆ 6   │
# │ 5   ┆ 4   ┆ 4   │
# │ 7   ┆ 4   ┆ 4   │
# └─────┴─────┴─────┘
```

[^1]: `NATURAL JOIN`: https://www.postgresql.org/docs/current/queries-table-expressions.html#QUERIES-JOIN
[^2]: `COLUMNS`: https://duckdb.org/docs/sql/expressions/star.html#columns-regular-expression