### PR TITLE
perf: Cache schema resolve back to DSL

### DIFF
--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
 use polars_core::prelude::*;
 use polars_io::RowIndex;
@@ -123,7 +124,7 @@ impl LazyFileListReader for LazyJsonLineReader {
 
         Ok(LazyFrame::from(DslPlan::Scan {
             paths,
-            file_info: None,
+            file_info: Arc::new(RwLock::new(None)),
             hive_parts: None,
             predicate: None,
             file_options,
@@ -157,7 +158,7 @@ impl LazyFileListReader for LazyJsonLineReader {
 
         Ok(LazyFrame::from(DslPlan::Scan {
             paths: self.paths,
-            file_info: None,
+            file_info: Arc::new(RwLock::new(None)),
             hive_parts: None,
             predicate: None,
             file_options,

--- a/crates/polars-plan/src/plans/builder_dsl.rs
+++ b/crates/polars-plan/src/plans/builder_dsl.rs
@@ -1,3 +1,5 @@
+use std::sync::RwLock;
+
 use polars_core::prelude::*;
 #[cfg(any(feature = "parquet", feature = "ipc", feature = "csv"))]
 use polars_io::cloud::CloudOptions;
@@ -57,7 +59,7 @@ impl DslBuilder {
 
         Ok(DslPlan::Scan {
             paths: Arc::new([]),
-            file_info: Some(file_info),
+            file_info: Arc::new(RwLock::new(Some(file_info))),
             hive_parts: None,
             predicate: None,
             file_options,
@@ -103,7 +105,7 @@ impl DslBuilder {
         };
         Ok(DslPlan::Scan {
             paths,
-            file_info: None,
+            file_info: Arc::new(RwLock::new(None)),
             hive_parts: None,
             predicate: None,
             file_options: options,
@@ -137,7 +139,7 @@ impl DslBuilder {
 
         Ok(DslPlan::Scan {
             paths,
-            file_info: None,
+            file_info: Arc::new(RwLock::new(None)),
             hive_parts: None,
             file_options: FileScanOptions {
                 with_columns: None,
@@ -192,7 +194,7 @@ impl DslBuilder {
         };
         Ok(DslPlan::Scan {
             paths,
-            file_info: None,
+            file_info: Arc::new(RwLock::new(None)),
             hive_parts: None,
             file_options: options,
             predicate: None,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -227,23 +227,23 @@ pub fn to_alp_impl(
                     )?;
                 }
 
-                file_options.with_columns = if resolved_file_info.reader_schema.is_some() {
-                    maybe_init_projection_excluding_hive(
-                        resolved_file_info.reader_schema.as_ref().unwrap(),
-                        hive_parts.as_ref().map(|x| &x[0]),
-                    )
-                } else {
-                    None
-                };
-
-                if let Some(row_index) = &file_options.row_index {
-                    let schema = Arc::make_mut(&mut resolved_file_info.schema);
-                    *schema = schema
-                        .new_inserting_at_index(0, row_index.name.as_ref().into(), IDX_DTYPE)
-                        .unwrap();
-                }
-
                 **lock = Some(resolved_file_info.clone());
+            }
+
+            file_options.with_columns = if resolved_file_info.reader_schema.is_some() {
+                maybe_init_projection_excluding_hive(
+                    resolved_file_info.reader_schema.as_ref().unwrap(),
+                    hive_parts.as_ref().map(|x| &x[0]),
+                )
+            } else {
+                None
+            };
+
+            if let Some(row_index) = &file_options.row_index {
+                let schema = Arc::make_mut(&mut resolved_file_info.schema);
+                *schema = schema
+                    .new_inserting_at_index(0, row_index.name.as_ref().into(), IDX_DTYPE)
+                    .unwrap();
             }
 
             IR::Scan {

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -8,6 +8,7 @@ mod scans;
 mod stack_opt;
 
 use std::borrow::Cow;
+use std::sync::RwLock;
 
 pub use dsl_to_ir::*;
 pub use expr_to_ir::*;
@@ -52,7 +53,7 @@ impl IR {
                 file_options: options,
             } => DslPlan::Scan {
                 paths,
-                file_info: Some(file_info),
+                file_info: Arc::new(RwLock::new(Some(file_info))),
                 hive_parts,
                 predicate: predicate.map(|e| e.to_expr(expr_arena)),
                 scan_type,

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use hive::HivePartitions;
 use polars_core::prelude::*;
@@ -80,7 +80,11 @@ pub enum DslPlan {
     Scan {
         paths: Arc<[PathBuf]>,
         // Option as this is mostly materialized on the IR phase.
-        file_info: Option<FileInfo>,
+        // During conversion we update the value in the DSL as well
+        // This is to cater to use cases where parts of a `LazyFrame`
+        // are used as base of different queries in a loop. That way
+        // the expensive schema resolving is cached.
+        file_info: Arc<RwLock<Option<FileInfo>>>,
         hive_parts: Option<Arc<[HivePartitions]>>,
         predicate: Option<Expr>,
         file_options: FileScanOptions,


### PR DESCRIPTION
This will ensure that a program like this:

```python

inital_q = my_lazy_frame_q...


for expr in my_exprs:
   result = initial_q.filter(expr).collect()
```

Will only resolve the schema of initial_q once. And subsequent loops will have resolved schema.

@stinodego this is similar to the path resolving case.