### PR TITLE
fix: Infer reshape dims when determining schema

### DIFF
--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -13,6 +13,7 @@ mod any_value;
 mod dtype;
 mod field;
 mod into_scalar;
+mod reshape;
 #[cfg(feature = "object")]
 mod static_array_collect;
 mod time_unit;
@@ -41,6 +42,7 @@ use polars_utils::abs_diff::AbsDiff;
 use polars_utils::float::IsFloat;
 use polars_utils::min_max::MinMax;
 use polars_utils::nulls::IsNull;
+pub use reshape::*;
 #[cfg(feature = "serde")]
 use serde::de::{EnumAccess, Error, Unexpected, VariantAccess, Visitor};
 #[cfg(any(feature = "serde", feature = "serde-lazy"))]

--- a/crates/polars-core/src/datatypes/reshape.rs
+++ b/crates/polars-core/src/datatypes/reshape.rs
@@ -1,0 +1,118 @@
+use std::fmt;
+use std::hash::Hash;
+use std::num::NonZeroU64;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(transparent)]
+pub struct Dimension(NonZeroU64);
+
+/// A dimension in a reshape.
+///
+/// Any dimension smaller than 0 is seen as an `infer`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ReshapeDimension {
+    Infer,
+    Specified(Dimension),
+}
+
+impl fmt::Debug for Dimension {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+impl fmt::Display for ReshapeDimension {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Infer => f.write_str("inferred"),
+            Self::Specified(v) => v.get().fmt(f),
+        }
+    }
+}
+
+impl Hash for ReshapeDimension {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.to_repr().hash(state)
+    }
+}
+
+impl Dimension {
+    #[inline]
+    pub const fn new(v: u64) -> Self {
+        assert!(v <= i64::MAX as u64);
+
+        // SAFETY: Bounds check done before
+        let dim = unsafe { NonZeroU64::new_unchecked(v.wrapping_add(1)) };
+        Self(dim)
+    }
+
+    #[inline]
+    pub const fn get(self) -> u64 {
+        self.0.get() - 1
+    }
+}
+
+impl ReshapeDimension {
+    #[inline]
+    pub const fn new(v: i64) -> Self {
+        if v < 0 {
+            Self::Infer
+        } else {
+            // SAFETY: We have bounds checked for -1
+            let dim = unsafe { NonZeroU64::new_unchecked((v as u64).wrapping_add(1)) };
+            Self::Specified(Dimension(dim))
+        }
+    }
+
+    #[inline]
+    fn to_repr(self) -> u64 {
+        match self {
+            Self::Infer => 0,
+            Self::Specified(dim) => dim.0.get(),
+        }
+    }
+
+    #[inline]
+    pub const fn get(self) -> Option<u64> {
+        match self {
+            ReshapeDimension::Infer => None,
+            ReshapeDimension::Specified(dim) => Some(dim.get()),
+        }
+    }
+
+    #[inline]
+    pub const fn get_or_infer(self, inferred: u64) -> u64 {
+        match self {
+            ReshapeDimension::Infer => inferred,
+            ReshapeDimension::Specified(dim) => dim.get(),
+        }
+    }
+
+    #[inline]
+    pub fn get_or_infer_with(self, f: impl Fn() -> u64) -> u64 {
+        match self {
+            ReshapeDimension::Infer => f(),
+            ReshapeDimension::Specified(dim) => dim.get(),
+        }
+    }
+
+    pub const fn new_dimension(dimension: u64) -> ReshapeDimension {
+        Self::Specified(Dimension::new(dimension))
+    }
+}
+
+impl TryFrom<i64> for Dimension {
+    type Error = ();
+
+    #[inline]
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        let ReshapeDimension::Specified(v) = ReshapeDimension::new(value) else {
+            return Err(());
+        };
+
+        Ok(v)
+    }
+}

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -9,6 +9,7 @@ use polars_utils::pl_str::PlSmallStr;
 use self::gather::check_bounds_ca;
 use crate::chunked_array::cast::CastOptions;
 use crate::chunked_array::metadata::{MetadataFlags, MetadataTrait};
+use crate::datatypes::ReshapeDimension;
 use crate::prelude::*;
 use crate::series::{BitRepr, IsSorted, SeriesPhysIter};
 use crate::utils::{slice_offsets, Container};
@@ -730,7 +731,7 @@ impl Column {
         self.as_materialized_series().unique().map(Column::from)
     }
 
