### PR TITLE
fix: Prevent unwanted supertype cast in 'search_sorted'

### DIFF
--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use num_traits::Signed;
 
 use super::*;
@@ -11,9 +12,43 @@ pub fn try_get_supertype(l: &DataType, r: &DataType) -> PolarsResult<DataType> {
     )
 }
 
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+    pub struct SuperTypeFlags: u8 {
+        /// Implode lists to match nesting types.
+        const ALLOW_IMPLODE_LIST = 1 << 0;
+        /// Allow casting of primitive types (numeric, bools) to strings
+        const ALLOW_PRIMITIVE_TO_STRING = 1 << 1;
+    }
+}
+
+impl Default for SuperTypeFlags {
+    fn default() -> Self {
+        SuperTypeFlags::from_bits_truncate(0) | SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Default)]
 pub struct SuperTypeOptions {
-    pub implode_list: bool,
+    pub flags: SuperTypeFlags,
+}
+
+impl From<SuperTypeFlags> for SuperTypeOptions {
+    fn from(flags: SuperTypeFlags) -> Self {
+        SuperTypeOptions { flags }
+    }
+}
+
+impl SuperTypeOptions {
+    pub fn allow_implode_list(&self) -> bool {
+        self.flags.contains(SuperTypeFlags::ALLOW_IMPLODE_LIST)
+    }
+
+    pub fn allow_primitive_to_string(&self) -> bool {
+        self.flags
+            .contains(SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING)
+    }
 }
 
 pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
