### PR TITLE
feat: Add POLARS_BACKTRACE_IN_ERR for debugging

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -6,10 +6,26 @@ use std::collections::TryReserveError;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops::Deref;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::{env, io};
 
 pub use warning::*;
+
+enum ErrorStrategy {
+    Panic,
+    WithBacktrace,
+    Normal,
+}
+
+static ERROR_STRATEGY: LazyLock<ErrorStrategy> = LazyLock::new(|| {
+    if env::var("POLARS_PANIC_ON_ERR").as_deref() == Ok("1") {
+        ErrorStrategy::Panic
+    } else if env::var("POLARS_BACKTRACE_IN_ERR").as_deref() == Ok("1") {
+        ErrorStrategy::WithBacktrace
+    } else {
+        ErrorStrategy::Normal
+    }
+});
 
 #[derive(Debug)]
 pub struct ErrString(Cow<'static, str>);
@@ -25,10 +41,14 @@ where
     T: Into<Cow<'static, str>>,
 {
     fn from(msg: T) -> Self {
-        if env::var("POLARS_PANIC_ON_ERR").as_deref().unwrap_or("") == "1" {
-            panic!("{}", msg.into())
-        } else {
-            ErrString(msg.into())
+        match &*ERROR_STRATEGY {
+            ErrorStrategy::Panic => panic!("{}", msg.into()),
+            ErrorStrategy::WithBacktrace => ErrString(Cow::Owned(format!(
+                "{}\n\nRust backtrace:\n{}",
+                msg.into(),
+                std::backtrace::Backtrace::force_capture()
+            ))),
+            ErrorStrategy::Normal => ErrString(msg.into()),
         }
     }
 }


### PR DESCRIPTION
You can now specify `POLARS_BACKTRACE_IN_ERR=1` to include a Rust backtrace inside errors to see where they get created:

```python
>>> import polars as pl
>>> df = pl.DataFrame({"x": [1]})
>>> df.select(pl.col.y)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/orlp/programming/rust/polars/py-polars/polars/dataframe/frame.py", line 8853, in select
    return self.lazy().select(*exprs, **named_exprs).collect(_eager=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/orlp/programming/rust/polars/py-polars/polars/lazyframe/frame.py", line 2034, in collect
    return wrap_df(ldf.collect(callback))
                   ^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.ColumnNotFoundError: y

Rust backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2: std::backtrace::Backtrace::create
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/std/src/backtrace.rs:331:13
   3: <polars_error::ErrString as core::convert::From<T>>::from
             at /Users/orlp/programming/rust/polars/crates/polars-error/src/lib.rs:49:17
   4: <T as core::convert::Into<U>>::into
             at /rustc/7120fdac7a6e55a5e4b606256042890b36067052/library/core/src/convert/mod.rs:759:9
   5: polars_plan::plans::aexpr::schema::<impl polars_plan::plans::aexpr::AExpr>::to_field_impl::{{closure}}::{{closure}}
             at /Users/orlp/programming/rust/polars/crates/polars-plan/src/plans/aexpr/schema.rs:78:60
...
```

One caveat: we now cache `POLARS_PANIC_ON_ERR` which already existed the first time we create an error object. So it's no longer supported to update that dynamically through `os.environ`.