### PR TITLE
fix: Enable "polars-json/timezones" feature from "polars-io"

### DIFF
--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -95,6 +95,7 @@ timezones = [
   "dtype-datetime",
   "arrow/timezones",
   "polars-json?/chrono-tz",
+  "polars-json?/timezones",
 ]
 dtype-time = ["polars-core/dtype-time", "polars-core/temporal", "polars-time/dtype-time"]
 dtype-struct = ["polars-core/dtype-struct"]


### PR DESCRIPTION
That feature is never enabled, so we can't dump NDJSON with datetimes that contain timezones.

The original problem was described in https://github.com/elixir-explorer/explorer/issues/977

PS: I'm not really sure if we can get rid of the `chrono-tz` feature and consolidate all in the `timezones` feature there.