### PR TITLE
docs(python): Update `plot` docs to refer to docstrings

### DIFF
--- a/py-polars/docs/source/reference/dataframe/plot.rst
+++ b/py-polars/docs/source/reference/dataframe/plot.rst
@@ -2,43 +2,6 @@
 Plot
 ====
 
-Polars does not implement plotting logic itself, but instead defers to
-hvplot. Please see the `hvplot reference gallery <https://hvplot.holoviz.org/reference/index.html>`_
-for more information and documentation.
+.. currentmodule:: polars
 
-Examples
---------
-Scatter plot:
-
-.. code-block:: python
-
-    df = pl.DataFrame(
-        {
-            "length": [1, 4, 6],
-            "width": [4, 5, 6],
-            "species": ["setosa", "setosa", "versicolor"],
-        }
-    )
-    df.plot.scatter(x="length", y="width", by="species")
-
-Line plot:
-
-.. code-block:: python
-
-    from datetime import date
-    df = pl.DataFrame(
-        {
-            "date": [date(2020, 1, 2), date(2020, 1, 3), date(2020, 1, 3)],
-            "stock_1": [1, 4, 6],
-            "stock_2": [1, 5, 2],
-        }
-    )
-    df.plot.line(x="date", y=["stock_1", "stock_2"])
-
-For more info on what you can pass, you can use ``hvplot.help``:
-
-.. code-block:: python
-
-    import hvplot
-    hvplot.help('scatter')
-
+.. autoproperty:: DataFrame.plot

--- a/py-polars/docs/source/reference/series/plot.rst
+++ b/py-polars/docs/source/reference/series/plot.rst
@@ -2,28 +2,6 @@
 Plot
 ====
 
-Polars does not implement plotting logic itself, but instead defers to
-hvplot. Please see the `hvplot reference gallery <https://hvplot.holoviz.org/reference/index.html>`_
-for more information and documentation.
+.. currentmodule:: polars
 
-Examples
---------
-Histogram:
-
-.. code-block:: python
-
-   s = pl.Series([1, 4, 2])
-   s.plot.hist()
-
-KDE plot (note: in addition to ``hvplot``, this one also requires ``scipy``):
-
-.. code-block:: python
-
-   s.plot.kde()
-
-For more info on what you can pass, you can use ``hvplot.help``:
-
-.. code-block:: python
-
-   import hvplot
-   hvplot.help("hist")
+.. autoproperty:: Series.plot


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17503

Have aligned these files with `py-polars/docs/source/reference/dataframe/style.rst`, so hopefully it should work the same. Leaving as draft so I can build the docs locally and double check.