@@ -209,11 +244,9 @@ pub fn get_supertype_with_options(
             #[cfg(feature = "dtype-time")]
             (Time, Float64) => Some(Float64),
 
-            // every known type can be casted to a string except binary
-            (dt, String) if !matches!(dt, DataType::Unknown(UnknownKind::Any)) && dt != &DataType::Binary => Some(String),
-
-            (dt, String) if !matches!(dt, DataType::Unknown(UnknownKind::Any)) => Some(String),
-
+            // Every known type can be cast to a string except binary
+            (dt, String) if !matches!(dt, Unknown(UnknownKind::Any)) && dt != &Binary && options.allow_primitive_to_string() || !dt.to_physical().is_primitive() => Some(String),
+            (String, Binary) => Some(Binary),
             (dt, Null) => Some(dt.clone()),
 
             #[cfg(all(feature = "dtype-duration", feature = "dtype-datetime"))]
@@ -258,7 +291,7 @@ pub fn get_supertype_with_options(
                 let st = get_supertype(inner_left, inner_right)?;
                 Some(Array(Box::new(st), *width_left))
             }
-            (List(inner), other) | (other, List(inner)) if options.implode_list => {
+            (List(inner), other) | (other, List(inner)) if options.allow_implode_list() => {
                 let st = get_supertype(inner, other)?;
                 Some(List(Box::new(st)))
             }

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -5,6 +5,8 @@ use polars_core::prelude::*;
 #[cfg(feature = "diff")]
 use polars_core::series::ops::NullBehavior;
 #[cfg(feature = "list_sets")]
+use polars_core::utils::SuperTypeFlags;
+#[cfg(feature = "list_sets")]
 use polars_core::utils::SuperTypeOptions;
 
 use crate::prelude::function_expr::ListFunction;
@@ -367,7 +369,9 @@ impl ListNameSpace {
             function: FunctionExpr::ListExpr(ListFunction::SetOperation(set_operation)),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ElementWise,
-                cast_to_supertypes: Some(SuperTypeOptions { implode_list: true }),
+                cast_to_supertypes: Some(SuperTypeOptions {
+                    flags: SuperTypeFlags::default() | SuperTypeFlags::ALLOW_IMPLODE_LIST,
+                }),
                 flags: FunctionFlags::default()
                     | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR,
                 ..Default::default()

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -63,6 +63,8 @@ use polars_core::prelude::*;
 use polars_core::series::ops::NullBehavior;
 use polars_core::series::IsSorted;
 use polars_core::utils::try_get_supertype;
+#[cfg(feature = "search_sorted")]
+use polars_core::utils::SuperTypeFlags;
 pub use selector::Selector;
 #[cfg(feature = "dtype-struct")]
 pub use struct_::*;
@@ -376,7 +378,9 @@ impl Expr {
                 collect_groups: ApplyOptions::GroupWise,
                 flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
                 fmt_str: "search_sorted",
-                cast_to_supertypes: Some(Default::default()),
+                cast_to_supertypes: Some(
+                    (SuperTypeFlags::default() & !SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING).into(),
+                ),
                 ..Default::default()
             },
         }

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -4,7 +4,6 @@ from datetime import date, datetime, timedelta, timezone
 from itertools import permutations
 from typing import TYPE_CHECKING, Any, cast
 
-import numpy as np
 import pytest
 
 import polars as pl
@@ -381,72 +380,6 @@ def test_rank_so_4109() -> None:
 def test_rank_string_null_11252() -> None:
     rank = pl.Series([None, "", "z", None, "a"]).rank()
     assert rank.to_list() == [None, 1.0, 3.0, None, 2.0]
-
-
-def test_search_sorted() -> None:
-    for seed in [1, 2, 3]:
-        np.random.seed(seed)
-        arr = np.sort(np.random.randn(10) * 100)
-        s = pl.Series(arr)
-
-        for v in range(int(np.min(arr)), int(np.max(arr)), 20):
-            assert np.searchsorted(arr, v) == s.search_sorted(v)
-
-    a = pl.Series([1, 2, 3])
-    b = pl.Series([1, 2, 2, -1])
-    assert a.search_sorted(b).to_list() == [0, 1, 1, 0]
-    b = pl.Series([1, 2, 2, None, 3])
-    assert a.search_sorted(b).to_list() == [0, 1, 1, 0, 2]
-
-    a = pl.Series(["b", "b", "d", "d"])
-    b = pl.Series(["a", "b", "c", "d", "e"])
-    assert a.search_sorted(b, side="left").to_list() == [0, 0, 2, 2, 4]
-    assert a.search_sorted(b, side="right").to_list() == [0, 2, 2, 4, 4]
-
-    a = pl.Series([1, 1, 4, 4])
-    b = pl.Series([0, 1, 2, 4, 5])
-    assert a.search_sorted(b, side="left").to_list() == [0, 0, 2, 2, 4]
-    assert a.search_sorted(b, side="right").to_list() == [0, 2, 2, 4, 4]
-
-
-def test_search_sorted_multichunk() -> None:
-    for seed in [1, 2, 3]:
-        np.random.seed(seed)
-        arr = np.sort(np.random.randn(10) * 100)
-        q = len(arr) // 4
-        a, b, c, d = map(
-            pl.Series, (arr[:q], arr[q : 2 * q], arr[2 * q : 3 * q], arr[3 * q :])
-        )
-        s = pl.concat([a, b, c, d], rechunk=False)
-        assert s.n_chunks() == 4
-
-        for v in range(int(np.min(arr)), int(np.max(arr)), 20):
-            assert np.searchsorted(arr, v) == s.search_sorted(v)
-
-    a = pl.concat(
-        [
-            pl.Series([None, None, None], dtype=pl.Int64),
-            pl.Series([None, 1, 1, 2, 3]),
-            pl.Series([4, 4, 5, 6, 7, 8, 8]),
-        ],
-        rechunk=False,
-    )
-    assert a.n_chunks() == 3
-    b = pl.Series([-10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, None])
-    left_ref = pl.Series(
-        [4, 4, 4, 6, 7, 8, 10, 11, 12, 13, 15, 0], dtype=pl.get_index_type()
-    )
-    right_ref = pl.Series(
-        [4, 4, 6, 7, 8, 10, 11, 12, 13, 15, 15, 4], dtype=pl.get_index_type()
-    )
-    assert_series_equal(a.search_sorted(b, side="left"), left_ref)
-    assert_series_equal(a.search_sorted(b, side="right"), right_ref)
-
-
-def test_search_sorted_right_nulls() -> None:
-    a = pl.Series([1, 2, None, None])
-    assert a.search_sorted(None, side="left") == 2
-    assert a.search_sorted(None, side="right") == 4
 
 
 def test_logical_boolean() -> None:

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -136,7 +136,7 @@ def test_is_in_series() -> None:
 
     with pytest.raises(
         InvalidOperationError,
-        match=r"`is_in` cannot check for String values in Int64 data",
+        match=r"'is_in' cannot check for String values in Int64 data",
     ):
         df.select(pl.col("b").is_in(["x", "x"]))
 
@@ -192,12 +192,12 @@ def test_is_in_float(dtype: PolarsDataType) -> None:
         (
             pl.DataFrame({"a": ["1", "2"], "b": [[1, 2], [3, 4]]}),
             None,
-            r"`is_in` cannot check for String values in List\(Int64\) data",
+            r"'is_in' cannot check for String values in List\(Int64\) data",
         ),
         (
             pl.DataFrame({"a": [date.today(), None], "b": [[1, 2], [3, 4]]}),
             None,
-            r"`is_in` cannot check for Date values in List\(Int64\) data",
+            r"'is_in' cannot check for Date values in List\(Int64\) data",
         ),
     ],
 )

