### PR TITLE
refactor(rust): Add feature gates for `polars-python` crate

### DIFF
--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -227,10 +227,14 @@ optimizations = [
 ]
 
 polars_cloud = ["polars/polars_cloud"]
+
 # also includes simd
 nightly = ["polars/nightly"]
 
+pymethods = []
+
 all = [
+  "pymethods",
   "optimizations",
   "io",
   "operations",

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -1,9 +1,12 @@
 use polars::frame::row::{rows_to_schema_supertypes, rows_to_supertypes, Row};
+use polars::prelude::*;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
-use super::*;
+use super::PyDataFrame;
 use crate::conversion::any_value::py_object_to_any_value;
 use crate::conversion::{vec_extract_wrapped, Wrap};
+use crate::error::PyPolarsErr;
 use crate::interop;
 
 #[pymethods]

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -1,11 +1,13 @@
 use polars::export::arrow::record_batch::RecordBatch;
+use polars::prelude::*;
 use polars_core::export::arrow::datatypes::IntegerType;
 use polars_core::utils::arrow::compute::cast::CastOptionsImpl;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyList, PyTuple};
 
-use super::*;
+use super::PyDataFrame;
 use crate::conversion::{ObjectValue, Wrap};
+use crate::error::PyPolarsErr;
 use crate::interop;
 use crate::interop::arrow::to_py::dataframe_to_stream;
 use crate::prelude::PyCompatLevel;

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -11,8 +11,9 @@ use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyList;
 
-use super::*;
+use super::PyDataFrame;
 use crate::conversion::Wrap;
