### PR TITLE
build(rust): Remove extension-module from polars-python

### DIFF
--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -35,7 +35,7 @@ num-traits = { workspace = true }
 # https://github.com/PyO3/rust-numpy/issues/409
 numpy = { git = "https://github.com/stinodego/rust-numpy.git", rev = "9ba9962ae57ba26e35babdce6f179edf5fe5b9c8", default-features = false }
 once_cell = { workspace = true }
-pyo3 = { workspace = true, features = ["abi3-py38", "chrono", "extension-module", "multiple-pymethods"] }
+pyo3 = { workspace = true, features = ["abi3-py38", "chrono", "multiple-pymethods"] }
 recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
This crate doesn't need `extension-module`. Only the Python library crates need to enable this.