### PR TITLE
fix(python): Fix a global variable table-discovery edge case for the `SQL` interface

### DIFF
--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -279,7 +279,7 @@ class SQLContext(Generic[FrameType]):
         possible_names = (
             {
                 nm.strip('"')
-                for nm in re.split(r"\s", q[1])
+                for nm in re.split(r"\b", q[1])
                 if re.match(r'^("[^"]+")$', nm) or nm.isidentifier()
             }
             if len(q) > 1

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -269,3 +269,16 @@ def test_read_csv(tmp_path: Path) -> None:
         match="`read_csv` expects a single file path; found 3 arguments",
     ):
         pl.sql("SELECT * FROM read_csv('a','b','c')")
+
+
+def test_global_variable_inference_17398():
+    users = pl.DataFrame({"id": "1"})
+
+    res = pl.sql(
+        query="""
+          WITH user_by_email AS (SELECT id FROM users)
+          SELECT * FROM user_by_email
+        """,
+        eager=True,
+    )
+    assert_frame_equal(res, users)

--- a/py-polars/tests/unit/sql/test_miscellaneous.py
+++ b/py-polars/tests/unit/sql/test_miscellaneous.py
@@ -271,7 +271,7 @@ def test_read_csv(tmp_path: Path) -> None:
         pl.sql("SELECT * FROM read_csv('a','b','c')")
 
 
-def test_global_variable_inference_17398():
+def test_global_variable_inference_17398() -> None:
     users = pl.DataFrame({"id": "1"})
 
     res = pl.sql(


### PR DESCRIPTION
Closes #17398.

Simple fix, though a better one would be having the underlying parser analyse the statement properly; I'll look into doing that at a later date (am on vacation at the moment ;)