### PR TITLE
fix(python): DataFrame.write_database() not passing along engine_options when using ADBC

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3967,6 +3967,7 @@ class DataFrame:
                         mode=mode,
                         catalog_name=catalog,
                         db_schema_name=db_schema,
+                        **(engine_options or {}),
                     )
                 elif db_schema is not None:
                     adbc_str_version = ".".join(str(v) for v in adbc_version)

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -320,6 +320,10 @@ def test_write_database_sa_commit(tmp_path: str, pass_connection: bool) -> None:
     assert_frame_equal(result, df)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9) or sys.platform == "win32",
+    reason="adbc not available on Windows or <= Python 3.8",
+)
 def test_write_database_adbc_temporary_table() -> None:
     """Confirm that execution_options are passed along to create temporary tables."""
     df = pl.DataFrame({"colx": [1, 2, 3]})

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -324,7 +324,9 @@ def test_write_database_adbc_temporary_table() -> None:
     """Confirm that execution_options are passed along to create temporary tables."""
     df = pl.DataFrame({"colx": [1, 2, 3]})
     temp_tbl_name = "should_be_temptable"
-    expected_temp_table_create_sql = """CREATE TABLE "should_be_temptable" ("colx" INTEGER)"""
+    expected_temp_table_create_sql = (
+        """CREATE TABLE "should_be_temptable" ("colx" INTEGER)"""
+    )
 
     # test with sqlite in memory
     conn = _open_adbc_connection("sqlite:///:memory:")


### PR DESCRIPTION
This is my first contribution to polars! Feedback welcome.

Fixes https://github.com/pola-rs/polars/issues/18478

It's a simple one line fix that allows things like properly creating temporary tables when using any ADBC driver. The test I added is written for sqlite3, but it also works when using the Postgres ADBC driver.