### PR TITLE
feat(python): Enable collection with gpu engine

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -174,7 +174,7 @@ from polars.io import (
     scan_parquet,
     scan_pyarrow_dataset,
 )
-from polars.lazyframe import LazyFrame
+from polars.lazyframe import GPUEngine, LazyFrame
 from polars.meta import (
     build_info,
     get_index_type,
@@ -206,6 +206,8 @@ __all__ = [
     "Expr",
     "LazyFrame",
     "Series",
+    # Engine configuration
+    "GPUEngine",
     # schema
     "Schema",
     # datatypes

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from polars.dependencies import numpy as np
     from polars.dependencies import pandas as pd
     from polars.dependencies import pyarrow as pa
+    from polars.lazyframe.engine_config import GPUEngine
     from polars.selectors import _selector_proxy_
 
     if sys.version_info >= (3, 10):
@@ -276,3 +277,6 @@ BooleanMask: TypeAlias = Union[
 ]
 SingleColSelector: TypeAlias = Union[SingleIndexSelector, SingleNameSelector]
 MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, BooleanMask]
+
+# LazyFrame engine selection
+EngineType: TypeAlias = Union[Literal["cpu", "gpu"], "GPUEngine"]

--- a/py-polars/polars/lazyframe/__init__.py
+++ b/py-polars/polars/lazyframe/__init__.py
@@ -1,5 +1,7 @@
+from polars.lazyframe.engine_config import GPUEngine
 from polars.lazyframe.frame import LazyFrame
 
 __all__ = [
+    "GPUEngine",
     "LazyFrame",
 ]

--- a/py-polars/polars/lazyframe/engine_config.py
+++ b/py-polars/polars/lazyframe/engine_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from rmm.mr import DeviceMemoryResource  # type: ignore[import-not-found]
+
+
+class GPUEngine:
+    """
+    Configuration options for the GPU execution engine.
+
+    Use this if you want control over details of the execution.
+
+    Supported options
+
+    - `device`: Select the device to run the query on.
+    - `memory_resource`: Set an RMM memory resource for
+       device-side allocations.
+    """
+
+    device: int | None
+    """Device on which to run query."""
+    memory_resource: DeviceMemoryResource | None
+    """Memory resource to use for device allocations."""
+    config: Mapping[str, Any]
+    """Additional configuration options for the engine."""
+
+    def __init__(
+        self,
+        *,
+        device: int | None = None,
+        memory_resource: Any | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.device = device
+        self.memory_resource = memory_resource
+        self.config = kwargs

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -75,6 +75,9 @@ plot = ["hvplot >= 0.9.1", "polars[pandas]"]
 style = ["great-tables >= 0.8.0"]
 timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
 
+# GPU Engine
+gpu = ["cudf-polars-cu12"]
+
 # All
 all = [
   "polars[async,cloudpickle,database,deltalake,excel,fsspec,graph,iceberg,numpy,pandas,plot,pyarrow,pydantic,style,timezone]",

--- a/py-polars/tests/unit/lazyframe/test_engine_selection.py
+++ b/py-polars/tests/unit/lazyframe/test_engine_selection.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from polars._typing import EngineType
+
+
+@pytest.fixture()
+def df() -> pl.LazyFrame:
+    return pl.LazyFrame({"a": [1, 2, 3]})
+
+
+@pytest.fixture(params=["gpu", pl.GPUEngine()])
+def engine(request: pytest.FixtureRequest) -> EngineType:
+    value: EngineType = request.param
+    return value
+
+
+def test_engine_selection_invalid_raises(df: pl.LazyFrame) -> None:
+    with pytest.raises(ValueError):
+        df.collect(engine="unknown")  # type: ignore[call-overload]
+
+
+def test_engine_selection_streaming_warns(df: pl.LazyFrame, engine: EngineType) -> None:
+    expect = df.collect()
+    with pytest.warns(
+        UserWarning, match="GPU engine does not support streaming or background"
+    ):
+        got = df.collect(engine=engine, streaming=True)
+        assert_frame_equal(expect, got)
+
+
+def test_engine_selection_background_warns(
+    df: pl.LazyFrame, engine: EngineType
+) -> None:
+    expect = df.collect()
+    with pytest.warns(
+        UserWarning, match="GPU engine does not support streaming or background"
+    ):
+        got = df.collect(engine=engine, background=True)
+        assert_frame_equal(expect, got.fetch_blocking())
+
+
+def test_engine_selection_eager_quiet(df: pl.LazyFrame, engine: EngineType) -> None:
+    expect = df.collect()
+    # _eager collection turns off GPU engine quietly
+    got = df.collect(engine=engine, _eager=True)
+    assert_frame_equal(expect, got)
+
+
+def test_engine_import_error_raises(df: pl.LazyFrame, engine: EngineType) -> None:
+    with pytest.raises(ImportError, match="GPU engine requested"):
+        df.collect(engine=engine)


### PR DESCRIPTION
Introduce option to collect a query using the cudf_polars gpu engine. By default this falls back transparently to the default cpu engine if the query cannot be executed. This can be controlled by setting POLARS_GPU_DISABLE_FALLBACK (mostly useful for testing/debugging).

The import of cudf_polars is currently quite expensive (will improve in the coming months), so since we lazy-load the gpu engine, the first query executed on gpu will pay this (one-time) cost.