### PR TITLE
feat(rust): Add NontemporalArithmeticChunked

### DIFF
--- a/crates/polars-compute/Cargo.toml
+++ b/crates/polars-compute/Cargo.toml
@@ -27,3 +27,4 @@ version_check = { workspace = true }
 nightly = []
 simd = ["arrow/simd"]
 dtype-array = []
+nontemporal = []

--- a/crates/polars-compute/src/arithmetic/float.rs
+++ b/crates/polars-compute/src/arithmetic/float.rs
@@ -1,115 +1,191 @@
 use arrow::array::PrimitiveArray as PArr;
 
 use super::PrimitiveArithmeticKernelImpl;
-use crate::arity::{prim_binary_values, prim_unary_values};
+use crate::arity::{prim_binary_values, prim_unary_values, StoreIntrinsic};
 
 macro_rules! impl_float_arith_kernel {
     ($T:ty) => {
         impl PrimitiveArithmeticKernelImpl for $T {
             type TrueDivT = $T;
 
-            fn prim_wrapping_abs(lhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(lhs, |x| x.abs())
+            fn prim_wrapping_abs<S: StoreIntrinsic>(lhs: PArr<$T>, s: S) -> PArr<$T> {
+                prim_unary_values(lhs, |x| x.abs(), s)
             }
 
-            fn prim_wrapping_neg(lhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(lhs, |x| -x)
+            fn prim_wrapping_neg<S: StoreIntrinsic>(lhs: PArr<$T>, s: S) -> PArr<$T> {
+                prim_unary_values(lhs, |x| -x, s)
             }
 
-            fn prim_wrapping_add(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, rhs, |l, r| l + r)
+            fn prim_wrapping_add<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, rhs, |l, r| l + r, s)
             }
 
-            fn prim_wrapping_sub(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, rhs, |l, r| l - r)
+            fn prim_wrapping_sub<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, rhs, |l, r| l - r, s)
             }
 
-            fn prim_wrapping_mul(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, rhs, |l, r| l * r)
+            fn prim_wrapping_mul<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, rhs, |l, r| l * r, s)
             }
 
-            fn prim_wrapping_floor_div(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, rhs, |l, r| (l / r).floor())
+            fn prim_wrapping_floor_div<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, rhs, |l, r| (l / r).floor(), s)
             }
 
-            fn prim_wrapping_trunc_div(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, rhs, |l, r| (l / r).trunc())
+            fn prim_wrapping_trunc_div<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, rhs, |l, r| (l / r).trunc(), s)
             }
 
-            fn prim_wrapping_mod(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, rhs, |l, r| l - r * (l / r).floor())
+            fn prim_wrapping_mod<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, rhs, |l, r| l - r * (l / r).floor(), s)
             }
 
-            fn prim_wrapping_add_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_add_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 if rhs == 0.0 {
                     return lhs;
                 }
-                prim_unary_values(lhs, |x| x + rhs)
+                prim_unary_values(lhs, |x| x + rhs, s)
             }
 
-            fn prim_wrapping_sub_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_sub_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 if rhs == 0.0 {
                     return lhs;
                 }
-                Self::prim_wrapping_add_scalar(lhs, -rhs)
+                Self::prim_wrapping_add_scalar(lhs, -rhs, s)
             }
 
-            fn prim_wrapping_sub_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
+            fn prim_wrapping_sub_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
                 if lhs == 0.0 {
-                    Self::prim_wrapping_neg(rhs)
+                    Self::prim_wrapping_neg(rhs, s)
                 } else {
-                    prim_unary_values(rhs, |x| lhs - x)
+                    prim_unary_values(rhs, |x| lhs - x, s)
                 }
             }
 
-            fn prim_wrapping_mul_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_mul_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 // No optimization for multiplication by zero, would invalidate NaNs/infinities.
                 if rhs == 1.0 {
                     lhs
                 } else if rhs == -1.0 {
-                    Self::prim_wrapping_neg(lhs)
+                    Self::prim_wrapping_neg(lhs, s)
                 } else {
-                    prim_unary_values(lhs, |x| x * rhs)
+                    prim_unary_values(lhs, |x| x * rhs, s)
                 }
             }
 
-            fn prim_wrapping_floor_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_floor_div_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 let inv = 1.0 / rhs;
-                prim_unary_values(lhs, |x| (x * inv).floor())
+                prim_unary_values(lhs, |x| (x * inv).floor(), s)
             }
 
-            fn prim_wrapping_floor_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(rhs, |x| (lhs / x).floor())
+            fn prim_wrapping_floor_div_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_unary_values(rhs, |x| (lhs / x).floor(), s)
             }
 
-            fn prim_wrapping_trunc_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_trunc_div_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 let inv = 1.0 / rhs;
-                prim_unary_values(lhs, |x| (x * inv).trunc())
+                prim_unary_values(lhs, |x| (x * inv).trunc(), s)
             }
 
-            fn prim_wrapping_trunc_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(rhs, |x| (lhs / x).trunc())
+            fn prim_wrapping_trunc_div_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_unary_values(rhs, |x| (lhs / x).trunc(), s)
             }
 
