### PR TITLE
perf: Change `PlSmallStr` impl from `Arc<str>` to `compact_str`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1049,21 @@ dependencies = [
  "strum",
  "strum_macros",
  "unicode-width",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2103,16 +2127,6 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "serde",
- "static_assertions",
 ]
 
 [[package]]
@@ -3494,9 +3508,9 @@ dependencies = [
  "ahash",
  "bytemuck",
  "bytes",
+ "compact_str",
  "hashbrown",
  "indexmap",
- "kstring",
  "libc",
  "memmap2",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,6 +3496,7 @@ dependencies = [
  "bytes",
  "hashbrown",
  "indexmap",
+ "kstring",
  "libc",
  "memmap2",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ hex = "0.4.3"
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
 itoap = { version = "1", features = ["simd"] }
+kstring = { version = "2.0.2", features = ["arc", "max_inline", "serde"] }
 libc = "0.2"
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ hex = "0.4.3"
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
 itoap = { version = "1", features = ["simd"] }
-kstring = { version = "2.0.2", default-features = false, features = ["std", "max_inline", "serde"] }
+kstring = { version = "2.0.2", default-features = false, features = ["std", "unsafe", "max_inline", "serde"] }
 libc = "0.2"
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ hex = "0.4.3"
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
 itoap = { version = "1", features = ["simd"] }
-kstring = { version = "2.0.2", features = ["arc", "max_inline", "serde"] }
+kstring = { version = "2.0.2", features = ["serde"] }
 libc = "0.2"
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ bytes = { version = "1.7" }
 chrono = { version = "0.4.31", default-features = false, features = ["std"] }
 chrono-tz = "0.8.1"
 ciborium = "0.2"
+compact_str = { version = "0.8.0", features = ["serde"] }
 crossbeam-channel = "0.5.8"
 crossbeam-deque = "0.8.5"
 crossbeam-queue = "0.3"
@@ -55,7 +56,6 @@ hex = "0.4.3"
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
 itoap = { version = "1", features = ["simd"] }
-kstring = { version = "2.0.2", default-features = false, features = ["std", "unsafe", "max_inline", "serde"] }
 libc = "0.2"
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ hex = "0.4.3"
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
 itoap = { version = "1", features = ["simd"] }
-kstring = { version = "2.0.2", features = ["serde"] }
+kstring = { version = "2.0.2", default-features = false, features = ["std", "max_inline", "serde"] }
 libc = "0.2"
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.7" }

--- a/crates/polars-arrow/src/ffi/schema.rs
+++ b/crates/polars-arrow/src/ffi/schema.rs
@@ -108,7 +108,7 @@ impl ArrowSchema {
                 None
             };
 
-        let name = CString::new(name.as_str()).unwrap();
+        let name = CString::new(name.as_bytes()).unwrap();
         let format = CString::new(format).unwrap();
 
         let mut private = Box::new(SchemaPrivateData {

--- a/crates/polars-arrow/src/ffi/schema.rs
+++ b/crates/polars-arrow/src/ffi/schema.rs
@@ -75,7 +75,7 @@ impl ArrowSchema {
         {
             flags += *is_ordered as i64;
             // we do not store field info in the dict values, so can't recover it all :(
-            let field = Field::new(PlSmallStr::const_default(), values.as_ref().clone(), true);
+            let field = Field::new(PlSmallStr::EMPTY, values.as_ref().clone(), true);
             Some(Box::new(ArrowSchema::new(&field)))
         } else {
             None

--- a/crates/polars-arrow/src/io/ipc/read/common.rs
+++ b/crates/polars-arrow/src/io/ipc/read/common.rs
@@ -280,11 +280,7 @@ pub fn read_dictionary<R: Read + Seek>(
     };
 
     // Make a fake schema for the dictionary batch.
-    let fields = vec![Field::new(
-        PlSmallStr::const_default(),
-        value_type.clone(),
-        false,
-    )];
+    let fields = vec![Field::new(PlSmallStr::EMPTY, value_type.clone(), false)];
     let ipc_schema = IpcSchema {
         fields: vec![first_ipc_field.clone()],
         is_little_endian: ipc_schema.is_little_endian,

--- a/crates/polars-arrow/src/mmap/mod.rs
+++ b/crates/polars-arrow/src/mmap/mod.rs
@@ -186,7 +186,7 @@ unsafe fn mmap_dictionary<T: AsRef<[u8]>>(
     };
 
     // Make a fake schema for the dictionary batch.
-    let field = Field::new(PlSmallStr::const_default(), value_type.clone(), false);
+    let field = Field::new(PlSmallStr::EMPTY, value_type.clone(), false);
 
     let chunk = _mmap_record(
         &[field],

--- a/crates/polars-core/src/chunked_array/array/iterator.rs
+++ b/crates/polars-core/src/chunked_array/array/iterator.rs
@@ -26,7 +26,7 @@ impl ArrayChunked {
     /// The lifetime of [AmortSeries] is bound to the iterator. Keeping it alive
     /// longer than the iterator is UB.
     pub fn amortized_iter(&self) -> AmortizedListIter<impl Iterator<Item = Option<ArrayBox>> + '_> {
-        self.amortized_iter_with_name(PlSmallStr::const_default())
+        self.amortized_iter_with_name(PlSmallStr::EMPTY)
     }
 
     /// This is an iterator over a [`ArrayChunked`] that save allocations.

--- a/crates/polars-core/src/chunked_array/builder/list/anonymous.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/anonymous.rs
@@ -9,7 +9,7 @@ pub struct AnonymousListBuilder<'a> {
 
 impl Default for AnonymousListBuilder<'_> {
     fn default() -> Self {
-        Self::new(PlSmallStr::const_default(), 0, None)
+        Self::new(PlSmallStr::EMPTY, 0, None)
     }
 }
 
@@ -91,7 +91,7 @@ impl<'a> AnonymousListBuilder<'a> {
                 Some(dt) => DataType::List(Box::new(dt)),
             };
 
-            let mut ca = ListChunked::with_chunk(PlSmallStr::const_default(), arr);
+            let mut ca = ListChunked::with_chunk(PlSmallStr::EMPTY, arr);
             if slf.fast_explode {
                 ca.set_fast_explode();
             }
@@ -111,7 +111,7 @@ pub struct AnonymousOwnedListBuilder {
 
 impl Default for AnonymousOwnedListBuilder {
     fn default() -> Self {
-        Self::new(PlSmallStr::const_default(), 0, None)
+        Self::new(PlSmallStr::EMPTY, 0, None)
     }
 }
 
@@ -151,7 +151,7 @@ impl ListBuilderTrait for AnonymousOwnedListBuilder {
             Some(dt) => DataType::List(Box::new(dt)),
         };
 
-        let mut ca = ListChunked::with_chunk(PlSmallStr::const_default(), arr);
+        let mut ca = ListChunked::with_chunk(PlSmallStr::EMPTY, arr);
         if slf.fast_explode {
             ca.set_fast_explode();
         }

--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -46,7 +46,7 @@ where
         let chunks = iter
             .into_iter()
             .map(|(values, opt_buffer)| to_primitive::<T>(values, opt_buffer));
-        ChunkedArray::from_chunk_iter(PlSmallStr::const_default(), chunks)
+        ChunkedArray::from_chunk_iter(PlSmallStr::EMPTY, chunks)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -617,7 +617,7 @@ fn cast_list(
     // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             vec![arr.values().clone()],
             ca.inner_dtype(),
         )
@@ -646,7 +646,7 @@ unsafe fn cast_list_unchecked(ca: &ListChunked, child_type: &DataType) -> Polars
     // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             vec![arr.values().clone()],
             ca.inner_dtype(),
         )
@@ -682,7 +682,7 @@ fn cast_fixed_size_list(
     // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             vec![arr.values().clone()],
             ca.inner_dtype(),
         )

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -30,21 +30,21 @@ where
                 if let Some(value) = rhs.get(0) {
                     self.equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_eq_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -70,7 +70,7 @@ where
                 self,
                 rhs,
                 |a, b| a.tot_eq_missing_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -82,21 +82,21 @@ where
                 if let Some(value) = rhs.get(0) {
                     self.not_equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_ne_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -122,7 +122,7 @@ where
                 self,
                 rhs,
                 |a, b| a.tot_ne_missing_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -134,21 +134,21 @@ where
                 if let Some(value) = rhs.get(0) {
                     self.lt(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_lt_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -160,21 +160,21 @@ where
                 if let Some(value) = rhs.get(0) {
                     self.lt_eq(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt_eq(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_le_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -244,21 +244,21 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 if let Some(value) = rhs.get(0) {
                     arity::unary_mut_values(self, |arr| arr.tot_eq_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     arity::unary_mut_values(rhs, |arr| arr.tot_eq_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_eq_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -288,7 +288,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 self,
                 rhs,
                 |a, b| a.tot_eq_missing_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -300,21 +300,21 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 if let Some(value) = rhs.get(0) {
                     arity::unary_mut_values(self, |arr| arr.tot_ne_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     arity::unary_mut_values(rhs, |arr| arr.tot_ne_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_ne_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -344,7 +344,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 self,
                 rhs,
                 |a, b| a.tot_ne_missing_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -356,21 +356,21 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 if let Some(value) = rhs.get(0) {
                     arity::unary_mut_values(self, |arr| arr.tot_lt_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     arity::unary_mut_values(rhs, |arr| arr.tot_gt_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_lt_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -382,21 +382,21 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 if let Some(value) = rhs.get(0) {
                     arity::unary_mut_values(self, |arr| arr.tot_le_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     arity::unary_mut_values(rhs, |arr| arr.tot_ge_kernel_broadcast(&value).into())
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_le_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -455,21 +455,21 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 if let Some(value) = rhs.get(0) {
                     self.equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_eq_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -495,7 +495,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 self,
                 rhs,
                 |a, b| a.tot_eq_missing_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -507,21 +507,21 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 if let Some(value) = rhs.get(0) {
                     self.not_equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_ne_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -547,7 +547,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 self,
                 rhs,
                 |a, b| a.tot_ne_missing_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -559,21 +559,21 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 if let Some(value) = rhs.get(0) {
                     self.lt(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_lt_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -585,21 +585,21 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 if let Some(value) = rhs.get(0) {
                     self.lt_eq(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), self.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, self.len())
                 }
             },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt_eq(value)
                 } else {
-                    BooleanChunked::full_null(PlSmallStr::const_default(), rhs.len())
+                    BooleanChunked::full_null(PlSmallStr::EMPTY, rhs.len())
                 }
             },
             _ => arity::binary_mut_values(
                 self,
                 rhs,
                 |a, b| a.tot_le_kernel(b).into(),
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
             ),
         }
     }
@@ -620,17 +620,13 @@ where
 {
     match (lhs.len(), rhs.len()) {
         (_, 1) => {
-            let right = rhs
-                .get_as_series(0)
-                .map(|s| s.with_name(PlSmallStr::const_default()));
+            let right = rhs.get_as_series(0).map(|s| s.with_name(PlSmallStr::EMPTY));
             lhs.amortized_iter()
                 .map(|left| op(left.as_ref().map(|us| us.as_ref()), right.as_ref()))
                 .collect_trusted()
         },
         (1, _) => {
-            let left = lhs
-                .get_as_series(0)
-                .map(|s| s.with_name(PlSmallStr::const_default()));
+            let left = lhs.get_as_series(0).map(|s| s.with_name(PlSmallStr::EMPTY));
             rhs.amortized_iter()
                 .map(|right| op(left.as_ref(), right.as_ref().map(|us| us.as_ref())))
                 .collect_trusted()
@@ -721,7 +717,7 @@ where
 {
     if a.len() != b.len() || a.struct_fields().len() != b.struct_fields().len() {
         // polars_ensure!(a.len() == 1 || b.len() == 1, ShapeMismatch: "length lhs: {}, length rhs: {}", a.len(), b.len());
-        BooleanChunked::full(PlSmallStr::const_default(), value, a.len())
+        BooleanChunked::full(PlSmallStr::EMPTY, value, a.len())
     } else {
         let (a, b) = align_chunks_binary(a, b);
         let mut out = a
@@ -793,49 +789,49 @@ impl ChunkCompare<&ArrayChunked> for ArrayChunked {
     type Item = BooleanChunked;
     fn equal(&self, rhs: &ArrayChunked) -> BooleanChunked {
         if self.width() != rhs.width() {
-            return BooleanChunked::full(PlSmallStr::const_default(), false, self.len());
+            return BooleanChunked::full(PlSmallStr::EMPTY, false, self.len());
         }
         arity::binary_mut_values(
             self,
             rhs,
             |a, b| a.tot_eq_kernel(b).into(),
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
         )
     }
 
     fn equal_missing(&self, rhs: &ArrayChunked) -> BooleanChunked {
         if self.width() != rhs.width() {
-            return BooleanChunked::full(PlSmallStr::const_default(), false, self.len());
+            return BooleanChunked::full(PlSmallStr::EMPTY, false, self.len());
         }
         arity::binary_mut_with_options(
             self,
             rhs,
             |a, b| a.tot_eq_missing_kernel(b).into(),
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
         )
     }
 
     fn not_equal(&self, rhs: &ArrayChunked) -> BooleanChunked {
         if self.width() != rhs.width() {
-            return BooleanChunked::full(PlSmallStr::const_default(), true, self.len());
+            return BooleanChunked::full(PlSmallStr::EMPTY, true, self.len());
         }
         arity::binary_mut_values(
             self,
             rhs,
             |a, b| a.tot_ne_kernel(b).into(),
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
         )
     }
 
     fn not_equal_missing(&self, rhs: &ArrayChunked) -> Self::Item {
         if self.width() != rhs.width() {
-            return BooleanChunked::full(PlSmallStr::const_default(), true, self.len());
+            return BooleanChunked::full(PlSmallStr::EMPTY, true, self.len());
         }
         arity::binary_mut_with_options(
             self,
             rhs,
             |a, b| a.tot_ne_missing_kernel(b).into(),
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
         )
     }
 
@@ -1218,13 +1214,9 @@ mod test {
 
     #[test]
     fn test_kleene() {
-        let a = BooleanChunked::new(
-            PlSmallStr::const_default(),
-            &[Some(true), Some(false), None],
-        );
-        let trues = BooleanChunked::from_slice(PlSmallStr::const_default(), &[true, true, true]);
-        let falses =
-            BooleanChunked::from_slice(PlSmallStr::const_default(), &[false, false, false]);
+        let a = BooleanChunked::new(PlSmallStr::EMPTY, &[Some(true), Some(false), None]);
+        let trues = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[true, true, true]);
+        let falses = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[false, false, false]);
 
         let c = &a | &trues;
         assert_eq!(Vec::from(&c), &[Some(true), Some(true), Some(true)]);
@@ -1235,9 +1227,9 @@ mod test {
 
     #[test]
     fn list_broadcasting_lists() {
-        let s_el = Series::new(PlSmallStr::const_default(), &[1, 2, 3]);
-        let s_lhs = Series::new(PlSmallStr::const_default(), &[s_el.clone(), s_el.clone()]);
-        let s_rhs = Series::new(PlSmallStr::const_default(), &[s_el.clone()]);
+        let s_el = Series::new(PlSmallStr::EMPTY, &[1, 2, 3]);
+        let s_lhs = Series::new(PlSmallStr::EMPTY, &[s_el.clone(), s_el.clone()]);
+        let s_rhs = Series::new(PlSmallStr::EMPTY, &[s_el.clone()]);
 
         let result = s_lhs.list().unwrap().equal(s_rhs.list().unwrap());
         assert_eq!(result.len(), 2);
@@ -1246,9 +1238,9 @@ mod test {
 
     #[test]
     fn test_broadcasting_bools() {
-        let a = BooleanChunked::from_slice(PlSmallStr::const_default(), &[true, false, true]);
-        let true_ = BooleanChunked::from_slice(PlSmallStr::const_default(), &[true]);
-        let false_ = BooleanChunked::from_slice(PlSmallStr::const_default(), &[false]);
+        let a = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[true, false, true]);
+        let true_ = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[true]);
+        let false_ = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[false]);
 
         let out = a.equal(&true_);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(true)]);
@@ -1304,13 +1296,10 @@ mod test {
         let out = false_.lt_eq(&a);
         assert_eq!(Vec::from(&out), &[Some(true), Some(true), Some(true)]);
 
-        let a = BooleanChunked::from_slice_options(
-            PlSmallStr::const_default(),
-            &[Some(true), Some(false), None],
-        );
-        let all_true = BooleanChunked::from_slice(PlSmallStr::const_default(), &[true, true, true]);
-        let all_false =
-            BooleanChunked::from_slice(PlSmallStr::const_default(), &[false, false, false]);
+        let a =
+            BooleanChunked::from_slice_options(PlSmallStr::EMPTY, &[Some(true), Some(false), None]);
+        let all_true = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[true, true, true]);
+        let all_false = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[false, false, false]);
         let out = a.equal(&true_);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), None]);
         let out = a.not_equal(&true_);
@@ -1332,9 +1321,9 @@ mod test {
 
     #[test]
     fn test_broadcasting_numeric() {
-        let a = Int32Chunked::from_slice(PlSmallStr::const_default(), &[1, 2, 3]);
-        let one = Int32Chunked::from_slice(PlSmallStr::const_default(), &[1]);
-        let three = Int32Chunked::from_slice(PlSmallStr::const_default(), &[3]);
+        let a = Int32Chunked::from_slice(PlSmallStr::EMPTY, &[1, 2, 3]);
+        let one = Int32Chunked::from_slice(PlSmallStr::EMPTY, &[1]);
+        let three = Int32Chunked::from_slice(PlSmallStr::EMPTY, &[3]);
 
         let out = a.equal(&one);
         assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(false)]);

--- a/crates/polars-core/src/chunked_array/comparison/scalar.rs
+++ b/crates/polars-core/src/chunked_array/comparison/scalar.rs
@@ -235,7 +235,7 @@ mod test {
 
     #[test]
     fn test_binary_search_cmp() {
-        let mut s = Series::new(PlSmallStr::const_default(), &[1, 1, 2, 2, 4, 8]);
+        let mut s = Series::new(PlSmallStr::EMPTY, &[1, 1, 2, 2, 4, 8]);
         s.set_sorted_flag(IsSorted::Ascending);
         let out = s.gt(10).unwrap();
         assert!(!out.any());
@@ -246,18 +246,12 @@ mod test {
         let out = s.gt(2).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [false, false, false, false, true, true]
-            )
+            Series::new(PlSmallStr::EMPTY, [false, false, false, false, true, true])
         );
         let out = s.gt(3).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [false, false, false, false, true, true]
-            )
+            Series::new(PlSmallStr::EMPTY, [false, false, false, false, true, true])
         );
 
         let out = s.gt_eq(10).unwrap();
@@ -268,18 +262,12 @@ mod test {
         let out = s.gt_eq(2).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [false, false, true, true, true, true]
-            )
+            Series::new(PlSmallStr::EMPTY, [false, false, true, true, true, true])
         );
         let out = s.gt_eq(3).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [false, false, false, false, true, true]
-            )
+            Series::new(PlSmallStr::EMPTY, [false, false, false, false, true, true])
         );
 
         let out = s.lt(10).unwrap();
@@ -290,18 +278,12 @@ mod test {
         let out = s.lt(2).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [true, true, false, false, false, false]
-            )
+            Series::new(PlSmallStr::EMPTY, [true, true, false, false, false, false])
         );
         let out = s.lt(3).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [true, true, true, true, false, false]
-            )
+            Series::new(PlSmallStr::EMPTY, [true, true, true, true, false, false])
         );
 
         let out = s.lt_eq(10).unwrap();
@@ -312,18 +294,12 @@ mod test {
         let out = s.lt_eq(2).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [true, true, true, true, false, false]
-            )
+            Series::new(PlSmallStr::EMPTY, [true, true, true, true, false, false])
         );
         let out = s.lt(3).unwrap();
         assert_eq!(
             out.into_series(),
-            Series::new(
-                PlSmallStr::const_default(),
-                [true, true, true, true, false, false]
-            )
+            Series::new(PlSmallStr::EMPTY, [true, true, true, true, false, false])
         );
     }
 }

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -27,7 +27,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
             let values_arr = list_arr.values();
             let cat = unsafe {
                 Series::_try_from_arrow_unchecked(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     vec![values_arr.clone()],
                     values_arr.data_type(),
                 )
@@ -59,7 +59,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
             let values_arr = list_arr.values();
             let cat = unsafe {
                 Series::_try_from_arrow_unchecked(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     vec![values_arr.clone()],
                     values_arr.data_type(),
                 )
@@ -88,7 +88,7 @@ where
     A: Array,
 {
     fn from(arr: A) -> Self {
-        Self::with_chunk(PlSmallStr::const_default(), arr)
+        Self::with_chunk(PlSmallStr::EMPTY, arr)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -20,7 +20,7 @@ where
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<T::Native>>>(iter: I) -> Self {
         // TODO: eliminate this FromIterator implementation entirely.
-        iter.into_iter().collect_ca(PlSmallStr::const_default())
+        iter.into_iter().collect_ca(PlSmallStr::EMPTY)
     }
 }
 
@@ -35,7 +35,7 @@ where
     fn from_iter<I: IntoIterator<Item = T::Native>>(iter: I) -> Self {
         // 2021-02-07: aligned vec was ~2x faster than arrow collect.
         let av = iter.into_iter().collect::<Vec<T::Native>>();
-        NoNull::new(ChunkedArray::from_vec(PlSmallStr::const_default(), av))
+        NoNull::new(ChunkedArray::from_vec(PlSmallStr::EMPTY, av))
     }
 }
 
@@ -49,14 +49,14 @@ impl FromIterator<Option<bool>> for ChunkedArray<BooleanType> {
 impl FromIterator<bool> for BooleanChunked {
     #[inline]
     fn from_iter<I: IntoIterator<Item = bool>>(iter: I) -> Self {
-        iter.into_iter().collect_ca(PlSmallStr::const_default())
+        iter.into_iter().collect_ca(PlSmallStr::EMPTY)
     }
 }
 
 impl FromIterator<bool> for NoNull<BooleanChunked> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = bool>>(iter: I) -> Self {
-        NoNull::new(iter.into_iter().collect_ca(PlSmallStr::const_default()))
+        NoNull::new(iter.into_iter().collect_ca(PlSmallStr::EMPTY))
     }
 }
 
@@ -69,7 +69,7 @@ where
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<Ptr>>>(iter: I) -> Self {
         let arr = MutableBinaryViewArray::from_iterator(iter.into_iter()).freeze();
-        ChunkedArray::with_chunk(PlSmallStr::const_default(), arr)
+        ChunkedArray::with_chunk(PlSmallStr::EMPTY, arr)
     }
 }
 
@@ -95,7 +95,7 @@ where
     #[inline]
     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let arr = MutableBinaryViewArray::from_values_iter(iter.into_iter()).freeze();
-        ChunkedArray::with_chunk(PlSmallStr::const_default(), arr)
+        ChunkedArray::with_chunk(PlSmallStr::EMPTY, arr)
     }
 }
 
@@ -107,7 +107,7 @@ where
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<Ptr>>>(iter: I) -> Self {
         let arr = MutableBinaryViewArray::from_iter(iter).freeze();
-        ChunkedArray::with_chunk(PlSmallStr::const_default(), arr)
+        ChunkedArray::with_chunk(PlSmallStr::EMPTY, arr)
     }
 }
 
@@ -118,7 +118,7 @@ where
     #[inline]
     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let arr = MutableBinaryViewArray::from_values_iter(iter.into_iter()).freeze();
-        ChunkedArray::with_chunk(PlSmallStr::const_default(), arr)
+        ChunkedArray::with_chunk(PlSmallStr::EMPTY, arr)
     }
 }
 
@@ -134,14 +134,14 @@ where
         // first take one to get the dtype.
         let v = match it.next() {
             Some(v) => v,
-            None => return ListChunked::full_null(PlSmallStr::const_default(), 0),
+            None => return ListChunked::full_null(PlSmallStr::EMPTY, 0),
         };
         // We don't know the needed capacity. We arbitrarily choose an average of 5 elements per series.
         let mut builder = get_list_builder(
             v.borrow().dtype(),
             capacity * 5,
             capacity,
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
         )
         .unwrap();
 
@@ -171,9 +171,7 @@ impl FromIterator<Option<Series>> for ListChunked {
                 Some(None) => {
                     init_null_count += 1;
                 },
-                None => {
-                    return ListChunked::full_null(PlSmallStr::const_default(), init_null_count)
-                },
+                None => return ListChunked::full_null(PlSmallStr::EMPTY, init_null_count),
             }
         }
 
@@ -190,7 +188,7 @@ impl FromIterator<Option<Series>> for ListChunked {
                 // the next non-empty series then must have the correct dtype.
                 if matches!(first_s.dtype(), DataType::Null) && first_s.is_empty() {
                     let mut builder =
-                        AnonymousOwnedListBuilder::new(PlSmallStr::const_default(), capacity, None);
+                        AnonymousOwnedListBuilder::new(PlSmallStr::EMPTY, capacity, None);
                     for _ in 0..init_null_count {
                         builder.append_null();
                     }
@@ -204,11 +202,8 @@ impl FromIterator<Option<Series>> for ListChunked {
                     match first_s.dtype() {
                         #[cfg(feature = "object")]
                         DataType::Object(_, _) => {
-                            let mut builder = first_s.get_list_builder(
-                                PlSmallStr::const_default(),
-                                capacity * 5,
-                                capacity,
-                            );
+                            let mut builder =
+                                first_s.get_list_builder(PlSmallStr::EMPTY, capacity * 5, capacity);
                             for _ in 0..init_null_count {
                                 builder.append_null();
                             }
@@ -225,7 +220,7 @@ impl FromIterator<Option<Series>> for ListChunked {
                                 first_s.dtype(),
                                 capacity * 5,
                                 capacity,
-                                PlSmallStr::const_default(),
+                                PlSmallStr::EMPTY,
                             )
                             .unwrap();
 
@@ -249,7 +244,7 @@ impl FromIterator<Option<Series>> for ListChunked {
 impl FromIterator<Option<Box<dyn Array>>> for ListChunked {
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<Box<dyn Array>>>>(iter: I) -> Self {
-        iter.into_iter().collect_ca(PlSmallStr::const_default())
+        iter.into_iter().collect_ca(PlSmallStr::EMPTY)
     }
 }
 
@@ -285,10 +280,7 @@ impl<T: PolarsObject> FromIterator<Option<T>> for ObjectChunked<T> {
             len,
         });
         ChunkedArray::new_with_compute_len(
-            Arc::new(Field::new(
-                PlSmallStr::const_default(),
-                get_object_type::<T>(),
-            )),
+            Arc::new(Field::new(PlSmallStr::EMPTY, get_object_type::<T>())),
             vec![arr],
         )
     }

--- a/crates/polars-core/src/chunked_array/from_iterator_par.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator_par.rs
@@ -72,7 +72,7 @@ where
         let vectors = collect_into_linked_list_vec(iter);
         let vectors = vectors.into_iter().collect::<Vec<_>>();
         let values = flatten_par(&vectors);
-        NoNull::new(ChunkedArray::new_vec(PlSmallStr::const_default(), values))
+        NoNull::new(ChunkedArray::new_vec(PlSmallStr::EMPTY, values))
     }
 }
 
@@ -82,21 +82,21 @@ where
 {
     fn from_par_iter<I: IntoParallelIterator<Item = Option<T::Native>>>(iter: I) -> Self {
         let chunks = collect_into_linked_list(iter, MutablePrimitiveArray::new);
-        Self::from_chunk_iter(PlSmallStr::const_default(), chunks).optional_rechunk()
+        Self::from_chunk_iter(PlSmallStr::EMPTY, chunks).optional_rechunk()
     }
 }
 
 impl FromParallelIterator<bool> for BooleanChunked {
     fn from_par_iter<I: IntoParallelIterator<Item = bool>>(iter: I) -> Self {
         let chunks = collect_into_linked_list(iter, MutableBooleanArray::new);
-        Self::from_chunk_iter(PlSmallStr::const_default(), chunks).optional_rechunk()
+        Self::from_chunk_iter(PlSmallStr::EMPTY, chunks).optional_rechunk()
     }
 }
 
 impl FromParallelIterator<Option<bool>> for BooleanChunked {
     fn from_par_iter<I: IntoParallelIterator<Item = Option<bool>>>(iter: I) -> Self {
         let chunks = collect_into_linked_list(iter, MutableBooleanArray::new);
-        Self::from_chunk_iter(PlSmallStr::const_default(), chunks).optional_rechunk()
+        Self::from_chunk_iter(PlSmallStr::EMPTY, chunks).optional_rechunk()
     }
 }
 
@@ -106,7 +106,7 @@ where
 {
     fn from_par_iter<I: IntoParallelIterator<Item = Ptr>>(iter: I) -> Self {
         let chunks = collect_into_linked_list(iter, MutableBinaryViewArray::new);
-        Self::from_chunk_iter(PlSmallStr::const_default(), chunks).optional_rechunk()
+        Self::from_chunk_iter(PlSmallStr::EMPTY, chunks).optional_rechunk()
     }
 }
 
@@ -116,7 +116,7 @@ where
 {
     fn from_par_iter<I: IntoParallelIterator<Item = Ptr>>(iter: I) -> Self {
         let chunks = collect_into_linked_list(iter, MutableBinaryViewArray::new);
-        Self::from_chunk_iter(PlSmallStr::const_default(), chunks).optional_rechunk()
+        Self::from_chunk_iter(PlSmallStr::EMPTY, chunks).optional_rechunk()
     }
 }
 
@@ -126,7 +126,7 @@ where
 {
     fn from_par_iter<I: IntoParallelIterator<Item = Option<Ptr>>>(iter: I) -> Self {
         let chunks = collect_into_linked_list(iter, MutableBinaryViewArray::new);
-        Self::from_chunk_iter(PlSmallStr::const_default(), chunks).optional_rechunk()
+        Self::from_chunk_iter(PlSmallStr::EMPTY, chunks).optional_rechunk()
     }
 }
 
@@ -136,7 +136,7 @@ where
 {
     fn from_par_iter<I: IntoParallelIterator<Item = Option<Ptr>>>(iter: I) -> Self {
         let chunks = collect_into_linked_list(iter, MutableBinaryViewArray::new);
-        Self::from_chunk_iter(PlSmallStr::const_default(), chunks).optional_rechunk()
+        Self::from_chunk_iter(PlSmallStr::EMPTY, chunks).optional_rechunk()
     }
 }
 
@@ -217,14 +217,10 @@ impl FromParallelIterator<Option<Series>> for ListChunked {
         let value_capacity = get_value_cap(&vectors);
         let dtype = get_dtype(&vectors);
         if let DataType::Null = dtype {
-            ListChunked::full_null_with_dtype(
-                PlSmallStr::const_default(),
-                list_capacity,
-                &DataType::Null,
-            )
+            ListChunked::full_null_with_dtype(PlSmallStr::EMPTY, list_capacity, &DataType::Null)
         } else {
             materialize_list(
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
                 &vectors,
                 dtype,
                 value_capacity,

--- a/crates/polars-core/src/chunked_array/iterator/mod.rs
+++ b/crates/polars-core/src/chunked_array/iterator/mod.rs
@@ -220,7 +220,7 @@ impl<'a> IntoIterator for &'a ListChunked {
                         .trust_my_length(self.len())
                         .map(move |arr| {
                             Some(Series::from_chunks_and_dtype_unchecked(
-                                PlSmallStr::const_default(),
+                                PlSmallStr::EMPTY,
                                 vec![arr],
                                 dtype,
                             ))
@@ -237,7 +237,7 @@ impl<'a> IntoIterator for &'a ListChunked {
                         .map(move |arr| {
                             arr.map(|arr| {
                                 Series::from_chunks_and_dtype_unchecked(
-                                    PlSmallStr::const_default(),
+                                    PlSmallStr::EMPTY,
                                     vec![arr],
                                     dtype,
                                 )
@@ -262,7 +262,7 @@ impl ListChunked {
                 .flat_map(|arr| arr.values_iter())
                 .map(move |arr| {
                     Series::from_chunks_and_dtype_unchecked(
-                        PlSmallStr::const_default(),
+                        PlSmallStr::EMPTY,
                         vec![arr],
                         inner_type,
                     )
@@ -288,7 +288,7 @@ impl<'a> IntoIterator for &'a ArrayChunked {
                         .trust_my_length(self.len())
                         .map(move |arr| {
                             Some(Series::from_chunks_and_dtype_unchecked(
-                                PlSmallStr::const_default(),
+                                PlSmallStr::EMPTY,
                                 vec![arr],
                                 dtype,
                             ))
@@ -305,7 +305,7 @@ impl<'a> IntoIterator for &'a ArrayChunked {
                         .map(move |arr| {
                             arr.map(|arr| {
                                 Series::from_chunks_and_dtype_unchecked(
-                                    PlSmallStr::const_default(),
+                                    PlSmallStr::EMPTY,
                                     vec![arr],
                                     dtype,
                                 )
@@ -350,7 +350,7 @@ impl<'a> Iterator for FixedSizeListIterNoNull<'a> {
             self.current += 1;
             unsafe {
                 Some(Series::from_chunks_and_dtype_unchecked(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     vec![self.array.value_unchecked(old)],
                     &self.inner_type,
                 ))
@@ -376,7 +376,7 @@ impl<'a> DoubleEndedIterator for FixedSizeListIterNoNull<'a> {
             unsafe {
                 Some(
                     Series::try_from((
-                        PlSmallStr::const_default(),
+                        PlSmallStr::EMPTY,
                         self.array.value_unchecked(self.current_end),
                     ))
                     .unwrap(),
@@ -652,7 +652,7 @@ mod test {
                     PlSmallStr::from_static("test"),
                     &[$first_val, $second_val],
                 );
-                let a_b = <$ca_type>::from_slice(PlSmallStr::const_default(), &[$third_val]);
+                let a_b = <$ca_type>::from_slice(PlSmallStr::EMPTY, &[$third_val]);
                 a.append(&a_b).unwrap();
 
                 // normal iterator
@@ -716,7 +716,7 @@ mod test {
             fn $test_name() {
                 let mut a =
                     <$ca_type>::new(PlSmallStr::from_static("test"), &[$first_val, $second_val]);
-                let a_b = <$ca_type>::new(PlSmallStr::const_default(), &[$third_val]);
+                let a_b = <$ca_type>::new(PlSmallStr::EMPTY, &[$third_val]);
                 a.append(&a_b).unwrap();
 
                 // normal iterator
@@ -876,7 +876,7 @@ mod test {
                     PlSmallStr::from_static("test"),
                     &[$first_val, $second_val],
                 );
-                let a_b = <$ca_type>::from_slice(PlSmallStr::const_default(), &[$third_val]);
+                let a_b = <$ca_type>::from_slice(PlSmallStr::EMPTY, &[$third_val]);
                 a.append(&a_b).unwrap();
 
                 // normal iterator

--- a/crates/polars-core/src/chunked_array/iterator/par/list.rs
+++ b/crates/polars-core/src/chunked_array/iterator/par/list.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 unsafe fn idx_to_array(idx: usize, arr: &ListArray<i64>, dtype: &DataType) -> Option<Series> {
     if arr.is_valid(idx) {
         Some(arr.value_unchecked(idx)).map(|arr: ArrayRef| {
-            Series::from_chunks_and_dtype_unchecked(PlSmallStr::const_default(), vec![arr], dtype)
+            Series::from_chunks_and_dtype_unchecked(PlSmallStr::EMPTY, vec![arr], dtype)
         })
     } else {
         None

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -51,7 +51,7 @@ impl<'a, I: Iterator<Item = Option<ArrayBox>>> Iterator for AmortizedListIter<'a
                     // dtype is known
                     unsafe {
                         let s = Series::from_chunks_and_dtype_unchecked(
-                            PlSmallStr::const_default(),
+                            PlSmallStr::EMPTY,
                             vec![array_ref],
                             &self.inner_dtype.to_physical(),
                         )
@@ -123,7 +123,7 @@ impl ListChunked {
     /// If the returned `AmortSeries` is cloned, the local copy will be replaced and a new container
     /// will be set.
     pub fn amortized_iter(&self) -> AmortizedListIter<impl Iterator<Item = Option<ArrayBox>> + '_> {
-        self.amortized_iter_with_name(PlSmallStr::const_default())
+        self.amortized_iter_with_name(PlSmallStr::EMPTY)
     }
 
     /// See `amortized_iter`.
@@ -392,16 +392,15 @@ mod test {
 
     #[test]
     fn test_iter_list() {
-        let mut builder =
-            get_list_builder(&DataType::Int32, 10, 10, PlSmallStr::const_default()).unwrap();
+        let mut builder = get_list_builder(&DataType::Int32, 10, 10, PlSmallStr::EMPTY).unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[1, 2, 3]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[1, 2, 3]))
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[3, 2, 1]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[3, 2, 1]))
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[1, 1]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[1, 1]))
             .unwrap();
         let ca = builder.finish();
 

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -505,9 +505,7 @@ mod test {
 
         assert_eq!(s.n_unique().unwrap(), 3);
         // Make sure that it does not take the fast path after take/slice.
-        let out = s
-            .take(&IdxCa::new(PlSmallStr::const_default(), [1, 2]))
-            .unwrap();
+        let out = s.take(&IdxCa::new(PlSmallStr::EMPTY, [1, 2])).unwrap();
         assert_eq!(out.n_unique().unwrap(), 2);
         let out = s.slice(1, 2);
         assert_eq!(out.n_unique().unwrap(), 2);

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -951,7 +951,7 @@ pub(crate) fn to_array<T: PolarsNumericType>(
 impl<T: PolarsDataType> Default for ChunkedArray<T> {
     fn default() -> Self {
         ChunkedArray {
-            field: Arc::new(Field::new(PlSmallStr::const_default(), DataType::Null)),
+            field: Arc::new(Field::new(PlSmallStr::EMPTY, DataType::Null)),
             chunks: Default::default(),
             md: Arc::new(IMMetadata::default()),
             length: 0,
@@ -1075,7 +1075,7 @@ pub(crate) mod test {
 
     #[test]
     fn sorting() {
-        let s = UInt32Chunked::new(PlSmallStr::const_default(), &[9, 2, 4]);
+        let s = UInt32Chunked::new(PlSmallStr::EMPTY, &[9, 2, 4]);
         let sorted = s.sort(false);
         assert_slice_equal(&sorted, &[2, 4, 9]);
         let sorted = s.sort(true);
@@ -1102,19 +1102,19 @@ pub(crate) mod test {
 
     #[test]
     fn reverse() {
-        let s = UInt32Chunked::new(PlSmallStr::const_default(), &[1, 2, 3]);
+        let s = UInt32Chunked::new(PlSmallStr::EMPTY, &[1, 2, 3]);
         // path with continuous slice
         assert_slice_equal(&s.reverse(), &[3, 2, 1]);
         // path with options
-        let s = UInt32Chunked::new(PlSmallStr::const_default(), &[Some(1), None, Some(3)]);
+        let s = UInt32Chunked::new(PlSmallStr::EMPTY, &[Some(1), None, Some(3)]);
         assert_eq!(Vec::from(&s.reverse()), &[Some(3), None, Some(1)]);
-        let s = BooleanChunked::new(PlSmallStr::const_default(), &[true, false]);
+        let s = BooleanChunked::new(PlSmallStr::EMPTY, &[true, false]);
         assert_eq!(Vec::from(&s.reverse()), &[Some(false), Some(true)]);
 
-        let s = StringChunked::new(PlSmallStr::const_default(), &["a", "b", "c"]);
+        let s = StringChunked::new(PlSmallStr::EMPTY, &["a", "b", "c"]);
         assert_eq!(Vec::from(&s.reverse()), &[Some("c"), Some("b"), Some("a")]);
 
-        let s = StringChunked::new(PlSmallStr::const_default(), &[Some("a"), None, Some("c")]);
+        let s = StringChunked::new(PlSmallStr::EMPTY, &[Some("a"), None, Some("c")]);
         assert_eq!(Vec::from(&s.reverse()), &[Some("c"), None, Some("a")]);
     }
 
@@ -1125,7 +1125,7 @@ pub(crate) mod test {
         let _lock = SINGLE_LOCK.lock();
         disable_string_cache();
         let ca = StringChunked::new(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[Some("foo"), None, Some("bar"), Some("ham")],
         );
         let ca = ca

--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -186,12 +186,12 @@ mod test {
 
     #[test]
     fn test_ndarray_from_ca() -> PolarsResult<()> {
-        let ca = Float64Chunked::new(PlSmallStr::const_default(), &[1.0, 2.0, 3.0]);
+        let ca = Float64Chunked::new(PlSmallStr::EMPTY, &[1.0, 2.0, 3.0]);
         let ndarr = ca.to_ndarray()?;
         assert_eq!(ndarr, ArrayView1::from(&[1.0, 2.0, 3.0]));
 
         let mut builder = ListPrimitiveChunkedBuilder::<Float64Type>::new(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             10,
             10,
             DataType::Float64,
@@ -207,7 +207,7 @@ mod test {
 
         // test list array that is not square
         let mut builder = ListPrimitiveChunkedBuilder::<Float64Type>::new(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             10,
             10,
             DataType::Float64,

--- a/crates/polars-core/src/chunked_array/object/builder.rs
+++ b/crates/polars-core/src/chunked_array/object/builder.rs
@@ -94,7 +94,7 @@ where
     T: PolarsObject,
 {
     fn default() -> Self {
-        ObjectChunkedBuilder::new(PlSmallStr::const_default(), 0)
+        ObjectChunkedBuilder::new(PlSmallStr::EMPTY, 0)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -221,7 +221,7 @@ mod test {
         };
 
         let values = &[Some(foo1), None, Some(foo2), None];
-        let ca = ObjectChunked::new(PlSmallStr::const_default(), values);
+        let ca = ObjectChunked::new(PlSmallStr::EMPTY, values);
 
         let groups =
             GroupsProxy::Idx(vec![(0, unitvec![0, 1]), (2, unitvec![2]), (3, unitvec![3])].into());
@@ -245,7 +245,7 @@ mod test {
         };
 
         let values = &[Some(foo1.clone()), None, Some(foo2.clone()), None];
-        let ca = ObjectChunked::new(PlSmallStr::const_default(), values);
+        let ca = ObjectChunked::new(PlSmallStr::EMPTY, values);
 
         let groups = vec![(0, unitvec![0, 1]), (2, unitvec![2]), (3, unitvec![3])].into();
         let out = unsafe { ca.agg_list(&GroupsProxy::Idx(groups)) };

--- a/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
@@ -13,7 +13,7 @@ impl PolarsExtension {
         let arr = arr.slice_typed_unchecked(i, 1);
         let pe = Self::new(arr);
         let pe = ManuallyDrop::new(pe);
-        pe.get_series(&PlSmallStr::const_default())
+        pe.get_series(&PlSmallStr::EMPTY)
             .get(0)
             .unwrap()
             .into_static()

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -636,9 +636,9 @@ mod test {
         // Validated with numpy. Note that numpy uses ddof as an argument which
         // influences results. The default ddof=0, we chose ddof=1, which is
         // standard in statistics.
-        let ca1 = Int32Chunked::new(PlSmallStr::const_default(), &[5, 8, 9, 5, 0]);
+        let ca1 = Int32Chunked::new(PlSmallStr::EMPTY, &[5, 8, 9, 5, 0]);
         let ca2 = Int32Chunked::new(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[
                 Some(5),
                 None,
@@ -694,7 +694,7 @@ mod test {
         assert_eq!(ca.median(), Some(4.0));
 
         let ca = Float32Chunked::from_slice(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[
                 0.166189, 0.166559, 0.168517, 0.169393, 0.175272, 0.233167, 0.238787, 0.266562,
                 0.26903, 0.285792, 0.292801, 0.293429, 0.301706, 0.308534, 0.331489, 0.346095,
@@ -707,7 +707,7 @@ mod test {
 
     #[test]
     fn test_mean() {
-        let ca = Float32Chunked::new(PlSmallStr::const_default(), &[Some(1.0), Some(2.0), None]);
+        let ca = Float32Chunked::new(PlSmallStr::EMPTY, &[Some(1.0), Some(2.0), None]);
         assert_eq!(ca.mean().unwrap(), 1.5);
         assert_eq!(
             ca.into_series()
@@ -718,7 +718,7 @@ mod test {
             1.5
         );
         // all null values case
-        let ca = Float32Chunked::full_null(PlSmallStr::const_default(), 3);
+        let ca = Float32Chunked::full_null(PlSmallStr::EMPTY, 3);
         assert_eq!(ca.mean(), None);
         assert_eq!(
             ca.into_series().mean_reduce().value().extract::<f32>(),
@@ -728,14 +728,10 @@ mod test {
 
     #[test]
     fn test_quantile_all_null() {
-        let test_f32 =
-            Float32Chunked::from_slice_options(PlSmallStr::const_default(), &[None, None, None]);
-        let test_i32 =
-            Int32Chunked::from_slice_options(PlSmallStr::const_default(), &[None, None, None]);
-        let test_f64 =
-            Float64Chunked::from_slice_options(PlSmallStr::const_default(), &[None, None, None]);
-        let test_i64 =
-            Int64Chunked::from_slice_options(PlSmallStr::const_default(), &[None, None, None]);
+        let test_f32 = Float32Chunked::from_slice_options(PlSmallStr::EMPTY, &[None, None, None]);
+        let test_i32 = Int32Chunked::from_slice_options(PlSmallStr::EMPTY, &[None, None, None]);
+        let test_f64 = Float64Chunked::from_slice_options(PlSmallStr::EMPTY, &[None, None, None]);
+        let test_i64 = Int64Chunked::from_slice_options(PlSmallStr::EMPTY, &[None, None, None]);
 
         let interpol_options = vec![
             QuantileInterpolOptions::Nearest,
@@ -755,12 +751,10 @@ mod test {
 
     #[test]
     fn test_quantile_single_value() {
-        let test_f32 =
-            Float32Chunked::from_slice_options(PlSmallStr::const_default(), &[Some(1.0)]);
-        let test_i32 = Int32Chunked::from_slice_options(PlSmallStr::const_default(), &[Some(1)]);
-        let test_f64 =
-            Float64Chunked::from_slice_options(PlSmallStr::const_default(), &[Some(1.0)]);
-        let test_i64 = Int64Chunked::from_slice_options(PlSmallStr::const_default(), &[Some(1)]);
+        let test_f32 = Float32Chunked::from_slice_options(PlSmallStr::EMPTY, &[Some(1.0)]);
+        let test_i32 = Int32Chunked::from_slice_options(PlSmallStr::EMPTY, &[Some(1)]);
+        let test_f64 = Float64Chunked::from_slice_options(PlSmallStr::EMPTY, &[Some(1.0)]);
+        let test_i64 = Int64Chunked::from_slice_options(PlSmallStr::EMPTY, &[Some(1)]);
 
         let interpol_options = vec![
             QuantileInterpolOptions::Nearest,
@@ -781,19 +775,19 @@ mod test {
     #[test]
     fn test_quantile_min_max() {
         let test_f32 = Float32Chunked::from_slice_options(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[None, Some(1f32), Some(5f32), Some(1f32)],
         );
         let test_i32 = Int32Chunked::from_slice_options(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[None, Some(1i32), Some(5i32), Some(1i32)],
         );
         let test_f64 = Float64Chunked::from_slice_options(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[None, Some(1f64), Some(5f64), Some(1f64)],
         );
         let test_i64 = Int64Chunked::from_slice_options(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[None, Some(1i64), Some(5i64), Some(1i64)],
         );
 

--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -49,15 +49,11 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
         DataType::List(dt) => {
             let v: ArrayRef = downcast!(LargeListArray);
             if dt.is_primitive() {
-                let s = Series::from_chunks_and_dtype_unchecked(
-                    PlSmallStr::const_default(),
-                    vec![v],
-                    dt,
-                );
+                let s = Series::from_chunks_and_dtype_unchecked(PlSmallStr::EMPTY, vec![v], dt);
                 AnyValue::List(s)
             } else {
                 let s = Series::from_chunks_and_dtype_unchecked(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     vec![v],
                     &dt.to_physical(),
                 )
@@ -70,15 +66,11 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
         DataType::Array(dt, width) => {
             let v: ArrayRef = downcast!(FixedSizeListArray);
             if dt.is_primitive() {
-                let s = Series::from_chunks_and_dtype_unchecked(
-                    PlSmallStr::const_default(),
-                    vec![v],
-                    dt,
-                );
+                let s = Series::from_chunks_and_dtype_unchecked(PlSmallStr::EMPTY, vec![v], dt);
                 AnyValue::Array(s, *width)
             } else {
                 let s = Series::from_chunks_and_dtype_unchecked(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     vec![v],
                     &dt.to_physical(),
                 )

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -519,9 +519,8 @@ impl<'a> ChunkApply<'a, Series> for ListChunked {
         let mut idx = 0;
         self.downcast_iter().for_each(|arr| {
             arr.iter().for_each(|opt_val| {
-                let opt_val = opt_val.map(|arrayref| {
-                    Series::try_from((PlSmallStr::const_default(), arrayref)).unwrap()
-                });
+                let opt_val = opt_val
+                    .map(|arrayref| Series::try_from((PlSmallStr::EMPTY, arrayref)).unwrap());
 
                 // SAFETY:
                 // length asserted above

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -398,7 +398,7 @@ mod test {
     #[test]
     #[cfg(feature = "dtype-categorical")]
     fn test_categorical_map_after_rechunk() {
-        let s = Series::new(PlSmallStr::const_default(), &["foo", "bar", "spam"]);
+        let s = Series::new(PlSmallStr::EMPTY, &["foo", "bar", "spam"]);
         let mut a = s
             .cast(&DataType::Categorical(None, Default::default()))
             .unwrap();

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -272,13 +272,13 @@ mod test {
         let mut builder = get_list_builder(&DataType::Int32, 5, 5, PlSmallStr::from_static("a"))?;
 
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[1, 2, 3, 3]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[1, 2, 3, 3]))
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[1]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[1]))
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[2]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[2]))
             .unwrap();
 
         let ca = builder.finish();
@@ -302,15 +302,13 @@ mod test {
         // primitive
         let mut builder = get_list_builder(&DataType::Int32, 5, 5, PlSmallStr::from_static("a"))?;
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[1i32, 2]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[1i32, 2]))
             .unwrap();
         builder
-            .append_series(
-                &Int32Chunked::from_slice(PlSmallStr::const_default(), &[]).into_series(),
-            )
+            .append_series(&Int32Chunked::from_slice(PlSmallStr::EMPTY, &[]).into_series())
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[3i32]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[3i32]))
             .unwrap();
 
         let ca = builder.finish();
@@ -323,23 +321,19 @@ mod test {
         // more primitive
         let mut builder = get_list_builder(&DataType::Int32, 5, 5, PlSmallStr::from_static("a"))?;
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[1i32]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[1i32]))
             .unwrap();
         builder
-            .append_series(
-                &Int32Chunked::from_slice(PlSmallStr::const_default(), &[]).into_series(),
-            )
+            .append_series(&Int32Chunked::from_slice(PlSmallStr::EMPTY, &[]).into_series())
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[2i32]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[2i32]))
             .unwrap();
         builder
-            .append_series(
-                &Int32Chunked::from_slice(PlSmallStr::const_default(), &[]).into_series(),
-            )
+            .append_series(&Int32Chunked::from_slice(PlSmallStr::EMPTY, &[]).into_series())
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[3, 4i32]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[3, 4i32]))
             .unwrap();
 
         let ca = builder.finish();
@@ -352,36 +346,36 @@ mod test {
         // string
         let mut builder = get_list_builder(&DataType::String, 5, 5, PlSmallStr::from_static("a"))?;
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &["abc"]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &["abc"]))
             .unwrap();
         builder
             .append_series(
                 &<StringChunked as NewChunkedArray<StringType, &str>>::from_slice(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     &[],
                 )
                 .into_series(),
             )
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &["de"]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &["de"]))
             .unwrap();
         builder
             .append_series(
                 &<StringChunked as NewChunkedArray<StringType, &str>>::from_slice(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     &[],
                 )
                 .into_series(),
             )
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &["fg"]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &["fg"]))
             .unwrap();
         builder
             .append_series(
                 &<StringChunked as NewChunkedArray<StringType, &str>>::from_slice(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     &[],
                 )
                 .into_series(),
@@ -398,23 +392,19 @@ mod test {
         // boolean
         let mut builder = get_list_builder(&DataType::Boolean, 5, 5, PlSmallStr::from_static("a"))?;
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[true]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[true]))
             .unwrap();
         builder
-            .append_series(
-                &BooleanChunked::from_slice(PlSmallStr::const_default(), &[]).into_series(),
-            )
+            .append_series(&BooleanChunked::from_slice(PlSmallStr::EMPTY, &[]).into_series())
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[false]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[false]))
             .unwrap();
         builder
-            .append_series(
-                &BooleanChunked::from_slice(PlSmallStr::const_default(), &[]).into_series(),
-            )
+            .append_series(&BooleanChunked::from_slice(PlSmallStr::EMPTY, &[]).into_series())
             .unwrap();
         builder
-            .append_series(&Series::new(PlSmallStr::const_default(), &[true, true]))
+            .append_series(&Series::new(PlSmallStr::EMPTY, &[true, true]))
             .unwrap();
 
         let ca = builder.finish();

--- a/crates/polars-core/src/chunked_array/ops/full.rs
+++ b/crates/polars-core/src/chunked_array/ops/full.rs
@@ -192,7 +192,7 @@ impl ListChunked {
 #[cfg(feature = "dtype-struct")]
 impl ChunkFullNull for StructChunked {
     fn full_null(name: PlSmallStr, length: usize) -> StructChunked {
-        let s = vec![Series::new_null(PlSmallStr::const_default(), length)];
+        let s = vec![Series::new_null(PlSmallStr::EMPTY, length)];
         StructChunked::from_series(name, &s)
             .unwrap()
             .with_outer_validity(Some(Bitmap::new_zeroed(length)))

--- a/crates/polars-core/src/chunked_array/ops/gather.rs
+++ b/crates/polars-core/src/chunked_array/ops/gather.rs
@@ -264,7 +264,7 @@ impl ChunkTakeUnchecked<IdxCa> for StringChunked {
 impl<I: AsRef<[IdxSize]> + ?Sized> ChunkTakeUnchecked<I> for BinaryChunked {
     /// Gather values from ChunkedArray by index.
     unsafe fn take_unchecked(&self, indices: &I) -> Self {
-        let indices = IdxCa::mmap_slice(PlSmallStr::const_default(), indices.as_ref());
+        let indices = IdxCa::mmap_slice(PlSmallStr::EMPTY, indices.as_ref());
         self.take_unchecked(&indices)
     }
 }
@@ -296,7 +296,7 @@ impl ChunkTakeUnchecked<IdxCa> for StructChunked {
 #[cfg(feature = "dtype-struct")]
 impl<I: AsRef<[IdxSize]> + ?Sized> ChunkTakeUnchecked<I> for StructChunked {
     unsafe fn take_unchecked(&self, indices: &I) -> Self {
-        let idx = IdxCa::mmap_slice(PlSmallStr::const_default(), indices.as_ref());
+        let idx = IdxCa::mmap_slice(PlSmallStr::EMPTY, indices.as_ref());
         self.take_unchecked(&idx)
     }
 }
@@ -307,7 +307,7 @@ impl IdxCa {
         let idx = bytemuck::cast_slice::<_, IdxSize>(idx);
         let arr = unsafe { arrow::ffi::mmap::slice(idx) };
         let arr = arr.with_validity_typed(Some(validity));
-        let ca = IdxCa::with_chunk(PlSmallStr::const_default(), arr);
+        let ca = IdxCa::with_chunk(PlSmallStr::EMPTY, arr);
 
         f(&ca)
     }

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -549,7 +549,7 @@ impl ChunkExpandAtIndex<StructType> for StructChunked {
                 .values()
                 .iter()
                 .map(|arr| {
-                    let s = Series::try_from((PlSmallStr::const_default(), arr.clone())).unwrap();
+                    let s = Series::try_from((PlSmallStr::EMPTY, arr.clone())).unwrap();
                     let s = s.new_from_index(idx, length);
                     s.chunks()[0].clone()
                 })

--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -67,7 +67,7 @@ impl ChunkReverse for BinaryChunked {
             }
         } else {
             let ca = IdxCa::from_vec(
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
                 (0..self.len() as IdxSize).rev().collect(),
             );
             unsafe { self.take_unchecked(&ca) }
@@ -124,7 +124,7 @@ impl<T: PolarsObject> ChunkReverse for ObjectChunked<T> {
             self.take_unchecked(
                 &(0..self.len() as IdxSize)
                     .rev()
-                    .collect_ca(PlSmallStr::const_default()),
+                    .collect_ca(PlSmallStr::EMPTY),
             )
         }
     }

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -106,8 +106,7 @@ mod inner_mod {
 
             let len = self.len();
             let arr = ca.downcast_iter().next().unwrap();
-            let mut ca =
-                ChunkedArray::<T>::from_slice(PlSmallStr::const_default(), &[T::Native::zero()]);
+            let mut ca = ChunkedArray::<T>::from_slice(PlSmallStr::EMPTY, &[T::Native::zero()]);
             let ptr = ca.chunks[0].as_mut() as *mut dyn Array as *mut PrimitiveArray<T::Native>;
             let mut series_container = ca.into_series();
 
@@ -232,7 +231,7 @@ mod inner_mod {
             // container where we swap the window contents every iteration doing
             // so will save a lot of heap allocations.
             let mut heap_container =
-                ChunkedArray::<T>::from_slice(PlSmallStr::const_default(), &[T::Native::zero()]);
+                ChunkedArray::<T>::from_slice(PlSmallStr::EMPTY, &[T::Native::zero()]);
             let ptr = heap_container.chunks[0].as_mut() as *mut dyn Array
                 as *mut PrimitiveArray<T::Native>;
 

--- a/crates/polars-core/src/chunked_array/ops/shift.rs
+++ b/crates/polars-core/src/chunked_array/ops/shift.rs
@@ -225,7 +225,7 @@ mod test {
 
     #[test]
     fn test_shift() {
-        let ca = Int32Chunked::new(PlSmallStr::const_default(), &[1, 2, 3]);
+        let ca = Int32Chunked::new(PlSmallStr::EMPTY, &[1, 2, 3]);
 
         // shift by 0, 1, 2, 3, 4
         let shifted = ca.shift_and_fill(0, Some(5));

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -122,7 +122,7 @@ pub fn encode_rows_vertical_par_unordered(by: &[Series]) -> PolarsResult<BinaryO
     let chunks = POOL.install(|| chunks.collect::<PolarsResult<Vec<_>>>());
 
     Ok(BinaryOffsetChunked::from_chunk_iter(
-        PlSmallStr::const_default(),
+        PlSmallStr::EMPTY,
         chunks?,
     ))
 }
@@ -160,7 +160,7 @@ pub fn encode_rows_vertical_par_unordered_broadcast_nulls(
     let chunks = POOL.install(|| chunks.collect::<PolarsResult<Vec<_>>>());
 
     Ok(BinaryOffsetChunked::from_chunk_iter(
-        PlSmallStr::const_default(),
+        PlSmallStr::EMPTY,
         chunks?,
     ))
 }
@@ -168,7 +168,7 @@ pub fn encode_rows_vertical_par_unordered_broadcast_nulls(
 pub(crate) fn encode_rows_unordered(by: &[Series]) -> PolarsResult<BinaryOffsetChunked> {
     let rows = _get_rows_encoded_unordered(by)?;
     Ok(BinaryOffsetChunked::with_chunk(
-        PlSmallStr::const_default(),
+        PlSmallStr::EMPTY,
         rows.into_array(),
     ))
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -124,7 +124,7 @@ mod test {
                 enable_string_cache();
             }
 
-            let s = Series::new(PlSmallStr::const_default(), init)
+            let s = Series::new(PlSmallStr::EMPTY, init)
                 .cast(&DataType::Categorical(None, CategoricalOrdering::Lexical))?;
             let ca = s.categorical()?;
             let ca_lexical = ca.clone();
@@ -132,7 +132,7 @@ mod test {
             let out = ca_lexical.sort(false);
             assert_order(&out, &["a", "b", "c", "d"]);
 
-            let s = Series::new(PlSmallStr::const_default(), init)
+            let s = Series::new(PlSmallStr::EMPTY, init)
                 .cast(&DataType::Categorical(None, Default::default()))?;
             let ca = s.categorical()?;
 
@@ -160,7 +160,7 @@ mod test {
                 enable_string_cache();
             }
 
-            let s = Series::new(PlSmallStr::const_default(), init)
+            let s = Series::new(PlSmallStr::EMPTY, init)
                 .cast(&DataType::Categorical(None, CategoricalOrdering::Lexical))?;
             let ca = s.categorical()?;
             let ca_lexical: CategoricalChunked = ca.clone();

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -321,7 +321,7 @@ mod test {
         );
 
         let ca = StringChunked::new(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[Some("a"), None, Some("a"), Some("b"), None],
         );
         assert_eq!(

--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -12,7 +12,7 @@ use crate::utils::NoNull;
 
 fn create_rand_index_with_replacement(n: usize, len: usize, seed: Option<u64>) -> IdxCa {
     if len == 0 {
-        return IdxCa::new_vec(PlSmallStr::const_default(), vec![]);
+        return IdxCa::new_vec(PlSmallStr::EMPTY, vec![]);
     }
     let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_else(get_global_random_u64));
     let dist = Uniform::new(0, len as IdxSize);
@@ -45,7 +45,7 @@ fn create_rand_index_no_replacement(
             IndexVec::USize(v) => v.into_iter().map(|x| x as IdxSize).collect(),
         };
     }
-    IdxCa::new_vec(PlSmallStr::const_default(), buf)
+    IdxCa::new_vec(PlSmallStr::EMPTY, buf)
 }
 
 impl<T> ChunkedArray<T>

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -110,7 +110,7 @@ impl StructChunked {
             }
             constructor(name, &new_fields)
         } else if fields.is_empty() {
-            let fields = &[Series::new_null(PlSmallStr::const_default(), 0)];
+            let fields = &[Series::new_null(PlSmallStr::EMPTY, 0)];
             constructor(name, fields)
         } else {
             constructor(name, fields)

--- a/crates/polars-core/src/chunked_array/trusted_len.rs
+++ b/crates/polars-core/src/chunked_array/trusted_len.rs
@@ -168,7 +168,7 @@ where
 {
     fn from_iter_trusted_length<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let arr = BinaryArray::from_iter_values(iter.into_iter());
-        ChunkedArray::with_chunk(PlSmallStr::const_default(), arr)
+        ChunkedArray::with_chunk(PlSmallStr::EMPTY, arr)
     }
 }
 
@@ -179,7 +179,7 @@ where
     fn from_iter_trusted_length<I: IntoIterator<Item = Option<Ptr>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let arr = BinaryArray::from_iter(iter);
-        ChunkedArray::with_chunk(PlSmallStr::const_default(), arr)
+        ChunkedArray::with_chunk(PlSmallStr::EMPTY, arr)
     }
 }
 

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -343,7 +343,7 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
 impl AnyValue<'static> {
     pub fn zero(dtype: &DataType) -> Self {
         match dtype {
-            DataType::String => AnyValue::StringOwned(PlSmallStr::const_default()),
+            DataType::String => AnyValue::StringOwned(PlSmallStr::EMPTY),
             DataType::Boolean => AnyValue::Boolean(false),
             // SAFETY:
             // Numeric values are static, inform the compiler of this.
@@ -1302,7 +1302,7 @@ mod test {
                 DataType::Datetime(TimeUnit::Milliseconds, None),
             ),
             (
-                ArrowDataType::Timestamp(ArrowTimeUnit::Second, Some(PlSmallStr::const_default())),
+                ArrowDataType::Timestamp(ArrowTimeUnit::Second, Some(PlSmallStr::EMPTY)),
                 DataType::Datetime(TimeUnit::Milliseconds, None),
             ),
             (ArrowDataType::LargeUtf8, DataType::String),

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -1354,11 +1354,8 @@ Series: 'Date' [date]
             format!("{:?}", s.into_series())
         );
 
-        let s = Int64Chunked::new(
-            PlSmallStr::const_default(),
-            &[Some(1), None, Some(1_000_000_000_000)],
-        )
-        .into_datetime(TimeUnit::Nanoseconds, None);
+        let s = Int64Chunked::new(PlSmallStr::EMPTY, &[Some(1), None, Some(1_000_000_000_000)])
+            .into_datetime(TimeUnit::Nanoseconds, None);
         assert_eq!(
             r#"shape: (3,)
 Series: '' [datetime[ns]]

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -102,7 +102,7 @@ impl DataFrame {
             let (exploded, offsets) = &exploded_columns[0];
 
             let row_idx = offsets_to_indexes(offsets.as_slice(), exploded.len());
-            let mut row_idx = IdxCa::from_vec(PlSmallStr::const_default(), row_idx);
+            let mut row_idx = IdxCa::from_vec(PlSmallStr::EMPTY, row_idx);
             row_idx.set_sorted_flag(IsSorted::Ascending);
 
             // SAFETY:

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -73,7 +73,7 @@ impl Series {
                             }
                         },
                     )
-                    .collect_ca(PlSmallStr::const_default());
+                    .collect_ca(PlSmallStr::EMPTY);
                 // SAFETY: groups are always in bounds.
                 s.take_unchecked(&indices)
             },
@@ -81,7 +81,7 @@ impl Series {
                 let indices = groups
                     .iter()
                     .map(|&[first, len]| if len == 0 { None } else { Some(first) })
-                    .collect_ca(PlSmallStr::const_default());
+                    .collect_ca(PlSmallStr::EMPTY);
                 // SAFETY: groups are always in bounds.
                 s.take_unchecked(&indices)
             },
@@ -175,7 +175,7 @@ impl Series {
                 * (MS_IN_DAY as f64))
                 .cast(&Datetime(TimeUnit::Milliseconds, None))
                 .unwrap(),
-            _ => Series::full_null(PlSmallStr::const_default(), groups.len(), s.dtype()),
+            _ => Series::full_null(PlSmallStr::EMPTY, groups.len(), s.dtype()),
         }
     }
 
@@ -227,7 +227,7 @@ impl Series {
                 * (MS_IN_DAY as f64))
                 .cast(&Datetime(TimeUnit::Milliseconds, None))
                 .unwrap(),
-            _ => Series::full_null(PlSmallStr::const_default(), groups.len(), s.dtype()),
+            _ => Series::full_null(PlSmallStr::EMPTY, groups.len(), s.dtype()),
         }
     }
 
@@ -262,7 +262,7 @@ impl Series {
                     s
                 }
             },
-            _ => Series::full_null(PlSmallStr::const_default(), groups.len(), s.dtype()),
+            _ => Series::full_null(PlSmallStr::EMPTY, groups.len(), s.dtype()),
         }
     }
 
@@ -287,7 +287,7 @@ impl Series {
                             Some(idx[idx.len() - 1])
                         }
                     })
-                    .collect_ca(PlSmallStr::const_default());
+                    .collect_ca(PlSmallStr::EMPTY);
                 s.take_unchecked(&indices)
             },
             GroupsProxy::Slice { groups, .. } => {
@@ -300,7 +300,7 @@ impl Series {
                             Some(first + len - 1)
                         }
                     })
-                    .collect_ca(PlSmallStr::const_default());
+                    .collect_ca(PlSmallStr::EMPTY);
                 s.take_unchecked(&indices)
             },
         };

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -324,7 +324,7 @@ impl IntoGroupsProxy for ListChunked {
         let ca = if multithreaded {
             encode_rows_vertical_par_unordered(by).unwrap()
         } else {
-            _get_rows_encoded_ca_unordered(PlSmallStr::const_default(), by).unwrap()
+            _get_rows_encoded_ca_unordered(PlSmallStr::EMPTY, by).unwrap()
         };
 
         ca.group_tuples(multithreaded, sorted)

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -284,7 +284,7 @@ impl<'df> GroupBy<'df> {
                             let indices = groups
                                 .iter()
                                 .map(|&[first, _len]| first)
-                                .collect_ca(PlSmallStr::const_default());
+                                .collect_ca(PlSmallStr::EMPTY);
                             // SAFETY: groups are always in bounds.
                             let mut out = unsafe { s.take_unchecked(&indices) };
                             // Sliced groups are always in order of discovery.

--- a/crates/polars-core/src/frame/group_by/proxy.rs
+++ b/crates/polars-core/src/frame/group_by/proxy.rs
@@ -345,7 +345,7 @@ impl GroupsProxy {
                 }
                 unsafe {
                     (
-                        Some(IdxCa::from_vec(PlSmallStr::const_default(), gather_offsets)),
+                        Some(IdxCa::from_vec(PlSmallStr::EMPTY, gather_offsets)),
                         OffsetsBuffer::new_unchecked(list_offset.into()),
                         can_fast_explode,
                     )
@@ -369,7 +369,7 @@ impl GroupsProxy {
 
                 unsafe {
                     (
-                        Some(IdxCa::from_vec(PlSmallStr::const_default(), gather_offsets)),
+                        Some(IdxCa::from_vec(PlSmallStr::EMPTY, gather_offsets)),
                         OffsetsBuffer::new_unchecked(list_offset.into()),
                         can_fast_explode,
                     )

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2881,7 +2881,7 @@ impl DataFrame {
                 }
             }
         }
-        let mut ca = IdxCa::mmap_slice(PlSmallStr::const_default(), idx);
+        let mut ca = IdxCa::mmap_slice(PlSmallStr::EMPTY, idx);
         ca.set_sorted_flag(sorted);
         self.take_unchecked_impl(&ca, allow_threads)
     }
@@ -3133,10 +3133,10 @@ mod test {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_filter_broadcast_on_list_col() {
-        let s1 = Series::new(PlSmallStr::const_default(), [true, false, true]);
+        let s1 = Series::new(PlSmallStr::EMPTY, [true, false, true]);
         let ll: ListChunked = [&s1].iter().copied().collect();
 
-        let mask = BooleanChunked::from_slice(PlSmallStr::const_default(), &[false]);
+        let mask = BooleanChunked::from_slice(PlSmallStr::EMPTY, &[false]);
         let new = ll.filter(&mask).unwrap();
 
         assert_eq!(new.chunks.len(), 1);

--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -249,13 +249,8 @@ impl<'a> AnyValueBuffer<'a> {
                 new.finish().into_series()
             },
             All(dtype, vals) => {
-                let out = Series::from_any_values_and_dtype(
-                    PlSmallStr::const_default(),
-                    vals,
-                    dtype,
-                    false,
-                )
-                .unwrap();
+                let out = Series::from_any_values_and_dtype(PlSmallStr::EMPTY, vals, dtype, false)
+                    .unwrap();
                 let mut new = Vec::with_capacity(capacity);
                 std::mem::swap(&mut new, vals);
                 out
@@ -278,79 +273,41 @@ impl From<(&DataType, usize)> for AnyValueBuffer<'_> {
         let (dt, len) = a;
         use DataType::*;
         match dt {
-            Boolean => AnyValueBuffer::Boolean(BooleanChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Int32 => AnyValueBuffer::Int32(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Int64 => AnyValueBuffer::Int64(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            UInt32 => AnyValueBuffer::UInt32(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            UInt64 => AnyValueBuffer::UInt64(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            Boolean => AnyValueBuffer::Boolean(BooleanChunkedBuilder::new(PlSmallStr::EMPTY, len)),
+            Int32 => AnyValueBuffer::Int32(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
+            Int64 => AnyValueBuffer::Int64(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
+            UInt32 => AnyValueBuffer::UInt32(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
+            UInt64 => AnyValueBuffer::UInt64(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
             #[cfg(feature = "dtype-i8")]
-            Int8 => AnyValueBuffer::Int8(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            Int8 => AnyValueBuffer::Int8(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
             #[cfg(feature = "dtype-i16")]
-            Int16 => AnyValueBuffer::Int16(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            Int16 => AnyValueBuffer::Int16(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
             #[cfg(feature = "dtype-u8")]
-            UInt8 => AnyValueBuffer::UInt8(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            UInt8 => AnyValueBuffer::UInt8(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
             #[cfg(feature = "dtype-u16")]
-            UInt16 => AnyValueBuffer::UInt16(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            UInt16 => AnyValueBuffer::UInt16(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
             #[cfg(feature = "dtype-date")]
-            Date => AnyValueBuffer::Date(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            Date => AnyValueBuffer::Date(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
             #[cfg(feature = "dtype-datetime")]
             Datetime(tu, tz) => AnyValueBuffer::Datetime(
-                PrimitiveChunkedBuilder::new(PlSmallStr::const_default(), len),
+                PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len),
                 *tu,
                 tz.clone(),
             ),
             #[cfg(feature = "dtype-duration")]
-            Duration(tu) => AnyValueBuffer::Duration(
-                PrimitiveChunkedBuilder::new(PlSmallStr::const_default(), len),
-                *tu,
-            ),
-            #[cfg(feature = "dtype-time")]
-            Time => AnyValueBuffer::Time(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Float32 => AnyValueBuffer::Float32(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Float64 => AnyValueBuffer::Float64(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            String => {
-                AnyValueBuffer::String(StringChunkedBuilder::new(PlSmallStr::const_default(), len))
+            Duration(tu) => {
+                AnyValueBuffer::Duration(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len), *tu)
             },
-            Null => AnyValueBuffer::Null(NullChunkedBuilder::new(PlSmallStr::const_default(), 0)),
+            #[cfg(feature = "dtype-time")]
+            Time => AnyValueBuffer::Time(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len)),
+            Float32 => {
+                AnyValueBuffer::Float32(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            Float64 => {
+                AnyValueBuffer::Float64(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            String => AnyValueBuffer::String(StringChunkedBuilder::new(PlSmallStr::EMPTY, len)),
+            Null => AnyValueBuffer::Null(NullChunkedBuilder::new(PlSmallStr::EMPTY, 0)),
             // Struct and List can be recursive so use AnyValues for that
             dt => AnyValueBuffer::All(dt.clone(), Vec::with_capacity(len)),
         }
@@ -667,7 +624,7 @@ impl<'a> AnyValueBufferTrusted<'a> {
                         s
                     })
                     .collect::<Vec<_>>();
-                StructChunked::from_series(PlSmallStr::const_default(), &v)
+                StructChunked::from_series(PlSmallStr::EMPTY, &v)
                     .unwrap()
                     .into_series()
             },
@@ -679,13 +636,8 @@ impl<'a> AnyValueBufferTrusted<'a> {
             All(dtype, vals) => {
                 let mut swap_vals = Vec::with_capacity(capacity);
                 std::mem::swap(vals, &mut swap_vals);
-                Series::from_any_values_and_dtype(
-                    PlSmallStr::const_default(),
-                    &swap_vals,
-                    dtype,
-                    false,
-                )
-                .unwrap()
+                Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &swap_vals, dtype, false)
+                    .unwrap()
             },
         }
     }
@@ -700,58 +652,46 @@ impl From<(&DataType, usize)> for AnyValueBufferTrusted<'_> {
         let (dt, len) = a;
         use DataType::*;
         match dt {
-            Boolean => AnyValueBufferTrusted::Boolean(BooleanChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Int32 => AnyValueBufferTrusted::Int32(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Int64 => AnyValueBufferTrusted::Int64(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            UInt32 => AnyValueBufferTrusted::UInt32(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            UInt64 => AnyValueBufferTrusted::UInt64(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            Boolean => {
+                AnyValueBufferTrusted::Boolean(BooleanChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            Int32 => {
+                AnyValueBufferTrusted::Int32(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            Int64 => {
+                AnyValueBufferTrusted::Int64(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            UInt32 => {
+                AnyValueBufferTrusted::UInt32(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            UInt64 => {
+                AnyValueBufferTrusted::UInt64(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
             #[cfg(feature = "dtype-i8")]
-            Int8 => AnyValueBufferTrusted::Int8(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            Int8 => {
+                AnyValueBufferTrusted::Int8(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
             #[cfg(feature = "dtype-i16")]
-            Int16 => AnyValueBufferTrusted::Int16(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            Int16 => {
+                AnyValueBufferTrusted::Int16(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
             #[cfg(feature = "dtype-u8")]
-            UInt8 => AnyValueBufferTrusted::UInt8(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            UInt8 => {
+                AnyValueBufferTrusted::UInt8(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
             #[cfg(feature = "dtype-u16")]
-            UInt16 => AnyValueBufferTrusted::UInt16(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Float32 => AnyValueBufferTrusted::Float32(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            Float64 => AnyValueBufferTrusted::Float64(PrimitiveChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
-            String => AnyValueBufferTrusted::String(StringChunkedBuilder::new(
-                PlSmallStr::const_default(),
-                len,
-            )),
+            UInt16 => {
+                AnyValueBufferTrusted::UInt16(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            Float32 => {
+                AnyValueBufferTrusted::Float32(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            Float64 => {
+                AnyValueBufferTrusted::Float64(PrimitiveChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
+            String => {
+                AnyValueBufferTrusted::String(StringChunkedBuilder::new(PlSmallStr::EMPTY, len))
+            },
             #[cfg(feature = "dtype-struct")]
             Struct(fields) => {
                 let buffers = fields

--- a/crates/polars-core/src/frame/row/mod.rs
+++ b/crates/polars-core/src/frame/row/mod.rs
@@ -238,7 +238,7 @@ pub fn rows_to_schema_first_non_null(
 
 impl<'a> From<&AnyValue<'a>> for Field {
     fn from(val: &AnyValue<'a>) -> Self {
-        Field::new(PlSmallStr::const_default(), val.into())
+        Field::new(PlSmallStr::EMPTY, val.into())
     }
 }
 

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -451,7 +451,7 @@ pub fn _df_rows_to_hashes_threaded_vertical(
                 let hb = hasher_builder.clone();
                 let mut hashes = vec![];
                 series_to_hashes(df.get_columns(), Some(hb), &mut hashes)?;
-                Ok(UInt64Chunked::from_vec(PlSmallStr::const_default(), hashes))
+                Ok(UInt64Chunked::from_vec(PlSmallStr::EMPTY, hashes))
             })
             .collect::<PolarsResult<Vec<_>>>()
     })?;

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -162,7 +162,7 @@ impl Series {
             DataType::Struct(fields) => any_values_to_struct(values, fields, strict)?,
             #[cfg(feature = "object")]
             DataType::Object(_, registry) => any_values_to_object(values, registry)?,
-            DataType::Null => Series::new_null(PlSmallStr::const_default(), values.len()),
+            DataType::Null => Series::new_null(PlSmallStr::EMPTY, values.len()),
             dt => {
                 polars_bail!(
                     InvalidOperation:
@@ -189,8 +189,7 @@ fn any_values_to_integer<T: PolarsIntegerType>(
     fn any_values_to_integer_strict<T: PolarsIntegerType>(
         values: &[AnyValue],
     ) -> PolarsResult<ChunkedArray<T>> {
-        let mut builder =
-            PrimitiveChunkedBuilder::<T>::new(PlSmallStr::const_default(), values.len());
+        let mut builder = PrimitiveChunkedBuilder::<T>::new(PlSmallStr::EMPTY, values.len());
         for av in values {
             match &av {
                 av if av.is_integer() => {
@@ -218,7 +217,7 @@ fn any_values_to_integer<T: PolarsIntegerType>(
 fn any_values_to_f32(values: &[AnyValue], strict: bool) -> PolarsResult<Float32Chunked> {
     fn any_values_to_f32_strict(values: &[AnyValue]) -> PolarsResult<Float32Chunked> {
         let mut builder =
-            PrimitiveChunkedBuilder::<Float32Type>::new(PlSmallStr::const_default(), values.len());
+            PrimitiveChunkedBuilder::<Float32Type>::new(PlSmallStr::EMPTY, values.len());
         for av in values {
             match av {
                 AnyValue::Float32(i) => builder.append_value(*i),
@@ -237,7 +236,7 @@ fn any_values_to_f32(values: &[AnyValue], strict: bool) -> PolarsResult<Float32C
 fn any_values_to_f64(values: &[AnyValue], strict: bool) -> PolarsResult<Float64Chunked> {
     fn any_values_to_f64_strict(values: &[AnyValue]) -> PolarsResult<Float64Chunked> {
         let mut builder =
-            PrimitiveChunkedBuilder::<Float64Type>::new(PlSmallStr::const_default(), values.len());
+            PrimitiveChunkedBuilder::<Float64Type>::new(PlSmallStr::EMPTY, values.len());
         for av in values {
             match av {
                 AnyValue::Float64(i) => builder.append_value(*i),
@@ -256,7 +255,7 @@ fn any_values_to_f64(values: &[AnyValue], strict: bool) -> PolarsResult<Float64C
 }
 
 fn any_values_to_bool(values: &[AnyValue], strict: bool) -> PolarsResult<BooleanChunked> {
-    let mut builder = BooleanChunkedBuilder::new(PlSmallStr::const_default(), values.len());
+    let mut builder = BooleanChunkedBuilder::new(PlSmallStr::EMPTY, values.len());
     for av in values {
         match av {
             AnyValue::Boolean(b) => builder.append_value(*b),
@@ -277,7 +276,7 @@ fn any_values_to_bool(values: &[AnyValue], strict: bool) -> PolarsResult<Boolean
 
 fn any_values_to_string(values: &[AnyValue], strict: bool) -> PolarsResult<StringChunked> {
     fn any_values_to_string_strict(values: &[AnyValue]) -> PolarsResult<StringChunked> {
-        let mut builder = StringChunkedBuilder::new(PlSmallStr::const_default(), values.len());
+        let mut builder = StringChunkedBuilder::new(PlSmallStr::EMPTY, values.len());
         for av in values {
             match av {
                 AnyValue::String(s) => builder.append_value(s),
@@ -289,7 +288,7 @@ fn any_values_to_string(values: &[AnyValue], strict: bool) -> PolarsResult<Strin
         Ok(builder.finish())
     }
     fn any_values_to_string_nonstrict(values: &[AnyValue]) -> StringChunked {
-        let mut builder = StringChunkedBuilder::new(PlSmallStr::const_default(), values.len());
+        let mut builder = StringChunkedBuilder::new(PlSmallStr::EMPTY, values.len());
         let mut owned = String::new(); // Amortize allocations.
         for av in values {
             match av {
@@ -315,7 +314,7 @@ fn any_values_to_string(values: &[AnyValue], strict: bool) -> PolarsResult<Strin
 
 fn any_values_to_binary(values: &[AnyValue], strict: bool) -> PolarsResult<BinaryChunked> {
     fn any_values_to_binary_strict(values: &[AnyValue]) -> PolarsResult<BinaryChunked> {
-        let mut builder = BinaryChunkedBuilder::new(PlSmallStr::const_default(), values.len());
+        let mut builder = BinaryChunkedBuilder::new(PlSmallStr::EMPTY, values.len());
         for av in values {
             match av {
                 AnyValue::Binary(s) => builder.append_value(*s),
@@ -347,8 +346,7 @@ fn any_values_to_binary(values: &[AnyValue], strict: bool) -> PolarsResult<Binar
 
 #[cfg(feature = "dtype-date")]
 fn any_values_to_date(values: &[AnyValue], strict: bool) -> PolarsResult<DateChunked> {
-    let mut builder =
-        PrimitiveChunkedBuilder::<Int32Type>::new(PlSmallStr::const_default(), values.len());
+    let mut builder = PrimitiveChunkedBuilder::<Int32Type>::new(PlSmallStr::EMPTY, values.len());
     for av in values {
         match av {
             AnyValue::Date(i) => builder.append_value(*i),
@@ -369,8 +367,7 @@ fn any_values_to_date(values: &[AnyValue], strict: bool) -> PolarsResult<DateChu
 
 #[cfg(feature = "dtype-time")]
 fn any_values_to_time(values: &[AnyValue], strict: bool) -> PolarsResult<TimeChunked> {
-    let mut builder =
-        PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::const_default(), values.len());
+    let mut builder = PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::EMPTY, values.len());
     for av in values {
         match av {
             AnyValue::Time(i) => builder.append_value(*i),
@@ -396,8 +393,7 @@ fn any_values_to_datetime(
     time_zone: Option<TimeZone>,
     strict: bool,
 ) -> PolarsResult<DatetimeChunked> {
-    let mut builder =
-        PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::const_default(), values.len());
+    let mut builder = PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::EMPTY, values.len());
     let target_dtype = DataType::Datetime(time_unit, time_zone.clone());
     for av in values {
         match av {
@@ -423,8 +419,7 @@ fn any_values_to_duration(
     time_unit: TimeUnit,
     strict: bool,
 ) -> PolarsResult<DurationChunked> {
-    let mut builder =
-        PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::const_default(), values.len());
+    let mut builder = PrimitiveChunkedBuilder::<Int64Type>::new(PlSmallStr::EMPTY, values.len());
     let target_dtype = DataType::Duration(time_unit);
     for av in values {
         match av {
@@ -496,8 +491,7 @@ fn any_values_to_decimal(
     };
     let target_dtype = DataType::Decimal(precision, Some(scale));
 
-    let mut builder =
-        PrimitiveChunkedBuilder::<Int128Type>::new(PlSmallStr::const_default(), values.len());
+    let mut builder = PrimitiveChunkedBuilder::<Int128Type>::new(PlSmallStr::EMPTY, values.len());
     for av in values {
         match av {
             // Allow equal or less scale. We do want to support different scales even in 'strict' mode.
@@ -538,10 +532,9 @@ fn any_values_to_list(
         // Structs don't support empty fields yet.
         // We must ensure the data-types match what we do physical
         #[cfg(feature = "dtype-struct")]
-        DataType::Struct(fields) if fields.is_empty() => DataType::Struct(vec![Field::new(
-            PlSmallStr::const_default(),
-            DataType::Null,
-        )]),
+        DataType::Struct(fields) if fields.is_empty() => {
+            DataType::Struct(vec![Field::new(PlSmallStr::EMPTY, DataType::Null)])
+        },
         _ => inner_type.clone(),
     };
     let target_dtype = DataType::List(Box::new(it));
@@ -632,7 +625,7 @@ fn any_values_to_array(
                     None
                 },
             })
-            .collect_ca_with_dtype(PlSmallStr::const_default(), target_dtype.clone())
+            .collect_ca_with_dtype(PlSmallStr::EMPTY, target_dtype.clone())
     }
     // Make sure that wrongly inferred AnyValues don't deviate from the datatype.
     else {
@@ -655,7 +648,7 @@ fn any_values_to_array(
                     None
                 },
             })
-            .collect_ca_with_dtype(PlSmallStr::const_default(), target_dtype.clone())
+            .collect_ca_with_dtype(PlSmallStr::EMPTY, target_dtype.clone())
     };
 
     if strict && !valid {
@@ -685,9 +678,7 @@ fn any_values_to_struct(
 ) -> PolarsResult<Series> {
     // Fast path for structs with no fields.
     if fields.is_empty() {
-        return Ok(
-            StructChunked::full_null(PlSmallStr::const_default(), values.len()).into_series(),
-        );
+        return Ok(StructChunked::full_null(PlSmallStr::EMPTY, values.len()).into_series());
     }
 
     // The physical series fields of the struct.
@@ -752,7 +743,7 @@ fn any_values_to_struct(
         series_fields.push(s)
     }
 
-    let mut out = StructChunked::from_series(PlSmallStr::const_default(), &series_fields)?;
+    let mut out = StructChunked::from_series(PlSmallStr::EMPTY, &series_fields)?;
     if has_outer_validity {
         let mut validity = MutableBitmap::new();
         validity.extend_constant(values.len(), true);
@@ -775,8 +766,7 @@ fn any_values_to_object(
         None => {
             use crate::chunked_array::object::registry;
             let converter = registry::get_object_converter();
-            let mut builder =
-                registry::get_object_builder(PlSmallStr::const_default(), values.len());
+            let mut builder = registry::get_object_builder(PlSmallStr::EMPTY, values.len());
             for av in values {
                 match av {
                     AnyValue::Object(val) => builder.append_value(val.as_any()),
@@ -792,8 +782,7 @@ fn any_values_to_object(
             builder
         },
         Some(registry) => {
-            let mut builder =
-                (*registry.builder_constructor)(PlSmallStr::const_default(), values.len());
+            let mut builder = (*registry.builder_constructor)(PlSmallStr::EMPTY, values.len());
             for av in values {
                 match av {
                     AnyValue::Object(val) => builder.append_value(val.as_any()),

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -504,12 +504,7 @@ unsafe fn to_physical_and_dtype(
             feature_gated!("dtype-categorical", {
                 let s = unsafe {
                     let dt = dt.clone();
-                    Series::_try_from_arrow_unchecked_with_md(
-                        PlSmallStr::const_default(),
-                        arrays,
-                        &dt,
-                        md,
-                    )
+                    Series::_try_from_arrow_unchecked_with_md(PlSmallStr::EMPTY, arrays, &dt, md)
                 }
                 .unwrap();
                 (s.chunks().clone(), s.dtype().clone())
@@ -627,8 +622,7 @@ unsafe fn to_physical_and_dtype(
         | ArrowDataType::Decimal(_, _)
         | ArrowDataType::Date64) => {
             let dt = dt.clone();
-            let mut s = Series::_try_from_arrow_unchecked(PlSmallStr::const_default(), arrays, &dt)
-                .unwrap();
+            let mut s = Series::_try_from_arrow_unchecked(PlSmallStr::EMPTY, arrays, &dt).unwrap();
             let dtype = s.dtype().clone();
             (std::mem::take(s.chunks_mut()), dtype)
         },

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -55,7 +55,7 @@ impl SeriesWrap<DecimalChunked> {
                 // SAFETY: dtype is passed correctly
                 let s = unsafe {
                     Series::from_chunks_and_dtype_unchecked(
-                        PlSmallStr::const_default(),
+                        PlSmallStr::EMPTY,
                         vec![arr.values().clone()],
                         dtype,
                     )

--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -34,7 +34,7 @@ impl Series {
                         let dtype = &field.dtype;
                         let s = unsafe {
                             Series::from_chunks_and_dtype_unchecked(
-                                PlSmallStr::const_default(),
+                                PlSmallStr::EMPTY,
                                 vec![values.clone()],
                                 &dtype.to_physical(),
                             )
@@ -59,7 +59,7 @@ impl Series {
                     // We pass physical arrays and cast to logical before we convert to arrow.
                     let s = unsafe {
                         Series::from_chunks_and_dtype_unchecked(
-                            PlSmallStr::const_default(),
+                            PlSmallStr::EMPTY,
                             vec![arr.values().clone()],
                             &inner.to_physical(),
                         )
@@ -84,8 +84,7 @@ impl Series {
                 let ca = self.categorical().unwrap();
                 let arr = ca.physical().chunks()[chunk_idx].clone();
                 // SAFETY: categoricals are always u32's.
-                let cats =
-                    unsafe { UInt32Chunked::from_chunks(PlSmallStr::const_default(), vec![arr]) };
+                let cats = unsafe { UInt32Chunked::from_chunks(PlSmallStr::EMPTY, vec![arr]) };
 
                 // SAFETY: we only take a single chunk and change nothing about the index/rev_map mapping.
                 let new = unsafe {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -167,10 +167,7 @@ impl Series {
             match self.dtype() {
                 #[cfg(feature = "object")]
                 DataType::Object(_, _) => self
-                    .take(&ChunkedArray::<IdxType>::new_vec(
-                        PlSmallStr::const_default(),
-                        vec![],
-                    ))
+                    .take(&ChunkedArray::<IdxType>::new_vec(PlSmallStr::EMPTY, vec![]))
                     .unwrap(),
                 dt => Series::new_empty(self.name().clone(), dt),
             }
@@ -654,7 +651,7 @@ impl Series {
     pub fn gather_every(&self, n: usize, offset: usize) -> Series {
         let idx = ((offset as IdxSize)..self.len() as IdxSize)
             .step_by(n)
-            .collect_ca(PlSmallStr::const_default());
+            .collect_ca(PlSmallStr::EMPTY);
         // SAFETY: we stay in-bounds.
         unsafe { self.take_unchecked(&idx) }
     }

--- a/crates/polars-core/src/series/ops/extend.rs
+++ b/crates/polars-core/src/series/ops/extend.rs
@@ -4,7 +4,7 @@ impl Series {
     /// Extend with a constant value.
     pub fn extend_constant(&self, value: AnyValue, n: usize) -> PolarsResult<Self> {
         // TODO: Use `from_any_values_and_dtype` here instead of casting afterwards
-        let s = Series::from_any_values(PlSmallStr::const_default(), &[value], true).unwrap();
+        let s = Series::from_any_values(PlSmallStr::EMPTY, &[value], true).unwrap();
         let s = s.cast(self.dtype())?;
         let to_append = s.new_from_index(0, n);
 

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -1189,9 +1189,9 @@ mod test {
 
     #[test]
     fn test_align_chunks() -> PolarsResult<()> {
-        let a = Int32Chunked::new(PlSmallStr::const_default(), &[1, 2, 3, 4]);
-        let mut b = Int32Chunked::new(PlSmallStr::const_default(), &[1]);
-        let b2 = Int32Chunked::new(PlSmallStr::const_default(), &[2, 3, 4]);
+        let a = Int32Chunked::new(PlSmallStr::EMPTY, &[1, 2, 3, 4]);
+        let mut b = Int32Chunked::new(PlSmallStr::EMPTY, &[1]);
+        let b2 = Int32Chunked::new(PlSmallStr::EMPTY, &[2, 3, 4]);
 
         b.append(&b2)?;
         let (a, b) = align_chunks_binary(&a, &b);
@@ -1200,8 +1200,8 @@ mod test {
             b.chunk_lengths().collect::<Vec<_>>()
         );
 
-        let a = Int32Chunked::new(PlSmallStr::const_default(), &[1, 2, 3, 4]);
-        let mut b = Int32Chunked::new(PlSmallStr::const_default(), &[1]);
+        let a = Int32Chunked::new(PlSmallStr::EMPTY, &[1, 2, 3, 4]);
+        let mut b = Int32Chunked::new(PlSmallStr::EMPTY, &[1]);
         let b1 = b.clone();
         b.append(&b1)?;
         b.append(&b1)?;

--- a/crates/polars-core/src/utils/series.rs
+++ b/crates/polars-core/src/utils/series.rs
@@ -9,7 +9,7 @@ pub fn with_unstable_series<F, T>(dtype: &DataType, f: F) -> T
 where
     F: Fn(&mut AmortSeries) -> T,
 {
-    let container = Series::full_null(PlSmallStr::const_default(), 0, dtype);
+    let container = Series::full_null(PlSmallStr::EMPTY, 0, dtype);
     let mut us = AmortSeries::new(Rc::new(container));
 
     f(&mut us)

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -156,7 +156,7 @@ impl ApplyExpr {
             // Create input for the function to determine the output dtype, see #3946.
             let agg = agg.list().unwrap();
             let input_dtype = agg.inner_dtype();
-            let input = Series::full_null(PlSmallStr::const_default(), 0, input_dtype);
+            let input = Series::full_null(PlSmallStr::EMPTY, 0, input_dtype);
 
             let output = self.eval_and_flatten(&mut [input])?;
             let ca = ListChunked::full(name, &output, 0);
@@ -185,7 +185,7 @@ impl ApplyExpr {
             if let Some(dtype) = dtype {
                 // TODO! uncomment this line and remove debug_assertion after a while.
                 // POOL.install(|| {
-                //     iter.collect_ca_with_dtype::<PolarsResult<_>>(PlSmallStr::const_default(), DataType::List(Box::new(dtype)))
+                //     iter.collect_ca_with_dtype::<PolarsResult<_>>(PlSmallStr::EMPTY, DataType::List(Box::new(dtype)))
                 // })?
                 let out: ListChunked = POOL.install(|| iter.collect::<PolarsResult<_>>())?;
 
@@ -597,14 +597,14 @@ impl ApplyExpr {
                     let (right, right_dtype) = (right.to_any_value()?, right.get_datatype());
 
                     let left = Series::from_any_values_and_dtype(
-                        PlSmallStr::const_default(),
+                        PlSmallStr::EMPTY,
                         &[left],
                         &left_dtype,
                         false,
                     )
                     .ok()?;
                     let right = Series::from_any_values_and_dtype(
-                        PlSmallStr::const_default(),
+                        PlSmallStr::EMPTY,
                         &[right],
                         &right_dtype,
                         false,

--- a/crates/polars-expr/src/expressions/group_iter.rs
+++ b/crates/polars-expr/src/expressions/group_iter.rs
@@ -16,7 +16,7 @@ impl<'a> AggregationContext<'a> {
                 let name = if keep_names {
                     s.name().clone()
                 } else {
-                    PlSmallStr::const_default()
+                    PlSmallStr::EMPTY
                 };
                 // SAFETY: dtype is correct
                 unsafe {
@@ -34,7 +34,7 @@ impl<'a> AggregationContext<'a> {
                 let name = if keep_names {
                     s.name().clone()
                 } else {
-                    PlSmallStr::const_default()
+                    PlSmallStr::EMPTY
                 };
                 // SAFETY: dtype is correct
                 unsafe {
@@ -52,7 +52,7 @@ impl<'a> AggregationContext<'a> {
                 let name = if keep_names {
                     s.name().clone()
                 } else {
-                    PlSmallStr::const_default()
+                    PlSmallStr::EMPTY
                 };
                 Box::new(list.amortized_iter_with_name(name))
             },
@@ -64,7 +64,7 @@ impl<'a> AggregationContext<'a> {
                 let name = if keep_names {
                     s.name().clone()
                 } else {
-                    PlSmallStr::const_default()
+                    PlSmallStr::EMPTY
                 };
                 Box::new(list.amortized_iter_with_name(name))
             },

--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -131,7 +131,7 @@ fn sort_by_groups_no_match_single<'a>(
                 },
                 _ => Ok(None),
             })
-            .collect_ca_with_dtype(PlSmallStr::const_default(), dtype)
+            .collect_ca_with_dtype(PlSmallStr::EMPTY, dtype)
     });
     let s = ca?.with_name(s_in.name().clone()).into_series();
     ac_in.with_series(s, true, Some(expr))?;

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -113,7 +113,7 @@ impl WindowExpr {
         // SAFETY:
         // we only have unique indices ranging from 0..len
         unsafe { perfect_sort(&POOL, &idx_mapping, &mut take_idx) };
-        let idx = IdxCa::from_vec(PlSmallStr::const_default(), take_idx);
+        let idx = IdxCa::from_vec(PlSmallStr::EMPTY, take_idx);
 
         // SAFETY:
         // groups should always be in bounds.

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -201,12 +201,8 @@ fn deserialize_all<'a>(
                 .iter()
                 .map(|val| deserialize_all(val, inner_dtype, ignore_errors))
                 .collect::<PolarsResult<_>>()?;
-            let s = Series::from_any_values_and_dtype(
-                PlSmallStr::const_default(),
-                &vals,
-                inner_dtype,
-                false,
-            )?;
+            let s =
+                Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vals, inner_dtype, false)?;
             AnyValue::List(s)
         },
         #[cfg(feature = "dtype-struct")]

--- a/crates/polars-io/src/parquet/read/predicates.rs
+++ b/crates/polars-io/src/parquet/read/predicates.rs
@@ -8,9 +8,9 @@ impl ColumnStats {
     fn from_arrow_stats(stats: Statistics, field: &ArrowField) -> Self {
         Self::new(
             field.into(),
-            Some(Series::try_from((PlSmallStr::const_default(), stats.null_count)).unwrap()),
-            Some(Series::try_from((PlSmallStr::const_default(), stats.min_value)).unwrap()),
-            Some(Series::try_from((PlSmallStr::const_default(), stats.max_value)).unwrap()),
+            Some(Series::try_from((PlSmallStr::EMPTY, stats.null_count)).unwrap()),
+            Some(Series::try_from((PlSmallStr::EMPTY, stats.min_value)).unwrap()),
+            Some(Series::try_from((PlSmallStr::EMPTY, stats.max_value)).unwrap()),
         )
     }
 }

--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -13,7 +13,7 @@ pub(crate) fn eval_field_to_dtype(f: &Field, expr: &Expr, list: bool) -> Field {
         .cloned()
         .unwrap_or_else(|| f.data_type().clone());
 
-    let df = Series::new_empty(PlSmallStr::const_default(), &dtype).into_frame();
+    let df = Series::new_empty(PlSmallStr::EMPTY, &dtype).into_frame();
 
     #[cfg(feature = "python")]
     let out = {
@@ -47,7 +47,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
         let expr2 = expr.clone();
         let func = move |mut s: Series| {
             let name = s.name().clone();
-            s.rename(PlSmallStr::const_default());
+            s.rename(PlSmallStr::EMPTY);
 
             // Ensure we get the new schema.
             let output_field = eval_field_to_dtype(s.field().as_ref(), &expr, false);

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -51,7 +51,7 @@ fn run_per_sublist(
     output_field: Field,
 ) -> PolarsResult<Option<Series>> {
     let phys_expr = prepare_expression_for_context(
-        PlSmallStr::const_default(),
+        PlSmallStr::EMPTY,
         expr,
         lst.inner_dtype(),
         Context::Default,
@@ -77,7 +77,7 @@ fn run_per_sublist(
                     }
                 })
             })
-            .collect_ca_with_dtype(PlSmallStr::const_default(), output_field.dtype.clone());
+            .collect_ca_with_dtype(PlSmallStr::EMPTY, output_field.dtype.clone());
         err = m_err.into_inner().unwrap();
         ca
     } else {
@@ -123,19 +123,15 @@ fn run_on_group_by_engine(
     let groups = offsets_to_groups(arr.offsets()).unwrap();
 
     // List elements in a series.
-    let values = Series::try_from((PlSmallStr::const_default(), arr.values().clone())).unwrap();
+    let values = Series::try_from((PlSmallStr::EMPTY, arr.values().clone())).unwrap();
     let inner_dtype = lst.inner_dtype();
     // SAFETY:
     // Invariant in List means values physicals can be cast to inner dtype
     let values = unsafe { values.cast_unchecked(inner_dtype).unwrap() };
 
     let df_context = values.into_frame();
-    let phys_expr = prepare_expression_for_context(
-        PlSmallStr::const_default(),
-        expr,
-        inner_dtype,
-        Context::Aggregation,
-    )?;
+    let phys_expr =
+        prepare_expression_for_context(PlSmallStr::EMPTY, expr, inner_dtype, Context::Aggregation)?;
 
     let state = ExecutionState::new();
     let mut ac = phys_expr.evaluate_on_groups(&df_context, &groups, &state)?;

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -33,7 +33,8 @@ impl PhysicalAggExpr for PivotExpr {
     }
 
     fn root_name(&self) -> PolarsResult<&PlSmallStr> {
-        Ok(PlSmallStr::EMPTY_REF)
+        // Ok(PlSmallStr::EMPTY_REF)
+        Ok(&polars_utils::pl_str::STATIC_EMPTY)
     }
 }
 

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -33,8 +33,7 @@ impl PhysicalAggExpr for PivotExpr {
     }
 
     fn root_name(&self) -> PolarsResult<&PlSmallStr> {
-        // Ok(PlSmallStr::EMPTY_REF)
-        Ok(&polars_utils::pl_str::STATIC_EMPTY)
+        Ok(PlSmallStr::EMPTY_REF)
     }
 }
 

--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -22,7 +22,7 @@ impl PhysicalAggExpr for PivotExpr {
         let state = ExecutionState::new();
         let dtype = df.get_columns()[0].dtype();
         let phys_expr = prepare_expression_for_context(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &self.0,
             dtype,
             Context::Aggregation,
@@ -33,7 +33,7 @@ impl PhysicalAggExpr for PivotExpr {
     }
 
     fn root_name(&self) -> PolarsResult<&PlSmallStr> {
-        Ok(PlSmallStr::empty_static())
+        Ok(PlSmallStr::EMPTY_REF)
     }
 }
 

--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -6,8 +6,8 @@ use crate::prelude::*;
 #[cfg(feature = "pivot")]
 pub(crate) fn prepare_eval_expr(expr: Expr) -> Expr {
     expr.map_expr(|e| match e {
-        Expr::Column(_) => Expr::Column(PlSmallStr::const_default()),
-        Expr::Nth(_) => Expr::Column(PlSmallStr::const_default()),
+        Expr::Column(_) => Expr::Column(PlSmallStr::EMPTY),
+        Expr::Nth(_) => Expr::Column(PlSmallStr::EMPTY),
         e => e,
     })
 }

--- a/crates/polars-mem-engine/src/executors/group_by_rolling.rs
+++ b/crates/polars-mem-engine/src/executors/group_by_rolling.rs
@@ -29,7 +29,7 @@ unsafe fn update_keys(keys: &mut [Series], groups: &GroupsProxy) {
                 let indices = groups
                     .iter()
                     .map(|[first, _len]| *first)
-                    .collect_ca(PlSmallStr::const_default());
+                    .collect_ca(PlSmallStr::EMPTY);
                 *key = key.take_unchecked(&indices);
             }
         },

--- a/crates/polars-ops/src/chunked_array/array/count.rs
+++ b/crates/polars-ops/src/chunked_array/array/count.rs
@@ -8,7 +8,7 @@ use super::*;
 
 #[cfg(feature = "array_count")]
 pub fn array_count_matches(ca: &ArrayChunked, value: AnyValue) -> PolarsResult<Series> {
-    let value = Series::new(PlSmallStr::const_default(), [value]);
+    let value = Series::new(PlSmallStr::EMPTY, [value]);
 
     let ca = ca.apply_to_inner(&|s| {
         ChunkCompare::<&Series>::equal_missing(&s, &value).map(|ca| ca.into_series())

--- a/crates/polars-ops/src/chunked_array/array/to_struct.rs
+++ b/crates/polars-ops/src/chunked_array/array/to_struct.rs
@@ -29,7 +29,7 @@ pub trait ToStruct: AsArray {
                 .into_par_iter()
                 .map(|i| {
                     ca.array_get(
-                        &Int64Chunked::from_slice(PlSmallStr::const_default(), &[i as i64]),
+                        &Int64Chunked::from_slice(PlSmallStr::EMPTY, &[i as i64]),
                         true,
                     )
                     .map(|mut s| {

--- a/crates/polars-ops/src/chunked_array/list/count.rs
+++ b/crates/polars-ops/src/chunked_array/list/count.rs
@@ -42,7 +42,7 @@ fn count_bits_set_by_offsets(values: &Bitmap, offset: &[i64]) -> Vec<IdxSize> {
 
 #[cfg(feature = "list_count")]
 pub fn list_count_matches(ca: &ListChunked, value: AnyValue) -> PolarsResult<Series> {
-    let value = Series::new(PlSmallStr::const_default(), [value]);
+    let value = Series::new(PlSmallStr::EMPTY, [value]);
 
     let ca = ca.apply_to_inner(&|s| {
         ChunkCompare::<&Series>::equal_missing(&s, &value).map(|ca| ca.into_series())

--- a/crates/polars-ops/src/chunked_array/list/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/list/sum_mean.rs
@@ -109,7 +109,7 @@ pub(super) fn sum_with_nulls(ca: &ListChunked, inner_dtype: &DataType) -> Polars
             .try_apply_amortized(|s| {
                 s.as_ref()
                     .sum_reduce()
-                    .map(|sc| sc.into_series(PlSmallStr::const_default()))
+                    .map(|sc| sc.into_series(PlSmallStr::EMPTY))
             })?
             .explode()
             .unwrap()

--- a/crates/polars-ops/src/chunked_array/repeat_by.rs
+++ b/crates/polars-ops/src/chunked_array/repeat_by.rs
@@ -15,7 +15,7 @@ fn check_lengths(length_srs: usize, length_by: usize) -> PolarsResult<()> {
 
 fn new_by(by: &IdxCa, len: usize) -> IdxCa {
     IdxCa::new(
-        PlSmallStr::const_default(),
+        PlSmallStr::EMPTY,
         std::iter::repeat(by.get(0).unwrap())
             .take(len)
             .collect::<Vec<IdxSize>>(),

--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -61,7 +61,7 @@ pub fn hor_str_concat(
     ignore_nulls: bool,
 ) -> PolarsResult<StringChunked> {
     if cas.is_empty() {
-        return Ok(StringChunked::full_null(PlSmallStr::const_default(), 0));
+        return Ok(StringChunked::full_null(PlSmallStr::EMPTY, 0));
     }
     if cas.len() == 1 {
         let ca = cas[0];

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -112,7 +112,7 @@ pub trait Utf8JsonPathImpl: AsString {
             ca.len(),
         )
         .map_err(|e| polars_err!(ComputeError: "error deserializing JSON: {}", e))?;
-        Series::try_from((PlSmallStr::const_default(), array))
+        Series::try_from((PlSmallStr::EMPTY, array))
     }
 
     fn json_path_select(&self, json_path: &str) -> PolarsResult<StringChunked> {

--- a/crates/polars-ops/src/frame/join/asof/default.rs
+++ b/crates/polars-ops/src/frame/join/asof/default.rs
@@ -15,7 +15,7 @@ where
     F: FnMut(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
     if left.len() == left.null_count() || right.len() == right.null_count() {
-        return IdxCa::full_null(PlSmallStr::const_default(), left.len());
+        return IdxCa::full_null(PlSmallStr::EMPTY, left.len());
     }
 
     let mut out = vec![0; left.len()];
@@ -55,7 +55,7 @@ where
     }
 
     let bitmap = Bitmap::try_new(mask, out.len()).unwrap();
-    IdxCa::from_vec_validity(PlSmallStr::const_default(), out, Some(bitmap))
+    IdxCa::from_vec_validity(PlSmallStr::EMPTY, out, Some(bitmap))
 }
 
 fn join_asof_forward<'a, T, F>(left: &'a T::Array, right: &'a T::Array, filter: F) -> IdxCa

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -679,10 +679,7 @@ pub trait AsofJoinBy: IntoDf {
 
         // SAFETY: join tuples are in bounds.
         let right_df = unsafe {
-            proj_other_df.take_unchecked(&IdxCa::with_chunk(
-                PlSmallStr::const_default(),
-                right_join_tuples,
-            ))
+            proj_other_df.take_unchecked(&IdxCa::with_chunk(PlSmallStr::EMPTY, right_join_tuples))
         };
 
         _finish_join(left, right_df, suffix)

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -147,8 +147,8 @@ pub trait JoinDispatch: IntoDf {
             join_idx_l.slice(offset, len);
             join_idx_r.slice(offset, len);
         }
-        let idx_ca_l = IdxCa::with_chunk(PlSmallStr::const_default(), join_idx_l);
-        let idx_ca_r = IdxCa::with_chunk(PlSmallStr::const_default(), join_idx_r);
+        let idx_ca_l = IdxCa::with_chunk(PlSmallStr::EMPTY, join_idx_l);
+        let idx_ca_r = IdxCa::with_chunk(PlSmallStr::EMPTY, join_idx_r);
 
         // Take the left and right dataframes by join tuples
         let (df_left, df_right) = POOL.join(

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -81,7 +81,7 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> PolarsR
                 .zip(rhs.fields_as_series())
                 .map(|(lhs, rhs)| merge_series(lhs, &rhs, merge_indicator))
                 .collect::<PolarsResult<Vec<_>>>()?;
-            StructChunked::from_series(PlSmallStr::const_default(), &new_fields)
+            StructChunked::from_series(PlSmallStr::EMPTY, &new_fields)
                 .unwrap()
                 .into_series()
         },

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -574,7 +574,7 @@ fn is_in_string_categorical(
     // In case of fast unique, we can directly use the categories. Otherwise we need to
     // first get the unique physicals
     let categories = StringChunked::with_chunk(
-        PlSmallStr::const_default(),
+        PlSmallStr::EMPTY,
         other.get_rev_map().get_categories().clone(),
     );
     let other = if other._can_fast_unique() {

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -92,10 +92,7 @@ pub trait LogSeries: SeriesSealed {
                 let pk = s.as_ref();
 
                 let pk = if normalize {
-                    let sum = pk
-                        .sum_reduce()
-                        .unwrap()
-                        .into_series(PlSmallStr::const_default());
+                    let sum = pk.sum_reduce().unwrap().into_series(PlSmallStr::EMPTY);
 
                     if sum.get(0).unwrap().extract::<f64>().unwrap() != 1.0 {
                         (pk / &sum)?

--- a/crates/polars-ops/src/series/ops/moment.rs
+++ b/crates/polars-ops/src/series/ops/moment.rs
@@ -129,7 +129,7 @@ mod test {
 
     #[test]
     fn test_moment_compute() -> PolarsResult<()> {
-        let s = Series::new(PlSmallStr::const_default(), &[1, 2, 3, 4, 5, 23]);
+        let s = Series::new(PlSmallStr::EMPTY, &[1, 2, 3, 4, 5, 23]);
 
         assert_eq!(moment(&s, 0)?, Some(1.0));
         assert_eq!(moment(&s, 1)?, Some(0.0));
@@ -141,9 +141,9 @@ mod test {
 
     #[test]
     fn test_skew() -> PolarsResult<()> {
-        let s = Series::new(PlSmallStr::const_default(), &[1, 2, 3, 4, 5, 23]);
+        let s = Series::new(PlSmallStr::EMPTY, &[1, 2, 3, 4, 5, 23]);
         let s2 = Series::new(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[Some(1), Some(2), Some(3), None, Some(1)],
         );
 
@@ -158,7 +158,7 @@ mod test {
 
     #[test]
     fn test_kurtosis() -> PolarsResult<()> {
-        let s = Series::new(PlSmallStr::const_default(), &[1, 2, 3, 4, 5, 23]);
+        let s = Series::new(PlSmallStr::EMPTY, &[1, 2, 3, 4, 5, 23]);
 
         assert!((s.kurtosis(true, true)?.unwrap() - 0.9945668771797536).abs() < 0.0001);
         assert!((s.kurtosis(true, false)?.unwrap() - 5.400820058440946).abs() < 0.0001);
@@ -166,7 +166,7 @@ mod test {
         assert!((s.kurtosis(false, false)?.unwrap() - 8.400820058440946).abs() < 0.0001);
 
         let s2 = Series::new(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             &[Some(1), Some(2), Some(3), None, Some(1), Some(2), Some(3)],
         );
         assert!((s2.kurtosis(true, true)?.unwrap() - (-1.5)).abs() < 0.0001);

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -138,10 +138,7 @@ fn replace_by_single_strict(s: &Series, old: &Series, new: &Series) -> PolarsRes
 
     // Transfer validity from `mask` to `out`.
     if mask.null_count() > 0 {
-        out = out.zip_with(
-            &mask,
-            &Series::new_null(PlSmallStr::const_default(), s.len()),
-        )?
+        out = out.zip_with(&mask, &Series::new_null(PlSmallStr::EMPTY, s.len()))?
     }
     Ok(out)
 }

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -94,7 +94,7 @@ pub trait SeriesMethods: SeriesSealed {
         #[cfg(feature = "dtype-struct")]
         if matches!(s.dtype(), DataType::Struct(_)) {
             let encoded = _get_rows_encoded_ca(
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
                 &[s.clone()],
                 &[options.descending],
                 &[options.nulls_last],

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -40,10 +40,7 @@ impl PhysicalPipedExpr for Len {
     fn evaluate(&self, chunk: &DataChunk, _lazy_state: &ExecutionState) -> PolarsResult<Series> {
         // the length must match the chunks as the operators expect that
         // so we fill a null series.
-        Ok(Series::new_null(
-            PlSmallStr::const_default(),
-            chunk.data.height(),
-        ))
+        Ok(Series::new_null(PlSmallStr::EMPTY, chunk.data.height()))
     }
 
     fn field(&self, _input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
@@ -271,7 +271,7 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
         cols.extend(
             key_columns
                 .into_iter()
-                .map(|arr| Series::try_from((PlSmallStr::const_default(), arr)).unwrap()),
+                .map(|arr| Series::try_from((PlSmallStr::EMPTY, arr)).unwrap()),
         );
         cols.extend(agg_builders.into_iter().map(|buf| buf.into_series()));
         physical_agg_to_logical(&mut cols, &self.output_schema);

--- a/crates/polars-pipe/src/executors/sinks/group_by/string.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/string.rs
@@ -186,8 +186,7 @@ impl StringGroupbySink {
                             .collect::<Vec<_>>();
 
                         let cap = std::cmp::min(slice_len, agg_map.len());
-                        let mut key_builder =
-                            StringChunkedBuilder::new(PlSmallStr::const_default(), cap);
+                        let mut key_builder = StringChunkedBuilder::new(PlSmallStr::EMPTY, cap);
                         agg_map.into_iter().skip(offset).take(slice_len).for_each(
                             |(k, &offset)| {
                                 let key_offset = k.idx as usize;

--- a/crates/polars-pipe/src/executors/sinks/io.rs
+++ b/crates/polars-pipe/src/executors/sinks/io.rs
@@ -242,10 +242,7 @@ impl IOThread {
     }
 
     pub(in crate::executors::sinks) fn dump_partition(&self, partition_no: IdxSize, df: DataFrame) {
-        let partition = Some(IdxCa::from_vec(
-            PlSmallStr::const_default(),
-            vec![partition_no],
-        ));
+        let partition = Some(IdxCa::from_vec(PlSmallStr::EMPTY, vec![partition_no]));
         let iter = Box::new(std::iter::once(df));
         self.dump_iter(partition, iter)
     }

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -191,9 +191,7 @@ impl Sink for SortSink {
             let mut lock = self.io_thread.write().unwrap();
             let io_thread = lock.take().unwrap();
 
-            let dist =
-                Series::from_any_values(PlSmallStr::const_default(), &self.dist_sample, true)
-                    .unwrap();
+            let dist = Series::from_any_values(PlSmallStr::EMPTY, &self.dist_sample, true).unwrap();
             let dist = dist.sort_with(SortOptions::from(&self.sort_options))?;
 
             let instant = self.ooc_start.unwrap();

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -217,7 +217,7 @@ fn any_horizontal(s: &[Series]) -> PolarsResult<Series> {
         .install(|| {
             s.par_iter()
                 .try_fold(
-                    || BooleanChunked::new(PlSmallStr::const_default(), &[false]),
+                    || BooleanChunked::new(PlSmallStr::EMPTY, &[false]),
                     |acc, b| {
                         let b = b.cast(&DataType::Boolean)?;
                         let b = b.bool()?;
@@ -225,7 +225,7 @@ fn any_horizontal(s: &[Series]) -> PolarsResult<Series> {
                     },
                 )
                 .try_reduce(
-                    || BooleanChunked::new(PlSmallStr::const_default(), [false]),
+                    || BooleanChunked::new(PlSmallStr::EMPTY, [false]),
                     |a, b| Ok(a.bitor(b)),
                 )
         })?
@@ -239,7 +239,7 @@ fn all_horizontal(s: &[Series]) -> PolarsResult<Series> {
         .install(|| {
             s.par_iter()
                 .try_fold(
-                    || BooleanChunked::new(PlSmallStr::const_default(), &[true]),
+                    || BooleanChunked::new(PlSmallStr::EMPTY, &[true]),
                     |acc, b| {
                         let b = b.cast(&DataType::Boolean)?;
                         let b = b.bool()?;
@@ -247,7 +247,7 @@ fn all_horizontal(s: &[Series]) -> PolarsResult<Series> {
                     },
                 )
                 .try_reduce(
-                    || BooleanChunked::new(PlSmallStr::const_default(), [true]),
+                    || BooleanChunked::new(PlSmallStr::EMPTY, [true]),
                     |a, b| Ok(a.bitand(b)),
                 )
         })?

--- a/crates/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/crates/polars-plan/src/dsl/function_expr/correlation.rs
@@ -97,7 +97,7 @@ fn spearman_rank_corr(s: &[Series], ddof: u8, propagate_nans: bool) -> PolarsRes
     let name = PlSmallStr::from_static("spearman_rank_correlation");
     if propagate_nans && a.dtype().is_float() {
         for s in [&a, &b] {
-            if nan_max_s(s, PlSmallStr::const_default())
+            if nan_max_s(s, PlSmallStr::EMPTY)
                 .get(0)
                 .unwrap()
                 .extract::<f64>()

--- a/crates/polars-plan/src/dsl/function_expr/fill_null.rs
+++ b/crates/polars-plan/src/dsl/function_expr/fill_null.rs
@@ -28,10 +28,7 @@ pub(super) fn fill_null(s: &[Series]) -> PolarsResult<Series> {
                     let cats = series.to_physical_repr();
                     let mask = cats.is_not_null();
                     let out = cats
-                        .zip_with_same_type(
-                            &mask,
-                            &Series::new(PlSmallStr::const_default(), &[idx]),
-                        )
+                        .zip_with_same_type(&mask, &Series::new(PlSmallStr::EMPTY, &[idx]))
                         .unwrap();
                     unsafe { return out.cast_unchecked(series.dtype()) }
                 }

--- a/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
@@ -75,7 +75,7 @@ pub(super) fn date_ranges(
 
     let range_impl = |start, end, builder: &mut ListPrimitiveChunkedBuilder<Int32Type>| {
         let rng = datetime_range_impl(
-            PlSmallStr::const_default(),
+            PlSmallStr::EMPTY,
             start,
             end,
             interval,

--- a/crates/polars-plan/src/dsl/function_expr/range/datetime_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/datetime_range.rs
@@ -202,7 +202,7 @@ pub(super) fn datetime_ranges(
             };
             let range_impl = |start, end, builder: &mut ListPrimitiveChunkedBuilder<Int64Type>| {
                 let rng = datetime_range_impl(
-                    PlSmallStr::const_default(),
+                    PlSmallStr::EMPTY,
                     start,
                     end,
                     interval,

--- a/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
@@ -54,7 +54,7 @@ pub(super) fn time_ranges(
     );
 
     let range_impl = |start, end, builder: &mut ListPrimitiveChunkedBuilder<Int64Type>| {
-        let rng = time_range_impl(PlSmallStr::const_default(), start, end, interval, closed)?;
+        let rng = time_range_impl(PlSmallStr::EMPTY, start, end, interval, closed)?;
         builder.append_slice(rng.cont_slice().unwrap());
         Ok(())
     };

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -290,7 +290,7 @@ pub(crate) fn py_object_to_any_value<'py>(
 
         if ob.is_empty()? {
             Ok(AnyValue::List(Series::new_empty(
-                PlSmallStr::const_default(),
+                PlSmallStr::EMPTY,
                 &DataType::Null,
             )))
         } else if ob.is_instance_of::<PyList>() | ob.is_instance_of::<PyTuple>() {
@@ -323,7 +323,7 @@ pub(crate) fn py_object_to_any_value<'py>(
                     avs.push(av)
                 }
 
-                let s = Series::from_any_values_and_dtype(PlSmallStr::const_default(), &avs, &dtype, strict)
+                let s = Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &avs, &dtype, strict)
                     .map_err(|e| {
                         PyTypeError::new_err(format!(
                             "{e}\n\nHint: Try setting `strict=False` to allow passing data with mixed types."

--- a/crates/polars-python/src/expr/rolling.rs
+++ b/crates/polars-python/src/expr/rolling.rs
@@ -363,14 +363,11 @@ impl PyExpr {
                             UInt8 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(UInt8Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as u8],
-                                    )
-                                    .into_series())
+                                    Ok(UInt8Chunked::from_slice(PlSmallStr::EMPTY, &[v as u8])
+                                        .into_series())
                                 } else {
                                     obj.extract::<u8>(py).map(|v| {
-                                        UInt8Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        UInt8Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
@@ -378,14 +375,11 @@ impl PyExpr {
                             UInt16 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(UInt16Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as u16],
-                                    )
-                                    .into_series())
+                                    Ok(UInt16Chunked::from_slice(PlSmallStr::EMPTY, &[v as u16])
+                                        .into_series())
                                 } else {
                                     obj.extract::<u16>(py).map(|v| {
-                                        UInt16Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        UInt16Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
@@ -393,14 +387,11 @@ impl PyExpr {
                             UInt32 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(UInt32Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as u32],
-                                    )
-                                    .into_series())
+                                    Ok(UInt32Chunked::from_slice(PlSmallStr::EMPTY, &[v as u32])
+                                        .into_series())
                                 } else {
                                     obj.extract::<u32>(py).map(|v| {
-                                        UInt32Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        UInt32Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
@@ -408,14 +399,11 @@ impl PyExpr {
                             UInt64 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(UInt64Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as u64],
-                                    )
-                                    .into_series())
+                                    Ok(UInt64Chunked::from_slice(PlSmallStr::EMPTY, &[v as u64])
+                                        .into_series())
                                 } else {
                                     obj.extract::<u64>(py).map(|v| {
-                                        UInt64Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        UInt64Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
@@ -423,14 +411,11 @@ impl PyExpr {
                             Int8 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(Int8Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as i8],
-                                    )
-                                    .into_series())
+                                    Ok(Int8Chunked::from_slice(PlSmallStr::EMPTY, &[v as i8])
+                                        .into_series())
                                 } else {
                                     obj.extract::<i8>(py).map(|v| {
-                                        Int8Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        Int8Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
@@ -438,14 +423,11 @@ impl PyExpr {
                             Int16 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(Int16Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as i16],
-                                    )
-                                    .into_series())
+                                    Ok(Int16Chunked::from_slice(PlSmallStr::EMPTY, &[v as i16])
+                                        .into_series())
                                 } else {
                                     obj.extract::<i16>(py).map(|v| {
-                                        Int16Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        Int16Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
@@ -453,14 +435,11 @@ impl PyExpr {
                             Int32 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(Int32Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as i32],
-                                    )
-                                    .into_series())
+                                    Ok(Int32Chunked::from_slice(PlSmallStr::EMPTY, &[v as i32])
+                                        .into_series())
                                 } else {
                                     obj.extract::<i32>(py).map(|v| {
-                                        Int32Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        Int32Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
@@ -468,25 +447,20 @@ impl PyExpr {
                             Int64 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
-                                    Ok(Int64Chunked::from_slice(
-                                        PlSmallStr::const_default(),
-                                        &[v as i64],
-                                    )
-                                    .into_series())
+                                    Ok(Int64Chunked::from_slice(PlSmallStr::EMPTY, &[v as i64])
+                                        .into_series())
                                 } else {
                                     obj.extract::<i64>(py).map(|v| {
-                                        Int64Chunked::from_slice(PlSmallStr::const_default(), &[v])
+                                        Int64Chunked::from_slice(PlSmallStr::EMPTY, &[v])
                                             .into_series()
                                     })
                                 }
                             },
                             Float32 => obj.extract::<f32>(py).map(|v| {
-                                Float32Chunked::from_slice(PlSmallStr::const_default(), &[v])
-                                    .into_series()
+                                Float32Chunked::from_slice(PlSmallStr::EMPTY, &[v]).into_series()
                             }),
                             Float64 => obj.extract::<f64>(py).map(|v| {
-                                Float64Chunked::from_slice(PlSmallStr::const_default(), &[v])
-                                    .into_series()
+                                Float64Chunked::from_slice(PlSmallStr::EMPTY, &[v]).into_series()
                             }),
                             dt => panic!("{dt:?} not implemented"),
                         };

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -20,7 +20,7 @@ pub(crate) fn to_py_array(
     pyarrow: &Bound<PyModule>,
 ) -> PyResult<PyObject> {
     let schema = Box::new(ffi::export_field_to_c(&ArrowField::new(
-        PlSmallStr::const_default(),
+        PlSmallStr::EMPTY,
         array.data_type().clone(),
         true,
     )));
@@ -103,7 +103,7 @@ impl DataFrameStreamIterator {
     }
 
     fn field(&self) -> ArrowField {
-        ArrowField::new(PlSmallStr::const_default(), self.data_type.clone(), false)
+        ArrowField::new(PlSmallStr::EMPTY, self.data_type.clone(), false)
     }
 }
 

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -269,7 +269,7 @@ fn iterator_to_list(
             Some(s) => {
                 if s.len() == 0 && s.dtype() != dt {
                     builder
-                        .append_series(&Series::full_null(PlSmallStr::const_default(), 0, dt))
+                        .append_series(&Series::full_null(PlSmallStr::EMPTY, 0, dt))
                         .unwrap()
                 } else {
                     builder.append_series(&s).map_err(PyPolarsErr::from)?

--- a/crates/polars-python/src/series/buffers.rs
+++ b/crates/polars-python/src/series/buffers.rs
@@ -151,7 +151,7 @@ fn get_string_bytes(arr: &Utf8Array<i64>) -> PyResult<PySeries> {
     let values_arr =
         PrimitiveArray::<u8>::try_new(ArrowDataType::UInt8, values_buffer.clone(), None)
             .map_err(PyPolarsErr::from)?;
-    let values = Series::from_arrow(PlSmallStr::const_default(), values_arr.to_boxed())
+    let values = Series::from_arrow(PlSmallStr::EMPTY, values_arr.to_boxed())
         .map_err(PyPolarsErr::from)?
         .into();
     Ok(values)
@@ -162,7 +162,7 @@ fn get_string_offsets(arr: &Utf8Array<i64>) -> PyResult<PySeries> {
     let offsets_arr =
         PrimitiveArray::<i64>::try_new(ArrowDataType::Int64, offsets_buffer.clone(), None)
             .map_err(PyPolarsErr::from)?;
-    let offsets = Series::from_arrow(PlSmallStr::const_default(), offsets_arr.to_boxed())
+    let offsets = Series::from_arrow(PlSmallStr::EMPTY, offsets_arr.to_boxed())
         .map_err(PyPolarsErr::from)?
         .into();
     Ok(offsets)
@@ -203,7 +203,7 @@ impl PySeries {
             },
         };
 
-        let s = Series::from_arrow(PlSmallStr::const_default(), arr_boxed)
+        let s = Series::from_arrow(PlSmallStr::EMPTY, arr_boxed)
             .unwrap()
             .into();
         Ok(s)
@@ -357,13 +357,13 @@ fn from_buffers_num_impl<T: NativeType>(
     validity: Option<Bitmap>,
 ) -> PyResult<Series> {
     let arr = PrimitiveArray::new(T::PRIMITIVE.into(), data, validity);
-    let s_result = Series::from_arrow(PlSmallStr::const_default(), arr.to_boxed());
+    let s_result = Series::from_arrow(PlSmallStr::EMPTY, arr.to_boxed());
     let s = s_result.map_err(PyPolarsErr::from)?;
     Ok(s)
 }
 fn from_buffers_bool_impl(data: Bitmap, validity: Option<Bitmap>) -> PyResult<Series> {
     let arr = BooleanArray::new(ArrowDataType::Boolean, data, validity);
-    let s_result = Series::from_arrow(PlSmallStr::const_default(), arr.to_boxed());
+    let s_result = Series::from_arrow(PlSmallStr::EMPTY, arr.to_boxed());
     let s = s_result.map_err(PyPolarsErr::from)?;
     Ok(s)
 }
@@ -378,7 +378,7 @@ fn from_buffers_string_impl(
     let arr = Utf8Array::new(ArrowDataType::LargeUtf8, offsets, data, validity);
 
     // This is not zero-copy
-    let s_result = Series::from_arrow(PlSmallStr::const_default(), arr.to_boxed());
+    let s_result = Series::from_arrow(PlSmallStr::EMPTY, arr.to_boxed());
 
     let s = s_result.map_err(PyPolarsErr::from)?;
     Ok(s)

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -248,7 +248,7 @@ impl SQLExprVisitor<'_> {
             })
             .collect::<PolarsResult<Vec<_>>>()?;
 
-        Series::from_any_values(PlSmallStr::const_default(), &array_elements, true)
+        Series::from_any_values(PlSmallStr::EMPTY, &array_elements, true)
     }
 
     fn visit_expr(&mut self, expr: &SQLExpr) -> PolarsResult<Expr> {

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -16,6 +16,7 @@ bytemuck = { workspace = true }
 bytes = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
+kstring = { workspace = true }
 libc = { workspace = true }
 memmap = { workspace = true, optional = true }
 num-traits = { workspace = true }

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -14,9 +14,9 @@ polars-error = { workspace = true }
 ahash = { workspace = true }
 bytemuck = { workspace = true }
 bytes = { workspace = true }
+compact_str = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
-kstring = { workspace = true }
 libc = { workspace = true }
 memmap = { workspace = true, optional = true }
 num-traits = { workspace = true }

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -1,13 +1,10 @@
-use std::sync::Arc;
-
-use once_cell::sync::Lazy;
+use kstring::KString;
 
 #[macro_export]
 macro_rules! format_pl_smallstr {
     ($($arg:tt)*) => {{
         use std::fmt::Write;
 
-        // TODO: Optimize
         let mut string = String::new();
         write!(string, $($arg)*).unwrap();
         PlSmallStr::from_string(string)
@@ -17,55 +14,43 @@ macro_rules! format_pl_smallstr {
 /// String type that interns small strings and has O(1) clone.
 #[derive(Clone, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PlSmallStr(Arc<str>);
+pub struct PlSmallStr(kstring::KStringBase<kstring::backend::ArcStr>);
 
 impl PlSmallStr {
-    /// Initialize an empty string ""
-    /// TODO: make this a `const fn`
-    #[inline(always)]
-    pub fn const_default() -> Self {
-        Self::empty_static().clone()
-    }
+    pub const EMPTY: Self = Self(KString::EMPTY);
+    pub const EMPTY_REF: &'static Self = &Self(KString::EMPTY);
 
-    /// This is a workaround until `const_default` becomes a const fn
     #[inline(always)]
-    pub fn empty_static() -> &'static Self {
-        static THIS: Lazy<PlSmallStr> = Lazy::new(|| PlSmallStr::from_static(""));
-        &THIS
-    }
-
-    /// TODO: make this a `const fn`
-    #[inline(always)]
-    pub fn from_static(s: &'static str) -> Self {
-        Self(Arc::from(s))
+    pub const fn from_static(s: &'static str) -> Self {
+        Self(KString::from_static(s))
     }
 
     #[inline(always)]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
-        Self(Arc::from(s))
+        Self(KString::from_ref(s))
     }
 
     #[inline(always)]
     pub fn from_string(s: String) -> Self {
-        Self(Arc::from(s))
+        Self(KString::from_string(s))
     }
 
     #[inline(always)]
     pub fn as_str(&self) -> &str {
-        self.0.as_ref()
+        self.0.as_str()
     }
 
     #[inline(always)]
     pub fn into_string(self) -> String {
-        self.0.to_string()
+        self.0.into_string()
     }
 }
 
 impl Default for PlSmallStr {
     #[inline(always)]
     fn default() -> Self {
-        Self::const_default()
+        Self::EMPTY
     }
 }
 
@@ -97,18 +82,21 @@ impl core::borrow::Borrow<str> for PlSmallStr {
 /// AsRef impls for other types
 
 impl AsRef<std::path::Path> for PlSmallStr {
+    #[inline(always)]
     fn as_ref(&self) -> &std::path::Path {
         self.as_str().as_ref()
     }
 }
 
 impl AsRef<[u8]> for PlSmallStr {
+    #[inline(always)]
     fn as_ref(&self) -> &[u8] {
         self.as_str().as_bytes()
     }
 }
 
 impl AsRef<std::ffi::OsStr> for PlSmallStr {
+    #[inline(always)]
     fn as_ref(&self) -> &std::ffi::OsStr {
         self.as_str().as_ref()
     }

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -1,4 +1,4 @@
-use kstring::KString;
+use kstring::{KString, KStringBase};
 
 #[macro_export]
 macro_rules! format_pl_smallstr {
@@ -16,9 +16,11 @@ macro_rules! format_pl_smallstr {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PlSmallStr(kstring::KStringBase<kstring::backend::ArcStr>);
 
+pub static STATIC_EMPTY: PlSmallStr = PlSmallStr(KString::EMPTY);
+
 impl PlSmallStr {
     pub const EMPTY: Self = Self(KString::EMPTY);
-    pub const EMPTY_REF: &'static Self = &Self(KString::EMPTY);
+    // pub const EMPTY_REF: &'static Self = &Self(KString::EMPTY);
 
     #[inline(always)]
     pub const fn from_static(s: &'static str) -> Self {

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -16,11 +16,9 @@ macro_rules! format_pl_smallstr {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PlSmallStr(kstring::KStringBase<kstring::backend::ArcStr>);
 
-pub static STATIC_EMPTY: PlSmallStr = PlSmallStr(KString::EMPTY);
-
 impl PlSmallStr {
     pub const EMPTY: Self = Self(KString::EMPTY);
-    // pub const EMPTY_REF: &'static Self = &Self(KString::EMPTY);
+    pub const EMPTY_REF: &'static Self = &Self(KString::EMPTY);
 
     #[inline(always)]
     pub const fn from_static(s: &'static str) -> Self {

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -1,4 +1,4 @@
-use kstring::{KString, KStringBase};
+use kstring::KString;
 
 #[macro_export]
 macro_rules! format_pl_smallstr {

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -9,7 +9,7 @@ macro_rules! format_pl_smallstr {
     }}
 }
 
-type Inner = kstring::KStringBase<kstring::backend::ArcStr>;
+type Inner = compact_str::CompactString;
 
 /// String type that interns small strings and has O(1) clone.
 #[derive(Clone, Eq, Hash, PartialOrd, Ord)]
@@ -17,23 +17,23 @@ type Inner = kstring::KStringBase<kstring::backend::ArcStr>;
 pub struct PlSmallStr(Inner);
 
 impl PlSmallStr {
-    pub const EMPTY: Self = Self(Inner::EMPTY);
-    pub const EMPTY_REF: &'static Self = &Self(Inner::EMPTY);
+    pub const EMPTY: Self = Self::from_static("");
+    pub const EMPTY_REF: &'static Self = &Self::from_static("");
 
     #[inline(always)]
     pub const fn from_static(s: &'static str) -> Self {
-        Self(Inner::from_static(s))
+        Self(Inner::const_new(s))
     }
 
     #[inline(always)]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
-        Self(Inner::from_ref(s))
+        Self(Inner::from(s))
     }
 
     #[inline(always)]
     pub fn from_string(s: String) -> Self {
-        Self(Inner::from_string(s))
+        Self(Inner::from(s))
     }
 
     #[inline(always)]

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -1,5 +1,3 @@
-use kstring::KString;
-
 #[macro_export]
 macro_rules! format_pl_smallstr {
     ($($arg:tt)*) => {{
@@ -11,29 +9,31 @@ macro_rules! format_pl_smallstr {
     }}
 }
 
+type Inner = kstring::KStringBase<kstring::backend::ArcStr>;
+
 /// String type that interns small strings and has O(1) clone.
 #[derive(Clone, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PlSmallStr(kstring::KStringBase<kstring::backend::ArcStr>);
+pub struct PlSmallStr(Inner);
 
 impl PlSmallStr {
-    pub const EMPTY: Self = Self(KString::EMPTY);
-    pub const EMPTY_REF: &'static Self = &Self(KString::EMPTY);
+    pub const EMPTY: Self = Self(Inner::EMPTY);
+    pub const EMPTY_REF: &'static Self = &Self(Inner::EMPTY);
 
     #[inline(always)]
     pub const fn from_static(s: &'static str) -> Self {
-        Self(KString::from_static(s))
+        Self(Inner::from_static(s))
     }
 
     #[inline(always)]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
-        Self(KString::from_ref(s))
+        Self(Inner::from_ref(s))
     }
 
     #[inline(always)]
     pub fn from_string(s: String) -> Self {
-        Self(KString::from_string(s))
+        Self(Inner::from_string(s))
     }
 
     #[inline(always)]


### PR DESCRIPTION
* `compact_str` for small-string in-lining, and after testing also preferred against `Arc<str>` / `kstring<arc>` as the atomic ref-counting performed badly under contention
* Replace `PlSmallStr::const_default()` with more ergonomic `PlSmallStr::EMPTY`