### PR TITLE
docs: Fix link to issue tracker and code snippet format in GPU docs

### DIFF
--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -15,7 +15,10 @@ See the [RAPIDS installation guide](https://docs.rapids.ai/install#system-req) f
 You can install the GPU backend for Polars with a feature flag as part of a normal [installation](installation.md).
 
 === ":fontawesome-brands-python: Python"
-`bash pip install --extra-index-url=https://pypi.nvidia.com polars[gpu]`
+
+```bash
+pip install --extra-index-url=https://pypi.nvidia.com polars[gpu]
+```
 
 !!! note Installation on a CUDA 11 system
 
@@ -163,4 +166,4 @@ GPU execution is only available in the Lazy API, so materialized DataFrames will
 
 ### Providing feedback
 
-Please report issues, and missing features, on the Polars [issue tracker](../development/contributing/index.md).
+Please report issues, and missing features, on the Polars [issue tracker](https://github.com/pola-rs/polars/issues).


### PR DESCRIPTION
There were two small issues on the new GPU support page. 

1. Installation example showed a `bash` command. Brought that back in line with the rest of the user guide and contribution guidelines.
2. Link to the issue tracker at the end of the page pointed to the contribution guidelines, instead of the Polars issue tracker on Github.