### PR TITLE
fix: Fix typo in `SchemaError` exception message

### DIFF
--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -39,7 +39,7 @@ macro_rules! impl_compare {
             _ => (),
         };
 
-        let (lhs, rhs) = coerce_lhs_rhs(lhs, rhs).map_err(|_| polars_err!(SchemaMismatch: "could not evalulate comparison between series '{}' of dtype: {} and series '{}' of dtype: {}",
+        let (lhs, rhs) = coerce_lhs_rhs(lhs, rhs).map_err(|_| polars_err!(SchemaMismatch: "could not evaluate comparison between series '{}' of dtype: {} and series '{}' of dtype: {}",
         lhs.name(), lhs.dtype(), rhs.name(), rhs.dtype()))?;
         let lhs = lhs.to_physical_repr();
         let rhs = rhs.to_physical_repr();

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -676,7 +676,7 @@ def test_raise_on_sorted_multi_args() -> None:
 def test_err_invalid_comparison() -> None:
     with pytest.raises(
         SchemaError,
-        match="could not evalulate comparison between series 'a' of dtype: date and series 'b' of dtype: bool",
+        match="could not evaluate comparison between series 'a' of dtype: date and series 'b' of dtype: bool",
     ):
         _ = pl.Series("a", [date(2020, 1, 1)]) == pl.Series("b", [True])
 


### PR DESCRIPTION
Just a typo in the `SchemaError` message.