### PR TITLE
feat: Implement single inequality joins for join_where

### DIFF
--- a/py-polars/tests/benchmark/test_join_where.py
+++ b/py-polars/tests/benchmark/test_join_where.py
@@ -38,6 +38,22 @@ def test_non_strict_inequalities(east_west: tuple[pl.DataFrame, pl.DataFrame]) -
     assert len(result) > 0
 
 
+def test_single_inequality(east_west: tuple[pl.DataFrame, pl.DataFrame]) -> None:
+    east, west = east_west
+    result = (
+        east.lazy()
+        # Reduce the number of results by scaling LHS dur column up
+        .with_columns((pl.col("dur") * 30).alias("scaled_dur"))
+        .join_where(
+            west.lazy(),
+            pl.col("scaled_dur") < pl.col("time"),
+        )
+        .collect()
+    )
+
+    assert len(result) > 0
+
+
 @pytest.fixture(scope="module")
 def east_west() -> tuple[pl.DataFrame, pl.DataFrame]:
     num_rows_left, num_rows_right = 50_000, 5_000

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -518,3 +518,33 @@ def test_single_inequality(left: pl.Series, right: pl.Series, op: str) -> None:
 
     expected = left_df.join(right_df, how="cross").filter(expr)
     assert_frame_equal(actual, expected, check_row_order=False, check_exact=True)
+
+
+@given(
+    offset=st.integers(-6, 5),
+    length=st.integers(0, 6),
+)
+def test_single_inequality_with_slice(offset: int, length: int) -> None:
+    left = pl.DataFrame(
+        {
+            "id": list(range(8)),
+            "x": [0, 1, 1, 2, 3, 5, 5, 7],
+        }
+    )
+    right = pl.DataFrame(
+        {
+            "id": list(range(6)),
+            "y": [-1, 2, 4, 4, 6, 9],
+        }
+    )
+
+    expr = pl.col("x") > pl.col("y")
+    actual = left.join_where(right, expr).slice(offset, length)
+
+    expected_full = left.join(right, how="cross").filter(expr)
+
+    assert len(actual) == len(expected_full.slice(offset, length))
+
+    expected_rows = set(expected_full.iter_rows())
+    for row in actual.iter_rows():
+        assert row in expected_rows, f"{row} not in expected rows"


### PR DESCRIPTION
This implements the "piecewise merge join" algorithm (described in [this DuckDB article](https://duckdb.org/2022/05/27/iejoin.html#piecewise-merge-join)) to handle `join_where` with a single inequality, without using a cross join and filter.

I've reused the `IEJoin` join type internally due to the similarities in how these two join types are handled. Technically this isn't using the IEJoin algorithm but it is another type of inequality join, so this seems OK, but it could be pulled out into its own join type if needed.