### PR TITLE
docs(rust): Clarify the use of `with_infer_schema_length` in `CsvReadOptions`

### DIFF
--- a/crates/polars-io/src/csv/read/options.rs
+++ b/crates/polars-io/src/csv/read/options.rs
@@ -216,7 +216,7 @@ impl CsvReadOptions {
         self
     }
 
-    /// Number of rows to use for schema inference. Pass [None] to use all rows.
+    /// Number of rows to use for schema inference. Pass [None] to use all rows, pass 0 to read all columns as [`String`]
     pub fn with_infer_schema_length(mut self, infer_schema_length: Option<usize>) -> Self {
         self.infer_schema_length = infer_schema_length;
         self


### PR DESCRIPTION
a possible relevant issue: #10342 