### PR TITLE
perf(python): Use underlying fileno for Python files when possible

### DIFF
--- a/py-polars/src/dataframe/io.rs
+++ b/py-polars/src/dataframe/io.rs
@@ -3,7 +3,6 @@ use std::num::NonZeroUsize;
 
 #[cfg(feature = "avro")]
 use polars::io::avro::AvroCompression;
-use polars::io::mmap::try_create_file;
 use polars::io::RowIndex;
 #[cfg(feature = "parquet")]
 use polars_parquet::arrow::write::StatisticsOptions;
@@ -354,30 +353,8 @@ impl PyDataFrame {
         quote_style: Option<Wrap<QuoteStyle>>,
     ) -> PyResult<()> {
         let null = null_value.unwrap_or_default();
-
-        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
-            let f = std::fs::File::create(&*s)?;
-            py.allow_threads(|| {
-                // No need for a buffered writer, because the csv writer does internal buffering.
-                CsvWriter::new(f)
-                    .include_bom(include_bom)
-                    .include_header(include_header)
-                    .with_separator(separator)
-                    .with_line_terminator(line_terminator)
-                    .with_quote_char(quote_char)
-                    .with_batch_size(batch_size)
-                    .with_datetime_format(datetime_format)
-                    .with_date_format(date_format)
-                    .with_time_format(time_format)
-                    .with_float_scientific(float_scientific)
-                    .with_float_precision(float_precision)
-                    .with_null_value(null)
-                    .with_quote_style(quote_style.map(|wrap| wrap.0).unwrap_or_default())
-                    .finish(&mut self.df)
-                    .map_err(PyPolarsErr::from)
-            })?;
-        } else {
-            let mut buf = get_file_like(py_f, true)?;
+        let mut buf = get_file_like(py_f, true)?;
+        py.allow_threads(|| {
             CsvWriter::new(&mut buf)
                 .include_bom(include_bom)
                 .include_header(include_header)
@@ -393,9 +370,8 @@ impl PyDataFrame {
                 .with_null_value(null)
                 .with_quote_style(quote_style.map(|wrap| wrap.0).unwrap_or_default())
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)?;
-        }
-
+                .map_err(PyPolarsErr::from)
+        })?;
         Ok(())
     }
 
@@ -412,29 +388,16 @@ impl PyDataFrame {
         data_page_size: Option<usize>,
     ) -> PyResult<()> {
         let compression = parse_parquet_compression(compression, compression_level)?;
-
-        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
-            let f = std::fs::File::create(&*s)?;
-            py.allow_threads(|| {
-                ParquetWriter::new(f)
-                    .with_compression(compression)
-                    .with_statistics(statistics.0)
-                    .with_row_group_size(row_group_size)
-                    .with_data_page_size(data_page_size)
-                    .finish(&mut self.df)
-                    .map_err(PyPolarsErr::from)
-            })?;
-        } else {
-            let buf = get_file_like(py_f, true)?;
+        let buf = get_file_like(py_f, true)?;
+        py.allow_threads(|| {
             ParquetWriter::new(buf)
                 .with_compression(compression)
                 .with_statistics(statistics.0)
                 .with_row_group_size(row_group_size)
                 .with_data_page_size(data_page_size)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)?;
-        }
-
+                .map_err(PyPolarsErr::from)
+        })?;
         Ok(())
     }
 
@@ -469,26 +432,14 @@ impl PyDataFrame {
         compression: Wrap<Option<IpcCompression>>,
         future: bool,
     ) -> PyResult<()> {
-        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
-            let s: &str = s.as_ref();
-            let path = std::path::Path::new(s);
-            let f = try_create_file(path).map_err(PyPolarsErr::from)?;
-            py.allow_threads(|| {
-                IpcWriter::new(f)
-                    .with_compression(compression.0)
-                    .with_pl_flavor(future)
-                    .finish(&mut self.df)
-                    .map_err(PyPolarsErr::from)
-            })?;
-        } else {
-            let mut buf = get_file_like(py_f, true)?;
-
+        let mut buf = get_file_like(py_f, true)?;
+        py.allow_threads(|| {
             IpcWriter::new(&mut buf)
                 .with_compression(compression.0)
                 .with_pl_flavor(future)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)?;
-        }
+                .map_err(PyPolarsErr::from)
+        })?;
         Ok(())
     }
 
@@ -500,24 +451,14 @@ impl PyDataFrame {
         compression: Wrap<Option<IpcCompression>>,
         future: bool,
     ) -> PyResult<()> {
-        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
-            let f = std::fs::File::create(&*s)?;
-            py.allow_threads(|| {
-                IpcStreamWriter::new(f)
-                    .with_compression(compression.0)
-                    .with_pl_flavor(future)
-                    .finish(&mut self.df)
-                    .map_err(PyPolarsErr::from)
-            })?;
-        } else {
-            let mut buf = get_file_like(py_f, true)?;
-
+        let mut buf = get_file_like(py_f, true)?;
+        py.allow_threads(|| {
             IpcStreamWriter::new(&mut buf)
                 .with_compression(compression.0)
                 .with_pl_flavor(future)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)?;
-        }
+                .map_err(PyPolarsErr::from)
+        })?;
         Ok(())
     }
 
