### PR TITLE
perf: Batch nested Parquet decoding

### DIFF
--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -42,7 +42,7 @@ fn url_and_creds_to_key(url: &Url, options: Option<&CloudOptions>) -> String {
 
 /// Construct an object_store `Path` from a string without any encoding/decoding.
 pub fn object_path_from_string(path: String) -> PolarsResult<object_store::path::Path> {
-    object_store::path::Path::parse(&path).map_err(to_compute_err)
+    object_store::path::Path::parse(path).map_err(to_compute_err)
 }
 
 /// Build an [`ObjectStore`] based on the URL and passed in url. Return the cloud location and an implementation of the object store.

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
@@ -9,19 +9,18 @@ use crate::parquet::deserialize::SliceFilteredIter;
 use crate::parquet::encoding::{delta_bitpacked, delta_length_byte_array, hybrid_rle, Encoding};
 use crate::parquet::error::ParquetResult;
 use crate::parquet::page::{split_buffer, DataPage};
-use crate::read::deserialize::utils::{page_is_filtered, page_is_optional};
 
 pub(crate) type BinaryDict = BinaryArray<i64>;
 
 #[derive(Debug)]
 pub(crate) struct Required<'a> {
-    pub values: std::iter::Take<BinaryIter<'a>>,
+    pub values: BinaryIter<'a>,
 }
 
 impl<'a> Required<'a> {
     pub fn try_new(page: &'a DataPage) -> PolarsResult<Self> {
         let values = split_buffer(page)?.values;
-        let values = BinaryIter::new(values).take(page.num_values());
+        let values = BinaryIter::new(values, page.num_values());
 
         Ok(Self { values })
     }
@@ -139,12 +138,12 @@ impl<'a> Iterator for DeltaBytes<'a> {
 
 #[derive(Debug)]
 pub(crate) struct FilteredRequired<'a> {
-    pub values: SliceFilteredIter<std::iter::Take<BinaryIter<'a>>>,
+    pub values: SliceFilteredIter<BinaryIter<'a>>,
 }
 
 impl<'a> FilteredRequired<'a> {
     pub fn new(page: &'a DataPage) -> Self {
-        let values = BinaryIter::new(page.buffer()).take(page.num_values());
+        let values = BinaryIter::new(page.buffer(), page.num_values());
 
         let rows = get_selected_rows(page);
         let values = SliceFilteredIter::new(values, rows);
@@ -277,7 +276,7 @@ impl<'a> utils::PageState<'a> for BinaryState<'a> {
 }
 
 pub(crate) fn deserialize_plain(values: &[u8], num_values: usize) -> BinaryDict {
-    let all = BinaryIter::new(values).take(num_values).collect::<Vec<_>>();
+    let all = BinaryIter::new(values, num_values).collect::<Vec<_>>();
     let values_size = all.iter().map(|v| v.len()).sum::<usize>();
     let mut dict_values = MutableBinaryValuesArray::<i64>::with_capacities(all.len(), values_size);
     for v in all {
@@ -331,8 +330,7 @@ pub(crate) fn build_binary_state<'a>(
         },
         (Encoding::Plain, _, true, false) => {
             let values = split_buffer(page)?.values;
-
-            let values = BinaryIter::new(values);
+            let values = BinaryIter::new(values, page.num_values());
 
             Ok(BinaryState::Optional(
                 OptionalPageValidity::try_new(page)?,
@@ -348,7 +346,7 @@ pub(crate) fn build_binary_state<'a>(
 
             Ok(BinaryState::FilteredOptional(
                 FilteredOptionalPageValidity::try_new(page)?,
-                BinaryIter::new(values),
+                BinaryIter::new(values, page.num_values()),
             ))
         },
         (Encoding::DeltaLengthByteArray, _, false, false) => {
@@ -371,57 +369,6 @@ pub(crate) fn build_binary_state<'a>(
         )),
         (Encoding::DeltaByteArray, _, false, false) => {
             Ok(BinaryState::DeltaByteArray(DeltaBytes::try_new(page)?))
-        },
-        _ => Err(utils::not_implemented(page)),
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum BinaryNestedState<'a> {
-    Optional(BinaryIter<'a>),
-    Required(BinaryIter<'a>),
-    RequiredDictionary(ValuesDictionary<'a>),
-    OptionalDictionary(ValuesDictionary<'a>),
-}
-
-impl<'a> utils::PageState<'a> for BinaryNestedState<'a> {
-    fn len(&self) -> usize {
-        match self {
-            BinaryNestedState::Optional(validity) => validity.size_hint().0,
-            BinaryNestedState::Required(state) => state.size_hint().0,
-            BinaryNestedState::RequiredDictionary(required) => required.len(),
-            BinaryNestedState::OptionalDictionary(optional) => optional.len(),
-        }
-    }
-}
-
-pub(crate) fn build_nested_state<'a>(
-    page: &'a DataPage,
-    dict: Option<&'a BinaryDict>,
-) -> PolarsResult<BinaryNestedState<'a>> {
-    let is_optional = page_is_optional(page);
-    let is_filtered = page_is_filtered(page);
-
-    match (page.encoding(), dict, is_optional, is_filtered) {
-        (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
-            ValuesDictionary::try_new(page, dict).map(BinaryNestedState::RequiredDictionary)
-        },
-        (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
-            ValuesDictionary::try_new(page, dict).map(BinaryNestedState::OptionalDictionary)
-        },
-        (Encoding::Plain, _, true, false) => {
-            let values = split_buffer(page)?.values;
-
-            let values = BinaryIter::new(values);
-
-            Ok(BinaryNestedState::Optional(values))
-        },
-        (Encoding::Plain, _, false, false) => {
-            let values = split_buffer(page)?.values;
-
-            let values = BinaryIter::new(values);
-
-            Ok(BinaryNestedState::Required(values))
         },
         _ => Err(utils::not_implemented(page)),
     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
@@ -61,7 +61,7 @@ fn read_dict<O: Offset>(data_type: ArrowDataType, dict: &DictPage) -> Box<dyn Ar
         _ => data_type,
     };
 
-    let values = BinaryIter::new(&dict.buffer).take(dict.num_values);
+    let values = BinaryIter::new(&dict.buffer, dict.num_values);
 
     let mut data = Binary::<O>::with_capacity(dict.num_values);
     data.values = Vec::with_capacity(dict.buffer.len() - 4 * dict.num_values);

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/dictionary.rs
@@ -55,7 +55,7 @@ fn read_dict(data_type: ArrowDataType, dict: &DictPage) -> Box<dyn Array> {
         _ => data_type,
     };
 
-    let values = BinaryIter::new(&dict.buffer).take(dict.num_values);
+    let values = BinaryIter::new(&dict.buffer, dict.num_values);
 
     let mut data = MutableBinaryViewArray::<[u8]>::with_capacity(dict.num_values);
     for item in values {

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/nested.rs
@@ -1,27 +1,50 @@
 use std::collections::VecDeque;
 
-use arrow::array::{ArrayRef, MutableBinaryViewArray};
+use arrow::array::{ArrayRef, MutableBinaryViewArray, View};
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
-use polars_utils::iter::FallibleIterator;
 
-use crate::parquet::page::{DataPage, DictPage};
-use crate::read::deserialize::binary::decoders::{
-    build_nested_state, deserialize_plain, BinaryDict, BinaryNestedState,
-};
+use crate::parquet::encoding::hybrid_rle::DictionaryTranslator;
+use crate::parquet::encoding::Encoding;
+use crate::parquet::error::ParquetResult;
+use crate::parquet::page::{split_buffer, DataPage, DictPage};
+use crate::read::deserialize::binary::decoders::{deserialize_plain, BinaryDict, ValuesDictionary};
+use crate::read::deserialize::binary::utils::BinaryIter;
 use crate::read::deserialize::binview::basic::finish;
 use crate::read::deserialize::nested_utils::{next, NestedDecoder};
-use crate::read::deserialize::utils::MaybeNext;
+use crate::read::deserialize::utils::{
+    binary_views_dict, not_implemented, page_is_filtered, page_is_optional, MaybeNext, PageState,
+};
 use crate::read::{InitNested, NestedState, PagesIter};
 
-#[derive(Debug, Default)]
-struct BinViewDecoder {}
+#[derive(Debug)]
+pub(crate) struct State<'a> {
+    pub is_optional: bool,
+    pub translation: StateTranslation<'a>,
+}
+
+#[derive(Debug)]
+pub(crate) enum StateTranslation<'a> {
+    Unit(BinaryIter<'a>),
+    Dictionary(ValuesDictionary<'a>, Option<Vec<View>>),
+}
+
+impl<'a> PageState<'a> for State<'a> {
+    fn len(&self) -> usize {
+        match &self.translation {
+            StateTranslation::Unit(iter) => iter.size_hint().0,
+            StateTranslation::Dictionary(values, _) => values.len(),
+        }
+    }
+}
+
+struct BinViewDecoder;
 
 type DecodedStateTuple = (MutableBinaryViewArray<[u8]>, MutableBitmap);
 
 impl<'a> NestedDecoder<'a> for BinViewDecoder {
-    type State = BinaryNestedState<'a>;
+    type State = State<'a>;
     type Dictionary = BinaryDict;
     type DecodedState = DecodedStateTuple;
 
@@ -30,7 +53,29 @@ impl<'a> NestedDecoder<'a> for BinViewDecoder {
         page: &'a DataPage,
         dict: Option<&'a Self::Dictionary>,
     ) -> PolarsResult<Self::State> {
-        build_nested_state(page, dict)
+        let is_optional = page_is_optional(page);
+        let is_filtered = page_is_filtered(page);
+
+        if is_filtered {
+            return Err(not_implemented(page));
+        }
+
+        let translation = match (page.encoding(), dict) {
+            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict)) => {
+                StateTranslation::Dictionary(ValuesDictionary::try_new(page, dict)?, None)
+            },
+            (Encoding::Plain, _) => {
+                let values = split_buffer(page)?.values;
+                let values = BinaryIter::new(values, page.num_values());
+                StateTranslation::Unit(values)
+            },
+            _ => return Err(not_implemented(page)),
+        };
+
+        Ok(State {
+            is_optional,
+            translation,
+        })
     }
 
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState {
@@ -40,51 +85,43 @@ impl<'a> NestedDecoder<'a> for BinViewDecoder {
         )
     }
 
-    fn push_valid(
+    fn push_n_valid(
         &self,
         state: &mut Self::State,
         decoded: &mut Self::DecodedState,
-    ) -> PolarsResult<()> {
+        n: usize,
+    ) -> ParquetResult<()> {
         let (values, validity) = decoded;
-        match state {
-            BinaryNestedState::Optional(page) => {
-                let value = page.next().unwrap_or_default();
-                values.push_value_ignore_validity(value);
-                validity.push(true);
+        match &mut state.translation {
+            StateTranslation::Unit(page) => {
+                // @TODO: This should probably be optimized to a better loop
+                for value in page.by_ref().take(n) {
+                    values.push_value_ignore_validity(value);
+                }
             },
-            BinaryNestedState::Required(page) => {
-                let value = page.next().unwrap_or_default();
-                values.push_value_ignore_validity(value);
-            },
-            BinaryNestedState::RequiredDictionary(page) => {
-                let dict_values = &page.dict;
-                let item = page
-                    .values
-                    .next()
-                    .map(|index| dict_values.value(index as usize))
-                    .unwrap_or_default();
-                values.push_value_ignore_validity(item);
-                page.values.get_result()?;
-            },
-            BinaryNestedState::OptionalDictionary(page) => {
-                let dict_values = &page.dict;
-                let item = page
-                    .values
-                    .next()
-                    .map(|index| dict_values.value(index as usize))
-                    .unwrap_or_default();
-                values.push_value_ignore_validity(item);
-                validity.push(true);
-                page.values.get_result()?;
+            StateTranslation::Dictionary(page, views_dict) => {
+                let views_dict =
+                    views_dict.get_or_insert_with(|| binary_views_dict(values, page.dict));
+                let translator = DictionaryTranslator(views_dict);
+                page.values
+                    .translate_and_collect_n_into(values.views_mut(), n, &translator)?;
+                if let Some(validity) = values.validity() {
+                    validity.extend_constant(n, true);
+                }
             },
         }
+
+        if state.is_optional {
+            validity.extend_constant(n, true);
+        }
+
         Ok(())
     }
 
-    fn push_null(&self, decoded: &mut Self::DecodedState) {
+    fn push_n_nulls(&self, decoded: &mut Self::DecodedState, n: usize) {
         let (values, validity) = decoded;
-        values.push_null();
-        validity.push(false);
+        values.extend_null(n);
+        validity.extend_constant(n, false);
     }
 
     fn deserialize_dict(&self, page: &DictPage) -> Self::Dictionary {
@@ -134,7 +171,7 @@ impl<I: PagesIter> Iterator for NestedIter<I> {
                 &mut self.remaining,
                 &self.init,
                 self.chunk_size,
-                &BinViewDecoder::default(),
+                &BinViewDecoder,
             );
             match maybe_state {
                 MaybeNext::Some(Ok((nested, decoded))) => {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -62,18 +62,12 @@ impl<'a> Values<'a> {
 }
 
 #[derive(Debug)]
-pub(super) struct ValuesDictionary<'a, T>
-where
-    T: NativeType,
-{
+pub(super) struct ValuesDictionary<'a, T: NativeType> {
     pub values: hybrid_rle::HybridRleDecoder<'a>,
     pub dict: &'a [T],
 }
 
-impl<'a, T> ValuesDictionary<'a, T>
-where
-    T: NativeType,
-{
+impl<'a, T: NativeType> ValuesDictionary<'a, T> {
     pub fn try_new(page: &'a DataPage, dict: &'a [T]) -> PolarsResult<Self> {
         let values = utils::dict_indices_decoder(page)?;
 

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -3,7 +3,7 @@ mod bitmap;
 mod buffered;
 mod decoder;
 mod encoder;
-mod translator;
+pub mod translator;
 
 #[cfg(test)]
 mod fuzz;
@@ -15,7 +15,7 @@ pub use encoder::encode;
 use polars_utils::iter::FallibleIterator;
 use polars_utils::slice::GetSaferUnchecked;
 pub use translator::{
-    BinaryDictionaryTranslator, DictionaryTranslator, FnTranslator, Translator, UnitTranslator,
+    DictionaryTranslator, FnTranslator, Translator, TryFromUsizeTranslator, UnitTranslator,
 };
 
 use self::buffered::HybridRleBuffered;

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/translator.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/translator.rs
@@ -1,5 +1,3 @@
-use arrow::array::{BinaryArray, View};
-
 use crate::parquet::encoding::bitpacked::{Decoder, Unpackable, Unpacked};
 use crate::parquet::encoding::hybrid_rle::{BufferedBitpacked, HybridRleBuffered};
 use crate::parquet::error::{ParquetError, ParquetResult};
@@ -241,57 +239,63 @@ impl<'a, T: Copy> Translator<T> for DictionaryTranslator<'a, T> {
     }
 }
 
-/// This is a binary dictionary translation variant of [`Translator`].
-///
-/// All the [`HybridRleDecoder`] values are regarded as a offset into a binary array regarded as a
-/// dictionary.
-///
-/// [`HybridRleDecoder`]: super::HybridRleDecoder
-pub struct BinaryDictionaryTranslator<'a> {
-    pub dictionary: &'a BinaryArray<i64>,
-    pub buffer_idx: u32,
-}
-
-impl<'a> Translator<View> for BinaryDictionaryTranslator<'a> {
-    fn translate(&self, index: u32) -> ParquetResult<View> {
-        if index as usize >= self.dictionary.len() {
-            return Err(ParquetError::oos("Dictionary index is out of range"));
-        }
-
-        let value = self.dictionary.value(index as usize);
-        let (start, _) = self.dictionary.offsets().start_end(index as usize);
-        Ok(View::new_from_bytes(value, self.buffer_idx, start as u32))
-    }
-
-    fn translate_slice(&self, target: &mut Vec<View>, source: &[u32]) -> ParquetResult<()> {
-        let Some(source_max) = source.iter().copied().max() else {
-            return Ok(());
-        };
-
-        if source_max as usize >= self.dictionary.len() {
-            return Err(ParquetError::oos("Dictionary index is out of range"));
-        }
-
-        let offsets = self.dictionary.offsets();
-
-        target.extend(source.iter().map(|&src_idx| {
-            // Safety: We have checked before that source only has indexes that are smaller than
-            // the dictionary length.
-            let value = unsafe { self.dictionary.value_unchecked(src_idx as usize) };
-            debug_assert!((src_idx as usize) < offsets.len_proxy());
-            let (start, _) = unsafe { offsets.start_end_unchecked(src_idx as usize) };
-            View::new_from_bytes(value, self.buffer_idx, start as u32)
-        }));
-
-        Ok(())
-    }
-}
-
 /// A closure-based translator
 pub struct FnTranslator<O, F: Fn(u32) -> ParquetResult<O>>(pub F);
 
 impl<O, F: Fn(u32) -> ParquetResult<O>> Translator<O> for FnTranslator<O, F> {
     fn translate(&self, value: u32) -> ParquetResult<O> {
         (self.0)(value)
+    }
+}
+
+#[derive(Default)]
+pub struct TryFromUsizeTranslator<O: TryFrom<usize>>(std::marker::PhantomData<O>);
+
+impl<O: TryFrom<usize>> Translator<O> for TryFromUsizeTranslator<O> {
+    fn translate(&self, value: u32) -> ParquetResult<O> {
+        O::try_from(value as usize).map_err(|_| ParquetError::oos("Invalid cast in translation"))
+    }
+}
+
+pub struct SliceDictionaryTranslator<'a, T> {
+    dict: &'a [T],
+    size: usize,
+}
+
+impl<'a, T> SliceDictionaryTranslator<'a, T> {
+    pub fn new(dict: &'a [T], size: usize) -> Self {
+        debug_assert_eq!(dict.len() % size, 0);
+        Self { dict, size }
+    }
+}
+
+impl<'a, T> Translator<&'a [T]> for SliceDictionaryTranslator<'a, T> {
+    fn translate(&self, value: u32) -> ParquetResult<&'a [T]> {
+        let idx = value as usize;
+
+        if idx >= self.dict.len() / self.size {
+            return Err(ParquetError::oos("Dictionary slice index is out of range"));
+        }
+
+        Ok(&self.dict[idx * self.size..(idx + 1) * self.size])
+    }
+
+    fn translate_slice(&self, target: &mut Vec<&'a [T]>, source: &[u32]) -> ParquetResult<()> {
+        let Some(source_max) = source.iter().copied().max() else {
+            return Ok(());
+        };
+
+        if source_max as usize >= self.dict.len() / self.size {
+            return Err(ParquetError::oos("Dictionary index is out of range"));
+        }
+
+        // Safety: We have checked before that source only has indexes that are smaller than the
+        // dictionary length.
+        target.extend(source.iter().map(|&src_idx| unsafe {
+            self.dict
+                .get_unchecked((src_idx as usize) * self.size..(src_idx as usize + 1) * self.size)
+        }));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR is a follow up to #17462. This batches the collects in the nested Parquet decoders, with that we can also simplify the code quite a lot.

I did a benchmark where we had one column `{ 'x': pl.List(pl.Int8) }` of length `10_000_000`. Then, we read that Parquet file 50 times. Here are the results.

```
Benchmark 1: After Optimization
  Time (mean ± σ):      3.398 s ±  0.064 s    [User: 49.412 s, System: 4.362 s]
  Range (min … max):    3.311 s …  3.490 s    10 runs

Benchmark 2: Before Optimization
  Time (mean ± σ):      4.135 s ±  0.015 s    [User: 59.506 s, System: 5.234 s]
  Range (min … max):    4.105 s …  4.149 s    10 runs

Summary
  After Optimization ran
    1.22 ± 0.02 times faster than Before Optimization
```

The nested decoder is still relatively inefficient, but this is a step in the right direction.