### PR TITLE
fix(rust): Qcut all nulls panics

### DIFF
--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -131,20 +131,18 @@ pub fn qcut(
 ) -> PolarsResult<Series> {
     polars_ensure!(!probs.iter().any(|x| x.is_nan()), ComputeError: "quantiles cannot be NaN");
 
+    if s.null_count() == s.len() {
+        // If we only have nulls we don't have any breakpoints.
+        return Ok(Series::full_null(
+            s.name().clone(),
+            s.len(),
+            &DataType::Categorical(None, Default::default()),
+        ));
+    }
+
     let s = s.cast(&DataType::Float64)?;
     let s2 = s.sort(SortOptions::default())?;
     let ca = s2.f64()?;
-
-    if ca.null_count() == ca.len() {
-        // If we only have nulls we don't have any breakpoints.
-        return cut(
-            &s,
-            vec![],
-            None::<Vec<PlSmallStr>>,
-            left_closed,
-            include_breaks,
-        );
-    }
 
     let f = |&p| {
         ca.quantile(p, QuantileInterpolOptions::Linear)

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -137,7 +137,13 @@ pub fn qcut(
 
     if ca.null_count() == ca.len() {
         // If we only have nulls we don't have any breakpoints.
-        return cut(&s, vec![], labels, left_closed, include_breaks);
+        return cut(
+            &s,
+            vec![],
+            None::<Vec<PlSmallStr>>,
+            left_closed,
+            include_breaks,
+        );
     }
 
     let f = |&p| {

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -100,6 +100,15 @@ def test_qcut_full_null() -> None:
     assert_series_equal(result, expected, categorical_as_str=True)
 
 
+def test_qcut_full_null_with_labels() -> None:
+    s = pl.Series("a", [None, None, None, None])
+
+    result = s.qcut([0.25, 0.50], labels=["1", "2", "3"])
+
+    expected = pl.Series("a", [None, None, None, None], dtype=pl.Categorical)
+    assert_series_equal(result, expected, categorical_as_str=True)
+
+
 def test_qcut_allow_duplicates() -> None:
     s = pl.Series([1, 2, 2, 3])
 


### PR DESCRIPTION
This PR is fixing an issue where if `qcut` is called for a series wth only null values, and with labels as an argument, it will panic.
Fixing https://github.com/pola-rs/polars/issues/10876

I've modified `qcut` function to call `cut` with None as labels after detecting all values are null in the series.
A unit test was added to check this specific scenario 