### PR TITLE
refactor(rust): Add Graphviz physical plan visualization for new streaming engine

### DIFF
--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -3,13 +3,16 @@ use std::sync::Arc;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::SortMultipleOptions;
 use polars_core::schema::Schema;
-use polars_plan::plans::DataFrameUdf;
+use polars_plan::plans::{AExpr, DataFrameUdf};
 use polars_plan::prelude::expr_ir::ExprIR;
 
 mod lower_ir;
 mod to_graph;
 
 pub use lower_ir::lower_ir;
+use polars_utils::arena::Arena;
+use polars_utils::itertools::Itertools;
+use slotmap::{Key, SlotMap};
 pub use to_graph::physical_plan_to_graph;
 
 slotmap::new_key_type! {
@@ -106,4 +109,125 @@ pub enum PhysNodeKind {
     Multiplexer {
         input: PhysNodeKey,
     },
+}
+
+fn escape_graphviz(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('"', "\\\"")
+}
+
+fn fmt_exprs(exprs: &[ExprIR], expr_arena: &Arena<AExpr>) -> String {
+    exprs
+        .iter()
+        .map(|e| escape_graphviz(&e.display(expr_arena).to_string()))
+        .collect_vec()
+        .join("\\n")
+}
+
+#[recursive::recursive]
+fn visualize_plan_rec(
+    node_key: PhysNodeKey,
+    phys_sm: &SlotMap<PhysNodeKey, PhysNode>,
+    expr_arena: &Arena<AExpr>,
+    out: &mut Vec<String>,
+) {
+    use std::slice::from_ref;
+    let (label, inputs) = match &phys_sm[node_key].kind {
+        PhysNodeKind::InMemorySource { df } => (
+            format!(
+                "in-memory-source\\ncols: {}",
+                df.get_column_names().join(", ")
+            ),
+            &[][..],
+        ),
+        PhysNodeKind::Select {
+            input,
+            selectors,
+            extend_original,
+        } => {
+            let label = if *extend_original {
+                "with-columns"
+            } else {
+                "select"
+            };
+            (
+                format!("{label}\\n{}", fmt_exprs(selectors, expr_arena)),
+                from_ref(input),
+            )
+        },
+        PhysNodeKind::Reduce { input, exprs } => (
+            format!("reduce\\n{}", fmt_exprs(exprs, expr_arena)),
+            from_ref(input),
+        ),
+        PhysNodeKind::StreamingSlice {
+            input,
+            offset,
+            length,
+        } => (
+            format!("slice\\noffset: {offset}, length: {length}"),
+            from_ref(input),
+        ),
+        PhysNodeKind::Filter { input, predicate } => (
+            format!("filter\\n{}", fmt_exprs(from_ref(predicate), expr_arena)),
+            from_ref(input),
+        ),
+        PhysNodeKind::SimpleProjection { input, columns } => (
+            format!("select\\ncols: {}", columns.join(", ")),
+            from_ref(input),
+        ),
+        PhysNodeKind::InMemorySink { input } => ("in-memory-sink".to_string(), from_ref(input)),
+        PhysNodeKind::InMemoryMap { input, map: _ } => {
+            ("in-memory-map".to_string(), from_ref(input))
+        },
+        PhysNodeKind::Map { input, map: _ } => ("map".to_string(), from_ref(input)),
+        PhysNodeKind::Sort {
+            input,
+            by_column,
+            slice: _,
+            sort_options: _,
+        } => (
+            format!("sort\\n{}", fmt_exprs(by_column, expr_arena)),
+            from_ref(input),
+        ),
+        PhysNodeKind::OrderedUnion { inputs } => ("ordered-union".to_string(), inputs.as_slice()),
+        PhysNodeKind::Zip {
+            inputs,
+            null_extend,
+        } => {
+            let label = if *null_extend {
+                "zip-null-extend"
+            } else {
+                "zip"
+            };
+            (label.to_string(), inputs.as_slice())
+        },
+        PhysNodeKind::Multiplexer { input } => ("multiplexer".to_string(), from_ref(input)),
+    };
+
+    out.push(format!(
+        "{} [label=\"{}\"];",
+        node_key.data().as_ffi(),
+        label
+    ));
+    for input in inputs {
+        visualize_plan_rec(*input, phys_sm, expr_arena, out);
+        out.push(format!(
+            "{} -> {};",
+            input.data().as_ffi(),
+            node_key.data().as_ffi()
+        ));
+    }
+}
+
+pub fn visualize_plan(
+    root: PhysNodeKey,
+    phys_sm: &SlotMap<PhysNodeKey, PhysNode>,
+    expr_arena: &Arena<AExpr>,
+) -> String {
+    let mut out = Vec::with_capacity(phys_sm.len() + 2);
+    out.push("digraph polars {\nrankdir=\"BT\"".to_string());
+    visualize_plan_rec(root, phys_sm, expr_arena, &mut out);
+    out.push("}".to_string());
+    out.join("\n")
 }

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -26,6 +26,10 @@ pub fn run_query(
         &mut phys_sm,
         &mut schema_cache,
     )?;
+    if let Ok(visual_path) = std::env::var("POLARS_VISUALIZE_PHYSICAL_PLAN") {
+        let visualization = crate::physical_plan::visualize_plan(root, &phys_sm, expr_arena);
+        std::fs::write(visual_path, visualization).unwrap();
+    }
     let (mut graph, phys_to_graph) =
         crate::physical_plan::physical_plan_to_graph(&phys_sm, expr_arena)?;
     let mut results = crate::execute::execute_graph(&mut graph)?;


### PR DESCRIPTION
This is fairly quick-and-dirty implementation, just set `POLARS_VISUALIZE_PHYSICAL_PLAN="tmp.dot"` before running your command to get a visualization. Going to be helpful while debugging the new streaming engine.