### PR TITLE
fix: Properly write nested `NullArray` in Parquet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,7 +2947,6 @@ dependencies = [
  "ethnum",
  "fast-float",
  "flate2",
- "foreign_vec",
  "futures",
  "getrandom",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "lz4",
  "multiversion",
  "num-traits",
+ "parking_lot",
  "polars-arrow-format",
  "polars-error",
  "polars-utils",

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -22,6 +22,7 @@ dyn-clone = { version = "1" }
 either = { workspace = true }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
+parking_lot = { workspace = true }
 polars-error = { workspace = true }
 polars-utils = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -20,7 +20,6 @@ chrono = { workspace = true }
 chrono-tz = { workspace = true, optional = true }
 dyn-clone = { version = "1" }
 either = { workspace = true }
-foreign_vec = { version = "0.1" }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
 polars-error = { workspace = true }

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -31,7 +31,11 @@ impl NullArray {
 
         let validity = Bitmap::new_zeroed(length);
 
-        Ok(Self { data_type, validity, length })
+        Ok(Self {
+            data_type,
+            validity,
+            length,
+        })
     }
 
     /// Returns a new [`NullArray`].

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -76,8 +76,9 @@ impl NullArray {
     ///
     /// # Safety
     /// The caller must ensure that `offset + length < self.len()`.
-    pub unsafe fn slice_unchecked(&mut self, _offset: usize, length: usize) {
+    pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
         self.length = length;
+        self.validity.slice_unchecked(offset, length);
     }
 
     #[inline]

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -410,15 +410,15 @@ impl Bitmap {
         });
 
         let zero_bytes = rwlock_zero_bytes.upgradable_read();
-        let bytes = if zero_bytes.len() * 8 < length {
+        let bytes = if zero_bytes.len() * 8 >= length {
+            zero_bytes.clone()
+        } else {
             let bytes = Arc::new(Bytes::from(vec![0; length.div_ceil(8)]));
 
             let mut zero_bytes = RwLockUpgradableReadGuard::upgrade(zero_bytes);
             *zero_bytes = bytes.clone();
 
             bytes
-        } else {
-            zero_bytes.clone()
         };
 
         Bitmap {

--- a/crates/polars-arrow/src/buffer/mod.rs
+++ b/crates/polars-arrow/src/buffer/mod.rs
@@ -19,7 +19,7 @@ pub(crate) enum BytesAllocator {
     #[allow(dead_code)]
     Arrow(arrow_buffer::Buffer),
 }
-pub(crate) type BytesInner<T> = foreign_vec::ForeignVec<BytesAllocator, T>;
+pub(crate) type BytesInner<T> = polars_utils::foreign_vec::ForeignVec<BytesAllocator, T>;
 
 /// Bytes representation.
 #[repr(transparent)]

--- a/crates/polars-parquet/src/arrow/write/primitive/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/nested.rs
@@ -11,14 +11,13 @@ use crate::parquet::page::DataPage;
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::types::NativeType;
 
-pub fn array_to_page<'a, T, R>(
-    array: &'a PrimitiveArray<T>,
+pub fn array_to_page<T, R>(
+    array: &PrimitiveArray<T>,
     options: WriteOptions,
     type_: PrimitiveType,
     nested: &[Nested],
 ) -> PolarsResult<DataPage>
 where
-    PrimitiveArray<T>: polars_compute::min_max::MinMaxKernel<Scalar<'a> = T>,
     T: ArrowNativeType,
     R: NativeType,
     T: num_traits::AsPrimitive<R>,

--- a/crates/polars-utils/src/foreign_vec.rs
+++ b/crates/polars-utils/src/foreign_vec.rs
@@ -1,0 +1,101 @@
+/// This is pulled out of https://github.com/DataEngineeringLabs/foreign_vec
+
+use std::mem::ManuallyDrop;
+use std::ops::DerefMut;
+use std::vec::Vec;
+
+/// Mode of deallocating memory regions
+enum Allocation<D> {
+    /// Native allocation
+    Native,
+    // A foreign allocator and its ref count
+    Foreign(D),
+}
+
+/// A continuous memory region that may be allocated externally.
+///
+/// In the most common case, this is created from [`Vec`].
+/// However, this region may also be allocated by a foreign allocator `D`
+/// and behave as `&[T]`.
+pub struct ForeignVec<D, T> {
+    /// An implementation using an `enum` of a `Vec` or a foreign pointer is not used
+    /// because `deref` is at least 50% more expensive than the deref of a `Vec`.
+    data: ManuallyDrop<Vec<T>>,
+    /// the region was allocated
+    allocation: Allocation<D>,
+}
+
+impl<D, T> ForeignVec<D, T> {
+    /// Takes ownership of an allocated memory region.
+    /// # Panics
+    /// This function panics if and only if pointer is not null
+    /// # Safety
+    /// This function is safe if and only if `ptr` is valid for `length`
+    /// # Implementation
+    /// This function leaks if and only if `owner` does not deallocate
+    /// the region `[ptr, ptr+length[` when dropped.
+    #[inline]
+    pub unsafe fn from_foreign(ptr: *const T, length: usize, owner: D) -> Self {
+        assert!(!ptr.is_null());
+        // This line is technically outside the assumptions of `Vec::from_raw_parts`, since
+        // `ptr` was not allocated by `Vec`. However, one of the invariants of this struct
+        // is that we do never expose this region as a `Vec`; we only use `Vec` on it to provide
+        // immutable access to the region (via `Vec::deref` to `&[T]`).
+        let data = Vec::from_raw_parts(ptr as *mut T, length, length);
+        let data = ManuallyDrop::new(data);
+
+        Self {
+            data,
+            allocation: Allocation::Foreign(owner),
+        }
+    }
+
+    /// Returns a `Some` mutable reference of [`Vec<T>`] iff this was initialized
+    /// from a [`Vec<T>`] and `None` otherwise.
+    pub fn get_vec(&mut self) -> Option<&mut Vec<T>> {
+        match &self.allocation {
+            Allocation::Foreign(_) => None,
+            Allocation::Native => Some(self.data.deref_mut()),
+        }
+    }
+}
+
+impl<D, T> Drop for ForeignVec<D, T> {
+    #[inline]
+    fn drop(&mut self) {
+        match self.allocation {
+            Allocation::Foreign(_) => {
+                // the foreign is dropped via its `Drop`
+            }
+            Allocation::Native => {
+                let data = core::mem::take(&mut self.data);
+                let _ = ManuallyDrop::into_inner(data);
+            }
+        }
+    }
+}
+
+impl<D, T> core::ops::Deref for ForeignVec<D, T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &[T] {
+        &self.data
+    }
+}
+
+impl<D, T: core::fmt::Debug> core::fmt::Debug for ForeignVec<D, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<D, T> From<Vec<T>> for ForeignVec<D, T> {
+    #[inline]
+    fn from(data: Vec<T>) -> Self {
+        Self {
+            data: ManuallyDrop::new(data),
+            allocation: Allocation::Native,
+        }
+    }
+}

--- a/crates/polars-utils/src/foreign_vec.rs
+++ b/crates/polars-utils/src/foreign_vec.rs
@@ -1,5 +1,4 @@
 /// This is pulled out of https://github.com/DataEngineeringLabs/foreign_vec
-
 use std::mem::ManuallyDrop;
 use std::ops::DerefMut;
 use std::vec::Vec;
@@ -66,11 +65,11 @@ impl<D, T> Drop for ForeignVec<D, T> {
         match self.allocation {
             Allocation::Foreign(_) => {
                 // the foreign is dropped via its `Drop`
-            }
+            },
             Allocation::Native => {
                 let data = core::mem::take(&mut self.data);
                 let _ = ManuallyDrop::into_inner(data);
-            }
+            },
         }
     }
 }

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -14,6 +14,7 @@ pub mod contention_pool;
 pub mod cpuid;
 mod error;
 pub mod floor_divmod;
+pub mod foreign_vec;
 pub mod functions;
 pub mod hashing;
 pub mod idx_vec;

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1230,7 +1230,7 @@ def test_read_byte_stream_split_arrays(
 def test_parquet_nested_null_array_17795(tmp_path: Path) -> None:
     filename = tmp_path / "nested_null.parquet"
 
-    pl.DataFrame([ {"struct": {"field": None}} ]).write_parquet(filename)
+    pl.DataFrame([{"struct": {"field": None}}]).write_parquet(filename)
     pq.read_table(filename)
 
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1227,6 +1227,14 @@ def test_read_byte_stream_split_arrays(
 
 
 @pytest.mark.write_disk()
+def test_parquet_nested_null_array_17795(tmp_path: Path) -> None:
+    filename = tmp_path / "nested_null.parquet"
+
+    pl.DataFrame([ {"struct": {"field": None}} ]).write_parquet(filename)
+    pq.read_table(filename)
+
+
+@pytest.mark.write_disk()
 def test_parquet_record_batches_pyarrow_fixed_size_list_16614(tmp_path: Path) -> None:
     filename = tmp_path / "a.parquet"
 


### PR DESCRIPTION
Fixes #17795.