### PR TITLE
fix(python): Remove default red formatting for negative floats in `write_excel`

### DIFF
--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -41,8 +41,8 @@ def _cluster(iterable: Iterable[Any], n: int = 2) -> Iterable[Any]:
     return zip(*[iter(iterable)] * n)
 
 
-_XL_DEFAULT_FLOAT_FORMAT_ = "#,##0.000;[Red]-#,##0.000"
-_XL_DEFAULT_INTEGER_FORMAT_ = "#,##0;[Red]-#,##0"
+_XL_DEFAULT_FLOAT_FORMAT_ = "#,##0.000;-#,##0.000"
+_XL_DEFAULT_INTEGER_FORMAT_ = "#,##0;-#,##0"
 _XL_DEFAULT_DTYPE_FORMATS_: dict[PolarsDataType, str] = {
     Datetime: "yyyy-mm-dd hh:mm:ss",
     Date: "yyyy-mm-dd;@",


### PR DESCRIPTION
Closes #17624 if it's accepted. @alexander-beedie.

Quick check as this isn't really worth testing:

```python
from datetime import date

import polars as pl

# Create a Pandas dataframe with some sample data.
df = pl.DataFrame(
    {
        "Dates": [date(2023, 1, 1), date(2023, 1, 2), date(2023, 1, 3)],
        "Strings": ["Alice", "Bob", "Carol"],
        "Numbers": [0.12345, 100, -99.523],
    }
)

df.write_excel(workbook="polars_format_default.xlsx")
```
Result:
![image](https://github.com/user-attachments/assets/05dca8d7-393d-47ad-b8bb-4e645fbfcd90)
