### PR TITLE
feat: Raise error instead of panic in unsupported serde

### DIFF
--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -163,7 +163,7 @@ impl Serialize for AnyValue<'_> {
             AnyValue::BinaryOwned(v) => {
                 serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v)
             },
-            _ => todo!(),
+            _ => panic!("Unknown data type. Can not serialize"),
         }
     }
 }

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -163,7 +163,9 @@ impl Serialize for AnyValue<'_> {
             AnyValue::BinaryOwned(v) => {
                 serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v)
             },
-            _ => Err(serde::ser::Error::custom("Unknown data type. Cannot serialize")),
+            _ => Err(serde::ser::Error::custom(
+                "Unknown data type. Cannot serialize",
+            )),
         }
     }
 }

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -163,7 +163,7 @@ impl Serialize for AnyValue<'_> {
             AnyValue::BinaryOwned(v) => {
                 serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v)
             },
-            _ => panic!("Unknown data type. Can not serialize"),
+            _ => Err(serde::ser::Error::custom("Unknown data type. Cannot serialize")),
         }
     }
 }


### PR DESCRIPTION
A `todo!()` was used in the wildcard scenario for the serialize method. Replaced it with panic so that the method is useable