### PR TITLE
refactor(rust): Add output_schema to all PhysNodes

### DIFF
--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -66,12 +66,12 @@ where
 }
 
 impl Schema {
-    /// Create a new, empty schema
+    /// Create a new, empty schema.
     pub fn new() -> Self {
         Self::with_capacity(0)
     }
 
-    /// Create a new, empty schema with capacity
+    /// Create a new, empty schema with the given capacity.
     ///
     /// If you know the number of fields you have ahead of time, using this is more efficient than using
     /// [`new`][Self::new]. Also consider using [`Schema::from_iter`] if you have the collection of fields available
@@ -87,7 +87,7 @@ impl Schema {
         self.inner.reserve(additional);
     }
 
-    /// The number of fields in the schema
+    /// The number of fields in the schema.
     #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
@@ -98,7 +98,7 @@ impl Schema {
         self.inner.is_empty()
     }
 
-    /// Rename field `old` to `new`, and return the (owned) old name
+    /// Rename field `old` to `new`, and return the (owned) old name.
     ///
     /// If `old` is not present in the schema, the schema is not modified and `None` is returned. Otherwise the schema
     /// is updated and `Some(old_name)` is returned.
@@ -114,7 +114,7 @@ impl Schema {
         Some(old_name)
     }
 
-    /// Create a new schema from this one, inserting a field with `name` and `dtype` at the given `index`
+    /// Create a new schema from this one, inserting a field with `name` and `dtype` at the given `index`.
     ///
     /// If a field named `name` already exists, it is updated with the new dtype. Regardless, the field named `name` is
     /// always moved to the given index. Valid indices range from `0` (front of the schema) to `self.len()` (after the
@@ -150,7 +150,7 @@ impl Schema {
         Ok(new)
     }
 
-    /// Insert a field with `name` and `dtype` at the given `index` into this schema
+    /// Insert a field with `name` and `dtype` at the given `index` into this schema.
     ///
     /// If a field named `name` already exists, it is updated with the new dtype. Regardless, the field named `name` is
     /// always moved to the given index. Valid indices range from `0` (front of the schema) to `self.len()` (after the
@@ -189,32 +189,32 @@ impl Schema {
         Ok(old_dtype)
     }
 
-    /// Get a reference to the dtype of the field named `name`, or `None` if the field doesn't exist
+    /// Get a reference to the dtype of the field named `name`, or `None` if the field doesn't exist.
     pub fn get(&self, name: &str) -> Option<&DataType> {
         self.inner.get(name)
     }
 
-    /// Get a reference to the dtype of the field named `name`, or `Err(PolarsErr)` if the field doesn't exist
+    /// Get a reference to the dtype of the field named `name`, or `Err(PolarsErr)` if the field doesn't exist.
     pub fn try_get(&self, name: &str) -> PolarsResult<&DataType> {
         self.get(name)
             .ok_or_else(|| polars_err!(SchemaFieldNotFound: "{}", name))
     }
 
-    /// Get a mutable reference to the dtype of the field named `name`, or `Err(PolarsErr)` if the field doesn't exist
+    /// Get a mutable reference to the dtype of the field named `name`, or `Err(PolarsErr)` if the field doesn't exist.
     pub fn try_get_mut(&mut self, name: &str) -> PolarsResult<&mut DataType> {
         self.inner
             .get_mut(name)
             .ok_or_else(|| polars_err!(SchemaFieldNotFound: "{}", name))
     }
 
-    /// Return all data about the field named `name`: its index in the schema, its name, and its dtype
+    /// Return all data about the field named `name`: its index in the schema, its name, and its dtype.
     ///
     /// Returns `Some((index, &name, &dtype))` if the field exists, `None` if it doesn't.
     pub fn get_full(&self, name: &str) -> Option<(usize, &SmartString, &DataType)> {
         self.inner.get_full(name)
     }
 
-    /// Return all data about the field named `name`: its index in the schema, its name, and its dtype
+    /// Return all data about the field named `name`: its index in the schema, its name, and its dtype.
     ///
     /// Returns `Ok((index, &name, &dtype))` if the field exists, `Err(PolarsErr)` if it doesn't.
     pub fn try_get_full(&self, name: &str) -> PolarsResult<(usize, &SmartString, &DataType)> {
@@ -223,7 +223,7 @@ impl Schema {
             .ok_or_else(|| polars_err!(SchemaFieldNotFound: "{}", name))
     }
 
-    /// Look up the name in the schema and return an owned [`Field`] by cloning the data
+    /// Look up the name in the schema and return an owned [`Field`] by cloning the data.
     ///
     /// Returns `None` if the field does not exist.
     ///
@@ -235,7 +235,7 @@ impl Schema {
             .map(|dtype| Field::new(name, dtype.clone()))
     }
 
-    /// Look up the name in the schema and return an owned [`Field`] by cloning the data
+    /// Look up the name in the schema and return an owned [`Field`] by cloning the data.
     ///
     /// Returns `Err(PolarsErr)` if the field does not exist.
     ///
@@ -248,7 +248,7 @@ impl Schema {
             .map(|dtype| Field::new(name, dtype.clone()))
     }
 
-    /// Get references to the name and dtype of the field at `index`
+    /// Get references to the name and dtype of the field at `index`.
     ///
     /// If `index` is inbounds, returns `Some((&name, &dtype))`, else `None`. See
     /// [`get_at_index_mut`][Self::get_at_index_mut] for a mutable version.
@@ -260,7 +260,7 @@ impl Schema {
         self.inner.get_index(index).ok_or_else(|| polars_err!(ComputeError: "index {index} out of bounds with 'schema' of len: {}", self.len()))
     }
 
-    /// Get mutable references to the name and dtype of the field at `index`
+    /// Get mutable references to the name and dtype of the field at `index`.
     ///
     /// If `index` is inbounds, returns `Some((&mut name, &mut dtype))`, else `None`. See
     /// [`get_at_index`][Self::get_at_index] for an immutable version.
@@ -268,7 +268,7 @@ impl Schema {
         self.inner.get_index_mut2(index)
     }
 
-    /// Swap-remove a field by name and, if the field existed, return its dtype
+    /// Swap-remove a field by name and, if the field existed, return its dtype.
     ///
     /// If the field does not exist, the schema is not modified and `None` is returned.
     ///
@@ -279,7 +279,7 @@ impl Schema {
         self.inner.swap_remove(name)
     }
 
-    /// Remove a field by name, preserving order, and, if the field existed, return its dtype
+    /// Remove a field by name, preserving order, and, if the field existed, return its dtype.
     ///
     /// If the field does not exist, the schema is not modified and `None` is returned.
     ///
@@ -289,7 +289,7 @@ impl Schema {
         self.inner.shift_remove(name)
     }
 
-    /// Remove a field by name, preserving order, and, if the field existed, return its dtype
+    /// Remove a field by name, preserving order, and, if the field existed, return its dtype.
     ///
     /// If the field does not exist, the schema is not modified and `None` is returned.
     ///
@@ -299,12 +299,12 @@ impl Schema {
         self.inner.shift_remove_index(index)
     }
 
-    /// Whether the schema contains a field named `name`
+    /// Whether the schema contains a field named `name`.
     pub fn contains(&self, name: &str) -> bool {
         self.get(name).is_some()
     }
 
-    /// Change the field named `name` to the given `dtype` and return the previous dtype
+    /// Change the field named `name` to the given `dtype` and return the previous dtype.
     ///
     /// If `name` doesn't already exist in the schema, the schema is not modified and `None` is returned. Otherwise
     /// returns `Some(old_dtype)`.
@@ -316,7 +316,7 @@ impl Schema {
         Some(std::mem::replace(old_dtype, dtype))
     }
 
-    /// Change the field at the given index to the given `dtype` and return the previous dtype
+    /// Change the field at the given index to the given `dtype` and return the previous dtype.
     ///
     /// If the index is out of bounds, the schema is not modified and `None` is returned. Otherwise returns
     /// `Some(old_dtype)`.
@@ -328,7 +328,7 @@ impl Schema {
         Some(std::mem::replace(old_dtype, dtype))
     }
 
-    /// Insert a new column in the [`Schema`]
+    /// Insert a new column in the [`Schema`].
     ///
     /// If an equivalent name already exists in the schema: the name remains and
     /// retains in its place in the order, its corresponding value is updated
@@ -344,7 +344,7 @@ impl Schema {
         self.inner.insert(name, dtype)
     }
 
-    /// Merge `other` into `self`
+    /// Merge `other` into `self`.
     ///
     /// Merging logic:
     /// - Fields that occur in `self` but not `other` are unmodified
@@ -355,7 +355,7 @@ impl Schema {
         self.inner.extend(other.inner)
     }
 
-    /// Merge borrowed `other` into `self`
+    /// Merge borrowed `other` into `self`.
     ///
     /// Merging logic:
     /// - Fields that occur in `self` but not `other` are unmodified
@@ -370,7 +370,7 @@ impl Schema {
         )
     }
 
-    /// Convert self to `ArrowSchema` by cloning the fields
+    /// Convert self to `ArrowSchema` by cloning the fields.
     pub fn to_arrow(&self, compat_level: CompatLevel) -> ArrowSchema {
         let fields: Vec<_> = self
             .inner
@@ -380,7 +380,7 @@ impl Schema {
         ArrowSchema::from(fields)
     }
 
-    /// Iterates the [`Field`]s in this schema, constructing them anew by cloning each `(&name, &dtype)` pair
+    /// Iterates the [`Field`]s in this schema, constructing them anew by cloning each `(&name, &dtype)` pair.
     ///
     /// Note that this clones each name and dtype in order to form an owned [`Field`]. For a clone-free version, use
     /// [`iter`][Self::iter], which returns `(&name, &dtype)`.
@@ -390,22 +390,22 @@ impl Schema {
             .map(|(name, dtype)| Field::new(name, dtype.clone()))
     }
 
-    /// Iterates over references to the dtypes in this schema
+    /// Iterates over references to the dtypes in this schema.
     pub fn iter_dtypes(&self) -> impl '_ + ExactSizeIterator<Item = &DataType> {
         self.inner.iter().map(|(_name, dtype)| dtype)
     }
 
-    /// Iterates over mut references to the dtypes in this schema
+    /// Iterates over mut references to the dtypes in this schema.
     pub fn iter_dtypes_mut(&mut self) -> impl '_ + ExactSizeIterator<Item = &mut DataType> {
         self.inner.iter_mut().map(|(_name, dtype)| dtype)
     }
 
