### PR TITLE
feat(rust): Support jumping into a debugger breakpoint on errors

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(internal_features)]
+#![feature(core_intrinsics)]
+
 pub mod constants;
 mod warning;
 
@@ -19,9 +22,14 @@ where
     T: Into<Cow<'static, str>>,
 {
     fn from(msg: T) -> Self {
-        if env::var("POLARS_PANIC_ON_ERR").as_deref().unwrap_or("") == "1" {
+        let panic = env::var("POLARS_PANIC_ON_ERR");
+        let panic_on_err = panic.as_deref().unwrap_or("");
+        if panic_on_err == "1" {
             panic!("{}", msg.into())
         } else {
+            if panic_on_err == "breakpoint" {
+                unsafe { std::intrinsics::breakpoint(); }
+            }
             ErrString(msg.into())
         }
     }

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -404,7 +404,8 @@
 //! * `POLARS_ALLOW_EXTENSION` -> allows for [`ObjectChunked<T>`] to be used in arrow, opening up possibilities like using
 //!                               `T` in complex lazy expressions. However this does require `unsafe` code allow this.
 //! * `POLARS_NO_PARQUET_STATISTICS` -> if set, statistics in parquet files are ignored.
-//! * `POLARS_PANIC_ON_ERR` -> panic instead of returning an Error.
+//! * `POLARS_PANIC_ON_ERR` -> if set to "1", panic instead of returning an Error. If set to "breakpoint",
+//!                            trigger a debugger breakpoint if the program is run under a debugger.
 //! * `POLARS_NO_CHUNKED_JOIN` -> force rechunk before joins.
 //!
 //! ## User guide


### PR DESCRIPTION
Currently `POLARS_PANIC_ON_ERR` turns an error into a panic. This PR extends that functionality to allow jumping into a debugger breakpoint instead of panicking.

This is a nicer than panic plus setting a breakpoint on `rust_panic`, because it doesn't distort the way the code runs, you can poke around, then tell the debugger to continue and the program runs as usual.

```
$ export POLARS_PANIC_ON_ERR=breakpoint
$ rust-gdb  --args python ../9188.py 
...
(gdb) run
Starting program: /home/itamarst/devel/polars/.venv/bin/python ../9188.py
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
original shape: (2,)
Series: 's' [list[i64]]
[
        [1, 2]
        [3]
]

Program received signal SIGTRAP, Trace/breakpoint trap.
0x00007ffff5094824 in polars_error::{impl#0}::from<alloc::string::String> (msg=...) at crates/polars-error/src/lib.rs:31
31                      unsafe { std::intrinsics::breakpoint(); }
(gdb) up
#1  0x00007ffff509a4fe in core::convert::{impl#3}::into<alloc::string::String, polars_error::ErrString> (self=...)
    at /rustc/3cb521a4344f0b556b81c55eec8facddeb1ead83/library/core/src/convert/mod.rs:759
759             U::from(self)
(gdb) up
#2  0x00007ffff3e25356 in polars_core::series::series_trait::private::PrivateSeries::add_to<polars_core::series::implementations::SeriesWrap<polars_core::chunked_array::ChunkedArray<polars_core::datatypes::ListType>>> (self=0x7fffe66562d0, 
    _rhs=0x7ffff6d37040) at crates/polars-core/src/series/series_trait.rs:145
145                 polars_bail!(opq = add, self._dtype());
(gdb) up
#3  0x00007ffff424f546 in polars_core::series::arithmetic::borrowed::{impl#7}::add (
    self=0x7ffff6d37040, rhs=0x7ffff6d37040)
    at crates/polars-core/src/series/arithmetic/borrowed.rs:503
503                     lhs.add_to(rhs.as_ref())
(gdb) c
Continuing.
Traceback (most recent call last):
  File "/home/itamarst/devel/polars/py-polars/../9188.py", line 5, in <module>
    added = s + s
  File "/home/itamarst/devel/polars/py-polars/polars/series/series.py", line 1053, in __add__
    return self._arithmetic(other, "add", "add_<>")
  File "/home/itamarst/devel/polars/py-polars/polars/series/series.py", line 1000, in _arithmetic
    return self._from_pyseries(getattr(self._s, op_s)(other._s))
polars.exceptions.InvalidOperationError: `add` operation not supported for dtype `list[i64]`
[Inferior 1 (process 861482) exited with code 01]
```