### PR TITLE
perf: Speedup writing of Parquet primitive values

### DIFF
--- a/crates/polars-compute/src/min_max/dyn_array.rs
+++ b/crates/polars-compute/src/min_max/dyn_array.rs
@@ -15,37 +15,55 @@ macro_rules! call_op {
         $op(arr)
             .map(|v| Box::new(<$scalar>::new(arr.data_type().clone(), Some(v))) as Box<dyn Scalar>)
     }};
+    ($T:ty, $scalar:ty, $arr:expr, $op:path, ret_two) => {{
+        let arr: &$T = $arr.as_any().downcast_ref().unwrap();
+        $op(arr).map(|(l, r)| {
+            (
+                Box::new(<$scalar>::new(Some(l))) as Box<dyn Scalar>,
+                Box::new(<$scalar>::new(Some(r))) as Box<dyn Scalar>,
+            )
+        })
+    }};
+    (dt: $T:ty, $scalar:ty, $arr:expr, $op:path, ret_two) => {{
+        let arr: &$T = $arr.as_any().downcast_ref().unwrap();
+        $op(arr).map(|(l, r)| {
+            (
+                Box::new(<$scalar>::new(arr.data_type().clone(), Some(l))) as Box<dyn Scalar>,
+                Box::new(<$scalar>::new(arr.data_type().clone(), Some(r))) as Box<dyn Scalar>,
+            )
+        })
+    }};
 }
 
 macro_rules! call {
-    ($arr:expr, $op:path) => {{
+    ($arr:expr, $op:path$(, $variant:ident)?) => {{
         let arr = $arr;
 
         use arrow::datatypes::{PhysicalType as PH, PrimitiveType as PR};
         use PrimitiveArray as PArr;
         use PrimitiveScalar as PScalar;
         match arr.data_type().to_physical_type() {
-            PH::Boolean => call_op!(BooleanArray, BooleanScalar, arr, $op),
-            PH::Primitive(PR::Int8) => call_op!(dt: PArr<i8>, PScalar<i8>, arr, $op),
-            PH::Primitive(PR::Int16) => call_op!(dt: PArr<i16>, PScalar<i16>, arr, $op),
-            PH::Primitive(PR::Int32) => call_op!(dt: PArr<i32>, PScalar<i32>, arr, $op),
-            PH::Primitive(PR::Int64) => call_op!(dt: PArr<i64>, PScalar<i64>, arr, $op),
-            PH::Primitive(PR::Int128) => call_op!(dt: PArr<i128>, PScalar<i128>, arr, $op),
-            PH::Primitive(PR::UInt8) => call_op!(dt: PArr<u8>, PScalar<u8>, arr, $op),
-            PH::Primitive(PR::UInt16) => call_op!(dt: PArr<u16>, PScalar<u16>, arr, $op),
-            PH::Primitive(PR::UInt32) => call_op!(dt: PArr<u32>, PScalar<u32>, arr, $op),
-            PH::Primitive(PR::UInt64) => call_op!(dt: PArr<u64>, PScalar<u64>, arr, $op),
-            PH::Primitive(PR::UInt128) => call_op!(dt: PArr<u128>, PScalar<u128>, arr, $op),
-            PH::Primitive(PR::Float32) => call_op!(dt: PArr<f32>, PScalar<f32>, arr, $op),
-            PH::Primitive(PR::Float64) => call_op!(dt: PArr<f64>, PScalar<f64>, arr, $op),
+            PH::Boolean => call_op!(BooleanArray, BooleanScalar, arr, $op$(, $variant)?),
+            PH::Primitive(PR::Int8) => call_op!(dt: PArr<i8>, PScalar<i8>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::Int16) => call_op!(dt: PArr<i16>, PScalar<i16>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::Int32) => call_op!(dt: PArr<i32>, PScalar<i32>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::Int64) => call_op!(dt: PArr<i64>, PScalar<i64>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::Int128) => call_op!(dt: PArr<i128>, PScalar<i128>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::UInt8) => call_op!(dt: PArr<u8>, PScalar<u8>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::UInt16) => call_op!(dt: PArr<u16>, PScalar<u16>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::UInt32) => call_op!(dt: PArr<u32>, PScalar<u32>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::UInt64) => call_op!(dt: PArr<u64>, PScalar<u64>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::UInt128) => call_op!(dt: PArr<u128>, PScalar<u128>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::Float32) => call_op!(dt: PArr<f32>, PScalar<f32>, arr, $op$(, $variant)?),
+            PH::Primitive(PR::Float64) => call_op!(dt: PArr<f64>, PScalar<f64>, arr, $op$(, $variant)?),
 
-            PH::BinaryView => call_op!(BinaryViewArray, BinaryViewScalar<[u8]>, arr, $op),
-            PH::Utf8View => call_op!(Utf8ViewArray, BinaryViewScalar<str>, arr, $op),
+            PH::BinaryView => call_op!(BinaryViewArray, BinaryViewScalar<[u8]>, arr, $op$(, $variant)?),
+            PH::Utf8View => call_op!(Utf8ViewArray, BinaryViewScalar<str>, arr, $op$(, $variant)?),
 
-            PH::Binary => call_op!(BinaryArray<i32>, BinaryScalar<i32>, arr, $op),
-            PH::LargeBinary => call_op!(BinaryArray<i64>, BinaryScalar<i64>, arr, $op),
-            PH::Utf8 => call_op!(Utf8Array<i32>, BinaryScalar<i32>, arr, $op),
-            PH::LargeUtf8 => call_op!(Utf8Array<i64>, BinaryScalar<i64>, arr, $op),
+            PH::Binary => call_op!(BinaryArray<i32>, BinaryScalar<i32>, arr, $op$(, $variant)?),
+            PH::LargeBinary => call_op!(BinaryArray<i64>, BinaryScalar<i64>, arr, $op$(, $variant)?),
+            PH::Utf8 => call_op!(Utf8Array<i32>, BinaryScalar<i32>, arr, $op$(, $variant)?),
+            PH::LargeUtf8 => call_op!(Utf8Array<i64>, BinaryScalar<i64>, arr, $op$(, $variant)?),
 
             _ => todo!("Dynamic MinMax is not yet implemented for {:?}", arr.data_type()),
         }
@@ -66,4 +84,10 @@ pub fn dyn_array_min_propagate_nan(arr: &dyn Array) -> Option<Box<dyn Scalar>> {
 
 pub fn dyn_array_max_propagate_nan(arr: &dyn Array) -> Option<Box<dyn Scalar>> {
     call!(arr, MinMaxKernel::max_propagate_nan_kernel)
+}
+
+pub fn dyn_array_min_max_propagate_nan(
+    arr: &dyn Array,
+) -> Option<(Box<dyn Scalar>, Box<dyn Scalar>)> {
+    call!(arr, MinMaxKernel::min_max_propagate_nan_kernel, ret_two)
 }

--- a/crates/polars-compute/src/min_max/mod.rs
+++ b/crates/polars-compute/src/min_max/mod.rs
@@ -2,7 +2,7 @@ use polars_utils::min_max::MinMax;
 
 pub use self::dyn_array::{
     dyn_array_max_ignore_nan, dyn_array_max_propagate_nan, dyn_array_min_ignore_nan,
-    dyn_array_min_propagate_nan,
+    dyn_array_min_max_propagate_nan, dyn_array_min_propagate_nan,
 };
 
 /// Low-level min/max kernel.

--- a/crates/polars-parquet/src/arrow/write/utils.rs
+++ b/crates/polars-parquet/src/arrow/write/utils.rs
@@ -4,41 +4,13 @@ use polars_error::*;
 
 use super::{Version, WriteOptions};
 use crate::parquet::compression::CompressionOptions;
-use crate::parquet::encoding::hybrid_rle::encode;
+use crate::parquet::encoding::hybrid_rle::{self, encode};
 use crate::parquet::encoding::Encoding;
 use crate::parquet::metadata::Descriptor;
 use crate::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, DataPageHeaderV2};
 use crate::parquet::schema::types::PrimitiveType;
 use crate::parquet::statistics::ParquetStatistics;
 use crate::parquet::CowBuffer;
-
-fn encode_iter_v1<I: Iterator<Item = bool>>(buffer: &mut Vec<u8>, iter: I) -> PolarsResult<()> {
-    buffer.extend_from_slice(&[0; 4]);
-    let start = buffer.len();
-    encode::<bool, _, _>(buffer, iter, 1)?;
-    let end = buffer.len();
-    let length = end - start;
-
-    // write the first 4 bytes as length
-    let length = (length as i32).to_le_bytes();
-    (0..4).for_each(|i| buffer[start - 4 + i] = length[i]);
-    Ok(())
-}
-
-fn encode_iter_v2<I: Iterator<Item = bool>>(writer: &mut Vec<u8>, iter: I) -> PolarsResult<()> {
-    Ok(encode::<bool, _, _>(writer, iter, 1)?)
-}
-
-fn encode_iter<I: Iterator<Item = bool>>(
-    writer: &mut Vec<u8>,
-    iter: I,
-    version: Version,
-) -> PolarsResult<()> {
-    match version {
-        Version::V1 => encode_iter_v1(writer, iter),
-        Version::V2 => encode_iter_v2(writer, iter),
-    }
-}
 
 /// writes the def levels to a `Vec<u8>` and returns it.
 pub fn write_def_levels(
@@ -48,11 +20,35 @@ pub fn write_def_levels(
     len: usize,
     version: Version,
 ) -> PolarsResult<()> {
-    // encode def levels
-    match (is_optional, validity) {
-        (true, Some(validity)) => encode_iter(writer, validity.iter(), version),
-        (true, None) => encode_iter(writer, std::iter::repeat(true).take(len), version),
-        _ => Ok(()), // is required => no def levels
+    if is_optional {
+        match version {
+            Version::V1 => {
+                writer.extend(&[0, 0, 0, 0]);
+                let start = writer.len();
+
+                match validity {
+                    None => <bool as hybrid_rle::Encoder<bool>>::run_length_encode(
+                        writer, len, true, 1,
+                    )?,
+                    Some(validity) => encode::<bool, _, _>(writer, validity.iter(), 1)?,
+                }
+
+                // write the first 4 bytes as length
+                let length = ((writer.len() - start) as i32).to_le_bytes();
+                (0..4).for_each(|i| writer[start - 4 + i] = length[i]);
+            },
+            Version::V2 => match validity {
+                None => {
+                    <bool as hybrid_rle::Encoder<bool>>::run_length_encode(writer, len, true, 1)?
+                },
+                Some(validity) => encode::<bool, _, _>(writer, validity.iter(), 1)?,
+            },
+        }
+
+        Ok(())
+    } else {
+        // is required => no def levels
+        Ok(())
     }
 }
 

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -9,7 +9,7 @@ mod fuzz;
 
 pub use bitmap::{encode_bool as bitpacked_encode, BitmapIter};
 pub use buffered::BufferedBitpacked;
-pub use encoder::encode;
+pub use encoder::{encode, Encoder};
 pub use gatherer::{
     DictionaryTranslator, FnTranslator, Translator, TryFromUsizeTranslator, UnitTranslator,
 };

--- a/crates/polars-parquet/src/parquet/types.rs
+++ b/crates/polars-parquet/src/parquet/types.rs
@@ -4,6 +4,7 @@ use crate::parquet::schema::types::PhysicalType;
 pub trait NativeType: std::fmt::Debug + Send + Sync + 'static + Copy + Clone {
     type Bytes: AsRef<[u8]>
         + bytemuck::Pod
+        + IntoIterator<Item = u8>
         + for<'a> TryFrom<&'a [u8], Error = std::array::TryFromSliceError>
         + std::fmt::Debug
         + Clone


### PR DESCRIPTION
This improves the performance writing of primitive arrays into Parquet.

Running the following program, which is made to really test this function.

```rust
use std::io::Seek;

use polars::frame::DataFrame;
use polars::prelude::NamedFrom;
use polars::series::Series;
use polars_io::parquet::write::ParquetWriter;
use rand::Rng;

const NUM_VALUES: usize = 10_000_000;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let mut rng = rand::thread_rng();
    let mut values: Vec<f32> = Vec::with_capacity(NUM_VALUES);

    unsafe { values.set_len(NUM_VALUES) };
    rng.fill(&mut values[..]);

    let values = &values[..];
    let s = Series::new("a", values);

    let mut f = std::fs::OpenOptions::new()
        .write(true)
        .create(true)
        .open("output.parquet")
        .unwrap();

    for _ in 0..100 {
        f.seek(std::io::SeekFrom::Start(0))?;
        let writer = ParquetWriter::new(&mut f)
            .with_compression(polars::prelude::ParquetCompression::Uncompressed);

        let mut df = DataFrame::new(vec![s.clone()]).unwrap();

        writer.finish(&mut df)?;
    }

    Ok(())
}
```

We run around ~1.8 times faster then before:

```
Benchmark 1: ./plparbench-before
  Time (mean ± σ):      5.718 s ±  0.804 s    [User: 4.425 s, System: 1.476 s]
  Range (min … max):    4.537 s …  6.458 s    5 runs

Benchmark 2: ./plparbench-after
  Time (mean ± σ):      3.194 s ±  0.034 s    [User: 1.640 s, System: 1.986 s]
  Range (min … max):    3.142 s …  3.228 s    5 runs

Summary
  ./plparbench-after ran
    1.79 ± 0.25 times faster than ./plparbench-before
```

This also adds specialized implementations for `MinMaxKernel::min_max_{ignore, propagate}_nan` for the Primitive Arrays. This halves the amount of work needed to calculate the column statistics.