-            fn prim_wrapping_mod_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_mod_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 let inv = 1.0 / rhs;
-                prim_unary_values(lhs, |x| x - rhs * (x * inv).floor())
+                prim_unary_values(lhs, |x| x - rhs * (x * inv).floor(), s)
             }
 
-            fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(rhs, |x| lhs - x * (lhs / x).floor())
+            fn prim_wrapping_mod_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_unary_values(rhs, |x| lhs - x * (lhs / x).floor(), s)
             }
 
-            fn prim_true_div(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<Self::TrueDivT> {
-                prim_binary_values(lhs, rhs, |l, r| l / r)
+            fn prim_true_div<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<Self::TrueDivT> {
+                prim_binary_values(lhs, rhs, |l, r| l / r, s)
             }
 
-            fn prim_true_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<Self::TrueDivT> {
-                Self::prim_wrapping_mul_scalar(lhs, 1.0 / rhs)
+            fn prim_true_div_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<Self::TrueDivT> {
+                Self::prim_wrapping_mul_scalar(lhs, 1.0 / rhs, s)
             }
 
-            fn prim_true_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<Self::TrueDivT> {
-                prim_unary_values(rhs, |x| lhs / x)
+            fn prim_true_div_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<Self::TrueDivT> {
+                prim_unary_values(rhs, |x| lhs / x, s)
             }
         }
     };

--- a/crates/polars-compute/src/arithmetic/mod.rs
+++ b/crates/polars-compute/src/arithmetic/mod.rs
@@ -3,6 +3,10 @@ use std::any::TypeId;
 use arrow::array::{Array, PrimitiveArray};
 use arrow::types::NativeType;
 
+#[cfg(feature = "nontemporal")]
+use crate::arity::NontemporalStore;
+use crate::arity::{StoreIntrinsic, TemporalStore};
+
 // Low-level comparison kernel.
 pub trait ArithmeticKernel: Sized + Array {
     type Scalar;
@@ -85,29 +89,73 @@ use PrimitiveArray as PArr;
 pub trait PrimitiveArithmeticKernelImpl: NativeType {
     type TrueDivT: NativeType;
 
-    fn prim_wrapping_abs(lhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_neg(lhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_add(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_sub(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_mul(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_floor_div(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_trunc_div(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_mod(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
+    fn prim_wrapping_abs<S: StoreIntrinsic>(lhs: PArr<Self>, s: S) -> PArr<Self>;
+    fn prim_wrapping_neg<S: StoreIntrinsic>(lhs: PArr<Self>, s: S) -> PArr<Self>;
+    fn prim_wrapping_add<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: PArr<Self>, s: S) -> PArr<Self>;
+    fn prim_wrapping_sub<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: PArr<Self>, s: S) -> PArr<Self>;
+    fn prim_wrapping_mul<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: PArr<Self>, s: S) -> PArr<Self>;
+    fn prim_wrapping_floor_div<S: StoreIntrinsic>(
+        lhs: PArr<Self>,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self>;
+    fn prim_wrapping_trunc_div<S: StoreIntrinsic>(
+        lhs: PArr<Self>,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self>;
+    fn prim_wrapping_mod<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: PArr<Self>, s: S) -> PArr<Self>;
 
-    fn prim_wrapping_add_scalar(lhs: PArr<Self>, rhs: Self) -> PArr<Self>;
-    fn prim_wrapping_sub_scalar(lhs: PArr<Self>, rhs: Self) -> PArr<Self>;
-    fn prim_wrapping_sub_scalar_lhs(lhs: Self, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_mul_scalar(lhs: PArr<Self>, rhs: Self) -> PArr<Self>;
-    fn prim_wrapping_floor_div_scalar(lhs: PArr<Self>, rhs: Self) -> PArr<Self>;
-    fn prim_wrapping_floor_div_scalar_lhs(lhs: Self, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_trunc_div_scalar(lhs: PArr<Self>, rhs: Self) -> PArr<Self>;
-    fn prim_wrapping_trunc_div_scalar_lhs(lhs: Self, rhs: PArr<Self>) -> PArr<Self>;
-    fn prim_wrapping_mod_scalar(lhs: PArr<Self>, rhs: Self) -> PArr<Self>;
-    fn prim_wrapping_mod_scalar_lhs(lhs: Self, rhs: PArr<Self>) -> PArr<Self>;
+    fn prim_wrapping_add_scalar<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: Self, s: S) -> PArr<Self>;
+    fn prim_wrapping_sub_scalar<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: Self, s: S) -> PArr<Self>;
+    fn prim_wrapping_sub_scalar_lhs<S: StoreIntrinsic>(
+        lhs: Self,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self>;
+    fn prim_wrapping_mul_scalar<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: Self, s: S) -> PArr<Self>;
+    fn prim_wrapping_floor_div_scalar<S: StoreIntrinsic>(
+        lhs: PArr<Self>,
+        rhs: Self,
+        s: S,
+    ) -> PArr<Self>;
+    fn prim_wrapping_floor_div_scalar_lhs<S: StoreIntrinsic>(
+        lhs: Self,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self>;
+    fn prim_wrapping_trunc_div_scalar<S: StoreIntrinsic>(
+        lhs: PArr<Self>,
+        rhs: Self,
+        s: S,
+    ) -> PArr<Self>;
+    fn prim_wrapping_trunc_div_scalar_lhs<S: StoreIntrinsic>(
+        lhs: Self,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self>;
+    fn prim_wrapping_mod_scalar<S: StoreIntrinsic>(lhs: PArr<Self>, rhs: Self, s: S) -> PArr<Self>;
+    fn prim_wrapping_mod_scalar_lhs<S: StoreIntrinsic>(
+        lhs: Self,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self>;
 
-    fn prim_true_div(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self::TrueDivT>;
-    fn prim_true_div_scalar(lhs: PArr<Self>, rhs: Self) -> PArr<Self::TrueDivT>;
-    fn prim_true_div_scalar_lhs(lhs: Self, rhs: PArr<Self>) -> PArr<Self::TrueDivT>;
+    fn prim_true_div<S: StoreIntrinsic>(
+        lhs: PArr<Self>,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self::TrueDivT>;
+    fn prim_true_div_scalar<S: StoreIntrinsic>(
+        lhs: PArr<Self>,
+        rhs: Self,
+        s: S,
+    ) -> PArr<Self::TrueDivT>;
+    fn prim_true_div_scalar_lhs<S: StoreIntrinsic>(
+        lhs: Self,
+        rhs: PArr<Self>,
+        s: S,
+    ) -> PArr<Self::TrueDivT>;
 }
 
 #[rustfmt::skip]
@@ -115,29 +163,93 @@ impl<T: HasPrimitiveArithmeticKernel> ArithmeticKernel for PrimitiveArray<T> {
     type Scalar = T;
     type TrueDivT = T::TrueDivT;
 
-    fn wrapping_abs(self) -> Self { T::prim_wrapping_abs(self) }
-    fn wrapping_neg(self) -> Self { T::prim_wrapping_neg(self) }
-    fn wrapping_add(self, rhs: Self) -> Self { T::prim_wrapping_add(self, rhs) }
-    fn wrapping_sub(self, rhs: Self) -> Self { T::prim_wrapping_sub(self, rhs) }
-    fn wrapping_mul(self, rhs: Self) -> Self { T::prim_wrapping_mul(self, rhs) }
-    fn wrapping_floor_div(self, rhs: Self) -> Self { T::prim_wrapping_floor_div(self, rhs) }
-    fn wrapping_trunc_div(self, rhs: Self) -> Self { T::prim_wrapping_trunc_div(self, rhs) }
-    fn wrapping_mod(self, rhs: Self) -> Self { T::prim_wrapping_mod(self, rhs) }
+    fn wrapping_abs(self) -> Self { T::prim_wrapping_abs(self, TemporalStore) }
+    fn wrapping_neg(self) -> Self { T::prim_wrapping_neg(self, TemporalStore) }
+    fn wrapping_add(self, rhs: Self) -> Self { T::prim_wrapping_add(self, rhs, TemporalStore) }
+    fn wrapping_sub(self, rhs: Self) -> Self { T::prim_wrapping_sub(self, rhs, TemporalStore) }
+    fn wrapping_mul(self, rhs: Self) -> Self { T::prim_wrapping_mul(self, rhs, TemporalStore) }
+    fn wrapping_floor_div(self, rhs: Self) -> Self { T::prim_wrapping_floor_div(self, rhs, TemporalStore) }
+    fn wrapping_trunc_div(self, rhs: Self) -> Self { T::prim_wrapping_trunc_div(self, rhs, TemporalStore) }
+    fn wrapping_mod(self, rhs: Self) -> Self { T::prim_wrapping_mod(self, rhs, TemporalStore) }
 
-    fn wrapping_add_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_add_scalar(self, rhs) }
-    fn wrapping_sub_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_sub_scalar(self, rhs) }
-    fn wrapping_sub_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_sub_scalar_lhs(lhs, rhs) }
-    fn wrapping_mul_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_mul_scalar(self, rhs) }
-    fn wrapping_floor_div_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_floor_div_scalar(self, rhs) }
-    fn wrapping_floor_div_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_floor_div_scalar_lhs(lhs, rhs) }
-    fn wrapping_trunc_div_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_trunc_div_scalar(self, rhs) }
-    fn wrapping_trunc_div_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_trunc_div_scalar_lhs(lhs, rhs) }
-    fn wrapping_mod_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_mod_scalar(self, rhs) }
-    fn wrapping_mod_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_mod_scalar_lhs(lhs, rhs) }
+    fn wrapping_add_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_add_scalar(self, rhs, TemporalStore) }
+    fn wrapping_sub_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_sub_scalar(self, rhs, TemporalStore) }
+    fn wrapping_sub_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_sub_scalar_lhs(lhs, rhs, TemporalStore) }
+    fn wrapping_mul_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_mul_scalar(self, rhs, TemporalStore) }
+    fn wrapping_floor_div_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_floor_div_scalar(self, rhs, TemporalStore) }
+    fn wrapping_floor_div_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_floor_div_scalar_lhs(lhs, rhs, TemporalStore) }
+    fn wrapping_trunc_div_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_trunc_div_scalar(self, rhs, TemporalStore) }
+    fn wrapping_trunc_div_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_trunc_div_scalar_lhs(lhs, rhs, TemporalStore) }
+    fn wrapping_mod_scalar(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_mod_scalar(self, rhs, TemporalStore) }
+    fn wrapping_mod_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_mod_scalar_lhs(lhs, rhs, TemporalStore) }
 
