### PR TITLE
feat: Enable parse of `0`/`1` as bool in csv

### DIFF
--- a/crates/polars-io/src/csv/read/buffer.rs
+++ b/crates/polars-io/src/csv/read/buffer.rs
@@ -355,7 +355,6 @@ impl ParsedBuffer for BooleanChunkedBuilder {
     }
 }
 
-
 #[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
 pub struct DatetimeField<T: PolarsNumericType> {
     compiled: Option<DatetimeInfer<T>>,

--- a/crates/polars-io/src/csv/read/buffer.rs
+++ b/crates/polars-io/src/csv/read/buffer.rs
@@ -339,9 +339,9 @@ impl ParsedBuffer for BooleanChunkedBuilder {
         } else {
             bytes
         };
-        if bytes.eq_ignore_ascii_case(b"false") {
+        if bytes == b"0" || bytes.eq_ignore_ascii_case(b"false") {
             self.append_value(false);
-        } else if bytes.eq_ignore_ascii_case(b"true") {
+        } else if bytes == b"1" || bytes.eq_ignore_ascii_case(b"true") {
             self.append_value(true);
         } else if ignore_errors || bytes.is_empty() {
             self.append_null();
@@ -354,6 +354,7 @@ impl ParsedBuffer for BooleanChunkedBuilder {
         Ok(())
     }
 }
+
 
 #[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
 pub struct DatetimeField<T: PolarsNumericType> {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2281,6 +2281,7 @@ def test_read_csv_cast_unparsable_later(
     df.write_csv(f)
     assert df.equals(pl.read_csv(f, schema={"x": dtype}))
 
+
 def test_csv_bool_formats() -> None:
     csv = io.StringIO(
         "a,b\n"

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2280,3 +2280,22 @@ def test_read_csv_cast_unparsable_later(
     f = io.BytesIO()
     df.write_csv(f)
     assert df.equals(pl.read_csv(f, schema={"x": dtype}))
+
+def test_csv_bool_formats() -> None:
+    csv = io.StringIO(
+        "a,b\n"
+        "1,true\n"
+        "0,false\n"
+    )  # fmt: skip
+    dtypes = {
+        "a": pl.Boolean,
+        "b": pl.Boolean,
+    }
+    result = pl.read_csv(csv, schema_overrides=dtypes)
+    expected = pl.DataFrame(
+        {
+            "a": [True, False],
+            "b": [True, False],
+        }
+    )
+    assert result.equals(expected)


### PR DESCRIPTION
#18502