### PR TITLE
refactor(rust): Fix input independence tests in new-streaming engine

### DIFF
--- a/crates/polars-stream/src/nodes/input_independent_select.rs
+++ b/crates/polars-stream/src/nodes/input_independent_select.rs
@@ -1,0 +1,64 @@
+use polars_core::prelude::IntoColumn;
+
+use super::compute_node_prelude::*;
+use crate::expression::StreamExpr;
+use crate::morsel::SourceToken;
+
+pub struct InputIndependentSelectNode {
+    selectors: Vec<StreamExpr>,
+    done: bool,
+}
+
+impl InputIndependentSelectNode {
+    pub fn new(selectors: Vec<StreamExpr>) -> Self {
+        Self {
+            selectors,
+            done: false,
+        }
+    }
+}
+
+impl ComputeNode for InputIndependentSelectNode {
+    fn name(&self) -> &str {
+        "input_independent_select"
+    }
+
+    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+        assert!(recv.is_empty() && send.len() == 1);
+        send[0] = if send[0] == PortState::Done || self.done {
+            PortState::Done
+        } else {
+            PortState::Ready
+        };
+        Ok(())
+    }
+
+    fn spawn<'env, 's>(
+        &'env mut self,
+        scope: &'s TaskScope<'s, 'env>,
+        recv: &mut [Option<RecvPort<'_>>],
+        send: &mut [Option<SendPort<'_>>],
+        state: &'s ExecutionState,
+        join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
+    ) {
+        assert!(recv.is_empty() && send.len() == 1);
+        let mut sender = send[0].take().unwrap().serial();
+
+        join_handles.push(scope.spawn_task(TaskPriority::Low, async move {
+            let empty_df = DataFrame::empty();
+            let mut selected = Vec::new();
+            for selector in self.selectors.iter() {
+                let s = selector.evaluate(&empty_df, state).await?;
+                selected.push(s.into_column());
+            }
+
+            let ret = DataFrame::new_with_broadcast(selected)?;
+            let seq = MorselSeq::default();
+            let source_token = SourceToken::new();
+            let morsel = Morsel::new(ret, seq, source_token);
+            sender.send(morsel).await.ok();
+            self.done = true;
+            Ok(())
+        }));
+    }
+}

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -2,6 +2,7 @@ pub mod filter;
 pub mod in_memory_map;
 pub mod in_memory_sink;
 pub mod in_memory_source;
+pub mod input_independent_select;
 pub mod map;
 pub mod multiplexer;
 pub mod ordered_union;

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -59,6 +59,13 @@ fn visualize_plan_rec(
                 from_ref(input),
             )
         },
+        PhysNodeKind::InputIndependentSelect { selectors } => (
+            format!(
+                "input-independent-select\\n{}",
+                fmt_exprs(selectors, expr_arena)
+            ),
+            &[][..],
+        ),
         PhysNodeKind::Reduce { input, exprs } => (
             format!("reduce\\n{}", fmt_exprs(exprs, expr_arena)),
             from_ref(input),

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -58,6 +58,10 @@ pub enum PhysNodeKind {
         extend_original: bool,
     },
 
+    InputIndependentSelect {
+        selectors: Vec<ExprIR>,
+    },
+
     Reduce {
         input: PhysNodeKey,
         exprs: Vec<ExprIR>,
@@ -156,7 +160,9 @@ fn insert_multiplexers(
 
     if !seen_before {
         match &phys_sm[node].kind {
-            PhysNodeKind::InMemorySource { .. } | PhysNodeKind::FileScan { .. } => {},
+            PhysNodeKind::InMemorySource { .. }
+            | PhysNodeKind::FileScan { .. }
+            | PhysNodeKind::InputIndependentSelect { .. } => {},
             PhysNodeKind::Select { input, .. }
             | PhysNodeKind::Reduce { input, .. }
             | PhysNodeKind::StreamingSlice { input, .. }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -130,6 +130,18 @@ fn to_graph_rec<'a>(
                 [input_key],
             )
         },
+
+        InputIndependentSelect { selectors } => {
+            let phys_selectors = selectors
+                .iter()
+                .map(|selector| create_stream_expr(selector, ctx))
+                .collect::<PolarsResult<_>>()?;
+            ctx.graph.add_node(
+                nodes::input_independent_select::InputIndependentSelectNode::new(phys_selectors),
+                [],
+            )
+        },
+
         Reduce { input, exprs } => {
             let input_key = to_graph_rec(*input, ctx)?;
             let input_schema = &ctx.phys_sm[*input].output_schema;

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -297,6 +297,7 @@ def test_streaming_empty_parquet_16523(tmp_path: Path) -> None:
     assert q.join(q2, on="a").collect(streaming=True).shape == (0, 1)
 
 
+@pytest.mark.may_fail_auto_streaming
 @pytest.mark.parametrize(
     "method",
     ["parquet", "csv"],


### PR DESCRIPTION
This involves a temporary and fragile hack, where we make the `InMemorySource` node always produce at least 1 morsel, even if that morsel is empty. This makes the `FastCount` work for now. 

This is fragile because other nodes may not preserve this morsel, we should remove this once we properly lower `FunctionIR` to a physical plan.