### PR TITLE
docs: Extend information about filtering context

### DIFF
--- a/docs/user-guide/concepts/contexts.md
+++ b/docs/user-guide/concepts/contexts.md
@@ -52,6 +52,11 @@ The filtering context filters a `DataFrame` based on one or more expressions tha
 --8<-- "python/user-guide/concepts/contexts.py:filter"
 ```
 
+!!! info "Multiple filtering expressions"
+
+    When passing multiple expressions into one `.filter()` call, the expressions are all evaluated independently against the full `DataFrame` and only combined afterwards.
+    
+
 ## Group by / aggregation
 
 In the `group_by` context, expressions work on groups and thus may yield results of any length (a group may have many members).

--- a/docs/user-guide/concepts/contexts.md
+++ b/docs/user-guide/concepts/contexts.md
@@ -55,7 +55,6 @@ The filtering context filters a `DataFrame` based on one or more expressions tha
 !!! info "Multiple filtering expressions"
 
     When passing multiple expressions into one `.filter()` call, the expressions are all evaluated independently against the full `DataFrame` and only combined afterwards.
-    
 
 ## Group by / aggregation
 


### PR DESCRIPTION
Hey there,

I slightly stumbled over how multiple expressions in a filtering call are evaluated.
Specifically, that each expressions receives the full `DataFrame` regardless of what earlier expressions do.

This, of course, makes a lot of sense when thinking about it, but I thought this may be something to proactively call out in the User Guide.

If this addition does not make sense, feel free to close the pull request.

Also: Polars is a huge pleasure to work with, great job! I'm very excited for your future work.

Best regards,