### PR TITLE
perf: Start on better Parquet delta decoding

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -64,7 +64,7 @@ where
                 let values = split_buffer(page)?.values;
                 Ok(Self::DeltaBinaryPacked(delta_bitpacked::Decoder::try_new(
                     values,
-                )?))
+                )?.0))
             },
             _ => Err(utils::not_implemented(page)),
         }

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/decode.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/decode.rs
@@ -1,5 +1,5 @@
 use super::{Packed, Unpackable, Unpacked};
-use crate::parquet::error::ParquetError;
+use crate::parquet::error::{ParquetError, ParquetResult};
 
 /// An [`Iterator`] of [`Unpackable`] unpacked from a bitpacked slice of bytes.
 /// # Implementation
@@ -14,29 +14,47 @@ pub struct Decoder<'a, T: Unpackable> {
 }
 
 #[derive(Debug)]
-pub struct DecoderIter<T: Unpackable> {
-    buffer: Vec<T>,
-    idx: usize,
+pub struct DecoderIter<'a, T: Unpackable> {
+    decoder: Decoder<'a, T>,
+    buffered: T::Unpacked,
+    unpacked_start: usize,
+    unpacked_end: usize,
 }
 
-impl<T: Unpackable> Iterator for DecoderIter<T> {
+impl<'a, T: Unpackable> Iterator for DecoderIter<'a, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.idx >= self.buffer.len() {
-            return None;
+        if self.unpacked_end <= self.unpacked_start {
+            let length;
+            (self.buffered, length) = self.decoder.chunked().next_inexact()?;
+            debug_assert!(length > 0);
+            self.unpacked_start = 1;
+            self.unpacked_end = length;
+            return Some(self.buffered[0]);
         }
 
-        let value = self.buffer[self.idx];
-        self.idx += 1;
-
-        Some(value)
+        let v = self.buffered[self.unpacked_start];
+        self.unpacked_start += 1;
+        Some(v)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.buffer.len() - self.idx;
-
+        let len = self.decoder.len() + self.unpacked_end - self.unpacked_start;
         (len, Some(len))
+    }
+}
+
+impl<'a, T: Unpackable> ExactSizeIterator for DecoderIter<'a, T> {}
+
+impl<'a, T: Unpackable> DecoderIter<'a, T> {
+    pub fn new(packed: &'a [u8], num_bits: usize, length: usize) -> ParquetResult<Self> {
+        Ok(Self {
+            decoder: Decoder::try_new(packed, num_bits, length)?,
+            buffered: T::Unpacked::zero(),
+            unpacked_start: 0,
+            unpacked_end: 0,
+        })
     }
 }
 
@@ -57,14 +75,8 @@ impl<'a, T: Unpackable> Decoder<'a, T> {
         Self::try_new(packed, num_bits, length).unwrap()
     }
 
-    pub fn collect_into_iter(self) -> DecoderIter<T> {
-        let mut buffer = Vec::new();
-        self.collect_into(&mut buffer);
-        DecoderIter { buffer, idx: 0 }
-    }
-
     /// Returns a [`Decoder`] with `T` encoded in `packed` with `num_bits`.
