### PR TITLE
fix: Use bytemuck in slice reinterpret for Parquet ArrayChunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,6 +3253,7 @@ dependencies = [
  "async-stream",
  "base64 0.22.1",
  "brotli",
+ "bytemuck",
  "ethnum",
  "fallible-streaming-iterator",
  "flate2",

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -16,6 +16,7 @@ description = "Apache Parquet I/O operations for Polars"
 ahash = { workspace = true }
 arrow = { workspace = true, features = ["io_ipc"] }
 base64 = { workspace = true }
+bytemuck = { workspace = true }
 ethnum = { workspace = true }
 fallible-streaming-iterator = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
@@ -20,9 +20,7 @@ impl<'a, P: ParquetNativeType> ArrayChunks<'a, P> {
             return None;
         }
 
-        // SAFETY:
-        // We know that that the alignment, size and provenance are the same.
-        let bytes = unsafe { std::mem::transmute::<&[u8], &[P::Bytes]>(bytes) };
+        let bytes = bytemuck::cast_slice(bytes);
 
         Some(Self { bytes })
     }

--- a/crates/polars-parquet/src/parquet/types.rs
+++ b/crates/polars-parquet/src/parquet/types.rs
@@ -3,6 +3,7 @@ use crate::parquet::schema::types::PhysicalType;
 /// A physical native representation of a Parquet fixed-sized type.
 pub trait NativeType: std::fmt::Debug + Send + Sync + 'static + Copy + Clone {
     type Bytes: AsRef<[u8]>
+        + bytemuck::Pod
         + for<'a> TryFrom<&'a [u8], Error = std::array::TryFromSliceError>
         + std::fmt::Debug
         + Clone


### PR DESCRIPTION
Fixes #17686.