### PR TITLE
feat: Respect input time zone if input is pandas Timestamp

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -179,7 +179,7 @@ def sequence_to_pyseries(
         python_dtype = type(value)
 
     # temporal branch
-    if python_dtype in py_temporal_types:
+    if issubclass(python_dtype, tuple(py_temporal_types)):
         if dtype is None:
             dtype = parse_into_dtype(python_dtype)  # construct from integer
         elif dtype in py_temporal_types:

--- a/py-polars/polars/datatypes/_parse.py
+++ b/py-polars/polars/datatypes/_parse.py
@@ -76,10 +76,10 @@ def parse_py_type_into_dtype(input: PythonDataType | type[object]) -> PolarsData
         return String()
     elif input is bool:
         return Boolean()
-    elif input is date:
-        return Date()
-    elif input is datetime:
+    elif isinstance(input, type) and issubclass(input, datetime):  # type: ignore[redundant-expr]
         return Datetime("us")
+    elif isinstance(input, type) and issubclass(input, date):  # type: ignore[redundant-expr]
+        return Date()
     elif input is timedelta:
         return Duration
     elif input is time:

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import polars as pl
@@ -146,6 +147,12 @@ def test_series_init_np_temporal_with_nat_15518() -> None:
 
     expected = pl.Series([date(2020, 1, 1), None, date(2020, 1, 3)])
     assert_series_equal(result, expected)
+
+
+def test_series_init_pandas_timestamp_18127() -> None:
+    result = pl.Series([pd.Timestamp("2000-01-01T00:00:00.123456789", tz="UTC")])
+    # Note: time unit is not (yet) respected, it should be Datetime('ns', 'UTC').
+    assert result.dtype == pl.Datetime("us", "UTC")
 
 
 def test_series_init_np_2d_zero_zero_shape() -> None:


### PR DESCRIPTION
addresses part of #18127

`pd.Timestamp` subclasses `datetime.datetime`, but the current code checks type too tightly (`elif input is datetime`)