### PR TITLE
perf(python): add future arg to Series.to_arrow

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4342,11 +4342,21 @@ class Series:
         # tensor.rename(self.name)
         return tensor
 
-    def to_arrow(self) -> pa.Array:
+    def to_arrow(self, *, future: bool = False) -> pa.Array:
         """
         Return the underlying Arrow array.
 
         If the Series contains only a single chunk this operation is zero copy.
+
+        Parameters
+        ----------
+        future
+            Setting this to `True` will write Polars' internal data structures that
+            might not be available by other Arrow implementations.
+
+            .. warning::
+                This functionality is considered **unstable**. It may be changed
+                at any point without it being considered a breaking change.
 
         Examples
         --------
@@ -4360,7 +4370,7 @@ class Series:
           3
         ]
         """
-        return self._s.to_arrow()
+        return self._s.to_arrow(future)
 
     def to_pandas(
         self, *, use_pyarrow_extension_array: bool = False, **kwargs: Any

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -145,12 +145,12 @@ impl PySeries {
 
     /// Return the underlying Arrow array.
     #[allow(clippy::wrong_self_convention)]
-    fn to_arrow(&mut self) -> PyResult<PyObject> {
+    fn to_arrow(&mut self, future: bool) -> PyResult<PyObject> {
         self.rechunk(true);
         Python::with_gil(|py| {
             let pyarrow = py.import_bound("pyarrow")?;
 
-            interop::arrow::to_py::to_py_array(self.series.to_arrow(0, false), py, &pyarrow)
+            interop::arrow::to_py::to_py_array(self.series.to_arrow(0, future), py, &pyarrow)
         })
     }
 }


### PR DESCRIPTION
There is a `future` argument in `DataFrame.to_arrow`, but it is missing in `Series.to_arrow`. This PR adds it. `Series.to_arrow` is used in `pyo3-polars`, and using `future=True` significantly improve its performance for e.g. string series.