### PR TITLE
perf: Lazy decompress Parquet pages

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -705,6 +705,7 @@ impl<D: utils::NestedDecoder> PageNestedDecoder<D> {
                         break;
                     };
                     let page = page?;
+                    let page = page.decompress(&mut self.iter)?;
 
                     let mut state =
                         utils::State::new_nested(&self.decoder, &page, self.dict.as_ref())?;
@@ -743,9 +744,11 @@ impl<D: utils::NestedDecoder> PageNestedDecoder<D> {
                         break;
                     };
                     let page = page?;
+                    // We cannot lazily decompress because we don't have the number of leaf values
+                    // at this point. This is encoded within the `definition level` values. *sign*.
+                    // In general, lazy decompression is quite difficult with nested values.
+                    let page = page.decompress(&mut self.iter)?;
 
-                    let mut state =
-                        utils::State::new_nested(&self.decoder, &page, self.dict.as_ref())?;
                     let (def_iter, rep_iter) = level_iters(&page)?;
 
                     let mut count = ZeroCount::default();
@@ -761,6 +764,9 @@ impl<D: utils::NestedDecoder> PageNestedDecoder<D> {
                     } else {
                         None
                     };
+
+                    let mut state =
+                        utils::State::new_nested(&self.decoder, &page, self.dict.as_ref())?;
 
                     let start_length = nested_state.len();
 

--- a/crates/polars/tests/it/io/parquet/read/mod.rs
+++ b/crates/polars/tests/it/io/parquet/read/mod.rs
@@ -159,6 +159,7 @@ where
             .map(|dict| dictionary::deserialize(&dict, column.physical_type()))
             .transpose()?;
         while let Some(page) = iterator.next().transpose()? {
+            let page = page.decompress(&mut iterator)?;
             if !has_filled {
                 struct_::extend_validity(&mut validity, &page)?;
             }


### PR DESCRIPTION
This only decompresses pages if they are actually going to be read from. This is only possible for unnested values and should save quite some time on slice pushdown and `parallel=prefiltered`.