### PR TITLE
enhancement: Interpolate_by support float in the by column + extrapolate_flat option

### DIFF
--- a/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
+++ b/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
@@ -300,9 +300,6 @@ where
 
 pub fn interpolate_by(s: &Series, by: &Series, by_is_sorted: bool, extrapolate_flat: bool) -> PolarsResult<Series> {
     
-    let s_len: usize = s.len();
-    let by_len: usize = by.len();
-
     polars_ensure!(s.len() == by.len(), InvalidOperation: "`by` column must be the same length as Series ({}), got {}", s.len(), by.len());
 
     fn func<T, F>(

--- a/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
+++ b/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
@@ -84,10 +84,11 @@ fn interpolate_impl_by_sorted<T, F, I>(
     chunked_arr: &ChunkedArray<T>,
     by: &ChunkedArray<F>,
     interpolation_branch: I,
+    extrapolate_flat: bool
 ) -> PolarsResult<ChunkedArray<T>>
 where
     T: PolarsNumericType,
-    F: PolarsIntegerType,
+    F: PolarsNumericType,
     I: Fn(T::Native, T::Native, &[F::Native], &mut Vec<T::Native>),
 {
     // This implementation differs from pandas as that boundary None's are not removed.
@@ -104,11 +105,21 @@ where
     let first = chunked_arr.first_non_null().unwrap();
     let last = chunked_arr.last_non_null().unwrap() + 1;
 
+    // Get lowest and highest value in case we are going to extrapolate
+    let lowest_value = chunked_arr.get(first).unwrap();
+    let highest_value = chunked_arr.get(last - 1).unwrap();
+
     // Fill out with `first` nulls.
     let mut out = Vec::with_capacity(chunked_arr.len());
     let mut iter = chunked_arr.iter().enumerate().skip(first);
     for _ in 0..first {
-        out.push(Zero::zero());
+        if extrapolate_flat {
+            out.push(lowest_value)
+        }
+        else {
+            out.push(Zero::zero());
+        }
+        
     }
 
     // The next element of `iter` is definitely `Some(idx, Some(v))`, because we skipped the first
@@ -141,13 +152,21 @@ where
         let mut validity = MutableBitmap::with_capacity(chunked_arr.len());
         validity.extend_constant(chunked_arr.len(), true);
 
-        for i in 0..first {
-            unsafe { validity.set_unchecked(i, false) };
+        // If we're not extrapolating, set the null mask for the area before 
+        if !extrapolate_flat {
+            for i in 0..first {
+                unsafe { validity.set_unchecked(i, false) };
+            }
         }
-
+        
         for i in last..chunked_arr.len() {
-            unsafe { validity.set_unchecked(i, false) }
-            out.push(Zero::zero());
+            if extrapolate_flat {
+                out.push(highest_value);
+            }
+            else {
+                unsafe { validity.set_unchecked(i, false) }
+                out.push(Zero::zero());
+            }
         }
 
         let array = PrimitiveArray::new(
@@ -166,10 +185,11 @@ fn interpolate_impl_by<T, F, I>(
     ca: &ChunkedArray<T>,
     by: &ChunkedArray<F>,
     interpolation_branch: I,
+    extrapolate_flat: bool
 ) -> PolarsResult<ChunkedArray<T>>
 where
     T: PolarsNumericType,
-    F: PolarsIntegerType,
+    F: PolarsNumericType,
     I: Fn(T::Native, T::Native, &[F::Native], &mut [T::Native], &[IdxSize]),
 {
     // This implementation differs from pandas as that boundary None's are not removed.
@@ -192,6 +212,10 @@ where
     // We first find the first and last so that we can set the null buffer.
     let first = ca_sorted.first_non_null().unwrap();
     let last = ca_sorted.last_non_null().unwrap() + 1;
+
+    // Get lowest and highest value in case we are going to extrapolate
+    let lowest_value = ca_sorted.get(first).unwrap();
+    let highest_value = ca_sorted.get(last - 1).unwrap();
 
     let mut out = zeroed_vec(ca_sorted.len());
     let mut iter = ca_sorted.iter().enumerate().skip(first);
@@ -241,14 +265,25 @@ where
         for i in 0..first {
             unsafe {
                 let out_idx = sorting_indices.get_unchecked(i);
-                validity.set_unchecked(*out_idx as usize, false);
+                if extrapolate_flat {
+                    *out.get_unchecked_mut(*out_idx as usize) = lowest_value;
+                }
+                else{
+                    validity.set_unchecked(*out_idx as usize, false);
+                }
+                
             }
         }
 
         for i in last..ca_sorted.len() {
             unsafe {
                 let out_idx = sorting_indices.get_unchecked(i);
-                validity.set_unchecked(*out_idx as usize, false);
+                if extrapolate_flat {
+                    *out.get_unchecked_mut(*out_idx as usize) = highest_value;
+                }
+                else {
+                    validity.set_unchecked(*out_idx as usize, false);
+                }
             }
         }
 
@@ -263,65 +298,82 @@ where
     }
 }
 
-pub fn interpolate_by(s: &Series, by: &Series, by_is_sorted: bool) -> PolarsResult<Series> {
+pub fn interpolate_by(s: &Series, by: &Series, by_is_sorted: bool, extrapolate_flat: bool) -> PolarsResult<Series> {
+    
+    let s_len: usize = s.len();
+    let by_len: usize = by.len();
+
     polars_ensure!(s.len() == by.len(), InvalidOperation: "`by` column must be the same length as Series ({}), got {}", s.len(), by.len());
 
     fn func<T, F>(
         ca: &ChunkedArray<T>,
         by: &ChunkedArray<F>,
         is_sorted: bool,
+        extrapolate_flat: bool
     ) -> PolarsResult<Series>
     where
         T: PolarsNumericType,
-        F: PolarsIntegerType,
+        F: PolarsNumericType,
         ChunkedArray<T>: IntoSeries,
     {
         if is_sorted {
             interpolate_impl_by_sorted(ca, by, |y_start, y_end, x, out| unsafe {
                 signed_interp_by_sorted(y_start, y_end, x, out)
-            })
+            }, extrapolate_flat)
             .map(|x| x.into_series())
         } else {
             interpolate_impl_by(ca, by, |y_start, y_end, x, out, sorting_indices| unsafe {
                 signed_interp_by(y_start, y_end, x, out, sorting_indices)
-            })
+            }, extrapolate_flat)
             .map(|x| x.into_series())
         }
     }
 
     match (s.dtype(), by.dtype()) {
+        (DataType::Float64, DataType::Float64) => {
+            func(s.f64().unwrap(), by.f64().unwrap(), by_is_sorted, extrapolate_flat)
+        },
+        (DataType::Float64, DataType::Float32) => {
+            func(s.f64().unwrap(), by.f32().unwrap(), by_is_sorted, extrapolate_flat)
+        },
+        (DataType::Float32, DataType::Float64) => {
+            func(s.f32().unwrap(), by.f64().unwrap(), by_is_sorted, extrapolate_flat)
+        },
+        (DataType::Float32, DataType::Float32) => {
+            func(s.f32().unwrap(), by.f32().unwrap(), by_is_sorted, extrapolate_flat)
+        },
         (DataType::Float64, DataType::Int64) => {
-            func(s.f64().unwrap(), by.i64().unwrap(), by_is_sorted)
+            func(s.f64().unwrap(), by.i64().unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::Float64, DataType::Int32) => {
-            func(s.f64().unwrap(), by.i32().unwrap(), by_is_sorted)
+            func(s.f64().unwrap(), by.i32().unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::Float64, DataType::UInt64) => {
-            func(s.f64().unwrap(), by.u64().unwrap(), by_is_sorted)
+            func(s.f64().unwrap(), by.u64().unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::Float64, DataType::UInt32) => {
-            func(s.f64().unwrap(), by.u32().unwrap(), by_is_sorted)
+            func(s.f64().unwrap(), by.u32().unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::Float32, DataType::Int64) => {
-            func(s.f32().unwrap(), by.i64().unwrap(), by_is_sorted)
+            func(s.f32().unwrap(), by.i64().unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::Float32, DataType::Int32) => {
-            func(s.f32().unwrap(), by.i32().unwrap(), by_is_sorted)
+            func(s.f32().unwrap(), by.i32().unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::Float32, DataType::UInt64) => {
-            func(s.f32().unwrap(), by.u64().unwrap(), by_is_sorted)
+            func(s.f32().unwrap(), by.u64().unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::Float32, DataType::UInt32) => {
-            func(s.f32().unwrap(), by.u32().unwrap(), by_is_sorted)
+            func(s.f32().unwrap(), by.u32().unwrap(), by_is_sorted, extrapolate_flat)
         },
         #[cfg(feature = "dtype-date")]
-        (_, DataType::Date) => interpolate_by(s, &by.cast(&DataType::Int32).unwrap(), by_is_sorted),
+        (_, DataType::Date) => interpolate_by(s, &by.cast(&DataType::Int32).unwrap(), by_is_sorted, extrapolate_flat),
         #[cfg(feature = "dtype-datetime")]
         (_, DataType::Datetime(_, _)) => {
-            interpolate_by(s, &by.cast(&DataType::Int64).unwrap(), by_is_sorted)
+            interpolate_by(s, &by.cast(&DataType::Int64).unwrap(), by_is_sorted, extrapolate_flat)
         },
         (DataType::UInt64 | DataType::UInt32 | DataType::Int64 | DataType::Int32, _) => {
-            interpolate_by(&s.cast(&DataType::Float64).unwrap(), by, by_is_sorted)
+            interpolate_by(&s.cast(&DataType::Float64).unwrap(), by, by_is_sorted, extrapolate_flat)
         },
         _ => {
             polars_bail!(InvalidOperation: "expected series to be Float64, Float32, \

--- a/crates/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/crates/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -25,10 +25,10 @@ pub(super) fn interpolate(s: &Series, method: InterpolationMethod) -> PolarsResu
 }
 
 #[cfg(feature = "interpolate_by")]
-pub(super) fn interpolate_by(s: &[Series]) -> PolarsResult<Series> {
+pub(super) fn interpolate_by(s: &[Series], extrapolate_flat: bool) -> PolarsResult<Series> {
     let by = &s[1];
     let by_is_sorted = by.is_sorted(Default::default())?;
-    polars_ops::prelude::interpolate_by(&s[0], by, by_is_sorted)
+    polars_ops::prelude::interpolate_by(&s[0], by, by_is_sorted, extrapolate_flat)
 }
 
 pub(super) fn to_physical(s: &Series) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -235,7 +235,9 @@ pub enum FunctionExpr {
     #[cfg(feature = "interpolate")]
     Interpolate(InterpolationMethod),
     #[cfg(feature = "interpolate_by")]
-    InterpolateBy,
+    InterpolateBy {
+        extrapolate_flat: bool
+    },
     #[cfg(feature = "log")]
     Entropy {
         base: f64,
@@ -395,7 +397,7 @@ impl Hash for FunctionExpr {
             #[cfg(feature = "interpolate")]
             Interpolate(f) => f.hash(state),
             #[cfg(feature = "interpolate_by")]
-            InterpolateBy => {},
+            InterpolateBy {extrapolate_flat} => extrapolate_flat.hash(state),
             #[cfg(feature = "ffi_plugin")]
             FfiPlugin {
                 lib,
@@ -1030,8 +1032,9 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 map!(dispatch::interpolate, method)
             },
             #[cfg(feature = "interpolate_by")]
-            InterpolateBy => {
-                map_as_slice!(dispatch::interpolate_by)
+            InterpolateBy {extrapolate_flat} => {
+                 map_as_slice!(dispatch::interpolate_by, extrapolate_flat)
+                 //map_as_slice!(dispatch::interpolate_by, extrapolate_flat)
             },
             #[cfg(feature = "log")]
             Entropy { base, normalize } => map!(log::entropy, base, normalize),

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1300,8 +1300,11 @@ impl Expr {
 
     #[cfg(feature = "interpolate_by")]
     /// Fill null values using interpolation.
-    pub fn interpolate_by(self, by: Expr) -> Expr {
-        self.apply_many_private(FunctionExpr::InterpolateBy, &[by], false, false)
+    pub fn interpolate_by(self, by: Expr, extrapolate_flat: bool) -> Expr {
+        self.apply_many_private(FunctionExpr::InterpolateBy { extrapolate_flat: extrapolate_flat }, 
+                                &[by], 
+                                false, 
+                                false)
     }
 
     #[cfg(feature = "rolling_window")]

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6119,7 +6119,7 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.interpolate(method))
 
-    def interpolate_by(self, by: IntoExpr) -> Expr:
+    def interpolate_by(self, by: IntoExpr, extrapolate_flat: bool = False) -> Expr:
         """
         Fill null values using interpolation based on another column.
 
@@ -6127,6 +6127,9 @@ class Expr:
         ----------
         by
             Column to interpolate values based on.
+        extrapolate_flat
+            If True, extrapolate the highest and lowest values of the expression in 
+            the regions below and above the highest/lowest by values 
 
         Examples
         --------
@@ -6152,7 +6155,7 @@ class Expr:
         └──────┴─────┴────────────────┘
         """
         by = parse_into_expression(by)
-        return self._from_pyexpr(self._pyexpr.interpolate_by(by))
+        return self._from_pyexpr(self._pyexpr.interpolate_by(by, extrapolate_flat))
 
     @unstable()
     def rolling_min_by(

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -734,8 +734,8 @@ impl PyExpr {
     fn interpolate(&self, method: Wrap<InterpolationMethod>) -> Self {
         self.inner.clone().interpolate(method.0).into()
     }
-    fn interpolate_by(&self, by: PyExpr) -> Self {
-        self.inner.clone().interpolate_by(by.inner).into()
+    fn interpolate_by(&self, by: PyExpr, extrapolate_flat: bool) -> Self {
+        self.inner.clone().interpolate_by(by.inner, extrapolate_flat).into()
     }
 
     fn lower_bound(&self) -> Self {

--- a/py-polars/src/lazyframe/visitor/expr_nodes.rs
+++ b/py-polars/src/lazyframe/visitor/expr_nodes.rs
@@ -1186,7 +1186,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::Interpolate(_) => {
                     return Err(PyNotImplementedError::new_err("interpolate"))
                 },
-                FunctionExpr::InterpolateBy => {
+                FunctionExpr::InterpolateBy {extrapolate_flat: _} => {
                     return Err(PyNotImplementedError::new_err("interpolate_by"))
                 },
                 FunctionExpr::Entropy {


### PR DESCRIPTION
This addresses [https://github.com/pola-rs/polars/issues/16794](url). Floats are now supported in the by expression of interpolate_by, and I also added the ability to extrapolate in the regions before and after the start of the by column, by just extending the lowest/highest value of the expressions (consistent with numpy interp function defaults, I believe).

This is my first PR, so I'm not totally sure what's going on. Running the test suite yields many failures, but most of them seem very unlikely to be related to my changes.

One test that is failing in test_interpolate_by. It is not correctly raising the error that it is looking for here:

    s = pl.Series([1, None, 3])
    by = pl.Series([1, 2])
    with pytest.raises(InvalidOperationError, match=r"\(3\), got 2"):
        s.interpolate_by(by)

But I am having trouble understanding where this code goes or debugging it, tbh. Anyway, hoping someone can help.