### PR TITLE
perf: Introduce `MemReader` to file buffer in Parquet reader

### DIFF
--- a/crates/polars-io/src/parquet/read/mmap.rs
+++ b/crates/polars-io/src/parquet/read/mmap.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 #[cfg(feature = "async")]
 use polars_core::datatypes::PlHashMap;
 use polars_error::PolarsResult;
+use polars_parquet::parquet::read::MemReader;
 use polars_parquet::read::{
     column_iter_to_arrays, get_field_columns, ArrayIter, BasicDecompressor, ColumnChunkMetaData,
     PageReader,
@@ -73,7 +74,7 @@ pub(super) fn to_deserializer<'a>(
         .into_iter()
         .map(|(column_meta, chunk)| {
             let pages = PageReader::new(
-                std::io::Cursor::new(chunk),
+                MemReader::from_slice(chunk),
                 column_meta,
                 std::sync::Arc::new(|_, _| true),
                 vec![],

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
@@ -146,7 +146,7 @@ impl DecodedState for (FixedSizeBinary, MutableBitmap) {
 
 impl<'a> Decoder<'a> for BinaryDecoder {
     type Translation = StateTranslation<'a>;
-    type Dict = Vec<u8>;
+    type Dict = &'a [u8];
     type DecodedState = (FixedSizeBinary, MutableBitmap);
 
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState {
@@ -156,8 +156,8 @@ impl<'a> Decoder<'a> for BinaryDecoder {
         )
     }
 
-    fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {
-        page.buffer.clone()
+    fn deserialize_dict(&self, page: &'a DictPage) -> Self::Dict {
+        page.buffer.as_ref()
     }
 }
 
@@ -207,7 +207,7 @@ impl<I: PagesIter> Iterator for Iter<I> {
             let maybe_state = next(
                 &mut self.iter,
                 &mut self.items,
-                &mut self.dict,
+                &mut self.dict.as_deref(),
                 &mut self.remaining,
                 self.chunk_size,
                 &BinaryDecoder { size: self.size },

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/dictionary.rs
@@ -56,7 +56,7 @@ fn read_dict(data_type: ArrowDataType, dict: &DictPage) -> Box<dyn Array> {
 
     let values = dict.buffer.clone();
 
-    FixedSizeBinaryArray::try_new(data_type, values.into(), None)
+    FixedSizeBinaryArray::try_new(data_type, values.to_vec().into(), None)
         .unwrap()
         .boxed()
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
@@ -36,17 +36,17 @@ use simple::page_iter_to_arrays;
 pub use self::nested_utils::{init_nested, InitNested, NestedArrayIter, NestedState};
 pub use self::struct_::StructIterator;
 use super::*;
-use crate::parquet::read::get_page_iterator as _get_page_iterator;
+use crate::parquet::read::{get_page_iterator as _get_page_iterator, MemReader};
 use crate::parquet::schema::types::PrimitiveType;
 
 /// Creates a new iterator of compressed pages.
-pub fn get_page_iterator<R: Read + Seek>(
+pub fn get_page_iterator(
     column_metadata: &ColumnChunkMetaData,
-    reader: R,
+    reader: MemReader,
     pages_filter: Option<PageFilter>,
     buffer: Vec<u8>,
     max_header_size: usize,
-) -> PolarsResult<PageReader<R>> {
+) -> PolarsResult<PageReader> {
     Ok(_get_page_iterator(
         column_metadata,
         reader,

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -229,7 +229,7 @@ pub(super) trait NestedDecoder<'a> {
     ) -> ParquetResult<()>;
     fn push_n_nulls(&self, decoded: &mut Self::DecodedState, n: usize);
 
-    fn deserialize_dict(&self, page: &DictPage) -> Self::Dictionary;
+    fn deserialize_dict(&self, page: &'a DictPage) -> Self::Dictionary;
 }
 
 /// The initial info of nested data types.

--- a/crates/polars-parquet/src/arrow/read/deserialize/null/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null/mod.rs
@@ -65,6 +65,7 @@ mod tests {
     use crate::parquet::fallible_streaming_iterator;
     use crate::parquet::metadata::Descriptor;
     use crate::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, Page};
+    use crate::parquet::read::CowBuffer;
     use crate::parquet::schema::types::{PhysicalType, PrimitiveType};
 
     #[test]
@@ -78,7 +79,7 @@ mod tests {
                     repetition_level_encoding: Encoding::Plain.into(),
                     statistics: None,
                 }),
-                vec![],
+                CowBuffer::Owned(vec![]),
                 Descriptor {
                     primitive_type: PrimitiveType::from_physical(
                         "a".to_string(),

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -215,8 +215,7 @@ where
         match (self, page_validity) {
             (Self::Unit(page), None) => {
                 values.extend(
-                    page.by_ref()
-                        .map(|v| decoder.decoder.decode(P::from_le_bytes(*v)))
+                    page.map(|v| decoder.decoder.decode(P::from_le_bytes(*v)))
                         .take(additional),
                 );
             },

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -484,7 +484,7 @@ pub(super) trait Decoder<'a>: Sized {
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState;
 
     /// Deserializes a [`DictPage`] into [`Self::Dict`].
-    fn deserialize_dict(&self, page: &DictPage) -> Self::Dict;
+    fn deserialize_dict(&self, page: &'a DictPage) -> Self::Dict;
 }
 
 pub(super) fn extend_from_new_page<'a, T: Decoder<'a>>(

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -19,6 +19,7 @@ use crate::arrow::write::{slice_nested_leaf, utils};
 use crate::parquet::encoding::hybrid_rle::encode;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::page::{DictPage, Page};
+use crate::parquet::read::CowBuffer;
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::statistics::ParquetStatistics;
 use crate::write::DynIter;
@@ -202,7 +203,10 @@ macro_rules! dyn_prim {
         } else {
             None
         };
-        (DictPage::new(buffer, values.len(), false), stats)
+        (
+            DictPage::new(CowBuffer::Owned(buffer), values.len(), false),
+            stats,
+        )
     }};
 }
 
@@ -254,7 +258,10 @@ pub fn array_to_pages<K: DictionaryKey>(
                         } else {
                             None
                         };
-                        (DictPage::new(buffer, array.len(), false), stats)
+                        (
+                            DictPage::new(CowBuffer::Owned(buffer), array.len(), false),
+                            stats,
+                        )
                     },
                     ArrowDataType::BinaryView => {
                         let array = array
@@ -274,7 +281,10 @@ pub fn array_to_pages<K: DictionaryKey>(
                         } else {
                             None
                         };
-                        (DictPage::new(buffer, array.len(), false), stats)
+                        (
+                            DictPage::new(CowBuffer::Owned(buffer), array.len(), false),
+                            stats,
+                        )
                     },
                     ArrowDataType::Utf8View => {
                         let array = array
@@ -295,7 +305,10 @@ pub fn array_to_pages<K: DictionaryKey>(
                         } else {
                             None
                         };
-                        (DictPage::new(buffer, array.len(), false), stats)
+                        (
+                            DictPage::new(CowBuffer::Owned(buffer), array.len(), false),
+                            stats,
+                        )
                     },
                     ArrowDataType::LargeBinary => {
                         let values = array.values().as_any().downcast_ref().unwrap();
@@ -311,7 +324,10 @@ pub fn array_to_pages<K: DictionaryKey>(
                         } else {
                             None
                         };
-                        (DictPage::new(buffer, values.len(), false), stats)
+                        (
+                            DictPage::new(CowBuffer::Owned(buffer), values.len(), false),
+                            stats,
+                        )
                     },
                     ArrowDataType::FixedSizeBinary(_) => {
                         let mut buffer = vec![];
@@ -327,7 +343,10 @@ pub fn array_to_pages<K: DictionaryKey>(
                         } else {
                             None
                         };
-                        (DictPage::new(buffer, array.len(), false), stats)
+                        (
+                            DictPage::new(CowBuffer::Owned(buffer), array.len(), false),
+                            stats,
+                        )
                     },
                     other => {
                         polars_bail!(nyi =

--- a/crates/polars-parquet/src/arrow/write/utils.rs
+++ b/crates/polars-parquet/src/arrow/write/utils.rs
@@ -8,6 +8,7 @@ use crate::parquet::encoding::hybrid_rle::encode;
 use crate::parquet::encoding::Encoding;
 use crate::parquet::metadata::Descriptor;
 use crate::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, DataPageHeaderV2};
+use crate::parquet::read::CowBuffer;
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::statistics::ParquetStatistics;
 
@@ -89,7 +90,7 @@ pub fn build_plain_page(
     };
     Ok(DataPage::new(
         header,
-        buffer,
+        CowBuffer::Owned(buffer),
         Descriptor {
             primitive_type: type_,
             max_def_level: 0,

--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -1,3 +1,4 @@
+use super::read::CowBuffer;
 use crate::parquet::compression::Compression;
 use crate::parquet::encoding::{get_length, Encoding};
 use crate::parquet::error::{ParquetError, ParquetResult};
@@ -19,7 +20,7 @@ pub enum PageResult {
 #[derive(Debug)]
 pub struct CompressedDataPage {
     pub(crate) header: DataPageHeader,
-    pub(crate) buffer: Vec<u8>,
+    pub(crate) buffer: CowBuffer,
     pub(crate) compression: Compression,
     uncompressed_page_size: usize,
     pub(crate) descriptor: Descriptor,
@@ -32,7 +33,7 @@ impl CompressedDataPage {
     /// Returns a new [`CompressedDataPage`].
     pub fn new(
         header: DataPageHeader,
-        buffer: Vec<u8>,
+        buffer: CowBuffer,
         compression: Compression,
         uncompressed_page_size: usize,
         descriptor: Descriptor,
@@ -51,7 +52,7 @@ impl CompressedDataPage {
     /// Returns a new [`CompressedDataPage`].
     pub(crate) fn new_read(
         header: DataPageHeader,
-        buffer: Vec<u8>,
+        buffer: CowBuffer,
         compression: Compression,
         uncompressed_page_size: usize,
         descriptor: Descriptor,
@@ -114,6 +115,10 @@ impl CompressedDataPage {
     pub fn select_rows(&mut self, selected_rows: Vec<Interval>) {
         self.selected_rows = Some(selected_rows);
     }
+
+    pub fn slice_mut(&mut self) -> &mut CowBuffer {
+        &mut self.buffer
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -136,7 +141,7 @@ impl DataPageHeader {
 #[derive(Debug, Clone)]
 pub struct DataPage {
     pub(super) header: DataPageHeader,
-    pub(super) buffer: Vec<u8>,
+    pub(super) buffer: CowBuffer,
     pub descriptor: Descriptor,
     pub selected_rows: Option<Vec<Interval>>,
 }
@@ -144,7 +149,7 @@ pub struct DataPage {
 impl DataPage {
     pub fn new(
         header: DataPageHeader,
-        buffer: Vec<u8>,
+        buffer: CowBuffer,
         descriptor: Descriptor,
         rows: Option<usize>,
     ) -> Self {
@@ -158,7 +163,7 @@ impl DataPage {
 
     pub(crate) fn new_read(
         header: DataPageHeader,
-        buffer: Vec<u8>,
+        buffer: CowBuffer,
         descriptor: Descriptor,
         selected_rows: Option<Vec<Interval>>,
     ) -> Self {
@@ -187,7 +192,7 @@ impl DataPage {
     /// Returns a mutable reference to the internal buffer.
     /// Useful to recover the buffer after the page has been decoded.
     pub fn buffer_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.buffer
+        self.buffer.to_mut()
     }
 
     pub fn num_values(&self) -> usize {
@@ -242,12 +247,13 @@ pub enum Page {
 }
 
 impl Page {
-    pub(crate) fn buffer(&mut self) -> &mut Vec<u8> {
+    pub(crate) fn buffer_mut(&mut self) -> &mut Vec<u8> {
         match self {
-            Self::Data(page) => &mut page.buffer,
-            Self::Dict(page) => &mut page.buffer,
+            Self::Data(page) => page.buffer.to_mut(),
+            Self::Dict(page) => page.buffer.to_mut(),
         }
     }
+
     pub(crate) fn unwrap_data(self) -> DataPage {
         match self {
             Self::Data(page) => page,
@@ -266,10 +272,17 @@ pub enum CompressedPage {
 }
 
 impl CompressedPage {
-    pub(crate) fn buffer(&mut self) -> &mut Vec<u8> {
+    pub(crate) fn buffer(&self) -> &[u8] {
         match self {
-            CompressedPage::Data(page) => &mut page.buffer,
-            CompressedPage::Dict(page) => &mut page.buffer,
+            CompressedPage::Data(page) => &page.buffer,
+            CompressedPage::Dict(page) => &page.buffer,
+        }
+    }
+
+    pub(crate) fn buffer_mut(&mut self) -> &mut Vec<u8> {
+        match self {
+            CompressedPage::Data(page) => page.buffer.to_mut(),
+            CompressedPage::Dict(page) => page.buffer.to_mut(),
         }
     }
 
@@ -305,13 +318,13 @@ impl CompressedPage {
 /// An uncompressed, encoded dictionary page.
 #[derive(Debug)]
 pub struct DictPage {
-    pub buffer: Vec<u8>,
+    pub buffer: CowBuffer,
     pub num_values: usize,
     pub is_sorted: bool,
 }
 
 impl DictPage {
-    pub fn new(buffer: Vec<u8>, num_values: usize, is_sorted: bool) -> Self {
+    pub fn new(buffer: CowBuffer, num_values: usize, is_sorted: bool) -> Self {
         Self {
             buffer,
             num_values,
@@ -323,7 +336,7 @@ impl DictPage {
 /// A compressed, encoded dictionary page.
 #[derive(Debug)]
 pub struct CompressedDictPage {
-    pub(crate) buffer: Vec<u8>,
+    pub(crate) buffer: CowBuffer,
     compression: Compression,
     pub(crate) num_values: usize,
     pub(crate) uncompressed_page_size: usize,
@@ -332,7 +345,7 @@ pub struct CompressedDictPage {
 
 impl CompressedDictPage {
     pub fn new(
-        buffer: Vec<u8>,
+        buffer: CowBuffer,
         compression: Compression,
         uncompressed_page_size: usize,
         num_values: usize,

--- a/crates/polars-parquet/src/parquet/read/mod.rs
+++ b/crates/polars-parquet/src/parquet/read/mod.rs
@@ -7,7 +7,7 @@ mod page;
 #[cfg(feature = "async")]
 mod stream;
 
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Seek, SeekFrom};
 use std::sync::Arc;
 
 pub use column::*;
@@ -16,7 +16,10 @@ pub use indexes::{read_columns_indexes, read_pages_locations};
 pub use metadata::{deserialize_metadata, read_metadata, read_metadata_with_size};
 #[cfg(feature = "async")]
 pub use page::{get_page_stream, get_page_stream_from_column_start};
-pub use page::{IndexedPageReader, PageFilter, PageIterator, PageMetaData, PageReader};
+pub use page::{
+    CowBuffer, IndexedPageReader, MemReader, MemReaderSlice, PageFilter, PageIterator,
+    PageMetaData, PageReader,
+};
 #[cfg(feature = "async")]
 pub use stream::read_metadata as read_metadata_async;
 
@@ -41,13 +44,13 @@ pub fn filter_row_groups(
 }
 
 /// Returns a new [`PageReader`] by seeking `reader` to the beginning of `column_chunk`.
-pub fn get_page_iterator<R: Read + Seek>(
+pub fn get_page_iterator(
     column_chunk: &ColumnChunkMetaData,
-    mut reader: R,
+    mut reader: MemReader,
     pages_filter: Option<PageFilter>,
     scratch: Vec<u8>,
     max_page_size: usize,
-) -> ParquetResult<PageReader<R>> {
+) -> ParquetResult<PageReader> {
     let pages_filter = pages_filter.unwrap_or_else(|| Arc::new(|_, _| true));
 
     let (col_start, _) = column_chunk.byte_range();

--- a/crates/polars-parquet/src/parquet/read/page/indexed_reader.rs
+++ b/crates/polars-parquet/src/parquet/read/page/indexed_reader.rs
@@ -1,7 +1,9 @@
 use std::collections::VecDeque;
-use std::io::{Cursor, Read, Seek, SeekFrom};
+use std::io::{Seek, SeekFrom};
 
+use super::memreader::MemReader;
 use super::reader::{finish_page, read_page_header, PageMetaData};
+use super::MemReaderSlice;
 use crate::parquet::error::ParquetError;
 use crate::parquet::indexes::{FilteredPage, Interval};
 use crate::parquet::metadata::{ColumnChunkMetaData, Descriptor};
@@ -17,9 +19,9 @@ enum State {
 /// A fallible [`Iterator`] of [`CompressedPage`]. This iterator leverages page indexes
 /// to skip pages that are not needed. Consequently, the pages from this
 /// iterator always have [`Some`] [`crate::parquet::page::CompressedDataPage::selected_rows()`]
-pub struct IndexedPageReader<R: Read + Seek> {
+pub struct IndexedPageReader {
     // The source
-    reader: R,
+    reader: MemReader,
 
     column_start: u64,
     compression: Compression,
@@ -38,43 +40,34 @@ pub struct IndexedPageReader<R: Read + Seek> {
     state: State,
 }
 
-fn read_page<R: Read + Seek>(
-    reader: &mut R,
+fn read_page(
+    reader: &mut MemReader,
     start: u64,
     length: usize,
-    buffer: &mut Vec<u8>,
-    data: &mut Vec<u8>,
-) -> Result<ParquetPageHeader, ParquetError> {
+) -> Result<(ParquetPageHeader, MemReaderSlice), ParquetError> {
     // seek to the page
     reader.seek(SeekFrom::Start(start))?;
 
-    // read [header][data] to buffer
-    buffer.clear();
-    buffer.try_reserve(length)?;
-    reader.by_ref().take(length as u64).read_to_end(buffer)?;
+    let start_position = reader.position();
 
     // deserialize [header]
-    let mut reader = Cursor::new(buffer);
-    let page_header = read_page_header(&mut reader, 1024 * 1024)?;
-    let header_size = reader.stream_position().unwrap() as usize;
-    let buffer = reader.into_inner();
+    let page_header = read_page_header(reader, 1024 * 1024)?;
+    let header_size = reader.position() - start_position;
 
     // copy [data]
-    data.clear();
-    data.extend_from_slice(&buffer[header_size..]);
-    Ok(page_header)
+    let data = reader.read_slice(length - header_size);
+
+    Ok((page_header, data))
 }
 
-fn read_dict_page<R: Read + Seek>(
-    reader: &mut R,
+fn read_dict_page(
+    reader: &mut MemReader,
     start: u64,
     length: usize,
-    buffer: &mut Vec<u8>,
-    data: &mut Vec<u8>,
     compression: Compression,
     descriptor: &Descriptor,
 ) -> Result<CompressedDictPage, ParquetError> {
-    let page_header = read_page(reader, start, length, buffer, data)?;
+    let (page_header, data) = read_page(reader, start, length)?;
 
     let page = finish_page(page_header, data, compression, descriptor, None)?;
     if let CompressedPage::Dict(page) = page {
@@ -86,10 +79,10 @@ fn read_dict_page<R: Read + Seek>(
     }
 }
 
-impl<R: Read + Seek> IndexedPageReader<R> {
+impl IndexedPageReader {
     /// Returns a new [`IndexedPageReader`].
     pub fn new(
-        reader: R,
+        reader: MemReader,
         column: &ColumnChunkMetaData,
         pages: Vec<FilteredPage>,
         buffer: Vec<u8>,
@@ -100,7 +93,7 @@ impl<R: Read + Seek> IndexedPageReader<R> {
 
     /// Returns a new [`IndexedPageReader`] with [`PageMetaData`].
     pub fn new_with_page_meta(
-        reader: R,
+        reader: MemReader,
         column: PageMetaData,
         pages: Vec<FilteredPage>,
         buffer: Vec<u8>,
@@ -120,7 +113,7 @@ impl<R: Read + Seek> IndexedPageReader<R> {
     }
 
     /// consumes self into the reader and the two internal buffers
-    pub fn into_inner(self) -> (R, Vec<u8>, Vec<u8>) {
+    pub fn into_inner(self) -> (MemReader, Vec<u8>, Vec<u8>) {
         (self.reader, self.buffer, self.data_buffer)
     }
 
@@ -130,14 +123,11 @@ impl<R: Read + Seek> IndexedPageReader<R> {
         length: usize,
         selected_rows: Vec<Interval>,
     ) -> Result<CompressedPage, ParquetError> {
-        // it will be read - take buffer
-        let mut data = std::mem::take(&mut self.data_buffer);
-
-        let page_header = read_page(&mut self.reader, start, length, &mut self.buffer, &mut data)?;
+        let (page_header, data) = read_page(&mut self.reader, start, length)?;
 
         finish_page(
             page_header,
-            &mut data,
+            data,
             self.compression,
             &self.descriptor,
             Some(selected_rows),
@@ -159,15 +149,10 @@ impl<R: Read + Seek> IndexedPageReader<R> {
             None => return None,
         };
 
-        // it will be read - take buffer
-        let mut data = std::mem::take(&mut self.data_buffer);
-
         let maybe_page = read_dict_page(
             &mut self.reader,
             start,
             length,
-            &mut self.buffer,
-            &mut data,
             self.compression,
             &self.descriptor,
         );
@@ -175,7 +160,7 @@ impl<R: Read + Seek> IndexedPageReader<R> {
     }
 }
 
-impl<R: Read + Seek> Iterator for IndexedPageReader<R> {
+impl Iterator for IndexedPageReader {
     type Item = Result<CompressedPage, ParquetError>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/polars-parquet/src/parquet/read/page/memreader.rs
+++ b/crates/polars-parquet/src/parquet/read/page/memreader.rs
@@ -1,0 +1,191 @@
+use std::io;
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// A cursor over a segment of heap allocated memory. This is used for the Parquet reader to avoid
+/// sequential allocations.
+#[derive(Debug, Clone)]
+pub struct MemReader {
+    data: Arc<[u8]>,
+    position: usize,
+}
+
+/// A reference to a slice of a memory reader.
+///
+/// This should not outlast the original the original [`MemReader`] because it still owns all the
+/// memory.
+#[derive(Debug, Clone)]
+pub struct MemReaderSlice {
+    data: Arc<[u8]>,
+    start: usize,
+    end: usize,
+}
+
+impl Default for MemReaderSlice {
+    fn default() -> Self {
+        let slice: &[u8] = &[];
+        Self {
+            data: Arc::from(slice),
+            start: 0,
+            end: 0,
+        }
+    }
+}
+
+impl Deref for MemReaderSlice {
+    type Target = [u8];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.data[self.start..self.end]
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CowBuffer {
+    Borrowed(MemReaderSlice),
+    Owned(Vec<u8>),
+}
+
+impl Deref for CowBuffer {
+    type Target = [u8];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            CowBuffer::Borrowed(v) => v.deref(),
+            CowBuffer::Owned(v) => v.deref(),
+        }
+    }
+}
+
+impl MemReader {
+    #[inline(always)]
+    pub fn new(data: Arc<[u8]>) -> Self {
+        Self { data, position: 0 }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    #[inline(always)]
+    pub fn remaining_len(&self) -> usize {
+        self.data.len() - self.position
+    }
+
+    #[inline(always)]
+    pub fn position(&self) -> usize {
+        self.position
+    }
+
+    #[inline(always)]
+    pub fn from_slice(data: &[u8]) -> Self {
+        let data = data.into();
+        Self { data, position: 0 }
+    }
+
+    #[inline(always)]
+    pub fn from_vec(data: Vec<u8>) -> Self {
+        let data = data.into_boxed_slice().into();
+        Self { data, position: 0 }
+    }
+
+    #[inline(always)]
+    pub fn from_reader<R: io::Read>(mut reader: R) -> io::Result<Self> {
+        let mut vec = Vec::new();
+        reader.read_to_end(&mut vec)?;
+        Ok(Self::from_vec(vec))
+    }
+
+    #[inline(always)]
+    pub fn read_slice(&mut self, n: usize) -> MemReaderSlice {
+        let start = self.position;
+        let end = usize::min(self.position + n, self.data.len());
+
+        self.position = end;
+
+        MemReaderSlice {
+            data: self.data.clone(),
+            start,
+            end,
+        }
+    }
+}
+
+impl io::Read for MemReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = usize::min(buf.len(), self.remaining_len());
+        buf[..n].copy_from_slice(&self.data[self.position..self.position + n]);
+        self.position += n;
+        Ok(n)
+    }
+}
+
+impl io::Seek for MemReader {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        let position = match pos {
+            io::SeekFrom::Start(position) => usize::min(position as usize, self.len()),
+            io::SeekFrom::End(offset) => {
+                let Some(position) = self.len().checked_add_signed(offset as isize) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "Seek before to before buffer",
+                    ));
+                };
+
+                position
+            },
+            io::SeekFrom::Current(offset) => {
+                let Some(position) = self.len().checked_add_signed(offset as isize) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "Seek before to before buffer",
+                    ));
+                };
+
+                position
+            },
+        };
+
+        eprintln!(
+            "pos = {}, new_pos = {}, seek = {:?}",
+            self.position, position, pos
+        );
+
+        self.position = position;
+
+        Ok(position as u64)
+    }
+}
+
+impl MemReaderSlice {
+    #[inline(always)]
+    pub fn to_vec(self) -> Vec<u8> {
+        <[u8]>::to_vec(&self)
+    }
+
+    #[inline]
+    pub fn from_vec(v: Vec<u8>) -> Self {
+        let end = v.len();
+
+        Self {
+            data: v.into(),
+            start: 0,
+            end,
+        }
+    }
+}
+
+impl CowBuffer {
+    pub fn to_mut(&mut self) -> &mut Vec<u8> {
+        match self {
+            CowBuffer::Borrowed(v) => {
+                *self = Self::Owned(v.clone().to_vec());
+                self.to_mut()
+            },
+            CowBuffer::Owned(v) => v,
+        }
+    }
+}

--- a/crates/polars-parquet/src/parquet/read/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/read/page/mod.rs
@@ -1,9 +1,11 @@
 mod indexed_reader;
+mod memreader;
 mod reader;
 #[cfg(feature = "async")]
 mod stream;
 
 pub use indexed_reader::IndexedPageReader;
+pub use memreader::{CowBuffer, MemReader, MemReaderSlice};
 pub use reader::{PageFilter, PageMetaData, PageReader};
 
 use crate::parquet::error::ParquetError;

--- a/crates/polars-parquet/src/parquet/read/page/stream.rs
+++ b/crates/polars-parquet/src/parquet/read/page/stream.rs
@@ -11,6 +11,7 @@ use crate::parquet::compression::Compression;
 use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::metadata::{ColumnChunkMetaData, Descriptor};
 use crate::parquet::page::{CompressedPage, ParquetPageHeader};
+use crate::parquet::read::MemReaderSlice;
 
 /// Returns a stream of compressed data pages
 pub async fn get_page_stream<'a, RR: AsyncRead + Unpin + Send + AsyncSeek>(
@@ -118,7 +119,7 @@ fn _get_page_stream<R: AsyncRead + Unpin + Send>(
 
             yield finish_page(
                 page_header,
-                &mut scratch,
+                MemReaderSlice::from_vec(std::mem::take(&mut scratch)),
                 compression,
                 &descriptor,
                 None,

--- a/crates/polars-parquet/src/parquet/write/compression.rs
+++ b/crates/polars-parquet/src/parquet/write/compression.rs
@@ -4,6 +4,7 @@ use crate::parquet::page::{
     CompressedDataPage, CompressedDictPage, CompressedPage, DataPage, DataPageHeader, DictPage,
     Page,
 };
+use crate::parquet::read::CowBuffer;
 use crate::parquet::{compression, FallibleStreamingIterator};
 
 /// Compresses a [`DataPage`] into a [`CompressedDataPage`].
@@ -37,11 +38,12 @@ fn compress_data(
             },
         };
     } else {
-        std::mem::swap(&mut buffer, &mut compressed_buffer);
-    };
+        std::mem::swap(buffer.to_mut(), &mut compressed_buffer);
+    }
+
     Ok(CompressedDataPage::new_read(
         header,
-        compressed_buffer,
+        CowBuffer::Owned(compressed_buffer),
         compression.into(),
         uncompressed_page_size,
         descriptor,
@@ -55,16 +57,19 @@ fn compress_dict(
     compression: CompressionOptions,
 ) -> ParquetResult<CompressedDictPage> {
     let DictPage {
-        mut buffer,
+        buffer,
         num_values,
         is_sorted,
     } = page;
+
     let uncompressed_page_size = buffer.len();
-    if compression != CompressionOptions::Uncompressed {
+    let compressed_buffer = if compression != CompressionOptions::Uncompressed {
         compression::compress(compression, &buffer, &mut compressed_buffer)?;
+        CowBuffer::Owned(compressed_buffer)
     } else {
-        std::mem::swap(&mut buffer, &mut compressed_buffer);
-    }
+        buffer
+    };
+
     Ok(CompressedDictPage::new(
         compressed_buffer,
         compression.into(),
@@ -124,7 +129,7 @@ impl<I: Iterator<Item = ParquetResult<Page>>> Compressor<I> {
     /// Deconstructs itself into its iterator and scratch buffer.
     pub fn into_inner(mut self) -> (I, Vec<u8>) {
         let mut buffer = if let Some(page) = self.current.as_mut() {
-            std::mem::take(page.buffer())
+            std::mem::take(page.buffer_mut())
         } else {
             std::mem::take(&mut self.buffer)
         };
@@ -139,7 +144,7 @@ impl<I: Iterator<Item = ParquetResult<Page>>> FallibleStreamingIterator for Comp
 
     fn advance(&mut self) -> std::result::Result<(), Self::Error> {
         let mut compressed_buffer = if let Some(page) = self.current.as_mut() {
-            std::mem::take(page.buffer())
+            std::mem::take(page.buffer_mut())
         } else {
             std::mem::take(&mut self.buffer)
         };

--- a/crates/polars-parquet/src/parquet/write/page.rs
+++ b/crates/polars-parquet/src/parquet/write/page.rs
@@ -218,11 +218,12 @@ async fn write_page_header_async<W: AsyncWrite + Unpin + Send>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parquet::read::CowBuffer;
 
     #[test]
     fn dict_too_large() {
         let page = CompressedDictPage::new(
-            vec![],
+            CowBuffer::Owned(vec![]),
             Compression::Uncompressed,
             i32::MAX as usize + 1,
             100,
@@ -234,7 +235,7 @@ mod tests {
     #[test]
     fn dict_too_many_values() {
         let page = CompressedDictPage::new(
-            vec![],
+            CowBuffer::Owned(vec![]),
             Compression::Uncompressed,
             0,
             i32::MAX as usize + 1,

--- a/crates/polars/tests/it/io/parquet/write/binary.rs
+++ b/crates/polars/tests/it/io/parquet/write/binary.rs
@@ -3,6 +3,7 @@ use polars_parquet::parquet::encoding::Encoding;
 use polars_parquet::parquet::error::ParquetResult;
 use polars_parquet::parquet::metadata::Descriptor;
 use polars_parquet::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, Page};
+use polars_parquet::parquet::read::CowBuffer;
 use polars_parquet::parquet::statistics::BinaryStatistics;
 use polars_parquet::parquet::types::ord_binary;
 use polars_parquet::parquet::write::WriteOptions;
@@ -80,7 +81,7 @@ pub fn array_to_page_v1(
 
     Ok(Page::Data(DataPage::new(
         DataPageHeader::V1(header),
-        buffer,
+        CowBuffer::Owned(buffer),
         descriptor.clone(),
         Some(array.len()),
     )))

--- a/crates/polars/tests/it/io/parquet/write/indexes.rs
+++ b/crates/polars/tests/it/io/parquet/write/indexes.rs
@@ -7,7 +7,8 @@ use polars_parquet::parquet::indexes::{
 };
 use polars_parquet::parquet::metadata::SchemaDescriptor;
 use polars_parquet::parquet::read::{
-    read_columns_indexes, read_metadata, read_pages_locations, BasicDecompressor, IndexedPageReader,
+    read_columns_indexes, read_metadata, read_pages_locations, BasicDecompressor,
+    IndexedPageReader, MemReader,
 };
 use polars_parquet::parquet::schema::types::{ParquetType, PhysicalType, PrimitiveType};
 use polars_parquet::parquet::write::{
@@ -59,7 +60,7 @@ fn write_file() -> ParquetResult<Vec<u8>> {
 #[test]
 fn read_indexed_page() -> ParquetResult<()> {
     let data = write_file()?;
-    let mut reader = Cursor::new(data);
+    let mut reader = MemReader::from_vec(data);
 
     let metadata = read_metadata(&mut reader)?;
 

--- a/crates/polars/tests/it/io/parquet/write/mod.rs
+++ b/crates/polars/tests/it/io/parquet/write/mod.rs
@@ -14,6 +14,7 @@ use polars_parquet::parquet::compression::{BrotliLevel, CompressionOptions};
 use polars_parquet::parquet::error::ParquetResult;
 use polars_parquet::parquet::metadata::{Descriptor, SchemaDescriptor};
 use polars_parquet::parquet::page::Page;
+use polars_parquet::parquet::read::MemReader;
 use polars_parquet::parquet::schema::types::{ParquetType, PhysicalType};
 use polars_parquet::parquet::statistics::Statistics;
 #[cfg(feature = "async")]
@@ -44,7 +45,8 @@ pub fn array_to_page(
 }
 
 fn read_column<R: Read + Seek>(reader: &mut R) -> ParquetResult<(Array, Option<Statistics>)> {
-    let (a, statistics) = super::read::read_column(reader, 0, "col")?;
+    let memreader = MemReader::from_reader(reader)?;
+    let (a, statistics) = super::read::read_column(memreader, 0, "col")?;
     Ok((a, statistics))
 }
 

--- a/crates/polars/tests/it/io/parquet/write/primitive.rs
+++ b/crates/polars/tests/it/io/parquet/write/primitive.rs
@@ -3,6 +3,7 @@ use polars_parquet::parquet::encoding::Encoding;
 use polars_parquet::parquet::error::ParquetResult;
 use polars_parquet::parquet::metadata::Descriptor;
 use polars_parquet::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, Page};
+use polars_parquet::parquet::read::CowBuffer;
 use polars_parquet::parquet::statistics::PrimitiveStatistics;
 use polars_parquet::parquet::types::NativeType;
 use polars_parquet::parquet::write::WriteOptions;
@@ -71,7 +72,7 @@ pub fn array_to_page_v1<T: NativeType>(
 
     Ok(Page::Data(DataPage::new(
         DataPageHeader::V1(header),
-        buffer,
+        CowBuffer::Owned(buffer),
         descriptor.clone(),
         Some(array.len()),
     )))


### PR DESCRIPTION
This PR introduces three structures:

- `MemReader`: Abstraction over part of a Parquet file loaded into memory
- `MemReaderSlice`: A slice of a `MemReader`. This should should not be kept around outside the Parquet crate.
- `CowBuffer`: A Cow that abstracts between a `MemReaderSlice` and a `Vec<u8>`.

Following this PR, we can avoid copying the memory around in the Parquet crate. This also allows us to guarantee that the memory is in RAM and does not need to be loaded from disk anymore. Leading to less page faults.

Later it might be useful to make the reads a bit more granular so that we don't need to load unnecessary data pages.