### PR TITLE
feat: Add `ignore_nulls` option to `struct.json_encode`

### DIFF
--- a/crates/polars-json/src/json/write/mod.rs
+++ b/crates/polars-json/src/json/write/mod.rs
@@ -88,7 +88,7 @@ impl<'a> RecordSerializer<'a> {
         let iterators = chunk
             .arrays()
             .iter()
-            .map(|arr| new_serializer(arr.as_ref(), 0, usize::MAX))
+            .map(|arr| new_serializer(arr.as_ref(), false, 0, usize::MAX))
             .collect();
 
         Self {

--- a/crates/polars-json/src/json/write/utf8.rs
+++ b/crates/polars-json/src/json/write/utf8.rs
@@ -141,9 +141,9 @@ where
     writer.write_all(s)
 }
 
-pub fn serialize_to_utf8(array: &dyn Array) -> Utf8ViewArray {
+pub fn serialize_to_utf8(array: &dyn Array, ignore_nulls: bool) -> Utf8ViewArray {
     let mut values = MutableBinaryViewArray::with_capacity(array.len());
-    let mut serializer = new_serializer(array, 0, usize::MAX);
+    let mut serializer = new_serializer(array, ignore_nulls, 0, usize::MAX);
 
     while let Some(v) = serializer.next() {
         unsafe { values.push_value(std::str::from_utf8_unchecked(v)) }

--- a/crates/polars-json/src/ndjson/write.rs
+++ b/crates/polars-json/src/ndjson/write.rs
@@ -8,7 +8,7 @@ use polars_error::{PolarsError, PolarsResult};
 use super::super::json::write::new_serializer;
 
 fn serialize(array: &dyn Array, buffer: &mut Vec<u8>) {
-    let mut serializer = new_serializer(array, 0, usize::MAX);
+    let mut serializer = new_serializer(array, false, 0, usize::MAX);
     (0..array.len()).for_each(|_| {
         buffer.extend_from_slice(serializer.next().unwrap());
         buffer.push(b'\n');

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -63,9 +63,11 @@ impl StructNameSpace {
     }
 
     #[cfg(feature = "json")]
-    pub fn json_encode(self) -> Expr {
+    pub fn json_encode(self, ignore_nulls: bool) -> Expr {
         self.0
-            .map_private(FunctionExpr::StructExpr(StructFunction::JsonEncode))
+            .map_private(FunctionExpr::StructExpr(StructFunction::JsonEncode {
+                ignore_nulls,
+            }))
     }
 
     pub fn with_fields(self, fields: Vec<Expr>) -> PolarsResult<Expr> {

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -214,9 +214,20 @@ class ExprStructNameSpace:
         """
         return wrap_expr(self._pyexpr.struct_rename_fields(names))
 
-    def json_encode(self) -> Expr:
+    def json_encode(self, *, ignore_nulls: bool = False) -> Expr:
         """
         Convert this struct to a string column with json values.
+
+        Parameters
+        ----------
+        ignore_nulls
+            Ignore missing values in the struct when serializing.
+
+                - When `ignore_nulls=False`, the values in the struct are included even
+                  if they are null
+
+                - When `ignore_nulls=True`, the values in the struct are skipped if they
+                  are null
 
         Examples
         --------
@@ -232,8 +243,22 @@ class ExprStructNameSpace:
         │ {[1, 2],[45]}    ┆ {"a":[1,2],"b":[45]}   │
         │ {[9, 1, 3],null} ┆ {"a":[9,1,3],"b":null} │
         └──────────────────┴────────────────────────┘
+        >>> pl.DataFrame(
+        ...     {"a": [{"a": [1, 2], "b": [45]}, {"a": [9, 1, 3], "b": None}]}
+        ... ).with_columns(
+        ...     pl.col("a").struct.json_encode(ignore_nulls=True).alias("encoded")
+        ... )
+        shape: (2, 2)
+        ┌──────────────────┬────────────────────────┐
+        │ a                ┆ encoded                │
+        │ ---              ┆ ---                    │
+        │ struct[2]        ┆ str                    │
+        ╞══════════════════╪════════════════════════╡
+        │ {[1, 2],[45]}    ┆ {"a":[1,2],"b":[45]}   │
+        │ {[9, 1, 3],null} ┆ {"a":[9,1,3]}          │
+        └──────────────────┴────────────────────────┘
         """
-        return wrap_expr(self._pyexpr.struct_json_encode())
+        return wrap_expr(self._pyexpr.struct_json_encode(ignore_nulls))
 
     def with_fields(
         self,

--- a/py-polars/src/expr/struct.rs
+++ b/py-polars/src/expr/struct.rs
@@ -23,8 +23,12 @@ impl PyExpr {
     }
 
     #[cfg(feature = "json")]
-    fn struct_json_encode(&self) -> Self {
-        self.inner.clone().struct_().json_encode().into()
+    fn struct_json_encode(&self, ignore_nulls: bool) -> Self {
+        self.inner
+            .clone()
+            .struct_()
+            .json_encode(ignore_nulls)
+            .into()
     }
 
     fn struct_with_fields(&self, fields: Vec<PyExpr>) -> PyResult<Self> {


### PR DESCRIPTION
Feature issue: https://github.com/pola-rs/polars/issues/17865

Adding an option to ignore null values inside a struct when performing json_encode.