### PR TITLE
fix: Properly write Parquet for sliced lists

### DIFF
--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -563,6 +563,13 @@ impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
     }
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        debug_assert!(
+            validity.as_ref().map_or(true, |v| v.len() == self.len()),
+            "{} != {}",
+            validity.as_ref().unwrap().len(),
+            self.len()
+        );
+
         let mut new = self.clone();
         new.validity = validity;
         Box::new(new)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1387,3 +1387,16 @@ def test_struct_plain_encoded_statistics(tmp_path: Path) -> None:
 )
 def test_scan_round_trip_parametric(tmp_path: Path, df: pl.DataFrame) -> None:
     test_scan_round_trip(tmp_path, df)
+
+
+def test_write_sliced_lists_18069() -> None:
+    f = io.BytesIO()
+    a = pl.Series(3 * [None, ["$"] * 3], dtype=pl.List(pl.String))
+
+    before = pl.DataFrame({"a": a}).slice(4, 2)
+    before.write_parquet(f)
+
+    f.seek(0)
+    after = pl.read_parquet(f)
+
+    assert_frame_equal(before, after)


### PR DESCRIPTION
This is a relatively small fix for what was a quite nasty bug.

Fixes #18069.