### PR TITLE
perf: Batch parquet primitive decoding

### DIFF
--- a/crates/polars-arrow/src/legacy/utils.rs
+++ b/crates/polars-arrow/src/legacy/utils.rs
@@ -18,7 +18,7 @@ pub trait CustomIterTools: Iterator {
     where
         Self: Sized,
     {
-        TrustMyLength::new(self, length)
+        unsafe { TrustMyLength::new(self, length) }
     }
 
     fn collect_trusted<T: FromTrustedLenIterator<Self::Item>>(self) -> T

--- a/crates/polars-arrow/src/pushable.rs
+++ b/crates/polars-arrow/src/pushable.rs
@@ -19,6 +19,12 @@ pub trait Pushable<T>: Sized + Default {
     fn push(&mut self, value: T);
     fn len(&self) -> usize;
     fn push_null(&mut self);
+    #[inline]
+    fn extend_n(&mut self, n: usize, iter: impl Iterator<Item = T>) {
+        for item in iter.take(n) {
+            self.push(item);
+        }
+    }
     fn extend_constant(&mut self, additional: usize, value: T);
     fn extend_null_constant(&mut self, additional: usize);
     fn freeze(self) -> Self::Freeze;
@@ -31,6 +37,7 @@ impl Pushable<bool> for MutableBitmap {
     fn reserve(&mut self, additional: usize) {
         MutableBitmap::reserve(self, additional)
     }
+
     #[inline]
     fn len(&self) -> usize {
         self.len()
@@ -80,6 +87,11 @@ impl<T: Copy + Default> Pushable<T> for Vec<T> {
     #[inline]
     fn push(&mut self, value: T) {
         self.push(value)
+    }
+
+    #[inline]
+    fn extend_n(&mut self, n: usize, iter: impl Iterator<Item = T>) {
+        self.extend(iter.take(n));
     }
 
     #[inline]

--- a/crates/polars-arrow/src/trusted_len.rs
+++ b/crates/polars-arrow/src/trusted_len.rs
@@ -87,8 +87,13 @@ impl<I, J> TrustMyLength<I, J>
 where
     I: Iterator<Item = J>,
 {
+    /// Create a new `TrustMyLength` iterator
+    ///
+    /// # Safety
+    ///
+    /// This is safe if the iterator always has the exact length given by `len`.
     #[inline]
-    pub fn new(iter: I, len: usize) -> Self {
+    pub unsafe fn new(iter: I, len: usize) -> Self {
         Self { iter, len }
     }
 }
@@ -104,6 +109,7 @@ where
         self.iter.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len, Some(self.len))
     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -70,7 +70,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 Some(additional),
                 values,
                 page_values,
-            ),
+            )?,
             BinaryState::Required(page) => {
                 for x in page.values.by_ref().take(additional) {
                     values.push(x)
@@ -92,7 +92,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                     Some(additional),
                     offsets,
                     page_values.lengths.by_ref(),
-                );
+                )?;
 
                 let length = *offsets.last() - last_offset;
 
@@ -123,7 +123,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                         .values
                         .by_ref()
                         .map(|index| page_dict.value(index as usize)),
-                );
+                )?;
                 page_values.values.get_result()?;
             },
             BinaryState::RequiredDictionary(page) => {
@@ -148,7 +148,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                     Some(additional),
                     values,
                     page_values.by_ref(),
-                );
+                )?;
             },
             BinaryState::FilteredOptionalDelta(page_validity, page_values) => {
                 extend_from_decoder(
@@ -157,7 +157,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                     Some(additional),
                     values,
                     page_values.by_ref(),
-                );
+                )?;
             },
             BinaryState::FilteredRequiredDictionary(page) => {
                 // Already done on the dict.
@@ -186,7 +186,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                         .values
                         .by_ref()
                         .map(|index| page_dict.value(index as usize)),
-                );
+                )?;
                 page_values.values.get_result()?;
             },
             BinaryState::OptionalDeltaByteArray(page_validity, page_values) => extend_from_decoder(
@@ -195,7 +195,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 Some(additional),
                 values,
                 page_values,
-            ),
+            )?,
             BinaryState::DeltaByteArray(page_values) => {
                 for x in page_values.take(additional) {
                     values.push(x)

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
@@ -179,13 +179,13 @@ impl<'a> FilteredDelta<'a> {
 
 #[derive(Debug)]
 pub(crate) struct RequiredDictionary<'a> {
-    pub values: hybrid_rle::BufferedHybridRleDecoderIter<'a>,
+    pub values: hybrid_rle::HybridRleDecoder<'a>,
     pub dict: &'a BinaryDict,
 }
 
 impl<'a> RequiredDictionary<'a> {
     pub fn try_new(page: &'a DataPage, dict: &'a BinaryDict) -> PolarsResult<Self> {
-        let values = utils::dict_indices_decoder(page)?.into_iter();
+        let values = utils::dict_indices_decoder(page)?;
 
         Ok(Self { dict, values })
     }
@@ -198,13 +198,13 @@ impl<'a> RequiredDictionary<'a> {
 
 #[derive(Debug)]
 pub(crate) struct FilteredRequiredDictionary<'a> {
-    pub values: SliceFilteredIter<hybrid_rle::BufferedHybridRleDecoderIter<'a>>,
+    pub values: SliceFilteredIter<hybrid_rle::HybridRleDecoder<'a>>,
     pub dict: &'a BinaryDict,
 }
 
 impl<'a> FilteredRequiredDictionary<'a> {
     pub fn try_new(page: &'a DataPage, dict: &'a BinaryDict) -> PolarsResult<Self> {
-        let values = utils::dict_indices_decoder(page)?.into_iter();
+        let values = utils::dict_indices_decoder(page)?;
 
         let rows = get_selected_rows(page);
         let values = SliceFilteredIter::new(values, rows);
@@ -220,13 +220,13 @@ impl<'a> FilteredRequiredDictionary<'a> {
 
 #[derive(Debug)]
 pub(crate) struct ValuesDictionary<'a> {
-    pub values: hybrid_rle::BufferedHybridRleDecoderIter<'a>,
+    pub values: hybrid_rle::HybridRleDecoder<'a>,
     pub dict: &'a BinaryDict,
 }
 
 impl<'a> ValuesDictionary<'a> {
     pub fn try_new(page: &'a DataPage, dict: &'a BinaryDict) -> PolarsResult<Self> {
-        let values = utils::dict_indices_decoder(page)?.into_iter();
+        let values = utils::dict_indices_decoder(page)?;
 
         Ok(Self { dict, values })
     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
@@ -69,7 +69,7 @@ impl<'a> utils::Decoder<'a> for BinViewDecoder {
                 Some(additional),
                 values,
                 page_values,
-            ),
+            )?,
             BinaryState::Required(page) => {
                 for x in page.values.by_ref().take(additional) {
                     values.push_value_ignore_validity(x)
@@ -87,7 +87,7 @@ impl<'a> utils::Decoder<'a> for BinViewDecoder {
                     Some(additional),
                     values,
                     page_values,
-                );
+                )?;
             },
             BinaryState::FilteredRequired(page) => {
                 for x in page.values.by_ref().take(additional) {
@@ -112,7 +112,7 @@ impl<'a> utils::Decoder<'a> for BinViewDecoder {
                         .values
                         .by_ref()
                         .map(|index| page_dict.value(index as usize)),
-                );
+                )?;
                 page_values.values.get_result()?;
             },
             BinaryState::RequiredDictionary(page) => {
@@ -137,7 +137,7 @@ impl<'a> utils::Decoder<'a> for BinViewDecoder {
                     Some(additional),
                     values,
                     page_values.by_ref(),
-                );
+                )?;
             },
             BinaryState::FilteredOptionalDelta(page_validity, page_values) => {
                 extend_from_decoder(
@@ -146,7 +146,7 @@ impl<'a> utils::Decoder<'a> for BinViewDecoder {
                     Some(additional),
                     values,
                     page_values.by_ref(),
-                );
+                )?;
             },
             BinaryState::FilteredRequiredDictionary(page) => {
                 // TODO! directly set the dict as buffers and only insert the proper views.
@@ -179,7 +179,7 @@ impl<'a> utils::Decoder<'a> for BinViewDecoder {
                         .values
                         .by_ref()
                         .map(|index| page_dict.value(index as usize)),
-                );
+                )?;
                 page_values.values.get_result()?;
             },
             BinaryState::OptionalDeltaByteArray(page_validity, page_values) => extend_from_decoder(
@@ -188,7 +188,7 @@ impl<'a> utils::Decoder<'a> for BinViewDecoder {
                 Some(additional),
                 values,
                 page_values,
-            ),
+            )?,
             BinaryState::DeltaByteArray(page_values) => {
                 for x in page_values.take(additional) {
                     values.push_value_ignore_validity(x)

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
@@ -171,7 +171,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
                 Some(remaining),
                 values,
                 &mut page_values.0,
-            ),
+            )?,
             State::Required(page) => {
                 let remaining = remaining.min(page.length - page.offset);
                 values.extend_from_slice(page.values, page.offset, remaining);
@@ -190,7 +190,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
                     Some(remaining),
                     values,
                     page_values.0.by_ref(),
-                );
+                )?;
             },
             State::RleOptional(page_validity, page_values) => {
                 utils::extend_from_decoder(
@@ -199,7 +199,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
                     Some(remaining),
                     values,
                     &mut *page_values,
-                );
+                )?;
             },
         }
         Ok(())

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary/nested.rs
@@ -10,7 +10,7 @@ use super::super::super::PagesIter;
 use super::super::nested_utils::*;
 use super::super::utils::{dict_indices_decoder, not_implemented, MaybeNext, PageState};
 use super::finish_key;
