### PR TITLE
feat(python): Optimise `read_excel` when using "calamine" engine with the latest `fastexcel`

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -38,7 +38,7 @@ cloudpickle
 fsspec
 s3fs[boto3]
 # Spreadsheet
-fastexcel>=0.9
+fastexcel>=0.11.5
 openpyxl
 xlsx2csv
 xlsxwriter


### PR DESCRIPTION
Since worksheets are directly converted to polars, fastexcel's eager loading functions can be used. This makes fastexcel use borrowed types under the hood, which allows it to run faster and have a slightly lower memory footprint. See https://github.com/ToucanToco/fastexcel/pull/147#issuecomment-2176264631