### PR TITLE
refactor(python): Add test and fix docstring for `prepare_cloud_plan` util

### DIFF
--- a/py-polars/polars/_utils/cloud.py
+++ b/py-polars/polars/_utils/cloud.py
@@ -32,12 +32,14 @@ def prepare_cloud_plan(
 
     Raises
     ------
-    ValueError
+    InvalidOperationError
         If the given LazyFrame is not eligible to be run on Polars Cloud.
         The following conditions will disqualify a LazyFrame from being eligible:
 
         - Contains a user-defined function
         - Scans or sinks to a local filesystem
+    ComputeError
+        If the given LazyFrame cannot be serialized.
     """
     uri = normalize_filepath(uri)
     pylf = lf._set_sink_optimizations(**optimizations)

--- a/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
+++ b/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
@@ -38,6 +38,14 @@ def test_prepare_cloud_plan_sink_added() -> None:
     assert "SINK (cloud)" in deserialized.explain()
 
 
+def test_prepare_cloud_plan_invalid_sink_uri() -> None:
+    lf = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
+    local_path = "~/local/result.parquet"
+
+    with pytest.raises(InvalidOperationError, match="non-cloud paths not supported"):
+        prepare_cloud_plan(lf, local_path)
+
+
 def test_prepare_cloud_plan_optimization_toggle() -> None:
     lf = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
 


### PR DESCRIPTION
Minor followup to https://github.com/pola-rs/polars/pull/17802 - I forgot to add a test / update the docstring when addressing the PR feedback.