### PR TITLE
ci: Add automated check for PR title formatting

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,15 @@
+{
+  "LABEL": {
+    "name": "title needs formatting",
+    "color": "FF0000"
+  },
+  "CHECKS": {
+    "regexp": "^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\\((python|rust)\\!?(,(python|rust)\\!?)?\\))?\\!?\\: [A-Z].*[^\\.\\!\\?,… ]$",
+    "ignoreLabels": ["skip changelog"]
+  },
+  "MESSAGES": {
+    "success": "PR title OK!",
+    "failure": "Invalid PR title! Please update according to the contributing guidelines: https://docs.pola.rs/development/contributing/#pull-requests",
+    "notice": ""
+  }
+}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,9 +9,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  main:
+  labeler:
     runs-on: ubuntu-latest
     steps:
+      - name: Check pull request title
+        uses: thehanimo/pr-title-checker@v1.4.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Label pull request
         uses: release-drafter/release-drafter@v6
         with:

--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -176,10 +176,20 @@ Two other things to keep in mind:
 When you have resolved your issue, [open a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork) in the Polars repository.
 Please adhere to the following guidelines:
 
-- Start your pull request title with a [conventional commit](https://www.conventionalcommits.org/) tag. This helps us add your contribution to the right section of the changelog. We use the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type). Scope can be `rust` and/or `python`, depending on your contribution.
-- Use a descriptive title starting with an uppercase letter. This text will end up in the [changelog](https://github.com/pola-rs/polars/releases).
-- In the pull request description, [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to the issue you were working on.
-- Add any relevant information to the description that you think may help the maintainers review your code.
+- Title
+  - Start your pull request title with a [conventional commit](https://www.conventionalcommits.org/) tag.
+    This helps us add your contribution to the right section of the changelog.
+    We use the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
+    Scope can be `rust` and/or `python`, depending on your contribution: this tag determines which changelog(s) will include your change.
+    Omit the scope if your change affects both Rust and Python.
+  - Use a descriptive title starting with an uppercase letter.
+    This text will end up in the [changelog](https://github.com/pola-rs/polars/releases), so make sure the text is meaningful to the user.
+    Use single backticks to annotate code snippets.
+    Use active language and do not end your title with punctuation.
+  - Example: ``fix(python): Fix `DataFrame.top_k` not handling nulls correctly``
+- Description
+  - In the pull request description, [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to the issue you were working on.
+  - Add any relevant information to the description that you think may help the maintainers review your code.
 - Make sure your branch is [rebased](https://docs.github.com/en/get-started/using-git/about-git-rebase) against the latest version of the `main` branch.
 - Make sure all [GitHub Actions checks](./ci.md) pass.
 


### PR DESCRIPTION
Pull request titles require a valid tag in order to determine in which changelog and which section they should be included. The text that follows is included in the changelog directly.

This means that PR titles must be formatted correctly, otherwise the changelog is useless.

Unfortunately I spend more time than I am comfortable with editing people's pull request titles to make sure the changelog makes sense and looks OK. I have previously posted a PSA with some guidance on the Discord channel, which helped, but not enough.

So I'm taking out the big guns: regex 😄 
A simple check will make sure pull requests have the right formatting, otherwise the CI will fail and the PR will be labelled `title needs formatting`. If you check out the failed job, it will link you to relevant section of the contributing guide, which I updated to be extra clear.

I realize this will probably cause some minor annoyance at first, but this should be in everyone's system soon enough. If you run into situations where you believe you have a valid PR title but the workflow fails, please ping me and I'll take a look.