### PR TITLE
fix(python): Handle boolean comparisons in Iceberg predicate pushdown

### DIFF
--- a/py-polars/polars/io/iceberg.py
+++ b/py-polars/polars/io/iceberg.py
@@ -245,6 +245,8 @@ def _(a: Call) -> Any:
     f = _convert_predicate(a.func)
     if f == "field":
         return args
+    elif f == "scalar":
+        return args[0]
     elif f in _temporal_conversions:
         # convert from polars-native i64 to ISO8601 string
         return _temporal_conversions[f](*args).isoformat()

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -163,3 +163,12 @@ class TestIcebergExpressions:
 
         expr = _to_ast("(pa.compute.field('ts') <= '2023-08-08')")
         assert _convert_predicate(expr) == LessThanOrEqual("ts", "2023-08-08")
+
+    def test_compare_boolean(self) -> None:
+        from pyiceberg.expressions import EqualTo
+
+        expr = _to_ast("(pa.compute.field('ts') == pa.compute.scalar(True))")
+        assert _convert_predicate(expr) == EqualTo("ts", True)
+
+        expr = _to_ast("(pa.compute.field('ts') == pa.compute.scalar(False))")
+        assert _convert_predicate(expr) == EqualTo("ts", False)


### PR DESCRIPTION
Filtering Iceberg table boolean columns on boolean literals fails trying to parse `pa.compute.scalar(True)`. This updates the Call predicate parser to handle the `scalar` type.

I originally posted about this in the Discord here which has a few more details: https://discord.com/channels/908022250106667068/1273409357685592159


```python
table = pl.scan_iceberg(iceberg.load_table("codes.icd10cm"))

# is_header is a boolean column in the Iceberg table
# Both of these statements fail in the same way
table.filter(pl.col("is_header") == False).collect()
table.sql("SELECT count(*) from self where is_header = false").collect()
```

The error was

```
File .venv/lib/python3.12/site-packages/polars/lazyframe/frame.py:2027, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, cluster_with_columns, no_optimization, streaming, engine, background, _eager, **_kwargs)
       2025 # Only for testing purposes
       2026 callback = _kwargs.get("post_opt_callback", callback)
    -> 2027 return wrap_df(ldf.collect(callback))
    
    ComputeError: ValueError: Could not convert predicate to PyIceberg: (pa.compute.field('is_header') == pa.compute.scalar(False))
```

which I traced back to the function that I've modified in this PR. 

In addition to the parsing test I added here, it might also advisable to update the Iceberg table fixture as well and modify `test_scan_iceberg_filter_on_column`.  But I'm not really sure what's the proper way to add a column to the fixture.


