### PR TITLE
chore: Rename Unit to Plain in Parquet reader

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -63,12 +63,12 @@ impl<'a, O: Offset> StateTranslation<'a, BinaryDecoder<O>> for BinaryStateTransl
 
         use BinaryStateTranslation as T;
         match (self, page_validity) {
-            (T::Unit(page_values), None) => {
+            (T::Plain(page_values), None) => {
                 for x in page_values.by_ref().take(additional) {
                     values.push(x)
                 }
             },
-            (T::Unit(page_values), Some(page_validity)) => extend_from_decoder(
+            (T::Plain(page_values), Some(page_validity)) => extend_from_decoder(
                 validity,
                 page_validity,
                 Some(additional),

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
@@ -139,7 +139,7 @@ impl<'a> ValuesDictionary<'a> {
 
 #[derive(Debug)]
 pub(crate) enum BinaryStateTranslation<'a> {
-    Unit(BinaryIter<'a>),
+    Plain(BinaryIter<'a>),
     Dictionary(ValuesDictionary<'a>, Option<Vec<View>>),
     Delta(Delta<'a>),
     DeltaBytes(DeltaBytes<'a>),
@@ -167,7 +167,7 @@ impl<'a> BinaryStateTranslation<'a> {
                 let values = split_buffer(page)?.values;
                 let values = BinaryIter::new(values, page.num_values());
 
-                Ok(BinaryStateTranslation::Unit(values))
+                Ok(BinaryStateTranslation::Plain(values))
             },
             (Encoding::DeltaLengthByteArray, _) => {
                 Ok(BinaryStateTranslation::Delta(Delta::try_new(page)?))
@@ -180,7 +180,7 @@ impl<'a> BinaryStateTranslation<'a> {
     }
     pub(crate) fn len_when_not_nullable(&self) -> usize {
         match self {
-            Self::Unit(v) => v.len_when_not_nullable(),
+            Self::Plain(v) => v.len_when_not_nullable(),
             Self::Dictionary(v, _) => v.len(),
             Self::Delta(v) => v.len(),
             Self::DeltaBytes(v) => v.size_hint().0,
@@ -193,7 +193,7 @@ impl<'a> BinaryStateTranslation<'a> {
         }
 
         match self {
-            Self::Unit(t) => _ = t.by_ref().nth(n - 1),
+            Self::Plain(t) => _ = t.by_ref().nth(n - 1),
             Self::Dictionary(t, _) => t.values.skip_in_place(n)?,
             Self::Delta(t) => _ = t.by_ref().nth(n - 1),
             Self::DeltaBytes(t) => _ = t.by_ref().nth(n - 1),

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/nested.rs
@@ -29,14 +29,14 @@ pub struct State<'a> {
 
 #[derive(Debug)]
 pub enum StateTranslation<'a> {
-    Unit(BinaryIter<'a>),
+    Plain(BinaryIter<'a>),
     Dictionary(ValuesDictionary<'a>, Option<Vec<&'a [u8]>>),
 }
 
 impl<'a> PageState<'a> for State<'a> {
     fn len(&self) -> usize {
         match &self.translation {
-            StateTranslation::Unit(iter) => iter.size_hint().0,
+            StateTranslation::Plain(iter) => iter.size_hint().0,
             StateTranslation::Dictionary(values, _) => values.len(),
         }
     }
@@ -69,7 +69,7 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
             (Encoding::Plain, _) => {
                 let values = split_buffer(page)?.values;
                 let values = BinaryIter::new(values, page.num_values());
-                StateTranslation::Unit(values)
+                StateTranslation::Plain(values)
             },
             _ => return Err(not_implemented(page)),
         };
@@ -96,7 +96,7 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
         let (values, validity) = decoded;
 
         match &mut state.translation {
-            StateTranslation::Unit(page) => {
+            StateTranslation::Plain(page) => {
                 // @TODO: This can be optimized to not be a constantly polling
                 for value in page.by_ref().take(n) {
                     values.push(value);

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
@@ -57,12 +57,12 @@ impl<'a> StateTranslation<'a, BinViewDecoder> for BinaryStateTranslation<'a> {
         let mut validate_utf8 = decoder.check_utf8.take();
 
         match (self, page_validity) {
-            (Self::Unit(page_values), None) => {
+            (Self::Plain(page_values), None) => {
                 for x in page_values.by_ref().take(additional) {
                     values.push_value_ignore_validity(x)
                 }
             },
-            (Self::Unit(page_values), Some(page_validity)) => extend_from_decoder(
+            (Self::Plain(page_values), Some(page_validity)) => extend_from_decoder(
                 validity,
                 page_validity,
                 Some(additional),

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/nested.rs
@@ -26,14 +26,14 @@ pub(crate) struct State<'a> {
 
 #[derive(Debug)]
 pub(crate) enum StateTranslation<'a> {
-    Unit(BinaryIter<'a>),
+    Plain(BinaryIter<'a>),
     Dictionary(ValuesDictionary<'a>, Option<Vec<View>>),
 }
 
 impl<'a> PageState<'a> for State<'a> {
     fn len(&self) -> usize {
         match &self.translation {
-            StateTranslation::Unit(iter) => iter.size_hint().0,
+            StateTranslation::Plain(iter) => iter.size_hint().0,
             StateTranslation::Dictionary(values, _) => values.len(),
         }
     }
@@ -67,7 +67,7 @@ impl<'a> NestedDecoder<'a> for BinViewDecoder {
             (Encoding::Plain, _) => {
                 let values = split_buffer(page)?.values;
                 let values = BinaryIter::new(values, page.num_values());
-                StateTranslation::Unit(values)
+                StateTranslation::Plain(values)
             },
             _ => return Err(not_implemented(page)),
         };
@@ -93,7 +93,7 @@ impl<'a> NestedDecoder<'a> for BinViewDecoder {
     ) -> ParquetResult<()> {
         let (values, validity) = decoded;
         match &mut state.translation {
-            StateTranslation::Unit(page) => {
+            StateTranslation::Plain(page) => {
                 // @TODO: This should probably be optimized to a better loop
                 for value in page.by_ref().take(n) {
                     values.push_value_ignore_validity(value);

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
@@ -27,7 +27,7 @@ struct State<'a> {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 enum StateTranslation<'a> {
-    Unit(std::slice::ChunksExact<'a, u8>),
+    Plain(std::slice::ChunksExact<'a, u8>),
     Dictionary {
         values: HybridRleDecoder<'a>,
         dict: &'a [u8],
@@ -37,7 +37,7 @@ enum StateTranslation<'a> {
 impl<'a> PageState<'a> for State<'a> {
     fn len(&self) -> usize {
         match &self.translation {
-            StateTranslation::Unit(chunks) => chunks.len(),
+            StateTranslation::Plain(chunks) => chunks.len(),
             StateTranslation::Dictionary {
                 values: decoder, ..
             } => decoder.len(),
@@ -69,7 +69,7 @@ impl<'a> NestedDecoder<'a> for BinaryDecoder {
                 let values = page.buffer();
                 assert_eq!(values.len() % self.size, 0);
                 let values = values.chunks_exact(self.size);
-                StateTranslation::Unit(values)
+                StateTranslation::Plain(values)
             },
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(&dict), false) => {
                 let values = dict_indices_decoder(page)?;
@@ -104,7 +104,7 @@ impl<'a> NestedDecoder<'a> for BinaryDecoder {
         }
 
         match &mut state.translation {
-            StateTranslation::Unit(page_values) => {
+            StateTranslation::Plain(page_values) => {
                 for value in page_values.by_ref().take(n) {
                     values.push(value);
                 }


### PR DESCRIPTION
This is more like the spec.