### PR TITLE
fix: Panic in pl.concat_list and list.concat on empty inputs

### DIFF
--- a/crates/polars-core/src/series/ops/reshape.rs
+++ b/crates/polars-core/src/series/ops/reshape.rs
@@ -202,7 +202,7 @@ impl Series {
                 let mut cols = dimensions[1];
 
                 if s_ref.len() == 0_usize {
-                    if (rows == -1 || rows == 0) && (cols == -1 || cols == 0) {
+                    if (rows == -1 || rows == 0) && (cols == -1 || cols == 0 || cols == 1) {
                         let s = reshape_fast_path(s.name(), s_ref);
                         return Ok(s);
                     } else {

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
@@ -163,6 +163,6 @@ def test_concat_list_reverse_struct_fields() -> None:
     assert_frame_equal(result1, result2)
 
 
-def test_concat_list_in_agg_16519() -> None:
+def test_concat_list_empty() -> None:
     df = pl.DataFrame({"a": []})
     df.select(pl.concat_list("a"))

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
@@ -161,3 +161,8 @@ def test_concat_list_reverse_struct_fields() -> None:
     result1 = df.select(pl.concat_list(["combo", "reverse_combo"]))
     result2 = df.select(pl.concat_list(["combo", "combo"]))
     assert_frame_equal(result1, result2)
+
+
+def test_concat_list_in_agg_16519() -> None:
+    df = pl.DataFrame({"a": []})
+    df.select(pl.concat_list("a"))

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
@@ -166,3 +166,8 @@ def test_concat_list_reverse_struct_fields() -> None:
 def test_concat_list_empty() -> None:
     df = pl.DataFrame({"a": []})
     df.select(pl.concat_list("a"))
+
+
+def test_concat_list_empty_struct() -> None:
+    df = pl.DataFrame({"a": []}, schema={"a": pl.Struct({"b": pl.Boolean})})
+    df.select(pl.concat_list("a"))

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -143,3 +143,8 @@ def test_empty_shift_over_16676() -> None:
 def test_empty_list_cat_16405() -> None:
     df = pl.DataFrame(schema={"cat": pl.List(pl.Categorical)})
     df.select(pl.col("cat") == pl.col("cat"))
+
+
+def test_empty_list_concat_16924() -> None:
+    df = pl.DataFrame(schema={"a": pl.Int16, "b": pl.List(pl.String)})
+    df.with_columns(pl.col("b").list.concat([pl.col("a").cast(pl.String)]))


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/16519
Fixes https://github.com/pola-rs/polars/issues/16924

ref https://github.com/pola-rs/polars/issues/15208 (fix one of repro panics), still wrong.
