### PR TITLE
fix(python): Change method op type hints to match dunder op type hints

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4965,7 +4965,7 @@ class Expr:
         """
         return self.head(n)
 
-    def and_(self, *others: Any) -> Expr:
+    def and_(self, *others: IntoExprColumn | int | bool) -> Expr:
         """
         Method equivalent of bitwise "and" operator `expr & other & ...`.
 
@@ -5006,9 +5006,9 @@ class Expr:
         │ false │
         └───────┘
         """
-        return reduce(operator.and_, (self, *others))
+        return reduce(operator.and_, (self, *others))  # type: ignore[return-value]
 
-    def or_(self, *others: Any) -> Expr:
+    def or_(self, *others: IntoExprColumn | int | bool) -> Expr:
         """
         Method equivalent of bitwise "or" operator `expr | other | ...`.
 
@@ -5048,9 +5048,9 @@ class Expr:
         │ false │
         └───────┘
         """
-        return reduce(operator.or_, (self,) + others)
+        return reduce(operator.or_, (self,) + others)  # type: ignore[return-value]
 
-    def eq(self, other: Any) -> Expr:
+    def eq(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of equality operator `expr == other`.
 
@@ -5084,7 +5084,7 @@ class Expr:
         """
         return self.__eq__(other)
 
-    def eq_missing(self, other: Any) -> Expr:
+    def eq_missing(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of equality operator `expr == other` where `None == None`.
 
@@ -5124,7 +5124,7 @@ class Expr:
         other = parse_into_expression(other, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.eq_missing(other))
 
-    def ge(self, other: Any) -> Expr:
+    def ge(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of "greater than or equal" operator `expr >= other`.
 
@@ -5158,7 +5158,7 @@ class Expr:
         """
         return self.__ge__(other)
 
-    def gt(self, other: Any) -> Expr:
+    def gt(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of "greater than" operator `expr > other`.
 
@@ -5192,7 +5192,7 @@ class Expr:
         """
         return self.__gt__(other)
 
-    def le(self, other: Any) -> Expr:
+    def le(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of "less than or equal" operator `expr <= other`.
 
@@ -5226,7 +5226,7 @@ class Expr:
         """
         return self.__le__(other)
 
-    def lt(self, other: Any) -> Expr:
+    def lt(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of "less than" operator `expr < other`.
 
@@ -5260,7 +5260,7 @@ class Expr:
         """
         return self.__lt__(other)
 
-    def ne(self, other: Any) -> Expr:
+    def ne(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of inequality operator `expr != other`.
 
@@ -5294,7 +5294,7 @@ class Expr:
         """
         return self.__ne__(other)
 
-    def ne_missing(self, other: Any) -> Expr:
+    def ne_missing(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of equality operator `expr != other` where `None == None`.
 
@@ -5334,7 +5334,7 @@ class Expr:
         other = parse_into_expression(other, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.neq_missing(other))
 
-    def add(self, other: Any) -> Expr:
+    def add(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of addition operator `expr + other`.
 
@@ -5380,7 +5380,7 @@ class Expr:
         """
         return self.__add__(other)
 
-    def floordiv(self, other: Any) -> Expr:
+    def floordiv(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of integer division operator `expr // other`.
 
@@ -5467,7 +5467,7 @@ class Expr:
         """
         return self.__floordiv__(other)
 
-    def mod(self, other: Any) -> Expr:
+    def mod(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of modulus operator `expr % other`.
 
@@ -5495,7 +5495,7 @@ class Expr:
         """
         return self.__mod__(other)
 
-    def mul(self, other: Any) -> Expr:
+    def mul(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of multiplication operator `expr * other`.
 
@@ -5526,7 +5526,7 @@ class Expr:
         """
         return self.__mul__(other)
 
-    def sub(self, other: Any) -> Expr:
+    def sub(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of subtraction operator `expr - other`.
 
@@ -5579,7 +5579,7 @@ class Expr:
         """
         return self.__neg__()
 
-    def truediv(self, other: Any) -> Expr:
+    def truediv(self, other: IntoExpr) -> Expr:
         """
         Method equivalent of float division operator `expr / other`.
 
@@ -5676,7 +5676,7 @@ class Expr:
         """
         return self.__pow__(exponent)
 
-    def xor(self, other: Any) -> Expr:
+    def xor(self, other: IntoExprColumn | int | bool) -> Expr:
         """
         Method equivalent of bitwise exclusive-or operator `expr ^ other`.
 


### PR DESCRIPTION
Type hints for operators were refined in #13635 [0], but the refinements were generally not propagated to the method equivalents (pow() being the sole exception). This can result in equivalent expressions being treated differently by type checkers, especially if stricter settings are used that discourage/disallow the use of Any.

This commit changes the type hints for the method equivalents to match those for the operators. This should ensure resulting types are consistent regardless of whether one uses infix operators or their method equivalents.

This also has the side benefit of making the documentation a bit more consistent as the type hint more closely matches the stated type of the argument in the docstring.

[0]: https://github.com/pola-rs/polars/pull/13635/commits/1c417e44cd7297d89a6931c50b3df565d3ee04e4