### PR TITLE
fix(python): Fix bool/string usage of "column_totals" parameter in `write_excel`

### DIFF
--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -193,7 +193,7 @@ ConditionalFormatDict: TypeAlias = Mapping[
 ]
 ColumnTotalsDefinition: TypeAlias = Union[
     # dict of colname(s) to str, a collection of str, or a boolean
-    Mapping[Union[str, Collection[str]], str],
+    Mapping[Union[ColumnNameOrSelector, Tuple[ColumnNameOrSelector]], str],
     Sequence[str],
     bool,
 ]


### PR DESCRIPTION
Somewhere along the line it turns out that the "column_totals" parameter of `write_excel` stopped working for the boolean and string 'func_name' variations (dict/list input was still fine, which is likely why this wasn't noticed earlier), eg:

* `column_totals=True`
* `column_totals="average"`

This PR fixes both of these uses, and updates "column_totals" typing (it supports selectors).

