### PR TITLE
refactor(rust): Fix new-streaming 'test_parquet::test_complex_types

### DIFF
--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -226,8 +226,7 @@ impl Splitable for FixedSizeListArray {
     unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {
         let (lhs_values, rhs_values) =
             unsafe { self.values.split_at_boxed_unchecked(offset * self.size) };
-        let (lhs_validity, rhs_validity) =
-            unsafe { self.validity.split_at_unchecked(offset * self.size) };
+        let (lhs_validity, rhs_validity) = unsafe { self.validity.split_at_unchecked(offset) };
 
         let size = self.size;
 


### PR DESCRIPTION
Before
```
df.with_columns(s.alias("b")) = shape: (4, 2)
┌───────────────┬────────────────────┐
│ a             ┆ b                  │
│ ---           ┆ ---                │
│ array[i64, 3] ┆ array[i64, 3]      │
╞═══════════════╪════════════════════╡
│ null          ┆ null               │
│ [1, null, 3]  ┆ [1, null, 3]       │
│ null          ┆ [null, null, null] │
│ [1, 2, null]  ┆ [1, 2, null]       │
└───────────────┴────────────────────┘
```
After
```python
df.with_columns(s.alias("b")) = shape: (4, 2)
┌───────────────┬───────────────┐
│ a             ┆ b             │
│ ---           ┆ ---           │
│ array[i64, 3] ┆ array[i64, 3] │
╞═══════════════╪═══════════════╡
│ null          ┆ null          │
│ [1, null, 3]  ┆ [1, null, 3]  │
│ null          ┆ null          │
│ [1, 2, null]  ┆ [1, 2, null]  │
└───────────────┴───────────────┘
```