-use crate::parquet::encoding::hybrid_rle::BufferedHybridRleDecoderIter;
+use crate::parquet::encoding::hybrid_rle::HybridRleDecoder;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::{DataPage, DictPage, Page};
 use crate::parquet::schema::Repetition;
@@ -18,13 +18,13 @@ use crate::parquet::schema::Repetition;
 // The state of a required DataPage with a boolean physical type
 #[derive(Debug)]
 pub struct Required<'a> {
-    values: BufferedHybridRleDecoderIter<'a>,
+    values: HybridRleDecoder<'a>,
     length: usize,
 }
 
 impl<'a> Required<'a> {
     fn try_new(page: &'a DataPage) -> PolarsResult<Self> {
-        let values = dict_indices_decoder(page)?.into_iter();
+        let values = dict_indices_decoder(page)?;
         let length = page.num_values();
         Ok(Self { values, length })
     }
@@ -34,7 +34,7 @@ impl<'a> Required<'a> {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum State<'a> {
-    Optional(BufferedHybridRleDecoderIter<'a>),
+    Optional(HybridRleDecoder<'a>),
     Required(Required<'a>),
 }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -8,7 +8,7 @@ use polars_utils::slice::GetSaferUnchecked;
 
 use super::super::PagesIter;
 use super::utils::{DecodedState, MaybeNext, PageState};
-use crate::parquet::encoding::hybrid_rle::{BufferedHybridRleDecoderIter, HybridRleDecoder};
+use crate::parquet::encoding::hybrid_rle::HybridRleDecoder;
 use crate::parquet::page::{split_buffer, DataPage, DictPage, Page};
 use crate::parquet::read::levels::get_bit_width;
 
@@ -239,7 +239,7 @@ pub fn init_nested(init: &[InitNested], capacity: usize) -> NestedState {
 }
 
 pub struct NestedPage<'a> {
-    iter: Peekable<Zip<BufferedHybridRleDecoderIter<'a>, BufferedHybridRleDecoderIter<'a>>>,
+    iter: Peekable<Zip<HybridRleDecoder<'a>, HybridRleDecoder<'a>>>,
 }
 
 impl<'a> NestedPage<'a> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -155,11 +155,11 @@ where
                     page_validity,
                     Some(remaining),
                     values,
-                    page_values
+                    &mut page_values
                         .by_ref()
                         .map(|x| x.unwrap().as_())
                         .map(self.0.op),
-                )
+                )?
             },
             State::FilteredDeltaBinaryPackedRequired(page) => {
                 values.extend(
@@ -175,11 +175,11 @@ where
                     page_validity,
                     Some(remaining),
                     values,
-                    page_values
+                    &mut page_values
                         .by_ref()
                         .map(|x| x.unwrap().as_())
                         .map(self.0.op),
-                );
+                )?;
             },
         }
         Ok(())

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/buffered.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/buffered.rs
@@ -1,0 +1,267 @@
+use super::Translator;
+use crate::parquet::encoding::bitpacked::{self, Unpackable, Unpacked};
+use crate::parquet::error::ParquetResult;
+
+#[derive(Debug, Clone)]
+pub struct BufferedBitpacked<'a> {
+    pub unpacked: [u32; 32],
+    pub unpacked_start: usize,
+    pub unpacked_end: usize,
+
+    pub decoder: bitpacked::Decoder<'a, u32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BufferedRle {
+    pub value: u32,
+    pub length: usize,
+}
+
+/// A buffered set of items for the [`HybridRleDecoder`]. This can be iterated over and stopped at
+/// any time.
+#[derive(Debug, Clone)]
+pub enum HybridRleBuffered<'a> {
+    Bitpacked(BufferedBitpacked<'a>),
+    Rle(BufferedRle),
+}
+
+impl Iterator for BufferedRle {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.length > 0 {
+            self.length -= 1;
+            Some(self.value)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.length, Some(self.length))
+    }
+}
+
+impl ExactSizeIterator for BufferedRle {}
+
+impl<'a> Iterator for BufferedBitpacked<'a> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.unpacked_start < self.unpacked_end {
+            let value = self.unpacked[self.unpacked_start];
+            self.unpacked_start += 1;
+            return Some(value);
+        }
+
+        self.decoder
+            .chunked()
+            .next_inexact()
+            .map(|(unpacked, unpacked_length)| {
+                debug_assert!(unpacked_length > 0);
+                let value = unpacked[0];
+                self.unpacked = unpacked;
+                self.unpacked_end = unpacked_length;
+                self.unpacked_start = 1;
+                value
+            })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let unpacked_num_elements = self.unpacked_end - self.unpacked_start;
+        let exact = unpacked_num_elements + self.decoder.len();
+        (exact, Some(exact))
+    }
+}
+
+impl<'a> ExactSizeIterator for BufferedBitpacked<'a> {}
+
+impl<'a> Iterator for HybridRleBuffered<'a> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            HybridRleBuffered::Bitpacked(b) => b.next(),
+            HybridRleBuffered::Rle(b) => b.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            HybridRleBuffered::Bitpacked(b) => b.size_hint(),
+            HybridRleBuffered::Rle(b) => b.size_hint(),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for HybridRleBuffered<'a> {}
+
+impl<'a> BufferedBitpacked<'a> {
+    fn translate_and_collect_limited_into<O: Clone + Default>(
+        &mut self,
+        target: &mut Vec<O>,
+        limit: usize,
+        translator: &impl Translator<O>,
+    ) -> ParquetResult<usize> {
+        let unpacked_num_elements = self.unpacked_end - self.unpacked_start;
+        if limit <= unpacked_num_elements {
+            translator.translate_slice(
+                target,
+                &self.unpacked[self.unpacked_start..self.unpacked_start + limit],
+            )?;
+            self.unpacked_start += limit;
+            return Ok(limit);
+        }
+
+        translator.translate_slice(
+            target,
+            &self.unpacked[self.unpacked_start..self.unpacked_end],
+        )?;
+        self.unpacked_end = 0;
+        self.unpacked_start = 0;
+        let limit = limit - unpacked_num_elements;
+
+        let decoder = self.decoder.take();
+        let decoder_len = decoder.len();
+        if limit >= decoder_len {
+            translator.translate_bitpacked_all(target, decoder)?;
+            Ok(unpacked_num_elements + decoder_len)
+        } else {
+            let buffered = translator.translate_bitpacked_limited(target, limit, decoder)?;
+            *self = buffered;
+            Ok(unpacked_num_elements + limit)
+        }
+    }
+
+    pub fn translate_and_collect_into<O: Clone + Default>(
+        self,
+        target: &mut Vec<O>,
+        translator: &impl Translator<O>,
+    ) -> ParquetResult<usize> {
+        let unpacked_num_elements = self.unpacked_end - self.unpacked_start;
+        translator.translate_slice(
+            target,
+            &self.unpacked[self.unpacked_start..self.unpacked_end],
+        )?;
+        let decoder_len = self.decoder.len();
+        translator.translate_bitpacked_all(target, self.decoder)?;
+        Ok(unpacked_num_elements + decoder_len)
+    }
+
+    pub fn skip_in_place(&mut self, n: usize) -> usize {
+        let unpacked_num_elements = self.unpacked_end - self.unpacked_start;
+
+        if n < unpacked_num_elements {
+            self.unpacked_start += n;
+            return n;
+        }
+
+        let n = n - unpacked_num_elements;
+
+        if self.decoder.len() > n {
+            let num_chunks = n / <u32 as Unpackable>::Unpacked::LENGTH;
+            let unpacked_offset = n % <u32 as Unpackable>::Unpacked::LENGTH;
+            self.decoder.skip_chunks(num_chunks);
+            let (unpacked, unpacked_length) = self.decoder.chunked().next_inexact().unwrap();
+
+            self.unpacked = unpacked;
+            self.unpacked_start = unpacked_offset;
+            self.unpacked_end = unpacked_length;
+
+            return unpacked_num_elements + n;
+        }
+
+        self.decoder.len() + unpacked_num_elements
+    }
+}
+
+impl BufferedRle {
+    pub fn translate_and_collect_limited_into<O: Clone + Default>(
+        &mut self,
+        target: &mut Vec<O>,
+        limit: usize,
+        translator: &impl Translator<O>,
+    ) -> ParquetResult<usize> {
+        let value = translator.translate(self.value)?;
+        let num_elements = usize::min(self.length, limit);
+        self.length -= num_elements;
+        target.resize(target.len() + num_elements, value);
+        Ok(num_elements)
+    }
+
+    pub fn translate_and_collect_into<O: Clone + Default>(
+        self,
+        target: &mut Vec<O>,
+        translator: &impl Translator<O>,
+    ) -> ParquetResult<usize> {
+        let value = translator.translate(self.value)?;
+        target.resize(target.len() + self.length, value);
+        Ok(self.length)
+    }
+
+    pub fn skip_in_place(&mut self, n: usize) -> usize {
+        let num_elements = usize::min(self.length, n);
+        self.length -= num_elements;
+        num_elements
+    }
+}
+
+impl<'a> HybridRleBuffered<'a> {
+    pub fn translate_and_collect_limited_into<O: Clone + Default>(
+        &mut self,
+        target: &mut Vec<O>,
+        limit: usize,
+        translator: &impl Translator<O>,
+    ) -> ParquetResult<usize> {
+        let start_target_length = target.len();
+        let start_length = self.len();
+
+        let num_processed = match self {
+            HybridRleBuffered::Bitpacked(b) => {
+                b.translate_and_collect_limited_into(target, limit, translator)
+            },
+            HybridRleBuffered::Rle(b) => {
+                b.translate_and_collect_limited_into(target, limit, translator)
+            },
+        }?;
+
+        debug_assert!(num_processed <= limit);
+        debug_assert_eq!(num_processed, target.len() - start_target_length);
+        debug_assert_eq!(num_processed, start_length - self.len());
+
+        Ok(num_processed)
+    }
+
+    pub fn translate_and_collect_into<O: Clone + Default>(
+        self,
+        target: &mut Vec<O>,
+        translator: &impl Translator<O>,
+    ) -> ParquetResult<usize> {
+        let start_target_length = target.len();
+        let start_length = self.len();
+
+        let num_processed = match self {
+            HybridRleBuffered::Bitpacked(b) => b.translate_and_collect_into(target, translator),
+            HybridRleBuffered::Rle(b) => b.translate_and_collect_into(target, translator),
+        }?;
+
+        debug_assert_eq!(num_processed, target.len() - start_target_length);
+        debug_assert_eq!(num_processed, start_length);
+
+        Ok(num_processed)
+    }
+
+    pub fn skip_in_place(&mut self, n: usize) -> usize {
+        let start_length = self.len();
+
+        let num_skipped = match self {
+            HybridRleBuffered::Bitpacked(b) => b.skip_in_place(n),
+            HybridRleBuffered::Rle(b) => b.skip_in_place(n),
+        };
+
+        debug_assert!(num_skipped <= n);
+        debug_assert_eq!(num_skipped, start_length - self.len());
+
+        num_skipped
+    }
+}

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
@@ -1,0 +1,359 @@
+/// Since the HybridRle decoder is very widely used within the Parquet reader and the code is quite
+/// complex to facilitate performance. We create this small fuzzer
+use std::collections::VecDeque;
+
+use rand::Rng;
+
+use super::*;
+
+fn run_iteration(
+    bs: &[u32],
+    collects: impl Iterator<Item = usize>,
+    encoded: &mut Vec<u8>,
+    decoded: &mut Vec<u32>,
+    num_bits: u32,
+) -> ParquetResult<()> {
+    encoded.clear();
+    decoded.clear();
+
+    encoder::encode(encoded, bs.iter().copied(), num_bits).unwrap();
+
+    let mut decoder = HybridRleDecoder::new(&encoded[..], num_bits, bs.len());
+
+    for c in collects {
+        decoder.collect_n_into(decoded, c)?;
+    }
+
+    Ok(())
+}
+
+/// Minimizes a failing case
+fn minimize_failing_case(
+    bs: &mut Vec<u32>,
+    collects: &mut VecDeque<usize>,
+    encoded: &mut Vec<u8>,
+    decoded: &mut Vec<u32>,
+    num_bits: u32,
+) -> ParquetResult<()> {
+    loop {
+        let initial_bs_len = bs.len();
+        let initial_collects_len = collects.len();
+
+        run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+        assert_ne!(&bs, &decoded);
+
+        while collects.len() > 2 {
+            let last = collects.pop_back().unwrap();
+
+            *collects.back_mut().unwrap() += last;
+
+            run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+            if bs == decoded {
+                *collects.back_mut().unwrap() -= last;
+                collects.push_back(last);
+                break;
+            }
+        }
+
+        while collects.len() > 2 {
+            let first = collects.pop_front().unwrap();
+
+            *collects.front_mut().unwrap() += first;
+
+            run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+            if bs == decoded {
+                *collects.front_mut().unwrap() -= first;
+                collects.push_front(first);
+                break;
+            }
+        }
+
+        while bs.len() > 1 {
+            let last = bs.pop().unwrap();
+            *collects.back_mut().unwrap() -= 1;
+
+            run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+            if bs == decoded {
+                bs.push(last);
+                *collects.back_mut().unwrap() += 1;
+                break;
+            }
+
+            if *collects.back().unwrap() == 0 {
+                collects.pop_back().unwrap();
+
+                run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                if bs == decoded {
+                    collects.push_back(0);
+                    break;
+                }
+            }
+        }
+
+        while bs.len() > 1 {
+            let last = bs.pop().unwrap();
+            *collects.front_mut().unwrap() -= 1;
+
+            run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+            if bs == decoded {
+                bs.push(last);
+                *collects.front_mut().unwrap() += 1;
+                break;
+            }
+
+            if *collects.front().unwrap() == 0 {
+                collects.pop_front().unwrap();
+
+                run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                if bs == decoded {
+                    collects.push_front(0);
+                    break;
+                }
+            }
+        }
+
+        while bs.len() > 1 {
+            let first = bs.remove(0);
+            *collects.back_mut().unwrap() -= 1;
+
+            run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+            if bs == decoded {
+                bs.insert(0, first);
+                *collects.back_mut().unwrap() += 1;
+                break;
+            }
+
+            if *collects.back().unwrap() == 0 {
+                collects.pop_back().unwrap();
+
+                run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                if bs == decoded {
+                    collects.push_back(0);
+                    break;
+                }
+            }
+        }
+
+        while bs.len() > 1 {
+            let first = bs.remove(0);
+            *collects.front_mut().unwrap() -= 1;
+
+            run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+            if bs == decoded {
+                bs.insert(0, first);
+                *collects.front_mut().unwrap() += 1;
+                break;
+            }
+
+            if *collects.front().unwrap() == 0 {
+                collects.pop_front().unwrap();
+
+                run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                if bs == decoded {
+                    collects.push_front(0);
+                    break;
+                }
+            }
+        }
+
+        let mut start_offset = collects[0];
+        for i in 1..collects.len() - 1 {
+            loop {
+                let start_length = collects[i];
+
+                while collects[i] > 0 {
+                    collects[i] -= 1;
+                    let item = bs.remove(start_offset);
+
+                    run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                    if bs == decoded {
+                        bs.insert(start_offset, item);
+                        collects[i] += 1;
+                        break;
+                    }
+
+                    if collects[i] == 0 {
+                        collects.remove(i);
+
+                        run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                        if bs == decoded {
+                            collects.insert(i, 0);
+                            break;
+                        }
+                    }
+                }
+
+                while collects[i] > 0 {
+                    collects[i] -= 1;
+                    let end_offset = start_offset + collects[i] - 1;
+                    let item = bs.remove(end_offset);
+
+                    run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                    if bs == decoded {
+                        bs.insert(end_offset, item);
+                        collects[i] += 1;
+                        break;
+                    }
+
+                    if collects[i] == 0 {
+                        collects.remove(i);
+
+                        run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+                        if bs == decoded {
+                            collects.insert(i, 0);
+                            break;
+                        }
+                    }
+                }
+
+                if collects[i] == start_length {
+                    break;
+                }
+            }
+
+            start_offset += collects[i];
+        }
+
+        let now_bs_len = bs.len();
+        let now_collects_len = collects.len();
+
+        if initial_bs_len == now_bs_len && initial_collects_len == now_collects_len {
+            break;
+        }
+    }
+
+    run_iteration(bs, collects.iter().copied(), encoded, decoded, num_bits)?;
+
+    Ok(())
+}
+
+fn fuzz_loops(num_loops: usize) -> ParquetResult<()> {
+    let mut rng = rand::thread_rng();
+
+    const MAX_LENGTH: usize = 10_000;
+
+    let mut encoded = Vec::with_capacity(1024);
+    let mut decoded = Vec::with_capacity(1024);
+
+    let mut bs = Vec::with_capacity(MAX_LENGTH);
+    let mut collects: VecDeque<usize> = VecDeque::with_capacity(2000);
+
+    for i in 0..num_loops {
+        collects.clear();
+        bs.clear();
+
+        let num_bits = rng.gen_range(0..=32);
+        let mask = 1u32.wrapping_shl(num_bits).wrapping_sub(1);
+
+        let length = rng.gen_range(1..=MAX_LENGTH);
+
+        unsafe { bs.set_len(length) };
+        rng.fill(&mut bs[..]);
+
+        let mut filled = 0;
+        while filled < bs.len() {
+            if rng.gen() {
+                let num_repeats = rng.gen_range(0..=(bs.len() - filled));
+                let value = bs[filled] & mask;
+                for j in 0..num_repeats {
+                    bs[filled + j] = value;
+                }
+                filled += num_repeats;
+            } else {
+                bs[filled] &= mask;
+                filled += 1;
+            }
+        }
+
+        if rng.gen() {
+            let mut num_values = bs.len();
+            while num_values > 0 {
+                let n = rng.gen_range(0..=num_values);
+                collects.push_back(n);
+                num_values -= n;
+            }
+        } else {
+            collects.resize(1, bs.len());
+        }
+
+        run_iteration(
+            &bs,
+            collects.iter().copied(),
+            &mut encoded,
+            &mut decoded,
+            num_bits,
+        )?;
+
+        if decoded != bs {
+            minimize_failing_case(&mut bs, &mut collects, &mut encoded, &mut decoded, num_bits)?;
+
+            eprintln!("Minimized case:");
+            eprintln!("Expected: {bs:?}");
+            eprintln!("Found:    {decoded:?}");
+            eprintln!("Collects: {collects:?}");
+            eprintln!();
+
+            panic!("Found a failing case...");
+        }
+
+        if i % 512 == 0 {
+            eprintln!("{i} iterations done.");
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn small_fuzz() -> ParquetResult<()> {
+    fuzz_loops(2048)
+}
+
+#[test]
+#[ignore = "Large fuzz test. Too slow"]
+fn large_fuzz() -> ParquetResult<()> {
+    fuzz_loops(1_000_000)
+}
+
+#[test]
+fn found_cases() -> ParquetResult<()> {
+    let mut encoded = Vec::with_capacity(1024);
+    let mut decoded = Vec::with_capacity(1024);
+
+    let num_bits = 7;
+
+    let bs: [u32; 1024] = std::array::from_fn(|i| (i / 10) as u32);
+
+    encoder::encode(&mut encoded, bs.iter().copied(), num_bits).unwrap();
+    let mut decoder = HybridRleDecoder::new(&encoded[..], num_bits, bs.len());
+
+    while decoder.len() != 0 {
+        let n = decoder.next().unwrap();
+        decoded.push(n);
+    }
+
+    for _ in 0..1 {
+        _ = decoder.next();
+    }
+
+    decoder.get_result()?;
+
+    assert_eq!(&decoded, &bs);
+
+    Ok(())
+}

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/translator.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/translator.rs
@@ -1,0 +1,249 @@
+use crate::parquet::encoding::bitpacked::{Decoder, Unpackable, Unpacked};
+use crate::parquet::encoding::hybrid_rle::{BufferedBitpacked, HybridRleBuffered};
+use crate::parquet::error::{ParquetError, ParquetResult};
+
+/// A trait to describe a translation from a HybridRLE encoding to an another format.
+///
+/// In essence, this is one method ([`Translator::translate`]) that maps an `u32` to the desired
+/// output type `O`. There are several other methods that may provide optimized routines
+/// for slices, chunks and decoders.
+///
+/// # Motivation
+///
+/// The [`HybridRleDecoder`] is used extensively during Parquet decoding because it is used for
+/// Dremel decoding and dictionary decoding. We want to perform a transformation from this
+/// space-efficient encoding to a buffer. Here, items might be skipped, might be mapped and only a
+/// few items might be needed. There are 3 main ways to do this.
+///
+/// 1. Element-by-element translation using iterator `map`, `filter`, `skip`, etc. This suffers
+///    from the problem that is difficult to SIMD the translation and that a `collect` might need
+///    to constantly poll the `next` function. Next to that monomorphization might need to generate
+///    many, many variants.
+/// 2. Buffer most everything, filter and translate later. This has high memory-consumption and
+///    might suffer from cache-eviction problems. This is computationally the most efficient, but
+///    probably still has a high runtime. Also, this fails to utilize run-length information and
+///    needs to retranslate all repeated elements.
+/// 3. Batched operations. Here, we try to utilize the run-length information and utilize SIMD to
+///    process many bitpacked items. This can provide the best of both worlds.
+///
+/// The [`HybridRleDecoder`][super::HybridRleDecoder] decoders utilizing both run-length encoding
+/// and bitpacking. In both processes, this [`Translator`] trait allows for translation with (i) no
+/// heap allocations and (ii) cheap buffering and can stop and start at any point. Consequently,
+/// the memory consumption while doing these translations can be relatively low while still
+/// processing items in batches.
+///
+/// [`HybridRleDecoder`]: super::HybridRleDecoder
+pub trait Translator<O> {
+    /// Translate from a decoded value to the output format
+    fn translate(&self, value: u32) -> ParquetResult<O>;
+
+    /// Translate from a slice of decoded values to the output format and write them to a `target`.
+    ///
+    /// This can overwritten to be more optimized.
+    fn translate_slice(&self, target: &mut Vec<O>, source: &[u32]) -> ParquetResult<()> {
+        target.reserve(source.len());
+        for v in source {
+            target.push(self.translate(*v)?);
+        }
+        Ok(())
+    }
+
+    /// Translate from a chunk of unpacked items to the output format and write them to a `target`.
+    ///
+    /// This is the same as [`Translator::translate_slice`] but with a known slice size. This can
+    /// allow SIMD routines to better optimize the procedure.
+    ///
+    /// This can overwritten to be more optimized.
+    fn translate_chunk(
+        &self,
+        target: &mut Vec<O>,
+        source: &<u32 as Unpackable>::Unpacked,
+    ) -> ParquetResult<()> {
+        self.translate_slice(target, &source[..])
+    }
+
+    /// Translate and collect all the items in a [`Decoder`] to a `target`.
+    ///
+    /// This can overwritten to be more optimized.
+    fn translate_bitpacked_all(
+        &self,
+        target: &mut Vec<O>,
+        mut decoder: Decoder<u32>,
+    ) -> ParquetResult<()> {
+        target.reserve(decoder.len());
+
+        let mut chunked = decoder.chunked();
+
+        for unpacked in &mut chunked {
+            self.translate_chunk(target, &unpacked)?;
+        }
+
+        if let Some((last, last_length)) = chunked.remainder() {
+            self.translate_slice(target, &last[..last_length])?;
+        }
+
+        Ok(())
+    }
+
+    /// Translate and collect a limited number of items in a [`Decoder`] to a `target`.
+    ///
+    /// This can overwritten to be more optimized.
+    ///
+    /// # Panics
+    ///
+    /// This method panics when `limit` is larger than the `decoder` length.
+    fn translate_bitpacked_limited<'a>(
+        &self,
+        target: &mut Vec<O>,
+        limit: usize,
+        mut decoder: Decoder<'a, u32>,
+    ) -> ParquetResult<BufferedBitpacked<'a>> {
+        assert!(limit < decoder.len());
+
+        const CHUNK_SIZE: usize = <u32 as Unpackable>::Unpacked::LENGTH;
+
+        let mut chunked = decoder.chunked();
+
+        let num_full_chunks = limit / CHUNK_SIZE;
+        for unpacked in (&mut chunked).take(num_full_chunks) {
+            self.translate_chunk(target, &unpacked)?;
+        }
+
+        let (unpacked, unpacked_length) = chunked.next_inexact().unwrap();
+        let unpacked_offset = limit % CHUNK_SIZE;
+        debug_assert!(unpacked_offset < unpacked_length);
+        self.translate_slice(target, &unpacked[..unpacked_offset])?;
+
+        Ok(BufferedBitpacked {
+            unpacked,
+
+            unpacked_start: unpacked_offset,
+            unpacked_end: unpacked_length,
+            decoder,
+        })
+    }
+
+    /// Translate and collect items in a [`Decoder`] to a `target`.
+    ///
+    /// This can overwritten to be more optimized.
+    fn translate_bitpacked_decoder<'a>(
+        &self,
+        decoder: Decoder<'a, u32>,
+        target: &mut Vec<O>,
+        limit: Option<usize>,
+    ) -> ParquetResult<(usize, Option<HybridRleBuffered<'a>>)> {
+        let length = decoder.len();
+
+        match limit {
+            None => self
+                .translate_bitpacked_all(target, decoder)
+                .map(|_| (length, None)),
+            Some(limit) if limit >= length => self
+                .translate_bitpacked_all(target, decoder)
+                .map(|_| (length, None)),
+            Some(limit) => self
+                .translate_bitpacked_limited(target, limit, decoder)
+                .map(|b| (limit, Some(HybridRleBuffered::Bitpacked(b)))),
+        }
+    }
+}
+
+/// This is a unit translation variant of [`Translator`]. This just maps all encoded values from a
+/// [`HybridRleDecoder`] to themselves.
+///
+/// [`HybridRleDecoder`]: super::HybridRleDecoder
+pub struct UnitTranslator;
+
+impl Translator<u32> for UnitTranslator {
+    fn translate(&self, value: u32) -> ParquetResult<u32> {
+        Ok(value)
+    }
+
+    fn translate_slice(&self, target: &mut Vec<u32>, source: &[u32]) -> ParquetResult<()> {
+        target.extend_from_slice(source);
+        Ok(())
+    }
+    fn translate_chunk(
+        &self,
+        target: &mut Vec<u32>,
+        source: &<u32 as Unpackable>::Unpacked,
+    ) -> ParquetResult<()> {
+        target.extend_from_slice(&source[..]);
+        Ok(())
+    }
+    fn translate_bitpacked_all(
+        &self,
+        target: &mut Vec<u32>,
+        decoder: Decoder<u32>,
+    ) -> ParquetResult<()> {
+        decoder.collect_into(target);
+        Ok(())
+    }
+}
+
+/// This is a dictionary translation variant of [`Translator`].
+///
+/// All the [`HybridRleDecoder`] values are regarded as a offset into a dictionary.
+///
+/// [`HybridRleDecoder`]: super::HybridRleDecoder
+pub struct DictionaryTranslator<'a, T>(pub &'a [T]);
+
+impl<'a, T: Copy> Translator<T> for DictionaryTranslator<'a, T> {
+    fn translate(&self, value: u32) -> ParquetResult<T> {
+        self.0
+            .get(value as usize)
+            .cloned()
+            .ok_or(ParquetError::oos("Dictionary index is out of range"))
+    }
+
+    fn translate_slice(&self, target: &mut Vec<T>, source: &[u32]) -> ParquetResult<()> {
+        let Some(source_max) = source.iter().copied().max() else {
+            return Ok(());
+        };
+
+        if source_max as usize >= self.0.len() {
+            return Err(ParquetError::oos("Dictionary index is out of range"));
+        }
+
+        // Safety: We have checked before that source only has indexes that are smaller than the
+        // dictionary length.
+        target.extend(
+            source
+                .iter()
+                .map(|&src_idx| unsafe { *self.0.get_unchecked(src_idx as usize) }),
+        );
+
+        Ok(())
+    }
+
+    fn translate_chunk(
+        &self,
+        target: &mut Vec<T>,
+        source: &<u32 as Unpackable>::Unpacked,
+    ) -> ParquetResult<()> {
+        let source_max: u32 = source.iter().copied().max().unwrap();
+
+        if source_max as usize >= self.0.len() {
+            return Err(ParquetError::oos("Dictionary index is out of range"));
+        }
+
+        // Safety: We have checked before that source only has indexes that are smaller than the
+        // dictionary length.
+        target.extend(
+            source
+                .iter()
+                .map(|&src_idx| unsafe { *self.0.get_unchecked(src_idx as usize) }),
+        );
+
+        Ok(())
+    }
+}
+
+/// A closure-based translator
+pub struct FnTranslator<O, F: Fn(u32) -> ParquetResult<O>>(pub F);
+
+impl<O, F: Fn(u32) -> ParquetResult<O>> Translator<O> for FnTranslator<O, F> {
+    fn translate(&self, value: u32) -> ParquetResult<O> {
+        (self.0)(value)
+    }
+}

