### PR TITLE
docs: Explanation in aggregation.md did not match code example

### DIFF
--- a/docs/user-guide/expressions/aggregation.md
+++ b/docs/user-guide/expressions/aggregation.md
@@ -17,8 +17,7 @@ Per GROUP `"first_name"` we
 <!-- dprint-ignore-start -->
 
 - count the number of rows in the group:
-    - short form: `pl.count("party")`
-    - full form: `pl.col("party").count()`
+    - full form: `pl.len()`
 - aggregate the gender values groups:
     - full form: `pl.col("gender")`
 - get the first value of column `"last_name"` in the group:

--- a/docs/user-guide/expressions/aggregation.md
+++ b/docs/user-guide/expressions/aggregation.md
@@ -16,8 +16,7 @@ Per GROUP `"first_name"` we
 
 <!-- dprint-ignore-start -->
 
-- count the number of rows in the group:
-    - full form: `pl.len()`
+- count the number of rows in the group: `pl.len()`
 - aggregate the gender values groups:
     - full form: `pl.col("gender")`
 - get the first value of column `"last_name"` in the group:


### PR DESCRIPTION
Explanation referenced `pl.count("party")` which was not present in the provided code example.

See issue #17858