@@ -531,23 +472,14 @@ impl PyDataFrame {
         name: String,
     ) -> PyResult<()> {
         use polars::io::avro::AvroWriter;
-
-        if let Ok(s) = py_f.extract::<PyBackedStr>(py) {
-            let f = std::fs::File::create(&*s)?;
-            AvroWriter::new(f)
-                .with_compression(compression.0)
-                .with_name(name)
-                .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)?;
-        } else {
-            let mut buf = get_file_like(py_f, true)?;
+        let mut buf = get_file_like(py_f, true)?;
+        py.allow_threads(|| {
             AvroWriter::new(&mut buf)
                 .with_compression(compression.0)
                 .with_name(name)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)?;
-        }
-
+                .map_err(PyPolarsErr::from)
+        })?;
         Ok(())
     }
 }

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -1,6 +1,9 @@
-use std::fs::File;
+use std::borrow::Cow;
+use std::fs::{self, File};
 use std::io;
 use std::io::{BufReader, Cursor, ErrorKind, Read, Seek, SeekFrom, Write};
+#[cfg(target_family = "unix")]
+use std::os::fd::{FromRawFd, RawFd};
 use std::path::PathBuf;
 
 use polars::io::mmap::MmapBytesReader;
@@ -179,27 +182,88 @@ pub enum EitherRustPythonFile {
     Rust(BufReader<File>),
 }
 