--- a/crates/polars/tests/it/io/parquet/read/binary.rs
+++ b/crates/polars/tests/it/io/parquet/read/binary.rs
@@ -24,13 +24,11 @@ pub fn page_to_vec(
             .collect(),
         FixedLenBinaryPageState::RequiredDictionary(dict) => dict
             .indexes
-            .iter()
             .map(|x| dict.dict.value(x as usize).map(|x| x.to_vec()).map(Some))
             .collect(),
         FixedLenBinaryPageState::OptionalDictionary(validity, dict) => {
             let values = dict
                 .indexes
-                .iter()
                 .map(|x| dict.dict.value(x as usize).map(|x| x.to_vec()));
             deserialize_optional(validity, values)
         },

--- a/crates/polars/tests/it/io/parquet/read/fixed_binary.rs
+++ b/crates/polars/tests/it/io/parquet/read/fixed_binary.rs
@@ -21,13 +21,11 @@ pub fn page_to_vec(
         },
         FixedLenBinaryPageState::RequiredDictionary(dict) => dict
             .indexes
-            .iter()
             .map(|x| dict.dict.value(x as usize).map(|x| x.to_vec()).map(Some))
             .collect(),
         FixedLenBinaryPageState::OptionalDictionary(validity, dict) => {
             let values = dict
                 .indexes
-                .iter()
                 .map(|x| dict.dict.value(x as usize).map(|x| x.to_vec()));
             deserialize_optional(validity, values)
         },

--- a/crates/polars/tests/it/io/parquet/read/primitive.rs
+++ b/crates/polars/tests/it/io/parquet/read/primitive.rs
@@ -102,14 +102,10 @@ pub fn page_to_vec<T: NativeType>(
             NativePageState::Required(values) => Ok(values.map(Some).collect()),
             NativePageState::RequiredDictionary(dict) => dict
                 .indexes
-                .iter()
                 .map(|x| dict.dict.value(x as usize).copied().map(Some))
                 .collect(),
             NativePageState::OptionalDictionary(validity, dict) => {
-                let values = dict
-                    .indexes
-                    .iter()
-                    .map(|x| dict.dict.value(x as usize).copied());
+                let values = dict.indexes.map(|x| dict.dict.value(x as usize).copied());
                 deserialize_optional(validity, values)
             },
         },

--- a/crates/polars/tests/it/io/parquet/read/primitive_nested.rs
+++ b/crates/polars/tests/it/io/parquet/read/primitive_nested.rs
@@ -88,7 +88,7 @@ fn read_array_impl<I: Iterator<Item = i64>>(
             let num_bits = get_bit_width(rep_level_encoding.1);
             let rep_levels = HybridRleDecoder::new(rep_levels, num_bits, length);
             compose_array(
-                rep_levels.iter(),
+                rep_levels,
                 std::iter::repeat(0).take(length),
                 max_rep_level,
                 max_def_level,
@@ -100,7 +100,7 @@ fn read_array_impl<I: Iterator<Item = i64>>(
             let def_levels = HybridRleDecoder::new(def_levels, num_bits, length);
             compose_array(
                 std::iter::repeat(0).take(length),
-                def_levels.iter(),
+                def_levels,
                 max_rep_level,
                 max_def_level,
                 values,
@@ -108,11 +108,9 @@ fn read_array_impl<I: Iterator<Item = i64>>(
         },
         ((Encoding::Rle, false), (Encoding::Rle, false)) => {
             let rep_levels =
-                HybridRleDecoder::new(rep_levels, get_bit_width(rep_level_encoding.1), length)
-                    .iter();
+                HybridRleDecoder::new(rep_levels, get_bit_width(rep_level_encoding.1), length);
             let def_levels =
-                HybridRleDecoder::new(def_levels, get_bit_width(def_level_encoding.1), length)
-                    .iter();
+                HybridRleDecoder::new(def_levels, get_bit_width(def_level_encoding.1), length);
             compose_array(rep_levels, def_levels, max_rep_level, max_def_level, values)
         },
         _ => todo!(),

--- a/crates/polars/tests/it/io/parquet/read/struct_.rs
+++ b/crates/polars/tests/it/io/parquet/read/struct_.rs
@@ -21,7 +21,7 @@ pub fn extend_validity(val: &mut Vec<bool>, page: &DataPage) -> ParquetResult<()
     );
 
     let mut def_levels =
-        HybridRleDecoder::new(def_levels, get_bit_width(def_level_encoding.1), length).iter();
+        HybridRleDecoder::new(def_levels, get_bit_width(def_level_encoding.1), length);
 
     val.reserve(length);
     def_levels.try_for_each(|x| {


### PR DESCRIPTION
This is rather large change that changes quite fundamentally how HybridRLE and Parquet decoding works. There are now two important concepts that speed up the performance of the Parquet reader while utilizing less memory than before. This does how increase the complexity of the code.

First, for a benchmark using the NYC Yellow-Taxi dataset (we decode the whole dataset 100x). Here, we see the following results.

No maximum threads:

```
Benchmark 1: After Optimization
  Time (mean ± σ):      4.918 s ±  0.076 s    [User: 28.748 s, System: 2.486 s]
  Range (min … max):    4.819 s …  5.064 s    10 runs

Benchmark 2: Before Optimization
  Time (mean ± σ):      7.333 s ±  2.144 s    [User: 60.374 s, System: 3.054 s]
  Range (min … max):    5.416 s … 11.132 s    10 runs

Summary
  After Optimization ran
    1.49 ± 0.44 times faster than Before Optimization
```

Maximum threads = 1:

```
Benchmark 1: After Optimization
  Time (mean ± σ):     18.452 s ±  0.054 s    [User: 16.058 s, System: 2.325 s]
  Range (min … max):   18.332 s … 18.511 s    10 runs

Benchmark 2: Before Optimization
  Time (mean ± σ):     27.027 s ±  0.062 s    [User: 24.668 s, System: 2.271 s]
  Range (min … max):   26.912 s … 27.105 s    10 runs

Summary
  After Optimization ran
    1.46 ± 0.01 times faster than Before Optimization
```

This PR introduces the concepts of a `Translator` and a `BatchedCollector`.

The `Translator` trait maps from hybrid RLE encoded values to an arbitrary set of values. The HybridRLEDecoder will can then collect and call the translator with batches of values. This way we minimize the amount of iterator polls and we do not need to allocate any more on the heap except the output buffer. This does however mean that the whole HybridRLEDecoder needs to be aware of the `Translator` trait.

Furthermore, the `HybridRLEDecoder` can now itself buffer, instead of using the `BufferedHybridRleDecoderIter` that was used before. Again, this allows minimal memory consumption and prevents constant polling.

The `BatchedCollector` is essentially a wrapper for the `Pushable` trait that automatically optimizes sequential pushes of valid and invalid values. It also allows for efficient skipping of values.

Overall, this change significantly speeds up the Parquet reader and extensive testing was done to ensure that no invalid data gets produced. But it is difficult to test all edge-cases.

From here, we can start incorporating the `BatchedCollector` and `Translator` traits in more places. In general, the `HybridRleDecoder` iterator implementation should effectively never be used.