### PR TITLE
feat: Add support for 31Dec2024-style dates when casting string to date

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/patterns.rs
+++ b/crates/polars-time/src/chunkedarray/string/patterns.rs
@@ -5,6 +5,7 @@ pub(super) static DATE_D_M_Y: &[&str] = &[
     "%d-%m-%Y", // 31-12-2021
     "%d/%m/%Y", // 31/12/2021
     "%d.%m.%Y", // 31.12.2021
+    "%d%b%Y",   // 31Dec2021
 ];
 
 pub(super) static DATE_Y_M_D: &[&str] = &[

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -11,7 +11,7 @@ from hypothesis import given
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ComputeError, InvalidOperationError
-from polars.testing import assert_series_equal, assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -203,3 +203,12 @@ def test_to_datetime_two_digit_year_17213(
 ) -> None:
     result = pl.Series([inputs]).str.to_date(format=format).item()
     assert result == expected
+
+
+def test_ddMonYYY_string_date() -> None:
+    df = pl.DataFrame({"x1": ["01Jan2021"]}).with_columns(
+        **{"x1-date": pl.col("x1").str.to_date()}
+    )
+    expected = pl.DataFrame({"x1-date": [date(2021, 1, 1)]})
+    out = df.select(pl.col("x1-date"))
+    assert_frame_equal(expected, out)

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -11,7 +11,7 @@ from hypothesis import given
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ComputeError, InvalidOperationError
-from polars.testing import assert_series_equal
+from polars.testing import assert_series_equal, assert_frame_equal
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -690,3 +690,12 @@ def test_bool_numeric_supertype(dtype: PolarsDataType) -> None:
     df = pl.DataFrame({"v": [1, 2, 3, 4, 5, 6]})
     result = df.select((pl.col("v") < 3).sum().cast(dtype) / pl.len())
     assert result.item() - 0.3333333 <= 0.00001
+
+
+def test_ddMonYYY_string_date() -> None:
+    df = pl.DataFrame({"x1": ["01Jan2021"]}).with_columns(
+        **{"x1-date": pl.col("x1").cast(pl.Date)}
+    )
+    expected = pl.DataFrame({"x1-date": [date(2021, 1, 1)]})
+    out = df.select(pl.col("x1-date"))
+    assert_frame_equal(expected, out)


### PR DESCRIPTION
Adds support for DMY formatted dates where the month is a three-character string:

```python
pl.DataFrame('x': ['31Dec2024']).with_columns(pl.col('x').cast(pl.Date))
```