### PR TITLE
refactor(rust): Add parquet source node to new streaming engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,9 +169,9 @@ checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow-array"
@@ -251,7 +257,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -262,7 +268,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -412,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.37.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1074e818fbe4f9169242d78448b15be8916a79daa38ea1231f2e2e10d993fcd2"
+checksum = "11822090cf501c316c6f75711d77b96fba30658e3867a7762e5e2f5d32d31e81"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -434,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.38.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29755c51e33fa3f678598f64324a169cf4b7d3c4865d2709d4308f53366a92a4"
+checksum = "78a2a06ff89176123945d1bbe865603c4d7101bea216a550bb4d2e4e9ba74d74"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -456,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.37.0"
+version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e52dc3fd7dfa6c01a69cf3903e00aa467261639138a05b06cd92314d2c8fb07"
+checksum = "a20a91795850826a6f456f4a48eff1dfa59a0e69bdbf5b8c50518fd372106574"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -591,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce87155eba55e11768b8c1afa607f3e864ae82f03caf63258b37455b0ad02537"
+checksum = "0abbf454960d0db2ad12684a1640120e7557294b0ff8e2f11236290a1b293225"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -635,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
+checksum = "6cee7cadb433c781d3299b916fbf620fea813bf38f49db282fb6858141a05cc8"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -692,7 +698,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -751,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ec96fe9a81b5e365f9db71fe00edc4fe4ca2cc7dcb7861f0603012a7caa210"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -820,22 +826,22 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -889,12 +895,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -967,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.15"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
 ]
@@ -1001,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
 dependencies = [
  "cc",
 ]
