### PR TITLE
fix(python): Make schema picklable

### DIFF
--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -47,7 +47,11 @@ class Schema(BaseSchema):
     2
     """
 
-    def __init__(self, schema: Mapping[str, DataType] | Iterable[tuple[str, DataType]]):
+    def __init__(
+        self,
+        schema: Mapping[str, DataType] | Iterable[tuple[str, DataType]] | None = None,
+    ):
+        schema = schema or {}
         super().__init__(schema)
 
     def names(self) -> list[str]:

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -1,3 +1,5 @@
+import pickle
+
 import polars as pl
 
 
@@ -32,3 +34,12 @@ def test_schema_equality() -> None:
     assert s1 != s2
     assert s1 != s3
     assert s2 != s3
+
+
+def test_schema_picklable() -> None:
+    s = pl.Schema({"foo": pl.Int8(), "bar": pl.String()})
+
+    pickled = pickle.dumps(s)
+    s2 = pickle.loads(pickled)
+
+    assert s == s2


### PR DESCRIPTION
fixes #17523 

during unpickling, an instance of `Schema` is instantiated without passing the `schema` argument. In this case, we should create an empty Schema instead of erroring.