### PR TITLE
perf: Remove temporary allocations in Parquet

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/decoders.rs
@@ -201,10 +201,11 @@ impl<'a> BinaryStateTranslation<'a> {
 }
 
 pub(crate) fn deserialize_plain(values: &[u8], num_values: usize) -> BinaryDict {
-    let all = BinaryIter::new(values, num_values).collect::<Vec<_>>();
-    let values_size = all.iter().map(|v| v.len()).sum::<usize>();
-    let mut dict_values = MutableBinaryValuesArray::<i64>::with_capacities(all.len(), values_size);
-    for v in all {
+    // Each value is prepended by the length which is 4 bytes.
+    let num_bytes = values.len() - 4 * num_values;
+
+    let mut dict_values = MutableBinaryValuesArray::<i64>::with_capacities(num_values, num_bytes);
+    for v in BinaryIter::new(values, num_values) {
         dict_values.push(v)
     }
 


### PR DESCRIPTION
This removes more than 50% of the temporary allocations in the Parquet readers. The only temporary allocations left are in the Thrift definitions and the `polars_io` code.