### PR TITLE
perf: Remove async directory auto-detection

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -174,7 +174,9 @@ pub fn expand_paths_hive(
 
                     let prefix = object_path_from_string(cloud_location.prefix.clone())?;
 
-                    let out = if !path.ends_with("/") && cloud_location.expansion.is_none() {
+                    let out = if !path.ends_with("/") && cloud_location.expansion.is_none() && {
+                        is_cloud || PathBuf::from(path).is_file()
+                    } {
                         (
                             0,
                             vec![PathBuf::from(format_path(

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -174,10 +174,7 @@ pub fn expand_paths_hive(
 
                     let prefix = object_path_from_string(cloud_location.prefix.clone())?;
 
-                    let out = if !path.ends_with("/")
-                        && cloud_location.expansion.is_none()
-                        && store.head(&prefix).await.is_ok()
-                    {
+                    let out = if !path.ends_with("/") && cloud_location.expansion.is_none() {
                         (
                             0,
                             vec![PathBuf::from(format_path(

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -175,6 +175,10 @@ pub fn expand_paths_hive(
                     let prefix = object_path_from_string(cloud_location.prefix.clone())?;
 
                     let out = if !path.ends_with("/") && cloud_location.expansion.is_none() && {
+                        // We need to check if it is a directory for local paths (we can be here due
+                        // to FORCE_ASYNC). For cloud paths the convention is that the user must add
+                        // a trailing slash `/` to scan directories. We don't infer it as that would
+                        // mean sending one network request per path serially (very slow).
                         is_cloud || PathBuf::from(path).is_file()
                     } {
                         (


### PR DESCRIPTION
This functionality requires we send 1 HEAD request per path in a serial manner - this can be extremely slow if the user provides a list of cloud file paths. This PR makes it so that an explicit trailing slash must be given if you want to scan from a cloud directory. This matches the behavior of the AWS CLI and improves performance.