### PR TITLE
docs(python): Add documentation for beta gpu support

### DIFF
--- a/docs/_build/API_REFERENCE_LINKS.yml
+++ b/docs/_build/API_REFERENCE_LINKS.yml
@@ -3,6 +3,8 @@ python:
   LazyFrame: https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html
   Series: https://docs.pola.rs/api/python/stable/reference/series/index.html
   Categorical: https://docs.pola.rs/api/python/stable/reference/api/polars.Categorical.html
+  GPUEngine: https://docs.pola.rs/api/python/stable/lazyframe/api/polars.lazyframe.engine_config.GPUEngine.html
+  Config: https://docs.pola.rs/api/python/stable/reference/config.html
   select: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.select.html
   filter: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.filter.html
   with_columns: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.with_columns.html

--- a/docs/_build/scripts/macro.py
+++ b/docs/_build/scripts/macro.py
@@ -132,6 +132,23 @@ def code_tab(
 
 def define_env(env):
     @env.macro
+    def code_header(language: str, section: str = [], api_functions: List[str] = []) -> str:
+        language_info = LANGUAGES[language]
+
+        language = language_info["code_name"]
+
+        # Create feature flags
+        feature_flags_links = create_feature_flag_links(language, api_functions)
+
+        # Create API Links if they are defined in the YAML
+        api_functions = [
+            link for f in api_functions if (link := create_api_function_link(language, f))
+        ]
+        language_headers = " ·".join(api_functions + feature_flags_links)
+        return f"""=== \":fontawesome-brands-{language_info['icon_name']}: {language_info['display_name']}\"
+    {language_headers}"""
+
+    @env.macro
     def code_block(
         path: str, section: str = None, api_functions: List[str] = None
     ) -> str:

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Polars is a blazingly fast DataFrame library for manipulating structured data. T
 - **Out of Core**: The streaming API allows you to process your results without requiring all your data to be in memory at the same time
 - **Parallel**: Utilises the power of your machine by dividing the workload among the available CPU cores without any additional configuration.
 - **Vectorized Query Engine**: Using [Apache Arrow](https://arrow.apache.org/), a columnar data format, to process your queries in a vectorized manner and SIMD to optimize CPU usage.
+- **GPU Support**: Optionally run queries on NVIDIA GPUs for maximum performance for in-memory workloads.
 
 <!-- dprint-ignore-start -->
 

--- a/docs/src/python/user-guide/lazy/gpu.py
+++ b/docs/src/python/user-guide/lazy/gpu.py
@@ -60,7 +60,3 @@ print("# some details elided")
 print()
 print(q.collect())
 # --8<- [end:fallback-result]
-
-# --8<-- [start:fallback-raise]
-q.collect(engine=pl.GPUEngine(raise_on_fail=True))
-# --8<-- [end:fallback-raise]

--- a/docs/src/python/user-guide/lazy/gpu.py
+++ b/docs/src/python/user-guide/lazy/gpu.py
@@ -1,15 +1,10 @@
 # --8<-- [start:setup]
-# --8<-- [start:simple]
 import polars as pl
 
 df = pl.LazyFrame({"a": [1.242, 1.535]})
 
 q = df.select(pl.col("a").round(1))
 # --8<-- [end:setup]
-
-result = q.collect(engine="gpu")
-print(result)
-# --8<-- [end:simple]
 
 # Avoiding requiring the GPU engine for doc build output
 # --8<-- [start:simple-result]
@@ -18,21 +13,16 @@ print(result)
 # --8<-- [end:simple-result]
 
 
-# --8<-- [start:engine]
 # --8<-- [start:engine-setup]
 q = df.select((pl.col("a") ** 4))
 
 # --8<-- [end:engine-setup]
-result = q.collect(engine=pl.GPUEngine(device=1))
-print(result)
-# --8<-- [end:engine]
 
 # --8<-- [start:engine-result]
 result = q.collect()
 print(result)
 # --8<-- [end:engine-result]
 
-# --8<-- [start:fallback-warning]
 # --8<-- [start:fallback-setup]
 df = pl.LazyFrame(
     {
@@ -45,12 +35,6 @@ q = df.select(pl.col("value").sum().over("key"))
 
 # --8<-- [end:fallback-setup]
 
-with pl.Config() as cfg:
-    cfg.set_verbose(True)
-    result = q.collect(engine="gpu")
-
-print(result)
-# --8<-- [end:fallback-warning]
 # --8<-- [start:fallback-result]
 print(
     "PerformanceWarning: Query execution with GPU not supported, reason: \n"

--- a/docs/src/python/user-guide/lazy/gpu.py
+++ b/docs/src/python/user-guide/lazy/gpu.py
@@ -1,0 +1,66 @@
+# --8<-- [start:setup]
+# --8<-- [start:simple]
+import polars as pl
+
+df = pl.LazyFrame({"a": [1.242, 1.535]})
+
+q = df.select(pl.col("a").round(1))
+# --8<-- [end:setup]
+
+result = q.collect(engine="gpu")
+print(result)
+# --8<-- [end:simple]
+
+# Avoiding requiring the GPU engine for doc build output
+# --8<-- [start:simple-result]
+result = q.collect()
+print(result)
+# --8<-- [end:simple-result]
+
+
+# --8<-- [start:engine]
+# --8<-- [start:engine-setup]
+q = df.select((pl.col("a") ** 4))
+
+# --8<-- [end:engine-setup]
+result = q.collect(engine=pl.GPUEngine(device=1))
+print(result)
+# --8<-- [end:engine]
+
+# --8<-- [start:engine-result]
+result = q.collect()
+print(result)
+# --8<-- [end:engine-result]
+
+# --8<-- [start:fallback-warning]
+# --8<-- [start:fallback-setup]
+df = pl.LazyFrame(
+    {
+        "key": [1, 1, 1, 2, 3, 3, 2, 2],
+        "value": [1, 2, 3, 4, 5, 6, 7, 8],
+    }
+)
+
+q = df.select(pl.col("value").sum().over("key"))
+
+# --8<-- [end:fallback-setup]
+
+with pl.Config() as cfg:
+    cfg.set_verbose(True)
+    result = q.collect(engine="gpu")
+
+print(result)
+# --8<-- [end:fallback-warning]
+# --8<-- [start:fallback-result]
+print(
+    "PerformanceWarning: Query execution with GPU not supported, reason: \n"
+    "<class 'NotImplementedError'>: Grouped rolling window not implemented"
+)
+print("# some details elided")
+print()
+print(q.collect())
+# --8<- [end:fallback-result]
+
+# --8<-- [start:fallback-raise]
+q.collect(engine=pl.GPUEngine(raise_on_fail=True))
+# --8<-- [end:fallback-raise]

--- a/docs/user-guide/gpu-support.md
+++ b/docs/user-guide/gpu-support.md
@@ -1,0 +1,132 @@
+# GPU Support [Open Beta]
+
+Polars provides an in-memory, GPU-accelerated execution engine for Python users of the Lazy API on NVIDIA GPUs using [RAPIDS cuDF](https://docs.rapids.ai/api/cudf/stable/). This functionality is available in Open Beta and is undergoing rapid development.
+
+### System Requirements
+- NVIDIA Volta™ or higher GPU with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
+- CUDA 11 or CUDA 12
+- Linux or Windows Subsystem for Linux 2 (WSL2)
+
+See the [RAPIDS installation guide](https://docs.rapids.ai/install#system-req) for full details.
+
+### Installation
+You can install the GPU backend for Polars with a feature flag as part of a normal [installation](installation.md).
+
+=== ":fontawesome-brands-python: Python"
+    ```bash
+    pip install --extra-index-url=https://pypi.nvidia.com polars[gpu]
+    ```
+
+
+!!! note Installation on a CUDA 11 system
+
+    If you have CUDA 11, the installation line is slightly more complicated: the relevant GPU package must be requested by hand.
+
+    === ":fontawesome-brands-python: Python"
+    ```bash
+    pip install --extra-index-url=https://pypi.nvidia.com polars cudf-polars-cu11
+    ```
+
+### Usage
+
+Having built a query using the lazy API [as normal](lazy/index.md), GPU-enabled execution is requested by running `.collect(engine="gpu")` instead of `.collect()`.
+
+{{code_block('user-guide/lazy/gpu', 'simple', ['collect'])}}
+```python exec="on" result="text" session="user-guide/lazy"
+--8<-- "python/user-guide/lazy/gpu.py:setup"
+--8<-- "python/user-guide/lazy/gpu.py:simple-result"
+```
+
+For more detailed control over the execution, for example to specify which GPU to use on a multi-GPU node, we can provide a `GPUEngine` object. By default, the GPU engine will use a configuration applicable to most use cases. 
+
+{{code_block('user-guide/lazy/gpu', 'engine', ['GPUEngine'])}}
+```python exec="on" result="text" session="user-guide/lazy"
+--8<-- "python/user-guide/lazy/gpu.py:engine-setup"
+--8<-- "python/user-guide/lazy/gpu.py:engine-result"
+```
+
+### How It Works
+
+When you use the GPU-accelerated engine, Polars creates and optimizes a query plan and dispatches to a [RAPIDS](https://rapids.ai/) cuDF-based physical execution engine to compute the results on NVIDIA GPUs. The final result is returned as a normal CPU-backed Polars dataframe.
+
+### What's Supported on the GPU?
+
+GPU support is currently in Open Beta and the engine is undergoing rapid development. The engine currently supports many, but not all, of the core expressions and data types.
+
+Since expressions are composable, it's not feasible to list a full matrix of expressions supported on the GPU. Instead, we provide a list of the high-level categories of expressions and interfaces that are currently supported and not supported.
+
+#### Supported
+
+- LazyFrame API
+- SQL API
+- I/O from CSV, Parquet, ndjson, and in-memory CPU DataFrames.
+- Operations on numeric, logical, string, and datetime types
+- String processing
+- Aggregations and grouped aggregations
+- Joins
+- Filters
+- Missing data
+- Concatenation
+
+#### Not Supported
+
+- Eager DataFrame API
+- Streaming API
+- Operations on categorical, struct, and list data types
+- Rolling aggregations
+- Time series resampling
+- Timezones
+- Folds
+- User-defined functions
+- JSON, Excel, and Database file formats
+
+#### Did my query use the GPU?
+
+The release of the GPU engine in Open Beta implies that we expect things to work well, but there are still some rough edges we're working on. In particular the full breadth of the Polars expression API is not yet supported. With fallback to the CPU, your query _should_ complete, but you might not observe any change in the time it takes to execute. There are two ways to get more information on whether the query ran on the GPU.
+
+When running in verbose mode, any queries that cannot execute on the GPU will issue a `PerformanceWarning`:
+
+{{code_block('user-guide/lazy/gpu', 'fallback-warning', ['Config'])}}
+```python exec="on" result="text" session="user-guide/lazy"
+--8<-- "python/user-guide/lazy/gpu.py:fallback-setup"
+--8<-- "python/user-guide/lazy/gpu.py:fallback-result"
+```
+
+To disable fallback, and have the GPU engine raise an exception if a query is unsupported, we can pass an appropriately configured `GPUEngine` object:
+
+{{code_block('user-guide/lazy/gpu', 'fallback-raise', ['GPUEngine'])}}
+```pytb
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/home/coder/third-party/polars/py-polars/polars/lazyframe/frame.py", line 2035, in collect
+    return wrap_df(ldf.collect(callback))
+polars.exceptions.ComputeError: 'cuda' conversion failed: NotImplementedError: Grouped rolling window not implemented
+```
+
+Currently, only the proximal cause of failure to execute on the GPU is reported, we plan to extend this functionality to report all unsupported operations for a query.
+
+### Testing
+
+The Polars and NVIDIA RAPIDS teams run comprehensive unit and integration tests to ensure that the GPU-accelerated Polars backend works smoothly.
+
+The **full** Polars test suite is run on every commit made to the GPU engine, ensuring consistency of results.
+
+The GPU engine currently passes 99.2% of the Polars unit tests with CPU fallback enabled. Without CPU fallback, the GPU engine passes 88.8% of the Polars unit tests. With fallback, there are approximately 100 failing tests: around 40 of these fail due to mismatching debug output; there are some cases where the GPU engine produces the a correct result but uses a different data type; the remainder are cases where we do not correctly determine that a query is unsupported and therefore fail at runtime, instead of falling back.
+
+
+### When Should I Use a GPU?
+
+Based on our benchmarking, you're most likely to observe speedups using the GPU engine when your workflow's profile is dominated by grouped aggregations and joins. In contrast I/O bound queries typically show similar performance on GPU and CPU. GPUs typically have less RAM than CPU systems, therefore very large datasets will fail due to out of memory errors. Based on our testing, raw datasets of 50-100 GiB fit (depending on the workflow) well with a GPU with 80GiB of memory.
+
+### CPU-GPU Interoperability
+
+Both the CPU and GPU engine use the Apache Arrow columnar memory specification, making it possible to quickly move data between the CPU and GPU. Additionally, files written by one engine can be read by the other engine.
+
+When using GPU mode, your workflow won't fail if something isn't supported. When you run `collect(engine="gpu")`, the optimized query plan is inspected to see whether it can be executed on the GPU. If it can't, it will transparently fall back to the standard Polars engine and run on the CPU.
+
+GPU execution is only available in the Lazy API, so materialized DataFrames will reside in CPU memory when the query execution finishes.
+
+### Providing feedback
+
+Please report issues, and missing features, on the Polars [issue tracker](../development/contributing/index.md).
+

--- a/docs/user-guide/gpu-support.md
+++ b/docs/user-guide/gpu-support.md
@@ -3,6 +3,7 @@
 Polars provides an in-memory, GPU-accelerated execution engine for Python users of the Lazy API on NVIDIA GPUs using [RAPIDS cuDF](https://docs.rapids.ai/api/cudf/stable/). This functionality is available in Open Beta and is undergoing rapid development.
 
 ### System Requirements
+
 - NVIDIA Volta™ or higher GPU with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
 - CUDA 11 or CUDA 12
 - Linux or Windows Subsystem for Linux 2 (WSL2)
@@ -10,13 +11,11 @@ Polars provides an in-memory, GPU-accelerated execution engine for Python users 
 See the [RAPIDS installation guide](https://docs.rapids.ai/install#system-req) for full details.
 
 ### Installation
+
 You can install the GPU backend for Polars with a feature flag as part of a normal [installation](installation.md).
 
 === ":fontawesome-brands-python: Python"
-    ```bash
-    pip install --extra-index-url=https://pypi.nvidia.com polars[gpu]
-    ```
-
+`bash pip install --extra-index-url=https://pypi.nvidia.com polars[gpu]`
 
 !!! note Installation on a CUDA 11 system
 
@@ -32,14 +31,16 @@ You can install the GPU backend for Polars with a feature flag as part of a norm
 Having built a query using the lazy API [as normal](lazy/index.md), GPU-enabled execution is requested by running `.collect(engine="gpu")` instead of `.collect()`.
 
 {{code_block('user-guide/lazy/gpu', 'simple', ['collect'])}}
+
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:setup"
 --8<-- "python/user-guide/lazy/gpu.py:simple-result"
 ```
 
-For more detailed control over the execution, for example to specify which GPU to use on a multi-GPU node, we can provide a `GPUEngine` object. By default, the GPU engine will use a configuration applicable to most use cases. 
+For more detailed control over the execution, for example to specify which GPU to use on a multi-GPU node, we can provide a `GPUEngine` object. By default, the GPU engine will use a configuration applicable to most use cases.
 
 {{code_block('user-guide/lazy/gpu', 'engine', ['GPUEngine'])}}
+
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:engine-setup"
 --8<-- "python/user-guide/lazy/gpu.py:engine-result"
@@ -87,6 +88,7 @@ The release of the GPU engine in Open Beta implies that we expect things to work
 When running in verbose mode, any queries that cannot execute on the GPU will issue a `PerformanceWarning`:
 
 {{code_block('user-guide/lazy/gpu', 'fallback-warning', ['Config'])}}
+
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:fallback-setup"
 --8<-- "python/user-guide/lazy/gpu.py:fallback-result"
@@ -95,6 +97,7 @@ When running in verbose mode, any queries that cannot execute on the GPU will is
 To disable fallback, and have the GPU engine raise an exception if a query is unsupported, we can pass an appropriately configured `GPUEngine` object:
 
 {{code_block('user-guide/lazy/gpu', 'fallback-raise', ['GPUEngine'])}}
+
 ```pytb
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
@@ -113,7 +116,6 @@ The **full** Polars test suite is run on every commit made to the GPU engine, en
 
 The GPU engine currently passes 99.2% of the Polars unit tests with CPU fallback enabled. Without CPU fallback, the GPU engine passes 88.8% of the Polars unit tests. With fallback, there are approximately 100 failing tests: around 40 of these fail due to mismatching debug output; there are some cases where the GPU engine produces the a correct result but uses a different data type; the remainder are cases where we do not correctly determine that a query is unsupported and therefore fail at runtime, instead of falling back.
 
-
 ### When Should I Use a GPU?
 
 Based on our benchmarking, you're most likely to observe speedups using the GPU engine when your workflow's profile is dominated by grouped aggregations and joins. In contrast I/O bound queries typically show similar performance on GPU and CPU. GPUs typically have less RAM than CPU systems, therefore very large datasets will fail due to out of memory errors. Based on our testing, raw datasets of 50-100 GiB fit (depending on the workflow) well with a GPU with 80GiB of memory.
@@ -129,4 +131,3 @@ GPU execution is only available in the Lazy API, so materialized DataFrames will
 ### Providing feedback
 
 Please report issues, and missing features, on the Polars [issue tracker](../development/contributing/index.md).
-

--- a/docs/user-guide/gpu-support.md
+++ b/docs/user-guide/gpu-support.md
@@ -30,7 +30,13 @@ You can install the GPU backend for Polars with a feature flag as part of a norm
 
 Having built a query using the lazy API [as normal](lazy/index.md), GPU-enabled execution is requested by running `.collect(engine="gpu")` instead of `.collect()`.
 
-{{code_block('user-guide/lazy/gpu', 'simple', ['collect'])}}
+{{ code_header("python", [], []) }}
+```python
+--8<-- "python/user-guide/lazy/gpu.py:setup"
+
+result = q.collect(engine="gpu")
+print(result)
+```
 
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:setup"
@@ -39,7 +45,12 @@ Having built a query using the lazy API [as normal](lazy/index.md), GPU-enabled 
 
 For more detailed control over the execution, for example to specify which GPU to use on a multi-GPU node, we can provide a `GPUEngine` object. By default, the GPU engine will use a configuration applicable to most use cases.
 
-{{code_block('user-guide/lazy/gpu', 'engine', ['GPUEngine'])}}
+{{ code_header("python", [], []) }}
+```python
+--8<-- "python/user-guide/lazy/gpu.py:engine-setup"
+result = q.collect(engine=pl.GPUEngine(device=1))
+print(result)
+```
 
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:engine-setup"
@@ -87,16 +98,32 @@ The release of the GPU engine in Open Beta implies that we expect things to work
 
 When running in verbose mode, any queries that cannot execute on the GPU will issue a `PerformanceWarning`:
 
-{{code_block('user-guide/lazy/gpu', 'fallback-warning', ['Config'])}}
+{{ code_header("python", [], []) }}
+```python
+--8<-- "python/user-guide/lazy/gpu.py:fallback-setup"
+
+with pl.Config() as cfg:
+    cfg.set_verbose(True)
+    result = q.collect(engine="gpu")
+
+print(result)
+```
 
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:fallback-setup"
---8<-- "python/user-guide/lazy/gpu.py:fallback-result"
+print(
+    "PerformanceWarning: Query execution with GPU not supported, reason: \n"
+    "<class 'NotImplementedError'>: Grouped rolling window not implemented"
+)
+print("# some details elided")
+print()
+print(q.collect())
 ```
 
 To disable fallback, and have the GPU engine raise an exception if a query is unsupported, we can pass an appropriately configured `GPUEngine` object:
 
-```python exec="on" result="text" session="user-guide/lazy"
+{{ code_header("python", [], []) }}
+```python
 q.collect(engine=pl.GPUEngine(raise_on_fail=True))
 ```
 

--- a/docs/user-guide/gpu-support.md
+++ b/docs/user-guide/gpu-support.md
@@ -31,6 +31,7 @@ You can install the GPU backend for Polars with a feature flag as part of a norm
 Having built a query using the lazy API [as normal](lazy/index.md), GPU-enabled execution is requested by running `.collect(engine="gpu")` instead of `.collect()`.
 
 {{ code_header("python", [], []) }}
+
 ```python
 --8<-- "python/user-guide/lazy/gpu.py:setup"
 
@@ -46,6 +47,7 @@ print(result)
 For more detailed control over the execution, for example to specify which GPU to use on a multi-GPU node, we can provide a `GPUEngine` object. By default, the GPU engine will use a configuration applicable to most use cases.
 
 {{ code_header("python", [], []) }}
+
 ```python
 --8<-- "python/user-guide/lazy/gpu.py:engine-setup"
 result = q.collect(engine=pl.GPUEngine(device=1))
@@ -99,6 +101,7 @@ The release of the GPU engine in Open Beta implies that we expect things to work
 When running in verbose mode, any queries that cannot execute on the GPU will issue a `PerformanceWarning`:
 
 {{ code_header("python", [], []) }}
+
 ```python
 --8<-- "python/user-guide/lazy/gpu.py:fallback-setup"
 
@@ -123,6 +126,7 @@ print(q.collect())
 To disable fallback, and have the GPU engine raise an exception if a query is unsupported, we can pass an appropriately configured `GPUEngine` object:
 
 {{ code_header("python", [], []) }}
+
 ```python
 q.collect(engine=pl.GPUEngine(raise_on_fail=True))
 ```

--- a/docs/user-guide/gpu-support.md
+++ b/docs/user-guide/gpu-support.md
@@ -96,7 +96,9 @@ When running in verbose mode, any queries that cannot execute on the GPU will is
 
 To disable fallback, and have the GPU engine raise an exception if a query is unsupported, we can pass an appropriately configured `GPUEngine` object:
 
-{{code_block('user-guide/lazy/gpu', 'fallback-raise', ['GPUEngine'])}}
+```python exec="on" result="text" session="user-guide/lazy"
+q.collect(engine=pl.GPUEngine(raise_on_fail=True))
+```
 
 ```pytb
 Traceback (most recent call last):

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -90,9 +90,9 @@ pip install 'polars[numpy,fsspec]'
 
 #### GPU
 
-| Tag | Description                       |
-| --- | --------------------------------- |
-| gpu | Run queries on NVIDIA GPUs        |
+| Tag | Description                |
+| --- | -------------------------- |
+| gpu | Run queries on NVIDIA GPUs |
 
 !!! note
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -88,6 +88,19 @@ pip install 'polars[numpy,fsspec]'
 | --- | --------------------------------- |
 | all | Install all optional dependencies |
 
+#### GPU
+
+| Tag | Description                       |
+| --- | --------------------------------- |
+| gpu | Run queries on NVIDIA GPUs        |
+
+!!! note
+
+    To install the GPU engine, you need to pass
+    `--extra-index-url=https://pypi.nvidia.com` to `pip`. See [GPU
+    support](gpu-support.md) for more detailed instructions and
+    prerequisites.
+
 #### Interop
 
 | Tag      | Description                                       |

--- a/docs/user-guide/lazy/gpu.md
+++ b/docs/user-guide/lazy/gpu.md
@@ -4,7 +4,13 @@ Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API 
 
 If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based execution by running `.collect(engine="gpu")` instead of `.collect()`.
 
-{{code_block('user-guide/lazy/gpu', 'simple', [])}}
+{{ code_header("python", [], []) }}
+```python
+--8<-- "python/user-guide/lazy/gpu.py:setup"
+
+result = q.collect(engine="gpu")
+print(result)
+```
 
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:setup"

--- a/docs/user-guide/lazy/gpu.md
+++ b/docs/user-guide/lazy/gpu.md
@@ -1,0 +1,14 @@
+# GPU Support
+
+Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API in Python using [RAPIDS cuDF](https://docs.rapids.ai/api/cudf/stable/) on NVIDIA GPUs. This functionality is available in Open Beta and is undergoing rapid development.
+
+If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based execution by running `.collect(engine="gpu")` instead of `.collect()`.
+
+
+{{code_block('user-guide/lazy/gpu', 'simple', [])}}
+```python exec="on" result="text" session="user-guide/lazy"
+--8<-- "python/user-guide/lazy/gpu.py:setup"
+--8<-- "python/user-guide/lazy/gpu.py:simple-result"
+```
+
+Learn more in the [GPU Support guide](../gpu-support.md).

--- a/docs/user-guide/lazy/gpu.md
+++ b/docs/user-guide/lazy/gpu.md
@@ -4,8 +4,8 @@ Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API 
 
 If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based execution by running `.collect(engine="gpu")` instead of `.collect()`.
 
-
 {{code_block('user-guide/lazy/gpu', 'simple', [])}}
+
 ```python exec="on" result="text" session="user-guide/lazy"
 --8<-- "python/user-guide/lazy/gpu.py:setup"
 --8<-- "python/user-guide/lazy/gpu.py:simple-result"

--- a/docs/user-guide/lazy/gpu.md
+++ b/docs/user-guide/lazy/gpu.md
@@ -5,6 +5,7 @@ Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API 
 If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based execution by running `.collect(engine="gpu")` instead of `.collect()`.
 
 {{ code_header("python", [], []) }}
+
 ```python
 --8<-- "python/user-guide/lazy/gpu.py:setup"
 

--- a/docs/user-guide/lazy/index.md
+++ b/docs/user-guide/lazy/index.md
@@ -8,3 +8,4 @@ The Lazy chapter is a guide for working with `LazyFrames`. It covers the functio
 - [Query plan](query-plan.md)
 - [Execution](execution.md)
 - [Streaming](streaming.md)
+- [GPU Support](gpu.md)

--- a/docs/user-guide/misc/multiprocessing.md
+++ b/docs/user-guide/misc/multiprocessing.md
@@ -56,7 +56,6 @@ Consider the example below, which is a slightly modified example posted on the [
 {{code_block('user-guide/misc/multiprocess','example1',[])}}
 
 Using `fork` as the method, instead of `spawn`, will cause a dead lock.
-Please note: Polars will not even start and raise the error on multiprocessing method being set wrong, but if the check had not been there, the deadlock would exist.
 
 The fork method is equivalent to calling `os.fork()`, which is a system call as defined in [the POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html):
 

--- a/docs/user-guide/misc/multiprocessing.md
+++ b/docs/user-guide/misc/multiprocessing.md
@@ -11,12 +11,10 @@ It does this by executing computations which can be done in parallel in separate
 For example, requesting two expressions in a `select` statement can be done in parallel, with the results only being combined at the end.
 Another example is aggregating a value within groups using `group_by().agg(<expr>)`, each group can be evaluated separately.
 It is very unlikely that the `multiprocessing` module can improve your code performance in these cases.
-If you're using the GPU Engine with Polars you should also avoid manual multiprocessing. When used simultaneously, they can compete 
+If you're using the GPU Engine with Polars you should also avoid manual multiprocessing. When used simultaneously, they can compete
 for system memory and processing power, leading to reduced performance.
 
-
 See [the optimizations section](../lazy/optimizations.md) for more optimizations.
-
 
 ## When to use multiprocessing
 

--- a/docs/user-guide/misc/multiprocessing.md
+++ b/docs/user-guide/misc/multiprocessing.md
@@ -11,8 +11,12 @@ It does this by executing computations which can be done in parallel in separate
 For example, requesting two expressions in a `select` statement can be done in parallel, with the results only being combined at the end.
 Another example is aggregating a value within groups using `group_by().agg(<expr>)`, each group can be evaluated separately.
 It is very unlikely that the `multiprocessing` module can improve your code performance in these cases.
+If you're using the GPU Engine with Polars you should also avoid manual multiprocessing. When used simultaneously, they can compete 
+for system memory and processing power, leading to reduced performance.
+
 
 See [the optimizations section](../lazy/optimizations.md) for more optimizations.
+
 
 ## When to use multiprocessing
 
@@ -52,6 +56,7 @@ Consider the example below, which is a slightly modified example posted on the [
 {{code_block('user-guide/misc/multiprocess','example1',[])}}
 
 Using `fork` as the method, instead of `spawn`, will cause a dead lock.
+Please note: Polars will not even start and raise the error on multiprocessing method being set wrong, but if the check had not been there, the deadlock would exist.
 
 The fork method is equivalent to calling `os.fork()`, which is a system call as defined in [the POSIX standard](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fork.html):
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - user-guide/lazy/query-plan.md
       - user-guide/lazy/execution.md
       - user-guide/lazy/streaming.md
+      - user-guide/lazy/gpu.md
     - IO:
       - user-guide/io/index.md
       - user-guide/io/csv.md
@@ -86,6 +87,7 @@ nav:
       - user-guide/misc/styling.md
       - user-guide/misc/comparison.md
       - user-guide/misc/arrow.md
+    - user-guide/gpu-support.md
 
   - API reference: api/index.md
 

--- a/py-polars/docs/source/reference/lazyframe/gpu_engine.rst
+++ b/py-polars/docs/source/reference/lazyframe/gpu_engine.rst
@@ -1,0 +1,14 @@
+=========
+GPUEngine
+=========
+
+This object provides fine-grained control over the behavior of the
+GPU engine when calling `LazyFrame.collect()` with an `engine`
+argument.
+
+.. currentmodule:: polars.lazyframe.engine_config
+
+.. autosummary::
+   :toctree: api/
+
+    GPUEngine

--- a/py-polars/docs/source/reference/lazyframe/index.rst
+++ b/py-polars/docs/source/reference/lazyframe/index.rst
@@ -15,6 +15,7 @@ This page gives an overview of all public LazyFrame methods.
    modify_select
    miscellaneous
    in_process
+   gpu_engine
 
 .. _lazyframe:
 

--- a/py-polars/polars/lazyframe/engine_config.py
+++ b/py-polars/polars/lazyframe/engine_config.py
@@ -40,8 +40,8 @@ class GPUEngine:
     """Memory resource to use for device allocations."""
     raise_on_fail: bool
     """
-    Should unsupported queries raise an error, rather than falling
-    back to the CPU engine?
+    Whether unsupported queries should raise an error, rather than falling
+    back to the CPU engine.
     """
     config: Mapping[str, Any]
     """Additional configuration options for the engine."""

--- a/py-polars/polars/lazyframe/engine_config.py
+++ b/py-polars/polars/lazyframe/engine_config.py
@@ -14,17 +14,35 @@ class GPUEngine:
 
     Use this if you want control over details of the execution.
 
-    Supported options
+    Parameters
+    ----------
+    device : int, default None
+        Select the GPU used to run the query. If not provided, the
+        query uses the current CUDA device.
+    memory_resource : rmm.mr.DeviceMemoryResource, default None
+        Provide a memory resource for GPU memory allocations.
 
-    - `device`: Select the device to run the query on.
-    - `memory_resource`: Set an RMM memory resource for
-      device-side allocations.
+        .. warning::
+           If passing a `memory_resource`, you must ensure that it is valid
+           for the selected `device`. See the `RMM documentation
+           <https://github.com/rapidsai/rmm?tab=readme-ov-file#multiple-devices>`_
+           for more details.
+
+    raise_on_fail : bool, default False
+        If True, do not fall back to the Polars CPU engine if the GPU
+        engine cannot execute the query, but instead raise an error.
+
     """
 
     device: int | None
     """Device on which to run query."""
     memory_resource: DeviceMemoryResource | None
     """Memory resource to use for device allocations."""
+    raise_on_fail: bool
+    """
+    Should unsupported queries raise an error, rather than falling
+    back to the CPU engine?
+    """
     config: Mapping[str, Any]
     """Additional configuration options for the engine."""
 
@@ -33,8 +51,11 @@ class GPUEngine:
         *,
         device: int | None = None,
         memory_resource: Any | None = None,
+        raise_on_fail: bool = False,
         **kwargs: Any,
     ) -> None:
         self.device = device
         self.memory_resource = memory_resource
+        # Avoids need for changes in cudf-polars
+        kwargs["raise_on_fail"] = raise_on_fail
         self.config = kwargs

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1865,7 +1865,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             polars CPU engine. If set to `"gpu"`, the GPU engine is
             used. Fine-grained control over the GPU engine, for
             example which device to use on a system with multiple
-            devices, is possible by providing a :class:`GPUEngine` object
+            devices, is possible by providing a :class:`~.GPUEngine` object
             with configuration options.
 
             .. note::
@@ -2019,9 +2019,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 "cudf_polars",
                 err_prefix="GPU engine requested, but required package",
                 install_message=(
-                    "Please install using the command `pip install cudf-polars-cu12` "
-                    "(or `pip install cudf-polars-cu11` if your system has a "
-                    "CUDA 11 driver)."
+                    "Please install using the command "
+                    "`pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu12` "
+                    "(or `pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11` "
+                    "if your system has a CUDA 11 driver)."
                 ),
             )
             if not is_config_obj:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -302,7 +302,7 @@ class LazyFrame:
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
         nan_to_null: bool = False,
-    ) -> None:
+    ):
         from polars.dataframe import DataFrame
 
         self._ldf = (
@@ -585,10 +585,10 @@ class LazyFrame:
         msg = f'"{operator!r}" comparison not supported for LazyFrame objects'
         raise TypeError(msg)
 
-    def __eq__(self, other: object) -> NoReturn:
+    def __eq__(self, other: Any) -> NoReturn:
         self._comparison_error("==")
 
-    def __ne__(self, other: object) -> NoReturn:
+    def __ne__(self, other: Any) -> NoReturn:
         self._comparison_error("!=")
 
     def __gt__(self, other: Any) -> NoReturn:
@@ -699,6 +699,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         >>> lf = pl.LazyFrame({"a": [1, 2, 3]}).sum()
         >>> bytes = lf.serialize()
+        >>> bytes  # doctest: +ELLIPSIS
+        b'\xa1kMapFunction\xa2einput\xa1mDataFrameScan\xa4bdf\xa1gcolumns\x81\xa4d...'
 
         The bytes can later be deserialized back into a LazyFrame.
 
@@ -1733,7 +1735,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             )
             import matplotlib.pyplot as plt
 
-            _fig, ax = plt.subplots(1, figsize=figsize)
+            fig, ax = plt.subplots(1, figsize=figsize)
 
             max_val = timings["end"][-1]
             timings_ = timings.reverse()
@@ -1865,7 +1867,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             polars CPU engine. If set to `"gpu"`, the GPU engine is
             used. Fine-grained control over the GPU engine, for
             example which device to use on a system with multiple
-            devices, is possible by providing a :class:`GPUEngine` object
+            devices, is possible by providing a :class:`~.GPUEngine` object
             with configuration options.
 
             .. note::
@@ -2019,9 +2021,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 "cudf_polars",
                 err_prefix="GPU engine requested, but required package",
                 install_message=(
-                    "Please install using the command `pip install cudf-polars-cu12` "
-                    "(or `pip install cudf-polars-cu11` if your system has a "
-                    "CUDA 11 driver)."
+                    "Please install using the command "
+                    "`pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu12` "
+                    "(or `pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11` "
+                    "if your system has a CUDA 11 driver)."
                 ),
             )
             if not is_config_obj:
@@ -2970,7 +2973,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             cast_map.update(
                 {c: dtype}
                 if isinstance(c, str)
-                else dict.fromkeys(expand_selector(self, c), dtype)  # type: ignore[arg-type]
+                else {x: dtype for x in expand_selector(self, c)}  # type: ignore[arg-type]
             )
 
         return self._from_pyldf(self._ldf.cast(cast_map, strict))
@@ -3498,7 +3501,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ c   ┆ 1   ┆ 1.0 │
         └─────┴─────┴─────┘
         """
-        for value in named_by.values():
+        for _key, value in named_by.items():
             if not isinstance(value, (str, pl.Expr, pl.Series)):
                 msg = (
                     f"Expected Polars expression or object convertible to one, got {type(value)}.\n\n"
@@ -4556,89 +4559,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 suffix,
                 validate,
                 coalesce,
-            )
-        )
-
-    @unstable()
-    def join_where(
-        self,
-        other: LazyFrame,
-        *predicates: Expr | Iterable[Expr],
-        suffix: str = "_right",
-    ) -> LazyFrame:
-        """
-        Perform a join based on one or multiple (in)equality predicates.
-
-        This performs an inner join, so only rows where all predicates are true
-        are included in the result, and a row from either DataFrame may be included
-        multiple times in the result.
-
-        .. note::
-            The row order of the input DataFrames is not preserved.
-
-        .. warning::
-            This functionality is experimental. It may be
-            changed at any point without it being considered a breaking change.
-
-        Parameters
-        ----------
-        other
-            DataFrame to join with.
-        *predicates
-            (In)Equality condition to join the two tables on.
-            When a column name occurs in both tables, the proper suffix must
-            be applied in the predicate.
-        suffix
-            Suffix to append to columns with a duplicate name.
-
-        Examples
-        --------
-        >>> east = pl.LazyFrame(
-        ...     {
-        ...         "id": [100, 101, 102],
-        ...         "dur": [120, 140, 160],
-        ...         "rev": [12, 14, 16],
-        ...         "cores": [2, 8, 4],
-        ...     }
-        ... )
-        >>> west = pl.LazyFrame(
-        ...     {
-        ...         "t_id": [404, 498, 676, 742],
-        ...         "time": [90, 130, 150, 170],
-        ...         "cost": [9, 13, 15, 16],
-        ...         "cores": [4, 2, 1, 4],
-        ...     }
-        ... )
-        >>> east.join_where(
-        ...     west,
-        ...     pl.col("dur") < pl.col("time"),
-        ...     pl.col("rev") < pl.col("cost"),
-        ... ).collect()
-        shape: (5, 8)
-        ┌─────┬─────┬─────┬───────┬──────┬──────┬──────┬─────────────┐
-        │ id  ┆ dur ┆ rev ┆ cores ┆ t_id ┆ time ┆ cost ┆ cores_right │
-        │ --- ┆ --- ┆ --- ┆ ---   ┆ ---  ┆ ---  ┆ ---  ┆ ---         │
-        │ i64 ┆ i64 ┆ i64 ┆ i64   ┆ i64  ┆ i64  ┆ i64  ┆ i64         │
-        ╞═════╪═════╪═════╪═══════╪══════╪══════╪══════╪═════════════╡
-        │ 100 ┆ 120 ┆ 12  ┆ 2     ┆ 498  ┆ 130  ┆ 13   ┆ 2           │
-        │ 100 ┆ 120 ┆ 12  ┆ 2     ┆ 676  ┆ 150  ┆ 15   ┆ 1           │
-        │ 100 ┆ 120 ┆ 12  ┆ 2     ┆ 742  ┆ 170  ┆ 16   ┆ 4           │
-        │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 676  ┆ 150  ┆ 15   ┆ 1           │
-        │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 742  ┆ 170  ┆ 16   ┆ 4           │
-        └─────┴─────┴─────┴───────┴──────┴──────┴──────┴─────────────┘
-
-        """
-        if not isinstance(other, LazyFrame):
-            msg = f"expected `other` join table to be a LazyFrame, not a {type(other).__name__!r}"
-            raise TypeError(msg)
-
-        pyexprs = parse_into_list_of_expressions(*predicates)
-
-        return self._from_pyldf(
-            self._ldf.join_where(
-                other._ldf,
-                pyexprs,
-                suffix,
             )
         )
 


### PR DESCRIPTION
This PR adds initial documentation for the beta Polars GPU engine. It includes:
- A general overview of the beta GPU engine in the user guide, including information on what's supported, how it works, testing, interoperability, installation, and similar
- Updated docs for the GPUEngine configuration object
- Minor updates to API docs where relevant