### PR TITLE
perf: Use bitmask to filter Parquet predicate-pushdown items

### DIFF
--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -613,6 +613,11 @@ impl PhysicalIoExpr for PhysicalIoHelper {
         self.expr.evaluate(df, &state)
     }
 
+    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
+        // @TODO: This should not unwrap
+        Ok(expr_to_leaf_column_names(self.expr.as_expression().unwrap()))
+    }
+
     #[cfg(feature = "parquet")]
     fn as_stats_evaluator(&self) -> Option<&dyn polars_io::predicates::StatsEvaluator> {
         self.expr.as_stats_evaluator()

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -613,9 +613,8 @@ impl PhysicalIoExpr for PhysicalIoHelper {
         self.expr.evaluate(df, &state)
     }
 
-    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
-        // @TODO: This should not unwrap
-        Ok(expr_to_leaf_column_names(self.expr.as_expression().unwrap()))
+    fn live_variables(&self) -> Option<Vec<Arc<str>>> {
+        Some(expr_to_leaf_column_names(self.expr.as_expression()?))
     }
 
     #[cfg(feature = "parquet")]

--- a/crates/polars-io/src/parquet/read/mmap.rs
+++ b/crates/polars-io/src/parquet/read/mmap.rs
@@ -65,7 +65,7 @@ fn _mmap_single_column<'a>(
 pub(super) fn to_deserializer<'a>(
     columns: Vec<(&ColumnChunkMetaData, MemSlice)>,
     field: Field,
-    num_rows: usize,
+    filter: Option<Filter>,
 ) -> PolarsResult<ArrayIter<'a>> {
     let (columns, types): (Vec<_>, Vec<_>) = columns
         .into_iter()
@@ -87,5 +87,5 @@ pub(super) fn to_deserializer<'a>(
         })
         .unzip();
 
-    column_iter_to_arrays(columns, types, field, Some(Filter::new_limited(num_rows)))
+    column_iter_to_arrays(columns, types, field, filter)
 }

