### PR TITLE
feat(python): Support the most recent version of "duckdb_engine" connections via `read_database`

### DIFF
--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -384,7 +384,7 @@ class ConnectionExecutor:
                     return conn.engine.raw_connection().cursor()
                 elif conn.engine.driver == "duckdb_engine":
                     self.driver_name = "duckdb"
-                    return conn.engine.raw_connection().driver_connection.c
+                    return conn.engine.raw_connection().driver_connection
                 elif self._is_alchemy_engine(conn):
                     # note: if we create it, we can close it
                     self.can_close_cursor = True


### PR DESCRIPTION
Closes #18263.

One of those rare two-character fixes... ;)

Following the "duckdb_engine" code a little more closely showed that we didn't need to expose the inner/private connection object to take advantage of the `fetch_arrow_table` fast-path; the driver connection's `__getattr__` accesses it implicitly for us. (Explicit access via `.c` was deprecated and removed recently, hence the reported error).

Confirmed the fix works and still takes the Arrow-aware fast path with old/new versions of the "duckdb_engine" alchemy driver.