### PR TITLE
fix: Throw informative error for 0-width Array

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -372,6 +372,10 @@ impl Series {
     pub fn cast_with_options(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Self> {
         use DataType as D;
 
+        if matches!(dtype, D::Array(_, width) if *width == 0) {
+            polars_bail!(InvalidOperation: "Arrays with 0 width are not yet supported");
+        }
+
         let do_clone = match dtype {
             D::Unknown(UnknownKind::Any) => true,
             D::Unknown(UnknownKind::Int(_)) if self.dtype().is_integer() => true,


### PR DESCRIPTION
This not only affects the example given in the issue but also just provides a generally better error.

Fixes #18921.