### PR TITLE
fix(python): Simultaneous usage of `named_expr` and `schema` in `pl.struct`

### DIFF
--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -598,7 +598,7 @@ def struct(
     pyexprs = parse_into_list_of_expressions(*exprs, **named_exprs)
 
     if schema:
-        if not exprs:
+        if not exprs and not named_exprs:
             # no columns or expressions provided; create one from schema keys
             expr = wrap_expr(
                 plr.as_struct(parse_into_list_of_expressions(list(schema.keys())))

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -970,3 +970,11 @@ def test_struct_out_nullability_from_arrow() -> None:
 def test_empty_struct_raise() -> None:
     with pytest.raises(ValueError):
         pl.struct()
+
+
+def test_named_exprs() -> None:
+    df = pl.DataFrame({"a": 1})
+    schema = {"b": pl.Int64}
+    res = df.select(pl.struct(schema=schema, b=pl.col("a")))
+    expected = df.select(pl.struct(pl.col("a").alias("b"), schema=schema))
+    assert_frame_equal(res, expected)

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -976,5 +976,5 @@ def test_named_exprs() -> None:
     df = pl.DataFrame({"a": 1})
     schema = {"b": pl.Int64}
     res = df.select(pl.struct(schema=schema, b=pl.col("a")))
-    expected = df.select(pl.struct(pl.col("a").alias("b"), schema=schema))
-    assert_frame_equal(res, expected)
+    assert res.to_dict(as_series=False) == {"b": [{"b": 1}]}
+    assert res.schema["b"] == pl.Struct(schema)


### PR DESCRIPTION
Resolves #16509

The fix seem very simple. I added a test that shows the (imho) expected behavior.