### PR TITLE
ci(python): Use `macos-latest` runner in CI

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -34,11 +34,15 @@ jobs:
   coverage-rust:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
-    # Pinned on macos-13 because latest does not work:
-    # https://github.com/pola-rs/polars/issues/15917
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Avoid potential out-of-memory errors
+      - name: Set swap space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Set up Rust
         run: rustup component add llvm-tools-preview
@@ -85,9 +89,15 @@ jobs:
   coverage-python:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Avoid potential out-of-memory errors
+      - name: Set swap space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/15917