### PR TITLE
feat(python): Add nicer default plot configuration, link to Altair Chart Configuration docs

### DIFF
--- a/docs/src/python/user-guide/misc/visualization.py
+++ b/docs/src/python/user-guide/misc/visualization.py
@@ -15,6 +15,7 @@ df.hvplot.scatter(
     y="sepal_length",
     by="species",
     width=650,
+    title="Irises",
 )
 # --8<-- [end:hvplot_show_plot]
 """
@@ -27,6 +28,7 @@ plot = df.hvplot.scatter(
     y="sepal_length",
     by="species",
     width=650,
+    title="Irises",
 )
 hvplot.save(plot, "docs/images/hvplot_scatter.html")
 with open("docs/images/hvplot_scatter.html", "r") as f:
@@ -44,6 +46,7 @@ ax.scatter(
     y=df["sepal_length"],
     c=df["species"].cast(pl.Categorical).to_physical(),
 )
+ax.set_title('Irises')
 # --8<-- [end:matplotlib_show_plot]
 """
 
@@ -58,6 +61,7 @@ ax.scatter(
     y=df["sepal_length"],
     c=df["species"].cast(pl.Categorical).to_physical(),
 )
+ax.set_title("Irises")
 fig.savefig("docs/images/matplotlib_scatter.png")
 with open("docs/images/matplotlib_scatter.png", "rb") as f:
     png = base64.b64encode(f.read()).decode()
@@ -72,7 +76,7 @@ sns.scatterplot(
     x="sepal_width",
     y="sepal_length",
     hue="species",
-)
+).set_title('Irises')
 # --8<-- [end:seaborn_show_plot]
 """
 
@@ -86,7 +90,7 @@ ax = sns.scatterplot(
     x="sepal_width",
     y="sepal_length",
     hue="species",
-)
+).set_title("Irises")
 fig.savefig("docs/images/seaborn_scatter.png")
 with open("docs/images/seaborn_scatter.png", "rb") as f:
     png = base64.b64encode(f.read()).decode()
@@ -103,6 +107,7 @@ px.scatter(
     y="sepal_length",
     color="species",
     width=650,
+    title="Irises",
 )
 # --8<-- [end:plotly_show_plot]
 """
@@ -116,6 +121,7 @@ fig = px.scatter(
     y="sepal_length",
     color="species",
     width=650,
+    title="Irises",
 )
 fig.write_html(
     "docs/images/plotly_scatter.html", full_html=False, include_plotlyjs="cdn"
@@ -132,6 +138,7 @@ with open("docs/images/plotly_scatter.html", "r") as f:
         x="sepal_length",
         y="sepal_width",
         color="species",
+        title="Irises",
     )
     .properties(width=500)
     .configure_scale(zero=False)
@@ -145,6 +152,7 @@ chart = (
         x="sepal_length",
         y="sepal_width",
         color="species",
+        title="Irises",
     )
     .properties(width=500)
     .configure_scale(zero=False)

--- a/docs/user-guide/misc/visualization.md
+++ b/docs/user-guide/misc/visualization.md
@@ -32,13 +32,16 @@ import altair as alt
         y="sepal_width",
         color="species",
     )
-    .properties(width=500)
+    .properties(width=500, title="Irises")
     .configure_scale(zero=False)
 )
 ```
 
-and is only provided for convenience, and to signal that Altair is known to work well with
+(with some extra configuration) and is only provided for convenience, and to signal that Altair is known to work well with
 Polars.
+
+For configuration, we suggest reading [Chart Configuration](https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html). For example, you can change the x-axis label rotation by appending
+`.configure_axisX(rotation=30)` to your call.
 
 ## hvPlot
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -618,22 +618,10 @@ class DataFrame:
             is add `import hvplot.polars` at the top of your script and replace
             `df.plot` with `df.hvplot`.
 
-        Polars does not implement plotting logic itself, but instead defers to
-        `Altair <https://altair-viz.github.io/>`_:
-
-        - `df.plot.line(**kwargs)`
-          is shorthand for
-          `alt.Chart(df).mark_line().encode(**kwargs).interactive()`
-        - `df.plot.point(**kwargs)`
-          is shorthand for
-          `alt.Chart(df).mark_point().encode(**kwargs).interactive()` (and
-          `plot.scatter` is provided as an alias)
-        - `df.plot.bar(**kwargs)`
-          is shorthand for
-          `alt.Chart(df).mark_bar().encode(**kwargs).interactive()`
-        - for any other attribute `attr`, `df.plot.attr(**kwargs)`
-          is shorthand for
-          `alt.Chart(df).mark_attr().encode(**kwargs).interactive()`
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         Examples
         --------

