### PR TITLE
feat: Add option to include file path for Parquet, IPC, CSV scans

### DIFF
--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -18,6 +18,7 @@ pub struct LazyCsvReader {
     cache: bool,
     read_options: CsvReadOptions,
     cloud_options: Option<CloudOptions>,
+    include_file_paths: Option<Arc<str>>,
 }
 
 #[cfg(feature = "csv")]
@@ -39,6 +40,7 @@ impl LazyCsvReader {
             cache: true,
             read_options: Default::default(),
             cloud_options: Default::default(),
+            include_file_paths: None,
         }
     }
 
@@ -258,6 +260,11 @@ impl LazyCsvReader {
 
         Ok(self.with_schema(Some(Arc::new(schema))))
     }
+
+    pub fn with_include_file_paths(mut self, include_file_paths: Option<Arc<str>>) -> Self {
+        self.include_file_paths = include_file_paths;
+        self
+    }
 }
 
 impl LazyFileListReader for LazyCsvReader {
@@ -269,6 +276,7 @@ impl LazyFileListReader for LazyCsvReader {
             self.cache,
             self.cloud_options,
             self.glob,
+            self.include_file_paths,
         )?
         .build()
         .into();

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -16,6 +16,7 @@ pub struct ScanArgsIpc {
     pub memory_map: bool,
     pub cloud_options: Option<CloudOptions>,
     pub hive_options: HiveOptions,
+    pub include_file_paths: Option<Arc<str>>,
 }
 
 impl Default for ScanArgsIpc {
@@ -28,6 +29,7 @@ impl Default for ScanArgsIpc {
             memory_map: true,
             cloud_options: Default::default(),
             hive_options: Default::default(),
+            include_file_paths: None,
         }
     }
 }
@@ -65,6 +67,7 @@ impl LazyFileListReader for LazyIpcReader {
             args.rechunk,
             args.cloud_options,
             args.hive_options,
+            args.include_file_paths,
         )?
         .build()
         .into();

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -107,6 +107,7 @@ impl LazyFileListReader for LazyJsonLineReader {
             file_counter: 0,
             hive_options: Default::default(),
             glob: true,
+            include_file_paths: None,
         };
 
         let options = NDJsonReadOptions {
@@ -140,6 +141,7 @@ impl LazyFileListReader for LazyJsonLineReader {
             file_counter: 0,
             hive_options: Default::default(),
             glob: false,
+            include_file_paths: None,
         };
 
         let options = NDJsonReadOptions {

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -20,6 +20,7 @@ pub struct ScanArgsParquet {
     pub cache: bool,
     /// Expand path given via globbing rules.
     pub glob: bool,
+    pub include_file_paths: Option<Arc<str>>,
 }
 
 impl Default for ScanArgsParquet {
@@ -35,6 +36,7 @@ impl Default for ScanArgsParquet {
             low_memory: false,
             cache: true,
             glob: true,
+            include_file_paths: None,
         }
     }
 }
@@ -71,6 +73,7 @@ impl LazyFileListReader for LazyParquetReader {
             self.args.use_statistics,
             self.args.hive_options,
             self.args.glob,
+            self.args.include_file_paths,
         )?
         .build()
         .into();

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -420,6 +420,7 @@ fn test_ipc_globbing() -> PolarsResult<()> {
             memory_map: true,
             cloud_options: None,
             hive_options: Default::default(),
+            include_file_paths: None,
         },
     )?
     .collect()?;

--- a/crates/polars-mem-engine/src/executors/scan/ipc.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ipc.rs
@@ -80,6 +80,12 @@ impl IpcExec {
                         .as_ref()
                         .map(|x| x[path_index].materialize_partition_columns()),
                 )