-    /// Iterates over references to the names in this schema
+    /// Iterates over references to the names in this schema.
     pub fn iter_names(&self) -> impl '_ + ExactSizeIterator<Item = &SmartString> {
         self.inner.iter().map(|(name, _dtype)| name)
     }
 
-    /// Iterates over the `(&name, &dtype)` pairs in this schema
+    /// Iterates over the `(&name, &dtype)` pairs in this schema.
     ///
     /// For an owned version, use [`iter_fields`][Self::iter_fields], which clones the data to iterate owned `Field`s
     pub fn iter(&self) -> impl Iterator<Item = (&SmartString, &DataType)> + '_ {
@@ -439,7 +439,7 @@ impl IntoIterator for Schema {
     }
 }
 
-/// This trait exists to be unify the API of polars Schema and arrows Schema
+/// This trait exists to be unify the API of polars Schema and arrows Schema.
 pub trait IndexOfSchema: Debug {
     /// Get the index of a column by name.
     fn index_of(&self, name: &str) -> Option<usize>;

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -107,4 +107,58 @@ impl IR {
         };
         Cow::Borrowed(schema)
     }
+
+    /// Get the schema of the logical plan node, using caching.
+    #[recursive]
+    pub fn schema_with_cache<'a>(
+        node: Node,
+        arena: &'a Arena<IR>,
+        cache: &mut PlHashMap<Node, Arc<Schema>>,
+    ) -> Arc<Schema> {
+        use IR::*;
+        if let Some(schema) = cache.get(&node) {
+            return schema.clone();
+        }
+
+        let schema = match arena.get(node) {
+            #[cfg(feature = "python")]
+            PythonScan { options } => options
+                .output_schema
+                .as_ref()
+                .unwrap_or(&options.schema)
+                .clone(),
+            Union { inputs, .. } => IR::schema_with_cache(inputs[0], arena, cache),
+            HConcat { schema, .. } => schema.clone(),
+            Cache { input, .. }
+            | Sort { input, .. }
+            | Filter { input, .. }
+            | Distinct { input, .. }
+            | Sink { input, .. }
+            | Slice { input, .. } => IR::schema_with_cache(*input, arena, cache),
+            Scan {
+                output_schema,
+                file_info,
+                ..
+            } => output_schema.as_ref().unwrap_or(&file_info.schema).clone(),
+            DataFrameScan {
+                schema,
+                output_schema,
+                ..
+            } => output_schema.as_ref().unwrap_or(schema).clone(),
+            Select { schema, .. }
+            | Reduce { schema, .. }
+            | GroupBy { schema, .. }
+            | Join { schema, .. }
+            | HStack { schema, .. }
+            | ExtContext { schema, .. }
+            | SimpleProjection { columns: schema, .. } => schema.clone(),
+            MapFunction { input, function } => {
+                let input_schema = IR::schema_with_cache(*input, arena, cache);
+                function.schema(&input_schema).unwrap().into_owned()
+            },
+            Invalid => unreachable!(),
+        };
+        cache.insert(node, schema.clone());
+        schema
+    }
 }

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -151,7 +151,9 @@ impl IR {
             | Join { schema, .. }
             | HStack { schema, .. }
             | ExtContext { schema, .. }
-            | SimpleProjection { columns: schema, .. } => schema.clone(),
+            | SimpleProjection {
+                columns: schema, ..
+            } => schema.clone(),
             MapFunction { input, function } => {
                 let input_schema = IR::schema_with_cache(*input, arena, cache);
                 function.schema(&input_schema).unwrap().into_owned()

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use polars_core::prelude::PlHashMap;
+use polars_core::schema::Schema;
 use polars_error::PolarsResult;
 use polars_expr::reduce::can_convert_into_reduction;
 use polars_plan::plans::{AExpr, Context, IR};
@@ -7,7 +9,7 @@ use polars_plan::prelude::SinkType;
 use polars_utils::arena::{Arena, Node};
 use slotmap::SlotMap;
 
-use super::{PhysNode, PhysNodeKey};
+use super::{PhysNode, PhysNodeKey, PhysNodeKind};
 
 fn is_streamable(node: Node, arena: &Arena<AExpr>) -> bool {
     polars_plan::plans::is_streamable(node, arena, Context::Default)
@@ -19,90 +21,59 @@ pub fn lower_ir(
     ir_arena: &mut Arena<IR>,
     expr_arena: &Arena<AExpr>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
+    schema_cache: &mut PlHashMap<Node, Arc<Schema>>,
 ) -> PolarsResult<PhysNodeKey> {
     let ir_node = ir_arena.get(node);
-    match ir_node {
+    let node_kind = match ir_node {
         IR::SimpleProjection { input, columns } => {
-            let input_ir_node = ir_arena.get(*input);
-            let input_schema = input_ir_node.schema(ir_arena).into_owned();
             let columns = columns.iter_names().map(|s| s.to_string()).collect();
-            let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-            Ok(phys_sm.insert(PhysNode::SimpleProjection {
-                input,
-                columns,
-                input_schema,
-            }))
+            let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+            PhysNodeKind::SimpleProjection { input: phys_input, columns }
         },
 
         // TODO: split partially streamable selections to avoid fallback as much as possible.
         IR::Select {
             input,
             expr,
-            schema,
             ..
         } if expr.iter().all(|e| is_streamable(e.node(), expr_arena)) => {
             let selectors = expr.clone();
-            let output_schema = schema.clone();
-            let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-            Ok(phys_sm.insert(PhysNode::Select {
-                input,
-                selectors,
-                output_schema,
-                extend_original: false,
-            }))
-        },
-        // TODO: split reductions and streamable selections. E.g. sum(a) + sum(b) should be split
-        // into Select(a + b) -> Reduce(sum(a), sum(b)
-        IR::Select {
-            input,
-            expr,
-            schema: output_schema,
-            ..
-        } if expr
-            .iter()
-            .all(|e| can_convert_into_reduction(e.node(), expr_arena)) =>
-        {
-            let exprs = expr.clone();
-            let input_ir_node = ir_arena.get(*input);
-            let input_schema = input_ir_node.schema(ir_arena).into_owned();
-            let output_schema = output_schema.clone();
-            let input_node = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-            Ok(phys_sm.insert(PhysNode::Reduce {
-                input: input_node,
-                exprs,
-                input_schema,
-                output_schema,
-            }))
+            let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+            PhysNodeKind::Select { input: phys_input, selectors, extend_original: false }
         },
 
         // TODO: split partially streamable selections to avoid fallback as much as possible.
         IR::HStack {
             input,
             exprs,
-            schema,
             ..
         } if exprs.iter().all(|e| is_streamable(e.node(), expr_arena)) => {
             let selectors = exprs.clone();
-            let output_schema = schema.clone();
-            let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-            Ok(phys_sm.insert(PhysNode::Select {
-                input,
-                selectors,
-                output_schema,
-                extend_original: true,
-            }))
+            let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+            PhysNodeKind::Select { input: phys_input, selectors, extend_original: true }
+        },
+
+        // TODO: split reductions and streamable selections. E.g. sum(a) + sum(b) should be split
+        // into Select(a + b) -> Reduce(sum(a), sum(b)
+        IR::Select {
+            input,
+            expr,
+            ..
+        } if expr
+            .iter()
+            .all(|e| can_convert_into_reduction(e.node(), expr_arena)) =>
+        {
+            let exprs = expr.clone();
+            let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+            PhysNodeKind::Reduce { input: phys_input, exprs }
         },
 
         IR::Slice { input, offset, len } => {
             if *offset >= 0 {
                 let offset = *offset as usize;
                 let length = *len as usize;
-                let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-                Ok(phys_sm.insert(PhysNode::StreamingSlice {
-                    input,
-                    offset,
-                    length,
-                }))
+                let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+                PhysNodeKind::StreamingSlice { input: phys_input, offset, length }
             } else {
                 todo!()
             }
@@ -110,71 +81,61 @@ pub fn lower_ir(
 
         IR::Filter { input, predicate } if is_streamable(predicate.node(), expr_arena) => {
             let predicate = predicate.clone();
-            let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-            Ok(phys_sm.insert(PhysNode::Filter { input, predicate }))
+            let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+            PhysNodeKind::Filter { input: phys_input, predicate }
         },
 
         IR::DataFrameScan {
             df,
-            output_schema,
+            output_schema: projection,
             filter,
-            schema: input_schema,
+            schema,
             ..
         } => {
-            if let Some(filter) = filter {
-                if !is_streamable(filter.node(), expr_arena) {
-                    todo!()
-                }
-            }
+            let mut schema = schema.clone(); // This is initially the schema of df, but can change with the projection.
+            let mut node_kind = PhysNodeKind::InMemorySource { df: df.clone() };
 
-            let mut phys_node = phys_sm.insert(PhysNode::InMemorySource { df: df.clone() });
-
-            if let Some(schema) = output_schema {
-                phys_node = phys_sm.insert(PhysNode::SimpleProjection {
-                    input: phys_node,
-                    input_schema: input_schema.clone(),
-                    columns: schema.iter_names().map(|s| s.to_string()).collect(),
-                })
+            if let Some(projection_schema) = projection {
+                let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
+                node_kind = PhysNodeKind::SimpleProjection {
+                    input: phys_input,
+                    columns: projection_schema.iter_names().map(|s| s.to_string()).collect(),
+                };
+                schema = projection_schema.clone();
             }
 
             if let Some(predicate) = filter.clone() {
-                phys_node = phys_sm.insert(PhysNode::Filter {
-                    input: phys_node,
-                    predicate,
-                })
-            }
+                if !is_streamable(predicate.node(), expr_arena) {
+                    todo!()
+                }
 
-            Ok(phys_node)
+                let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
+                node_kind = PhysNodeKind::Filter { input: phys_input, predicate };
+            }
+            
+            node_kind
         },
 
         IR::Sink { input, payload } => {
             if *payload == SinkType::Memory {
-                let schema = ir_node.schema(ir_arena).into_owned();
-                let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-                return Ok(phys_sm.insert(PhysNode::InMemorySink { input, schema }));
+                let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+                PhysNodeKind::InMemorySink { input: phys_input }
+            } else {
+                todo!()
             }
-
-            todo!()
         },
 
         IR::MapFunction { input, function } => {
-            let input_schema = ir_arena.get(*input).schema(ir_arena).into_owned();
             let function = function.clone();
-            let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
+            let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
 
-            let phys_node = if function.is_streamable() {
+            if function.is_streamable() {
                 let map = Arc::new(move |df| function.evaluate(df));
-                PhysNode::Map { input, map }
+                PhysNodeKind::Map { input: phys_input, map }
             } else {
                 let map = Arc::new(move |df| function.evaluate(df));
-                PhysNode::InMemoryMap {
-                    input,
-                    input_schema,
-                    map,
-                }
-            };
-
-            Ok(phys_sm.insert(phys_node))
+                PhysNodeKind::InMemoryMap { input: phys_input, map }
+            }
         },
 
         IR::Sort {
@@ -183,15 +144,12 @@ pub fn lower_ir(
             slice,
             sort_options,
         } => {
-            let input_schema = ir_arena.get(*input).schema(ir_arena).into_owned();
-            let phys_node = PhysNode::Sort {
-                input_schema,
+            PhysNodeKind::Sort {
                 by_column: by_column.clone(),
                 slice: *slice,
                 sort_options: sort_options.clone(),
-                input: lower_ir(*input, ir_arena, expr_arena, phys_sm)?,
-            };
-            Ok(phys_sm.insert(phys_node))
+                input: lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?,
+            }
         },
 
         IR::Union { inputs, options } => {
@@ -202,9 +160,9 @@ pub fn lower_ir(
             let inputs = inputs
                 .clone() // Needed to borrow ir_arena mutably.
                 .into_iter()
-                .map(|input| lower_ir(input, ir_arena, expr_arena, phys_sm))
+                .map(|input| lower_ir(input, ir_arena, expr_arena, phys_sm, schema_cache))
                 .collect::<Result<_, _>>()?;
-            Ok(phys_sm.insert(PhysNode::OrderedUnion { inputs }))
+            PhysNodeKind::OrderedUnion { inputs }
         },
 
         IR::HConcat {
@@ -212,26 +170,20 @@ pub fn lower_ir(
             schema: _,
             options: _,
         } => {
-            let input_schemas = inputs
-                .iter()
-                .map(|input| {
-                    let input_ir_node = ir_arena.get(*input);
-                    input_ir_node.schema(ir_arena).into_owned()
-                })
-                .collect();
-
             let inputs = inputs
                 .clone() // Needed to borrow ir_arena mutably.
                 .into_iter()
-                .map(|input| lower_ir(input, ir_arena, expr_arena, phys_sm))
+                .map(|input| lower_ir(input, ir_arena, expr_arena, phys_sm, schema_cache))
                 .collect::<Result<_, _>>()?;
-            Ok(phys_sm.insert(PhysNode::Zip {
+            PhysNodeKind::Zip {
                 inputs,
-                input_schemas,
                 null_extend: true,
-            }))
+            }
         },
 
         _ => todo!(),
-    }
+    };
+    
+    let output_schema = IR::schema_with_cache(node, ir_arena, schema_cache);
+    Ok(phys_sm.insert(PhysNode::new(output_schema, node_kind)))
 }

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -29,7 +29,10 @@ pub struct PhysNode {
 
 impl PhysNode {
     pub fn new(output_schema: Arc<Schema>, kind: PhysNodeKind) -> Self {
-        Self { output_schema, kind }
+        Self {
+            output_schema,
+            kind,
+        }
     }
 }
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -22,7 +22,19 @@ slotmap::new_key_type! {
 /// A physical plan is created when the `IR` is translated to a directed
 /// acyclic graph of operations that can run on the streaming engine.
 #[derive(Clone, Debug)]
-pub enum PhysNode {
+pub struct PhysNode {
+    output_schema: Arc<Schema>,
+    kind: PhysNodeKind,
+}
+
+impl PhysNode {
+    pub fn new(output_schema: Arc<Schema>, kind: PhysNodeKind) -> Self {
+        Self { output_schema, kind }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum PhysNodeKind {
     InMemorySource {
         df: Arc<DataFrame>,
     },
@@ -31,14 +43,11 @@ pub enum PhysNode {
         input: PhysNodeKey,
         selectors: Vec<ExprIR>,
         extend_original: bool,
-        output_schema: Arc<Schema>,
     },
 
     Reduce {
         input: PhysNodeKey,
         exprs: Vec<ExprIR>,
-        input_schema: Arc<Schema>,
-        output_schema: Arc<Schema>,
     },
 
     StreamingSlice {
@@ -54,18 +63,15 @@ pub enum PhysNode {
 
     SimpleProjection {
         input: PhysNodeKey,
-        input_schema: Arc<Schema>,
         columns: Vec<String>,
     },
 
     InMemorySink {
         input: PhysNodeKey,
-        schema: Arc<Schema>,
     },
 
     InMemoryMap {
         input: PhysNodeKey,
-        input_schema: Arc<Schema>,
         map: Arc<dyn DataFrameUdf>,
     },
 
@@ -76,7 +82,6 @@ pub enum PhysNode {
 
     Sort {
         input: PhysNodeKey,
-        input_schema: Arc<Schema>, // TODO: remove when not using fallback impl.
         by_column: Vec<ExprIR>,
         slice: Option<(i64, usize)>,
         sort_options: SortMultipleOptions,
@@ -88,7 +93,6 @@ pub enum PhysNode {
 
     Zip {
         inputs: Vec<PhysNodeKey>,
-        input_schemas: Vec<Arc<Schema>>,
         /// If true shorter inputs are extended with nulls to the longest input,
         /// if false all inputs must be the same length, or have length 1 in
         /// which case they are broadcast.

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -10,10 +10,11 @@ use polars_plan::plans::expr_ir::ExprIR;
 use polars_plan::plans::{AExpr, ArenaExprIter, Context, IR};
 use polars_plan::prelude::FunctionFlags;
 use polars_utils::arena::{Arena, Node};
+use polars_utils::itertools::Itertools;
 use recursive::recursive;
 use slotmap::{SecondaryMap, SlotMap};
 
-use super::{PhysNode, PhysNodeKey};
+use super::{PhysNode, PhysNodeKind, PhysNodeKey};
 use crate::expression::StreamExpr;
 use crate::graph::{Graph, GraphNodeKey};
 use crate::nodes;
@@ -81,8 +82,9 @@ fn to_graph_rec<'a>(
         return Ok(*graph_key);
     }
 
-    use PhysNode::*;
-    let graph_key = match &ctx.phys_sm[phys_node_key] {
+    use PhysNodeKind::*;
+    let node = &ctx.phys_sm[phys_node_key];
+    let graph_key = match &node.kind {
         InMemorySource { df } => ctx.graph.add_node(
             nodes::in_memory_source::InMemorySourceNode::new(df.clone()),
             [],
@@ -112,7 +114,6 @@ fn to_graph_rec<'a>(
         Select {
             selectors,
             input,
-            output_schema,
             extend_original,
         } => {
             let phys_selectors = selectors
@@ -123,7 +124,7 @@ fn to_graph_rec<'a>(
             ctx.graph.add_node(
                 nodes::select::SelectNode::new(
                     phys_selectors,
-                    output_schema.clone(),
+                    node.output_schema.clone(),
                     *extend_original,
                 ),
                 [input_key],
@@ -132,17 +133,16 @@ fn to_graph_rec<'a>(
         Reduce {
             input,
             exprs,
-            input_schema,
-            output_schema,
         } => {
             let input_key = to_graph_rec(*input, ctx)?;
+            let input_schema = &ctx.phys_sm[*input].output_schema;
 
             let mut reductions = Vec::with_capacity(exprs.len());
             let mut inputs = Vec::with_capacity(reductions.len());
 
             for e in exprs {
                 let (red, input_node) =
-                    into_reduction(e.node(), ctx.expr_arena, input_schema.as_ref())?
+                    into_reduction(e.node(), ctx.expr_arena, input_schema)?
                         .expect("invariant");
                 reductions.push(red);
 
@@ -153,41 +153,42 @@ fn to_graph_rec<'a>(
             }
 
             ctx.graph.add_node(
-                nodes::reduce::ReduceNode::new(inputs, reductions, output_schema.clone()),
+                nodes::reduce::ReduceNode::new(inputs, reductions, node.output_schema.clone()),
                 [input_key],
             )
         },
         SimpleProjection {
             input,
             columns,
-            input_schema,
         } => {
+            let input_schema = ctx.phys_sm[*input].output_schema.clone();
             let input_key = to_graph_rec(*input, ctx)?;
             ctx.graph.add_node(
                 nodes::simple_projection::SimpleProjectionNode::new(
                     columns.clone(),
-                    input_schema.clone(),
+                    input_schema,
                 ),
                 [input_key],
             )
         },
 
-        InMemorySink { input, schema } => {
+        InMemorySink { input } => {
+            let input_schema = ctx.phys_sm[*input].output_schema.clone();
             let input_key = to_graph_rec(*input, ctx)?;
             ctx.graph.add_node(
-                nodes::in_memory_sink::InMemorySinkNode::new(schema.clone()),
+                nodes::in_memory_sink::InMemorySinkNode::new(input_schema),
                 [input_key],
             )
         },
 
         InMemoryMap {
             input,
-            input_schema,
             map,
         } => {
+            let input_schema = ctx.phys_sm[*input].output_schema.clone();
             let input_key = to_graph_rec(*input, ctx)?;
             ctx.graph.add_node(
-                nodes::in_memory_map::InMemoryMapNode::new(input_schema.clone(), map.clone()),
+                nodes::in_memory_map::InMemoryMapNode::new(input_schema, map.clone()),
                 [input_key],
             )
         },
@@ -200,11 +201,11 @@ fn to_graph_rec<'a>(
 
         Sort {
             input,
-            input_schema,
             by_column,
             slice,
             sort_options,
         } => {
+            let input_schema = ctx.phys_sm[*input].output_schema.clone();
             let lmdf = Arc::new(LateMaterializedDataFrame::default());
             let mut lp_arena = Arena::default();
             let df_node = lp_arena.add(lmdf.clone().as_ir_node(input_schema.clone()));
@@ -223,7 +224,7 @@ fn to_graph_rec<'a>(
             let input_key = to_graph_rec(*input, ctx)?;
             ctx.graph.add_node(
                 nodes::in_memory_map::InMemoryMapNode::new(
-                    input_schema.clone(),
+                    input_schema,
                     Arc::new(move |df| {
                         lmdf.set_materialized_dataframe(df);
                         let mut state = ExecutionState::new();
@@ -245,15 +246,15 @@ fn to_graph_rec<'a>(
 
         Zip {
             inputs,
-            input_schemas,
             null_extend,
         } => {
+            let input_schemas = inputs.iter().map(|i| ctx.phys_sm[*i].output_schema.clone()).collect_vec();
             let input_keys = inputs
                 .iter()
                 .map(|i| to_graph_rec(*i, ctx))
-                .collect::<Result<Vec<_>, _>>()?;
+                .try_collect_vec()?;
             ctx.graph.add_node(
-                nodes::zip::ZipNode::new(*null_extend, input_schemas.clone()),
+                nodes::zip::ZipNode::new(*null_extend, input_schemas),
                 input_keys,
             )
         },

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -19,7 +19,13 @@ pub fn run_query(
 ) -> PolarsResult<DataFrame> {
     let mut phys_sm = SlotMap::with_capacity_and_key(ir_arena.len());
     let mut schema_cache = PlHashMap::with_capacity(ir_arena.len());
-    let root = crate::physical_plan::lower_ir(node, &mut ir_arena, expr_arena, &mut phys_sm, &mut schema_cache)?;
+    let root = crate::physical_plan::lower_ir(
+        node,
+        &mut ir_arena,
+        expr_arena,
+        &mut phys_sm,
+        &mut schema_cache,
+    )?;
     let (mut graph, phys_to_graph) =
         crate::physical_plan::physical_plan_to_graph(&phys_sm, expr_arena)?;
     let mut results = crate::execute::execute_graph(&mut graph)?;

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -18,8 +18,8 @@ pub fn run_query(
     expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<DataFrame> {
     let mut phys_sm = SlotMap::with_capacity_and_key(ir_arena.len());
-
-    let root = crate::physical_plan::lower_ir(node, &mut ir_arena, expr_arena, &mut phys_sm)?;
+    let mut schema_cache = PlHashMap::with_capacity(ir_arena.len());
+    let root = crate::physical_plan::lower_ir(node, &mut ir_arena, expr_arena, &mut phys_sm, &mut schema_cache)?;
     let (mut graph, phys_to_graph) =
         crate::physical_plan::physical_plan_to_graph(&phys_sm, expr_arena)?;
     let mut results = crate::execute::execute_graph(&mut graph)?;


### PR DESCRIPTION
This is necessary for lowering expressions, we need to be able to get the schema of arbitrary `PhysNode`s.