### PR TITLE
docs(python): Fix literal type mapping example in `lit` docstrings

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -42,11 +42,11 @@ def lit(
     -----
     Expected datatypes:
 
-    - `pl.lit([])` -> empty  Series Float32
-    - `pl.lit([1, 2, 3])` -> Series Int64
-    - `pl.lit([[]])`-> empty  Series List<Null>
-    - `pl.lit([[1, 2, 3]])` -> Series List<i64>
-    - `pl.lit(None)` -> Series Null
+    - `pl.lit([])` -> empty List<Null>
+    - `pl.lit([1, 2, 3])` -> List<i64>
+    - `pl.lit(pl.Series([]))`-> empty Series Null
+    - `pl.lit(pl.Series([1, 2, 3]))` -> Series Int64
+    - `pl.lit(None)` -> Null
 
     Examples
     --------


### PR DESCRIPTION
They seem to have been wrong for a long time.