### PR TITLE
fix(rust): Correctly display multilevel nested Arrays

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -228,6 +228,21 @@ impl DataType {
         prev
     }
 
+    #[cfg(feature = "dtype-array")]
+    /// Get the inner data type of a multidimensional array.
+    pub fn array_leaf_dtype(&self) -> Option<&DataType> {
+        let mut prev = self;
+        match prev {
+            DataType::Array(_, _) => {
+                while let DataType::Array(inner, _) = &prev {
+                    prev = &inner;
+                }
+                Some(prev)
+            },
+            _ => None,
+        }
+    }
+
     /// Cast the leaf types of Lists/Arrays and keep the nesting.
     pub fn cast_leaf(&self, to: DataType) -> DataType {
         use DataType::*;
@@ -717,7 +732,7 @@ impl Display for DataType {
             DataType::Time => "time",
             #[cfg(feature = "dtype-array")]
             DataType::Array(_, _) => {
-                let tp = self.leaf_dtype();
+                let tp = self.array_leaf_dtype().unwrap();
 
                 let dims = self.get_shape().unwrap();
                 let shape = if dims.len() == 1 {

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -291,6 +291,10 @@ def test_recursive_array_dtype() -> None:
     s = pl.Series(np.arange(6).reshape((2, 3)), dtype=dtype)
     assert s.dtype == dtype
     assert s.len() == 2
+    dtype = pl.Array(pl.List(pl.Array(pl.Int8, (2, 2))), 2)
+    s = pl.Series(dtype=dtype)
+    assert s.dtype == dtype
+    assert str(s) == "shape: (0,)\nSeries: '' [array[list[array[i8, (2, 2)]], 2]]\n[\n]"
 
 
 def test_ndarray_construction() -> None:


### PR DESCRIPTION
While trying to get a py-polars-like display on Rust in r-polars, I noticed a lack of functionality on the Rust side.
<https://github.com/pola-rs/r-polars/blob/de575b0a72664b5f386fb6dfd72024122179e8e2/src/rust/src/datatypes.rs#L71-L95>

The following example shows that the type is not displayed correctly when the Series is displayed in Python.

```python
>>> import polars as pl
>>> pl.Array(pl.List(pl.Array(pl.Int8, (2, 2))), 2)
Array(List(Array(Int8, shape=(2, 2))), shape=(2,))
>>> pl.Series(dtype=pl.Array(pl.List(pl.Array(pl.Int8, (2, 2))), 2))
shape: (0,)
Series: '' [array[i8, 2]]
[
]
```

This PR should be modified as follows to eliminate the difference in display between Python and Rust.

```python
>>> pl.Series(dtype=pl.Array(pl.List(pl.Array(pl.Int8, (2, 2))), 2))
shape: (0,)
Series: '' [array[list[array[i8, (2, 2)]], 2]]
[
]
```