+                .with_include_file_path(self.file_options.include_file_paths.as_ref().map(|x| {
+                    (
+                        x.clone(),
+                        Arc::from(self.paths[path_index].to_str().unwrap().to_string()),
+                    )
+                }))
                 .memory_mapped(
                     self.options
                         .memory_map

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -132,6 +132,12 @@ impl ParquetSource {
                 .with_predicate(predicate.clone())
                 .use_statistics(options.use_statistics)
                 .with_hive_partition_columns(hive_partitions)
+                .with_include_file_path(
+                    self.file_options
+                        .include_file_paths
+                        .as_ref()
+                        .map(|x| (x.clone(), Arc::from(path.to_str().unwrap()))),
+                )
                 .batched(chunk_size)?
         };
         self.finish_init_reader(batched_reader)?;
@@ -171,6 +177,12 @@ impl ParquetSource {
                 .with_predicate(predicate.clone())
                 .use_statistics(options.use_statistics)
                 .with_hive_partition_columns(hive_partitions)
+                .with_include_file_path(
+                    self.file_options
+                        .include_file_paths
+                        .as_ref()
+                        .map(|x| (x.clone(), Arc::from(path.to_str().unwrap()))),
+                )
                 .batched(chunk_size)
                 .await?
         };

--- a/crates/polars-plan/src/plans/builder_dsl.rs
+++ b/crates/polars-plan/src/plans/builder_dsl.rs
@@ -52,6 +52,7 @@ impl DslBuilder {
                 ..Default::default()
             },
             glob: false,
+            include_file_paths: None,
         };
 
         Ok(DslPlan::Scan {
@@ -85,6 +86,7 @@ impl DslBuilder {
         use_statistics: bool,
         hive_options: HiveOptions,
         glob: bool,
+        include_file_paths: Option<Arc<str>>,
     ) -> PolarsResult<Self> {
         let paths = paths.into();
 
@@ -97,6 +99,7 @@ impl DslBuilder {
             file_counter: Default::default(),
             hive_options,
             glob,
+            include_file_paths,
         };
         Ok(DslPlan::Scan {
             paths,
@@ -128,6 +131,7 @@ impl DslBuilder {
         rechunk: bool,
         cloud_options: Option<CloudOptions>,
         hive_options: HiveOptions,
+        include_file_paths: Option<Arc<str>>,
     ) -> PolarsResult<Self> {
         let paths = paths.into();
 
@@ -144,6 +148,7 @@ impl DslBuilder {
                 file_counter: Default::default(),
                 hive_options,
                 glob: true,
+                include_file_paths,
             },
             predicate: None,
             scan_type: FileScan::Ipc {
@@ -163,6 +168,7 @@ impl DslBuilder {
         cache: bool,
         cloud_options: Option<CloudOptions>,
         glob: bool,
+        include_file_paths: Option<Arc<str>>,
     ) -> PolarsResult<Self> {
         let paths = paths.into();
 
@@ -182,6 +188,7 @@ impl DslBuilder {
                 ..Default::default()
             },
             glob,
+            include_file_paths,
         };
         Ok(DslPlan::Scan {
             paths,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -193,6 +193,23 @@ pub fn to_alp_impl(
                 file_info.update_schema_with_hive_schema(hive_schema.clone());
             }
 
+            if let Some(ref file_path_col) = file_options.include_file_paths {
+                let schema = Arc::make_mut(&mut file_info.schema);
+
+                if schema.contains(file_path_col) {
+                    polars_bail!(
+                        Duplicate: r#"column name for file paths "{}" conflicts with column name from file"#,
+                        file_path_col
+                    );
+                }
+
+                schema.insert_at_index(
+                    schema.len(),
+                    file_path_col.as_ref().into(),
+                    DataType::String,
+                )?;
+            }
+
             file_options.with_columns = if file_info.reader_schema.is_some() {
                 maybe_init_projection_excluding_hive(
                     file_info.reader_schema.as_ref().unwrap(),

--- a/crates/polars-plan/src/plans/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cache_states.rs
@@ -121,7 +121,7 @@ pub(super) fn set_cache_states(
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
     scratch: &mut Vec<Node>,
-    hive_partition_eval: HiveEval<'_>,
+    expr_eval: ExprEval<'_>,
     verbose: bool,
 ) -> PolarsResult<()> {
     let mut stack = Vec::with_capacity(4);
@@ -294,7 +294,7 @@ pub(super) fn set_cache_states(
     // back to the cache node again
     if !cache_schema_and_children.is_empty() {
         let mut proj_pd = ProjectionPushDown::new();
-        let pred_pd = PredicatePushDown::new(hive_partition_eval).block_at_cache(false);
+        let pred_pd = PredicatePushDown::new(expr_eval).block_at_cache(false);
         for (_cache_id, v) in cache_schema_and_children {
             // # CHECK IF WE NEED TO REMOVE CACHES
             // If we encounter multiple predicates we remove the cache nodes completely as we don't

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -35,6 +35,7 @@ pub struct FileScanOptions {
     pub file_counter: FileCount,
     pub hive_options: HiveOptions,
     pub glob: bool,
+    pub include_file_paths: Option<Arc<str>>,
 }
 
 #[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -936,6 +936,7 @@ def scan_csv(
     storage_options: dict[str, Any] | None = None,
     retries: int = 2,
     file_cache_ttl: int | None = None,
+    include_file_paths: str | None = None,
 ) -> LazyFrame:
     r"""
     Lazily read from a CSV file or multiple files via glob patterns.
@@ -1052,6 +1053,8 @@ def scan_csv(
         Amount of time to keep downloaded cloud files since their last access time,
         in seconds. Uses the `POLARS_FILE_CACHE_TTL` environment variable
         (which defaults to 1 hour) if not given.
+    include_file_paths
+        Include the path of the source file(s) as a column with this name.
 
     Returns
     -------
@@ -1177,6 +1180,7 @@ def scan_csv(
         retries=retries,
         storage_options=storage_options,
         file_cache_ttl=file_cache_ttl,
+        include_file_paths=include_file_paths,
     )
 
 
@@ -1212,6 +1216,7 @@ def _scan_csv_impl(
     storage_options: dict[str, Any] | None = None,
     retries: int = 2,
     file_cache_ttl: int | None = None,
+    include_file_paths: str | None = None,
 ) -> LazyFrame:
     dtype_list: list[tuple[str, PolarsDataType]] | None = None
     if schema_overrides is not None:
@@ -1263,5 +1268,6 @@ def _scan_csv_impl(
         cloud_options=storage_options,
         retries=retries,
         file_cache_ttl=file_cache_ttl,
+        include_file_paths=include_file_paths,
     )
     return wrap_ldf(pylf)

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -316,6 +316,7 @@ def scan_ipc(
     hive_partitioning: bool | None = None,
     hive_schema: SchemaDict | None = None,
     try_parse_hive_dates: bool = True,
+    include_file_paths: str | None = None,
 ) -> LazyFrame:
     """
     Lazily read from an Arrow IPC (Feather v2) file or multiple files via glob patterns.
@@ -374,6 +375,8 @@ def scan_ipc(
             at any point without it being considered a breaking change.
     try_parse_hive_dates
         Whether to try parsing hive values as date/datetime types.
+    include_file_paths
+        Include the path of the source file(s) as a column with this name.
     """
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source, check_not_directory=False)
@@ -398,5 +401,6 @@ def scan_ipc(
         hive_partitioning=hive_partitioning,
         hive_schema=hive_schema,
         try_parse_hive_dates=try_parse_hive_dates,
+        include_file_paths=include_file_paths,
     )
     return wrap_ldf(pylf)

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -192,6 +192,7 @@ def read_parquet(
         storage_options=storage_options,
         retries=retries,
         glob=glob,
+        include_file_paths=None,
     )
 
     if columns is not None:
@@ -304,6 +305,7 @@ def scan_parquet(
     cache: bool = True,
     storage_options: dict[str, Any] | None = None,
     retries: int = 2,
+    include_file_paths: str | None = None,
 ) -> LazyFrame:
     """
     Lazily read from a local or cloud-hosted parquet file (or files).
@@ -364,6 +366,8 @@ def scan_parquet(
         from environment variables.
     retries
         Number of retries if accessing a cloud instance fails.
+    include_file_paths
+        Include the path of the source file(s) as a column with this name.
 
     See Also
     --------
@@ -414,6 +418,7 @@ def scan_parquet(
         try_parse_hive_dates=try_parse_hive_dates,
         retries=retries,
         glob=glob,
+        include_file_paths=include_file_paths,
     )
 
 
@@ -434,6 +439,7 @@ def _scan_parquet_impl(
     hive_schema: SchemaDict | None = None,
     try_parse_hive_dates: bool = True,
     retries: int = 2,
+    include_file_paths: str | None = None,
 ) -> LazyFrame:
     if isinstance(source, list):
         sources = source
@@ -463,5 +469,6 @@ def _scan_parquet_impl(
         try_parse_hive_dates=try_parse_hive_dates,
         retries=retries,
         glob=glob,
+        include_file_paths=include_file_paths,
     )
     return wrap_ldf(pylf)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/10481

This introduces an `include_file_paths` parameter, which accepts a column name to use for the column storing the file path.

```python
pl.scan_csv(
    ["https://j.mp/iriscsv", ".env/iris.csv"], include_file_paths="path"
).collect()
shape: (300, 6)
┌──────────────┬─────────────┬──────────────┬─────────────┬───────────┬─────────────────────────────────┐
│ sepal_length ┆ sepal_width ┆ petal_length ┆ petal_width ┆ species   ┆ path                            │
│ ---          ┆ ---         ┆ ---          ┆ ---         ┆ ---       ┆ ---                             │
│ f64          ┆ f64         ┆ f64          ┆ f64         ┆ str       ┆ str                             │
╞══════════════╪═════════════╪══════════════╪═════════════╪═══════════╪═════════════════════════════════╡
│ 5.1          ┆ 3.5         ┆ 1.4          ┆ 0.2         ┆ setosa    ┆ https://j.mp/iriscsv            │
│ 4.9          ┆ 3.0         ┆ 1.4          ┆ 0.2         ┆ setosa    ┆ https://j.mp/iriscsv            │
│ 4.7          ┆ 3.2         ┆ 1.3          ┆ 0.2         ┆ setosa    ┆ https://j.mp/iriscsv            │
│ 4.6          ┆ 3.1         ┆ 1.5          ┆ 0.2         ┆ setosa    ┆ https://j.mp/iriscsv            │
│ 5.0          ┆ 3.6         ┆ 1.4          ┆ 0.2         ┆ setosa    ┆ https://j.mp/iriscsv            │
│ …            ┆ …           ┆ …            ┆ …           ┆ …         ┆ …                               │
│ 6.7          ┆ 3.0         ┆ 5.2          ┆ 2.3         ┆ virginica ┆ file:////Users/nxs/git/polars/… │
│ 6.3          ┆ 2.5         ┆ 5.0          ┆ 1.9         ┆ virginica ┆ file:////Users/nxs/git/polars/… │
│ 6.5          ┆ 3.0         ┆ 5.2          ┆ 2.0         ┆ virginica ┆ file:////Users/nxs/git/polars/… │
│ 6.2          ┆ 3.4         ┆ 5.4          ┆ 2.3         ┆ virginica ┆ file:////Users/nxs/git/polars/… │
│ 5.9          ┆ 3.0         ┆ 5.1          ┆ 1.8         ┆ virginica ┆ file:////Users/nxs/git/polars/… │
└──────────────┴─────────────┴──────────────┴─────────────┴───────────┴─────────────────────────────────┘
```