### PR TITLE
docs(rust): Typo for `IntoDf` trait

### DIFF
--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -27,7 +27,7 @@ impl IntoDf for DataFrame {
 impl<T: IntoDf> DataFrameOps for T {}
 
 pub trait DataFrameOps: IntoDf {
-    /// Crea dummy variables.
+    /// Create dummy variables.
     ///
     /// # Example
     ///


### PR DESCRIPTION
- Fixing a typo: "Crea" to "Create" in the docs for the `IntoDf` trait.