### PR TITLE
fix(python): Don't enforce row order in join test results where not guaranteed

### DIFF
--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -435,7 +435,7 @@ def test_natural_joins_01() -> None:
 
 
 @pytest.mark.parametrize(
-    ("cols_constraint", "expected"),
+    ("cols_constraint", "expect_data"),
     [
         (">= 5", [(8, 8, 6)]),
         ("< 7", [(5, 4, 4)]),
@@ -465,6 +465,4 @@ def test_natural_joins_02(cols_constraint: str, expect_data: list[tuple[int]]) -
     ).collect()
 
     expected = pl.DataFrame(expect_data, schema=actual.columns, orient="row")
-    expected = expected.sort(by=expected.columns)
-    actual = actual.sort(by=actual.columns)
-    assert_frame_equal(actual, expected)
+    assert_frame_equal(actual, expected, check_row_order=False)

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -443,7 +443,7 @@ def test_natural_joins_01() -> None:
         ("!= 4", [(8, 8, 6), (2, 8, 6), (0, 7, 2)]),
     ],
 )
-def test_natural_joins_02(cols_constraint: str, expected: list[tuple[int]]) -> None:
+def test_natural_joins_02(cols_constraint: str, expect_data: list[tuple[int]]) -> None:
     df1 = pl.DataFrame(  # noqa: F841
         {
             "x": [1, 5, 3, 8, 6, 7, 4, 0, 2],
@@ -464,4 +464,7 @@ def test_natural_joins_02(cols_constraint: str, expected: list[tuple[int]]) -> N
         """
     ).collect()
 
-    assert actual.rows() == expected
+    expected = pl.DataFrame(expect_data, schema=actual.columns, orient="row")
+    expected = expected.sort(by=expected.columns)
+    actual = actual.sort(by=actual.columns)
+    assert_frame_equal(actual, expected)

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -188,7 +188,9 @@ def test_streaming_generic_left_and_inner_join_from_disk(tmp_path: Path) -> None
     join_strategies: list[JoinStrategy] = ["left", "inner"]
     for how in join_strategies:
         q = lf0.join(lf1, left_on="id", right_on="id_r", how=how)
-        assert_frame_equal(q.collect(streaming=True), q.collect(streaming=False))
+        assert_frame_equal(
+            q.collect(streaming=True), q.collect(streaming=False), check_row_order=False
+        )
 
 
 def test_streaming_9776() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -191,7 +191,7 @@ def test_streaming_generic_left_and_inner_join_from_disk(tmp_path: Path) -> None
         assert_frame_equal(
             q.collect(streaming=True),
             q.collect(streaming=False),
-            check_row_order=how != "left",
+            check_row_order=how == "left",
         )
 
 

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -189,7 +189,9 @@ def test_streaming_generic_left_and_inner_join_from_disk(tmp_path: Path) -> None
     for how in join_strategies:
         q = lf0.join(lf1, left_on="id", right_on="id_r", how=how)
         assert_frame_equal(
-            q.collect(streaming=True), q.collect(streaming=False), check_row_order=False
+            q.collect(streaming=True),
+            q.collect(streaming=False),
+            check_row_order=how != "left",
         )
 
 

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -47,7 +47,7 @@ def test_streaming_full_outer_joins() -> None:
         )
         a = q.collect(streaming=True)
         b = q.collect(streaming=False)
-        assert_frame_equal(a, b)
+        assert_frame_equal(a, b, check_row_order=False)
 
 
 def test_streaming_joins() -> None:
@@ -167,7 +167,9 @@ def test_join_null_matches(streaming: bool) -> None:
     # Inner
     expected = pl.DataFrame({"idx_a": [2, 1], "a": [2, 1], "idx_b": [1, 2]})
     assert_frame_equal(
-        df_a.join(df_b, on="a", how="inner").collect(streaming=streaming), expected
+        df_a.join(df_b, on="a", how="inner").collect(streaming=streaming),
+        expected,
+        check_row_order=False,
     )
 
     # Left outer
@@ -175,7 +177,9 @@ def test_join_null_matches(streaming: bool) -> None:
         {"idx_a": [0, 1, 2], "a": [None, 1, 2], "idx_b": [None, 2, 1]}
     )
     assert_frame_equal(
-        df_a.join(df_b, on="a", how="left").collect(streaming=streaming), expected
+        df_a.join(df_b, on="a", how="left").collect(streaming=streaming),
+        expected,
+        check_row_order=False,
     )
     # Full outer
     expected = pl.DataFrame(
@@ -186,7 +190,9 @@ def test_join_null_matches(streaming: bool) -> None:
             "a_right": [None, 2, 1, None, None],
         }
     )
-    assert_frame_equal(df_a.join(df_b, on="a", how="full").collect(), expected)
+    assert_frame_equal(
+        df_a.join(df_b, on="a", how="full").collect(), expected, check_row_order=False
+    )
 
 
 @pytest.mark.parametrize("streaming", [False, True])
@@ -217,6 +223,7 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
     assert_frame_equal(
         df_a.join(df_b, on=["a", "idx"], how="left").collect(streaming=streaming),
         expected,
+        check_row_order=False,
     )
 
     expected = pl.DataFrame(
@@ -229,7 +236,9 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
         }
     )
     assert_frame_equal(
-        df_a.join(df_b, on=["a", "idx"], how="full").sort("a").collect(), expected
+        df_a.join(df_b, on=["a", "idx"], how="full").sort("a").collect(),
+        expected,
+        check_row_order=False,
     )
 
 

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -177,9 +177,7 @@ def test_join_null_matches(streaming: bool) -> None:
         {"idx_a": [0, 1, 2], "a": [None, 1, 2], "idx_b": [None, 2, 1]}
     )
     assert_frame_equal(
-        df_a.join(df_b, on="a", how="left").collect(streaming=streaming),
-        expected,
-        check_row_order=False,
+        df_a.join(df_b, on="a", how="left").collect(streaming=streaming), expected
     )
     # Full outer
     expected = pl.DataFrame(

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -221,7 +221,6 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
     assert_frame_equal(
         df_a.join(df_b, on=["a", "idx"], how="left").collect(streaming=streaming),
         expected,
-        check_row_order=False,
     )
 
     expected = pl.DataFrame(


### PR DESCRIPTION
Hi Polars team, while working on the GPU backend I encountered a few join tests that seem to rely on the order of rows returned by the join to pass, where the docs only indicate a particular ordering for left joins. This PR proposes some minor changes to the py-polars test suite that drop this as a pass condition in the places I encountered it. Hopefully I've not missed any obvious ones here, let me know if so. 