### PR TITLE
refactor(rust): Allow polars to pass cargo check on windows

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -31,10 +31,7 @@ env:
 
 jobs:
   clippy-nightly:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -51,10 +48,7 @@ jobs:
 
   # Default feature set should compile on the stable toolchain
   clippy-stable:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -31,7 +31,10 @@ env:
 
 jobs:
   clippy-nightly:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -48,7 +51,10 @@ jobs:
 
   # Default feature set should compile on the stable toolchain
   clippy-stable:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/polars-utils/src/mmap.rs
+++ b/crates/polars-utils/src/mmap.rs
@@ -127,7 +127,9 @@ mod private {
 }
 
 use memmap::MmapOptions;
-use polars_error::{polars_bail, PolarsResult};
+#[cfg(target_family = "unix")]
+use polars_error::polars_bail;
+use polars_error::PolarsResult;
 pub use private::MemSlice;
 
 /// A cursor over a [`MemSlice`].


### PR DESCRIPTION
This fix is similar to what was done in #18498. We also added windows to `lint-rust.yml` in CI to prevent similar issues from occuring again.

It fixes `cargo check` regression in windows as of 5c4e7e97a66007d3052042543486c42d23cfac74 with the message
```
$ cargo check --workspace --all-targets --all-features
...
   --> crates\polars-utils\src\mmap.rs:130:20
    |
130 | use polars_error::{polars_bail, PolarsResult};
    |                    ^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default
...
```
This is caused by #18532 at
https://github.com/pola-rs/polars/blob/ac2456c7ce4db7ac0acc2b259c84fbb09f747ab9/crates/polars-utils/src/mmap.rs#L127
https://github.com/pola-rs/polars/blob/ac2456c7ce4db7ac0acc2b259c84fbb09f747ab9/crates/polars-utils/src/mmap.rs#L311-L319