### PR TITLE
perf: Shrink `MemSliceInner` enum

### DIFF
--- a/crates/polars-utils/src/mmap.rs
+++ b/crates/polars-utils/src/mmap.rs
@@ -11,10 +11,10 @@ mod private {
 
     use crate::mem::prefetch_l2;
 
-    /// A read-only reference to a slice of memory.
+    /// A read-only reference to a slice of memory that can potentially be memory-mapped.
     ///
-    /// This maintains a reference count to the underlying buffer to ensure the memory is kept
-    /// alive. [`MemSlice::slice`] can be used to slice the memory in a zero-copy manner.
+    /// A reference count to the underlying buffer to ensure the memory is kept alive.
+    /// [`MemSlice::slice`] can be used to slice the memory in a zero-copy manner.
     ///
     /// This still owns the all the original memory and therefore should probably not be a long-lasting
     /// structure.

--- a/crates/polars-utils/src/mmap.rs
+++ b/crates/polars-utils/src/mmap.rs
@@ -33,10 +33,8 @@ mod private {
     #[derive(Clone, Debug)]
     #[allow(unused)]
     enum MemSliceInner {
-        Vec(Arc<Vec<u8>>),
         Bytes(bytes::Bytes),
         Mmap(Arc<Mmap>),
-        Unbacked,
     }
 
     impl Deref for MemSlice {
@@ -50,10 +48,7 @@ mod private {
 
     impl Default for MemSlice {
         fn default() -> Self {
-            Self {
-                slice: &[],
-                inner: MemSliceInner::Unbacked,
-            }
+            Self::from_bytes(bytes::Bytes::new())
         }
     }
 
@@ -67,12 +62,7 @@ mod private {
         /// Construct a `MemSlice` from an existing `Vec<u8>`. This is zero-copy.
         #[inline]
         pub fn from_vec(v: Vec<u8>) -> Self {
-            let arc_vec = Arc::new(v);
-
-            Self {
-                slice: unsafe { std::mem::transmute::<&[u8], &'static [u8]>(arc_vec.as_slice()) },
-                inner: MemSliceInner::Vec(arc_vec),
-            }
+            Self::from_bytes(bytes::Bytes::from(v))
         }
 
         /// Construct a `MemSlice` from [`bytes::Bytes`]. This is zero-copy.
@@ -97,10 +87,7 @@ mod private {
         /// Construct a `MemSlice` that simply wraps around a `&[u8]`.
         #[inline]
         pub fn from_slice(slice: &'static [u8]) -> Self {
-            Self {
-                slice,
-                inner: MemSliceInner::Unbacked,
-            }
+            Self::from_bytes(bytes::Bytes::from_static(slice))
         }
 
         /// Attempt to prefetch the memory belonging to to this [`MemSlice`]
@@ -259,6 +246,17 @@ mod tests {
 
         {
             let vec = vec![1u8, 2, 3, 4, 5];
+            let ptr = vec.as_ptr();
+
+            let mem_slice = MemSlice::from_vec(vec);
+            let ptr_out = mem_slice.as_ptr();
+
+            assert_eq!(ptr_out, ptr);
+        }
+
+        {
+            let mut vec = vec![1u8, 2, 3, 4, 5];
+            vec.truncate(2);
             let ptr = vec.as_ptr();
 
             let mem_slice = MemSlice::from_vec(vec);

--- a/crates/polars-utils/src/mmap.rs
+++ b/crates/polars-utils/src/mmap.rs
@@ -13,7 +13,7 @@ mod private {
 
     /// A read-only reference to a slice of memory that can potentially be memory-mapped.
     ///
-    /// A reference count to the underlying buffer to ensure the memory is kept alive.
+    /// A reference count is kept to the underlying buffer to ensure the memory is kept alive.
     /// [`MemSlice::slice`] can be used to slice the memory in a zero-copy manner.
     ///
     /// This still owns the all the original memory and therefore should probably not be a long-lasting


### PR DESCRIPTION
Learned a few things after looking into the `bytes::Bytes` implementation. They essentially already do most of what we want from `MemSliceInner`, just without the Mmap support:

* Creating a `Bytes` from a `Vec` is zero-copy
* Creating an empty `Bytes::new()` doesn't heap-allocate
* They have `const fn Bytes::from_static` we can use for the `&'static [u8]` case, which also doesn't allocate

This shrinks the size of `MemSliceInner` from 40 to 32 bytes