### PR TITLE
refactor(rust): Lower arbitrary expressions in the new streaming engine

### DIFF
--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -4,6 +4,7 @@ use std::hash::{Hash, Hasher};
 use arrow::datatypes::ArrowSchemaRef;
 use indexmap::map::MutableKeys;
 use indexmap::IndexMap;
+use polars_utils::itertools::Itertools;
 use polars_utils::aliases::PlRandomState;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
@@ -425,6 +426,21 @@ impl Schema {
             *dt = st
         }
         Ok(changed)
+    }
+    
+    /// Generates another schema with just the specified columns selected from this one.
+    pub fn select<I>(&self, columns: I) -> PolarsResult<Self>
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>
+    {
+        Ok(Self {
+            inner: columns.into_iter().map(|c| {
+                let name = c.as_ref();
+                let dtype = self.inner.get(name).ok_or_else(|| polars_err!(col_not_found = name))?;
+                PolarsResult::Ok((SmartString::from(name), dtype.clone()))
+            }).try_collect()?
+        })
     }
 }
 

--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -4,8 +4,8 @@ use std::hash::{Hash, Hasher};
 use arrow::datatypes::ArrowSchemaRef;
 use indexmap::map::MutableKeys;
 use indexmap::IndexMap;
-use polars_utils::itertools::Itertools;
 use polars_utils::aliases::PlRandomState;
+use polars_utils::itertools::Itertools;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
@@ -427,19 +427,25 @@ impl Schema {
         }
         Ok(changed)
     }
-    
+
     /// Generates another schema with just the specified columns selected from this one.
     pub fn select<I>(&self, columns: I) -> PolarsResult<Self>
     where
         I: IntoIterator,
-        I::Item: AsRef<str>
+        I::Item: AsRef<str>,
     {
         Ok(Self {
-            inner: columns.into_iter().map(|c| {
-                let name = c.as_ref();
-                let dtype = self.inner.get(name).ok_or_else(|| polars_err!(col_not_found = name))?;
-                PolarsResult::Ok((SmartString::from(name), dtype.clone()))
-            }).try_collect()?
+            inner: columns
+                .into_iter()
+                .map(|c| {
+                    let name = c.as_ref();
+                    let dtype = self
+                        .inner
+                        .get(name)
+                        .ok_or_else(|| polars_err!(col_not_found = name))?;
+                    PolarsResult::Ok((SmartString::from(name), dtype.clone()))
+                })
+                .try_collect()?,
         })
     }
 }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -705,7 +705,7 @@ impl LazyFrame {
                 return polars_stream::run_query(
                     stream_lp_top,
                     alp_plan.lp_arena,
-                    &alp_plan.expr_arena,
+                    &mut alp_plan.expr_arena,
                 );
             }
 
@@ -718,7 +718,7 @@ impl LazyFrame {
                     polars_stream::run_query(
                         stream_lp_top,
                         alp_plan.lp_arena.clone(),
-                        &alp_plan.expr_arena,
+                        &mut alp_plan.expr_arena,
                     )
                 };
                 match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -151,7 +151,7 @@ impl ExprIR {
         self.output_name = OutputName::Alias(name)
     }
 