+use crate::error::PyPolarsErr;
 use crate::map::dataframe::{
     apply_lambda_unknown, apply_lambda_with_bool_out_type, apply_lambda_with_primitive_out_type,
     apply_lambda_with_string_out_type,

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -1,19 +1,22 @@
 use std::io::BufWriter;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 #[cfg(feature = "avro")]
 use polars::io::avro::AvroCompression;
 use polars::io::mmap::ensure_not_mapped;
 use polars::io::RowIndex;
+use polars::prelude::*;
 #[cfg(feature = "parquet")]
 use polars_parquet::arrow::write::StatisticsOptions;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 
-use super::*;
+use super::PyDataFrame;
 #[cfg(feature = "parquet")]
 use crate::conversion::parse_parquet_compression;
 use crate::conversion::Wrap;
+use crate::error::PyPolarsErr;
 use crate::file::{
     get_either_file, get_file_like, get_mmap_bytes_reader, get_mmap_bytes_reader_and_path,
     read_if_bytesio, EitherRustPythonFile,

--- a/crates/polars-python/src/dataframe/mod.rs
+++ b/crates/polars-python/src/dataframe/mod.rs
@@ -1,7 +1,12 @@
+#[cfg(feature = "pymethods")]
 mod construction;
+#[cfg(feature = "pymethods")]
 mod export;
+#[cfg(feature = "pymethods")]
 mod general;
+#[cfg(feature = "pymethods")]
 mod io;
+#[cfg(feature = "pymethods")]
 mod serde;
 
 use polars::prelude::DataFrame;

--- a/crates/polars-python/src/dataframe/mod.rs
+++ b/crates/polars-python/src/dataframe/mod.rs
@@ -5,7 +5,7 @@ mod io;
 mod serde;
 
 use polars::prelude::DataFrame;
-use pyo3::prelude::*;
+use pyo3::pyclass;
 
 #[pyclass]
 #[repr(transparent)]

--- a/crates/polars-python/src/dataframe/mod.rs
+++ b/crates/polars-python/src/dataframe/mod.rs
@@ -4,11 +4,8 @@ mod general;
 mod io;
 mod serde;
 
-use polars::prelude::*;
+use polars::prelude::DataFrame;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
-
-use crate::error::PyPolarsErr;
 
 #[pyclass]
 #[repr(transparent)]

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -1,6 +1,7 @@
 use std::io::{BufReader, BufWriter, Cursor};
 use std::ops::Deref;
 
+use polars::prelude::*;
 use polars_io::mmap::ReaderBytes;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -9,7 +10,6 @@ use super::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::exceptions::ComputeError;
 use crate::file::{get_file_like, get_mmap_bytes_reader};
-use crate::prelude::*;
 
 #[pymethods]
 impl PyDataFrame {

--- a/crates/polars-python/src/expr/mod.rs
+++ b/crates/polars-python/src/expr/mod.rs
@@ -15,7 +15,7 @@ mod r#struct;
 use std::mem::ManuallyDrop;
 
 use polars::lazy::dsl::Expr;
-use pyo3::prelude::*;
+use pyo3::pyclass;
 
 #[pyclass]
 #[repr(transparent)]

--- a/crates/polars-python/src/expr/mod.rs
+++ b/crates/polars-python/src/expr/mod.rs
@@ -1,15 +1,26 @@
+#[cfg(feature = "pymethods")]
 mod array;
+#[cfg(feature = "pymethods")]
 mod binary;
+#[cfg(feature = "pymethods")]
 mod categorical;
+#[cfg(feature = "pymethods")]
 mod datetime;
+#[cfg(feature = "pymethods")]
 mod general;
+#[cfg(feature = "pymethods")]
 mod list;
-#[cfg(feature = "meta")]
+#[cfg(all(feature = "meta", feature = "pymethods"))]
 mod meta;
+#[cfg(feature = "pymethods")]
 mod name;
+#[cfg(feature = "pymethods")]
 mod rolling;
+#[cfg(feature = "pymethods")]
 mod serde;
+#[cfg(feature = "pymethods")]
 mod string;
+#[cfg(feature = "pymethods")]
 mod r#struct;
 
 use std::mem::ManuallyDrop;

--- a/crates/polars-python/src/functions/misc.rs
+++ b/crates/polars-python/src/functions/misc.rs
@@ -65,3 +65,8 @@ pub fn register_plugin_function(
     }
     .into())
 }
+
+#[pyfunction]
+pub fn __register_startup_deps() {
+    crate::on_startup::register_startup_deps()
+}

--- a/crates/polars-python/src/lazyframe/exitable.rs
+++ b/crates/polars-python/src/lazyframe/exitable.rs
@@ -1,4 +1,9 @@
-use super::*;
+use polars::prelude::*;
+use pyo3::prelude::*;
+
+use super::PyLazyFrame;
+use crate::error::PyPolarsErr;
+use crate::PyDataFrame;
 
 #[pymethods]
 impl PyLazyFrame {

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -5,13 +5,8 @@ pub mod visit;
 pub mod visitor;
 
 pub use exitable::PyInProcessQuery;
-use polars_core::prelude::*;
-use pyo3::prelude::*;
-use pyo3::types::PyList;
-
-use crate::error::PyPolarsErr;
-use crate::prelude::*;
-use crate::{PyDataFrame, PyExpr};
+use polars::prelude::LazyFrame;
+use pyo3::pyclass;
 
 #[pyclass]
 #[repr(transparent)]

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -1,5 +1,7 @@
 mod exitable;
+#[cfg(feature = "pymethods")]
 mod general;
+#[cfg(feature = "pymethods")]
 mod serde;
 pub mod visit;
 pub mod visitor;

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -1,14 +1,17 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+use polars::prelude::PolarsError;
 use polars_plan::plans::{to_aexpr, Context, IR};
 use polars_plan::prelude::expr_ir::ExprIR;
 use polars_plan::prelude::{AExpr, PythonOptions, PythonScanSource};
 use polars_utils::arena::{Arena, Node};
 use pyo3::prelude::*;
-use visitor::{expr_nodes, nodes};
+use pyo3::types::PyList;
 
-use super::*;
-use crate::raise_err;
+use super::visitor::{expr_nodes, nodes};
+use super::PyLazyFrame;
+use crate::error::PyPolarsErr;
+use crate::{raise_err, PyExpr, Wrap};
 
 #[derive(Clone)]
 #[pyclass]

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -7,8 +7,8 @@ use polars_plan::prelude::{
 use pyo3::exceptions::{PyNotImplementedError, PyValueError};
 use pyo3::prelude::*;
 
-use super::super::visit::PyExprIR;
 use super::expr_nodes::PyGroupbyOptions;
+use crate::lazyframe::visit::PyExprIR;
 use crate::PyDataFrame;
 
 #[pyclass]

--- a/crates/polars-python/src/lib.rs
+++ b/crates/polars-python/src/lib.rs
@@ -15,6 +15,7 @@ pub mod error;
 pub mod exceptions;
 pub mod expr;
 pub mod file;
+#[cfg(feature = "pymethods")]
 pub mod functions;
 pub mod gil_once_cell;
 pub mod interop;

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -65,8 +65,7 @@ fn warning_function(msg: &str, warning: PolarsWarning) {
     });
 }
 
-#[pyfunction]
-pub fn __register_startup_deps() {
+pub fn register_startup_deps() {
     set_polars_allow_extension(true);
     if !registry::is_object_builder_registered() {
         // Stack frames can get really large in debug mode.

--- a/crates/polars-python/src/series/aggregation.rs
+++ b/crates/polars-python/src/series/aggregation.rs
@@ -1,9 +1,10 @@
+use polars::prelude::*;
 use pyo3::prelude::*;
 use DataType::*;
 
+use super::PySeries;
+use crate::conversion::Wrap;
 use crate::error::PyPolarsErr;
-use crate::prelude::*;
-use crate::PySeries;
 
 #[pymethods]
 impl PySeries {

--- a/crates/polars-python/src/series/arithmetic.rs
+++ b/crates/polars-python/src/series/arithmetic.rs
@@ -1,8 +1,8 @@
+use polars::prelude::*;
 use pyo3::prelude::*;
 
+use super::PySeries;
 use crate::error::PyPolarsErr;
-use crate::prelude::*;
-use crate::PySeries;
 
 #[pymethods]
 impl PySeries {

--- a/crates/polars-python/src/series/buffers.rs
+++ b/crates/polars-python/src/series/buffers.rs
@@ -18,9 +18,15 @@ use polars::export::arrow::bitmap::Bitmap;
 use polars::export::arrow::buffer::Buffer;
 use polars::export::arrow::offset::OffsetsBuffer;
 use polars::export::arrow::types::NativeType;
+use polars::prelude::*;
+use polars_core::{with_match_physical_numeric_polars_type, with_match_physical_numeric_type};
 use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
 
-use super::*;
+use super::{PySeries, ToSeries};
+use crate::conversion::Wrap;
+use crate::error::PyPolarsErr;
+use crate::raise_err;
 
 struct BufferInfo {
     pointer: usize,

--- a/crates/polars-python/src/series/c_interface.rs
+++ b/crates/polars-python/src/series/c_interface.rs
@@ -1,7 +1,10 @@
 use polars::export::arrow;
+use polars::prelude::*;
 use pyo3::ffi::Py_uintptr_t;
+use pyo3::prelude::*;
 
-use super::*;
+use super::PySeries;
+use crate::error::PyPolarsErr;
 
 // Import arrow data directly without requiring pyarrow (used in pyo3-polars)
 #[pymethods]

--- a/crates/polars-python/src/series/export.rs
+++ b/crates/polars-python/src/series/export.rs
@@ -2,9 +2,10 @@ use polars_core::prelude::*;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyList};
 
+use super::PySeries;
+use crate::interop;
 use crate::interop::arrow::to_py::series_to_stream;
 use crate::prelude::*;
-use crate::{interop, PySeries};
 
 #[pymethods]
 impl PySeries {

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -1,9 +1,19 @@
+use std::io::Cursor;
+
+use polars_core::chunked_array::cast::CastOptions;
+use polars_core::series::IsSorted;
+use polars_core::utils::flatten::flatten_series;
+use pyo3::exceptions::{PyIndexError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
 use pyo3::Python;
 
-use super::{PySeries, *};
+use super::PySeries;
+use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
+use crate::map::series::{call_lambda_and_extract, ApplyLambda};
 use crate::prelude::*;
+use crate::py_modules::POLARS;
 use crate::{apply_method_all_arrow_series2, raise_err};
 
 #[pymethods]

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -810,6 +810,7 @@ impl_get!(get_duration, duration, i64);
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::series::ToSeries;
 
     #[test]
     fn transmute_to_series() {

--- a/crates/polars-python/src/series/import.rs
+++ b/crates/polars-python/src/series/import.rs
@@ -4,11 +4,12 @@ use polars::export::arrow::ffi;
 use polars::export::arrow::ffi::{
     ArrowArray, ArrowArrayStream, ArrowArrayStreamReader, ArrowSchema,
 };
+use polars::prelude::*;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyTuple, PyType};
 
-use super::*;
+use super::PySeries;
 
 /// Validate PyCapsule has provided name
 fn validate_pycapsule_name(capsule: &Bound<PyCapsule>, expected_name: &str) -> PyResult<()> {

--- a/crates/polars-python/src/series/mod.rs
+++ b/crates/polars-python/src/series/mod.rs
@@ -1,13 +1,24 @@
+#[cfg(feature = "pymethods")]
 mod aggregation;
+#[cfg(feature = "pymethods")]
 mod arithmetic;
+#[cfg(feature = "pymethods")]
 mod buffers;
+#[cfg(feature = "pymethods")]
 mod c_interface;
+#[cfg(feature = "pymethods")]
 mod comparison;
+#[cfg(feature = "pymethods")]
 mod construction;
+#[cfg(feature = "pymethods")]
 mod export;
+#[cfg(feature = "pymethods")]
 mod general;
+#[cfg(feature = "pymethods")]
 mod import;
+#[cfg(feature = "pymethods")]
 mod numpy_ufunc;
+#[cfg(feature = "pymethods")]
 mod scatter;
 
 use polars::prelude::Series;

--- a/crates/polars-python/src/series/mod.rs
+++ b/crates/polars-python/src/series/mod.rs
@@ -10,23 +10,8 @@ mod import;
 mod numpy_ufunc;
 mod scatter;
 
-use std::io::Cursor;
-
-use polars_core::chunked_array::cast::CastOptions;
-use polars_core::series::IsSorted;
-use polars_core::utils::flatten::flatten_series;
-use polars_core::{with_match_physical_numeric_polars_type, with_match_physical_numeric_type};
-use pyo3::exceptions::{PyIndexError, PyRuntimeError, PyValueError};
-use pyo3::prelude::*;
-use pyo3::types::PyBytes;
-use pyo3::Python;
-
-use crate::dataframe::PyDataFrame;
-use crate::error::PyPolarsErr;
-use crate::map::series::{call_lambda_and_extract, ApplyLambda};
-use crate::prelude::*;
-use crate::py_modules::POLARS;
-use crate::raise_err;
+use polars::prelude::Series;
+use pyo3::pyclass;
 
 #[pyclass]
 #[repr(transparent)]

--- a/crates/polars-python/src/series/numpy_ufunc.rs
+++ b/crates/polars-python/src/series/numpy_ufunc.rs
@@ -9,7 +9,7 @@ use polars_core::utils::arrow::types::NativeType;
 use pyo3::prelude::*;
 use pyo3::types::{PyNone, PyTuple};
 
-use crate::series::PySeries;
+use super::PySeries;
 
 /// Create an empty numpy array arrows 64 byte alignment
 ///

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -2,8 +2,8 @@ use polars::export::arrow::array::Array;
 use polars::prelude::*;
 use pyo3::prelude::*;
 
+use super::PySeries;
 use crate::error::PyPolarsErr;
-use crate::PySeries;
 
 #[pymethods]
 impl PySeries {

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 libc = { workspace = true }
-polars-python = { workspace = true }
+polars-python = { workspace = true, features = ["pymethods"] }
 pyo3 = { workspace = true, features = ["abi3-py38", "chrono", "extension-module", "multiple-pymethods"] }
 
 [build-dependencies]

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -23,8 +23,6 @@ use polars_python::expr::PyExpr;
 use polars_python::functions::PyStringCacheHolder;
 use polars_python::lazyframe::{PyInProcessQuery, PyLazyFrame};
 use polars_python::lazygroupby::PyLazyGroupBy;
-#[cfg(feature = "object")]
-use polars_python::on_startup;
 use polars_python::series::PySeries;
 #[cfg(feature = "sql")]
 use polars_python::sql::PySQLContext;
@@ -276,7 +274,7 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::dtype_str_repr))
         .unwrap();
     #[cfg(feature = "object")]
-    m.add_wrapped(wrap_pyfunction!(on_startup::__register_startup_deps))
+    m.add_wrapped(wrap_pyfunction!(functions::__register_startup_deps))
         .unwrap();
 
     // Functions - random


### PR DESCRIPTION
This feature gates the stuff that is only useful for the `py-polars` crate behind the `pymethods` feature.