### PR TITLE
fix: Interpret %y consistently with Chrono in to_date/to_datetime/strptime

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -160,7 +160,7 @@ impl StrpTimeState {
                             return None;
                         }
 
-                        if decade < 50 {
+                        if decade < 70 {
                             year = 2000 + decade;
                         } else {
                             year = 1900 + decade;

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import hypothesis.strategies as st
@@ -187,3 +187,19 @@ def test_to_datetime_aware_values_aware_dtype() -> None:
         dtype=pl.Datetime("us", "Asia/Kathmandu"),
     )
     assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "format", "expected"),
+    [
+        ("01-01-69", "%d-%m-%y", date(2069, 1, 1)),  # Polars' parser
+        ("01-01-70", "%d-%m-%y", date(1970, 1, 1)),  # Polars' parser
+        ("01-January-69", "%d-%B-%y", date(2069, 1, 1)),  # Chrono
+        ("01-January-70", "%d-%B-%y", date(1970, 1, 1)),  # Chrono
+    ],
+)
+def test_to_datetime_two_digit_year_17213(
+    inputs: str, format: str, expected: date
+) -> None:
+    result = pl.Series([inputs]).str.to_date(format=format).item()
+    assert result == expected


### PR DESCRIPTION
closes #17213 

Personally I don't think the cutoff should be configurable (for a start, Chrono doesn't make it configurable, so there'd be no way to control what happens when the Chrono parser is used)

The Polars docs already point to the Chrono docs, so I think that's sufficient (I've also made a PR to chrono to note the cutoff in their docs https://github.com/chronotope/chrono/pull/1598)

This is one of those borderline bugfix / breaking changes that I think would be better suited to 1.2 than to 1.1.1. At the same time, I don't think it's significant enough that it warrants waiting until 2.0