### PR TITLE
feat: Allow reshaping empty array to Array dtype

### DIFF
--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -159,7 +159,9 @@ def test_series_init_np_2d_zero_zero_shape() -> None:
     arr = np.array([]).reshape(0, 0)
     with pytest.raises(
         InvalidOperationError,
-        match=re.escape("cannot reshape empty array into shape (0, 0)"),
+        match=re.escape(
+            "cannot reshape array into shape containing a zero dimension after the first: (0, 0)"
+        ),
     ):
         pl.Series(arr)
 

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_series.py
@@ -24,3 +24,12 @@ def test_from_numpy_timedelta(time_unit: TimeUnit) -> None:
     assert s.name == "name"
     assert s.dt[0] == timedelta(days=1)
     assert s.dt[1] == timedelta(seconds=1)
+
+
+def test_from_zero_length_array() -> None:
+    a = np.zeros(dtype=np.int32, shape=(0, 4))
+    s = pl.Series("name", a)
+
+    assert s.dtype == pl.Array(pl.Int32, 4)
+    assert s.name == "name"
+    assert s.len() == 0


### PR DESCRIPTION
Changes `reshape` logic to allow reshaping to a Series with Array dtype of length 0. Zero *width* arrays are still unsupported.

This is a rough draft, please let me know what you think.

Examples:
```
  pl.Series([]).reshape((0, 2)) => shape(0, 2) (used to error)
  pl.Series([]).reshape((-1, 2, 3)) => shape (0, 2, 3) (used to error)
  pl.Series([]).reshape((0, 0)) => InvalidOperationError("cannot reshape array into shape containing a zero dimension after the first")
  pl.Series([]).reshape((5, -1)) => InvalidOperationError("cannot reshape empty array into shape (5, -1)")
```

Some error messages are changed. Does polars consider that a breaking change? For instance, `pl.Series([]).reshape((0, 0))` used to error with the message "cannot reshape empty array into shape (0, 0)".

Fixes #18369