### PR TITLE
fix: Wrong output column name in `or` and `xor` operations

### DIFF
--- a/crates/polars-core/src/chunked_array/bitwise.rs
+++ b/crates/polars-core/src/chunked_array/bitwise.rs
@@ -129,7 +129,7 @@ impl BitXor for &BooleanChunked {
                 return match rhs.get(0) {
                     Some(true) => self.not(),
                     Some(false) => self.clone(),
-                    None => &rhs.new_from_index(0, self.len()) | self,
+                    None => self | &rhs.new_from_index(0, self.len()),
                 };
             },
             _ => {},

--- a/crates/polars-core/src/chunked_array/bitwise.rs
+++ b/crates/polars-core/src/chunked_array/bitwise.rs
@@ -84,7 +84,7 @@ impl BitOr for &BooleanChunked {
                 return match rhs.get(0) {
                     Some(true) => BooleanChunked::full(self.name().clone(), true, self.len()),
                     Some(false) => self.clone(),
-                    None => &rhs.new_from_index(0, self.len()) | self,
+                    None => self | &rhs.new_from_index(0, self.len()),
                 };
             },
             _ => {},

--- a/py-polars/tests/unit/operations/test_bitwise.py
+++ b/py-polars/tests/unit/operations/test_bitwise.py
@@ -1,4 +1,5 @@
 import pytest
+
 import polars as pl
 
 
@@ -7,6 +8,7 @@ def test_bitwise_integral_schema(op: str) -> None:
     df = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
     q = df.select(getattr(pl.col("a"), op)(pl.col("b")))
     assert q.collect_schema()["a"] == df.collect_schema()["a"]
+
 
 @pytest.mark.parametrize("op", ["and_", "or_", "xor"])
 def test_bitwise_single_null_value_schema(op: str) -> None:

--- a/py-polars/tests/unit/operations/test_bitwise.py
+++ b/py-polars/tests/unit/operations/test_bitwise.py
@@ -1,5 +1,4 @@
 import pytest
-
 import polars as pl
 
 
@@ -8,3 +7,11 @@ def test_bitwise_integral_schema(op: str) -> None:
     df = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
     q = df.select(getattr(pl.col("a"), op)(pl.col("b")))
     assert q.collect_schema()["a"] == df.collect_schema()["a"]
+
+@pytest.mark.parametrize("op", ["and_", "or_", "xor"])
+def test_bitwise_single_null_value_schema(op: str) -> None:
+    df = pl.DataFrame({"a": [True, True]})
+    q = df.select(getattr(pl.col("a"), op)(None))
+    result_schema = q.collect_schema()
+    assert result_schema.len() == 1
+    assert "a" in result_schema


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/18442.

I noticed also that the `xor` operation uses the `or` operation when dealing with single `None` column, wheras in multiple `None` values column, it takes the general path, which is `xor` operation:

```rust
fn bitxor(self, rhs: Self) -> Self::Output {
        match (self.len(), rhs.len()) {
            // make sure that we fall through if both are equal unit lengths
            // otherwise we stackoverflow
            (1, 1) => {},
            (1, _) => {
                return match self.get(0) {
                    Some(true) => {
                        let mut rhs = rhs.not();
                        rhs.rename(self.name().clone());
                        rhs
                    },
                    Some(false) => {
                        let mut rhs = rhs.clone();
                        rhs.rename(self.name().clone());
                        rhs
                    },
                    None => &self.new_from_index(0, rhs.len()) | rhs,
                };
            },
            (_, 1) => {
                return match rhs.get(0) {
                    Some(true) => self.not(),
                    Some(false) => self.clone(),
                    None => self | &rhs.new_from_index(0, self.len()),
                };
            },
            _ => {},
        }

        arity::binary(self, rhs, |l_arr, r_arr| {
            let validity = combine_validities_and(l_arr.validity(), r_arr.validity());
            let values = l_arr.values() ^ r_arr.values();
            BooleanArray::from_data_default(values, validity)
        })
    }
```

Is it intended?