### PR TITLE
Refactor: Prefer ParquetError::oos to ParquetError::OutOfSpec

### DIFF
--- a/crates/polars-io/src/parquet/read/async_impl.rs
+++ b/crates/polars-io/src/parquet/read/async_impl.rs
@@ -123,8 +123,8 @@ pub async fn fetch_metadata(
             file_byte_length
                 .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize)
                 .ok_or_else(|| {
-                    polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                        "not enough bytes to contain parquet footer".to_string(),
+                    ParquetError::oos(
+                        "not enough bytes to contain parquet footer",
                     )
                 })?..file_byte_length,
         )
@@ -136,14 +136,14 @@ pub async fn fetch_metadata(
         let magic = read_n(reader).unwrap();
         debug_assert!(reader.is_empty());
         if magic != polars_parquet::parquet::PARQUET_MAGIC {
-            return Err(polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                "incorrect magic in parquet footer".to_string(),
+            return Err(ParquetError::oos(
+                "incorrect magic in parquet footer",
             )
             .into());
         }
         footer_byte_size.try_into().map_err(|_| {
-            polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                "negative footer byte length".to_string(),
+            ParquetError::oos(
+                "negative footer byte length",
             )
         })?
     };
@@ -154,8 +154,8 @@ pub async fn fetch_metadata(
             file_byte_length
                 .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize + footer_byte_length)
                 .ok_or_else(|| {
-                    polars_parquet::parquet::error::ParquetError::OutOfSpec(
-                        "not enough bytes to contain parquet footer".to_string(),
+                    ParquetError::oos(
+                        "not enough bytes to contain parquet footer",
                     )
                 })?..file_byte_length,
         )

--- a/crates/polars-io/src/parquet/read/async_impl.rs
+++ b/crates/polars-io/src/parquet/read/async_impl.rs
@@ -122,8 +122,11 @@ pub async fn fetch_metadata(
             path,
             file_byte_length
                 .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize)
-                .ok_or_else(|| ParquetError::oos("not enough bytes to contain parquet footer"))?
-                ..file_byte_length,
+                .ok_or_else(|| {
+                    polars_parquet::parquet::error::ParquetError::OutOfSpec(
+                        "not enough bytes to contain parquet footer".to_string(),
+                    )
+                })?..file_byte_length,
         )
         .await?;
 
@@ -133,11 +136,16 @@ pub async fn fetch_metadata(
         let magic = read_n(reader).unwrap();
         debug_assert!(reader.is_empty());
         if magic != polars_parquet::parquet::PARQUET_MAGIC {
-            return Err(ParquetError::oos("incorrect magic in parquet footer").into());
+            return Err(polars_parquet::parquet::error::ParquetError::OutOfSpec(
+                "incorrect magic in parquet footer".to_string(),
+            )
+            .into());
         }
-        footer_byte_size
-            .try_into()
-            .map_err(|_| ParquetError::oos("negative footer byte length"))?
+        footer_byte_size.try_into().map_err(|_| {
+            polars_parquet::parquet::error::ParquetError::OutOfSpec(
+                "negative footer byte length".to_string(),
+            )
+        })?
     };
 
     let footer_bytes = store
@@ -145,8 +153,11 @@ pub async fn fetch_metadata(
             path,
             file_byte_length
                 .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize + footer_byte_length)
-                .ok_or_else(|| ParquetError::oos("not enough bytes to contain parquet footer"))?
-                ..file_byte_length,
+                .ok_or_else(|| {
+                    polars_parquet::parquet::error::ParquetError::OutOfSpec(
+                        "not enough bytes to contain parquet footer".to_string(),
+                    )
+                })?..file_byte_length,
         )
         .await?;
 

--- a/crates/polars-io/src/parquet/read/async_impl.rs
+++ b/crates/polars-io/src/parquet/read/async_impl.rs
@@ -122,11 +122,8 @@ pub async fn fetch_metadata(
             path,
             file_byte_length
                 .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize)
