### PR TITLE
fix: Incorrect filter on categorical columns from parquet files

### DIFF
--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -190,7 +190,8 @@ impl ColumnStats {
 
 /// Returns whether the [`DataType`] supports minimum/maximum operations.
 fn use_min_max(dtype: &DataType) -> bool {
-    dtype.to_physical().is_numeric()
+    dtype.is_numeric()
+        || dtype.is_temporal()
         || matches!(
             dtype,
             DataType::String | DataType::Binary | DataType::Boolean


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/17944
Fixes https://github.com/pola-rs/polars/issues/17744

Regression by https://github.com/pola-rs/polars/pull/17545