### PR TITLE
feat: Parse hive from full path for multiple directory inputs if enabled

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -207,11 +207,11 @@ pub fn expand_paths_hive(
                 let path = if glob_start_idx.is_some() {
                     path.clone()
                 } else {
-                    let (i, paths) = expand_path_cloud(path.to_str().unwrap(), cloud_options)?;
+                    let (i, new_paths) = expand_path_cloud(path.to_str().unwrap(), cloud_options)?;
                     if paths.len() == 1 {
                         expand_start_idx = i;
                     }
-                    out_paths.extend_from_slice(&paths);
+                    out_paths.extend_from_slice(&new_paths);
                     continue;
                 };
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -771,12 +771,8 @@ fn expand_scan_paths_with_hive_update(
     cloud_options: &Option<CloudOptions>,
 ) -> PolarsResult<Arc<[PathBuf]>> {
     let hive_enabled = file_options.hive_options.enabled;
-    let (expanded_paths, hive_start_idx) = expand_paths_hive(
-        paths,
-        file_options.glob,
-        cloud_options.as_ref(),
-        hive_enabled.unwrap_or(false),
-    )?;
+    let (expanded_paths, hive_start_idx) =
+        expand_paths_hive(paths, file_options.glob, cloud_options.as_ref())?;
     let inferred_hive_enabled = hive_enabled
         .unwrap_or_else(|| expanded_from_single_directory(paths, expanded_paths.as_ref()));
 


### PR DESCRIPTION
In hindsight the current behavior is a bit odd - the limitation doesn't really make sense, and we should include the full hive parts because they could be different

#### Before

```python
pl.scan_parquet(
    [".env/_data/a=0/b=0/", ".env/_data/a=1/"], hive_partitioning=True
).collect()

# polars.exceptions.InvalidOperationError: attempted to read from different directory levels with
# hive partitioning enabled: first path: .env/_data/a=0/b=0/, second path: .env/_data/a=1/

pl.scan_parquet(
    [".env/_data/a=0/", ".env/_data/a=1/"], hive_partitioning=True
).collect()

# shape: (2, 2)
# ┌─────┬─────┐
# │ c   ┆ b   │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 0   ┆ 0   │
# │ 1   ┆ 1   │
# └─────┴─────┘
```

#### After

```python
pl.scan_parquet(
    [".env/_data/a=0/b=0/", ".env/_data/a=1/"], hive_partitioning=True
).collect()

# shape: (2, 3)
# ┌─────┬─────┬─────┐
# │ a   ┆ b   ┆ c   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 0   ┆ 0   ┆ 0   │
# │ 1   ┆ 1   ┆ 1   │
# └─────┴─────┴─────┘

pl.scan_parquet(
    [".env/_data/a=0/", ".env/_data/a=1/"], hive_partitioning=True
).collect()

# shape: (2, 3)
# ┌─────┬─────┬─────┐
# │ a   ┆ b   ┆ c   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 0   ┆ 0   ┆ 0   │
# │ 1   ┆ 1   ┆ 1   │
# └─────┴─────┴─────┘
```