### PR TITLE
perf: Add `ArrayChunks` to optimize codegen of BatchDecoder

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -75,7 +75,7 @@ impl<'a, O: Offset> StateTranslation<'a, BinaryDecoder<O>> for BinaryStateTransl
                 values,
                 page_values,
             )?,
-            (T::Dictionary(page), None) => {
+            (T::Dictionary(page, _), None) => {
                 // Already done on the dict.
                 validate_utf8 = false;
                 let page_dict = &page.dict;
@@ -90,7 +90,7 @@ impl<'a, O: Offset> StateTranslation<'a, BinaryDecoder<O>> for BinaryStateTransl
                 }
                 page.values.get_result()?;
             },
-            (T::Dictionary(page), Some(page_validity)) => {
+            (T::Dictionary(page, _), Some(page_validity)) => {
                 // Already done on the dict.
                 validate_utf8 = false;
                 let page_dict = &page.dict;

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
@@ -69,13 +69,13 @@ impl<'a> StateTranslation<'a, BinViewDecoder> for BinaryStateTranslation<'a> {
                 values,
                 page_values,
             )?,
-            (Self::Dictionary(page), None) => {
+            (Self::Dictionary(page, views_dict), None) => {
                 // Already done on the dict.
                 validate_utf8 = false;
 
-                let page_dict = &page.dict;
-                let views_dict = binary_views_dict(values, page_dict);
-                let translator = DictionaryTranslator(&views_dict);
+                let views_dict =
+                    views_dict.get_or_insert_with(|| binary_views_dict(values, page.dict));
+                let translator = DictionaryTranslator(views_dict);
 
                 page.values.translate_and_collect_n_into(
                     values.views_mut(),
@@ -86,13 +86,13 @@ impl<'a> StateTranslation<'a, BinViewDecoder> for BinaryStateTranslation<'a> {
                     validity.extend_constant(additional, true);
                 }
             },
-            (Self::Dictionary(page), Some(page_validity)) => {
+            (Self::Dictionary(page, views_dict), Some(page_validity)) => {
                 // Already done on the dict.
                 validate_utf8 = false;
 
-                let page_dict = &page.dict;
-                let views_dict = binary_views_dict(values, page_dict);
-                let translator = DictionaryTranslator(&views_dict);
+                let views_dict =
+                    views_dict.get_or_insert_with(|| binary_views_dict(values, page.dict));
+                let translator = DictionaryTranslator(views_dict);
                 let collector = TranslatedHybridRle::new(&mut page.values, &translator);
 
                 extend_from_decoder(validity, page_validity, Some(additional), values, collector)?;

--- a/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
@@ -1,4 +1,20 @@
 //! APIs to read from Parquet format.
+
+macro_rules! decoder_fn {
+    (($x:ident $(, $field:ident:$ty:ty)* $(,)?) => <$p:ty, $t:ty> => $expr:expr) => {{
+        #[derive(Clone, Copy)]
+        struct DecoderFn($($ty),*);
+        impl crate::arrow::read::deserialize::primitive::DecoderFunction<$p, $t> for DecoderFn {
+            #[inline(always)]
+            fn decode(self, $x: $p) -> $t {
+                let Self($($field),*) = self;
+                $expr
+            }
+        }
+        DecoderFn($($field),*)
+    }};
+}
+
 mod binary;
 mod binview;
 mod boolean;

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -13,28 +13,9 @@ use crate::parquet::encoding::{byte_stream_split, hybrid_rle, Encoding};
 use crate::parquet::error::ParquetResult;
 use crate::parquet::page::{split_buffer, DataPage, DictPage};
 use crate::parquet::types::{decode, NativeType as ParquetNativeType};
+use crate::read::deserialize::utils::array_chunks::ArrayChunks;
 use crate::read::deserialize::utils::filter::Filter;
-use crate::read::deserialize::utils::{PageValidity, TranslatedHybridRle};
-
-#[derive(Debug)]
-pub(super) struct Values<'a> {
-    pub values: std::slice::ChunksExact<'a, u8>,
-}
-
-impl<'a> Values<'a> {
-    pub fn try_new<P: ParquetNativeType>(page: &'a DataPage) -> PolarsResult<Self> {
-        let values = split_buffer(page)?.values;
-        assert_eq!(values.len() % std::mem::size_of::<P>(), 0);
-        Ok(Self {
-            values: values.chunks_exact(std::mem::size_of::<P>()),
-        })
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.values.size_hint().0
-    }
-}
+use crate::read::deserialize::utils::{BatchableCollector, PageValidity, TranslatedHybridRle};
 
 #[derive(Debug)]
 pub(super) struct ValuesDictionary<'a, T: NativeType> {
@@ -55,24 +36,129 @@ impl<'a, T: NativeType> ValuesDictionary<'a, T> {
     }
 }
 
+/// A function that defines how to decode from the
+/// [`parquet::types::NativeType`][ParquetNativeType] to the [`arrow::types::NativeType`].
+///
+/// This should almost always be inlined.
+pub(crate) trait DecoderFunction<P, T>: Copy
+where
+    T: NativeType,
+    P: ParquetNativeType,
+{
+    fn decode(self, x: P) -> T;
+}
+
+#[derive(Default, Clone, Copy)]
+pub(crate) struct IntoDecoderFunction<P, T>(std::marker::PhantomData<(P, T)>);
+impl<P: Into<T>, T> DecoderFunction<P, T> for IntoDecoderFunction<P, T>
+where
+    P: ParquetNativeType,
+    T: NativeType,
+{
+    #[inline(always)]
+    fn decode(self, x: P) -> T {
+        x.into()
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+pub(crate) struct AsDecoderFunction<P, T>(std::marker::PhantomData<(P, T)>);
+macro_rules! as_decoder_impl {
+    ($($p:ty => $t:ty,)+) => {
+        $(
+        impl DecoderFunction<$p, $t> for AsDecoderFunction<$p, $t> {
+            #[inline(always)]
+            fn decode(self, x : $p) -> $t {
+                x as $t
+            }
+        }
+        )+
+    };
+}
+
+as_decoder_impl![
+    i32 => i8,
+    i32 => i16,
+    i32 => u8,
+    i32 => u16,
+    i32 => u32,
+    i64 => i32,
+    i64 => u32,
+    i64 => u64,
+];
+
+#[derive(Default, Clone, Copy)]
+pub(crate) struct UnitDecoderFunction<T>(std::marker::PhantomData<T>);
+impl<T> DecoderFunction<T, T> for UnitDecoderFunction<T>
+where
+    T: NativeType + ParquetNativeType,
+{
+    #[inline(always)]
+    fn decode(self, x: T) -> T {
+        x
+    }
+}
+
+struct BatchDecoder<'a, 'b, P, T, D>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    D: DecoderFunction<P, T>,
+{
+    chunks: &'b mut ArrayChunks<'a, P>,
+    decoder: D,
+    _pd: std::marker::PhantomData<T>,
+}
+
+impl<'a, 'b, P, T, D: DecoderFunction<P, T>> BatchableCollector<(), Vec<T>>
+    for BatchDecoder<'a, 'b, P, T, D>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    D: DecoderFunction<P, T>,
+{
+    fn reserve(target: &mut Vec<T>, n: usize) {
+        target.reserve(n);
+    }
+
+    fn push_n(&mut self, target: &mut Vec<T>, n: usize) -> ParquetResult<()> {
+        let n = usize::min(self.chunks.len(), n);
+        let (items, remainder) = self.chunks.bytes.split_at(n);
+        let decoder = self.decoder;
+        target.extend(
+            items
+                .iter()
+                .map(|chunk| decoder.decode(P::from_le_bytes(*chunk))),
+        );
+        self.chunks.bytes = remainder;
+        Ok(())
+    }
+
+    fn push_n_nulls(&mut self, target: &mut Vec<T>, n: usize) -> ParquetResult<()> {
+        target.resize(target.len() + n, T::default());
+        Ok(())
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
-pub(super) enum StateTranslation<'a, T: NativeType> {
-    Unit(Values<'a>),
+pub(super) enum StateTranslation<'a, P: ParquetNativeType, T: NativeType> {
+    Unit(ArrayChunks<'a, P>),
     Dictionary(ValuesDictionary<'a, T>),
     ByteStreamSplit(byte_stream_split::Decoder<'a>),
 }
 
-impl<'a, T, P, F> utils::StateTranslation<'a, PrimitiveDecoder<T, P, F>> for StateTranslation<'a, T>
+impl<'a, P, T, D> utils::StateTranslation<'a, PrimitiveDecoder<P, T, D>>
+    for StateTranslation<'a, P, T>
 where
     T: NativeType,
     P: ParquetNativeType,
-    F: Copy + Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
     fn new(
-        _decoder: &PrimitiveDecoder<T, P, F>,
+        _decoder: &PrimitiveDecoder<P, T, D>,
         page: &'a DataPage,
-        dict: Option<&'a <PrimitiveDecoder<T, P, F> as utils::Decoder<'a>>::Dict>,
+        dict: Option<&'a <PrimitiveDecoder<P, T, D> as utils::Decoder<'a>>::Dict>,
         _page_validity: Option<&PageValidity<'a>>,
         _filter: Option<&Filter<'a>>,
     ) -> PolarsResult<Self> {
@@ -80,7 +166,10 @@ where
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict)) => {
                 Ok(Self::Dictionary(ValuesDictionary::try_new(page, dict)?))
             },
-            (Encoding::Plain, _) => Ok(Self::Unit(Values::try_new::<P>(page)?)),
+            (Encoding::Plain, _) => {
+                let values = split_buffer(page)?.values;
+                Ok(Self::Unit(ArrayChunks::new(values).unwrap()))
+            },
             (Encoding::ByteStreamSplit, _) => {
                 let values = split_buffer(page)?.values;
                 Ok(Self::ByteStreamSplit(byte_stream_split::Decoder::try_new(
@@ -106,7 +195,7 @@ where
         }
 
         match self {
-            Self::Unit(t) => _ = t.values.by_ref().nth(n - 1),
+            Self::Unit(t) => _ = t.nth(n - 1),
             Self::Dictionary(t) => t.values.skip_in_place(n)?,
             Self::ByteStreamSplit(t) => _ = t.iter_converted(|_| ()).nth(n - 1),
         }
@@ -116,29 +205,40 @@ where
 
     fn extend_from_state(
         &mut self,
-        decoder: &PrimitiveDecoder<T, P, F>,
-        decoded: &mut <PrimitiveDecoder<T, P, F> as utils::Decoder<'a>>::DecodedState,
+        decoder: &PrimitiveDecoder<P, T, D>,
+        decoded: &mut <PrimitiveDecoder<P, T, D> as utils::Decoder<'a>>::DecodedState,
         page_validity: &mut Option<PageValidity<'a>>,
         additional: usize,
     ) -> ParquetResult<()> {
         let (values, validity) = decoded;
 
         match (self, page_validity) {
-            (Self::Unit(page), Some(page_validity)) => utils::extend_from_decoder(
-                validity,
-                page_validity,
-                Some(additional),
-                values,
-                &mut page.values.by_ref().map(decode).map(decoder.op),
-            )?,
             (Self::Unit(page), None) => {
                 values.extend(
-                    page.values
-                        .by_ref()
-                        .map(decode)
-                        .map(decoder.op)
+                    page.by_ref()
+                        .map(|v| decoder.decoder.decode(P::from_le_bytes(*v)))
                         .take(additional),
                 );
+            },
+            (Self::Unit(page), Some(page_validity)) => {
+                let batched = BatchDecoder {
+                    chunks: page,
+                    decoder: decoder.decoder,
+                    _pd: std::marker::PhantomData,
+                };
+
+                utils::extend_from_decoder(
+                    validity,
+                    page_validity,
+                    Some(additional),
+                    values,
+                    batched,
+                )?
+            },
+            (Self::Dictionary(page), None) => {
+                let translator = DictionaryTranslator(page.dict);
+                page.values
+                    .translate_and_collect_n_into(values, additional, &translator)?;
             },
             (Self::Dictionary(page), Some(page_validity)) => {
                 let translator = DictionaryTranslator(page.dict);
@@ -152,10 +252,12 @@ where
                     translated_hybridrle,
                 )?;
             },
-            (Self::Dictionary(page), None) => {
-                let translator = DictionaryTranslator(page.dict);
-                page.values
-                    .translate_and_collect_n_into(values, additional, &translator)?;
+            (Self::ByteStreamSplit(page_values), None) => {
+                values.extend(
+                    page_values
+                        .iter_converted(|v| decoder.decoder.decode(decode(v)))
+                        .take(additional),
+                );
             },
             (Self::ByteStreamSplit(page_values), Some(page_validity)) => {
                 utils::extend_from_decoder(
@@ -163,16 +265,8 @@ where
                     page_validity,
                     Some(additional),
                     values,
-                    &mut page_values.iter_converted(decode).map(decoder.op),
+                    &mut page_values.iter_converted(|v| decoder.decoder.decode(decode(v))),
                 )?
-            },
-            (Self::ByteStreamSplit(page_values), None) => {
-                values.extend(
-                    page_values
-                        .iter_converted(decode)
-                        .map(decoder.op)
-                        .take(additional),
-                );
             },
         }
 
@@ -181,29 +275,27 @@ where
 }
 
 #[derive(Debug)]
-pub(super) struct PrimitiveDecoder<T, P, F>
+pub(super) struct PrimitiveDecoder<P, T, D>
 where
     T: NativeType,
     P: ParquetNativeType,
-    F: Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
-    phantom: std::marker::PhantomData<T>,
-    phantom_p: std::marker::PhantomData<P>,
-    pub op: F,
+    pub(crate) decoder: D,
+    _pd: std::marker::PhantomData<(P, T)>,
 }
 
-impl<T, P, F> PrimitiveDecoder<T, P, F>
+impl<P, T, D> PrimitiveDecoder<P, T, D>
 where
     T: NativeType,
     P: ParquetNativeType,
-    F: Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
     #[inline]
-    pub(super) fn new(op: F) -> Self {
+    pub(super) fn new(decoder: D) -> Self {
         Self {
-            phantom: std::marker::PhantomData,
-            phantom_p: std::marker::PhantomData,
-            op,
+            decoder,
+            _pd: std::marker::PhantomData,
         }
     }
 }
@@ -214,13 +306,13 @@ impl<T: std::fmt::Debug> utils::DecodedState for (Vec<T>, MutableBitmap) {
     }
 }
 
-impl<'a, T, P, F> utils::Decoder<'a> for PrimitiveDecoder<T, P, F>
+impl<'a, P, T, D> utils::Decoder<'a> for PrimitiveDecoder<P, T, D>
 where
     T: NativeType,
     P: ParquetNativeType,
-    F: Copy + Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
-    type Translation = StateTranslation<'a, T>;
+    type Translation = StateTranslation<'a, P, T>;
     type Dict = Vec<T>;
     type DecodedState = (Vec<T>, MutableBitmap);
 
@@ -232,7 +324,7 @@ where
     }
 
     fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {
-        deserialize_plain(&page.buffer, self.op)
+        deserialize_plain::<P, T, D>(&page.buffer, self.decoder)
     }
 }
 
@@ -251,12 +343,12 @@ pub(super) fn finish<T: NativeType>(
 
 /// An [`Iterator`] adapter over [`PagesIter`] assumed to be encoded as primitive arrays
 #[derive(Debug)]
-pub struct Iter<T, I, P, F>
+pub struct Iter<T, I, P, D>
 where
     I: PagesIter,
     T: NativeType,
     P: ParquetNativeType,
-    F: Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
     iter: I,
     data_type: ArrowDataType,
@@ -264,24 +356,24 @@ where
     remaining: usize,
     chunk_size: Option<usize>,
     dict: Option<Vec<T>>,
-    op: F,
+    decoder: D,
     phantom: std::marker::PhantomData<P>,
 }
 
-impl<T, I, P, F> Iter<T, I, P, F>
+impl<T, I, P, D> Iter<T, I, P, D>
 where
     I: PagesIter,
     T: NativeType,
 
     P: ParquetNativeType,
-    F: Copy + Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
     pub fn new(
         iter: I,
         data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
-        op: F,
+        decoder: D,
     ) -> Self {
         Self {
             iter,
@@ -290,18 +382,18 @@ where
             dict: None,
             remaining: num_rows,
             chunk_size,
-            op,
+            decoder,
             phantom: Default::default(),
         }
     }
 }
 
-impl<T, I, P, F> Iterator for Iter<T, I, P, F>
+impl<T, I, P, D> Iterator for Iter<T, I, P, D>
 where
     I: PagesIter,
     T: NativeType,
     P: ParquetNativeType,
-    F: Copy + Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
     type Item = PolarsResult<MutablePrimitiveArray<T>>;
 
@@ -313,7 +405,7 @@ where
                 &mut self.dict,
                 &mut self.remaining,
                 self.chunk_size,
-                &PrimitiveDecoder::new(self.op),
+                &PrimitiveDecoder::new(self.decoder),
             );
             match maybe_state {
                 MaybeNext::Some(Ok((values, validity))) => {
@@ -327,15 +419,15 @@ where
     }
 }
 
-pub(super) fn deserialize_plain<T, P, F>(values: &[u8], op: F) -> Vec<T>
+pub(super) fn deserialize_plain<P, T, D>(values: &[u8], decoder: D) -> Vec<T>
 where
     T: NativeType,
     P: ParquetNativeType,
-    F: Copy + Fn(P) -> T,
+    D: DecoderFunction<P, T>,
 {
     values
         .chunks_exact(std::mem::size_of::<P>())
         .map(decode)
-        .map(op)
+        .map(|v| decoder.decode(v))
         .collect::<Vec<_>>()
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/mod.rs
@@ -3,7 +3,9 @@ mod dictionary;
 mod integer;
 mod nested;
 
-pub use basic::Iter;
+pub(crate) use basic::{
+    AsDecoderFunction, DecoderFunction, IntoDecoderFunction, Iter, UnitDecoderFunction,
+};
 pub use dictionary::{DictIter, NestedDictIter};
 pub use integer::IntegerIter;
 pub use nested::NestedIter;

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
@@ -1,0 +1,54 @@
+use crate::parquet::types::NativeType as ParquetNativeType;
+
+/// A slice of chunks that fit the `P` type.
+///
+/// This is essentially the equivalent of [`ChunksExact`][std::slice::ChunksExact], but with a size
+/// and type known at compile-time. This makes the compiler able to reason much more about the
+/// code. Especially, since the chunk-sizes for this type are almost always powers of 2 and
+/// bitshifts or special instructions would be much better to use.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ArrayChunks<'a, P: ParquetNativeType> {
+    pub(crate) bytes: &'a [P::Bytes],
+}
+
+impl<'a, P: ParquetNativeType> ArrayChunks<'a, P> {
+    /// Create a new [`ArrayChunks`]
+    ///
+    /// This returns null if the `bytes` slice's length is not a multiple of the size of `P::Bytes`.
+    pub(crate) fn new(bytes: &'a [u8]) -> Option<Self> {
+        if bytes.len() % std::mem::size_of::<P::Bytes>() != 0 {
+            return None;
+        }
+
+        // SAFETY:
+        // We know that that the alignment, size and provenance are the same.
+        let bytes = unsafe { std::mem::transmute::<&[u8], &[P::Bytes]>(bytes) };
+
+        Some(Self { bytes })
+    }
+}
+
+impl<'a, P: ParquetNativeType> Iterator for ArrayChunks<'a, P> {
+    type Item = &'a P::Bytes;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.bytes.first()?;
+        self.bytes = &self.bytes[1..];
+        Some(item)
+    }
+
+    #[inline(always)]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let item = self.bytes.get(n)?;
+        self.bytes = &self.bytes[n + 1..];
+        Some(item)
+    }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.bytes.len(), Some(self.bytes.len()))
+    }
+}
+
+impl<'a, P: ParquetNativeType> ExactSizeIterator for ArrayChunks<'a, P> {}

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 
+pub(crate) mod array_chunks;
 pub(crate) mod filter;
 
 use arrow::array::{BinaryArray, MutableBinaryViewArray, View};


### PR DESCRIPTION
This increases visibility and allows for better control of inlining.

From the first commit we get the following benchmark.

```
Benchmark 1: After Optimization
  Time (mean ± σ):     18.095 s ±  0.135 s    [User: 10.459 s, System: 7.564 s]
  Range (min … max):   17.976 s … 18.412 s    10 runs

Benchmark 2: Before Optimization
  Time (mean ± σ):     20.863 s ±  0.041 s    [User: 13.129 s, System: 7.648 s]
  Range (min … max):   20.794 s … 20.918 s    10 runs

Summary
  After Optimization ran
    1.15 ± 0.01 times faster than Before Optimization
```