### PR TITLE
feat: Support authentication with HuggingFace login

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -22,7 +22,6 @@ use object_store::ClientOptions;
 use object_store::{BackoffConfig, RetryConfig};
 #[cfg(feature = "aws")]
 use once_cell::sync::Lazy;
-use polars_core::config;
 use polars_error::*;
 #[cfg(feature = "aws")]
 use polars_utils::cache::FastFixedCache;
@@ -475,6 +474,8 @@ impl CloudOptions {
             CloudType::Hf => {
                 #[cfg(feature = "http")]
                 {
+                    use polars_core::config;
+
                     let mut this = Self::default();
                     let mut token = None;
                     let verbose = config::verbose();

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -39,8 +39,6 @@ use url::Url;
 #[cfg(feature = "file_cache")]
 use crate::file_cache::get_env_file_cache_ttl;
 #[cfg(feature = "aws")]
-use crate::path_utils::resolve_homedir;
-#[cfg(feature = "aws")]
 use crate::pl_async::with_concurrency_budget;
 
 #[cfg(feature = "aws")]
@@ -211,6 +209,8 @@ fn read_config(
     builder: &mut AmazonS3Builder,
     items: &[(&Path, &[(&str, AmazonS3ConfigKey)])],
 ) -> Option<()> {
+    use crate::path_utils::resolve_homedir;
+
     for (path, keys) in items {
         if keys
             .iter()
@@ -475,6 +475,8 @@ impl CloudOptions {
                 #[cfg(feature = "http")]
                 {
                     use polars_core::config;
+
+                    use crate::path_utils::resolve_homedir;
 
                     let mut this = Self::default();
                     let mut token = None;

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -502,7 +502,7 @@ impl CloudOptions {
 
                     if token.is_none() {
                         token = (|| {
-                            let hf_home = std::env::var("HF_TOKEN");
+                            let hf_home = std::env::var("HF_HOME");
                             let hf_home = hf_home.as_deref();
                             let hf_home = hf_home.unwrap_or("~/.cache/huggingface");
                             let hf_home = resolve_homedir(std::path::Path::new(&hf_home));


### PR DESCRIPTION
ref https://github.com/huggingface/dataset-viewer/pull/2997#pullrequestreview-2199284560
ref https://github.com/huggingface/hub-docs/pull/1345#discussion_r1691497655

Support a login mechanism Hugging Face uses that stores the token in a file under `$HF_HOME/token`.

We attempt to source the token in the following order:
* `storage_options` passed to `pl.(scan|read)_(...)`
* `HF_TOKEN` environment variable
* `$HF_HOME/token` on the filesystem