-                .ok_or_else(|| {
-                    ParquetError::oos(
-                        "not enough bytes to contain parquet footer",
-                    )
-                })?..file_byte_length,
+                .ok_or_else(|| ParquetError::oos("not enough bytes to contain parquet footer"))?
+                ..file_byte_length,
         )
         .await?;
 
@@ -136,16 +133,11 @@ pub async fn fetch_metadata(
         let magic = read_n(reader).unwrap();
         debug_assert!(reader.is_empty());
         if magic != polars_parquet::parquet::PARQUET_MAGIC {
-            return Err(ParquetError::oos(
-                "incorrect magic in parquet footer",
-            )
-            .into());
+            return Err(ParquetError::oos("incorrect magic in parquet footer").into());
         }
-        footer_byte_size.try_into().map_err(|_| {
-            ParquetError::oos(
-                "negative footer byte length",
-            )
-        })?
+        footer_byte_size
+            .try_into()
+            .map_err(|_| ParquetError::oos("negative footer byte length"))?
     };
 
     let footer_bytes = store
@@ -153,11 +145,8 @@ pub async fn fetch_metadata(
             path,
             file_byte_length
                 .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize + footer_byte_length)
-                .ok_or_else(|| {
-                    ParquetError::oos(
-                        "not enough bytes to contain parquet footer",
-                    )
-                })?..file_byte_length,
+                .ok_or_else(|| ParquetError::oos("not enough bytes to contain parquet footer"))?
+                ..file_byte_length,
         )
         .await?;
 

--- a/crates/polars-parquet/src/arrow/write/row_group.rs
+++ b/crates/polars-parquet/src/arrow/write/row_group.rs
@@ -42,7 +42,7 @@ pub fn row_group_iter<A: AsRef<dyn Array> + 'static + Send + Sync>(
                         let pages = DynIter::new(
                             pages
                                 .into_iter()
-                                .map(|x| x.map_err(|e| ParquetError::oos(e))),
+                                .map(|x| x.map_err(|e| ParquetError::oos(e.to_string()))),
                         );
 
                         let compressed_pages = Compressor::new(pages, options.compression, vec![])

--- a/crates/polars-parquet/src/arrow/write/row_group.rs
+++ b/crates/polars-parquet/src/arrow/write/row_group.rs
@@ -42,7 +42,7 @@ pub fn row_group_iter<A: AsRef<dyn Array> + 'static + Send + Sync>(
                         let pages = DynIter::new(
                             pages
                                 .into_iter()
-                                .map(|x| x.map_err(|e| ParquetError::OutOfSpec(e.to_string()))),
+                                .map(|x| x.map_err(|e| ParquetError::oos(e))),
                         );
 
                         let compressed_pages = Compressor::new(pages, options.compression, vec![])

