### PR TITLE
feat(python): Make expressions containing Python UDFs serializable

### DIFF
--- a/crates/polars-plan/src/client/check.rs
+++ b/crates/polars-plan/src/client/check.rs
@@ -3,28 +3,15 @@ use polars_io::path_utils::is_cloud_url;
 
 use crate::dsl::Expr;
 use crate::plans::options::SinkType;
-use crate::plans::{DslFunction, DslPlan, FileScan, FunctionIR};
+use crate::plans::{DslPlan, FileScan};
 
 /// Assert that the given [`DslPlan`] is eligible to be executed on Polars Cloud.
 pub(super) fn assert_cloud_eligible(dsl: &DslPlan) -> PolarsResult<()> {
     let mut expr_stack = vec![];
     for plan_node in dsl.into_iter() {
         match plan_node {
-            DslPlan::MapFunction { function, .. } => match function {
-                DslFunction::FunctionIR(FunctionIR::Opaque { .. }) => {
-                    return ineligible_error("contains opaque function")
-                },
-                #[cfg(feature = "python")]
-                DslFunction::OpaquePython { .. } => {
-                    return ineligible_error("contains Python function")
-                },
-                _ => (),
-            },
             #[cfg(feature = "python")]
             DslPlan::PythonScan { .. } => return ineligible_error("contains Python scan"),
-            DslPlan::GroupBy { apply: Some(_), .. } => {
-                return ineligible_error("contains Python function in group by operation")
-            },
             DslPlan::Scan { paths, .. }
                 if paths.lock().unwrap().0.iter().any(|p| !is_cloud_url(p)) =>
             {

--- a/crates/polars-plan/src/client/check.rs
+++ b/crates/polars-plan/src/client/check.rs
@@ -1,13 +1,11 @@
 use polars_core::error::{polars_err, PolarsResult};
 use polars_io::path_utils::is_cloud_url;
 
-use crate::dsl::Expr;
 use crate::plans::options::SinkType;
 use crate::plans::{DslPlan, FileScan};
 
 /// Assert that the given [`DslPlan`] is eligible to be executed on Polars Cloud.
 pub(super) fn assert_cloud_eligible(dsl: &DslPlan) -> PolarsResult<()> {
-    let mut expr_stack = vec![];
     for plan_node in dsl.into_iter() {
         match plan_node {
             #[cfg(feature = "python")]
@@ -26,23 +24,7 @@ pub(super) fn assert_cloud_eligible(dsl: &DslPlan) -> PolarsResult<()> {
                     return ineligible_error("contains sink to non-cloud location");
                 }
             },
-            plan => {
-                plan.get_expr(&mut expr_stack);
-
-                for expr in expr_stack.drain(..) {
-                    for expr_node in expr.into_iter() {
-                        match expr_node {
-                            Expr::AnonymousFunction { .. } => {
-                                return ineligible_error("contains anonymous function")
-                            },
-                            Expr::RenameAlias { .. } => {
-                                return ineligible_error("contains custom name remapping")
-                            },
-                            _ => (),
-                        }
-                    }
-                }
-            },
+            _ => (),
         }
     }
     Ok(())
@@ -84,47 +66,6 @@ impl DslPlan {
             },
             IR { dsl, .. } => scratch.push(dsl),
             Scan { .. } | DataFrameScan { .. } => (),
-            #[cfg(feature = "python")]
-            PythonScan { .. } => (),
-        }
-    }
-
-    fn get_expr<'a>(&'a self, scratch: &mut Vec<&'a Expr>) {
-        use DslPlan::*;
-        match self {
-            Filter { predicate, .. } => scratch.push(predicate),
-            Scan { predicate, .. } => {
-                if let Some(expr) = predicate {
-                    scratch.push(expr)
-                }
-            },
-            DataFrameScan { filter, .. } => {
-                if let Some(expr) = filter {
-                    scratch.push(expr)
-                }
-            },
-            Select { expr, .. } => scratch.extend(expr),
-            HStack { exprs, .. } => scratch.extend(exprs),
-            Sort { by_column, .. } => scratch.extend(by_column),
-            GroupBy { keys, aggs, .. } => {
-                scratch.extend(keys);
-                scratch.extend(aggs);
-            },
-            Join {
-                left_on, right_on, ..
-            } => {
-                scratch.extend(left_on);
-                scratch.extend(right_on);
-            },
-            Cache { .. }
-            | Distinct { .. }
-            | Slice { .. }
-            | MapFunction { .. }
-            | Union { .. }
-            | HConcat { .. }
-            | ExtContext { .. }
-            | Sink { .. }
-            | IR { .. } => (),
             #[cfg(feature = "python")]
             PythonScan { .. } => (),
         }

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -143,8 +143,6 @@ pub enum Expr {
     Len,
     /// Take the nth column in the `DataFrame`
     Nth(i64),
-    // skipped fields must be last otherwise serde fails in pickle
-    #[cfg_attr(feature = "serde", serde(skip))]
     RenameAlias {
         function: SpecialEq<Arc<dyn RenameAliasFn>>,
         expr: Arc<Expr>,
@@ -157,7 +155,6 @@ pub enum Expr {
         /// function to apply
         function: SpecialEq<Arc<dyn SeriesUdf>>,
         /// output dtype of the function
-        #[cfg_attr(feature = "serde", serde(skip))]
         output_type: GetOutput,
         options: FunctionOptions,
     },

--- a/crates/polars-plan/src/dsl/expr_dyn_fn.rs
+++ b/crates/polars-plan/src/dsl/expr_dyn_fn.rs
@@ -56,7 +56,7 @@ impl<'a> Deserialize<'a> for SpecialEq<Arc<dyn SeriesUdf>> {
         {
             let buf = Vec::<u8>::deserialize(deserializer)?;
 
-            if buf.starts_with(python_udf::MAGIC_BYTE_MARK_UDF) {
+            if buf.starts_with(python_udf::MAGIC_BYTE_MARK) {
                 let udf = python_udf::PythonUdfExpression::try_deserialize(&buf)
                     .map_err(|e| D::Error::custom(format!("{e}")))?;
                 Ok(SpecialEq::new(udf))
@@ -382,7 +382,7 @@ impl<'a> Deserialize<'a> for GetOutput {
         {
             let buf = Vec::<u8>::deserialize(deserializer)?;
 
-            if buf.starts_with(python_udf::MAGIC_BYTE_MARK_GET_OUTPUT) {
+            if buf.starts_with(python_udf::MAGIC_BYTE_MARK) {
                 let get_output = python_udf::PythonGetOutput::try_deserialize(&buf)
                     .map_err(|e| D::Error::custom(format!("{e}")))?;
                 Ok(SpecialEq::new(get_output))

--- a/crates/polars-plan/src/dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_udf.rs
@@ -5,6 +5,7 @@ use polars_core::datatypes::{DataType, Field};
 use polars_core::error::*;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::Series;
+use polars_core::schema::Schema;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
@@ -17,14 +18,15 @@ use super::expr_dyn_fn::*;
 use crate::constants::MAP_LIST_NAME;
 use crate::prelude::*;
 
-// Will be overwritten on python polar start up.
+// Will be overwritten on Python Polars start up.
 pub static mut CALL_SERIES_UDF_PYTHON: Option<
     fn(s: Series, lambda: &PyObject) -> PolarsResult<Series>,
 > = None;
 pub static mut CALL_DF_UDF_PYTHON: Option<
     fn(s: DataFrame, lambda: &PyObject) -> PolarsResult<DataFrame>,
 > = None;
-pub(super) const MAGIC_BYTE_MARK: &[u8] = "POLARS_PYTHON_UDF".as_bytes();
+pub(super) const MAGIC_BYTE_MARK_UDF: &[u8] = "POLARS_PYTHON_UDF".as_bytes();
+pub(super) const MAGIC_BYTE_MARK_GET_OUTPUT: &[u8] = "POLARS_PYTHON_GET_OUTPUT".as_bytes();
 
 #[derive(Clone, Debug)]
 pub struct PythonFunction(pub PyObject);
@@ -124,9 +126,9 @@ impl PythonUdfExpression {
 
     #[cfg(feature = "serde")]
     pub(crate) fn try_deserialize(buf: &[u8]) -> PolarsResult<Arc<dyn SeriesUdf>> {
-        debug_assert!(buf.starts_with(MAGIC_BYTE_MARK));
+        debug_assert!(buf.starts_with(MAGIC_BYTE_MARK_UDF));
         // skip header
-        let buf = &buf[MAGIC_BYTE_MARK.len()..];
+        let buf = &buf[MAGIC_BYTE_MARK_UDF.len()..];
         let mut reader = Cursor::new(buf);
         let (output_type, is_elementwise, returns_scalar): (Option<DataType>, bool, bool) =
             ciborium::de::from_reader(&mut reader).map_err(map_err)?;
@@ -141,7 +143,7 @@ impl PythonUdfExpression {
                 .unwrap();
             let arg = (PyBytes::new_bound(py, remainder),);
             let python_function = pickle.call1(arg).map_err(from_pyerr)?;
-            Ok(Arc::new(PythonUdfExpression::new(
+            Ok(Arc::new(Self::new(
                 python_function.into(),
                 output_type,
                 is_elementwise,
@@ -188,7 +190,7 @@ impl SeriesUdf for PythonUdfExpression {
 
     #[cfg(feature = "serde")]
     fn try_serialize(&self, buf: &mut Vec<u8>) -> PolarsResult<()> {
-        buf.extend_from_slice(MAGIC_BYTE_MARK);
+        buf.extend_from_slice(MAGIC_BYTE_MARK_UDF);
         ciborium::ser::into_writer(
             &(
                 self.output_type.clone(),
@@ -229,6 +231,54 @@ impl SeriesUdf for PythonUdfExpression {
     }
 }
 
+/// Serializable version of [`GetOutput`] for Python UDFs.
+pub struct PythonGetOutput {
+    return_dtype: Option<DataType>,
+}
+
+impl PythonGetOutput {
+    pub fn new(return_dtype: Option<DataType>) -> Self {
+        Self { return_dtype }
+    }
+
+    #[cfg(feature = "serde")]
+    pub(crate) fn try_deserialize(buf: &[u8]) -> PolarsResult<Arc<dyn FunctionOutputField>> {
+        // Skip header.
+        debug_assert!(buf.starts_with(MAGIC_BYTE_MARK_GET_OUTPUT));
+        let buf = &buf[MAGIC_BYTE_MARK_GET_OUTPUT.len()..];
+
+        let mut reader = Cursor::new(buf);
+        let return_dtype: Option<DataType> =
+            ciborium::de::from_reader(&mut reader).map_err(map_err)?;
+
+        Ok(Arc::new(Self::new(return_dtype)) as Arc<dyn FunctionOutputField>)
+    }
+}
+
+impl FunctionOutputField for PythonGetOutput {
+    fn get_field(
+        &self,
+        _input_schema: &Schema,
+        _cntxt: Context,
+        fields: &[Field],
+    ) -> PolarsResult<Field> {
+        // Take the name of first field, just like [`GetOutput::map_field`].
+        let name = fields[0].name();
+        let return_dtype = match self.return_dtype {
+            Some(ref dtype) => dtype.clone(),
+            None => DataType::Unknown(Default::default()),
+        };
+        Ok(Field::new(name.clone(), return_dtype))
+    }
+
+    #[cfg(feature = "serde")]
+    fn try_serialize(&self, buf: &mut Vec<u8>) -> PolarsResult<()> {
+        buf.extend_from_slice(MAGIC_BYTE_MARK_GET_OUTPUT);
+        ciborium::ser::into_writer(&self.return_dtype, &mut *buf).unwrap();
+        Ok(())
+    }
+}
+
 impl Expr {
     pub fn map_python(self, func: PythonUdfExpression, agg_list: bool) -> Expr {
         let (collect_groups, name) = if agg_list {
@@ -241,16 +291,10 @@ impl Expr {
 
         let returns_scalar = func.returns_scalar;
         let return_dtype = func.output_type.clone();
-        let output_type = GetOutput::map_field(move |fld| {
-            Ok(match return_dtype {
-                Some(ref dt) => Field::new(fld.name().clone(), dt.clone()),
-                None => {
-                    let mut fld = fld.clone();
-                    fld.coerce(DataType::Unknown(Default::default()));
-                    fld
-                },
-            })
-        });
+
+        let output_field = PythonGetOutput::new(return_dtype);
+        let output_type = SpecialEq::new(Arc::new(output_field) as Arc<dyn FunctionOutputField>);
+
         let mut flags = FunctionFlags::default() | FunctionFlags::OPTIONAL_RE_ENTRANT;
         if returns_scalar {
             flags |= FunctionFlags::RETURNS_SCALAR;

--- a/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
+++ b/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
@@ -47,6 +47,9 @@ def test_prepare_cloud_plan(lf: pl.LazyFrame) -> None:
         pl.scan_parquet(CLOUD_SOURCE).filter(
             pl.col("a") < pl.lit(1).map_elements(lambda x: x + 1)
         ),
+        pl.LazyFrame({"a": [1, 2], "b": [3, 4]}).select(
+            pl.col("a").map_elements(lambda x: sum(x), return_dtype=pl.Int64)
+        ),
     ],
 )
 def test_prepare_cloud_plan_udf(lf: pl.LazyFrame) -> None:
@@ -112,11 +115,8 @@ def test_prepare_cloud_plan_fail_on_python_scan(tmp_path: Path) -> None:
         pl.LazyFrame({"a": [{"x": 1, "y": 2}]}).select(
             pl.col("a").name.map_fields(lambda x: x.upper())
         ),
-        pl.LazyFrame({"a": [1, 2], "b": [3, 4]}).select(
-            pl.col("a").map_elements(lambda x: sum(x), return_dtype=pl.Int64)
-        ),
     ],
 )
 def test_prepare_cloud_plan_fail_on_serialization(lf: pl.LazyFrame) -> None:
-    with pytest.raises(ComputeError, match="serialize"):
+    with pytest.raises(ComputeError, match="serialization not supported"):
         prepare_cloud_plan(lf)

--- a/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
+++ b/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
@@ -28,20 +28,6 @@ def test_prepare_cloud_plan(lf: pl.LazyFrame) -> None:
     assert isinstance(deserialized, pl.LazyFrame)
 
 
-def test_prepare_cloud_plan_optimization_toggle() -> None:
-    lf = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
-
-    with pytest.raises(TypeError, match="unexpected keyword argument"):
-        prepare_cloud_plan(lf, nonexistent_optimization=False)
-
-    result = prepare_cloud_plan(lf, projection_pushdown=False)
-    assert isinstance(result, bytes)
-
-    # TODO: How to check that this optimization was toggled correctly?
-    deserialized = pl.LazyFrame.deserialize(BytesIO(result))
-    assert isinstance(deserialized, pl.LazyFrame)
-
-
 @pytest.mark.parametrize(
     "lf",
     [
@@ -69,12 +55,26 @@ def test_prepare_cloud_plan_optimization_toggle() -> None:
         ),
     ],
 )
-def test_prepare_cloud_plan_fail_on_udf(lf: pl.LazyFrame) -> None:
-    with pytest.raises(
-        InvalidOperationError,
-        match="logical plan ineligible for execution on Polars Cloud",
-    ):
-        prepare_cloud_plan(lf)
+def test_prepare_cloud_plan_udf(lf: pl.LazyFrame) -> None:
+    result = prepare_cloud_plan(lf)
+    assert isinstance(result, bytes)
+
+    deserialized = pl.LazyFrame.deserialize(BytesIO(result))
+    assert isinstance(deserialized, pl.LazyFrame)
+
+
+def test_prepare_cloud_plan_optimization_toggle() -> None:
+    lf = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
+
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        prepare_cloud_plan(lf, nonexistent_optimization=False)
+
+    result = prepare_cloud_plan(lf, projection_pushdown=False)
+    assert isinstance(result, bytes)
+
+    # TODO: How to check that this optimization was toggled correctly?
+    deserialized = pl.LazyFrame.deserialize(BytesIO(result))
+    assert isinstance(deserialized, pl.LazyFrame)
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
+++ b/py-polars/tests/unit/cloud/test_prepare_cloud_plan.py
@@ -47,7 +47,7 @@ def test_prepare_cloud_plan(lf: pl.LazyFrame) -> None:
         pl.scan_parquet(CLOUD_SOURCE).filter(
             pl.col("a") < pl.lit(1).map_elements(lambda x: x + 1)
         ),
-        pl.LazyFrame({"a": [1, 2], "b": [3, 4]}).select(
+        pl.LazyFrame({"a": [[1, 2], [3, 4, 5]], "b": [3, 4]}).select(
             pl.col("a").map_elements(lambda x: sum(x), return_dtype=pl.Int64)
         ),
     ],

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import pickle
 from datetime import datetime, timedelta
 
@@ -207,3 +208,12 @@ def test_serde_data_type_instantiated_with_attributes() -> None:
     deserialized = pickle.loads(serialized)
     assert deserialized == dtype
     assert isinstance(deserialized, pl.DataType)
+
+
+def test_serde_udf() -> None:
+    lf = pl.LazyFrame({"a": [[1, 2], [3, 4, 5]], "b": [3, 4]}).select(
+        pl.col("a").map_elements(lambda x: sum(x), return_dtype=pl.Int32)
+    )
+    result = pl.LazyFrame.deserialize(io.BytesIO(lf.serialize()))
+
+    assert_frame_equal(lf, result)


### PR DESCRIPTION
Changes:
* Update `Expr::AnonymousFunction` to implement SerDe for Python functions.
* Update `Expr::RenameAlias` to raise an error when serializing instead of simply being skipped. Can implement SerDe for this later.
* Update the Polars Cloud prep functionality accordingly.