--- a/crates/polars-io/src/parquet/read/options.rs
+++ b/crates/polars-io/src/parquet/read/options.rs
@@ -18,6 +18,14 @@ pub enum ParallelStrategy {
     Columns,
     /// Parallelize over the row groups
     RowGroups,
+    /// First evaluates the pushed-down predicates in parallel and determines a mask of which rows
+    /// to read. Then, it parallelizes over both the columns and the row groups while filtering out
+    /// rows that do not need to be read. This can provide significant speedups for large files
+    /// (i.e. many row-groups) with a predicate that filters clustered rows or filters heavily. In
+    /// other cases, this may slow down the scan compared other strategies.
+    ///
+    /// If no predicate is given, this falls back to back to [`ParallelStrategy::Auto`].
+    Prefiltered,
     /// Automatically determine over which unit to parallelize
     /// This will choose the most occurring unit.
     #[default]

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -360,7 +360,7 @@ fn rg_to_dfs_prefiltered(
             *previous_row_count += df.height() as IdxSize;
         }
 
-        // @TODO: Incorperate this if we how we can properly use it. The problem here is that
+        // @TODO: Incorporate this if we how we can properly use it. The problem here is that
         // different columns really have a different cost when it comes to collecting them. We
         // would need a cost model to properly estimate this.
         //

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -71,11 +71,7 @@ fn column_idx_to_series(
     let columns = mmap_columns(store, md.columns(), &field.name);
     let iter = mmap::to_deserializer(columns, field.clone(), filter)?;
 
-    // let mut series = if remaining_rows < md.num_rows() {
-    //     array_iter_to_series(iter, field, Some(remaining_rows))
-    // } else {
     let mut series = array_iter_to_series(iter, field, None)?;
-    // }?;
 
     // See if we can find some statistics for this series. If we cannot find anything just return
     // the series as is.

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -7,6 +7,7 @@ pub trait PhysicalIoExpr: Send + Sync {
     /// as a predicate mask
     fn evaluate_io(&self, df: &DataFrame) -> PolarsResult<Series>;
 
+    /// Get the variables that are used in the expression i.e. live variables.
     fn live_variables(&self) -> Option<Vec<Arc<str>>>;
 
     /// Can take &dyn Statistics and determine of a file should be

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -7,6 +7,8 @@ pub trait PhysicalIoExpr: Send + Sync {
     /// as a predicate mask
     fn evaluate_io(&self, df: &DataFrame) -> PolarsResult<Series>;
 
+    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>>;
+
     /// Can take &dyn Statistics and determine of a file should be
     /// read -> `true`
     /// or not -> `false`

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -7,7 +7,7 @@ pub trait PhysicalIoExpr: Send + Sync {
     /// as a predicate mask
     fn evaluate_io(&self, df: &DataFrame) -> PolarsResult<Series>;
 
-    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>>;
+    fn live_variables(&self) -> Option<Vec<Arc<str>>>;
 
     /// Can take &dyn Statistics and determine of a file should be
     /// read -> `true`

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -26,6 +26,10 @@ impl PhysicalIoExpr for Wrap {
         };
         h.evaluate_io(df)
     }
+    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
+        // @TODO: This should not unwrap
+        Ok(expr_to_leaf_column_names(self.0.as_expression().unwrap()))
+    }
     fn as_stats_evaluator(&self) -> Option<&dyn StatsEvaluator> {
         self.0.as_stats_evaluator()
     }

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -26,9 +26,9 @@ impl PhysicalIoExpr for Wrap {
         };
         h.evaluate_io(df)
     }
-    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
+    fn live_variables(&self) -> Option<Vec<Arc<str>>> {
         // @TODO: This should not unwrap
-        Ok(expr_to_leaf_column_names(self.0.as_expression().unwrap()))
+        Some(expr_to_leaf_column_names(self.0.as_expression()?))
     }
     fn as_stats_evaluator(&self) -> Option<&dyn StatsEvaluator> {
         self.0.as_stats_evaluator()

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -6,7 +6,6 @@ use arrow::array::{Array, BinaryArray, DictionaryArray, DictionaryKey, Primitive
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::{ArrowDataType, PhysicalType};
 use arrow::offset::Offset;
-use polars_error::PolarsResult;
 
 use super::super::utils;
 use super::super::utils::extend_from_decoder;
@@ -33,7 +32,7 @@ impl<'a, O: Offset> StateTranslation<'a, BinaryDecoder<O>> for BinaryStateTransl
         page: &'a DataPage,
         dict: Option<&'a <BinaryDecoder<O> as utils::Decoder>::Dict>,
         page_validity: Option<&utils::PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         let is_string = matches!(
             page.descriptor.primitive_type.logical_type,
             Some(PrimitiveLogicalType::String)

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
@@ -150,7 +150,7 @@ impl<'a> BinaryStateTranslation<'a> {
         dict: Option<&'a BinaryDict>,
         _page_validity: Option<&PageValidity<'a>>,
         is_string: bool,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         match (page.encoding(), dict) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict)) => {
                 if is_string {

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview.rs
@@ -6,7 +6,6 @@ use arrow::array::{
 };
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::{ArrowDataType, PhysicalType};
-use polars_error::PolarsResult;
 
 use super::binary::decoders::*;
 use super::utils::freeze_validity;
@@ -30,7 +29,7 @@ impl<'a> StateTranslation<'a, BinViewDecoder> for BinaryStateTranslation<'a> {
         page: &'a DataPage,
         dict: Option<&'a <BinViewDecoder as utils::Decoder>::Dict>,
         page_validity: Option<&PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         let is_string = matches!(
             page.descriptor.primitive_type.logical_type,
             Some(PrimitiveLogicalType::String)

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
@@ -2,7 +2,6 @@ use arrow::array::BooleanArray;
 use arrow::bitmap::utils::BitmapIter;
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::ArrowDataType;
-use polars_error::PolarsResult;
 
 use super::utils::{self, extend_from_decoder, freeze_validity, Decoder, ExactSize};
 use crate::parquet::encoding::hybrid_rle::gatherer::HybridRleGatherer;
@@ -27,7 +26,7 @@ impl<'a> utils::StateTranslation<'a, BooleanDecoder> for StateTranslation<'a> {
         page: &'a DataPage,
         _dict: Option<&'a <BooleanDecoder as Decoder>::Dict>,
         page_validity: Option<&PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         let values = split_buffer(page)?.values;
 
         match page.encoding() {

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
@@ -3,7 +3,6 @@ use std::sync::atomic::AtomicUsize;
 use arrow::array::{DictionaryArray, DictionaryKey, PrimitiveArray};
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::ArrowDataType;
-use polars_error::PolarsResult;
 
 use super::utils::{
     self, dict_indices_decoder, extend_from_decoder, freeze_validity, BatchableCollector, Decoder,
@@ -25,7 +24,7 @@ impl<'a, K: DictionaryKey, D: utils::DictDecodable> StateTranslation<'a, Diction
         page: &'a DataPage,
         _dict: Option<&'a <DictionaryDecoder<K, D> as Decoder>::Dict>,
         _page_validity: Option<&PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         if !matches!(
             page.encoding(),
             Encoding::PlainDictionary | Encoding::RleDictionary

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
@@ -32,7 +32,7 @@ impl<'a, K: DictionaryKey, D: utils::DictDecodable> StateTranslation<'a, Diction
             return Err(utils::not_implemented(page));
         }
 
-        Ok(dict_indices_decoder(page)?)
+        dict_indices_decoder(page)
     }
 
     fn len_when_not_nullable(&self) -> usize {

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -2,9 +2,7 @@ use arrow::array::{DictionaryArray, DictionaryKey, FixedSizeBinaryArray, Primiti
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::ArrowDataType;
 
-use super::utils::{
-    dict_indices_decoder, extend_from_decoder, freeze_validity, Decoder,
-};
+use super::utils::{dict_indices_decoder, extend_from_decoder, freeze_validity, Decoder};
 use crate::parquet::encoding::hybrid_rle::gatherer::HybridRleGatherer;
 use crate::parquet::encoding::{hybrid_rle, Encoding};
 use crate::parquet::error::{ParquetError, ParquetResult};
@@ -40,8 +38,7 @@ impl<'a> utils::StateTranslation<'a, BinaryDecoder> for StateTranslation<'a> {
                         "Fixed size binary data length {} is not divisible by size {}",
                         values.len(),
                         decoder.size
-                    ))
-                    .into());
+                    )));
                 }
                 Ok(Self::Plain(values, decoder.size))
             },

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -1,10 +1,9 @@
 use arrow::array::{DictionaryArray, DictionaryKey, FixedSizeBinaryArray, PrimitiveArray};
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::ArrowDataType;
-use polars_error::PolarsResult;
 
 use super::utils::{
-    dict_indices_decoder, extend_from_decoder, freeze_validity, not_implemented, Decoder,
+    dict_indices_decoder, extend_from_decoder, freeze_validity, Decoder,
 };
 use crate::parquet::encoding::hybrid_rle::gatherer::HybridRleGatherer;
 use crate::parquet::encoding::{hybrid_rle, Encoding};
@@ -32,7 +31,7 @@ impl<'a> utils::StateTranslation<'a, BinaryDecoder> for StateTranslation<'a> {
         page: &'a DataPage,
         dict: Option<&'a <BinaryDecoder as Decoder>::Dict>,
         _page_validity: Option<&PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         match (page.encoding(), dict) {
             (Encoding::Plain, _) => {
                 let values = split_buffer(page)?.values;
@@ -50,7 +49,7 @@ impl<'a> utils::StateTranslation<'a, BinaryDecoder> for StateTranslation<'a> {
                 let values = dict_indices_decoder(page)?;
                 Ok(Self::Dictionary(values, dict))
             },
-            _ => Err(not_implemented(page)),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/null.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null.rs
@@ -4,7 +4,6 @@
 
 use arrow::array::{Array, NullArray};
 use arrow::datatypes::ArrowDataType;
-use polars_error::PolarsResult;
 
 use super::utils;
 use super::utils::filter::Filter;
@@ -31,7 +30,7 @@ impl<'a> utils::StateTranslation<'a, NullDecoder> for () {
         _page: &'a DataPage,
         _dict: Option<&'a <NullDecoder as utils::Decoder>::Dict>,
         _page_validity: Option<&utils::PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         Ok(())
     }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -171,7 +171,7 @@ where
         page: &'a DataPage,
         dict: Option<&'a <PrimitiveDecoder<P, T, D> as utils::Decoder>::Dict>,
         _page_validity: Option<&PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         match (page.encoding(), dict) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict)) => {
                 Ok(Self::Dictionary(ValuesDictionary::try_new(page, dict)?))

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -3,7 +3,6 @@ use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use num_traits::AsPrimitive;
-use polars_error::PolarsResult;
 
 use super::super::utils;
 use super::basic::{
@@ -43,7 +42,7 @@ where
         page: &'a DataPage,
         dict: Option<&'a <IntDecoder<P, T, D> as utils::Decoder>::Dict>,
         _page_validity: Option<&PageValidity<'a>>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         match (page.encoding(), dict) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict)) => {
                 Ok(Self::Dictionary(ValuesDictionary::try_new(page, dict)?))

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -150,7 +150,7 @@ impl<'a, D: Decoder> State<'a, D> {
                             num_ones,
                         )?;
 
-                        if self.len() == 0 {
+                        if iter.num_remaining() == 0 || self.len() == 0 {
                             break;
                         }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -8,7 +8,6 @@ use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::datatypes::ArrowDataType;
 use arrow::pushable::Pushable;
 use arrow::types::Offset;
-use polars_error::{polars_err, PolarsError, PolarsResult};
 
 use self::filter::Filter;
 use super::binary::utils::Binary;
@@ -17,7 +16,7 @@ use crate::parquet::encoding::hybrid_rle::gatherer::{
     HybridRleGatherer, ZeroCount, ZeroCountGatherer,
 };
 use crate::parquet::encoding::hybrid_rle::{self, HybridRleDecoder, Translator};
-use crate::parquet::error::ParquetResult;
+use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::page::{split_buffer, DataPage, DictPage};
 use crate::parquet::schema::Repetition;
 
@@ -35,7 +34,7 @@ pub(crate) trait StateTranslation<'a, D: Decoder>: Sized {
         page: &'a DataPage,
         dict: Option<&'a D::Dict>,
         page_validity: Option<&PageValidity<'a>>,
-    ) -> PolarsResult<Self>;
+    ) -> ParquetResult<Self>;
     fn len_when_not_nullable(&self) -> usize;
     fn skip_in_place(&mut self, n: usize) -> ParquetResult<()>;
 
@@ -51,7 +50,7 @@ pub(crate) trait StateTranslation<'a, D: Decoder>: Sized {
 }
 
 impl<'a, D: Decoder> State<'a, D> {
-    pub fn new(decoder: &D, page: &'a DataPage, dict: Option<&'a D::Dict>) -> PolarsResult<Self> {
+    pub fn new(decoder: &D, page: &'a DataPage, dict: Option<&'a D::Dict>) -> ParquetResult<Self> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
 
@@ -71,7 +70,7 @@ impl<'a, D: Decoder> State<'a, D> {
         decoder: &D,
         page: &'a DataPage,
         dict: Option<&'a D::Dict>,
-    ) -> PolarsResult<Self> {
+    ) -> ParquetResult<Self> {
         let translation = D::Translation::new(decoder, page, dict, None)?;
 
         Ok(Self {
@@ -170,18 +169,16 @@ impl<'a, D: Decoder> State<'a, D> {
     }
 }
 
-pub fn not_implemented(page: &DataPage) -> PolarsError {
+pub fn not_implemented(page: &DataPage) -> ParquetError {
     let is_optional = page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
     let is_filtered = page.selected_rows().is_some();
     let required = if is_optional { "optional" } else { "required" };
     let is_filtered = if is_filtered { ", index-filtered" } else { "" };
-    polars_err!(ComputeError:
-        "Decoding {:?} \"{:?}\"-encoded {} {} parquet pages not yet implemented",
+    ParquetError::not_supported(format!(
+        "Decoding {:?} \"{:?}\"-encoded {required}{is_filtered} parquet pages not yet supported",
         page.descriptor.primitive_type.physical_type,
         page.encoding(),
-        required,
-        is_filtered,
-    )
+    ))
 }
 
 pub trait BatchableCollector<I, T> {

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/buffered.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/buffered.rs
@@ -171,7 +171,12 @@ impl<'a> BufferedBitpacked<'a> {
             return unpacked_num_elements + n;
         }
 
-        self.decoder.len() + unpacked_num_elements
+        // We skip the entire decoder. Essentially, just zero it out.
+        let decoder = self.decoder.take();
+        self.unpacked_start = 0;
+        self.unpacked_end = 0;
+
+        decoder.len() + unpacked_num_elements
     }
 }
 

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/buffered.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/buffered.rs
@@ -163,6 +163,7 @@ impl<'a> BufferedBitpacked<'a> {
             let unpacked_offset = n % <u32 as Unpackable>::Unpacked::LENGTH;
             self.decoder.skip_chunks(num_chunks);
             let (unpacked, unpacked_length) = self.decoder.chunked().next_inexact().unwrap();
+            debug_assert!(unpacked_offset < unpacked_length);
 
             self.unpacked = unpacked;
             self.unpacked_start = unpacked_offset;
@@ -267,7 +268,12 @@ impl<'a> HybridRleBuffered<'a> {
         };
 
         debug_assert!(num_skipped <= n);
-        debug_assert_eq!(num_skipped, start_length - self.len());
+        debug_assert_eq!(
+            num_skipped,
+            start_length - self.len(),
+            "{self:?}: {num_skipped} != {start_length} - {}",
+            self.len()
+        );
 
         num_skipped
     }

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
@@ -2,6 +2,7 @@
 /// complex to facilitate performance. We create this small fuzzer
 use std::collections::VecDeque;
 
+use arrow::pushable::Pushable;
 use rand::Rng;
 
 use super::*;
@@ -328,4 +329,63 @@ fn small_fuzz() -> ParquetResult<()> {
 #[ignore = "Large fuzz test. Too slow"]
 fn large_fuzz() -> ParquetResult<()> {
     fuzz_loops(1_000_000)
+}
+
+#[test]
+fn skip_fuzz() -> ParquetResult<()> {
+    let mut rng = rand::thread_rng();
+
+    const MAX_LENGTH: usize = 10_000;
+
+    let mut encoded = Vec::with_capacity(10000);
+
+    let mut bs: Vec<u32> = Vec::with_capacity(MAX_LENGTH);
+    let mut skips: VecDeque<usize> = VecDeque::with_capacity(2000);
+
+    let num_loops = 100_000;
+
+    for i in 0..num_loops {
+        skips.clear();
+        bs.clear();
+
+        let num_bits = rng.gen_range(0..=32);
+        let mask = 1u32.wrapping_shl(num_bits).wrapping_sub(1);
+
+        let length = rng.gen_range(1..=MAX_LENGTH);
+
+        unsafe { bs.set_len(length) };
+        rng.fill(&mut bs[..]);
+
+        let mut filled = 0;
+        while filled < bs.len() {
+            if rng.gen() {
+                let num_repeats = rng.gen_range(0..=(bs.len() - filled));
+                let value = bs[filled] & mask;
+                for j in 0..num_repeats {
+                    bs[filled + j] = value;
+                }
+                filled += num_repeats;
+            } else {
+                bs[filled] &= mask;
+                filled += 1;
+            }
+        }
+
+        let mut num_done = 0;
+        while num_done < filled {
+            let num_skip = rng.gen_range(1..=filled - num_done);
+            num_done += num_skip;
+            skips.push_back(num_skip);
+        }
+
+        encoder::encode(&mut encoded, bs.iter().copied(), num_bits).unwrap();
+        let mut decoder = HybridRleDecoder::new(&encoded, num_bits, filled);
+
+        dbg!(&skips);
+        for s in &skips {
+            decoder.skip_in_place(*s).unwrap();
+        }
+    }
+
+    Ok(())
 }

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
@@ -332,6 +332,7 @@ fn large_fuzz() -> ParquetResult<()> {
 }
 
 #[test]
+#[ignore = "Large fuzz test. Too slow"]
 fn skip_fuzz() -> ParquetResult<()> {
     let mut rng = rand::thread_rng();
 
@@ -344,7 +345,7 @@ fn skip_fuzz() -> ParquetResult<()> {
 
     let num_loops = 100_000;
 
-    for i in 0..num_loops {
+    for _ in 0..num_loops {
         skips.clear();
         bs.clear();
 

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/fuzz.rs
@@ -2,7 +2,6 @@
 /// complex to facilitate performance. We create this small fuzzer
 use std::collections::VecDeque;
 
-use arrow::pushable::Pushable;
 use rand::Rng;
 
 use super::*;
@@ -382,7 +381,6 @@ fn skip_fuzz() -> ParquetResult<()> {
         encoder::encode(&mut encoded, bs.iter().copied(), num_bits).unwrap();
         let mut decoder = HybridRleDecoder::new(&encoded, num_bits, filled);
 
-        dbg!(&skips);
         for s in &skips {
             decoder.skip_in_place(*s).unwrap();
         }

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -399,7 +399,7 @@ impl<'a> HybridRleDecoder<'a> {
 
             debug_assert_eq!(num_skipped, start_num_values - self.num_values);
             debug_assert!(num_skipped <= n, "{num_skipped} <= {n}");
-            debug_assert!(num_skipped > 0, "{num_skipped} > 0");
+            debug_assert!(indicator >> 1 == 0 || num_skipped > 0);
 
             n -= num_skipped;
         }

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -31,8 +31,8 @@ impl PhysicalIoExpr for Len {
         unimplemented!()
     }
 
-    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
-        Ok(vec![])
+    fn live_variables(&self) -> Option<Vec<Arc<str>>> {
+        Some(vec![])
     }
 }
 impl PhysicalPipedExpr for Len {

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -30,6 +30,10 @@ impl PhysicalIoExpr for Len {
     fn evaluate_io(&self, _df: &DataFrame) -> PolarsResult<Series> {
         unimplemented!()
     }
+
+    fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
+        Ok(vec![])
+    }
 }
 impl PhysicalPipedExpr for Len {
     fn evaluate(&self, chunk: &DataChunk, _lazy_state: &ExecutionState) -> PolarsResult<Series> {

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -131,8 +131,8 @@ where
                                     self.p.evaluate_io(df)
                                 }
 
-                                fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
-                                    todo!()
+                                fn live_variables(&self) -> Option<Vec<Arc<str>>> {
+                                    None
                                 }
 
                                 fn as_stats_evaluator(&self) -> Option<&dyn StatsEvaluator> {

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -130,6 +130,11 @@ where
                                 fn evaluate_io(&self, df: &DataFrame) -> PolarsResult<Series> {
                                     self.p.evaluate_io(df)
                                 }
+
+                                fn live_variables(&self) -> PolarsResult<Vec<Arc<str>>> {
+                                    todo!()
+                                }
+
                                 fn as_stats_evaluator(&self) -> Option<&dyn StatsEvaluator> {
                                     self.p.as_stats_evaluator()
                                 }

--- a/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
+++ b/crates/polars-plan/src/plans/optimizer/cluster_with_columns.rs
@@ -4,6 +4,7 @@ use arrow::bitmap::MutableBitmap;
 use polars_core::schema::Schema;
 use polars_utils::aliases::{InitHashMaps, PlHashMap};
 use polars_utils::arena::{Arena, Node};
+use polars_utils::vec::inplace_zip_filtermap;
 
 use super::aexpr::AExpr;
 use super::ir::IR;
@@ -298,85 +299,4 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &Arena<AExpr>)
             lp_arena.replace(moved_current, current);
         }
     }
-}
-
-/// Perform a inplace `filtermap` over two vectors at the same time.
-fn inplace_zip_filtermap<T, U>(
-    x: &mut Vec<T>,
-    y: &mut Vec<U>,
-    mut f: impl FnMut(T, U) -> Option<(T, U)>,
-) {
-    assert_eq!(x.len(), y.len());
-
-    let length = x.len();
-
-    struct OwnedBuffer<T> {
-        end: *mut T,
-        length: usize,
-    }
-
-    impl<T> Drop for OwnedBuffer<T> {
-        fn drop(&mut self) {
-            for i in 0..self.length {
-                unsafe { self.end.wrapping_sub(i + 1).read() };
-            }
-        }
-    }
-
-    let x_ptr = x.as_mut_ptr();
-    let y_ptr = y.as_mut_ptr();
-
-    let mut x_buf = OwnedBuffer {
-        end: x_ptr.wrapping_add(length),
-        length,
-    };
-    let mut y_buf = OwnedBuffer {
-        end: y_ptr.wrapping_add(length),
-        length,
-    };
-
-    // SAFETY: All items are now owned by `x_buf` and `y_buf`. Since we know that `x_buf` and
-    // `y_buf` will be dropped before the vecs representing `x` and `y`, this is safe.
-    unsafe {
-        x.set_len(0);
-        y.set_len(0);
-    }
-
-    // SAFETY:
-    //
-    // We know we have a exclusive reference to x and y.
-    //
-    // We know that `i` is always smaller than `x.len()` and `y.len()`. Furthermore, we also know
-    // that `i - num_deleted > 0`.
-    //
-    // Items are dropped exactly once, even if `f` panics.
-    for i in 0..length {
-        let xi = unsafe { x_ptr.wrapping_add(i).read() };
-        let yi = unsafe { y_ptr.wrapping_add(i).read() };
-
-        x_buf.length -= 1;
-        y_buf.length -= 1;
-
-        // We hold the invariant here that all items that are not yet deleted are either in
-        // - `xi` or `yi`
-        // - `x_buf` or `y_buf`
-        // ` `x` or `y`
-        //
-        // This way if `f` ever panics, we are sure that all items are dropped exactly once.
-        // Deleted items will be dropped when they are deleted.
-        let result = f(xi, yi);
-
-        if let Some((xi, yi)) = result {
-            x.push(xi);
-            y.push(yi);
-        }
-    }
-
-    debug_assert_eq!(x_buf.length, 0);
-    debug_assert_eq!(y_buf.length, 0);
-
-    // We are safe to forget `x_buf` and `y_buf` here since they will not deallocate anything
-    // anymore.
-    std::mem::forget(x_buf);
-    std::mem::forget(y_buf);
 }

--- a/crates/polars-utils/src/vec.rs
+++ b/crates/polars-utils/src/vec.rs
@@ -97,3 +97,84 @@ impl<T, Out> ConvertVec<Out> for Vec<T> {
         self.iter().map(f).collect()
     }
 }
+
+/// Perform an in-place `Iterator::filter_map` over two vectors at the same time.
+pub fn inplace_zip_filtermap<T, U>(
+    x: &mut Vec<T>,
+    y: &mut Vec<U>,
+    mut f: impl FnMut(T, U) -> Option<(T, U)>,
+) {
+    assert_eq!(x.len(), y.len());
+
+    let length = x.len();
+
+    struct OwnedBuffer<T> {
+        end: *mut T,
+        length: usize,
+    }
+
+    impl<T> Drop for OwnedBuffer<T> {
+        fn drop(&mut self) {
+            for i in 0..self.length {
+                unsafe { self.end.wrapping_sub(i + 1).read() };
+            }
+        }
+    }
+
+    let x_ptr = x.as_mut_ptr();
+    let y_ptr = y.as_mut_ptr();
+
+    let mut x_buf = OwnedBuffer {
+        end: x_ptr.wrapping_add(length),
+        length,
+    };
+    let mut y_buf = OwnedBuffer {
+        end: y_ptr.wrapping_add(length),
+        length,
+    };
+
+    // SAFETY: All items are now owned by `x_buf` and `y_buf`. Since we know that `x_buf` and
+    // `y_buf` will be dropped before the vecs representing `x` and `y`, this is safe.
+    unsafe {
+        x.set_len(0);
+        y.set_len(0);
+    }
+
+    // SAFETY:
+    //
+    // We know we have a exclusive reference to x and y.
+    //
+    // We know that `i` is always smaller than `x.len()` and `y.len()`. Furthermore, we also know
+    // that `i - num_deleted > 0`.
+    //
+    // Items are dropped exactly once, even if `f` panics.
+    for i in 0..length {
+        let xi = unsafe { x_ptr.wrapping_add(i).read() };
+        let yi = unsafe { y_ptr.wrapping_add(i).read() };
+
+        x_buf.length -= 1;
+        y_buf.length -= 1;
+
+        // We hold the invariant here that all items that are not yet deleted are either in
+        // - `xi` or `yi`
+        // - `x_buf` or `y_buf`
+        // ` `x` or `y`
+        //
+        // This way if `f` ever panics, we are sure that all items are dropped exactly once.
+        // Deleted items will be dropped when they are deleted.
+        let result = f(xi, yi);
+
+        if let Some((xi, yi)) = result {
+            x.push(xi);
+            y.push(yi);
+        }
+    }
+
+    debug_assert_eq!(x_buf.length, 0);
+    debug_assert_eq!(y_buf.length, 0);
+
+    // We are safe to forget `x_buf` and `y_buf` here since they will not deallocate anything
+    // anymore.
+    std::mem::forget(x_buf);
+    std::mem::forget(y_buf);
+}

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -113,7 +113,9 @@ JoinValidation: TypeAlias = Literal["m:m", "m:1", "1:m", "1:1"]
 Label: TypeAlias = Literal["left", "right", "datapoint"]
 NonExistent: TypeAlias = Literal["raise", "null"]
 NullBehavior: TypeAlias = Literal["ignore", "drop"]
-ParallelStrategy: TypeAlias = Literal["auto", "columns", "row_groups", "none"]
+ParallelStrategy: TypeAlias = Literal[
+    "auto", "columns", "row_groups", "prefiltered", "none"
+]
 ParquetCompression: TypeAlias = Literal[
     "lz4", "uncompressed", "snappy", "gzip", "lzo", "brotli", "zstd"
 ]

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -332,9 +332,20 @@ def scan_parquet(
         DataFrame
     row_index_offset
         Offset to start the row index column (only used if the name is set)
-    parallel : {'auto', 'columns', 'row_groups', 'none'}
-        This determines the direction of parallelism. 'auto' will try to determine the
-        optimal direction.
+    parallel : {'auto', 'columns', 'row_groups', 'prefiltered', 'none'}
+        This determines the direction and strategy of parallelism. 'auto' will
+        try to determine the optimal direction.
+
+        The `prefiltered` setting first evaluates the pushed-down predicates in
+        parallel and determines a mask of which rows to read. Then, it
+        parallelizes over both the columns and the row groups while filtering
+        out rows that do not need to be read. This can provide significant
+        speedups for large files (i.e. many row-groups) with a predicate that
+        filters clustered rows or filters heavily. In other cases,
+        `prefiltered` may slow down the scan compared other strategies.
+
+        The `prefiltered` settings falls back to `auto` if no predicate is
+        given.
     use_statistics
         Use statistics in the parquet to determine if pages
         can be skipped from reading.

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -336,7 +336,7 @@ def scan_parquet(
         This determines the direction and strategy of parallelism. 'auto' will
         try to determine the optimal direction.
 
-        The `prefiltered` setting first evaluates the pushed-down predicates in
+        The `prefiltered` strategy first evaluates the pushed-down predicates in
         parallel and determines a mask of which rows to read. Then, it
         parallelizes over both the columns and the row groups while filtering
         out rows that do not need to be read. This can provide significant
@@ -346,6 +346,11 @@ def scan_parquet(
 
         The `prefiltered` settings falls back to `auto` if no predicate is
         given.
+
+        .. warning::
+            The `prefiltered` strategy is considered **unstable**. It may be
+            changed at any point without it being considered a breaking change.
+
     use_statistics
         Use statistics in the parquet to determine if pages
         can be skipped from reading.

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -871,10 +871,11 @@ impl<'py> FromPyObject<'py> for Wrap<ParallelStrategy> {
             "auto" => ParallelStrategy::Auto,
             "columns" => ParallelStrategy::Columns,
             "row_groups" => ParallelStrategy::RowGroups,
+            "prefiltered" => ParallelStrategy::Prefiltered,
             "none" => ParallelStrategy::None,
             v => {
                 return Err(PyValueError::new_err(format!(
-                "`parallel` must be one of {{'auto', 'columns', 'row_groups', 'none'}}, got {v}",
+                "`parallel` must be one of {{'auto', 'columns', 'row_groups', 'prefiltered', 'none'}}, got {v}",
             )))
             },
         };


### PR DESCRIPTION
This adds the `prefiltered` option to `scan_parquet(parallel='...')` which first evaluates the predicates and then only reads the relevant rows. For large files with predicates that are clustered or biased towards selecting or not-selecting, this provides a significant speed-up.