-    fn true_div(self, rhs: Self) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div(self, rhs) }
-    fn true_div_scalar(self, rhs: Self::Scalar) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div_scalar(self, rhs) }
-    fn true_div_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div_scalar_lhs(lhs, rhs) }
+    fn true_div(self, rhs: Self) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div(self, rhs, TemporalStore) }
+    fn true_div_scalar(self, rhs: Self::Scalar) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div_scalar(self, rhs, TemporalStore) }
+    fn true_div_scalar_lhs(lhs: Self::Scalar, rhs: Self) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div_scalar_lhs(lhs, rhs, TemporalStore) }
+}
+
+#[cfg(feature = "nontemporal")]
+pub trait NontemporalArithmeticKernel: Sized + Array {
+    type Scalar;
+    type TrueDivT: NativeType;
+
+    fn wrapping_abs_nontemporal(self) -> Self;
+    fn wrapping_neg_nontemporal(self) -> Self;
+    fn wrapping_add_nontemporal(self, rhs: Self) -> Self;
+    fn wrapping_sub_nontemporal(self, rhs: Self) -> Self;
+    fn wrapping_mul_nontemporal(self, rhs: Self) -> Self;
+    fn wrapping_floor_div_nontemporal(self, rhs: Self) -> Self;
+    fn wrapping_trunc_div_nontemporal(self, rhs: Self) -> Self;
+    fn wrapping_mod_nontemporal(self, rhs: Self) -> Self;
+
+    fn wrapping_add_scalar_nontemporal(self, rhs: Self::Scalar) -> Self;
+    fn wrapping_sub_scalar_nontemporal(self, rhs: Self::Scalar) -> Self;
+    fn wrapping_sub_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self;
+    fn wrapping_mul_scalar_nontemporal(self, rhs: Self::Scalar) -> Self;
+    fn wrapping_floor_div_scalar_nontemporal(self, rhs: Self::Scalar) -> Self;
+    fn wrapping_floor_div_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self;
+    fn wrapping_trunc_div_scalar_nontemporal(self, rhs: Self::Scalar) -> Self;
+    fn wrapping_trunc_div_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self;
+    fn wrapping_mod_scalar_nontemporal(self, rhs: Self::Scalar) -> Self;
+    fn wrapping_mod_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self;
+
+    fn true_div_nontemporal(self, rhs: Self) -> PrimitiveArray<Self::TrueDivT>;
+    fn true_div_scalar_nontemporal(self, rhs: Self::Scalar) -> PrimitiveArray<Self::TrueDivT>;
+    fn true_div_scalar_lhs_nontemporal(
+        lhs: Self::Scalar,
+        rhs: Self,
+    ) -> PrimitiveArray<Self::TrueDivT>;
+}
+
+#[cfg(feature = "nontemporal")]
+#[rustfmt::skip]
+impl<T: HasPrimitiveArithmeticKernel> NontemporalArithmeticKernel for PrimitiveArray<T> {
+    type Scalar = T;
+    type TrueDivT = T::TrueDivT;
+
+    fn wrapping_abs_nontemporal(self) -> Self { T::prim_wrapping_abs(self, NontemporalStore) }
+    fn wrapping_neg_nontemporal(self) -> Self { T::prim_wrapping_neg(self, NontemporalStore) }
+    fn wrapping_add_nontemporal(self, rhs: Self) -> Self { T::prim_wrapping_add(self, rhs, NontemporalStore) }
+    fn wrapping_sub_nontemporal(self, rhs: Self) -> Self { T::prim_wrapping_sub(self, rhs, NontemporalStore) }
+    fn wrapping_mul_nontemporal(self, rhs: Self) -> Self { T::prim_wrapping_mul(self, rhs, NontemporalStore) }
+    fn wrapping_floor_div_nontemporal(self, rhs: Self) -> Self { T::prim_wrapping_floor_div(self, rhs, NontemporalStore) }
+    fn wrapping_trunc_div_nontemporal(self, rhs: Self) -> Self { T::prim_wrapping_trunc_div(self, rhs, NontemporalStore) }
+    fn wrapping_mod_nontemporal(self, rhs: Self) -> Self { T::prim_wrapping_mod(self, rhs, NontemporalStore) }
+
+    fn wrapping_add_scalar_nontemporal(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_add_scalar(self, rhs, NontemporalStore) }
+    fn wrapping_sub_scalar_nontemporal(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_sub_scalar(self, rhs, NontemporalStore) }
+    fn wrapping_sub_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_sub_scalar_lhs(lhs, rhs, NontemporalStore) }
+    fn wrapping_mul_scalar_nontemporal(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_mul_scalar(self, rhs, NontemporalStore) }
+    fn wrapping_floor_div_scalar_nontemporal(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_floor_div_scalar(self, rhs, NontemporalStore) }
+    fn wrapping_floor_div_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_floor_div_scalar_lhs(lhs, rhs, NontemporalStore) }
+    fn wrapping_trunc_div_scalar_nontemporal(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_trunc_div_scalar(self, rhs, NontemporalStore) }
+    fn wrapping_trunc_div_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_trunc_div_scalar_lhs(lhs, rhs, NontemporalStore) }
+    fn wrapping_mod_scalar_nontemporal(self, rhs: Self::Scalar) -> Self { T::prim_wrapping_mod_scalar(self, rhs, NontemporalStore) }
+    fn wrapping_mod_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> Self { T::prim_wrapping_mod_scalar_lhs(lhs, rhs, NontemporalStore) }
+
+    fn true_div_nontemporal(self, rhs: Self) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div(self, rhs, NontemporalStore) }
+    fn true_div_scalar_nontemporal(self, rhs: Self::Scalar) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div_scalar(self, rhs, NontemporalStore) }
+    fn true_div_scalar_lhs_nontemporal(lhs: Self::Scalar, rhs: Self) -> PrimitiveArray<Self::TrueDivT> { T::prim_true_div_scalar_lhs(lhs, rhs, NontemporalStore) }
 }
 
 mod float;

