### PR TITLE
fix(rust): Tighten up error checking on join keys

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -479,6 +479,9 @@ pub fn to_alp_impl(
                 }
                 if turn_off_coalesce {
                     let options = Arc::make_mut(&mut options);
+                    if matches!(options.args.coalesce, JoinCoalesce::CoalesceColumns) {
+                        polars_warn!("Coalescing join requested but not all join keys are column references, turning off key coalescing");
+                    }
                     options.args.coalesce = JoinCoalesce::KeepColumns;
                 }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -523,6 +523,14 @@ pub fn to_alp_impl(
             convert.fill_scratch(&left_on, expr_arena);
             convert.fill_scratch(&right_on, expr_arena);
 
+            // Every expression must be elementwise so that we are
+            // guaranteed the keys for a join are all the same length.
+            let all_elementwise =
+                |aexprs: &[ExprIR]| all_streamable(aexprs, &*expr_arena, Context::Default);
+            polars_ensure!(
+                all_elementwise(&left_on) && all_elementwise(&right_on),
+                InvalidOperation: "All join key expressions must be elementwise."
+            );
             let lp = IR::Join {
                 input_left,
                 input_right,

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -76,19 +76,6 @@ pub(crate) fn aexpr_is_simple_projection(current_node: Node, arena: &Arena<AExpr
         .all(|(_node, e)| matches!(e, AExpr::Column(_) | AExpr::Alias(_, _)))
 }
 
-pub(crate) fn single_aexpr_is_elementwise(ae: &AExpr) -> bool {
-    use AExpr::*;
-    match ae {
-        AnonymousFunction { options, .. } | Function { options, .. } => {
-            !matches!(options.collect_groups, ApplyOptions::GroupWise)
-        },
-        Column(_) | Alias(_, _) | Literal(_) | BinaryExpr { .. } | Ternary { .. } | Cast { .. } => {
-            true
-        },
-        _ => false,
-    }
-}
-
 pub fn has_aexpr<F>(current_node: Node, arena: &Arena<AExpr>, matches: F) -> bool
 where
     F: Fn(&AExpr) -> bool,


### PR DESCRIPTION
After discussion in #17184:

- Reject multiple join key expressions if they are not all elementwise
- Emit UserWarning if a coalescing join is requested but not all key expressions are column references, in which case the coalescing behaviour is turned off.