### PR TITLE
fix(python): Improve default `write_excel` int/float format when using a dark "table_style"

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3186,6 +3186,7 @@ class DataFrame:
             dtype_formats=dtype_formats,
             header_format=header_format,
             float_precision=float_precision,
+            table_style=table_style,
             row_totals=row_totals,
             sparklines=sparklines,
             formulas=formulas,

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -545,7 +545,7 @@ def test_read_excel_all_sheets_with_sheet_name(path_xlsx: Path, engine: str) -> 
         # basic formatting
         {
             "autofit": True,
-            "table_style": "Table Style Light 16",
+            "table_style": "Table Style Dark 2",
             "column_totals": True,
             "float_precision": 0,
         },


### PR DESCRIPTION
Much better default output when given a "dark" `table_style`:

## Example

```python
import polars as pl

df = pl.DataFrame({
    "dtm": [date(2023, 1, 1), date(2023, 1, 2), date(2023, 1, 3)],
    "str": ["xxx", "yyy", "xxx"],
    "val": [100.5, 55.0, -99.5],
})

df.write_excel(
    workbook="output.xlsx",
    table_style="Table Style Dark 2",
    column_totals=True,
    autofit=True,
)
```
#### Before:

Numeric formatting does not work with _dark_ styles -

![Screenshot 2024-07-25 at 17 46 17](https://github.com/user-attachments/assets/92d938a3-7b2d-4a86-9404-c89d8adab5eb)

#### After:

Now it does -

![Screenshot 2024-07-25 at 17 46 11](https://github.com/user-attachments/assets/cf819a28-4198-4385-9a37-dcc64487f9f0)
