### PR TITLE
fix: Fix `CloudWriter` to use buffer before making requests

### DIFF
--- a/examples/write_parquet_cloud/Cargo.toml
+++ b/examples/write_parquet_cloud/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2021"
 
 [dependencies]
 aws-creds = "0.36.0"
-polars = { path = "../../crates/polars", features = ["lazy", "aws", "parquet", "cloud_write"] }
+polars = { path = "../../crates/polars", features = ["lazy", "aws", "parquet", "cloud_write", "streaming"] }
+
+[workspace]

--- a/examples/write_parquet_cloud/src/main.rs
+++ b/examples/write_parquet_cloud/src/main.rs
@@ -2,7 +2,6 @@ use awscreds::Credentials;
 use cloud::AmazonS3ConfigKey as Key;
 use polars::prelude::*;
 
-// Login to your aws account and then copy the ../datasets/foods1.parquet file to your own bucket.
 // Adjust the link below.
 const TEST_S3_LOCATION: &str = "s3://polarstesting/polars_write_example_cloud.parquet";
 


### PR DESCRIPTION
The issue started after the bump of `ObjectStore` to v0.10. Before that, ObjectStore was doing an internal buffer.

The implementation is using `ObjectStore::BufWriter`, that is going to perform a "put" request if the size of data is below the "capacity". Otherwise it is going to do a "put multipart" instead.

Fixes https://github.com/pola-rs/polars/issues/17172