### PR TITLE
feat(python): Right-align numerical headers in `write_excel`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3190,6 +3190,7 @@ class DataFrame:
             row_totals=row_totals,
             sparklines=sparklines,
             formulas=formulas,
+            autofilter=autofilter,
         )
 
         # normalise cell refs (eg: "B3" => (2,1)) and establish table start/finish,

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -453,7 +453,9 @@ def _xl_setup_table_columns(
     # associate formats/functions with specific columns
     header_dict = header_format or {}
     add_align = "align" not in header_dict
-    header_alignment = {"align": "right"} | ({"indent": 2} if autofilter else {})
+    header_alignment = {"align": "right"}
+    if autofilter:
+        header_alignment["indent"] = 2  # type: ignore[assignment]
     col_header_format = {}
     for col, tp in df.schema.items():
         base_type = tp.base_type()
@@ -462,7 +464,7 @@ def _xl_setup_table_columns(
             fmt = dtype_formats.get(tp, dtype_formats[base_type])
             column_formats.setdefault(col, fmt)
             if add_align and base_type in [*FLOAT_DTYPES, *INTEGER_DTYPES]:
-                header_fmt = header_dict | header_alignment
+                header_fmt = {**header_dict, **header_alignment}
         if col not in column_formats:
             column_formats[col] = fmt_default
 


### PR DESCRIPTION
Resolves #17852.

@alexander-beedie the logic is the following:

* If a header is specified with an alignment, no logic is applied (respect user header format).
* If a header is specified without an alignment, or no header logic is specified, then numerical columns are right-aligned.
* If the table `autofilter` is enabled, then an indent is applied so that the headers are not hidden.

Here is my test to ensure it's working:

```python
import polars as pl

data = {
    "id": ["a123", "b345", "c567", "d789"],
    "a": [99, 45, 50, 85],
    "b": [1.2, -3.4, 5.6, 7.8],
    "c": [1.2, -3.4, 5.6, 7.8],
    "d": [1.2, -3.4, 5.6, 7.8],
}

column_formats = {
    "b": {
        "font": "Consolas",
        "align": "center",
        "num_format": "0.000;-0.000;0",
        "valign": "top",
    },
    "c": {
        "num_format": "$#,##0.00;[red]-$#,##0.00;-",
        "font": "Consolas",
        "font_size": 10,
        "valign": "top",
    },
    "d": {
        "num_format": "$#,##0.00;[red]-$#,##0.00;-",
        "font": "Consolas",
        "font_size": 10,
        "valign": "top",
    },
}

header_format = {
    "bg_color": "#FFFFEE",
    "font_color": "blue",
}

# Write header with specified alignment. Header should not include new logic.
header_format["align"] = "left"
pl.DataFrame(data).write_excel(
    "output_left_align.xlsx",
    table_style={"style": "Table Style Medium 15"},
    column_formats=column_formats,
    header_format=header_format,
)

# Write header with no specified alignment. Header should right-align with indent.
header_format.pop("align")
pl.DataFrame(data).write_excel(
    "output_no_align.xlsx",
    table_style={"style": "Table Style Medium 15"},
    column_formats=column_formats,
    header_format=header_format,
)

# Write header no header formatting. Header should right-align with indent.
header_format["align"] = "left"
pl.DataFrame(data).write_excel(
    "output_no_fmt.xlsx",
    table_style={"style": "Table Style Medium 15"},
    column_formats=column_formats,
    header_format=None,
)

# Write with no formatting and autofilter off. Header should right-align without an indent.
header_format["align"] = "left"
pl.DataFrame(data).write_excel(
    "output_no_filter.xlsx",
    table_style={"style": "Table Style Medium 15"},
    column_formats=column_formats,
    header_format=None,
    autofilter=False,
)
```

Output:

#### Header with specified alignment. Header should **not** include new logic.

![image](https://github.com/user-attachments/assets/ac628aa1-40a9-408f-b590-550ab0c137be)

#### Header with no specified alignment. Header should right-align with indent.

![image](https://github.com/user-attachments/assets/04197e61-952a-4653-baff-31f50f5979ba)

#### No header formatting specified. Header should right-align with indent.

![image](https://github.com/user-attachments/assets/c295516c-9dea-4101-b936-bf2503973f61)

#### No header formatting and autofilter off. Header should right-align without an indent.

![image](https://github.com/user-attachments/assets/8c27d1c2-a0c5-47b8-bf32-5755e849d2c6)
