### PR TITLE
docs(python): Fix typos and add see also links to struct name expressions

### DIFF
--- a/py-polars/docs/source/reference/expressions/col.rst
+++ b/py-polars/docs/source/reference/expressions/col.rst
@@ -2,7 +2,7 @@
 polars.col
 ==========
 
-Create an expression representing column(s) in a dataframe.
+Create an expression representing column(s) in a DataFrame.
 
 ``col`` is technically not a function, but it can be used like one.
 

--- a/py-polars/docs/source/reference/expressions/functions.rst
+++ b/py-polars/docs/source/reference/expressions/functions.rst
@@ -97,7 +97,6 @@ These functions are available from the Polars module root and can be used as exp
    Expr.any
    Expr.approx_n_unique
    Expr.count
-   Expr.exclude
    Expr.first
    Expr.head
    Expr.implode

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -681,9 +681,9 @@ class Expr:
 
         See Also
         --------
-        map
-        prefix
-        suffix
+        name.map
+        name.prefix
+        name.suffix
 
         Examples
         --------

--- a/py-polars/polars/expr/name.py
+++ b/py-polars/polars/expr/name.py
@@ -286,16 +286,21 @@ class ExprNameNameSpace:
 
     def map_fields(self, function: Callable[[str], str]) -> Expr:
         """
-        Rename fields of a struct by mapping a function over the field name.
+        Rename fields of a struct by mapping a function over the field name(s).
 
         Notes
         -----
-        This only take effects for struct.
+        This only takes effect for struct columns.
 
         Parameters
         ----------
         function
             Function that maps a field name to a new name.
+
+        See Also
+        --------
+        prefix_fields
+        suffix_fields
 
         Examples
         --------
@@ -307,16 +312,21 @@ class ExprNameNameSpace:
 
     def prefix_fields(self, prefix: str) -> Expr:
         """
-        Add a prefix to all fields name of a struct.
+        Add a prefix to all field names of a struct.
 
         Notes
         -----
-        This only take effects for struct.
+        This only takes effect for struct columns.
 
         Parameters
         ----------
         prefix
-            Prefix to add to the filed name
+            Prefix to add to the field name.
+
+        See Also
+        --------
+        map_fields
+        suffix_fields
 
         Examples
         --------
@@ -328,16 +338,21 @@ class ExprNameNameSpace:
 
     def suffix_fields(self, suffix: str) -> Expr:
         """
-        Add a suffix to all fields name of a struct.
+        Add a suffix to all field names of a struct.
 
         Notes
         -----
-        This only take effects for struct.
+        This only takes effect for struct columns.
 
         Parameters
         ----------
         suffix
-            Suffix to add to the filed name
+            Suffix to add to the field name.
+
+        See Also
+        --------
+        map_fields
+        prefix_fields
 
         Examples
         --------


### PR DESCRIPTION
I have built the docs locally and verified that all changes render correctly.