-///
-/// # Arguments
-/// * `truncate` - open or create a new file.
-pub fn get_either_file(py_f: PyObject, truncate: bool) -> PyResult<EitherRustPythonFile> {
+fn get_either_file_and_path(
+    py_f: PyObject,
+    truncate: bool,
+) -> PyResult<(EitherRustPythonFile, Option<PathBuf>)> {
     Python::with_gil(|py| {
-        if let Ok(pstring) = py_f.downcast_bound::<PyString>(py) {
-            let s = pstring.to_cow()?;
+        let py_f = py_f.bind(py);
+        if let Ok(s) = py_f.extract::<Cow<str>>() {
             let file_path = std::path::Path::new(&*s);
             let file_path = resolve_homedir(file_path);
             let f = if truncate {
-                File::create(file_path)?
+                File::create(&file_path)?
             } else {
                 polars_utils::open_file(&file_path).map_err(PyPolarsErr::from)?
             };
             let reader = BufReader::new(f);
-            Ok(EitherRustPythonFile::Rust(reader))
+            Ok((EitherRustPythonFile::Rust(reader), Some(file_path)))
         } else {
-            let f = PyFileLikeObject::with_requirements(py_f, !truncate, truncate, !truncate)?;
-            Ok(EitherRustPythonFile::Py(f))
+            let io = py.import_bound("io").unwrap();
+            #[cfg(target_family = "unix")]
+            if let Some(fd) = ((py_f.is_exact_instance(&io.getattr("FileIO").unwrap())
+                || py_f.is_exact_instance(&io.getattr("BufferedReader").unwrap())
+                || py_f.is_exact_instance(&io.getattr("BufferedWriter").unwrap())
+                || py_f.is_exact_instance(&io.getattr("BufferedRandom").unwrap())
+                || py_f.is_exact_instance(&io.getattr("BufferedRWPair").unwrap())
+                || (py_f.is_exact_instance(&io.getattr("TextIOWrapper").unwrap())
+                    && py_f
+                        .getattr("encoding")
+                        .ok()
+                        .filter(|encoding| match encoding.extract::<Cow<str>>() {
+                            Ok(encoding) => {
+                                encoding.eq_ignore_ascii_case("utf-8")
+                                    || encoding.eq_ignore_ascii_case("utf8")
+                            },
+                            Err(_) => false,
+                        })
+                        .is_some()))
+                && (!truncate
+                    || py_f
+                        .getattr("flush")
+                        .and_then(|flush| flush.call0())
+                        .is_ok()))
+            .then(|| {
+                py_f.getattr("fileno")
+                    .and_then(|fileno| fileno.call0())
+                    .and_then(|fileno| fileno.extract::<libc::c_int>())
+                    .ok()
+            })
+            .flatten()
+            .map(|fileno| unsafe { libc::dup(fileno) })
+            .filter(|fileno| *fileno != -1)
+            .map(|fileno| fileno as RawFd)
+            {
+                return Ok((
+                    EitherRustPythonFile::Rust(BufReader::new(unsafe { File::from_raw_fd(fd) })),
+                    // This works on Linux and BSD with procfs mounted,
+                    // otherwise it fails silently.
+                    fs::canonicalize(format!("/proc/self/fd/{fd}")).ok(),
+                ));
+            }
+
+            // BytesIO is relatively fast, and some code relies on it.
+            if !py_f.is_exact_instance(&io.getattr("BytesIO").unwrap()) {
+                polars_warn!("Polars found a filename. \
+                Ensure you pass a path to the file instead of a python file object when possible for best \
+                performance.");
+            }
+            let f = PyFileLikeObject::with_requirements(
+                py_f.to_object(py),
+                !truncate,
+                truncate,
+                !truncate,
+            )?;
+            Ok((EitherRustPythonFile::Py(f), None))
         }
     })
+}
+
+///
+/// # Arguments
+/// * `truncate` - open or create a new file.
+pub fn get_either_file(py_f: PyObject, truncate: bool) -> PyResult<EitherRustPythonFile> {
+    Ok(get_either_file_and_path(py_f, truncate)?.0)
 }
 
 pub fn get_file_like(f: PyObject, truncate: bool) -> PyResult<Box<dyn FileLike>> {
@@ -239,25 +303,10 @@ pub fn get_mmap_bytes_reader_and_path<'a>(
         Ok((Box::new(Cursor::new(bytes.as_bytes())), None))
     }
     // string so read file
-    else if let Ok(pstring) = py_f.downcast::<PyString>() {
-        let s = pstring.to_cow()?;
-        let p = std::path::Path::new(&*s);
-        let p_resolved = resolve_homedir(p);
-        let f = polars_utils::open_file(p_resolved).map_err(PyPolarsErr::from)?;
-        Ok((Box::new(f), Some(p.to_path_buf())))
-    }
-    // hopefully a normal python file: with open(...) as f:.
     else {
-        // we can still get a file name, inform the user of possibly wrong API usage.
-        if py_f.getattr("read").is_ok() && py_f.getattr("name").is_ok() {
-            polars_warn!("Polars found a filename. \
-            Ensure you pass a path to the file instead of a python file object when possible for best \
-            performance.")
+        match get_either_file_and_path(py_f.to_object(py_f.py()), false)? {
+            (EitherRustPythonFile::Rust(f), path) => Ok((Box::new(f.into_inner()), path)),
+            (EitherRustPythonFile::Py(f), path) => Ok((Box::new(f), path)),
         }
-        // don't really know what we got here, just read.
-        let f = Python::with_gil(|py| {
-            PyFileLikeObject::with_requirements(py_f.to_object(py), true, false, true)
-        })?;
-        Ok((Box::new(f), None))
     }
 }

--- a/py-polars/src/functions/io.rs
+++ b/py-polars/src/functions/io.rs
@@ -1,3 +1,5 @@
+use std::io::BufReader;
+
 use polars_core::datatypes::create_enum_data_type;
 use polars_core::export::arrow::array::Utf8ViewArray;
 use polars_core::export::arrow::datatypes::Field;
@@ -15,8 +17,8 @@ use crate::prelude::ArrowDataType;
 pub fn read_ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
     use polars_core::export::arrow::io::ipc::read::read_file_metadata;
     let metadata = match get_either_file(py_f, false)? {
-        EitherRustPythonFile::Rust(mut r) => {
-            read_file_metadata(&mut r).map_err(PyPolarsErr::from)?
+        EitherRustPythonFile::Rust(r) => {
+            read_file_metadata(&mut BufReader::new(r)).map_err(PyPolarsErr::from)?
         },
         EitherRustPythonFile::Py(mut r) => read_file_metadata(&mut r).map_err(PyPolarsErr::from)?,
     };
@@ -32,7 +34,9 @@ pub fn read_parquet_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
     use polars_parquet::read::{infer_schema, read_metadata};
 
     let metadata = match get_either_file(py_f, false)? {
-        EitherRustPythonFile::Rust(mut r) => read_metadata(&mut r).map_err(PyPolarsErr::from)?,
+        EitherRustPythonFile::Rust(r) => {
+            read_metadata(&mut BufReader::new(r)).map_err(PyPolarsErr::from)?
+        },
         EitherRustPythonFile::Py(mut r) => read_metadata(&mut r).map_err(PyPolarsErr::from)?,
     };
     let arrow_schema = infer_schema(&metadata).map_err(PyPolarsErr::from)?;


### PR DESCRIPTION
If a Python file object is passed as the argument of IO functions (e.g. `read_*` & `write_*`), currently it is wrapped into a `PyFileLikeObject`, and each read & write will acquire the GIL and call into Python, which is inefficient. This PR introduces a improvement that extracts the underlying fd through `fileno()` and opens the fd as a Rust `File`, which does not require GIL and have better performance.