### PR TITLE
build(python): Add support for NumPy 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,8 +2537,7 @@ dependencies = [
 [[package]]
 name = "numpy"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
+source = "git+https://github.com/stinodego/rust-numpy.git?rev=9ba9962ae57ba26e35babdce6f179edf5fe5b9c8#9ba9962ae57ba26e35babdce6f179edf5fe5b9c8"
 dependencies = [
  "libc",
  "ndarray",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,9 +6,7 @@ seaborn
 plotly
 altair
 numba
-# Unpin NumPy when support is implemented in numpy crate:
-# https://github.com/pola-rs/polars/issues/16998
-numpy<2
+numpy
 
 mkdocs-material==9.5.27
 mkdocs-macros-plugin==1.0.5

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -29,7 +29,9 @@ itoa = { workspace = true }
 libc = "0.2"
 ndarray = { workspace = true }
 num-traits = { workspace = true }
-numpy = { version = "0.21", default-features = false }
+# TODO: Pin to released version once NumPy 2.0 support is merged
+# https://github.com/PyO3/rust-numpy/issues/409
+numpy = { git = "https://github.com/stinodego/rust-numpy.git", rev = "9ba9962ae57ba26e35babdce6f179edf5fe5b9c8", default-features = false }
 once_cell = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3-py38", "chrono", "extension-module", "multiple-pymethods"] }
 recursive = { workspace = true }

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -1,7 +1,5 @@
 hypothesis
-# Unpin NumPy when support is implemented in numpy crate:
-# https://github.com/pola-rs/polars/issues/16998
-numpy<2
+numpy
 pandas
 pyarrow
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -42,7 +42,7 @@ Changelog = "https://github.com/pola-rs/polars/releases"
 # Interop
 # TODO: Remove NumPy upper bound once we support NumPy 2.0.0
 # https://github.com/pola-rs/polars/issues/16998
-numpy = ["numpy >= 1.16.0, < 2.0.0"]
+numpy = ["numpy >= 1.16.0"]
 pandas = ["pandas", "polars[pyarrow]"]
 pyarrow = ["pyarrow >= 7.0.0"]
 pydantic = ["pydantic"]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -16,9 +16,7 @@ pip
 # ------------
 
 # Interop
-# Unpin NumPy when support is implemented in numpy crate:
-# https://github.com/pola-rs/polars/issues/16998
-numpy<2
+numpy
 numba; python_version < '3.13'  # Numba can lag Python releases
 pandas
 pyarrow


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/16998

#### Changes

* Pin the `numpy` crate in Cargo.toml to a git commit that includes NumPy 2.0 support. The git commit is based on https://github.com/PyO3/rust-numpy/pull/429 and includes a minor fix to enable Windows support.
* Remove `< 2.0.0` version constraint for NumPy dependency

We are dependent on the `numpy` crate for NumPy support. There is a PR open that adds NumPy 2.0 support, however, it is still in review. We understand that reviews in open source take time, since we are open source maintainers ourselves. However, due to the great impact on our users, we elect to build Polars based off of that PR. This passes our full test suite, both on NumPy 1.26 and 2.0.