### PR TITLE
fix: Properly handle empty Parquet row groups with no dictionary

### DIFF
--- a/crates/polars-io/src/parquet/read/mmap.rs
+++ b/crates/polars-io/src/parquet/read/mmap.rs
@@ -73,13 +73,7 @@ pub(super) fn to_deserializer<'a>(
             // Advise fetching the data for the column chunk
             chunk.prefetch();
 
-            let pages = PageReader::new(
-                MemReader::new(chunk),
-                column_meta,
-                std::sync::Arc::new(|_, _| true),
-                vec![],
-                usize::MAX,
-            );
+            let pages = PageReader::new(MemReader::new(chunk), column_meta, vec![], usize::MAX);
             (
                 BasicDecompressor::new(pages, vec![]),
                 &column_meta.descriptor().descriptor.primitive_type,

--- a/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
@@ -29,14 +29,12 @@ use crate::parquet::schema::types::PrimitiveType;
 pub fn get_page_iterator(
     column_metadata: &ColumnChunkMetaData,
     reader: MemReader,
-    pages_filter: Option<PageFilter>,
     buffer: Vec<u8>,
     max_header_size: usize,
 ) -> PolarsResult<PageReader> {
     Ok(_get_page_iterator(
         column_metadata,
         reader,
-        pages_filter,
         buffer,
         max_header_size,
     )?)

--- a/crates/polars-parquet/src/arrow/read/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/mod.rs
@@ -35,7 +35,7 @@ pub use crate::parquet::{
     read::{
         decompress, get_column_iterator, read_columns_indexes as _read_columns_indexes,
         read_metadata as _read_metadata, read_pages_locations, BasicDecompressor,
-        MutStreamingIterator, PageFilter, PageReader, ReadColumnIterator, State,
+        MutStreamingIterator, PageReader, ReadColumnIterator, State,
     },
     schema::types::{
         GroupLogicalType, ParquetType, PhysicalType, PrimitiveConvertedType, PrimitiveLogicalType,

--- a/crates/polars-parquet/src/arrow/read/row_group.rs
+++ b/crates/polars-parquet/src/arrow/read/row_group.rs
@@ -146,7 +146,6 @@ pub fn to_deserializer<'a>(
             let pages = PageReader::new(
                 MemReader::from_vec(chunk),
                 column_meta,
-                std::sync::Arc::new(|_, _| true),
                 vec![],
                 len * 2 + 1024,
             );

--- a/crates/polars-parquet/src/parquet/read/mod.rs
+++ b/crates/polars-parquet/src/parquet/read/mod.rs
@@ -8,7 +8,6 @@ mod page;
 mod stream;
 
 use std::io::{Seek, SeekFrom};
-use std::sync::Arc;
 
 pub use column::*;
 pub use compression::{decompress, BasicDecompressor};
@@ -16,7 +15,7 @@ pub use indexes::{read_columns_indexes, read_pages_locations};
 pub use metadata::{deserialize_metadata, read_metadata, read_metadata_with_size};
 #[cfg(feature = "async")]
 pub use page::{get_page_stream, get_page_stream_from_column_start};
-pub use page::{PageFilter, PageIterator, PageMetaData, PageReader};
+pub use page::{PageIterator, PageMetaData, PageReader};
 use polars_utils::mmap::MemReader;
 #[cfg(feature = "async")]
 pub use stream::read_metadata as read_metadata_async;
@@ -45,18 +44,14 @@ pub fn filter_row_groups(
 pub fn get_page_iterator(
     column_chunk: &ColumnChunkMetaData,
     mut reader: MemReader,
-    pages_filter: Option<PageFilter>,
     scratch: Vec<u8>,
     max_page_size: usize,
 ) -> ParquetResult<PageReader> {
-    let pages_filter = pages_filter.unwrap_or_else(|| Arc::new(|_, _| true));
-
     let (col_start, _) = column_chunk.byte_range();
     reader.seek(SeekFrom::Start(col_start))?;
     Ok(PageReader::new(
         reader,
         column_chunk,
-        pages_filter,
         scratch,
         max_page_size,
     ))

--- a/crates/polars-parquet/src/parquet/read/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/read/page/mod.rs
@@ -2,7 +2,7 @@ mod reader;
 #[cfg(feature = "async")]
 mod stream;
 
-pub use reader::{PageFilter, PageMetaData, PageReader};
+pub use reader::{PageMetaData, PageReader};
 
 use crate::parquet::error::ParquetError;
 use crate::parquet::page::CompressedPage;

--- a/crates/polars-parquet/src/parquet/read/page/reader.rs
+++ b/crates/polars-parquet/src/parquet/read/page/reader.rs
@@ -135,6 +135,12 @@ impl PageReader {
     }
 
     pub fn read_dict(&mut self) -> ParquetResult<Option<CompressedDictPage>> {
+        // If there are no pages, we cannot check if the first page is a dictionary page. Just
+        // return the fact there is no dictionary page.
+        if self.reader.remaining_len() == 0 {
+            return Ok(None);
+        }
+
         // a dictionary page exists iff the first data page is not at the start of
         // the column
         let seek_offset = self.reader.position();

--- a/crates/polars-parquet/src/parquet/read/page/reader.rs
+++ b/crates/polars-parquet/src/parquet/read/page/reader.rs
@@ -1,5 +1,5 @@
 use std::io::Seek;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use parquet_format_safe::thrift::protocol::TCompactInputProtocol;
 use polars_utils::mmap::{MemReader, MemSlice};
@@ -56,9 +56,6 @@ impl From<&ColumnChunkMetaData> for PageMetaData {
     }
 }
 
-/// Type declaration for a page filter
-pub type PageFilter = Arc<dyn Fn(&Descriptor, &DataPageHeader) -> bool + Send + Sync>;
-
 /// A fallible [`Iterator`] of [`CompressedDataPage`]. This iterator reads pages back
 /// to back until all pages have been consumed.
 /// The pages from this iterator always have [`None`] [`crate::parquet::page::CompressedDataPage::selected_rows()`] since
@@ -75,8 +72,6 @@ pub struct PageReader {
 
     // The number of total values in this column chunk.
     total_num_values: i64,
-
-    pages_filter: PageFilter,
 
     descriptor: Descriptor,
 
@@ -95,11 +90,10 @@ impl PageReader {
     pub fn new(
         reader: MemReader,
         column: &ColumnChunkMetaData,
-        pages_filter: PageFilter,
         scratch: Vec<u8>,
         max_page_size: usize,
     ) -> Self {
-        Self::new_with_page_meta(reader, column.into(), pages_filter, scratch, max_page_size)
+        Self::new_with_page_meta(reader, column.into(), scratch, max_page_size)
     }
 
     /// Create a a new [`PageReader`] with [`PageMetaData`].
@@ -108,7 +102,6 @@ impl PageReader {
     pub fn new_with_page_meta(
         reader: MemReader,
         reader_meta: PageMetaData,
-        pages_filter: PageFilter,
         scratch: Vec<u8>,
         max_page_size: usize,
     ) -> Self {
@@ -118,7 +111,6 @@ impl PageReader {
             compression: reader_meta.compression,
             seen_num_values: 0,
             descriptor: reader_meta.descriptor,
-            pages_filter,
             scratch,
             max_page_size,
         }
@@ -196,16 +188,7 @@ impl Iterator for PageReader {
     fn next(&mut self) -> Option<Self::Item> {
         let mut buffer = std::mem::take(&mut self.scratch);
         let maybe_maybe_page = next_page(self).transpose();
-        if let Some(ref maybe_page) = maybe_maybe_page {
-            if let Ok(CompressedPage::Data(page)) = maybe_page {
-                // check if we should filter it (only valid for data pages)
-                let to_consume = (self.pages_filter)(&self.descriptor, page.header());
-                if !to_consume {
-                    self.scratch = std::mem::take(&mut buffer);
-                    return self.next();
-                }
-            }
-        } else {
+        if maybe_maybe_page.is_none() {
             // no page => we take back the buffer
             self.scratch = std::mem::take(&mut buffer);
         }

--- a/crates/polars-parquet/src/parquet/read/page/stream.rs
+++ b/crates/polars-parquet/src/parquet/read/page/stream.rs
@@ -1,13 +1,11 @@
 use std::io::SeekFrom;
 
 use async_stream::try_stream;
-use futures::io::{copy, sink};
 use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, Stream};
 use parquet_format_safe::thrift::protocol::TCompactInputStreamProtocol;
 use polars_utils::mmap::MemSlice;
 
 use super::reader::{finish_page, PageMetaData};
-use super::PageFilter;
 use crate::parquet::compression::Compression;
 use crate::parquet::error::{ParquetError, ParquetResult};
 use crate::parquet::metadata::{ColumnChunkMetaData, Descriptor};
@@ -19,17 +17,9 @@ pub async fn get_page_stream<'a, RR: AsyncRead + Unpin + Send + AsyncSeek>(
     column_metadata: &'a ColumnChunkMetaData,
     reader: &'a mut RR,
     scratch: Vec<u8>,
-    pages_filter: PageFilter,
     max_page_size: usize,
 ) -> ParquetResult<impl Stream<Item = ParquetResult<CompressedPage>> + 'a> {
-    get_page_stream_with_page_meta(
-        column_metadata.into(),
-        reader,
-        scratch,
-        pages_filter,
-        max_page_size,
-    )
-    .await
+    get_page_stream_with_page_meta(column_metadata.into(), reader, scratch, max_page_size).await
 }
 
 /// Returns a stream of compressed data pages from a reader that begins at the start of the column
@@ -37,7 +27,6 @@ pub async fn get_page_stream_from_column_start<'a, R: AsyncRead + Unpin + Send>(
     column_metadata: &'a ColumnChunkMetaData,
     reader: &'a mut R,
     scratch: Vec<u8>,
-    pages_filter: PageFilter,
     max_header_size: usize,
 ) -> ParquetResult<impl Stream<Item = ParquetResult<CompressedPage>> + 'a> {
     let page_metadata: PageMetaData = column_metadata.into();
@@ -47,7 +36,6 @@ pub async fn get_page_stream_from_column_start<'a, R: AsyncRead + Unpin + Send>(
         page_metadata.compression,
         page_metadata.descriptor,
         scratch,
-        pages_filter,
         max_header_size,
     ))
 }
@@ -57,7 +45,6 @@ pub async fn get_page_stream_with_page_meta<RR: AsyncRead + Unpin + Send + Async
     page_metadata: PageMetaData,
     reader: &mut RR,
     scratch: Vec<u8>,
-    pages_filter: PageFilter,
     max_page_size: usize,
 ) -> ParquetResult<impl Stream<Item = ParquetResult<CompressedPage>> + '_> {
     let column_start = page_metadata.column_start;
@@ -68,7 +55,6 @@ pub async fn get_page_stream_with_page_meta<RR: AsyncRead + Unpin + Send + Async
         page_metadata.compression,
         page_metadata.descriptor,
         scratch,
-        pages_filter,
         max_page_size,
     ))
 }
@@ -79,7 +65,6 @@ fn _get_page_stream<R: AsyncRead + Unpin + Send>(
     compression: Compression,
     descriptor: Descriptor,
     mut scratch: Vec<u8>,
-    pages_filter: PageFilter,
     max_page_size: usize,
 ) -> impl Stream<Item = ParquetResult<CompressedPage>> + '_ {
     let mut seen_values = 0i64;
@@ -92,14 +77,6 @@ fn _get_page_stream<R: AsyncRead + Unpin + Send>(
             seen_values += data_header.as_ref().map(|x| x.num_values() as i64).unwrap_or_default();
 
             let read_size: usize = page_header.compressed_page_size.try_into()?;
-
-            if let Some(data_header) = data_header {
-                if !pages_filter(&descriptor, &data_header) {
-                    // page to be skipped, we sill need to seek
-                    copy(reader.take(read_size as u64), &mut sink()).await?;
-                    continue
-                }
-            }
 
             if read_size > max_page_size {
                 Err(ParquetError::WouldOverAllocate)?

--- a/crates/polars/tests/it/io/parquet/read/mod.rs
+++ b/crates/polars/tests/it/io/parquet/read/mod.rs
@@ -200,7 +200,6 @@ pub fn read_column(
         reader,
         &metadata.row_groups[row_group],
         field.name(),
-        None,
         usize::MAX,
     );
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1389,6 +1389,20 @@ def test_scan_round_trip_parametric(tmp_path: Path, df: pl.DataFrame) -> None:
     test_scan_round_trip(tmp_path, df)
 
 
+def test_empty_rg_no_dict_page_18146() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [],
+        },
+        schema={"a": pl.String},
+    )
+
+    f = io.BytesIO()
+    pq.write_table(df.to_arrow(), f, compression="NONE", use_dictionary=False)
+    f.seek(0)
+    assert_frame_equal(pl.read_parquet(f), df)
+
+
 def test_write_sliced_lists_18069() -> None:
     f = io.BytesIO()
     a = pl.Series(3 * [None, ["$"] * 3], dtype=pl.List(pl.String))


### PR DESCRIPTION
Fixes #18146.