### PR TITLE
perf(python): Also set target features and tune cpu for CC

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -134,20 +134,26 @@ jobs:
           if [[ "$IS_LTS_CPU" = true ]]; then
             TUNE_CPU=x86-64-v2
             FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b
+            CC_FEATURES="-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16"
           else
             TUNE_CPU=skylake
             FEATURES=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe
+            CC_FEATURES="-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe"
           fi
           echo "features=$FEATURES" >> $GITHUB_OUTPUT
           echo "tune_cpu=$TUNE_CPU" >> $GITHUB_OUTPUT
+          echo "cc_features=$CC_FEATURES" >> $GITHUB_OUTPUT
 
       - name: Set RUSTFLAGS for x86-64
         if: matrix.architecture == 'x86-64'
         env:
           FEATURES: ${{ steps.features.outputs.features }}
           TUNE_CPU: ${{ steps.features.outputs.tune_cpu }}
+          CC_FEATURES: ${{ steps.features.outputs.cc_features }}
           CFG: ${{ matrix.package == 'polars-lts-cpu' && '--cfg allocator="default"' || '' }}
-        run: echo "RUSTFLAGS=-C target-feature=$FEATURES -Z tune-cpu=$TUNE_CPU $CFG" >> $GITHUB_ENV
+        run: |
+          echo "RUSTFLAGS=-C target-feature=$FEATURES -Z tune-cpu=$TUNE_CPU $CFG" >> $GITHUB_ENV
+          echo "CFLAGS=$CC_FEATURES -mtune=$TUNE_CPU" >> $GITHUB_ENV
 
       - name: Set variables in CPU check module
         run: |


### PR DESCRIPTION
cc @orlp 

It turns out the `cc` crate does not pass `target-features` and `tune-cpu` to the C compiler, as a result the C dependencies do not benefit from these tunings. This PR workarounds this by setting `CFLAGS` accordingly.