### PR TITLE
refactor(rust): Expose many more function expressions to python IR

### DIFF
--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -57,7 +57,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (1, 0);
+    const VERSION: Version = (1, 1);
 
     pub(crate) fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {


### PR DESCRIPTION
This covers the remaining "easy" ones where we just need to pass names and some trivial information through.