### PR TITLE
perf: Improve rename performace for Lazy API

### DIFF
--- a/crates/polars-plan/src/plans/functions/rename.rs
+++ b/crates/polars-plan/src/plans/functions/rename.rs
@@ -9,10 +9,7 @@ pub(super) fn rename_impl(
         let schema = df.schema();
         existing
             .iter()
-            .map(|old| match schema.get_full(old) {
-                Some((idx, _, _)) => Some(idx),
-                None => None,
-            })
+            .map(|old| schema.get_full(old).map(|(idx, _, _)| idx))
             .collect::<Vec<_>>()
     } else {
         existing


### PR DESCRIPTION
Closes [#17336](https://github.com/pola-rs/polars/issues/17336)

For the python rename API, if we pass a dictionary arguments, we convert to LazyFrame and internally call the rename operation; the issue is that we need to get index number for all the columns we are renaming; this is an O(n^2) operation.
If we pass a function as argument to rename, we convert to LazyFrame and internally call the select operation; here we get the index for each column from the Schema, which is an IndexMap and hence overall the operation becomes O(n).
Have tried to fix this issue in a similar fashion by constructing the schema first and then getting index from it.

After the fix :
```
import polars as pl
df = pl.DataFrame({f"column_{i}": ['x', 'y', 'z'] for i in range(10000)})
cols_map = {f"column_{i}": f"renamed_{i}" for i in range(10000)}
start = time.perf_counter()
_ = df.rename(cols_map)
end = time.perf_counter()
print(f"Time for rename(): {end - start} | Version: {pl.__version__}")
```

Time for rename(): 0.041061488911509514 | Version: 1.7.1

```start = time.perf_counter()
df2 = df.rename(lambda col: cols_map.get(col, col))
end = time.perf_counter()
print(f"Time for rename(): {end - start} | Version: {pl.__version__}")
```
Time for rename(): 0.06575666600838304 | Version: 1.7.1

In the Eager API for Rust, this was fixed in [#1028 ](https://github.com/pola-rs/polars/pull/1028) by implementing a hash map.