### PR TITLE
refactor(python): Re-export PyO3 in `polars-python` crate

### DIFF
--- a/crates/polars-python/src/export.rs
+++ b/crates/polars-python/src/export.rs
@@ -1,0 +1,1 @@
+pub use pyo3;

--- a/crates/polars-python/src/lib.rs
+++ b/crates/polars-python/src/lib.rs
@@ -13,6 +13,7 @@ pub mod dataframe;
 pub mod datatypes;
 pub mod error;
 pub mod exceptions;
+pub mod export;
 pub mod expr;
 pub mod file;
 #[cfg(feature = "pymethods")]


### PR DESCRIPTION
This allows dependent code in the Polars Cloud worker to use the same PyO3 version.