### PR TITLE
chore: Fix the required version of rust in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ improvements point to the `main` branch of this repo.
 polars = { git = "https://github.com/pola-rs/polars", rev = "<optional git tag>" }
 ```
 
-Requires Rust version `>=1.79`.
+Requires Rust version `>=1.80`.
 
 ## Contributing
 


### PR DESCRIPTION
rustc version should be >=`1.80`. 
refer to https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html, `impl Default for Arc<[T]>` is stable in rustc 1.80.
Close #18356