### PR TITLE
docs(python): Add deprecated `LazyFrame.fetch` back to API reference

### DIFF
--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -10,6 +10,7 @@ Miscellaneous
     LazyFrame.collect
     LazyFrame.collect_async
     LazyFrame.collect_schema
+    LazyFrame.fetch
     LazyFrame.lazy
     LazyFrame.map_batches
     LazyFrame.pipe

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2606,8 +2606,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Collect a small number of rows for debugging purposes.
 
-        .. deprecated:: 1.0
-            Use :meth:`collect` instead, in conjunction with a call to :meth:`head`.`
+        .. deprecated:: 1.0.0
+            Use :meth:`collect` instead, in conjunction with a call to :meth:`head`.
 
         Notes
         -----


### PR DESCRIPTION
`LazyFrame.fetch` was deprecated, but not removed. It should still be discoverable in the docs until it is removed.
I also made two small drive-by changes to the docstring.