### PR TITLE
fix(rust): add seek to Start(0) for mmap reading of whole buffer

### DIFF
--- a/crates/polars-io/src/mmap.rs
+++ b/crates/polars-io/src/mmap.rs
@@ -172,6 +172,7 @@ impl<'a, T: 'a + MmapBytesReader> From<&'a mut T> for ReaderBytes<'a> {
                         eprintln!("could not memory map file; read to buffer.")
                     }
                     let mut buf = vec![];
+                    m.seek(std::io::SeekFrom::Start(0));
                     m.read_to_end(&mut buf).expect("could not read");
                     ReaderBytes::Owned(buf)
                 }


### PR DESCRIPTION
When implementing my own parquet file Read trait, parquet files skip to the end to validate the file, so when reading the whole buffer I needed the file to seek back to 0 before calling read_to_end.