### PR TITLE
refactor(rust): Add the capability to run new streaming engine on test suite

### DIFF
--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -275,6 +275,15 @@ impl RuntimeManager {
     {
         self.rt.spawn(future)
     }
+
+    // See [`tokio::runtime::Runtime::spawn_blocking`].
+    pub fn spawn_blocking<F, R>(&self, f: F) -> tokio::task::JoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static
+    {
+        self.rt.spawn_blocking(f)
+    }
 }
 
 static RUNTIME: Lazy<RuntimeManager> = Lazy::new(RuntimeManager::new);

--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -280,7 +280,7 @@ impl RuntimeManager {
     pub fn spawn_blocking<F, R>(&self, f: F) -> tokio::task::JoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
-        R: Send + 'static
+        R: Send + 'static,
     {
         self.rt.spawn_blocking(f)
     }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -30,7 +30,6 @@ pub use ipc::*;
 pub use ndjson::*;
 #[cfg(feature = "parquet")]
 pub use parquet::*;
-use polars_core::config::verbose;
 use polars_core::prelude::*;
 use polars_expr::{create_physical_expr, ExpressionConversionState};
 use polars_io::RowIndex;
@@ -756,7 +755,7 @@ impl LazyFrame {
                         // Fallback to normal engine if error is due to not being implemented,
                         // otherwise propagate error.
                         if e.downcast_ref::<&str>() != Some(&"not yet implemented") {
-                            if verbose() {
+                            if polars_core::config::verbose() {
                                 eprintln!("caught unimplemented error in new streaming engine, falling back to normal engine");
                             }
                             std::panic::resume_unwind(e);

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -734,8 +734,8 @@ impl LazyFrame {
             let run_on_new_streaming_engine = move || {
                 let alp_plan = slf.clone().to_alp_optimized()?;
                 let lp_top = alp_plan.lp_top;
-                let mut ir_arena = alp_plan.lp_arena.clone();
-                let expr_arena = alp_plan.expr_arena.clone();
+                let mut ir_arena = alp_plan.lp_arena;
+                let expr_arena = alp_plan.expr_arena;
 
                 let lp_top = ir_arena.add(IR::Sink {
                     input: lp_top,

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -747,8 +747,12 @@ impl LazyFrame {
             if self.opt_state.new_streaming {
                 return run_on_new_streaming_engine();
             }
-            
-            if std::env::var("POLARS_AUTO_NEW_STREAMING").as_deref().unwrap_or("") == "1" {
+
+            if std::env::var("POLARS_AUTO_NEW_STREAMING")
+                .as_deref()
+                .unwrap_or("")
+                == "1"
+            {
                 match std::panic::catch_unwind(run_on_new_streaming_engine) {
                     Ok(r) => return r,
                     Err(e) => {
@@ -760,7 +764,7 @@ impl LazyFrame {
                             }
                             std::panic::resume_unwind(e);
                         }
-                    }
+                    },
                 }
             }
         }

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -531,6 +531,7 @@ impl Expr {
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ElementWise,
                 fmt_str: "map",
+                flags: FunctionFlags::default() | FunctionFlags::OPTIONAL_RE_ENTRANT,
                 ..Default::default()
             },
         }

--- a/crates/polars-plan/src/dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_udf.rs
@@ -251,7 +251,7 @@ impl Expr {
                 },
             })
         });
-        let mut flags = FunctionFlags::default();
+        let mut flags = FunctionFlags::default() | FunctionFlags::OPTIONAL_RE_ENTRANT;
         if returns_scalar {
             flags |= FunctionFlags::RETURNS_SCALAR;
         }

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -147,6 +147,10 @@ bitflags!(
             /// head_1(x) -> {1}
             /// sum(x) -> {4}
             const RETURNS_SCALAR = 1 << 5;
+            /// This can happen with UDF's that use Polars within the UDF.
+            /// This can lead to recursively entering the engine and sometimes deadlocks.
+            /// This flag must be set to handle that.
+            const OPTIONAL_RE_ENTRANT = 1 << 6;
         }
 );
 

--- a/crates/polars-stream/src/async_executor/mod.rs
+++ b/crates/polars-stream/src/async_executor/mod.rs
@@ -85,13 +85,13 @@ impl Executor {
         let thread = TLS_THREAD_ID.get();
         let meta = task.metadata();
         let opt_ttl = self.thread_task_lists.get(thread);
-        
+
         let mut use_global_queue = opt_ttl.is_none();
         if meta.freshly_spawned.load(Ordering::Relaxed) {
             use_global_queue = true;
             meta.freshly_spawned.store(false, Ordering::Relaxed);
         }
-        
+
         if use_global_queue {
             // Scheduled from an unknown thread, add to global queue.
             if meta.priority == TaskPriority::High {

--- a/crates/polars-stream/src/async_executor/mod.rs
+++ b/crates/polars-stream/src/async_executor/mod.rs
@@ -5,7 +5,7 @@ use std::cell::{Cell, UnsafeCell};
 use std::future::Future;
 use std::marker::PhantomData;
 use std::panic::AssertUnwindSafe;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker as WorkQueue};
@@ -44,6 +44,7 @@ pub enum TaskPriority {
 /// Metadata associated with a task to help schedule it and clean it up.
 struct TaskMetadata {
     priority: TaskPriority,
+    freshly_spawned: AtomicBool,
 
     task_key: TaskKey,
     completed_tasks: Weak<Mutex<Vec<TaskKey>>>,
@@ -82,12 +83,29 @@ struct Executor {
 impl Executor {
     fn schedule_task(&self, task: ReadyTask) {
         let thread = TLS_THREAD_ID.get();
-        let priority = task.metadata().priority;
-        if let Some(ttl) = self.thread_task_lists.get(thread) {
+        let meta = task.metadata();
+        let opt_ttl = self.thread_task_lists.get(thread);
+        
+        let mut use_global_queue = opt_ttl.is_none();
+        if meta.freshly_spawned.load(Ordering::Relaxed) {
+            use_global_queue = true;
+            meta.freshly_spawned.store(false, Ordering::Relaxed);
+        }
+        
+        if use_global_queue {
+            // Scheduled from an unknown thread, add to global queue.
+            if meta.priority == TaskPriority::High {
+                self.global_high_prio_task_queue.push(task);
+            } else {
+                self.global_low_prio_task_queue.push(task);
+            }
+            self.park_group.unpark_one();
+        } else {
+            let ttl = opt_ttl.unwrap();
             // SAFETY: this slot may only be accessed from the local thread, which we are.
             let slot = unsafe { &mut *ttl.local_slot.get() };
 
-            if priority == TaskPriority::High {
+            if meta.priority == TaskPriority::High {
                 // Insert new task into thread local slot, taking out the old task.
                 let Some(task) = slot.replace(task) else {
                     // We pushed a task into our local slot which was empty. Since
@@ -107,14 +125,6 @@ impl Executor {
                     self.park_group.unpark_one();
                 }
             }
-        } else {
-            // Scheduled from an unknown thread, add to global queue.
-            if priority == TaskPriority::High {
-                self.global_high_prio_task_queue.push(task);
-            } else {
-                self.global_low_prio_task_queue.push(task);
-            }
-            self.park_group.unpark_one();
         }
     }
 
@@ -288,6 +298,7 @@ impl<'scope, 'env> TaskScope<'scope, 'env> {
                     TaskMetadata {
                         task_key,
                         priority,
+                        freshly_spawned: AtomicBool::new(true),
                         completed_tasks: Arc::downgrade(&self.completed_tasks),
                     },
                 )

--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -261,6 +261,9 @@ pub fn execute_graph(
             break;
         }
         run_subgraph(graph, &nodes, &pipes, num_pipelines)?;
+        if polars_core::config::verbose() {
+            eprintln!("polars-stream: done running graph phase");
+        }
     }
 
     // Ensure everything is done.

--- a/crates/polars-stream/src/morsel.rs
+++ b/crates/polars-stream/src/morsel.rs
@@ -63,8 +63,8 @@ impl Morsel {
     }
 
     #[allow(unused)]
-    pub fn into_df(self) -> DataFrame {
-        self.df
+    pub fn into_inner(self) -> (DataFrame, MorselSeq, Option<WaitToken>) {
+        (self.df, self.seq, self.consume_token)
     }
 
     pub fn df(&self) -> &DataFrame {

--- a/crates/polars-stream/src/nodes/select.rs
+++ b/crates/polars-stream/src/nodes/select.rs
@@ -88,7 +88,7 @@ impl ComputeNode for SelectNode {
                         PolarsResult::Ok(ret)
                     })?;
                     */
-                    
+
                     let (df, seq, consume_token) = morsel.into_inner();
                     let mut selected = Vec::new();
                     for selector in &slf.selectors {
@@ -96,7 +96,10 @@ impl ComputeNode for SelectNode {
                         let selector = selector.clone();
                         let state = state.clone();
                         selected.push(
-                            polars_io::pl_async::get_runtime().spawn_blocking(move || selector.evaluate(&df, &state)).await.unwrap()?
+                            polars_io::pl_async::get_runtime()
+                                .spawn_blocking(move || selector.evaluate(&df, &state))
+                                .await
+                                .unwrap()?,
                         );
                     }
 
@@ -126,7 +129,7 @@ impl ComputeNode for SelectNode {
                     if let Some(token) = consume_token {
                         morsel.set_consume_token(token);
                     }
-                    
+
                     if send.send(morsel).await.is_err() {
                         break;
                     }

--- a/crates/polars-stream/src/nodes/select.rs
+++ b/crates/polars-stream/src/nodes/select.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use polars_core::prelude::Series;
 use polars_core::schema::Schema;
 use polars_expr::prelude::PhysicalExpr;
 
@@ -9,6 +10,7 @@ pub struct SelectNode {
     selectors: Vec<Arc<dyn PhysicalExpr>>,
     schema: Arc<Schema>,
     extend_original: bool,
+    maybe_re_entrant: bool,
 }
 
 impl SelectNode {
@@ -16,11 +18,13 @@ impl SelectNode {
         selectors: Vec<Arc<dyn PhysicalExpr>>,
         schema: Arc<Schema>,
         extend_original: bool,
+        maybe_re_entrant: bool,
     ) -> Self {
         Self {
             selectors,
             schema,
             extend_original,
+            maybe_re_entrant,
         }
     }
 }
@@ -51,21 +55,10 @@ impl ComputeNode for SelectNode {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 while let Ok(morsel) = recv.recv().await {
-                    // TODO: restore this code instead of using spawn_blocking for everything.
-                    // We need spawn_blocking because evaluate could contain Python UDFs which
-                    // recursively call the executor again.
-                    /*
-                    let morsel = morsel.try_map(|df| {
-                        // Select columns.
-                        let mut selected: Vec<_> = slf
-                            .selectors
-                            .iter()
-                            .map(|s| s.evaluate(&df, state))
-                            .collect::<PolarsResult<_>>()?;
-
+                    let extend_or_create = |df: DataFrame, mut selected: Vec<Series>| {
                         // Extend or create new dataframe.
                         let ret = if slf.extend_original {
-                            let mut out = df.clone();
+                            let mut out = df;
                             out._add_columns(selected, &slf.schema)?;
                             out
                         } else {
@@ -84,51 +77,45 @@ impl ComputeNode for SelectNode {
                             }
                             unsafe { DataFrame::new_no_checks(selected) }
                         };
-
                         PolarsResult::Ok(ret)
-                    })?;
-                    */
-
-                    let (df, seq, consume_token) = morsel.into_inner();
-                    let mut selected = Vec::new();
-                    for selector in &slf.selectors {
-                        let df = df.clone();
-                        let selector = selector.clone();
-                        let state = state.clone();
-                        selected.push(
-                            polars_io::pl_async::get_runtime()
-                                .spawn_blocking(move || selector.evaluate(&df, &state))
-                                .await
-                                .unwrap()?,
-                        );
-                    }
-
-                    // Extend or create new dataframe.
-                    let ret = if slf.extend_original {
-                        let mut out = df.clone();
-                        out._add_columns(selected, &slf.schema)?;
-                        out
-                    } else {
-                        // Broadcast scalars.
-                        let max_non_unit_length = selected
-                            .iter()
-                            .map(|s| s.len())
-                            .filter(|l| *l != 1)
-                            .max()
-                            .unwrap_or(1);
-                        for s in &mut selected {
-                            if s.len() != max_non_unit_length {
-                                assert!(s.len() == 1, "got series of incompatible lengths");
-                                *s = s.new_from_index(0, max_non_unit_length);
-                            }
-                        }
-                        unsafe { DataFrame::new_no_checks(selected) }
                     };
 
-                    let mut morsel = Morsel::new(ret, seq);
-                    if let Some(token) = consume_token {
-                        morsel.set_consume_token(token);
-                    }
+                    // We need spawn_blocking because evaluate could contain Python UDFs which
+                    // recursively call the executor again.
+                    let morsel = if slf.maybe_re_entrant {
+                        let (df, seq, consume_token) = morsel.into_inner();
+                        let mut selected = Vec::new();
+                        for selector in &slf.selectors {
+                            let df = df.clone();
+                            let selector = selector.clone();
+                            let state = state.clone();
+                            selected.push(
+                                polars_io::pl_async::get_runtime()
+                                    .spawn_blocking(move || selector.evaluate(&df, &state))
+                                    .await
+                                    .unwrap()?,
+                            );
+                        }
+
+                        let ret = extend_or_create(df, selected)?;
+
+                        let mut morsel = Morsel::new(ret, seq);
+                        if let Some(token) = consume_token {
+                            morsel.set_consume_token(token);
+                        }
+                        morsel
+                    } else {
+                        morsel.try_map(|df| {
+                            // Select columns.
+                            let selected: Vec<_> = slf
+                                .selectors
+                                .iter()
+                                .map(|s| s.evaluate(&df, state))
+                                .collect::<PolarsResult<_>>()?;
+
+                            extend_or_create(df, selected)
+                        })?
+                    };
 
                     if send.send(morsel).await.is_err() {
                         break;

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -15,7 +15,7 @@ fn is_streamable(node: Node, arena: &Arena<AExpr>) -> bool {
 
 fn has_potential_recurring_entrance(node: Node, arena: &Arena<AExpr>) -> bool {
     arena.iter(node).any(|(_n, ae)| match ae {
-        AExpr::Function { options, .. } => {
+        AExpr::Function { options, .. } | AExpr::AnonymousFunction { options, .. } => {
             options.flags.contains(FunctionFlags::OPTIONAL_RE_ENTRANT)
         },
         _ => false,

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -31,6 +31,7 @@ pub enum PhysNode {
         input: PhysNodeKey,
         selectors: Vec<ExprIR>,
         extend_original: bool,
+        maybe_re_entrant: bool,
         output_schema: Arc<Schema>,
     },
     Reduce {

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -30,8 +30,8 @@ pub enum PhysNode {
     Select {
         input: PhysNodeKey,
         selectors: Vec<ExprIR>,
+        selector_reentrant: Vec<bool>,
         extend_original: bool,
-        maybe_re_entrant: bool,
         output_schema: Arc<Schema>,
     },
     Reduce {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -91,10 +91,10 @@ fn to_graph_rec<'a>(
 
         Select {
             selectors,
+            selector_reentrant,
             input,
             output_schema,
             extend_original,
-            maybe_re_entrant,
         } => {
             let phys_selectors = selectors
                 .iter()
@@ -112,9 +112,9 @@ fn to_graph_rec<'a>(
             ctx.graph.add_node(
                 nodes::select::SelectNode::new(
                     phys_selectors,
+                    selector_reentrant.clone(),
                     output_schema.clone(),
                     *extend_original,
-                    *maybe_re_entrant,
                 ),
                 [input_key],
             )

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -94,6 +94,7 @@ fn to_graph_rec<'a>(
             input,
             output_schema,
             extend_original,
+            maybe_re_entrant,
         } => {
             let phys_selectors = selectors
                 .iter()
@@ -113,6 +114,7 @@ fn to_graph_rec<'a>(
                     phys_selectors,
                     output_schema.clone(),
                     *extend_original,
+                    *maybe_re_entrant,
                 ),
                 [input_key],
             )

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -15,13 +15,13 @@ fn is_streamable(node: Node, arena: &Arena<AExpr>) -> bool {
 pub fn run_query(
     node: Node,
     mut ir_arena: Arena<IR>,
-    mut expr_arena: Arena<AExpr>,
+    expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<DataFrame> {
     let mut phys_sm = SlotMap::with_capacity_and_key(ir_arena.len());
 
-    let root = crate::physical_plan::lower_ir(node, &mut ir_arena, &mut expr_arena, &mut phys_sm)?;
+    let root = crate::physical_plan::lower_ir(node, &mut ir_arena, expr_arena, &mut phys_sm)?;
     let (mut graph, phys_to_graph) =
-        crate::physical_plan::physical_plan_to_graph(&phys_sm, &expr_arena)?;
+        crate::physical_plan::physical_plan_to_graph(&phys_sm, expr_arena)?;
     let mut results = crate::execute::execute_graph(&mut graph)?;
     Ok(results.remove(phys_to_graph[root]).unwrap())
 }


### PR DESCRIPTION
You still need to manually compile with `new_streaming` feature turned on, but now when environment variable `POLARS_AUTO_NEW_STREAMING=1` is set Polars will first try to enter the new streaming engine and only when that panics with an unimplemented error it will try the normal choice of engine. Any panics which are not the `todo!()` error are propagated as real errors.