--- a/py-polars/tests/unit/operations/test_search_sorted.py
+++ b/py-polars/tests/unit/operations/test_search_sorted.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+
+def test_search_sorted() -> None:
+    for seed in [1, 2, 3]:
+        np.random.seed(seed)
+        arr = np.sort(np.random.randn(10) * 100)
+        s = pl.Series(arr)
+
+        for v in range(int(np.min(arr)), int(np.max(arr)), 20):
+            assert np.searchsorted(arr, v) == s.search_sorted(v)
+
+    a = pl.Series([1, 2, 3])
+    b = pl.Series([1, 2, 2, -1])
+    assert a.search_sorted(b).to_list() == [0, 1, 1, 0]
+    b = pl.Series([1, 2, 2, None, 3])
+    assert a.search_sorted(b).to_list() == [0, 1, 1, 0, 2]
+
+    a = pl.Series(["b", "b", "d", "d"])
+    b = pl.Series(["a", "b", "c", "d", "e"])
+    assert a.search_sorted(b, side="left").to_list() == [0, 0, 2, 2, 4]
+    assert a.search_sorted(b, side="right").to_list() == [0, 2, 2, 4, 4]
+
+    a = pl.Series([1, 1, 4, 4])
+    b = pl.Series([0, 1, 2, 4, 5])
+    assert a.search_sorted(b, side="left").to_list() == [0, 0, 2, 2, 4]
+    assert a.search_sorted(b, side="right").to_list() == [0, 2, 2, 4, 4]
+
+
+def test_search_sorted_multichunk() -> None:
+    for seed in [1, 2, 3]:
+        np.random.seed(seed)
+        arr = np.sort(np.random.randn(10) * 100)
+        q = len(arr) // 4
+        a, b, c, d = map(
+            pl.Series, (arr[:q], arr[q : 2 * q], arr[2 * q : 3 * q], arr[3 * q :])
+        )
+        s = pl.concat([a, b, c, d], rechunk=False)
+        assert s.n_chunks() == 4
+
+        for v in range(int(np.min(arr)), int(np.max(arr)), 20):
+            assert np.searchsorted(arr, v) == s.search_sorted(v)
+
+    a = pl.concat(
+        [
+            pl.Series([None, None, None], dtype=pl.Int64),
+            pl.Series([None, 1, 1, 2, 3]),
+            pl.Series([4, 4, 5, 6, 7, 8, 8]),
+        ],
+        rechunk=False,
+    )
+    assert a.n_chunks() == 3
+    b = pl.Series([-10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, None])
+    left_ref = pl.Series(
+        [4, 4, 4, 6, 7, 8, 10, 11, 12, 13, 15, 0], dtype=pl.get_index_type()
+    )
+    right_ref = pl.Series(
+        [4, 4, 6, 7, 8, 10, 11, 12, 13, 15, 15, 4], dtype=pl.get_index_type()
+    )
+    assert_series_equal(a.search_sorted(b, side="left"), left_ref)
+    assert_series_equal(a.search_sorted(b, side="right"), right_ref)
+
+
+def test_search_sorted_right_nulls() -> None:
+    a = pl.Series([1, 2, None, None])
+    assert a.search_sorted(None, side="left") == 2
+    assert a.search_sorted(None, side="right") == 4
+
+
+def test_raise_literal_numeric_search_sorted_18096() -> None:
+    df = pl.DataFrame({"foo": [1, 4, 7], "bar": [2, 3, 5]})
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        df.with_columns(idx=pl.col("foo").search_sorted("bar"))

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -587,7 +587,7 @@ def test_invalid_is_in_dtypes(
     if expected is None:
         with pytest.raises(
             InvalidOperationError,
-            match="`is_in` cannot check for .*? values in .*? data",
+            match="'is_in' cannot check for .*? values in .*? data",
         ):
             df.select(pl.col(colname).is_in(values))
     else:


### PR DESCRIPTION
fixes #18096