### PR TITLE
fix(rust): `chrono::TimeDelta` needs chrono >= 0.4.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ avro-schema = { version = "0.3" }
 base64 = "0.22.0"
 bitflags = "2"
 bytemuck = { version = "1.11", features = ["derive", "extern_crate_alloc"] }
-chrono = { version = "0.4.31", default-features = false, features = ["std"] }
+chrono = { version = "0.4.34", default-features = false, features = ["std"] }
 chrono-tz = "0.8.1"
 ciborium = "0.2"
 crossbeam-channel = "0.5.8"


### PR DESCRIPTION
`chrono::TimeDelta` is referenced by polars-arrow/src/temporal_conversions.rs:

https://github.com/pola-rs/polars/blob/05d4703b4e9910c00f6601bd8c3041bfd80f7ce0/crates/polars-arrow/src/temporal_conversions.rs#L4

See previous chrono version, which lacks `TimeDelta`: https://docs.rs/chrono/0.4.33/chrono/?search=TimeDelta

---

It's possible that there are more such issues. To verify that minimum specified versions actually work in CI, you could use the following nightly command:
```
cargo +nightly update -Z minimal-versions
```