### PR TITLE
build(python): Pin `setuptools` to fix failing CI

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -10,6 +10,8 @@ maturin
 # extra dependency for maturin (linux-only)
 patchelf; platform_system == 'Linux'
 pip
+# Temporarily pinned to fix CI
+setuptools==70.3.0
 
 # ------------
 # DEPENDENCIES


### PR DESCRIPTION
CI runs have been failing:
* Test Python / test-python (windows-latest, 3.12) (pull_request)
* Code coverage / coverage-python (pull_request)

It's something to do with the setuptools upgrade, but unsure of the exact cause.

```python
=================================== FAILURES ===================================
______________________________ test_tracebackhide ______________________________
[gw1] darwin -- Python 3.12.4 /Users/runner/work/polars/polars/.venv/bin/python3
/Users/runner/work/polars/polars/py-polars/tests/unit/testing/test_assert_frame_equal.py:411: in test_tracebackhide
    result.assert_outcomes(passed=0, failed=4)
/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/pytester.py:568: in parseoutcomes
    return self.parse_summary_nouns(self.outlines)
/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/pytester.py:586: in parse_summary_nouns
    raise ValueError("Pytest terminal summary report not found")
E   ValueError: Pytest terminal summary report not found
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/pytester.py", line 1161, in runpytest_inprocess
    reprec = self.inline_run(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/pytester.py", line 1126, in inline_run
    ret = main([str(x) for x in args], plugins=plugins)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 159, in main
    config = _prepareconfig(args, plugins)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 346, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/helpconfig.py", line 106, in pytest_cmdline_parse
    config = yield
             ^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 1152, in pytest_cmdline_parse
    self.parse(args)
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 1501, in parse
    self._preparse(args, addopts=addopts)
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 1388, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 421, in load_setuptools_entrypoints
    plugin = ep.load()
             ^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/importlib_metadata/__init__.py", line 183, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/setuptools/_vendor/typeguard/__init__.py", line 21, in <module>
    from ._importhook import ImportHookManager as ImportHookManager
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/setuptools/_vendor/typeguard/_importhook.py", line 35, in <module>
    OPTIMIZATION = "typeguard" + "".join(version("typeguard").split(".")[:3])
                                         ^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/metadata/__init__.py", line 889, in version
    return distribution(distribution_name).version
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/importlib_metadata/__init__.py", line 470, in version
    return self.metadata['Version']
           ~~~~~~~~~~~~~^^^^^^^^^^^
  File "/Users/runner/work/polars/polars/.venv/lib/python3.12/site-packages/importlib_metadata/_adapters.py", line 54, in __getitem__
    raise KeyError(item)
KeyError: 'Version'

---------- coverage: platform darwin, python 3.12.4-final-0 ----------
Coverage XML written to file main.xml

Required test coverage of 85.0% reached. Total coverage: 90.49%
=========================== short test summary info ============================
FAILED tests/unit/testing/test_assert_frame_equal.py::test_tracebackhide - ValueError: Pytest terminal summary report not found
====== 1 failed, 11111 passed, 11 skipped, 3 xfailed in 350.73s (0:05:50) ======
##[error]Process completed with exit code 1.
```