### PR TITLE
docs(python): Show return type for Series attributes in API reference

### DIFF
--- a/py-polars/docs/source/reference/series/attributes.rst
+++ b/py-polars/docs/source/reference/series/attributes.rst
@@ -5,7 +5,6 @@ Attributes
 .. currentmodule:: polars
 .. autosummary::
    :toctree: api/
-   :template: autosummary/accessor_attribute.rst
 
    Series.dtype
    Series.name


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17640

Example before
![image](https://github.com/user-attachments/assets/2e61923e-3376-4828-9228-b03a0889d3bf)

Example after (consistent with `DataFrame` and `LazyFrame` docs)
![image](https://github.com/user-attachments/assets/e25a27ce-a317-4406-8ab1-3b907c553113)