### PR TITLE
fix(rust): Allow `read_csv` `schema` to take unparsable types

### DIFF
--- a/crates/polars-io/src/csv/read/options.rs
+++ b/crates/polars-io/src/csv/read/options.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use polars_core::datatypes::DataType;
+use polars_core::datatypes::{DataType, Field};
 use polars_core::schema::{IndexOfSchema, Schema, SchemaRef};
 use polars_error::PolarsResult;
 #[cfg(feature = "serde")]
@@ -36,6 +36,7 @@ pub struct CsvReadOptions {
     pub infer_schema_length: Option<usize>,
     pub raise_if_empty: bool,
     pub ignore_errors: bool,
+    pub fields_to_cast: Vec<Field>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -80,6 +81,7 @@ impl Default for CsvReadOptions {
             infer_schema_length: Some(100),
             raise_if_empty: true,
             ignore_errors: false,
+            fields_to_cast: vec![],
         }
     }
 }
@@ -94,7 +96,6 @@ impl Default for CsvParseOptions {
             encoding: Default::default(),
             null_values: None,
             missing_is_null: true,
-
             truncate_ragged_lines: false,
             comment_prefix: None,
             try_parse_dates: false,

--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -43,6 +43,12 @@ pub(crate) fn cast_columns(
                 .as_date(None, false)
                 .map(|ca| ca.into_series()),
             #[cfg(feature = "temporal")]
+            (DataType::String, DataType::Time) => s
+                .str()
+                .unwrap()
+                .as_time(None, false)
+                .map(|ca| ca.into_series()),
+            #[cfg(feature = "temporal")]
             (DataType::String, DataType::Datetime(tu, _)) => s
                 .str()
                 .unwrap()

--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -171,7 +171,6 @@ impl<R: MmapBytesReader> CsvReader<R> {
                     match fld.data_type() {
                         Time => {
                             self.options.fields_to_cast.push(fld.clone());
-                            // let inference decide the column type
                             fld.coerce(String);
                             Ok(fld)
                         },

--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -114,11 +114,7 @@ impl CsvReadOptions {
 }
 
 impl<R: MmapBytesReader> CsvReader<R> {
-    fn core_reader(
-        &mut self,
-        schema: Option<SchemaRef>,
-        to_cast: Vec<Field>,
-    ) -> PolarsResult<CoreReader> {
+    fn core_reader(&mut self) -> PolarsResult<CoreReader> {
         let reader_bytes = get_reader_bytes(&mut self.reader)?;
 
         let parse_options = self.options.get_parse_options();
@@ -136,7 +132,7 @@ impl<R: MmapBytesReader> CsvReader<R> {
             self.options.columns.clone(),
             parse_options.encoding,
             self.options.n_threads,
-            schema,
+            self.options.schema_overwrite.clone(),
             self.options.dtype_overwrite.clone(),
             self.options.sample_size,
             self.options.chunk_size,
@@ -147,7 +143,7 @@ impl<R: MmapBytesReader> CsvReader<R> {
             parse_options.null_values.clone(),
             parse_options.missing_is_null,
             self.predicate.clone(),
-            to_cast,
+            self.options.fields_to_cast.clone(),
             self.options.skip_rows_after_header,
             self.options.row_index.clone(),
             parse_options.try_parse_dates,
@@ -161,70 +157,62 @@ impl<R: MmapBytesReader> CsvReader<R> {
     // * Move this step outside of the reader so that we don't do it multiple times
     //   when we read a file list.
     // * See if we can avoid constructing a filtered schema.
-    fn prepare_schema_overwrite(
-        &self,
-        overwriting_schema: &Schema,
-    ) -> PolarsResult<(Schema, Vec<Field>, bool)> {
+    fn prepare_schema(&mut self) -> PolarsResult<bool> {
         // This branch we check if there are dtypes we cannot parse.
         // We only support a few dtypes in the parser and later cast to the required dtype
-        let mut to_cast = Vec::with_capacity(overwriting_schema.len());
-
         let mut _has_categorical = false;
-        let mut _err: Option<PolarsError> = None;
 
-        #[allow(unused_mut)]
-        let schema = overwriting_schema
-            .iter_fields()
-            .filter_map(|mut fld| {
-                use DataType::*;
-                match fld.data_type() {
-                    Time => {
-                        to_cast.push(fld);
-                        // let inference decide the column type
-                        None
-                    },
-                    #[cfg(feature = "dtype-categorical")]
-                    Categorical(_, _) => {
-                        _has_categorical = true;
-                        Some(fld)
-                    },
-                    #[cfg(feature = "dtype-decimal")]
-                    Decimal(precision, scale) => match (precision, scale) {
-                        (_, Some(_)) => {
-                            to_cast.push(fld.clone());
-                            fld.coerce(String);
-                            Some(fld)
-                        },
-                        _ => {
-                            _err = Some(PolarsError::ComputeError(
-                                "'scale' must be set when reading csv column as Decimal".into(),
-                            ));
+        let mut process_schema = |schema: &Schema| {
+            schema
+                .iter_fields()
+                .filter_map(|mut fld| {
+                    use DataType::*;
+
+                    match fld.data_type() {
+                        Time => {
+                            self.options.fields_to_cast.push(fld);
+                            // let inference decide the column type
                             None
                         },
-                    },
-                    _ => Some(fld),
-                }
-            })
-            .collect::<Schema>();
+                        #[cfg(feature = "dtype-categorical")]
+                        Categorical(_, _) => {
+                            _has_categorical = true;
+                            Some(Ok(fld))
+                        },
+                        #[cfg(feature = "dtype-decimal")]
+                        Decimal(precision, scale) => match (precision, scale) {
+                            (_, Some(_)) => {
+                                self.options.fields_to_cast.push(fld.clone());
+                                fld.coerce(String);
+                                Some(Ok(fld))
+                            },
+                            _ => Some(Err(PolarsError::ComputeError(
+                                "'scale' must be set when reading csv column as Decimal".into(),
+                            ))),
+                        },
+                        _ => Some(Ok(fld)),
+                    }
+                })
+                .collect::<PolarsResult<Schema>>()
+        };
 
-        if let Some(err) = _err {
-            Err(err)
-        } else {
-            Ok((schema, to_cast, _has_categorical))
+        if let Some(schema) = self.options.schema.as_ref() {
+            self.options.schema = Some(Arc::new(process_schema(schema)?));
+        } else if let Some(schema) = self.options.schema_overwrite.as_ref() {
+            self.options.schema_overwrite = Some(Arc::new(process_schema(schema)?));
         }
+
+        Ok(_has_categorical)
     }
 
     pub fn batched_borrowed(&mut self) -> PolarsResult<BatchedCsvReader> {
-        if let Some(schema) = self.options.schema_overwrite.as_deref() {
-            let (schema, to_cast, has_cat) = self.prepare_schema_overwrite(schema)?;
-            let schema = Arc::new(schema);
+        let has_cat = match self.options.schema_overwrite.as_deref() {
+            Some(_) => self.prepare_schema()?,
+            None => false,
+        };
 
-            let csv_reader = self.core_reader(Some(schema), to_cast)?;
-            csv_reader.batched(has_cat)
-        } else {
-            let csv_reader = self.core_reader(self.options.schema.clone(), vec![])?;
-            csv_reader.batched(false)
-        }
+        let csv_reader = self.core_reader()?;
+        csv_reader.batched(has_cat)
     }
 }
 
@@ -281,39 +269,17 @@ where
         let schema_overwrite = self.options.schema_overwrite.clone();
         let low_memory = self.options.low_memory;
 
+        let has_cat = self.prepare_schema()?;
+
         #[cfg(feature = "dtype-categorical")]
-        let mut _cat_lock = None;
-
-        let mut df = if let Some(schema) = schema_overwrite.as_deref() {
-            let (schema, to_cast, _has_cat) = self.prepare_schema_overwrite(schema)?;
-
-            #[cfg(feature = "dtype-categorical")]
-            if _has_cat {
-                _cat_lock = Some(polars_core::StringCacheHolder::hold())
-            }
-
-            let mut csv_reader = self.core_reader(Some(Arc::new(schema)), to_cast)?;
-            csv_reader.as_df()?
+        let mut _cat_lock = if has_cat {
+            Some(polars_core::StringCacheHolder::hold())
         } else {
-            #[cfg(feature = "dtype-categorical")]
-            {
-                let has_cat = self
-                    .options
-                    .schema
-                    .clone()
-                    .map(|schema| {
-                        schema
-                            .iter_dtypes()
-                            .any(|dtype| matches!(dtype, DataType::Categorical(_, _)))
-                    })
-                    .unwrap_or(false);
-                if has_cat {
-                    _cat_lock = Some(polars_core::StringCacheHolder::hold())
-                }
-            }
-            let mut csv_reader = self.core_reader(self.options.schema.clone(), vec![])?;
-            csv_reader.as_df()?
+            None
         };
+
+        let mut csv_reader = self.core_reader()?;
+        let mut df = csv_reader.as_df()?;
 
         // Important that this rechunk is never done in parallel.
         // As that leads to great memory overhead.

--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -165,7 +165,7 @@ impl<R: MmapBytesReader> CsvReader<R> {
         let mut process_schema = |schema: &Schema| {
             schema
                 .iter_fields()
-                .filter_map(|mut fld| {
+                .map(|mut fld| {
                     use DataType::*;
 
                     match fld.data_type() {
@@ -173,25 +173,25 @@ impl<R: MmapBytesReader> CsvReader<R> {
                             self.options.fields_to_cast.push(fld.clone());
                             // let inference decide the column type
                             fld.coerce(String);
-                            Some(Ok(fld))
+                            Ok(fld)
                         },
                         #[cfg(feature = "dtype-categorical")]
                         Categorical(_, _) => {
                             _has_categorical = true;
-                            Some(Ok(fld))
+                            Ok(fld)
                         },
                         #[cfg(feature = "dtype-decimal")]
                         Decimal(precision, scale) => match (precision, scale) {
                             (_, Some(_)) => {
                                 self.options.fields_to_cast.push(fld.clone());
                                 fld.coerce(String);
-                                Some(Ok(fld))
+                                Ok(fld)
                             },
-                            _ => Some(Err(PolarsError::ComputeError(
+                            _ => Err(PolarsError::ComputeError(
                                 "'scale' must be set when reading csv column as Decimal".into(),
-                            ))),
+                            )),
                         },
-                        _ => Some(Ok(fld)),
+                        _ => Ok(fld),
                     }
                 })
                 .collect::<PolarsResult<Schema>>()

--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -270,10 +270,10 @@ where
         let schema_overwrite = self.options.schema_overwrite.clone();
         let low_memory = self.options.low_memory;
 
-        let has_cat = self.prepare_schema()?;
+        let _has_cat = self.prepare_schema()?;
 
         #[cfg(feature = "dtype-categorical")]
-        let mut _cat_lock = if has_cat {
+        let mut _cat_lock = if _has_cat {
             Some(polars_core::StringCacheHolder::hold())
         } else {
             None

--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -170,9 +170,10 @@ impl<R: MmapBytesReader> CsvReader<R> {
 
                     match fld.data_type() {
                         Time => {
-                            self.options.fields_to_cast.push(fld);
+                            self.options.fields_to_cast.push(fld.clone());
                             // let inference decide the column type
-                            None
+                            fld.coerce(String);
+                            Some(Ok(fld))
                         },
                         #[cfg(feature = "dtype-categorical")]
                         Categorical(_, _) => {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2269,6 +2269,7 @@ def test_write_csv_raise_on_non_utf8_17328(
     with pytest.raises(InvalidOperationError, match="file encoding is not UTF-8"):
         df_no_lists.write_csv((tmp_path / "dangling.csv").open("w", encoding="gbk"))
 
+
 @pytest.mark.write_disk()
 def test_write_csv_appending_17543(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
@@ -2280,6 +2281,7 @@ def test_write_csv_appending_17543(tmp_path: Path) -> None:
         assert f.readline() == "# test\n"
         assert pl.read_csv(f).equals(df)
 
+
 @pytest.mark.parametrize(
     ("dtype", "df"),
     [
@@ -2289,19 +2291,15 @@ def test_write_csv_appending_17543(tmp_path: Path) -> None:
             pl.Time,
             pl.DataFrame({"x": ["12:15:00"]}).with_columns(
                 pl.col("x").str.strptime(pl.Time)
-            )
+            ),
         ),
-    ]
+    ],
 )
 def test_read_csv_cast_unparsable_later(
-    tmp_path: Path,
-    dtype: pl.Decimal | pl.Categorical | pl.Time,
-    df: pl.DataFrame
+    tmp_path: Path, dtype: pl.Decimal | pl.Categorical | pl.Time, df: pl.DataFrame
 ) -> None:
     tmp_path.mkdir(exist_ok=True)
     with (tmp_path / "append.csv").open("w") as f:
         df.write_csv(f)
     with (tmp_path / "append.csv").open("r") as f:
-        assert df.equals(
-            pl.read_csv(f, schema={"x": dtype})
-        )
+        assert df.equals(pl.read_csv(f, schema={"x": dtype}))

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2269,7 +2269,6 @@ def test_write_csv_raise_on_non_utf8_17328(
     with pytest.raises(InvalidOperationError, match="file encoding is not UTF-8"):
         df_no_lists.write_csv((tmp_path / "dangling.csv").open("w", encoding="gbk"))
 
-
 @pytest.mark.write_disk()
 def test_write_csv_appending_17543(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
@@ -2280,3 +2279,29 @@ def test_write_csv_appending_17543(tmp_path: Path) -> None:
     with (tmp_path / "append.csv").open("r") as f:
         assert f.readline() == "# test\n"
         assert pl.read_csv(f).equals(df)
+
+@pytest.mark.parametrize(
+    ("dtype", "df"),
+    [
+        (pl.Decimal(scale=2), pl.DataFrame({"x": ["0.1"]}).cast(pl.Decimal(scale=2))),
+        (pl.Categorical, pl.DataFrame({"x": ["A"]})),
+        (
+            pl.Time,
+            pl.DataFrame({"x": ["12:15:00"]}).with_columns(
+                pl.col("x").str.strptime(pl.Time)
+            )
+        ),
+    ]
+)
+def test_read_csv_cast_unparsable_later(
+    tmp_path: Path,
+    dtype: pl.Decimal | pl.Categorical | pl.Time,
+    df: pl.DataFrame
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    with (tmp_path / "append.csv").open("w") as f:
+        df.write_csv(f)
+    with (tmp_path / "append.csv").open("r") as f:
+        assert df.equals(
+            pl.read_csv(f, schema={"x": dtype})
+        )

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2296,10 +2296,8 @@ def test_write_csv_appending_17543(tmp_path: Path) -> None:
     ],
 )
 def test_read_csv_cast_unparsable_later(
-    tmp_path: Path, dtype: pl.Decimal | pl.Categorical | pl.Time, df: pl.DataFrame
+    dtype: pl.Decimal | pl.Categorical | pl.Time, df: pl.DataFrame
 ) -> None:
-    tmp_path.mkdir(exist_ok=True)
-    with (tmp_path / "append.csv").open("w") as f:
-        df.write_csv(f)
-    with (tmp_path / "append.csv").open("r") as f:
-        assert df.equals(pl.read_csv(f, schema={"x": dtype}))
+    f = io.BytesIO()
+    df.write_csv(f)
+    assert df.equals(pl.read_csv(f, schema={"x": dtype}))


### PR DESCRIPTION
Resolves #17349, also including support for `pl.Time` and `pl.Categorical`.

`read_csv` actually already supported passing these types to `schema_overrides`, but not to `schema` directly. This is mostly moving that to be shared functionally (which is the cause of the ugly diff in `reader.rs`) and fixing another bug I found in testing that prevented `pl.Time` from being read correctly.