### PR TITLE
Fix(python): Fix `ml.torch.py` delete unknown mypy annotation

### DIFF
--- a/py-polars/polars/ml/torch.py
+++ b/py-polars/polars/ml/torch.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code="unused-ignore"
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence


### PR DESCRIPTION
This is a quick attempt to fix https://github.com/pola-rs/polars/issues/18578

As far as I can tell, this is directing mypy to ignore a class of errors called "unused-ignore" but that doesn't exist in the list of error codes mypy supports https://mypy.readthedocs.io/en/stable/error_code_list.html