### PR TITLE
fix(rust): Fix type inference failure caused by double transpose

### DIFF
--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -397,14 +397,11 @@ impl<'a, 'b> fmt::Write for EscapeLabel<'a, 'b> {
             // This escapes quotes and new lines
             // @NOTE: I am aware this does not work for \" and such. I am ignoring that fact as we
             // are not really using such strings.
-            let f = char_indices
-                .find_map(|(i, c)| {
-                    match c {
-                        '"' => Some((i + 1, r#"\""#)),
-                        '\n' => Some((i + 1, r#"\n"#)),
-                        _ => None,
-                    }
-                });
+            let f = char_indices.find_map(|(i, c)| match c {
+                '"' => Some((i + 1, r#"\""#)),
+                '\n' => Some((i + 1, r#"\n"#)),
+                _ => None,
+            });
 
             let Some((at, to_write)) = f else {
                 break;

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -398,8 +398,8 @@ impl<'a, 'b> fmt::Write for EscapeLabel<'a, 'b> {
             // @NOTE: I am aware this does not work for \" and such. I am ignoring that fact as we
             // are not really using such strings.
             let f = char_indices.find_map(|(i, c)| match c {
-                '"' => Some((i + 1, r#"\""#)),
-                '\n' => Some((i + 1, r#"\n"#)),
+                '"' => Some((i, r#"\""#)),
+                '\n' => Some((i, r#"\n"#)),
                 _ => None,
             });
 
@@ -409,7 +409,7 @@ impl<'a, 'b> fmt::Write for EscapeLabel<'a, 'b> {
 
             self.0.write_str(&s[..at])?;
             self.0.write_str(to_write)?;
-            s = &s[at..];
+            s = &s[at + 1..];
         }
 
         self.0.write_str(s)?;

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -399,27 +399,19 @@ impl<'a, 'b> fmt::Write for EscapeLabel<'a, 'b> {
             // are not really using such strings.
             let f = char_indices
                 .find_map(|(i, c)| {
-                    (|| match c {
-                        '"' => {
-                            self.0.write_str(&s[..i])?;
-                            self.0.write_str(r#"\""#)?;
-                            Ok(Some(i + 1))
-                        },
-                        '\n' => {
-                            self.0.write_str(&s[..i])?;
-                            self.0.write_str(r#"\n"#)?;
-                            Ok(Some(i + 1))
-                        },
-                        _ => Ok(None),
-                    })()
-                    .transpose()
-                })
-                .transpose()?;
+                    match c {
+                        '"' => Some((i + 1, r#"\""#)),
+                        '\n' => Some((i + 1, r#"\n"#)),
+                        _ => None,
+                    }
+                });
 
-            let Some(at) = f else {
+            let Some((at, to_write)) = f else {
                 break;
             };
 
+            self.0.write_str(&s[..at])?;
+            self.0.write_str(to_write)?;
             s = &s[at..];
         }
 


### PR DESCRIPTION
Under some circumstances, compiling Polars failed with a type inference error involving `openssl::error::ErrorStack`. It was possibly related to compiling with libssl-dev. This PR fixes that issue by removing a nasty double `transpose`. A nice side effect is that the problematic code has become a lot cleaner.