### PR TITLE
fix: Mark Expr.(lower|upper)_bound as returning scalar

### DIFF
--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1707,12 +1707,20 @@ impl Expr {
 
     /// Get maximal value that could be hold by this dtype.
     pub fn upper_bound(self) -> Expr {
-        self.map_private(FunctionExpr::UpperBound)
+        self.apply_private(FunctionExpr::UpperBound)
+            .with_function_options(|mut options| {
+                options.flags |= FunctionFlags::RETURNS_SCALAR;
+                options
+            })
     }
 
     /// Get minimal value that could be hold by this dtype.
     pub fn lower_bound(self) -> Expr {
-        self.map_private(FunctionExpr::LowerBound)
+        self.apply_private(FunctionExpr::LowerBound)
+            .with_function_options(|mut options| {
+                options.flags |= FunctionFlags::RETURNS_SCALAR;
+                options
+            })
     }
 
     pub fn reshape(self, dimensions: &[i64], nested_type: NestedType) -> Self {


### PR DESCRIPTION
Necessary for the new streaming engine, but also fixes this (obscure) bug in the current engine:

```python
>>> df = pl.DataFrame({"a": [1, 2, 3, 2, 1]})
>>> df.group_by("a").agg(pl.col("a").lower_bound().alias("lower"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/orlp/.localpython/lib/python3.11/site-packages/polars/dataframe/group_by.py", line 231, in agg
    .collect(no_optimization=True)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/orlp/.localpython/lib/python3.11/site-packages/polars/lazyframe/frame.py", line 2027, in collect
    return wrap_df(ldf.collect(callback))
                   ^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.InvalidOperationError: output length of `map` (1) must be equal to the input length (5); consider using `apply` instead

Error originated in expression: 'col("a").lower_bound()'
```