### PR TITLE
fix(python): Raise if single argument form in `replace`/`replace_strict` is not a mapping

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -10245,7 +10245,12 @@ class Expr:
                 old, new, default=default, return_dtype=return_dtype
             )
 
-        if new is no_default and isinstance(old, Mapping):
+        if new is no_default:
+            if not isinstance(old, Mapping):
+                msg = (
+                    "`new` argument is required if `old` argument is not a Mapping type"
+                )
+                raise TypeError(msg)
             new = pl.Series(old.values())
             old = pl.Series(old.keys())
         else:
@@ -10436,7 +10441,12 @@ class Expr:
         │ 3   ┆ 1.0 ┆ 10.0     │
         └─────┴─────┴──────────┘
         """  # noqa: W505
-        if new is no_default and isinstance(old, Mapping):
+        if new is no_default:
+            if not isinstance(old, Mapping):
+                msg = (
+                    "`new` argument is required if `old` argument is not a Mapping type"
+                )
+                raise TypeError(msg)
             new = pl.Series(old.values())
             old = pl.Series(old.keys())
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -10260,7 +10260,7 @@ class Expr:
                 new = pl.Series(new)
 
         old = parse_into_expression(old, str_as_lit=True)  # type: ignore[arg-type]
-        new = parse_into_expression(new, str_as_lit=True)  # type: ignore[arg-type]
+        new = parse_into_expression(new, str_as_lit=True)
 
         result = self._from_pyexpr(self._pyexpr.replace(old, new))
 

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -281,3 +281,12 @@ def test_replace_default_deprecated() -> None:
         result = s.replace(1, 10, default=None)
     expected = pl.Series([10, None, None], dtype=pl.Int32)
     assert_series_equal(result, expected)
+
+
+def test_replace_single_argument_not_mapping() -> None:
+    df = pl.DataFrame({"a": ["a", "b", "c"]})
+    with pytest.raises(
+        TypeError,
+        match="`new` argument is required if `old` argument is not a Mapping type",
+    ):
+        df.select(pl.col("a").replace("b"))

--- a/py-polars/tests/unit/operations/test_replace_strict.py
+++ b/py-polars/tests/unit/operations/test_replace_strict.py
@@ -398,3 +398,12 @@ def test_replace_strict_cat_cat(
             s = pl.Series("s", ["a", "b"], dtype=dt)
             s_replaced = s.replace_strict(old, new, default=pl.lit("OTHER", dtype=dt))  # type: ignore[arg-type]
             assert_series_equal(s_replaced, expected.fill_null("OTHER"))
+
+
+def test_replace_strict_single_argument_not_mapping() -> None:
+    df = pl.DataFrame({"a": ["b", "b", "b"]})
+    with pytest.raises(
+        TypeError,
+        match="`new` argument is required if `old` argument is not a Mapping type",
+    ):
+        df.select(pl.col("a").replace_strict("b"))


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/18185