### PR TITLE
chore(python): Better deprecate message for _import_from_c

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -355,7 +355,10 @@ class Series:
         return series
 
     @classmethod
-    @deprecate_function("use _import_arrow_from_c", version="1.3")
+    @deprecate_function(
+        "use _import_arrow_from_c; if you are using an extension, please compile it with latest 'pyo3-polars'",
+        version="1.3",
+    )
     def _import_from_c(cls, name: str, pointers: list[tuple[int, int]]) -> Self:
         return cls._from_pyseries(PySeries._import_arrow_from_c(name, pointers))
 


### PR DESCRIPTION
`_import_from_c` is mainly used by pyo3 extensions. This PR makes its deprecate message more informative.