### PR TITLE
perf(python): Add AlignedAllocator

### DIFF
--- a/py-polars/src/allocator.rs
+++ b/py-polars/src/allocator.rs
@@ -11,6 +11,7 @@ use jemallocator::Jemalloc;
 ))]
 use mimalloc::MiMalloc;
 
+use crate::memory::AlignedAllocator;
 #[cfg(all(
     debug_assertions,
     target_family = "unix",
@@ -26,7 +27,7 @@ use crate::memory::TracemallocAllocator;
     not(allocator = "default"),
     target_family = "unix",
 ))]
-static ALLOC: Jemalloc = Jemalloc;
+static ALLOC: AlignedAllocator<Jemalloc> = AlignedAllocator::new(Jemalloc);
 
 #[global_allocator]
 #[cfg(all(
@@ -34,7 +35,7 @@ static ALLOC: Jemalloc = Jemalloc;
     not(allocator = "default"),
     any(not(target_family = "unix"), allocator = "mimalloc"),
 ))]
-static ALLOC: MiMalloc = MiMalloc;
+static ALLOC: AlignedAllocator<MiMalloc> = AlignedAllocator::new(MiMalloc);
 
 // On Windows tracemalloc does work. However, we build abi3 wheels, and the
 // relevant C APIs are not part of the limited stable CPython API. As a result,
@@ -47,4 +48,5 @@ static ALLOC: MiMalloc = MiMalloc;
     not(allocator = "default"),
     not(allocator = "mimalloc"),
 ))]
-static ALLOC: TracemallocAllocator<Jemalloc> = TracemallocAllocator::new(Jemalloc);
+static ALLOC: AlignedAllocator<TracemallocAllocator<Jemalloc>> =
+    AlignedAllocator::new(TracemallocAllocator::new(Jemalloc));

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -28,7 +28,6 @@ mod interop;
 mod lazyframe;
 mod lazygroupby;
 mod map;
-#[cfg(debug_assertions)]
 mod memory;
 #[cfg(feature = "object")]
 mod object;


### PR DESCRIPTION
This PR adds `AlignedAllocator` that aligns large allocation (>=1024 bytes) to the cache line size (512 bits) if SIMD (i.e. feature `nightly`) is enabled.

Currently, SIMD functions in `polars-compute` does not take alignment into account. Unaligned SIMD suffers great penalties. It is even worse on ARM.

By aligning allocation to the cache line size, we can at least alleviate this problem.
