### PR TITLE
fix: Method dt.truncate was sometimes returning incorrect results for pre-1970 datetimes

### DIFF
--- a/crates/polars-time/src/truncate.rs
+++ b/crates/polars-time/src/truncate.rs
@@ -37,7 +37,7 @@ impl PolarsTruncate for DatetimeChunked {
                     return Ok(self
                         .apply_values(|t| {
                             let remainder = t % every;
-                            t - remainder + every * (remainder < 0) as i64
+                            t - (remainder + every * (remainder < 0) as i64)
                         })
                         .into_datetime(self.time_unit(), time_zone.clone()));
                 } else {

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -270,9 +270,8 @@ class ExprDateTimeNameSpace:
         │ 2001-01-01 01:00:00 ┆ 2001-01-01 01:00:00 │
         └─────────────────────┴─────────────────────┘
         """
-        if not isinstance(every, pl.Expr):
+        if isinstance(every, dt.timedelta):
             every = parse_as_duration_string(every)
-
         every = parse_into_expression(every, str_as_lit=True)
         return wrap_expr(self._pyexpr.dt_truncate(every))
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1642,7 +1642,7 @@ class DateTimeNameSpace:
         ]
         """
 
-    def truncate(self, every: str | dt.timedelta | Expr) -> Series:
+    def truncate(self, every: str | dt.timedelta | IntoExprColumn) -> Series:
         """
         Divide the date/ datetime range into buckets.
 


### PR DESCRIPTION
closes #17581