### PR TITLE
feat(python): Make show_versions more responsive

### DIFF
--- a/py-polars/polars/meta/versions.py
+++ b/py-polars/polars/meta/versions.py
@@ -61,7 +61,7 @@ def show_versions() -> None:
 
 
 # See the list of dependencies in pyproject.toml.
-def _get_dependency_list() -> str:
+def _get_dependency_list() -> list[str]:
     return [
         "adbc_driver_manager",
         "cloudpickle",

--- a/py-polars/polars/meta/versions.py
+++ b/py-polars/polars/meta/versions.py
@@ -5,31 +5,6 @@ import sys
 from polars._utils.polars_version import get_polars_version
 from polars.meta.index_type import get_index_type
 
-# See the list of dependencies in pyproject.toml.
-_OPT_DEPS = [
-    "adbc_driver_manager",
-    "cloudpickle",
-    "connectorx",
-    "deltalake",
-    "fastexcel",
-    "fsspec",
-    "gevent",
-    "great_tables",
-    "hvplot",
-    "matplotlib",
-    "nest_asyncio",
-    "numpy",
-    "openpyxl",
-    "pandas",
-    "pyarrow",
-    "pydantic",
-    "pyiceberg",
-    "sqlalchemy",
-    "torch",
-    "xlsx2csv",
-    "xlsxwriter",
-]
-
 
 def show_versions() -> None:
     """
@@ -69,8 +44,9 @@ def show_versions() -> None:
     # module) as a micro-optimization for polars' initial import
     import platform
 
+    deps = _get_dependency_list()
     core_properties = ("Polars", "Index type", "Platform", "Python")
-    keylen = max(len(x) for x in [*core_properties, *_OPT_DEPS]) + 1
+    keylen = max(len(x) for x in [*core_properties, *deps]) + 1
 
     print("--------Version info---------")
     print(f"{'Polars:':{keylen}s} {get_polars_version()}")
@@ -79,9 +55,36 @@ def show_versions() -> None:
     print(f"{'Python:':{keylen}s} {sys.version}")
 
     print("\n----Optional dependencies----")
-    for name in _OPT_DEPS:
+    for name in deps:
         print(f"{name:{keylen}s} ", end="", flush=True)
         print(_get_dependency_version(name))
+
+
+# See the list of dependencies in pyproject.toml.
+def _get_dependency_list() -> str:
+    return [
+        "adbc_driver_manager",
+        "cloudpickle",
+        "connectorx",
+        "deltalake",
+        "fastexcel",
+        "fsspec",
+        "gevent",
+        "great_tables",
+        "hvplot",
+        "matplotlib",
+        "nest_asyncio",
+        "numpy",
+        "openpyxl",
+        "pandas",
+        "pyarrow",
+        "pydantic",
+        "pyiceberg",
+        "sqlalchemy",
+        "torch",
+        "xlsx2csv",
+        "xlsxwriter",
+    ]
 
 
 def _get_dependency_version(dep_name: str) -> str:

--- a/py-polars/polars/meta/versions.py
+++ b/py-polars/polars/meta/versions.py
@@ -5,6 +5,31 @@ import sys
 from polars._utils.polars_version import get_polars_version
 from polars.meta.index_type import get_index_type
 
+# See the list of dependencies in pyproject.toml.
+_OPT_DEPS = [
+    "adbc_driver_manager",
+    "cloudpickle",
+    "connectorx",
+    "deltalake",
+    "fastexcel",
+    "fsspec",
+    "gevent",
+    "great_tables",
+    "hvplot",
+    "matplotlib",
+    "nest_asyncio",
+    "numpy",
+    "openpyxl",
+    "pandas",
+    "pyarrow",
+    "pydantic",
+    "pyiceberg",
+    "sqlalchemy",
+    "torch",
+    "xlsx2csv",
+    "xlsxwriter",
+]
+
 
 def show_versions() -> None:
     """
@@ -44,9 +69,8 @@ def show_versions() -> None:
     # module) as a micro-optimization for polars' initial import
     import platform
 
-    deps = _get_dependency_info()
     core_properties = ("Polars", "Index type", "Platform", "Python")
-    keylen = max(len(x) for x in [*core_properties, *deps.keys()]) + 1
+    keylen = max(len(x) for x in [*core_properties, *_OPT_DEPS]) + 1
 
     print("--------Version info---------")
     print(f"{'Polars:':{keylen}s} {get_polars_version()}")
@@ -55,36 +79,9 @@ def show_versions() -> None:
     print(f"{'Python:':{keylen}s} {sys.version}")
 
     print("\n----Optional dependencies----")
-    for name, v in deps.items():
-        print(f"{name:{keylen}s} {v}")
-
-
-def _get_dependency_info() -> dict[str, str]:
-    # see the list of dependencies in pyproject.toml
-    opt_deps = [
-        "adbc_driver_manager",
-        "cloudpickle",
-        "connectorx",
-        "deltalake",
-        "fastexcel",
-        "fsspec",
-        "gevent",
-        "great_tables",
-        "hvplot",
-        "matplotlib",
-        "nest_asyncio",
-        "numpy",
-        "openpyxl",
-        "pandas",
-        "pyarrow",
-        "pydantic",
-        "pyiceberg",
-        "sqlalchemy",
-        "torch",
-        "xlsx2csv",
-        "xlsxwriter",
-    ]
-    return {f"{name}:": _get_dependency_version(name) for name in opt_deps}
+    for name in _OPT_DEPS:
+        print(f"{name:{keylen}s} ", end="", flush=True)
+        print(_get_dependency_version(name))
 
 
 def _get_dependency_version(dep_name: str) -> str:


### PR DESCRIPTION
Instead of waiting for all imports to finish before showing any output, now `pl.show_versions()` will show versions as we compute them.