### PR TITLE
docs(python): Clarify documentation for `schema` in `read_csv` function

### DIFF
--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -111,7 +111,8 @@ def read_csv(
     schema
         Provide the schema. This means that polars doesn't do schema inference.
         This argument expects the complete schema, whereas `schema_overrides` can be
-        used to partially overwrite a schema.
+        used to partially overwrite a schema. Note that the order of the columns in
+        the provided `schema` must match the order of the columns in the CSV being read.
     schema_overrides
         Overwrite dtypes for specific or all columns during schema inference.
     null_values


### PR DESCRIPTION
The `read_csv` function expects that the order of the columns in a provided schema match the order of the columns in the CSV file being read. This was not documented and led to unexpected behavior. Since `dict` types do not guarantee the ordering of their keys this requirement was surprising to me. 

[This](https://github.com/pola-rs/polars/issues/15854) issue discusses the fact that this happens but no fix has been implemented. Improving the documentation is quick and will enable users from experiencing the issue if they are willing to read.

```python
from io import StringIO

import polars as pl

csv = """A,B
1,"foo"
3,"bar"
"""

buf = StringIO(csv)

# Works fine
schema_good = {"A": pl.Int64, "B": pl.String}
pl.read_csv(buf, schema=schema_good)

# Raises ComputeError
buf.seek(0)
schema_bad = {"B": pl.String, "A": pl.Int64}
pl.read_csv(buf, schema=schema_bad)
```