### PR TITLE
fix: Fix `sink_ipc_cloud` panicking with runtime error

### DIFF
--- a/examples/write_ipc_cloud/Cargo.toml
+++ b/examples/write_ipc_cloud/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "write_ipc_cloud"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-creds = "0.36.0"
+polars = { path = "../../crates/polars", features = ["lazy", "aws", "ipc", "cloud_write", "streaming"] }
+
+[workspace]

--- a/examples/write_ipc_cloud/src/main.rs
+++ b/examples/write_ipc_cloud/src/main.rs
@@ -1,0 +1,30 @@
+use cloud::AmazonS3ConfigKey as Key;
+use polars::prelude::*;
+
+const TEST_S3_LOCATION: &str = "s3://test-bucket/test-writes/polars_write_example_cloud.ipc";
+
+fn main() -> PolarsResult<()> {
+    let cloud_options = cloud::CloudOptions::default().with_aws([
+        (Key::AccessKeyId, "test".to_string()),
+        (Key::SecretAccessKey, "test".to_string()),
+        (Key::Endpoint, "http://localhost:4566".to_string()),
+        (Key::Region, "us-east-1".to_string()),
+    ]);
+    let cloud_options = Some(cloud_options);
+
+    let df = df!(
+        "foo" => &[1, 2, 3],
+        "bar" => &[None, Some("bak"), Some("baz")],
+    )
+    .unwrap();
+
+    df.lazy()
+        .sink_ipc_cloud(
+            TEST_S3_LOCATION.to_string(),
+            cloud_options,
+            Default::default(),
+        )
+        .unwrap();
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #13614

When writing to ObjectStore-compatible storage using the IPC format, it seems like the `block_on` calls inside the constructed `CloudWriter` might sometimes get called inside another `block_on` call. Tokio does not like this, resulting in a panic.

This PR resolves this issue by using `block_on_potential_spawn` in the necessary places instead.

This is a fix that was originally written by @Qqwy in another PR: https://github.com/pola-rs/polars/pull/14262