-    pub(crate) fn output_name_inner(&self) -> &OutputName {
+    pub fn output_name_inner(&self) -> &OutputName {
         &self.output_name
     }
 

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -27,7 +27,7 @@ pub enum OutputName {
 }
 
 impl OutputName {
-    fn unwrap(&self) -> &ColumnName {
+    pub fn unwrap(&self) -> &ColumnName {
         match self {
             OutputName::Alias(name) => name,
             OutputName::ColumnLhs(name) => name,

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -214,6 +214,13 @@ impl FunctionOptions {
     pub fn check_lengths(&self) -> bool {
         self.check_lengths.0
     }
+    
+    pub fn is_elementwise(&self) -> bool {
+        self.collect_groups == ApplyOptions::ElementWise
+            && !self
+                .flags
+                .contains(FunctionFlags::CHANGES_LENGTH | FunctionFlags::RETURNS_SCALAR)
+    }
 }
 
 impl Default for FunctionOptions {

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -214,7 +214,7 @@ impl FunctionOptions {
     pub fn check_lengths(&self) -> bool {
         self.check_lengths.0
     }
-    
+
     pub fn is_elementwise(&self) -> bool {
         self.collect_groups == ApplyOptions::ElementWise
             && !self

--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -205,10 +205,11 @@ fn run_subgraph(
             for input in &node.inputs {
                 let sender = graph.pipes[*input].sender;
                 if let Some(count) = num_send_ports_not_yet_ready.get_mut(sender) {
-                    assert!(*count > 0);
-                    *count -= 1;
-                    if *count == 0 {
-                        ready.push(sender);
+                    if *count > 0 {
+                        *count -= 1;
+                        if *count == 0 {
+                            ready.push(sender);
+                        }
                     }
                 }
             }

--- a/crates/polars-stream/src/expression.rs
+++ b/crates/polars-stream/src/expression.rs
@@ -6,7 +6,7 @@ use polars_error::PolarsResult;
 use polars_expr::prelude::{ExecutionState, PhysicalExpr};
 
 #[derive(Clone)]
-pub(crate) struct StreamExpr {
+pub struct StreamExpr {
     inner: Arc<dyn PhysicalExpr>,
     // Whether the expression can be re-entering the engine (e.g. a function use the lazy api
     // within that function)
@@ -14,18 +14,14 @@ pub(crate) struct StreamExpr {
 }
 
 impl StreamExpr {
-    pub(crate) fn new(phys_expr: Arc<dyn PhysicalExpr>, reentrant: bool) -> Self {
+    pub fn new(phys_expr: Arc<dyn PhysicalExpr>, reentrant: bool) -> Self {
         Self {
             inner: phys_expr,
             reentrant,
         }
     }
 
-    pub(crate) async fn evaluate(
-        &self,
-        df: &DataFrame,
-        state: &ExecutionState,
-    ) -> PolarsResult<Series> {
+    pub async fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         if self.reentrant {
             let state = state.clone();
             let phys_expr = self.inner.clone();

--- a/crates/polars-stream/src/graph.rs
+++ b/crates/polars-stream/src/graph.rs
@@ -69,6 +69,8 @@ impl Graph {
         let mut scheduled_for_update: SecondaryMap<GraphNodeKey, ()> =
             self.nodes.keys().map(|k| (k, ())).collect();
 
+        let verbose = std::env::var("POLARS_VERBOSE_STATE_UPDATE").as_deref() == Ok("1");
+
         let mut recv_state = Vec::new();
         let mut send_state = Vec::new();
         while let Some(node_key) = to_update.pop() {
@@ -82,15 +84,18 @@ impl Graph {
             send_state.extend(node.outputs.iter().map(|o| self.pipes[*o].recv_state));
 
             // Compute the new state of this node given its environment.
-            // eprintln!("updating {}, before: {recv_state:?} {send_state:?}", node.compute.name());
+            if verbose {
+                eprintln!("updating {}, before: {recv_state:?} {send_state:?}", node.compute.name());
+            }
             node.compute.update_state(&mut recv_state, &mut send_state);
-            // eprintln!("updating {}, after: {recv_state:?} {send_state:?}", node.compute.name());
+            if verbose {
+                eprintln!("updating {}, after: {recv_state:?} {send_state:?}", node.compute.name());
+            }
 
             // Propagate information.
             for (input, state) in node.inputs.iter().zip(recv_state.iter()) {
                 let pipe = &mut self.pipes[*input];
                 if pipe.recv_state != *state {
-                    // eprintln!("transitioning input pipe from {:?} to {state:?}", pipe.recv_state);
                     assert!(pipe.recv_state != PortState::Done, "implementation error: state transition from Done to Blocked/Ready attempted");
                     pipe.recv_state = *state;
                     if scheduled_for_update.insert(pipe.sender, ()).is_none() {
@@ -102,7 +107,6 @@ impl Graph {
             for (output, state) in node.outputs.iter().zip(send_state.iter()) {
                 let pipe = &mut self.pipes[*output];
                 if pipe.send_state != *state {
-                    // eprintln!("transitioning output pipe from {:?} to {state:?}", pipe.send_state);
                     assert!(pipe.send_state != PortState::Done, "implementation error: state transition from Done to Blocked/Ready attempted");
                     pipe.send_state = *state;
                     if scheduled_for_update.insert(pipe.receiver, ()).is_none() {

--- a/crates/polars-stream/src/graph.rs
+++ b/crates/polars-stream/src/graph.rs
@@ -85,11 +85,17 @@ impl Graph {
 
             // Compute the new state of this node given its environment.
             if verbose {
-                eprintln!("updating {}, before: {recv_state:?} {send_state:?}", node.compute.name());
+                eprintln!(
+                    "updating {}, before: {recv_state:?} {send_state:?}",
+                    node.compute.name()
+                );
             }
             node.compute.update_state(&mut recv_state, &mut send_state);
             if verbose {
-                eprintln!("updating {}, after: {recv_state:?} {send_state:?}", node.compute.name());
+                eprintln!(
+                    "updating {}, after: {recv_state:?} {send_state:?}",
+                    node.compute.name()
+                );
             }
 
             // Propagate information.

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1,13 +1,14 @@
 use std::borrow::Borrow;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use polars_core::prelude::PlHashMap;
+use polars_core::prelude::{InitHashMaps, PlHashMap};
 use polars_error::PolarsResult;
 use polars_plan::plans::expr_ir::ExprIR;
 use polars_plan::plans::{AExpr, LiteralValue, IR};
 use polars_plan::prelude::*;
 use polars_utils::arena::{Arena, Node};
-use slotmap::SlotMap;
+use polars_utils::itertools::Itertools;
+use slotmap::{Key, SlotMap};
 
 use super::{PhysNode, PhysNodeKey};
 
@@ -199,6 +200,13 @@ fn is_input_independent(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool
     )
 }
 
+fn is_aggregation(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool {
+    match ctx.expr_arena.get(expr_key) {
+        AExpr::Agg(_) => true,
+        _ => false
+    }
+}
+
 struct LowerExprContext<'a> {
     ir_arena: &'a mut Arena<IR>,
     expr_arena: &'a mut Arena<AExpr>,
@@ -207,16 +215,88 @@ struct LowerExprContext<'a> {
     is_input_independent_cache: PlHashMap<Node, bool>,
 }
 
+/// Lowers an input node plus a set of expressions on that input node to an
+/// equivalent (input node, set of expressions) pair, ensuring that the new set
+/// of expressions can run on the streaming engine.
 #[recursive::recursive]
-fn lower_exprs_rec(
+fn lower_expr_with_ctx(
     input: PhysNodeKey,
     exprs: &[ExprIR],
     ctx: &mut LowerExprContext,
 ) -> PolarsResult<(PhysNodeKey, Vec<ExprIR>)> {
-    let streamable_subset: Vec<_> = exprs.iter().cloned().filter(|e| is_input_independent(e.node(), ctx)).collect();
-    if streamable_subset.len() == exprs.len() {
-        return Ok((input, streamable_subset));
+    if exprs.iter().all(|e| is_input_independent(e.node(), ctx)) {
+        // Run expression on empty dataframe and insert InMemorySourceNode.
+        // Probably want some sort of efficient path for Series literals.
+        return todo!();
     }
+
+    // let streamable_subset = exprs.iter().filter(|e| is_streamable(e.node(), ctx)).cloned().collect_vec();
+    // let agg_subset = exprs.iter().filter(|e| is_aggregation(e.node(), ctx)).collect_vec();
+    // let rest = exprs.iter().filter(|e| !is_streamable(e.node(), ctx) && !is_aggregation(e.node(), ctx)).collect_vec();
+
+    // if agg_subset.len() == 0 && rest.len() == 0 {
+    //     return Ok((input, streamable_subset));
+    // }
+    
+    let mut streamable_subset = Vec::new();
+    let mut agg_subset = Vec::new();
+    // let mut transformed = Vec::new();
+    // let mut fallback_subset = Vec::new();
+    
+    for expr in exprs {
+        if is_streamable(expr.node(), ctx) {
+            streamable_subset.push(expr.clone());
+        }
+        
+        match ctx.expr_arena.get(expr.node()) {
+            AExpr::Explode(_) => todo!(),
+            AExpr::Alias(_, _) => todo!(),
+            AExpr::Column(_) => todo!(),
+            AExpr::Literal(_) => todo!(),
+            AExpr::BinaryExpr { left, op, right } => todo!(),
+            AExpr::Cast { expr, data_type, options } => todo!(),
+            AExpr::Sort { expr: inner, options } => {
+                // let inner_expr_ir = ExprIR::new(*inner, *expr.output_name_inner());
+                // let (input, select) = lower_expr_with_ctx(input, &[inner_expr_ir], ctx)?;
+                
+                
+                
+
+            // let input_schema = ir_arena.get(*input).schema(ir_arena).into_owned();
+            // let phys_node = PhysNode::Sort {
+            //     input_schema,
+            //     by_column: by_column.clone(),
+            //     slice: *slice,
+            //     sort_options: sort_options.clone(),
+            //     input: lower_ir(*input, ir_arena, expr_arena, phys_sm)?,
+            // };
+            // Ok(phys_sm.insert(phys_node))
+                
+            },
+            AExpr::Gather { .. } => todo!(),
+            AExpr::SortBy { expr, by, sort_options } => todo!(),
+            AExpr::Filter { input, by } => todo!(),
+            AExpr::Agg(agg) => agg_subset.push(agg.clone()),
+            AExpr::Ternary { predicate, truthy, falsy } => todo!(),
+            AExpr::AnonymousFunction { input, function, output_type, options } => todo!(),
+            AExpr::Function { input, function, options } => todo!(),
+            AExpr::Window { function, partition_by, order_by, options } => todo!(),
+            AExpr::Slice { input, offset, length } => todo!(),
+            AExpr::Len => todo!(),
+        }
+    }
+    
+
+    let multiplexer = ctx.phys_sm.insert(PhysNode::Multiplexer { input });
+    // let mut transformed = Vec::with_capacity(exprs.len());
+    // if streamable_subset.len() > 0 {
+
+    // }
+    // for expr in exprs {
+
+    // }
+    
+    // let multiplexer = PhysNode::Multiplexer { input };
     
     
     
@@ -230,6 +310,11 @@ fn lower_exprs_rec(
             //     extend_original: false,
             // }))
     
+    // Replace original input node with multiplexer.
+    let orig_input_node = core::mem::replace(&mut ctx.phys_sm[input], PhysNode::Multiplexer { input: PhysNodeKey::null() });
+    let orig_input_key = ctx.phys_sm.insert(orig_input_node);
+    ctx.phys_sm[input] = PhysNode::Multiplexer { input: orig_input_key };
+    
     todo!()
 }
 
@@ -241,4 +326,41 @@ pub fn lower_exprs(
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
 ) -> PolarsResult<(PhysNodeKey, Vec<ExprIR>)> {
     todo!()
+}
+
+
+pub fn build_select_node_with_ctx(
+    input: PhysNodeKey,
+    exprs: &[ExprIR],
+    ctx: &mut LowerExprContext,
+) -> PolarsResult<PhysNodeKey> {
+    let simple_columns: Option<Vec<String>> = exprs.iter().map(|e| {
+        match ctx.expr_arena.get(e.node()) {
+            AExpr::Column(name) => Some(name.to_string()),
+            _ => None,
+        }
+    }).collect();
+    
+    if let Some(columns) = simple_columns {
+        let input_schema = todo!();
+        return Ok(ctx.phys_sm.insert(PhysNode::SimpleProjection {
+            input,
+            columns,
+            input_schema,
+        }))
+    }
+    
+    todo!()
+}
+
+/// Builds a selection node given an input node and the expressions to select for.
+pub fn build_select_node(
+    input: PhysNodeKey,
+    exprs: &[ExprIR],
+    ir_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+    phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
+) -> PolarsResult<PhysNodeKey> {
+    let mut ctx = LowerExprContext { ir_arena, expr_arena, phys_sm, is_streamable_cache: PlHashMap::new(), is_input_independent_cache: PlHashMap::new() };
+    build_select_node_with_ctx(input, exprs, &mut ctx)
 }

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -203,7 +203,7 @@ fn is_input_independent(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool
 fn is_aggregation(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool {
     match ctx.expr_arena.get(expr_key) {
         AExpr::Agg(_) => true,
-        _ => false
+        _ => false,
     }
 }
 
@@ -237,55 +237,83 @@ fn lower_expr_with_ctx(
     // if agg_subset.len() == 0 && rest.len() == 0 {
     //     return Ok((input, streamable_subset));
     // }
-    
+
     let mut streamable_subset = Vec::new();
     let mut agg_subset = Vec::new();
     // let mut transformed = Vec::new();
     // let mut fallback_subset = Vec::new();
-    
+
     for expr in exprs {
         if is_streamable(expr.node(), ctx) {
             streamable_subset.push(expr.clone());
         }
-        
+
         match ctx.expr_arena.get(expr.node()) {
             AExpr::Explode(_) => todo!(),
             AExpr::Alias(_, _) => todo!(),
             AExpr::Column(_) => todo!(),
             AExpr::Literal(_) => todo!(),
             AExpr::BinaryExpr { left, op, right } => todo!(),
-            AExpr::Cast { expr, data_type, options } => todo!(),
-            AExpr::Sort { expr: inner, options } => {
+            AExpr::Cast {
+                expr,
+                data_type,
+                options,
+            } => todo!(),
+            AExpr::Sort {
+                expr: inner,
+                options,
+            } => {
                 // let inner_expr_ir = ExprIR::new(*inner, *expr.output_name_inner());
                 // let (input, select) = lower_expr_with_ctx(input, &[inner_expr_ir], ctx)?;
-                
-                
-                
 
-            // let input_schema = ir_arena.get(*input).schema(ir_arena).into_owned();
-            // let phys_node = PhysNode::Sort {
-            //     input_schema,
-            //     by_column: by_column.clone(),
-            //     slice: *slice,
-            //     sort_options: sort_options.clone(),
-            //     input: lower_ir(*input, ir_arena, expr_arena, phys_sm)?,
-            // };
-            // Ok(phys_sm.insert(phys_node))
-                
+                // let input_schema = ir_arena.get(*input).schema(ir_arena).into_owned();
+                // let phys_node = PhysNode::Sort {
+                //     input_schema,
+                //     by_column: by_column.clone(),
+                //     slice: *slice,
+                //     sort_options: sort_options.clone(),
+                //     input: lower_ir(*input, ir_arena, expr_arena, phys_sm)?,
+                // };
+                // Ok(phys_sm.insert(phys_node))
             },
             AExpr::Gather { .. } => todo!(),
-            AExpr::SortBy { expr, by, sort_options } => todo!(),
+            AExpr::SortBy {
+                expr,
+                by,
+                sort_options,
+            } => todo!(),
             AExpr::Filter { input, by } => todo!(),
             AExpr::Agg(agg) => agg_subset.push(agg.clone()),
-            AExpr::Ternary { predicate, truthy, falsy } => todo!(),
-            AExpr::AnonymousFunction { input, function, output_type, options } => todo!(),
-            AExpr::Function { input, function, options } => todo!(),
-            AExpr::Window { function, partition_by, order_by, options } => todo!(),
-            AExpr::Slice { input, offset, length } => todo!(),
+            AExpr::Ternary {
+                predicate,
+                truthy,
+                falsy,
+            } => todo!(),
+            AExpr::AnonymousFunction {
+                input,
+                function,
+                output_type,
+                options,
+            } => todo!(),
+            AExpr::Function {
+                input,
+                function,
+                options,
+            } => todo!(),
+            AExpr::Window {
+                function,
+                partition_by,
+                order_by,
+                options,
+            } => todo!(),
+            AExpr::Slice {
+                input,
+                offset,
+                length,
+            } => todo!(),
             AExpr::Len => todo!(),
         }
     }
-    
 
     let multiplexer = ctx.phys_sm.insert(PhysNode::Multiplexer { input });
     // let mut transformed = Vec::with_capacity(exprs.len());
@@ -295,26 +323,31 @@ fn lower_expr_with_ctx(
     // for expr in exprs {
 
     // }
-    
+
     // let multiplexer = PhysNode::Multiplexer { input };
-    
-    
-    
-            // let selectors = expr.clone();
-            // let output_schema = schema.clone();
-            // let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
-            // Ok(phys_sm.insert(PhysNode::Select {
-            //     input,
-            //     selectors,
-            //     output_schema,
-            //     extend_original: false,
-            // }))
-    
+
+    // let selectors = expr.clone();
+    // let output_schema = schema.clone();
+    // let input = lower_ir(*input, ir_arena, expr_arena, phys_sm)?;
+    // Ok(phys_sm.insert(PhysNode::Select {
+    //     input,
+    //     selectors,
+    //     output_schema,
+    //     extend_original: false,
+    // }))
+
     // Replace original input node with multiplexer.
-    let orig_input_node = core::mem::replace(&mut ctx.phys_sm[input], PhysNode::Multiplexer { input: PhysNodeKey::null() });
+    let orig_input_node = core::mem::replace(
+        &mut ctx.phys_sm[input],
+        PhysNode::Multiplexer {
+            input: PhysNodeKey::null(),
+        },
+    );
     let orig_input_key = ctx.phys_sm.insert(orig_input_node);
-    ctx.phys_sm[input] = PhysNode::Multiplexer { input: orig_input_key };
-    
+    ctx.phys_sm[input] = PhysNode::Multiplexer {
+        input: orig_input_key,
+    };
+
     todo!()
 }
 
@@ -328,28 +361,28 @@ pub fn lower_exprs(
     todo!()
 }
 
-
 pub fn build_select_node_with_ctx(
     input: PhysNodeKey,
     exprs: &[ExprIR],
     ctx: &mut LowerExprContext,
 ) -> PolarsResult<PhysNodeKey> {
-    let simple_columns: Option<Vec<String>> = exprs.iter().map(|e| {
-        match ctx.expr_arena.get(e.node()) {
+    let simple_columns: Option<Vec<String>> = exprs
+        .iter()
+        .map(|e| match ctx.expr_arena.get(e.node()) {
             AExpr::Column(name) => Some(name.to_string()),
             _ => None,
-        }
-    }).collect();
-    
+        })
+        .collect();
+
     if let Some(columns) = simple_columns {
         let input_schema = todo!();
         return Ok(ctx.phys_sm.insert(PhysNode::SimpleProjection {
             input,
             columns,
             input_schema,
-        }))
+        }));
     }
-    
+
     todo!()
 }
 
@@ -361,6 +394,12 @@ pub fn build_select_node(
     expr_arena: &mut Arena<AExpr>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
 ) -> PolarsResult<PhysNodeKey> {
-    let mut ctx = LowerExprContext { ir_arena, expr_arena, phys_sm, is_streamable_cache: PlHashMap::new(), is_input_independent_cache: PlHashMap::new() };
+    let mut ctx = LowerExprContext {
+        ir_arena,
+        expr_arena,
+        phys_sm,
+        is_streamable_cache: PlHashMap::new(),
+        is_input_independent_cache: PlHashMap::new(),
+    };
     build_select_node_with_ctx(input, exprs, &mut ctx)
 }

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1,8 +1,10 @@
+use std::borrow::Borrow;
+
 use polars_core::prelude::PlHashMap;
 use polars_error::PolarsResult;
 use polars_plan::plans::expr_ir::ExprIR;
 use polars_plan::plans::{AExpr, LiteralValue, IR};
-use polars_plan::prelude::FunctionFlags;
+use polars_plan::prelude::*;
 use polars_utils::arena::{Arena, Node};
 use slotmap::SlotMap;
 
@@ -10,8 +12,12 @@ use super::{PhysNode, PhysNodeKey};
 
 type IRNodeKey = Node;
 
-// #[recursive::recursive]
-fn is_streamable_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &mut PlHashMap<IRNodeKey, bool>) -> bool {
+#[recursive::recursive]
+fn is_streamable_rec(
+    expr_key: IRNodeKey,
+    arena: &Arena<AExpr>,
+    cache: &mut PlHashMap<IRNodeKey, bool>,
+) -> bool {
     if let Some(ret) = cache.get(&expr_key) {
         return *ret;
     }
@@ -21,42 +27,41 @@ fn is_streamable_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &mut PlHa
         AExpr::Alias(inner, _) => is_streamable_rec(*inner, arena, cache),
         AExpr::Column(_) => true,
         AExpr::Literal(lit) => !matches!(lit, LiteralValue::Series(_) | LiteralValue::Range { .. }),
-        AExpr::BinaryExpr { left, op: _, right } => is_streamable_rec(*left, arena, cache) && is_streamable_rec(*right, arena, cache),
+        AExpr::BinaryExpr { left, op: _, right } => {
+            is_streamable_rec(*left, arena, cache) && is_streamable_rec(*right, arena, cache)
+        },
         AExpr::Cast {
             expr,
             data_type: _,
             options: _,
         } => is_streamable_rec(*expr, arena, cache),
         AExpr::Sort { .. } | AExpr::SortBy { .. } | AExpr::Gather { .. } => false,
-        AExpr::Filter { input, by } => is_streamable_rec(*input, arena, cache) && is_streamable_rec(*by, arena, cache),
+        AExpr::Filter { input, by } => {
+            is_streamable_rec(*input, arena, cache) && is_streamable_rec(*by, arena, cache)
+        },
         AExpr::Agg(_) => false,
         AExpr::Ternary {
             predicate,
             truthy,
             falsy,
-        } => is_streamable_rec(*predicate, arena, cache) && is_streamable_rec(*truthy, arena, cache) && is_streamable_rec(*falsy, arena, cache),
+        } => {
+            is_streamable_rec(*predicate, arena, cache)
+                && is_streamable_rec(*truthy, arena, cache)
+                && is_streamable_rec(*falsy, arena, cache)
+        },
         AExpr::AnonymousFunction {
             input: _,
             function: _,
             output_type: _,
             options,
-        } => options.flags & FunctionFlags::CHANGES_LENGTH,
-        AExpr::Function {
-            input,
-            function,
+        }
+        | AExpr::Function {
+            input: _,
+            function: _,
             options,
-        } => todo!(),
-        AExpr::Window {
-            function,
-            partition_by,
-            order_by,
-            options,
-        } => todo!(),
-        AExpr::Slice {
-            input,
-            offset,
-            length,
-        } => todo!(),
+        } => options.is_elementwise(),
+        AExpr::Window { .. } => false,
+        AExpr::Slice { .. } => false,
         AExpr::Len => false,
     };
 
@@ -69,7 +74,11 @@ fn is_streamable(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool {
 }
 
 #[recursive::recursive]
-fn is_input_independent_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &mut PlHashMap<IRNodeKey, bool>) -> bool {
+fn is_input_independent_rec(
+    expr_key: IRNodeKey,
+    arena: &Arena<AExpr>,
+    cache: &mut PlHashMap<IRNodeKey, bool>,
+) -> bool {
     if let Some(ret) = cache.get(&expr_key) {
         return *ret;
     }
@@ -85,44 +94,52 @@ fn is_input_independent_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &m
         | AExpr::Sort {
             expr: inner,
             options: _,
-        } => {
-            is_input_independent_rec(*inner, arena, cache)
-        },
+        } => is_input_independent_rec(*inner, arena, cache),
         AExpr::Column(_) => false,
         AExpr::Literal(_) => true,
         AExpr::BinaryExpr { left, op: _, right } => {
-            is_input_independent_rec(*left, arena, cache) && is_input_independent_rec(*right, arena, cache)
+            is_input_independent_rec(*left, arena, cache)
+                && is_input_independent_rec(*right, arena, cache)
         },
         AExpr::Gather {
             expr,
             idx,
             returns_scalar: _,
         } => {
-            is_input_independent_rec(*expr, arena, cache) && is_input_independent_rec(*idx, arena, cache)
+            is_input_independent_rec(*expr, arena, cache)
+                && is_input_independent_rec(*idx, arena, cache)
         },
         AExpr::SortBy {
             expr,
             by,
             sort_options: _,
         } => {
-            is_input_independent_rec(*expr, arena, cache) && by.iter().all(|expr| is_input_independent_rec(*expr, arena, cache))
+            is_input_independent_rec(*expr, arena, cache)
+                && by
+                    .iter()
+                    .all(|expr| is_input_independent_rec(*expr, arena, cache))
         },
         AExpr::Filter { input, by } => {
-            is_input_independent_rec(*input, arena, cache) && is_input_independent_rec(*by, arena, cache)
+            is_input_independent_rec(*input, arena, cache)
+                && is_input_independent_rec(*by, arena, cache)
         },
-        AExpr::Agg(agg_expr) => {
-            match agg_expr.get_input() {
-                polars_plan::plans::NodeInputs::Leaf => true,
-                polars_plan::plans::NodeInputs::Single(expr) => is_input_independent_rec(expr, arena, cache),
-                polars_plan::plans::NodeInputs::Many(exprs) => exprs.iter().all(|expr| is_input_independent_rec(*expr, arena, cache)),
-            }
+        AExpr::Agg(agg_expr) => match agg_expr.get_input() {
+            polars_plan::plans::NodeInputs::Leaf => true,
+            polars_plan::plans::NodeInputs::Single(expr) => {
+                is_input_independent_rec(expr, arena, cache)
+            },
+            polars_plan::plans::NodeInputs::Many(exprs) => exprs
+                .iter()
+                .all(|expr| is_input_independent_rec(*expr, arena, cache)),
         },
         AExpr::Ternary {
             predicate,
             truthy,
             falsy,
         } => {
-            is_input_independent_rec(*predicate, arena, cache) && is_input_independent_rec(*truthy, arena, cache) && is_input_independent_rec(*falsy, arena, cache)
+            is_input_independent_rec(*predicate, arena, cache)
+                && is_input_independent_rec(*truthy, arena, cache)
+                && is_input_independent_rec(*falsy, arena, cache)
         },
         AExpr::AnonymousFunction {
             input,
@@ -134,25 +151,31 @@ fn is_input_independent_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &m
             input,
             function: _,
             options: _,
-        } => {
-            input.iter().all(|expr| is_input_independent_rec(expr.node(), arena, cache))
-        },
+        } => input
+            .iter()
+            .all(|expr| is_input_independent_rec(expr.node(), arena, cache)),
         AExpr::Window {
             function,
             partition_by,
             order_by,
             options: _,
         } => {
-            is_input_independent_rec(*function, arena, cache) &&
-            partition_by.iter().all(|expr| is_input_independent_rec(*expr, arena, cache)) &&
-            order_by.iter().all(|(expr, _options)| is_input_independent_rec(*expr, arena, cache))
-        }
+            is_input_independent_rec(*function, arena, cache)
+                && partition_by
+                    .iter()
+                    .all(|expr| is_input_independent_rec(*expr, arena, cache))
+                && order_by
+                    .iter()
+                    .all(|(expr, _options)| is_input_independent_rec(*expr, arena, cache))
+        },
         AExpr::Slice {
             input,
             offset,
             length,
         } => {
-            is_input_independent_rec(*input, arena, cache) && is_input_independent_rec(*offset, arena, cache) && is_input_independent_rec(*length, arena, cache)
+            is_input_independent_rec(*input, arena, cache)
+                && is_input_independent_rec(*offset, arena, cache)
+                && is_input_independent_rec(*length, arena, cache)
         },
         AExpr::Len => false,
     };
@@ -162,7 +185,11 @@ fn is_input_independent_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &m
 }
 
 fn is_input_independent(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool {
-    is_input_independent_rec(expr_key, &ctx.expr_arena, &mut ctx.is_input_independent_cache)
+    is_input_independent_rec(
+        expr_key,
+        &ctx.expr_arena,
+        &mut ctx.is_input_independent_cache,
+    )
 }
 
 struct LowerExprContext<'a> {
@@ -179,6 +206,12 @@ fn lower_exprs_rec(
     exprs: &[ExprIR],
     ctx: &mut LowerExprContext,
 ) -> PolarsResult<(PhysNodeKey, Vec<ExprIR>)> {
+    if exprs.iter().all(|e| is_input_independent(e.node(), ctx)) {
+        return Ok((input, exprs.to_vec()));
+    }
+    
+    let streamable_subset: Vec<_> = exprs.iter().filter(|e| is_input_independent(e.node(), ctx)).collect();
+    
     todo!()
 }
 

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1,0 +1,196 @@
+use polars_core::prelude::PlHashMap;
+use polars_error::PolarsResult;
+use polars_plan::plans::expr_ir::ExprIR;
+use polars_plan::plans::{AExpr, IR};
+use polars_utils::arena::{Arena, Node};
+use slotmap::SlotMap;
+
+use super::{PhysNode, PhysNodeKey};
+
+type IRNodeKey = Node;
+
+// #[recursive::recursive]
+fn is_streamable_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &mut PlHashMap<IRNodeKey, bool>) -> bool {
+    if let Some(ret) = cache.get(&expr_key) {
+        return *ret;
+    }
+
+    let ret = match arena.get(expr_key) {
+        AExpr::Explode(_) => false,
+        AExpr::Alias(inner, _) => is_streamable_rec(*inner, arena, cache),
+        AExpr::Column(_) => true,
+        AExpr::Literal(_) => true, // TODO: literals not always streamable.
+        AExpr::BinaryExpr { left, op: _, right } => is_streamable_rec(*left, arena, cache) && is_streamable_rec(*right, arena, cache),
+        AExpr::Cast {
+            expr,
+            data_type: _,
+            options: _,
+        } => is_streamable_rec(*expr, arena, cache),
+        AExpr::Sort { .. } | AExpr::SortBy { .. } | AExpr::Gather { .. } => false,
+        AExpr::Filter { input, by } => is_streamable_rec(*input, arena, cache) && is_streamable_rec(*by, arena, cache),
+        AExpr::Agg(_) => false,
+        AExpr::Ternary {
+            predicate,
+            truthy,
+            falsy,
+        } => is_streamable_rec(*predicate, arena, cache) && is_streamable_rec(*truthy, arena, cache) && is_streamable_rec(*falsy, arena, cache),
+        AExpr::AnonymousFunction {
+            input: _,
+            function: _,
+            output_type: _,
+            options,
+        } => options.flags.
+        AExpr::Function {
+            input,
+            function,
+            options,
+        } => todo!(),
+        AExpr::Window {
+            function,
+            partition_by,
+            order_by,
+            options,
+        } => todo!(),
+        AExpr::Wildcard => todo!(),
+        AExpr::Slice {
+            input,
+            offset,
+            length,
+        } => todo!(),
+        AExpr::Len => false,
+        AExpr::Nth(_) => false,
+    };
+
+    cache.insert(expr_key, ret);
+    ret
+}
+
+fn is_streamable(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool {
+    is_streamable_rec(expr_key, &ctx.expr_arena, &mut ctx.is_streamable_cache)
+}
+
+#[recursive::recursive]
+fn is_input_independent_rec(expr_key: IRNodeKey, arena: &Arena<AExpr>, cache: &mut PlHashMap<IRNodeKey, bool>) -> bool {
+    if let Some(ret) = cache.get(&expr_key) {
+        return *ret;
+    }
+
+    let ret = match arena.get(expr_key) {
+        AExpr::Explode(inner)
+        | AExpr::Alias(inner, _)
+        | AExpr::Cast {
+            expr: inner,
+            data_type: _,
+            options: _,
+        }
+        | AExpr::Sort {
+            expr: inner,
+            options: _,
+        } => {
+            is_input_independent_rec(*inner, arena, cache)
+        },
+        AExpr::Column(_) => false,
+        AExpr::Literal(_) => true,
+        AExpr::BinaryExpr { left, op: _, right } => {
+            is_input_independent_rec(*left, arena, cache) && is_input_independent_rec(*right, arena, cache)
+        },
+        AExpr::Gather {
+            expr,
+            idx,
+            returns_scalar: _,
+        } => {
+            is_input_independent_rec(*expr, arena, cache) && is_input_independent_rec(*idx, arena, cache)
+        },
+        AExpr::SortBy {
+            expr,
+            by,
+            sort_options: _,
+        } => {
+            is_input_independent_rec(*expr, arena, cache) && by.iter().all(|expr| is_input_independent_rec(*expr, arena, cache))
+        },
+        AExpr::Filter { input, by } => {
+            is_input_independent_rec(*input, arena, cache) && is_input_independent_rec(*by, arena, cache)
+        },
+        AExpr::Agg(agg_expr) => {
+            match agg_expr.get_input() {
+                polars_plan::plans::NodeInputs::Leaf => true,
+                polars_plan::plans::NodeInputs::Single(expr) => is_input_independent_rec(expr, arena, cache),
+                polars_plan::plans::NodeInputs::Many(exprs) => exprs.iter().all(|expr| is_input_independent_rec(*expr, arena, cache)),
+            }
+        },
+        AExpr::Ternary {
+            predicate,
+            truthy,
+            falsy,
+        } => {
+            is_input_independent_rec(*predicate, arena, cache) && is_input_independent_rec(*truthy, arena, cache) && is_input_independent_rec(*falsy, arena, cache)
+        },
+        AExpr::AnonymousFunction {
+            input,
+            function: _,
+            output_type: _,
+            options: _,
+        }
+        | AExpr::Function {
+            input,
+            function: _,
+            options: _,
+        } => {
+            input.iter().all(|expr| is_input_independent_rec(expr.node(), arena, cache))
+        },
+        AExpr::Window {
+            function,
+            partition_by,
+            order_by,
+            options: _,
+        } => {
+            is_input_independent_rec(*function, arena, cache) &&
+            partition_by.iter().all(|expr| is_input_independent_rec(*expr, arena, cache)) &&
+            order_by.iter().all(|(expr, _options)| is_input_independent_rec(*expr, arena, cache))
+        }
+        AExpr::Wildcard => false,
+        AExpr::Slice {
+            input,
+            offset,
+            length,
+        } => {
+            is_input_independent_rec(*input, arena, cache) && is_input_independent_rec(*offset, arena, cache) && is_input_independent_rec(*length, arena, cache)
+        },
+        AExpr::Len => false,
+        AExpr::Nth(_) => false,
+    };
+
+    cache.insert(expr_key, ret);
+    ret
+}
+
+fn is_input_independent(expr_key: IRNodeKey, ctx: &mut LowerExprContext) -> bool {
+    is_input_independent_rec(expr_key, &ctx.expr_arena, &mut ctx.is_input_independent_cache)
+}
+
+struct LowerExprContext<'a> {
+    ir_arena: &'a mut Arena<IR>,
+    expr_arena: &'a mut Arena<AExpr>,
+    phys_sm: &'a mut SlotMap<PhysNodeKey, PhysNode>,
+    is_streamable_cache: PlHashMap<Node, bool>,
+    is_input_independent_cache: PlHashMap<Node, bool>,
+}
+
+#[recursive::recursive]
+fn lower_exprs_rec(
+    input: PhysNodeKey,
+    exprs: &[ExprIR],
+    ctx: &mut LowerExprContext,
+) -> PolarsResult<(PhysNodeKey, Vec<ExprIR>)> {
+    todo!()
+}
+
+pub fn lower_exprs(
+    input: PhysNodeKey,
+    exprs: &[ExprIR],
+    ir_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+    phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
+) -> PolarsResult<(PhysNodeKey, Vec<ExprIR>)> {
+    todo!()
+}

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -62,13 +62,10 @@ pub fn lower_ir(
 
         // TODO: split reductions and streamable selections. E.g. sum(a) + sum(b) should be split
         // into Select(a + b) -> Reduce(sum(a), sum(b)).
-        IR::Select {
-            input,
-            expr,
-            ..
-        } if expr
-            .iter()
-            .all(|e| can_convert_into_reduction(e.node(), expr_arena)) =>
+        IR::Select { input, expr, .. }
+            if expr
+                .iter()
+                .all(|e| can_convert_into_reduction(e.node(), expr_arena)) =>
         {
             let exprs = expr.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -40,7 +40,7 @@ pub fn lower_ir(
             let selectors = expr.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
             return super::lower_expr::build_select_node(
-                phys_input, &selectors, ir_arena, expr_arena, phys_sm,
+                phys_input, &selectors, expr_arena, phys_sm,
             );
         },
 
@@ -79,7 +79,7 @@ pub fn lower_ir(
             }
             let selectors = selectors.into_values().collect_vec();
             return super::lower_expr::build_select_node(
-                phys_input, &selectors, ir_arena, expr_arena, phys_sm,
+                phys_input, &selectors, expr_arena, phys_sm,
             );
         },
 
@@ -101,13 +101,8 @@ pub fn lower_ir(
         IR::Filter { input, predicate } => {
             let predicate = predicate.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
-            let (trans_input, trans_predicate) = super::lower_expr::lower_exprs(
-                phys_input,
-                &[predicate],
-                ir_arena,
-                expr_arena,
-                phys_sm,
-            )?;
+            let (trans_input, trans_predicate) =
+                super::lower_expr::lower_exprs(phys_input, &[predicate], expr_arena, phys_sm)?;
 
             let filter = PhysNodeKind::Filter {
                 input: trans_input,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -102,20 +102,27 @@ pub fn lower_ir(
             let predicate = predicate.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
             let (trans_input, trans_predicate) = super::lower_expr::lower_exprs(
-                phys_input, &[predicate], ir_arena, expr_arena, phys_sm,
+                phys_input,
+                &[predicate],
+                ir_arena,
+                expr_arena,
+                phys_sm,
             )?;
 
             let filter = PhysNodeKind::Filter {
                 input: trans_input,
                 predicate: trans_predicate.into_iter().next().unwrap(),
             };
-            
+
             // Drop the computed predicate column if necessary.
             if trans_input == phys_input {
                 filter
             } else {
                 let filter_schema = phys_sm[trans_input].output_schema.clone();
-                let columns = output_schema.iter_names().map(|name| name.to_string()).collect_vec();
+                let columns = output_schema
+                    .iter_names()
+                    .map(|name| name.to_string())
+                    .collect_vec();
                 PhysNodeKind::SimpleProjection {
                     input: phys_sm.insert(PhysNode::new(filter_schema, filter)),
                     columns,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
-use polars_core::prelude::PlHashMap;
+use polars_core::prelude::{InitHashMaps, PlHashMap, PlIndexMap};
 use polars_core::schema::Schema;
 use polars_error::PolarsResult;
-use polars_expr::reduce::can_convert_into_reduction;
+use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::{AExpr, Context, IR};
 use polars_plan::prelude::SinkType;
 use polars_utils::arena::{Arena, Node};
+use polars_utils::itertools::Itertools;
 use slotmap::SlotMap;
 
 use super::{PhysNode, PhysNodeKey, PhysNodeKind};
@@ -24,6 +25,7 @@ pub fn lower_ir(
     schema_cache: &mut PlHashMap<Node, Arc<Schema>>,
 ) -> PolarsResult<PhysNodeKey> {
     let ir_node = ir_arena.get(node);
+    let output_schema = IR::schema_with_cache(node, ir_arena, schema_cache);
     let node_kind = match ir_node {
         IR::SimpleProjection { input, columns } => {
             let columns = columns.iter_names().map(|s| s.to_string()).collect();
@@ -37,26 +39,15 @@ pub fn lower_ir(
         IR::Select { input, expr, .. } => {
             let selectors = expr.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
-            return super::lower_expr::build_select_node(phys_input, &selectors, ir_arena, expr_arena, phys_sm);
+            return super::lower_expr::build_select_node(
+                phys_input, &selectors, ir_arena, expr_arena, phys_sm,
+            );
         },
 
-        // TODO: split partially streamable selections to avoid fallback as much as possible.
-        // IR::Select { input, expr, .. }
-        //     if expr.iter().all(|e| is_streamable(e.node(), expr_arena)) =>
-        // {
-        //     let selectors = expr.clone();
-        //     let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
-        //     PhysNodeKind::Select {
-        //         input: phys_input,
-        //         selectors,
-        //         extend_original: false,
-        //     }
-        // },
-
-        // TODO: split partially streamable selections to avoid fallback as much as possible.
         IR::HStack { input, exprs, .. }
             if exprs.iter().all(|e| is_streamable(e.node(), expr_arena)) =>
         {
+            // FIXME: constant literal columns should be broadcasted with hstack.
             let selectors = exprs.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
             PhysNodeKind::Select {
@@ -66,20 +57,31 @@ pub fn lower_ir(
             }
         },
 
-        // TODO: split reductions and streamable selections. E.g. sum(a) + sum(b) should be split
-        // into Select(a + b) -> Reduce(sum(a), sum(b)).
-        // IR::Select { input, expr, .. }
-        //     if expr
-        //         .iter()
-        //         .all(|e| can_convert_into_reduction(e.node(), expr_arena)) =>
-        // {
-        //     let exprs = expr.clone();
-        //     let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
-        //     PhysNodeKind::Reduce {
-        //         input: phys_input,
-        //         exprs,
-        //     }
-        // },
+        IR::HStack { input, exprs, .. } => {
+            // We already handled the all-streamable case above, so things get more complicated.
+            // For simplicity we just do a normal select with all the original columns prepended.
+            //
+            // FIXME: constant literal columns should be broadcasted with hstack.
+            let exprs = exprs.clone();
+            let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
+            let input_schema = &phys_sm[phys_input].output_schema;
+            let mut selectors = PlIndexMap::with_capacity(input_schema.len() + exprs.len());
+            for name in input_schema.iter_names() {
+                let col_name: Arc<str> = name.as_str().into();
+                let col_expr = expr_arena.add(AExpr::Column(col_name.clone()));
+                selectors.insert(
+                    name.clone(),
+                    ExprIR::new(col_expr, OutputName::ColumnLhs(col_name)),
+                );
+            }
+            for expr in exprs {
+                selectors.insert(expr.output_name().into(), expr);
+            }
+            let selectors = selectors.into_values().collect_vec();
+            return super::lower_expr::build_select_node(
+                phys_input, &selectors, ir_arena, expr_arena, phys_sm,
+            );
+        },
 
         IR::Slice { input, offset, len } => {
             if *offset >= 0 {
@@ -96,12 +98,28 @@ pub fn lower_ir(
             }
         },
 
-        IR::Filter { input, predicate } if is_streamable(predicate.node(), expr_arena) => {
+        IR::Filter { input, predicate } => {
             let predicate = predicate.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;
-            PhysNodeKind::Filter {
-                input: phys_input,
-                predicate,
+            let (trans_input, trans_predicate) = super::lower_expr::lower_exprs(
+                phys_input, &[predicate], ir_arena, expr_arena, phys_sm,
+            )?;
+
+            let filter = PhysNodeKind::Filter {
+                input: trans_input,
+                predicate: trans_predicate.into_iter().next().unwrap(),
+            };
+            
+            // Drop the computed predicate column if necessary.
+            if trans_input == phys_input {
+                filter
+            } else {
+                let filter_schema = phys_sm[trans_input].output_schema.clone();
+                let columns = output_schema.iter_names().map(|name| name.to_string()).collect_vec();
+                PhysNodeKind::SimpleProjection {
+                    input: phys_sm.insert(PhysNode::new(filter_schema, filter)),
+                    columns,
+                }
             }
         },
 
@@ -115,16 +133,24 @@ pub fn lower_ir(
             let mut schema = schema.clone(); // This is initially the schema of df, but can change with the projection.
             let mut node_kind = PhysNodeKind::InMemorySource { df: df.clone() };
 
+            // Do we need to apply a projection?
             if let Some(projection_schema) = projection {
-                let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
-                node_kind = PhysNodeKind::SimpleProjection {
-                    input: phys_input,
-                    columns: projection_schema
+                if projection_schema.len() != schema.len()
+                    || projection_schema
                         .iter_names()
-                        .map(|s| s.to_string())
-                        .collect(),
-                };
-                schema = projection_schema.clone();
+                        .zip(schema.iter_names())
+                        .any(|(l, r)| l != r)
+                {
+                    let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
+                    node_kind = PhysNodeKind::SimpleProjection {
+                        input: phys_input,
+                        columns: projection_schema
+                            .iter_names()
+                            .map(|s| s.to_string())
+                            .collect(),
+                    };
+                    schema = projection_schema.clone();
+                }
             }
 
             if let Some(predicate) = filter.clone() {
@@ -214,6 +240,5 @@ pub fn lower_ir(
         _ => todo!(),
     };
 
-    let output_schema = IR::schema_with_cache(node, ir_arena, schema_cache);
     Ok(phys_sm.insert(PhysNode::new(output_schema, node_kind)))
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -61,11 +61,14 @@ pub fn lower_ir(
         },
 
         // TODO: split reductions and streamable selections. E.g. sum(a) + sum(b) should be split
-        // into Select(a + b) -> Reduce(sum(a), sum(b)
-        IR::Select { input, expr, .. }
-            if expr
-                .iter()
-                .all(|e| can_convert_into_reduction(e.node(), expr_arena)) =>
+        // into Select(a + b) -> Reduce(sum(a), sum(b)).
+        IR::Select {
+            input,
+            expr,
+            ..
+        } if expr
+            .iter()
+            .all(|e| can_convert_into_reduction(e.node(), expr_arena)) =>
         {
             let exprs = expr.clone();
             let phys_input = lower_ir(*input, ir_arena, expr_arena, phys_sm, schema_cache)?;

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -6,8 +6,8 @@ use polars_core::schema::Schema;
 use polars_plan::plans::{AExpr, DataFrameUdf};
 use polars_plan::prelude::expr_ir::ExprIR;
 
-mod lower_ir;
 mod lower_expr;
+mod lower_ir;
 mod to_graph;
 
 pub use lower_ir::lower_ir;

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -7,6 +7,7 @@ use polars_plan::plans::{AExpr, DataFrameUdf};
 use polars_plan::prelude::expr_ir::ExprIR;
 
 mod lower_ir;
+mod lower_expr;
 mod to_graph;
 
 pub use lower_ir::lower_ir;

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -15,7 +15,7 @@ fn is_streamable(node: Node, arena: &Arena<AExpr>) -> bool {
 pub fn run_query(
     node: Node,
     mut ir_arena: Arena<IR>,
-    expr_arena: &Arena<AExpr>,
+    expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<DataFrame> {
     let mut phys_sm = SlotMap::with_capacity_and_key(ir_arena.len());
     let mut schema_cache = PlHashMap::with_capacity(ir_arena.len());


### PR DESCRIPTION
Most non-elementwise expressions still fall back to the in-memory-map, but at least the groundwork is laid for lowering more and more expressions to the streaming engine over time.

Known bug: common subexpression elimination does not work for the streaming engine in general.

An example:

```python
df.lazy().select(
    gt_avg = pl.col.x.filter(pl.col.x > pl.col.x.mean()).sum(),
    mae = (pl.col.x - pl.col.y).abs().mean()
)
```

![out](https://github.com/user-attachments/assets/abea161d-268c-43c4-b2f9-1da28769cfa4)
