### PR TITLE
docs(python): Fix incorrect comments in `group_by_dynamic`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6326,7 +6326,7 @@ class DataFrame:
         │ 2021-12-16 03:00:00 ┆ 6   │
         └─────────────────────┴─────┘
 
-        Group by windows of 1 hour starting at 2021-12-16 00:00:00.
+        Group by windows of 1 hour.
 
         >>> df.group_by_dynamic("time", every="1h", closed="right").agg(pl.col("n"))
         shape: (4, 2)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3823,7 +3823,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 2021-12-16 03:00:00 ┆ 6   │
         └─────────────────────┴─────┘
 
-        Group by windows of 1 hour starting at 2021-12-16 00:00:00.
+        Group by windows of 1 hour.
 
         >>> lf.group_by_dynamic("time", every="1h", closed="right").agg(
         ...     pl.col("n")


### PR DESCRIPTION
The group by window can go back to `2021-12-15 23:00:00` depending on the end-point option `closed` as shown by the code examples. Hence removing the misleading comment "... starting at 2021-12-16 00:00:00".