### PR TITLE
chore: Upgrade ndarray to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,6 +2438,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "087ee1ca8a7c22830c2bba4a96ed8e72ce0968ae944349324d52522f66aa3944"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "now"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,7 +2556,7 @@ version = "0.21.0"
 source = "git+https://github.com/stinodego/rust-numpy.git?rev=9ba9962ae57ba26e35babdce6f179edf5fe5b9c8#9ba9962ae57ba26e35babdce6f179edf5fe5b9c8"
 dependencies = [
  "libc",
- "ndarray",
+ "ndarray 0.15.6",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -3022,7 +3037,7 @@ dependencies = [
  "either",
  "hashbrown",
  "indexmap",
- "ndarray",
+ "ndarray 0.16.0",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -3442,6 +3457,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdd8420072e66d54a407b3316991fe946ce3ab1083a7f575b2463866624704d"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3524,7 +3548,7 @@ dependencies = [
  "jemallocator",
  "libc",
  "mimalloc",
- "ndarray",
+ "ndarray 0.16.0",
  "num-traits",
  "numpy",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itoap = { version = "1", features = ["simd"] }
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.7" }
 multiversion = "0.7"
-ndarray = { version = "0.15", default-features = false }
+ndarray = { version = "0.16", default-features = false }
 num-traits = "0.2"
 object_store = { version = "0.10", default-features = false }
 once_cell = "1"


### PR DESCRIPTION
The PR upgrades the `ndarray` dependency to let to use methods like [`log2()`](https://docs.rs/ndarray/0.16.0/ndarray/struct.ArrayBase.html#method.log2).