### PR TITLE
fix: Parquet nested values that span several pages

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/filter.rs
@@ -22,6 +22,13 @@ impl Filter {
         Filter::Mask(mask)
     }
 
+    pub fn do_include_at(&self, at: usize) -> bool {
+        match self {
+            Filter::Range(range) => range.contains(&at),
+            Filter::Mask(bitmap) => bitmap.get_bit(at),
+        }
+    }
+
     pub(crate) fn num_rows(&self) -> usize {
         match self {
             Filter::Range(range) => range.len(),

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -283,10 +283,6 @@ impl<'a, I, T, C: BatchableCollector<I, T>> BatchedCollector<'a, I, T, C> {
             .push_n_nulls(self.target, self.num_waiting_invalids)?;
         Ok(())
     }
-
-    pub fn collector(&mut self) -> &mut C {
-        &mut self.collector
-    }
 }
 
 pub(crate) type PageValidity<'a> = HybridRleDecoder<'a>;

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -283,6 +283,10 @@ impl<'a, I, T, C: BatchableCollector<I, T>> BatchedCollector<'a, I, T, C> {
             .push_n_nulls(self.target, self.num_waiting_invalids)?;
         Ok(())
     }
+
+    pub fn collector(&mut self) -> &mut C {
+        &mut self.collector
+    }
 }
 
 pub(crate) type PageValidity<'a> = HybridRleDecoder<'a>;
@@ -759,4 +763,14 @@ pub fn freeze_validity(validity: MutableBitmap) -> Option<Bitmap> {
     }
 
     Some(validity)
+}
+
+pub(crate) fn hybrid_rle_count_zeros(
+    decoder: &hybrid_rle::HybridRleDecoder<'_>,
+) -> ParquetResult<usize> {
+    let mut count = ZeroCount::default();
+    decoder
+        .clone()
+        .gather_into(&mut count, &ZeroCountGatherer)?;
+    Ok(count.num_zero)
 }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1690,7 +1690,7 @@ def test_nested_span_multiple_pages_18400() -> None:
 @given(
     df=dataframes(
         min_size=0,
-        max_size=10,
+        max_size=1000,
         min_cols=2,
         max_cols=5,
         excluded_dtypes=[pl.Decimal, pl.Categorical, pl.Enum, pl.Array],

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1659,6 +1659,62 @@ def test_nested_skip_18303(
     assert_frame_equal(scanned, pl.DataFrame(tb).slice(1, 1))
 
 
+def test_nested_span_multiple_pages_18400() -> None:
+    width = 4100
+    df = pl.DataFrame(
+        [
+            pl.Series(
+                "a",
+                [
+                    list(range(width)),
+                    list(range(width)),
+                ],
+                pl.Array(pl.Int64, width),
+            ),
+        ]
+    )
+
+    f = io.BytesIO()
+    pq.write_table(
+        df.to_arrow(),
+        f,
+        use_dictionary=False,
+        data_page_size=1024,
+        column_encoding={"a": "PLAIN"},
+    )
+
+    f.seek(0)
+    assert_frame_equal(df.head(1), pl.read_parquet(f, n_rows=1))
+
+
+@given(
+    df=dataframes(
+        min_size=0,
+        max_size=10,
+        min_cols=2,
+        max_cols=5,
+        excluded_dtypes=[pl.Decimal, pl.Categorical, pl.Enum, pl.Array],
+        include_cols=[column("filter_col", pl.Boolean, allow_null=False)],
+    ),
+)
+@pytest.mark.write_disk()
+@settings(
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_parametric_small_page_mask_filtering(
+    tmp_path: Path,
+    df: pl.DataFrame,
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    f = tmp_path / "test.parquet"
+
+    df.write_parquet(f, data_page_size=1024)
+
+    expr = pl.col("filter_col")
+    result = pl.scan_parquet(f, parallel="prefiltered").filter(expr).collect()
+    assert_frame_equal(result, df.filter(expr))
+
+
 @given(
     df=dataframes(
         min_size=0,


### PR DESCRIPTION
Fixes #18400.

This completely rewrites the logic that deal with decoding filtered nested values. This was needed to accommodate the fact that any kind of row value might span several data pages. This was not really accounted for in the previous implementation and where it worked, it was mostly by coincidence.

This also made it possible to add many fast paths for the decoder that were previously not there. Therefore, I think there are also some performance improvements here, but I am not sure how much.

I also wrote two tests to make sure that it actually works.