### PR TITLE
fix(python): Raise suitable error when invalid column passed to `get_column_index`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4754,8 +4754,13 @@ class DataFrame:
         ... )
         >>> df.get_column_index("ham")
         2
+        >>> df.get_column_index("sandwich")  # doctest: +SKIP
+        ColumnNotFoundError: 'sandwich' not found in DataFrame
         """
-        return self._df.get_column_index(name)
+        if (idx := self._df.get_column_index(name)) is None:
+            msg = f"{name!r} not found in DataFrame"
+            raise ColumnNotFoundError(msg)
+        return idx
 
     def replace_column(self, index: int, column: Series) -> DataFrame:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4755,12 +4755,9 @@ class DataFrame:
         >>> df.get_column_index("ham")
         2
         >>> df.get_column_index("sandwich")  # doctest: +SKIP
-        ColumnNotFoundError: 'sandwich' not found in DataFrame
+        ColumnNotFoundError: sandwich
         """
-        if (idx := self._df.get_column_index(name)) is None:
-            msg = f"{name!r} not found in DataFrame"
-            raise ColumnNotFoundError(msg)
-        return idx
+        return self._df.get_column_index(name)
 
     def replace_column(self, index: int, column: Series) -> DataFrame:
         """

--- a/py-polars/src/dataframe/general.rs
+++ b/py-polars/src/dataframe/general.rs
@@ -226,8 +226,11 @@ impl PyDataFrame {
         }
     }
 
-    pub fn get_column_index(&self, name: &str) -> Option<usize> {
-        self.df.get_column_index(name)
+    pub fn get_column_index(&self, name: &str) -> PyResult<usize> {
+        Ok(self
+            .df
+            .try_get_column_index(name)
+            .map_err(PyPolarsErr::from)?)
     }
 
     pub fn get_column(&self, name: &str) -> PyResult<PySeries> {

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2832,7 +2832,6 @@ def test_from_records_u64_12329() -> None:
 
 def test_negative_slice_12642() -> None:
     df = pl.DataFrame({"x": range(5)})
-
     assert_frame_equal(df.slice(-2, 1), df.tail(2).head(1))
 
 
@@ -2841,3 +2840,13 @@ def test_iter_columns() -> None:
     iter_columns = df.iter_columns()
     assert_series_equal(next(iter_columns), pl.Series("a", [1, 1, 2]))
     assert_series_equal(next(iter_columns), pl.Series("b", [4, 5, 6]))
+
+
+def test_get_column_index() -> None:
+    df = pl.DataFrame({"actual": [1001], "expected": [1000]})
+
+    assert df.get_column_index("actual") == 0
+    assert df.get_column_index("expected") == 1
+
+    with pytest.raises(ColumnNotFoundError, match="'missing' not found in DataFrame"):
+        df.get_column_index("missing")

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2848,5 +2848,5 @@ def test_get_column_index() -> None:
     assert df.get_column_index("actual") == 0
     assert df.get_column_index("expected") == 1
 
-    with pytest.raises(ColumnNotFoundError, match="'missing' not found in DataFrame"):
+    with pytest.raises(ColumnNotFoundError, match="missing"):
         df.get_column_index("missing")


### PR DESCRIPTION
Invalid column name lookups were returning `None` from `get_column_index`.

This isn't consistent with `get_column` or the function typing (which indicates it will only return `int`, or raise an error), and was discovered after tracking down a much more cryptic error in some work code caused by the unexpected `None` propagation :)

Now raises the expected `ColumnNotFoundError`.
Test coverage added.

## Example

```python
df = pl.DataFrame({
  "foo": [1, 2, 3],
  "bar": [4, 5, 6],
  "ham": [7, 8, 9],
})
```
Column exists; returns index:
```python
df.get_column_index("ham")
# 2
```
Column does not exist; raises the expected error:
```python
df.get_column_index("sandwich")
# ColumnNotFoundError: 'sandwich' not found in DataFrame
```