### PR TITLE
fix(rust): Fix panic when trigger projection push down with anonymous scan

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -487,10 +487,15 @@ impl ProjectionPushDown {
                         }
                         Some(Arc::new(schema))
                     } else {
-                        file_options.with_columns = maybe_init_projection_excluding_hive(
-                            file_info.reader_schema.as_ref().unwrap(),
-                            hive_parts.as_ref().map(|x| &x[0]),
-                        );
+                        file_options.with_columns =
+                            if let Some(schema) = file_info.reader_schema.as_ref() {
+                                maybe_init_projection_excluding_hive(
+                                    schema,
+                                    hive_parts.as_ref().map(|x| &x[0]),
+                                )
+                            } else {
+                                None
+                            };
                         None
                     };
                 }


### PR DESCRIPTION
here is the reproduce code:
```rust
use polars::prelude::*;

pub struct Test;

impl AnonymousScan for Test {
    fn allows_projection_pushdown(&self) -> bool {
        true
    }

    fn as_any(&self) -> &dyn std::any::Any {
        self
    }

    fn schema(&self, _infer_schema_length: Option<usize>) -> PolarsResult<SchemaRef> {
        Ok([
            Field::new("a", DataType::Int64),
            Field::new("b", DataType::Int64),
        ]
        .into_iter()
        .collect::<Schema>()
        .into())
    }

    fn scan(&self, _scan_opts: AnonymousScanArgs) -> PolarsResult<DataFrame> {
        df!(
            "a" => [1, 2, 3],
            "b" => [1, 2, 3],
        )
    }
}

#[cfg(test)]
mod tests {

    use polars::lazy::dsl::col;

    use super::*;

    #[test]
    fn test() {
        let df = LazyFrame::anonymous_scan(Arc::new(Test), Default::default())
            .unwrap()
            .filter(col("a").is_not_nan())
            .collect()
            .unwrap();

        println!("{df}");
    }
}
```

and here is the backtrace:

```
thread 'tests::test' panicked at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/projection_pushdown/mod.rs:478:62:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/core/src/panicking.rs:74:14
   2: core::panicking::panic
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/core/src/panicking.rs:148:5
   3: core::option::unwrap_failed
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/core/src/option.rs:2020:5
   4: core::option::Option<T>::unwrap
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/core/src/option.rs:970:21
   5: polars_plan::plans::optimizer::projection_pushdown::ProjectionPushDown::push_down::{{closure}}
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/projection_pushdown/mod.rs:478:29
   6: stacker::maybe_grow
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/stacker-0.1.15/src/lib.rs:55:9
   7: polars_plan::plans::optimizer::projection_pushdown::ProjectionPushDown::push_down
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/projection_pushdown/mod.rs:315:5
   8: polars_plan::plans::optimizer::projection_pushdown::ProjectionPushDown::pushdown_and_assign
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/projection_pushdown/mod.rs:260:18
   9: polars_plan::plans::optimizer::projection_pushdown::ProjectionPushDown::push_down::{{closure}}
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/projection_pushdown/mod.rs:581:17
  10: stacker::maybe_grow
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/stacker-0.1.15/src/lib.rs:55:9
  11: polars_plan::plans::optimizer::projection_pushdown::ProjectionPushDown::push_down
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/projection_pushdown/mod.rs:315:5
  12: polars_plan::plans::optimizer::projection_pushdown::ProjectionPushDown::optimize
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/projection_pushdown/mod.rs:772:9
  13: polars_plan::plans::optimizer::optimize
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-plan-0.41.3/src/plans/optimizer/mod.rs:145:19
  14: polars_lazy::frame::LazyFrame::optimize_with_scratch
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-lazy-0.41.3/src/frame/mod.rs:615:22
  15: polars_lazy::frame::LazyFrame::prepare_collect_post_opt
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-lazy-0.41.3/src/frame/mod.rs:670:13
  16: polars_lazy::frame::LazyFrame::_collect_post_opt
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-lazy-0.41.3/src/frame/mod.rs:691:49
  17: polars_lazy::frame::LazyFrame::collect
             at /root/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/polars-lazy-0.41.3/src/frame/mod.rs:737:9
  18: polars_test::tests::test
             at ./src/lib.rs:41:18
  19: polars_test::tests::test::{{closure}}
             at ./src/lib.rs:40:14
  20: core::ops::function::FnOnce::call_once
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/core/src/ops/function.rs:250:5
  21: core::ops::function::FnOnce::call_once
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```