### PR TITLE
feat: Quantile function in SQL

### DIFF
--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
@@ -3,13 +3,11 @@ mod min_max;
 mod quantile;
 mod sum;
 mod variance;
-use std::fmt::{Debug, Display};
-use std::str::FromStr;
+use std::fmt::Debug;
 
 pub use mean::*;
 pub use min_max::*;
 use num_traits::{Float, Num, NumCast};
-use polars_error::PolarsError;
 pub use quantile::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -80,41 +78,6 @@ pub enum QuantileInterpolOptions {
     Higher,
     Midpoint,
     Linear,
-}
-
-impl Display for QuantileInterpolOptions {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl QuantileInterpolOptions {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            QuantileInterpolOptions::Nearest => "nearest",
-            QuantileInterpolOptions::Lower => "lower",
-            QuantileInterpolOptions::Higher => "higher",
-            QuantileInterpolOptions::Midpoint => "midpoint",
-            QuantileInterpolOptions::Linear => "linear",
-        }
-    }
-}
-
-impl FromStr for QuantileInterpolOptions {
-    type Err = PolarsError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "nearest" => Ok(QuantileInterpolOptions::Nearest),
-            "lower" => Ok(QuantileInterpolOptions::Lower),
-            "higher" => Ok(QuantileInterpolOptions::Higher),
-            "midpoint" => Ok(QuantileInterpolOptions::Midpoint),
-            "linear" => Ok(QuantileInterpolOptions::Linear),
-            _ => Err(PolarsError::InvalidOperation(
-                "not a valid quantile interpolation".into(),
-            )),
-        }
-    }
 }
 
 pub(super) fn rolling_apply_weights<T, Fo, Fa>(

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
@@ -3,11 +3,13 @@ mod min_max;
 mod quantile;
 mod sum;
 mod variance;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
 
 pub use mean::*;
 pub use min_max::*;
 use num_traits::{Float, Num, NumCast};
+use polars_error::PolarsError;
 pub use quantile::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -78,6 +80,41 @@ pub enum QuantileInterpolOptions {
     Higher,
     Midpoint,
     Linear,
+}
+
+impl Display for QuantileInterpolOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl QuantileInterpolOptions {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QuantileInterpolOptions::Nearest => "nearest",
+            QuantileInterpolOptions::Lower => "lower",
+            QuantileInterpolOptions::Higher => "higher",
+            QuantileInterpolOptions::Midpoint => "midpoint",
+            QuantileInterpolOptions::Linear => "linear",
+        }
+    }
+}
+
+impl FromStr for QuantileInterpolOptions {
+    type Err = PolarsError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "nearest" => Ok(QuantileInterpolOptions::Nearest),
+            "lower" => Ok(QuantileInterpolOptions::Lower),
+            "higher" => Ok(QuantileInterpolOptions::Higher),
+            "midpoint" => Ok(QuantileInterpolOptions::Midpoint),
+            "linear" => Ok(QuantileInterpolOptions::Linear),
+            _ => Err(PolarsError::InvalidOperation(
+                "not a valid quantile interpolation".into(),
+            )),
+        }
+    }
 }
 
 pub(super) fn rolling_apply_weights<T, Fo, Fa>(

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1255,9 +1255,9 @@ impl SQLFunctionVisitor<'_> {
             Median => self.visit_unary(Expr::median),
             Quantile => {
                 let args = extract_args(function)?;
-                let getValue = |e: Expr| match e {
+                let get_value = |e: Expr| match e {
                     Expr::Literal(LiteralValue::Float(f)) => {
-                        if f >= 0.0 && f <= 1.0 {
+                        if (0.0..=1.0).contains(&f) {
                             Ok(Expr::from(f))
                         } else {
                             polars_bail!(SQLSyntax: "QUANTILE value must be between 0 and 1 ({})", args[1])
@@ -1268,11 +1268,11 @@ impl SQLFunctionVisitor<'_> {
 
                 match args.len() {
                     2 => self.try_visit_binary(|e, q| {
-                        Ok(e.quantile(getValue(q)?, QuantileInterpolOptions::Nearest))
+                        Ok(e.quantile(get_value(q)?, QuantileInterpolOptions::Nearest))
                     }),
                     3 => self.try_visit_ternary(|e, q, opt| {
                         Ok(e.quantile(
-                            getValue(q)?,
+                            get_value(q)?,
                             match opt {
                                 Expr::Literal(LiteralValue::String(s)) => {
                                     QuantileInterpolOptions::from_str(&s)?

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -694,7 +694,7 @@ impl PolarsSQLFunctions {
             "pi",
             "pow",
             "power",
-            "quantile",
+            "quantile_cont",
             "radians",
             "regexp_like",
             "replace",

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1273,6 +1273,13 @@ impl SQLFunctionVisitor<'_> {
                                     polars_bail!(SQLSyntax: "QUANTILE_DISC value must be between 0 and 1 ({})", args[1])
                                 }
                             },
+                            Expr::Literal(LiteralValue::Int(n)) => {
+                                if (0..=1).contains(&n) {
+                                    Expr::from(n as f64)
+                                } else {
+                                    polars_bail!(SQLSyntax: "QUANTILE_DISC value must be between 0 and 1 ({})", args[1])
+                                }
+                            },
                             _ => polars_bail!(SQLSyntax: "invalid value for QUANTILE_DISC ({})", args[1])
                         };
                         Ok(e.quantile(value, QuantileInterpolOptions::Lower))
@@ -1288,6 +1295,13 @@ impl SQLFunctionVisitor<'_> {
                             Expr::Literal(LiteralValue::Float(f)) => {
                                 if (0.0..=1.0).contains(&f) {
                                     Expr::from(f)
+                                } else {
+                                    polars_bail!(SQLSyntax: "QUANTILE_CONT value must be between 0 and 1 ({})", args[1])
+                                }
+                            },
+                            Expr::Literal(LiteralValue::Int(n)) => {
+                                if (0..=1).contains(&n) {
+                                    Expr::from(n as f64)
                                 } else {
                                     polars_bail!(SQLSyntax: "QUANTILE_CONT value must be between 0 and 1 ({})", args[1])
                                 }

--- a/crates/polars-sql/tests/functions_aggregate.rs
+++ b/crates/polars-sql/tests/functions_aggregate.rs
@@ -50,31 +50,23 @@ fn test_median() {
 }
 
 #[test]
-fn test_quantiles() {
+fn test_quantile_disc() {
     for &q in &[0.25, 0.5, 0.75] {
-        for &interpol in &[
-            QuantileInterpolOptions::Linear,
-            QuantileInterpolOptions::Lower,
-            QuantileInterpolOptions::Higher,
-            QuantileInterpolOptions::Nearest,
-            QuantileInterpolOptions::Midpoint,
-        ] {
-            let expr = col("Sales").quantile(lit(q), interpol);
+        let expr = col("Sales").quantile(lit(q), QuantileInterpolOptions::Lower);
 
-            let sql_expr = format!("QUANTILE(Sales, {}, '{}')", q, interpol);
-            let (expected, actual) = create_expected(expr, &sql_expr);
+        let sql_expr = format!("QUANTILE_DISC(Sales, {})", q);
+        let (expected, actual) = create_expected(expr, &sql_expr);
 
-            assert!(expected.equals(&actual))
-        }
+        assert!(expected.equals(&actual))
     }
 }
 
 #[test]
-fn test_quantile_default_nearest() {
+fn test_quantile_cont() {
     for &q in &[0.25, 0.5, 0.75] {
-        let expr = col("Sales").quantile(lit(q), QuantileInterpolOptions::Nearest);
+        let expr = col("Sales").quantile(lit(q), QuantileInterpolOptions::Linear);
 
-        let sql_expr = format!("QUANTILE(Sales, {})", q);
+        let sql_expr = format!("QUANTILE_CONT(Sales, {})", q);
         let (expected, actual) = create_expected(expr, &sql_expr);
 
         assert!(expected.equals(&actual))

--- a/crates/polars-sql/tests/functions_aggregate.rs
+++ b/crates/polars-sql/tests/functions_aggregate.rs
@@ -1,0 +1,82 @@
+use polars_core::prelude::*;
+use polars_lazy::prelude::*;
+use polars_plan::dsl::Expr;
+use polars_sql::*;
+
+fn create_df() -> LazyFrame {
+    df! {
+      "Year" => [2018, 2018, 2019, 2019, 2020, 2020],
+      "Country" => ["US", "UK", "US", "UK", "US", "UK"],
+      "Sales" => [1000, 2000, 3000, 4000, 5000, 6000]
+    }
+    .unwrap()
+    .lazy()
+}
+
+fn create_expected(expr: Expr, sql: &str) -> (DataFrame, DataFrame) {
+    let df = create_df();
+    let alias = "TEST";
+
+    let query = format!(
+        r#"
+      SELECT
+          {sql} as {alias}
+      FROM
+          df
+      "#
+    );
+
+    let expected = df
+        .clone()
+        .select(&[expr.alias(alias)])
+        .sort([alias], Default::default())
+        .collect()
+        .unwrap();
+    let mut ctx = SQLContext::new();
+    ctx.register("df", df);
+
+    let actual = ctx.execute(&query).unwrap().collect().unwrap();
+    (expected, actual)
+}
+
+#[test]
+fn test_median() {
+    let expr = col("Sales").median();
+
+    let sql_expr = "MEDIAN(Sales)";
+    let (expected, actual) = create_expected(expr, sql_expr);
+
+    assert!(expected.equals(&actual))
+}
+
+#[test]
+fn test_quantiles() {
+    for &q in &[0.25, 0.5, 0.75] {
+        for &interpol in &[
+            QuantileInterpolOptions::Linear,
+            QuantileInterpolOptions::Lower,
+            QuantileInterpolOptions::Higher,
+            QuantileInterpolOptions::Nearest,
+            QuantileInterpolOptions::Midpoint,
+        ] {
+            let expr = col("Sales").quantile(lit(q), interpol);
+
+            let sql_expr = format!("QUANTILE(Sales, {}, '{}')", q, interpol);
+            let (expected, actual) = create_expected(expr, &sql_expr);
+
+            assert!(expected.equals(&actual))
+        }
+    }
+}
+
+#[test]
+fn test_quantile_default_nearest() {
+    for &q in &[0.25, 0.5, 0.75] {
+        let expr = col("Sales").quantile(lit(q), QuantileInterpolOptions::Nearest);
+
+        let sql_expr = format!("QUANTILE(Sales, {})", q);
+        let (expected, actual) = create_expected(expr, &sql_expr);
+
+        assert!(expected.equals(&actual))
+    }
+}

--- a/crates/polars-sql/tests/functions_aggregate.rs
+++ b/crates/polars-sql/tests/functions_aggregate.rs
@@ -50,49 +50,6 @@ fn test_median() {
 }
 
 #[test]
-fn test_quantile_disc() {
-    for &q in &[0.25, 0.5, 0.75] {
-        let expr = col("Sales").quantile(lit(q), QuantileInterpolOptions::Lower);
-
-        let sql_expr = format!("QUANTILE_DISC(Sales, {})", q);
-        let (expected, actual) = create_expected(expr, &sql_expr);
-
-        assert!(
-            expected.equals(&actual),
-            "q: {q}: expected {expected:?}, got {actual:?}"
-        )
-    }
-}
-
-#[test]
-fn test_quantile_disc_conformance() {
-    for (q, expected) in [
-        (0., 1000),
-        (0.1, 1000),
-        (0.2, 2000),
-        (0.3, 2000),
-        (0.4, 3000),
-        (0.5, 3000),
-        (0.6, 4000),
-        (0.7, 4000),
-        (0.8, 5000),
-        (0.9, 5000),
-        (1., 6000),
-    ] {
-        let expr = lit(expected);
-
-        let sql_expr = format!("QUANTILE_DISC(Sales, {q})");
-
-        let (expected, actual) = create_expected(expr, &sql_expr);
-
-        assert!(
-            expected.equals(&actual),
-            "q: {q}: expected {expected:?}, got {actual:?}"
-        );
-    }
-}
-
-#[test]
 fn test_quantile_cont() {
     for &q in &[0.25, 0.5, 0.75] {
         let expr = col("Sales").quantile(lit(q), QuantileInterpolOptions::Linear);

--- a/crates/polars-sql/tests/functions_aggregate.rs
+++ b/crates/polars-sql/tests/functions_aggregate.rs
@@ -57,7 +57,38 @@ fn test_quantile_disc() {
         let sql_expr = format!("QUANTILE_DISC(Sales, {})", q);
         let (expected, actual) = create_expected(expr, &sql_expr);
 
-        assert!(expected.equals(&actual))
+        assert!(
+            expected.equals(&actual),
+            "q: {q}: expected {expected:?}, got {actual:?}"
+        )
+    }
+}
+
+#[test]
+fn test_quantile_disc_conformance() {
+    for (q, expected) in [
+        (0., 1000),
+        (0.1, 1000),
+        (0.2, 2000),
+        (0.3, 2000),
+        (0.4, 3000),
+        (0.5, 3000),
+        (0.6, 4000),
+        (0.7, 4000),
+        (0.8, 5000),
+        (0.9, 5000),
+        (1., 6000),
+    ] {
+        let expr = lit(expected);
+
+        let sql_expr = format!("QUANTILE_DISC(Sales, {q})");
+
+        let (expected, actual) = create_expected(expr, &sql_expr);
+
+        assert!(
+            expected.equals(&actual),
+            "q: {q}: expected {expected:?}, got {actual:?}"
+        );
     }
 }
 
@@ -69,6 +100,9 @@ fn test_quantile_cont() {
         let sql_expr = format!("QUANTILE_CONT(Sales, {})", q);
         let (expected, actual) = create_expected(expr, &sql_expr);
 
-        assert!(expected.equals(&actual))
+        assert!(
+            expected.equals(&actual),
+            "q: {q}: expected {expected:?}, got {actual:?}"
+        )
     }
 }


### PR DESCRIPTION
This implements a feature requested in https://github.com/pola-rs/polars/issues/7227: quantile functions in SQL. I also went ahead and added median function tests as those were missing.