### PR TITLE
fix: Support reading empty parquet files

### DIFF
--- a/crates/polars-io/src/parquet/write/writer.rs
+++ b/crates/polars-io/src/parquet/write/writer.rs
@@ -158,3 +158,35 @@ fn encoding_map(data_type: &ArrowDataType) -> Encoding {
         _ => Encoding::Plain,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // use polars::prelude::{DataFrame, ParquetReader, ParquetWriter, PolarsResult, SerReader};
+    use std::io::Cursor;
+
+    use polars_core::prelude::*;
+
+    use super::*;
+    use crate::prelude::{ParquetReader, ParquetWriter, SerReader};
+
+    // polars = { path = "~/src/polars/crates/polars", features = ["lazy", "parquet", "json"]}
+
+    // check round-trip to parquet of empty DataFrame
+    #[test]
+    fn round_trip_no_data() -> Result<(), ParquetError> {
+        let mut src_df = DataFrame::default();
+        let mut data = vec![];
+
+        ParquetWriter::new(&mut data)
+            .finish(&mut src_df)
+            .expect("Failed to write empty data to parquet");
+
+        let read_df = ParquetReader::new(Cursor::new(data)).finish()?;
+
+        // Expect empty Dataframe back
+        let no_cols: Vec<&str> = Vec::new();
+        assert_eq!(read_df.get_column_names(), no_cols);
+        assert_eq!(read_df.shape(), (0, 0));
+        Ok(())
+    }
+}

--- a/crates/polars-parquet/src/parquet/schema/io_thrift/from_thrift.rs
+++ b/crates/polars-parquet/src/parquet/schema/io_thrift/from_thrift.rs
@@ -51,6 +51,12 @@ fn from_thrift_helper(
         // Sometimes parquet-cpp sets num_children field to 0 for primitive types, so we
         // have to handle this case too.
         None | Some(0) => {
+            // empty root
+            if is_root_node {
+                let fields = vec![];
+                let tp = ParquetType::new_root(name, fields);
+                return Ok((index + 1, tp));
+            }
             // primitive type
             let repetition = element
                 .repetition_type

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -26,6 +26,22 @@ def foods_parquet_path(io_files_path: Path) -> Path:
     return io_files_path / "foods1.parquet"
 
 
+@pytest.mark.write_disk()
+def test_empty_parquet(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    file_path_pd = tmp_path / "empty_pd.parquet"
+    file_path_pl = tmp_path / "empty_pl.parquet"
+
+    pd.DataFrame().to_parquet(file_path_pd)
+    pl.DataFrame().write_parquet(file_path_pl)
+
+    empty_from_pd = pl.read_parquet(file_path_pd)
+    assert empty_from_pd.shape == (0, 0)
+
+    empty_from_pl = pl.read_parquet(file_path_pl)
+    assert empty_from_pl.shape == (0, 0)
+
+
 def test_scan_parquet(parquet_file_path: Path) -> None:
     df = pl.scan_parquet(parquet_file_path)
     assert df.collect().shape == (4, 3)


### PR DESCRIPTION
Fix https://github.com/pola-rs/polars/issues/13457

Add support for reading empty parquet files.
I'm new to this project so I could use help with the unit tests that I added to verify correct behavior. I'm not sure if they are in the correct place/am having trouble getting `make test` to pick up the new tests.