### PR TITLE
fix(python): Raise for overlapping index/column names in pandas dataframes post string coercion

### DIFF
--- a/py-polars/tests/unit/interop/test_from_pandas.py
+++ b/py-polars/tests/unit/interop/test_from_pandas.py
@@ -15,6 +15,13 @@ if TYPE_CHECKING:
     from polars._typing import PolarsDataType
 
 
+def index_not_silently_excluded() -> None:
+    ddict = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    df = pd.DataFrame(ddict, index=pd.Index([7, 8, 9], name="a"))
+    with pytest.raises(ValueError, match="indices and column names must not overlap"):
+        pl.from_pandas(df, include_index=True)
+
+
 def test_from_pandas() -> None:
     df = pd.DataFrame(
         {
@@ -174,13 +181,19 @@ def test_from_pandas_include_indexes() -> None:
 
 def test_duplicate_cols_diff_types() -> None:
     df = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["0", 0, "1", 1])
-    with pytest.raises(ValueError, match="Polars dataframes must have unique string"):
+    with pytest.raises(
+        ValueError,
+        match="Pandas dataframe contains non-unique indices and/or column names",
+    ):
         pl.from_pandas(df)
 
 
 def test_from_pandas_duplicated_columns() -> None:
     df = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["a", "b", "c", "b"])
-    with pytest.raises(ValueError, match="Polars dataframes must have unique string"):
+    with pytest.raises(
+        ValueError,
+        match="Pandas dataframe contains non-unique indices and/or column names",
+    ):
         pl.from_pandas(df)
 
 


### PR DESCRIPTION
Hi Polars team, this pr does 3 main things. First, it solves for #15938 and #16023 , by checking the stringified index names for overlap w/column names. Second, it solves for duplicated index names, post string conversion. For example, an index of 0 and '0' would not be caught without this explicit check. Third, I combine this logic with the code I wrote for issue #16025 , because I considered this all a part of the same general problem.

I altered some unit tests to include the new error message, two of which I already altered for my pr on #16025 . I wrote/borrowed a new unit test that was written directly from the desired behavior in #15938 .

Let me know if you need anything else. I'd love for any feedback on the code, if there's anything you'd change.

Thank you.