### PR TITLE
perf: Disable Parquet compression in certain situations

### DIFF
--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -123,6 +123,13 @@ impl DataPageHeader {
             DataPageHeader::V2(d) => d.num_values as usize,
         }
     }
+
+    pub fn encoding(&self) -> Encoding {
+        match self {
+            Self::V1(d) => d.encoding(),
+            Self::V2(d) => d.encoding(),
+        }
+    }
 }
 
 /// A [`DataPage`] is an uncompressed, encoded representation of a Parquet data page. It holds actual data


### PR DESCRIPTION
This disables Parquet compression when writing for:
- Dictionary-encoded pages / Boolean RLE-encoded pages
- Pages where the compression turned out to be larger than the uncompressed buffer