--- a/crates/polars-compute/src/arithmetic/unsigned.rs
+++ b/crates/polars-compute/src/arithmetic/unsigned.rs
@@ -3,7 +3,7 @@ use arrow::compute::utils::{combine_validities_and, combine_validities_and3};
 use strength_reduce::*;
 
 use super::PrimitiveArithmeticKernelImpl;
-use crate::arity::{prim_binary_values, prim_unary_values};
+use crate::arity::{prim_binary_values, prim_unary_values, StoreIntrinsic};
 use crate::comparisons::TotalEqKernel;
 
 macro_rules! impl_unsigned_arith_kernel {
@@ -11,65 +11,105 @@ macro_rules! impl_unsigned_arith_kernel {
         impl PrimitiveArithmeticKernelImpl for $T {
             type TrueDivT = f64;
 
-            fn prim_wrapping_abs(lhs: PArr<$T>) -> PArr<$T> {
+            fn prim_wrapping_abs<S: StoreIntrinsic>(lhs: PArr<$T>, _: S) -> PArr<$T> {
                 lhs
             }
 
-            fn prim_wrapping_neg(lhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(lhs, |x| x.wrapping_neg())
+            fn prim_wrapping_neg<S: StoreIntrinsic>(lhs: PArr<$T>, s: S) -> PArr<$T> {
+                prim_unary_values(lhs, |x| x.wrapping_neg(), s)
             }
 
-            fn prim_wrapping_add(lhs: PArr<$T>, other: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, other, |a, b| a.wrapping_add(b))
+            fn prim_wrapping_add<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                other: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, other, |a, b| a.wrapping_add(b), s)
             }
 
-            fn prim_wrapping_sub(lhs: PArr<$T>, other: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, other, |a, b| a.wrapping_sub(b))
+            fn prim_wrapping_sub<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                other: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, other, |a, b| a.wrapping_sub(b), s)
             }
 
-            fn prim_wrapping_mul(lhs: PArr<$T>, other: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, other, |a, b| a.wrapping_mul(b))
+            fn prim_wrapping_mul<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                other: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_binary_values(lhs, other, |a, b| a.wrapping_mul(b), s)
             }
 
