### PR TITLE
perf: Batch `DELTA_LENGTH_BYTE_ARRAY` decoding

### DIFF
--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -643,11 +643,16 @@ impl MutableBinaryViewArray<[u8]> {
             // implementation.
             if min_length == max_length {
                 let length = min_length;
-                View::extend_with_inlinable_strided(
-                    &mut self.views,
-                    &buffer[..length * num_items],
-                    length as u8,
-                );
+                if length == 0 {
+                    self.views
+                        .resize(self.views.len() + num_items, View::new_inline(&[]));
+                } else {
+                    View::extend_with_inlinable_strided(
+                        &mut self.views,
+                        &buffer[..length * num_items],
+                        length as u8,
+                    );
+                }
             } else {
                 self.views.extend(lengths_iterator.map(|length| {
                     // SAFETY: We asserted before that the sum of all lengths is smaller or equal

--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -573,6 +573,123 @@ impl MutableBinaryViewArray<[u8]> {
         }
         Ok(())
     }
+
+    /// Extend from a `buffer` and `length` of items given some statistics about the lengths.
+    ///
+    /// This will attempt to dispatch to several optimized implementations.
+    ///
+    /// # Safety
+    ///
+    /// This is safe if the statistics are correct.
+    pub unsafe fn extend_from_lengths_with_stats(
+        &mut self,
+        buffer: &[u8],
+        lengths_iterator: impl Clone + ExactSizeIterator<Item = usize>,
+        min_length: usize,
+        max_length: usize,
+        sum_length: usize,
+    ) {
+        let num_items = lengths_iterator.len();
+
+        if num_items == 0 {
+            return;
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            let (min, max, sum) = lengths_iterator.clone().map(|v| (v, v, v)).fold(
+                (usize::MAX, usize::MIN, 0usize),
+                |(cmin, cmax, csum), (emin, emax, esum)| {
+                    (cmin.min(emin), cmax.max(emax), csum + esum)
+                },
+            );
+
+            assert_eq!(min, min_length);
+            assert_eq!(max, max_length);
+            assert_eq!(sum, sum_length);
+        }
+
+        assert!(sum_length <= buffer.len());
+
+        let mut buffer_offset = 0;
+        if min_length > View::MAX_INLINE_SIZE as usize
+            && (num_items == 1 || sum_length + self.in_progress_buffer.len() <= u32::MAX as usize)
+        {
+            let buffer_idx = self.completed_buffers().len() as u32;
+            let in_progress_buffer_offset = self.in_progress_buffer.len();
+
+            self.in_progress_buffer
+                .extend_from_slice(&buffer[..sum_length]);
+            self.views.extend(lengths_iterator.map(|length| {
+                // SAFETY: We asserted before that the sum of all lengths is smaller or equal to
+                // the buffer length.
+                let view_buffer =
+                    unsafe { buffer.get_unchecked(buffer_offset..buffer_offset + length) };
+
+                // SAFETY: We know that the minimum length > View::MAX_INLINE_SIZE. Therefore, this
+                // length is > View::MAX_INLINE_SIZE.
+                let view = unsafe {
+                    View::new_noninline_unchecked(
+                        view_buffer,
+                        buffer_idx,
+                        (buffer_offset + in_progress_buffer_offset) as u32,
+                    )
+                };
+                buffer_offset += length;
+                view
+            }));
+        } else if max_length <= View::MAX_INLINE_SIZE as usize {
+            // If the min and max are the same, we can dispatch to the optimized SIMD
+            // implementation.
+            if min_length == max_length {
+                let length = min_length;
+                View::extend_with_inlinable_strided(
+                    &mut self.views,
+                    &buffer[..length * num_items],
+                    length as u8,
+                );
+            } else {
+                self.views.extend(lengths_iterator.map(|length| {
+                    // SAFETY: We asserted before that the sum of all lengths is smaller or equal
+                    // to the buffer length.
+                    let view_buffer =
+                        unsafe { buffer.get_unchecked(buffer_offset..buffer_offset + length) };
+
+                    // SAFETY: We know that each view has a length <= View::MAX_INLINE_SIZE because
+                    // the maximum length is <= View::MAX_INLINE_SIZE
+                    let view = unsafe { View::new_inline_unchecked(view_buffer) };
+                    buffer_offset += length;
+                    view
+                }));
+            }
+        } else {
+            // If all fails, just fall back to a base implementation.
+            self.reserve(num_items);
+            for length in lengths_iterator {
+                let value = &buffer[buffer_offset..buffer_offset + length];
+                buffer_offset += length;
+                self.push_value(value);
+            }
+        }
+    }
+
+    /// Extend from a `buffer` and `length` of items.
+    ///
+    /// This will attempt to dispatch to several optimized implementations.
+    #[inline]
+    pub fn extend_from_lengths(
+        &mut self,
+        buffer: &[u8],
+        lengths_iterator: impl Clone + ExactSizeIterator<Item = usize>,
+    ) {
+        let (min, max, sum) = lengths_iterator.clone().map(|v| (v, v, v)).fold(
+            (usize::MAX, 0usize, 0usize),
+            |(cmin, cmax, csum), (emin, emax, esum)| (cmin.min(emin), cmax.max(emax), csum + esum),
+        );
+
+        // SAFETY: We just collected the right stats.
+        unsafe { self.extend_from_lengths_with_stats(buffer, lengths_iterator, min, max, sum) }
+    }
 }
 
 impl<T: ViewType + ?Sized, P: AsRef<T>> Extend<Option<P>> for MutableBinaryViewArray<T> {
@@ -644,5 +761,56 @@ impl<T: ViewType + ?Sized, P: AsRef<T>> TryPush<Option<P>> for MutableBinaryView
     fn try_push(&mut self, item: Option<P>) -> PolarsResult<()> {
         self.push(item.as_ref().map(|p| p.as_ref()));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(values: &[&[u8]]) -> bool {
+        let buffer = values
+            .iter()
+            .flat_map(|v| v.iter().copied())
+            .collect::<Vec<u8>>();
+        let lengths = values.iter().map(|v| v.len()).collect::<Vec<usize>>();
+        let mut bv = MutableBinaryViewArray::<[u8]>::with_capacity(values.len());
+
+        bv.extend_from_lengths(&buffer[..], lengths.into_iter());
+
+        &bv.values_iter().collect::<Vec<&[u8]>>()[..] == values
+    }
+
+    #[test]
+    fn extend_with_lengths_basic() {
+        assert!(roundtrip(&[]));
+        assert!(roundtrip(&[b"abc"]));
+        assert!(roundtrip(&[
+            b"a_very_very_long_string_that_is_not_inlinable"
+        ]));
+        assert!(roundtrip(&[
+            b"abc",
+            b"a_very_very_long_string_that_is_not_inlinable"
+        ]));
+    }
+
+    #[test]
+    fn extend_with_inlinable_fastpath() {
+        assert!(roundtrip(&[b"abc", b"defg", b"hix"]));
+        assert!(roundtrip(&[b"abc", b"defg", b"hix", b"xyza1234abcd"]));
+    }
+
+    #[test]
+    fn extend_with_inlinable_eq_len_fastpath() {
+        assert!(roundtrip(&[b"abc", b"def", b"hix"]));
+        assert!(roundtrip(&[b"abc", b"def", b"hix", b"xyz"]));
+    }
+
+    #[test]
+    fn extend_with_not_inlinable_fastpath() {
+        assert!(roundtrip(&[
+            b"a_very_long_string123",
+            b"a_longer_string_than_the_previous"
+        ]));
     }
 }

--- a/crates/polars-arrow/src/trusted_len.rs
+++ b/crates/polars-arrow/src/trusted_len.rs
@@ -98,6 +98,14 @@ where
     }
 }
 
+impl<J: Clone> TrustMyLength<std::iter::Take<std::iter::Repeat<J>>, J> {
+    /// Create a new `TrustMyLength` iterator that repeats `value` `len` times.
+    pub fn new_repeat_n(value: J, len: usize) -> Self {
+        // SAFETY: This is always safe since repeat(..).take(n) always repeats exactly `n` times`.
+        unsafe { Self::new(std::iter::repeat(value).take(len), len) }
+    }
+}
+
 impl<I, J> Iterator for TrustMyLength<I, J>
 where
     I: Iterator<Item = J>,

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -210,7 +210,7 @@ impl<'a, O: Offset> StateTranslation<'a, BinaryDecoder<O>> for BinaryStateTransl
                 page.dict,
                 additional,
             )?,
-            T::Delta(ref mut page) => {
+            T::DeltaLengthByteArray(ref mut page, ref mut _lengths) => {
                 let (values, validity) = decoded;
 
                 let mut collector = DeltaCollector {

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview.rs
@@ -85,23 +85,27 @@ impl<'a> StateTranslation<'a, BinViewDecoder> for BinaryStateTranslation<'a> {
                 // Already done in decode_plain_encoded
                 validate_utf8 = false;
             },
-            Self::Delta(ref mut page_values) => {
+            Self::DeltaLengthByteArray(ref mut page_values, ref mut lengths) => {
                 let (values, validity) = decoded;
 
                 let mut collector = DeltaCollector {
+                    gatherer: &mut StatGatherer::default(),
+                    pushed_lengths: lengths,
                     decoder: page_values,
                 };
 
                 match page_validity {
-                    None => collector.push_n(values, additional)?,
+                    None => (&mut collector).push_n(values, additional)?,
                     Some(page_validity) => extend_from_decoder(
                         validity,
                         page_validity,
                         Some(additional),
                         values,
-                        collector,
+                        &mut collector,
                     )?,
                 }
+
+                collector.flush(values);
             },
             Self::DeltaBytes(ref mut page_values) => {
                 let (values, validity) = decoded;
@@ -147,6 +151,12 @@ impl utils::ExactSize for DecodedStateTuple {
 }
 
 pub(crate) struct DeltaCollector<'a, 'b> {
+    // We gatherer the decoded lengths into `pushed_lengths`. Then, we `flush` those to the
+    // `BinView` This allows us to group many memcopies into one and take better potential fast
+    // paths for inlineable views and such.
+    pub(crate) gatherer: &'b mut StatGatherer,
+    pub(crate) pushed_lengths: &'b mut Vec<u32>,
+
     pub(crate) decoder: &'b mut delta_length_byte_array::Decoder<'a>,
 }
 
@@ -154,44 +164,143 @@ pub(crate) struct DeltaBytesCollector<'a, 'b> {
     pub(crate) decoder: &'b mut delta_byte_array::Decoder<'a>,
 }
 
-pub(crate) struct ViewGatherer<'a, 'b> {
-    values: &'a [u8],
-    offset: &'b mut usize,
+/// A [`DeltaGatherer`] that gathers the minimum, maximum and summation of the values as `usize`s.
+pub(crate) struct StatGatherer {
+    min: usize,
+    max: usize,
+    flat_length: usize,
 }
 
-impl<'a, 'b> DeltaGatherer for ViewGatherer<'a, 'b> {
-    type Target = MutableBinaryViewArray<[u8]>;
+impl Default for StatGatherer {
+    fn default() -> Self {
+        Self {
+            min: usize::MAX,
+            max: usize::MIN,
+            flat_length: 0,
+        }
+    }
+}
+
+impl DeltaGatherer for StatGatherer {
+    type Target = Vec<u32>;
 
     fn target_len(&self, target: &Self::Target) -> usize {
         target.len()
     }
 
     fn target_reserve(&self, target: &mut Self::Target, n: usize) {
-        target.views_mut().reserve(n)
+        target.reserve(n);
     }
 
     fn gather_one(&mut self, target: &mut Self::Target, v: i64) -> ParquetResult<()> {
+        if v < 0 {
+            return Err(ParquetError::oos("DELTA_LENGTH_BYTE_ARRAY length < 0"));
+        }
+
+        if v > i64::from(u32::MAX) {
+            return Err(ParquetError::not_supported(
+                "DELTA_LENGTH_BYTE_ARRAY length > u32::MAX",
+            ));
+        }
+
         let v = v as usize;
-        let s = &self.values[*self.offset..*self.offset + v];
-        *self.offset += v;
-        target.push(Some(s));
+
+        self.min = self.min.min(v);
+        self.max = self.max.max(v);
+        self.flat_length += v;
+
+        target.push(v as u32);
+
+        Ok(())
+    }
+
+    fn gather_slice(&mut self, target: &mut Self::Target, slice: &[i64]) -> ParquetResult<()> {
+        let mut is_invalid = false;
+        let mut is_too_large = false;
+
+        target.extend(slice.iter().map(|&v| {
+            is_invalid |= v < 0;
+            is_too_large |= v > i64::from(u32::MAX);
+
+            let v = v as usize;
+
+            self.min = self.min.min(v);
+            self.max = self.max.max(v);
+            self.flat_length += v;
+
+            v as u32
+        }));
+
+        if is_invalid {
+            target.truncate(target.len() - slice.len());
+            return Err(ParquetError::oos("DELTA_LENGTH_BYTE_ARRAY length < 0"));
+        }
+
+        if is_too_large {
+            return Err(ParquetError::not_supported(
+                "DELTA_LENGTH_BYTE_ARRAY length > u32::MAX",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn gather_constant(
+        &mut self,
+        target: &mut Self::Target,
+        v: i64,
+        delta: i64,
+        num_repeats: usize,
+    ) -> ParquetResult<()> {
+        if v < 0 || (delta < 0 && num_repeats as i64 * delta + v < 0) {
+            return Err(ParquetError::oos("Invalid delta encoding length"));
+        }
+
+        if v > i64::from(u32::MAX) || v + ((num_repeats - 1) as i64) * delta > i64::from(u32::MAX) {
+            return Err(ParquetError::not_supported(
+                "DELTA_LENGTH_BYTE_ARRAY length > u32::MAX",
+            ));
+        }
+
+        target.extend((0..num_repeats).map(|i| (v + (i as i64) * delta) as u32));
+
+        let base = v * num_repeats as i64;
+        let is_even = num_repeats & 1;
+        // SUM_i=0^n f * i = f * (n(n+1)/2)
+        let increment = (num_repeats >> is_even) * ((num_repeats + 1) >> (is_even ^ 1));
+        let increment = delta * increment as i64;
+
+        let vstart = v;
+        let vend = v + (num_repeats - 1) as i64 * delta;
+
+        let (min, max) = if delta < 0 {
+            (vend, vstart)
+        } else {
+            (vstart, vend)
+        };
+
+        self.min = self.min.min(min as usize);
+        self.max = self.max.max(max as usize);
+
+        self.flat_length += (base + increment) as usize;
+
         Ok(())
     }
 }
 
-impl<'a, 'b> BatchableCollector<(), MutableBinaryViewArray<[u8]>> for DeltaCollector<'a, 'b> {
+impl<'a, 'b> BatchableCollector<(), MutableBinaryViewArray<[u8]>> for &mut DeltaCollector<'a, 'b> {
     fn reserve(target: &mut MutableBinaryViewArray<[u8]>, n: usize) {
         target.views_mut().reserve(n);
     }
 
-    fn push_n(&mut self, target: &mut MutableBinaryViewArray<[u8]>, n: usize) -> ParquetResult<()> {
-        let mut gatherer = ViewGatherer {
-            values: self.decoder.values,
-            offset: &mut self.decoder.offset,
-        };
+    fn push_n(
+        &mut self,
+        _target: &mut MutableBinaryViewArray<[u8]>,
+        n: usize,
+    ) -> ParquetResult<()> {
         self.decoder
             .lengths
-            .gather_n_into(target, n, &mut gatherer)?;
+            .gather_n_into(self.pushed_lengths, n, self.gatherer)?;
 
         Ok(())
     }
@@ -201,8 +310,29 @@ impl<'a, 'b> BatchableCollector<(), MutableBinaryViewArray<[u8]>> for DeltaColle
         target: &mut MutableBinaryViewArray<[u8]>,
         n: usize,
     ) -> ParquetResult<()> {
+        self.flush(target);
         target.extend_constant(n, <Option<&[u8]>>::None);
         Ok(())
+    }
+}
+
+impl<'a, 'b> DeltaCollector<'a, 'b> {
+    pub fn flush(&mut self, target: &mut MutableBinaryViewArray<[u8]>) {
+        if !self.pushed_lengths.is_empty() {
+            unsafe {
+                target.extend_from_lengths_with_stats(
+                    &self.decoder.values[self.decoder.offset..],
+                    self.pushed_lengths.iter().map(|&v| v as usize),
+                    self.gatherer.min,
+                    self.gatherer.max,
+                    self.gatherer.flat_length,
+                )
+            };
+
+            self.decoder.offset += self.gatherer.flat_length;
+            self.pushed_lengths.clear();
+            *self.gatherer = StatGatherer::default();
+        }
     }
 }
 

--- a/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/mod.rs
@@ -5,10 +5,38 @@ mod fuzz;
 pub(crate) use decoder::{Decoder, DeltaGatherer, SumGatherer};
 pub(crate) use encoder::encode;
 
+/// The sum of `start, start + delta, start + 2 * delta, ... len times`.
+pub(crate) fn lin_natural_sum(start: i64, delta: i64, len: usize) -> i64 {
+    debug_assert!(len < i64::MAX as usize);
+
+    let base = start * len as i64;
+    let sum = (len == 0).then_some(0).unwrap_or({
+        let is_odd = len & 1;
+        // SUM_i=0^n f * i = f * (n(n+1)/2)
+        let sum = (len >> (is_odd ^ 1)) * (len.wrapping_sub(1) >> is_odd);
+        let sum = delta * sum as i64;
+
+        sum
+    });
+
+    base + sum
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::parquet::error::{ParquetError, ParquetResult};
+
+    #[test]
+    fn linear_natural_sum() {
+        assert_eq!(lin_natural_sum(0, 0, 0), 0);
+        assert_eq!(lin_natural_sum(10, 4, 0), 0);
+        assert_eq!(lin_natural_sum(0, 1, 1), 0);
+        assert_eq!(lin_natural_sum(0, 1, 3), 3);
+        assert_eq!(lin_natural_sum(0, 1, 4), 6);
+        assert_eq!(lin_natural_sum(0, 2, 3), 6);
+        assert_eq!(lin_natural_sum(2, 2, 3), 12);
+    }
 
     #[test]
     fn basic() -> Result<(), ParquetError> {

--- a/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/delta_bitpacked/mod.rs
@@ -10,14 +10,14 @@ pub(crate) fn lin_natural_sum(start: i64, delta: i64, len: usize) -> i64 {
     debug_assert!(len < i64::MAX as usize);
 
     let base = start * len as i64;
-    let sum = (len == 0).then_some(0).unwrap_or({
+    let sum = if len == 0 {
+        0
+    } else {
         let is_odd = len & 1;
         // SUM_i=0^n f * i = f * (n(n+1)/2)
         let sum = (len >> (is_odd ^ 1)) * (len.wrapping_sub(1) >> is_odd);
-        let sum = delta * sum as i64;
-
-        sum
-    });
+        delta * sum as i64
+    };
 
     base + sum
 }


### PR DESCRIPTION
This introduces an intermediate buffer for decode `DELTA_LENGTH_BYTE_ARRAY` lengths. This has the benefits that we can dispatch to fast paths for many common cases.

For the following dataset.

```python
import pyarrow as pa
import pyarrow.parquet as pq
import uuid

NUM_ROWS = 10_000_000
LENGTH = 9

cols = {
    'a': pa.array([str(uuid.uuid4())[:LENGTH] for _ in range(NUM_ROWS)]),
    'b': pa.array([str(uuid.uuid4())[:LENGTH] for _ in range(NUM_ROWS)]),
    'c': pa.array([str(uuid.uuid4())[:LENGTH] for _ in range(NUM_ROWS)]),
    'd': pa.array([str(uuid.uuid4())[:LENGTH] for _ in range(NUM_ROWS)]),
    'e': pa.array([str(uuid.uuid4())[:LENGTH] for _ in range(NUM_ROWS)]),
}

tab = pa.table(cols)

pq.write_table(
    tab, 'test.parquet',
    compression="NONE",
    use_dictionary=False,
    column_encoding={
        'a': 'DELTA_LENGTH_BYTE_ARRAY',
        'b': 'DELTA_LENGTH_BYTE_ARRAY',
        'c': 'DELTA_LENGTH_BYTE_ARRAY',
        'd': 'DELTA_LENGTH_BYTE_ARRAY',
        'e': 'DELTA_LENGTH_BYTE_ARRAY',
    }
)

```

Wall-time speed decreases by ~37%.

While, there is no noticeable overhead for random data.

This PR also removes some unnecessary allocations in the Delta decoder.