### PR TITLE
perf: Use direct path for `time`/`timedelta` literals

### DIFF
--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -437,8 +437,9 @@ pub fn lit(value: &Bound<'_, PyAny>, allow_object: bool) -> PyResult<PyExpr> {
         Ok(dsl::lit(value.as_bytes()).into())
     } else if matches!(
         value.get_type().qualname().unwrap().as_str(),
-        "date" | "datetime" | "Decimal"
+        "date" | "datetime" | "time" | "timedelta" | "Decimal"
     ) {
+        println!("here");
         let av = py_object_to_any_value(value, true)?;
         Ok(Expr::Literal(LiteralValue::try_from(av).unwrap()).into())
     } else if allow_object {

--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -439,7 +439,6 @@ pub fn lit(value: &Bound<'_, PyAny>, allow_object: bool) -> PyResult<PyExpr> {
         value.get_type().qualname().unwrap().as_str(),
         "date" | "datetime" | "time" | "timedelta" | "Decimal"
     ) {
-        println!("here");
         let av = py_object_to_any_value(value, true)?;
         Ok(Expr::Literal(LiteralValue::try_from(av).unwrap()).into())
     } else if allow_object {

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -109,14 +109,14 @@ def lit(
             )
         return expr
 
-    elif isinstance(value, time):
-        return wrap_expr(plr.lit(value, allow_object=False))
-
     elif isinstance(value, timedelta):
         expr = wrap_expr(plr.lit(value, allow_object=False))
-        if dtype == Duration and (tu := getattr(dtype, "time_unit", None)) is not None:  # type: ignore[union-attr]
+        if dtype == Duration and (tu := getattr(dtype, "time_unit", None)) is not None:
             expr = expr.cast(Duration(tu))
         return expr
+
+    elif isinstance(value, time):
+        return wrap_expr(plr.lit(value, allow_object=False))
 
     elif isinstance(value, date):
         if dtype == Datetime:

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -111,7 +111,7 @@ def lit(
 
     elif isinstance(value, timedelta):
         expr = wrap_expr(plr.lit(value, allow_object=False))
-        if dtype == Duration and (tu := getattr(dtype, "time_unit", None)) is not None:
+        if dtype is not None and (tu := getattr(dtype, "time_unit", None)) is not None:
             expr = expr.cast(Duration(tu))
         return expr
 

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1427,3 +1427,42 @@ def test_literal_from_datetime(
 
     assert out.schema == OrderedDict({"literal": dtype})
     assert out.item() == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        time(0),
+        time(hour=1),
+        time(hour=16, minute=43, microsecond=500),
+        time(hour=23, minute=59, second=59, microsecond=999999),
+    ],
+)
+def test_literal_from_time(value: time) -> None:
+    out = pl.select(pl.lit(value))
+    assert out.schema == OrderedDict({"literal": pl.Time})
+    assert out.item() == value
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        None,
+        pl.Duration("ms"),
+        pl.Duration("us"),
+        pl.Duration("ns"),
+    ],
+)
+@pytest.mark.parametrize(
+    "value",
+    [
+        timedelta(0),
+        timedelta(hours=1),
+        timedelta(days=-99999),
+        timedelta(days=99999),
+    ],
+)
+def test_literal_from_timedelta(value: time, dtype: pl.Duration | None) -> None:
+    out = pl.select(pl.lit(value, dtype=dtype))
+    assert out.schema == OrderedDict({"literal": dtype or pl.Duration("us")})
+    assert out.item() == value

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1442,7 +1442,6 @@ def test_literal_from_time(value: time) -> None:
     out = pl.select(pl.lit(value))
     assert out.schema == OrderedDict({"literal": pl.Time})
     assert out.item() == value
-    assert "cast" not in pl.LazyFrame().select(pl.lit(value)).explain(optimized=False)
 
 
 @pytest.mark.parametrize(
@@ -1467,4 +1466,3 @@ def test_literal_from_timedelta(value: time, dtype: pl.Duration | None) -> None:
     out = pl.select(pl.lit(value, dtype=dtype))
     assert out.schema == OrderedDict({"literal": dtype or pl.Duration("us")})
     assert out.item() == value
-    assert "cast" not in pl.LazyFrame().select(pl.lit(value)).explain(optimized=False)

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -1442,6 +1442,7 @@ def test_literal_from_time(value: time) -> None:
     out = pl.select(pl.lit(value))
     assert out.schema == OrderedDict({"literal": pl.Time})
     assert out.item() == value
+    assert "cast" not in pl.LazyFrame().select(pl.lit(value)).explain(optimized=False)
 
 
 @pytest.mark.parametrize(
@@ -1466,3 +1467,4 @@ def test_literal_from_timedelta(value: time, dtype: pl.Duration | None) -> None:
     out = pl.select(pl.lit(value, dtype=dtype))
     assert out.schema == OrderedDict({"literal": dtype or pl.Duration("us")})
     assert out.item() == value
+    assert "cast" not in pl.LazyFrame().select(pl.lit(value)).explain(optimized=False)


### PR DESCRIPTION
Slight followup to #16018, allows direct construction of literals from `datetime.time` and `datetime.timedelta` objects.