### PR TITLE
feat(python): Support passing `Worksheet` objects to the `write_excel` method

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3161,7 +3161,7 @@ class DataFrame:
         categories is strongly recommended so that you do not have to calculate
         cell positions with respect to the frame data and worksheet:
 
-        >>> with Workbook("basic_chart.xlsx") as wb:
+        >>> with Workbook("basic_chart.xlsx") as wb:  # doctest: +SKIP
         ...     # create worksheet object and write frame data to it
         ...     ws = wb.add_worksheet("demo")
         ...     df.write_excel(


### PR DESCRIPTION
Closes #17994.
Closes #17968.

## Example

```python
from xlsxwriter import Workbook
import polars as pl

df = pl.DataFrame({
    "id": ["a123", "b345", "c567", "d789", "e101"],
    "points": [99, 45, 50, 85, 35],
})

with Workbook("basic_chart.xlsx") as wb:
    # create worksheet object
    ws = wb.add_worksheet("demo")

    # write polars frame data to the worksheet
    df.write_excel(
        workbook=wb,
        worksheet=ws,
        table_name="DataTable",
        table_style="Table Style Medium 26",
        hide_gridlines=True,
    )

    # create a chart object against the written
    # frame data using structured references
    chart = wb.add_chart({"type": "column"})
    chart.set_title({"name": "Example Chart"})
    chart.set_legend({"none": True})
    chart.set_style(38)
    chart.add_series({
        "values": "=DataTable[points]",
        "categories": "=DataTable[id]",
        "data_labels": {"value": True},
    })

    # add chart to the worksheet
    ws.insert_chart("D1", chart)
```
<img width="753" alt="write_xl_worksheet" src="https://github.com/user-attachments/assets/0653552f-e3be-44d1-9fb5-c7083216c122">
