### PR TITLE
refactor(rust): Group arguments in conversion in a Context

### DIFF
--- a/crates/polars-lazy/src/dsl/functions.rs
+++ b/crates/polars-lazy/src/dsl/functions.rs
@@ -30,8 +30,8 @@ pub(crate) fn concat_impl<L: AsRef<[LazyFrame]>>(
 
     for lf in &mut inputs[1..] {
         // Ensure we enable file caching if any lf has it enabled.
-        if lf.opt_state.contains(OptState::FILE_CACHING) {
-            opt_state |= OptState::FILE_CACHING;
+        if lf.opt_state.contains(OptFlags::FILE_CACHING) {
+            opt_state |= OptFlags::FILE_CACHING;
         }
         let lp = std::mem::take(&mut lf.logical_plan);
         lps.push(lp)
@@ -67,8 +67,8 @@ pub fn concat_lf_horizontal<L: AsRef<[LazyFrame]>>(
 
     for lf in &lfs[1..] {
         // Ensure we enable file caching if any lf has it enabled.
-        if lf.opt_state.contains(OptState::FILE_CACHING) {
-            opt_state |= OptState::FILE_CACHING;
+        if lf.opt_state.contains(OptFlags::FILE_CACHING) {
+            opt_state |= OptFlags::FILE_CACHING;
         }
     }
 

--- a/crates/polars-lazy/src/frame/cached_arenas.rs
+++ b/crates/polars-lazy/src/frame/cached_arenas.rs
@@ -19,7 +19,12 @@ impl LazyFrame {
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<SchemaRef> {
-        let node = to_alp(self.logical_plan.clone(), expr_arena, lp_arena, false, true)?;
+        let node = to_alp(
+            self.logical_plan.clone(),
+            expr_arena,
+            lp_arena,
+            &mut OptState::schema_only(),
+        )?;
 
         let schema = lp_arena.get(node).schema(lp_arena).into_owned();
         // Cache the logical plan so that next schema call is cheap.
@@ -48,8 +53,7 @@ impl LazyFrame {
                     self.logical_plan.clone(),
                     &mut expr_arena,
                     &mut lp_arena,
-                    false,
-                    true,
+                    &mut OptState::schema_only(),
                 )?;
 
                 let schema = lp_arena.get(node).schema(&lp_arena).into_owned();
@@ -83,8 +87,7 @@ impl LazyFrame {
                             self.logical_plan.clone(),
                             &mut arenas.expr_arena,
                             &mut arenas.lp_arena,
-                            false,
-                            true,
+                            &mut OptState::schema_only(),
                         )?;
 
                         let schema = arenas

--- a/crates/polars-lazy/src/frame/cached_arenas.rs
+++ b/crates/polars-lazy/src/frame/cached_arenas.rs
@@ -23,7 +23,7 @@ impl LazyFrame {
             self.logical_plan.clone(),
             expr_arena,
             lp_arena,
-            &mut OptState::schema_only(),
+            &mut OptFlags::schema_only(),
         )?;
 
         let schema = lp_arena.get(node).schema(lp_arena).into_owned();
@@ -53,7 +53,7 @@ impl LazyFrame {
                     self.logical_plan.clone(),
                     &mut expr_arena,
                     &mut lp_arena,
-                    &mut OptState::schema_only(),
+                    &mut OptFlags::schema_only(),
                 )?;
 
                 let schema = lp_arena.get(node).schema(&lp_arena).into_owned();
@@ -87,7 +87,7 @@ impl LazyFrame {
                             self.logical_plan.clone(),
                             &mut arenas.expr_arena,
                             &mut arenas.lp_arena,
-                            &mut OptState::schema_only(),
+                            &mut OptFlags::schema_only(),
                         )?;
 
                         let schema = arenas

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -566,8 +566,7 @@ impl LazyFrame {
             self.logical_plan,
             &mut expr_arena,
             &mut lp_arena,
-            true,
-            true,
+            &mut self.opt_state,
         )?;
         let plan = IRPlan::new(node, lp_arena, expr_arena);
         Ok(plan)

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -282,7 +282,7 @@ impl LazyFileListReader for LazyCsvReader {
         )?
         .build()
         .into();
-        lf.opt_state |= OptState::FILE_CACHING;
+        lf.opt_state |= OptFlags::FILE_CACHING;
         Ok(lf)
     }
 

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -71,7 +71,7 @@ impl LazyFileListReader for LazyIpcReader {
         )?
         .build()
         .into();
-        lf.opt_state |= OptState::FILE_CACHING;
+        lf.opt_state |= OptFlags::FILE_CACHING;
 
         Ok(lf)
     }

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -83,7 +83,7 @@ impl LazyFileListReader for LazyParquetReader {
             lf = lf.with_row_index(&row_index.name, Some(row_index.offset))
         }
 
-        lf.opt_state |= OptState::FILE_CACHING;
+        lf.opt_state |= OptFlags::FILE_CACHING;
         Ok(lf)
     }
 

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -102,7 +102,7 @@ fn filter_added_column_issue_2470() -> PolarsResult<()> {
 fn filter_blocked_by_map() -> PolarsResult<()> {
     let df = fruits_cars();
 
-    let allowed = OptState::default() & !OptState::PREDICATE_PUSHDOWN;
+    let allowed = OptFlags::default() & !OptFlags::PREDICATE_PUSHDOWN;
     let q = df
         .lazy()
         .map(Ok, allowed, None, None)

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -558,7 +558,13 @@ fn test_simplify_expr() {
 
     let mut expr_arena = Arena::new();
     let mut lp_arena = Arena::new();
-    let lp_top = to_alp(plan, &mut expr_arena, &mut lp_arena, true, false).unwrap();
+    let lp_top = to_alp(
+        plan,
+        &mut expr_arena,
+        &mut lp_arena,
+        &mut OptState::schema_only(),
+    )
+    .unwrap();
     let plan = node_to_lp(lp_top, &expr_arena, &mut lp_arena);
     assert!(
         matches!(plan, DslPlan::Select{ expr, ..} if matches!(&expr[0], Expr::BinaryExpr{left, ..} if **left == Expr::Literal(LiteralValue::Float(2.0))))
@@ -637,7 +643,7 @@ fn test_type_coercion() {
 
     let mut expr_arena = Arena::new();
     let mut lp_arena = Arena::new();
-    let lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena, true, true).unwrap();
+    let lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptState::default()).unwrap();
     let lp = node_to_lp(lp_top, &expr_arena, &mut lp_arena);
 
     if let DslPlan::Select { expr, .. } = lp {

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -562,7 +562,7 @@ fn test_simplify_expr() {
         plan,
         &mut expr_arena,
         &mut lp_arena,
-        &mut OptFlags::schema_only(),
+        &mut OptFlags::default(),
     )
     .unwrap();
     let plan = node_to_lp(lp_top, &expr_arena, &mut lp_arena);

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -562,7 +562,7 @@ fn test_simplify_expr() {
         plan,
         &mut expr_arena,
         &mut lp_arena,
-        &mut OptState::schema_only(),
+        &mut OptFlags::schema_only(),
     )
     .unwrap();
     let plan = node_to_lp(lp_top, &expr_arena, &mut lp_arena);
@@ -643,7 +643,7 @@ fn test_type_coercion() {
 
     let mut expr_arena = Arena::new();
     let mut lp_arena = Arena::new();
-    let lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptState::default()).unwrap();
+    let lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptFlags::default()).unwrap();
     let lp = node_to_lp(lp_top, &expr_arena, &mut lp_arena);
 
     if let DslPlan::Select { expr, .. } = lp {

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -558,11 +558,13 @@ fn test_simplify_expr() {
 
     let mut expr_arena = Arena::new();
     let mut lp_arena = Arena::new();
+
+    #[allow(const_item_mutation)]
     let lp_top = to_alp(
         plan,
         &mut expr_arena,
         &mut lp_arena,
-        &mut OptFlags::default(),
+        &mut OptFlags::SIMPLIFY_EXPR,
     )
     .unwrap();
     let plan = node_to_lp(lp_top, &expr_arena, &mut lp_arena);

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -3,7 +3,7 @@ use bitflags::bitflags;
 bitflags! {
 #[derive(Copy, Clone, Debug)]
     /// Allowed optimizations.
-    pub struct OptState: u32 {
+    pub struct OptFlags: u32 {
         /// Only read columns that are used later in the query.
         const PROJECTION_PUSHDOWN = 1;
         /// Apply predicates/filters as early as possible.
@@ -38,13 +38,13 @@ bitflags! {
     }
 }
 
-impl OptState {
+impl OptFlags {
     pub fn schema_only() -> Self {
         Self::TYPE_COERCION
     }
 }
 
-impl Default for OptState {
+impl Default for OptFlags {
     fn default() -> Self {
         Self::from_bits_truncate(u32::MAX) & !Self::NEW_STREAMING & !Self::STREAMING & !Self::EAGER
             // will be toggled by a scan operation such as csv scan or parquet scan
@@ -53,4 +53,4 @@ impl Default for OptState {
 }
 
 /// AllowedOptimizations
-pub type AllowedOptimizations = OptState;
+pub type AllowedOptimizations = OptFlags;

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -38,6 +38,12 @@ bitflags! {
     }
 }
 
+impl OptState {
+    pub fn schema_only() -> Self {
+        Self::TYPE_COERCION
+    }
+}
+
 impl Default for OptState {
     fn default() -> Self {
         Self::from_bits_truncate(u32::MAX) & !Self::NEW_STREAMING & !Self::STREAMING & !Self::EAGER

--- a/crates/polars-plan/src/plans/builder_dsl.rs
+++ b/crates/polars-plan/src/plans/builder_dsl.rs
@@ -431,9 +431,9 @@ impl DslBuilder {
             function: DslFunction::OpaquePython(OpaquePythonUdf {
                 function,
                 schema,
-                predicate_pd: optimizations.contains(OptState::PREDICATE_PUSHDOWN),
-                projection_pd: optimizations.contains(OptState::PROJECTION_PUSHDOWN),
-                streamable: optimizations.contains(OptState::STREAMING),
+                predicate_pd: optimizations.contains(OptFlags::PREDICATE_PUSHDOWN),
+                projection_pd: optimizations.contains(OptFlags::PROJECTION_PUSHDOWN),
+                streamable: optimizations.contains(OptFlags::STREAMING),
                 validate_output,
             }),
         }
@@ -457,9 +457,9 @@ impl DslBuilder {
             function: DslFunction::FunctionIR(FunctionIR::Opaque {
                 function,
                 schema,
-                predicate_pd: optimizations.contains(OptState::PREDICATE_PUSHDOWN),
-                projection_pd: optimizations.contains(OptState::PROJECTION_PUSHDOWN),
-                streamable: optimizations.contains(OptState::STREAMING),
+                predicate_pd: optimizations.contains(OptFlags::PREDICATE_PUSHDOWN),
+                projection_pd: optimizations.contains(OptFlags::PROJECTION_PUSHDOWN),
+                streamable: optimizations.contains(OptFlags::STREAMING),
                 fmt_str: name.into(),
             }),
         }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -56,10 +56,12 @@ pub fn to_alp(
     lp: DslPlan,
     expr_arena: &mut Arena<AExpr>,
     lp_arena: &mut Arena<IR>,
-    simplify_expr: bool,
-    type_coercion: bool,
+    opt_state: &mut OptState,
 ) -> PolarsResult<Node> {
-    let conversion_optimizer = ConversionOptimizer::new(simplify_expr, type_coercion);
+    let conversion_optimizer = ConversionOptimizer::new(
+        opt_state.contains(OptState::SIMPLIFY_EXPR),
+        opt_state.contains(OptState::TYPE_COERCION),
+    );
 
     let mut ctxt = ConversionContext {
         expr_arena,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -56,11 +56,11 @@ pub fn to_alp(
     lp: DslPlan,
     expr_arena: &mut Arena<AExpr>,
     lp_arena: &mut Arena<IR>,
-    opt_state: &mut OptState,
+    opt_state: &mut OptFlags,
 ) -> PolarsResult<Node> {
     let conversion_optimizer = ConversionOptimizer::new(
-        opt_state.contains(OptState::SIMPLIFY_EXPR),
-        opt_state.contains(OptState::TYPE_COERCION),
+        opt_state.contains(OptFlags::SIMPLIFY_EXPR),
+        opt_state.contains(OptFlags::TYPE_COERCION),
     );
 
     let mut ctxt = ConversionContext {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -56,6 +56,7 @@ pub fn to_alp(
     lp: DslPlan,
     expr_arena: &mut Arena<AExpr>,
     lp_arena: &mut Arena<IR>,
+    // Only `SIMPLIFY_EXPR` and `TYPE_COERCION` are respected.
     opt_state: &mut OptFlags,
 ) -> PolarsResult<Node> {
     let conversion_optimizer = ConversionOptimizer::new(

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -59,32 +59,34 @@ pub fn to_alp(
     simplify_expr: bool,
     type_coercion: bool,
 ) -> PolarsResult<Node> {
-    let mut convert = ConversionOptimizer::new(simplify_expr, type_coercion);
-    to_alp_impl(lp, expr_arena, lp_arena, &mut convert)
+    let conversion_optimizer = ConversionOptimizer::new(simplify_expr, type_coercion);
+
+    let mut ctxt = ConversionContext {
+        expr_arena,
+        lp_arena,
+        conversion_optimizer,
+    };
+
+    to_alp_impl(lp, &mut ctxt)
+}
+
+struct ConversionContext<'a> {
+    expr_arena: &'a mut Arena<AExpr>,
+    lp_arena: &'a mut Arena<IR>,
+    conversion_optimizer: ConversionOptimizer,
 }
 
 /// converts LogicalPlan to IR
 /// it adds expressions & lps to the respective arenas as it traverses the plan
 /// finally it returns the top node of the logical plan
 #[recursive]
-pub fn to_alp_impl(
-    lp: DslPlan,
-    expr_arena: &mut Arena<AExpr>,
-    lp_arena: &mut Arena<IR>,
-    convert: &mut ConversionOptimizer,
-) -> PolarsResult<Node> {
+pub fn to_alp_impl(lp: DslPlan, ctxt: &mut ConversionContext) -> PolarsResult<Node> {
     let owned = Arc::unwrap_or_clone;
 
-    fn run_conversion(
-        lp: IR,
-        lp_arena: &mut Arena<IR>,
-        expr_arena: &mut Arena<AExpr>,
-        convert: &mut ConversionOptimizer,
-        name: &str,
-    ) -> PolarsResult<Node> {
-        let lp_node = lp_arena.add(lp);
-        convert
-            .coerce_types(expr_arena, lp_arena, lp_node)
+    fn run_conversion(lp: IR, ctxt: &mut ConversionContext, name: &str) -> PolarsResult<Node> {
+        let lp_node = ctxt.lp_arena.add(lp);
+        ctxt.conversion_optimizer
+            .coerce_types(ctxt.expr_arena, ctxt.lp_arena, lp_node)
             .map_err(|e| e.context(format!("'{name}' failed").into()))?;
 
         Ok(lp_node)
@@ -255,7 +257,7 @@ pub fn to_alp_impl(
                 hive_parts,
                 output_schema: None,
                 predicate: predicate
-                    .map(|expr| to_expr_ir(expr, expr_arena))
+                    .map(|expr| to_expr_ir(expr, ctxt.expr_arena))
                     .transpose()?,
                 scan_type,
                 file_options,
@@ -266,16 +268,17 @@ pub fn to_alp_impl(
         DslPlan::Union { inputs, args } => {
             let mut inputs = inputs
                 .into_iter()
-                .map(|lp| to_alp_impl(lp, expr_arena, lp_arena, convert))
+                .map(|lp| to_alp_impl(lp, ctxt))
                 .collect::<PolarsResult<Vec<_>>>()
                 .map_err(|e| e.context(failed_input!(vertical concat)))?;
 
             if args.diagonal {
-                inputs = convert_utils::convert_diagonal_concat(inputs, lp_arena, expr_arena)?;
+                inputs =
+                    convert_utils::convert_diagonal_concat(inputs, ctxt.lp_arena, ctxt.expr_arena)?;
             }
 
             if args.to_supertypes {
-                convert_utils::convert_st_union(&mut inputs, lp_arena, expr_arena)
+                convert_utils::convert_st_union(&mut inputs, ctxt.lp_arena, ctxt.expr_arena)
                     .map_err(|e| e.context(failed_input!(vertical concat)))?;
             }
             let options = args.into();
@@ -284,11 +287,11 @@ pub fn to_alp_impl(
         DslPlan::HConcat { inputs, options } => {
             let inputs = inputs
                 .into_iter()
-                .map(|lp| to_alp_impl(lp, expr_arena, lp_arena, convert))
+                .map(|lp| to_alp_impl(lp, ctxt))
                 .collect::<PolarsResult<Vec<_>>>()
                 .map_err(|e| e.context(failed_input!(horizontal concat)))?;
 
-            let schema = convert_utils::h_concat_schema(&inputs, lp_arena)?;
+            let schema = convert_utils::h_concat_schema(&inputs, ctxt.lp_arena)?;
 
             IR::HConcat {
                 inputs,
@@ -297,14 +300,14 @@ pub fn to_alp_impl(
             }
         },
         DslPlan::Filter { input, predicate } => {
-            let mut input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(filter)))?;
-            let predicate = expand_filter(predicate, input, lp_arena)
+            let mut input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(filter)))?;
+            let predicate = expand_filter(predicate, input, ctxt.lp_arena)
                 .map_err(|e| e.context(failed_here!(filter)))?;
 
-            let predicate_ae = to_expr_ir(predicate.clone(), expr_arena)?;
+            let predicate_ae = to_expr_ir(predicate.clone(), ctxt.expr_arena)?;
 
-            return if is_streamable(predicate_ae.node(), expr_arena, Context::Default) {
+            return if is_streamable(predicate_ae.node(), ctxt.expr_arena, Context::Default) {
                 // Split expression that are ANDed into multiple Filter nodes as the optimizer can then
                 // push them down independently. Especially if they refer columns from different tables
                 // this will be more performant.
@@ -329,24 +332,26 @@ pub fn to_alp_impl(
                 }
 
                 for predicate in predicates {
-                    let predicate = to_expr_ir(predicate, expr_arena)?;
-                    convert.push_scratch(predicate.node(), expr_arena);
+                    let predicate = to_expr_ir(predicate, ctxt.expr_arena)?;
+                    ctxt.conversion_optimizer
+                        .push_scratch(predicate.node(), ctxt.expr_arena);
                     let lp = IR::Filter { input, predicate };
-                    input = run_conversion(lp, lp_arena, expr_arena, convert, "filter")?;
+                    input = run_conversion(lp, ctxt, "filter")?;
                 }
                 Ok(input)
             } else {
-                convert.push_scratch(predicate_ae.node(), expr_arena);
+                ctxt.conversion_optimizer
+                    .push_scratch(predicate_ae.node(), ctxt.expr_arena);
                 let lp = IR::Filter {
                     input,
                     predicate: predicate_ae,
                 };
-                run_conversion(lp, lp_arena, expr_arena, convert, "filter")
+                run_conversion(lp, ctxt, "filter")
             };
         },
         DslPlan::Slice { input, offset, len } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(slice)))?;
+            let input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(slice)))?;
             IR::Slice { input, offset, len }
         },
         DslPlan::DataFrameScan {
@@ -359,7 +364,7 @@ pub fn to_alp_impl(
             schema,
             output_schema,
             filter: selection
-                .map(|expr| to_expr_ir(expr, expr_arena))
+                .map(|expr| to_expr_ir(expr, ctxt.expr_arena))
                 .transpose()?,
         },
         DslPlan::Select {
@@ -367,19 +372,20 @@ pub fn to_alp_impl(
             input,
             options,
         } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(select)))?;
-            let schema = lp_arena.get(input).schema(lp_arena);
+            let input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(select)))?;
+            let schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
             let (exprs, schema) =
                 prepare_projection(expr, &schema).map_err(|e| e.context(failed_here!(select)))?;
 
             if exprs.is_empty() {
-                lp_arena.replace(input, empty_df());
+                ctxt.lp_arena.replace(input, empty_df());
             }
 
             let schema = Arc::new(schema);
-            let eirs = to_expr_irs(exprs, expr_arena)?;
-            convert.fill_scratch(&eirs, expr_arena);
+            let eirs = to_expr_irs(exprs, ctxt.expr_arena)?;
+            ctxt.conversion_optimizer
+                .fill_scratch(&eirs, ctxt.expr_arena);
 
             let lp = IR::Select {
                 expr: eirs,
@@ -388,7 +394,7 @@ pub fn to_alp_impl(
                 options,
             };
 
-            return run_conversion(lp, lp_arena, expr_arena, convert, "select");
+            return run_conversion(lp, ctxt, "select");
         },
         DslPlan::Sort {
             input,
@@ -416,8 +422,8 @@ pub fn to_alp_impl(
                 ComputeError: "the length of `nulls_last` ({}) does not match the length of `by` ({})", n_nulls_last, by_column.len()
             );
 
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(sort)))?;
+            let input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(sort)))?;
 
             let mut expanded_cols = Vec::new();
             let mut nulls_last = Vec::new();
@@ -433,7 +439,7 @@ pub fn to_alp_impl(
                     .cycle()
                     .zip(sort_options.descending.iter().cycle()),
             ) {
-                let exprs = expand_expressions(input, vec![c], lp_arena, expr_arena)
+                let exprs = expand_expressions(input, vec![c], ctxt.lp_arena, ctxt.expr_arena)
                     .map_err(|e| e.context(failed_here!(sort)))?;
 
                 nulls_last.extend(std::iter::repeat(n).take(exprs.len()));
@@ -443,7 +449,8 @@ pub fn to_alp_impl(
             sort_options.nulls_last = nulls_last;
             sort_options.descending = descending;
 
-            convert.fill_scratch(&expanded_cols, expr_arena);
+            ctxt.conversion_optimizer
+                .fill_scratch(&expanded_cols, ctxt.expr_arena);
             let by_column = expanded_cols;
 
             let lp = IR::Sort {
@@ -453,15 +460,15 @@ pub fn to_alp_impl(
                 sort_options,
             };
 
-            return run_conversion(lp, lp_arena, expr_arena, convert, "sort");
+            return run_conversion(lp, ctxt, "sort");
         },
         DslPlan::Cache {
             input,
             id,
             cache_hits,
         } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(cache)))?;
+            let input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(cache)))?;
             IR::Cache {
                 input,
                 id,
@@ -476,11 +483,11 @@ pub fn to_alp_impl(
             maintain_order,
             options,
         } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(group_by)))?;
+            let input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(group_by)))?;
 
             let (keys, aggs, schema) =
-                resolve_group_by(input, keys, aggs, &options, lp_arena, expr_arena)
+                resolve_group_by(input, keys, aggs, &options, ctxt.lp_arena, ctxt.expr_arena)
                     .map_err(|e| e.context(failed_here!(group_by)))?;
 
             let (apply, schema) = if let Some((apply, schema)) = apply {
@@ -489,8 +496,10 @@ pub fn to_alp_impl(
                 (None, schema)
             };
 
-            convert.fill_scratch(&keys, expr_arena);
-            convert.fill_scratch(&aggs, expr_arena);
+            ctxt.conversion_optimizer
+                .fill_scratch(&keys, ctxt.expr_arena);
+            ctxt.conversion_optimizer
+                .fill_scratch(&aggs, ctxt.expr_arena);
 
             let lp = IR::GroupBy {
                 input,
@@ -502,7 +511,7 @@ pub fn to_alp_impl(
                 options,
             };
 
-            return run_conversion(lp, lp_arena, expr_arena, convert, "group_by");
+            return run_conversion(lp, ctxt, "group_by");
         },
         DslPlan::Join {
             input_left,
@@ -546,20 +555,20 @@ pub fn to_alp_impl(
                 );
             }
 
-            let input_left = to_alp_impl(owned(input_left), expr_arena, lp_arena, convert)
+            let input_left = to_alp_impl(owned(input_left), ctxt)
                 .map_err(|e| e.context(failed_input!(join left)))?;
-            let input_right = to_alp_impl(owned(input_right), expr_arena, lp_arena, convert)
+            let input_right = to_alp_impl(owned(input_right), ctxt)
                 .map_err(|e| e.context(failed_input!(join, right)))?;
 
-            let schema_left = lp_arena.get(input_left).schema(lp_arena);
-            let schema_right = lp_arena.get(input_right).schema(lp_arena);
+            let schema_left = ctxt.lp_arena.get(input_left).schema(ctxt.lp_arena);
+            let schema_right = ctxt.lp_arena.get(input_right).schema(ctxt.lp_arena);
 
             let schema =
                 det_join_schema(&schema_left, &schema_right, &left_on, &right_on, &options)
                     .map_err(|e| e.context(failed_here!(join schema resolving)))?;
 
-            let left_on = to_expr_irs_ignore_alias(left_on, expr_arena)?;
-            let right_on = to_expr_irs_ignore_alias(right_on, expr_arena)?;
+            let left_on = to_expr_irs_ignore_alias(left_on, ctxt.expr_arena)?;
+            let right_on = to_expr_irs_ignore_alias(right_on, ctxt.expr_arena)?;
             let mut joined_on = PlHashSet::new();
             for (l, r) in left_on.iter().zip(right_on.iter()) {
                 polars_ensure!(
@@ -571,13 +580,15 @@ pub fn to_alp_impl(
             }
             drop(joined_on);
 
-            convert.fill_scratch(&left_on, expr_arena);
-            convert.fill_scratch(&right_on, expr_arena);
+            ctxt.conversion_optimizer
+                .fill_scratch(&left_on, ctxt.expr_arena);
+            ctxt.conversion_optimizer
+                .fill_scratch(&right_on, ctxt.expr_arena);
 
             // Every expression must be elementwise so that we are
             // guaranteed the keys for a join are all the same length.
             let all_elementwise =
-                |aexprs: &[ExprIR]| all_streamable(aexprs, &*expr_arena, Context::Default);
+                |aexprs: &[ExprIR]| all_streamable(aexprs, &*ctxt.expr_arena, Context::Default);
             polars_ensure!(
                 all_elementwise(&left_on) && all_elementwise(&right_on),
                 InvalidOperation: "All join key expressions must be elementwise."
@@ -590,31 +601,33 @@ pub fn to_alp_impl(
                 right_on,
                 options,
             };
-            return run_conversion(lp, lp_arena, expr_arena, convert, "join");
+            return run_conversion(lp, ctxt, "join");
         },
         DslPlan::HStack {
             input,
             exprs,
             options,
         } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
+            let input = to_alp_impl(owned(input), ctxt)
                 .map_err(|e| e.context(failed_input!(with_columns)))?;
-            let (exprs, schema) = resolve_with_columns(exprs, input, lp_arena, expr_arena)
-                .map_err(|e| e.context(failed_here!(with_columns)))?;
+            let (exprs, schema) =
+                resolve_with_columns(exprs, input, ctxt.lp_arena, ctxt.expr_arena)
+                    .map_err(|e| e.context(failed_here!(with_columns)))?;
 
-            convert.fill_scratch(&exprs, expr_arena);
+            ctxt.conversion_optimizer
+                .fill_scratch(&exprs, ctxt.expr_arena);
             let lp = IR::HStack {
                 input,
                 exprs,
                 schema,
                 options,
             };
-            return run_conversion(lp, lp_arena, expr_arena, convert, "with_columns");
+            return run_conversion(lp, ctxt, "with_columns");
         },
         DslPlan::Distinct { input, options } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(unique)))?;
-            let input_schema = lp_arena.get(input).schema(lp_arena);
+            let input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(unique)))?;
+            let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
 
             let subset = options
                 .subset
@@ -630,10 +643,10 @@ pub fn to_alp_impl(
             IR::Distinct { input, options }
         },
         DslPlan::MapFunction { input, function } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert).map_err(|e| {
+            let input = to_alp_impl(owned(input), ctxt).map_err(|e| {
                 e.context(failed_input_args!(format!("{}", function).to_lowercase()))
             })?;
-            let input_schema = lp_arena.get(input).schema(lp_arena);
+            let input_schema = ctxt.lp_arena.get(input).schema(ctxt.lp_arena);
 
             match function {
                 DslFunction::Explode {
@@ -651,7 +664,7 @@ pub fn to_alp_impl(
                         schema: Default::default(),
                     };
                     let ir = IR::MapFunction { input, function };
-                    return Ok(lp_arena.add(ir));
+                    return Ok(ctxt.lp_arena.add(ir));
                 },
                 DslFunction::FillNan(fill_value) => {
                     let exprs = input_schema
@@ -664,10 +677,12 @@ pub fn to_alp_impl(
                         })
                         .collect::<Vec<_>>();
 
-                    let (exprs, schema) = resolve_with_columns(exprs, input, lp_arena, expr_arena)
-                        .map_err(|e| e.context(failed_here!(fill_nan)))?;
+                    let (exprs, schema) =
+                        resolve_with_columns(exprs, input, ctxt.lp_arena, ctxt.expr_arena)
+                            .map_err(|e| e.context(failed_here!(fill_nan)))?;
 
-                    convert.fill_scratch(&exprs, expr_arena);
+                    ctxt.conversion_optimizer
+                        .fill_scratch(&exprs, ctxt.expr_arena);
 
                     let lp = IR::HStack {
                         input,
@@ -678,7 +693,7 @@ pub fn to_alp_impl(
                             ..Default::default()
                         },
                     };
-                    return run_conversion(lp, lp_arena, expr_arena, convert, "fill_nan");
+                    return run_conversion(lp, ctxt, "fill_nan");
                 },
                 DslFunction::Drop(DropFunction { to_drop, strict }) => {
                     let to_drop = expand_selectors(to_drop, &input_schema, &[])?;
@@ -703,7 +718,7 @@ pub fn to_alp_impl(
                     }
 
                     if output_schema.is_empty() {
-                        lp_arena.replace(input, empty_df());
+                        ctxt.lp_arena.replace(input, empty_df());
                     }
 
                     IR::SimpleProjection {
@@ -759,9 +774,10 @@ pub fn to_alp_impl(
                         &input_schema,
                         Context::Default,
                     )?);
-                    let eirs = to_expr_irs(exprs, expr_arena)?;
+                    let eirs = to_expr_irs(exprs, ctxt.expr_arena)?;
 
-                    convert.fill_scratch(&eirs, expr_arena);
+                    ctxt.conversion_optimizer
+                        .fill_scratch(&eirs, ctxt.expr_arena);
 
                     let lp = IR::Select {
                         input,
@@ -772,7 +788,7 @@ pub fn to_alp_impl(
                             ..Default::default()
                         },
                     };
-                    return run_conversion(lp, lp_arena, expr_arena, convert, "stats");
+                    return run_conversion(lp, ctxt, "stats");
                 },
                 _ => {
                     let function = function.into_function_ir(&input_schema)?;
@@ -781,17 +797,17 @@ pub fn to_alp_impl(
             }
         },
         DslPlan::ExtContext { input, contexts } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
+            let input = to_alp_impl(owned(input), ctxt)
                 .map_err(|e| e.context(failed_input!(with_context)))?;
             let contexts = contexts
                 .into_iter()
-                .map(|lp| to_alp_impl(lp, expr_arena, lp_arena, convert))
+                .map(|lp| to_alp_impl(lp, ctxt))
                 .collect::<PolarsResult<Vec<_>>>()
                 .map_err(|e| e.context(failed_here!(with_context)))?;
 
-            let mut schema = (**lp_arena.get(input).schema(lp_arena)).clone();
+            let mut schema = (**ctxt.lp_arena.get(input).schema(ctxt.lp_arena)).clone();
             for input in &contexts {
-                let other_schema = lp_arena.get(*input).schema(lp_arena);
+                let other_schema = ctxt.lp_arena.get(*input).schema(ctxt.lp_arena);
                 for fld in other_schema.iter_fields() {
                     if schema.get(fld.name()).is_none() {
                         schema.with_column(fld.name, fld.dtype);
@@ -806,22 +822,22 @@ pub fn to_alp_impl(
             }
         },
         DslPlan::Sink { input, payload } => {
-            let input = to_alp_impl(owned(input), expr_arena, lp_arena, convert)
-                .map_err(|e| e.context(failed_input!(sink)))?;
+            let input =
+                to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_input!(sink)))?;
             IR::Sink { input, payload }
         },
         DslPlan::IR { node, dsl, version } => {
             return if node.is_some()
-                && version == lp_arena.version()
-                && convert.used_arenas.insert(version)
+                && version == ctxt.lp_arena.version()
+                && ctxt.conversion_optimizer.used_arenas.insert(version)
             {
                 Ok(node.unwrap())
             } else {
-                to_alp_impl(owned(dsl), expr_arena, lp_arena, convert)
+                to_alp_impl(owned(dsl), ctxt)
             }
         },
     };
-    Ok(lp_arena.add(v))
+    Ok(ctxt.lp_arena.add(v))
 }
 
 /// Expand scan paths if they were not already expanded.

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -633,7 +633,7 @@ mod test {
             .build();
 
         let mut lp_top =
-            to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptState::default()).unwrap();
+            to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptFlags::default()).unwrap();
         lp_top = optimizer
             .optimize_loop(rules, &mut expr_arena, &mut lp_arena, lp_top)
             .unwrap();
@@ -649,7 +649,7 @@ mod test {
             .project(expr_in, Default::default())
             .build();
         let mut lp_top =
-            to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptState::default()).unwrap();
+            to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptFlags::default()).unwrap();
         lp_top = optimizer
             .optimize_loop(rules, &mut expr_arena, &mut lp_arena, lp_top)
             .unwrap();

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -632,7 +632,8 @@ mod test {
             .project(expr_in.clone(), Default::default())
             .build();
 
-        let mut lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena, true, true).unwrap();
+        let mut lp_top =
+            to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptState::default()).unwrap();
         lp_top = optimizer
             .optimize_loop(rules, &mut expr_arena, &mut lp_arena, lp_top)
             .unwrap();
@@ -647,7 +648,8 @@ mod test {
         let lp = DslBuilder::from_existing_df(df)
             .project(expr_in, Default::default())
             .build();
-        let mut lp_top = to_alp(lp, &mut expr_arena, &mut lp_arena, true, true).unwrap();
+        let mut lp_top =
+            to_alp(lp, &mut expr_arena, &mut lp_arena, &mut OptState::default()).unwrap();
         lp_top = optimizer
             .optimize_loop(rules, &mut expr_arena, &mut lp_arena, lp_top)
             .unwrap();

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -247,7 +247,12 @@ impl DslPlan {
         let mut lp_arena = Arena::with_capacity(16);
         let mut expr_arena = Arena::with_capacity(16);
 
-        let node = to_alp(self, &mut expr_arena, &mut lp_arena, true, true)?;
+        let node = to_alp(
+            self,
+            &mut expr_arena,
+            &mut lp_arena,
+            &mut OptState::default(),
+        )?;
         let plan = IRPlan::new(node, lp_arena, expr_arena);
 
         Ok(plan)

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -251,7 +251,7 @@ impl DslPlan {
             self,
             &mut expr_arena,
             &mut lp_arena,
-            &mut OptState::default(),
+            &mut OptFlags::default(),
         )?;
         let plan = IRPlan::new(node, lp_arena, expr_arena);
 

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -34,7 +34,7 @@ use slice_pushdown_lp::SlicePushDown;
 pub use stack_opt::{OptimizationRule, StackOptimizer};
 
 use self::flatten_union::FlattenUnionRule;
-pub use crate::frame::{AllowedOptimizations, OptState};
+pub use crate::frame::{AllowedOptimizations, OptFlags};
 pub use crate::plans::conversion::type_coercion::TypeCoercionRule;
 use crate::plans::optimizer::count_star::CountStar;
 #[cfg(feature = "cse")]
@@ -59,7 +59,7 @@ pub(crate) fn init_hashmap<K, V>(max_len: Option<usize>) -> PlHashMap<K, V> {
 
 pub fn optimize(
     logical_plan: DslPlan,
-    mut opt_state: OptState,
+    mut opt_state: OptFlags,
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
     scratch: &mut Vec<Node>,
@@ -75,27 +75,27 @@ pub fn optimize(
     let mut lp_top = to_alp(logical_plan, expr_arena, lp_arena, &mut opt_state)?;
 
     // get toggle values
-    let cluster_with_columns = opt_state.contains(OptState::CLUSTER_WITH_COLUMNS);
-    let predicate_pushdown = opt_state.contains(OptState::PREDICATE_PUSHDOWN);
-    let projection_pushdown = opt_state.contains(OptState::PROJECTION_PUSHDOWN);
-    let simplify_expr = opt_state.contains(OptState::SIMPLIFY_EXPR);
-    let slice_pushdown = opt_state.contains(OptState::SLICE_PUSHDOWN);
-    let streaming = opt_state.contains(OptState::STREAMING);
-    let fast_projection = opt_state.contains(OptState::FAST_PROJECTION);
+    let cluster_with_columns = opt_state.contains(OptFlags::CLUSTER_WITH_COLUMNS);
+    let predicate_pushdown = opt_state.contains(OptFlags::PREDICATE_PUSHDOWN);
+    let projection_pushdown = opt_state.contains(OptFlags::PROJECTION_PUSHDOWN);
+    let simplify_expr = opt_state.contains(OptFlags::SIMPLIFY_EXPR);
+    let slice_pushdown = opt_state.contains(OptFlags::SLICE_PUSHDOWN);
+    let streaming = opt_state.contains(OptFlags::STREAMING);
+    let fast_projection = opt_state.contains(OptFlags::FAST_PROJECTION);
 
     // Don't run optimizations that don't make sense on a single node.
     // This keeps eager execution more snappy.
-    let eager = opt_state.contains(OptState::EAGER);
+    let eager = opt_state.contains(OptFlags::EAGER);
     #[cfg(feature = "cse")]
-    let comm_subplan_elim = opt_state.contains(OptState::COMM_SUBPLAN_ELIM) && !eager;
+    let comm_subplan_elim = opt_state.contains(OptFlags::COMM_SUBPLAN_ELIM) && !eager;
 
     #[cfg(feature = "cse")]
-    let comm_subexpr_elim = opt_state.contains(OptState::COMM_SUBEXPR_ELIM) && !eager;
+    let comm_subexpr_elim = opt_state.contains(OptFlags::COMM_SUBEXPR_ELIM) && !eager;
     #[cfg(not(feature = "cse"))]
     let comm_subexpr_elim = false;
 
     #[allow(unused_variables)]
-    let agg_scan_projection = opt_state.contains(OptState::FILE_CACHING) && !streaming && !eager;
+    let agg_scan_projection = opt_state.contains(OptFlags::FILE_CACHING) && !streaming && !eager;
 
     // During debug we check if the optimizations have not modified the final schema.
     #[cfg(debug_assertions)]

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -18,7 +18,12 @@ impl DslPlan {
     pub fn compute_schema(&self) -> PolarsResult<SchemaRef> {
         let mut lp_arena = Default::default();
         let mut expr_arena = Default::default();
-        let node = to_alp(self.clone(), &mut expr_arena, &mut lp_arena, false, true)?;
+        let node = to_alp(
+            self.clone(),
+            &mut expr_arena,
+            &mut lp_arena,
+            &mut OptState::schema_only(),
+        )?;
 
         Ok(lp_arena.get(node).schema(&lp_arena).into_owned())
     }

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -22,7 +22,7 @@ impl DslPlan {
             self.clone(),
             &mut expr_arena,
             &mut lp_arena,
-            &mut OptState::schema_only(),
+            &mut OptFlags::schema_only(),
         )?;
 
         Ok(lp_arena.get(node).schema(&lp_arena).into_owned())

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -1126,11 +1126,11 @@ impl PyLazyFrame {
         schema: Option<Wrap<Schema>>,
         validate_output: bool,
     ) -> Self {
-        let mut opt = OptState::default();
-        opt.set(OptState::PREDICATE_PUSHDOWN, predicate_pushdown);
-        opt.set(OptState::PROJECTION_PUSHDOWN, projection_pushdown);
-        opt.set(OptState::SLICE_PUSHDOWN, slice_pushdown);
-        opt.set(OptState::STREAMING, streamable);
+        let mut opt = OptFlags::default();
+        opt.set(OptFlags::PREDICATE_PUSHDOWN, predicate_pushdown);
+        opt.set(OptFlags::PROJECTION_PUSHDOWN, projection_pushdown);
+        opt.set(OptFlags::SLICE_PUSHDOWN, slice_pushdown);
+        opt.set(OptFlags::STREAMING, streamable);
 
         self.ldf
             .clone()


### PR DESCRIPTION
This is preparation for a fix where we set `CSE` in eager if we apply expression expansion.  This is required as those expressions look stateful in the API, whilst it actually is syntactic sugar for multiple expressions. `CSE` will hide the symptoms here and align with expectation (except for random).