### PR TITLE
docs(python): Fixup "deprecated" directive for `DataFrame.melt` and `LazyFrame.melt`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2199,7 +2199,7 @@ class DataFrame:
         dtype: object
         """
         if use_pyarrow_extension_array:
-            if parse_version(pd.__version__) < parse_version("1.5"):
+            if parse_version(pd.__version__) < (1, 5):
                 msg = f'pandas>=1.5.0 is required for `to_pandas("use_pyarrow_extension_array=True")`, found Pandas {pd.__version__!r}'
                 raise ModuleUpgradeRequiredError(msg)
             if not _PYARROW_AVAILABLE or parse_version(pa.__version__) < (8, 0):
@@ -3874,7 +3874,7 @@ class DataFrame:
 
             import_optional(
                 module_name="sqlalchemy",
-                min_version=("2.0" if pd_version >= parse_version("2.2") else "1.4"),
+                min_version=("2.0" if pd_version >= (2, 2) else "1.4"),
                 min_err_prefix="pandas >= 2.2 requires",
             )
             # note: the catalog (database) should be a part of the connection string
@@ -10896,7 +10896,7 @@ class DataFrame:
         measured variables (value_vars), are "unpivoted" to the row axis leaving just
         two non-identifier columns, 'variable' and 'value'.
 
-        .. deprecated 1.0.0
+        .. deprecated:: 1.0.0
             Please use :meth:`.unpivot` instead.
 
         Parameters

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -6455,7 +6455,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         measured variables (value_vars), are "unpivoted" to the row axis leaving just
         two non-identifier columns, 'variable' and 'value'.
 
-        .. deprecated 1.0.0
+        .. deprecated:: 1.0.0
             Please use :meth:`.unpivot` instead.
 
         Parameters

--- a/py-polars/tests/unit/functions/test_business_day_count.py
+++ b/py-polars/tests/unit/functions/test_business_day_count.py
@@ -158,7 +158,7 @@ def test_against_np_busday_count(
         .item()
     )
     expected = np.busday_count(start, end, weekmask=week_mask, holidays=holidays)
-    if start > end and parse_version(np.__version__) < parse_version("1.25"):
+    if start > end and parse_version(np.__version__) < (1, 25):
         # Bug in old versions of numpy
         reject()
     assert result == expected


### PR DESCRIPTION
the deprecation isn't currently rendering

also, drive-by, by `parse_version` parses a string as a tuple of ints - it would be better to just construct the tuple of ints directly