### PR TITLE
perf(python): Specify tune-cpu & add more features

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -133,10 +133,10 @@ jobs:
         run: |
           if [[ "$IS_LTS_CPU" = true ]]; then
             TUNE_CPU=x86-64-v2
-            FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt
+            FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b
           else
             TUNE_CPU=skylake
-            FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe
+            FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe
           fi
           echo "features=$FEATURES" >> $GITHUB_OUTPUT
           echo "tune_cpu=$TUNE_CPU" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -132,20 +132,22 @@ jobs:
         # IMPORTANT: All features enabled here should also be included in py-polars/polars/_cpu_check.py
         run: |
           if [[ "$IS_LTS_CPU" = true ]]; then
+            TUNE_CPU=x86-64-v2
             FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt
-          elif [[ "$IS_MACOS" = true ]]; then
-            FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma,+pclmulqdq
           else
+            TUNE_CPU=skylake
             FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
           fi
           echo "features=$FEATURES" >> $GITHUB_OUTPUT
+          echo "tune_cpu=$TUNE_CPU" >> $GITHUB_OUTPUT
 
       - name: Set RUSTFLAGS for x86-64
         if: matrix.architecture == 'x86-64'
         env:
           FEATURES: ${{ steps.features.outputs.features }}
+          TUNE_CPU: ${{ steps.features.outputs.tune_cpu }}
           CFG: ${{ matrix.package == 'polars-lts-cpu' && '--cfg allocator="default"' || '' }}
-        run: echo "RUSTFLAGS=-C target-feature=${{ steps.features.outputs.features }} $CFG" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=-C target-feature=$FEATURES -Z tune-cpu=$TUNE_CPU $CFG" >> $GITHUB_ENV
 
       - name: Set variables in CPU check module
         run: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -136,7 +136,7 @@ jobs:
             FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt
           else
             TUNE_CPU=skylake
-            FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq
+            FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe
           fi
           echo "features=$FEATURES" >> $GITHUB_OUTPUT
           echo "tune_cpu=$TUNE_CPU" >> $GITHUB_OUTPUT

--- a/py-polars/polars/_cpu_check.py
+++ b/py-polars/polars/_cpu_check.py
@@ -219,6 +219,7 @@ def _read_cpu_flags() -> dict[str, bool]:
         "sse3": bool(cpuid1.ecx & (1 << 0)),
         "ssse3": bool(cpuid1.ecx & (1 << 9)),
         "fma": bool(cpuid1.ecx & (1 << 12)),
+        "cmpxchg16b": bool(cpuid1.ecx & (1 << 13)),
         "sse4.1": bool(cpuid1.ecx & (1 << 19)),
         "sse4.2": bool(cpuid1.ecx & (1 << 20)),
         "movbe": bool(cpuid1.ecx & (1 << 22)),

--- a/py-polars/polars/_cpu_check.py
+++ b/py-polars/polars/_cpu_check.py
@@ -221,6 +221,7 @@ def _read_cpu_flags() -> dict[str, bool]:
         "fma": bool(cpuid1.ecx & (1 << 12)),
         "sse4.1": bool(cpuid1.ecx & (1 << 19)),
         "sse4.2": bool(cpuid1.ecx & (1 << 20)),
+        "movbe": bool(cpuid1.ecx & (1 << 22)),
         "popcnt": bool(cpuid1.ecx & (1 << 23)),
         "pclmulqdq": bool(cpuid1.ecx & (1 << 1)),
         "avx": bool(cpuid1.ecx & (1 << 28)),


### PR DESCRIPTION
This PR makes use of standard x86 microarhitecture levels[^1] for `target-cpu` instead of manually specified `target-features` when building the release wheels. This brings the following benefits:

- Consistent with the standard: Many Linux distros, e.g. openSUSE[^2] and CachyOS[^3], use x86 microarhitecture levels when compiling optimized versions of packages. Using standard levels better aligns with the downstream packaging.
- Reduce maintain burden: No need to define and update[^4] a list of features. Each level includes all supported features. 
- Performance improvement: Setting `target-cpu` implies `tune-cpu`, while setting `target-features` does not. e.g., `target-cpu=x86-84-v3` enables tuning for those v3 cpu models[^5].

This PR uses:
- `x86-64-v3` for normal release; it includes sse, avx, avx2, etc.
- `x86-64-v2` for lts-cpu release; it includes sse, etc.

Supported CPU models (i.e. compatibility) of either of them is not changed.

The special configuration for macOS is removed. I cannot find a cpu model that support fma but not avx2. Please correct me if I'm wrong.

This PR does not affect `_cpu_check.py`. A list of features is still given to it.

XXX:
- Is it worthy to also set `tune-cpu`? `x86-64-v3` is tuned for a kind of old cpu model (Haswell). We may set `target-cpu` and `tune-cpu` to different values, e.g. `-C target-cpu=x86-64-v3 -Z tune-cpu=skylake`.
- It is not necessary to check every feature in `_cpu_check.py`. e.g. a cpu that has avx also has sse. We can simplify its logic and only check a sentinel feature.

[^1]: https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
[^2]: https://news.opensuse.org/2023/03/02/tw-gains-optional-optimizations
[^3]: https://wiki.cachyos.org/cachyos_repositories/what_are_the_cachyos_repo/#performance-and-optimizations
[^4]: https://github.com/pola-rs/polars/pull/14746
[^5]: https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/X86/X86.td