-            fn prim_wrapping_floor_div(mut lhs: PArr<$T>, mut other: PArr<$T>) -> PArr<$T> {
+            fn prim_wrapping_floor_div<S: StoreIntrinsic>(
+                mut lhs: PArr<$T>,
+                mut other: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
                 let mask = other.tot_ne_kernel_broadcast(&0);
                 let valid = combine_validities_and3(
                     lhs.take_validity().as_ref(),   // Take validity so we don't
                     other.take_validity().as_ref(), // compute combination twice.
                     Some(&mask),
                 );
-                let ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a / b } else { 0 });
+                let ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a / b } else { 0 }, s);
                 ret.with_validity(valid)
             }
 
-            fn prim_wrapping_trunc_div(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                Self::prim_wrapping_floor_div(lhs, rhs)
+            fn prim_wrapping_trunc_div<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                Self::prim_wrapping_floor_div(lhs, rhs, s)
             }
 
-            fn prim_wrapping_mod(mut lhs: PArr<$T>, mut other: PArr<$T>) -> PArr<$T> {
+            fn prim_wrapping_mod<S: StoreIntrinsic>(
+                mut lhs: PArr<$T>,
+                mut other: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
                 let mask = other.tot_ne_kernel_broadcast(&0);
                 let valid = combine_validities_and3(
                     lhs.take_validity().as_ref(),   // Take validity so we don't
                     other.take_validity().as_ref(), // compute combination twice.
                     Some(&mask),
                 );
-                let ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a % b } else { 0 });
+                let ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a % b } else { 0 }, s);
                 ret.with_validity(valid)
             }
 
