### PR TITLE
docs: Pre-compute plugin_path before defining plugin

### DIFF
--- a/docs/user-guide/expressions/plugins.md
+++ b/docs/user-guide/expressions/plugins.md
@@ -103,11 +103,12 @@ import polars as pl
 from polars.plugins import register_plugin_function
 from polars._typing import IntoExpr
 
+PLUGIN_PATH = Path(__file__).parent
 
 def pig_latinnify(expr: IntoExpr) -> pl.Expr:
     """Pig-latinnify expression."""
     return register_plugin_function(
-        plugin_path=Path(__file__).parent,
+        plugin_path=PLUGIN_PATH,
         function_name="pig_latinnify",
         args=expr,
         is_elementwise=True,
@@ -190,7 +191,7 @@ def append_args(
     This example shows how arguments other than `Series` can be used.
     """
     return register_plugin_function(
-        plugin_path=Path(__file__).parent,
+        plugin_path=PLUGIN_PATH,
         function_name="append_kwargs",
         args=expr,
         kwargs={

--- a/py-polars/polars/series/plotting.py
+++ b/py-polars/polars/series/plotting.py
@@ -75,7 +75,7 @@ class SeriesPlot:
         **kwargs: Unpack[EncodeKwds],
     ) -> alt.Chart:
         """
-        Draw kernel dentity estimate plot.
+        Draw kernel density estimate plot.
 
         Polars does not implement plotting logic itself but instead defers to
         `Altair <https://altair-viz.github.io/>`_.


### PR DESCRIPTION
the way the user guide currently shows, it re-computes `plugin_path` each time the plugin function is called (probably my fault from https://github.com/pola-rs/polars/pull/14804)