### PR TITLE
refactor(rust): Replace `DynArgs` with an enum containing all its variants

### DIFF
--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mean.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mean.rs
@@ -11,7 +11,7 @@ impl<
         T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign + Div<Output = T> + NumCast,
     > RollingAggWindowNoNulls<'a, T> for MeanWindow<'a, T>
 {
-    fn new(slice: &'a [T], start: usize, end: usize, params: DynArgs) -> Self {
+    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self {
         Self {
             sum: SumWindow::new(slice, start, end, params),
         }
@@ -29,7 +29,7 @@ pub fn rolling_mean<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
 ) -> PolarsResult<ArrayRef>
 where
     T: NativeType + Float + std::iter::Sum<T> + SubAssign + AddAssign + IsFloat,

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/min_max.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/min_max.rs
@@ -135,7 +135,12 @@ macro_rules! minmax_window {
         impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T>
             for $m_window<'a, T>
         {
-            fn new(slice: &'a [T], start: usize, end: usize, _params: DynArgs) -> Self {
+            fn new(
+                slice: &'a [T],
+                start: usize,
+                end: usize,
+                _params: Option<RollingFnParams>,
+            ) -> Self {
                 let (idx, m) =
                     unsafe { $get_m_and_idx(slice, start, end, 0).unwrap_or((0, &slice[start])) };
                 Self {
@@ -238,7 +243,7 @@ macro_rules! rolling_minmax_func {
             min_periods: usize,
             center: bool,
             weights: Option<&[f64]>,
-            _params: DynArgs,
+            _params: Option<RollingFnParams>,
         ) -> PolarsResult<ArrayRef>
         where
             T: NativeType + PartialOrd + IsFloat + Bounded + NumCast + Mul<Output = T> + Num,

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
@@ -21,7 +21,7 @@ use crate::legacy::error::PolarsResult;
 use crate::types::NativeType;
 
 pub trait RollingAggWindowNoNulls<'a, T: NativeType> {
-    fn new(slice: &'a [T], start: usize, end: usize, params: DynArgs) -> Self;
+    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self;
 
     /// Update and recompute the window
     ///
@@ -36,7 +36,7 @@ pub(super) fn rolling_apply_agg_window<'a, Agg, T, Fo>(
     window_size: usize,
     min_periods: usize,
     det_offsets_fn: Fo,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
 ) -> PolarsResult<ArrayRef>
 where
     Fo: Fn(Idx, WindowSize, Len) -> (Start, End),

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
@@ -25,9 +25,12 @@ impl<
             + Sub<Output = T>,
     > RollingAggWindowNoNulls<'a, T> for QuantileWindow<'a, T>
 {
-    fn new(slice: &'a [T], start: usize, end: usize, params: DynArgs) -> Self {
+    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self {
         let params = params.unwrap();
-        let params = params.downcast_ref::<RollingQuantileParams>().unwrap();
+        let RollingFnParams::Quantile(params) = params else {
+            unreachable!("expected Quantile params");
+        };
+
         Self {
             sorted: SortedBuf::new(slice, start, end),
             prob: params.prob,
@@ -103,7 +106,7 @@ pub fn rolling_quantile<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
 ) -> PolarsResult<ArrayRef>
 where
     T: NativeType
@@ -127,7 +130,9 @@ where
         None => {
             if !center {
                 let params = params.as_ref().unwrap();
-                let params = params.downcast_ref::<RollingQuantileParams>().unwrap();
+                let RollingFnParams::Quantile(params) = params else {
+                    unreachable!("expected Quantile params");
+                };
                 let out = super::quantile_filter::rolling_quantile::<_, Vec<_>>(
                     params.interpol,
                     min_periods,
@@ -158,7 +163,10 @@ where
                 ComputeError: "Weighted quantile is undefined if weights sum to 0"
             );
             let params = params.unwrap();
-            let params = params.downcast_ref::<RollingQuantileParams>().unwrap();
+            let RollingFnParams::Quantile(params) = params else {
+                unreachable!("expected Quantile params");
+            };
+
             Ok(rolling_apply_weighted_quantile(
                 values,
                 params.prob,
@@ -263,10 +271,10 @@ mod test {
     #[test]
     fn test_rolling_median() {
         let values = &[1.0, 2.0, 3.0, 4.0];
-        let med_pars = Some(Arc::new(RollingQuantileParams {
+        let med_pars = Some(RollingFnParams::Quantile(RollingQuantileParams {
             prob: 0.5,
             interpol: Linear,
-        }) as Arc<dyn Any + Send + Sync>);
+        }));
         let out = rolling_quantile(values, 2, 2, false, None, med_pars.clone()).unwrap();
         let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
         let out = out.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
@@ -306,10 +314,10 @@ mod test {
         ];
 
         for interpol in interpol_options {
-            let min_pars = Some(Arc::new(RollingQuantileParams {
+            let min_pars = Some(RollingFnParams::Quantile(RollingQuantileParams {
                 prob: 0.0,
                 interpol,
-            }) as Arc<dyn Any + Send + Sync>);
+            }));
             let out1 = rolling_min(values, 2, 2, false, None, None).unwrap();
             let out1 = out1.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
             let out1 = out1.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
@@ -318,10 +326,10 @@ mod test {
             let out2 = out2.into_iter().map(|v| v.copied()).collect::<Vec<_>>();
             assert_eq!(out1, out2);
 
-            let max_pars = Some(Arc::new(RollingQuantileParams {
+            let max_pars = Some(RollingFnParams::Quantile(RollingQuantileParams {
                 prob: 1.0,
                 interpol,
-            }) as Arc<dyn Any + Send + Sync>);
+            }));
             let out1 = rolling_max(values, 2, 2, false, None, None).unwrap();
             let out1 = out1.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
             let out1 = out1.into_iter().map(|v| v.copied()).collect::<Vec<_>>();

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
@@ -10,7 +10,7 @@ pub struct SumWindow<'a, T> {
 impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign>
     RollingAggWindowNoNulls<'a, T> for SumWindow<'a, T>
 {
-    fn new(slice: &'a [T], start: usize, end: usize, _params: DynArgs) -> Self {
+    fn new(slice: &'a [T], start: usize, end: usize, _params: Option<RollingFnParams>) -> Self {
         let sum = slice[start..end].iter().copied().sum::<T>();
         Self {
             slice,
@@ -70,7 +70,7 @@ pub fn rolling_sum<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
 ) -> PolarsResult<ArrayRef>
 where
     T: NativeType

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mean.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mean.rs
@@ -14,7 +14,7 @@ impl<
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        params: DynArgs,
+        params: Option<RollingFnParams>,
     ) -> Self {
         Self {
             sum: SumWindow::new(slice, validity, start, end, params),
@@ -36,7 +36,7 @@ pub fn rolling_mean<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
 ) -> ArrayRef
 where
     T: NativeType

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
@@ -38,7 +38,7 @@ impl<'a, T: NativeType> RollingAggWindowNulls<'a, T> for SortedMinMax<'a, T> {
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        _params: DynArgs,
+        _params: Option<RollingFnParams>,
     ) -> Self {
         let mut out = Self {
             slice,
@@ -258,7 +258,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNulls<'a, T> for 
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        _params: DynArgs,
+        _params: Option<RollingFnParams>,
     ) -> Self {
         Self {
             inner: MinMaxWindow::new(
@@ -287,7 +287,7 @@ pub fn rolling_min<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
 ) -> ArrayRef
 where
     T: NativeType + std::iter::Sum + Zero + AddAssign + Copy + PartialOrd + Bounded + IsFloat,
@@ -326,7 +326,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNulls<'a, T> for 
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        _params: DynArgs,
+        _params: Option<RollingFnParams>,
     ) -> Self {
         Self {
             inner: MinMaxWindow::new(
@@ -355,7 +355,7 @@ pub fn rolling_max<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
 ) -> ArrayRef
 where
     T: NativeType + std::iter::Sum + Zero + AddAssign + Copy + PartialOrd + Bounded + IsFloat,

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
@@ -20,7 +20,7 @@ pub trait RollingAggWindowNulls<'a, T: NativeType> {
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        params: DynArgs,
+        params: Option<RollingFnParams>,
     ) -> Self;
 
     /// # Safety
@@ -37,7 +37,7 @@ pub(super) fn rolling_apply_agg_window<'a, Agg, T, Fo>(
     window_size: usize,
     min_periods: usize,
     det_offsets_fn: Fo,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
 ) -> ArrayRef
 where
     Fo: Fn(Idx, WindowSize, Len) -> (Start, End) + Copy,
@@ -175,7 +175,7 @@ mod test {
 
         assert_eq!(out, &[0.0, 0.0, 2.0, 12.5]);
 
-        let testpars = Some(Arc::new(RollingVarParams { ddof: 0 }) as Arc<dyn Any + Send + Sync>);
+        let testpars = Some(RollingFnParams::Var(RollingVarParams { ddof: 0 }));
         let out = rolling_var(arr, 3, 1, false, None, testpars.clone());
         let out = out.as_any().downcast_ref::<PrimitiveArray<f64>>().unwrap();
         let out = out

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
@@ -40,7 +40,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        _params: DynArgs,
+        _params: Option<RollingFnParams>,
     ) -> Self {
         let mut out = Self {
             slice,
@@ -126,7 +126,7 @@ pub fn rolling_sum<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
 ) -> ArrayRef
 where
     T: NativeType + IsFloat + PartialOrd + Add<Output = T> + Sub<Output = T>,

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
@@ -42,7 +42,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + Mul<Outpu
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        _params: DynArgs,
+        _params: Option<RollingFnParams>,
     ) -> Self {
         let mut out = Self {
             slice,
@@ -153,14 +153,17 @@ impl<
         validity: &'a Bitmap,
         start: usize,
         end: usize,
-        params: DynArgs,
+        params: Option<RollingFnParams>,
     ) -> Self {
         Self {
             mean: MeanWindow::new(slice, validity, start, end, None),
             sum_of_squares: SumSquaredWindow::new(slice, validity, start, end, None),
             ddof: match params {
                 None => 1,
-                Some(pars) => pars.downcast_ref::<RollingVarParams>().unwrap().ddof,
+                Some(pars) => match pars {
+                    RollingFnParams::Var(p) => p.ddof,
+                    _ => unreachable!("expected Var params"),
+                },
             },
         }
     }
@@ -197,7 +200,7 @@ pub fn rolling_var<T>(
     min_periods: usize,
     center: bool,
     weights: Option<&[f64]>,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
 ) -> ArrayRef
 where
     T: NativeType + std::iter::Sum<T> + Zero + AddAssign + SubAssign + IsFloat + Float,

--- a/crates/polars-arrow/src/legacy/prelude.rs
+++ b/crates/polars-arrow/src/legacy/prelude.rs
@@ -3,7 +3,9 @@ pub use crate::legacy::array::default_arrays::*;
 pub use crate::legacy::array::*;
 pub use crate::legacy::index::*;
 pub use crate::legacy::kernels::rolling::no_nulls::QuantileInterpolOptions;
-pub use crate::legacy::kernels::rolling::{DynArgs, RollingQuantileParams, RollingVarParams};
+pub use crate::legacy::kernels::rolling::{
+    RollingFnParams, RollingQuantileParams, RollingVarParams,
+};
 pub use crate::legacy::kernels::{Ambiguous, NonExistent};
 
 pub type LargeStringArray = Utf8Array<i64>;

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -1,9 +1,10 @@
-use arrow::legacy::prelude::DynArgs;
+use arrow::legacy::prelude::RollingFnParams;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "rolling_window", derive(PartialEq))]
 pub struct RollingOptionsFixedWindow {
     /// The length of the window.
     pub window_size: usize,
@@ -14,20 +15,9 @@ pub struct RollingOptionsFixedWindow {
     pub weights: Option<Vec<f64>>,
     /// Set the labels at the center of the window.
     pub center: bool,
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub fn_params: DynArgs,
-}
-
-#[cfg(feature = "rolling_window")]
-impl PartialEq for RollingOptionsFixedWindow {
-    fn eq(&self, other: &Self) -> bool {
-        self.window_size == other.window_size
-            && self.min_periods == other.min_periods
-            && self.weights == other.weights
-            && self.center == other.center
-            && self.fn_params.is_none()
-            && other.fn_params.is_none()
-    }
+    /// Optional parameters for the rolling
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub fn_params: Option<RollingFnParams>,
 }
 
 impl Default for RollingOptionsFixedWindow {

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -65,7 +65,7 @@ pub fn _rolling_apply_agg_window_nulls<'a, Agg, T, O>(
     values: &'a [T],
     validity: &'a Bitmap,
     offsets: O,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
 ) -> PrimitiveArray<T>
 where
     O: Iterator<Item = (IdxSize, IdxSize)> + TrustedLen,
@@ -120,7 +120,7 @@ where
 pub fn _rolling_apply_agg_window_no_nulls<'a, Agg, T, O>(
     values: &'a [T],
     offsets: O,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
 ) -> PrimitiveArray<T>
 where
     // items (offset, len) -> so offsets are offset, offset + len
@@ -388,7 +388,7 @@ where
                     None => _rolling_apply_agg_window_no_nulls::<QuantileWindow<_>, _, _>(
                         values,
                         offset_iter,
-                        Some(Arc::new(RollingQuantileParams {
+                        Some(RollingFnParams::Quantile(RollingQuantileParams {
                             prob: quantile,
                             interpol,
                         })),
@@ -398,7 +398,7 @@ where
                             values,
                             validity,
                             offset_iter,
-                            Some(Arc::new(RollingQuantileParams {
+                            Some(RollingFnParams::Quantile(RollingQuantileParams {
                                 prob: quantile,
                                 interpol,
                             })),
@@ -797,14 +797,14 @@ where
                         None => _rolling_apply_agg_window_no_nulls::<VarWindow<_>, _, _>(
                             values,
                             offset_iter,
-                            Some(Arc::new(RollingVarParams { ddof })),
+                            Some(RollingFnParams::Var(RollingVarParams { ddof })),
                         ),
                         Some(validity) => {
                             _rolling_apply_agg_window_nulls::<rolling::nulls::VarWindow<_>, _, _>(
                                 values,
                                 validity,
                                 offset_iter,
-                                Some(Arc::new(RollingVarParams { ddof })),
+                                Some(RollingFnParams::Var(RollingVarParams { ddof })),
                             )
                         },
                     };
@@ -862,14 +862,14 @@ where
                         None => _rolling_apply_agg_window_no_nulls::<VarWindow<_>, _, _>(
                             values,
                             offset_iter,
-                            Some(Arc::new(RollingVarParams { ddof })),
+                            Some(RollingFnParams::Var(RollingVarParams { ddof })),
                         ),
                         Some(validity) => {
                             _rolling_apply_agg_window_nulls::<rolling::nulls::VarWindow<_>, _, _>(
                                 values,
                                 validity,
                                 offset_iter,
-                                Some(Arc::new(RollingVarParams { ddof })),
+                                Some(RollingFnParams::Var(RollingVarParams { ddof })),
                             )
                         },
                     };

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -3,9 +3,6 @@
 #[cfg(feature = "dtype-categorical")]
 pub mod cat;
 
-#[cfg(any(feature = "rolling_window", feature = "rolling_window_by"))]
-use std::any::Any;
-
 #[cfg(feature = "dtype-categorical")]
 pub use cat::*;
 #[cfg(feature = "rolling_window_by")]
@@ -1359,10 +1356,10 @@ impl Expr {
         quantile: f64,
         mut options: RollingOptionsDynamicWindow,
     ) -> Expr {
-        options.fn_params = Some(Arc::new(RollingQuantileParams {
+        options.fn_params = Some(RollingFnParams::Quantile(RollingQuantileParams {
             prob: quantile,
             interpol,
-        }) as Arc<dyn Any + Send + Sync>);
+        }));
 
         self.finish_rolling_by(by, options, RollingFunctionBy::QuantileBy)
     }
@@ -1435,10 +1432,10 @@ impl Expr {
         quantile: f64,
         mut options: RollingOptionsFixedWindow,
     ) -> Expr {
-        options.fn_params = Some(Arc::new(RollingQuantileParams {
+        options.fn_params = Some(RollingFnParams::Quantile(RollingQuantileParams {
             prob: quantile,
             interpol,
-        }) as Arc<dyn Any + Send + Sync>);
+        }));
 
         self.finish_rolling(options, RollingFunction::Quantile)
     }

--- a/crates/polars-python/src/expr/rolling.rs
+++ b/crates/polars-python/src/expr/rolling.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use polars::prelude::*;
 use pyo3::prelude::*;
 use pyo3::types::PyFloat;
@@ -170,7 +168,7 @@ impl PyExpr {
             weights,
             min_periods,
             center,
-            fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
+            fn_params: Some(RollingFnParams::Var(RollingVarParams { ddof })),
         };
 
         self.inner.clone().rolling_std(options).into()
@@ -189,7 +187,7 @@ impl PyExpr {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
-            fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
+            fn_params: Some(RollingFnParams::Var(RollingVarParams { ddof })),
         };
 
         self.inner.clone().rolling_std_by(by.inner, options).into()
@@ -210,7 +208,7 @@ impl PyExpr {
             weights,
             min_periods,
             center,
-            fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
+            fn_params: Some(RollingFnParams::Var(RollingVarParams { ddof })),
         };
 
         self.inner.clone().rolling_var(options).into()
@@ -229,7 +227,7 @@ impl PyExpr {
             window_size: Duration::parse(window_size),
             min_periods,
             closed_window: closed.0,
-            fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
+            fn_params: Some(RollingFnParams::Var(RollingVarParams { ddof })),
         };
 
         self.inner.clone().rolling_var_by(by.inner, options).into()

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -16,7 +16,7 @@ fn rolling_agg<T>(
         usize,
         bool,
         Option<&[f64]>,
-        DynArgs,
+        Option<RollingFnParams>,
     ) -> PolarsResult<ArrayRef>,
     rolling_agg_fn_nulls: &dyn Fn(
         &PrimitiveArray<T::Native>,
@@ -24,7 +24,7 @@ fn rolling_agg<T>(
         usize,
         bool,
         Option<&[f64]>,
-        DynArgs,
+        Option<RollingFnParams>,
     ) -> ArrayRef,
 ) -> PolarsResult<Series>
 where
@@ -72,7 +72,7 @@ fn rolling_agg_by<T>(
         usize,
         TimeUnit,
         Option<&TimeZone>,
-        DynArgs,
+        Option<RollingFnParams>,
         Option<&[IdxSize]>,
     ) -> PolarsResult<ArrayRef>,
 ) -> PolarsResult<Series>

--- a/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "rolling_window_by", derive(PartialEq))]
 pub struct RollingOptionsDynamicWindow {
     /// The length of the window.
     pub window_size: Duration,
@@ -20,18 +21,7 @@ pub struct RollingOptionsDynamicWindow {
     pub min_periods: usize,
     /// Which side windows should be closed.
     pub closed_window: ClosedWindow,
-    /// Optional parameters for the rolling function
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub fn_params: DynArgs,
-}
-
-#[cfg(feature = "rolling_window_by")]
-impl PartialEq for RollingOptionsDynamicWindow {
-    fn eq(&self, other: &Self) -> bool {
-        self.window_size == other.window_size
-            && self.min_periods == other.min_periods
-            && self.closed_window == other.closed_window
-            && self.fn_params.is_none()
-            && other.fn_params.is_none()
-    }
+    /// Optional parameters for the rolling
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub fn_params: Option<RollingFnParams>,
 }

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -12,7 +12,7 @@ pub(crate) fn rolling_apply_agg_window_sorted<'a, Agg, T, O>(
     values: &'a [T],
     offsets: O,
     min_periods: usize,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
 ) -> PolarsResult<ArrayRef>
 where
     // items (offset, len) -> so offsets are offset, offset + len
@@ -73,7 +73,7 @@ pub(crate) fn rolling_apply_agg_window<'a, Agg, T, O>(
     values: &'a [T],
     offsets: O,
     min_periods: usize,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
     sorting_indices: Option<&[IdxSize]>,
 ) -> PolarsResult<ArrayRef>
 where
@@ -144,7 +144,7 @@ pub(crate) fn rolling_min<T>(
     min_periods: usize,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
     sorting_indices: Option<&[IdxSize]>,
 ) -> PolarsResult<ArrayRef>
 where
@@ -182,7 +182,7 @@ pub(crate) fn rolling_max<T>(
     min_periods: usize,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
     sorting_indices: Option<&[IdxSize]>,
 ) -> PolarsResult<ArrayRef>
 where
@@ -220,7 +220,7 @@ pub(crate) fn rolling_sum<T>(
     min_periods: usize,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
     sorting_indices: Option<&[IdxSize]>,
 ) -> PolarsResult<ArrayRef>
 where
@@ -258,7 +258,7 @@ pub(crate) fn rolling_mean<T>(
     min_periods: usize,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    _params: DynArgs,
+    _params: Option<RollingFnParams>,
     sorting_indices: Option<&[IdxSize]>,
 ) -> PolarsResult<ArrayRef>
 where
@@ -296,7 +296,7 @@ pub(crate) fn rolling_var<T>(
     min_periods: usize,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
     sorting_indices: Option<&[IdxSize]>,
 ) -> PolarsResult<ArrayRef>
 where
@@ -334,7 +334,7 @@ pub(crate) fn rolling_quantile<T>(
     min_periods: usize,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    params: DynArgs,
+    params: Option<RollingFnParams>,
     sorting_indices: Option<&[IdxSize]>,
 ) -> PolarsResult<ArrayRef>
 where

--- a/py-polars/tests/unit/expr/test_serde.py
+++ b/py-polars/tests/unit/expr/test_serde.py
@@ -6,14 +6,33 @@ import polars as pl
 from polars.exceptions import ComputeError
 
 
-def test_expr_serde_roundtrip_binary() -> None:
-    expr = pl.col("foo").sum().over("bar")
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col("foo").sum().over("bar"),
+        pl.col("foo").rolling_quantile(0.25, window_size=5),
+        pl.col("foo").rolling_var(window_size=4, ddof=2),
+        pl.col("foo").rolling_min(window_size=2),
+        pl.col("foo").rolling_quantile_by("bar", window_size="1mo", quantile=0.75),
+    ],
+)
+def test_expr_serde_roundtrip_binary(expr: pl.Expr) -> None:
     json = expr.meta.serialize(format="binary")
     round_tripped = pl.Expr.deserialize(io.BytesIO(json), format="binary")
     assert round_tripped.meta == expr
 
 
-def test_expr_serde_roundtrip_json() -> None:
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pl.col("foo").sum().over("bar"),
+        pl.col("foo").rolling_quantile(0.25, window_size=5),
+        pl.col("foo").rolling_var(window_size=4, ddof=2),
+        pl.col("foo").rolling_min(window_size=2),
+        pl.col("foo").rolling_quantile_by("bar", window_size="1mo", quantile=0.75),
+    ],
+)
+def test_expr_serde_roundtrip_json(expr: pl.Expr) -> None:
     expr = pl.col("foo").sum().over("bar")
     json = expr.meta.serialize(format="json")
     round_tripped = pl.Expr.deserialize(io.StringIO(json), format="json")


### PR DESCRIPTION
This PR presents one way to fix #18595.

Information present in `DynArgs` was being lost after a serialization/deserialization roundtrip, so I had to implement `Serialize` and `Deserialize` in order to handle them.

This is my first contribution so I'm pretty excited about that!