-            fn prim_wrapping_add_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                prim_unary_values(lhs, |x| x.wrapping_add(rhs))
+            fn prim_wrapping_add_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
+                prim_unary_values(lhs, |x| x.wrapping_add(rhs), s)
             }
 
-            fn prim_wrapping_sub_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                Self::prim_wrapping_add_scalar(lhs, rhs.wrapping_neg())
+            fn prim_wrapping_sub_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
+                Self::prim_wrapping_add_scalar(lhs, rhs.wrapping_neg(), s)
             }
 
-            fn prim_wrapping_sub_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(rhs, |x| lhs.wrapping_sub(x))
+            fn prim_wrapping_sub_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                prim_unary_values(rhs, |x| lhs.wrapping_sub(x), s)
             }
 
-            fn prim_wrapping_mul_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_mul_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 if rhs == 0 {
                     lhs.fill_with(0)
                 } else if rhs == 1 {
@@ -77,75 +117,111 @@ macro_rules! impl_unsigned_arith_kernel {
                 } else if rhs & (rhs - 1) == 0 {
                     // Power of two.
                     let shift = rhs.trailing_zeros();
-                    prim_unary_values(lhs, |x| x << shift)
+                    prim_unary_values(lhs, |x| x << shift, s)
                 } else {
-                    prim_unary_values(lhs, |x| x.wrapping_mul(rhs))
+                    prim_unary_values(lhs, |x| x.wrapping_mul(rhs), s)
                 }
             }
 
-            fn prim_wrapping_floor_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_floor_div_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 if rhs == 0 {
                     PArr::full_null(lhs.len(), lhs.data_type().clone())
                 } else if rhs == 1 {
                     lhs
                 } else {
                     let red = <$StrRed>::new(rhs);
-                    prim_unary_values(lhs, |x| x / red)
+                    prim_unary_values(lhs, |x| x / red, s)
                 }
             }
 
-            fn prim_wrapping_floor_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
+            fn prim_wrapping_floor_div_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
                 if lhs == 0 {
                     return rhs.fill_with(0);
                 }
 
                 let mask = rhs.tot_ne_kernel_broadcast(&0);
                 let valid = combine_validities_and(rhs.validity(), Some(&mask));
-                let ret = prim_unary_values(rhs, |x| if x != 0 { lhs / x } else { 0 });
+                let ret = prim_unary_values(rhs, |x| if x != 0 { lhs / x } else { 0 }, s);
                 ret.with_validity(valid)
             }
 
-            fn prim_wrapping_trunc_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                Self::prim_wrapping_floor_div_scalar(lhs, rhs)
+            fn prim_wrapping_trunc_div_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
+                Self::prim_wrapping_floor_div_scalar(lhs, rhs, s)
             }
 
-            fn prim_wrapping_trunc_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                Self::prim_wrapping_floor_div_scalar_lhs(lhs, rhs)
+            fn prim_wrapping_trunc_div_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
+                Self::prim_wrapping_floor_div_scalar_lhs(lhs, rhs, s)
             }
 
-            fn prim_wrapping_mod_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
+            fn prim_wrapping_mod_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<$T> {
                 if rhs == 0 {
                     PArr::full_null(lhs.len(), lhs.data_type().clone())
                 } else if rhs == 1 {
                     lhs.fill_with(0)
                 } else {
                     let red = <$StrRed>::new(rhs);
-                    prim_unary_values(lhs, |x| x % red)
+                    prim_unary_values(lhs, |x| x % red, s)
                 }
             }
 
-            fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
+            fn prim_wrapping_mod_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<$T> {
                 if lhs == 0 {
                     return rhs.fill_with(0);
                 }
 
                 let mask = rhs.tot_ne_kernel_broadcast(&0);
                 let valid = combine_validities_and(rhs.validity(), Some(&mask));
-                let ret = prim_unary_values(rhs, |x| if x != 0 { lhs % x } else { 0 });
+                let ret = prim_unary_values(rhs, |x| if x != 0 { lhs % x } else { 0 }, s);
                 ret.with_validity(valid)
             }
 
-            fn prim_true_div(lhs: PArr<$T>, other: PArr<$T>) -> PArr<Self::TrueDivT> {
-                prim_binary_values(lhs, other, |a, b| a as f64 / b as f64)
+            fn prim_true_div<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                other: PArr<$T>,
+                s: S,
+            ) -> PArr<Self::TrueDivT> {
+                prim_binary_values(lhs, other, |a, b| a as f64 / b as f64, s)
             }
 
