### PR TITLE
refactor(python): Deprecate serialize json for LazyFrame

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import warnings
 from datetime import date, datetime, time, timedelta
 from functools import lru_cache, partial, reduce
 from io import BytesIO, StringIO
@@ -41,6 +42,7 @@ from polars._utils.various import (
     _in_notebook,
     _is_generator,
     extend_bool,
+    find_stacklevel,
     is_bool_sequence,
     is_sequence,
     issue_warning,
@@ -680,7 +682,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             The format in which to serialize. Options:
 
             - `"binary"`: Serialize to binary format (bytes). This is the default.
-            - `"json"`: Serialize to JSON format (string).
+            - `"json"`: Serialize to JSON format (string) (deprecated).
 
         See Also
         --------
@@ -716,6 +718,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if format == "binary":
             serializer = self._ldf.serialize_binary
         elif format == "json":
+            msg = "'json' serialization format of LazyFrame is deprecated"
+            warnings.warn(
+                msg,
+                stacklevel=find_stacklevel(),
+            )
             serializer = self._ldf.serialize_json
         else:
             msg = f"`format` must be one of {{'binary', 'json'}}, got {format!r}"

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -40,6 +40,7 @@ def test_lf_serde_roundtrip_binary(lf: pl.LazyFrame) -> None:
         ],
     )
 )
+@pytest.mark.filterwarnings("ignore")
 def test_lf_serde_roundtrip_json(lf: pl.LazyFrame) -> None:
     serialized = lf.serialize(format="json")
     result = pl.LazyFrame.deserialize(io.StringIO(serialized), format="json")

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -52,17 +52,18 @@ def lf() -> pl.LazyFrame:
     return pl.LazyFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}).select("a").sum()
 
 
-def test_lf_serde(lf: pl.LazyFrame) -> None:
-    serialized = lf.serialize()
-    assert isinstance(serialized, bytes)
-    result = pl.LazyFrame.deserialize(io.BytesIO(serialized))
-    assert_frame_equal(result, lf)
-
-
+@pytest.mark.filterwarnings("ignore")
 def test_lf_serde_json_stringio(lf: pl.LazyFrame) -> None:
     serialized = lf.serialize(format="json")
     assert isinstance(serialized, str)
     result = pl.LazyFrame.deserialize(io.StringIO(serialized), format="json")
+    assert_frame_equal(result, lf)
+
+
+def test_lf_serde(lf: pl.LazyFrame) -> None:
+    serialized = lf.serialize()
+    assert isinstance(serialized, bytes)
+    result = pl.LazyFrame.deserialize(io.BytesIO(serialized))
     assert_frame_equal(result, lf)
 
 
@@ -74,6 +75,7 @@ def test_lf_serde_json_stringio(lf: pl.LazyFrame) -> None:
         ("json", io.BytesIO()),
     ],
 )
+@pytest.mark.filterwarnings("ignore")
 def test_lf_serde_to_from_buffer(
     lf: pl.LazyFrame, format: SerializationFormat, buf: io.IOBase
 ) -> None:


### PR DESCRIPTION
Doesn't need to be human readable. Especially since json cannot support all our state, so this may not round-trip. Also want to remove it, so I can drop the serde proc macro's on our DSL.