### PR TITLE
fix: Do not remove double-sort if `maintain_order=True`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
@@ -128,7 +128,11 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                 input,
                 by_column,
                 slice,
-                sort_options,
+                sort_options:
+                    sort_options @ SortMultipleOptions {
+                        maintain_order: false, // `maintain_order=True` is influenced by result of earlier sorts
+                        ..
+                    },
             } => match lp_arena.get(*input) {
                 Sort {
                     input: inner,

--- a/py-polars/tests/unit/lazyframe/optimizations.py
+++ b/py-polars/tests/unit/lazyframe/optimizations.py
@@ -1,4 +1,5 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_remove_double_sort() -> None:
@@ -6,3 +7,23 @@ def test_remove_double_sort() -> None:
         pl.LazyFrame({"a": [1, 2, 3, 3]}).sort("a").sort("a").explain().count("SORT")
         == 1
     )
+
+
+def test_double_sort_maintain_order_18558() -> None:
+    df = pl.DataFrame(
+        {
+            "col1": [1, 2, 2, 4, 5, 6],
+            "col2": [2, 2, 0, 0, 2, None],
+        }
+    )
+
+    lf = df.lazy().sort("col2").sort("col1", maintain_order=True)
+
+    expect = pl.DataFrame(
+        [
+            pl.Series("col1", [1, 2, 2, 4, 5, 6], dtype=pl.Int64),
+            pl.Series("col2", [2, 0, 2, 0, 2, None], dtype=pl.Int64),
+        ]
+    )
+
+    assert_frame_equal(lf.collect(), expect)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/18558