--- a/crates/polars-parquet/src/parquet/compression.rs
+++ b/crates/polars-parquet/src/parquet/compression.rs
@@ -168,9 +168,7 @@ pub fn decompress(
 
             let len = decompress_len(input_buf)?;
             if len > output_buf.len() {
-                return Err(ParquetError::oos(
-                    "snappy header out of spec",
-                ));
+                return Err(ParquetError::oos("snappy header out of spec"));
             }
             Decoder::new()
                 .decompress(input_buf, output_buf)

--- a/crates/polars-parquet/src/parquet/compression.rs
+++ b/crates/polars-parquet/src/parquet/compression.rs
@@ -168,9 +168,9 @@ pub fn decompress(
 
             let len = decompress_len(input_buf)?;
             if len > output_buf.len() {
-                return Err(ParquetError::OutOfSpec(String::from(
+                return Err(ParquetError::oos(
                     "snappy header out of spec",
-                )));
+                ));
             }
             Decoder::new()
                 .decompress(input_buf, output_buf)

--- a/crates/polars-parquet/src/parquet/error.rs
+++ b/crates/polars-parquet/src/parquet/error.rs
@@ -34,6 +34,7 @@ pub enum ParquetError {
 }
 
 impl ParquetError {
+    /// Create an OutOfSpec error from any Into<String>
     pub(crate) fn oos<I: Into<String>>(message: I) -> Self {
         Self::OutOfSpec(message.into())
     }

--- a/crates/polars-parquet/src/parquet/read/compression.rs
+++ b/crates/polars-parquet/src/parquet/read/compression.rs
@@ -33,8 +33,8 @@ fn decompress_v2(
 
     if can_decompress {
         if offset > buffer.len() || offset > compressed.len() {
-            return Err(ParquetError::OutOfSpec(
-                "V2 Page Header reported incorrect offset to compressed data".to_string(),
+            return Err(ParquetError::oos(
+                "V2 Page Header reported incorrect offset to compressed data",
             ));
         }
 
@@ -43,8 +43,8 @@ fn decompress_v2(
         compression::decompress(compression, &compressed[offset..], &mut buffer[offset..])?;
     } else {
         if buffer.len() != compressed.len() {
-            return Err(ParquetError::OutOfSpec(
-                "V2 Page Header reported incorrect decompressed size".to_string(),
+            return Err(ParquetError::oos(
+                "V2 Page Header reported incorrect decompressed size",
             ));
         }
         buffer.copy_from_slice(compressed);

--- a/crates/polars-parquet/src/parquet/read/page/reader.rs
+++ b/crates/polars-parquet/src/parquet/read/page/reader.rs
@@ -206,7 +206,7 @@ pub(super) fn build_page<R: Read>(
 
     if bytes_read != read_size {
         return Err(ParquetError::oos(
-            "The page header reported the wrong page size".to_string(),
+            "The page header reported the wrong page size",
         ));
     }
 

--- a/crates/polars-parquet/src/parquet/read/page/stream.rs
+++ b/crates/polars-parquet/src/parquet/read/page/stream.rs
@@ -112,7 +112,7 @@ fn _get_page_stream<R: AsyncRead + Unpin + Send>(
 
             if bytes_read != read_size {
                 Err(ParquetError::oos(
-                    "The page header reported the wrong page size".to_string(),
+                    "The page header reported the wrong page size",
                 ))?
             }
 

--- a/crates/polars-parquet/src/parquet/schema/types/spec.rs
+++ b/crates/polars-parquet/src/parquet/schema/types/spec.rs
@@ -62,8 +62,7 @@ fn check_decimal_invariants(
         PhysicalType::ByteArray => {},
         _ => {
             return Err(ParquetError::oos(
-                "DECIMAL can only annotate INT32, INT64, BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY"
-                    .to_string(),
+                "DECIMAL can only annotate INT32, INT64, BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY",
             ))
         },
     };
@@ -111,14 +110,14 @@ pub fn check_converted_invariants(
         Interval => {
             if physical_type != &PhysicalType::FixedLenByteArray(12) {
                 return Err(ParquetError::oos(
-                    "INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)".to_string(),
+                    "INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)",
                 ));
             }
         },
         Enum => {
             if physical_type != &PhysicalType::ByteArray {
                 return Err(ParquetError::oos(
-                    "ENUM can only annotate BYTE_ARRAY fields".to_string(),
+                    "ENUM can only annotate BYTE_ARRAY fields",
                 ));
             }
         },
@@ -153,7 +152,7 @@ pub fn check_logical_invariants(
         (Time { unit, .. }, PhysicalType::Int64) => {
             if unit == TimeUnit::Milliseconds {
                 return Err(ParquetError::oos(
-                    "Cannot use millisecond unit on INT64 type".to_string(),
+                    "Cannot use millisecond unit on INT64 type",
                 ));
             }
         },


### PR DESCRIPTION
There are mixed uses of `ParquetError::oos` and `ParquetError::OutOfSpec` where it would just be clearer to pick one. So I favored the convenience constructor that saves a few keystrokes. I didn't make changes to the tests because that requires making `pub fn oos(..)` and I am not sure if people want that API to be exposed. If we made that change, there would be a few dozen more references cleaned up.

(This is my first commit to Polars - I'm doing some minor refactors to get my bearings so I can implement some improvements I need at work)