### PR TITLE
fix(rust): Ensure result name of pow matches schema in grouped context

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -37,12 +37,15 @@ where
     ChunkedArray<T>: IntoSeries,
 {
     if (base.len() == 1) && (exponent.len() != 1) {
+        let name = base.name();
         let base = base
             .get(0)
             .ok_or_else(|| polars_err!(ComputeError: "base is null"))?;
 
         Ok(Some(
-            unary_elementwise_values(exponent, |exp| Pow::pow(base, exp)).into_series(),
+            unary_elementwise_values(exponent, |exp| Pow::pow(base, exp))
+                .into_series()
+                .with_name(name.clone()),
         ))
     } else {
         Ok(Some(

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -861,7 +861,7 @@ def test_group_by_apply_first_input_is_literal() -> None:
     pow = df.group_by("g").agg(2 ** pl.col("x"))
     assert pow.sort("g").to_dict(as_series=False) == {
         "g": [1, 2],
-        "x": [[2.0, 4.0], [8.0, 16.0, 32.0]],
+        "literal": [[2.0, 4.0], [8.0, 16.0, 32.0]],
     }
 
 


### PR DESCRIPTION
We must transfer the name from the base column to the result so that the rule that the left operand produces the result name is obeyed.

- Closes #18524