### PR TITLE
docs(python): Add 'frame_equal' renamed to 'equals' comment to v1 Upgrade Guide

### DIFF
--- a/docs/releases/upgrade/1.md
+++ b/docs/releases/upgrade/1.md
@@ -634,6 +634,10 @@ True
 False
 ```
 
+### `DataFrame.frame_equal(df)` renamed to `DataFrame.equals(df)`
+
+The method `frame_equal` has been renamed to `equals`.
+
 ### Remove `columns` parameter from `nth` expression function
 
 The `columns` parameter was removed in favor of treating positional inputs as additional indices.

--- a/docs/releases/upgrade/1.md
+++ b/docs/releases/upgrade/1.md
@@ -417,7 +417,7 @@ shape: (3, 1)
 
 In `.str.to_datetime`, when specifying `%.f` as the format, the default was to set the resulting datatype to nanosecond precision. This has been changed to microsecond precision.
 
-#### Example
+**Example**
 
 **Before**
 
@@ -801,7 +801,7 @@ There may be subtle differences between this engine and the previous default (`x
 One clear difference is that the `calamine` engine does not support the `engine_options` parameter.
 If you cannot get your desired behavior with the `calamine` engine, specify `engine="xlsx2csv"` to restore previous behavior.
 
-### Example
+**Example**
 
 Before:
 


### PR DESCRIPTION
Fixes #17998 