### PR TITLE
fix: Return the truth values of `ne_missing` and `eq_missing` operations for struct instead of `null`

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -720,22 +720,13 @@ where
         BooleanChunked::full(PlSmallStr::EMPTY, value, a.len())
     } else {
         let (a, b) = align_chunks_binary(a, b);
-        let mut out = a
+        let out = a
             .fields_as_series()
             .iter()
             .zip(b.fields_as_series().iter())
             .map(|(l, r)| op(l, r))
             .reduce(reduce)
             .unwrap();
-        if a.null_count() > 0 || b.null_count() > 0 {
-            let mut a = a.into_owned();
-            a.zip_outer_validity(&b);
-            unsafe {
-                for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
-                    arr.set_validity(a.validity().cloned())
-                }
-            }
-        }
         out
     }
 }

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -801,7 +801,7 @@ impl ChunkCompareEq<&StructChunked> for StructChunked {
         struct_helper(
             self,
             rhs,
-            |l, r| l.equal_missing(r).unwrap(),
+            |l, r| l.equal(r).unwrap(),
             |a, b| a.bitand(b),
             false,
             false,

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -716,8 +716,6 @@ where
     F: Fn(&Series, &Series) -> BooleanChunked,
     R: Fn(BooleanChunked, BooleanChunked) -> BooleanChunked,
 {
-    //dbg!(&a);
-    //dbg!(&b);
     if a.len() != b.len() || a.struct_fields().len() != b.struct_fields().len() {
         // polars_ensure!(a.len() == 1 || b.len() == 1, ShapeMismatch: "length lhs: {}, length rhs: {}", a.len(), b.len());
         BooleanChunked::full(PlSmallStr::EMPTY, value, a.len())
@@ -730,19 +728,17 @@ where
             .map(|(l, r)| op(l, r))
             .reduce(reduce)
             .unwrap();
-        dbg!(&out);
-        if a.null_count() > 0 || b.null_count() > 0 {
+
+        if apply_null_validity & (a.null_count() > 0 || b.null_count() > 0) {
             let mut a = a.into_owned();
             a.zip_outer_validity(&b);
-            if true {
-                unsafe {
-                    for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
-                        arr.set_validity(a.validity().cloned())
-                    }
+            unsafe {
+                for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
+                    arr.set_validity(a.validity().cloned())
                 }
             }
         }
-        dbg!(&out);
+
         out
     }
 }

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -716,6 +716,8 @@ where
     F: Fn(&Series, &Series) -> BooleanChunked,
     R: Fn(BooleanChunked, BooleanChunked) -> BooleanChunked,
 {
+    //dbg!(&a);
+    //dbg!(&b);
     if a.len() != b.len() || a.struct_fields().len() != b.struct_fields().len() {
         // polars_ensure!(a.len() == 1 || b.len() == 1, ShapeMismatch: "length lhs: {}, length rhs: {}", a.len(), b.len());
         BooleanChunked::full(PlSmallStr::EMPTY, value, a.len())
@@ -728,10 +730,11 @@ where
             .map(|(l, r)| op(l, r))
             .reduce(reduce)
             .unwrap();
+        dbg!(&out);
         if a.null_count() > 0 || b.null_count() > 0 {
             let mut a = a.into_owned();
             a.zip_outer_validity(&b);
-            if apply_null_validity {
+            if true {
                 unsafe {
                     for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
                         arr.set_validity(a.validity().cloned())
@@ -739,6 +742,7 @@ where
                 }
             }
         }
+        dbg!(&out);
         out
     }
 }

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -728,12 +728,14 @@ where
             .map(|(l, r)| op(l, r))
             .reduce(reduce)
             .unwrap();
-        if apply_null_validity && (a.null_count() > 0 || b.null_count() > 0) {
+        if a.null_count() > 0 || b.null_count() > 0 {
             let mut a = a.into_owned();
             a.zip_outer_validity(&b);
-            unsafe {
-                for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
-                    arr.set_validity(a.validity().cloned())
+            if apply_null_validity {
+                unsafe {
+                    for (arr, a) in out.downcast_iter_mut().zip(a.downcast_iter()) {
+                        arr.set_validity(a.validity().cloned())
+                    }
                 }
             }
         }

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -759,7 +759,7 @@ fn struct_helper<F, R>(
     op: F,
     reduce: R,
     value: bool,
-    apply_null_validity: bool,
+    is_missing: bool,
 ) -> BooleanChunked
 where
     F: Fn(&Series, &Series) -> BooleanChunked,
@@ -780,7 +780,7 @@ where
             .reduce(reduce)
             .unwrap();
 
-        if apply_null_validity & (a.null_count() > 0 || b.null_count() > 0) {
+        if !is_missing & (a.null_count() > 0 || b.null_count() > 0) {
             let mut a = a.into_owned();
             a.zip_outer_validity(&b);
             unsafe {
@@ -801,10 +801,10 @@ impl ChunkCompareEq<&StructChunked> for StructChunked {
         struct_helper(
             self,
             rhs,
-            |l, r| l.equal(r).unwrap(),
+            |l, r| l.equal_missing(r).unwrap(),
             |a, b| a.bitand(b),
             false,
-            true,
+            false,
         )
     }
 
@@ -815,7 +815,7 @@ impl ChunkCompareEq<&StructChunked> for StructChunked {
             |l, r| l.equal_missing(r).unwrap(),
             |a, b| a.bitand(b),
             false,
-            false,
+            true,
         )
     }
 
@@ -826,7 +826,7 @@ impl ChunkCompareEq<&StructChunked> for StructChunked {
             |l, r| l.not_equal(r).unwrap(),
             |a, b| a | b,
             true,
-            true,
+            false,
         )
     }
 
@@ -837,7 +837,7 @@ impl ChunkCompareEq<&StructChunked> for StructChunked {
             |l, r| l.not_equal_missing(r).unwrap(),
             |a, b| a | b,
             true,
-            false,
+            true,
         )
     }
 }

--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -54,6 +54,8 @@ fn apply_operator_owned(left: Series, right: Series, op: Operator) -> PolarsResu
 
 pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResult<Series> {
     use DataType::*;
+    dbg!(&left);
+    dbg!(&right);
     match op {
         Operator::Gt => ChunkCompare::gt(left, right).map(|ca| ca.into_series()),
         Operator::GtEq => ChunkCompare::gt_eq(left, right).map(|ca| ca.into_series()),

--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -54,8 +54,6 @@ fn apply_operator_owned(left: Series, right: Series, op: Operator) -> PolarsResu
 
 pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResult<Series> {
     use DataType::*;
-    dbg!(&left);
-    dbg!(&right);
     match op {
         Operator::Gt => ChunkCompare::gt(left, right).map(|ca| ca.into_series()),
         Operator::GtEq => ChunkCompare::gt_eq(left, right).map(|ca| ca.into_series()),

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -158,6 +158,30 @@ def test_missing_equality_on_bools() -> None:
     ]
 
 
+def test_struct_equality_18870() -> None:
+    s = pl.Series([{"a": 1}, None])
+
+    # eq
+    result = s.eq(s).to_list()
+    expected = [True, None]
+    assert result == expected
+
+    # ne
+    result = s.ne(s).to_list()
+    expected = [False, None]
+    assert result == expected
+
+    # eq_missing
+    result = s.eq_missing(s).to_list()
+    expected = [True, True]
+    assert result == expected
+
+    # ne_missing
+    result = s.ne_missing(s).to_list()
+    expected = [False, False]
+    assert result == expected
+
+
 def isnan(x: Any) -> bool:
     return isinstance(x, float) and math.isnan(x)
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/18870.