### PR TITLE
refactor: Completely redo structure of Parquet decoder

### DIFF
--- a/crates/polars-arrow/src/compute/concatenate.rs
+++ b/crates/polars-arrow/src/compute/concatenate.rs
@@ -19,7 +19,7 @@ use crate::array::growable::make_growable;
 use crate::array::Array;
 use crate::bitmap::{Bitmap, MutableBitmap};
 
-/// Concatenate multiple [Array] of the same type into a single [`Array`].
+/// Concatenate multiple [`Array`] of the same type into a single [`Array`].
 pub fn concatenate(arrays: &[&dyn Array]) -> PolarsResult<Box<dyn Array>> {
     if arrays.is_empty() {
         polars_bail!(InvalidOperation: "concat requires input of at least one array")

--- a/crates/polars-arrow/src/offset.rs
+++ b/crates/polars-arrow/src/offset.rs
@@ -148,6 +148,20 @@ impl<O: Offset> Offsets<O> {
     /// This is safe iff the invariants of this struct are guaranteed in `offsets`.
     #[inline]
     pub unsafe fn new_unchecked(offsets: Vec<O>) -> Self {
+        #[cfg(debug_assertions)]
+        {
+            let mut prev_offset = O::default();
+            let mut is_monotonely_increasing = true;
+            for offset in &offsets {
+                is_monotonely_increasing &= *offset >= prev_offset;
+                prev_offset = *offset;
+            }
+            assert!(
+                is_monotonely_increasing,
+                "Unsafe precondition violated. Invariant of offsets broken."
+            );
+        }
+
         Self(offsets)
     }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
@@ -8,141 +8,129 @@ use polars_error::PolarsResult;
 use polars_utils::iter::FallibleIterator;
 
 use super::super::utils::{
-    dict_indices_decoder, extend_from_decoder, get_selected_rows, next, not_implemented,
-    DecodedState, Decoder, FilteredOptionalPageValidity, MaybeNext, OptionalPageValidity,
-    PageState,
+    dict_indices_decoder, extend_from_decoder, next, not_implemented, DecodedState, Decoder,
+    MaybeNext,
 };
 use super::super::PagesIter;
 use super::utils::FixedSizeBinary;
-use crate::parquet::deserialize::SliceFilteredIter;
-use crate::parquet::encoding::{hybrid_rle, Encoding};
+use crate::parquet::encoding::hybrid_rle::HybridRleDecoder;
+use crate::parquet::encoding::Encoding;
+use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::page::{split_buffer, DataPage, DictPage};
-use crate::read::deserialize::utils;
+use crate::read::deserialize::utils::filter::Filter;
+use crate::read::deserialize::utils::{self, PageValidity};
 
-pub(super) type Dict = Vec<u8>;
-
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-pub(super) struct Optional<'a> {
-    pub(super) values: std::slice::ChunksExact<'a, u8>,
-    pub(super) validity: OptionalPageValidity<'a>,
+enum StateTranslation<'a> {
+    Unit(std::slice::ChunksExact<'a, u8>),
+    Dictionary(HybridRleDecoder<'a>, &'a [u8]),
 }
 
-impl<'a> Optional<'a> {
-    pub(super) fn try_new(page: &'a DataPage, size: usize) -> PolarsResult<Self> {
-        let values = split_buffer(page)?.values;
-
-        let values = values.chunks_exact(size);
-
-        Ok(Self {
-            values,
-            validity: OptionalPageValidity::try_new(page)?,
-        })
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct Required<'a> {
-    pub values: std::slice::ChunksExact<'a, u8>,
-}
-
-impl<'a> Required<'a> {
-    pub(super) fn new(page: &'a DataPage, size: usize) -> Self {
-        let values = page.buffer();
-        assert_eq!(values.len() % size, 0);
-        let values = values.chunks_exact(size);
-        Self { values }
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.values.size_hint().0
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct FilteredRequired<'a> {
-    pub values: SliceFilteredIter<std::slice::ChunksExact<'a, u8>>,
-}
-
-impl<'a> FilteredRequired<'a> {
-    fn new(page: &'a DataPage, size: usize) -> Self {
-        let values = page.buffer();
-        assert_eq!(values.len() % size, 0);
-        let values = values.chunks_exact(size);
-
-        let rows = get_selected_rows(page);
-        let values = SliceFilteredIter::new(values, rows);
-
-        Self { values }
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.values.size_hint().0
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct RequiredDictionary<'a> {
-    pub values: hybrid_rle::HybridRleDecoder<'a>,
-    pub dict: &'a Dict,
-}
-
-impl<'a> RequiredDictionary<'a> {
-    pub(super) fn try_new(page: &'a DataPage, dict: &'a Dict) -> PolarsResult<Self> {
-        let values = dict_indices_decoder(page)?;
-
-        Ok(Self { dict, values })
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.values.size_hint().0
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct OptionalDictionary<'a> {
-    pub(super) values: hybrid_rle::HybridRleDecoder<'a>,
-    pub(super) validity: OptionalPageValidity<'a>,
-    pub(super) dict: &'a Dict,
-}
-
-impl<'a> OptionalDictionary<'a> {
-    pub(super) fn try_new(page: &'a DataPage, dict: &'a Dict) -> PolarsResult<Self> {
-        let values = dict_indices_decoder(page)?;
-
-        Ok(Self {
-            values,
-            validity: OptionalPageValidity::try_new(page)?,
-            dict,
-        })
-    }
-}
-
-#[derive(Debug)]
-enum State<'a> {
-    Optional(Optional<'a>),
-    Required(Required<'a>),
-    RequiredDictionary(RequiredDictionary<'a>),
-    OptionalDictionary(OptionalDictionary<'a>),
-    FilteredRequired(FilteredRequired<'a>),
-    FilteredOptional(
-        FilteredOptionalPageValidity<'a>,
-        std::slice::ChunksExact<'a, u8>,
-    ),
-}
-
-impl<'a> PageState<'a> for State<'a> {
-    fn len(&self) -> usize {
-        match self {
-            State::Optional(state) => state.validity.len(),
-            State::Required(state) => state.len(),
-            State::RequiredDictionary(state) => state.len(),
-            State::OptionalDictionary(state) => state.validity.len(),
-            State::FilteredRequired(state) => state.len(),
-            State::FilteredOptional(state, _) => state.len(),
+impl<'a> utils::StateTranslation<'a, BinaryDecoder> for StateTranslation<'a> {
+    fn new(
+        decoder: &BinaryDecoder,
+        page: &'a DataPage,
+        dict: Option<&'a <BinaryDecoder as Decoder>::Dict>,
+        _page_validity: Option<&PageValidity<'a>>,
+        _filter: Option<&Filter<'a>>,
+    ) -> PolarsResult<Self> {
+        match (page.encoding(), dict) {
+            (Encoding::Plain, _) => {
+                let values = split_buffer(page)?.values;
+                if values.len() % decoder.size != 0 {
+                    return Err(ParquetError::oos(format!(
+                        "Fixed size binary data length {} is not divisible by size {}",
+                        values.len(),
+                        decoder.size
+                    ))
+                    .into());
+                }
+                let values = values.chunks_exact(decoder.size);
+                Ok(Self::Unit(values))
+            },
+            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict)) => {
+                let values = dict_indices_decoder(page)?;
+                Ok(Self::Dictionary(values, dict))
+            },
+            _ => Err(not_implemented(page)),
         }
+    }
+
+    fn len_when_not_nullable(&self) -> usize {
+        match self {
+            Self::Unit(v) => v.len(),
+            Self::Dictionary(v, _) => v.len(),
+        }
+    }
+
+    fn skip_in_place(&mut self, n: usize) -> ParquetResult<()> {
+        if n == 0 {
+            return Ok(());
+        }
+
+        match self {
+            Self::Unit(v) => _ = v.nth(n - 1),
+            Self::Dictionary(v, _) => v.skip_in_place(n)?,
+        }
+
+        Ok(())
+    }
+
+    fn extend_from_state(
+        &mut self,
+        decoder: &BinaryDecoder,
+        decoded: &mut <BinaryDecoder as Decoder>::DecodedState,
+        page_validity: &mut Option<PageValidity<'a>>,
+        additional: usize,
+    ) -> ParquetResult<()> {
+        let (values, validity) = decoded;
+
+        use StateTranslation as T;
+        match (self, page_validity) {
+            (T::Unit(page_values), None) => {
+                // @TODO: This can be done through a extend
+                for x in page_values.by_ref().take(additional) {
+                    values.push(x)
+                }
+            },
+            (T::Unit(page_values), Some(page_validity)) => extend_from_decoder(
+                validity,
+                page_validity,
+                Some(additional),
+                values,
+                page_values,
+            )?,
+            (T::Dictionary(page_values, dict), None) => {
+                // @TODO: Use Gatherer
+                for x in page_values
+                    .by_ref()
+                    .map(|index| {
+                        let index = index as usize;
+                        &dict[index * decoder.size..(index + 1) * decoder.size]
+                    })
+                    .take(additional)
+                {
+                    values.push(x)
+                }
+                page_values.get_result()?;
+            },
+            (T::Dictionary(page_values, dict), Some(page_validity)) => {
+                extend_from_decoder(
+                    validity,
+                    page_validity,
+                    Some(additional),
+                    values,
+                    page_values.by_ref().map(|index| {
+                        let index = index as usize;
+                        &dict[index * decoder.size..(index + 1) * decoder.size]
+                    }),
+                )?;
+                page_values.get_result()?;
+            },
+        }
+
+        Ok(())
     }
 }
 
@@ -157,117 +145,15 @@ impl DecodedState for (FixedSizeBinary, MutableBitmap) {
 }
 
 impl<'a> Decoder<'a> for BinaryDecoder {
-    type State = State<'a>;
-    type Dict = Dict;
+    type Translation = StateTranslation<'a>;
+    type Dict = Vec<u8>;
     type DecodedState = (FixedSizeBinary, MutableBitmap);
-
-    fn build_state(
-        &self,
-        page: &'a DataPage,
-        dict: Option<&'a Self::Dict>,
-    ) -> PolarsResult<Self::State> {
-        let is_optional = utils::page_is_optional(page);
-        let is_filtered = utils::page_is_filtered(page);
-
-        match (page.encoding(), dict, is_optional, is_filtered) {
-            (Encoding::Plain, _, true, false) => {
-                Ok(State::Optional(Optional::try_new(page, self.size)?))
-            },
-            (Encoding::Plain, _, false, false) => {
-                Ok(State::Required(Required::new(page, self.size)))
-            },
-            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
-                RequiredDictionary::try_new(page, dict).map(State::RequiredDictionary)
-            },
-            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
-                OptionalDictionary::try_new(page, dict).map(State::OptionalDictionary)
-            },
-            (Encoding::Plain, None, false, true) => Ok(State::FilteredRequired(
-                FilteredRequired::new(page, self.size),
-            )),
-            (Encoding::Plain, _, true, true) => {
-                let values = split_buffer(page)?.values;
-
-                Ok(State::FilteredOptional(
-                    FilteredOptionalPageValidity::try_new(page)?,
-                    values.chunks_exact(self.size),
-                ))
-            },
-            _ => Err(not_implemented(page)),
-        }
-    }
 
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState {
         (
             FixedSizeBinary::with_capacity(capacity, self.size),
             MutableBitmap::with_capacity(capacity),
         )
-    }
-
-    fn extend_from_state(
-        &self,
-        state: &mut Self::State,
-        decoded: &mut Self::DecodedState,
-
-        remaining: usize,
-    ) -> PolarsResult<()> {
-        let (values, validity) = decoded;
-        match state {
-            State::Optional(page) => extend_from_decoder(
-                validity,
-                &mut page.validity,
-                Some(remaining),
-                values,
-                &mut page.values,
-            )?,
-            State::Required(page) => {
-                for x in page.values.by_ref().take(remaining) {
-                    values.push(x)
-                }
-            },
-            State::FilteredRequired(page) => {
-                for x in page.values.by_ref().take(remaining) {
-                    values.push(x)
-                }
-            },
-            State::OptionalDictionary(page) => {
-                extend_from_decoder(
-                    validity,
-                    &mut page.validity,
-                    Some(remaining),
-                    values,
-                    &mut page.values.by_ref().map(|index| {
-                        let index = index as usize;
-                        &page.dict[index * self.size..(index + 1) * self.size]
-                    }),
-                )?;
-                page.values.get_result()?;
-            },
-            State::RequiredDictionary(page) => {
-                for x in page
-                    .values
-                    .by_ref()
-                    .map(|index| {
-                        let index = index as usize;
-                        &page.dict[index * self.size..(index + 1) * self.size]
-                    })
-                    .take(remaining)
-                {
-                    values.push(x)
-                }
-                page.values.get_result()?;
-            },
-            State::FilteredOptional(page_validity, page_values) => {
-                extend_from_decoder(
-                    validity,
-                    page_validity,
-                    Some(remaining),
-                    values,
-                    page_values.by_ref(),
-                )?;
-            },
-        }
-        Ok(())
     }
 
     fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {
@@ -288,7 +174,7 @@ pub struct Iter<I: PagesIter> {
     data_type: ArrowDataType,
     size: usize,
     items: VecDeque<(FixedSizeBinary, MutableBitmap)>,
-    dict: Option<Dict>,
+    dict: Option<Vec<u8>>,
     chunk_size: Option<usize>,
     remaining: usize,
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
@@ -7,10 +7,10 @@ use polars_error::PolarsResult;
 
 use super::super::utils::{not_implemented, MaybeNext, PageState};
 use super::utils::FixedSizeBinary;
-use crate::arrow::read::deserialize::fixed_size_binary::basic::{finish, Dict};
+use crate::arrow::read::deserialize::fixed_size_binary::basic::finish;
 use crate::arrow::read::deserialize::nested_utils::{next, NestedDecoder};
 use crate::arrow::read::{InitNested, NestedState, PagesIter};
-use crate::parquet::encoding::hybrid_rle::translator::{SliceDictionaryTranslator, Translator};
+use crate::parquet::encoding::hybrid_rle::gatherer::{SliceDictionaryTranslator, Translator};
 use crate::parquet::encoding::hybrid_rle::HybridRleDecoder;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::error::{ParquetError, ParquetResult};
@@ -52,7 +52,7 @@ struct BinaryDecoder {
 
 impl<'a> NestedDecoder<'a> for BinaryDecoder {
     type State = State<'a>;
-    type Dictionary = Dict;
+    type Dictionary = Vec<u8>;
     type DecodedState = (FixedSizeBinary, MutableBitmap);
 
     fn build_state(
@@ -144,7 +144,7 @@ pub struct NestedIter<I: PagesIter> {
     size: usize,
     init: Vec<InitNested>,
     items: VecDeque<(NestedState, (FixedSizeBinary, MutableBitmap))>,
-    dict: Option<Dict>,
+    dict: Option<Vec<u8>>,
     chunk_size: Option<usize>,
     remaining: usize,
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -204,10 +204,6 @@ impl<'a, 'b, 'c, D: NestedDecoder<'a>> BatchableCollector<(), D::DecodedState>
         self.decoder.push_n_nulls(target, n);
         Ok(())
     }
-
-    fn skip_n(&mut self, _n: usize) -> ParquetResult<()> {
-        unreachable!()
-    }
 }
 
 /// A decoder that knows how to map `State` -> Array

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
@@ -1,20 +1,14 @@
-use super::PageState;
-use crate::parquet::error::ParquetResult;
 use crate::parquet::indexes::Interval;
 use crate::parquet::page::DataPage;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct Filter<'a> {
-    selected_rows: &'a [Interval],
+    pub(super) selected_rows: &'a [Interval],
 
     /// Index of the [`Interval`] that is >= `current_index`
-    current_interval: usize,
+    pub(super) current_interval: usize,
     /// Global offset
-    current_index: usize,
-}
-
-pub(crate) trait SkipInPlace {
-    fn skip_in_place(&mut self, n: usize) -> ParquetResult<()>;
+    pub(super) current_index: usize,
 }
 
 impl<'a> Filter<'a> {
@@ -26,60 +20,5 @@ impl<'a> Filter<'a> {
             current_interval: 0,
             current_index: 0,
         })
-    }
-}
-
-pub(crate) fn extend_from_state_with_opt_filter<
-    'a,
-    S: PageState<'a> + SkipInPlace,
-    F: FnMut(&mut S, usize) -> ParquetResult<()>,
->(
-    state: &mut S,
-    filter: &mut Option<Filter>,
-    remaining: usize,
-    mut collect_fn: F,
-) -> ParquetResult<()> {
-    match filter {
-        None => collect_fn(state, remaining),
-        Some(filter) => {
-            let mut n = remaining;
-            while n > 0 && state.len() > 0 {
-                // Skip over all intervals that we have already passed or that are length == 0.
-                while filter
-                    .selected_rows
-                    .get(filter.current_interval)
-                    .is_some_and(|iv| {
-                        iv.length == 0 || iv.start + iv.length <= filter.current_index
-                    })
-                {
-                    filter.current_interval += 1;
-                }
-
-                let Some(iv) = filter.selected_rows.get(filter.current_interval) else {
-                    state.skip_in_place(state.len())?;
-                    return Ok(());
-                };
-
-                // Move to at least the start of the interval
-                if filter.current_index < iv.start {
-                    state.skip_in_place(iv.start - filter.current_index)?;
-                    filter.current_index = iv.start;
-                }
-
-                let n_this_round = usize::min(iv.start + iv.length - filter.current_index, n);
-
-                collect_fn(state, n_this_round)?;
-
-                let iv = &filter.selected_rows[filter.current_interval];
-                filter.current_index += n_this_round;
-                if filter.current_index >= iv.start + iv.length {
-                    filter.current_interval += 1;
-                }
-
-                n -= n_this_round;
-            }
-
-            Ok(())
-        },
     }
 }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1083,9 +1083,6 @@ def test_hybrid_rle() -> None:
     assert_frame_equal(pl.read_parquet(f), df)
 
 
-@pytest.mark.skip(
-    reason="This test causes too many panics in other parts of the code base"
-)
 @given(
     df=dataframes(
         allowed_dtypes=[
@@ -1095,8 +1092,8 @@ def test_hybrid_rle() -> None:
             pl.UInt8,
             pl.UInt32,
             pl.Int64,
-            pl.Date,
-            pl.Time,
+            # pl.Date, # Turned off because of issue #17599
+            # pl.Time, # Turned off because of issue #17599
             pl.Binary,
             pl.Float32,
             pl.Float64,
@@ -1113,6 +1110,8 @@ def test_hybrid_rle() -> None:
 def test_roundtrip_parametric(df: pl.DataFrame, tmp_path: Path) -> None:
     # delete if exists
     path = tmp_path / "data.parquet"
+
+    print(df)
 
     df.write_parquet(path)
     result = pl.read_parquet(path)


### PR DESCRIPTION
This PR completely redoes the Parquet read/deserialize workings, removing all the combinatorics and trait objects. After this, I want to remove the rest of the iterators and remove even more abstraction layers.