### PR TITLE
refactor(rust): Remove extra schema traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
  "polars-error",
  "polars-json",
  "polars-parquet",
+ "polars-schema",
  "polars-time",
  "polars-utils",
  "rayon",

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -13,8 +13,8 @@ polars-core = { workspace = true }
 polars-error = { workspace = true }
 polars-json = { workspace = true, optional = true }
 polars-parquet = { workspace = true, optional = true }
-polars-time = { workspace = true, features = [], optional = true }
 polars-schema = { workspace = true }
+polars-time = { workspace = true, features = [], optional = true }
 polars-utils = { workspace = true, features = ['mmap'] }
 
 ahash = { workspace = true }

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -14,6 +14,7 @@ polars-error = { workspace = true }
 polars-json = { workspace = true, optional = true }
 polars-parquet = { workspace = true, optional = true }
 polars-time = { workspace = true, features = [], optional = true }
+polars-schema = { workspace = true }
 polars-utils = { workspace = true, features = ['mmap'] }
 
 ahash = { workspace = true }

--- a/crates/polars-io/src/csv/read/options.rs
+++ b/crates/polars-io/src/csv/read/options.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use polars_core::datatypes::{DataType, Field};
-use polars_core::schema::{IndexOfSchema, Schema, SchemaRef};
+use polars_core::schema::{Schema, SchemaRef};
 use polars_error::PolarsResult;
 use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "serde")]

--- a/crates/polars-io/src/csv/write/writer.rs
+++ b/crates/polars-io/src/csv/write/writer.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::num::NonZeroUsize;
 
 use polars_core::frame::DataFrame;
-use polars_core::schema::{IndexOfSchema, Schema};
+use polars_core::schema::Schema;
 use polars_core::POOL;
 use polars_error::PolarsResult;
 
