### PR TITLE
fix(python): When setting `write_excel` column totals, don't forget to include any row-total cols

### DIFF
--- a/crates/polars-plan/src/dsl/functions/selectors.rs
+++ b/crates/polars-plan/src/dsl/functions/selectors.rs
@@ -20,7 +20,7 @@ use super::*;
 /// ```
 ///
 /// ```ignore
-/// // select specific column by writing a regular expression that starts with `^` and ends with `$`
+/// // select specific columns by writing a regular expression that starts with `^` and ends with `$`
 /// // only if regex features is activated
 /// col("^foo.*$")
 /// ```

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2889,13 +2889,13 @@ class DataFrame:
             * If passing a list of colnames, only those given will have a total.
             * For more control, pass a `{colname:funcname,}` dict.
 
-            Valid total function names are "average", "count_nums", "count", "max",
-            "min", "std_dev", "sum", and "var".
+            Valid column-total function names are "average", "count_nums", "count",
+            "max", "min", "std_dev", "sum", and "var".
         column_widths : {dict, int}
             A `{colname:int,}` or `{selector:int,}` dict or a single integer that
             sets (or overrides if autofitting) table column widths, in integer pixel
             units. If given as an integer the same value is used for all table columns.
-        row_totals : {dict, bool}
+        row_totals : {dict, list, bool}
             Add a row-total column to the right-hand side of the exported table.
 
             * If True, a column called "total" will be added at the end of the table

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -396,7 +396,11 @@ def _xl_setup_table_columns(
                 df, row_totals, expand_keys=False, expand_values=True
             )
             row_totals_dtype = {  # type: ignore[assignment]
-                nm: (Int64 if _all_integer_cols(cols, schema) else Float64)
+                nm: (
+                    Int64
+                    if _all_integer_cols(numeric_cols if cols is True else cols, schema)
+                    else Float64
+                )
                 for nm, cols in row_totals.items()
             }
             row_total_funcs = {

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -88,6 +88,8 @@ __all__ = [
 
 @overload
 def is_selector(obj: _selector_proxy_) -> Literal[True]: ...
+
+
 @overload
 def is_selector(obj: Any) -> Literal[False]: ...
 
@@ -109,8 +111,8 @@ def is_selector(obj: Any) -> bool:
     return isinstance(obj, _selector_proxy_) and hasattr(obj, "_attrs")
 
 
-# TODO: Don't use this. It collects a schema.
-# This should all go to IR conversion.
+# TODO: Don't use this for LazyFrame as it collects a schema.
+#  This should all go to IR conversion.
 def expand_selector(
     target: DataFrame | LazyFrame | Mapping[str, PolarsDataType],
     selector: SelectorType | Expr,
@@ -190,8 +192,8 @@ def expand_selector(
     return tuple(target.select(selector).collect_schema())
 
 
-# TODO: Don't use this. It collects a schema.
-# This should all go to IR conversion.
+# TODO: Don't use this for LazyFrame as it collects a schema.
+#  This should all go to IR conversion.
 def _expand_selectors(frame: DataFrame | LazyFrame, *items: Any) -> list[Any]:
     """
     Internal function that expands any selectors to column names in the given input.

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -111,8 +111,8 @@ def is_selector(obj: Any) -> bool:
     return isinstance(obj, _selector_proxy_) and hasattr(obj, "_attrs")
 
 
-# TODO: Don't use this for LazyFrame as it collects a schema.
-#  This should all go to IR conversion.
+# TODO: Don't use this as it collects a schema (can be very expensive for LazyFrame).
+#  This should move to IR conversion / Rust.
 def expand_selector(
     target: DataFrame | LazyFrame | Mapping[str, PolarsDataType],
     selector: SelectorType | Expr,
@@ -192,8 +192,8 @@ def expand_selector(
     return tuple(target.select(selector).collect_schema())
 
 
-# TODO: Don't use this for LazyFrame as it collects a schema.
-#  This should all go to IR conversion.
+# TODO: Don't use this as it collects a schema (can be very expensive for LazyFrame).
+#  This should move to IR conversion / Rust.
 def _expand_selectors(frame: DataFrame | LazyFrame, *items: Any) -> list[Any]:
     """
     Internal function that expands any selectors to column names in the given input.

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -688,24 +688,25 @@ def test_excel_write_column_and_row_totals(engine: ExcelSpreadsheetEngine) -> No
             "q4": [75, 55, 25, -10, -55],
         }
     )
-    xls = BytesIO()
-    df.write_excel(
-        xls,
-        worksheet="misc",
-        sparklines={"trend": ["q1", "q2", "q3", "q4"]},
-        row_totals={
-            # add semiannual row total columns
-            "h1": ("q1", "q2"),
-            "h2": ("q3", "q4"),
-        },
-        column_totals=True,
-    )
+    for fn_sum in (True, "sum", "SUM"):
+        xls = BytesIO()
+        df.write_excel(
+            xls,
+            worksheet="misc",
+            sparklines={"trend": ["q1", "q2", "q3", "q4"]},
+            row_totals={
+                # add semiannual row total columns
+                "h1": ("q1", "q2"),
+                "h2": ("q3", "q4"),
+            },
+            column_totals=fn_sum,
+        )
 
-    # note that the row totals are written as formulae, so we won't
-    # actually have the calculated values in the dataframe (yet)
-    xldf = pl.read_excel(xls, sheet_name="misc", engine=engine)
-    assert xldf.columns == ["id", "q1", "q2", "q3", "q4", "trend", "h1", "h2"]
-    assert xldf.row(-1) == (None, 0.0, 0.0, 0, 0, None, 0.0, 0)
+        # note that the totals are written as formulae, so we
+        # won't have the calculated values in the dataframe
+        xldf = pl.read_excel(xls, sheet_name="misc", engine=engine)
+        assert xldf.columns == ["id", "q1", "q2", "q3", "q4", "trend", "h1", "h2"]
+        assert xldf.row(-1) == (None, 0.0, 0.0, 0, 0, None, 0.0, 0)
 
 
 @pytest.mark.parametrize("engine", ["xlsx2csv", "openpyxl", "calamine"])


### PR DESCRIPTION
When setting `column_totals=True` we should account for any columns created via `row_totals` (we used to[^1], and it seems this went missing somewhere in a refactor).

Also:
* The `row_totals` column(s) dtype (int/float) should be determined by the constant columns; if all are int, the total should _also_ be int, not float.
* Default numeric value formats now better-match explicit table style colours.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "id": ["aaa", "bbb", "ccc", "ddd", "eee"],
    "q1": [100.0, 55.5, -20.0, 0.5, 35.0],
    "q2": [30.5, -10.25, 15.0, 60.0, 20.5],
    "q3": [-50, 0, 40, 80, 80],
    "q4": [75, 55, 25, -10, -55],
})

df.write_excel(
    "testing.xlsx",
    table_style = "Table Style Light 2",
    sparklines = {"trend": ["q1", "q2", "q3", "q4"]},
    row_totals = {
        # add semiannual row total columns
        "h1": ("q1","q2"),
        "h2": ("q3","q4"),
    },
    column_totals = True,
    autofit = True,
)
```
Output:

* Column totals now exist for "h1" and "h2". 
* The "h1" totals are float, "h2" totals are integer.
* Numeric values match the table style colour (and string value colour).

<img width="428" alt="Screenshot 2024-08-04 at 23 23 38" src="https://github.com/user-attachments/assets/61d506b4-1dcf-4070-b1aa-00427b2db012">

[^1]: https://github.com/pola-rs/polars/pull/7751