--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -76,9 +76,9 @@ def configure_chart(
             titleAngle=0,
             titleAlign="left",
             titlePadding=0,
-            # This pushes the title high enough so it does not overlap with the latest tick.
-            # For some edge cases, this might still happen and there is no automated way
-            # to resolve it right now but it usually works well.
+            # This pushes the title high enough so it does not overlap with the latest
+            # tick. For some edge cases, this might still happen and there is no
+            # automated way to resolve it right now but it usually works well.
             titleY=-25,
         )
         .configure_axisTemporal(grid=False)

--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -35,6 +35,73 @@ if TYPE_CHECKING:
     ]
 
 
+def configure_chart(
+    chart: alt.Chart,
+    *,
+    title: str | None,
+    x_axis_title: str | None,
+    y_axis_title: str | None,
+) -> alt.Chart:
+    """
+    A nice-looking default configuration, produced by Altair maintainer.
+
+    Source: https://gist.github.com/binste/b4042fa76a89d72d45cbbb9355ec6906.
+    """
+    properties = {}
+    if title is not None:
+        properties["title"] = title
+    if x_axis_title is not None:
+        chart.encoding.x.title = x_axis_title
+    if y_axis_title is not None:
+        chart.encoding.y.title = y_axis_title
+    return (
+        chart.properties(**properties)
+        .configure_axis(
+            labelFontSize=16,
+            titleFontSize=16,
+            titleFontWeight="normal",
+            gridColor="lightGray",
+            labelAngle=0,
+            labelFlush=False,
+            labelPadding=5,
+        )
+        .configure_axisY(
+            domain=False,
+            ticks=False,
+            labelPadding=10,
+            titleAngle=0,
+            titleY=-20,
+            titleAlign="left",
+            titlePadding=0,
+        )
+        .configure_axisTemporal(grid=False)
+        .configure_axisDiscrete(ticks=False, labelPadding=10, grid=False)
+        .configure_scale(barBandPaddingInner=0.2)
+        .configure_header(labelFontSize=16, titleFontSize=16)
+        .configure_legend(labelFontSize=16, titleFontSize=16, titleFontWeight="normal")
+        .configure_title(
+            fontSize=20,
+            fontStyle="normal",
+            align="left",
+            anchor="start",
+            orient="top",
+            fontWeight=600,
+            offset=10,
+            subtitlePadding=3,
+            subtitleFontSize=16,
+        )
+        .configure_view(
+            strokeWidth=0, continuousHeight=350, continuousWidth=600, step=50
+        )
+        .configure_line(strokeWidth=3.5)
+        .configure_text(fontSize=16)
+        .configure_circle(size=60)
+        .configure_point(size=60)
+        .configure_square(size=60)
+        .interactive()
+    )
+
+
 class DataFramePlot:
     """DataFrame.plot namespace."""
 
