### PR TITLE
test(python): Fix version bifurcation for `test_read_database_cx_credentials`

### DIFF
--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -686,7 +686,7 @@ def test_read_database_exceptions(
     ],
 )
 def test_read_database_cx_credentials(uri: str) -> None:
-    if sys.version_info > (3, 11):
+    if sys.version_info > (3, 9, 4):
         # slightly different error on more recent Python versions
         with pytest.raises(RuntimeError, match=r"Source.*not supported"):
             pl.read_database_uri("SELECT * FROM data", uri=uri, engine="connectorx")


### PR DESCRIPTION
Closes #18218. Bifurcation occurs at 3.9.5, see the following for version evidence:

<details><summary><b>3.9.4</b></summary>

```
mcrumiller@Saline-PC:~/projects/polars/py-polars$ pyenv global 3.9.4
mcrumiller@Saline-PC:~/projects/polars/py-polars$ python
Python 3.9.4 (default, Aug 15 2024, 12:38:05) 
[GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import polars as pl
>>> uri = "fakedb://123:456@account/database/schema?warehouse=warehouse&role=role"
>>> pl.read_database_uri("SELECT * FROM data", uri=uri, engine="connectorx")
thread '<unnamed>' panicked at 'not implemented: Connection: fakedb://123:456@account/database/schema?warehouse=warehouse&role=role not supported!', /__w/connector-x/connector-x/connectorx/src/source_router.rs:80:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "/home/mcrumiller/projects/polars/py-polars/polars/io/database/_utils.py", line 54, in _read_sql_connectorx
    tbl = cx.read_sql(
  File "/home/mcrumiller/.pyenv/versions/3.9.4/lib/python3.9/site-packages/connectorx/__init__.py", line 257, in read_sql
    result = _read_sql(
pyo3_runtime.PanicException: not implemented: Connection: fakedb://123:456@account/database/schema?warehouse=warehouse&role=role not supported!

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mcrumiller/projects/polars/py-polars/polars/io/database/functions.py", line 395, in read_database_uri
    return _read_sql_connectorx(
  File "/home/mcrumiller/projects/polars/py-polars/polars/io/database/_utils.py", line 66, in _read_sql_connectorx
    raise type(err)(errmsg) from err
pyo3_runtime.PanicException: not implemented: Connection: fakedb://***:***@account/database/schema?warehouse=warehouse&role=role not supported!
```
</details>

<details><summary><b>3.9.5</b></summary>

```
mcrumiller@Saline-PC:~/projects/polars/py-polars$ pyenv global 3.9.5
mcrumiller@Saline-PC:~/projects/polars/py-polars$ python
Python 3.9.5 (default, Aug 15 2024, 12:39:57) 
[GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import polars as pl
>>> uri = "fakedb://123:456@account/database/schema?warehouse=warehouse&role=role"
>>> pl.read_database_uri("SELECT * FROM data", uri=uri, engine="connectorx")
Traceback (most recent call last):
  File "/home/mcrumiller/projects/polars/py-polars/polars/io/database/_utils.py", line 54, in _read_sql_connectorx
    tbl = cx.read_sql(
  File "/home/mcrumiller/.pyenv/versions/3.9.5/lib/python3.9/site-packages/connectorx/__init__.py", line 386, in read_sql
    result = _read_sql(
RuntimeError: Source Unknown not supported.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mcrumiller/projects/polars/py-polars/polars/io/database/functions.py", line 395, in read_database_uri
    return _read_sql_connectorx(
  File "/home/mcrumiller/projects/polars/py-polars/polars/io/database/_utils.py", line 66, in _read_sql_connectorx
    raise type(err)(errmsg) from err
RuntimeError: Source Unknown not supported.
```
</details>