### PR TITLE
fix(python): Normalize by default in Series.entropy like Expr.entropy does

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2565,7 +2565,7 @@ class Series:
         ]
         """
 
-    def entropy(self, base: float = math.e, *, normalize: bool = False) -> float | None:
+    def entropy(self, base: float = math.e, *, normalize: bool = True) -> float | None:
         """
         Computes the entropy.
 


### PR DESCRIPTION
@stinodego Theoretically backwards-incompatible, but I consider it a bug that the `Series` method did something different than the `Expr` method. However, in any sensible use-case of `Series.entropy` the probabilities would have already summed to 1, meaning that turning on normalize shouldn't *actually* change behavior for users.