### PR TITLE
docs(python): Add missing `Series` methods to API reference

### DIFF
--- a/py-polars/docs/source/reference/series/aggregation.rst
+++ b/py-polars/docs/source/reference/series/aggregation.rst
@@ -8,6 +8,7 @@ Aggregation
 
     Series.arg_max
     Series.arg_min
+    Series.count
     Series.implode
     Series.max
     Series.mean

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -19,6 +19,7 @@ Computation
     Series.cos
     Series.cosh
     Series.cot
+    Series.count
     Series.cum_count
     Series.cum_max
     Series.cum_min

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -19,7 +19,6 @@ Computation
     Series.cos
     Series.cosh
     Series.cot
-    Series.count
     Series.cum_count
     Series.cum_max
     Series.cum_min

--- a/py-polars/docs/source/reference/series/index.rst
+++ b/py-polars/docs/source/reference/series/index.rst
@@ -19,6 +19,7 @@ This page gives an overview of all public Series methods.
    export
    list
    modify_select
+   operators
    miscellaneous
    plot
    string

--- a/py-polars/docs/source/reference/series/operators.rst
+++ b/py-polars/docs/source/reference/series/operators.rst
@@ -1,0 +1,31 @@
+=========
+Operators
+=========
+
+Polars supports native Python operators for all common operations;
+many of these operators are also available as methods on the :class:`Series`
+class.
+
+Comparison
+~~~~~~~~~~
+
+.. currentmodule:: polars
+.. autosummary::
+   :toctree: api/
+
+    Series.eq
+    Series.eq_missing
+    Series.ge
+    Series.gt
+    Series.le
+    Series.lt
+    Series.ne
+    Series.ne_missing
+
+Numeric
+~~~~~~~
+
+.. autosummary::
+   :toctree: api/
+
+    Series.pow


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17786

Missing doc items identified by looking at any methods without links [here](https://docs.pola.rs/api/python/stable/reference/series/index.html#:~:text=2%0A%20%20%20%20%20%20%20%203%0A%5D-,Methods%3A,-abs). Have validated that all works as expected against a local docs build.

Also note that `Series` does not implement many of the operator methods offered on DataFrame.