### PR TITLE
build: Bump Rust toolchain to `nightly-2024-08-26`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -841,7 +841,7 @@ checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1363,7 +1363,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1418,9 +1418,9 @@ checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "ff"
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
@@ -1539,7 +1539,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2250,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6409efc61b12687963e602df8ecf70e8ddacf95bc6576bcf16e3ac6328083c5"
+checksum = "4436751a01da56f1277f323c80d584ffad94a3d14aecd959dd0dff75aa73a438"
 dependencies = [
  "cmake",
  "libc",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -2843,7 +2843,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3631,7 +3631,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3644,7 +3644,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3842,7 +3842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3871,7 +3871,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4270,29 +4270,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4560,7 +4560,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4573,7 +4573,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4595,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4668,7 +4668,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4760,7 +4760,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4878,7 +4878,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -4923,7 +4923,7 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -5096,7 +5096,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
@@ -5130,7 +5130,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5234,7 +5234,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -5245,7 +5245,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -5525,7 +5525,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]

--- a/crates/polars-arrow/src/array/binary/mutable.rs
+++ b/crates/polars-arrow/src/array/binary/mutable.rs
@@ -442,9 +442,8 @@ impl<O: Offset, T: AsRef<[u8]>> TryPush<Option<T>> for MutableBinaryArray<O> {
             Some(value) => {
                 self.values.try_push(value.as_ref())?;
 
-                match &mut self.validity {
-                    Some(validity) => validity.push(true),
-                    None => {},
+                if let Some(validity) = &mut self.validity {
+                    validity.push(true)
                 }
             },
             None => {

--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -101,9 +101,8 @@ impl MutableBooleanArray {
     #[inline]
     pub fn push_value(&mut self, value: bool) {
         self.values.push(value);
-        match &mut self.validity {
-            Some(validity) => validity.push(true),
-            None => {},
+        if let Some(validity) = &mut self.validity {
+            validity.push(true)
         }
     }
 

--- a/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
@@ -114,9 +114,8 @@ impl MutableFixedSizeBinaryArray {
                 }
                 self.values.extend_from_slice(bytes);
 
-                match &mut self.validity {
-                    Some(validity) => validity.push(true),
-                    None => {},
+                if let Some(validity) = &mut self.validity {
+                    validity.push(true)
                 }
             },
             None => {

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -195,6 +195,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
 dyn_clone::clone_trait_object!(Array);
 
 /// A trait describing a mutable array; i.e. an array whose values can be changed.
+///
 /// Mutable arrays cannot be cloned but can be mutated in place,
 /// thereby making them useful to perform numeric operations without allocations.
 /// As in [`Array`], concrete arrays (such as [`MutablePrimitiveArray`]) implement how they are mutated.
@@ -370,6 +371,7 @@ pub fn new_empty_array(data_type: ArrowDataType) -> Box<dyn Array> {
 }
 
 /// Creates a new [`Array`] of [`ArrowDataType`] `data_type` and `length`.
+///
 /// The array is guaranteed to have [`Array::null_count`] equal to [`Array::len`]
 /// for all types except Union, which does not have a validity.
 pub fn new_null_array(data_type: ArrowDataType, length: usize) -> Box<dyn Array> {

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -130,9 +130,8 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     #[inline]
     pub fn push_value(&mut self, value: T) {
         self.values.push(value);
-        match &mut self.validity {
-            Some(validity) => validity.push(true),
-            None => {},
+        if let Some(validity) = &mut self.validity {
+            validity.push(true)
         }
     }
 

--- a/crates/polars-arrow/src/array/utf8/mutable.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable.rs
@@ -522,9 +522,8 @@ impl<O: Offset, T: AsRef<str>> TryPush<Option<T>> for MutableUtf8Array<O> {
             Some(value) => {
                 self.values.try_push(value.as_ref())?;
 
-                match &mut self.validity {
-                    Some(validity) => validity.push(true),
-                    None => {},
+                if let Some(validity) = &mut self.validity {
+                    validity.push(true)
                 }
             },
             None => {

--- a/crates/polars-arrow/src/bitmap/utils/slice_iterator.rs
+++ b/crates/polars-arrow/src/bitmap/utils/slice_iterator.rs
@@ -9,7 +9,8 @@ enum State {
     Finished,
 }
 
-/// Iterator over a bitmap that returns slices of set regions
+/// Iterator over a bitmap that returns slices of set regions.
+///
 /// This is the most efficient method to extract slices of values from arrays
 /// with a validity bitmap.
 /// For example, the bitmap `00101111` returns `[(0,4), (6,1)]`

--- a/crates/polars-arrow/src/compute/arity.rs
+++ b/crates/polars-arrow/src/compute/arity.rs
@@ -8,10 +8,10 @@ use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::datatypes::ArrowDataType;
 use crate::types::NativeType;
 
-/// Applies an unary and infallible function to a [`PrimitiveArray`]. This is the
-/// fastest way to perform an operation on a [`PrimitiveArray`] when the benefits
-/// of a vectorized operation outweighs the cost of branching nulls and
-/// non-nulls.
+/// Applies an unary and infallible function to a [`PrimitiveArray`].
+///
+/// This is the /// fastest way to perform an operation on a [`PrimitiveArray`] when the benefits
+/// of a vectorized operation outweighs the cost of branching nulls and non-nulls.
 ///
 /// # Implementation
 /// This will apply the function for all values, including those on null slots.
@@ -131,11 +131,14 @@ where
     PrimitiveArray::<O>::new(data_type, values, validity)
 }
 
-/// Applies a binary operations to two primitive arrays. This is the fastest
-/// way to perform an operation on two primitive array when the benefits of a
+/// Applies a binary operations to two primitive arrays.
+///
+/// This is the fastest way to perform an operation on two primitive array when the benefits of a
 /// vectorized operation outweighs the cost of branching nulls and non-nulls.
+///
 /// # Errors
 /// This function errors iff the arrays have a different length.
+///
 /// # Implementation
 /// This will apply the function for all values, including those on null slots.
 /// This implies that the operation must be infallible for any value of the

--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -75,12 +75,14 @@ macro_rules! date_like {
 }
 
 /// Extracts the years of a temporal array as [`PrimitiveArray<i32>`].
+///
 /// Use [`can_year`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn year(array: &dyn Array) -> PolarsResult<PrimitiveArray<i32>> {
     date_like!(year, array, ArrowDataType::Int32)
 }
 
 /// Extracts the months of a temporal array as [`PrimitiveArray<i8>`].
+///
 /// Value ranges from 1 to 12.
 /// Use [`can_month`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn month(array: &dyn Array) -> PolarsResult<PrimitiveArray<i8>> {
@@ -88,6 +90,7 @@ pub fn month(array: &dyn Array) -> PolarsResult<PrimitiveArray<i8>> {
 }
 
 /// Extracts the days of a temporal array as [`PrimitiveArray<i8>`].
+///
 /// Value ranges from 1 to 32 (Last day depends on month).
 /// Use [`can_day`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn day(array: &dyn Array) -> PolarsResult<PrimitiveArray<i8>> {
@@ -95,13 +98,15 @@ pub fn day(array: &dyn Array) -> PolarsResult<PrimitiveArray<i8>> {
 }
 
 /// Extracts weekday of a temporal array as [`PrimitiveArray<i8>`].
+///
 /// Monday is 1, Tuesday is 2, ..., Sunday is 7.
 /// Use [`can_weekday`] to check if this operation is supported for the target [`ArrowDataType`]
 pub fn weekday(array: &dyn Array) -> PolarsResult<PrimitiveArray<i8>> {
     date_like!(i8_weekday, array, ArrowDataType::Int8)
 }
 
-/// Extracts ISO week of a temporal array as [`PrimitiveArray<i8>`]
+/// Extracts ISO week of a temporal array as [`PrimitiveArray<i8>`].
+///
 /// Value ranges from 1 to 53 (Last week depends on the year).
 /// Use [`can_iso_week`] to check if this operation is supported for the target [`ArrowDataType`]
 pub fn iso_week(array: &dyn Array) -> PolarsResult<PrimitiveArray<i8>> {
@@ -161,6 +166,7 @@ pub fn second(array: &dyn Array) -> PolarsResult<PrimitiveArray<i8>> {
 }
 
 /// Extracts the nanoseconds of a temporal array as [`PrimitiveArray<i32>`].
+///
 /// Value ranges from 0 to 1_999_999_999.
 /// The range from 1_000_000_000 to 1_999_999_999 represents the leap second.
 /// Use [`can_nanosecond`] to check if this operation is supported for the target [`ArrowDataType`].

--- a/crates/polars-arrow/src/datatypes/physical_type.rs
+++ b/crates/polars-arrow/src/datatypes/physical_type.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub use crate::types::PrimitiveType;
 
 /// The set of physical types: unique in-memory representations of an Arrow array.
+///
 /// A physical type has a one-to-many relationship with a [`crate::datatypes::ArrowDataType`] and
 /// a one-to-one mapping to each struct in this crate that implements [`crate::array::Array`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/polars-arrow/src/legacy/kernels/take_agg/var.rs
+++ b/crates/polars-arrow/src/legacy/kernels/take_agg/var.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-/// Numerical stable online variance aggregation
+/// Numerical stable online variance aggregation.
+///
 /// See:
 /// Welford, B. P. (1962). "Note on a method for calculating corrected sums of squares and products".
 /// Technometrics. 4 (3): 419–420. doi:10.2307/1266577. JSTOR 1266577.

--- a/crates/polars-arrow/src/temporal_conversions.rs
+++ b/crates/polars-arrow/src/temporal_conversions.rs
@@ -267,6 +267,7 @@ pub fn parse_offset(offset: &str) -> PolarsResult<FixedOffset> {
 }
 
 /// Parses `value` to `Option<i64>` consistent with the Arrow's definition of timestamp with timezone.
+///
 /// `tz` must be built from `timezone` (either via [`parse_offset`] or `chrono-tz`).
 /// Returns in scale `tz` of `TimeUnit`.
 #[inline]

--- a/crates/polars-arrow/src/trusted_len.rs
+++ b/crates/polars-arrow/src/trusted_len.rs
@@ -3,6 +3,7 @@ use std::iter::Scan;
 use std::slice::Iter;
 
 /// An iterator of known, fixed size.
+///
 /// A trait denoting Rusts' unstable [TrustedLen](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
 /// This is re-defined here and implemented for some iterators until `std::iter::TrustedLen`
 /// is stabilized.

--- a/crates/polars-arrow/src/types/bit_chunk.rs
+++ b/crates/polars-arrow/src/types/bit_chunk.rs
@@ -48,8 +48,10 @@ bit_chunk!(u16);
 bit_chunk!(u32);
 bit_chunk!(u64);
 
-/// An [`Iterator<Item=bool>`] over a [`BitChunk`]. This iterator is often
-/// compiled to SIMD.
+/// An [`Iterator<Item=bool>`] over a [`BitChunk`].
+///
+/// This iterator is often compiled to SIMD.
+///
 /// The [LSB](https://en.wikipedia.org/wiki/Bit_numbering#Least_significant_bit) corresponds
 /// to the first slot, as defined by the arrow specification.
 /// # Example

--- a/crates/polars-core/src/chunked_array/object/registry.rs
+++ b/crates/polars-core/src/chunked_array/object/registry.rs
@@ -1,4 +1,5 @@
 //! This is a heap allocated utility that can be used to register an object type.
+//!
 //! That object type will know its own generic type parameter `T` and callers can simply
 //! send `&Any` values and don't have to know the generic type themselves.
 use std::any::Any;

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -121,6 +121,7 @@ pub trait ChunkTakeUnchecked<Idx: ?Sized> {
 }
 
 /// Create a `ChunkedArray` with new values by index or by boolean mask.
+///
 /// Note that these operations clone data. This is however the only way we can modify at mask or
 /// index level as the underlying Arrow arrays are immutable.
 pub trait ChunkSet<'a, A, B> {

--- a/crates/polars-core/src/chunked_array/ops/search_sorted.rs
+++ b/crates/polars-core/src/chunked_array/ops/search_sorted.rs
@@ -38,8 +38,10 @@ where
 }
 
 /// Search through a series of chunks for the first position where f(x) is true,
-/// assuming it is first always false and then always true. It repeats this for
-/// each value in search_values. If the search value is null null_idx is returned.
+/// assuming it is first always false and then always true.
+///
+/// It repeats this for each value in search_values. If the search value is null null_idx is
+/// returned.
 ///
 /// Assumes the chunks are non-empty.
 pub fn lower_bound_chunks<'a, T, F>(

--- a/crates/polars-core/src/hashing/identity.rs
+++ b/crates/polars-core/src/hashing/identity.rs
@@ -36,6 +36,7 @@ pub type IdBuildHasher = BuildHasherDefault<IdHasher>;
 
 #[derive(Debug)]
 /// Contains an idx of a row in a DataFrame and the precomputed hash of that row.
+///
 /// That hash still needs to be used to create another hash to be able to resize hashmaps without
 /// accidental quadratic behavior. So do not use an Identity function!
 pub struct IdxHash {

--- a/crates/polars-core/src/hashing/mod.rs
+++ b/crates/polars-core/src/hashing/mod.rs
@@ -39,6 +39,7 @@ pub(crate) unsafe fn compare_df_rows(keys: &DataFrame, idx_a: usize, idx_b: usiz
 }
 
 /// Populate a multiple key hashmap with row indexes.
+///
 /// Instead of the keys (which could be very large), the row indexes are stored.
 /// To check if a row is equal the original DataFrame is also passed as ref.
 /// When a hash collision occurs the indexes are ptrs to the rows and the rows are compared

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -162,7 +162,9 @@ impl PartialEq for DataFrame {
 }
 
 /// Asserts that two expressions of type [`DataFrame`] are equal according to [`DataFrame::equals`]
-/// at runtime. If the expression are not equal, the program will panic with a message that displays
+/// at runtime.
+///
+/// If the expression are not equal, the program will panic with a message that displays
 /// both dataframes.
 #[macro_export]
 macro_rules! assert_df_eq {

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -40,7 +40,8 @@ pub fn _set_partition_size() -> usize {
     POOL.current_num_threads()
 }
 
-/// Just a wrapper structure. Useful for certain impl specializations
+/// Just a wrapper structure which is useful for certain impl specializations.
+///
 /// This is for instance use to implement
 /// `impl<T> FromIterator<T::Native> for NoNull<ChunkedArray<T>>`
 /// as `Option<T::Native>` was already implemented:

--- a/crates/polars-io/src/cloud/adaptors.rs
+++ b/crates/polars-io/src/cloud/adaptors.rs
@@ -11,11 +11,13 @@ use tokio::io::AsyncWriteExt;
 use super::CloudOptions;
 use crate::pl_async::get_runtime;
 
-/// Adaptor which wraps the interface of [ObjectStore::BufWriter](https://docs.rs/object_store/latest/object_store/buffered/struct.BufWriter.html)
-/// exposing a synchronous interface which implements `std::io::Write`.
+/// Adaptor which wraps the interface of [ObjectStore::BufWriter] exposing a synchronous interface
+/// which implements `std::io::Write`.
 ///
 /// This allows it to be used in sync code which would otherwise write to a simple File or byte stream,
 /// such as with `polars::prelude::CsvWriter`.
+///
+/// [ObjectStore::BufWriter]: https://docs.rs/object_store/latest/object_store/buffered/struct.BufWriter.html
 pub struct CloudWriter {
     // Internal writer, constructed at creation
     writer: BufWriter,

--- a/crates/polars-io/src/json/mod.rs
+++ b/crates/polars-io/src/json/mod.rs
@@ -87,9 +87,11 @@ pub struct JsonWriterOptions {
     pub maintain_order: bool,
 }
 
-/// The format to use to write the DataFrame to JSON: `Json` (a JSON array) or `JsonLines` (each row output on a
-/// separate line). In either case, each row is serialized as a JSON object whose keys are the column names and whose
-/// values are the row's corresponding values.
+/// The format to use to write the DataFrame to JSON: `Json` (a JSON array)
+/// or `JsonLines` (each row output on a separate line).
+///
+/// In either case, each row is serialized as a JSON object whose keys are the column names and
+/// whose values are the row's corresponding values.
 pub enum JsonFormat {
     /// A single JSON array containing each DataFrame row as an object. The length of the array is the number of rows in
     /// the DataFrame.

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -67,6 +67,7 @@ impl IntoLazy for LazyFrame {
 }
 
 /// Lazy abstraction over an eager `DataFrame`.
+///
 /// It really is an abstraction over a logical plan. The methods of this struct will incrementally
 /// modify a logical plan until output is requested (via [`collect`](crate::frame::LazyFrame::collect)).
 #[derive(Clone, Default)]

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -1,3 +1,5 @@
+//! Module containing implementation of the pivot operation.
+//!
 //! Polars lazy does not implement a pivot because it is impossible to know the schema without
 //! materializing the whole dataset. This makes a pivot quite a terrible operation for performant
 //! workflows. An optimization can never be pushed down passed a pivot.

--- a/crates/polars-parquet/src/arrow/read/schema/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/mod.rs
@@ -33,9 +33,11 @@ impl Default for SchemaInferenceOptions {
     }
 }
 
-/// Infers a [`ArrowSchema`] from parquet's [`FileMetaData`]. This first looks for the metadata key
-/// `"ARROW:schema"`; if it does not exist, it converts the parquet types declared in the
-/// file's parquet schema to Arrow's equivalent.
+/// Infers a [`ArrowSchema`] from parquet's [`FileMetaData`].
+///
+/// This first looks for the metadata key `"ARROW:schema"`; if it does not exist, it converts the
+/// Parquet types declared in the file's Parquet schema to Arrow's equivalent.
+///
 /// # Error
 /// This function errors iff the key `"ARROW:schema"` exists but is not correctly encoded,
 /// indicating that that the file's arrow metadata was incorrectly written.

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -1024,6 +1024,7 @@ fn transverse_recursive<T, F: Fn(&ArrowDataType) -> T + Clone>(
 
 /// Transverses the `data_type` up to its (parquet) columns and returns a vector of
 /// items based on `map`.
+///
 /// This is used to assign an [`Encoding`] to every parquet column based on the columns' type (see example)
 pub fn transverse<T, F: Fn(&ArrowDataType) -> T + Clone>(
     data_type: &ArrowDataType,

--- a/crates/polars-parquet/src/parquet/compression.rs
+++ b/crates/polars-parquet/src/parquet/compression.rs
@@ -26,6 +26,7 @@ fn inner_compress<
 
 /// Compresses data stored in slice `input_buf` and writes the compressed result
 /// to `output_buf`.
+///
 /// Note that you'll need to call `clear()` before reusing the same `output_buf`
 /// across different `compress` calls.
 #[allow(unused_variables)]

--- a/crates/polars-parquet/src/parquet/read/page/reader.rs
+++ b/crates/polars-parquet/src/parquet/read/page/reader.rs
@@ -57,6 +57,7 @@ impl From<&ColumnChunkMetaData> for PageMetaData {
 
 /// A fallible [`Iterator`] of [`CompressedDataPage`]. This iterator reads pages back
 /// to back until all pages have been consumed.
+///
 /// The pages from this iterator always have [`None`] [`crate::parquet::page::CompressedDataPage::selected_rows()`] since
 /// filter pushdown is not supported without a
 /// pre-computed [page index](https://github.com/apache/parquet-format/blob/master/PageIndex.md).

--- a/crates/polars-parquet/src/parquet/schema/io_message/from_message.rs
+++ b/crates/polars-parquet/src/parquet/schema/io_message/from_message.rs
@@ -158,9 +158,11 @@ fn type_from_str(s: &str) -> ParquetResult<Type> {
     }
 }
 
-/// Parses message type as string into a Parquet [`ParquetType`](crate::parquet::schema::types::ParquetType)
-/// which, for example, could be used to extract individual columns. Returns Parquet
-/// general error when parsing or validation fails.
+/// Parses message type as string into a Parquet [`ParquetType`](crate::parquet::schema::types::ParquetType).
+///
+/// This could, for example, be used to extract individual columns.
+///
+/// Returns Parquet general error when parsing or validation fails.
 pub fn from_message(message_type: &str) -> ParquetResult<ParquetType> {
     let mut parser = Parser {
         tokenizer: &mut Tokenizer::from_str(message_type),

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -61,9 +61,11 @@ impl AsRef<Expr> for AggExpr {
     }
 }
 
-/// Expressions that can be used in various contexts. Queries consist of multiple expressions. When using the polars
-/// lazy API, don't construct an `Expr` directly; instead, create one using the functions in the `polars_lazy::dsl`
-/// module. See that module's docs for more info.
+/// Expressions that can be used in various contexts.
+///
+/// Queries consist of multiple expressions.
+/// When using the polars lazy API, don't construct an `Expr` directly; instead, create one using
+/// the functions in the `polars_lazy::dsl` module. See that module's docs for more info.
 #[derive(Clone, PartialEq)]
 #[must_use]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/polars-plan/src/dsl/functions/index.rs
+++ b/crates/polars-plan/src/dsl/functions/index.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 /// Find the indexes that would sort these series in order of appearance.
+///
 /// That means that the first `Series` will be used to determine the ordering
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.

--- a/crates/polars-plan/src/dsl/functions/repeat.rs
+++ b/crates/polars-plan/src/dsl/functions/repeat.rs
@@ -1,8 +1,9 @@
 use super::*;
 
-/// Create a column of length `n` containing `n` copies of the literal `value`. Generally you won't need this function,
-/// as `lit(value)` already represents a column containing only `value` whose length is automatically set to the correct
-/// number of rows.
+/// Create a column of length `n` containing `n` copies of the literal `value`.
+///
+/// Generally you won't need this function, as `lit(value)` already represents a column containing
+/// only `value` whose length is automatically set to the correct number of rows.
 pub fn repeat<E: Into<Expr>>(value: E, n: Expr) -> Expr {
     let function = |s: Series, n: Series| {
         polars_ensure!(

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -557,7 +557,9 @@ pub(crate) fn group_by_values_iter_lookahead_collected(
 }
 
 /// Different from `group_by_windows`, where define window buckets and search which values fit that
-/// pre-defined bucket, this function defines every window based on the:
+/// pre-defined bucket.
+///
+/// This function defines every window based on the:
 ///     - timestamp (lower bound)
 ///     - timestamp + period (upper bound)
 /// where timestamps are the individual values in the array `time`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-07-26"
+channel = "nightly-2024-08-26"


### PR DESCRIPTION
The new toolchain includes two new lints:
* A lint for using `if let` instead of a `match` statement in certain cases.
* A lint for splitting a docstring summary from the rest of the docstring (similar to what we have in Python).