### PR TITLE
fix: Fix failed AWS credential load from '~/.aws/credentials' due to formatting

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -277,7 +277,7 @@ impl CloudOptions {
             &mut builder,
             &[(
                 Path::new("~/.aws/config"),
-                &[("region = (.*)\n", AmazonS3ConfigKey::Region)],
+                &[("region\\s*=\\s*(.*)\n", AmazonS3ConfigKey::Region)],
             )],
         );
         read_config(
@@ -285,14 +285,19 @@ impl CloudOptions {
             &[(
                 Path::new("~/.aws/credentials"),
                 &[
-                    ("aws_access_key_id = (.*)\n", AmazonS3ConfigKey::AccessKeyId),
                     (
-                        "aws_secret_access_key = (.*)\n",
+                        "aws_access_key_id\\s*=\\s*(.*)\n",
+                        AmazonS3ConfigKey::AccessKeyId,
+                    ),
+                    (
+                        "aws_secret_access_key\\s*=\\s*(.*)\n",
                         AmazonS3ConfigKey::SecretAccessKey,
                     ),
                 ],
             )],
         );
+
+        dbg!(&builder);
 
         if builder
             .get_config_value(&AmazonS3ConfigKey::DefaultRegion)

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -297,8 +297,6 @@ impl CloudOptions {
             )],
         );
 
-        dbg!(&builder);
-
         if builder
             .get_config_value(&AmazonS3ConfigKey::DefaultRegion)
             .is_none()


### PR DESCRIPTION
As it turns out, this functionality was already there (ref https://github.com/pola-rs/polars/pull/13062) - it's just that it failed to load if the credential lines didn't have space padding 😄. But now we will be able to load them regardless of spaces.

Fixes https://github.com/pola-rs/polars/issues/18254