### PR TITLE
docs(python): Document dropping non-existent column causes Exception now in v1 upgrade guide

### DIFF
--- a/docs/releases/upgrade/1.md
+++ b/docs/releases/upgrade/1.md
@@ -1047,6 +1047,10 @@ After:
 pip install 'polars[calamine,async,graph]'
 ```
 
+### `df.drop('non_existent_column')` now raises a `ColumnNotFoundError`
+
+Previously, dropping a non-existent column would silently ignore the non-existent column. Now, an error is raised.
+
 ## Deprecations
 
 ### Issue `PerformanceWarning` when LazyFrame properties `schema/dtypes/columns/width` are used

--- a/docs/releases/upgrade/1.md
+++ b/docs/releases/upgrade/1.md
@@ -1051,6 +1051,8 @@ pip install 'polars[calamine,async,graph]'
 
 Previously, dropping a non-existent column would silently ignore the non-existent column. Now, an error is raised.
 
+To restore the old behavior (ignore non-existent columns), pass `strict=False`.
+
 ## Deprecations
 
 ### Issue `PerformanceWarning` when LazyFrame properties `schema/dtypes/columns/width` are used


### PR DESCRIPTION
Fixes #18045 