### PR TITLE
refactor: rename delimiter to separator

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -4,7 +4,7 @@ use polars_core::prelude::arity::unary_elementwise;
 use polars_core::prelude::*;
 
 // Vertically concatenate all strings in a StringChunked.
-pub fn str_join(ca: &StringChunked, delimiter: &str, ignore_nulls: bool) -> StringChunked {
+pub fn str_join(ca: &StringChunked, separator: &str, ignore_nulls: bool) -> StringChunked {
     if ca.is_empty() {
         return StringChunked::new(ca.name(), &[""]);
     }
@@ -24,14 +24,14 @@ pub fn str_join(ca: &StringChunked, delimiter: &str, ignore_nulls: bool) -> Stri
     }
 
     // Calculate capacity.
-    let capacity = ca.get_values_size() + delimiter.len() * (ca.len() - 1);
+    let capacity = ca.get_values_size() + separator.len() * (ca.len() - 1);
 
     let mut buf = String::with_capacity(capacity);
     let mut first = true;
     ca.for_each(|val| {
         if let Some(val) = val {
             if !first {
-                buf.push_str(delimiter);
+                buf.push_str(separator);
             }
             buf.push_str(val);
             first = false;
@@ -57,7 +57,7 @@ enum ColumnIter<I, T> {
 /// Each array should have length 1 or a length equal to the maximum length.
 pub fn hor_str_concat(
     cas: &[&StringChunked],
-    delimiter: &str,
+    separator: &str,
     ignore_nulls: bool,
 ) -> PolarsResult<StringChunked> {
     if cas.is_empty() {
@@ -115,7 +115,7 @@ pub fn hor_str_concat(
 
             if let Some(s) = val {
                 if found_not_null_value {
-                    buf.push_str(delimiter);
+                    buf.push_str(separator);
                 }
                 buf.push_str(s);
                 found_not_null_value = true;

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -9,7 +9,7 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, separator: &str, ignore_nulls: bool) -
     Expr::Function {
         input,
         function: StringFunction::ConcatHorizontal {
-            delimiter: separator,
+            separator,
             ignore_nulls,
         }
         .into(),

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -327,13 +327,13 @@ impl StringNameSpace {
     /// Concat the values into a string array.
     /// # Arguments
     ///
-    /// * `delimiter` - A string that will act as delimiter between values.
+    /// * `separator` - A string that will act as separator between values.
     #[cfg(feature = "concat_str")]
-    pub fn join(self, delimiter: &str, ignore_nulls: bool) -> Expr {
+    pub fn join(self, separator: &str, ignore_nulls: bool) -> Expr {
         self.0
             .apply_private(
                 StringFunction::ConcatVertical {
-                    delimiter: delimiter.to_owned(),
+                    separator: separator.to_owned(),
                     ignore_nulls,
                 }
                 .into(),

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr.rs
@@ -325,7 +325,7 @@ fn string_addition_to_linear_concat(
                         input: input_left,
                         function:
                             ref fun_l @ FunctionExpr::StringExpr(StringFunction::ConcatHorizontal {
-                                delimiter: sep_l,
+                                separator: sep_l,
                                 ignore_nulls: ignore_nulls_l,
                             }),
                         options,
@@ -334,7 +334,7 @@ fn string_addition_to_linear_concat(
                         input: input_right,
                         function:
                             FunctionExpr::StringExpr(StringFunction::ConcatHorizontal {
-                                delimiter: sep_r,
+                                separator: sep_r,
                                 ignore_nulls: ignore_nulls_r,
                             }),
                         ..
@@ -359,7 +359,7 @@ fn string_addition_to_linear_concat(
                         input,
                         function:
                             ref fun @ FunctionExpr::StringExpr(StringFunction::ConcatHorizontal {
-                                delimiter: sep,
+                                separator: sep,
                                 ignore_nulls,
                             }),
                         options,
@@ -385,7 +385,7 @@ fn string_addition_to_linear_concat(
                         input: input_right,
                         function:
                             ref fun @ FunctionExpr::StringExpr(StringFunction::ConcatHorizontal {
-                                delimiter: sep,
+                                separator: sep,
                                 ignore_nulls,
                             }),
                         options,
@@ -407,7 +407,7 @@ fn string_addition_to_linear_concat(
                 _ => Some(AExpr::Function {
                     input: vec![left_e, right_e],
                     function: StringFunction::ConcatHorizontal {
-                        delimiter: "".to_string(),
+                        separator: "".to_string(),
                         ignore_nulls: false,
                     }
                     .into(),

--- a/crates/polars-plan/src/plans/optimizer/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_functions.rs
@@ -41,7 +41,7 @@ pub(super) fn optimize_functions(
         // flatten nested concat_str calls
         #[cfg(all(feature = "strings", feature = "concat_str"))]
         function @ FunctionExpr::StringExpr(StringFunction::ConcatHorizontal {
-            delimiter: sep,
+            separator: sep,
             ignore_nulls,
         }) if sep.is_empty() => {
             if input
@@ -258,7 +258,7 @@ pub(super) fn optimize_functions(
 fn is_string_concat(ae: &AExpr, ignore_nulls: bool) -> bool {
     matches!(ae, AExpr::Function {
                 function:FunctionExpr::StringExpr(
-                    StringFunction::ConcatHorizontal{delimiter: sep, ignore_nulls: func_inore_nulls},
+                    StringFunction::ConcatHorizontal{separator: sep, ignore_nulls: func_inore_nulls},
                 ),
                 ..
             } if sep.is_empty() && *func_inore_nulls == ignore_nulls)
@@ -275,7 +275,7 @@ fn get_string_concat_input(
             input,
             function:
                 FunctionExpr::StringExpr(StringFunction::ConcatHorizontal {
-                    delimiter: sep,
+                    separator: sep,
                     ignore_nulls: func_ignore_nulls,
                 }),
             ..

--- a/crates/polars-python/src/expr/string.rs
+++ b/crates/polars-python/src/expr/string.rs
@@ -7,11 +7,11 @@ use crate::PyExpr;
 
 #[pymethods]
 impl PyExpr {
-    fn str_join(&self, delimiter: &str, ignore_nulls: bool) -> Self {
+    fn str_join(&self, separator: &str, ignore_nulls: bool) -> Self {
         self.inner
             .clone()
             .str()
-            .join(delimiter, ignore_nulls)
+            .join(separator, ignore_nulls)
             .into()
     }
 

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -759,20 +759,20 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 },
                 FunctionExpr::StringExpr(strfun) => match strfun {
                     StringFunction::ConcatHorizontal {
-                        delimiter,
+                        separator,
                         ignore_nulls,
                     } => (
                         PyStringFunction::ConcatHorizontal.into_py(py),
-                        delimiter,
+                        separator,
                         ignore_nulls,
                     )
                         .to_object(py),
                     StringFunction::ConcatVertical {
-                        delimiter,
+                        separator,
                         ignore_nulls,
                     } => (
                         PyStringFunction::ConcatVertical.into_py(py),
-                        delimiter,
+                        separator,
                         ignore_nulls,
                     )
                         .to_object(py),

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -7,6 +7,7 @@ import polars._reexport as pl
 from polars import functions as F
 from polars._utils.deprecation import (
     deprecate_function,
+    deprecate_renamed_parameter,
     issue_deprecation_warning,
 )
 from polars._utils.parse import parse_into_expression
@@ -2681,14 +2682,17 @@ class ExprStringNameSpace:
             self._pyexpr.str_extract_many(patterns, ascii_case_insensitive, overlapping)
         )
 
-    def join(self, delimiter: str = "", *, ignore_nulls: bool = True) -> Expr:
+    @deprecate_renamed_parameter(
+        old_name="delimiter", new_name="separator", version="1.6.0"
+    )
+    def join(self, separator: str = "", *, ignore_nulls: bool = True) -> Expr:
         """
         Vertically concatenate the string values in the column to a single string value.
 
         Parameters
         ----------
-        delimiter
-            The delimiter to insert between consecutive string values.
+        separator
+            The separator to insert between consecutive string values.
         ignore_nulls
             Ignore null values (default).
             If set to `False`, null values will be propagated. This means that
@@ -2721,22 +2725,25 @@ class ExprStringNameSpace:
         │ null │
         └──────┘
         """
-        return wrap_expr(self._pyexpr.str_join(delimiter, ignore_nulls=ignore_nulls))
+        return wrap_expr(self._pyexpr.str_join(separator, ignore_nulls=ignore_nulls))
 
+    @deprecate_renamed_parameter(
+        old_name="delimiter", new_name="separator", version="1.6.0"
+    )
     def concat(
-        self, delimiter: str | None = None, *, ignore_nulls: bool = True
+        self, separator: str | None = None, *, ignore_nulls: bool = True
     ) -> Expr:
         """
         Vertically concatenate the string values in the column to a single string value.
 
         .. deprecated:: 1.0.0
-            Use :meth:`join` instead. Note that the default `delimiter` for :meth:`join`
+            Use :meth:`join` instead. Note that the default `separator` for :meth:`join`
             is an empty string instead of a hyphen.
 
         Parameters
         ----------
-        delimiter
-            The delimiter to insert between consecutive string values.
+        separator
+            The separator to insert between consecutive string values.
         ignore_nulls
             Ignore null values (default).
             If set to `False`, null values will be propagated. This means that
@@ -2771,14 +2778,14 @@ class ExprStringNameSpace:
         │ null │
         └──────┘
         """
-        if delimiter is None:
+        if separator is None:
             issue_deprecation_warning(
-                "The default `delimiter` for `str.concat` will change from '-' to an empty string."
-                " Pass a delimiter to silence this warning.",
+                "The default `separator` for `str.concat` will change from '-' to an empty string."
+                " Pass a separator to silence this warning.",
                 version="0.20.5",
             )
-            delimiter = "-"
-        return self.join(delimiter, ignore_nulls=ignore_nulls)
+            separator = "-"
+        return self.join(separator, ignore_nulls=ignore_nulls)
 
 
 def _validate_format_argument(format: str | None) -> None:

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Mapping
 
-from polars._utils.deprecation import deprecate_function
+from polars._utils.deprecation import deprecate_function, deprecate_renamed_parameter
 from polars._utils.unstable import unstable
 from polars._utils.various import no_default
 from polars.datatypes.constants import N_INFER_DEFAULT
@@ -1996,14 +1996,17 @@ class StringNameSpace:
 
         """
 
-    def join(self, delimiter: str = "", *, ignore_nulls: bool = True) -> Series:
+    @deprecate_renamed_parameter(
+        old_name="delimiter", new_name="separator", version="1.6.0"
+    )
+    def join(self, separator: str = "", *, ignore_nulls: bool = True) -> Series:
         """
         Vertically concatenate the string values in the column to a single string value.
 
         Parameters
         ----------
-        delimiter
-            The delimiter to insert between consecutive string values.
+        separator
+            The separator to insert between consecutive string values.
         ignore_nulls
             Ignore null values (default).
             If set to `False`, null values will be propagated. This means that
@@ -2036,8 +2039,11 @@ class StringNameSpace:
         " is an empty string instead of a hyphen.",
         version="1.0.0",
     )
+    @deprecate_renamed_parameter(
+        old_name="delimiter", new_name="separator", version="1.6.0"
+    )
     def concat(
-        self, delimiter: str | None = None, *, ignore_nulls: bool = True
+        self, separator: str | None = None, *, ignore_nulls: bool = True
     ) -> Series:
         """
         Vertically concatenate the string values in the column to a single string value.
@@ -2048,8 +2054,8 @@ class StringNameSpace:
 
         Parameters
         ----------
-        delimiter
-            The delimiter to insert between consecutive string values.
+        separator
+            The separator to insert between consecutive string values.
         ignore_nulls
             Ignore null values (default).
             If set to `False`, null values will be propagated. This means that

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -775,7 +775,7 @@ def test_str_join_returns_scalar() -> None:
     )
     grouped = (
         df.group_by("id")
-        .agg(pl.col("val").str.join(delimiter=",").alias("grouped"))
+        .agg(pl.col("val").str.join(separator=",").alias("grouped"))
         .get_column("grouped")
     )
     assert grouped.dtype == pl.String


### PR DESCRIPTION
Fixes #13786 

I add renaming decorators to the python API, but are unaware of such functions within the Rust Codebase.

If someone could point me in the right direction, that would be immensely helpful.