### PR TITLE
perf: Partition metadata for parquet statistic loading

### DIFF
--- a/crates/polars-io/src/parquet/read/metadata.rs
+++ b/crates/polars-io/src/parquet/read/metadata.rs
@@ -7,7 +7,7 @@ use polars_utils::unitvec;
 /// This is a utility struct that Partitions the `ColumnChunkMetaData` by `field.name == descriptor.path_in_schema[0]`
 /// This is required to fix quadratic behavior in wide parquet files. See #18319.
 pub struct PartitionedColumnChunkMD<'a> {
-    partitions: PlHashMap<String, UnitVec<usize>>,
+    partitions: Option<PlHashMap<String, UnitVec<usize>>>,
     metadata: &'a RowGroupMetaData,
 }
 
@@ -24,13 +24,14 @@ impl<'a> PartitionedColumnChunkMD<'a> {
     }
 
     pub fn set_partitions(&mut self, field_names: Option<&PlHashSet<&str>>) {
+        let mut partitions = PlHashMap::default();
         for (i, ccmd) in self.metadata.columns().iter().enumerate() {
             let name = &ccmd.descriptor().path_in_schema[0];
             if field_names
                 .map(|field_names| field_names.contains(name.as_str()))
                 .unwrap_or(true)
             {
-                let entry = self.partitions.raw_entry_mut().from_key(name.as_str());
+                let entry = partitions.raw_entry_mut().from_key(name.as_str());
 
                 match entry {
                     RawEntryMut::Vacant(slot) => {
@@ -42,17 +43,15 @@ impl<'a> PartitionedColumnChunkMD<'a> {
                 };
             }
         }
+        self.partitions = Some(partitions)
     }
 
-    pub fn get_partitions(&self, name: &str) -> UnitVec<&ColumnChunkMetaData> {
-        debug_assert!(
-            !self.partitions.is_empty(),
-            "fields should be partitioned first"
-        );
+    pub fn get_partitions(&self, name: &str) -> Option<UnitVec<&ColumnChunkMetaData>> {
         let columns = self.metadata.columns();
         self.partitions
+            .as_ref()
+            .expect("fields should be partitioned first")
             .get(name)
             .map(|idx| idx.iter().map(|i| &columns[*i]).collect::<UnitVec<_>>())
-            .unwrap_or_default()
     }
 }

--- a/crates/polars-io/src/parquet/read/mod.rs
+++ b/crates/polars-io/src/parquet/read/mod.rs
@@ -40,6 +40,7 @@ pub use reader::{BatchedParquetReader, ParquetReader};
 pub use utils::materialize_empty_df;
 
 pub mod _internal {
+    pub use super::metadata::PartitionedColumnChunkMD;
     pub use super::mmap::to_deserializer;
     pub use super::predicates::read_this_row_group;
 }

--- a/crates/polars-io/src/parquet/read/predicates.rs
+++ b/crates/polars-io/src/parquet/read/predicates.rs
@@ -1,8 +1,7 @@
-use arrow::datatypes::ArrowSchemaRef;
 use polars_core::prelude::*;
 use polars_parquet::read::statistics::{deserialize, Statistics};
-use polars_parquet::read::RowGroupMetaData;
 
+use crate::parquet::read::metadata::PartitionedColumnChunkMD;
 use crate::predicates::{BatchStats, ColumnStats, PhysicalIoExpr};
 
 impl ColumnStats {
@@ -16,16 +15,16 @@ impl ColumnStats {
     }
 }
 
-/// Collect the statistics in a column chunk.
+/// Collect the statistics in a row-group
 pub(crate) fn collect_statistics(
-    md: &RowGroupMetaData,
+    part_md: &PartitionedColumnChunkMD,
     schema: &ArrowSchema,
 ) -> PolarsResult<Option<BatchStats>> {
     let stats = schema
         .fields
         .iter()
         .map(|field| {
-            let st = deserialize(field, md)?;
+            let st = deserialize(field, &part_md.get_partitions(&field.name))?;
             Ok(ColumnStats::from_arrow_stats(st, field))
         })
         .collect::<PolarsResult<Vec<_>>>()?;
@@ -37,18 +36,18 @@ pub(crate) fn collect_statistics(
     Ok(Some(BatchStats::new(
         Arc::new(schema.into()),
         stats,
-        Some(md.num_rows()),
+        Some(part_md.num_rows()),
     )))
 }
 
 pub fn read_this_row_group(
     predicate: Option<&dyn PhysicalIoExpr>,
-    md: &RowGroupMetaData,
-    schema: &ArrowSchemaRef,
+    part_md: &PartitionedColumnChunkMD,
+    schema: &ArrowSchema,
 ) -> PolarsResult<bool> {
     if let Some(pred) = predicate {
         if let Some(pred) = pred.as_stats_evaluator() {
-            if let Some(stats) = collect_statistics(md, schema)? {
+            if let Some(stats) = collect_statistics(part_md, schema)? {
                 let should_read = pred.should_read(&stats);
                 // a parquet file may not have statistics of all columns
                 if matches!(should_read, Ok(false)) {

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -324,7 +324,7 @@ fn rg_to_dfs_prefiltered(
 
                 let name = &schema.fields[col_idx].name;
                 let rg_idx = row_groups[i / num_live_columns].index;
-                let field_md = part_mds[rg_idx as usize].get_partitions(name);
+                let field_md = part_mds[rg_idx as usize].get_partitions(name).unwrap();
 
                 column_idx_to_series(col_idx, field_md.as_slice(), None, schema, store)
             })
@@ -441,7 +441,7 @@ fn rg_to_dfs_prefiltered(
                     let md = &file_metadata.row_groups[rg_idx as usize];
                     debug_assert_eq!(md.num_rows(), mask.len());
                 }
-                let field_md = part_mds[rg_idx as usize].get_partitions(name);
+                let field_md = part_mds[rg_idx as usize].get_partitions(name).unwrap();
 
                 column_idx_to_series(
                     col_idx,
@@ -527,7 +527,7 @@ fn rg_to_dfs_optionally_par_over_columns(
                     .par_iter()
                     .map(|column_i| {
                         let name = &schema.fields[*column_i].name;
-                        let part = part_md.get_partitions(name);
+                        let part = part_md.get_partitions(name).unwrap();
 
                         column_idx_to_series(
                             *column_i,
@@ -544,7 +544,7 @@ fn rg_to_dfs_optionally_par_over_columns(
                 .iter()
                 .map(|column_i| {
                     let name = &schema.fields[*column_i].name;
-                    let part = part_md.get_partitions(name);
+                    let part = part_md.get_partitions(name).unwrap();
 
                     column_idx_to_series(
                         *column_i,
@@ -658,7 +658,7 @@ fn rg_to_dfs_par_over_rg(
                     .iter()
                     .map(|column_i| {
                         let name = &schema.fields[*column_i].name;
-                        let field_md = part_md.get_partitions(name);
+                        let field_md = part_md.get_partitions(name).unwrap();
 
                         column_idx_to_series(
                             *column_i,

--- a/crates/polars-parquet/src/arrow/read/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/mod.rs
@@ -40,18 +40,6 @@ pub use crate::parquet::{
 
 /// Returns all [`ColumnChunkMetaData`] associated to `field_name`.
 /// For non-nested parquet types, this returns a single column
-pub fn get_field_columns<'a>(
-    columns: &'a [ColumnChunkMetaData],
-    field_name: &str,
-) -> Vec<&'a ColumnChunkMetaData> {
-    columns
-        .iter()
-        .filter(|x| x.descriptor().path_in_schema[0] == field_name)
-        .collect()
-}
-
-/// Returns all [`ColumnChunkMetaData`] associated to `field_name`.
-/// For non-nested parquet types, this returns a single column
 pub fn get_field_pages<'a, T>(
     columns: &'a [ColumnChunkMetaData],
     items: &'a [T],

--- a/crates/polars/tests/it/io/parquet/arrow/mod.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/mod.rs
@@ -17,8 +17,6 @@ use polars_parquet::write::*;
 
 use super::read::file::FileReader;
 
-type ArrayStats = (Box<dyn Array>, Statistics);
-
 fn new_struct(
     arrays: Vec<Box<dyn Array>>,
     names: Vec<String>,
@@ -32,23 +30,17 @@ fn new_struct(
     StructArray::new(ArrowDataType::Struct(fields), arrays, validity)
 }
 
-pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> PolarsResult<ArrayStats> {
+pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> PolarsResult<Box<dyn Array>> {
     let metadata = p_read::read_metadata(&mut reader)?;
     let schema = p_read::infer_schema(&metadata)?;
 
-    let row_group = &metadata.row_groups[0];
-
     let schema = schema.filter(|_, f| f.name == column);
-
-    let field = &schema.fields[0];
-
-    let statistics = deserialize(field, row_group)?;
 
     let mut reader = FileReader::new(reader, metadata.row_groups, schema, None);
 
     let array = reader.next().unwrap()?.into_arrays().pop().unwrap();
 
-    Ok((array, statistics))
+    Ok(array)
 }
 
 pub fn pyarrow_nested_edge(column: &str) -> Box<dyn Array> {
@@ -1289,10 +1281,6 @@ fn integration_read(data: &[u8], limit: Option<usize>) -> PolarsResult<Integrati
     let mut reader = Cursor::new(data);
     let metadata = p_read::read_metadata(&mut reader)?;
     let schema = p_read::infer_schema(&metadata)?;
-
-    for (field, row_group) in schema.fields.iter().zip(metadata.row_groups.iter()) {
-        let mut _statistics = deserialize(field, row_group)?;
-    }
 
     let reader = FileReader::new(
         Cursor::new(data),

--- a/crates/polars/tests/it/io/parquet/arrow/write.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/write.rs
@@ -9,7 +9,7 @@ fn round_trip(
     compression: CompressionOptions,
     encodings: Vec<Encoding>,
 ) -> PolarsResult<()> {
-    round_trip_opt_stats(column, file, version, compression, encodings, true)
+    round_trip_opt_stats(column, file, version, compression, encodings)
 }
 
 fn round_trip_opt_stats(
@@ -18,9 +18,8 @@ fn round_trip_opt_stats(
     version: Version,
     compression: CompressionOptions,
     encodings: Vec<Encoding>,
-    check_stats: bool,
 ) -> PolarsResult<()> {
-    let (array, statistics) = match file {
+    let (array, _statistics) = match file {
         "nested" => (
             pyarrow_nested_nullable(column),
             pyarrow_nested_nullable_statistics(column),
@@ -68,12 +67,9 @@ fn round_trip_opt_stats(
 
     std::fs::write("list_struct_list_nullable.parquet", &data).unwrap();
 
-    let (result, stats) = read_column(&mut Cursor::new(data), "a1")?;
+    let result = read_column(&mut Cursor::new(data), "a1")?;
 
     assert_eq!(array.as_ref(), result.as_ref());
-    if check_stats {
-        assert_eq!(statistics, stats);
-    }
     Ok(())
 }
 
@@ -364,7 +360,6 @@ fn list_nested_inner_required_required_i64() -> PolarsResult<()> {
         Version::V1,
         CompressionOptions::Uncompressed,
         vec![Encoding::Plain],
-        false,
     )
 }
 
@@ -376,7 +371,6 @@ fn v1_nested_struct_list_nullable() -> PolarsResult<()> {
         Version::V1,
         CompressionOptions::Uncompressed,
         vec![Encoding::Plain],
-        true,
     )
 }
 
@@ -388,7 +382,6 @@ fn v1_nested_list_struct_list_nullable() -> PolarsResult<()> {
         Version::V1,
         CompressionOptions::Uncompressed,
         vec![Encoding::Plain],
-        true,
     )
 }
 


### PR DESCRIPTION
fixes #18319

I am convinced we need a metadata supertype so we can amortize this as we need this all over.
We also need the arrow schema to be backed by an `IndexSet`. Currently we need a linear search to get a dtype.