### PR TITLE
feat: Expose binary_elementwise_into_string_amortized for plugin authors, recommend `apply_into_string_amortized` instead of `apply_to_buffer`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -363,21 +363,6 @@ impl StringChunked {
         });
         StringChunked::from_chunk_iter(self.name(), chunks)
     }
-
-    /// Utility that reuses an string buffer to amortize allocations.
-    /// Prefer this over an `apply` that returns an owned `String`.
-    pub fn apply_to_buffer<'a, F>(&'a self, mut f: F) -> Self
-    where
-        F: FnMut(&'a str, &mut String),
-    {
-        let mut buf = String::new();
-        let outer = |s: &'a str| {
-            buf.clear();
-            f(s, &mut buf);
-            unsafe { std::mem::transmute::<&str, &'a str>(buf.as_str()) }
-        };
-        self.apply_mut(outer)
-    }
 }
 
 impl BinaryChunked {

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -332,6 +332,10 @@ where
     ChunkedArray::from_chunk_iter(lhs.name(), iter)
 }
 
+/// Apply elementwise binary function which produces string, amortising allocations.
+///
+/// Currently unused within Polars itself, but it's a useful utility for plugin authors.
+#[inline]
 pub fn binary_elementwise_into_string_amortized<T, U, F>(
     lhs: &ChunkedArray<T>,
     rhs: &ChunkedArray<U>,


### PR DESCRIPTION
This does a couple of things:
- add `binary_elementwise_into_string_amortized` as a utility for plugin authors (and it may end up being useful internally if the great expressification continues?)  - there's a a few plugins that have binary operations which produce strings which could benefit from this
- remove `apply_to_buffer` and recommend `apply_into_string_amortized` to plugin authors instead - their perf is about the same, but the latter has the advantage that the input isn't required to be exactly `StringChunked`