### PR TITLE
fix: Fix `from_arrow` for struct type

### DIFF
--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -164,6 +164,9 @@ def test_from_arrow(monkeypatch: Any) -> None:
             "d": pa.array([1, 2], pa.timestamp("ns")),
             "e": pa.array([1, 2], pa.int32()),
             "decimal1": pa.array([1, 2], pa.decimal128(2, 1)),
+            "struct": pa.array(
+                [{"a": 1}, {"a": 2}], pa.struct([pa.field("a", pa.int32())])
+            ),
         }
     )
     record_batches = tbl.to_batches(max_chunksize=1)
@@ -174,6 +177,7 @@ def test_from_arrow(monkeypatch: Any) -> None:
         "d": pl.Datetime("ns"),
         "e": pl.Int32,
         "decimal1": pl.Decimal(2, 1),
+        "struct": pl.Struct({"a": pl.Int32()}),
     }
     expected_data = [
         (
@@ -183,6 +187,7 @@ def test_from_arrow(monkeypatch: Any) -> None:
             datetime(1970, 1, 1, 0, 0),
             1,
             Decimal("1.0"),
+            {"a": 1},
         ),
         (
             datetime(1970, 1, 1, 0, 0, 2),
@@ -191,6 +196,7 @@ def test_from_arrow(monkeypatch: Any) -> None:
             datetime(1970, 1, 1, 0, 0),
             2,
             Decimal("2.0"),
+            {"a": 2},
         ),
     ]
     for arrow_data in (tbl, record_batches, (rb for rb in record_batches)):

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -282,8 +282,8 @@ def test_from_arrow(monkeypatch: Any) -> None:
         ),
     ],
 )
-def test_from_arrow_struct_column(data: pa.Table):
-    df = pl.from_arrow(data=data)
+def test_from_arrow_struct_column(data: pa.Table) -> None:
+    df = cast(pl.DataFrame, pl.from_arrow(data=data))
     expected_schema = pl.Schema({"struct": pl.Struct({"a": pl.Int32()})})
     expected_data = [({"a": 1},), ({"a": 2},)]
     assert df.schema == expected_schema
@@ -2131,7 +2131,9 @@ def test_fill_null_limits() -> None:
     ).select(
         pl.all().fill_null(strategy="forward", limit=2),
         pl.all().fill_null(strategy="backward", limit=2).name.suffix("_backward"),
-    ).to_dict(as_series=False) == {
+    ).to_dict(
+        as_series=False
+    ) == {
         "a": [1, 1, 1, None, 5, 6, 6, 6, None, 10],
         "b": ["a", "a", "a", None, "b", "c", "c", "c", None, "d"],
         "c": [True, True, True, None, False, True, True, True, None, False],

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2131,9 +2131,7 @@ def test_fill_null_limits() -> None:
     ).select(
         pl.all().fill_null(strategy="forward", limit=2),
         pl.all().fill_null(strategy="backward", limit=2).name.suffix("_backward"),
-    ).to_dict(
-        as_series=False
-    ) == {
+    ).to_dict(as_series=False) == {
         "a": [1, 1, 1, None, 5, 6, 6, 6, None, 10],
         "b": ["a", "a", "a", None, "b", "c", "c", "c", None, "d"],
         "c": [True, True, True, None, False, True, True, True, None, False],


### PR DESCRIPTION
# Motivation

Using an arrow `struct` column type in an arrow table causes `from_arrow` to fail with the following error message:

```
tests/unit/dataframe/test_df.py:210: in test_from_arrow
    df = cast(pl.DataFrame, pl.from_arrow(b))
polars/convert/general.py:433: in from_arrow
    arrow_to_pydf(
polars/_utils/construction/dataframe.py:1171: in arrow_to_pydf
    elif isinstance(column.type, pa.StructType) and column.num_chunks > 1:
E   AttributeError: 'pyarrow.lib.StructArray' object has no attribute 'num_chunks'
```

# Changes

* Fix `arrow_to_pydf` function to first check for the `num_chunks` attribute 
* Update unit test
* Ruff updates