### PR TITLE
refactor(rust): Smaller filter / valid in Parquet

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
@@ -1,0 +1,85 @@
+use super::PageState;
+use crate::parquet::error::ParquetResult;
+use crate::parquet::indexes::Interval;
+use crate::parquet::page::DataPage;
+
+#[derive(Debug)]
+pub(crate) struct Filter<'a> {
+    selected_rows: &'a [Interval],
+
+    /// Index of the [`Interval`] that is >= `current_index`
+    current_interval: usize,
+    /// Global offset
+    current_index: usize,
+}
+
+pub(crate) trait SkipInPlace {
+    fn skip_in_place(&mut self, n: usize) -> ParquetResult<()>;
+}
+
+impl<'a> Filter<'a> {
+    pub fn new(page: &'a DataPage) -> Option<Self> {
+        let selected_rows = page.selected_rows()?;
+
+        Some(Self {
+            selected_rows,
+            current_interval: 0,
+            current_index: 0,
+        })
+    }
+}
+
+pub(crate) fn extend_from_state_with_opt_filter<
+    'a,
+    S: PageState<'a> + SkipInPlace,
+    F: FnMut(&mut S, usize) -> ParquetResult<()>,
+>(
+    state: &mut S,
+    filter: &mut Option<Filter>,
+    remaining: usize,
+    mut collect_fn: F,
+) -> ParquetResult<()> {
+    match filter {
+        None => collect_fn(state, remaining),
+        Some(filter) => {
+            let mut n = remaining;
+            while n > 0 && state.len() > 0 {
+                // Skip over all intervals that we have already passed or that are length == 0.
+                while filter
+                    .selected_rows
+                    .get(filter.current_interval)
+                    .is_some_and(|iv| {
+                        iv.length == 0 || iv.start + iv.length <= filter.current_index
+                    })
+                {
+                    filter.current_interval += 1;
+                }
+
+                let Some(iv) = filter.selected_rows.get(filter.current_interval) else {
+                    state.skip_in_place(state.len())?;
+                    return Ok(());
+                };
+
+                // Move to at least the start of the interval
+                if filter.current_index < iv.start {
+                    state.skip_in_place(iv.start - filter.current_index)?;
+                    filter.current_index = iv.start;
+                }
+
+                let n_this_round = usize::min(iv.start + iv.length - filter.current_index, n);
+
+                collect_fn(state, n_this_round)?;
+
+                let iv = &filter.selected_rows[filter.current_interval];
+                filter.current_index += n_this_round;
+                if filter.current_index >= iv.start + iv.length {
+                    filter.current_interval += 1;
+                }
+
+                n -= n_this_round;
+            }
+
+            Ok(())
+        },
+    }
+}

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 
+pub(crate) mod filter;
+
 use arrow::array::{BinaryArray, MutableBinaryViewArray, View};
 use arrow::bitmap::utils::BitmapIter;
 use arrow::bitmap::MutableBitmap;
@@ -246,7 +248,7 @@ impl<'a> OptionalPageValidity<'a> {
                 .unwrap_or_default()
     }
 
-    fn next_limited(&mut self, limit: usize) -> Option<FilteredHybridEncoded<'a>> {
+    pub fn next_limited(&mut self, limit: usize) -> Option<FilteredHybridEncoded<'a>> {
         let (run, offset) = if let Some((run, offset)) = self.current {
             (run, offset)
         } else {

--- a/crates/polars-parquet/src/parquet/deserialize/filtered_rle.rs
+++ b/crates/polars-parquet/src/parquet/deserialize/filtered_rle.rs
@@ -43,6 +43,25 @@ impl<'a> FilteredHybridEncoded<'a> {
         }
     }
 
+    #[inline]
+    pub fn count_ones(self) -> usize {
+        match self {
+            FilteredHybridEncoded::Bitmap {
+                values,
+                offset,
+                length,
+            } => is_set_count(values, offset, length),
+            FilteredHybridEncoded::Repeated { is_set, length } => {
+                if is_set {
+                    length
+                } else {
+                    0
+                }
+            },
+            FilteredHybridEncoded::Skipped(_) => 0,
+        }
+    }
+
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0


### PR DESCRIPTION
This PR removes a lot of the crazy stuff that was being done in the Parquet reader for primitive decoding. This should also make it quite easy to add `Filter` to other decoders.