### PR TITLE
fix(python): Fix cast Float to String where Float is not turn to Integer before turning to String

### DIFF
--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -536,17 +536,41 @@ impl<'a> AnyValue<'a> {
             (AnyValue::Float64(v), DataType::Boolean) => AnyValue::Boolean(*v != f64::default()),
 
             // to string
-            (AnyValue::UInt8(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u8>()?)),
-            (AnyValue::UInt16(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u16>()?)),
-            (AnyValue::UInt32(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u32>()?)),
-            (AnyValue::UInt64(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}",  self.extract::<u64>()?)),
-            (AnyValue::Int8(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i8>()?)),
-            (AnyValue::Int16(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i16>()?)),
-            (AnyValue::Int32(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i32>()?)),
-            (AnyValue::Int64(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i64>()?)),
-            (AnyValue::Float32(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f32>()?)),
-            (AnyValue::Float64(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f64>()?)),
-            (av, DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", av)),
+            (AnyValue::UInt8(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u8>()?))
+            },
+            (AnyValue::UInt16(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u16>()?))
+            },
+            (AnyValue::UInt32(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u32>()?))
+            },
+            (AnyValue::UInt64(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u64>()?))
+            },
+            (AnyValue::Int8(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i8>()?))
+            },
+            (AnyValue::Int16(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i16>()?))
+            },
+            (AnyValue::Int32(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i32>()?))
+            },
+            (AnyValue::Int64(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i64>()?))
+            },
+            (AnyValue::Float32(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f32>()?))
+            },
+            (AnyValue::Float64(_v), DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f64>()?))
+            },
+            // this is needed other types
+            // if this isn't present then tests: agg, max, min break for other types
+            (_, DataType::String) => {
+                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i64>()?))
+            },
 
             // to binary
             (AnyValue::String(v), DataType::Binary) => AnyValue::Binary(v.as_bytes()),

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -536,15 +536,17 @@ impl<'a> AnyValue<'a> {
             (AnyValue::Float64(v), DataType::Boolean) => AnyValue::Boolean(*v != f64::default()),
 
             // to string
-            (av, DataType::String) => {
-                if av.is_integer() {
-                    AnyValue::StringOwned(format_smartstring!("{}", av.extract::<i64>()?))
-                } else if av.is_float() {
-                    AnyValue::StringOwned(format_smartstring!("{}", av.extract::<f64>()?))
-                } else {
-                    AnyValue::StringOwned(format_smartstring!("{}", av))
-                }
-            },
+            (AnyValue::UInt8(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u8>()?)),
+            (AnyValue::UInt16(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u16>()?)),
+            (AnyValue::UInt32(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u32>()?)),
+            (AnyValue::UInt64(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}",  self.extract::<u64>()?)),
+            (AnyValue::Int8(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i8>()?)),
+            (AnyValue::Int16(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i16>()?)),
+            (AnyValue::Int32(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i32>()?)),
+            (AnyValue::Int64(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i64>()?)),
+            (AnyValue::Float32(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f32>()?)),
+            (AnyValue::Float64(_v), DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f64>()?)),
+            (av, DataType::String) => AnyValue::StringOwned(format_smartstring!("{}", av)),
 
             // to binary
             (AnyValue::String(v), DataType::Binary) => AnyValue::Binary(v.as_bytes()),

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -536,40 +536,14 @@ impl<'a> AnyValue<'a> {
             (AnyValue::Float64(v), DataType::Boolean) => AnyValue::Boolean(*v != f64::default()),
 
             // to string
-            (AnyValue::UInt8(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u8>()?))
-            },
-            (AnyValue::UInt16(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u16>()?))
-            },
-            (AnyValue::UInt32(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u32>()?))
-            },
-            (AnyValue::UInt64(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<u64>()?))
-            },
-            (AnyValue::Int8(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i8>()?))
-            },
-            (AnyValue::Int16(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i16>()?))
-            },
-            (AnyValue::Int32(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i32>()?))
-            },
-            (AnyValue::Int64(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i64>()?))
-            },
-            (AnyValue::Float32(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f32>()?))
-            },
-            (AnyValue::Float64(_v), DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<f64>()?))
-            },
-            // this is needed other types
-            // if this isn't present then tests: agg, max, min break for other types
-            (_, DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i64>()?))
+            (av, DataType::String) => {
+                if av.is_unsigned_integer() {
+                    AnyValue::StringOwned(format_smartstring!("{}", av.extract::<u64>()?))
+                } else if av.is_float() {
+                    AnyValue::StringOwned(format_smartstring!("{}", av.extract::<f64>()?))
+                } else {
+                    AnyValue::StringOwned(format_smartstring!("{}", av.extract::<i64>()?))
+                }
             },
 
             // to binary

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -537,7 +537,13 @@ impl<'a> AnyValue<'a> {
 
             // to string
             (av, DataType::String) => {
-                AnyValue::StringOwned(format_smartstring!("{}", av.extract::<i64>()?))
+                if av.is_integer() {
+                    AnyValue::StringOwned(format_smartstring!("{}", av.extract::<i64>()?))
+                } else if av.is_float() {
+                    AnyValue::StringOwned(format_smartstring!("{}", av.extract::<f64>()?))
+                } else {
+                    AnyValue::StringOwned(format_smartstring!("{}", av))
+                }
             },
 
             // to binary

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -173,6 +173,17 @@ def test_lit_decimal() -> None:
     assert result == value
 
 
+def test_lit_string_float() -> None:
+    value = 3.2
+
+    expr = pl.lit(value, dtype=pl.Utf8)
+    df = pl.select(expr)
+    result = df.item()
+
+    assert df.dtypes[0] == pl.String
+    assert result == str(value)
+
+
 @given(s=series(min_size=1, max_size=1, allow_null=False, allowed_dtypes=pl.Decimal))
 def test_lit_decimal_parametric(s: pl.Series) -> None:
     scale = s.dtype.scale  # type: ignore[attr-defined]


### PR DESCRIPTION
closes #17773 

Fixed:
```
>>> pl.select(pl.lit(3.2, dtype=pl.Utf8))
shape: (1, 1)
┌─────────┐
│ literal │
│ ---     │
│ str     │
╞═════════╡
│ 3.2     │
└─────────┘
```

This is my first time doing a PR for this project so set it to draft to hear feedback. If I keep the below line in test where we use agg, max, min break for Categorical data.
` (_, DataType::String) => {
  AnyValue::StringOwned(format_smartstring!("{}", self.extract::<i64>()?))
},`

I can add more cases for string casting if that is wanted so we define all types.