### PR TITLE
refactor(rust): Bump NodeTraverser major version

### DIFF
--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -57,7 +57,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (1, 1);
+    const VERSION: Version = (2, 0);
 
     pub(crate) fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {


### PR DESCRIPTION
The migration of `Schema` into its own crate in #18539 changed the (internal) field name from `inner` to the more obvious `fields`. This was exposed in the Python IR, so bump the major version.

cc: @ritchie46