### PR TITLE
fix: Properly broadcast list arithmetic

### DIFF
--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -688,16 +688,6 @@ def test_list_arithmetic_nulls(a: list[Any], b: list[Any], expected: list[Any]) 
 
 
 def test_list_arithmetic_error_cases() -> None:
-    # Different series length:
-    with pytest.raises(
-        InvalidOperationError, match="Series of the same size; got 1 and 2"
-    ):
-        _ = pl.Series("a", [[1, 2]]) / pl.Series("b", [[1, 2], [3, 4]])
-    with pytest.raises(
-        InvalidOperationError, match="Series of the same size; got 1 and 2"
-    ):
-        _ = pl.Series("a", [[1, 2]]) / pl.Series("b", [[1, 2], None])
-
     # Different list length:
     with pytest.raises(InvalidOperationError, match="lists of the same size"):
         _ = pl.Series("a", [[1, 2]]) / pl.Series("b", [[1]])

--- a/py-polars/tests/unit/operations/arithmetic/test_list.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_list.py
@@ -1,0 +1,26 @@
+import polars as pl
+
+
+def test_literal_broadcast_list() -> None:
+    df = pl.DataFrame({"A": [[0.1, 0.2], [0.3, 0.4]]})
+
+    lit = pl.lit([3.0, 5.0])
+    assert df.select(
+        mul=pl.all() * lit,
+        div=pl.all() / lit,
+        add=pl.all() + lit,
+        sub=pl.all() - lit,
+        div_=lit / pl.all(),
+        add_=lit + pl.all(),
+        sub_=lit - pl.all(),
+        mul_=lit * pl.all(),
+    ).to_dict(as_series=False) == {
+        "mul": [[0.30000000000000004, 1.0], [0.8999999999999999, 2.0]],
+        "div": [[0.03333333333333333, 0.04], [0.09999999999999999, 0.08]],
+        "add": [[3.1, 5.2], [3.3, 5.4]],
+        "sub": [[-2.9, -4.8], [-2.7, -4.6]],
+        "div_": [[30.0, 25.0], [10.0, 12.5]],
+        "add_": [[3.1, 5.2], [3.3, 5.4]],
+        "sub_": [[2.9, 4.8], [2.7, 4.6]],
+        "mul_": [[0.30000000000000004, 1.0], [0.8999999999999999, 2.0]],
+    }


### PR DESCRIPTION
ref: https://github.com/pola-rs/polars/issues/18831

It seems like I just needed to copy the `broadcast_array()` impl from https://github.com/pola-rs/polars/pull/18851

