### PR TITLE
feat(python): Write data at table level in `write_excel`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3188,6 +3188,7 @@ class DataFrame:
                 *table_start,
                 *table_finish,
                 {
+                    "data": df.rows(),
                     "style": table_style,
                     "columns": table_columns,
                     "header_row": include_header,
@@ -3197,14 +3198,6 @@ class DataFrame:
                     **table_options,
                 },
             )
-
-            # write data into the table range, column-wise
-            if not is_empty:
-                column_start = [table_start[0] + int(include_header), table_start[1]]
-                for c in df.columns:
-                    if c in self.columns:
-                        ws.write_column(*column_start, data=df[c].to_list())
-                    column_start[1] += 1
 
             # apply conditional formats
             if conditional_formats:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3203,11 +3203,7 @@ class DataFrame:
                 column_start = [table_start[0] + int(include_header), table_start[1]]
                 for c in df.columns:
                     if c in self.columns:
-                        ws.write_column(
-                            *column_start,
-                            data=df[c].to_list(),
-                            cell_format=column_formats.get(c),
-                        )
+                        ws.write_column(*column_start, data=df[c].to_list())
                     column_start[1] += 1
 
             # apply conditional formats
@@ -3234,6 +3230,7 @@ class DataFrame:
 
         for column in df.columns:
             col_idx, options = table_start[1] + df.get_column_index(column), {}
+            fmt = column_formats.get(column)
             if column in hidden_columns:
                 options = {"hidden": True}
             if column in column_widths:  # type: ignore[operator]
@@ -3241,11 +3238,11 @@ class DataFrame:
                     col_idx,
                     col_idx,
                     column_widths[column],  # type: ignore[index]
-                    None,
+                    fmt,
                     options,
                 )
             elif options:
-                ws.set_column(col_idx, col_idx, None, None, options)
+                ws.set_column(col_idx, col_idx, None, fmt, options)
 
         # finally, inject any sparklines into the table
         for column, params in (sparklines or {}).items():

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3241,7 +3241,7 @@ class DataFrame:
                     fmt,
                     options,
                 )
-            elif options:
+            elif options or fmt:
                 ws.set_column(col_idx, col_idx, None, fmt, options)
 
         # finally, inject any sparklines into the table

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3223,7 +3223,6 @@ class DataFrame:
 
         for column in df.columns:
             col_idx, options = table_start[1] + df.get_column_index(column), {}
-            fmt = column_formats.get(column)
             if column in hidden_columns:
                 options = {"hidden": True}
             if column in column_widths:  # type: ignore[operator]
@@ -3231,11 +3230,9 @@ class DataFrame:
                     col_idx,
                     col_idx,
                     column_widths[column],  # type: ignore[index]
-                    fmt,
+                    None,
                     options,
                 )
-            elif options or fmt:
-                ws.set_column(col_idx, col_idx, None, fmt, options)
 
         # finally, inject any sparklines into the table
         for column, params in (sparklines or {}).items():


### PR DESCRIPTION
Resolves #17756.

Previously, `write_column` was used to write data to the table, which writes formatting to each cell individually. This update writes the data in the `add_table` step, which is much simpler, and which also supplies formatting to the table, which in turn formats the columns. The result is simpler data write, simpler formatting, and (very minor) reduction in file size.