### PR TITLE
docs: Fix minor rogue apostrophes

### DIFF
--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -1,4 +1,4 @@
-//! Implementations of arithmetic operations on ChunkedArray's.
+//! Implementations of arithmetic operations on ChunkedArrays.
 #[cfg(feature = "dtype-decimal")]
 mod decimal;
 mod numeric;

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -80,7 +80,7 @@ pub type ChunkLenIter<'a> = std::iter::Map<std::slice::Iter<'a, ArrayRef>, fn(&A
 /// }
 /// ```
 ///
-/// ## Conversion between Series and ChunkedArray's
+/// ## Conversion between Series and ChunkedArrays
 /// Conversion from a [`Series`] to a [`ChunkedArray`] is effortless.
 ///
 /// ```rust

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -144,7 +144,7 @@ fn broadcast_array(lhs: &ArrayChunked, rhs: &Series) -> PolarsResult<(ArrayChunk
         },
         (a, b) if a == b => (lhs.clone(), rhs.clone()),
         _ => {
-            polars_bail!(InvalidOperation: "can only do arithmetic of array's of the same type and shape; got {} and {}", lhs.dtype(), rhs.dtype())
+            polars_bail!(InvalidOperation: "can only do arithmetic of arrays of the same type and shape; got {} and {}", lhs.dtype(), rhs.dtype())
         },
     };
     Ok(out)
@@ -165,7 +165,7 @@ impl ArrayChunked {
         let r_leaf_array = if rhs.dtype().is_numeric() && rhs.len() == 1 {
             rhs.clone()
         } else {
-            polars_ensure!(lhs.dtype() == rhs.dtype(), InvalidOperation: "can only do arithmetic of array's of the same type and shape; got {} and {}", self.dtype(), rhs.dtype());
+            polars_ensure!(lhs.dtype() == rhs.dtype(), InvalidOperation: "can only do arithmetic of arrays of the same type and shape; got {} and {}", self.dtype(), rhs.dtype());
             rhs.get_leaf_array()
         };
 

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -93,7 +93,7 @@ use crate::POOL;
 /// See all the comparison operators in the [CmpOps trait](crate::chunked_array::ops::ChunkCompare)
 ///
 /// ## Iterators
-/// The Series variants contain differently typed [ChunkedArray's](crate::chunked_array::ChunkedArray).
+/// The Series variants contain differently typed [ChunkedArray](crate::chunked_array::ChunkedArray)s.
 /// These structs can be turned into iterators, making it possible to use any function/ closure you want
 /// on a Series.
 ///

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -392,7 +392,7 @@ macro_rules! match_dtype_to_logical_apply_macro {
     }};
 }
 
-/// Apply a macro on the Downcasted ChunkedArray's
+/// Apply a macro on the Downcasted ChunkedArrays
 #[macro_export]
 macro_rules! match_arrow_dtype_apply_macro_ca {
     ($self:expr, $macro:ident, $macro_string:ident, $macro_bool:ident $(, $opt_args:expr)*) => {{
@@ -537,7 +537,7 @@ macro_rules! with_match_physical_integer_polars_type {(
     }
 })}
 
-/// Apply a macro on the Downcasted ChunkedArray's of DataTypes that are logical numerics.
+/// Apply a macro on the Downcasted ChunkedArrays of DataTypes that are logical numerics.
 /// So no logical.
 #[macro_export]
 macro_rules! downcast_as_macro_arg_physical {
@@ -562,7 +562,7 @@ macro_rules! downcast_as_macro_arg_physical {
     }};
 }
 
-/// Apply a macro on the Downcasted ChunkedArray's of DataTypes that are logical numerics.
+/// Apply a macro on the Downcasted ChunkedArrays of DataTypes that are logical numerics.
 /// So no logical.
 #[macro_export]
 macro_rules! downcast_as_macro_arg_physical_mut {


### PR DESCRIPTION
Super minor, removes some apostrophes that shouldn't be there.