### PR TITLE
docs(python): Add missing aggregation entries (#18334)

### DIFF
--- a/py-polars/docs/source/reference/expressions/aggregation.rst
+++ b/py-polars/docs/source/reference/expressions/aggregation.rst
@@ -7,6 +7,9 @@ Aggregation
    :toctree: api/
 
     Expr.agg_groups
+    Expr.all
+    Expr.any
+    Expr.approx_n_unique
     Expr.arg_max
     Expr.arg_min
     Expr.count
@@ -18,6 +21,7 @@ Aggregation
     Expr.mean
     Expr.median
     Expr.min
+    Expr.n_unique
     Expr.nan_max
     Expr.nan_min
     Expr.product


### PR DESCRIPTION
Resolves #18334.

The missing entries now appear in the generated Python documentation.

<img width="1313" alt="1" src="https://github.com/user-attachments/assets/dbd0bfde-1605-413c-bfc2-2b3c8a28582b">
