### PR TITLE
docs(python): Fixed default name for `value_counts` methods based on normalize parameter

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9671,8 +9671,8 @@ class Expr:
                 as the computation is already parallelized per group.
         name
             Give the resulting count column a specific name;
-            if `normalize` is True defaults to "count",
-            otherwise defaults to "proportion".
+            if `normalize` is True defaults to "proportion",
+            otherwise defaults to "count".
         normalize
             If true gives relative frequencies of the unique values
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2429,8 +2429,8 @@ class Series:
                 as the computation is already parallelized per group.
         name
             Give the resulting count column a specific name;
-            if `normalize` is True defaults to "count",
-            otherwise defaults to "proportion".
+            if `normalize` is True defaults to "proportion",
+            otherwise defaults to "count".
         normalize
             If true gives relative frequencies of the unique values
 


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/pola-rs/polars/issues/17660)