### PR TITLE
refactor(rust): Only instantiate used portion of graph

### DIFF
--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -53,6 +53,7 @@ struct GraphConversionContext<'a> {
 }
 
 pub fn physical_plan_to_graph(
+    root: PhysNodeKey,
     phys_sm: &SlotMap<PhysNodeKey, PhysNode>,
     expr_arena: &Arena<AExpr>,
 ) -> PolarsResult<(Graph, SecondaryMap<PhysNodeKey, GraphNodeKey>)> {
@@ -65,9 +66,7 @@ pub fn physical_plan_to_graph(
         expr_conversion_state: ExpressionConversionState::new(false, expr_depth_limit),
     };
 
-    for key in phys_sm.keys() {
-        to_graph_rec(key, &mut ctx)?;
-    }
+    to_graph_rec(root, &mut ctx)?;
 
     Ok((ctx.graph, ctx.phys_to_graph))
 }

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -31,7 +31,7 @@ pub fn run_query(
         std::fs::write(visual_path, visualization).unwrap();
     }
     let (mut graph, phys_to_graph) =
-        crate::physical_plan::physical_plan_to_graph(&phys_sm, expr_arena)?;
+        crate::physical_plan::physical_plan_to_graph(root, &phys_sm, expr_arena)?;
     let mut results = crate::execute::execute_graph(&mut graph)?;
     Ok(results.remove(phys_to_graph[root]).unwrap())
 }


### PR DESCRIPTION
During our lowering to a PhysicalPlan we end up producing some physical plan nodes that end up going unused (e.g. because a node ends up being input independent). We ended up spawning execution graph nodes for this which caused failed asserts, etc.