### PR TITLE
perf: Use `Arc<Vec<_>>` instead of `Arc<[_]>` for paths and hive partitions

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -88,7 +88,7 @@ pub fn expand_paths(
     paths: &[PathBuf],
     glob: bool,
     #[allow(unused_variables)] cloud_options: Option<&CloudOptions>,
-) -> PolarsResult<Arc<[PathBuf]>> {
+) -> PolarsResult<Arc<Vec<PathBuf>>> {
     expand_paths_hive(paths, glob, cloud_options, false).map(|x| x.0)
 }
 
@@ -129,7 +129,7 @@ pub fn expand_paths_hive(
     glob: bool,
     #[allow(unused_variables)] cloud_options: Option<&CloudOptions>,
     check_directory_level: bool,
-) -> PolarsResult<(Arc<[PathBuf]>, usize)> {
+) -> PolarsResult<(Arc<Vec<PathBuf>>, usize)> {
     let Some(first_path) = paths.first() else {
         return Ok((vec![].into(), 0));
     };
@@ -356,12 +356,12 @@ pub fn expand_paths_hive(
 
                 Ok(path)
             })
-            .collect::<PolarsResult<Arc<[_]>>>()?
+            .collect::<PolarsResult<Vec<_>>>()?
     } else {
-        Arc::<[_]>::from(out_paths)
+        out_paths
     };
 
