### PR TITLE
test(python): Add/fix version-gating in some SQLAlchemy and Pandas tests

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -250,6 +250,9 @@ filterwarnings = [
   # TODO: Excel tests lead to unclosed file warnings
   # https://github.com/pola-rs/polars/issues/14466
   "ignore:unclosed file.*:ResourceWarning",
+  # Ignore invalid warnings when running earlier versions of SQLAlchemy (we
+  # know they are invalid because our standard tests run the latest version)
+  "ignore:Deprecated API features detected.*:DeprecationWarning",
 ]
 xfail_strict = true
 

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -11,6 +11,7 @@ import pytest
 from hypothesis import given
 
 import polars as pl
+from polars._utils.various import parse_version
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
@@ -277,8 +278,8 @@ def test_to_dataframe_pyarrow_boolean_midbyte_slice() -> None:
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="Older versions of pandas do not implement the required conversions",
+    parse_version(pd.__version__) < (2, 2),
+    reason="Pandas versions < 2.2 do not implement the required conversions",
 )
 def test_from_dataframe_pandas_timestamp_ns() -> None:
     df = pl.Series("a", [datetime(2000, 1, 1)], dtype=pl.Datetime("ns")).to_frame()

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -5,9 +5,11 @@ from math import ceil
 from typing import TYPE_CHECKING, Any, Iterable, overload
 
 import pytest
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+import sqlalchemy
+from sqlalchemy.ext.asyncio import create_async_engine
 
 import polars as pl
+from polars._utils.various import parse_version
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -66,9 +68,14 @@ class MockSurrealConnection:
         return [{"result": self._mock_data, "status": "OK", "time": "32.083µs"}]
 
 
+@pytest.mark.skipif(
+    parse_version(sqlalchemy.__version__) < (2, 0),
+    reason="SQLAlchemy 2.0+ required for async tests",
+)
 def test_read_async(tmp_sqlite_db: Path) -> None:
     # confirm that we can load frame data from the core sqlalchemy async
     # primitives: AsyncConnection, AsyncEngine, and async_sessionmaker
+    from sqlalchemy.ext.asyncio import async_sessionmaker
 
     async_engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_sqlite_db}")
     async_connection = async_engine.connect()
@@ -111,6 +118,10 @@ async def _nested_async_test(tmp_sqlite_db: Path) -> pl.DataFrame:
     )
 
 
+@pytest.mark.skipif(
+    parse_version(sqlalchemy.__version__) < (2, 0),
+    reason="SQLAlchemy 2.0+ required for async tests",
+)
 def test_read_async_nested(tmp_sqlite_db: Path) -> None:
     # this tests validates that we can handle nested async calls. without
     # the nested asyncio handling provided by `nest_asyncio` this test


### PR DESCRIPTION
Closes #17487.

Adds/tweaks some version-gating for a couple of tests.

* One test should have been gated on the Pandas version, but was using the Python version to imply this instead.
* Also, there's still a large SQLAlchemy 1.x install base (and it has been updated independently of 2.x as recently as March), so allowing tests to run with both versions is worthwhile (we still run it in a few places at work, for example, due to some otherwise incompatible drivers).