### PR TITLE
fix: Bitmap collect into safety

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1088,12 +1088,27 @@ def test_hybrid_rle() -> None:
 )
 @given(
     df=dataframes(
-        include_dtypes=[pl.List, pl.Array, pl.Int8, pl.Struct],
-        min_size=90,
-        max_size=110,
+        allowed_dtypes=[
+            pl.List,
+            pl.Array,
+            pl.Int8,
+            pl.UInt8,
+            pl.UInt32,
+            pl.Int64,
+            pl.Date,
+            pl.Time,
+            pl.Binary,
+            pl.Float32,
+            pl.Float64,
+            pl.String,
+            pl.Boolean,
+        ],
+        min_size=1,
+        max_size=5000,
     )
 )
 @pytest.mark.slow()
+@pytest.mark.write_disk()
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_roundtrip_parametric(df: pl.DataFrame, tmp_path: Path) -> None:
     # delete if exists
@@ -1102,7 +1117,7 @@ def test_roundtrip_parametric(df: pl.DataFrame, tmp_path: Path) -> None:
     df.write_parquet(path)
     result = pl.read_parquet(path)
 
-    assert str(df) == str(result)
+    assert_frame_equal(df, result)
 
 
 def test_parquet_statistics_uint64_16683() -> None:


### PR DESCRIPTION
Fixes #17579.

This fixes a regression in #17542. This now properly checks the safety within the `BitmapIter::collect_n_into`. This was sloppy on my end and it is now much better tested.