### PR TITLE
feat: List json encode

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -56,6 +56,8 @@ pub enum ListFunction {
     Join(bool),
     #[cfg(feature = "dtype-array")]
     ToArray(usize),
+    #[cfg(feature = "json")]
+    JsonEncode,
 }
 
 impl ListFunction {
@@ -103,6 +105,8 @@ impl ListFunction {
             #[cfg(feature = "dtype-array")]
             ToArray(width) => mapper.try_map_dtype(|dt| map_list_dtype_to_array_dtype(dt, *width)),
             NUnique => mapper.with_dtype(IDX_DTYPE),
+            #[cfg(feature = "json")]
+            JsonEncode => mapper.with_dtype(DataType::String),
         }
     }
 }
@@ -174,6 +178,8 @@ impl Display for ListFunction {
             Join(_) => "join",
             #[cfg(feature = "dtype-array")]
             ToArray(_) => "to_array",
+            #[cfg(feature = "json")]
+            JsonEncode => "to_json",
         };
         write!(f, "list.{name}")
     }
@@ -235,6 +241,8 @@ impl From<ListFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "dtype-array")]
             ToArray(width) => map!(to_array, width),
             NUnique => map!(n_unique),
+            #[cfg(feature = "json")]
+            JsonEncode => map!(to_json),
         }
     }
 }
@@ -640,4 +648,19 @@ pub(super) fn to_array(s: &Series, width: usize) -> PolarsResult<Series> {
 
 pub(super) fn n_unique(s: &Series) -> PolarsResult<Series> {
     Ok(s.list()?.lst_n_unique()?.into_series())
+}
+
+#[cfg(feature = "json")]
+pub(super) fn to_json(s: &Series) -> PolarsResult<Series> {
+    let ca = s.list()?;
+
+
+    let dtype = ca.dtype().to_arrow(CompatLevel::newest());
+
+    let iter = ca.chunks().iter().map(|arr| {
+        let arr = arrow::compute::cast::cast_unchecked(arr.as_ref(), &dtype).unwrap();
+        polars_json::json::write::serialize_to_utf8(arr.as_ref())
+    });
+
+    Ok(StringChunked::from_chunk_iter(ca.name(), iter).into_series())
 }

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -654,7 +654,6 @@ pub(super) fn n_unique(s: &Series) -> PolarsResult<Series> {
 pub(super) fn to_json(s: &Series) -> PolarsResult<Series> {
     let ca = s.list()?;
 
-
     let dtype = ca.dtype().to_arrow(CompatLevel::newest());
 
     let iter = ca.chunks().iter().map(|arr| {

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -406,4 +406,11 @@ impl ListNameSpace {
         let other = other.into();
         self.set_operation(other, SetOperation::SymmetricDifference)
     }
+
+    #[cfg(feature = "json")]
+    pub fn json_encode(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ListExpr(ListFunction::JsonEncode))
+    }
+
 }

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -412,5 +412,4 @@ impl ListNameSpace {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::JsonEncode))
     }
-
 }

--- a/crates/polars-python/src/expr/list.rs
+++ b/crates/polars-python/src/expr/list.rs
@@ -253,4 +253,9 @@ impl PyExpr {
         }
         .into()
     }
+
+    #[cfg(feature = "json")]
+    fn list_json_encode(&self) -> Self {
+        self.inner.clone().list().json_encode().into()
+    }
 }

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1365,9 +1365,9 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> pl.DataFrame(
-        ...     {"a": [[1, 2], [45], [9, 1, 3], None]}
-        ... ).with_columns(pl.col("a").list.json_encode().alias("encoded"))
+        >>> pl.DataFrame({"a": [[1, 2], [45], [9, 1, 3], None]}).with_columns(
+        ...     pl.col("a").list.json_encode().alias("encoded")
+        ... )
         shape: (4, 2)
         ┌───────────┬───────────┐
         │ a         ┆ encoded   │
@@ -1380,9 +1380,9 @@ class ExprListNameSpace:
         │ null      ┆ null      │
         └───────────┴───────────┘
 
-        >>> pl.DataFrame(
-        ...     {"a": [["\\", "\\foo"], ["\a\"'", "{\" bar}"]]}
-        ... ).with_columns(pl.col("a").list.json_encode().alias("encoded"))
+        >>> pl.DataFrame({"a": [["\\", "\\foo"], ["\a\"'", '{" bar}']]}).with_columns(
+        ...     pl.col("a").list.json_encode().alias("encoded")
+        ... )
         shape: (2, 2)
         ┌────────────────────┬───────────────────────────┐
         │ a                  ┆ encoded                   │

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1358,3 +1358,39 @@ class ExprListNameSpace:
         """  # noqa: W505.
         other = parse_into_expression(other, str_as_lit=False)
         return wrap_expr(self._pyexpr.list_set_operation(other, "symmetric_difference"))
+
+    def json_encode(self) -> Expr:
+        r"""
+        Convert this list to a string column with json values.
+
+        Examples
+        --------
+        >>> pl.DataFrame(
+        ...     {"a": [[1, 2], [45], [9, 1, 3], None]}
+        ... ).with_columns(pl.col("a").list.json_encode().alias("encoded"))
+        shape: (4, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ encoded   │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ str       │
+        ╞═══════════╪═══════════╡
+        │ [1, 2]    ┆ [1, 2]    │
+        │ [45]      ┆ [45]      │
+        │ [9, 1, 3] ┆ [9, 1, 3] │
+        │ null      ┆ null      │
+        └───────────┴───────────┘
+
+        >>> pl.DataFrame(
+        ...     {"a": [["\\", "\\foo"], ["\a\"'", "{\" bar}"]]}
+        ... ).with_columns(pl.col("a").list.json_encode().alias("encoded"))
+        shape: (2, 2)
+        ┌────────────────────┬───────────────────────────┐
+        │ a                  ┆ encoded                   │
+        │ ---                ┆ ---                       │
+        │ list[str]          ┆ str                       │
+        ╞════════════════════╪═══════════════════════════╡
+        │ ["\", "\foo"]      ┆ ['\', '\bar']             │
+        │ [""'", "{" bar}"] ┆ ["\u0007\"'", "{\" bar}"] │
+        └────────────────────┴───────────────────────────┘
+        """
+        return wrap_expr(self._pyexpr.list_json_encode())

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -1052,3 +1052,22 @@ class ListNameSpace:
             [5, 7, 8]
         ]
         """  # noqa: W505
+
+    def json_encode(self) -> Series:
+        """
+        Convert this list Series into a string Series with json values.
+
+        Examples
+        --------
+        >>> a = pl.Series([[1, 2, 3], [], [None, 3], [5, 6, 7]])
+        >>> a.list.json_encode(b)
+        shape: (4,)
+        Series: '' [String]
+        [
+            "[1, 2, 3]"
+            "[]"
+            "[null, 3]"
+            "[5, 6, 7]"
+        ]
+        """
+

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -1070,4 +1070,3 @@ class ListNameSpace:
             "[5, 6, 7]"
         ]
         """
-


### PR DESCRIPTION
https://github.com/pola-rs/polars/issues/14029
https://github.com/pola-rs/polars/issues/8482

Involve most of the relevant discussion. It seems as though `src/json/write/serialize.rs` had all the relevant code, all that needed to be done was wrap these calls as the `pl.Struct` / `struct_` does.

Is there any reason why all (or nearly all) polars types shouldn't have a .json_encode method? This might be preferred and reduce code duplication if it is desired to add a `json_encode` to more types that `pl.Struct` and `pl.List`

I will add more tests this evening.