### PR TITLE
fix: Fix `cum_max` using exception text of `cum_min` for invalid dtype

### DIFF
--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -204,7 +204,7 @@ pub fn cum_max(s: &Series, reverse: bool) -> PolarsResult<Series> {
                 }
             })
         },
-        dt => polars_bail!(opq = cum_min, dt),
+        dt => polars_bail!(opq = cum_max, dt),
     }
 }
 


### PR DESCRIPTION
closes #18754