-            fn prim_true_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<Self::TrueDivT> {
+            fn prim_true_div_scalar<S: StoreIntrinsic>(
+                lhs: PArr<$T>,
+                rhs: $T,
+                s: S,
+            ) -> PArr<Self::TrueDivT> {
                 let inv = 1.0 / rhs as f64;
-                prim_unary_values(lhs, |x| x as f64 * inv)
+                prim_unary_values(lhs, |x| x as f64 * inv, s)
             }
 
-            fn prim_true_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<Self::TrueDivT> {
-                prim_unary_values(rhs, |x| lhs as f64 / x as f64)
+            fn prim_true_div_scalar_lhs<S: StoreIntrinsic>(
+                lhs: $T,
+                rhs: PArr<$T>,
+                s: S,
+            ) -> PArr<Self::TrueDivT> {
+                prim_unary_values(rhs, |x| lhs as f64 / x as f64, s)
             }
         }
     };

--- a/crates/polars-compute/src/arity.rs
+++ b/crates/polars-compute/src/arity.rs
@@ -2,6 +2,33 @@ use arrow::array::PrimitiveArray;
 use arrow::compute::utils::combine_validities_and;
 use arrow::types::NativeType;
 
+#[doc(hidden)]
+pub trait StoreIntrinsic: Copy + Clone {
+    unsafe fn store<T>(ptr: *mut T, val: T);
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct TemporalStore;
+
+impl StoreIntrinsic for TemporalStore {
+    #[inline(always)]
+    unsafe fn store<T>(ptr: *mut T, val: T) {
+        ptr.write(val)
+    }
+}
+
+#[cfg(feature = "nontemporal")]
+#[derive(Copy, Clone)]
+pub(crate) struct NontemporalStore;
+
+#[cfg(feature = "nontemporal")]
+impl StoreIntrinsic for NontemporalStore {
+    #[inline(always)]
+    unsafe fn store<T>(ptr: *mut T, val: T) {
+        std::intrinsics::nontemporal_store(ptr, val);
+    }
+}
+
 /// To reduce codegen we use these helpers where the input and output arrays
 /// may overlap. These are marked to never be inlined, this way only a single
 /// unrolled kernel gets generated, even if we call it in multiple ways.
@@ -10,15 +37,16 @@ use arrow::types::NativeType;
 ///  - arr must point to a readable slice of length len.
 ///  - out must point to a writable slice of length len.
 #[inline(never)]
-unsafe fn ptr_apply_unary_kernel<I: Copy, O, F: Fn(I) -> O>(
+unsafe fn ptr_apply_unary_kernel<I: Copy, O, F: Fn(I) -> O, S: StoreIntrinsic>(
     arr: *const I,
     out: *mut O,
     len: usize,
     op: F,
+    _: S,
 ) {
     for i in 0..len {
         let ret = op(arr.add(i).read());
-        out.add(i).write(ret);
+        S::store(out.add(i), ret);
     }
 }
 
@@ -27,27 +55,29 @@ unsafe fn ptr_apply_unary_kernel<I: Copy, O, F: Fn(I) -> O>(
 ///  - right must point to a readable slice of length len.
 ///  - out must point to a writable slice of length len.
 #[inline(never)]
-unsafe fn ptr_apply_binary_kernel<L: Copy, R: Copy, O, F: Fn(L, R) -> O>(
+unsafe fn ptr_apply_binary_kernel<L: Copy, R: Copy, O, F: Fn(L, R) -> O, S: StoreIntrinsic>(
     left: *const L,
     right: *const R,
     out: *mut O,
     len: usize,
     op: F,
+    _: S,
 ) {
     for i in 0..len {
         let ret = op(left.add(i).read(), right.add(i).read());
-        out.add(i).write(ret);
+        S::store(out.add(i), ret);
     }
 }
 
 /// Applies a function to all the values (regardless of nullability).
 ///
 /// May reuse the memory of the array if possible.
-pub fn prim_unary_values<I, O, F>(mut arr: PrimitiveArray<I>, op: F) -> PrimitiveArray<O>
+pub fn prim_unary_values<I, O, F, S>(mut arr: PrimitiveArray<I>, op: F, s: S) -> PrimitiveArray<O>
 where
     I: NativeType,
     O: NativeType,
     F: Fn(I) -> O,
+    S: StoreIntrinsic,
 {
     let len = arr.len();
 
@@ -58,7 +88,7 @@ where
         if let Some(values) = arr.get_mut_values() {
             let ptr = values.as_mut_ptr();
             // SAFETY: checked same size & alignment I/O, NativeType is always Pod.
-            unsafe { ptr_apply_unary_kernel(ptr, ptr as *mut O, len, op) }
+            unsafe { ptr_apply_unary_kernel(ptr, ptr as *mut O, len, op, s) }
             return arr.transmute::<O>();
         }
     }
@@ -66,7 +96,7 @@ where
     let mut out = Vec::with_capacity(len);
     unsafe {
         // SAFETY: checked pointers point to slices of length len.
-        ptr_apply_unary_kernel(arr.values().as_ptr(), out.as_mut_ptr(), len, op);
+        ptr_apply_unary_kernel(arr.values().as_ptr(), out.as_mut_ptr(), len, op, s);
         out.set_len(len);
     }
     PrimitiveArray::from_vec(out).with_validity(arr.take_validity())
@@ -76,16 +106,18 @@ where
 /// in (lhs, rhs). Combines the validities with a bitand.
 ///
 /// May reuse the memory of one of its arguments if possible.
-pub fn prim_binary_values<L, R, O, F>(
+pub fn prim_binary_values<L, R, O, F, S>(
     mut lhs: PrimitiveArray<L>,
     mut rhs: PrimitiveArray<R>,
     op: F,
+    s: S,
 ) -> PrimitiveArray<O>
 where
     L: NativeType,
     R: NativeType,
     O: NativeType,
     F: Fn(L, R) -> O,
+    S: StoreIntrinsic,
 {
     assert_eq!(lhs.len(), rhs.len());
     let len = lhs.len();
@@ -101,7 +133,7 @@ where
             let rp = rhs.values().as_ptr();
             unsafe {
                 // SAFETY: checked same size & alignment L/O, NativeType is always Pod.
-                ptr_apply_binary_kernel(lp, rp, lp as *mut O, len, op);
+                ptr_apply_binary_kernel(lp, rp, lp as *mut O, len, op, s);
             }
             return lhs.transmute::<O>().with_validity(validity);
         }
@@ -114,7 +146,7 @@ where
             let rp = rv.as_mut_ptr();
             unsafe {
                 // SAFETY: checked same size & alignment R/O, NativeType is always Pod.
-                ptr_apply_binary_kernel(lp, rp, rp as *mut O, len, op);
+                ptr_apply_binary_kernel(lp, rp, rp as *mut O, len, op, s);
             }
             return rhs.transmute::<O>().with_validity(validity);
         }
@@ -125,7 +157,7 @@ where
         // SAFETY: checked pointers point to slices of length len.
         let lp = lhs.values().as_ptr();
         let rp = rhs.values().as_ptr();
-        ptr_apply_binary_kernel(lp, rp, out.as_mut_ptr(), len, op);
+        ptr_apply_binary_kernel(lp, rp, out.as_mut_ptr(), len, op, s);
         out.set_len(len);
     }
     PrimitiveArray::from_vec(out).with_validity(validity)

--- a/crates/polars-compute/src/lib.rs
+++ b/crates/polars-compute/src/lib.rs
@@ -4,6 +4,8 @@
     all(feature = "simd", target_arch = "x86_64"),
     feature(stdarch_x86_avx512)
 )]
+#![allow(internal_features)]
+#![cfg_attr(feature = "nontemporal", feature(core_intrinsics))]
 
 use arrow::types::NativeType;
 

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -48,7 +48,8 @@ version_check = { workspace = true }
 
 [features]
 simd = ["arrow/simd", "polars-compute/simd"]
-nightly = ["simd", "hashbrown/nightly", "polars-utils/nightly", "arrow/nightly"]
+nontemporal = ["polars-compute/nontemporal"]
+nightly = ["simd", "nontemporal", "hashbrown/nightly", "polars-utils/nightly", "arrow/nightly"]
 avx512 = []
 docs = []
 temporal = ["regex", "chrono", "polars-error/regex"]

--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -8,6 +8,8 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 use arrow::compute::utils::combine_validities_and;
 use num_traits::{Num, NumCast, ToPrimitive};
 pub use numeric::ArithmeticChunked;
+#[cfg(feature = "nontemporal")]
+pub use numeric::NontemporalArithmeticChunked;
 
 use crate::prelude::*;
 


### PR DESCRIPTION
For arrays that are larger than cache size, arithmetic is usually memory bound. Temporal store (`std::ptr::write`) used in `ArithmeticChunked` will quickly fill up the cache, discarding previously cached data. What's worse, because we usually perform operations from the head of an array to the tail, after temporal store fills up the cache, the following operations will have to re-read the array from the memory to cache, which is a significant performance penalty.

This PR adds `NontemporalArithmeticChunked` that uses nontemporal store (`std::intrinsics::nontemporal_store`), which 1) does not allocate new lines in the cache, instead storing directly to the memory with higher bandwidth, 2) is not ordered with regard to other loads/stores, giving the CPU more flexibility in hiding memory latency. There are public benchmarks w.r.t. temporal store and nontemporal store, demonstrating the performance improvement of nontemporal store on large amount of data.

`NontemporalArithmeticChunked` is only enabled when the feature `nontemporal` is enabled, which is enabled by the feature `nightly`. The Rust doc says `std::intrinsics::nontemporal_store` will probably never become stable, so `NontemporalArithmeticChunked` will never, either. The doc also says `std::intrinsics::nontemporal_store` violates the memory model of Rust; we do not care about that; after all, no one will put atomic integers in a `PrimitiveArray`.

This PR only adds a trait in Rust. It is not used in lazy and is not exposed to Python, yet. In the future, optimizations like automatically choosing nontemporal arithmetic when operands are large arrays can be added.
