### PR TITLE
fix: Turn panic into error when serializing Object types

### DIFF
--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -80,6 +80,7 @@ impl Serialize for Series {
                 let ca = self.null().unwrap();
                 ca.serialize(serializer)
             },
+            #[cfg(feature = "object")]
             DataType::Object(_, _) => Err(S::Error::custom(
                 "serializing data of type Object is not supported",
             )),

--- a/py-polars/src/dataframe/serde.rs
+++ b/py-polars/src/dataframe/serde.rs
@@ -2,12 +2,12 @@ use std::io::{BufReader, BufWriter, Cursor};
 use std::ops::Deref;
 
 use polars_io::mmap::ReaderBytes;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
 use super::PyDataFrame;
 use crate::error::PyPolarsErr;
+use crate::exceptions::ComputeError;
 use crate::file::{get_file_like, get_mmap_bytes_reader};
 use crate::prelude::*;
 
@@ -48,7 +48,7 @@ impl PyDataFrame {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         ciborium::into_writer(&self.df, writer)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))
+            .map_err(|err| ComputeError::new_err(err.to_string()))
     }
 
     /// Serialize into a JSON string.
@@ -57,7 +57,7 @@ impl PyDataFrame {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, &self.df)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))
+            .map_err(|err| ComputeError::new_err(err.to_string()))
     }
 
     /// Deserialize a file-like object containing binary data into a DataFrame.
@@ -66,7 +66,7 @@ impl PyDataFrame {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
         let df = ciborium::from_reader::<DataFrame, _>(reader)
-            .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
+            .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(df.into())
     }
 
@@ -81,14 +81,9 @@ impl PyDataFrame {
         py.allow_threads(move || {
             let mmap_read: ReaderBytes = (&mut mmap_bytes_r).into();
             let bytes = mmap_read.deref();
-            match serde_json::from_slice::<DataFrame>(bytes) {
-                Ok(df) => Ok(df.into()),
-                Err(e) => {
-                    let msg = format!("{e}");
-                    let e = PyPolarsErr::from(PolarsError::ComputeError(msg.into()));
-                    Err(PyErr::from(e))
-                },
-            }
+            let df = serde_json::from_slice::<DataFrame>(bytes)
+                .map_err(|err| ComputeError::new_err(err.to_string()))?;
+            Ok(df.into())
         })
     }
 }

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -221,3 +221,11 @@ def test_df_deserialize_validation() -> None:
     )
     with pytest.raises(ComputeError, match=r"lengths don't match"):
         pl.DataFrame.deserialize(f, format="json")
+
+
+def test_df_serialize_invalid_type() -> None:
+    df = pl.DataFrame({"a": [object()]})
+    with pytest.raises(
+        ValueError, match="serializing data of type Object is not supported"
+    ):
+        df.serialize()

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -226,6 +226,6 @@ def test_df_deserialize_validation() -> None:
 def test_df_serialize_invalid_type() -> None:
     df = pl.DataFrame({"a": [object()]})
     with pytest.raises(
-        ValueError, match="serializing data of type Object is not supported"
+        ComputeError, match="serializing data of type Object is not supported"
     ):
         df.serialize()

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -91,7 +91,7 @@ def test_lf_serde_to_from_file(lf: pl.LazyFrame, tmp_path: Path) -> None:
 def test_lf_deserialize_validation() -> None:
     f = io.BytesIO(b"hello world!")
     with pytest.raises(ComputeError, match="expected value at line 1 column 1"):
-        pl.DataFrame.deserialize(f, format="json")
+        pl.LazyFrame.deserialize(f, format="json")
 
 
 @pytest.mark.write_disk()


### PR DESCRIPTION
These are not supported by design, so it should throw a nice error.