### PR TITLE
fix(python): Verify the integrity of pandas column names before implied string conversion

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1040,6 +1040,14 @@ def pandas_to_pydf(
     include_index: bool = False,
 ) -> PyDataFrame:
     """Construct a PyDataFrame from a pandas DataFrame."""
+    stringified_cols = {str(col) for col in data.columns}
+    if len(stringified_cols) < len(data.columns):
+        msg = (
+            "Polars dataframes must have unique string column names."
+            "Please check your pandas dataframe for duplicates."
+        )
+        raise ValueError(msg)
+
     convert_index = include_index and not _pandas_has_default_index(data)
     if not convert_index and all(
         is_simple_numpy_backed_pandas_series(data[col]) for col in data.columns

--- a/py-polars/tests/unit/interop/test_from_pandas.py
+++ b/py-polars/tests/unit/interop/test_from_pandas.py
@@ -172,9 +172,15 @@ def test_from_pandas_include_indexes() -> None:
     assert df.to_dict(as_series=False) == data
 
 
+def test_duplicate_cols_diff_types() -> None:
+    df = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["0", 0, "1", 1])
+    with pytest.raises(ValueError, match="Polars dataframes must have unique string"):
+        pl.from_pandas(df)
+
+
 def test_from_pandas_duplicated_columns() -> None:
     df = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["a", "b", "c", "b"])
-    with pytest.raises(ValueError, match="duplicate column names found: "):
+    with pytest.raises(ValueError, match="Polars dataframes must have unique string"):
         pl.from_pandas(df)
 
 


### PR DESCRIPTION
In the issue #16025 , the author converts a pandas dataframe who's columns are 0 and '0'. In polars dataframes, this is illegal, as all the column names are converted to strings. This is done in the pl.from_pandas, but the conversion happens in a way that overwrites a prior column. For example, if 0 and '0' are columns, the '0' will overwrite the first column, since that column was converted first, to a '0'.

I check the uniqueness of the stringified names in `from_pandas`. This should also catch some unusual column names, like arbitrary objects with __str__ methods.

I did change the behavior of `test_from_pandas_duplicated_columns` in `test_interop`. The test now raises the error message I wrote since the duplicate columns were caught earlier. I understand this may be undesirable since it's more consistent to propagate the pandas error up the stack to the user, which was the original behavior.

Also, I opened a pull request on this issue yesterday but deleted it since I was on the wrong branch. Excuse my git skills, I'm a beginner with it. Let me know if you need any changes to this or have any questions! Thank you.