### PR TITLE
ci: Add lower-bound pin for numba

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -16,10 +16,8 @@ pip
 # ------------
 
 # Interop
-# TODO: Unpin NumPy when issue has been resolved.
-# https://github.com/pola-rs/polars/issues/18543
-numpy < 2.1
-numba; python_version < '3.13'  # Numba can lag Python releases
+numpy
+numba >= 0.54; python_version < '3.13'  # Numba can lag Python releases
 pandas
 pyarrow
 pydantic>=2.0.0


### PR DESCRIPTION
Numba, prior to version 0.54, did not provide upper bound pins for numpy. uv's backtracking resolver therefore assumes that 0.53.1 is compatible with new numpy releases. This causes problems for python versions >= 3.10 since that version of numba has a runtime dependency on python < 3.10.

Since numba 0.54 is already quite old (older than what is installed on any supported python version), just provide a lower-bound pin to stop uv backtracking too far. This way we can remove the pin on numpy again. See also astral-sh/uv#7020.

- Closes #18543

cc @stinodego