### PR TITLE
feat(python): Allow `pl.element()` in `Series.filter`

### DIFF
--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::series::IsSorted;
 use polars_core::utils::flatten::flatten_series;
-use pyo3::exceptions::{PyIndexError, PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::Python;
@@ -235,16 +235,6 @@ impl PySeries {
             Err(PyValueError::new_err("index is out of bounds"))
         } else {
             Ok(self.series.new_from_index(index, length).into())
-        }
-    }
-
-    fn filter(&self, filter: &PySeries) -> PyResult<Self> {
-        let filter_series = &filter.series;
-        if let Ok(ca) = filter_series.bool() {
-            let series = self.series.filter(ca).map_err(PyPolarsErr::from)?;
-            Ok(PySeries { series })
-        } else {
-            Err(PyRuntimeError::new_err("Expected a boolean mask"))
         }
     }
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2986,7 +2986,7 @@ class Series:
         return self
 
     def filter(
-        self, predicate: Series | list[bool] | IntoExpr
+        self, predicate: Series | list[bool] | Expr
     ) -> Self:
         """
         Filter elements by a boolean mask.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3010,7 +3010,7 @@ class Series:
                 1
                 3
         ]
-        >>> s.filter(pl.element() < 2)
+        >>> s.filter(pl.element() != 2)
         shape: (2,)
         Series: 'a' [i64]
         [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3018,11 +3018,7 @@ class Series:
                 3
         ]
         """
-        if isinstance(predicate, pl.Expr):
-            return self.to_frame("").filter(predicate).to_series().rename(self.name)
-        elif isinstance(predicate, list):
-            predicate = Series("", predicate)
-        return self._from_pyseries(self._s.filter(predicate._s))
+        return self.to_frame("").filter(predicate).to_series().rename(self.name)
 
     def head(self, n: int = 10) -> Series:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2985,9 +2985,7 @@ class Series:
                 raise
         return self
 
-    def filter(
-        self, predicate: Series | list[bool] | Expr
-    ) -> Self:
+    def filter(self, predicate: Series | list[bool] | Expr) -> Series:
         """
         Filter elements by a boolean mask.
 
@@ -3021,12 +3019,7 @@ class Series:
         ]
         """
         if isinstance(predicate, pl.Expr):
-            return (
-                self.to_frame("")
-                .filter(predicate)
-                .to_series()
-                .rename(self.name)
-            )
+            return self.to_frame("").filter(predicate).to_series().rename(self.name)
         elif isinstance(predicate, list):
             predicate = Series("", predicate)
         return self._from_pyseries(self._s.filter(predicate._s))

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1366,6 +1366,13 @@ def test_filter() -> None:
 def test_filter_element() -> None:
     s = pl.Series("a", [1, 2, 3])
     assert_series_equal(s.filter(pl.element() < 3), pl.Series("a", [1, 2]))
+    assert_series_equal(s.filter(pl.element() != 2), pl.Series("a", [1, 3]))
+
+    s = pl.Series("a", [None, None, None], dtype=pl.UInt8)
+    assert_series_equal(
+        s.filter(pl.element().is_not_null()),
+        pl.Series("a", [], dtype=pl.UInt8),
+    )
 
 
 def test_gather_every() -> None:

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1363,6 +1363,11 @@ def test_filter() -> None:
     assert_series_equal(s.filter([True, False, True]), pl.Series("a", [1, 3]))
 
 
+def test_filter_element() -> None:
+    s = pl.Series("a", [1, 2, 3])
+    assert_series_equal(s.filter(pl.element() < 3), pl.Series("a", [1, 2]))
+
+
 def test_gather_every() -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     assert_series_equal(s.gather_every(2), pl.Series("a", [1, 3]))


### PR DESCRIPTION
Closes #13772.

This allows a Series to self-reference via `pl.element()` in filter:

```pycon
>>> pl.Series([1, 2, 3]).filter(pl.element() < 3)
shape: (2,)
Series: '' [i64]
[
        1
        2
]
```

Note that we now go entirely through the expression system for `Series.filter`, so I have removed the associated rust binding to the underlying Series.