@@ -228,7 +228,11 @@ impl<W: Write> BatchedWriter<W> {
 
         if !self.has_written_header {
             self.has_written_header = true;
-            let names = self.schema.get_names_str();
+            let names = self
+                .schema
+                .iter_names()
+                .map(|x| x.as_str())
+                .collect::<Vec<_>>();
             write_header(&mut self.writer.buffer, &names, &self.writer.options)?;
         };
 

--- a/crates/polars-io/src/hive.rs
+++ b/crates/polars-io/src/hive.rs
@@ -1,5 +1,4 @@
 use polars_core::frame::DataFrame;
-use polars_core::schema::IndexOfSchema;
 use polars_core::series::Series;
 
 /// Materializes hive partitions.
@@ -9,9 +8,9 @@ use polars_core::series::Series;
 /// # Safety
 ///
 /// num_rows equals the height of the df when the df height is non-zero.
-pub(crate) fn materialize_hive_partitions<S: IndexOfSchema>(
+pub(crate) fn materialize_hive_partitions<D>(
     df: &mut DataFrame,
-    reader_schema: &S,
+    reader_schema: &polars_schema::Schema<D>,
     hive_partition_columns: Option<&[Series]>,
     num_rows: usize,
 ) {

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -475,7 +475,7 @@ fn rg_to_dfs_prefiltered(
                 // We first add the columns with the live columns at the start. Then, we do a
                 // projections that puts the columns at the right spot.
                 df._add_columns(rg_columns, &rearranged_schema)?;
-                let df = df.select(schema.iter_names().cloned())?;
+                let df = df.select(schema.iter_names_cloned())?;
 
                 PolarsResult::Ok(Some(df))
             })

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -475,7 +475,7 @@ fn rg_to_dfs_prefiltered(
                 // We first add the columns with the live columns at the start. Then, we do a
                 // projections that puts the columns at the right spot.
                 df._add_columns(rg_columns, &rearranged_schema)?;
-                let df = df.select(schema.get_names_owned())?;
+                let df = df.select(schema.iter_names().cloned())?;
 
                 PolarsResult::Ok(Some(df))
             })

--- a/crates/polars-io/src/utils/other.rs
+++ b/crates/polars-io/src/utils/other.rs
@@ -111,26 +111,10 @@ pub(crate) fn columns_to_projection(
     schema: &ArrowSchema,
 ) -> PolarsResult<Vec<usize>> {
     let mut prj = Vec::with_capacity(columns.len());
-    if columns.len() > 100 {
-        let mut column_names = PlHashMap::with_capacity(schema.len());
-        schema.iter_values().enumerate().for_each(|(i, c)| {
-            column_names.insert(c.name.as_str(), i);
-        });
 
-        for column in columns.iter() {
-            let Some(&i) = column_names.get(column.as_str()) else {
-                polars_bail!(
-                    ColumnNotFound:
-                    "unable to find column {:?}; valid columns: {:?}", column, schema.get_names(),
-                );
-            };
-            prj.push(i);
-        }
-    } else {
-        for column in columns.iter() {
-            let i = schema.try_index_of(column)?;
-            prj.push(i);
-        }
+    for column in columns {
+        let i = schema.try_index_of(column)?;
+        prj.push(i);
     }
 
     Ok(prj)

--- a/crates/polars-mem-engine/src/executors/projection_simple.rs
+++ b/crates/polars-mem-engine/src/executors/projection_simple.rs
@@ -15,7 +15,7 @@ impl ProjectionSimple {
 impl Executor for ProjectionSimple {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
         state.should_stop()?;
-        let columns = self.columns.get_names_owned();
+        let columns = self.columns.iter_names().cloned().collect::<Vec<_>>();
 
         let profile_name = if state.has_node_timer() {
             let name = comma_delimited("simple-projection".to_string(), columns.as_slice());

--- a/crates/polars-mem-engine/src/executors/projection_simple.rs
+++ b/crates/polars-mem-engine/src/executors/projection_simple.rs
@@ -15,7 +15,7 @@ impl ProjectionSimple {
 impl Executor for ProjectionSimple {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
         state.should_stop()?;
-        let columns = self.columns.iter_names().cloned().collect::<Vec<_>>();
+        let columns = self.columns.iter_names_cloned().collect::<Vec<_>>();
 
         let profile_name = if state.has_node_timer() {
             let name = comma_delimited("simple-projection".to_string(), columns.as_slice());

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -430,7 +430,7 @@ fn create_physical_plan_impl(
                 .transpose()?;
             Ok(Box::new(executors::DataFrameExec {
                 df,
-                projection: output_schema.map(|s| s.iter_names().cloned().collect()),
+                projection: output_schema.map(|s| s.iter_names_cloned().collect()),
                 filter: selection,
                 predicate_has_windows: state.has_windows,
             }))

--- a/crates/polars-pipe/src/executors/operators/reproject.rs
+++ b/crates/polars-pipe/src/executors/operators/reproject.rs
@@ -1,6 +1,5 @@
 use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::IndexOfSchema;
 use polars_core::schema::Schema;
 
 use crate::operators::DataChunk;
@@ -15,12 +14,9 @@ pub(crate) fn reproject_chunk(
         // the positions for subsequent calls
         let chunk_schema = chunk.data.schema();
 
-        let check_duplicates = false;
-        let out = chunk.data._select_with_schema_impl(
-            schema.get_names_owned().as_slice(),
-            &chunk_schema,
-            check_duplicates,
-        )?;
+        let out = chunk
+            .data
+            .select_with_schema_unchecked(schema.iter_names().cloned(), &chunk_schema)?;
 
         *positions = out
             .get_columns()

--- a/crates/polars-pipe/src/executors/operators/reproject.rs
+++ b/crates/polars-pipe/src/executors/operators/reproject.rs
@@ -16,7 +16,7 @@ pub(crate) fn reproject_chunk(
 
         let out = chunk
             .data
-            .select_with_schema_unchecked(schema.iter_names().cloned(), &chunk_schema)?;
+            .select_with_schema_unchecked(schema.iter_names_cloned(), &chunk_schema)?;
 
         *positions = out
             .get_columns()

--- a/crates/polars-pipe/src/executors/sinks/reproject.rs
+++ b/crates/polars-pipe/src/executors/sinks/reproject.rs
@@ -1,6 +1,5 @@
 use std::any::Any;
 
-use polars_core::prelude::IndexOfSchema;
 use polars_core::schema::SchemaRef;
 
 use crate::executors::sources::ReProjectSource;
@@ -41,7 +40,7 @@ impl Sink for ReProjectSink {
     fn finalize(&mut self, context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
         Ok(match self.sink.finalize(context)? {
             FinalizedSink::Finished(df) => {
-                FinalizedSink::Finished(df._select_impl(self.schema.get_names_owned().as_slice())?)
+                FinalizedSink::Finished(df.select(self.schema.iter_names().cloned())?)
             },
             FinalizedSink::Source(source) => {
                 FinalizedSink::Source(Box::new(ReProjectSource::new(self.schema.clone(), source)))

--- a/crates/polars-pipe/src/executors/sinks/reproject.rs
+++ b/crates/polars-pipe/src/executors/sinks/reproject.rs
@@ -40,7 +40,7 @@ impl Sink for ReProjectSink {
     fn finalize(&mut self, context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
         Ok(match self.sink.finalize(context)? {
             FinalizedSink::Finished(df) => {
-                FinalizedSink::Finished(df.select(self.schema.iter_names().cloned())?)
+                FinalizedSink::Finished(df.select(self.schema.iter_names_cloned())?)
             },
             FinalizedSink::Source(source) => {
                 FinalizedSink::Source(Box::new(ReProjectSource::new(self.schema.clone(), source)))

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -67,7 +67,7 @@ where
                 }
                 // projection is free
                 if let Some(schema) = output_schema {
-                    let columns = schema.iter_names().cloned().collect::<Vec<_>>();
+                    let columns = schema.iter_names_cloned().collect::<Vec<_>>();
                     df = df._select_impl_unchecked(&columns)?;
                 }
             }
@@ -590,7 +590,7 @@ where
     let op = match lp_arena.get(node) {
         SimpleProjection { input, columns, .. } => {
             let input_schema = lp_arena.get(*input).schema(lp_arena);
-            let columns = columns.iter_names().cloned().collect();
+            let columns = columns.iter_names_cloned().collect();
             let op = operators::SimpleProjectionOperator::new(columns, input_schema.into_owned());
             Box::new(op) as Box<dyn Operator>
         },

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -1077,10 +1077,10 @@ pub(crate) fn maybe_init_projection_excluding_hive(
     let names = match reader_schema {
         Either::Left(ref v) => v
             .contains(first_hive_name.as_str())
-            .then(|| v.iter_names().cloned().collect::<Vec<_>>()),
+            .then(|| v.iter_names_cloned().collect::<Vec<_>>()),
         Either::Right(ref v) => v
             .contains(first_hive_name.as_str())
-            .then(|| v.iter_names().cloned().collect()),
+            .then(|| v.iter_names_cloned().collect()),
     };
 
     let names = names?;

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -1073,14 +1073,14 @@ pub(crate) fn maybe_init_projection_excluding_hive(
 
     let (first_hive_name, _) = hive_schema.get_at_index(0)?;
 
+    // TODO: Optimize this
     let names = match reader_schema {
-        Either::Left(ref v) => {
-            let names = v.get_names_owned();
-            names.contains(first_hive_name).then_some(names)
-        },
+        Either::Left(ref v) => v
+            .contains(first_hive_name.as_str())
+            .then(|| v.iter_names().cloned().collect::<Vec<_>>()),
         Either::Right(ref v) => v
             .contains(first_hive_name.as_str())
-            .then(|| v.get_names_owned()),
+            .then(|| v.iter_names().cloned().collect()),
     };
 
     let names = names?;

--- a/crates/polars-plan/src/plans/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cache_states.rs
@@ -15,7 +15,7 @@ fn get_upper_projections(
     // During projection pushdown all accumulated.
     match parent {
         SimpleProjection { columns, .. } => {
-            let iter = columns.iter_names().cloned();
+            let iter = columns.iter_names_cloned();
             names_scratch.extend(iter);
             *found_required_columns = true;
             false
@@ -264,7 +264,7 @@ pub(super) fn set_cache_states(
                     // all columns
                     if !found_required_columns {
                         let schema = lp.schema(lp_arena);
-                        v.names_union.extend(schema.iter_names().cloned());
+                        v.names_union.extend(schema.iter_names_cloned());
                     }
                 }
                 frame.cache_id = Some(*id);

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -346,7 +346,7 @@ impl ProjectionPushDown {
                 expr_arena,
             ),
             SimpleProjection { columns, input, .. } => {
-                let exprs = names_to_expr_irs(columns.iter_names().cloned(), expr_arena);
+                let exprs = names_to_expr_irs(columns.iter_names_cloned(), expr_arena);
                 process_projection(
                     self,
                     input,

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -14,10 +14,7 @@ pub struct Schema<D> {
 
 impl<D: Eq> Eq for Schema<D> {}
 
-impl<D> Schema<D>
-where
-    D: Clone + Default,
-{
+impl<D> Schema<D> {
     pub fn with_capacity(capacity: usize) -> Self {
         let fields = PlIndexMap::with_capacity(capacity);
         Self { fields }
@@ -57,42 +54,6 @@ where
 
     pub fn insert(&mut self, key: PlSmallStr, value: D) -> Option<D> {
         self.fields.insert(key, value)
-    }
-
-    /// Create a new schema from this one, inserting a field with `name` and `dtype` at the given `index`.
-    ///
-    /// If a field named `name` already exists, it is updated with the new dtype. Regardless, the field named `name` is
-    /// always moved to the given index. Valid indices range from `0` (front of the schema) to `self.len()` (after the
-    /// end of the schema).
-    ///
-    /// For a mutating version that doesn't clone, see [`insert_at_index`][Self::insert_at_index].
-    ///
-    /// Runtime: **O(m * n)** where `m` is the (average) length of the field names and `n` is the number of fields in
-    /// the schema. This method clones every field in the schema.
-    ///
-    /// Returns: `Ok(new_schema)` if `index <= self.len()`, else `Err(PolarsError)`
-    pub fn new_inserting_at_index(
-        &self,
-        index: usize,
-        name: PlSmallStr,
-        field: D,
-    ) -> PolarsResult<Self> {
-        polars_ensure!(
-            index <= self.len(),
-            OutOfBounds:
-                "index {} is out of bounds for schema with length {} (the max index allowed is self.len())",
-                    index,
-                    self.len()
-        );
-
-        let mut new = Self::default();
-        let mut iter = self.fields.iter().filter_map(|(fld_name, dtype)| {
-            (fld_name != &name).then_some((fld_name.clone(), dtype.clone()))
-        });
-        new.fields.extend(iter.by_ref().take(index));
-        new.fields.insert(name.clone(), field);
-        new.fields.extend(iter);
-        Ok(new)
     }
 
     /// Insert a field with `name` and `dtype` at the given `index` into this schema.
@@ -275,21 +236,6 @@ where
         self.fields.extend(other.fields)
     }
 
-    /// Merge borrowed `other` into `self`.
-    ///
-    /// Merging logic:
-    /// - Fields that occur in `self` but not `other` are unmodified
-    /// - Fields that occur in `other` but not `self` are appended, in order, to the end of `self`
-    /// - Fields that occur in both `self` and `other` are updated with the dtype from `other`, but keep their original
-    ///   index
-    pub fn merge_from_ref(&mut self, other: &Self) {
-        self.fields.extend(
-            other
-                .iter()
-                .map(|(column, field)| (column.clone(), field.clone())),
-        )
-    }
-
     /// Iterates over the `(&name, &dtype)` pairs in this schema.
     ///
     /// For an owned version, use [`iter_fields`][Self::iter_fields], which clones the data to iterate owned `Field`s
@@ -322,6 +268,74 @@ where
 
     pub fn index_of(&self, name: &str) -> Option<usize> {
         self.fields.get_index_of(name)
+    }
+
+    pub fn try_index_of(&self, name: &str) -> PolarsResult<usize> {
+        let Some(i) = self.fields.get_index_of(name) else {
+            polars_bail!(
+                ColumnNotFound:
+                "unable to find column {:?}; valid columns: {:?}",
+                name, self.iter_names().collect::<Vec<_>>(),
+            )
+        };
+
+        Ok(i)
+    }
+}
+
+impl<D> Schema<D>
+where
+    D: Clone + Default,
+{
+    /// Create a new schema from this one, inserting a field with `name` and `dtype` at the given `index`.
+    ///
+    /// If a field named `name` already exists, it is updated with the new dtype. Regardless, the field named `name` is
+    /// always moved to the given index. Valid indices range from `0` (front of the schema) to `self.len()` (after the
+    /// end of the schema).
+    ///
+    /// For a mutating version that doesn't clone, see [`insert_at_index`][Self::insert_at_index].
+    ///
+    /// Runtime: **O(m * n)** where `m` is the (average) length of the field names and `n` is the number of fields in
+    /// the schema. This method clones every field in the schema.
+    ///
+    /// Returns: `Ok(new_schema)` if `index <= self.len()`, else `Err(PolarsError)`
+    pub fn new_inserting_at_index(
+        &self,
+        index: usize,
+        name: PlSmallStr,
+        field: D,
+    ) -> PolarsResult<Self> {
+        polars_ensure!(
+            index <= self.len(),
+            OutOfBounds:
+                "index {} is out of bounds for schema with length {} (the max index allowed is self.len())",
+                    index,
+                    self.len()
+        );
+
+        let mut new = Self::default();
+        let mut iter = self.fields.iter().filter_map(|(fld_name, dtype)| {
+            (fld_name != &name).then_some((fld_name.clone(), dtype.clone()))
+        });
+        new.fields.extend(iter.by_ref().take(index));
+        new.fields.insert(name.clone(), field);
+        new.fields.extend(iter);
+        Ok(new)
+    }
+
+    /// Merge borrowed `other` into `self`.
+    ///
+    /// Merging logic:
+    /// - Fields that occur in `self` but not `other` are unmodified
+    /// - Fields that occur in `other` but not `self` are appended, in order, to the end of `self`
+    /// - Fields that occur in both `self` and `other` are updated with the dtype from `other`, but keep their original
+    ///   index
+    pub fn merge_from_ref(&mut self, other: &Self) {
+        self.fields.extend(
+            other
+                .iter()
+                .map(|(column, field)| (column.clone(), field.clone())),
+        )
     }
 
     /// Generates another schema with just the specified columns selected from this one.
@@ -421,7 +435,6 @@ impl<D> From<PlIndexMap<PlSmallStr, D>> for Schema<D> {
 impl<F, D> FromIterator<F> for Schema<D>
 where
     F: Into<(PlSmallStr, D)>,
-    D: Clone,
 {
     fn from_iter<I: IntoIterator<Item = F>>(iter: I) -> Self {
         let fields = PlIndexMap::from_iter(iter.into_iter().map(|x| x.into()));

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -253,7 +253,7 @@ impl<D> Schema<D> {
     }
 
     pub fn iter_names_cloned(&self) -> impl '_ + ExactSizeIterator<Item = PlSmallStr> {
-        self.iter_names_cloned()
+        self.iter_names().cloned()
     }
 
     /// Iterates over references to the dtypes in this schema.

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -252,6 +252,10 @@ impl<D> Schema<D> {
         self.fields.iter().map(|(name, _dtype)| name)
     }
 
+    pub fn iter_names_cloned(&self) -> impl '_ + ExactSizeIterator<Item = PlSmallStr> {
+        self.iter_names_cloned()
+    }
+
     /// Iterates over references to the dtypes in this schema.
     pub fn iter_values(&self) -> impl '_ + ExactSizeIterator<Item = &D> {
         self.fields.iter().map(|(_name, dtype)| dtype)

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -26,7 +26,7 @@ pub fn lower_ir(
     let output_schema = IR::schema_with_cache(node, ir_arena, schema_cache);
     let node_kind = match ir_node {
         IR::SimpleProjection { input, columns } => {
-            let columns = columns.iter_names().cloned().collect::<Vec<_>>();
+            let columns = columns.iter_names_cloned().collect::<Vec<_>>();
             let phys_input = lower_ir(
                 *input,
                 ir_arena,
@@ -200,7 +200,7 @@ pub fn lower_ir(
                     let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
                     node_kind = PhysNodeKind::SimpleProjection {
                         input: phys_input,
-                        columns: projection_schema.iter_names().cloned().collect::<Vec<_>>(),
+                        columns: projection_schema.iter_names_cloned().collect::<Vec<_>>(),
                     };
                     schema = projection_schema.clone();
                 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars_core::prelude::{InitHashMaps, PlHashMap, PlIndexMap};
-use polars_core::schema::{IndexOfSchema, Schema};
+use polars_core::schema::Schema;
 use polars_error::{polars_err, PolarsResult};
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::{AExpr, IR};
@@ -26,7 +26,7 @@ pub fn lower_ir(
     let output_schema = IR::schema_with_cache(node, ir_arena, schema_cache);
     let node_kind = match ir_node {
         IR::SimpleProjection { input, columns } => {
-            let columns = columns.get_names_owned();
+            let columns = columns.iter_names().cloned().collect::<Vec<_>>();
             let phys_input = lower_ir(
                 *input,
                 ir_arena,
@@ -200,7 +200,7 @@ pub fn lower_ir(
                     let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
                     node_kind = PhysNodeKind::SimpleProjection {
                         input: phys_input,
-                        columns: projection_schema.get_names_owned(),
+                        columns: projection_schema.iter_names().cloned().collect::<Vec<_>>(),
                     };
                     schema = projection_schema.clone();
                 }

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -520,7 +520,7 @@ fn test_empty_bytes_to_dataframe() {
 
     let result = CsvReadOptions::default()
         .with_has_header(false)
-        .with_columns(Some(schema.iter_names().cloned().collect()))
+        .with_columns(Some(schema.iter_names_cloned().collect()))
         .with_schema(Some(Arc::new(schema)))
         .into_reader_with_file_handle(file)
         .finish();


### PR DESCRIPTION
* Move required methods to the main `polars_schema::Schema<D>` struct
* Split impls for `Schema<D>`, most functions don't need `D: Default + Clone`