@@ -50,18 +117,18 @@ class DataFramePlot:
         color: ChannelColor | None = None,
         tooltip: ChannelTooltip | None = None,
         /,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
         **kwargs: Unpack[EncodeKwds],
     ) -> alt.Chart:
         """
         Draw bar plot.
 
-        Polars does not implement plotting logic itself but instead defers to
-        `Altair <https://altair-viz.github.io/>`_.
-
-        `df.plot.bar(**kwargs)` is shorthand for
-        `alt.Chart(df).mark_bar().encode(**kwargs).interactive()`,
-        and is provided for convenience - for full customisatibility, use a plotting
-        library directly.
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         .. versionchanged:: 1.6.0
             In prior versions of Polars, HvPlot was the plotting backend. If you would
@@ -79,6 +146,12 @@ class DataFramePlot:
             Column to color bars by.
         tooltip
             Columns to show values of when hovering over bars with pointer.
+        title
+            Plot title.
+        x_axis_title
+            Title of x-axis.
+        y_axis_title
+            Title of y-axis.
         **kwargs
             Additional keyword arguments passed to Altair.
 
@@ -104,7 +177,12 @@ class DataFramePlot:
             encodings["color"] = color
         if tooltip is not None:
             encodings["tooltip"] = tooltip
-        return self._chart.mark_bar().encode(**encodings, **kwargs).interactive()
+        return configure_chart(
+            self._chart.mark_bar().encode(**encodings, **kwargs),
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
+        )
 
     def line(
         self,
@@ -114,17 +192,18 @@ class DataFramePlot:
         order: ChannelOrder | None = None,
         tooltip: ChannelTooltip | None = None,
         /,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
         **kwargs: Unpack[EncodeKwds],
     ) -> alt.Chart:
         """
         Draw line plot.
 
-        Polars does not implement plotting logic itself but instead defers to
-        `Altair <https://altair-viz.github.io/>`_.
-
-        `alt.Chart(df).mark_line().encode(**kwargs).interactive()`,
-        and is provided for convenience - for full customisatibility, use a plotting
-        library directly.
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         .. versionchanged:: 1.6.0
             In prior versions of Polars, HvPlot was the plotting backend. If you would
@@ -144,6 +223,12 @@ class DataFramePlot:
             Column to use for order of data points in lines.
         tooltip
             Columns to show values of when hovering over lines with pointer.
+        title
+            Plot title.
+        x_axis_title
+            Title of x-axis.
+        y_axis_title
+            Title of y-axis.
         **kwargs
             Additional keyword arguments passed to Altair.
 
@@ -170,7 +255,12 @@ class DataFramePlot:
             encodings["order"] = order
         if tooltip is not None:
             encodings["tooltip"] = tooltip
