### PR TITLE
fix: Fix `map_elements` for List return dtypes

### DIFF
--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -260,9 +260,11 @@ fn iterator_to_list(
     for _ in 0..init_null_count {
         builder.append_null()
     }
-    builder
-        .append_opt_series(first_value)
-        .map_err(PyPolarsErr::from)?;
+    if first_value.is_some() {
+        builder
+            .append_opt_series(first_value)
+            .map_err(PyPolarsErr::from)?;
+    }
     for opt_val in it {
         match opt_val {
             None => builder.append_null(),

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -39,7 +39,13 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
         let series = py_pyseries.extract::<PySeries>().unwrap().series;
         let dt = series.dtype();
         applyer
-            .apply_lambda_with_list_out_type(py, lambda.to_object(py), null_count, &series, dt)
+            .apply_lambda_with_list_out_type(
+                py,
+                lambda.to_object(py),
+                null_count,
+                Some(&series),
+                dt,
+            )
             .map(|ca| ca.into_series().into())
     } else if out.is_instance_of::<PyList>() || out.is_instance_of::<PyTuple>() {
         let series = SERIES.call1(py, (out,))?;
@@ -63,13 +69,14 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
         let new_lambda = PyCFunction::new_closure_bound(py, None, None, move |args, _kwargs| {
             Python::with_gil(|py| {
                 let out = lambda_owned.call1(py, args)?;
+                // check if Series, if not, call series constructor on it
                 SERIES.call1(py, (out,))
             })
         })?
         .to_object(py);
 
         let result = applyer
-            .apply_lambda_with_list_out_type(py, new_lambda, null_count, &series, dt)
+            .apply_lambda_with_list_out_type(py, new_lambda, null_count, Some(&series), dt)
             .map(|ca| ca.into_series().into());
         match result {
             Ok(out) => Ok(out),
@@ -172,7 +179,7 @@ pub trait ApplyLambda<'a> {
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked>;
 
@@ -417,10 +424,10 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked> {
-        let skip = 1;
+        let skip = usize::from(first_value.is_some());
         let lambda = lambda.bind(py);
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name().clone(), self.len()))
@@ -434,7 +441,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -449,7 +456,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -720,10 +727,10 @@ where
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked> {
-        let skip = 1;
+        let skip = usize::from(first_value.is_some());
         let lambda = lambda.bind(py);
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name().clone(), self.len()))
@@ -737,7 +744,7 @@ where
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -752,7 +759,7 @@ where
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -1017,10 +1024,10 @@ impl<'a> ApplyLambda<'a> for StringChunked {
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked> {
-        let skip = 1;
+        let skip = usize::from(first_value.is_some());
         let lambda = lambda.bind(py);
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name().clone(), self.len()))
@@ -1034,7 +1041,7 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -1049,7 +1056,7 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -1441,10 +1448,10 @@ impl<'a> ApplyLambda<'a> for ListChunked {
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked> {
-        let skip = 1;
+        let skip = usize::from(first_value.is_some());
         let pypolars = PyModule::import_bound(py, "polars")?;
         let lambda = lambda.bind(py);
         if init_null_count == self.len() {
@@ -1459,7 +1466,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -1472,7 +1479,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -1868,10 +1875,10 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked> {
-        let skip = 1;
+        let skip = usize::from(first_value.is_some());
         let pypolars = PyModule::import_bound(py, "polars")?;
         let lambda = lambda.bind(py);
         if init_null_count == self.len() {
@@ -1886,7 +1893,7 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -1899,7 +1906,7 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -2187,10 +2194,10 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked> {
-        let skip = 1;
+        let skip = usize::from(first_value.is_some());
         let lambda = lambda.bind(py);
         if init_null_count == self.len() {
             Ok(ChunkedArray::full_null(self.name().clone(), self.len()))
@@ -2204,7 +2211,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -2219,7 +2226,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 dt,
                 it,
                 init_null_count,
-                Some(first_value),
+                first_value,
                 self.name().clone(),
                 self.len(),
             )
@@ -2415,10 +2422,10 @@ impl<'a> ApplyLambda<'a> for StructChunked {
         py: Python,
         lambda: PyObject,
         init_null_count: usize,
-        first_value: &Series,
+        first_value: Option<&Series>,
         dt: &DataType,
     ) -> PyResult<ListChunked> {
-        let skip = 1;
+        let skip = usize::from(first_value.is_some());
         let lambda = lambda.bind(py);
         let it = iter_struct(self)
             .skip(init_null_count + skip)
@@ -2427,7 +2434,7 @@ impl<'a> ApplyLambda<'a> for StructChunked {
             dt,
             it,
             init_null_count,
-            Some(first_value),
+            first_value,
             self.name().clone(),
             self.len(),
         )

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -371,3 +371,15 @@ def test_map_elements_list_dtype_18472() -> None:
     result = s.map_elements(lambda s: [i.strip() if i else None for i in s])
     expected = pl.Series([[None], ["abc", None]])
     assert_series_equal(result, expected)
+
+
+def test_map_elements_list_return_dtype() -> None:
+    s = pl.Series([[1], [2, 3]])
+    return_dtype = pl.List(pl.UInt16)
+
+    result = s.map_elements(
+        lambda s: [i + 1 for i in s],
+        return_dtype=return_dtype,
+    )
+    expected = pl.Series([[2], [3, 4]], dtype=return_dtype)
+    assert_series_equal(result, expected)


### PR DESCRIPTION
Closes [#18472](https://github.com/pola-rs/polars/issues/18472)

This makes sure we respect the `return_dtype` if it's a `List` type, rather than discarding it and relying on auto-inference.