### PR TITLE
perf: Speedup ndjson reader `~40%`

### DIFF
--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -40,7 +40,7 @@ regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"], optional = true }
-serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value", "std"], optional = true }
+serde_json = { version = "1", default-features = false, features = ["alloc"], optional = true }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
 smartstring = { workspace = true }
@@ -63,7 +63,6 @@ json = [
   "polars-json",
   "simd-json",
   "atoi_simd",
-  "serde_json",
   "dtype-struct",
   "csv",
 ]


### PR DESCRIPTION
This speeds it up by 40% in the following benchmark:
```rust
use criterion::{criterion_group, criterion_main, Criterion};
use mimalloc::MiMalloc;
use polars::prelude::*;
use polars_core::POOL;
use rand::{thread_rng, Rng};

#[global_allocator]
static MIMALLOC: MiMalloc = MiMalloc;

fn from_json(json: &[u8]) -> DataFrame {
    JsonReader::new(std::io::Cursor::new(json))
        .with_json_format(JsonFormat::JsonLines)
        .set_rechunk(false)
        .finish()
        .unwrap()
}

fn my_benchmark(_c: &mut Criterion) {
    POOL.install(|| {
        let mut c = Criterion::default().configure_from_args();

        const SIZE: i32 = 5_000_000;
        let mut rng = thread_rng();
        let mut df = df![
            "a" => (0..SIZE).map(|_| rng.gen::<i32>()).collect::<Vec<_>>(),
            "b" => (0..SIZE).map(|v| v.to_string()).collect::<Vec<_>>(),
        ]
        .unwrap();

        let mut json = Vec::new();
        JsonWriter::new(&mut json)
            .with_json_format(JsonFormat::JsonLines)
            .finish(&mut df)
            .unwrap();

        c.bench_function("JSON Lines Deserialization", |b| {
            b.iter(|| from_json(&json))
        });
    });
}

criterion_group!(benches, my_benchmark);
criterion_main!(benches);
```

I had a plan to improve it more, but I can't find time for that and this will involve bigger changes, even a rewrite of the mechanism, while the changes in this PR are simple and effective, so I thought I'll just send them.

Best reviewed commit-by-commit.

A warning from the second commit, repeated here for noticeability:

> This *could* break people's code since we will not split correctly (and thus error) if one object spans two lines or two objects are in the same line. However, such code was already broken, since NDJSON is not allowed to contain any line breaks. If this is a concern, it is possible (at some perf degradation) to check for `}\n` instead of `\n` alone, and that will make this basically equivalent to the splitting logic we have for threads.