### PR TITLE
chore: Minor bump to `comfy-table` version

### DIFF
--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = { workspace = true }
 bytemuck = { workspace = true }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
-comfy-table = { version = "7.0.1", default-features = false, optional = true }
+comfy-table = { version = "7.1.1", default-features = false, optional = true }
 either = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }


### PR DESCRIPTION
No changes needed on our side; just picking up a minor width-calc fix on the off-chance someone is using (or wants to use) ANSI escape sequences somewhere. (See: https://github.com/Nukesor/comfy-table/releases)