### PR TITLE
fix(rust,python): Fix materialize_hive_partitions that should not rely on whether the first partition is in schema

### DIFF
--- a/crates/polars-io/src/hive.rs
+++ b/crates/polars-io/src/hive.rs
@@ -20,7 +20,7 @@ pub(crate) fn materialize_hive_partitions<S: IndexOfSchema>(
         for s in hive_columns {
             let i = match df.get_columns().binary_search_by_key(
                 &reader_schema.index_of(s.name()).unwrap_or(usize::MAX),
-                |s| reader_schema.index_of(s.name()).unwrap_or(usize::MIN),
+                |df_col| reader_schema.index_of(df_col.name()).unwrap_or(usize::MIN),
             ) {
                 Ok(i) => i,
                 Err(i) => i,

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -555,19 +555,20 @@ def test_hive_partition_columns_contained_in_file(
     assert_with_projections(lf, rhs)
 
     # partial cols in file
+    partial_path = tmp_path / "a=1/b=2/partial_data.bin"
     df = pl.DataFrame(
         {"x": 1, "b": 2, "y": 1},
         schema={"x": pl.Int32, "b": pl.Int16, "y": pl.Int32},
     )
-    write_func(df, path)
+    write_func(df, partial_path)
 
-    lf = scan_func(path, hive_partitioning=True)  # type: ignore[call-arg]
+    lf = scan_func(partial_path, hive_partitioning=True)  # type: ignore[call-arg]
     rhs = df
     assert_frame_equal(lf.collect(projection_pushdown=projection_pushdown), rhs)
     assert_with_projections(lf, rhs)
 
     lf = scan_func(  # type: ignore[call-arg]
-        path,
+        partial_path,
         hive_schema={"a": pl.String, "b": pl.String},
         hive_partitioning=True,
     )


### PR DESCRIPTION
https://github.com/pola-rs/polars/issues/12041

I still met duplicated columns on polars 1.6.0 when the column exists in both hive path and parquet.
There are 5 cols in the path, and only 1 of 5 in the parquet file
I just took a look at the implementation. It seems like it depends on whether the first col in the schema?

https://github.com/pola-rs/polars/pull/17203/files#diff-5fbba3b3c960c05ee1ff71769819814cb53e44b17e2004e33b42a301aa91eb57R166-R170