-    pub fn try_new(packed: &'a [u8], num_bits: usize, length: usize) -> Result<Self, ParquetError> {
+    pub fn try_new(packed: &'a [u8], num_bits: usize, length: usize) -> ParquetResult<Self> {
         let block_size = std::mem::size_of::<T>() * num_bits;
 
         if num_bits == 0 {
@@ -92,6 +104,7 @@ impl<'a, T: Unpackable> Decoder<'a, T> {
 /// A iterator over the exact chunks in a [`Decoder`].
 ///
 /// The remainder can be accessed using `remainder` or `next_inexact`.
+#[derive(Debug)]
 pub struct ChunkedDecoder<'a, 'b, T: Unpackable> {
     pub(crate) decoder: &'b mut Decoder<'a, T>,
 }

--- a/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/decoder.rs
+++ b/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/decoder.rs
@@ -1,121 +1,187 @@
 use super::super::{bitpacked, uleb128, zigzag_leb128};
-use crate::parquet::encoding::ceil8;
 use crate::parquet::error::{ParquetError, ParquetResult};
 
 /// An [`Iterator`] of [`i64`]
 #[derive(Debug)]
 struct Block<'a> {
-    // this is the minimum delta that must be added to every value.
+    /// this is the minimum delta that must be added to every value.
     min_delta: i64,
-    _num_mini_blocks: usize,
-    /// Number of values that each mini block has.
-    values_per_mini_block: usize,
-    bitwidths: std::slice::Iter<'a, u8>,
-    values: &'a [u8],
-    remaining: usize,     // number of elements
-    current_index: usize, // invariant: < values_per_mini_block
-    // None represents a relative delta of zero, in which case there is no miniblock.
-    current_miniblock: Option<bitpacked::DecoderIter<u64>>,
-    // number of bytes consumed.
-    consumed_bytes: usize,
+    bitwidths: &'a [u8],
+    current_miniblock: bitpacked::DecoderIter<'a, u64>,
+    remainder: &'a [u8],
+}
+
+impl<'a> Default for Block<'a> {
+    fn default() -> Self {
+        Self {
+            min_delta: 0,
+            bitwidths: &[],
+            current_miniblock: bitpacked::DecoderIter::new(&[], 0, 0).unwrap(),
+            remainder: &[],
+        }
+    }
+}
+
+fn collect_miniblock(
+    target: &'_ mut Vec<i64>,
+    min_delta: i64,
+    bitwidth: u8,
+    values: &'_ [u8],
+    values_per_miniblock: usize,
+    last_value: &mut i64,
+) {
+    let bitwidth = bitwidth as usize;
+
+    debug_assert!(bitwidth <= 64);
+    debug_assert!((bitwidth * values_per_miniblock).div_ceil(8) == values.len());
+
+    let start_length = target.len();
+
+    // SAFETY: u64 and i64 have the same size, alignment and they are both Copy.
+    let target = unsafe { std::mem::transmute::<&mut Vec<i64>, &mut Vec<u64>>(target) };
+    bitpacked::Decoder::new(values, bitwidth, values_per_miniblock).collect_into(target);
+    let target_length = target.len();
+
+    debug_assert_eq!(target_length - start_length, values_per_miniblock);
+
+    // @TODO: This should include the last value
+    // Offset everything by the delta value.
+    &mut target[target_length - values_per_miniblock..]
+        .iter_mut()
+        .for_each(|v| {
+            *last_value = *last_value + (*v as i64) + min_delta;
+            *v = *last_value as u64;
+        });
+}
+
+fn sum_miniblock(
+    min_delta: i64,
+    bitwidth: u8,
+    values: &[u8],
+    values_per_miniblock: usize,
+    last_value: &mut i64,
+) -> i64 {
+    let bitwidth = bitwidth as usize;
+
+    debug_assert!(bitwidth <= 64);
+    debug_assert!((bitwidth * values_per_miniblock).div_ceil(8) == values.len());
+
+    let mut iter = bitpacked::Decoder::<u64>::new(values, bitwidth, values_per_miniblock);
+
+    // @TODO: This should include the last value
+    let mut accum = 0i64;
+    for chunk in iter.chunked() {
+        accum += chunk
+            .into_iter()
+            .map(|v| {
+                *last_value = *last_value + (v as i64) + min_delta;
+                *last_value
+            })
+            .sum::<i64>();
+    }
+
+    if let Some((chunk, length)) = iter.chunked().next_inexact() {
+        accum += chunk[..length]
+            .into_iter()
+            .map(|&v| {
+                *last_value = *last_value + (v as i64) + min_delta;
+                *last_value
+            })
+            .sum::<i64>();
+    }
+
+    accum
+}
+
+fn collect_block(
+    target: &'_ mut Vec<i64>,
+    num_miniblocks: usize,
+    values_per_miniblock: usize,
+    mut values: &'_ [u8],
+    last_value: &mut i64,
+) {
+    let (min_delta, consumed) = zigzag_leb128::decode(values);
+    values = &values[consumed..];
+    let bitwidths;
+    (bitwidths, values) = values.split_at(num_miniblocks);
+
+    target.reserve(num_miniblocks * values_per_miniblock);
+    for &bitwidth in bitwidths {
+        let miniblock;
+        (miniblock, values) =
+            values.split_at((bitwidth as usize * values_per_miniblock).div_ceil(8));
+        collect_miniblock(
+            target,
+            min_delta,
+            bitwidth,
+            miniblock,
+            values_per_miniblock,
+            last_value,
+        );
+    }
+}
+
+fn sum_block(
+    num_miniblocks: usize,
+    values_per_miniblock: usize,
+    mut values: &'_ [u8],
+
+    last_value: &mut i64,
+) -> i64 {
+    let (min_delta, consumed) = zigzag_leb128::decode(values);
+    values = &values[consumed..];
+    let bitwidths;
+    (bitwidths, values) = values.split_at(num_miniblocks);
+
+    let mut accum = 0i64;
+    for &bitwidth in bitwidths {
+        let miniblock;
+        (miniblock, values) =
+            values.split_at((bitwidth as usize * values_per_miniblock).div_ceil(8));
+        accum += sum_miniblock(
+            min_delta,
+            bitwidth,
+            miniblock,
+            values_per_miniblock,
+            last_value,
+        );
+    }
+    accum
 }
 
 impl<'a> Block<'a> {
-    pub fn try_new(
+    fn new(
         mut values: &'a [u8],
-        num_mini_blocks: usize,
-        values_per_mini_block: usize,
+        num_miniblocks: usize,
+        values_per_miniblock: usize,
         length: usize,
     ) -> ParquetResult<Self> {
-        let length = std::cmp::min(length, num_mini_blocks * values_per_mini_block);
+        let length = std::cmp::min(length, num_miniblocks * values_per_miniblock);
+        let actual_num_miniblocks =
+            usize::min(num_miniblocks, length.div_ceil(values_per_miniblock));
 
-        let mut consumed_bytes = 0;
+        if actual_num_miniblocks == 0 {
+            return Ok(Self::default());
+        }
+
         let (min_delta, consumed) = zigzag_leb128::decode(values);
-        consumed_bytes += consumed;
         values = &values[consumed..];
+        let (bitwidths, remainder) = values.split_at(num_miniblocks);
 
-        if num_mini_blocks > values.len() {
-            return Err(ParquetError::oos(
-                "Block must contain at least num_mini_blocks bytes (the bitwidths)",
-            ));
-        }
-        let (bitwidths, remaining) = values.split_at(num_mini_blocks);
-        consumed_bytes += num_mini_blocks;
-        values = remaining;
+        let bitwidths = &bitwidths[..actual_num_miniblocks];
+        let first_bitwidth = bitwidths[0] as usize;
 
-        let mut block = Block {
+        let num_bytes = (first_bitwidth * values_per_miniblock).div_ceil(8);
+        let (bytes, remainder) = remainder.split_at(num_bytes);
+        let current_miniblock =
+            bitpacked::DecoderIter::new(bytes, first_bitwidth, values_per_miniblock)?;
+
+        Ok(Block {
             min_delta,
-            _num_mini_blocks: num_mini_blocks,
-            values_per_mini_block,
-            bitwidths: bitwidths.iter(),
-            remaining: length,
-            values,
-            current_index: 0,
-            current_miniblock: None,
-            consumed_bytes,
-        };
-
-        // Set up first mini-block
-        block.advance_miniblock()?;
-
-        Ok(block)
-    }
-
-    fn advance_miniblock(&mut self) -> ParquetResult<()> {
-        // unwrap is ok: we sliced it by num_mini_blocks in try_new
-        let num_bits = self.bitwidths.next().copied().unwrap() as usize;
-
-        self.current_miniblock = if num_bits > 0 {
-            let length = std::cmp::min(self.remaining, self.values_per_mini_block);
-
-            let miniblock_length = ceil8(self.values_per_mini_block * num_bits);
-            if miniblock_length > self.values.len() {
-                return Err(ParquetError::oos(
-                    "block must contain at least miniblock_length bytes (the mini block)",
-                ));
-            }
-            let (miniblock, remainder) = self.values.split_at(miniblock_length);
-
-            self.values = remainder;
-            self.consumed_bytes += miniblock_length;
-
-            Some(
-                bitpacked::Decoder::try_new(miniblock, num_bits, length)
-                    .unwrap()
-                    .collect_into_iter(),
-            )
-        } else {
-            None
-        };
-        self.current_index = 0;
-
-        Ok(())
-    }
-}
-
-impl<'a> Iterator for Block<'a> {
-    type Item = Result<i64, ParquetError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining == 0 {
-            return None;
-        }
-        let result = self.min_delta
-            + self
-                .current_miniblock
-                .as_mut()
-                .map(|x| x.next().unwrap_or_default())
-                .unwrap_or(0) as i64;
-        self.current_index += 1;
-        self.remaining -= 1;
-
-        if self.remaining > 0 && self.current_index == self.values_per_mini_block {
-            if let Err(e) = self.advance_miniblock() {
-                return Some(Err(e));
-            }
-        }
-
-        Some(Ok(result))
+            bitwidths,
+            current_miniblock,
+            remainder,
+        })
     }
 }
 
@@ -124,60 +190,140 @@ impl<'a> Iterator for Block<'a> {
 /// This struct does not allocate on the heap.
 #[derive(Debug)]
 pub struct Decoder<'a> {
-    num_mini_blocks: usize,
-    values_per_mini_block: usize,
+    num_miniblocks_per_block: usize,
+    values_per_block: usize,
+
     values_remaining: usize,
-    next_value: i64,
+
+    first_value: i64,
     values: &'a [u8],
-    current_block: Option<Block<'a>>,
+    current_block: Block<'a>,
     // the total number of bytes consumed up to a given point, excluding the bytes on the current_block
     consumed_bytes: usize,
 }
 
 impl<'a> Decoder<'a> {
-    pub fn try_new(mut values: &'a [u8]) -> Result<Self, ParquetError> {
+    pub fn try_new(mut values: &'a [u8]) -> ParquetResult<(Self, &'a [u8])> {
+        let header_err = || ParquetError::oos("Insufficient bytes for Delta encoding header");
+
         let mut consumed_bytes = 0;
-        let (block_size, consumed) = uleb128::decode(values);
+
+        // header:
+        // <block size in values> <number of miniblocks in a block> <total value count> <first value>
+
+        let (values_per_block, consumed) = uleb128::decode(values);
+        let values_per_block = values_per_block as usize;
         consumed_bytes += consumed;
-        assert_eq!(block_size % 128, 0);
-        values = &values[consumed..];
-        let (num_mini_blocks, consumed) = uleb128::decode(values);
-        let num_mini_blocks = num_mini_blocks as usize;
+        values = values.get(consumed..).ok_or_else(header_err)?;
+
+        assert_eq!(values_per_block % 128, 0);
+
+        let (num_miniblocks_per_block, consumed) = uleb128::decode(values);
+        let num_miniblocks_per_block = num_miniblocks_per_block as usize;
         consumed_bytes += consumed;
-        values = &values[consumed..];
+        values = values.get(consumed..).ok_or_else(header_err)?;
+
         let (total_count, consumed) = uleb128::decode(values);
         let total_count = total_count as usize;
         consumed_bytes += consumed;
-        values = &values[consumed..];
+        values = values.get(consumed..).ok_or_else(header_err)?;
+
         let (first_value, consumed) = zigzag_leb128::decode(values);
         consumed_bytes += consumed;
-        values = &values[consumed..];
+        values = values.get(consumed..).ok_or_else(header_err)?;
 
-        let values_per_mini_block = block_size as usize / num_mini_blocks;
-        assert_eq!(values_per_mini_block % 8, 0);
+        assert_eq!(values_per_block % num_miniblocks_per_block, 0);
+        assert_eq!((values_per_block / num_miniblocks_per_block) % 32, 0);
+
+        let values_per_miniblock = values_per_block / num_miniblocks_per_block;
+        assert_eq!(values_per_miniblock % 8, 0);
 
         // If we only have one value (first_value), there are no blocks.
         let current_block = if total_count > 1 {
             Some(Block::try_new(
                 values,
-                num_mini_blocks,
-                values_per_mini_block,
+                num_miniblocks_per_block,
+                values_per_miniblock,
                 total_count - 1,
             )?)
         } else {
             None
         };
 
-        Ok(Self {
-            num_mini_blocks,
-            values_per_mini_block,
-            values_remaining: total_count,
-            next_value: first_value,
-            values,
-            current_block,
-            consumed_bytes,
-        })
+        // We skip over all the values to determine where the slice stops.
+        let remainder = if total_count > 0 {
+            let mut rem = values;
+            let mut num_values_read = total_count - 1;
+            while num_values_read > 0 {
+                // If the number of values is does not need all the miniblocks anymore, we need to
+                // ignore the later miniblocks and regard them as having bitwidth = 0.
+                //
+                // Quoted from the specification:
+                //
+                // > If, in the last block, less than <number of miniblocks in a block> miniblocks
+                // > are needed to store the values, the bytes storing the bit widths of the
+                // > unneeded miniblocks are still present, their value should be zero, but readers
+                // > must accept arbitrary values as well. There are no additional padding bytes for
+                // > the miniblock bodies though, as if their bit widths were 0 (regardless of the
+                // > actual byte values). The reader knows when to stop reading by keeping track of
+                // > the number of values read.
+                let num_remaining_mini_blocks = usize::min(
+                    num_miniblocks_per_block,
+                    num_values_read.div_ceil(values_per_miniblock),
+                );
+
+                // block:
+                // <min delta> <list of bitwidths of miniblocks> <miniblocks>
+
+                let (_, consumed) = zigzag_leb128::decode(values);
+                rem = rem.get(consumed..).ok_or(ParquetError::oos(
+                    "No min-delta value in delta encoding miniblock",
+                ))?;
+
+                if rem[..num_remaining_mini_blocks]
+                    .iter()
+                    .copied()
+                    .any(|bitwidth| bitwidth > 64)
+                {
+                    return Err(ParquetError::oos(
+                        "Delta encoding miniblock with bitwidth higher than maximum 64 bits",
+                    ));
+                }
+
+                let num_bitpacking_bytes = rem[..num_remaining_mini_blocks]
+                    .iter()
+                    .copied()
+                    .map(|bitwidth| (bitwidth as usize * values_per_miniblock).div_ceil(8))
+                    .sum::<usize>();
+
+                rem = rem
+                    .get(num_miniblocks_per_block + num_bitpacking_bytes..)
+                    .ok_or(ParquetError::oos(
+                        "Not enough bytes for all bitpacked values in delta encoding",
+                    ))?;
+
+                num_values_read = num_values_read.saturating_sub(values_per_block as usize);
+            }
+            rem
+        } else {
+            values
+        };
+
+        Ok((
+            Self {
+                num_miniblocks_per_block,
+                values_per_block,
+                values_remaining: total_count,
+                first_value,
+                values: &values[..values.len() - remainder.len()],
+                current_block,
+                consumed_bytes,
+            },
+            remainder,
+        ))
     }
+
+    pub fn skip_in_place(&mut self, n: usize) {}
 
     /// Returns the total number of bytes consumed up to this point by [`Decoder`].
     pub fn consumed_bytes(&self) -> usize {
@@ -196,8 +342,8 @@ impl<'a> Decoder<'a> {
 
             let next_block = Block::try_new(
                 self.values,
-                self.num_mini_blocks,
-                self.values_per_mini_block,
+                self.num_miniblocks_per_block,
+                self.values_per_block / self.num_miniblocks_per_block,
                 self.values_remaining,
             );
             match next_block {
@@ -222,7 +368,7 @@ impl<'a> Iterator for Decoder<'a> {
             return None;
         }
 
-        let result = Some(Ok(self.next_value));
+        let result = Some(Ok(self.first_value));
 
         self.values_remaining -= 1;
         if self.values_remaining == 0 {
@@ -235,7 +381,7 @@ impl<'a> Iterator for Decoder<'a> {
             Err(e) => return Some(Err(e)),
         };
 
-        self.next_value += delta;
+        self.first_value += delta;
         result
     }
 
@@ -259,7 +405,7 @@ mod tests {
         // first_value: 2 <=z> 1
         let data = &[128, 1, 4, 1, 2];
 
-        let mut decoder = Decoder::try_new(data).unwrap();
+        let (mut decoder, _) = Decoder::try_new(data).unwrap();
         let r = decoder.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
 
         assert_eq!(&r[..], &[1]);
@@ -280,7 +426,7 @@ mod tests {
         // bit_width: 0
         let data = &[128, 1, 4, 5, 2, 2, 0, 0, 0, 0];
 
-        let mut decoder = Decoder::try_new(data).unwrap();
+        let (mut decoder, _) = Decoder::try_new(data).unwrap();
         let r = decoder.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
 
         assert_eq!(expected, r);
@@ -311,11 +457,12 @@ mod tests {
             1, 2, 3,
         ];
 
-        let mut decoder = Decoder::try_new(data).unwrap();
+        let (mut decoder, remainder) = Decoder::try_new(data).unwrap();
         let r = decoder.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
 
         assert_eq!(expected, r);
         assert_eq!(decoder.consumed_bytes(), data.len() - 3);
+        assert_eq!(remainder.len(), 3);
     }
 
     #[test]
@@ -357,10 +504,11 @@ mod tests {
             -2, 2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50,
         ];
 
-        let mut decoder = Decoder::try_new(data).unwrap();
+        let (mut decoder, remainder) = Decoder::try_new(data).unwrap();
         let r = decoder.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
 
         assert_eq!(&expected[..], &r[..]);
         assert_eq!(decoder.consumed_bytes(), data.len() - 3);
+        assert_eq!(remainder.len(), 3);
     }
 }

--- a/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/mod.rs
@@ -15,7 +15,7 @@ mod tests {
 
         let mut buffer = vec![];
         encode(data.clone().into_iter(), &mut buffer);
-        let iter = Decoder::try_new(&buffer)?;
+        let (iter, _) = Decoder::try_new(&buffer)?;
 
         let result = iter.collect::<Result<Vec<_>, _>>()?;
         assert_eq!(result, data);
@@ -28,7 +28,7 @@ mod tests {
 
         let mut buffer = vec![];
         encode(data.clone().into_iter(), &mut buffer);
-        let iter = Decoder::try_new(&buffer)?;
+        let (iter, _) = Decoder::try_new(&buffer)?;
 
         let result = iter.collect::<Result<Vec<_>, _>>()?;
         assert_eq!(result, data);
@@ -49,7 +49,7 @@ mod tests {
 
         let mut buffer = vec![];
         encode(data.clone().into_iter(), &mut buffer);
-        let iter = Decoder::try_new(&buffer)?;
+        let (iter, _) = Decoder::try_new(&buffer)?;
 
         let result = iter.collect::<Result<Vec<_>, ParquetError>>()?;
         assert_eq!(result, data);
@@ -65,7 +65,7 @@ mod tests {
 
         let mut buffer = vec![];
         encode(data.clone().into_iter(), &mut buffer);
-        let iter = Decoder::try_new(&buffer)?;
+        let (iter, _) = Decoder::try_new(&buffer)?;
 
         let result = iter.collect::<Result<Vec<_>, _>>()?;
         assert_eq!(result, data);
@@ -79,7 +79,7 @@ mod tests {
         let mut buffer = vec![];
         encode(data.clone().into_iter(), &mut buffer);
         let len = buffer.len();
-        let mut iter = Decoder::try_new(&buffer)?;
+        let (mut iter, _) = Decoder::try_new(&buffer)?;
 
         let result = iter.by_ref().collect::<Result<Vec<_>, _>>()?;
         assert_eq!(result, data);

--- a/crates/polars-parquet/src/parquet/encoding/delta_byte_array/decoder.rs
+++ b/crates/polars-parquet/src/parquet/encoding/delta_byte_array/decoder.rs
@@ -13,7 +13,7 @@ pub struct Decoder<'a> {
 
 impl<'a> Decoder<'a> {
     pub fn try_new(values: &'a [u8]) -> Result<Self, ParquetError> {
-        let prefix_lengths = delta_bitpacked::Decoder::try_new(values)?;
+        let (prefix_lengths, _) = delta_bitpacked::Decoder::try_new(values)?;
         Ok(Self {
             values,
             prefix_lengths,

--- a/crates/polars-parquet/src/parquet/encoding/delta_length_byte_array/decoder.rs
+++ b/crates/polars-parquet/src/parquet/encoding/delta_length_byte_array/decoder.rs
@@ -36,7 +36,7 @@ pub struct Decoder<'a> {
 
 impl<'a> Decoder<'a> {
     pub fn try_new(values: &'a [u8]) -> Result<Self, ParquetError> {
-        let lengths = delta_bitpacked::Decoder::try_new(values)?;
+        let (lengths, _) = delta_bitpacked::Decoder::try_new(values)?;
         Ok(Self {
             values,
             lengths,


### PR DESCRIPTION
Since Delta Lengths Byte Array will be the default decoding for strings, we want to speed this up and get it up to power with other encodings. This starts the work of implementing `collect`, `sum` and `skip` methods and removing the allocations that it currently does.