@@ -1356,7 +1363,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1427,13 +1434,13 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1532,7 +1539,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1655,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1728,6 +1735,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1860,7 +1873,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1898,7 +1911,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.12",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.2",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -1960,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1989,11 +2002,11 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2149,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libflate"
@@ -2386,12 +2399,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -2821,7 +2843,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3405,6 +3427,8 @@ dependencies = [
  "atomic-waker",
  "crossbeam-deque",
  "crossbeam-utils",
+ "futures",
+ "memmap2",
  "parking_lot",
  "pin-project-lite",
  "polars-core",
@@ -3412,6 +3436,7 @@ dependencies = [
  "polars-expr",
  "polars-io",
  "polars-mem-engine",
+ "polars-parquet",
  "polars-plan",
  "polars-utils",
  "rand",
@@ -3451,6 +3476,7 @@ dependencies = [
  "bytes",
  "hashbrown",
  "indexmap",
+ "libc",
  "memmap2",
  "num-traits",
  "once_cell",
@@ -3604,7 +3630,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3617,7 +3643,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3697,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -3815,7 +3841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3844,7 +3870,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3890,16 +3916,16 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -3915,7 +3941,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.12",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.2",
  "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
@@ -3931,7 +3957,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4046,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.3",
@@ -4243,29 +4269,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4316,6 +4342,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4467,15 +4499,15 @@ dependencies = [
 
 [[package]]
 name = "stacker"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+checksum = "95a5daa25ea337c85ed954c0496e3bdd2c7308cc3b24cf7b50d04876654c579f"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "winapi",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -4527,7 +4559,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4540,7 +4572,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4562,9 +4594,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4576,12 +4608,15 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "sysinfo"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4115055da5f572fff541dd0c4e61b0262977f453cc9fe04be83aba25a89bdab"
+checksum = "2b92e0bdf838cbc1c4c9ba14f9c97a7ec6cdcd1ae66b10e1e42775a25553f45d"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4632,7 +4667,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4701,9 +4736,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4724,7 +4759,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4813,15 +4848,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -4842,7 +4877,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4887,7 +4922,7 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5060,7 +5095,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
@@ -5094,7 +5129,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5186,7 +5221,7 @@ checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -5198,7 +5233,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5209,7 +5244,18 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5222,12 +5268,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-result"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -5293,6 +5362,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5302,6 +5377,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5323,6 +5404,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5332,6 +5419,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5359,6 +5452,12 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -5376,16 +5475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5435,7 +5524,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -4,6 +4,7 @@
 //! We could use [serde_1712](https://github.com/serde-rs/serde/issues/1712), but that gave problems caused by
 //! [rust_96956](https://github.com/rust-lang/rust/issues/96956), so we make a dummy type without static
 
+#[cfg(feature = "dtype-categorical")]
 use serde::de::SeqAccess;
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::fmt::Formatter;
 
 use serde::de::{Error as DeError, MapAccess, Visitor};
+#[cfg(feature = "object")]
 use serde::ser::Error as SerError;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -1181,6 +1181,22 @@ pub fn coalesce_nulls_series(a: &Series, b: &Series) -> (Series, Series) {
     }
 }
 
+pub fn operation_exceeded_idxsize_msg(operation: &str) -> String {
+    if core::mem::size_of::<IdxSize>() == core::mem::size_of::<u32>() {
+        format!(
+            "{} exceeded the maximum supported limit of {} rows. Consider installing 'polars-u64-idx'.",
+            operation,
+            IdxSize::MAX,
+        )
+    } else {
+        format!(
+            "{} exceeded the maximum supported limit of {} rows.",
+            operation,
+            IdxSize::MAX,
+        )
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -204,7 +204,7 @@ impl PolarsError {
         }
     }
 
-    fn wrap_msg<F: FnOnce(&str) -> String>(&self, func: F) -> Self {
+    pub fn wrap_msg<F: FnOnce(&str) -> String>(&self, func: F) -> Self {
         use PolarsError::*;
         match self {
             ColumnNotFound(msg) => ColumnNotFound(func(msg).into()),

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -16,6 +16,7 @@ use crate::pl_async::{
 /// concurrent requests for the entire application.
 #[derive(Debug, Clone)]
 pub struct PolarsObjectStore(Arc<dyn ObjectStore>);
+pub type ObjectStorePath = object_store::path::Path;
 
 impl PolarsObjectStore {
     pub fn new(store: Arc<dyn ObjectStore>) -> Self {

--- a/crates/polars-io/src/parquet/read/mmap.rs
+++ b/crates/polars-io/src/parquet/read/mmap.rs
@@ -63,7 +63,7 @@ fn _mmap_single_column<'a>(
 
 // similar to arrow2 serializer, except this accepts a slice instead of a vec.
 // this allows us to memory map
-pub(super) fn to_deserializer(
+pub fn to_deserializer(
     columns: Vec<(&ColumnChunkMetaData, MemSlice)>,
     field: Field,
     filter: Option<Filter>,

--- a/crates/polars-io/src/parquet/read/mod.rs
+++ b/crates/polars-io/src/parquet/read/mod.rs
@@ -37,3 +37,8 @@ use polars_error::{ErrString, PolarsError};
 pub use reader::ParquetAsyncReader;
 pub use reader::{BatchedParquetReader, ParquetReader};
 pub use utils::materialize_empty_df;
+
+pub mod _internal {
+    pub use super::mmap::to_deserializer;
+    pub use super::predicates::read_this_row_group;
+}

--- a/crates/polars-io/src/parquet/read/predicates.rs
+++ b/crates/polars-io/src/parquet/read/predicates.rs
@@ -41,7 +41,7 @@ pub(crate) fn collect_statistics(
     )))
 }
 
-pub(super) fn read_this_row_group(
+pub fn read_this_row_group(
     predicate: Option<&dyn PhysicalIoExpr>,
     md: &RowGroupMetaData,
     schema: &ArrowSchemaRef,

--- a/crates/polars-io/src/utils/byte_source.rs
+++ b/crates/polars-io/src/utils/byte_source.rs
@@ -1,0 +1,176 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use polars_error::{to_compute_err, PolarsResult};
+use polars_utils::_limit_path_len_io_err;
+use polars_utils::mmap::MemSlice;
+
+use crate::cloud::{
+    build_object_store, object_path_from_str, CloudLocation, CloudOptions, ObjectStorePath,
+    PolarsObjectStore,
+};
+
+#[allow(async_fn_in_trait)]
+pub trait ByteSource: Send + Sync {
+    async fn get_size(&self) -> PolarsResult<usize>;
+    /// # Panics
+    /// Panics if `range` is not in bounds.
+    async fn get_range(&self, range: Range<usize>) -> PolarsResult<MemSlice>;
+    async fn get_ranges(&self, ranges: &[Range<usize>]) -> PolarsResult<Vec<MemSlice>>;
+}
+
+/// Byte source backed by a `MemSlice`, which can potentially be memory-mapped.
+pub struct MemSliceByteSource(pub MemSlice);
+
+impl MemSliceByteSource {
+    async fn try_new_mmap_from_path(
+        path: &str,
+        _cloud_options: Option<&CloudOptions>,
+    ) -> PolarsResult<Self> {
+        let file = Arc::new(
+            tokio::fs::File::open(path)
+                .await
+                .map_err(|err| _limit_path_len_io_err(path.as_ref(), err))?
+                .into_std()
+                .await,
+        );
+        let mmap = Arc::new(unsafe { memmap::Mmap::map(file.as_ref()) }.map_err(to_compute_err)?);
+
+        Ok(Self(MemSlice::from_mmap(mmap)))
+    }
+}
+
+impl ByteSource for MemSliceByteSource {
+    async fn get_size(&self) -> PolarsResult<usize> {
+        Ok(self.0.as_ref().len())
+    }
+
+    async fn get_range(&self, range: Range<usize>) -> PolarsResult<MemSlice> {
+        let out = self.0.slice(range);
+        Ok(out)
+    }
+
+    async fn get_ranges(&self, ranges: &[Range<usize>]) -> PolarsResult<Vec<MemSlice>> {
+        Ok(ranges
+            .iter()
+            .map(|x| self.0.slice(x.clone()))
+            .collect::<Vec<_>>())
+    }
+}
+
+pub struct ObjectStoreByteSource {
+    store: PolarsObjectStore,
+    path: ObjectStorePath,
+}
+
+impl ObjectStoreByteSource {
+    async fn try_new_from_path(
+        path: &str,
+        cloud_options: Option<&CloudOptions>,
+    ) -> PolarsResult<Self> {
+        let (CloudLocation { prefix, .. }, store) =
+            build_object_store(path, cloud_options, false).await?;
+        let path = object_path_from_str(&prefix)?;
+        let store = PolarsObjectStore::new(store);
+
+        Ok(Self { store, path })
+    }
+}
+
+impl ByteSource for ObjectStoreByteSource {
+    async fn get_size(&self) -> PolarsResult<usize> {
+        Ok(self.store.head(&self.path).await?.size)
+    }
+
+    async fn get_range(&self, range: Range<usize>) -> PolarsResult<MemSlice> {
+        let bytes = self.store.get_range(&self.path, range).await?;
+        let mem_slice = MemSlice::from_bytes(bytes);
+
+        Ok(mem_slice)
+    }
+
+    async fn get_ranges(&self, ranges: &[Range<usize>]) -> PolarsResult<Vec<MemSlice>> {
+        let ranges = self.store.get_ranges(&self.path, ranges).await?;
+        Ok(ranges.into_iter().map(MemSlice::from_bytes).collect())
+    }
+}
+
+/// Dynamic dispatch to async functions.
+pub enum DynByteSource {
+    MemSlice(MemSliceByteSource),
+    Cloud(ObjectStoreByteSource),
+}
+
+impl DynByteSource {
+    pub fn variant_name(&self) -> &str {
+        match self {
+            Self::MemSlice(_) => "MemSlice",
+            Self::Cloud(_) => "Cloud",
+        }
+    }
+}
+
+impl Default for DynByteSource {
+    fn default() -> Self {
+        Self::MemSlice(MemSliceByteSource(MemSlice::default()))
+    }
+}
+
+impl ByteSource for DynByteSource {
+    async fn get_size(&self) -> PolarsResult<usize> {
+        match self {
+            Self::MemSlice(v) => v.get_size().await,
+            Self::Cloud(v) => v.get_size().await,
+        }
+    }
+
+    async fn get_range(&self, range: Range<usize>) -> PolarsResult<MemSlice> {
+        match self {
+            Self::MemSlice(v) => v.get_range(range).await,
+            Self::Cloud(v) => v.get_range(range).await,
+        }
+    }
+
+    async fn get_ranges(&self, ranges: &[Range<usize>]) -> PolarsResult<Vec<MemSlice>> {
+        match self {
+            Self::MemSlice(v) => v.get_ranges(ranges).await,
+            Self::Cloud(v) => v.get_ranges(ranges).await,
+        }
+    }
+}
+
+impl From<MemSliceByteSource> for DynByteSource {
+    fn from(value: MemSliceByteSource) -> Self {
+        Self::MemSlice(value)
+    }
+}
+
+impl From<ObjectStoreByteSource> for DynByteSource {
+    fn from(value: ObjectStoreByteSource) -> Self {
+        Self::Cloud(value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum DynByteSourceBuilder {
+    Mmap,
+    /// Supports both cloud and local files.
+    ObjectStore,
+}
+
+impl DynByteSourceBuilder {
+    pub async fn try_build_from_path(
+        &self,
+        path: &str,
+        cloud_options: Option<&CloudOptions>,
+    ) -> PolarsResult<DynByteSource> {
+        Ok(match self {
+            Self::Mmap => MemSliceByteSource::try_new_mmap_from_path(path, cloud_options)
+                .await?
+                .into(),
+            Self::ObjectStore => ObjectStoreByteSource::try_new_from_path(path, cloud_options)
+                .await?
+                .into(),
+        })
+    }
+}

--- a/crates/polars-io/src/utils/mod.rs
+++ b/crates/polars-io/src/utils/mod.rs
@@ -3,6 +3,8 @@ mod other;
 
 pub use compression::is_compressed;
 pub use other::*;
+#[cfg(feature = "cloud")]
+pub mod byte_source;
 pub mod slice;
 
 pub const URL_ENCODE_CHAR_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS

--- a/crates/polars-io/src/utils/slice.rs
+++ b/crates/polars-io/src/utils/slice.rs
@@ -1,33 +1,58 @@
 /// Given a `slice` that is relative to the start of a list of files, calculate the slice to apply
 /// at a file with a row offset of `current_row_offset`.
 pub fn split_slice_at_file(
-    current_row_offset: &mut usize,
+    current_row_offset_ref: &mut usize,
     n_rows_this_file: usize,
     global_slice_start: usize,
     global_slice_end: usize,
 ) -> (usize, usize) {
-    let next_file_offset = *current_row_offset + n_rows_this_file;
-    // e.g.
-    // slice: (start: 1, end: 2)
-    // files:
-    //   0: (1 row): current_offset: 0, next_file_offset: 1
-    //   1: (1 row): current_offset: 1, next_file_offset: 2
-    //   2: (1 row): current_offset: 2, next_file_offset: 3
-    // in this example we want to include only file 1.
-    let has_overlap_with_slice =
-        *current_row_offset < global_slice_end && next_file_offset > global_slice_start;
+    let current_row_offset = *current_row_offset_ref;
+    *current_row_offset_ref += n_rows_this_file;
+    match SplitSlicePosition::split_slice_at_file(
+        current_row_offset,
+        n_rows_this_file,
+        global_slice_start..global_slice_end,
+    ) {
+        SplitSlicePosition::Overlapping(offset, len) => (offset, len),
+        SplitSlicePosition::Before | SplitSlicePosition::After => (0, 0),
+    }
+}
 
-    let (rel_start, slice_len) = if !has_overlap_with_slice {
-        (0, 0)
-    } else {
-        let n_rows_to_skip = global_slice_start.saturating_sub(*current_row_offset);
-        let n_excess_rows = next_file_offset.saturating_sub(global_slice_end);
-        (
-            n_rows_to_skip,
-            n_rows_this_file - n_rows_to_skip - n_excess_rows,
-        )
-    };
+#[derive(Debug)]
+pub enum SplitSlicePosition {
+    Before,
+    Overlapping(usize, usize),
+    After,
+}
 
-    *current_row_offset = next_file_offset;
-    (rel_start, slice_len)
+impl SplitSlicePosition {
+    pub fn split_slice_at_file(
+        current_row_offset: usize,
+        n_rows_this_file: usize,
+        global_slice: std::ops::Range<usize>,
+    ) -> Self {
+        // e.g.
+        // slice: (start: 1, end: 2)
+        // files:
+        //   0: (1 row): current_offset: 0, next_file_offset: 1
+        //   1: (1 row): current_offset: 1, next_file_offset: 2
+        //   2: (1 row): current_offset: 2, next_file_offset: 3
+        // in this example we want to include only file 1.
+
+        let next_row_offset = current_row_offset + n_rows_this_file;
+
+        if next_row_offset <= global_slice.start {
+            Self::Before
+        } else if current_row_offset >= global_slice.end {
+            Self::After
+        } else {
+            let n_rows_to_skip = global_slice.start.saturating_sub(current_row_offset);
+            let n_excess_rows = next_row_offset.saturating_sub(global_slice.end);
+
+            Self::Overlapping(
+                n_rows_to_skip,
+                n_rows_this_file - n_rows_to_skip - n_excess_rows,
+            )
+        }
+    }
 }

--- a/crates/polars-plan/src/plans/conversion/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/scans.rs
@@ -40,7 +40,7 @@ fn prepare_schemas(mut schema: Schema, row_index: Option<&RowIndex>) -> (SchemaR
 pub(super) fn parquet_file_info(
     paths: &[PathBuf],
     file_options: &FileScanOptions,
-    cloud_options: Option<&polars_io::cloud::CloudOptions>,
+    #[allow(unused)] cloud_options: Option<&polars_io::cloud::CloudOptions>,
 ) -> PolarsResult<(FileInfo, Option<FileMetaDataRef>)> {
     let path = get_first_path(paths)?;
 

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -92,7 +92,7 @@ pub fn count_rows(paths: &Arc<Vec<PathBuf>>, scan_type: &FileScan) -> PolarsResu
 #[cfg(feature = "parquet")]
 pub(super) fn count_rows_parquet(
     paths: &Arc<Vec<PathBuf>>,
-    cloud_options: Option<&CloudOptions>,
+    #[allow(unused)] cloud_options: Option<&CloudOptions>,
 ) -> PolarsResult<usize> {
     if paths.is_empty() {
         return Ok(0);

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -12,9 +12,11 @@ description = "Private crate for the streaming execution engine for the Polars D
 atomic-waker = { workspace = true }
 crossbeam-deque = { workspace = true }
 crossbeam-utils = { workspace = true }
+futures = { workspace = true }
+memmap = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
-polars-io = { workspace = true, features = ["async"] }
+polars-io = { workspace = true, features = ["async", "cloud", "aws"] }
 polars-utils = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
@@ -25,8 +27,9 @@ tokio = { workspace = true }
 polars-core = { workspace = true }
 polars-error = { workspace = true }
 polars-expr = { workspace = true }
-polars-mem-engine = { workspace = true }
-polars-plan = { workspace = true }
+polars-mem-engine = { workspace = true, features = ["parquet"] }
+polars-parquet = { workspace = true }
+polars-plan = { workspace = true, features = ["parquet"] }
 
 [build-dependencies]
 version_check = { workspace = true }

--- a/crates/polars-stream/src/async_executor/mod.rs
+++ b/crates/polars-stream/src/async_executor/mod.rs
@@ -15,7 +15,7 @@ use parking_lot::Mutex;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use slotmap::SlotMap;
-pub use task::JoinHandle;
+pub use task::{AbortOnDropHandle, JoinHandle};
 use task::{CancelHandle, Runnable};
 
 static NUM_EXECUTOR_THREADS: AtomicUsize = AtomicUsize::new(0);
@@ -345,7 +345,6 @@ where
     }
 }
 
-#[allow(unused)]
 pub fn spawn<F: Future + Send + 'static>(priority: TaskPriority, fut: F) -> JoinHandle<F::Output>
 where
     <F as Future>::Output: Send + 'static,

--- a/crates/polars-stream/src/async_primitives/distributor_channel.rs
+++ b/crates/polars-stream/src/async_primitives/distributor_channel.rs
@@ -198,6 +198,8 @@ impl<T: Send> Sender<T> {
 }
 
 impl<T: Send> Receiver<T> {
+    /// Note: This intentionally takes `&mut` to ensure it is only accessed in a single-threaded
+    /// manner.
     pub async fn recv(&mut self) -> Result<T, ()> {
         loop {
             // Fast-path.

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -5,6 +5,7 @@ pub mod in_memory_source;
 pub mod map;
 pub mod multiplexer;
 pub mod ordered_union;
+pub mod parquet_source;
 pub mod reduce;
 pub mod select;
 pub mod simple_projection;

--- a/crates/polars-stream/src/nodes/parquet_source.rs
+++ b/crates/polars-stream/src/nodes/parquet_source.rs
@@ -1,0 +1,1891 @@
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use polars_core::config;
+use polars_core::frame::DataFrame;
+use polars_core::prelude::{
+    ArrowSchema, ChunkFull, DataType, IdxCa, InitHashMaps, PlHashMap, StringChunked,
+};
+use polars_core::schema::IndexOfSchema;
+use polars_core::series::{IntoSeries, IsSorted, Series};
+use polars_core::utils::operation_exceeded_idxsize_msg;
+use polars_error::{polars_bail, polars_err, PolarsResult};
+use polars_expr::prelude::PhysicalExpr;
+use polars_io::cloud::CloudOptions;
+use polars_io::predicates::PhysicalIoExpr;
+use polars_io::prelude::{FileMetaData, ParquetOptions};
+use polars_io::utils::byte_source::{
+    ByteSource, DynByteSource, DynByteSourceBuilder, MemSliceByteSource,
+};
+use polars_io::utils::slice::SplitSlicePosition;
+use polars_io::{is_cloud_url, RowIndex};
+use polars_parquet::read::RowGroupMetaData;
+use polars_plan::plans::hive::HivePartitions;
+use polars_plan::plans::FileInfo;
+use polars_plan::prelude::FileScanOptions;
+use polars_utils::mmap::MemSlice;
+use polars_utils::slice::GetSaferUnchecked;
+use polars_utils::IdxSize;
+
+use super::{MorselSeq, TaskPriority};
+use crate::async_executor::{self};
+use crate::async_primitives::connector::connector;
+use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
+use crate::morsel::get_ideal_morsel_size;
+use crate::utils::notify_channel::{notify_channel, NotifyReceiver};
+use crate::utils::task_handles_ext;
+
+type AsyncTaskData = Option<(
+    Vec<crate::async_primitives::connector::Receiver<(DataFrame, MorselSeq, WaitToken)>>,
+    async_executor::AbortOnDropHandle<PolarsResult<()>>,
+)>;
+
+#[allow(clippy::type_complexity)]
+pub struct ParquetSourceNode {
+    paths: Arc<Vec<PathBuf>>,
+    file_info: FileInfo,
+    hive_parts: Option<Arc<Vec<HivePartitions>>>,
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    options: ParquetOptions,
+    cloud_options: Option<CloudOptions>,
+    file_options: FileScanOptions,
+    // Run-time vars
+    config: Config,
+    verbose: bool,
+    physical_predicate: Option<Arc<dyn PhysicalIoExpr>>,
+    projected_arrow_fields: Arc<[polars_core::prelude::ArrowField]>,
+    byte_source_builder: DynByteSourceBuilder,
+    memory_prefetch_func: fn(&[u8]) -> (),
+    // This permit blocks execution until the first morsel is requested.
+    morsel_stream_starter: Option<tokio::sync::oneshot::Sender<()>>,
+    // This is behind a Mutex so that we can call `shutdown()` asynchronously.
+    async_task_data: Arc<tokio::sync::Mutex<AsyncTaskData>>,
+    row_group_decoder: Option<Arc<RowGroupDecoder>>,
+    is_finished: Arc<AtomicBool>,
+}
+
+#[allow(clippy::too_many_arguments)]
+impl ParquetSourceNode {
+    pub fn new(
+        paths: Arc<Vec<PathBuf>>,
+        file_info: FileInfo,
+        hive_parts: Option<Arc<Vec<HivePartitions>>>,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+        options: ParquetOptions,
+        cloud_options: Option<CloudOptions>,
+        file_options: FileScanOptions,
+    ) -> Self {
+        let verbose = config::verbose();
+
+        let byte_source_builder =
+            if is_cloud_url(paths[0].to_str().unwrap()) || config::force_async() {
+                DynByteSourceBuilder::ObjectStore
+            } else {
+                DynByteSourceBuilder::Mmap
+            };
+        let memory_prefetch_func = get_memory_prefetch_func(verbose);
+
+        Self {
+            paths,
+            file_info,
+            hive_parts,
+            predicate,
+            options,
+            cloud_options,
+            file_options,
+
+            config: Config {
+                // Initialized later
+                num_pipelines: 0,
+                metadata_prefetch_size: 0,
+                metadata_decode_ahead_size: 0,
+                row_group_prefetch_size: 0,
+            },
+            verbose,
+            physical_predicate: None,
+            projected_arrow_fields: Arc::new([]),
+            byte_source_builder,
+            memory_prefetch_func,
+
+            morsel_stream_starter: None,
+            async_task_data: Arc::new(tokio::sync::Mutex::new(None)),
+            row_group_decoder: None,
+            is_finished: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+mod compute_node_impl {
+
+    use std::sync::Arc;
+
+    use polars_expr::prelude::phys_expr_to_io_expr;
+
+    use super::super::compute_node_prelude::*;
+    use super::{Config, ParquetSourceNode};
+    use crate::morsel::SourceToken;
+
+    impl ComputeNode for ParquetSourceNode {
+        fn name(&self) -> &str {
+            "parquet_source"
+        }
+
+        fn initialize(&mut self, num_pipelines: usize) {
+            self.config = {
+                let metadata_prefetch_size = polars_core::config::get_file_prefetch_size();
+                // Limit metadata decode to the number of threads.
+                let metadata_decode_ahead_size =
+                    (metadata_prefetch_size / 2).min(1 + num_pipelines).max(1);
+                let row_group_prefetch_size = polars_core::config::get_rg_prefetch_size();
+
+                Config {
+                    num_pipelines,
+                    metadata_prefetch_size,
+                    metadata_decode_ahead_size,
+                    row_group_prefetch_size,
+                }
+            };
+
+            if self.verbose {
+                eprintln!("[ParquetSource]: {:?}", &self.config);
+            }
+
+            self.init_projected_arrow_fields();
+            self.physical_predicate = self.predicate.clone().map(phys_expr_to_io_expr);
+
+            let (raw_morsel_receivers, morsel_stream_task_handle) = self.init_raw_morsel_stream();
+
+            self.async_task_data
+                .try_lock()
+                .unwrap()
+                .replace((raw_morsel_receivers, morsel_stream_task_handle));
+
+            let row_group_decoder = self.init_row_group_decoder();
+            self.row_group_decoder = Some(Arc::new(row_group_decoder));
+        }
+
+        fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) {
+            use std::sync::atomic::Ordering;
+
+            assert!(recv.is_empty());
+            assert_eq!(send.len(), 1);
+
+            if self.is_finished.load(Ordering::Relaxed) {
+                send[0] = PortState::Done;
+                assert!(
+                    self.async_task_data.try_lock().unwrap().is_none(),
+                    "should have already been shut down"
+                );
+            } else if send[0] == PortState::Done {
+                {
+                    // Early shutdown - our port state was set to `Done` by the downstream nodes.
+                    self.shutdown_in_background();
+                };
+                self.is_finished.store(true, Ordering::Relaxed);
+            } else {
+                send[0] = PortState::Ready
+            }
+        }
+
+        fn spawn<'env, 's>(
+            &'env mut self,
+            scope: &'s TaskScope<'s, 'env>,
+            recv: &mut [Option<RecvPort<'_>>],
+            send: &mut [Option<SendPort<'_>>],
+            _state: &'s ExecutionState,
+            join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
+        ) {
+            use std::sync::atomic::Ordering;
+
+            assert!(recv.is_empty());
+            assert_eq!(send.len(), 1);
+            assert!(!self.is_finished.load(Ordering::Relaxed));
+
+            let morsel_senders = send[0].take().unwrap().parallel();
+
+            let mut async_task_data_guard = self.async_task_data.try_lock().unwrap();
+            let (raw_morsel_receivers, _) = async_task_data_guard.as_mut().unwrap();
+
+            assert_eq!(raw_morsel_receivers.len(), morsel_senders.len());
+
+            if let Some(v) = self.morsel_stream_starter.take() {
+                v.send(()).unwrap();
+            }
+            let is_finished = self.is_finished.clone();
+
+            let task_handles = raw_morsel_receivers
+                .drain(..)
+                .zip(morsel_senders)
+                .map(|(mut raw_morsel_rx, mut morsel_tx)| {
+                    let is_finished = is_finished.clone();
+
+                    scope.spawn_task(TaskPriority::Low, async move {
+                        let source_token = SourceToken::new();
+                        loop {
+                            let Ok((df, morsel_seq, wait_token)) = raw_morsel_rx.recv().await
+                            else {
+                                is_finished.store(true, Ordering::Relaxed);
+                                break;
+                            };
+
+                            let mut morsel = Morsel::new(df, morsel_seq, source_token.clone());
+                            morsel.set_consume_token(wait_token);
+
+                            if morsel_tx.send(morsel).await.is_err() {
+                                break;
+                            }
+
+                            if source_token.stop_requested() {
+                                break;
+                            }
+                        }
+
+                        raw_morsel_rx
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            drop(async_task_data_guard);
+
+            let async_task_data = self.async_task_data.clone();
+
+            join_handles.push(scope.spawn_task(TaskPriority::Low, async move {
+                {
+                    let mut async_task_data_guard = async_task_data.try_lock().unwrap();
+                    let (raw_morsel_receivers, _) = async_task_data_guard.as_mut().unwrap();
+
+                    for handle in task_handles {
+                        raw_morsel_receivers.push(handle.await);
+                    }
+                }
+
+                if self.is_finished.load(Ordering::Relaxed) {
+                    self.shutdown().await?;
+                }
+
+                Ok(())
+            }))
+        }
+    }
+}
+
+impl ParquetSourceNode {
+    /// # Panics
+    /// Panics if called more than once.
+    async fn shutdown_impl(
+        async_task_data: Arc<tokio::sync::Mutex<AsyncTaskData>>,
+        verbose: bool,
+    ) -> PolarsResult<()> {
+        if verbose {
+            eprintln!("[ParquetSource]: Shutting down");
+        }
+
+        let (mut raw_morsel_receivers, morsel_stream_task_handle) =
+            async_task_data.try_lock().unwrap().take().unwrap();
+
+        raw_morsel_receivers.clear();
+        // Join on the producer handle to catch errors/panics.
+        // Safety
+        // * We dropped the receivers on the line above
+        // * This function is only called once.
+        morsel_stream_task_handle.await
+    }
+
+    fn shutdown(&self) -> impl Future<Output = PolarsResult<()>> {
+        if self.verbose {
+            eprintln!("[ParquetSource]: Shutdown via `shutdown()`");
+        }
+        Self::shutdown_impl(self.async_task_data.clone(), self.verbose)
+    }
+
+    /// Spawns a task to shut down the source node to avoid blocking the current thread. This is
+    /// usually called when data is no longer needed from the source node, as such it does not
+    /// propagate any (non-critical) errors. If on the other hand the source node does not provide
+    /// more data when requested, then it is more suitable to call [`Self::shutdown`], as it returns
+    /// a result that can be used to distinguish between whether the data stream stopped due to an
+    /// error or EOF.
+    fn shutdown_in_background(&self) {
+        if self.verbose {
+            eprintln!("[ParquetSource]: Shutdown via `shutdown_in_background()`");
+        }
+        let async_task_data = self.async_task_data.clone();
+        polars_io::pl_async::get_runtime()
+            .spawn(Self::shutdown_impl(async_task_data, self.verbose));
+    }
+
+    /// Constructs the task that provides a morsel stream.
+    #[allow(clippy::type_complexity)]
+    fn init_raw_morsel_stream(
+        &mut self,
+    ) -> (
+        Vec<crate::async_primitives::connector::Receiver<(DataFrame, MorselSeq, WaitToken)>>,
+        async_executor::AbortOnDropHandle<PolarsResult<()>>,
+    ) {
+        let verbose = self.verbose;
+
+        let use_statistics = self.options.use_statistics;
+
+        let (mut raw_morsel_senders, raw_morsel_receivers): (Vec<_>, Vec<_>) =
+            (0..self.config.num_pipelines).map(|_| connector()).unzip();
+
+        if let Some((_, 0)) = self.file_options.slice {
+            return (
+                raw_morsel_receivers,
+                async_executor::AbortOnDropHandle::new(async_executor::spawn(
+                    TaskPriority::Low,
+                    std::future::ready(Ok(())),
+                )),
+            );
+        }
+
+        let reader_schema = self
+            .file_info
+            .reader_schema
+            .as_ref()
+            .unwrap()
+            .as_ref()
+            .unwrap_left()
+            .clone();
+
+        let (normalized_slice_oneshot_rx, metadata_rx, metadata_task_handle) =
+            self.init_metadata_fetcher();
+
+        let num_pipelines = self.config.num_pipelines;
+        let row_group_prefetch_size = self.config.row_group_prefetch_size;
+        let projection = self.file_options.with_columns.clone();
+        assert_eq!(self.physical_predicate.is_some(), self.predicate.is_some());
+        let predicate = self.physical_predicate.clone();
+        let memory_prefetch_func = self.memory_prefetch_func;
+        let (start_tx, start_rx) = tokio::sync::oneshot::channel();
+        self.morsel_stream_starter = Some(start_tx);
+
+        let mut row_group_data_fetcher = RowGroupDataFetcher {
+            metadata_rx,
+            use_statistics,
+            verbose,
+            reader_schema,
+            projection,
+            predicate,
+            slice_range: None, // Initialized later
+            memory_prefetch_func,
+            current_path_index: 0,
+            current_byte_source: Default::default(),
+            current_row_groups: Default::default(),
+            current_row_group_idx: 0,
+            current_max_row_group_height: 0,
+            current_row_offset: 0,
+            current_shared_file_state: Default::default(),
+        };
+
+        let row_group_decoder = self.init_row_group_decoder();
+        let row_group_decoder = Arc::new(row_group_decoder);
+
+        // Processes row group metadata and spawns I/O tasks to fetch row group data. This is
+        // currently spawned onto the CPU runtime as it does not directly make any async I/O calls,
+        // but instead it potentially performs predicate/slice evaluation on metadata. If we observe
+        // that under heavy CPU load scenarios the I/O throughput drops due to this task not being
+        // scheduled we can change it to be a high priority task.
+        let morsel_stream_task_handle = async_executor::spawn(TaskPriority::Low, async move {
+            if start_rx.await.is_err() {
+                drop(row_group_data_fetcher);
+                return metadata_task_handle.await.unwrap();
+            }
+
+            if verbose {
+                eprintln!("[ParquetSource]: Starting row group data fetch")
+            }
+
+            // We must `recv()` from the `NotifyReceiver` before awaiting on the
+            // `normalized_slice_oneshot_rx`, as in the negative offset case the slice resolution
+            // only runs after the first notify.
+            if !row_group_data_fetcher.init_next_file_state().await {
+                drop(row_group_data_fetcher);
+                return metadata_task_handle.await.unwrap();
+            };
+
+            let slice_range = {
+                let Ok(slice) = normalized_slice_oneshot_rx.await else {
+                    // If we are here then the producer probably errored.
+                    drop(row_group_data_fetcher);
+                    return metadata_task_handle.await.unwrap();
+                };
+
+                slice.map(|(offset, len)| offset..offset + len)
+            };
+
+            row_group_data_fetcher.slice_range = slice_range;
+
+            // Pins a wait group to a channel index.
+            struct IndexedWaitGroup {
+                index: usize,
+                wait_group: WaitGroup,
+            }
+
+            impl IndexedWaitGroup {
+                async fn wait(self) -> Self {
+                    self.wait_group.wait().await;
+                    self
+                }
+            }
+
+            // Ensure proper backpressure by only polling the buffered iterator when a wait group
+            // is free.
+            let mut wait_groups = (0..num_pipelines)
+                .map(|index| {
+                    let wait_group = WaitGroup::default();
+                    {
+                        let _prime_this_wait_group = wait_group.token();
+                    }
+                    IndexedWaitGroup {
+                        index,
+                        wait_group: WaitGroup::default(),
+                    }
+                    .wait()
+                })
+                .collect::<FuturesUnordered<_>>();
+
+            let mut df_stream = row_group_data_fetcher
+                .into_stream()
+                .map(|x| async {
+                    match x {
+                        Ok(handle) => handle.await,
+                        Err(e) => Err(e),
+                    }
+                })
+                .buffered(row_group_prefetch_size)
+                .map(|x| async {
+                    let row_group_decoder = row_group_decoder.clone();
+
+                    match x {
+                        Ok(row_group_data) => {
+                            async_executor::spawn(TaskPriority::Low, async move {
+                                row_group_decoder.row_group_data_to_df(row_group_data).await
+                            })
+                            .await
+                        },
+                        Err(e) => Err(e),
+                    }
+                })
+                .buffered(
+                    // Because we are using an ordered buffer, we may suffer from head-of-line blocking,
+                    // so we add a small amount of buffer.
+                    num_pipelines + 4,
+                );
+
+            let morsel_seq_ref = &mut MorselSeq::default();
+            let mut dfs = vec![].into_iter();
+
+            'main: loop {
+                let Some(mut indexed_wait_group) = wait_groups.next().await else {
+                    break;
+                };
+
+                if dfs.len() == 0 {
+                    let Some(v) = df_stream.next().await else {
+                        break;
+                    };
+
+                    let v = v?;
+                    assert!(!v.is_empty());
+
+                    dfs = v.into_iter();
+                }
+
+                let mut df = dfs.next().unwrap();
+                let morsel_seq = *morsel_seq_ref;
+                *morsel_seq_ref = morsel_seq.successor();
+
+                loop {
+                    use crate::async_primitives::connector::SendError;
+
+                    let channel_index = indexed_wait_group.index;
+                    let wait_token = indexed_wait_group.wait_group.token();
+
+                    match raw_morsel_senders[channel_index].try_send((df, morsel_seq, wait_token)) {
+                        Ok(_) => {
+                            wait_groups.push(indexed_wait_group.wait());
+                            break;
+                        },
+                        Err(SendError::Closed(v)) => {
+                            // The port assigned to this wait group has been closed, so we will not
+                            // add it back to the list of wait groups, and we will try to send this
+                            // across another port.
+                            df = v.0
+                        },
+                        Err(SendError::Full(_)) => unreachable!(),
+                    }
+
+                    let Some(v) = wait_groups.next().await else {
+                        // All ports have closed
+                        break 'main;
+                    };
+
+                    indexed_wait_group = v;
+                }
+            }
+
+            // Join on the producer handle to catch errors/panics.
+            drop(df_stream);
+            metadata_task_handle.await.unwrap()
+        });
+
+        let morsel_stream_task_handle =
+            async_executor::AbortOnDropHandle::new(morsel_stream_task_handle);
+
+        (raw_morsel_receivers, morsel_stream_task_handle)
+    }
+
+    /// Constructs the task that fetches file metadata.
+    /// Note: This must be called AFTER `self.projected_arrow_fields` has been initialized.
+    ///
+    /// TODO: During IR conversion the metadata of the first file is already downloaded - see if
+    /// we can find a way to re-use it.
+    #[allow(clippy::type_complexity)]
+    fn init_metadata_fetcher(
+        &self,
+    ) -> (
+        tokio::sync::oneshot::Receiver<Option<(usize, usize)>>,
+        NotifyReceiver<(usize, usize, Arc<DynByteSource>, FileMetaData, usize)>,
+        task_handles_ext::AbortOnDropHandle<PolarsResult<()>>,
+    ) {
+        let verbose = self.verbose;
+        let io_runtime = polars_io::pl_async::get_runtime();
+
+        assert!(
+            !self.projected_arrow_fields.is_empty()
+                || self.file_options.with_columns.as_deref() == Some(&[])
+        );
+        let projected_arrow_fields = self.projected_arrow_fields.clone();
+        let needs_max_row_group_height_calc =
+            self.file_options.include_file_paths.is_some() || self.hive_parts.is_some();
+
+        let (normalized_slice_oneshot_tx, normalized_slice_oneshot_rx) =
+            tokio::sync::oneshot::channel();
+        let (metadata_tx, mut metadata_notify_rx, metadata_rx) = notify_channel();
+
+        let byte_source_builder = self.byte_source_builder.clone();
+
+        if self.verbose {
+            eprintln!(
+                "[ParquetSource]: Byte source builder: {:?}",
+                &byte_source_builder
+            );
+        }
+
+        let fetch_metadata_bytes_for_path_index = {
+            let paths = &self.paths;
+            let cloud_options = Arc::new(self.cloud_options.clone());
+
+            let paths = paths.clone();
+            let cloud_options = cloud_options.clone();
+            let byte_source_builder = byte_source_builder.clone();
+
+            move |path_idx: usize| {
+                let paths = paths.clone();
+                let cloud_options = cloud_options.clone();
+                let byte_source_builder = byte_source_builder.clone();
+
+                let handle = io_runtime.spawn(async move {
+                    let mut byte_source = Arc::new(
+                        byte_source_builder
+                            .try_build_from_path(
+                                paths[path_idx].to_str().unwrap(),
+                                cloud_options.as_ref().as_ref(),
+                            )
+                            .await?,
+                    );
+                    let (metadata_bytes, maybe_full_bytes) =
+                        read_parquet_metadata_bytes(byte_source.as_ref(), verbose).await?;
+
+                    if let Some(v) = maybe_full_bytes {
+                        if !matches!(byte_source.as_ref(), DynByteSource::MemSlice(_)) {
+                            if verbose {
+                                eprintln!(
+                                    "[ParquetSource]: Parquet file was fully fetched during \
+                                         metadata read ({} bytes).",
+                                    v.len(),
+                                );
+                            }
+
+                            byte_source = Arc::new(DynByteSource::from(MemSliceByteSource(v)))
+                        }
+                    }
+
+                    PolarsResult::Ok((path_idx, byte_source, metadata_bytes))
+                });
+
+                let handle = task_handles_ext::AbortOnDropHandle(handle);
+
+                std::future::ready(handle)
+            }
+        };
+
+        let process_metadata_bytes = {
+            move |handle: task_handles_ext::AbortOnDropHandle<
+                PolarsResult<(usize, Arc<DynByteSource>, MemSlice)>,
+            >| {
+                let projected_arrow_fields = projected_arrow_fields.clone();
+                // Run on CPU runtime - metadata deserialization is expensive, especially
+                // for very wide tables.
+                let handle = async_executor::spawn(TaskPriority::Low, async move {
+                    let (path_index, byte_source, metadata_bytes) = handle.await.unwrap()?;
+
+                    let metadata = polars_parquet::parquet::read::deserialize_metadata(
+                        metadata_bytes.as_ref(),
+                        metadata_bytes.len() * 2 + 1024,
+                    )?;
+
+                    ensure_metadata_has_projected_fields(
+                        projected_arrow_fields.as_ref(),
+                        &metadata,
+                    )?;
+
+                    let file_max_row_group_height = if needs_max_row_group_height_calc {
+                        metadata
+                            .row_groups
+                            .iter()
+                            .map(|x| x.num_rows())
+                            .max()
+                            .unwrap_or(0)
+                    } else {
+                        0
+                    };
+
+                    PolarsResult::Ok((path_index, byte_source, metadata, file_max_row_group_height))
+                });
+
+                async_executor::AbortOnDropHandle::new(handle)
+            }
+        };
+
+        let metadata_prefetch_size = self.config.metadata_prefetch_size;
+        let metadata_decode_ahead_size = self.config.metadata_decode_ahead_size;
+
+        let metadata_task_handle = if self
+            .file_options
+            .slice
+            .map(|(offset, _)| offset >= 0)
+            .unwrap_or(true)
+        {
+            normalized_slice_oneshot_tx
+                .send(
+                    self.file_options
+                        .slice
+                        .map(|(offset, len)| (offset as usize, len)),
+                )
+                .unwrap();
+
+            // Safety: `offset + len` does not overflow.
+            let slice_range = self
+                .file_options
+                .slice
+                .map(|(offset, len)| offset as usize..offset as usize + len);
+
+            let mut metadata_stream = futures::stream::iter(0..self.paths.len())
+                .map(fetch_metadata_bytes_for_path_index)
+                .buffered(metadata_prefetch_size)
+                .map(process_metadata_bytes)
+                .buffered(metadata_decode_ahead_size);
+
+            let paths = self.paths.clone();
+
+            // We need to be able to both stop early as well as skip values, which is easier to do
+            // using a custom task instead of futures::stream
+            io_runtime.spawn(async move {
+                let current_row_offset_ref = &mut 0usize;
+                let current_path_index_ref = &mut 0usize;
+
+                'main: while metadata_notify_rx.recv().await.is_some() {
+                    loop {
+                        let current_path_index = *current_path_index_ref;
+                        *current_path_index_ref += 1;
+
+                        let Some(v) = metadata_stream.next().await else {
+                            break 'main;
+                        };
+
+                        let (path_index, byte_source, metadata, file_max_row_group_height) = v
+                            .map_err(|err| {
+                                err.wrap_msg(|msg| {
+                                    format!(
+                                        "error at path (index: {}, path: {}): {}",
+                                        current_path_index,
+                                        paths[current_path_index].to_str().unwrap(),
+                                        msg
+                                    )
+                                })
+                            })?;
+
+                        assert_eq!(path_index, current_path_index);
+
+                        let current_row_offset = *current_row_offset_ref;
+                        *current_row_offset_ref =
+                            current_row_offset.saturating_add(metadata.num_rows);
+
+                        if let Some(slice_range) = slice_range.clone() {
+                            match SplitSlicePosition::split_slice_at_file(
+                                current_row_offset,
+                                metadata.num_rows,
+                                slice_range,
+                            ) {
+                                SplitSlicePosition::Before => {
+                                    if verbose {
+                                        eprintln!(
+                                            "[ParquetSource]: Slice pushdown: \
+                                            Skipped file at index {} ({} rows)",
+                                            current_path_index, metadata.num_rows
+                                        );
+                                    }
+                                    continue;
+                                },
+                                SplitSlicePosition::After => unreachable!(),
+                                SplitSlicePosition::Overlapping(..) => {},
+                            };
+                        };
+
+                        {
+                            use tokio::sync::mpsc::error::*;
+                            match metadata_tx.try_send((
+                                path_index,
+                                current_row_offset,
+                                byte_source,
+                                metadata,
+                                file_max_row_group_height,
+                            )) {
+                                Err(TrySendError::Closed(_)) => break 'main,
+                                Ok(_) => {},
+                                Err(TrySendError::Full(_)) => unreachable!(),
+                            }
+                        }
+
+                        if let Some(slice_range) = slice_range.as_ref() {
+                            if *current_row_offset_ref >= slice_range.end {
+                                if verbose {
+                                    eprintln!(
+                                        "[ParquetSource]: Slice pushdown: \
+                                        Stopped reading at file at index {} \
+                                        (remaining {} files will not be read)",
+                                        current_path_index,
+                                        paths.len() - current_path_index - 1,
+                                    );
+                                }
+                                break 'main;
+                            }
+                        };
+
+                        break;
+                    }
+                }
+
+                Ok(())
+            })
+        } else {
+            // Walk the files in reverse to translate the slice into a positive offset.
+            let slice = self.file_options.slice.unwrap();
+            let slice_start_as_n_from_end = -slice.0 as usize;
+
+            let mut metadata_stream = futures::stream::iter((0..self.paths.len()).rev())
+                .map(fetch_metadata_bytes_for_path_index)
+                .buffered(metadata_prefetch_size)
+                .map(process_metadata_bytes)
+                .buffered(metadata_decode_ahead_size);
+
+            // Note:
+            // * We want to wait until the first morsel is requested before starting this
+            let init_negative_slice_and_metadata = async move {
+                let mut processed_metadata_rev = vec![];
+                let mut cum_rows = 0;
+
+                while let Some(v) = metadata_stream.next().await {
+                    let v = v?;
+                    let (_, _, metadata, _) = &v;
+                    cum_rows += metadata.num_rows;
+                    processed_metadata_rev.push(v);
+
+                    if cum_rows >= slice_start_as_n_from_end {
+                        break;
+                    }
+                }
+
+                let (start, len) = if slice_start_as_n_from_end > cum_rows {
+                    // We need to trim the slice, e.g. SLICE[offset: -100, len: 75] on a file of 50
+                    // rows should only give the first 25 rows.
+                    let first_file_position = slice_start_as_n_from_end - cum_rows;
+                    (0, slice.1.saturating_sub(first_file_position))
+                } else {
+                    (cum_rows - slice_start_as_n_from_end, slice.1)
+                };
+
+                if len == 0 {
+                    processed_metadata_rev.clear();
+                }
+
+                normalized_slice_oneshot_tx
+                    .send(Some((start, len)))
+                    .unwrap();
+
+                let slice_range = start..(start + len);
+
+                PolarsResult::Ok((slice_range, processed_metadata_rev, cum_rows))
+            };
+
+            let path_count = self.paths.len();
+
+            io_runtime.spawn(async move {
+                // Wait for the first morsel request before we call `init_negative_slice_and_metadata`
+                // This also means the receiver must `recv()` once before awaiting on the
+                // `normalized_slice_oneshot_rx` to avoid hanging.
+                if metadata_notify_rx.recv().await.is_none() {
+                    return Ok(());
+                }
+
+                let (slice_range, processed_metadata_rev, cum_rows) =
+                    async_executor::AbortOnDropHandle::new(async_executor::spawn(
+                        TaskPriority::Low,
+                        init_negative_slice_and_metadata,
+                    ))
+                    .await?;
+
+                if verbose {
+                    if let Some((path_index, ..)) = processed_metadata_rev.last() {
+                        eprintln!(
+                            "[ParquetSource]: Slice pushdown: Negatively-offsetted slice {:?} \
+                            begins at file index {}, translated to {:?}",
+                            slice, path_index, slice_range
+                        );
+                    } else {
+                        eprintln!(
+                            "[ParquetSource]: Slice pushdown: Negatively-offsetted slice {:?} \
+                            skipped all files ({} files containing {} rows)",
+                            slice, path_count, cum_rows
+                        )
+                    }
+                }
+
+                let mut metadata_iter = processed_metadata_rev.into_iter().rev();
+                let current_row_offset_ref = &mut 0usize;
+
+                // do-while: We already consumed a notify above.
+                loop {
+                    let Some((
+                        current_path_index,
+                        byte_source,
+                        metadata,
+                        file_max_row_group_height,
+                    )) = metadata_iter.next()
+                    else {
+                        break;
+                    };
+
+                    let current_row_offset = *current_row_offset_ref;
+                    *current_row_offset_ref = current_row_offset.saturating_add(metadata.num_rows);
+
+                    assert!(matches!(
+                        SplitSlicePosition::split_slice_at_file(
+                            current_row_offset,
+                            metadata.num_rows,
+                            slice_range.clone(),
+                        ),
+                        SplitSlicePosition::Overlapping(..)
+                    ));
+
+                    {
+                        use tokio::sync::mpsc::error::*;
+                        match metadata_tx.try_send((
+                            current_path_index,
+                            current_row_offset,
+                            byte_source,
+                            metadata,
+                            file_max_row_group_height,
+                        )) {
+                            Err(TrySendError::Closed(_)) => break,
+                            Ok(v) => v,
+                            Err(TrySendError::Full(_)) => unreachable!(),
+                        }
+                    }
+
+                    if *current_row_offset_ref >= slice_range.end {
+                        if verbose {
+                            eprintln!(
+                                "[ParquetSource]: Slice pushdown: \
+                                Stopped reading at file at index {} \
+                                (remaining {} files will not be read)",
+                                current_path_index,
+                                path_count - current_path_index - 1,
+                            );
+                        }
+                        break;
+                    }
+
+                    if metadata_notify_rx.recv().await.is_none() {
+                        break;
+                    }
+                }
+
+                Ok(())
+            })
+        };
+
+        let metadata_task_handle = task_handles_ext::AbortOnDropHandle(metadata_task_handle);
+
+        (
+            normalized_slice_oneshot_rx,
+            metadata_rx,
+            metadata_task_handle,
+        )
+    }
+
+    /// Creates a `RowGroupDecoder` that turns `RowGroupData` into DataFrames.
+    /// This must be called AFTER the following have been initialized:
+    /// * `self.projected_arrow_fields`
+    /// * `self.physical_predicate`
+    fn init_row_group_decoder(&self) -> RowGroupDecoder {
+        assert!(
+            !self.projected_arrow_fields.is_empty()
+                || self.file_options.with_columns.as_deref() == Some(&[])
+        );
+        assert_eq!(self.predicate.is_some(), self.physical_predicate.is_some());
+
+        let paths = self.paths.clone();
+        let hive_partitions = self.hive_parts.clone();
+        let hive_partitions_width = hive_partitions
+            .as_deref()
+            .map(|x| x[0].get_statistics().column_stats().len())
+            .unwrap_or(0);
+        let include_file_paths = self.file_options.include_file_paths.clone();
+        let projected_arrow_fields = self.projected_arrow_fields.clone();
+        let row_index = self.file_options.row_index.clone();
+        let physical_predicate = self.physical_predicate.clone();
+        let ideal_morsel_size = get_ideal_morsel_size();
+
+        RowGroupDecoder {
+            paths,
+            hive_partitions,
+            hive_partitions_width,
+            include_file_paths,
+            projected_arrow_fields,
+            row_index,
+            physical_predicate,
+            ideal_morsel_size,
+        }
+    }
+
+    fn init_projected_arrow_fields(&mut self) {
+        let reader_schema = self
+            .file_info
+            .reader_schema
+            .as_ref()
+            .unwrap()
+            .as_ref()
+            .unwrap_left()
+            .clone();
+
+        self.projected_arrow_fields =
+            if let Some(columns) = self.file_options.with_columns.as_deref() {
+                columns
+                    .iter()
+                    .map(|x| {
+                        // `index_of` on ArrowSchema is slow, so we use the polars native Schema,
+                        // but we need to remember to subtact the row index.
+                        let pos = self.file_info.schema.index_of(x.as_str()).unwrap()
+                            - (self.file_options.row_index.is_some() as usize);
+                        reader_schema.fields[pos].clone()
+                    })
+                    .collect()
+            } else {
+                Arc::from(reader_schema.fields.as_slice())
+            };
+
+        if self.verbose {
+            eprintln!(
+                "[ParquetSource]: {} columns to be projected from {} files",
+                self.projected_arrow_fields.len(),
+                self.paths.len(),
+            );
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Config {
+    num_pipelines: usize,
+    /// Number of files to pre-fetch metadata for concurrently
+    metadata_prefetch_size: usize,
+    /// Number of files to decode metadata for in parallel in advance
+    metadata_decode_ahead_size: usize,
+    /// Number of row groups to pre-fetch concurrently, this can be across files
+    row_group_prefetch_size: usize,
+}
+
+/// Represents byte-data that can be transformed into a DataFrame after some computation.
+struct RowGroupData {
+    byte_source: FetchedBytes,
+    path_index: usize,
+    row_offset: usize,
+    slice: Option<(usize, usize)>,
+    file_max_row_group_height: usize,
+    row_group_metadata: RowGroupMetaData,
+    shared_file_state: Arc<tokio::sync::OnceCell<SharedFileState>>,
+}
+
+struct RowGroupDataFetcher {
+    metadata_rx: NotifyReceiver<(usize, usize, Arc<DynByteSource>, FileMetaData, usize)>,
+    use_statistics: bool,
+    verbose: bool,
+    reader_schema: Arc<ArrowSchema>,
+    projection: Option<Arc<[String]>>,
+    predicate: Option<Arc<dyn PhysicalIoExpr>>,
+    slice_range: Option<std::ops::Range<usize>>,
+    memory_prefetch_func: fn(&[u8]) -> (),
+    current_path_index: usize,
+    current_byte_source: Arc<DynByteSource>,
+    current_row_groups: std::vec::IntoIter<RowGroupMetaData>,
+    current_row_group_idx: usize,
+    current_max_row_group_height: usize,
+    current_row_offset: usize,
+    current_shared_file_state: Arc<tokio::sync::OnceCell<SharedFileState>>,
+}
+
+impl RowGroupDataFetcher {
+    fn into_stream(self) -> RowGroupDataStream {
+        RowGroupDataStream::new(self)
+    }
+
+    async fn init_next_file_state(&mut self) -> bool {
+        let Some((path_index, row_offset, byte_source, metadata, file_max_row_group_height)) =
+            self.metadata_rx.recv().await
+        else {
+            return false;
+        };
+
+        self.current_path_index = path_index;
+        self.current_byte_source = byte_source;
+        self.current_max_row_group_height = file_max_row_group_height;
+        // The metadata task also sends a row offset to start counting from as it may skip files
+        // during slice pushdown.
+        self.current_row_offset = row_offset;
+        self.current_row_group_idx = 0;
+        self.current_row_groups = metadata.row_groups.into_iter();
+        self.current_shared_file_state = Default::default();
+
+        true
+    }
+
+    async fn next(
+        &mut self,
+    ) -> Option<PolarsResult<async_executor::AbortOnDropHandle<PolarsResult<RowGroupData>>>> {
+        'main: loop {
+            for row_group_metadata in self.current_row_groups.by_ref() {
+                let current_row_offset = self.current_row_offset;
+                let current_row_group_idx = self.current_row_group_idx;
+
+                let num_rows = row_group_metadata.num_rows();
+
+                self.current_row_offset = current_row_offset.saturating_add(num_rows);
+                self.current_row_group_idx += 1;
+
+                if self.use_statistics
+                    && !match polars_io::prelude::_internal::read_this_row_group(
+                        self.predicate.as_deref(),
+                        &row_group_metadata,
+                        &self.reader_schema,
+                    ) {
+                        Ok(v) => v,
+                        Err(e) => return Some(Err(e)),
+                    }
+                {
+                    if self.verbose {
+                        eprintln!(
+                            "[ParquetSource]: Predicate pushdown: \
+                            Skipped row group {} in file {} ({} rows)",
+                            current_row_group_idx, self.current_path_index, num_rows
+                        );
+                    }
+                    continue;
+                }
+
+                if num_rows > IdxSize::MAX as usize {
+                    let msg = operation_exceeded_idxsize_msg(
+                        format!("number of rows in row group ({})", num_rows).as_str(),
+                    );
+                    return Some(Err(polars_err!(ComputeError: msg)));
+                }
+
+                let slice = if let Some(slice_range) = self.slice_range.clone() {
+                    let (offset, len) = match SplitSlicePosition::split_slice_at_file(
+                        current_row_offset,
+                        num_rows,
+                        slice_range,
+                    ) {
+                        SplitSlicePosition::Before => {
+                            if self.verbose {
+                                eprintln!(
+                                    "[ParquetSource]: Slice pushdown: \
+                                    Skipped row group {} in file {} ({} rows)",
+                                    current_row_group_idx, self.current_path_index, num_rows
+                                );
+                            }
+                            continue;
+                        },
+                        SplitSlicePosition::After => {
+                            if self.verbose {
+                                eprintln!(
+                                    "[ParquetSource]: Slice pushdown: \
+                                    Stop at row group {} in file {} \
+                                    (remaining {} row groups will not be read)",
+                                    current_row_group_idx,
+                                    self.current_path_index,
+                                    self.current_row_groups.len(),
+                                );
+                            };
+                            break 'main;
+                        },
+                        SplitSlicePosition::Overlapping(offset, len) => (offset, len),
+                    };
+
+                    Some((offset, len))
+                } else {
+                    None
+                };
+
+                let current_byte_source = self.current_byte_source.clone();
+                let projection = self.projection.clone();
+                let current_shared_file_state = self.current_shared_file_state.clone();
+                let memory_prefetch_func = self.memory_prefetch_func;
+                let io_runtime = polars_io::pl_async::get_runtime();
+                let current_path_index = self.current_path_index;
+                let current_max_row_group_height = self.current_max_row_group_height;
+
+                // Push calculation of byte ranges to a task to run in parallel, as it can be
+                // expensive for very wide tables and projections.
+                let handle = async_executor::spawn(TaskPriority::Low, async move {
+                    let byte_source = if let DynByteSource::MemSlice(mem_slice) =
+                        current_byte_source.as_ref()
+                    {
+                        // Skip byte range calculation for `no_prefetch`.
+                        if memory_prefetch_func as usize != mem_prefetch_funcs::no_prefetch as usize
+                        {
+                            let slice = mem_slice.0.as_ref();
+
+                            if let Some(columns) = projection.as_ref() {
+                                for range in get_row_group_byte_ranges_for_projection(
+                                    &row_group_metadata,
+                                    columns.as_ref(),
+                                ) {
+                                    memory_prefetch_func(unsafe {
+                                        slice.get_unchecked_release(range)
+                                    })
+                                }
+                            } else {
+                                let mut iter = get_row_group_byte_ranges(&row_group_metadata);
+                                let first = iter.next().unwrap();
+                                let range =
+                                    iter.fold(first, |l, r| l.start.min(r.start)..l.end.max(r.end));
+
+                                memory_prefetch_func(unsafe { slice.get_unchecked_release(range) })
+                            };
+                        }
+
+                        // We have a mmapped or in-memory slice representing the entire
+                        // file that can be sliced directly, so we can skip the byte-range
+                        // calculations and HashMap allocation.
+                        let mem_slice = mem_slice.0.clone();
+                        FetchedBytes::MemSlice {
+                            offset: 0,
+                            mem_slice,
+                        }
+                    } else if let Some(columns) = projection.as_ref() {
+                        let ranges = get_row_group_byte_ranges_for_projection(
+                            &row_group_metadata,
+                            columns.as_ref(),
+                        )
+                        .collect::<Arc<[_]>>();
+
+                        let bytes = {
+                            let ranges_2 = ranges.clone();
+                            task_handles_ext::AbortOnDropHandle(io_runtime.spawn(async move {
+                                current_byte_source.get_ranges(ranges_2.as_ref()).await
+                            }))
+                            .await
+                            .unwrap()?
+                        };
+
+                        assert_eq!(bytes.len(), ranges.len());
+
+                        let mut bytes_map = PlHashMap::with_capacity(ranges.len());
+
+                        for (range, bytes) in ranges.iter().zip(bytes) {
+                            memory_prefetch_func(bytes.as_ref());
+                            let v = bytes_map.insert(range.start, bytes);
+                            debug_assert!(v.is_none(), "duplicate range start {}", range.start);
+                        }
+
+                        FetchedBytes::BytesMap(bytes_map)
+                    } else {
+                        // We have a dedicated code-path for a full projection that performs a
+                        // single range request for the entire row group. During testing this
+                        // provided much higher throughput from cloud than making multiple range
+                        // request with `get_ranges()`.
+                        let mut iter = get_row_group_byte_ranges(&row_group_metadata);
+                        let mut ranges = Vec::with_capacity(iter.len());
+                        let first = iter.next().unwrap();
+                        ranges.push(first.clone());
+                        let full_range = iter.fold(first, |l, r| {
+                            ranges.push(r.clone());
+                            l.start.min(r.start)..l.end.max(r.end)
+                        });
+
+                        let mem_slice = {
+                            let full_range_2 = full_range.clone();
+                            task_handles_ext::AbortOnDropHandle(io_runtime.spawn(async move {
+                                current_byte_source.get_range(full_range_2).await
+                            }))
+                            .await
+                            .unwrap()?
+                        };
+
+                        FetchedBytes::MemSlice {
+                            offset: full_range.start,
+                            mem_slice,
+                        }
+                    };
+
+                    PolarsResult::Ok(RowGroupData {
+                        byte_source,
+                        path_index: current_path_index,
+                        row_offset: current_row_offset,
+                        slice,
+                        file_max_row_group_height: current_max_row_group_height,
+                        row_group_metadata,
+                        shared_file_state: current_shared_file_state.clone(),
+                    })
+                });
+
+                let handle = async_executor::AbortOnDropHandle::new(handle);
+                return Some(Ok(handle));
+            }
+
+            // Initialize state to the next file.
+            if !self.init_next_file_state().await {
+                break;
+            }
+        }
+
+        None
+    }
+}
+
+enum FetchedBytes {
+    MemSlice { mem_slice: MemSlice, offset: usize },
+    BytesMap(PlHashMap<usize, MemSlice>),
+}
+
+impl FetchedBytes {
+    fn get_range(&self, range: std::ops::Range<usize>) -> MemSlice {
+        match self {
+            Self::MemSlice { mem_slice, offset } => {
+                let offset = *offset;
+                debug_assert!(range.start >= offset);
+                mem_slice.slice(range.start - offset..range.end - offset)
+            },
+            Self::BytesMap(v) => {
+                let v = v.get(&range.start).unwrap();
+                debug_assert_eq!(v.len(), range.len());
+                v.clone()
+            },
+        }
+    }
+}
+
+#[rustfmt::skip]
+type RowGroupDataStreamFut = std::pin::Pin<Box<
+    dyn Future<
+        Output =
+            (
+                Box<RowGroupDataFetcher>           ,
+                Option                             <
+                PolarsResult                       <
+                async_executor::AbortOnDropHandle  <
+                PolarsResult                       <
+                RowGroupData     >     >     >     >
+            )
+    > + Send
+>>;
+
+struct RowGroupDataStream {
+    current_future: RowGroupDataStreamFut,
+}
+
+impl RowGroupDataStream {
+    fn new(row_group_data_fetcher: RowGroupDataFetcher) -> Self {
+        // [`RowGroupDataFetcher`] is a big struct, so we Box it once here to avoid boxing it on
+        // every `next()` call.
+        let current_future = Self::call_next_owned(Box::new(row_group_data_fetcher));
+        Self { current_future }
+    }
+
+    fn call_next_owned(
+        mut row_group_data_fetcher: Box<RowGroupDataFetcher>,
+    ) -> RowGroupDataStreamFut {
+        Box::pin(async move {
+            let out = row_group_data_fetcher.next().await;
+            (row_group_data_fetcher, out)
+        })
+    }
+}
+
+impl futures::stream::Stream for RowGroupDataStream {
+    type Item = PolarsResult<async_executor::AbortOnDropHandle<PolarsResult<RowGroupData>>>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::pin::Pin;
+        use std::task::Poll;
+
+        match Pin::new(&mut self.current_future.as_mut()).poll(cx) {
+            Poll::Ready((row_group_data_fetcher, out)) => {
+                if out.is_some() {
+                    self.current_future = Self::call_next_owned(row_group_data_fetcher);
+                }
+
+                Poll::Ready(out)
+            },
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// State shared across row groups for a single file.
+struct SharedFileState {
+    path_index: usize,
+    hive_series: Vec<Series>,
+    file_path_series: Option<Series>,
+}
+
+/// Turns row group data into DataFrames.
+struct RowGroupDecoder {
+    paths: Arc<Vec<PathBuf>>,
+    hive_partitions: Option<Arc<Vec<HivePartitions>>>,
+    hive_partitions_width: usize,
+    include_file_paths: Option<Arc<str>>,
+    projected_arrow_fields: Arc<[polars_core::prelude::ArrowField]>,
+    row_index: Option<RowIndex>,
+    physical_predicate: Option<Arc<dyn PhysicalIoExpr>>,
+    ideal_morsel_size: usize,
+}
+
+impl RowGroupDecoder {
+    async fn row_group_data_to_df(
+        &self,
+        row_group_data: RowGroupData,
+    ) -> PolarsResult<Vec<DataFrame>> {
+        let row_group_data = Arc::new(row_group_data);
+
+        let out_width = self.row_index.is_some() as usize
+            + self.projected_arrow_fields.len()
+            + self.hive_partitions_width
+            + self.include_file_paths.is_some() as usize;
+
+        let mut out_columns = Vec::with_capacity(out_width);
+
+        if self.row_index.is_some() {
+            // Add a placeholder so that we don't have to shift the entire vec
+            // later.
+            out_columns.push(Series::default());
+        }
+
+        let slice_range = row_group_data
+            .slice
+            .map(|(offset, len)| offset..offset + len)
+            .unwrap_or(0..row_group_data.row_group_metadata.num_rows());
+
+        let projected_arrow_fields = &self.projected_arrow_fields;
+        let projected_arrow_fields = projected_arrow_fields.clone();
+
+        let row_group_data_2 = row_group_data.clone();
+        let slice_range_2 = slice_range.clone();
+
+        // Minimum number of values to amortize the overhead of spawning tasks.
+        // This value is arbitrarily chosen.
+        const VALUES_PER_THREAD: usize = 16_777_216;
+        let n_rows = row_group_data.row_group_metadata.num_rows();
+        let cols_per_task = 1 + VALUES_PER_THREAD / n_rows;
+
+        let decode_fut_iter = (0..self.projected_arrow_fields.len())
+            .step_by(cols_per_task)
+            .map(move |offset| {
+                let row_group_data = row_group_data_2.clone();
+                let slice_range = slice_range_2.clone();
+                let projected_arrow_fields = projected_arrow_fields.clone();
+
+                async move {
+                    (offset
+                        ..offset
+                            .saturating_add(cols_per_task)
+                            .min(projected_arrow_fields.len()))
+                        .map(|i| {
+                            let arrow_field = projected_arrow_fields[i].clone();
+
+                            let columns_to_deserialize = row_group_data
+                                .row_group_metadata
+                                .columns()
+                                .iter()
+                                .filter(|col_md| {
+                                    col_md.descriptor().path_in_schema[0] == arrow_field.name
+                                })
+                                .map(|col_md| {
+                                    let (offset, len) = col_md.byte_range();
+                                    let offset = offset as usize;
+                                    let len = len as usize;
+
+                                    (
+                                        col_md,
+                                        row_group_data.byte_source.get_range(offset..offset + len),
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+
+                            assert!(
+                                slice_range.end <= row_group_data.row_group_metadata.num_rows()
+                            );
+
+                            let array = polars_io::prelude::_internal::to_deserializer(
+                                columns_to_deserialize,
+                                arrow_field.clone(),
+                                Some(polars_parquet::read::Filter::Range(slice_range.clone())),
+                            )?;
+
+                            let series = Series::try_from((&arrow_field, array))?;
+
+                            // TODO: Also load in the metadata.
+
+                            PolarsResult::Ok(series)
+                        })
+                        .collect::<PolarsResult<Vec<_>>>()
+                }
+            });
+
+        if decode_fut_iter.len() > 1 {
+            for handle in decode_fut_iter.map(|fut| {
+                async_executor::AbortOnDropHandle::new(async_executor::spawn(
+                    TaskPriority::Low,
+                    fut,
+                ))
+            }) {
+                out_columns.extend(handle.await?);
+            }
+        } else {
+            for fut in decode_fut_iter {
+                out_columns.extend(fut.await?);
+            }
+        }
+
+        let projection_height = if self.projected_arrow_fields.is_empty() {
+            slice_range.len()
+        } else {
+            debug_assert!(out_columns.len() > self.row_index.is_some() as usize);
+            out_columns.last().unwrap().len()
+        };
+
+        if let Some(RowIndex { name, offset }) = self.row_index.as_ref() {
+            let Some(offset) = (|| {
+                let offset = offset
+                    .checked_add((row_group_data.row_offset + slice_range.start) as IdxSize)?;
+                offset.checked_add(projection_height as IdxSize)?;
+
+                Some(offset)
+            })() else {
+                let msg = format!(
+                    "adding a row index column with offset {} overflows at {} rows",
+                    offset,
+                    row_group_data.row_offset + slice_range.end
+                );
+                polars_bail!(ComputeError: msg)
+            };
+
+            // The DataFrame can be empty at this point if no columns were projected from the file,
+            // so we create the row index column manually instead of using `df.with_row_index` to
+            // ensure it has the correct number of rows.
+            let mut ca = IdxCa::from_vec(
+                name,
+                (offset..offset + projection_height as IdxSize).collect(),
+            );
+            ca.set_sorted_flag(IsSorted::Ascending);
+
+            out_columns[0] = ca.into_series();
+        }
+
+        let shared_file_state = row_group_data
+            .shared_file_state
+            .get_or_init(|| async {
+                let path_index = row_group_data.path_index;
+
+                let hive_series = if let Some(hp) = self.hive_partitions.as_deref() {
+                    let mut v = hp[path_index].materialize_partition_columns();
+                    for s in v.iter_mut() {
+                        *s = s.new_from_index(0, row_group_data.file_max_row_group_height);
+                    }
+                    v
+                } else {
+                    vec![]
+                };
+
+                let file_path_series = self.include_file_paths.as_deref().map(|file_path_col| {
+                    StringChunked::full(
+                        file_path_col,
+                        self.paths[path_index].to_str().unwrap(),
+                        row_group_data.file_max_row_group_height,
+                    )
+                    .into_series()
+                });
+
+                SharedFileState {
+                    path_index,
+                    hive_series,
+                    file_path_series,
+                }
+            })
+            .await;
+
+        assert_eq!(shared_file_state.path_index, row_group_data.path_index);
+
+        for s in &shared_file_state.hive_series {
+            debug_assert!(s.len() >= projection_height);
+            out_columns.push(s.slice(0, projection_height));
+        }
+
+        if let Some(file_path_series) = &shared_file_state.file_path_series {
+            debug_assert!(file_path_series.len() >= projection_height);
+            out_columns.push(file_path_series.slice(0, projection_height));
+        }
+
+        let df = unsafe { DataFrame::new_no_checks(out_columns) };
+
+        // Re-calculate: A slice may have been applied.
+        let cols_per_task = 1 + VALUES_PER_THREAD / df.height();
+
+        let df = if let Some(predicate) = self.physical_predicate.as_deref() {
+            let mask = predicate.evaluate_io(&df)?;
+            let mask = mask.bool().unwrap();
+
+            if cols_per_task <= df.width() {
+                df._filter_seq(mask)?
+            } else {
+                let mask = mask.clone();
+                let cols = Arc::new(df.take_columns());
+                let mut out_cols = Vec::with_capacity(cols.len());
+
+                for handle in (0..cols.len())
+                    .step_by(cols_per_task)
+                    .map(move |offset| {
+                        let cols = cols.clone();
+                        let mask = mask.clone();
+                        async move {
+                            cols[offset..offset.saturating_add(cols_per_task).min(cols.len())]
+                                .iter()
+                                .map(|s| s.filter(&mask))
+                                .collect::<PolarsResult<Vec<_>>>()
+                        }
+                    })
+                    .map(|fut| {
+                        async_executor::AbortOnDropHandle::new(async_executor::spawn(
+                            TaskPriority::Low,
+                            fut,
+                        ))
+                    })
+                {
+                    out_cols.extend(handle.await?);
+                }
+
+                unsafe { DataFrame::new_no_checks(out_cols) }
+            }
+        } else {
+            df
+        };
+
+        assert_eq!(df.width(), out_width);
+
+        let n_morsels = if df.height() > 3 * self.ideal_morsel_size / 2 {
+            // num_rows > (1.5 * ideal_morsel_size)
+            (df.height() / self.ideal_morsel_size).max(2)
+        } else {
+            1
+        } as u64;
+
+        if n_morsels == 1 {
+            return Ok(vec![df]);
+        }
+
+        let rows_per_morsel = 1 + df.height() / n_morsels as usize;
+
+        let out = (0..i64::try_from(df.height()).unwrap())
+            .step_by(rows_per_morsel)
+            .map(|offset| df.slice(offset, rows_per_morsel))
+            .collect::<Vec<_>>();
+
+        Ok(out)
+    }
+}
+
+/// Read the metadata bytes of a parquet file, does not decode the bytes. If during metadata fetch
+/// the bytes of the entire file are loaded, it is returned in the second return value.
+async fn read_parquet_metadata_bytes(
+    byte_source: &DynByteSource,
+    verbose: bool,
+) -> PolarsResult<(MemSlice, Option<MemSlice>)> {
+    use polars_parquet::parquet::error::ParquetError;
+    use polars_parquet::parquet::PARQUET_MAGIC;
+
+    const FOOTER_HEADER_SIZE: usize = polars_parquet::parquet::FOOTER_SIZE as usize;
+
+    let file_size = byte_source.get_size().await?;
+
+    if file_size < FOOTER_HEADER_SIZE {
+        return Err(ParquetError::OutOfSpec(format!(
+            "file size ({}) is less than minimum size required to store parquet footer ({})",
+            file_size, FOOTER_HEADER_SIZE
+        ))
+        .into());
+    }
+
+    let estimated_metadata_size = if let DynByteSource::MemSlice(_) = byte_source {
+        // Mmapped or in-memory, reads are free.
+        file_size
+    } else {
+        (file_size / 2048).clamp(16_384, 131_072).min(file_size)
+    };
+
+    let bytes = byte_source
+        .get_range((file_size - estimated_metadata_size)..file_size)
+        .await?;
+
+    let footer_header_bytes = bytes.slice((bytes.len() - FOOTER_HEADER_SIZE)..bytes.len());
+
+    let (v, remaining) = footer_header_bytes.split_at(4);
+    let footer_size = i32::from_le_bytes(v.try_into().unwrap());
+
+    if remaining != PARQUET_MAGIC {
+        return Err(ParquetError::OutOfSpec(format!(
+            r#"expected parquet magic bytes "{}" in footer, got "{}" instead"#,
+            std::str::from_utf8(&PARQUET_MAGIC).unwrap(),
+            String::from_utf8_lossy(remaining)
+        ))
+        .into());
+    }
+
+    if footer_size < 0 {
+        return Err(ParquetError::OutOfSpec(format!(
+            "expected positive footer size, got {} instead",
+            footer_size
+        ))
+        .into());
+    }
+
+    let footer_size = footer_size as usize + FOOTER_HEADER_SIZE;
+
+    if file_size < footer_size {
+        return Err(ParquetError::OutOfSpec(format!(
+            "file size ({}) is less than the indicated footer size ({})",
+            file_size, footer_size
+        ))
+        .into());
+    }
+
+    if bytes.len() < footer_size {
+        debug_assert!(!matches!(byte_source, DynByteSource::MemSlice(_)));
+        if verbose {
+            eprintln!(
+                "[ParquetSource]: Extra {} bytes need to be fetched for metadata \
+            (initial estimate = {}, actual size = {})",
+                footer_size - estimated_metadata_size,
+                bytes.len(),
+                footer_size,
+            );
+        }
+
+        let mut out = Vec::with_capacity(footer_size);
+        let offset = file_size - footer_size;
+        let len = footer_size - bytes.len();
+        let delta_bytes = byte_source.get_range(offset..(offset + len)).await?;
+
+        debug_assert!(out.capacity() >= delta_bytes.len() + bytes.len());
+
+        out.extend_from_slice(&delta_bytes);
+        out.extend_from_slice(&bytes);
+
+        Ok((MemSlice::from_vec(out), None))
+    } else {
+        if verbose && !matches!(byte_source, DynByteSource::MemSlice(_)) {
+            eprintln!(
+                "[ParquetSource]: Fetched all bytes for metadata on first try \
+                (initial estimate = {}, actual size = {}, excess = {})",
+                bytes.len(),
+                footer_size,
+                estimated_metadata_size - footer_size,
+            );
+        }
+
+        let metadata_bytes = bytes.slice((bytes.len() - footer_size)..bytes.len());
+
+        if bytes.len() == file_size {
+            Ok((metadata_bytes, Some(bytes)))
+        } else {
+            debug_assert!(!matches!(byte_source, DynByteSource::MemSlice(_)));
+            let metadata_bytes = if bytes.len() - footer_size >= bytes.len() {
+                // Re-allocate to drop the excess bytes
+                MemSlice::from_vec(metadata_bytes.to_vec())
+            } else {
+                metadata_bytes
+            };
+
+            Ok((metadata_bytes, None))
+        }
+    }
+}
+
+fn get_row_group_byte_ranges(
+    row_group_metadata: &RowGroupMetaData,
+) -> impl ExactSizeIterator<Item = std::ops::Range<usize>> + '_ {
+    let row_group_columns = row_group_metadata.columns();
+
+    row_group_columns.iter().map(|rg_col_metadata| {
+        let (offset, len) = rg_col_metadata.byte_range();
+        (offset as usize)..(offset + len) as usize
+    })
+}
+
+/// TODO: This is quadratic - incorporate https://github.com/pola-rs/polars/pull/18327 that is
+/// merged.
+fn get_row_group_byte_ranges_for_projection<'a>(
+    row_group_metadata: &'a RowGroupMetaData,
+    columns: &'a [String],
+) -> impl Iterator<Item = std::ops::Range<usize>> + 'a {
+    let row_group_columns = row_group_metadata.columns();
+
+    row_group_columns.iter().filter_map(move |rg_col_metadata| {
+        for col_name in columns {
+            if &rg_col_metadata.descriptor().path_in_schema[0] == col_name {
+                let (offset, len) = rg_col_metadata.byte_range();
+                let range = (offset as usize)..((offset + len) as usize);
+                return Some(range);
+            }
+        }
+        None
+    })
+}
+
+/// Ensures that a parquet file has all the necessary columns for a projection with the correct
+/// dtype. There are no ordering requirements and extra columns are permitted.
+fn ensure_metadata_has_projected_fields(
+    projected_fields: &[polars_core::prelude::ArrowField],
+    metadata: &FileMetaData,
+) -> PolarsResult<()> {
+    let schema = polars_parquet::arrow::read::infer_schema(metadata)?;
+
+    // Note: We convert to Polars-native dtypes for timezone normalization.
+    let mut schema = schema
+        .fields
+        .into_iter()
+        .map(|x| {
+            let dtype = DataType::from_arrow(&x.data_type, true);
+            (x.name, dtype)
+        })
+        .collect::<PlHashMap<String, DataType>>();
+
+    for field in projected_fields {
+        let Some(dtype) = schema.remove(&field.name) else {
+            polars_bail!(SchemaMismatch: "did not find column: {}", field.name)
+        };
+
+        let expected_dtype = DataType::from_arrow(&field.data_type, true);
+
+        if dtype != expected_dtype {
+            polars_bail!(SchemaMismatch: "data type mismatch for column {}: found: {}, expected: {}",
+                &field.name, dtype, expected_dtype
+            )
+        }
+    }
+
+    Ok(())
+}
+
+fn get_memory_prefetch_func(verbose: bool) -> fn(&[u8]) -> () {
+    let memory_prefetch_func = match std::env::var("POLARS_MEMORY_PREFETCH").ok().as_deref() {
+        None => {
+            // Sequential advice was observed to provide speedups on Linux.
+            // ref https://github.com/pola-rs/polars/pull/18152#discussion_r1721701965
+            #[cfg(target_os = "linux")]
+            {
+                mem_prefetch_funcs::madvise_sequential
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                mem_prefetch_funcs::no_prefetch
+            }
+        },
+        Some("no_prefetch") => mem_prefetch_funcs::no_prefetch,
+        Some("prefetch_l2") => mem_prefetch_funcs::prefetch_l2,
+        Some("madvise_sequential") => {
+            #[cfg(target_family = "unix")]
+            {
+                mem_prefetch_funcs::madvise_sequential
+            }
+            #[cfg(not(target_family = "unix"))]
+            {
+                panic!("POLARS_MEMORY_PREFETCH=madvise_sequential is not supported by this system");
+            }
+        },
+        Some("madvise_willneed") => {
+            #[cfg(target_family = "unix")]
+            {
+                mem_prefetch_funcs::madvise_willneed
+            }
+            #[cfg(not(target_family = "unix"))]
+            {
+                panic!("POLARS_MEMORY_PREFETCH=madvise_willneed is not supported by this system");
+            }
+        },
+        Some("madvise_populate_read") => {
+            #[cfg(target_os = "linux")]
+            {
+                mem_prefetch_funcs::madvise_populate_read
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                panic!(
+                    "POLARS_MEMORY_PREFETCH=madvise_populate_read is not supported by this system"
+                );
+            }
+        },
+        Some(v) => panic!("invalid value for POLARS_MEMORY_PREFETCH: {}", v),
+    };
+
+    if verbose {
+        let func_name = match memory_prefetch_func as usize {
+            v if v == mem_prefetch_funcs::no_prefetch as usize => "no_prefetch",
+            v if v == mem_prefetch_funcs::prefetch_l2 as usize => "prefetch_l2",
+            v if v == mem_prefetch_funcs::madvise_sequential as usize => "madvise_sequential",
+            v if v == mem_prefetch_funcs::madvise_willneed as usize => "madvise_willneed",
+            v if v == mem_prefetch_funcs::madvise_populate_read as usize => "madvise_populate_read",
+            _ => unreachable!(),
+        };
+
+        eprintln!("[ParquetSource] Memory prefetch function: {}", func_name);
+    }
+
+    memory_prefetch_func
+}
+
+mod mem_prefetch_funcs {
+    pub use polars_utils::mem::{
+        madvise_populate_read, madvise_sequential, madvise_willneed, prefetch_l2,
+    };
+
+    pub fn no_prefetch(_: &[u8]) {}
+}

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -239,6 +239,31 @@ pub fn lower_ir(
             }
         },
 
+        v @ IR::Scan { .. } => {
+            let IR::Scan {
+                paths,
+                file_info,
+                hive_parts,
+                output_schema,
+                scan_type,
+                predicate,
+                file_options,
+            } = v.clone()
+            else {
+                unreachable!();
+            };
+
+            PhysNodeKind::FileScan {
+                paths,
+                file_info,
+                hive_parts,
+                output_schema,
+                scan_type,
+                predicate,
+                file_options,
+            }
+        },
+
         _ => todo!(),
     };
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -1,9 +1,11 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use polars_core::frame::DataFrame;
 use polars_core::prelude::SortMultipleOptions;
-use polars_core::schema::Schema;
-use polars_plan::plans::{AExpr, DataFrameUdf};
+use polars_core::schema::{Schema, SchemaRef};
+use polars_plan::plans::hive::HivePartitions;
+use polars_plan::plans::{AExpr, DataFrameUdf, FileInfo, FileScan};
 use polars_plan::prelude::expr_ir::ExprIR;
 
 mod lower_expr;
@@ -11,6 +13,7 @@ mod lower_ir;
 mod to_graph;
 
 pub use lower_ir::lower_ir;
+use polars_plan::prelude::FileScanOptions;
 use polars_utils::arena::Arena;
 use polars_utils::itertools::Itertools;
 use slotmap::{Key, SecondaryMap, SlotMap};
@@ -109,6 +112,16 @@ pub enum PhysNodeKind {
     #[allow(unused)]
     Multiplexer {
         input: PhysNodeKey,
+    },
+
+    FileScan {
+        paths: Arc<Vec<PathBuf>>,
+        file_info: FileInfo,
+        hive_parts: Option<Arc<Vec<HivePartitions>>>,
+        predicate: Option<ExprIR>,
+        output_schema: Option<SchemaRef>,
+        scan_type: FileScan,
+        file_options: FileScanOptions,
     },
 }
 
@@ -210,6 +223,24 @@ fn visualize_plan_rec(
             (label.to_string(), inputs.as_slice())
         },
         PhysNodeKind::Multiplexer { input } => ("multiplexer".to_string(), from_ref(input)),
+        #[allow(unused)]
+        PhysNodeKind::FileScan {
+            paths,
+            file_info,
+            hive_parts,
+            output_schema,
+            scan_type,
+            predicate,
+            file_options,
+        } => {
+            // TODO: Improve formatting
+            let label = match scan_type {
+                FileScan::Parquet { .. } => "parquet-source",
+                _ => todo!(),
+            };
+
+            (label.to_string(), &[][..])
+        },
     };
 
     out.push(format!(

--- a/crates/polars-stream/src/utils/mod.rs
+++ b/crates/polars-stream/src/utils/mod.rs
@@ -1,3 +1,5 @@
 pub mod in_memory_linearize;
 pub mod late_materialized_df;
 pub mod linearizer;
+pub mod notify_channel;
+pub mod task_handles_ext;

--- a/crates/polars-stream/src/utils/notify_channel.rs
+++ b/crates/polars-stream/src/utils/notify_channel.rs
@@ -1,0 +1,56 @@
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+/// Receiver that calls `notify()` before `recv()`
+pub struct NotifyReceiver<T> {
+    receiver: Receiver<T>,
+    /// We use a channel for notify because it lets the sender know when the receiver has been
+    /// dropped.
+    notify: Sender<()>,
+}
+
+impl<T: Send> NotifyReceiver<T> {
+    pub async fn recv(&mut self) -> Option<T> {
+        match self.notify.try_send(()) {
+            Err(TrySendError::Closed(_)) => None,
+            Ok(_) => self.receiver.recv().await,
+            v @ Err(TrySendError::Full(_)) => {
+                v.unwrap();
+                unreachable!();
+            },
+        }
+    }
+}
+
+/// The notify allows us to make the producer only produce values when requested. Otherwise it would
+/// produce a new value as soon as the previous value was consumed (as there would be channel
+/// capacity).
+pub fn notify_channel<T>() -> (Sender<T>, Receiver<()>, NotifyReceiver<T>) {
+    let (tx, rx) = channel::<T>(1);
+    let (notify_tx, notify_rx) = channel(1);
+
+    (
+        tx,
+        notify_rx,
+        NotifyReceiver {
+            receiver: rx,
+            notify: notify_tx,
+        },
+    )
+}
+
+mod tests {
+
+    #[test]
+    fn test_notify_channel() {
+        use futures::FutureExt;
+
+        use super::notify_channel;
+        let (tx, mut notify, mut rx) = notify_channel();
+        assert!(notify.recv().now_or_never().is_none());
+        assert!(rx.recv().now_or_never().is_none());
+        assert_eq!(notify.recv().now_or_never().unwrap(), Some(()));
+        assert!(tx.try_send(()).is_ok());
+        assert!(rx.recv().now_or_never().is_some());
+    }
+}

--- a/crates/polars-stream/src/utils/task_handles_ext.rs
+++ b/crates/polars-stream/src/utils/task_handles_ext.rs
@@ -1,0 +1,20 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Calls [`tokio::task::JoinHandle::abort`] on the join handle when dropped.
+pub struct AbortOnDropHandle<T>(pub tokio::task::JoinHandle<T>);
+
+impl<T> Future for AbortOnDropHandle<T> {
+    type Output = Result<T, tokio::task::JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+impl<T> Drop for AbortOnDropHandle<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -16,6 +16,7 @@ bytemuck = { workspace = true }
 bytes = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
+libc = { workspace = true }
 memmap = { workspace = true, optional = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/polars-utils/src/mem.rs
+++ b/crates/polars-utils/src/mem.rs
@@ -1,3 +1,15 @@
+use once_cell::sync::Lazy;
+static PAGE_SIZE: Lazy<usize> = Lazy::new(|| {
+    #[cfg(target_family = "unix")]
+    unsafe {
+        libc::sysconf(libc::_SC_PAGESIZE) as usize
+    }
+    #[cfg(not(target_family = "unix"))]
+    {
+        4096
+    }
+});
+
 /// # Safety
 /// This may break aliasing rules, make sure you are the only owner.
 #[allow(clippy::mut_from_ref)]
@@ -10,7 +22,7 @@ pub unsafe fn to_mutable_slice<T: Copy>(s: &[T]) -> &mut [T] {
 /// # Safety
 ///
 /// This should only be called with pointers to valid memory.
-pub unsafe fn prefetch_l2(ptr: *const u8) {
+unsafe fn prefetch_l2_impl(ptr: *const u8) {
     #[cfg(target_arch = "x86_64")]
     {
         use std::arch::x86_64::*;
@@ -21,5 +33,56 @@ pub unsafe fn prefetch_l2(ptr: *const u8) {
     {
         use std::arch::aarch64::*;
         unsafe { _prefetch(ptr as *const _, _PREFETCH_READ, _PREFETCH_LOCALITY2) };
+    }
+}
+
+/// Attempt to prefetch the memory in the slice to the L2 cache.
+pub fn prefetch_l2(slice: &[u8]) {
+    if slice.is_empty() {
+        return;
+    }
+
+    // @TODO: We can play a bit more with this prefetching. Maybe introduce a maximum number of
+    // prefetches as to not overwhelm the processor. The linear prefetcher should pick it up
+    // at a certain point.
+
+    for i in (0..slice.len()).step_by(*PAGE_SIZE) {
+        unsafe { prefetch_l2_impl(slice[i..].as_ptr()) };
+    }
+
+    unsafe { prefetch_l2_impl(slice[slice.len() - 1..].as_ptr()) }
+}
+
+/// `madvise()` with `MADV_SEQUENTIAL` on unix systems. This is a no-op on non-unix systems.
+pub fn madvise_sequential(slice: &[u8]) {
+    #[cfg(target_family = "unix")]
+    madvise(slice, libc::MADV_SEQUENTIAL);
+}
+
+/// `madvise()` with `MADV_WILLNEED` on unix systems. This is a no-op on non-unix systems.
+pub fn madvise_willneed(slice: &[u8]) {
+    #[cfg(target_family = "unix")]
+    madvise(slice, libc::MADV_WILLNEED);
+}
+
+/// `madvise()` with `MADV_POPULATE_READ` on linux systems. This a no-op on non-linux systems.
+pub fn madvise_populate_read(#[allow(unused)] slice: &[u8]) {
+    #[cfg(target_os = "linux")]
+    madvise(slice, libc::MADV_POPULATE_READ);
+}
+
+#[cfg(target_family = "unix")]
+fn madvise(slice: &[u8], advice: libc::c_int) {
+    let ptr = slice.as_ptr();
+
+    let align = ptr as usize % *PAGE_SIZE;
+    let ptr = ptr.wrapping_sub(align);
+    let len = slice.len() + align;
+
+    if unsafe { libc::madvise(ptr as *mut libc::c_void, len, advice) } != 0 {
+        let err = std::io::Error::last_os_error();
+        if let std::io::ErrorKind::InvalidInput = err.kind() {
+            panic!("{}", err);
+        }
     }
 }

--- a/crates/polars-utils/src/mmap.rs
+++ b/crates/polars-utils/src/mmap.rs
@@ -93,19 +93,7 @@ mod private {
         /// Attempt to prefetch the memory belonging to to this [`MemSlice`]
         #[inline]
         pub fn prefetch(&self) {
-            if self.len() == 0 {
-                return;
-            }
-
-            // @TODO: We can play a bit more with this prefetching. Maybe introduce a maximum number of
-            // prefetches as to not overwhelm the processor. The linear prefetcher should pick it up
-            // at a certain point.
-
-            const PAGE_SIZE: usize = 4096;
-            for i in 0..self.len() / PAGE_SIZE {
-                unsafe { prefetch_l2(self[i * PAGE_SIZE..].as_ptr()) };
-            }
-            unsafe { prefetch_l2(self[self.len() - 1..].as_ptr()) }
+            prefetch_l2(self.as_ref());
         }
 
         /// # Panics


### PR DESCRIPTION
Enables scanning parquet files in the new streaming engine. This is done via a new parquet source
node that has been built to run natively on the new async executor for maximum performance.

### Benchmarks

#### Setup

<details>
<summary>Dataset generation</summary>

```python
import os

os.environ["POLARS_VERBOSE"] = "1"
from datetime import date
from pathlib import Path

import polars as pl

prefix = Path(".env/data/")
file_path = prefix / "data.parquet"
partitioned_files_path = prefix / "data"


def write_datasets():
    cols = {}
    for i in range(10):
        cols[f"a{i}"] = range(50_000_000)
        cols[f"b{i}"] = range(-50_000_000, 0)
        cols[f"c{i}"] = "a_string_value"
        cols[f"d{i}"] = "another_string_value"
        cols[f"e{i}"] = date.today()

    df = pl.DataFrame(data=cols).select(
        (1 + pl.int_range(pl.len()) // 1_000_000).alias("partition_id"), pl.all()
    )
    df.write_parquet(file_path)
    df.write_parquet(partitioned_files_path, partition_by="partition_id")


if not prefix.exists():
    print("Creating datasets")
    prefix.mkdir(parents=True)
    partitioned_files_path.mkdir()
    write_datasets()
    exit()

```

</details>

```python
pl.scan_parquet(file_path).collect() # 1x 50M rows, 51 columns

this branch  (new streaming, build-opt) :  8.79s user 3.69s system 433% cpu 2.880 total
polars 1.4.1 (mem-engine)               :  8.75s user 3.80s system 432% cpu 2.904 total
polars 1.4.1 (streaming)                : 10.04s user 5.25s system 268% cpu 5.691 total
```

```python
pl.scan_parquet(partitioned_files_path).collect() # 50x 1M rows (total 50M rows), 51 columns

this branch  (new streaming, build-opt) : 8.72s user 3.36s system 432% cpu 2.793 total
polars 1.4.1 (mem-engine)               : 8.71s user 3.65s system 436% cpu 2.834 total
polars 1.4.1 (streaming)                : 9.52s user 4.57s system 338% cpu 4.165 total
```

### Feature parity

The source node in this PR should fully support all existing functionality of the in-memory engine
(including slices with negative offsets, which isn't supported by the existing streaming engine).

#### Metadata fetching optimization

The new source node uses a metadata size estimate for async reads that can allows us to potentially
save network requests. Small parquet files are also fully downloaded in one network request:

```python
[ParquetSource]: 5 columns to be projected from 1 files
[ParquetSource]: Fetched all bytes for metadata on first try (initial estimate = 3108, actual size = 1101, excess = 2007)
[ParquetSource]: Parquet file was fully fetched during metadata read (3108 bytes).
```

```python
[ParquetSource]: 50 columns to be projected from 1 files
[ParquetSource]: Extra 691849 bytes need to be fetched for metadata (initial estimate = 131072, actual size = 822921)
```

#### Slice pushdown

```python
[ParquetSource]: 50 columns to be projected from 1 files
[ParquetSource]: Slice pushdown: Stopped reading at file at index 0 (remaining 0 files will not be read)
[ParquetSource]: Slice pushdown: Skipped row group 0 in file 0 (263157 rows)
[ParquetSource]: Slice pushdown: Skipped row group 1 in file 0 (263157 rows)
...(repeated lines omitted)
[ParquetSource]: Slice pushdown: Skipped row group 170 in file 0 (263157 rows)
[ParquetSource]: Slice pushdown: Stop at row group 172 in file 0 (remaining 17 row groups will not be read)
```

#### Slice pushdown (negative offset)

```python
[ParquetSource]: 50 columns to be projected from 100 files
[ParquetSource]: Slice pushdown: Negatively-offsetted slice (-45000000, 10) begins at file index 10, translated to 0..10
[ParquetSource]: Slice pushdown: Stopped reading at file at index 10 (remaining 89 files will not be read)
```

#### Predicate pushdown

```python
[ParquetSource]: 50 columns to be projected from 1 files
parquet file can be skipped, the statistics were sufficient to apply the predicate.
[ParquetSource]: Predicate pushdown: Skipped row group 0 in file 0 (263157 rows)
parquet file can be skipped, the statistics were sufficient to apply the predicate.
[ParquetSource]: Predicate pushdown: Skipped row group 1 in file 0 (263157 rows)
parquet file can be skipped, the statistics were sufficient to apply the predicate.
...(repeated lines omitted)
parquet file can be skipped, the statistics were sufficient to apply the predicate.
[ParquetSource]: Predicate pushdown: Skipped row group 170 in file 0 (263157 rows)
parquet file must be read, statistics not sufficient for predicate.
...(repeated lines omitted)
```

### Byte source trait

This PR also introduces a new byte source trait that provides a unified interface to efficiently fetch byte ranges from both local and cloud files.