### PR TITLE
perf: Several large parquet optimizations

### DIFF
--- a/crates/polars-arrow/src/bitmap/bitmap_ops.rs
+++ b/crates/polars-arrow/src/bitmap/bitmap_ops.rs
@@ -300,6 +300,22 @@ pub fn intersects_with_mut(lhs: &MutableBitmap, rhs: &MutableBitmap) -> bool {
     )
 }
 
+pub fn num_edges(lhs: &Bitmap) -> usize {
+    if lhs.len() == 0 {
+        return 0;
+    }
+
+    // @TODO: If is probably quite inefficient to do it like this because now either one is not
+    // aligned. Maybe, we can implement a smarter way to do this.
+    binary_fold(
+        &unsafe { lhs.clone().sliced_unchecked(0, lhs.len() - 1) },
+        &unsafe { lhs.clone().sliced_unchecked(1, lhs.len() - 1) },
+        |l, r| (l ^ r).count_ones() as usize,
+        0,
+        |acc, v| acc + v,
+    )
+}
+
 /// Compute `out[i] = if selector[i] { truthy[i] } else { falsy }`.
 pub fn select_constant(selector: &Bitmap, truthy: &Bitmap, falsy: bool) -> Bitmap {
     let falsy_mask: u64 = if falsy {

--- a/crates/polars-arrow/src/bitmap/bitmap_ops.rs
+++ b/crates/polars-arrow/src/bitmap/bitmap_ops.rs
@@ -301,7 +301,7 @@ pub fn intersects_with_mut(lhs: &MutableBitmap, rhs: &MutableBitmap) -> bool {
 }
 
 pub fn num_edges(lhs: &Bitmap) -> usize {
-    if lhs.len() == 0 {
+    if lhs.is_empty() {
         return 0;
     }
 

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -555,6 +555,11 @@ impl Bitmap {
     pub fn select_constant(&self, truthy: &Self, falsy: bool) -> Self {
         super::bitmap_ops::select_constant(self, truthy, falsy)
     }
+
+    /// Calculates the number of edges from `0 -> 1` and `1 -> 0`.
+    pub fn num_edges(&self) -> usize {
+        super::bitmap_ops::num_edges(self)
+    }
 }
 
 impl<P: AsRef<[bool]>> From<P> for Bitmap {

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -545,6 +545,23 @@ impl ArrowDataType {
         }
     }
 
+    pub fn is_nested(&self) -> bool {
+        use ArrowDataType as D;
+
+        matches!(
+            self,
+            D::List(_) |
+            D::LargeList(_) |
+            D::FixedSizeList(_, _) |
+            D::Struct(_) |
+            D::Union(_, _, _) |
+            D::Map(_, _) |
+            D::Dictionary(_, _, _) |
+            D::Extension(_, _, _)
+        )
+
+    }
+
     pub fn is_view(&self) -> bool {
         matches!(self, ArrowDataType::Utf8View | ArrowDataType::BinaryView)
     }

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -550,16 +550,15 @@ impl ArrowDataType {
 
         matches!(
             self,
-            D::List(_) |
-            D::LargeList(_) |
-            D::FixedSizeList(_, _) |
-            D::Struct(_) |
-            D::Union(_, _, _) |
-            D::Map(_, _) |
-            D::Dictionary(_, _, _) |
-            D::Extension(_, _, _)
+            D::List(_)
+                | D::LargeList(_)
+                | D::FixedSizeList(_, _)
+                | D::Struct(_)
+                | D::Union(_, _, _)
+                | D::Map(_, _)
+                | D::Dictionary(_, _, _)
+                | D::Extension(_, _, _)
         )
-
     }
 
     pub fn is_view(&self) -> bool {

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -481,7 +481,7 @@ fn rg_to_dfs_prefiltered(
                         // higher.
                         let is_nested = schema.fields[col_idx].data_type.is_nested();
                         let prefilter_cost = rg_prefilter_costs[i / num_dead_columns];
-                        
+
                         // We empirically selected these numbers.
                         let do_prefilter = (is_nested && prefilter_cost <= 0.01)
                             || (!is_nested && prefilter_cost <= 0.02);

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::ops::{Deref, Range};
 
+use arrow::array::BooleanArray;
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::datatypes::ArrowSchemaRef;
 use polars_core::prelude::*;
@@ -313,6 +314,20 @@ fn rg_to_dfs_prefiltered(
     debug_assert_eq!(live_idx_to_col_idx.len(), num_live_columns);
     debug_assert_eq!(dead_idx_to_col_idx.len(), num_dead_columns);
 
+    enum MaskSetting {
+        Auto,
+        Pre,
+        Post,
+    }
+
+    let mask_setting =
+        std::env::var("POLARS_PQ_PREFILTERED_MASK").map_or(MaskSetting::Auto, |v| match &v[..] {
+            "auto" => MaskSetting::Auto,
+            "pre" => MaskSetting::Pre,
+            "post" => MaskSetting::Post,
+            _ => panic!("Invalid `POLARS_PQ_PREFILTERED_MASK` value '{v}'."),
+        });
+
     POOL.install(|| {
         // Set partitioned fields to prevent quadratic behavior.
         // Ensure all row groups are partitioned.
@@ -394,38 +409,34 @@ fn rg_to_dfs_prefiltered(
             return Ok(dfs.into_iter().map(|(_, df)| df).collect());
         }
 
-        // @TODO: Incorporate this if we how we can properly use it. The problem here is that
-        // different columns really have a different cost when it comes to collecting them. We
-        // would need a cost model to properly estimate this.
-        //
-        // // For bitmasks that are seemingly random (i.e. not clustered or biased towards 0 or 1),
-        // // filtering with a bitmask in the Parquet reader is actually around 1.5 - 2.2 times slower
-        // // than collecting everything and filtering afterwards. This is because stopping and
-        // // starting decoding is not free.
-        // //
-        // // To combat this we try to detect here how biased our data is. We do this with a bithack
-        // // that estimates the amount of switches from 0 to 1 and from 1 to 0. This can be SIMD-ed
-        // // very well and gives us quite good estimate of how random our bitmask is. Then, we select
-        // // the filter if the bitmask is not that random.
-        // let do_filter_rg = dfs
-        //     .par_iter()
-        //     .map(|(mask, _)| {
-        //         let iter = mask.fast_iter_u64();
-        //
-        //         // The iter is TrustedLen so the size_hint is exact.
-        //         let num_items = iter.size_hint().0;
-        //         let num_switches = iter
-        //             .map(|v| (v ^ v.rotate_right(1)).count_ones() as u64)
-        //             .sum::<u64>();
-        //
-        //         // We ignore the iter remainder since we only really care about the average.
-        //         let avg_num_switches_per_element = num_switches / num_items as u64;
-        //
-        //         // We select the filter if the average amount of switches per 64 elements is less
-        //         // than or equal to 2.
-        //         avg_num_switches_per_element <= 2
-        //     })
-        //     .collect::<Vec<_>>();
+        let rg_prefilter_costs = matches!(mask_setting, MaskSetting::Auto)
+            .then(|| {
+                dfs.par_iter()
+                    .map(|(mask, _)| {
+                        let num_edges = mask.num_edges() as f64;
+                        let rg_len = mask.len() as f64;
+
+                        // @GB: I did quite some analysis on this.
+                        //
+                        // Pre-filtered and Post-filtered can both be faster in certain scenarios.
+                        //
+                        // - Pre-filtered is faster when there is some amount of clustering or
+                        // sorting involved or if the number of values selected is small.
+                        // - Post-filtering is faster when the predicate selects a somewhat random
+                        // elements throughout the row group.
+                        //
+                        // The following is a heuristic value to try and estimate which one is
+                        // faster. Essentially, it sees how many times it needs to switch between
+                        // skipping items and collecting items and compares it against the number
+                        // of values that it will collect.
+                        //
+                        // Closer to 0: post-filtering is probably better.
+                        // Closer to 1: pre-filtering is probably better.
+                        (num_edges / rg_len).clamp(0.0, 1.0)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
 
         let mut rg_columns = (0..dfs.len() * num_dead_columns)
             .into_par_iter()
@@ -444,26 +455,66 @@ fn rg_to_dfs_prefiltered(
                 }
                 let field_md = part_mds[rg_idx as usize].get_partitions(name).unwrap();
 
-                column_idx_to_series(
-                    col_idx,
-                    field_md.as_slice(),
-                    Some(Filter::new_masked(mask.clone())),
-                    schema,
-                    store,
-                )
+                let pre = || {
+                    column_idx_to_series(
+                        col_idx,
+                        field_md.as_slice(),
+                        Some(Filter::new_masked(mask.clone())),
+                        schema,
+                        store,
+                    )
+                };
+                let post = || {
+                    let array =
+                        column_idx_to_series(col_idx, field_md.as_slice(), None, schema, store)?;
+
+                    debug_assert_eq!(array.len(), mask.len());
+
+                    let mask_arr = BooleanArray::new(ArrowDataType::Boolean, mask.clone(), None);
+                    let mask_arr = BooleanChunked::from(mask_arr);
+                    array.filter(&mask_arr)
+                };
+
+                let array = match mask_setting {
+                    MaskSetting::Auto => {
+                        // Prefiltering is more expensive for nested types so we make the cut-off
+                        // higher.
+                        let is_nested = schema.fields[col_idx].data_type.is_nested();
+                        let prefilter_cost = rg_prefilter_costs[i / num_dead_columns];
+                        
+                        // We empirically selected these numbers.
+                        let do_prefilter = (is_nested && prefilter_cost <= 0.01)
+                            || (!is_nested && prefilter_cost <= 0.02);
+
+                        if do_prefilter {
+                            pre()?
+                        } else {
+                            post()?
+                        }
+                    },
+                    MaskSetting::Pre => pre()?,
+                    MaskSetting::Post => post()?,
+                };
+
+                debug_assert_eq!(array.len(), mask.set_bits());
+
+                Ok(array)
             })
             .collect::<PolarsResult<Vec<_>>>()?;
 
         let Some(df) = dfs.first().map(|(_, df)| df) else {
             return Ok(Vec::new());
         };
-        let rearranged_schema = df.schema();
+        let mut rearranged_schema = df.schema();
+        rearranged_schema.merge(Schema::from(schema));
 
         rg_columns
             .par_chunks_exact_mut(num_dead_columns)
             .zip(dfs)
             .map(|(rg_cols, (_, mut df))| {
                 let rg_cols = rg_cols.iter_mut().map(std::mem::take).collect::<Vec<_>>();
+
+                debug_assert!(rg_cols.iter().all(|v| v.len() == df.height()));
 
                 // We first add the columns with the live columns at the start. Then, we do a
                 // projections that puts the columns at the right spot.

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
@@ -89,6 +89,7 @@ impl<'a> utils::StateTranslation<'a, BooleanDecoder> for StateTranslation<'a> {
         &mut self,
         decoder: &mut BooleanDecoder,
         decoded: &mut <BooleanDecoder as Decoder>::DecodedState,
+        is_optional: bool,
         page_validity: &mut Option<PageValidity<'a>>,
         _: Option<&'a <BooleanDecoder as Decoder>::Dict>,
         additional: usize,
@@ -97,13 +98,20 @@ impl<'a> utils::StateTranslation<'a, BooleanDecoder> for StateTranslation<'a> {
             Self::Plain(page_values) => decoder.decode_plain_encoded(
                 decoded,
                 page_values,
+                is_optional,
                 page_validity.as_mut(),
                 additional,
             )?,
             Self::Rle(page_values) => {
                 let (values, validity) = decoded;
                 match page_validity {
-                    None => page_values.gather_n_into(values, additional, &BitmapGatherer)?,
+                    None => {
+                        page_values.gather_n_into(values, additional, &BitmapGatherer)?;
+
+                        if is_optional {
+                            validity.extend_constant(additional, true);
+                        }
+                    },
                     Some(page_validity) => utils::extend_from_decoder(
                         validity,
                         page_validity,
@@ -207,11 +215,18 @@ impl Decoder for BooleanDecoder {
         &mut self,
         (values, validity): &mut Self::DecodedState,
         page_values: &mut <Self::Translation<'a> as utils::StateTranslation<'a, Self>>::PlainDecoder,
+        is_optional: bool,
         page_validity: Option<&mut PageValidity<'a>>,
         limit: usize,
     ) -> ParquetResult<()> {
         match page_validity {
-            None => page_values.collect_n_into(values, limit),
+            None => {
+                page_values.collect_n_into(values, limit);
+
+                if is_optional {
+                    validity.extend_constant(limit, true);
+                }
+            },
             Some(page_validity) => {
                 extend_from_decoder(validity, page_validity, Some(limit), values, page_values)?
             },
@@ -224,6 +239,7 @@ impl Decoder for BooleanDecoder {
         &mut self,
         _decoded: &mut Self::DecodedState,
         _page_values: &mut HybridRleDecoder<'a>,
+        _is_optional: bool,
         _page_validity: Option<&mut PageValidity<'a>>,
         _dict: &Self::Dict,
         _limit: usize,

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean.rs
@@ -199,7 +199,9 @@ impl Decoder for BooleanDecoder {
         )
     }
 
-    fn deserialize_dict(&self, _: DictPage) -> Self::Dict {}
+    fn deserialize_dict(&self, _: DictPage) -> ParquetResult<Self::Dict> {
+        Ok(())
+    }
 
     fn decode_plain_encoded<'a>(
         &mut self,

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
@@ -105,11 +105,11 @@ impl<K: DictionaryKey, D: utils::DictDecodable> utils::Decoder for DictionaryDec
         )
     }
 
-    fn deserialize_dict(&self, page: DictPage) -> Self::Dict {
-        let dict = self.decoder.deserialize_dict(page);
+    fn deserialize_dict(&self, page: DictPage) -> ParquetResult<Self::Dict> {
+        let dict = self.decoder.deserialize_dict(page)?;
         self.dict_size
             .store(dict.len(), std::sync::atomic::Ordering::Relaxed);
-        dict
+        Ok(dict)
     }
 
     fn finalize(

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary.rs
@@ -47,6 +47,7 @@ impl<'a, K: DictionaryKey, D: utils::DictDecodable> StateTranslation<'a, Diction
         &mut self,
         decoder: &mut DictionaryDecoder<K, D>,
         decoded: &mut <DictionaryDecoder<K, D> as Decoder>::DecodedState,
+        is_optional: bool,
         page_validity: &mut Option<PageValidity<'a>>,
         _: Option<&'a <DictionaryDecoder<K, D> as Decoder>::Dict>,
         additional: usize,
@@ -65,7 +66,13 @@ impl<'a, K: DictionaryKey, D: utils::DictDecodable> StateTranslation<'a, Diction
         };
 
         match page_validity {
-            None => collector.push_n(&mut decoded.0, additional)?,
+            None => {
+                collector.push_n(&mut decoded.0, additional)?;
+
+                if is_optional {
+                    validity.extend_constant(additional, true);
+                }
+            },
             Some(page_validity) => {
                 extend_from_decoder(validity, page_validity, Some(additional), values, collector)?
             },
@@ -129,6 +136,7 @@ impl<K: DictionaryKey, D: utils::DictDecodable> utils::Decoder for DictionaryDec
         &mut self,
         _decoded: &mut Self::DecodedState,
         _page_values: &mut <Self::Translation<'a> as StateTranslation<'a, Self>>::PlainDecoder,
+        _is_optional: bool,
         _page_validity: Option<&mut PageValidity<'a>>,
         _limit: usize,
     ) -> ParquetResult<()> {
@@ -139,6 +147,7 @@ impl<K: DictionaryKey, D: utils::DictDecodable> utils::Decoder for DictionaryDec
         &mut self,
         _decoded: &mut Self::DecodedState,
         _page_values: &mut HybridRleDecoder<'a>,
+        _is_optional: bool,
         _page_validity: Option<&mut PageValidity<'a>>,
         _dict: &Self::Dict,
         _limit: usize,

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary.rs
@@ -134,8 +134,8 @@ impl Decoder for BinaryDecoder {
         )
     }
 
-    fn deserialize_dict(&self, page: DictPage) -> Self::Dict {
-        page.buffer.into_vec()
+    fn deserialize_dict(&self, page: DictPage) -> ParquetResult<Self::Dict> {
+        Ok(page.buffer.into_vec())
     }
 
     fn decode_plain_encoded<'a>(

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
@@ -162,7 +162,7 @@ pub fn columns_to_iter_recursive(
             PageNestedDecoder::new(
                 columns.pop().unwrap(),
                 field.data_type().clone(),
-                primitive::PrimitiveDecoder::<f32, _, _>::unit(),
+                primitive::FloatDecoder::<f32, _, _>::unit(),
                 init,
             )?
             .collect_n(filter)
@@ -174,7 +174,7 @@ pub fn columns_to_iter_recursive(
             PageNestedDecoder::new(
                 columns.pop().unwrap(),
                 field.data_type().clone(),
-                primitive::PrimitiveDecoder::<f64, _, _>::unit(),
+                primitive::FloatDecoder::<f64, _, _>::unit(),
                 init,
             )?
             .collect_n(filter)
@@ -524,14 +524,14 @@ fn dict_read<K: DictionaryKey>(
         Float32 => PageNestedDecoder::new(
             iter,
             data_type,
-            dictionary::DictionaryDecoder::new(primitive::PrimitiveDecoder::<f32, _, _>::unit()),
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<f32, _, _>::unit()),
             init,
         )?
         .collect_n(filter)?,
         Float64 => PageNestedDecoder::new(
             iter,
             data_type,
-            dictionary::DictionaryDecoder::new(primitive::PrimitiveDecoder::<f64, _, _>::unit()),
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<f64, _, _>::unit()),
             init,
         )?
         .collect_n(filter)?,

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -742,7 +742,7 @@ impl<D: utils::NestedDecoder> PageNestedDecoder<D> {
         init: Vec<InitNested>,
     ) -> ParquetResult<Self> {
         let dict_page = iter.read_dict_page()?;
-        let dict = dict_page.map(|d| decoder.deserialize_dict(d));
+        let dict = dict_page.map(|d| decoder.deserialize_dict(d)).transpose()?;
 
         Ok(Self {
             iter,

--- a/crates/polars-parquet/src/arrow/read/deserialize/null.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null.rs
@@ -67,7 +67,9 @@ impl utils::Decoder for NullDecoder {
         NullArrayLength { length: 0 }
     }
 
-    fn deserialize_dict(&self, _: DictPage) -> Self::Dict {}
+    fn deserialize_dict(&self, _: DictPage) -> ParquetResult<Self::Dict> {
+        Ok(())
+    }
 
     fn decode_plain_encoded<'a>(
         &mut self,

--- a/crates/polars-parquet/src/arrow/read/deserialize/null.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null.rs
@@ -47,6 +47,7 @@ impl<'a> utils::StateTranslation<'a, NullDecoder> for () {
         &mut self,
         _decoder: &mut NullDecoder,
         decoded: &mut <NullDecoder as utils::Decoder>::DecodedState,
+        _is_optional: bool,
         _page_validity: &mut Option<utils::PageValidity<'a>>,
         _: Option<&'a <NullDecoder as utils::Decoder>::Dict>,
         additional: usize,
@@ -75,6 +76,7 @@ impl utils::Decoder for NullDecoder {
         &mut self,
         _decoded: &mut Self::DecodedState,
         _page_values: &mut <Self::Translation<'a> as utils::StateTranslation<'a, Self>>::PlainDecoder,
+        _is_optional: bool,
         _page_validity: Option<&mut utils::PageValidity<'a>>,
         _limit: usize,
     ) -> ParquetResult<()> {
@@ -85,6 +87,7 @@ impl utils::Decoder for NullDecoder {
         &mut self,
         _decoded: &mut Self::DecodedState,
         _page_values: &mut hybrid_rle::HybridRleDecoder<'a>,
+        _is_optional: bool,
         _page_validity: Option<&mut utils::PageValidity<'a>>,
         _dict: &Self::Dict,
         _limit: usize,

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -204,6 +204,7 @@ where
         &mut self,
         decoder: &mut PrimitiveDecoder<P, T, D>,
         decoded: &mut <PrimitiveDecoder<P, T, D> as utils::Decoder>::DecodedState,
+        is_optional: bool,
         page_validity: &mut Option<PageValidity<'a>>,
         dict: Option<&'a <PrimitiveDecoder<P, T, D> as utils::Decoder>::Dict>,
         additional: usize,
@@ -212,12 +213,14 @@ where
             Self::Plain(page_values) => decoder.decode_plain_encoded(
                 decoded,
                 page_values,
+                is_optional,
                 page_validity.as_mut(),
                 additional,
             )?,
             Self::Dictionary(ref mut page) => decoder.decode_dictionary_encoded(
                 decoded,
                 page,
+                is_optional,
                 page_validity.as_mut(),
                 dict.unwrap(),
                 additional,
@@ -232,6 +235,10 @@ where
                                 .iter_converted(|v| decoder.decoder.decode(decode(v)))
                                 .take(additional),
                         );
+
+                        if is_optional {
+                            validity.extend_constant(additional, true);
+                        }
                     },
                     Some(page_validity) => utils::extend_from_decoder(
                         validity,
@@ -349,6 +356,7 @@ where
         &mut self,
         (values, validity): &mut Self::DecodedState,
         page_values: &mut <Self::Translation<'a> as utils::StateTranslation<'a, Self>>::PlainDecoder,
+        is_optional: bool,
         page_validity: Option<&mut PageValidity<'a>>,
         limit: usize,
     ) -> ParquetResult<()> {
@@ -360,6 +368,10 @@ where
                     _pd: std::marker::PhantomData,
                 }
                 .push_n(values, limit)?;
+
+                if is_optional {
+                    validity.extend_constant(limit, true);
+                }
             },
             Some(page_validity) => {
                 let collector = PlainDecoderFnCollector {
@@ -385,6 +397,7 @@ where
         &mut self,
         (values, validity): &mut Self::DecodedState,
         page_values: &mut hybrid_rle::HybridRleDecoder<'a>,
+        is_optional: bool,
         page_validity: Option<&mut PageValidity<'a>>,
         dict: &Self::Dict,
         limit: usize,
@@ -394,6 +407,10 @@ where
         match page_validity {
             None => {
                 page_values.translate_and_collect_n_into(values, limit, &translator)?;
+
+                if is_optional {
+                    validity.extend_constant(limit, true);
+                }
             },
             Some(page_validity) => {
                 let translated_hybridrle = TranslatedHybridRle::new(page_values, &translator);

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -341,8 +341,8 @@ where
         )
     }
 
-    fn deserialize_dict(&self, page: DictPage) -> Self::Dict {
-        deserialize_plain::<P, T, D>(&page.buffer, self.decoder)
+    fn deserialize_dict(&self, page: DictPage) -> ParquetResult<Self::Dict> {
+        Ok(deserialize_plain::<P, T, D>(&page.buffer, self.decoder))
     }
 
     fn decode_plain_encoded<'a>(

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -5,7 +5,9 @@ use arrow::types::NativeType;
 
 use super::super::utils;
 use super::{
-    deserialize_plain, AsDecoderFunction, ClosureDecoderFunction, DecoderFunction, DeltaCollector, DeltaTranslator, IntoDecoderFunction, PlainDecoderFnCollector, PrimitiveDecoder, UnitDecoderFunction
+    deserialize_plain, AsDecoderFunction, ClosureDecoderFunction, DecoderFunction, DeltaCollector,
+    DeltaTranslator, IntoDecoderFunction, PlainDecoderFnCollector, PrimitiveDecoder,
+    UnitDecoderFunction,
 };
 use crate::parquet::encoding::hybrid_rle::{self, DictionaryTranslator};
 use crate::parquet::encoding::{byte_stream_split, delta_bitpacked, Encoding};

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -253,7 +253,7 @@ where
         self.0.with_capacity(capacity)
     }
 
-    fn deserialize_dict(&self, page: DictPage) -> Self::Dict {
+    fn deserialize_dict(&self, page: DictPage) -> ParquetResult<Self::Dict> {
         self.0.deserialize_dict(page)
     }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/mod.rs
@@ -1,18 +1,177 @@
 use arrow::types::NativeType;
 use num_traits::AsPrimitive;
 
-use crate::parquet::types::NativeType as ParquetNativeType;
+use crate::parquet::types::{decode, NativeType as ParquetNativeType};
 
-mod basic;
+mod float;
 mod integer;
 
-pub(crate) use basic::PrimitiveDecoder;
+pub(crate) use float::FloatDecoder;
 pub(crate) use integer::IntDecoder;
 
-use self::basic::DecoderFunction;
+use super::utils::array_chunks::ArrayChunks;
 use super::utils::BatchableCollector;
 use super::ParquetResult;
 use crate::parquet::encoding::delta_bitpacked::{self, DeltaGatherer};
+
+#[derive(Debug)]
+pub(crate) struct PrimitiveDecoder<P, T, D>
+where
+    P: ParquetNativeType,
+    T: NativeType,
+    D: DecoderFunction<P, T>,
+{
+    pub(crate) decoder: D,
+    _pd: std::marker::PhantomData<(P, T)>,
+}
+
+impl<P, T, D> PrimitiveDecoder<P, T, D>
+where
+    P: ParquetNativeType,
+    T: NativeType,
+    D: DecoderFunction<P, T>,
+{
+    #[inline]
+    pub(crate) fn new(decoder: D) -> Self {
+        Self {
+            decoder,
+            _pd: std::marker::PhantomData,
+        }
+    }
+}
+
+/// A function that defines how to decode from the
+/// [`parquet::types::NativeType`][ParquetNativeType] to the [`arrow::types::NativeType`].
+///
+/// This should almost always be inlined.
+pub(crate) trait DecoderFunction<P, T>: Copy
+where
+    T: NativeType,
+    P: ParquetNativeType,
+{
+    fn decode(self, x: P) -> T;
+}
+
+#[derive(Default, Clone, Copy)]
+pub(crate) struct UnitDecoderFunction<T>(std::marker::PhantomData<T>);
+impl<T: NativeType + ParquetNativeType> DecoderFunction<T, T> for UnitDecoderFunction<T> {
+    #[inline(always)]
+    fn decode(self, x: T) -> T {
+        x
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+pub(crate) struct AsDecoderFunction<P, T>(std::marker::PhantomData<(P, T)>);
+macro_rules! as_decoder_impl {
+    ($($p:ty => $t:ty,)+) => {
+        $(
+        impl DecoderFunction<$p, $t> for AsDecoderFunction<$p, $t> {
+            #[inline(always)]
+            fn decode(self, x : $p) -> $t {
+                x as $t
+            }
+        }
+        )+
+    };
+}
+
+as_decoder_impl![
+    i32 => i8,
+    i32 => i16,
+    i32 => u8,
+    i32 => u16,
+    i32 => u32,
+    i64 => i32,
+    i64 => u32,
+    i64 => u64,
+];
+
+#[derive(Default, Clone, Copy)]
+pub(crate) struct IntoDecoderFunction<P, T>(std::marker::PhantomData<(P, T)>);
+impl<P, T> DecoderFunction<P, T> for IntoDecoderFunction<P, T>
+where
+    P: ParquetNativeType + Into<T>,
+    T: NativeType,
+{
+    #[inline(always)]
+    fn decode(self, x: P) -> T {
+        x.into()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ClosureDecoderFunction<P, T, F>(F, std::marker::PhantomData<(P, T)>);
+impl<P, T, F> DecoderFunction<P, T> for ClosureDecoderFunction<P, T, F>
+where
+    P: ParquetNativeType,
+    T: NativeType,
+    F: Copy + Fn(P) -> T,
+{
+    #[inline(always)]
+    fn decode(self, x: P) -> T {
+        (self.0)(x)
+    }
+}
+
+pub(crate) struct PlainDecoderFnCollector<'a, 'b, P, T, D>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    D: DecoderFunction<P, T>,
+{
+    pub(crate) chunks: &'b mut ArrayChunks<'a, P>,
+    pub(crate) decoder: D,
+    pub(crate) _pd: std::marker::PhantomData<T>,
+}
+
+impl<'a, 'b, P, T, D: DecoderFunction<P, T>> BatchableCollector<(), Vec<T>>
+    for PlainDecoderFnCollector<'a, 'b, P, T, D>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    D: DecoderFunction<P, T>,
+{
+    fn reserve(target: &mut Vec<T>, n: usize) {
+        target.reserve(n);
+    }
+
+    fn push_n(&mut self, target: &mut Vec<T>, n: usize) -> ParquetResult<()> {
+        let n = usize::min(self.chunks.len(), n);
+        let (items, remainder) = self.chunks.bytes.split_at(n);
+        let decoder = self.decoder;
+        target.extend(
+            items
+                .iter()
+                .map(|chunk| decoder.decode(P::from_le_bytes(*chunk))),
+        );
+        self.chunks.bytes = remainder;
+        Ok(())
+    }
+
+    fn push_n_nulls(&mut self, target: &mut Vec<T>, n: usize) -> ParquetResult<()> {
+        target.resize(target.len() + n, T::default());
+        Ok(())
+    }
+
+    fn skip_in_place(&mut self, n: usize) -> ParquetResult<()> {
+        self.chunks.skip_in_place(n);
+        Ok(())
+    }
+}
+
+fn deserialize_plain<P, T, D>(values: &[u8], decoder: D) -> Vec<T>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    D: DecoderFunction<P, T>,
+{
+    values
+        .chunks_exact(std::mem::size_of::<P>())
+        .map(decode)
+        .map(|v| decoder.decode(v))
+        .collect::<Vec<_>>()
+}
 
 struct DeltaTranslator<P, T, D>
 where

--- a/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
@@ -278,13 +278,13 @@ pub fn page_iter_to_array(
         (PhysicalType::Float, Float32) => Box::new(PageDecoder::new(
             pages,
             data_type,
-            primitive::PrimitiveDecoder::<f32, _, _>::unit(),
+            primitive::FloatDecoder::<f32, _, _>::unit(),
         )?
         .collect_n(filter)?),
         (PhysicalType::Double, Float64) => Box::new(PageDecoder::new(
             pages,
             data_type,
-            primitive::PrimitiveDecoder::<f64, _, _>::unit(),
+            primitive::FloatDecoder::<f64, _, _>::unit(),
         )?
         .collect_n(filter)?),
         // Don't compile this code with `i32` as we don't use this in polars
@@ -393,7 +393,7 @@ fn timestamp(
                 PageDecoder::new(
                     pages,
                     data_type,
-                    primitive::PrimitiveDecoder::closure(|x: [u32; 3]| int96_to_i64_ns(x)),
+                    primitive::FloatDecoder::closure(|x: [u32; 3]| int96_to_i64_ns(x)),
                 )?
                 .collect_n(filter)?,
             )),
@@ -401,7 +401,7 @@ fn timestamp(
                 PageDecoder::new(
                     pages,
                     data_type,
-                    primitive::PrimitiveDecoder::closure(|x: [u32; 3]| int96_to_i64_us(x)),
+                    primitive::FloatDecoder::closure(|x: [u32; 3]| int96_to_i64_us(x)),
                 )?
                 .collect_n(filter)?,
             )),
@@ -409,7 +409,7 @@ fn timestamp(
                 PageDecoder::new(
                     pages,
                     data_type,
-                    primitive::PrimitiveDecoder::closure(|x: [u32; 3]| int96_to_i64_ms(x)),
+                    primitive::FloatDecoder::closure(|x: [u32; 3]| int96_to_i64_ms(x)),
                 )?
                 .collect_n(filter)?,
             )),
@@ -417,7 +417,7 @@ fn timestamp(
                 PageDecoder::new(
                     pages,
                     data_type,
-                    primitive::PrimitiveDecoder::closure(|x: [u32; 3]| int96_to_i64_s(x)),
+                    primitive::FloatDecoder::closure(|x: [u32; 3]| int96_to_i64_s(x)),
                 )?
                 .collect_n(filter)?,
             )),
@@ -473,7 +473,7 @@ fn timestamp_dict<K: DictionaryKey>(
             (a, true) => PageDecoder::new(
                 pages,
                 ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
-                dictionary::DictionaryDecoder::<K, _>::new(primitive::PrimitiveDecoder::closure(
+                dictionary::DictionaryDecoder::<K, _>::new(primitive::FloatDecoder::closure(
                     |x: [u32; 3]| int96_to_i64_ns(x) * a,
                 )),
             )?
@@ -481,7 +481,7 @@ fn timestamp_dict<K: DictionaryKey>(
             (a, false) => PageDecoder::new(
                 pages,
                 ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
-                dictionary::DictionaryDecoder::<K, _>::new(primitive::PrimitiveDecoder::closure(
+                dictionary::DictionaryDecoder::<K, _>::new(primitive::FloatDecoder::closure(
                     |x: [u32; 3]| int96_to_i64_ns(x) / a,
                 )),
             )?
@@ -494,7 +494,7 @@ fn timestamp_dict<K: DictionaryKey>(
         (a, true) => PageDecoder::new(
             pages,
             data_type,
-            dictionary::DictionaryDecoder::new(primitive::PrimitiveDecoder::closure(|x: i64| {
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::closure(|x: i64| {
                 x * a
             })),
         )?
@@ -502,7 +502,7 @@ fn timestamp_dict<K: DictionaryKey>(
         (a, false) => PageDecoder::new(
             pages,
             data_type,
-            dictionary::DictionaryDecoder::new(primitive::PrimitiveDecoder::closure(|x: i64| {
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::closure(|x: i64| {
                 x / a
             })),
         )?
@@ -530,7 +530,7 @@ fn dict_read<K: DictionaryKey>(
                 iter,
                 data_type,
                 dictionary::DictionaryDecoder::new(
-                    primitive::PrimitiveDecoder::<i32, u8, _>::cast_as(),
+                    primitive::FloatDecoder::<i32, u8, _>::cast_as(),
                 ),
             )?
             .collect_n(filter)?,
@@ -538,7 +538,7 @@ fn dict_read<K: DictionaryKey>(
                 iter,
                 data_type,
                 dictionary::DictionaryDecoder::new(
-                    primitive::PrimitiveDecoder::<i32, u16, _>::cast_as(),
+                    primitive::FloatDecoder::<i32, u16, _>::cast_as(),
                 ),
             )?
             .collect_n(filter)?,
@@ -546,7 +546,7 @@ fn dict_read<K: DictionaryKey>(
                 iter,
                 data_type,
                 dictionary::DictionaryDecoder::new(
-                    primitive::PrimitiveDecoder::<i32, u32, _>::cast_as(),
+                    primitive::FloatDecoder::<i32, u32, _>::cast_as(),
                 ),
             )?
             .collect_n(filter)?,
@@ -554,7 +554,7 @@ fn dict_read<K: DictionaryKey>(
                 iter,
                 data_type,
                 dictionary::DictionaryDecoder::new(
-                    primitive::PrimitiveDecoder::<i64, u64, _>::cast_as(),
+                    primitive::FloatDecoder::<i64, u64, _>::cast_as(),
                 ),
             )?
             .collect_n(filter)?,
@@ -562,7 +562,7 @@ fn dict_read<K: DictionaryKey>(
                 iter,
                 data_type,
                 dictionary::DictionaryDecoder::new(
-                    primitive::PrimitiveDecoder::<i32, i8, _>::cast_as(),
+                    primitive::FloatDecoder::<i32, i8, _>::cast_as(),
                 ),
             )?
             .collect_n(filter)?,
@@ -570,7 +570,7 @@ fn dict_read<K: DictionaryKey>(
                 iter,
                 data_type,
                 dictionary::DictionaryDecoder::new(
-                    primitive::PrimitiveDecoder::<i32, i16, _>::cast_as(),
+                    primitive::FloatDecoder::<i32, i16, _>::cast_as(),
                 ),
             )?
             .collect_n(filter)?,
@@ -582,7 +582,7 @@ fn dict_read<K: DictionaryKey>(
                     iter,
                     data_type,
                     dictionary::DictionaryDecoder::new(
-                        primitive::PrimitiveDecoder::<i32, _, _>::unit(),
+                        primitive::FloatDecoder::<i32, _, _>::unit(),
                     ),
                 )?
                 .collect_n(filter)?
@@ -605,7 +605,7 @@ fn dict_read<K: DictionaryKey>(
                     iter,
                     data_type,
                     dictionary::DictionaryDecoder::new(
-                        primitive::PrimitiveDecoder::<i64, _, _>::unit(),
+                        primitive::FloatDecoder::<i64, _, _>::unit(),
                     ),
                 )?
                 .collect_n(filter)?
@@ -615,7 +615,7 @@ fn dict_read<K: DictionaryKey>(
                     iter,
                     data_type,
                     dictionary::DictionaryDecoder::new(
-                        primitive::PrimitiveDecoder::<f32, _, _>::unit(),
+                        primitive::FloatDecoder::<f32, _, _>::unit(),
                     ),
                 )?
                 .collect_n(filter)?
@@ -625,7 +625,7 @@ fn dict_read<K: DictionaryKey>(
                     iter,
                     data_type,
                     dictionary::DictionaryDecoder::new(
-                        primitive::PrimitiveDecoder::<f64, _, _>::unit(),
+                        primitive::FloatDecoder::<f64, _, _>::unit(),
                     ),
                 )?
                 .collect_n(filter)?

--- a/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
@@ -494,17 +494,13 @@ fn timestamp_dict<K: DictionaryKey>(
         (a, true) => PageDecoder::new(
             pages,
             data_type,
-            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::closure(|x: i64| {
-                x * a
-            })),
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::closure(|x: i64| x * a)),
         )?
         .collect_n(filter),
         (a, false) => PageDecoder::new(
             pages,
             data_type,
-            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::closure(|x: i64| {
-                x / a
-            })),
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::closure(|x: i64| x / a)),
         )?
         .collect_n(filter),
     }
@@ -524,132 +520,99 @@ fn dict_read<K: DictionaryKey>(
         panic!()
     };
 
-    Ok(
-        match (physical_type, values_data_type.to_logical_type()) {
-            (PhysicalType::Int32, UInt8) => PageDecoder::new(
+    Ok(match (physical_type, values_data_type.to_logical_type()) {
+        (PhysicalType::Int32, UInt8) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i32, u8, _>::cast_as()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Int32, UInt16) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i32, u16, _>::cast_as()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Int32, UInt32) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i32, u32, _>::cast_as()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Int64, UInt64) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i64, u64, _>::cast_as()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Int32, Int8) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i32, i8, _>::cast_as()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Int32, Int16) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i32, i16, _>::cast_as()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Int32, Int32 | Date32 | Time32(_) | Interval(IntervalUnit::YearMonth)) => {
+            PageDecoder::new(
                 iter,
                 data_type,
-                dictionary::DictionaryDecoder::new(
-                    primitive::FloatDecoder::<i32, u8, _>::cast_as(),
-                ),
+                dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i32, _, _>::unit()),
             )?
-            .collect_n(filter)?,
-            (PhysicalType::Int32, UInt16) => PageDecoder::new(
-                iter,
-                data_type,
-                dictionary::DictionaryDecoder::new(
-                    primitive::FloatDecoder::<i32, u16, _>::cast_as(),
-                ),
-            )?
-            .collect_n(filter)?,
-            (PhysicalType::Int32, UInt32) => PageDecoder::new(
-                iter,
-                data_type,
-                dictionary::DictionaryDecoder::new(
-                    primitive::FloatDecoder::<i32, u32, _>::cast_as(),
-                ),
-            )?
-            .collect_n(filter)?,
-            (PhysicalType::Int64, UInt64) => PageDecoder::new(
-                iter,
-                data_type,
-                dictionary::DictionaryDecoder::new(
-                    primitive::FloatDecoder::<i64, u64, _>::cast_as(),
-                ),
-            )?
-            .collect_n(filter)?,
-            (PhysicalType::Int32, Int8) => PageDecoder::new(
-                iter,
-                data_type,
-                dictionary::DictionaryDecoder::new(
-                    primitive::FloatDecoder::<i32, i8, _>::cast_as(),
-                ),
-            )?
-            .collect_n(filter)?,
-            (PhysicalType::Int32, Int16) => PageDecoder::new(
-                iter,
-                data_type,
-                dictionary::DictionaryDecoder::new(
-                    primitive::FloatDecoder::<i32, i16, _>::cast_as(),
-                ),
-            )?
-            .collect_n(filter)?,
-            (
-                PhysicalType::Int32,
-                Int32 | Date32 | Time32(_) | Interval(IntervalUnit::YearMonth),
-            ) => {
-                PageDecoder::new(
-                    iter,
-                    data_type,
-                    dictionary::DictionaryDecoder::new(
-                        primitive::FloatDecoder::<i32, _, _>::unit(),
-                    ),
-                )?
-                .collect_n(filter)?
-            },
-
-            (PhysicalType::Int64, Timestamp(time_unit, _)) => {
-                let time_unit = *time_unit;
-                return timestamp_dict::<K>(
-                    iter,
-                    physical_type,
-                    logical_type,
-                    data_type,
-                    filter,
-                    time_unit,
-                );
-            },
-
-            (PhysicalType::Int64, Int64 | Date64 | Time64(_) | Duration(_)) => {
-                PageDecoder::new(
-                    iter,
-                    data_type,
-                    dictionary::DictionaryDecoder::new(
-                        primitive::FloatDecoder::<i64, _, _>::unit(),
-                    ),
-                )?
-                .collect_n(filter)?
-            },
-            (PhysicalType::Float, Float32) => {
-                PageDecoder::new(
-                    iter,
-                    data_type,
-                    dictionary::DictionaryDecoder::new(
-                        primitive::FloatDecoder::<f32, _, _>::unit(),
-                    ),
-                )?
-                .collect_n(filter)?
-            },
-            (PhysicalType::Double, Float64) => {
-                PageDecoder::new(
-                    iter,
-                    data_type,
-                    dictionary::DictionaryDecoder::new(
-                        primitive::FloatDecoder::<f64, _, _>::unit(),
-                    ),
-                )?
-                .collect_n(filter)?
-            },
-            (_, LargeUtf8 | LargeBinary | Utf8 | Binary) => unreachable!(),
-            (PhysicalType::ByteArray, Utf8View | BinaryView) => PageDecoder::new(
-                iter,
-                data_type,
-                dictionary::DictionaryDecoder::new(BinViewDecoder::default()),
-            )?
-            .collect_n(filter)?,
-            (PhysicalType::FixedLenByteArray(size), FixedSizeBinary(_)) => PageDecoder::new(
-                iter,
-                data_type,
-                dictionary::DictionaryDecoder::new(fixed_size_binary::BinaryDecoder {
-                    size: *size,
-                }),
-            )?
-            .collect_n(filter)?,
-            other => {
-                return Err(ParquetError::FeatureNotSupported(format!(
-                    "Reading dictionaries of type {other:?}"
-                )));
-            },
+            .collect_n(filter)?
         },
-    )
+
+        (PhysicalType::Int64, Timestamp(time_unit, _)) => {
+            let time_unit = *time_unit;
+            return timestamp_dict::<K>(
+                iter,
+                physical_type,
+                logical_type,
+                data_type,
+                filter,
+                time_unit,
+            );
+        },
+
+        (PhysicalType::Int64, Int64 | Date64 | Time64(_) | Duration(_)) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<i64, _, _>::unit()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Float, Float32) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<f32, _, _>::unit()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::Double, Float64) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(primitive::FloatDecoder::<f64, _, _>::unit()),
+        )?
+        .collect_n(filter)?,
+        (_, LargeUtf8 | LargeBinary | Utf8 | Binary) => unreachable!(),
+        (PhysicalType::ByteArray, Utf8View | BinaryView) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(BinViewDecoder::default()),
+        )?
+        .collect_n(filter)?,
+        (PhysicalType::FixedLenByteArray(size), FixedSizeBinary(_)) => PageDecoder::new(
+            iter,
+            data_type,
+            dictionary::DictionaryDecoder::new(fixed_size_binary::BinaryDecoder { size: *size }),
+        )?
+        .collect_n(filter)?,
+        other => {
+            return Err(ParquetError::FeatureNotSupported(format!(
+                "Reading dictionaries of type {other:?}"
+            )));
+        },
+    })
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -19,6 +19,7 @@ use crate::parquet::schema::Repetition;
 #[derive(Debug)]
 pub(crate) struct State<'a, D: Decoder> {
     pub(crate) dict: Option<&'a D::Dict>,
+    pub(crate) is_optional: bool,
     pub(crate) page_validity: Option<PageValidity<'a>>,
     pub(crate) translation: D::Translation<'a>,
 }
@@ -41,6 +42,7 @@ pub(crate) trait StateTranslation<'a, D: Decoder>: Sized {
         &mut self,
         decoder: &mut D,
         decoded: &mut D::DecodedState,
+        is_optional: bool,
         page_validity: &mut Option<PageValidity<'a>>,
         dict: Option<&'a D::Dict>,
         additional: usize,
@@ -52,14 +54,25 @@ impl<'a, D: Decoder> State<'a, D> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
 
-        let page_validity = is_optional
+        let mut page_validity = is_optional
             .then(|| page_validity_decoder(page))
             .transpose()?;
+
+        // Make the page_validity None if there are no nulls in the page
+        let null_count = page
+            .null_count()
+            .map(Ok)
+            .or_else(|| page_validity.as_ref().map(hybrid_rle_count_zeros))
+            .transpose()?;
+        if null_count == Some(0) {
+            page_validity = None;
+        }
 
         let translation = D::Translation::new(decoder, page, dict, page_validity.as_ref())?;
 
         Ok(Self {
             dict,
+            is_optional,
             page_validity,
             translation,
         })
@@ -75,6 +88,9 @@ impl<'a, D: Decoder> State<'a, D> {
         Ok(Self {
             dict,
             translation,
+
+            // Nested values may be optional, but all that is handled elsewhere.
+            is_optional: false,
             page_validity: None,
         })
     }
@@ -120,6 +136,7 @@ impl<'a, D: Decoder> State<'a, D> {
                 self.translation.extend_from_state(
                     decoder,
                     decoded,
+                    self.is_optional,
                     &mut self.page_validity,
                     self.dict,
                     num_rows,
@@ -137,6 +154,7 @@ impl<'a, D: Decoder> State<'a, D> {
                         self.translation.extend_from_state(
                             decoder,
                             decoded,
+                            self.is_optional,
                             &mut self.page_validity,
                             self.dict,
                             end - start,
@@ -158,6 +176,7 @@ impl<'a, D: Decoder> State<'a, D> {
                             self.translation.extend_from_state(
                                 decoder,
                                 decoded,
+                                self.is_optional,
                                 &mut self.page_validity,
                                 self.dict,
                                 num_ones,
@@ -600,6 +619,7 @@ pub(super) trait Decoder: Sized {
         &mut self,
         decoded: &mut Self::DecodedState,
         page_values: &mut <Self::Translation<'a> as StateTranslation<'a, Self>>::PlainDecoder,
+        is_optional: bool,
         page_validity: Option<&mut PageValidity<'a>>,
         limit: usize,
     ) -> ParquetResult<()>;
@@ -607,6 +627,7 @@ pub(super) trait Decoder: Sized {
         &mut self,
         decoded: &mut Self::DecodedState,
         page_values: &mut HybridRleDecoder<'a>,
+        is_optional: bool,
         page_validity: Option<&mut PageValidity<'a>>,
         dict: &Self::Dict,
         limit: usize,

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/mod.rs
@@ -586,7 +586,7 @@ pub(super) trait Decoder: Sized {
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState;
 
     /// Deserializes a [`DictPage`] into [`Self::Dict`].
-    fn deserialize_dict(&self, page: DictPage) -> Self::Dict;
+    fn deserialize_dict(&self, page: DictPage) -> ParquetResult<Self::Dict>;
 
     fn apply_dictionary(
         &mut self,
@@ -675,7 +675,7 @@ impl<D: Decoder> PageDecoder<D> {
         decoder: D,
     ) -> ParquetResult<Self> {
         let dict_page = iter.read_dict_page()?;
-        let dict = dict_page.map(|d| decoder.deserialize_dict(d));
+        let dict = dict_page.map(|d| decoder.deserialize_dict(d)).transpose()?;
 
         Ok(Self {
             iter,

--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -123,6 +123,13 @@ impl DataPageHeader {
             DataPageHeader::V2(d) => d.num_values as usize,
         }
     }
+
+    pub fn null_count(&self) -> Option<usize> {
+        match &self {
+            DataPageHeader::V1(_) => None,
+            DataPageHeader::V2(d) => Some(d.num_nulls as usize),
+        }
+    }
 }
 
 /// A [`DataPage`] is an uncompressed, encoded representation of a Parquet data page. It holds actual data
@@ -179,6 +186,10 @@ impl DataPage {
 
     pub fn num_values(&self) -> usize {
         self.header.num_values()
+    }
+
+    pub fn null_count(&self) -> Option<usize> {
+        self.header.null_count()
     }
 
     pub fn num_rows(&self) -> Option<usize> {


### PR DESCRIPTION
- Only verify UTF-8 on a dictionary page once (*duh*)
- Don't even worry about the page validity if it is never null
- Dispatch between pre-filter and post-filter for `parallel=prefiltered`.