### PR TITLE
docs(python): Alphabetise methods in Python API reference

### DIFF
--- a/py-polars/docs/source/reference/expressions/array.rst
+++ b/py-polars/docs/source/reference/expressions/array.rst
@@ -9,27 +9,27 @@ The following methods are available under the `expr.arr` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
-    Expr.arr.max
-    Expr.arr.min
-    Expr.arr.median
-    Expr.arr.sum
-    Expr.arr.std
-    Expr.arr.to_list
-    Expr.arr.unique
-    Expr.arr.n_unique
-    Expr.arr.var
     Expr.arr.all
     Expr.arr.any
-    Expr.arr.sort
-    Expr.arr.reverse
-    Expr.arr.arg_min
     Expr.arr.arg_max
-    Expr.arr.get
-    Expr.arr.first
-    Expr.arr.last
-    Expr.arr.join
-    Expr.arr.explode
+    Expr.arr.arg_min
     Expr.arr.contains
     Expr.arr.count_matches
-    Expr.arr.to_struct
+    Expr.arr.explode
+    Expr.arr.first
+    Expr.arr.get
+    Expr.arr.join
+    Expr.arr.last
+    Expr.arr.max
+    Expr.arr.median
+    Expr.arr.min
+    Expr.arr.n_unique
+    Expr.arr.reverse
     Expr.arr.shift
+    Expr.arr.sort
+    Expr.arr.std
+    Expr.arr.sum
+    Expr.arr.to_list
+    Expr.arr.to_struct
+    Expr.arr.unique
+    Expr.arr.var

--- a/py-polars/docs/source/reference/expressions/functions.rst
+++ b/py-polars/docs/source/reference/expressions/functions.rst
@@ -35,9 +35,9 @@ These functions are available from the Polars module root and can be used as exp
    cum_sum
    cum_sum_horizontal
    date
-   datetime
    date_range
    date_ranges
+   datetime
    datetime_range
    datetime_ranges
    duration
@@ -73,12 +73,12 @@ These functions are available from the Polars module root and can be used as exp
    rolling_corr
    rolling_cov
    select
+   sql
+   sql_expr
    std
    struct
    sum
    sum_horizontal
-   sql
-   sql_expr
    tail
    time
    time_range

--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -11,17 +11,18 @@ The following methods are available under the `expr.list` attribute.
 
     Expr.list.all
     Expr.list.any
-    Expr.list.drop_nulls
     Expr.list.arg_max
     Expr.list.arg_min
     Expr.list.concat
     Expr.list.contains
     Expr.list.count_matches
     Expr.list.diff
+    Expr.list.drop_nulls
     Expr.list.eval
     Expr.list.explode
     Expr.list.first
     Expr.list.gather
+    Expr.list.gather_every
     Expr.list.get
     Expr.list.head
     Expr.list.join
@@ -31,6 +32,7 @@ The following methods are available under the `expr.list` attribute.
     Expr.list.mean
     Expr.list.median
     Expr.list.min
+    Expr.list.n_unique
     Expr.list.reverse
     Expr.list.sample
     Expr.list.set_difference
@@ -46,6 +48,4 @@ The following methods are available under the `expr.list` attribute.
     Expr.list.to_array
     Expr.list.to_struct
     Expr.list.unique
-    Expr.list.n_unique
     Expr.list.var
-    Expr.list.gather_every

--- a/py-polars/docs/source/reference/expressions/name.rst
+++ b/py-polars/docs/source/reference/expressions/name.rst
@@ -11,10 +11,10 @@ The following methods are available under the `expr.name` attribute.
 
     Expr.name.keep
     Expr.name.map
+    Expr.name.map_fields
     Expr.name.prefix
+    Expr.name.prefix_fields
     Expr.name.suffix
+    Expr.name.suffix_fields
     Expr.name.to_lowercase
     Expr.name.to_uppercase
-    Expr.name.map_fields
-    Expr.name.prefix_fields
-    Expr.name.suffix_fields

--- a/py-polars/docs/source/reference/expressions/operators.rst
+++ b/py-polars/docs/source/reference/expressions/operators.rst
@@ -42,9 +42,9 @@ Numeric
     Expr.mod
     Expr.mul
     Expr.neg
+    Expr.pow
     Expr.sub
     Expr.truediv
-    Expr.pow
 
 
 Binary

--- a/py-polars/docs/source/reference/expressions/string.rst
+++ b/py-polars/docs/source/reference/expressions/string.rst
@@ -51,7 +51,7 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.to_decimal
     Expr.str.to_integer
     Expr.str.to_lowercase
-    Expr.str.to_titlecase
     Expr.str.to_time
+    Expr.str.to_titlecase
     Expr.str.to_uppercase
     Expr.str.zfill

--- a/py-polars/docs/source/reference/lazyframe/index.rst
+++ b/py-polars/docs/source/reference/lazyframe/index.rst
@@ -11,9 +11,9 @@ This page gives an overview of all public LazyFrame methods.
    aggregation
    attributes
    descriptive
