### PR TITLE
fix: Json feature flag missing imports

### DIFF
--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -14,8 +14,7 @@ use crate::mmap::{MmapBytesReader, ReaderBytes};
 use crate::ndjson::buffer::*;
 use crate::predicates::PhysicalIoExpr;
 use crate::prelude::*;
-use crate::RowIndex;
-use crate::SerReader;
+use crate::{RowIndex, SerReader};
 const NEWLINE: u8 = b'\n';
 const CLOSING_BRACKET: u8 = b'}';
 

--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -15,6 +15,7 @@ use crate::ndjson::buffer::*;
 use crate::predicates::PhysicalIoExpr;
 use crate::prelude::*;
 use crate::RowIndex;
+use crate::SerReader;
 const NEWLINE: u8 = b'\n';
 const CLOSING_BRACKET: u8 = b'}';
 

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -4,14 +4,14 @@ use arrow::io::ipc::read::get_row_count as count_rows_ipc_sync;
 use polars_io::cloud::CloudOptions;
 #[cfg(feature = "csv")]
 use polars_io::csv::read::count_rows as count_rows_csv;
+#[cfg(any(feature = "parquet", feature = "ipc", feature = "json"))]
+use polars_io::is_cloud_url;
 #[cfg(all(feature = "parquet", feature = "cloud"))]
 use polars_io::parquet::read::ParquetAsyncReader;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::read::ParquetReader;
 #[cfg(all(feature = "parquet", feature = "async"))]
 use polars_io::pl_async::{get_runtime, with_concurrency_budget};
-#[cfg(any(feature = "parquet", feature = "ipc", feature = "json"))]
-use polars_io::is_cloud_url;
 #[cfg(feature = "json")]
 use polars_io::SerReader;
 

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "ipc")]
 use arrow::io::ipc::read::get_row_count as count_rows_ipc_sync;
-#[cfg(feature = "parquet")]
+#[cfg(any(feature = "parquet", feature = "json"))]
 use polars_io::cloud::CloudOptions;
 #[cfg(feature = "csv")]
 use polars_io::csv::read::count_rows as count_rows_csv;
@@ -10,8 +10,10 @@ use polars_io::parquet::read::ParquetAsyncReader;
 use polars_io::parquet::read::ParquetReader;
 #[cfg(all(feature = "parquet", feature = "async"))]
 use polars_io::pl_async::{get_runtime, with_concurrency_budget};
-#[cfg(any(feature = "parquet", feature = "ipc"))]
-use polars_io::{path_utils::is_cloud_url, SerReader};
+#[cfg(any(feature = "parquet", feature = "ipc", feature = "json"))]
+use polars_io::is_cloud_url;
+#[cfg(feature = "json")]
+use polars_io::SerReader;
 
 use super::*;
 


### PR DESCRIPTION
Fixes: https://github.com/pola-rs/polars/issues/18258

Some codepaths included in json flag needed imports that are only supplied by possibly other (parquet/ipc + parquet) flags but not with json flag and polars_io::SerReader was missing altogether.

Not sure if this is the way you handle flags for this repo, you can let me know if within function imports are preferred? It could be better in case of use polars_io::SerReader's case, since requiring count_rows_ndjson function is behind a json flag already.