### PR TITLE
fix(python): Pass missing user params in `write_csv`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2859,7 +2859,22 @@ class DataFrame:
 
         def write_csv_to_string() -> str:
             with BytesIO() as buf:
-                self.write_csv(buf)
+                self.write_csv(
+                    buf,
+                    include_bom=include_bom,
+                    include_header=include_header,
+                    separator=separator,
+                    line_terminator=line_terminator,
+                    quote_char=quote_char,
+                    batch_size=batch_size,
+                    datetime_format=datetime_format,
+                    date_format=date_format,
+                    time_format=time_format,
+                    float_scientific=float_scientific,
+                    float_precision=float_precision,
+                    null_value=null_value,
+                    quote_style=quote_style,
+                )
                 csv_bytes = buf.getvalue()
             return csv_bytes.decode("utf8")
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2263,6 +2263,17 @@ def test_write_csv_appending_17543(tmp_path: Path) -> None:
         assert pl.read_csv(f).equals(df)
 
 
+def test_write_csv_passing_params_18825() -> None:
+    df = pl.DataFrame({"c1": [1, 2], "c2": [3, 4]})
+    buffer = io.StringIO()
+    df.write_csv(buffer, separator="\t", include_header=False)
+
+    result_str = buffer.getvalue()
+    expected_str = "1\t3\n2\t4\n"
+
+    assert result_str == expected_str
+
+
 @pytest.mark.parametrize(
     ("dtype", "df"),
     [


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/18825.