-        return self._chart.mark_line().encode(**encodings, **kwargs).interactive()
+        return configure_chart(
+            self._chart.mark_line().encode(**encodings, **kwargs),
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
+        )
 
     def point(
         self,
@@ -180,18 +270,18 @@ class DataFramePlot:
         size: ChannelSize | None = None,
         tooltip: ChannelTooltip | None = None,
         /,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
         **kwargs: Unpack[EncodeKwds],
     ) -> alt.Chart:
         """
         Draw scatter plot.
 
-        Polars does not implement plotting logic itself but instead defers to
-        `Altair <https://altair-viz.github.io/>`_.
-
-        `df.plot.point(**kwargs)` is shorthand for
-        `alt.Chart(df).mark_point().encode(**kwargs).interactive()`,
-        and is provided for convenience - for full customisatibility, use a plotting
-        library directly.
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         .. versionchanged:: 1.6.0
             In prior versions of Polars, HvPlot was the plotting backend. If you would
@@ -211,6 +301,12 @@ class DataFramePlot:
             Column which determines points' sizes.
         tooltip
             Columns to show values of when hovering over points with pointer.
+        title
+            Plot title.
+        x_axis_title
+            Title of x-axis.
+        y_axis_title
+            Title of y-axis.
         **kwargs
             Additional keyword arguments passed to Altair.
 
@@ -236,21 +332,34 @@ class DataFramePlot:
             encodings["size"] = size
         if tooltip is not None:
             encodings["tooltip"] = tooltip
-        return (
-            self._chart.mark_point()
-            .encode(
+        return configure_chart(
+            self._chart.mark_point().encode(
                 **encodings,
                 **kwargs,
-            )
-            .interactive()
+            ),
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
         )
 
     # Alias to `point` because of how common it is.
     scatter = point
 
-    def __getattr__(self, attr: str) -> Callable[..., alt.Chart]:
+    def __getattr__(
+        self,
+        attr: str,
+        *,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
+    ) -> Callable[..., alt.Chart]:
         method = getattr(self._chart, f"mark_{attr}", None)
         if method is None:
             msg = "Altair has no method 'mark_{attr}'"
             raise AttributeError(msg)
-        return lambda **kwargs: method().encode(**kwargs).interactive()
+        return lambda **kwargs: configure_chart(
+            method().encode(**kwargs),
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
+        )

--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -71,10 +71,15 @@ def configure_chart(
             # Add some padding to compensate for the removed ticks as else
             # the labels would be too close to the axis
             labelPadding=10,
+            # The settings below move the axis title on top of the axis
+            # and orient it horizontally
             titleAngle=0,
-            titleY=-20,
             titleAlign="left",
             titlePadding=0,
+            # This pushes the title high enough so it does not overlap with the latest tick.
+            # For some edge cases, this might still happen and there is no automated way
+            # to resolve it right now but it usually works well.
+            titleY=-25,
         )
         .configure_axisTemporal(grid=False)
         .configure_axisDiscrete(ticks=False, labelPadding=10, grid=False)

--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -68,6 +68,8 @@ def configure_chart(
         .configure_axisY(
             domain=False,
             ticks=False,
+            # Add some padding to compensate for the removed ticks as else
+            # the labels would be too close to the axis
             labelPadding=10,
             titleAngle=0,
             titleY=-20,

--- a/py-polars/polars/series/plotting.py
+++ b/py-polars/polars/series/plotting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
+from polars.dataframe.plotting import configure_chart
 from polars.dependencies import altair as alt
 
 if TYPE_CHECKING:
@@ -30,18 +31,18 @@ class SeriesPlot:
     def hist(
         self,
         /,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
         **kwargs: Unpack[EncodeKwds],
     ) -> alt.Chart:
         """
         Draw histogram.
 
-        Polars does not implement plotting logic itself but instead defers to
-        `Altair <https://altair-viz.github.io/>`_.
-
-        `s.plot.hist(**kwargs)` is shorthand for
-        `alt.Chart(s.to_frame()).mark_bar().encode(x=alt.X(f'{s.name}:Q', bin=True), y='count()', **kwargs).interactive()`,
-        and is provided for convenience - for full customisatibility, use a plotting
-        library directly.
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         .. versionchanged:: 1.6.0
             In prior versions of Polars, HvPlot was the plotting backend. If you would
@@ -51,6 +52,12 @@ class SeriesPlot:
 
         Parameters
         ----------
+        title
+            Plot title.
+        x_axis_title
+            Title of x-axis.
+        y_axis_title
+            Title of y-axis.
         **kwargs
             Additional arguments and keyword arguments passed to Altair.
 
@@ -58,32 +65,34 @@ class SeriesPlot:
         --------
         >>> s = pl.Series("price", [1, 3, 3, 3, 5, 2, 6, 5, 5, 5, 7])
         >>> s.plot.hist()  # doctest: +SKIP
-        """  # noqa: W505
+        """
         if self._series_name == "count()":
             msg = "Cannot use `plot.hist` when Series name is `'count()'`"
             raise ValueError(msg)
