### PR TITLE
refactor(rust): More refactor for PlSmallStr

### DIFF
--- a/crates/polars-expr/src/expressions/column.rs
+++ b/crates/polars-expr/src/expressions/column.rs
@@ -123,7 +123,7 @@ impl ColumnExpr {
         // Linear search will be relatively cheap as we only search the CSE columns.
         Ok(columns
             .iter()
-            .find(|s| s.name() == self.name.as_ref())
+            .find(|s| s.name() == &self.name)
             .unwrap()
             .clone())
     }

--- a/crates/polars-io/src/ipc/ipc_reader_async.rs
+++ b/crates/polars-io/src/ipc/ipc_reader_async.rs
@@ -142,7 +142,7 @@ impl IpcReaderAsync {
             Some(projection) => {
                 fn prepare_schema(mut schema: Schema, row_index: Option<&RowIndex>) -> Schema {
                     if let Some(rc) = row_index {
-                        let _ = schema.insert_at_index(0, rc.name.as_ref().into(), IDX_DTYPE);
+                        let _ = schema.insert_at_index(0, rc.name.clone(), IDX_DTYPE);
                     }
                     schema
                 }

--- a/crates/polars-io/src/partition.rs
+++ b/crates/polars-io/src/partition.rs
@@ -54,8 +54,8 @@ where
         let partition_by_col_idx = partition_by
             .iter()
             .map(|x| {
-                let Some(i) = schema.index_of(x.as_ref()) else {
-                    polars_bail!(col_not_found = x.as_ref())
+                let Some(i) = schema.index_of(x.as_str()) else {
+                    polars_bail!(col_not_found = x)
                 };
                 Ok(i)
             })

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1095,7 +1095,7 @@ impl LazyFrame {
         mut options: DynamicGroupOptions,
     ) -> LazyGroupBy {
         if let Expr::Column(name) = index_column {
-            options.index_column = name.as_ref().into();
+            options.index_column = name;
         } else {
             let output_field = index_column
                 .to_field(&self.collect_schema().unwrap(), Context::Default)

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1050,7 +1050,7 @@ impl LazyFrame {
         mut options: RollingGroupOptions,
     ) -> LazyGroupBy {
         if let Expr::Column(name) = index_column {
-            options.index_column = name.as_ref().into();
+            options.index_column = name;
         } else {
             let output_field = index_column
                 .to_field(&self.collect_schema().unwrap(), Context::Default)

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -81,17 +81,13 @@ pub trait DataFrameJoinOps: IntoDf {
     /// | Pear   | 12                   | 115                 |
     /// +--------+----------------------+---------------------+
     /// ```
-    fn join<I, S>(
+    fn join(
         &self,
         other: &DataFrame,
-        left_on: I,
-        right_on: I,
+        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
         args: JoinArgs,
-    ) -> PolarsResult<DataFrame>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
-    {
+    ) -> PolarsResult<DataFrame> {
         let df_left = self.to_df();
         let selected_left = df_left.select_series(left_on)?;
         let selected_right = other.select_series(right_on)?;
@@ -370,16 +366,12 @@ pub trait DataFrameJoinOps: IntoDf {
     ///     left.inner_join(right, ["join_column_left"], ["join_column_right"])
     /// }
     /// ```
-    fn inner_join<I, S>(
+    fn inner_join(
         &self,
         other: &DataFrame,
-        left_on: I,
-        right_on: I,
-    ) -> PolarsResult<DataFrame>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
-    {
+        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+    ) -> PolarsResult<DataFrame> {
         self.join(other, left_on, right_on, JoinArgs::new(JoinType::Inner))
     }
 
@@ -418,11 +410,12 @@ pub trait DataFrameJoinOps: IntoDf {
     /// | 100             | null   |
     /// +-----------------+--------+
     /// ```
-    fn left_join<I, S>(&self, other: &DataFrame, left_on: I, right_on: I) -> PolarsResult<DataFrame>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
-    {
+    fn left_join(
+        &self,
+        other: &DataFrame,
+        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+    ) -> PolarsResult<DataFrame> {
         self.join(other, left_on, right_on, JoinArgs::new(JoinType::Left))
     }
 
@@ -436,11 +429,12 @@ pub trait DataFrameJoinOps: IntoDf {
     ///     left.full_join(right, ["join_column_left"], ["join_column_right"])
     /// }
     /// ```
-    fn full_join<I, S>(&self, other: &DataFrame, left_on: I, right_on: I) -> PolarsResult<DataFrame>
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<PlSmallStr>,
-    {
+    fn full_join(
+        &self,
+        other: &DataFrame,
+        left_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+        right_on: impl IntoIterator<Item = impl Into<PlSmallStr>>,
+    ) -> PolarsResult<DataFrame> {
         self.join(other, left_on, right_on, JoinArgs::new(JoinType::Full))
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/struct_.rs
+++ b/crates/polars-plan/src/dsl/function_expr/struct_.rs
@@ -39,11 +39,11 @@ impl StructFunction {
                 if let DataType::Struct(ref fields) = field.dtype {
                     let fld = fields
                         .iter()
-                        .find(|fld| fld.name() == name.as_ref())
-                        .ok_or_else(|| polars_err!(StructFieldNotFound: "{}", name.as_ref()))?;
+                        .find(|fld| fld.name() == name)
+                        .ok_or_else(|| polars_err!(StructFieldNotFound: "{}", name))?;
                     Ok(fld.clone())
                 } else {
-                    polars_bail!(StructFieldNotFound: "{}", name.as_ref());
+                    polars_bail!(StructFieldNotFound: "{}", name);
                 }
             }),
             RenameFields(names) => mapper.map_dtype(|dt| match dt {

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -41,7 +41,7 @@ impl StructNameSpace {
     /// This expression also supports wildcard "*" and regex expansion.
     pub fn field_by_name(self, name: &str) -> Expr {
         if name == "*" || is_regex_projection(name) {
-            return self.field_by_names(&[name][..]);
+            return self.field_by_names([name]);
         }
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::FieldByName(

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -233,7 +233,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut ConversionContext) -> PolarsResult<No
 
                     schema.insert_at_index(
                         schema.len(),
-                        file_path_col.as_ref().into(),
+                        file_path_col.clone(),
                         DataType::String,
                     )?;
                 }
@@ -253,7 +253,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut ConversionContext) -> PolarsResult<No
             if let Some(row_index) = &file_options.row_index {
                 let schema = Arc::make_mut(&mut resolved_file_info.schema);
                 *schema = schema
-                    .new_inserting_at_index(0, row_index.name.as_ref().into(), IDX_DTYPE)
+                    .new_inserting_at_index(0, row_index.name.clone(), IDX_DTYPE)
                     .unwrap();
             }
 

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -117,7 +117,7 @@ fn expand_regex(
             let mut new_expr = remove_exclude(expr.clone());
 
             new_expr = new_expr.map_expr(|e| match e {
-                Expr::Column(pat) if pat.as_ref() == pattern => Expr::Column(name.clone()),
+                Expr::Column(pat) if pat.as_str() == pattern => Expr::Column(name.clone()),
                 e => e,
             });
 
@@ -415,7 +415,7 @@ fn expand_struct_fields(
     }
 
     for name in names {
-        polars_ensure!(name.as_ref() != "*", InvalidOperation: "cannot combine wildcards and column names");
+        polars_ensure!(name.as_str() != "*", InvalidOperation: "cannot combine wildcards and column names");
 
         if !exclude.contains(name) {
             let mut new_expr = replace_struct_multiple_fields_with_field(full_expr.clone(), name)?;

--- a/crates/polars-plan/src/plans/conversion/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/scans.rs
@@ -19,7 +19,7 @@ fn get_first_path(paths: &[PathBuf]) -> PolarsResult<&PathBuf> {
 #[cfg(any(feature = "parquet", feature = "ipc"))]
 fn prepare_output_schema(mut schema: Schema, row_index: Option<&RowIndex>) -> SchemaRef {
     if let Some(rc) = row_index {
-        let _ = schema.insert_at_index(0, rc.name.as_ref().into(), IDX_DTYPE);
+        let _ = schema.insert_at_index(0, rc.name.clone(), IDX_DTYPE);
     }
     Arc::new(schema)
 }
@@ -28,7 +28,7 @@ fn prepare_output_schema(mut schema: Schema, row_index: Option<&RowIndex>) -> Sc
 fn prepare_schemas(mut schema: Schema, row_index: Option<&RowIndex>) -> (SchemaRef, SchemaRef) {
     if let Some(rc) = row_index {
         let reader_schema = schema.clone();
-        let _ = schema.insert_at_index(0, rc.name.as_ref().into(), IDX_DTYPE);
+        let _ = schema.insert_at_index(0, rc.name.clone(), IDX_DTYPE);
         (Arc::new(reader_schema), Arc::new(schema))
     } else {
         let schema = Arc::new(schema);
@@ -254,7 +254,7 @@ pub(super) fn csv_file_info(
     let reader_schema = if let Some(rc) = &file_options.row_index {
         let reader_schema = schema.clone();
         let mut output_schema = (*reader_schema).clone();
-        output_schema.insert_at_index(0, rc.name.as_ref().into(), IDX_DTYPE)?;
+        output_schema.insert_at_index(0, rc.name.clone(), IDX_DTYPE)?;
         schema = Arc::new(output_schema);
         reader_schema
     } else {

--- a/crates/polars-plan/src/plans/functions/dsl.rs
+++ b/crates/polars-plan/src/plans/functions/dsl.rs
@@ -102,10 +102,10 @@ impl DslFunction {
                 validate_columns_in_input(index.as_ref(), input_schema, "unpivot")?;
 
                 let args = UnpivotArgsIR {
-                    on: on.iter().map(|s| s.as_ref().into()).collect(),
-                    index: index.iter().map(|s| s.as_ref().into()).collect(),
-                    variable_name: args.variable_name.map(|s| s.as_ref().into()),
-                    value_name: args.value_name.map(|s| s.as_ref().into()),
+                    on: on.iter().cloned().collect(),
+                    index: index.iter().cloned().collect(),
+                    variable_name: args.variable_name.clone(),
+                    value_name: args.value_name.clone(),
                 };
 
                 FunctionIR::Unpivot {

--- a/crates/polars-plan/src/plans/functions/schema.rs
+++ b/crates/polars-plan/src/plans/functions/schema.rs
@@ -54,7 +54,7 @@ impl FunctionIR {
                 {
                     let mut new_schema = Schema::with_capacity(input_schema.len() * 2);
                     for (name, dtype) in input_schema.iter() {
-                        if _columns.iter().any(|item| item.as_ref() == name.as_str()) {
+                        if _columns.iter().any(|item| item == name) {
                             match dtype {
                                 DataType::Struct(flds) => {
                                     for fld in flds {
@@ -136,7 +136,7 @@ fn explode_schema<'a>(
     columns.iter().try_for_each(|name| {
         if let DataType::List(inner) = schema.try_get(name)? {
             let inner = *inner.clone();
-            schema.with_column(name.as_ref().into(), inner);
+            schema.with_column(name.clone(), inner);
         };
         PolarsResult::Ok(())
     })?;

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -26,8 +26,8 @@ impl fmt::Display for TreeFmtAExpr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self.0 {
             AExpr::Explode(_) => "explode",
-            AExpr::Alias(_, name) => return write!(f, "alias({})", name.as_ref()),
-            AExpr::Column(name) => return write!(f, "col({})", name.as_ref()),
+            AExpr::Alias(_, name) => return write!(f, "alias({})", name),
+            AExpr::Column(name) => return write!(f, "col({})", name),
             AExpr::Literal(lv) => return write!(f, "lit({lv:?})"),
             AExpr::BinaryExpr { op, .. } => return write!(f, "binary: {}", op),
             AExpr::Cast {

--- a/crates/polars-plan/src/plans/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cache_states.rs
@@ -339,15 +339,15 @@ pub(super) fn set_cache_states(
                     // order we discovered all values.
                     let child_schema = child_lp.schema(lp_arena);
                     let child_schema = child_schema.as_ref();
-                    let projection: Vec<_> = child_schema
+                    let projection = child_schema
                         .iter_names()
-                        .flat_map(|name| columns.get(name.as_str()).map(|name| name.as_ref()))
-                        .collect();
+                        .flat_map(|name| columns.get(name.as_str()).cloned())
+                        .collect::<Vec<_>>();
 
                     let new_child = lp_arena.add(child_lp);
 
                     let lp = IRBuilder::new(new_child, expr_arena, lp_arena)
-                        .project_simple(projection.iter().copied())
+                        .project_simple(projection)
                         .unwrap()
                         .build();
 

--- a/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
@@ -55,7 +55,7 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                         .map(|e| e.output_name().clone())
                         .collect::<Vec<_>>();
                     let alp = IRBuilder::new(*input, expr_arena, lp_arena)
-                        .project_simple(exprs.iter().map(|s| s.as_ref()))
+                        .project_simple(exprs.iter().cloned())
                         .ok()?
                         .build();
 

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -90,11 +90,8 @@ fn all_pred_cols_in_left_on(
     expr_arena: &mut Arena<AExpr>,
     left_on: &[ExprIR],
 ) -> bool {
-    aexpr_to_leaf_names_iter(predicate.node(), expr_arena).all(|pred_column_name| {
-        left_on
-            .iter()
-            .any(|e| e.output_name() == pred_column_name.as_ref())
-    })
+    aexpr_to_leaf_names_iter(predicate.node(), expr_arena)
+        .all(|pred_column_name| left_on.iter().any(|e| e.output_name() == &pred_column_name))
 }
 
 // Checks if a predicate refers to columns in both tables

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
@@ -483,7 +483,7 @@ fn resolve_join_suffixes(
         .map(|proj| {
             let name = column_node_to_name(*proj, expr_arena).clone();
             if name.ends_with(suffix) && schema_after_join.get(&name).is_none() {
-                let downstream_name = &name.as_ref()[..name.len() - suffix.len()];
+                let downstream_name = &name.as_str()[..name.len() - suffix.len()];
                 let col = AExpr::Column(downstream_name.into());
                 let node = expr_arena.add(col);
                 all_columns = false;

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/projection.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/projection.rs
@@ -26,7 +26,7 @@ fn check_double_projection(
         name: &str,
         expr_arena: &Arena<AExpr>,
     ) {
-        acc_projections.retain(|node| column_node_to_name(*node, expr_arena).as_ref() != name);
+        acc_projections.retain(|node| column_node_to_name(*node, expr_arena) != name);
     }
     if let Some(name) = expr.get_non_projected_name() {
         if projected_names.remove(name) {

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/rename.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/rename.rs
@@ -15,7 +15,7 @@ fn iter_and_update_nodes(
         let node = column_node.0;
         if !processed.contains(&node.0) {
             // We walk the query backwards, so we rename new to existing
-            if column_node_to_name(*column_node, expr_arena).as_ref() == new {
+            if column_node_to_name(*column_node, expr_arena) == new {
                 let new_node = expr_arena.add(AExpr::Column(PlSmallStr::from_str(existing)));
                 *column_node = ColumnNode(new_node);
                 processed.insert(new_node.0);
@@ -41,7 +41,7 @@ pub(super) fn process_rename(
         for col in acc_projections {
             let name = column_node_to_name(*col, expr_arena);
 
-            if let Some(previous) = reverse_map.get(name.as_ref()) {
+            if let Some(previous) = reverse_map.get(name) {
                 let new = expr_arena.add(AExpr::Column(previous.clone()));
                 *col = ColumnNode(new);
                 let _ = new_projected_names.insert(previous.clone());

--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -37,7 +37,7 @@ pub fn predicate_to_pa(
                 None
             }
         },
-        AExpr::Column(name) => Some(format!("pa.compute.field('{}')", name.as_ref())),
+        AExpr::Column(name) => Some(format!("pa.compute.field('{}')", name)),
         AExpr::Literal(LiteralValue::Series(s)) => {
             if !args.allow_literal_series || s.is_empty() || s.len() > 100 {
                 None

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -360,7 +360,7 @@ pub(crate) fn expr_irs_to_schema<I: IntoIterator<Item = K>, K: AsRef<ExprIR>>(
             let mut field = arena.get(e.node()).to_field(schema, ctxt, arena).unwrap();
 
             if let Some(name) = e.get_alias() {
-                field.name = name.as_ref().into()
+                field.name = name.clone()
             }
             field
         })

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -75,7 +75,7 @@ impl PyFileOptions {
             .inner
             .row_index
             .as_ref()
-            .map_or_else(|| py.None(), |n| (n.name.as_ref(), n.offset).to_object(py)))
+            .map_or_else(|| py.None(), |n| (n.name.as_str(), n.offset).to_object(py)))
     }
     #[getter]
     fn rechunk(&self, _py: Python<'_>) -> PyResult<bool> {

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1303,7 +1303,7 @@ impl SQLFunctionVisitor<'_> {
                                 cols(col_names)
                             })
                         } else {
-                            Ok(col(&pat))
+                            Ok(col(pat.as_str()))
                         }
                     },
                     Expr::Wildcard => Ok(col("*")),

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -213,8 +213,8 @@ fn upsample_single_impl(
                     .into_frame();
                     range.join(
                         source,
-                        [index_col_name],
-                        [index_col_name],
+                        [index_col_name.clone()],
+                        [index_col_name.clone()],
                         JoinArgs::new(JoinType::Left),
                     )
                 },

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -78,11 +78,20 @@ impl AsRef<str> for PlSmallStr {
     }
 }
 
-impl<T> AsRef<T> for PlSmallStr
-where
-    str: AsRef<T>,
-{
-    fn as_ref(&self) -> &T {
+impl AsRef<std::path::Path> for PlSmallStr {
+    fn as_ref(&self) -> &std::path::Path {
+        self.as_str().as_ref()
+    }
+}
+
+impl AsRef<[u8]> for PlSmallStr {
+    fn as_ref(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+}
+
+impl AsRef<std::ffi::OsStr> for PlSmallStr {
+    fn as_ref(&self) -> &std::ffi::OsStr {
         self.as_str().as_ref()
     }
 }

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -7,6 +7,7 @@ macro_rules! format_pl_smallstr {
     ($($arg:tt)*) => {{
         use std::fmt::Write;
 
+        // TODO: Optimize
         let mut string = String::new();
         write!(string, $($arg)*).unwrap();
         PlSmallStr::from_string(string)
@@ -68,49 +69,21 @@ impl Default for PlSmallStr {
     }
 }
 
+/// AsRef, Deref and Borrow impls to &str
+
 impl AsRef<str> for PlSmallStr {
     #[inline(always)]
     fn as_ref(&self) -> &str {
-        self.0.as_ref()
+        self.as_str()
     }
 }
 
-impl<T> PartialEq<T> for PlSmallStr
+impl<T> AsRef<T> for PlSmallStr
 where
-    T: AsRef<str> + ?Sized,
+    str: AsRef<T>,
 {
-    fn eq(&self, other: &T) -> bool {
-        self.as_str() == other.as_ref()
-    }
-}
-
-impl PartialEq<PlSmallStr> for &str {
-    fn eq(&self, other: &PlSmallStr) -> bool {
-        *self == other.as_str()
-    }
-}
-
-impl PartialEq<PlSmallStr> for &&str {
-    fn eq(&self, other: &PlSmallStr) -> bool {
-        **self == other.as_str()
-    }
-}
-
-impl PartialEq<PlSmallStr> for String {
-    fn eq(&self, other: &PlSmallStr) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl PartialEq<PlSmallStr> for &String {
-    fn eq(&self, other: &PlSmallStr) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl core::fmt::Debug for PlSmallStr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.as_str().fmt(f)
+    fn as_ref(&self) -> &T {
+        self.as_str().as_ref()
     }
 }
 
@@ -119,32 +92,20 @@ impl core::ops::Deref for PlSmallStr {
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
+        self.as_str()
     }
 }
 
 impl core::borrow::Borrow<str> for PlSmallStr {
     #[inline(always)]
     fn borrow(&self) -> &str {
-        self.0.as_ref()
+        self.as_str()
     }
 }
 
-/// We implement `From<&PlSmallStr>` to support `&[S] where S: Into<PlSmallStr>`,
-/// prefer calling `.clone()` for existing `PlSmallStr`s where possible.
-impl From<&PlSmallStr> for PlSmallStr {
-    #[inline(always)]
-    fn from(value: &PlSmallStr) -> Self {
-        value.clone()
-    }
-}
+/// AsRef impls for other types (TODO)
 
-impl From<&&PlSmallStr> for PlSmallStr {
-    #[inline(always)]
-    fn from(value: &&PlSmallStr) -> Self {
-        (*value).clone()
-    }
-}
+/// From impls
 
 impl From<&str> for PlSmallStr {
     #[inline(always)]
@@ -153,6 +114,7 @@ impl From<&str> for PlSmallStr {
     }
 }
 
+/// TODO: remove
 impl From<&&str> for PlSmallStr {
     #[inline(always)]
     fn from(value: &&str) -> Self {
@@ -174,9 +136,46 @@ impl From<&String> for PlSmallStr {
     }
 }
 
+/// FromIterator impls (TODO)
+
+/// PartialEq impls
+
+impl<T> PartialEq<T> for PlSmallStr
+where
+    T: AsRef<str> + ?Sized,
+{
+    #[inline(always)]
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == other.as_ref()
+    }
+}
+
+impl PartialEq<PlSmallStr> for &str {
+    #[inline(always)]
+    fn eq(&self, other: &PlSmallStr) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl PartialEq<PlSmallStr> for String {
+    #[inline(always)]
+    fn eq(&self, other: &PlSmallStr) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+/// Debug, Display
+
+impl core::fmt::Debug for PlSmallStr {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
 impl core::fmt::Display for PlSmallStr {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        self.as_str().fmt(f)
     }
 }

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -78,6 +78,24 @@ impl AsRef<str> for PlSmallStr {
     }
 }
 
+impl core::ops::Deref for PlSmallStr {
+    type Target = str;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl core::borrow::Borrow<str> for PlSmallStr {
+    #[inline(always)]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+/// AsRef impls for other types
+
 impl AsRef<std::path::Path> for PlSmallStr {
     fn as_ref(&self) -> &std::path::Path {
         self.as_str().as_ref()
@@ -95,24 +113,6 @@ impl AsRef<std::ffi::OsStr> for PlSmallStr {
         self.as_str().as_ref()
     }
 }
-
-impl core::ops::Deref for PlSmallStr {
-    type Target = str;
-
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        self.as_str()
-    }
-}
-
-impl core::borrow::Borrow<str> for PlSmallStr {
-    #[inline(always)]
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-/// AsRef impls for other types (TODO)
 
 /// From impls
 

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -508,8 +508,8 @@ fn test_multi_joins_with_duplicates() -> PolarsResult<()> {
     let df_inner_join = df_left
         .join(
             &df_right,
-            &["col1", "join_col2"],
-            &["join_col1", "col2"],
+            ["col1", "join_col2"],
+            ["join_col1", "col2"],
             JoinType::Inner.into(),
         )
         .unwrap();
@@ -523,8 +523,8 @@ fn test_multi_joins_with_duplicates() -> PolarsResult<()> {
     let df_left_join = df_left
         .join(
             &df_right,
-            &["col1", "join_col2"],
-            &["join_col1", "col2"],
+            ["col1", "join_col2"],
+            ["join_col1", "col2"],
             JoinType::Left.into(),
         )
         .unwrap();
@@ -538,8 +538,8 @@ fn test_multi_joins_with_duplicates() -> PolarsResult<()> {
     let df_full_outer_join = df_left
         .join(
             &df_right,
-            &["col1", "join_col2"],
-            &["join_col1", "col2"],
+            ["col1", "join_col2"],
+            ["join_col1", "col2"],
             JoinArgs::new(JoinType::Full).with_coalesce(JoinCoalesce::CoalesceColumns),
         )
         .unwrap();

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -393,7 +393,7 @@ hello,","," ",world,"!"
         .finish()
         .unwrap();
 
-    for (col, val) in &[
+    for (col, val) in [
         ("column_1", "hello"),
         ("column_2", ","),
         ("column_3", " "),
@@ -403,7 +403,7 @@ hello,","," ",world,"!"
         assert!(df
             .column(col)
             .unwrap()
-            .equals(&Series::new(col.into(), &[&**val; 4])));
+            .equals(&Series::new(col.into(), &[val; 4])));
     }
 }
 

--- a/crates/polars/tests/it/lazy/expressions/literals.rs
+++ b/crates/polars/tests/it/lazy/expressions/literals.rs
@@ -5,7 +5,7 @@ fn test_datetime_as_lit() {
     let Expr::Alias(e, name) = datetime(Default::default()) else {
         panic!()
     };
-    assert_eq!(name.as_ref(), "datetime");
+    assert_eq!(name, "datetime");
     assert!(matches!(e.as_ref(), Expr::Literal(_)))
 }
 
@@ -14,6 +14,6 @@ fn test_duration_as_lit() {
     let Expr::Alias(e, name) = duration(Default::default()) else {
         panic!()
     };
-    assert_eq!(name.as_ref(), "duration");
+    assert_eq!(name, "duration");
     assert!(matches!(e.as_ref(), Expr::Literal(_)))
 }


### PR DESCRIPTION
* Organize the impls
* Some remaining cleanup of `.as_ref().into()` -> `.clone()`
* ~~Removes `From<&&str>`:~~ *breaks a lot of things - will do separately
   * ~~Existing code calling with constant arrays are changed from e.g. `Series::new(_, &["a", ...])` to `Series::new(_, ["a", ...])`~~
   * ~~`&[&str]` can no longer be passed to most API functions accepting `impl IntoIterator<Item = impl Into<PlSmallStr>>`~~
* Add `AsRef<Path>`, `AsRef<[u8]>`, `AsRef<OsStr>`
