### PR TITLE
docs(python): Remove defeatist quote from timezones.md

### DIFF
--- a/docs/user-guide/transformations/time-series/timezones.md
+++ b/docs/user-guide/transformations/time-series/timezones.md
@@ -5,10 +5,6 @@ hide:
 
 # Time zones
 
-!!! quote "Tom Scott"
-
-    You really should never, ever deal with time zones if you can help it.
-
 The `Datetime` datatype can have a time zone associated with it.
 Examples of valid time zones are:
 


### PR DESCRIPTION
We are forced to deal with time zones, so this is not a helpful piece of docs, because it discourages contributors from improving polars' time zone support.