### PR TITLE
build(python): Correctly reference released package in optional dependencies

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Add bigidx feature
         if: matrix.package == 'polars-u64-idx'
         run: tomlq -i -t '.dependencies.polars.features += ["bigidx"]' py-polars/Cargo.toml
+      - name: Update optional dependencies
+        if: matrix.package != 'polars'
+        run: sed $SED_INPLACE 's/polars\[/${{ matrix.package }}\[/' py-polars/pyproject.toml
 
       - name: Create source distribution
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -35,6 +35,9 @@ jobs:
       matrix:
         package: [polars, polars-lts-cpu, polars-u64-idx]
 
+    env:
+      SED_INPLACE: ${{ matrix.os == 'macos-13' && '-i ''''' || '-i'}}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -125,6 +128,9 @@ jobs:
       - name: Add bigidx feature
         if: matrix.package == 'polars-u64-idx'
         run: tomlq -i -t '.dependencies.polars.features += ["bigidx"]' py-polars/Cargo.toml
+      - name: Update optional dependencies
+        if: matrix.package != 'polars'
+        run: sed $SED_INPLACE 's/polars\[/${{ matrix.package }}\[/' py-polars/pyproject.toml
 
       - name: Determine CPU features for x86-64
         id: features


### PR DESCRIPTION
This change ensures that during the release, `pyproject.toml` contains the name of the released package. This way, we avoid bringing in `polars` package when one installs other package types (like `polars-u64-idx`) with optional dependencies.

Fixes #14301