### PR TITLE
feat: Support "BY NAME" qualifier for `SQL` "INTERSECT" and "EXCEPT" set ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4435,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.47.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
+checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
 dependencies = [
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ simd-json = { version = "0.13", features = ["known-key"] }
 simdutf8 = "0.1.4"
 slotmap = "1"
 smartstring = "1"
-sqlparser = "0.47"
+sqlparser = "0.49"
 stacker = "0.1"
 streaming-iterator = "0.1.9"
 strength_reduce = "0.2"

--- a/py-polars/tests/unit/sql/test_set_ops.py
+++ b/py-polars/tests/unit/sql/test_set_ops.py
@@ -39,6 +39,36 @@ def test_except_intersect() -> None:
         assert_frame_equal(pl.DataFrame({"x": [2], "y": [2]}), res)
 
 
+def test_except_intersect_by_name() -> None:
+    df1 = pl.DataFrame(  # noqa: F841
+        {
+            "x": [1, 9, 1, 1],
+            "y": [2, 3, 4, 4],
+            "z": [5, 5, 5, 5],
+        }
+    )
+    df2 = pl.DataFrame(  # noqa: F841
+        {
+            "y": [2, None, 4],
+            "w": ["?", "!", "%"],
+            "z": [7, 6, 5],
+            "x": [1, 9, 1],
+        }
+    )
+    res_e = pl.sql(
+        "SELECT x, y, z FROM df1 EXCEPT BY NAME SELECT * FROM df2",
+        eager=True,
+    )
+    res_i = pl.sql(
+        "SELECT * FROM df1 INTERSECT BY NAME SELECT * FROM df2",
+        eager=True,
+    )
+    assert sorted(res_e.rows()) == [(1, 2, 5), (9, 3, 5)]
+    assert sorted(res_i.rows()) == [(1, 4, 5)]
+    assert res_e.columns == ["x", "y", "z"]
+    assert res_i.columns == ["x", "y", "z"]
+
+
 @pytest.mark.parametrize("op", ["EXCEPT", "INTERSECT", "UNION"])
 def test_except_intersect_errors(op: str) -> None:
     df1 = pl.DataFrame({"x": [1, 9, 1, 1], "y": [2, 3, 4, 4], "z": [5, 5, 5, 5]})  # noqa: F841

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -196,6 +196,9 @@ def test_extract_century_millennium(dt: date, expected: list[int]) -> None:
         ("dtm > '2006-01-01'", [0, 1, 2]),  # << implies '2006-01-01 00:00:00'
         ("dtm <= '2006-01-01'", []),  # << implies '2006-01-01 00:00:00'
         ("dt != '1960-01-07'", [0, 1]),
+        ("tm != '22:10:30'", [0, 2]),
+        ("tm >= '11:00:00' AND tm < '22:00:00'", [0]),
+        ("tm BETWEEN '12:00:00' AND '23:59:58'", [0, 1]),
         ("dt BETWEEN '2050-01-01' AND '2100-12-31'", [1]),
         ("dt::datetime = '1960-01-07'", [2]),
         ("dt::datetime = '1960-01-07 00:00:00'", [2]),
@@ -220,6 +223,11 @@ def test_implicit_temporal_strings(constraint: str, expected: list[int]) -> None
                 date(2020, 12, 30),
                 date(2077, 1, 1),
                 date(1960, 1, 7),
+            ],
+            "tm": [
+                time(17, 30, 45),
+                time(22, 10, 30),
+                time(10, 25, 15),
             ],
         }
     )
@@ -447,6 +455,6 @@ def test_timestamp_time_unit_errors() -> None:
 
         with pytest.raises(
             SQLInterfaceError,
-            match="sql parser error: Expected literal int, found: - ",
+            match="sql parser error: Expected: literal int, found: - ",
         ):
             ctx.execute("SELECT ts::timestamp(-3) FROM frame_data")

--- a/py-polars/tests/unit/sql/test_wildcard_opts.py
+++ b/py-polars/tests/unit/sql/test_wildcard_opts.py
@@ -132,6 +132,11 @@ def test_select_rename_exclude_sort(order_by: str, df: pl.DataFrame) -> None:
             [(333,), (222,), (111,)],
         ),
         (
+            "(ID // 3 AS ID) RENAME (ID AS Identifier)",
+            ["Identifier"],
+            [(333,), (222,), (111,)],
+        ),
+        (
             "((City || ':' || City) AS City, ID // -3 AS ID)",
             ["City", "ID"],
             [
@@ -151,10 +156,13 @@ def test_select_replace(
     for order_by in ("", "ORDER BY ID DESC", "ORDER BY -ID ASC"):
         res = df.sql(f"SELECT * REPLACE {replacements} FROM self {order_by}")
         if not order_by:
-            res = res.sort("ID", descending=True)
+            res = res.sort(check_cols[-1], descending=True)
 
         assert res.select(check_cols).rows() == expected
-        assert res.columns == df.columns
+        expected_columns = (
+            check_cols + df.columns[1:] if check_cols == ["Identifier"] else df.columns
+        )
+        assert res.columns == expected_columns
 
 
 def test_select_wildcard_errors(df: pl.DataFrame) -> None:


### PR DESCRIPTION
Updates `sqlparser-rs` to 0.49 to take advantage of some PRs I've made upstream.

* Adds support for the `BY NAME` qualifier across _all_ set ops; like the existing support for this in `UNION`, the modifier aligns the second frame to the first by column name (in much the same way as "diagonal" frame concat).
* Follows-up https://github.com/pola-rs/polars/pull/17109 by enabling `SELECT * REPLACE … RENAME …` query patterns (previously you could not use _both_ REPLACE and RENAME in the same sequence of SELECT modifiers - with the upstream fix available, now you can).
* A few other minor internal improvements/tidy-ups.

## Example

Setup:
```python
import polars as pl

df1 = pl.DataFrame({
    "x": [1, 9, 1, 1],
    "y": [2, 3, 4, 4],
    "z": [5, 5, 5, 5],
})
df2 = pl.DataFrame({
    "y": [2, None, 4],
    "w": ["?", "!", "%"],
    "z": [7, 6, 5],
    "x": [1, 9, 1],
})
```
Use of the `BY NAME` qualifier automatically aligns the columns in the second DataFrame to those in the first (note that we also support the PostgreSQL `TABLE tbl` shortcut, which is equivalent to `SELECT * FROM tbl`):
```python
df_except = pl.sql(
  "SELECT x, y, z FROM df1 EXCEPT BY NAME TABLE df2",
).collect()
# shape: (2, 3)
# ┌─────┬─────┬─────┐
# │ x   ┆ y   ┆ z   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 1   ┆ 2   ┆ 5   │
# │ 9   ┆ 3   ┆ 5   │
# └─────┴─────┴─────┘
```
```python
df_intersect = pl.sql(
  "SELECT * FROM df1 INTERSECT BY NAME TABLE df2",
).collect()
# shape: (1, 3)
# ┌─────┬─────┬─────┐
# │ x   ┆ y   ┆ z   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 1   ┆ 4   ┆ 5   │
# └─────┴─────┴─────┘
```

---

#### Reference

`sqplarser-rs` updates:

* https://github.com/sqlparser-rs/sqlparser-rs/pull/1309
* https://github.com/sqlparser-rs/sqlparser-rs/pull/1321
* https://github.com/sqlparser-rs/sqlparser-rs/pull/1346