-    pub fn reshape_list(&self, dimensions: &[i64]) -> PolarsResult<Self> {
+    pub fn reshape_list(&self, dimensions: &[ReshapeDimension]) -> PolarsResult<Self> {
         // @scalar-opt
         self.as_materialized_series()
             .reshape_list(dimensions)
@@ -738,7 +739,7 @@ impl Column {
     }
 
     #[cfg(feature = "dtype-array")]
-    pub fn reshape_array(&self, dimensions: &[i64]) -> PolarsResult<Self> {
+    pub fn reshape_array(&self, dimensions: &[ReshapeDimension]) -> PolarsResult<Self> {
         // @scalar-opt
         self.as_materialized_series()
             .reshape_array(dimensions)

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -115,16 +115,18 @@ impl NumOpsDispatchInner for BooleanType {
 }
 
 #[cfg(feature = "dtype-array")]
-fn array_shape(dt: &DataType, infer: bool) -> Vec<i64> {
-    fn inner(dt: &DataType, buf: &mut Vec<i64>) {
+fn array_shape(dt: &DataType, infer: bool) -> Vec<ReshapeDimension> {
+    fn inner(dt: &DataType, buf: &mut Vec<ReshapeDimension>) {
         if let DataType::Array(_, size) = dt {
-            buf.push(*size as i64)
+            buf.push(ReshapeDimension::Specified(
+                Dimension::try_from(*size as i64).unwrap(),
+            ))
         }
     }
 
     let mut buf = vec![];
     if infer {
-        buf.push(-1)
+        buf.push(ReshapeDimension::Infer)
     }
     inner(dt, &mut buf);
     buf

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -375,7 +375,12 @@ impl PhysicalExpr for AggregationExpr {
                     let s = match ac.agg_state() {
                         // mean agg:
                         // -> f64 -> list<f64>
-                        AggState::AggregatedScalar(s) => s.reshape_list(&[-1, 1]).unwrap(),
+                        AggState::AggregatedScalar(s) => s
+                            .reshape_list(&[
+                                ReshapeDimension::Infer,
+                                ReshapeDimension::new_dimension(1),
+                            ])
+                            .unwrap(),
                         _ => {
                             let agg = ac.aggregated();
                             agg.as_list().into_series()

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -421,7 +421,12 @@ impl<'a> AggregationContext<'a> {
                 self.groups();
                 let rows = self.groups.len();
                 let s = s.new_from_index(0, rows);
-                let out = s.reshape_list(&[rows as i64, -1]).unwrap();
+                let out = s
+                    .reshape_list(&[
+                        ReshapeDimension::new_dimension(rows as u64),
+                        ReshapeDimension::Infer,
+                    ])
+                    .unwrap();
                 self.state = AggState::AggregatedList(out.clone());
                 out
             },

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -44,7 +44,9 @@ fn cast_rhs(
         }
         if !matches!(s.dtype(), DataType::List(_)) && s.dtype() == inner_type {
             // coerce to list JIT
-            *s = s.reshape_list(&[-1, 1]).unwrap();
+            *s = s
+                .reshape_list(&[ReshapeDimension::Infer, ReshapeDimension::new_dimension(1)])
+                .unwrap();
         }
         if s.dtype() != dtype {
             *s = s.cast(dtype).map_err(|e| {

--- a/crates/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/crates/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -72,12 +72,9 @@ pub(super) fn unique_counts(s: &Column) -> PolarsResult<Column> {
     polars_ops::prelude::unique_counts(s.as_materialized_series()).map(Column::from)
 }
 
-pub(super) fn reshape(s: &Column, dimensions: &[i64], nested: &NestedType) -> PolarsResult<Column> {
-    match nested {
-        NestedType::List => s.reshape_list(dimensions),
-        #[cfg(feature = "dtype-array")]
-        NestedType::Array => s.reshape_array(dimensions),
-    }
+#[cfg(feature = "dtype-array")]
+pub(super) fn reshape(c: &Column, dimensions: &[ReshapeDimension]) -> PolarsResult<Column> {
+    c.reshape_array(dimensions)
 }
 
 #[cfg(feature = "repeat_by")]

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -395,7 +395,9 @@ pub(super) fn concat(s: &mut [Column]) -> PolarsResult<Option<Column>> {
     let mut first_ca = match first.list().ok() {
         Some(ca) => ca,
         None => {
-            first = first.reshape_list(&[-1, 1]).unwrap();
+            first = first
+                .reshape_list(&[ReshapeDimension::Infer, ReshapeDimension::new_dimension(1)])
+                .unwrap();
             first.list().unwrap()
         },
     }
@@ -506,7 +508,7 @@ pub(super) fn gather(args: &[Column], null_on_oob: bool) -> PolarsResult<Column>
         let idx = idx.get(0)?.try_extract::<i64>()?;
         let out = ca.lst_get(idx, null_on_oob).map(Column::from)?;
         // make sure we return a list
-        out.reshape_list(&[-1, 1])
+        out.reshape_list(&[ReshapeDimension::Infer, ReshapeDimension::new_dimension(1)])
     } else {
         ca.lst_gather(idx.as_materialized_series(), null_on_oob)
             .map(Column::from)

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -244,25 +244,43 @@ impl FunctionExpr {
             },
             #[cfg(feature = "repeat_by")]
             RepeatBy => mapper.map_dtype(|dt| DataType::List(dt.clone().into())),
-            Reshape(dims, nested_type) => mapper.map_dtype(|dt| {
+            #[cfg(feature = "dtype-array")]
+            Reshape(dims) => mapper.try_map_dtype(|dt: &DataType| {
                 let dtype = dt.inner_dtype().unwrap_or(dt).clone();
-                if dims.len() == 1 {
-                    dtype
-                } else {
-                    match nested_type {
-                        NestedType::List => DataType::List(Box::new(dtype)),
-                        #[cfg(feature = "dtype-array")]
-                        NestedType::Array => {
-                            let mut prev_dtype = dtype.leaf_dtype().clone();
 
-                            // We pop the outer dimension as that is the height of the series.
-                            for dim in &dims[1..] {
-                                prev_dtype = DataType::Array(Box::new(prev_dtype), *dim as usize);
-                            }
-                            prev_dtype
-                        },
-                    }
+                if dims.len() == 1 {
+                    return Ok(dtype);
                 }
+
+                let num_infers = dims.iter().filter(|d| matches!(d, ReshapeDimension::Infer)).count();
+
+                polars_ensure!(num_infers <= 1, InvalidOperation: "can only specify one inferred dimension");
+
+                let mut inferred_size = 0;
+                if num_infers == 1 {
+                    let mut total_size = 1u64;
+                    let mut current = dt;
+                    while let DataType::Array(dt, width) = current {
+                        if *width == 0 {
+                            total_size = 0;
+                            break;
+                        }
+
+                        current = dt.as_ref();
+                        total_size *= *width as u64;
+                    }
+
+                    let current_size = dims.iter().map(|d| d.get_or_infer(1)).product::<u64>();
+                    inferred_size = total_size / current_size;
+                }
+
+                let mut prev_dtype = dtype.leaf_dtype().clone();
+
+                // We pop the outer dimension as that is the height of the series.
+                for dim in &dims[1..] {
+                    prev_dtype = DataType::Array(Box::new(prev_dtype), dim.get_or_infer(inferred_size) as usize);
+                }
+                Ok(prev_dtype)
             }),
             #[cfg(feature = "cutqcut")]
             QCut {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1738,9 +1738,13 @@ impl Expr {
             })
     }
 
-    pub fn reshape(self, dimensions: &[i64], nested_type: NestedType) -> Self {
-        let dimensions = dimensions.to_vec();
-        self.apply_private(FunctionExpr::Reshape(dimensions, nested_type))
+    #[cfg(feature = "dtype-array")]
+    pub fn reshape(self, dimensions: &[i64]) -> Self {
+        let dimensions = dimensions
+            .iter()
+            .map(|&v| ReshapeDimension::new(v))
+            .collect();
+        self.apply_private(FunctionExpr::Reshape(dimensions))
     }
 
     #[cfg(feature = "ewma")]

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -106,7 +106,7 @@ pub enum WindowMapping {
 pub enum NestedType {
     #[cfg(feature = "dtype-array")]
     Array,
-    List,
+    // List,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -762,8 +762,9 @@ impl PyExpr {
         self.inner.clone().kurtosis(fisher, bias).into()
     }
 
+    #[cfg(feature = "dtype-array")]
     fn reshape(&self, dims: Vec<i64>) -> Self {
-        self.inner.clone().reshape(&dims, NestedType::Array).into()
+        self.inner.clone().reshape(&dims).into()
     }
 
     fn to_physical(&self) -> Self {

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1169,9 +1169,8 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::Mode => ("mode",).to_object(py),
                 FunctionExpr::Skew(bias) => ("skew", bias).to_object(py),
                 FunctionExpr::Kurtosis(fisher, bias) => ("kurtosis", fisher, bias).to_object(py),
-                FunctionExpr::Reshape(_, _) => {
-                    return Err(PyNotImplementedError::new_err("reshape"))
-                },
+                #[cfg(feature = "dtype-array")]
+                FunctionExpr::Reshape(_) => return Err(PyNotImplementedError::new_err("reshape")),
                 #[cfg(feature = "repeat_by")]
                 FunctionExpr::RepeatBy => ("repeat_by",).to_object(py),
                 FunctionExpr::ArgUnique => ("arg_unique",).to_object(py),

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -77,7 +77,13 @@ impl PySeries {
         })
     }
 
+    #[cfg(feature = "dtype-array")]
     fn reshape(&self, dims: Vec<i64>) -> PyResult<Self> {
+        let dims = dims
+            .into_iter()
+            .map(ReshapeDimension::new)
+            .collect::<Vec<_>>();
+
         let out = self
             .series
             .reshape_array(&dims)

--- a/py-polars/tests/unit/operations/test_reshape.py
+++ b/py-polars/tests/unit/operations/test_reshape.py
@@ -9,6 +9,10 @@ from polars.exceptions import InvalidOperationError
 from polars.testing import assert_series_equal
 
 
+def display_shape(shape: tuple[int, ...]) -> str:
+    return "(" + ", ".join(tuple(str(d) if d >= 0 else "inferred" for d in shape)) + ")"
+
+
 def test_reshape() -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     out = s.reshape((-1, 2))
@@ -47,10 +51,11 @@ def test_reshape() -> None:
 @pytest.mark.parametrize("shape", [(1, 3), (5, 1), (-1, 5), (3, -1)])
 def test_reshape_invalid_dimension_size(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [1, 2, 3, 4])
-    print(shape)
     with pytest.raises(
         InvalidOperationError,
-        match=re.escape(f"cannot reshape array of size 4 into shape {shape}"),
+        match=re.escape(
+            f"cannot reshape array of size 4 into shape {display_shape(shape)}"
+        ),
     ):
         s.reshape(shape)
 
@@ -61,7 +66,7 @@ def test_reshape_invalid_zero_dimension() -> None:
     with pytest.raises(
         InvalidOperationError,
         match=re.escape(
-            f"cannot reshape array into shape containing a zero dimension after the first: {shape}"
+            f"cannot reshape array into shape containing a zero dimension after the first: {display_shape(shape)}"
         ),
     ):
         s.reshape(shape)
@@ -73,7 +78,7 @@ def test_reshape_invalid_zero_dimension2(shape: tuple[int, ...]) -> None:
     with pytest.raises(
         InvalidOperationError,
         match=re.escape(
-            f"cannot reshape non-empty array into shape containing a zero dimension: {shape}"
+            f"cannot reshape non-empty array into shape containing a zero dimension: {display_shape(shape)}"
         ),
     ):
         s.reshape(shape)
@@ -83,7 +88,7 @@ def test_reshape_invalid_zero_dimension2(shape: tuple[int, ...]) -> None:
 def test_reshape_invalid_multiple_unknown_dims(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [1, 2, 3, 4])
     with pytest.raises(
-        InvalidOperationError, match="can only specify one unknown dimension"
+        InvalidOperationError, match="can only specify one inferred dimension"
     ):
         s.reshape(shape)
 
@@ -100,7 +105,9 @@ def test_reshape_empty_invalid_2d(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [], dtype=pl.Int64)
     with pytest.raises(
         InvalidOperationError,
-        match=re.escape(f"cannot reshape empty array into shape {shape}"),
+        match=re.escape(
+            f"cannot reshape empty array into shape {display_shape(shape)}"
+        ),
     ):
         s.reshape(shape)
 


### PR DESCRIPTION
This fixes the `reshape` function to properly infer dimensions in the schema.

I did this by adding a "zero-cost" `ReshapeDimension` enum that can either be `Specified(u64)` or `Infer`. This also makes the reshaping behavior more consistent as now all negative values are always assumed to be `Infer`.

During this work, I saw an unneeded allocation in `reshape_array` and removed it.

Fixes #18879.