### PR TITLE
feat(python): Enum(python) constructors

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import enum
 from datetime import date, datetime, time, timedelta
 from itertools import islice
 from typing import (
@@ -12,7 +13,7 @@ from typing import (
     Iterator,
     Sequence,
 )
-import enum
+
 import polars._reexport as pl
 import polars._utils.construction as plc
 from polars._utils.construction.utils import (

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -12,7 +12,7 @@ from typing import (
     Iterator,
     Sequence,
 )
-
+import enum
 import polars._reexport as pl
 import polars._utils.construction as plc
 from polars._utils.construction.utils import (
@@ -108,6 +108,12 @@ def sequence_to_pyseries(
             return pl.DataFrame(values).to_struct(name)._s
         elif isinstance(value, range) and dtype is None:
             values = [range_to_series("", v) for v in values]
+        elif isinstance(value, enum.Enum) and dtype is None:
+            dtype = Enum(value.__class__)
+            if all(isinstance(x.value, str) for x in values):
+                values = [x.value for x in values]
+            else:
+                values = [x.name for x in values]
         else:
             # for temporal dtypes:
             # * if the values are integer, we take the physical branch.

--- a/py-polars/polars/datatypes/_utils.py
+++ b/py-polars/polars/datatypes/_utils.py
@@ -1,7 +1,14 @@
 """Utility functions for handling and processing of datatypes."""
 
-from polars._typing import PolarsDataType
+from __future__ import annotations
+
+import enum
+from typing import TYPE_CHECKING, Iterable, cast
+
 from polars.datatypes.classes import Array, List, Struct
+
+if TYPE_CHECKING:
+    from polars._typing import PolarsDataType
 
 
 def dtype_to_init_repr(dtype: PolarsDataType, prefix: str = "pl.") -> str:
@@ -46,3 +53,13 @@ def _dtype_to_init_repr_struct(dtype: Struct, prefix: str) -> str:
     inner_repr = "{" + ", ".join(inner_list) + "}"
     init_repr = f"{prefix}{class_name}({inner_repr})"
     return init_repr
+
+
+def _extract_enum_values(pyenum: enum.EnumMeta) -> list[str]:
+    enum_keys = list(pyenum.__members__.keys())
+    enum_values = [x.value for x in cast(Iterable[enum.Enum], pyenum)]
+
+    if all(isinstance(x, str) for x in enum_values):
+        return enum_values
+    else:
+        return enum_keys

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -514,14 +514,9 @@ class Enum(DataType):
             " It is a work-in-progress feature and may not always work as expected."
         )
         if isinstance(categories, enum.EnumMeta):
-            # If the values are ints then infer that we want the name otherwise
-            # take the values
-            enum_keys = categories.__members__.keys()
-            enum_values = [x.value for x in categories.__members__.values()]
-            if all(isinstance(x, str) for x in enum_values):
-                categories = pl.Series(values=enum_values)
-            else:
-                categories = pl.Series(values=enum_keys)
+            from polars.datatypes._utils import _extract_enum_values
+
+            categories = pl.Series(values=_extract_enum_values(categories))
         if not isinstance(categories, pl.Series):
             categories = pl.Series(values=categories)
 

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -128,9 +128,12 @@ def lit(
         return lit(pl.Series("literal", [value], dtype=dtype))
 
     elif isinstance(value, enum.Enum):
-        lit_value = value.value
-        if dtype is None and isinstance(value, str):
-            dtype = Enum(m.value for m in type(value))
+        if isinstance(value.value, str):
+            lit_value = value.value
+        else:
+            lit_value = value.name
+        if dtype is None:
+            dtype = Enum(type(value))
         return lit(lit_value, dtype=dtype)
 
     if dtype:

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import OrderedDict, namedtuple
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
+from enum import Enum, auto
 from random import shuffle
 from typing import TYPE_CHECKING, Any, List, Literal, NamedTuple
 
@@ -86,6 +87,17 @@ class _TestBarNT(NamedTuple):
 class _TestFooNT(NamedTuple):
     x: int
     y: _TestBarNT
+
+
+class Color(Enum):  # noqa: D101
+    red = auto()
+    green = auto()
+    blue = auto()
+
+
+class State(str, Enum):  # noqa: D101
+    VIC = "victoria"
+    NSW = "new south wales"
 
 
 # --------------------------------------------------------------------------------
@@ -1747,3 +1759,15 @@ def test_init_list_of_dicts_with_timezone(tz: Any) -> None:
     assert_frame_equal(df, expected)
 
     assert df.schema == {"dt": pl.Datetime("us", time_zone=tz and "UTC")}
+
+
+def python_enum() -> None:
+    colors = [Color.red, Color.green, Color.blue]
+    states = [State.VIC, State.NSW]
+    colors_enum = pl.Enum(["red", "green", "blue"])
+    states_enum = pl.Enum(["victoria", "new south wales"])
+    df = pl.DataFrame({"color": colors * 2, "states": states * 3})
+    assert df["color"].dtype == colors_enum
+    assert df["states"].dtype == states_enum
+    assert df.filter(pl.col("states") == State.VIC)["states"][0] == "victoria"
+    assert df.filter(pl.col("color") == Color.red)["color"][0] == "red"

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -123,24 +123,6 @@ def test_lit_enum_input_16668() -> None:
     assert pl.select(result).item() == "victoria"
 
 
-def test_lit_enum_input_non_string() -> None:
-    # https://github.com/pola-rs/polars/issues/16668
-
-    class State(int, enum.Enum):
-        ONE = 1
-        TWO = 2
-
-    value = State.ONE
-
-    result = pl.lit(value)
-    assert pl.select(result).dtypes[0] == pl.Int32
-    assert pl.select(result).item() == 1
-
-    result = pl.lit(value, dtype=pl.Int8)
-    assert pl.select(result).dtypes[0] == pl.Int8
-    assert pl.select(result).item() == 1
-
-
 @given(value=datetimes("ns"))
 def test_datetime_ns(value: datetime) -> None:
     result = pl.select(pl.lit(value, dtype=pl.Datetime("ns")))["literal"][0]


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/18018

This allows a df to be constructed with python Enums while creating a pl.Enum that matches. It also allows for pl.Enum to take a python Enum as a direct input to its categories.

This addresses two flavors of python Enums. One case is

```
class State(str, Enum):
    
    VIC = "victoria"
    NSW = "new south wales"
```
where the thing we want to maintain is "victoria" and "new south wales".

The other is
```
class Color(StrEnum):
    red = auto()
    green = auto()
    blue = auto()
```

where the thing we want to maintain is "red", "green", "blue".

Since a pl.Enum only works with Strings and not integers, this checks if the pyEnum has all string values (as in State) and uses those for the categories. In the case of Color where all the values aren't strings then it takes the names as categories instead.

Before this, `pl.lit` would treat the second case as an integer. I changed that so if the value isn't a string then it takes the name as the value. In theory this *could* be a breaking change but I've seen more people ask about the second flavor of python Enums which couldn't work without this behavior. Additionally, I believe the old behavior had more to do with dealing with pl.Enum's inability to have non-string values than an explicitly desired behavior.