### PR TITLE
perf: Apply slice pushdown before predicate pushdown

### DIFF
--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -76,17 +76,17 @@ fn write_scan(
     } else {
         write!(f, "\n{:indent$}PROJECT */{total_columns} COLUMNS", "")?;
     }
-    if let Some(predicate) = predicate {
-        write!(f, "\n{:indent$}SELECTION: {predicate}", "")?;
-    }
-    if let Some(slice) = slice {
-        write!(f, "\n{:indent$}SLICE: {slice:?}", "")?;
-    }
     if let Some(row_index) = row_index {
         write!(f, "\n{:indent$}ROW_INDEX: {}", "", row_index.name)?;
         if row_index.offset != 0 {
             write!(f, " (offset: {})", row_index.offset)?;
         }
+    }
+    if let Some(slice) = slice {
+        write!(f, "\n{:indent$}SLICE: {slice:?}", "")?;
+    }
+    if let Some(predicate) = predicate {
+        write!(f, "\n{:indent$}SELECTION: {predicate}", "")?;
     }
     Ok(())
 }


### PR DESCRIPTION
Push filters into the scan for `scan_parquet().slice().filter()` queries

Before:
```python
FILTER [(col("species")) == (String(setosa))] FROM
  Parquet SCAN [/Users/nxs/git/polars/.env/iris_hive/a=1/b=1/iris.parquet]
  PROJECT */7 COLUMNS
  SLICE: (50, 50)
```
After:
```python
Parquet SCAN [/Users/nxs/git/polars/.env/iris_hive/a=1/b=1/iris.parquet]
PROJECT */7 COLUMNS
SLICE: (50, 50)
SELECTION: [(col("species")) == (String(setosa))]
```