### PR TITLE
docs: Possibly fix table display issue

### DIFF
--- a/docs/_build/css/extra.css
+++ b/docs/_build/css/extra.css
@@ -15,8 +15,8 @@ span .md-typeset .emojione, .md-typeset .gemoji, .md-typeset .twemoji {
     src: 'https://fonts.cdnfonts.com/css/proxima-nova-2'
 }
 
-:root {
-  --md-code-font: "Source Code Pro" !important;
+code, kdb, pre {
+  font-family: monospace !important;
 }
 
 .contributor_icon {


### PR DESCRIPTION
I wasn't able to reproduce https://github.com/pola-rs/polars/issues/11106, but I'm quite sure this PR will fix the issue.

From the screenshots that people posted in the issue, it looks like the table is displayed in a variable width (non-monospace) font. When setting the font to a non-monospace, namely `serif`, in the Firefox developer tools, then the output looks indeed wrong (see "serif" in the bottom right):

![image](https://github.com/user-attachments/assets/12a47ba9-40b2-46c5-9dc1-6e5b87137986)

And if I directly set 
```css
code {
  font-family: "Source Code Pro";
}
```
Then Firefox (and Chrome; tested also) cannot find that font and falls back to a non-monospace font:

![image](https://github.com/user-attachments/assets/0350f08e-9a82-4d5a-96d6-08f99d05ecf8)

But this doesn't explain the issue, because normally devices should fallback to a monospace font due to

```css
/* From extra.css */
:root {
  --md-code-font: "Source Code Pro" !important;
}

/* From some mkdocs CSS file */
code, kdb, pre {
  font-family: var(--md-code-font-family) !important;
}

body {
  --md-code-font-family: var(--md-code-font), SFMono-Regular, Consolas, Menlo, monospace;
}
```

So essentially when substituting the variables, this should mean that

```css
code, kdb, pre {
  font-family: "Source Code Pro", SFMono-Regular, Consolas, Menlo, monospace !important;
}
```
which should work fine everywhere.

What could be the root-cause though is the `!important` part. Maybe certain browsers substitute that as:

```css
code, kdb, pre {
  font-family: "Source Code Pro" !important, SFMono-Regular, Consolas, Menlo, monospace !important;
}
```
which could then make the line invalid and then the browser falls back to a non-monspace font.

A solution to this could be to remove the `!important`. 

This PR suggests an even more robust solution, namely to override the `font-family` and thus sidestep the `var`:

```css
code, kdb, pre {
  font-family: monospace !important;
}
```

All devices should have a monospace font available, so although this might be slightly less pretty, it should work everywhere. Also, since this is less dependent on which fonts are available system-wide, issues should occur for everyone instead of in specific situations only.