-        return (
+        return configure_chart(
             alt.Chart(self._df)
             .mark_bar()
-            .encode(x=alt.X(f"{self._series_name}:Q", bin=True), y="count()", **kwargs)  # type: ignore[misc]
-            .interactive()
+            .encode(x=alt.X(f"{self._series_name}:Q", bin=True), y="count()", **kwargs),  # type: ignore[misc]
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
         )
 
     def kde(
         self,
         /,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
         **kwargs: Unpack[EncodeKwds],
     ) -> alt.Chart:
         """
         Draw kernel density estimate plot.
 
-        Polars does not implement plotting logic itself but instead defers to
-        `Altair <https://altair-viz.github.io/>`_.
-
-        `s.plot.kde(**kwargs)` is shorthand for
-        `alt.Chart(s.to_frame()).transform_density(s.name, as_=[s.name, 'density']).mark_area().encode(x=s.name, y='density:Q', **kwargs).interactive()`,
-        and is provided for convenience - for full customisatibility, use a plotting
-        library directly.
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         .. versionchanged:: 1.6.0
             In prior versions of Polars, HvPlot was the plotting backend. If you would
@@ -93,6 +102,12 @@ class SeriesPlot:
 
         Parameters
         ----------
+        title
+            Plot title.
+        x_axis_title
+            Title of x-axis.
+        y_axis_title
+            Title of y-axis.
         **kwargs
             Additional keyword arguments passed to Altair.
 
@@ -100,33 +115,35 @@ class SeriesPlot:
         --------
         >>> s = pl.Series("price", [1, 3, 3, 3, 5, 2, 6, 5, 5, 5, 7])
         >>> s.plot.kde()  # doctest: +SKIP
-        """  # noqa: W505
+        """
         if self._series_name == "density":
             msg = "Cannot use `plot.kde` when Series name is `'density'`"
             raise ValueError(msg)
-        return (
+        return configure_chart(
             alt.Chart(self._df)
             .transform_density(self._series_name, as_=[self._series_name, "density"])
             .mark_area()
-            .encode(x=self._series_name, y="density:Q", **kwargs)  # type: ignore[misc]
-            .interactive()
+            .encode(x=self._series_name, y="density:Q", **kwargs),  # type: ignore[misc]
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
         )
 
     def line(
         self,
         /,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
         **kwargs: Unpack[EncodeKwds],
     ) -> alt.Chart:
         """
         Draw line plot.
 
-        Polars does not implement plotting logic itself but instead defers to
-        `Altair <https://altair-viz.github.io/>`_.
-
-        `s.plot.line(**kwargs)` is shorthand for
-        `alt.Chart(s.to_frame().with_row_index()).mark_line().encode(x='index', y=s.name, **kwargs).interactive()`,
-        and is provided for convenience - for full customisatibility, use a plotting
-        library directly.
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         .. versionchanged:: 1.6.0
             In prior versions of Polars, HvPlot was the plotting backend. If you would
@@ -136,6 +153,12 @@ class SeriesPlot:
 
         Parameters
         ----------
+        title
+            Plot title.
+        x_axis_title
+            Title of x-axis.
+        y_axis_title
+            Title of y-axis.
         **kwargs
             Additional keyword arguments passed to Altair.
 
@@ -143,18 +166,27 @@ class SeriesPlot:
         --------
         >>> s = pl.Series("price", [1, 3, 3, 3, 5, 2, 6, 5, 5, 5, 7])
         >>> s.plot.kde()  # doctest: +SKIP
-        """  # noqa: W505
+        """
         if self._series_name == "index":
             msg = "Cannot call `plot.line` when Series name is 'index'"
             raise ValueError(msg)
-        return (
+        return configure_chart(
             alt.Chart(self._df.with_row_index())
             .mark_line()
-            .encode(x="index", y=self._series_name, **kwargs)  # type: ignore[misc]
-            .interactive()
+            .encode(x="index", y=self._series_name, **kwargs),  # type: ignore[misc]
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
         )
 
-    def __getattr__(self, attr: str) -> Callable[..., alt.Chart]:
+    def __getattr__(
+        self,
+        attr: str,
+        *,
+        title: str | None = None,
+        x_axis_title: str | None = None,
+        y_axis_title: str | None = None,
+    ) -> Callable[..., alt.Chart]:
         if self._series_name == "index":
             msg = "Cannot call `plot.{attr}` when Series name is 'index'"
             raise ValueError(msg)
@@ -165,8 +197,9 @@ class SeriesPlot:
         if method is None:
             msg = "Altair has no method 'mark_{attr}'"
             raise AttributeError(msg)
-        return (
-            lambda **kwargs: method()
-            .encode(x="index", y=self._series_name, **kwargs)
-            .interactive()
+        return lambda **kwargs: configure_chart(
+            method().encode(x="index", y=self._series_name, **kwargs),
+            title=title,
+            x_axis_title=x_axis_title,
+            y_axis_title=y_axis_title,
         )

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -7403,18 +7403,10 @@ class Series:
             is add `import hvplot.polars` at the top of your script and replace
             `df.plot` with `df.hvplot`.
 
-        Polars does not implement plotting logic itself, but instead defers to
-        Altair:
-
-        - `s.plot.hist(**kwargs)`
-          is shorthand for
-          `alt.Chart(s.to_frame()).mark_bar().encode(x=alt.X(f'{s.name}:Q', bin=True), y='count()', **kwargs).interactive()`
-        - `s.plot.kde(**kwargs)`
-          is shorthand for
-          `alt.Chart(s.to_frame()).transform_density(s.name, as_=[s.name, 'density']).mark_area().encode(x=s.name, y='density:Q', **kwargs).interactive()`
-        - for any other attribute `attr`, `s.plot.attr(**kwargs)`
-          is shorthand for
-          `alt.Chart(s.to_frame().with_row_index()).mark_attr().encode(x='index', y=s.name, **kwargs).interactive()`
+        Polars defers to `Altair <https://altair-viz.github.io/>`_ for plotting, and
+        this functionality is only provided for convenience.
+        For configuration, we suggest reading `Chart Configuration
+        <https://altair-viz.github.io/altair-tutorial/notebooks/08-Configuration.html>`_.
 
         Examples
         --------
@@ -7430,7 +7422,7 @@ class Series:
         Line plot:
 
         >>> s.plot.line()  # doctest: +SKIP
-        """  # noqa: W505
+        """
         if not _ALTAIR_AVAILABLE or parse_version(altair.__version__) < (5, 4, 0):
             msg = "altair>=5.4.0 is required for `.plot`"
             raise ModuleUpgradeRequiredError(msg)

--- a/py-polars/tests/unit/operations/namespaces/test_plot.py
+++ b/py-polars/tests/unit/operations/namespaces/test_plot.py
@@ -11,6 +11,14 @@ def test_dataframe_plot() -> None:
         }
     )
     df.plot.line(x="length", y="width", color="species").to_json()
+    df.plot.line(
+        x="length",
+        y="width",
+        color="species",
+        title="title",
+        x_axis_title="x_axis_title",
+        y_axis_title="y_axis_title",
+    ).to_json()
     df.plot.point(x="length", y="width", size="species").to_json()
     df.plot.scatter(x="length", y="width", size="species").to_json()
     df.plot.bar(x="length", y="width", color="species").to_json()


### PR DESCRIPTION
Summary:
- cut down a bit on the docstrings
- add easily-findable `title`, `x_axis_title`, `y_axis_title` args to plotting functions
- add a nicer configuration by default, taken from https://gist.github.com/binste/b4042fa76a89d72d45cbbb9355ec6906 by @binste
- link to Altair's chart customisation tutorial, so people wanting further customisation have it to hand

Quick demo

**Before**:

![image](https://github.com/user-attachments/assets/9f8ec05e-a230-4eea-aa97-5bb0ff0e6e0c)

**After**:

![image](https://github.com/user-attachments/assets/106d6d1f-eb94-47c5-b170-e0a71ba3f11b)

---

Personally I think this looks better by default - I've included a link to the Altair Chart Customisation docs anyway so anyone wanting further customise can use that

---

EDIT: still a bit torn between adding `title` / `x_axis_title` / `y_axis_title` vs just documenting that you can pass `alt.X` and set it like that...will sleep on it