### PR TITLE
feat(python): Update `BytecodeParser` for upcoming Python 3.13

### DIFF
--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -604,10 +604,10 @@ class InstructionTranslator:
             return "replace_strict"
         else:
             msg = (
-                "unrecognized opname"
-                "\n\nPlease report a bug to https://github.com/pola-rs/polars/issues"
-                " with the content of function you were passing to `map` and the"
-                f" following instruction object:\n{inst!r}"
+                f"unexpected or unrecognised op name ({inst.opname})\n\n"
+                "Please report a bug to https://github.com/pola-rs/polars/issues "
+                "with the content of function you were passing to the `map` "
+                f"expressions and the following instruction object:\n{inst!r}"
             )
             raise AssertionError(msg)
 
@@ -751,7 +751,7 @@ class RewrittenInstructions:
         self._original_instructions = list(instructions)
         self._rewritten_instructions = self._rewrite(
             self._upgrade_instruction(inst)
-            for inst in self._original_instructions
+            for inst in self._unpack_superinstructions(self._original_instructions)
             if inst.opname not in self._ignored_ops
         )
 
@@ -1017,6 +1017,22 @@ class RewrittenInstructions:
             updated_instructions.append(px)
 
         return len(matching_instructions)
+
+    @staticmethod
+    def _unpack_superinstructions(
+        instructions: list[Instruction],
+    ) -> Iterator[Instruction]:
+        """Expand known 'superinstructions' into their component parts."""
+        for inst in instructions:
+            if inst.opname == "LOAD_FAST_LOAD_FAST":
+                for idx in (0, 1):
+                    yield inst._replace(
+                        opname="LOAD_FAST",
+                        argval=inst.argval[idx],
+                        argrepr=inst.argval[idx],
+                    )
+            else:
+                yield inst
 
     @staticmethod
     def _upgrade_instruction(inst: Instruction) -> Instruction:


### PR DESCRIPTION
Still mildly painful to install/debug under the Python 3.13rc1, but here's another update for the `BytecodeParser`, building on #16304. Might be the last one needed, but will have to wait on the final release to be sure 🤔

We now recognise specific "superinstructions"[^1] and unpack them to the underlying individual instructions (eg: `LOAD_FAST_LOAD_FAST`→`LOAD_FAST`+`LOAD_FAST`).

```python
from polars._utils.udfs import BytecodeParser

bp = BytecodeParser(
    function = lambda x: (x/x) * (x+x),
    map_target = "expr",
)
```
* Python 3.11/3.12 bytecode:
  ```python
  bp.dis()
  # 4    0 RESUME                   0
  #      2 LOAD_FAST                0 (x)
  #      4 LOAD_FAST                0 (x)
  #      6 BINARY_OP               11 (/)
  #     10 LOAD_FAST                0 (x)
  #     12 LOAD_FAST                0 (x)
  #     14 BINARY_OP                0 (+)
  #     18 BINARY_OP                5 (*)
  #     22 RETURN_VALUE
  ```
* Python 3.13 bytecode (note presence of superinstructions):
  ```python
  bp.dis()
  # 4   RESUME                   0
  #     LOAD_FAST_LOAD_FAST      0 (x, x)
  #     BINARY_OP               11 (/)
  #     LOAD_FAST_LOAD_FAST      0 (x, x)
  #     BINARY_OP                0 (+)
  #     BINARY_OP                5 (*)
  #     RETURN_VALUE             
  ```
* Result (across all Python versions):
  ```python
  bp.to_expression("x")
  # (pl.col("x") / pl.col("x")) * (pl.col("x") + pl.col("x"))
  ```

[^1]: https://github.com/faster-cpython/ideas/issues/16