### PR TITLE
test(python): Avoid use of `np.trapz` in tests to prepare for NumPy 2.0

### DIFF
--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -41,7 +41,7 @@ def test_error_on_reducing_map() -> None:
             r"the input length \(6\); consider using `apply` instead"
         ),
     ):
-        df.group_by("id").agg(pl.map_batches(["t", "y"], np.trapz))
+        df.group_by("id").agg(pl.map_batches(["t", "y"], np.mean))
 
     df = pl.DataFrame({"x": [1, 2, 3, 4], "group": [1, 2, 1, 2]})
 

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -141,10 +141,8 @@ def test_map_groups_numpy_output_3057() -> None:
     )
 
     result = df.group_by("id", maintain_order=True).agg(
-        pl.map_groups(["y", "t"], lambda lst: np.trapz(y=lst[0], x=lst[1])).alias(
-            "result"
-        )
+        pl.map_groups(["y", "t"], lambda lst: np.mean([lst[0], lst[1]])).alias("result")
     )
 
-    expected = pl.DataFrame({"id": [0, 1], "result": [1.955, 13.0]})
+    expected = pl.DataFrame({"id": [0, 1], "result": [2.266666, 7.333333]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -45,7 +45,7 @@ def test_error_on_reducing_map() -> None:
             r"the input length \(6\); consider using `apply` instead"
         ),
     ):
-        df.group_by("id").agg(pl.map_batches(["t", "y"], np.trapz))
+        df.group_by("id").agg(pl.map_batches(["t", "y"], np.mean))
 
     df = pl.DataFrame({"x": [1, 2, 3, 4], "group": [1, 2, 1, 2]})
     with pytest.raises(


### PR DESCRIPTION
Splitting this off from the other PR just to separate concerns.