### PR TITLE
fix(python): Support duplicate expression names when calling ufuncs

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -303,16 +303,15 @@ class Expr:
             # np.divide(pl.col("a"), pl.col("a")); we'll be creating a struct
             # below, and structs can't have duplicate names.
             first_renamable_expr = True
-            new_exprs = []
+            actual_exprs = []
             for inp, is_actual_expr, index in exprs:
                 if is_actual_expr:
                     if first_renamable_expr:
                         first_renamable_expr = False
                     else:
                         inp = inp.alias(f"argument_{index}")
-                new_exprs.append((inp, is_actual_expr, index))
-            exprs = new_exprs
-            root_expr = F.struct(expr[0] for expr in exprs if is_actual_expr)
+                    actual_exprs.append(inp)
+            root_expr = F.struct(actual_exprs)
 
         def function(s: Series) -> Series:  # pragma: no cover
             args = []

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
@@ -126,8 +126,8 @@ def test_repeated_name_ufunc_17472():
     """
     df = pl.DataFrame({"a": [6.0]})
     result = df.select(np.divide(pl.col("a"), pl.col("a")))
-    expected = pl.Series("a", [1.0])
-    assert_series_equal(expected, np.divide(series1, series2))
+    expected = pl.DataFrame({"a": [1.0]})
+    assert_frame_equal(expected, result)
 
 
 def test_grouped_ufunc() -> None:

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
@@ -120,6 +120,16 @@ def test_ufunc_multiple_expressions() -> None:
     assert_series_equal(expected, result)  # type: ignore[arg-type]
 
 
+def test_repeated_name_ufunc_17472():
+    """
+    If a ufunc takes multiple inputs has a repeating name, this works.
+    """
+    df = pl.DataFrame({"a": [6.0]})
+    result = df.select(np.divide(pl.col("a"), pl.col("a")))
+    expected = pl.Series("a", [1.0])
+    assert_series_equal(expected, np.divide(series1, series2))
+
+
 def test_grouped_ufunc() -> None:
     df = pl.DataFrame({"id": ["a", "a", "b", "b"], "values": [0.1, 0.1, -0.1, -0.1]})
     df.group_by("id").agg(pl.col("values").log1p().sum().pipe(np.expm1))

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_expr.py
@@ -120,12 +120,10 @@ def test_ufunc_multiple_expressions() -> None:
     assert_series_equal(expected, result)  # type: ignore[arg-type]
 
 
-def test_repeated_name_ufunc_17472():
-    """
-    If a ufunc takes multiple inputs has a repeating name, this works.
-    """
+def test_repeated_name_ufunc_17472() -> None:
+    """If a ufunc takes multiple inputs has a repeating name, this works."""
     df = pl.DataFrame({"a": [6.0]})
-    result = df.select(np.divide(pl.col("a"), pl.col("a")))
+    result = df.select(np.divide(pl.col("a"), pl.col("a")))  # type: ignore[call-overload]
     expected = pl.DataFrame({"a": [1.0]})
     assert_frame_equal(expected, result)
 


### PR DESCRIPTION
Fixes #17472 