### PR TITLE
fix: Raise suitable error on unsupported `SQL` set op syntax

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -382,7 +382,7 @@ impl SQLContext {
         let lf_schema = self.get_frame_schema(&mut lf)?;
         let lf_cols: Vec<_> = lf_schema.iter_names().map(|nm| col(nm)).collect();
         let joined_tbl = match quantifier {
-            SetQuantifier::ByName | SetQuantifier::AllByName => join.on(lf_cols).finish(),
+            SetQuantifier::ByName => join.on(lf_cols).finish(),
             SetQuantifier::Distinct | SetQuantifier::None => {
                 let rf_schema = self.get_frame_schema(&mut rf)?;
                 let rf_cols: Vec<_> = rf_schema.iter_names().map(|nm| col(nm)).collect();

--- a/py-polars/tests/unit/sql/test_set_ops.py
+++ b/py-polars/tests/unit/sql/test_set_ops.py
@@ -69,6 +69,26 @@ def test_except_intersect_by_name() -> None:
     assert res_i.columns == ["x", "y", "z"]
 
 
+@pytest.mark.parametrize(
+    ("op", "op_subtype"),
+    [
+        ("EXCEPT", "ALL"),
+        ("EXCEPT", "ALL BY NAME"),
+        ("INTERSECT", "ALL"),
+        ("INTERSECT", "ALL BY NAME"),
+    ],
+)
+def test_except_intersect_all_unsupported(op: str, op_subtype: str) -> None:
+    df1 = pl.DataFrame({"n": [1, 1, 1, 2, 2, 2, 3]})  # noqa: F841
+    df2 = pl.DataFrame({"n": [1, 1, 2, 2]})  # noqa: F841
+
+    with pytest.raises(
+        SQLInterfaceError,
+        match=f"'{op} {op_subtype}' is not supported",
+    ):
+        pl.sql(f"SELECT * FROM df1 {op} {op_subtype} SELECT * FROM df2")
+
+
 @pytest.mark.parametrize("op", ["EXCEPT", "INTERSECT", "UNION"])
 def test_except_intersect_errors(op: str) -> None:
     df1 = pl.DataFrame({"x": [1, 9, 1, 1], "y": [2, 3, 4, 4], "z": [5, 5, 5, 5]})  # noqa: F841


### PR DESCRIPTION
We don't support the `ALL` modifier for `EXCEPT` and `INTERSECT` set ops in the SQL interface (_yet_ - I know how we can add this, and plan to do so in the near future). 

Until this support is implemented we need to make sure we raise a suitable error instead (`ALL` already did this, but the `ALL BY NAME` qualifier was sneaking through):

## Example
```python
import polars as pl

df1 = pl.DataFrame({"n": [1, 1, 1, 2, 2, 2, 3]})
df2 = pl.DataFrame({"n": [1, 1, 2, 2]})

pl.sql("SELECT * FROM df1 EXCEPT ALL BY NAME TABLE df2")
# SQLInterfaceError: 'EXCEPT ALL BY NAME' is not supported
```
Was previously returning (incorrectly) the same result as `EXCEPT BY NAME`.