### PR TITLE
chore: Update the required version of rust in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ improvements point to the `main` branch of this repo.
 polars = { git = "https://github.com/pola-rs/polars", rev = "<optional git tag>" }
 ```
 
-Requires Rust version `>=1.71`.
+Requires Rust version `>=1.79`.
 
 ## Contributing
 


### PR DESCRIPTION
Run with rust 1.77 stable, Rust Polars 0.42.0:
```
cargo run -r
   Compiling polars-arrow v0.42.0
error[E0658]: inline-const is experimental
  --> E:\Program-Files\rust\.cargo\registry\src\rsproxy.cn-0dccff568467c15b\polars-arrow-0.42.0\src\array\static_array.rs:70:9
   |
70 |         no_call_const!()
   |         ^^^^^^^^^^^^^^^^
   |
   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
   = note: this error originates in the macro `no_call_const` (in Nightly builds, run with -Z macro-backtrace for more info)
```
I found that this macro uses `Inline const expressions`, which has been stable since version Rust 1.79 stable:  
```rust
#[macro_export]
macro_rules! no_call_const {
    () => {{
        const { assert!(false, "should not be called") }
        unreachable!()
    }};
}

```

refer to https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html