### PR TITLE
fix(rust): Refactor decompression checks and add support for decompressing JSON

### DIFF
--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -14,7 +14,7 @@ use super::options::{CommentPrefix, NullValuesCompiled};
 use super::splitfields::SplitFields;
 use super::utils::get_file_chunks;
 use crate::path_utils::is_cloud_url;
-use crate::utils::maybe_decompress_bytes;
+use crate::utils::compression::maybe_decompress_bytes;
 
 /// Read the number of rows without parsing columns
 /// useful for count(*) queries

--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -24,7 +24,7 @@ use super::utils::get_file_chunks;
 use crate::mmap::ReaderBytes;
 use crate::predicates::PhysicalIoExpr;
 #[cfg(not(any(feature = "decompress", feature = "decompress-fast")))]
-use crate::utils::is_compressed;
+use crate::utils::compression::SupportedCompression;
 use crate::utils::update_row_counts;
 use crate::RowIndex;
 
@@ -179,7 +179,7 @@ impl<'a> CoreReader<'a> {
         let mut reader_bytes = reader_bytes;
 
         #[cfg(not(any(feature = "decompress", feature = "decompress-fast")))]
-        if is_compressed(&reader_bytes) {
+        if SupportedCompression::check(&reader_bytes).is_some() {
             polars_bail!(
                 ComputeError: "cannot read compressed CSV file; \
                 compile with feature 'decompress' or 'decompress-fast'"

--- a/crates/polars-io/src/utils/compression.rs
+++ b/crates/polars-io/src/utils/compression.rs
@@ -1,19 +1,66 @@
-// magic numbers
-pub mod magic {
-    pub const GZIP: [u8; 2] = [31, 139];
-    pub const ZLIB0: [u8; 2] = [0x78, 0x01];
-    pub const ZLIB1: [u8; 2] = [0x78, 0x9C];
-    pub const ZLIB2: [u8; 2] = [0x78, 0xDA];
-    pub const ZSTD: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+use std::io::Read;
+
+use polars_core::prelude::*;
+use polars_error::to_compute_err;
+
+/// Represents the compression algorithms that we have decoders for
+pub enum SupportedCompression {
+    GZIP,
+    ZLIB,
+    ZSTD,
 }
 
-/// check if csv file is compressed
-pub fn is_compressed(bytes: &[u8]) -> bool {
-    use magic::*;
+impl SupportedCompression {
+    /// If the given byte slice starts with the "magic" bytes for a supported compression family, return
+    /// that family, for unsupported/uncompressed slices, return None
+    pub fn check(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 4 {
+            // not enough bytes to perform prefix checks
+            return None;
+        }
+        match bytes[..4] {
+            [31, 139, _, _]          => Some(Self::GZIP),
+            [0x78, 0x01, _, _] | // ZLIB0
+            [0x78, 0x9C, _, _] | // ZLIB1
+            [0x78, 0xDA, _, _]   // ZLIB2
+                                     => Some(Self::ZLIB),
+            [0x28, 0xB5, 0x2F, 0xFD] => Some(Self::ZSTD),
+            _ => None,
+        }
+    }
+}
 
-    bytes.starts_with(&ZLIB0)
-        || bytes.starts_with(&ZLIB1)
-        || bytes.starts_with(&ZLIB2)
-        || bytes.starts_with(&GZIP)
-        || bytes.starts_with(&ZSTD)
+/// Decompress `bytes` if compression is detected, otherwise simply return it.
+/// An `out` vec must be given for ownership of the decompressed data.
+pub fn maybe_decompress_bytes<'a>(bytes: &'a [u8], out: &'a mut Vec<u8>) -> PolarsResult<&'a [u8]> {
+    assert!(out.is_empty());
+
+    if let Some(algo) = SupportedCompression::check(bytes) {
+        #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
+        {
+            match algo {
+                SupportedCompression::GZIP => {
+                    flate2::read::MultiGzDecoder::new(bytes)
+                        .read_to_end(out)
+                        .map_err(to_compute_err)?;
+                },
+                SupportedCompression::ZLIB => {
+                    flate2::read::ZlibDecoder::new(bytes)
+                        .read_to_end(out)
+                        .map_err(to_compute_err)?;
+                },
+                SupportedCompression::ZSTD => {
+                    zstd::Decoder::new(bytes)?.read_to_end(out)?;
+                },
+            }
+
+            Ok(out)
+        }
+        #[cfg(not(any(feature = "decompress", feature = "decompress-fast")))]
+        {
+            panic!("cannot decompress without 'decompress' or 'decompress-fast' feature")
+        }
+    } else {
+        Ok(bytes)
+    }
 }

--- a/crates/polars-io/src/utils/mod.rs
+++ b/crates/polars-io/src/utils/mod.rs
@@ -1,7 +1,6 @@
 pub mod compression;
 mod other;
 
-pub use compression::is_compressed;
 pub use other::*;
 #[cfg(feature = "cloud")]
 pub mod byte_source;

--- a/crates/polars-io/src/utils/other.rs
+++ b/crates/polars-io/src/utils/other.rs
@@ -6,7 +6,6 @@ use once_cell::sync::Lazy;
 use polars_core::prelude::*;
 #[cfg(any(feature = "ipc_streaming", feature = "parquet"))]
 use polars_core::utils::{accumulate_dataframes_vertical_unchecked, split_df_as_ref};
-use polars_error::to_compute_err;
 use polars_utils::mmap::MMapSemaphore;
 use regex::{Regex, RegexBuilder};
 
@@ -43,46 +42,6 @@ pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
             reader.read_to_end(&mut bytes)?;
             Ok(ReaderBytes::Owned(bytes))
         }
-    }
-}
-
-/// Decompress `bytes` if compression is detected, otherwise simply return it.
-/// An `out` vec must be given for ownership of the decompressed data.
-pub fn maybe_decompress_bytes<'a>(bytes: &'a [u8], out: &'a mut Vec<u8>) -> PolarsResult<&'a [u8]> {
-    assert!(out.is_empty());
-    use crate::prelude::is_compressed;
-    let is_compressed = bytes.len() >= 4 && is_compressed(bytes);
-
-    if is_compressed {
-        #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
-        {
-            use crate::utils::compression::magic::*;
-
-            if bytes.starts_with(&GZIP) {
-                flate2::read::MultiGzDecoder::new(bytes)
-                    .read_to_end(out)
-                    .map_err(to_compute_err)?;
-            } else if bytes.starts_with(&ZLIB0)
-                || bytes.starts_with(&ZLIB1)
-                || bytes.starts_with(&ZLIB2)
-            {
-                flate2::read::ZlibDecoder::new(bytes)
-                    .read_to_end(out)
-                    .map_err(to_compute_err)?;
-            } else if bytes.starts_with(&ZSTD) {
-                zstd::Decoder::new(bytes)?.read_to_end(out)?;
-            } else {
-                polars_bail!(ComputeError: "unimplemented compression format")
-            }
-
-            Ok(out)
-        }
-        #[cfg(not(any(feature = "decompress", feature = "decompress-fast")))]
-        {
-            panic!("cannot decompress without 'decompress' or 'decompress-fast' feature")
-        }
-    } else {
-        Ok(bytes)
     }
 }
 

--- a/crates/polars-mem-engine/src/executors/scan/csv.rs
+++ b/crates/polars-mem-engine/src/executors/scan/csv.rs
@@ -4,6 +4,7 @@ use polars_core::config;
 use polars_core::utils::{
     accumulate_dataframes_vertical, accumulate_dataframes_vertical_unchecked,
 };
+use polars_io::utils::compression::maybe_decompress_bytes;
 
 use super::*;
 

--- a/crates/polars-mem-engine/src/executors/scan/ndjson.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ndjson.rs
@@ -1,5 +1,6 @@
 use polars_core::config;
 use polars_core::utils::accumulate_dataframes_vertical;
+use polars_io::utils::compression::maybe_decompress_bytes;
 
 use super::*;
 

--- a/crates/polars-plan/src/plans/conversion/scans.rs
+++ b/crates/polars-plan/src/plans/conversion/scans.rs
@@ -3,6 +3,7 @@ use polars_io::path_utils::is_cloud_url;
 #[cfg(feature = "cloud")]
 use polars_io::pl_async::get_runtime;
 use polars_io::prelude::*;
+use polars_io::utils::compression::maybe_decompress_bytes;
 use polars_io::RowIndex;
 
 use super::*;

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -219,7 +219,7 @@ pub(super) fn count_rows_ndjson(
     cloud_options: Option<&CloudOptions>,
 ) -> PolarsResult<usize> {
     use polars_core::config;
-    use polars_io::utils::maybe_decompress_bytes;
+    use polars_io::utils::compression::maybe_decompress_bytes;
 
     if sources.is_empty() {
         return Ok(0);


### PR DESCRIPTION
It looks like the bulk of the work for supporting on the fly decompression (https://github.com/pola-rs/polars/issues/8323) was already implemented. However there appeared to be a couple of inconsistencies, some of which this PR attempts to address. 

The first commit is refactoring the compression detection logic to only be performed in a single function, instead of checking prefix bytes in multiple places. It also moves `maybe_decompress_bytes` to live with other compression related code. 
The second commit is a small change to add automatic decompression for JSON files. This essentially mirrors what is done for the Lazy JSON reader + the CSV reader, adapted for use with `simd_json`

There does seem to be some extra unification work that could be done around CSV and Lazy reader decompression, but I wanted to submit the feature without making too many wide-sweeping changes. Another point of divergence is that decompression is only done for JSON on the rust side, as when reading ND-JSON from Python, the bindings call into the Lazy API which already supported decompression.

As a final note, I wasn't sure if the docs should be updated, especially since they were not when this was originally implemented. The docs probably should mention that any compressed file, read via eager or lazy methods, will read the entire file into memory. The underlying reason being that the polars parsing functions want their readers to be `Seek` which `flate2` does not support (see https://github.com/rust-lang/flate2-rs/issues/310)