### PR TITLE
perf: Cache path resolving of `scan` functions

### DIFF
--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -218,7 +218,8 @@ impl LazyCsvReader {
     where
         F: Fn(Schema) -> PolarsResult<Schema>,
     {
-        // TODO: This should be done when converting to the IR
+        // TODO: Path expansion should happen when converting to the IR
+        // https://github.com/pola-rs/polars/issues/17634
         let paths = expand_paths(self.paths(), self.glob(), self.cloud_options())?;
 
         let Some(path) = paths.first() else {

--- a/crates/polars-plan/src/plans/builder_dsl.rs
+++ b/crates/polars-plan/src/plans/builder_dsl.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "csv", feature = "ipc", feature = "parquet"))]
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -463,6 +464,7 @@ impl DslBuilder {
 }
 
 /// Initialize paths as non-expanded.
+#[cfg(any(feature = "csv", feature = "ipc", feature = "parquet"))]
 fn init_paths<P>(paths: P) -> Arc<Mutex<(Arc<[PathBuf]>, bool)>>
 where
     P: Into<Arc<[std::path::PathBuf]>>,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "ipc", feature = "parquet"))]
 use std::path::PathBuf;
 
 use arrow::datatypes::ArrowSchemaRef;
@@ -711,6 +710,7 @@ pub fn to_alp_impl(
 }
 
 /// Expand scan paths if they were not already expanded.
+#[allow(unused_variables)]
 fn expand_scan_paths(
     paths: Arc<Mutex<(Arc<[PathBuf]>, bool)>>,
     scan_type: &mut FileScan,
@@ -738,7 +738,7 @@ fn expand_scan_paths(
         } => expand_paths(&lock.0, file_options.glob, cloud_options.as_ref())?,
         #[cfg(feature = "json")]
         FileScan::NDJson { .. } => expand_paths(&lock.0, file_options.glob, None)?,
-        FileScan::Anonymous { .. } => unreachable!(), // Anonymous scans are already expanded.
+        FileScan::Anonymous { .. } => lock.0.clone(), // Anonymous scans are already expanded.
     };
 
     *lock = (paths_expanded, true);

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -163,7 +163,7 @@ pub fn to_alp_impl(
 
             let hive_parts = if hive_parts.is_some() {
                 hive_parts
-            } else if file_options.hive_options.enabled.unwrap()
+            } else if file_options.hive_options.enabled.unwrap_or(false)
                 && resolved_file_info.reader_schema.is_some()
             {
                 #[allow(unused_assignments)]
@@ -746,6 +746,7 @@ fn expand_scan_paths(
     Ok(lock.0.clone())
 }
 
+/// Expand scan paths and update the Hive partition information of `file_options`.
 #[cfg(any(feature = "ipc", feature = "parquet"))]
 fn expand_scan_paths_with_hive_update(
     paths: &[PathBuf],

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -8,7 +8,7 @@ mod scans;
 mod stack_opt;
 
 use std::borrow::Cow;
-use std::sync::RwLock;
+use std::sync::{Arc, Mutex, RwLock};
 
 pub use dsl_to_ir::*;
 pub use expr_to_ir::*;
@@ -52,7 +52,7 @@ impl IR {
                 output_schema: _,
                 file_options: options,
             } => DslPlan::Scan {
-                paths,
+                paths: Arc::new(Mutex::new((paths, true))),
                 file_info: Arc::new(RwLock::new(Some(file_info))),
                 hive_parts,
                 predicate: predicate.map(|e| e.to_expr(expr_arena)),

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 use hive::HivePartitions;
 use polars_core::prelude::*;
@@ -78,7 +78,7 @@ pub enum DslPlan {
         cache_hits: u32,
     },
     Scan {
-        paths: Arc<[PathBuf]>,
+        paths: Arc<Mutex<(Arc<[PathBuf]>, bool)>>,
         // Option as this is mostly materialized on the IR phase.
         // During conversion we update the value in the DSL as well
         // This is to cater to use cases where parts of a `LazyFrame`

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -425,7 +425,7 @@ c
     assert_frame_equal(out, expect)
 
 
-@pytest.mark.xfail(reason="Bug: https://github.com/pola-rs/polars/issues/17444")
+@pytest.mark.xfail(reason="Bug: https://github.com/pola-rs/polars/issues/17634")
 def test_scan_csv_with_column_names_nonexistent_file() -> None:
     path_str = "my-nonexistent-data.csv"
     path = Path(path_str)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17584

#### Changes

* Update the `DslPlan` after resolving paths. This avoids re-resolving the paths upon repeated `collect` calls on the same LazyFrame.