### PR TITLE
chore: Remove apply_generic, use unary_elementwise

### DIFF
--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -9,6 +9,7 @@ use arrow::compute::utils::combine_validities_and;
 use num_traits::{Num, NumCast, ToPrimitive};
 pub use numeric::ArithmeticChunked;
 
+use crate::prelude::arity::unary_elementwise_values;
 use crate::prelude::*;
 
 #[inline]
@@ -135,7 +136,7 @@ impl Add for &BooleanChunked {
         if rhs.len() == 1 {
             let rhs = rhs.get(0);
             return match rhs {
-                Some(rhs) => self.apply_values_generic(|v| v as IdxSize + rhs as IdxSize),
+                Some(rhs) => unary_elementwise_values(self, |v| v as IdxSize + rhs as IdxSize),
                 None => IdxCa::full_null(self.name(), self.len()),
             };
         }

--- a/crates/polars-core/src/chunked_array/float.rs
+++ b/crates/polars-core/src/chunked_array/float.rs
@@ -3,6 +3,7 @@ use arrow::legacy::kernels::set::set_at_nulls;
 use num_traits::Float;
 use polars_utils::total_ord::{canonical_f32, canonical_f64};
 
+use crate::prelude::arity::unary_elementwise_values;
 use crate::prelude::*;
 
 impl<T> ChunkedArray<T>
@@ -57,6 +58,6 @@ where
     T::Native: Float + Canonical,
 {
     pub fn to_canonical(&self) -> Self {
-        self.apply_values_generic(|v| v.canonical())
+        unary_elementwise_values(self, |v| v.canonical())
     }
 }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -75,8 +75,8 @@ pub type ChunkLenIter<'a> = std::iter::Map<std::slice::Iter<'a, ArrayRef>, fn(&A
 ///
 /// ```rust
 /// # use polars_core::prelude::*;
-/// fn apply_cosine_and_cast(ca: &Float32Chunked) -> Float64Chunked {
-///     ca.apply_values_generic(|v| v.cos() as f64)
+/// fn apply_cosine_and_cast(ca: &Float32Chunked) -> Float32Chunked {
+///     ca.apply_values(|v| v.cos())
 /// }
 /// ```
 ///

--- a/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
@@ -1,3 +1,5 @@
+use arity::unary_elementwise_values;
+
 use super::*;
 
 pub trait VarAggSeries {
@@ -19,7 +21,7 @@ where
         }
 
         let mean = self.mean()?;
-        let squared: Float64Chunked = ChunkedArray::apply_values_generic(self, |value| {
+        let squared: Float64Chunked = unary_elementwise_values(self, |value| {
             let tmp = value.to_f64().unwrap() - mean;
             tmp * tmp
         });

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -74,10 +74,17 @@ where
     F: UnaryFnMut<Option<T::Physical<'a>>>,
     V::Array: ArrayFromIter<<F as UnaryFnMut<Option<T::Physical<'a>>>>::Ret>,
 {
-    let iter = ca
-        .downcast_iter()
-        .map(|arr| arr.iter().map(&mut op).collect_arr());
-    ChunkedArray::from_chunk_iter(ca.name(), iter)
+    if ca.null_count == 0 {
+        let iter = ca
+            .downcast_iter()
+            .map(|arr| arr.values_iter().map(|x| op(Some(x))).collect_arr());
+        ChunkedArray::from_chunk_iter(ca.name(), iter)
+    } else {
+        let iter = ca
+            .downcast_iter()
+            .map(|arr| arr.iter().map(&mut op).collect_arr());
+        ChunkedArray::from_chunk_iter(ca.name(), iter)
+    }
 }
 
 #[inline]

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -74,15 +74,15 @@ where
     F: UnaryFnMut<Option<T::Physical<'a>>>,
     V::Array: ArrayFromIter<<F as UnaryFnMut<Option<T::Physical<'a>>>>::Ret>,
 {
-    if ca.null_count == 0 {
+    if ca.has_nulls() {
         let iter = ca
             .downcast_iter()
-            .map(|arr| arr.values_iter().map(|x| op(Some(x))).collect_arr());
+            .map(|arr| arr.iter().map(&mut op).collect_arr());
         ChunkedArray::from_chunk_iter(ca.name(), iter)
     } else {
         let iter = ca
             .downcast_iter()
-            .map(|arr| arr.iter().map(&mut op).collect_arr());
+            .map(|arr| arr.values_iter().map(|x| op(Some(x))).collect_arr());
         ChunkedArray::from_chunk_iter(ca.name(), iter)
     }
 }

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -6,7 +6,7 @@ use base64::engine::general_purpose;
 #[cfg(feature = "binary_encoding")]
 use base64::Engine as _;
 use memchr::memmem::find;
-use polars_core::prelude::arity::broadcast_binary_elementwise_values;
+use polars_core::prelude::arity::{broadcast_binary_elementwise_values, unary_elementwise_values};
 
 use super::*;
 
@@ -15,7 +15,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     fn contains(&self, lit: &[u8]) -> BooleanChunked {
         let ca = self.as_binary();
         let f = |s: &[u8]| find(s, lit).is_some();
-        ca.apply_values_generic(f)
+        unary_elementwise_values(ca, f)
     }
 
     fn contains_chunked(&self, lit: &BinaryChunked) -> BooleanChunked {

--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -1,5 +1,6 @@
 use arrow::array::{Utf8Array, ValueSize};
 use arrow::compute::cast::utf8_to_utf8view;
+use polars_core::prelude::arity::unary_elementwise;
 use polars_core::prelude::*;
 
 // Vertically concatenate all strings in a StringChunked.
@@ -67,7 +68,7 @@ pub fn hor_str_concat(
         return if !ignore_nulls || ca.null_count() == 0 {
             Ok(ca.clone())
         } else {
-            Ok(ca.apply_generic(|val| Some(val.unwrap_or(""))))
+            Ok(unary_elementwise(ca, |val| Some(val.unwrap_or(""))))
         };
     }
 

--- a/crates/polars-ops/src/chunked_array/strings/find_many.rs
+++ b/crates/polars-ops/src/chunked_array/strings/find_many.rs
@@ -1,5 +1,6 @@
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 use arrow::array::Utf8ViewArray;
+use polars_core::prelude::arity::unary_elementwise;
 use polars_core::prelude::*;
 use polars_core::utils::align_chunks_binary;
 
@@ -27,7 +28,9 @@ pub fn contains_any(
 ) -> PolarsResult<BooleanChunked> {
     let ac = build_ac(patterns, ascii_case_insensitive)?;
 
-    Ok(ca.apply_generic(|opt_val| opt_val.map(|val| ac.find(val).is_some())))
+    Ok(unary_elementwise(ca, |opt_val| {
+        opt_val.map(|val| ac.find(val).is_some())
+    }))
 }
 
 pub fn replace_all(
@@ -52,7 +55,9 @@ pub fn replace_all(
 
     let ac = build_ac(patterns, ascii_case_insensitive)?;
 
-    Ok(ca.apply_generic(|opt_val| opt_val.map(|val| ac.replace_all(val, replace_with.as_slice()))))
+    Ok(unary_elementwise(ca, |opt_val| {
+        opt_val.map(|val| ac.replace_all(val, replace_with.as_slice()))
+    }))
 }
 
 fn push(val: &str, builder: &mut ListStringChunkedBuilder, ac: &AhoCorasick, overlapping: bool) {

--- a/crates/polars-ops/src/chunked_array/strings/reverse.rs
+++ b/crates/polars-ops/src/chunked_array/strings/reverse.rs
@@ -1,3 +1,4 @@
+use polars_core::prelude::arity::unary_elementwise;
 use polars_core::prelude::StringChunked;
 use unicode_reverse::reverse_grapheme_clusters_in_place;
 
@@ -10,5 +11,5 @@ fn to_reverse_helper(s: Option<&str>) -> Option<String> {
 }
 
 pub fn reverse(ca: &StringChunked) -> StringChunked {
-    ca.apply_generic(to_reverse_helper)
+    unary_elementwise(ca, to_reverse_helper)
 }

--- a/crates/polars-ops/src/chunked_array/strings/strip.rs
+++ b/crates/polars-ops/src/chunked_array/strings/strip.rs
@@ -1,4 +1,4 @@
-use polars_core::prelude::arity::broadcast_binary_elementwise;
+use polars_core::prelude::arity::{broadcast_binary_elementwise, unary_elementwise};
 
 use super::*;
 
@@ -58,14 +58,16 @@ pub fn strip_chars(ca: &StringChunked, pat: &StringChunked) -> StringChunked {
             if let Some(pat) = pat.get(0) {
                 if pat.chars().count() == 1 {
                     // Fast path for when a single character is passed
-                    ca.apply_generic(|opt_s| {
+                    unary_elementwise(ca, |opt_s| {
                         opt_s.map(|s| s.trim_matches(pat.chars().next().unwrap()))
                     })
                 } else {
-                    ca.apply_generic(|opt_s| opt_s.map(|s| s.trim_matches(|c| pat.contains(c))))
+                    unary_elementwise(ca, |opt_s| {
+                        opt_s.map(|s| s.trim_matches(|c| pat.contains(c)))
+                    })
                 }
             } else {
-                ca.apply_generic(|opt_s| opt_s.map(|s| s.trim()))
+                unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim()))
             }
         },
         _ => broadcast_binary_elementwise(ca, pat, strip_chars_binary),
@@ -78,16 +80,16 @@ pub fn strip_chars_start(ca: &StringChunked, pat: &StringChunked) -> StringChunk
             if let Some(pat) = pat.get(0) {
                 if pat.chars().count() == 1 {
                     // Fast path for when a single character is passed
-                    ca.apply_generic(|opt_s| {
+                    unary_elementwise(ca, |opt_s| {
                         opt_s.map(|s| s.trim_start_matches(pat.chars().next().unwrap()))
                     })
                 } else {
-                    ca.apply_generic(|opt_s| {
+                    unary_elementwise(ca, |opt_s| {
                         opt_s.map(|s| s.trim_start_matches(|c| pat.contains(c)))
                     })
                 }
             } else {
-                ca.apply_generic(|opt_s| opt_s.map(|s| s.trim_start()))
+                unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_start()))
             }
         },
         _ => broadcast_binary_elementwise(ca, pat, strip_chars_start_binary),
@@ -100,14 +102,16 @@ pub fn strip_chars_end(ca: &StringChunked, pat: &StringChunked) -> StringChunked
             if let Some(pat) = pat.get(0) {
                 if pat.chars().count() == 1 {
                     // Fast path for when a single character is passed
-                    ca.apply_generic(|opt_s| {
+                    unary_elementwise(ca, |opt_s| {
                         opt_s.map(|s| s.trim_end_matches(pat.chars().next().unwrap()))
                     })
                 } else {
-                    ca.apply_generic(|opt_s| opt_s.map(|s| s.trim_end_matches(|c| pat.contains(c))))
+                    unary_elementwise(ca, |opt_s| {
+                        opt_s.map(|s| s.trim_end_matches(|c| pat.contains(c)))
+                    })
                 }
             } else {
-                ca.apply_generic(|opt_s| opt_s.map(|s| s.trim_end()))
+                unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_end()))
             }
         },
         _ => broadcast_binary_elementwise(ca, pat, strip_chars_end_binary),
@@ -117,9 +121,9 @@ pub fn strip_chars_end(ca: &StringChunked, pat: &StringChunked) -> StringChunked
 pub fn strip_prefix(ca: &StringChunked, prefix: &StringChunked) -> StringChunked {
     match prefix.len() {
         1 => match prefix.get(0) {
-            Some(prefix) => {
-                ca.apply_generic(|opt_s| opt_s.map(|s| s.strip_prefix(prefix).unwrap_or(s)))
-            },
+            Some(prefix) => unary_elementwise(ca, |opt_s| {
+                opt_s.map(|s| s.strip_prefix(prefix).unwrap_or(s))
+            }),
             _ => StringChunked::full_null(ca.name(), ca.len()),
         },
         _ => broadcast_binary_elementwise(ca, prefix, strip_prefix_binary),
@@ -129,9 +133,9 @@ pub fn strip_prefix(ca: &StringChunked, prefix: &StringChunked) -> StringChunked
 pub fn strip_suffix(ca: &StringChunked, suffix: &StringChunked) -> StringChunked {
     match suffix.len() {
         1 => match suffix.get(0) {
-            Some(suffix) => {
-                ca.apply_generic(|opt_s| opt_s.map(|s| s.strip_suffix(suffix).unwrap_or(s)))
-            },
+            Some(suffix) => unary_elementwise(ca, |opt_s| {
+                opt_s.map(|s| s.strip_suffix(suffix).unwrap_or(s))
+            }),
             _ => StringChunked::full_null(ca.name(), ca.len()),
         },
         _ => broadcast_binary_elementwise(ca, suffix, strip_suffix_binary),

--- a/crates/polars-ops/src/series/ops/clip.rs
+++ b/crates/polars-ops/src/series/ops/clip.rs
@@ -1,4 +1,4 @@
-use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise};
+use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise, unary_elementwise};
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
 
@@ -146,7 +146,7 @@ where
     T: PolarsNumericType,
     F: Fn(T::Native) -> T::Native + Copy,
 {
-    ca.apply_generic(|v| v.map(op))
+    unary_elementwise(ca, |v| v.map(op))
 }
 
 fn clip_binary<T, F>(ca: &ChunkedArray<T>, bound: &ChunkedArray<T>, op: F) -> ChunkedArray<T>

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -1,5 +1,6 @@
 use std::ops::{Add, AddAssign, Mul};
 
+use arity::unary_elementwise_values;
 use num_traits::{Bounded, One, Zero};
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
@@ -216,7 +217,7 @@ pub fn cum_count(s: &Series, reverse: bool) -> PolarsResult<Series> {
         let out: IdxCa = if reverse {
             let mut count = (s.len() - s.null_count()) as IdxSize;
             let mut prev = false;
-            ca.apply_values_generic(|v: bool| {
+            unary_elementwise_values(&ca, |v: bool| {
                 if prev {
                     count -= 1;
                 }
@@ -225,7 +226,7 @@ pub fn cum_count(s: &Series, reverse: bool) -> PolarsResult<Series> {
             })
         } else {
             let mut count = 0 as IdxSize;
-            ca.apply_values_generic(|v: bool| {
+            unary_elementwise_values(&ca, |v: bool| {
                 if v {
                     count += 1;
                 }

--- a/crates/polars-ops/src/series/ops/index.rs
+++ b/crates/polars-ops/src/series/ops/index.rs
@@ -1,5 +1,6 @@
 use num_traits::{Signed, Zero};
 use polars_core::error::{polars_ensure, PolarsResult};
+use polars_core::prelude::arity::unary_elementwise_values;
 use polars_core::prelude::{ChunkedArray, DataType, IdxCa, PolarsIntegerType, Series, IDX_DTYPE};
 use polars_utils::index::ToIdx;
 
@@ -9,7 +10,7 @@ where
     T::Native: ToIdx,
 {
     let target_len = target_len as u64;
-    Ok(ca.apply_values_generic(|v| v.to_idx(target_len)))
+    Ok(unary_elementwise_values(ca, |v| v.to_idx(target_len)))
 }
 
 pub fn convert_to_unsigned_index(s: &Series, target_len: usize) -> PolarsResult<IdxCa> {

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -1,5 +1,6 @@
 use std::hash::Hash;
 
+use polars_core::prelude::arity::unary_elementwise_values;
 use polars_core::prelude::*;
 use polars_core::utils::{try_get_supertype, CustomIterTools};
 use polars_core::with_match_physical_numeric_polars_type;
@@ -24,9 +25,7 @@ where
             }
         })
     });
-    Ok(ca
-        .apply_values_generic(|val| set.contains(&val.to_total_ord()))
-        .with_name(ca.name()))
+    Ok(unary_elementwise_values(ca, |val| set.contains(&val.to_total_ord())).with_name(ca.name()))
 }
 
 fn is_in_helper<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
@@ -623,10 +622,10 @@ fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<Boolean
                 },
             }
 
-            Ok(ca_in
-                .physical()
-                .apply_values_generic(|val| set.contains(&val.to_total_ord()))
-                .with_name(ca_in.name()))
+            Ok(
+                unary_elementwise_values(ca_in.physical(), |val| set.contains(&val.to_total_ord()))
+                    .with_name(ca_in.name()),
+            )
         },
 
         DataType::List(dt)

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -1,4 +1,5 @@
 use num_traits::Bounded;
+use polars_core::prelude::arity::unary_elementwise_values;
 #[cfg(feature = "dtype-struct")]
 use polars_core::prelude::sort::arg_sort_multiple::_get_rows_encoded_ca;
 use polars_core::prelude::*;
@@ -30,7 +31,8 @@ pub trait SeriesMethods: SeriesSealed {
 
         let counts = if normalize {
             let len = s.len() as f64;
-            let counts: Float64Chunked = counts.apply_values_generic(|count| count as f64 / len);
+            let counts: Float64Chunked =
+                unary_elementwise_values(&counts, |count| count as f64 / len);
             counts.into_series()
         } else {
             counts.into_series()

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -2,6 +2,7 @@ use arrow::legacy::kernels::pow::pow as pow_kernel;
 use num::pow::Pow;
 use polars_core::export::num;
 use polars_core::export::num::{Float, ToPrimitive};
+use polars_core::prelude::arity::unary_elementwise_values;
 use polars_core::with_match_physical_integer_type;
 
 use super::*;
@@ -41,9 +42,7 @@ where
             .ok_or_else(|| polars_err!(ComputeError: "base is null"))?;
 
         Ok(Some(
-            exponent
-                .apply_values_generic(|exp| Pow::pow(base, exp))
-                .into_series(),
+            unary_elementwise_values(exponent, |exp| Pow::pow(base, exp)).into_series(),
         ))
     } else {
         Ok(Some(

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -247,6 +247,7 @@
 //!
 //! ```
 //! use polars::prelude::*;
+//! use polars::prelude::arity::unary_elementwise_values;
 //! # fn example() -> PolarsResult<()> {
 //!
 //! // apply a closure over all values
@@ -255,7 +256,7 @@
 //!
 //! // count string lengths
 //! let s = Series::new("foo", &["foo", "bar", "foobar"]);
-//! s.str()?.apply_values_generic(|str_val| str_val.len() as u64);
+//! unary_elementwise_values(s.str()?, |str_val| str_val.len() as u64);
 //!
 //! # Ok(())
 //! # }


### PR DESCRIPTION
This is what I was talking about yesterday

It seems to me that `apply_generic` and `unary_elementwise` overlap? There's an extra little fastpath in the first one for when there's no nulls (which I ported over), but other than that, is it necessary to have both?