-    Ok((out_paths, hive_idx_tracker.idx))
+    Ok((Arc::new(out_paths), hive_idx_tracker.idx))
 }
 
 /// Ignores errors from `std::fs::create_dir_all` if the directory exists.

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
 #[derive(Clone)]
 #[cfg(feature = "csv")]
 pub struct LazyCsvReader {
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
     glob: bool,
     cache: bool,
     read_options: CsvReadOptions,
@@ -30,13 +30,13 @@ impl LazyCsvReader {
         self
     }
 
-    pub fn new_paths(paths: Arc<[PathBuf]>) -> Self {
+    pub fn new_paths(paths: Arc<Vec<PathBuf>>) -> Self {
         Self::new("").with_paths(paths)
     }
 
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyCsvReader {
-            paths: Arc::new([path.as_ref().to_path_buf()]),
+            paths: Arc::new(vec![path.as_ref().to_path_buf()]),
             glob: true,
             cache: true,
             read_options: Default::default(),
@@ -298,7 +298,7 @@ impl LazyFileListReader for LazyCsvReader {
         &self.paths
     }
 
-    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
+    fn with_paths(mut self, paths: Arc<Vec<PathBuf>>) -> Self {
         self.paths = paths;
         self
     }

--- a/crates/polars-lazy/src/scan/file_list_reader.rs
+++ b/crates/polars-lazy/src/scan/file_list_reader.rs
@@ -27,7 +27,7 @@ pub trait LazyFileListReader: Clone {
                     .with_n_rows(None)
                     // Each individual reader should not apply a row index.
                     .with_row_index(None)
-                    .with_paths(Arc::new([path.clone()]))
+                    .with_paths(Arc::new(vec![path.clone()]))
                     .with_rechunk(false)
                     .finish_no_glob()
                     .map_err(|e| {
@@ -83,7 +83,7 @@ pub trait LazyFileListReader: Clone {
 
     /// Set paths of the scanned files.
     #[must_use]
-    fn with_paths(self, paths: Arc<[PathBuf]>) -> Self;
+    fn with_paths(self, paths: Arc<Vec<PathBuf>>) -> Self;
 
     /// Configure the row limit.
     fn with_n_rows(self, n_rows: impl Into<Option<usize>>) -> Self;

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -37,14 +37,14 @@ impl Default for ScanArgsIpc {
 #[derive(Clone)]
 struct LazyIpcReader {
     args: ScanArgsIpc,
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
 }
 
 impl LazyIpcReader {
     fn new(args: ScanArgsIpc) -> Self {
         Self {
             args,
-            paths: Arc::new([]),
+            paths: Arc::new(vec![]),
         }
     }
 }
@@ -84,7 +84,7 @@ impl LazyFileListReader for LazyIpcReader {
         &self.paths
     }
 
-    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
+    fn with_paths(mut self, paths: Arc<Vec<PathBuf>>) -> Self {
         self.paths = paths;
         self
     }
@@ -126,11 +126,11 @@ impl LazyFrame {
     /// Create a LazyFrame directly from a ipc scan.
     pub fn scan_ipc(path: impl AsRef<Path>, args: ScanArgsIpc) -> PolarsResult<Self> {
         LazyIpcReader::new(args)
-            .with_paths(Arc::new([path.as_ref().to_path_buf()]))
+            .with_paths(Arc::new(vec![path.as_ref().to_path_buf()]))
             .finish()
     }
 
-    pub fn scan_ipc_files(paths: Arc<[PathBuf]>, args: ScanArgsIpc) -> PolarsResult<Self> {
+    pub fn scan_ipc_files(paths: Arc<Vec<PathBuf>>, args: ScanArgsIpc) -> PolarsResult<Self> {
         LazyIpcReader::new(args).with_paths(paths).finish()
     }
 }

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -13,7 +13,7 @@ use crate::scan::file_list_reader::LazyFileListReader;
 
 #[derive(Clone)]
 pub struct LazyJsonLineReader {
-    pub(crate) paths: Arc<[PathBuf]>,
+    pub(crate) paths: Arc<Vec<PathBuf>>,
     pub(crate) batch_size: Option<NonZeroUsize>,
     pub(crate) low_memory: bool,
     pub(crate) rechunk: bool,
@@ -28,13 +28,13 @@ pub struct LazyJsonLineReader {
 }
 
 impl LazyJsonLineReader {
-    pub fn new_paths(paths: Arc<[PathBuf]>) -> Self {
+    pub fn new_paths(paths: Arc<Vec<PathBuf>>) -> Self {
         Self::new(PathBuf::new()).with_paths(paths)
     }
 
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyJsonLineReader {
-            paths: Arc::new([path.as_ref().to_path_buf()]),
+            paths: Arc::new(vec![path.as_ref().to_path_buf()]),
             batch_size: None,
             low_memory: false,
             rechunk: false,
@@ -164,7 +164,7 @@ impl LazyFileListReader for LazyJsonLineReader {
         &self.paths
     }
 
-    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
+    fn with_paths(mut self, paths: Arc<Vec<PathBuf>>) -> Self {
         self.paths = paths;
         self
     }

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -44,14 +44,14 @@ impl Default for ScanArgsParquet {
 #[derive(Clone)]
 struct LazyParquetReader {
     args: ScanArgsParquet,
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
 }
 
 impl LazyParquetReader {
     fn new(args: ScanArgsParquet) -> Self {
         Self {
             args,
-            paths: Arc::new([]),
+            paths: Arc::new(vec![]),
         }
     }
 }
@@ -99,7 +99,7 @@ impl LazyFileListReader for LazyParquetReader {
         &self.paths
     }
 
-    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
+    fn with_paths(mut self, paths: Arc<Vec<PathBuf>>) -> Self {
         self.paths = paths;
         self
     }
@@ -140,12 +140,15 @@ impl LazyFrame {
     /// Create a LazyFrame directly from a parquet scan.
     pub fn scan_parquet(path: impl AsRef<Path>, args: ScanArgsParquet) -> PolarsResult<Self> {
         LazyParquetReader::new(args)
-            .with_paths(Arc::new([path.as_ref().to_path_buf()]))
+            .with_paths(Arc::new(vec![path.as_ref().to_path_buf()]))
             .finish()
     }
 
     /// Create a LazyFrame directly from a parquet scan.
-    pub fn scan_parquet_files(paths: Arc<[PathBuf]>, args: ScanArgsParquet) -> PolarsResult<Self> {
+    pub fn scan_parquet_files(
+        paths: Arc<Vec<PathBuf>>,
+        args: ScanArgsParquet,
+    ) -> PolarsResult<Self> {
         LazyParquetReader::new(args).with_paths(paths).finish()
     }
 }

--- a/crates/polars-mem-engine/src/executors/scan/csv.rs
+++ b/crates/polars-mem-engine/src/executors/scan/csv.rs
@@ -9,7 +9,7 @@ use polars_core::utils::{
 use super::*;
 
 pub struct CsvExec {
-    pub paths: Arc<[PathBuf]>,
+    pub paths: Arc<Vec<PathBuf>>,
     pub file_info: FileInfo,
     pub options: CsvReadOptions,
     pub file_options: FileScanOptions,

--- a/crates/polars-mem-engine/src/executors/scan/ipc.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ipc.rs
@@ -11,12 +11,12 @@ use rayon::prelude::*;
 use super::*;
 
 pub struct IpcExec {
-    pub(crate) paths: Arc<[PathBuf]>,
+    pub(crate) paths: Arc<Vec<PathBuf>>,
     pub(crate) file_info: FileInfo,
     pub(crate) predicate: Option<Arc<dyn PhysicalExpr>>,
     pub(crate) options: IpcScanOptions,
     pub(crate) file_options: FileScanOptions,
-    pub(crate) hive_parts: Option<Arc<[HivePartitions]>>,
+    pub(crate) hive_parts: Option<Arc<Vec<HivePartitions>>>,
     pub(crate) cloud_options: Option<CloudOptions>,
 }
 

--- a/crates/polars-mem-engine/src/executors/scan/ndjson.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ndjson.rs
@@ -6,7 +6,7 @@ use polars_core::utils::accumulate_dataframes_vertical;
 use super::*;
 
 pub struct JsonExec {
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
     options: NDJsonReadOptions,
     file_scan_options: FileScanOptions,
     file_info: FileInfo,
@@ -15,7 +15,7 @@ pub struct JsonExec {
 
 impl JsonExec {
     pub fn new(
-        paths: Arc<[PathBuf]>,
+        paths: Arc<Vec<PathBuf>>,
         options: NDJsonReadOptions,
         file_scan_options: FileScanOptions,
         file_info: FileInfo,

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -14,9 +14,9 @@ use polars_io::RowIndex;
 use super::*;
 
 pub struct ParquetExec {
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
     file_info: FileInfo,
-    hive_parts: Option<Arc<[HivePartitions]>>,
+    hive_parts: Option<Arc<Vec<HivePartitions>>>,
     predicate: Option<Arc<dyn PhysicalExpr>>,
     options: ParquetOptions,
     #[allow(dead_code)]
@@ -29,9 +29,9 @@ pub struct ParquetExec {
 impl ParquetExec {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        paths: Arc<[PathBuf]>,
+        paths: Arc<Vec<PathBuf>>,
         file_info: FileInfo,
-        hive_parts: Option<Arc<[HivePartitions]>>,
+        hive_parts: Option<Arc<Vec<HivePartitions>>>,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         options: ParquetOptions,
         cloud_options: Option<CloudOptions>,

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -20,7 +20,7 @@ pub(crate) struct CsvSource {
     batched_reader: Option<BatchedCsvReader<'static>>,
     reader: Option<CsvReader<File>>,
     n_threads: usize,
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
     options: Option<CsvReadOptions>,
     file_options: FileScanOptions,
     verbose: bool,
@@ -139,7 +139,7 @@ impl CsvSource {
     }
 
     pub(crate) fn new(
-        paths: Arc<[PathBuf]>,
+        paths: Arc<Vec<PathBuf>>,
         schema: SchemaRef,
         options: CsvReadOptions,
         file_options: FileScanOptions,

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -34,14 +34,14 @@ pub struct ParquetSource {
     processed_paths: usize,
     processed_rows: usize,
     iter: Range<usize>,
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
     options: ParquetOptions,
     file_options: FileScanOptions,
     #[allow(dead_code)]
     cloud_options: Option<CloudOptions>,
     metadata: Option<FileMetaDataRef>,
     file_info: FileInfo,
-    hive_parts: Option<Arc<[HivePartitions]>>,
+    hive_parts: Option<Arc<Vec<HivePartitions>>>,
     verbose: bool,
     run_async: bool,
     prefetch_size: usize,
@@ -217,13 +217,13 @@ impl ParquetSource {
     #[allow(unused_variables)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        paths: Arc<[PathBuf]>,
+        paths: Arc<Vec<PathBuf>>,
         options: ParquetOptions,
         cloud_options: Option<CloudOptions>,
         metadata: Option<FileMetaDataRef>,
         file_options: FileScanOptions,
         file_info: FileInfo,
-        hive_parts: Option<Arc<[HivePartitions]>>,
+        hive_parts: Option<Arc<Vec<HivePartitions>>>,
         verbose: bool,
         predicate: Option<Arc<dyn PhysicalIoExpr>>,
     ) -> PolarsResult<Self> {

--- a/crates/polars-plan/src/plans/builder_dsl.rs
+++ b/crates/polars-plan/src/plans/builder_dsl.rs
@@ -60,7 +60,7 @@ impl DslBuilder {
         };
 
         Ok(DslPlan::Scan {
-            paths: Arc::new(Mutex::new((Arc::new([]), true))),
+            paths: Arc::new(Mutex::new((Arc::new(vec![]), true))),
             file_info: Arc::new(RwLock::new(Some(file_info))),
             hive_parts: None,
             predicate: None,
@@ -78,8 +78,8 @@ impl DslBuilder {
 
     #[cfg(feature = "parquet")]
     #[allow(clippy::too_many_arguments)]
-    pub fn scan_parquet<P: Into<Arc<[std::path::PathBuf]>>>(
-        paths: P,
+    pub fn scan_parquet(
+        paths: Arc<Vec<std::path::PathBuf>>,
         n_rows: Option<usize>,
         cache: bool,
         parallel: polars_io::parquet::read::ParallelStrategy,
@@ -126,8 +126,8 @@ impl DslBuilder {
 
     #[cfg(feature = "ipc")]
     #[allow(clippy::too_many_arguments)]
-    pub fn scan_ipc<P: Into<Arc<[std::path::PathBuf]>>>(
-        paths: P,
+    pub fn scan_ipc(
+        paths: Arc<Vec<std::path::PathBuf>>,
         options: IpcScanOptions,
         n_rows: Option<usize>,
         cache: bool,
@@ -166,8 +166,8 @@ impl DslBuilder {
 
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "csv")]
-    pub fn scan_csv<P: Into<Arc<[std::path::PathBuf]>>>(
-        paths: P,
+    pub fn scan_csv(
+        paths: Arc<Vec<std::path::PathBuf>>,
         read_options: CsvReadOptions,
         cache: bool,
         cloud_options: Option<CloudOptions>,
@@ -465,9 +465,6 @@ impl DslBuilder {
 
 /// Initialize paths as non-expanded.
 #[cfg(any(feature = "csv", feature = "ipc", feature = "parquet"))]
-fn init_paths<P>(paths: P) -> Arc<Mutex<(Arc<[PathBuf]>, bool)>>
-where
-    P: Into<Arc<[std::path::PathBuf]>>,
-{
-    Arc::new(Mutex::new((paths.into(), false)))
+fn init_paths(paths: Arc<Vec<std::path::PathBuf>>) -> Arc<Mutex<(Arc<Vec<PathBuf>>, bool)>> {
+    Arc::new(Mutex::new((paths, false)))
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -790,10 +790,10 @@ pub fn to_alp_impl(
 /// Expand scan paths if they were not already expanded.
 #[allow(unused_variables)]
 fn expand_scan_paths(
-    paths: Arc<Mutex<(Arc<[PathBuf]>, bool)>>,
+    paths: Arc<Mutex<(Arc<Vec<PathBuf>>, bool)>>,
     scan_type: &mut FileScan,
     file_options: &mut FileScanOptions,
-) -> PolarsResult<Arc<[PathBuf]>> {
+) -> PolarsResult<Arc<Vec<PathBuf>>> {
     #[allow(unused_mut)]
     let mut lock = paths.lock().unwrap();
 
@@ -838,7 +838,7 @@ fn expand_scan_paths_with_hive_update(
     paths: &[PathBuf],
     file_options: &mut FileScanOptions,
     cloud_options: &Option<CloudOptions>,
-) -> PolarsResult<Arc<[PathBuf]>> {
+) -> PolarsResult<Arc<Vec<PathBuf>>> {
     let hive_enabled = file_options.hive_options.enabled;
     let (expanded_paths, hive_start_idx) = expand_paths_hive(
         paths,

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -16,7 +16,7 @@ use polars_io::{path_utils::is_cloud_url, SerReader};
 use super::*;
 
 #[allow(unused_variables)]
-pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<DataFrame> {
+pub fn count_rows(paths: &Arc<Vec<PathBuf>>, scan_type: &FileScan) -> PolarsResult<DataFrame> {
     #[cfg(not(any(
         feature = "parquet",
         feature = "ipc",
@@ -89,7 +89,7 @@ pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<
 }
 #[cfg(feature = "parquet")]
 pub(super) fn count_rows_parquet(
-    paths: &Arc<[PathBuf]>,
+    paths: &Arc<Vec<PathBuf>>,
     cloud_options: Option<&CloudOptions>,
 ) -> PolarsResult<usize> {
     if paths.is_empty() {
@@ -119,7 +119,7 @@ pub(super) fn count_rows_parquet(
 
 #[cfg(all(feature = "parquet", feature = "async"))]
 async fn count_rows_cloud_parquet(
-    paths: &Arc<[PathBuf]>,
+    paths: &Arc<Vec<PathBuf>>,
     cloud_options: Option<&CloudOptions>,
 ) -> PolarsResult<usize> {
     let collection = paths.iter().map(|path| {
@@ -136,7 +136,7 @@ async fn count_rows_cloud_parquet(
 
 #[cfg(feature = "ipc")]
 pub(super) fn count_rows_ipc(
-    paths: &Arc<[PathBuf]>,
+    paths: &Arc<Vec<PathBuf>>,
     #[cfg(feature = "cloud")] cloud_options: Option<&CloudOptions>,
     metadata: Option<&arrow::io::ipc::read::FileMetadata>,
 ) -> PolarsResult<usize> {
@@ -166,7 +166,7 @@ pub(super) fn count_rows_ipc(
 
 #[cfg(all(feature = "ipc", feature = "async"))]
 async fn count_rows_cloud_ipc(
-    paths: &Arc<[PathBuf]>,
+    paths: &Arc<Vec<PathBuf>>,
     cloud_options: Option<&CloudOptions>,
     metadata: Option<&arrow::io::ipc::read::FileMetadata>,
 ) -> PolarsResult<usize> {
@@ -185,7 +185,7 @@ async fn count_rows_cloud_ipc(
 
 #[cfg(feature = "json")]
 pub(super) fn count_rows_ndjson(
-    paths: &Arc<[PathBuf]>,
+    paths: &Arc<Vec<PathBuf>>,
     cloud_options: Option<&CloudOptions>,
 ) -> PolarsResult<usize> {
     use polars_core::config;

--- a/crates/polars-plan/src/plans/functions/mod.rs
+++ b/crates/polars-plan/src/plans/functions/mod.rs
@@ -53,7 +53,7 @@ pub enum FunctionNode {
         fmt_str: &'static str,
     },
     Count {
-        paths: Arc<[PathBuf]>,
+        paths: Arc<Vec<PathBuf>>,
         scan_type: FileScan,
         alias: Option<Arc<str>>,
     },

--- a/crates/polars-plan/src/plans/hive.rs
+++ b/crates/polars-plan/src/plans/hive.rs
@@ -65,7 +65,7 @@ pub fn hive_partitions_from_paths(
     schema: Option<SchemaRef>,
     reader_schema: &Schema,
     try_parse_dates: bool,
-) -> PolarsResult<Option<Arc<[HivePartitions]>>> {
+) -> PolarsResult<Option<Arc<Vec<HivePartitions>>>> {
     let Some(path) = paths.first() else {
         return Ok(None);
     };

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -48,9 +48,9 @@ pub enum IR {
         predicate: ExprIR,
     },
     Scan {
-        paths: Arc<[PathBuf]>,
+        paths: Arc<Vec<PathBuf>>,
         file_info: FileInfo,
-        hive_parts: Option<Arc<[HivePartitions]>>,
+        hive_parts: Option<Arc<Vec<HivePartitions>>>,
         predicate: Option<ExprIR>,
         /// schema of the projected file
         output_schema: Option<SchemaRef>,

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -78,14 +78,14 @@ pub enum DslPlan {
         cache_hits: u32,
     },
     Scan {
-        paths: Arc<Mutex<(Arc<[PathBuf]>, bool)>>,
+        paths: Arc<Mutex<(Arc<Vec<PathBuf>>, bool)>>,
         // Option as this is mostly materialized on the IR phase.
         // During conversion we update the value in the DSL as well
         // This is to cater to use cases where parts of a `LazyFrame`
         // are used as base of different queries in a loop. That way
         // the expensive schema resolving is cached.
         file_info: Arc<RwLock<Option<FileInfo>>>,
-        hive_parts: Option<Arc<[HivePartitions]>>,
+        hive_parts: Option<Arc<Vec<HivePartitions>>>,
         predicate: Option<Expr>,
         file_options: FileScanOptions,
         scan_type: FileScan,

--- a/crates/polars-plan/src/plans/optimizer/count_star.rs
+++ b/crates/polars-plan/src/plans/optimizer/count_star.rs
@@ -49,7 +49,7 @@ struct CountStarExpr {
     // Top node of the projection to replace
     node: Node,
     // Paths to the input files
-    paths: Arc<[PathBuf]>,
+    paths: Arc<Vec<PathBuf>>,
     // File Type
     scan_type: FileScan,
     // Column Alias

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -440,7 +440,7 @@ impl ProjectionPushDown {
                                     &with_columns.iter().cloned().collect::<PlHashSet<_>>(),
                                 );
 
-                            Some(
+                            Some(Arc::new(
                                 hive_parts
                                     .iter()
                                     .cloned()
@@ -451,8 +451,8 @@ impl ProjectionPushDown {
                                         );
                                         hp
                                     })
-                                    .collect::<Arc<[_]>>(),
-                            )
+                                    .collect::<Vec<_>>(),
+                            ))
                         } else {
                             None
                         };

--- a/crates/polars-stream/src/utils/late_materialized_df.rs
+++ b/crates/polars-stream/src/utils/late_materialized_df.rs
@@ -25,7 +25,7 @@ impl LateMaterializedDataFrame {
             fmt_str: "LateMaterializedDataFrame",
         });
         IR::Scan {
-            paths: Arc::new([]),
+            paths: Arc::new(vec![]),
             file_info: FileInfo::new(schema, None, (None, usize::MAX)),
             hive_parts: None,
             predicate: None,


### PR DESCRIPTION
This saves some copying as constructing an `Arc<Vec<_>>` re-uses the buffer. For paths and hive partitions in particular, they are potentially re-constructed during predicate pushdown.
