### PR TITLE
fix(python): Handle DB cursor descriptions that contain more fields than the DBAPI2 standard

### DIFF
--- a/py-polars/polars/io/database/_inference.py
+++ b/py-polars/polars/io/database/_inference.py
@@ -203,7 +203,7 @@ def _infer_dtype_from_cursor_description(
     description: tuple[Any, ...],
 ) -> PolarsDataType | None:
     """Attempt to infer Polars dtype from database cursor description `type_code`."""
-    type_code, _disp_size, internal_size, precision, scale, _null_ok = description
+    type_code, _disp_size, internal_size, precision, scale, *_ = description
     dtype: PolarsDataType | None = None
 
     if isclass(type_code):


### PR DESCRIPTION
Closes #17466.

Not all drivers adhere to the DBAPI2 standard[^1] for the cursor description; the standard specifies exactly 7 attributes, but MariaDB's native driver (and possibly others, though no reports of such yet) returns more.

Trivial fix to handle the additional params.

[^1]: https://peps.python.org/pep-0249/#cursor-attributes