### PR TITLE
perf: Reduce default async thread count

### DIFF
--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -237,8 +237,16 @@ pub struct RuntimeManager {
 
 impl RuntimeManager {
     fn new() -> Self {
+        let n_threads = std::env::var("POLARS_ASYNC_THREAD_COUNT")
+            .map(|x| x.parse::<usize>().expect("integer"))
+            .unwrap_or((POOL.current_num_threads() / 4).clamp(1, 4));
+
+        if polars_core::config::verbose() {
+            eprintln!("Async thread count: {}", n_threads);
+        }
+
         let rt = Builder::new_multi_thread()
-            .worker_threads(std::cmp::max(POOL.current_num_threads(), 4))
+            .worker_threads(n_threads)
             .enable_io()
             .enable_time()
             .build()


### PR DESCRIPTION
Work spawned onto tokio threads are generally lightweight I/O tasks that spend most of their time `await`ing, so we don't need a lot of threads for it.