### PR TITLE
feat: Add boolean Parquet HybridRle encoding

### DIFF
--- a/crates/polars-io/src/parquet/write/writer.rs
+++ b/crates/polars-io/src/parquet/write/writer.rs
@@ -146,6 +146,7 @@ fn encoding_map(data_type: &ArrowDataType) -> Encoding {
         | PhysicalType::LargeUtf8
         | PhysicalType::Utf8View
         | PhysicalType::BinaryView => Encoding::RleDictionary,
+        PhysicalType::Boolean => Encoding::Rle,
         PhysicalType::Primitive(dt) => {
             use arrow::types::PrimitiveType::*;
             match dt {

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -361,9 +361,12 @@ pub fn array_to_page_simple(
     let data_type = array.data_type();
 
     match data_type.to_logical_type() {
-        ArrowDataType::Boolean => {
-            boolean::array_to_page(array.as_any().downcast_ref().unwrap(), options, type_)
-        },
+        ArrowDataType::Boolean => boolean::array_to_page(
+            array.as_any().downcast_ref().unwrap(),
+            options,
+            type_,
+            encoding,
+        ),
         // casts below MUST match the casts done at the metadata (field -> parquet type).
         ArrowDataType::UInt8 => {
             return primitive::array_to_page_integer::<u8, i32>(


### PR DESCRIPTION
This is a more efficient encoding for `Boolean`s especially when considering columns that might be biased towards either true or false.

For a column with `100_000_000` times `True`, we see.

```
# Uncompressed
No Hybrid RLE: 12M
Hybrid RLE: 66K

# ZSTD compression
No Hybrid RLE: 75K
Hybrid RLE: 70K
```