### PR TITLE
fix: Arguments for `upsample` only have to be sorted within groups

### DIFF
--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -121,7 +121,9 @@ fn upsample_impl(
     stable: bool,
 ) -> PolarsResult<DataFrame> {
     let s = source.column(index_column)?;
-    s.ensure_sorted_arg("upsample")?;
+    if by.is_empty() {
+        s.ensure_sorted_arg("upsample")?;
+    }
     let time_type = s.dtype();
     if matches!(time_type, DataType::Date) {
         let mut df = source.clone();
@@ -174,6 +176,7 @@ fn upsample_impl(
         // don't parallelize this, this may SO on large data.
         gb?.apply(|df| {
             let index_column = df.column(index_column)?;
+            index_column.ensure_sorted_arg("upsample")?;
             upsample_single_impl(&df, index_column, every)
         })
     }

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -121,9 +121,6 @@ fn upsample_impl(
     stable: bool,
 ) -> PolarsResult<DataFrame> {
     let s = source.column(index_column)?;
-    if by.is_empty() {
-        s.ensure_sorted_arg("upsample")?;
-    }
     let time_type = s.dtype();
     if matches!(time_type, DataType::Date) {
         let mut df = source.clone();
@@ -176,7 +173,6 @@ fn upsample_impl(
         // don't parallelize this, this may SO on large data.
         gb?.apply(|df| {
             let index_column = df.column(index_column)?;
-            index_column.ensure_sorted_arg("upsample")?;
             upsample_single_impl(&df, index_column, every)
         })
     }
@@ -187,6 +183,7 @@ fn upsample_single_impl(
     index_column: &Series,
     every: Duration,
 ) -> PolarsResult<DataFrame> {
+    index_column.ensure_sorted_arg("upsample")?;
     let index_col_name = index_column.name();
 
     use DataType::*;

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -239,10 +239,6 @@ def test_upsample_sorted_only_within_group() -> None:
         maintain_order=True,
     ).select(pl.all().forward_fill())
 
-    # this print will panic if timezones feature is not activated
-    # don't remove
-    print(up)
-
     expected = pl.DataFrame(
         {
             "time": [

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -218,16 +218,7 @@ def test_upsample_index_invalid(
         )
 
 
-@pytest.mark.parametrize(
-    ("time_zone", "tzinfo"),
-    [
-        (None, None),
-        ("Europe/Warsaw", ZoneInfo("Europe/Warsaw")),
-    ],
-)
-def test_upsample_sorted_only_within_group(
-    time_zone: str | None, tzinfo: ZoneInfo | timezone | None
-) -> None:
+def test_upsample_sorted_only_within_group() -> None:
     df = pl.DataFrame(
         {
             "time": [
@@ -239,7 +230,7 @@ def test_upsample_sorted_only_within_group(
             "admin": ["Netherlands", "Åland", "Åland", "Netherlands"],
             "test2": [1, 0, 2, 3],
         }
-    ).with_columns(pl.col("time").dt.replace_time_zone(time_zone))
+    )
 
     up = df.upsample(
         time_column="time",
@@ -275,21 +266,11 @@ def test_upsample_sorted_only_within_group(
             "test2": [1, 1, 3, 0, 0, 0, 2],
         }
     )
-    expected = expected.with_columns(pl.col("time").dt.replace_time_zone(time_zone))
 
     assert_frame_equal(up, expected)
 
 
-@pytest.mark.parametrize(
-    ("time_zone", "tzinfo"),
-    [
-        (None, None),
-        ("Europe/Warsaw", ZoneInfo("Europe/Warsaw")),
-    ],
-)
-def test_upsample_sorted_only_within_group_but_no_group_by_provided(
-    time_zone: str | None, tzinfo: ZoneInfo | timezone | None
-) -> None:
+def test_upsample_sorted_only_within_group_but_no_group_by_provided() -> None:
     df = pl.DataFrame(
         {
             "time": [
@@ -301,13 +282,9 @@ def test_upsample_sorted_only_within_group_but_no_group_by_provided(
             "admin": ["Netherlands", "Åland", "Åland", "Netherlands"],
             "test2": [1, 0, 2, 3],
         }
-    ).with_columns(pl.col("time").dt.replace_time_zone(time_zone))
+    )
     with pytest.raises(
         InvalidOperationError,
         match=r"argument in operation 'upsample' is not sorted, please sort the 'expr/series/column' first",
     ):
-        df.upsample(
-            time_column="time",
-            every="1mo",
-            maintain_order=True,
-        ).select(pl.all().forward_fill())
+        df.upsample(time_column="time", every="1mo")


### PR DESCRIPTION
In the case of `group_by` being provide as an extra argument to `upsample`, the index needs to be only sorted within those groups. This tries to fix the issue observed in https://github.com/pola-rs/polars/issues/18229.

Tests are added to check that
- No error occurs if the index is only sorted within groups and groups are provided.
- An error occurs if the index is only sorted within groups and _no_ groups are provided.

Note, this is my first commit and **I am not a Rust developer**. 