### PR TITLE
fix(python): pl.Series detect self-referential list and throw error, prevent segfault

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -242,6 +242,7 @@ def sequence_to_pyseries(
             )
 
     elif python_dtype in (list, tuple):
+        assert not contains_self_reference(values)
         if dtype is None:
             return PySeries.new_from_any_values(name, values, strict=strict)
         elif dtype == Object:
@@ -346,7 +347,6 @@ def iterable_to_pyseries(
         values = iter(values)
 
     def to_series_chunk(values: list[Any], dtype: PolarsDataType | None) -> Series:
-        assert not contains_self_reference(values)
         return pl.Series(
             name=name,
             values=values,

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -242,7 +242,11 @@ def sequence_to_pyseries(
             )
 
     elif python_dtype in (list, tuple):
-        assert not contains_self_reference(values)
+        print(f"{python_dtype}")
+        print(f"{values=}")
+        print(f"{repr(values)}")
+        print(f"{type(values)=}")
+        assert not contains_self_reference(values), "values must not contain a self-reference"
         if dtype is None:
             return PySeries.new_from_any_values(name, values, strict=strict)
         elif dtype == Object:
@@ -318,7 +322,10 @@ def _construct_series_with_fallbacks(
             )
 
 
-def contains_self_reference(lst: list[Any], seen: Optional[set[Any]]=None):
+def contains_self_reference(lst: list[Any] | tuple[Any], seen: Optional[set[Any]]=None):
+    if not (isinstance(lst, list) or isinstance(lst, tuple)):
+        return false
+
     if seen is None:
         seen = set()
     
@@ -328,7 +335,7 @@ def contains_self_reference(lst: list[Any], seen: Optional[set[Any]]=None):
     seen.add(id(lst))
     
     for item in lst:
-        if isinstance(item, list):
+        if isinstance(item, list) or isinstance(item, tuple):
             if contains_self_reference(item, seen):
                 return True
     

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -10,6 +10,7 @@ from typing import (
     Generator,
     Iterable,
     Iterator,
+    Optional,
     Sequence,
 )
 
@@ -316,6 +317,22 @@ def _construct_series_with_fallbacks(
             )
 
 
+def contains_self_reference(lst: list[Any], seen: Optional[set[Any]]=None):
+    if seen is None:
+        seen = set()
+    
+    if id(lst) in seen:
+        return True
+    
+    seen.add(id(lst))
+    
+    for item in lst:
+        if isinstance(item, list):
+            if contains_self_reference(item, seen):
+                return True
+    
+    return False
+
 def iterable_to_pyseries(
     name: str,
     values: Iterable[Any],
@@ -329,6 +346,7 @@ def iterable_to_pyseries(
         values = iter(values)
 
     def to_series_chunk(values: list[Any], dtype: PolarsDataType | None) -> Series:
+        assert not contains_self_reference(values)
         return pl.Series(
             name=name,
             values=values,

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2165,3 +2165,9 @@ def test_series_from_numpy_with_dtye() -> None:
     s = pl.Series("foo", np.array([-1, 2, 3]), dtype=pl.UInt8, strict=False)
     assert s.to_list() == [None, 2, 3]
     assert s.dtype == pl.UInt8
+
+def test_error_on_nested_list() -> None:
+    a = []
+    a.append(a)
+    with pytest.raises(Exception):
+        pl.Series("a",a)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2170,4 +2170,4 @@ def test_error_on_nested_list() -> None:
     a = []
     a.append(a)
     with pytest.raises(Exception):
-        pl.Series("a",a)
+        pl.Series("a",a) 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2167,7 +2167,10 @@ def test_series_from_numpy_with_dtye() -> None:
     assert s.dtype == pl.UInt8
 
 def test_error_on_nested_list() -> None:
+    from polars._utils.construction.series import contains_self_reference
     a = []
+    assert not contains_self_reference(a)
     a.append(a)
+    assert contains_self_reference(a)
     with pytest.raises(Exception):
         pl.Series("a",a) 


### PR DESCRIPTION
Fixes #17960 by detecting self-referential lists and raising an Exception. I think it is worth the extra work to prevent the python API from exposing a way to segfault.

For some reason on my fork it skips the tests during CI even with the same workflow file, so I wasn't able to test the changes before submitting. If you have any insight into that issue it would help me fix the PR up if there are issues or change requests.  