### PR TITLE
 __init__.py: remove non-existing names from __all__ 

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -317,8 +317,6 @@ __all__ = [
     "cum_count",
     "cum_fold",
     "cum_reduce",
-    "cumfold",
-    "cumreduce",
     "date",
     "datetime",
     "duration",

--- a/py-polars/tests/unit/test_init.py
+++ b/py-polars/tests/unit/test_init.py
@@ -35,3 +35,7 @@ def test_type_aliases_deprecated() -> None:
     ):
         from polars.type_aliases import PolarsDataType
     assert str(PolarsDataType).startswith("typing.Union")
+
+
+def test_import_all() -> None:
+    from polars import *


### PR DESCRIPTION
`from polars import *` used to raise the following error before this change:
```
AttributeError: module 'polars' has no attribute 'cumfold'. Did you mean: 'cum_fold'?
```