+   group_by
    modify_select
    miscellaneous
-   group_by
    in_process
 
 .. _lazyframe:

--- a/py-polars/docs/source/reference/series/array.rst
+++ b/py-polars/docs/source/reference/series/array.rst
@@ -9,27 +9,27 @@ The following methods are available under the `Series.arr` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
-    Series.arr.max
-    Series.arr.min
-    Series.arr.median
-    Series.arr.sum
-    Series.arr.std
-    Series.arr.to_list
-    Series.arr.unique
-    Series.arr.n_unique
-    Series.arr.var
     Series.arr.all
     Series.arr.any
-    Series.arr.sort
-    Series.arr.reverse
-    Series.arr.arg_min
     Series.arr.arg_max
-    Series.arr.get
-    Series.arr.first
-    Series.arr.last
-    Series.arr.join
-    Series.arr.explode
+    Series.arr.arg_min
     Series.arr.contains
     Series.arr.count_matches
-    Series.arr.to_struct
+    Series.arr.explode
+    Series.arr.first
+    Series.arr.get
+    Series.arr.join
+    Series.arr.last
+    Series.arr.max
+    Series.arr.median
+    Series.arr.min
+    Series.arr.n_unique
+    Series.arr.reverse
     Series.arr.shift
+    Series.arr.sort
+    Series.arr.std
+    Series.arr.sum
+    Series.arr.to_list
+    Series.arr.to_struct
+    Series.arr.unique
+    Series.arr.var

--- a/py-polars/docs/source/reference/series/attributes.rst
+++ b/py-polars/docs/source/reference/series/attributes.rst
@@ -7,6 +7,6 @@ Attributes
    :toctree: api/
 
    Series.dtype
+   Series.flags
    Series.name
    Series.shape
-   Series.flags

--- a/py-polars/docs/source/reference/series/export.rst
+++ b/py-polars/docs/source/reference/series/export.rst
@@ -12,9 +12,9 @@ Export Series data to other formats:
    Series.__arrow_c_stream__
    Series.to_arrow
    Series.to_frame
+   Series.to_init_repr
    Series.to_jax
    Series.to_list
    Series.to_numpy
    Series.to_pandas
-   Series.to_init_repr
    Series.to_torch

--- a/py-polars/docs/source/reference/series/index.rst
+++ b/py-polars/docs/source/reference/series/index.rst
@@ -19,8 +19,8 @@ This page gives an overview of all public Series methods.
    export
    list
    modify_select
-   operators
    miscellaneous
+   operators
    plot
    string
    struct

--- a/py-polars/docs/source/reference/series/list.rst
+++ b/py-polars/docs/source/reference/series/list.rst
@@ -11,17 +11,18 @@ The following methods are available under the `Series.list` attribute.
 
     Series.list.all
     Series.list.any
-    Series.list.drop_nulls
     Series.list.arg_max
     Series.list.arg_min
     Series.list.concat
     Series.list.contains
     Series.list.count_matches
     Series.list.diff
+    Series.list.drop_nulls
     Series.list.eval
     Series.list.explode
     Series.list.first
     Series.list.gather
+    Series.list.gather_every
     Series.list.get
     Series.list.head
     Series.list.join
@@ -31,6 +32,7 @@ The following methods are available under the `Series.list` attribute.
     Series.list.mean
     Series.list.median
     Series.list.min
+    Series.list.n_unique
     Series.list.reverse
     Series.list.sample
     Series.list.set_difference
@@ -46,6 +48,4 @@ The following methods are available under the `Series.list` attribute.
     Series.list.to_array
     Series.list.to_struct
     Series.list.unique
-    Series.list.n_unique
     Series.list.var
-    Series.list.gather_every

--- a/py-polars/docs/source/reference/series/miscellaneous.rst
+++ b/py-polars/docs/source/reference/series/miscellaneous.rst
@@ -7,8 +7,8 @@ Miscellaneous
    :toctree: api/
 
     Series.equals
+    Series.get_chunks
     Series.map_elements
     Series.reinterpret
     Series.set_sorted
     Series.to_physical
-    Series.get_chunks

--- a/py-polars/docs/source/reference/sql/functions/aggregate.rst
+++ b/py-polars/docs/source/reference/sql/functions/aggregate.rst
@@ -202,7 +202,7 @@ Returns the smallest (minimum) of all the elements in the grouping.
 
 STDDEV
 ------
-Returns the standard deviation of all the elements in the grouping.
+Returns the sample standard deviation of all the elements in the grouping.
 
 .. admonition:: Aliases
 


### PR DESCRIPTION
It is evident based on the existing API reference that the methods are intended to be in alphabetical order (and they mostly are).

This does the remainder.

Note that there were a few exceptions where I decided alphabetical order was not better. `strip_chars_end` coming after `strip_chars_start` being one example. Let me know if you have a difference of opinion.