### PR TITLE
feat: do not check repeated join keys

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -556,16 +556,6 @@ pub fn to_alp_impl(
 
             let left_on = to_expr_irs_ignore_alias(left_on, expr_arena);
             let right_on = to_expr_irs_ignore_alias(right_on, expr_arena);
-            let mut joined_on = PlHashSet::new();
-            for (l, r) in left_on.iter().zip(right_on.iter()) {
-                polars_ensure!(
-                    joined_on.insert((l.output_name(), r.output_name())),
-                    InvalidOperation: "joining with repeated key names; already joined on {} and {}",
-                    l.output_name(),
-                    r.output_name()
-                )
-            }
-            drop(joined_on);
 
             convert.fill_scratch(&left_on, expr_arena);
             convert.fill_scratch(&right_on, expr_arena);


### PR DESCRIPTION
fix #18007

This PR attempts to fix #18007 by removing the check. It will make three of the existing tests fail (need to remove them in order to pass all tests):
```
FAILED tests/unit/operations/test_join.py::test_join_raise_on_repeated_expression_key_names[False] - Failed: DID NOT RAISE <class 'polars.exceptions.InvalidOperationError'>
FAILED tests/unit/operations/test_join.py::test_join_raise_on_redundant_keys - Failed: DID NOT RAISE <class 'polars.exceptions.InvalidOperationError'>
FAILED tests/unit/operations/test_join.py::test_join_raise_on_repeated_expression_key_names[True] - Failed: DID NOT RAISE <class 'polars.exceptions.InvalidOperationError'>
```

Can anyone check whether these checking on repeated key names are necessary (since it prevents from supporting valid SQL queries)?