### PR TITLE
refactor: Fix CI on Windows by installing timezone data

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -71,6 +71,10 @@ jobs:
           # https://github.com/astral-sh/uv/issues/6028#issuecomment-2287232150
           uv pip install -U typing-extensions
           uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose
+      
+      - name: Install timezone data on Windows
+        if: matrix.os == 'windows-latest'
+        run: uv pip install tzdata
 
       - name: Set up Rust
         run: rustup show


### PR DESCRIPTION
Some of our tests refer to timezones that I guess the latest Windows runners don't have. Haven't tested locally but installing `tzdata` (which is maintained by the Python time) should fix it.