### PR TITLE
fix(rust): Fix broken feature gate for `ParquetReader`

### DIFF
--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -12,7 +12,7 @@ use polars_io::parquet::read::ParquetAsyncReader;
 use polars_io::parquet::read::ParquetReader;
 #[cfg(all(feature = "parquet", feature = "async"))]
 use polars_io::pl_async::{get_runtime, with_concurrency_budget};
-#[cfg(feature = "json")]
+#[cfg(any(feature = "json", feature = "parquet"))]
 use polars_io::SerReader;
 
 use super::*;


### PR DESCRIPTION
Very minor fix - ran into this while working on Polars Cloud.

See line 115 of the affected file - it uses the functionality that is gated behind the `json` feature in the `parquet` feature flag.