### PR TITLE
fix(rust): fix `async` feature compile error

### DIFF
--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -13,7 +13,7 @@ use polars_io::cloud::CloudOptions;
 use polars_io::csv::read::{
     count_rows as count_rows_csv, count_rows_from_slice as count_rows_csv_from_slice,
 };
-#[cfg(all(feature = "parquet", feature = "cloud"))]
+#[cfg(all(feature = "parquet", feature = "async"))]
 use polars_io::parquet::read::ParquetAsyncReader;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::read::ParquetReader;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb2fb98f-4969-4077-b01f-2c0151d335d5)

fix this compile error with following feature gate

```toml
polars = { version = "0.43", features = [
     "lazy",
     "async",
     "parquet",
     "is_in",
     "dtype-categorical",
     "performant",
] }

```