### PR TITLE
ci(python): On Python release, trigger docs build after API reference build

### DIFF
--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/docs-global.yml
   repository_dispatch:
     types:
-      - python-release
+      - python-release-docs
   # Allow manual trigger until we have properly versioned docs
   workflow_dispatch:
 

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -51,7 +51,7 @@ jobs:
         run: make html
 
       - name: Deploy Python docs for latest development version
-        if: ${{ github.ref_name == 'main' }}
+        if: github.event_name == 'push' && github.ref_name == 'main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -84,3 +84,14 @@ jobs:
           folder: py-polars/docs/build/html
           target-folder: api/python/stable
           single-commit: true
+
+      # Build global docs _after_ this workflow to avoid contention on the gh-pages branch
+      - name: Trigger global docs workflow
+        if: github.event_name == 'repository_dispatch'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: python-release-docs
+          client-payload: >
+            {
+              "sha": "${{ github.event.client_payload.sha }}"
+            }


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17329

I believe the issue is that the global docs workflow and the Python docs workflow try updating the `gh-pages` branch simultaneously. This leads to some of the updates being lost, e.g.:

* A checks out branch
* B checks out branch
* A writes to branch
* B writes to branch (updates from A are lost)

Now the global docs will be built _after_ the Python API docs. That should take care of the issue.

Not super happy with this fix - it introduces some complexity - but it should work.