### PR TITLE
feat: Allow for zero-width fixed size lists

### DIFF
--- a/crates/polars-arrow/src/array/fixed_size_list/data.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/data.rs
@@ -18,6 +18,7 @@ impl Arrow2Arrow for FixedSizeListArray {
 
     fn from_data(data: &ArrayData) -> Self {
         let dtype: ArrowDataType = data.data_type().clone().into();
+        let length = data.len() - data.offset();
         let size = match dtype {
             ArrowDataType::FixedSizeList(_, size) => size,
             _ => unreachable!("must be FixedSizeList type"),
@@ -28,6 +29,7 @@ impl Arrow2Arrow for FixedSizeListArray {
 
         Self {
             size,
+            length,
             dtype,
             values,
             validity: data.nulls().map(|n| Bitmap::from_null_buffer(n.clone())),

--- a/crates/polars-arrow/src/array/fixed_size_list/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mutable.rs
@@ -14,6 +14,7 @@ use crate::datatypes::{ArrowDataType, Field};
 pub struct MutableFixedSizeListArray<M: MutableArray> {
     dtype: ArrowDataType,
     size: usize,
+    length: usize,
     values: M,
     validity: Option<MutableBitmap>,
 }
@@ -22,6 +23,7 @@ impl<M: MutableArray> From<MutableFixedSizeListArray<M>> for FixedSizeListArray 
     fn from(mut other: MutableFixedSizeListArray<M>) -> Self {
         FixedSizeListArray::new(
             other.dtype,
+            other.length,
             other.values.as_box(),
             other.validity.map(|x| x.into()),
         )
@@ -53,10 +55,17 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
         };
         Self {
             size,
+            length: 0,
             dtype,
             values,
             validity: None,
         }
+    }
+
+    #[inline]
+    fn has_valid_invariants(&self) -> bool {
+        (self.size == 0 && self.values().len() == 0)
+            || (self.size > 0 && self.values.len() / self.size == self.length)
     }
 
     /// Returns the size (number of elements per slot) of this [`FixedSizeListArray`].
@@ -66,7 +75,8 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
 
     /// The length of this array
     pub fn len(&self) -> usize {
-        self.values.len() / self.size
+        debug_assert!(self.has_valid_invariants());
+        self.length
     }
 
     /// The inner values
@@ -98,6 +108,10 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
         if let Some(validity) = &mut self.validity {
             validity.push(true)
         }
+        self.length += 1;
+
+        debug_assert!(self.has_valid_invariants());
+
         Ok(())
     }
 
@@ -108,6 +122,9 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
         if let Some(validity) = &mut self.validity {
             validity.push(true)
         }
+        self.length += 1;
+
+        debug_assert!(self.has_valid_invariants());
     }
 
     #[inline]
@@ -117,6 +134,9 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
             Some(validity) => validity.push(false),
             None => self.init_validity(),
         }
+        self.length += 1;
+
+        debug_assert!(self.has_valid_invariants());
     }
 
     /// Reserves `additional` slots.
@@ -138,7 +158,8 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
 
 impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     fn len(&self) -> usize {
-        self.values.len() / self.size
+        debug_assert!(self.has_valid_invariants());
+        self.length
     }
 
     fn validity(&self) -> Option<&MutableBitmap> {
@@ -148,6 +169,7 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     fn as_box(&mut self) -> Box<dyn Array> {
         FixedSizeListArray::new(
             self.dtype.clone(),
+            self.length,
             self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         )
@@ -157,6 +179,7 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     fn as_arc(&mut self) -> Arc<dyn Array> {
         FixedSizeListArray::new(
             self.dtype.clone(),
+            self.length,
             self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         )
@@ -185,6 +208,9 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
         } else {
             self.init_validity()
         }
+        self.length += 1;
+
+        debug_assert!(self.has_valid_invariants());
     }
 
     fn reserve(&mut self, additional: usize) {
@@ -206,6 +232,9 @@ where
         for items in iter {
             self.try_push(items)?;
         }
+
+        debug_assert!(self.has_valid_invariants());
+
         Ok(())
     }
 }
@@ -223,6 +252,9 @@ where
         } else {
             self.push_null();
         }
+
+        debug_assert!(self.has_valid_invariants());
+
         Ok(())
     }
 }
@@ -243,6 +275,8 @@ where
         } else {
             self.push_null();
         }
+
+        debug_assert!(self.has_valid_invariants());
     }
 }
 
@@ -251,8 +285,12 @@ where
     M: MutableArray + TryExtendFromSelf,
 {
     fn try_extend_from_self(&mut self, other: &Self) -> PolarsResult<()> {
+        self.length += other.len();
         extend_validity(self.len(), &mut self.validity, &other.validity);
 
-        self.values.try_extend_from_self(&other.values)
+        self.values.try_extend_from_self(&other.values)?;
+        debug_assert!(self.has_valid_invariants());
+
+        Ok(())
     }
 }

--- a/crates/polars-arrow/src/array/fixed_size_list/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mutable.rs
@@ -84,11 +84,6 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
         &self.values
     }
 
-    /// The values as a mutable reference
-    pub fn mut_values(&mut self) -> &mut M {
-        &mut self.values
-    }
-
     fn init_validity(&mut self) {
         let len = self.values.len() / self.size;
 
@@ -285,10 +280,11 @@ where
     M: MutableArray + TryExtendFromSelf,
 {
     fn try_extend_from_self(&mut self, other: &Self) -> PolarsResult<()> {
-        self.length += other.len();
         extend_validity(self.len(), &mut self.validity, &other.validity);
 
         self.values.try_extend_from_self(&other.values)?;
+        self.length += other.len();
+
         debug_assert!(self.has_valid_invariants());
 
         Ok(())

--- a/crates/polars-arrow/src/array/static_array.rs
+++ b/crates/polars-arrow/src/array/static_array.rs
@@ -1,6 +1,7 @@
 use bytemuck::Zeroable;
 use polars_utils::no_call_const;
 
+use super::growable::{Growable, GrowableFixedSizeList};
 use crate::array::binview::BinaryViewValueIter;
 use crate::array::static_array_collect::ArrayFromIterDtype;
 use crate::array::{
@@ -390,6 +391,13 @@ impl StaticArray for FixedSizeListArray {
 
     fn full_null(length: usize, dtype: ArrowDataType) -> Self {
         Self::new_null(dtype, length)
+    }
+
+    fn full(length: usize, value: Self::ValueT<'_>, dtype: ArrowDataType) -> Self {
+        let singular_arr = FixedSizeListArray::new(dtype, 1, value, None);
+        let mut arr = GrowableFixedSizeList::new(vec![&singular_arr], false, length);
+        unsafe { arr.extend_copies(0, 0, 1, length) }
+        arr.into()
     }
 }
 

--- a/crates/polars-arrow/src/array/static_array.rs
+++ b/crates/polars-arrow/src/array/static_array.rs
@@ -2,7 +2,6 @@ use bytemuck::Zeroable;
 use polars_utils::no_call_const;
 
 use crate::array::binview::BinaryViewValueIter;
-use crate::array::growable::{Growable, GrowableFixedSizeList};
 use crate::array::static_array_collect::ArrayFromIterDtype;
 use crate::array::{
     Array, ArrayValuesIter, BinaryArray, BinaryValueIter, BinaryViewArray, BooleanArray,
@@ -391,13 +390,6 @@ impl StaticArray for FixedSizeListArray {
 
     fn full_null(length: usize, dtype: ArrowDataType) -> Self {
         Self::new_null(dtype, length)
-    }
-
-    fn full(length: usize, value: Self::ValueT<'_>, dtype: ArrowDataType) -> Self {
-        let singular_arr = FixedSizeListArray::new(dtype, value, None);
-        let mut arr = GrowableFixedSizeList::new(vec![&singular_arr], false, length);
-        unsafe { arr.extend_copies(0, 0, 1, length) }
-        arr.into()
     }
 }
 

--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -174,25 +174,20 @@ fn cast_list_to_fixed_size_list<O: Offset>(
 ) -> PolarsResult<FixedSizeListArray> {
     let null_cnt = list.null_count();
     let new_values = if null_cnt == 0 {
-        let offsets = list.offsets().buffer().iter();
-        let expected =
-            (list.offsets().first().to_usize()..list.len()).map(|ix| O::from_as_usize(ix * size));
+        let start_offset = list.offsets().first().to_usize();
+        let offsets = list.offsets().buffer();
 
-        match offsets
-            .zip(expected)
-            .find(|(actual, expected)| *actual != expected)
-        {
-            Some(_) => polars_bail!(ComputeError:
-                "not all elements have the specified width {size}"
-            ),
-            None => {
-                let sliced_values = list.values().sliced(
-                    list.offsets().first().to_usize(),
-                    list.offsets().range().to_usize(),
-                );
-                cast(sliced_values.as_ref(), inner.dtype(), options)?
-            },
+        let mut is_valid = true;
+        for (i, offset) in offsets.iter().enumerate() {
+            is_valid &= offset.to_usize() == start_offset + i * size;
         }
+
+        polars_ensure!(is_valid, ComputeError: "not all elements have the specified width {size}");
+
+        let sliced_values = list
+            .values()
+            .sliced(start_offset, list.offsets().range().to_usize());
+        cast(sliced_values.as_ref(), inner.dtype(), options)?
     } else {
         let offsets = list.offsets().as_slice();
         // Check the lengths of each list are equal to the fixed size.
@@ -232,8 +227,10 @@ fn cast_list_to_fixed_size_list<O: Offset>(
 
         cast(take_values.as_ref(), inner.dtype(), options)?
     };
+
     FixedSizeListArray::try_new(
         ArrowDataType::FixedSizeList(Box::new(inner.clone()), size),
+        list.len(),
         new_values,
         list.validity().cloned(),
     )

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -567,6 +567,17 @@ impl ArrowDataType {
     pub fn is_view(&self) -> bool {
         matches!(self, ArrowDataType::Utf8View | ArrowDataType::BinaryView)
     }
+
+    pub fn to_fixed_size_list(self, size: usize, is_nullable: bool) -> ArrowDataType {
+        ArrowDataType::FixedSizeList(
+            Box::new(Field::new(
+                PlSmallStr::from_static("item"),
+                self,
+                is_nullable,
+            )),
+            size,
+        )
+    }
 }
 
 impl From<IntegerType> for ArrowDataType {

--- a/crates/polars-arrow/src/io/ipc/read/array/fixed_size_list.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/fixed_size_list.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::io::{Read, Seek};
 
-use polars_error::{polars_err, PolarsResult};
+use polars_error::{polars_ensure, polars_err, PolarsResult};
 
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
@@ -41,6 +41,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
     )?;
 
     let (field, size) = FixedSizeListArray::get_child_and_size(&dtype);
+    polars_ensure!(size > 0, nyi = "Cannot read zero sized arrays from IPC");
 
     let limit = limit.map(|x| x.saturating_mul(size));
 
@@ -59,7 +60,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
         version,
         scratch,
     )?;
-    FixedSizeListArray::try_new(dtype, values, validity)
+    FixedSizeListArray::try_new(dtype, values.len() / size, values, validity)
 }
 
 pub fn skip_fixed_size_list(

--- a/crates/polars-arrow/src/legacy/array/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/array/fixed_size_list.rs
@@ -10,6 +10,7 @@ use crate::legacy::kernels::concatenate::concatenate_owned_unchecked;
 pub struct AnonymousBuilder {
     arrays: Vec<ArrayRef>,
     validity: Option<MutableBitmap>,
+    length: usize,
     pub width: usize,
 }
 
@@ -19,6 +20,7 @@ impl AnonymousBuilder {
             arrays: Vec::with_capacity(capacity),
             validity: None,
             width,
+            length: 0,
         }
     }
     pub fn is_empty(&self) -> bool {
@@ -32,6 +34,8 @@ impl AnonymousBuilder {
         if let Some(validity) = &mut self.validity {
             validity.push(true)
         }
+
+        self.length += 1;
     }
 
     pub fn push_null(&mut self) {
@@ -41,6 +45,8 @@ impl AnonymousBuilder {
             Some(validity) => validity.push(false),
             None => self.init_validity(),
         }
+
+        self.length += 1;
     }
 
     fn init_validity(&mut self) {
@@ -82,6 +88,7 @@ impl AnonymousBuilder {
         let dtype = FixedSizeListArray::default_datatype(inner_dtype.clone(), self.width);
         Ok(FixedSizeListArray::new(
             dtype,
+            self.length,
             values,
             self.validity.map(|validity| validity.into()),
         ))

--- a/crates/polars-arrow/src/legacy/array/mod.rs
+++ b/crates/polars-arrow/src/legacy/array/mod.rs
@@ -212,11 +212,23 @@ pub fn convert_inner_type(array: &dyn Array, dtype: &ArrowDataType) -> Box<dyn A
             .boxed()
         },
         ArrowDataType::FixedSizeList(field, width) => {
+            let width = *width;
+
             let array = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
             let inner = array.values();
+            let length = if width == array.len() {
+                array.len()
+            } else {
+                assert!(array.values().len() > 0 || width != 0);
+                if width == 0 {
+                    0
+                } else {
+                    array.values().len() / width
+                }
+            };
             let new_values = convert_inner_type(inner.as_ref(), field.dtype());
-            let dtype = FixedSizeListArray::default_datatype(new_values.dtype().clone(), *width);
-            FixedSizeListArray::new(dtype, new_values, array.validity().cloned()).boxed()
+            let dtype = FixedSizeListArray::default_datatype(new_values.dtype().clone(), width);
+            FixedSizeListArray::new(dtype, length, new_values, array.validity().cloned()).boxed()
         },
         ArrowDataType::Struct(fields) => {
             let array = array.as_any().downcast_ref::<StructArray>().unwrap();

--- a/crates/polars-arrow/src/legacy/array/mod.rs
+++ b/crates/polars-arrow/src/legacy/array/mod.rs
@@ -216,7 +216,7 @@ pub fn convert_inner_type(array: &dyn Array, dtype: &ArrowDataType) -> Box<dyn A
 
             let array = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
             let inner = array.values();
-            let length = if width == array.len() {
+            let length = if width == array.size() {
                 array.len()
             } else {
                 assert!(array.values().len() > 0 || width != 0);

--- a/crates/polars-compute/src/comparisons/array.rs
+++ b/crates/polars-compute/src/comparisons/array.rs
@@ -48,6 +48,10 @@ impl TotalEqKernel for FixedSizeListArray {
             return Bitmap::new_with_value(false, self.len());
         }
 
+        if *self_width == 0 {
+            return Bitmap::new_with_value(true, self.len());
+        }
+
         let inner = array_tot_eq_missing_kernel(self.values().as_ref(), other.values().as_ref());
 
         agg_array_bitmap(inner, self.size(), |zeroes| zeroes == 0)
@@ -67,6 +71,10 @@ impl TotalEqKernel for FixedSizeListArray {
 
         if self_width != other_width {
             return Bitmap::new_with_value(true, self.len());
+        }
+
+        if *self_width == 0 {
+            return Bitmap::new_with_value(false, self.len());
         }
 
         let inner = array_tot_ne_missing_kernel(self.values().as_ref(), other.values().as_ref());

--- a/crates/polars-core/src/chunked_array/array/mod.rs
+++ b/crates/polars-core/src/chunked_array/array/mod.rs
@@ -74,7 +74,8 @@ impl ArrayChunked {
                 out.dtype().to_arrow(CompatLevel::newest()),
                 ca.width(),
             );
-            let arr = FixedSizeListArray::new(inner_dtype, values, arr.validity().cloned());
+            let arr =
+                FixedSizeListArray::new(inner_dtype, arr.len(), values, arr.validity().cloned());
             Ok(arr)
         });
 

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -664,7 +664,7 @@ fn cast_fixed_size_list(
     let new_values = new_inner.array_ref(0).clone();
 
     let dtype = FixedSizeListArray::default_datatype(new_values.dtype().clone(), ca.width());
-    let new_arr = FixedSizeListArray::new(dtype, new_values, arr.validity().cloned());
+    let new_arr = FixedSizeListArray::new(dtype, ca.len(), new_values, arr.validity().cloned());
     Ok((Box::new(new_arr), inner_dtype))
 }
 

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -71,6 +71,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
             let arrow_dtype = FixedSizeListArray::default_datatype(ArrowDataType::UInt32, width);
             let new_array = FixedSizeListArray::new(
                 arrow_dtype,
+                values_arr.len(),
                 cat.array_ref(0).clone(),
                 list_arr.validity().cloned(),
             );

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -591,10 +591,9 @@ impl DataType {
             Duration(unit) => Ok(ArrowDataType::Duration(unit.to_arrow())),
             Time => Ok(ArrowDataType::Time64(ArrowTimeUnit::Nanosecond)),
             #[cfg(feature = "dtype-array")]
-            Array(dt, size) => Ok(ArrowDataType::FixedSizeList(
-                Box::new(dt.to_arrow_field(PlSmallStr::from_static("item"), compat_level)),
-                *size,
-            )),
+            Array(dt, size) => Ok(dt
+                .try_to_arrow(compat_level)?
+                .to_fixed_size_list(*size, true)),
             List(dt) => Ok(ArrowDataType::LargeList(Box::new(
                 dt.to_arrow_field(PlSmallStr::from_static("item"), compat_level),
             ))),

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -189,6 +189,84 @@ impl Column {
         }
     }
 
+    // # Try to Chunked Arrays
+    pub fn try_bool(&self) -> Option<&BooleanChunked> {
+        self.as_materialized_series().try_bool()
+    }
+    pub fn try_i8(&self) -> Option<&Int8Chunked> {
+        self.as_materialized_series().try_i8()
+    }
+    pub fn try_i16(&self) -> Option<&Int16Chunked> {
+        self.as_materialized_series().try_i16()
+    }
+    pub fn try_i32(&self) -> Option<&Int32Chunked> {
+        self.as_materialized_series().try_i32()
+    }
+    pub fn try_i64(&self) -> Option<&Int64Chunked> {
+        self.as_materialized_series().try_i64()
+    }
+    pub fn try_u8(&self) -> Option<&UInt8Chunked> {
+        self.as_materialized_series().try_u8()
+    }
+    pub fn try_u16(&self) -> Option<&UInt16Chunked> {
+        self.as_materialized_series().try_u16()
+    }
+    pub fn try_u32(&self) -> Option<&UInt32Chunked> {
+        self.as_materialized_series().try_u32()
+    }
+    pub fn try_u64(&self) -> Option<&UInt64Chunked> {
+        self.as_materialized_series().try_u64()
+    }
+    pub fn try_f32(&self) -> Option<&Float32Chunked> {
+        self.as_materialized_series().try_f32()
+    }
+    pub fn try_f64(&self) -> Option<&Float64Chunked> {
+        self.as_materialized_series().try_f64()
+    }
+    pub fn try_str(&self) -> Option<&StringChunked> {
+        self.as_materialized_series().try_str()
+    }
+    pub fn try_list(&self) -> Option<&ListChunked> {
+        self.as_materialized_series().try_list()
+    }
+    pub fn try_binary(&self) -> Option<&BinaryChunked> {
+        self.as_materialized_series().try_binary()
+    }
+    pub fn try_idx(&self) -> Option<&IdxCa> {
+        self.as_materialized_series().try_idx()
+    }
+    pub fn try_binary_offset(&self) -> Option<&BinaryOffsetChunked> {
+        self.as_materialized_series().try_binary_offset()
+    }
+    #[cfg(feature = "dtype-datetime")]
+    pub fn try_datetime(&self) -> Option<&DatetimeChunked> {
+        self.as_materialized_series().try_datetime()
+    }
+    #[cfg(feature = "dtype-struct")]
+    pub fn try_struct(&self) -> Option<&StructChunked> {
+        self.as_materialized_series().try_struct()
+    }
+    #[cfg(feature = "dtype-decimal")]
+    pub fn try_decimal(&self) -> Option<&DecimalChunked> {
+        self.as_materialized_series().try_decimal()
+    }
+    #[cfg(feature = "dtype-array")]
+    pub fn try_array(&self) -> Option<&ArrayChunked> {
+        self.as_materialized_series().try_array()
+    }
+    #[cfg(feature = "dtype-categorical")]
+    pub fn try_categorical(&self) -> Option<&CategoricalChunked> {
+        self.as_materialized_series().try_categorical()
+    }
+    #[cfg(feature = "dtype-date")]
+    pub fn try_date(&self) -> Option<&DateChunked> {
+        self.as_materialized_series().try_date()
+    }
+    #[cfg(feature = "dtype-duration")]
+    pub fn try_duration(&self) -> Option<&DurationChunked> {
+        self.as_materialized_series().try_duration()
+    }
+
     // # To Chunked Arrays
     pub fn bool(&self) -> PolarsResult<&BooleanChunked> {
         self.as_materialized_series().bool()

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -825,6 +825,17 @@ impl Series {
         unsafe { Ok(self.take_unchecked(&idx)) }
     }
 
+    pub fn try_idx(&self) -> Option<&IdxCa> {
+        #[cfg(feature = "bigidx")]
+        {
+            self.try_u64()
+        }
+        #[cfg(not(feature = "bigidx"))]
+        {
+            self.try_u32()
+        }
+    }
+
     pub fn idx(&self) -> PolarsResult<&IdxCa> {
         #[cfg(feature = "bigidx")]
         {

--- a/crates/polars-core/src/series/ops/downcast.rs
+++ b/crates/polars-core/src/series/ops/downcast.rs
@@ -1,36 +1,190 @@
 use crate::prelude::*;
 use crate::series::implementations::null::NullChunked;
 
-macro_rules! unpack_chunked {
-    ($series:expr, $expected:pat => $ca:ty, $name:expr) => {
+macro_rules! unpack_chunked_err {
+    ($series:expr => $name:expr) => {
+        polars_err!(SchemaMismatch: "invalid series dtype: expected `{}`, got `{}`", $name, $series.dtype())
+    };
+}
+
+macro_rules! try_unpack_chunked {
+    ($series:expr, $expected:pat => $ca:ty) => {
         match $series.dtype() {
             $expected => {
                 // Check downcast in debug compiles
                 #[cfg(debug_assertions)]
                 {
-                    Ok($series.as_ref().as_any().downcast_ref::<$ca>().unwrap())
+                    Some($series.as_ref().as_any().downcast_ref::<$ca>().unwrap())
                 }
                 #[cfg(not(debug_assertions))]
                 unsafe {
-                    Ok(&*($series.as_ref() as *const dyn SeriesTrait as *const $ca))
+                    Some(&*($series.as_ref() as *const dyn SeriesTrait as *const $ca))
                 }
             },
-            dt => polars_bail!(
-                SchemaMismatch: "invalid series dtype: expected `{}`, got `{}`", $name, dt,
-            ),
+            _ => None,
         }
     };
 }
 
 impl Series {
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int8]`
+    pub fn try_i8(&self) -> Option<&Int8Chunked> {
+        try_unpack_chunked!(self, DataType::Int8 => Int8Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int16]`
+    pub fn try_i16(&self) -> Option<&Int16Chunked> {
+        try_unpack_chunked!(self, DataType::Int16 => Int16Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`]
+    /// ```
+    /// # use polars_core::prelude::*;
+    /// let s = Series::new("foo".into(), [1i32 ,2, 3]);
+    /// let s_squared: Series = s.i32()
+    ///     .unwrap()
+    ///     .into_iter()
+    ///     .map(|opt_v| {
+    ///         match opt_v {
+    ///             Some(v) => Some(v * v),
+    ///             None => None, // null value
+    ///         }
+    /// }).collect();
+    /// ```
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int32]`
+    pub fn try_i32(&self) -> Option<&Int32Chunked> {
+        try_unpack_chunked!(self, DataType::Int32 => Int32Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int64]`
+    pub fn try_i64(&self) -> Option<&Int64Chunked> {
+        try_unpack_chunked!(self, DataType::Int64 => Int64Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float32]`
+    pub fn try_f32(&self) -> Option<&Float32Chunked> {
+        try_unpack_chunked!(self, DataType::Float32 => Float32Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float64]`
+    pub fn try_f64(&self) -> Option<&Float64Chunked> {
+        try_unpack_chunked!(self, DataType::Float64 => Float64Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt8]`
+    pub fn try_u8(&self) -> Option<&UInt8Chunked> {
+        try_unpack_chunked!(self, DataType::UInt8 => UInt8Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt16]`
+    pub fn try_u16(&self) -> Option<&UInt16Chunked> {
+        try_unpack_chunked!(self, DataType::UInt16 => UInt16Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt32]`
+    pub fn try_u32(&self) -> Option<&UInt32Chunked> {
+        try_unpack_chunked!(self, DataType::UInt32 => UInt32Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt64]`
+    pub fn try_u64(&self) -> Option<&UInt64Chunked> {
+        try_unpack_chunked!(self, DataType::UInt64 => UInt64Chunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Boolean]`
+    pub fn try_bool(&self) -> Option<&BooleanChunked> {
+        try_unpack_chunked!(self, DataType::Boolean => BooleanChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::String]`
+    pub fn try_str(&self) -> Option<&StringChunked> {
+        try_unpack_chunked!(self, DataType::String => StringChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
+    pub fn try_binary(&self) -> Option<&BinaryChunked> {
+        try_unpack_chunked!(self, DataType::Binary => BinaryChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
+    pub fn try_binary_offset(&self) -> Option<&BinaryOffsetChunked> {
+        try_unpack_chunked!(self, DataType::BinaryOffset => BinaryOffsetChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Time]`
+    #[cfg(feature = "dtype-time")]
+    pub fn try_time(&self) -> Option<&TimeChunked> {
+        try_unpack_chunked!(self, DataType::Time => TimeChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Date]`
+    #[cfg(feature = "dtype-date")]
+    pub fn try_date(&self) -> Option<&DateChunked> {
+        try_unpack_chunked!(self, DataType::Date => DateChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Datetime]`
+    #[cfg(feature = "dtype-datetime")]
+    pub fn try_datetime(&self) -> Option<&DatetimeChunked> {
+        try_unpack_chunked!(self, DataType::Datetime(_, _) => DatetimeChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Duration]`
+    #[cfg(feature = "dtype-duration")]
+    pub fn try_duration(&self) -> Option<&DurationChunked> {
+        try_unpack_chunked!(self, DataType::Duration(_) => DurationChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Decimal]`
+    #[cfg(feature = "dtype-decimal")]
+    pub fn try_decimal(&self) -> Option<&DecimalChunked> {
+        try_unpack_chunked!(self, DataType::Decimal(_, _) => DecimalChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype list
+    pub fn try_list(&self) -> Option<&ListChunked> {
+        try_unpack_chunked!(self, DataType::List(_) => ListChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Array]`
+    #[cfg(feature = "dtype-array")]
+    pub fn try_array(&self) -> Option<&ArrayChunked> {
+        try_unpack_chunked!(self, DataType::Array(_, _) => ArrayChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Categorical]`
+    #[cfg(feature = "dtype-categorical")]
+    pub fn try_categorical(&self) -> Option<&CategoricalChunked> {
+        try_unpack_chunked!(self, DataType::Categorical(_, _) | DataType::Enum(_, _) => CategoricalChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Struct]`
+    #[cfg(feature = "dtype-struct")]
+    pub fn try_struct(&self) -> Option<&StructChunked> {
+        #[cfg(debug_assertions)]
+        {
+            if let DataType::Struct(_) = self.dtype() {
+                let any = self.as_any();
+                assert!(any.is::<StructChunked>());
+            }
+        }
+        try_unpack_chunked!(self, DataType::Struct(_) => StructChunked)
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Null]`
+    pub fn try_null(&self) -> Option<&NullChunked> {
+        try_unpack_chunked!(self, DataType::Null => NullChunked)
+    }
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int8]`
     pub fn i8(&self) -> PolarsResult<&Int8Chunked> {
-        unpack_chunked!(self, DataType::Int8 => Int8Chunked, "Int8")
+        self.try_i8()
+            .ok_or_else(|| unpack_chunked_err!(self => "Int8"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int16]`
     pub fn i16(&self) -> PolarsResult<&Int16Chunked> {
-        unpack_chunked!(self, DataType::Int16 => Int16Chunked, "Int16")
+        self.try_i16()
+            .ok_or_else(|| unpack_chunked_err!(self => "Int16"))
     }
 
     /// Unpack to [`ChunkedArray`]
@@ -49,109 +203,129 @@ impl Series {
     /// ```
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int32]`
     pub fn i32(&self) -> PolarsResult<&Int32Chunked> {
-        unpack_chunked!(self, DataType::Int32 => Int32Chunked, "Int32")
+        self.try_i32()
+            .ok_or_else(|| unpack_chunked_err!(self => "Int32"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int64]`
     pub fn i64(&self) -> PolarsResult<&Int64Chunked> {
-        unpack_chunked!(self, DataType::Int64 => Int64Chunked, "Int64")
+        self.try_i64()
+            .ok_or_else(|| unpack_chunked_err!(self => "Int64"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float32]`
     pub fn f32(&self) -> PolarsResult<&Float32Chunked> {
-        unpack_chunked!(self, DataType::Float32 => Float32Chunked, "Float32")
+        self.try_f32()
+            .ok_or_else(|| unpack_chunked_err!(self => "Float32"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float64]`
     pub fn f64(&self) -> PolarsResult<&Float64Chunked> {
-        unpack_chunked!(self, DataType::Float64 => Float64Chunked, "Float64")
+        self.try_f64()
+            .ok_or_else(|| unpack_chunked_err!(self => "Float64"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt8]`
     pub fn u8(&self) -> PolarsResult<&UInt8Chunked> {
-        unpack_chunked!(self, DataType::UInt8 => UInt8Chunked, "UInt8")
+        self.try_u8()
+            .ok_or_else(|| unpack_chunked_err!(self => "UInt8"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt16]`
     pub fn u16(&self) -> PolarsResult<&UInt16Chunked> {
-        unpack_chunked!(self, DataType::UInt16 => UInt16Chunked, "UInt16")
+        self.try_u16()
+            .ok_or_else(|| unpack_chunked_err!(self => "UInt16"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt32]`
     pub fn u32(&self) -> PolarsResult<&UInt32Chunked> {
-        unpack_chunked!(self, DataType::UInt32 => UInt32Chunked, "UInt32")
+        self.try_u32()
+            .ok_or_else(|| unpack_chunked_err!(self => "UInt32"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt64]`
     pub fn u64(&self) -> PolarsResult<&UInt64Chunked> {
-        unpack_chunked!(self, DataType::UInt64 => UInt64Chunked, "UInt64")
+        self.try_u64()
+            .ok_or_else(|| unpack_chunked_err!(self => "UInt64"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Boolean]`
     pub fn bool(&self) -> PolarsResult<&BooleanChunked> {
-        unpack_chunked!(self, DataType::Boolean => BooleanChunked, "Boolean")
+        self.try_bool()
+            .ok_or_else(|| unpack_chunked_err!(self => "Boolean"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::String]`
     pub fn str(&self) -> PolarsResult<&StringChunked> {
-        unpack_chunked!(self, DataType::String => StringChunked, "String")
+        self.try_str()
+            .ok_or_else(|| unpack_chunked_err!(self => "String"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
     pub fn binary(&self) -> PolarsResult<&BinaryChunked> {
-        unpack_chunked!(self, DataType::Binary => BinaryChunked, "Binary")
+        self.try_binary()
+            .ok_or_else(|| unpack_chunked_err!(self => "Binary"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
     pub fn binary_offset(&self) -> PolarsResult<&BinaryOffsetChunked> {
-        unpack_chunked!(self, DataType::BinaryOffset => BinaryOffsetChunked, "BinaryOffset")
+        self.try_binary_offset()
+            .ok_or_else(|| unpack_chunked_err!(self => "BinaryOffset"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Time]`
     #[cfg(feature = "dtype-time")]
     pub fn time(&self) -> PolarsResult<&TimeChunked> {
-        unpack_chunked!(self, DataType::Time => TimeChunked, "Time")
+        self.try_time()
+            .ok_or_else(|| unpack_chunked_err!(self => "Time"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Date]`
     #[cfg(feature = "dtype-date")]
     pub fn date(&self) -> PolarsResult<&DateChunked> {
-        unpack_chunked!(self, DataType::Date => DateChunked, "Date")
+        self.try_date()
+            .ok_or_else(|| unpack_chunked_err!(self => "Date"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Datetime]`
     #[cfg(feature = "dtype-datetime")]
     pub fn datetime(&self) -> PolarsResult<&DatetimeChunked> {
-        unpack_chunked!(self, DataType::Datetime(_, _) => DatetimeChunked, "Datetime")
+        self.try_datetime()
+            .ok_or_else(|| unpack_chunked_err!(self => "Datetime"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Duration]`
     #[cfg(feature = "dtype-duration")]
     pub fn duration(&self) -> PolarsResult<&DurationChunked> {
-        unpack_chunked!(self, DataType::Duration(_) => DurationChunked, "Duration")
+        self.try_duration()
+            .ok_or_else(|| unpack_chunked_err!(self => "Duration"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Decimal]`
     #[cfg(feature = "dtype-decimal")]
     pub fn decimal(&self) -> PolarsResult<&DecimalChunked> {
-        unpack_chunked!(self, DataType::Decimal(_, _) => DecimalChunked, "Decimal")
+        self.try_decimal()
+            .ok_or_else(|| unpack_chunked_err!(self => "Decimal"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype list
     pub fn list(&self) -> PolarsResult<&ListChunked> {
-        unpack_chunked!(self, DataType::List(_) => ListChunked, "List")
+        self.try_list()
+            .ok_or_else(|| unpack_chunked_err!(self => "List"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Array]`
     #[cfg(feature = "dtype-array")]
     pub fn array(&self) -> PolarsResult<&ArrayChunked> {
-        unpack_chunked!(self, DataType::Array(_, _) => ArrayChunked, "FixedSizeList")
+        self.try_array()
+            .ok_or_else(|| unpack_chunked_err!(self => "FixedSizeList"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Categorical]`
     #[cfg(feature = "dtype-categorical")]
     pub fn categorical(&self) -> PolarsResult<&CategoricalChunked> {
-        unpack_chunked!(self, DataType::Categorical(_, _) | DataType::Enum(_, _) => CategoricalChunked, "Enum | Categorical")
+        self.try_categorical()
+            .ok_or_else(|| unpack_chunked_err!(self => "Enum | Categorical"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Struct]`
@@ -164,11 +338,14 @@ impl Series {
                 assert!(any.is::<StructChunked>());
             }
         }
-        unpack_chunked!(self, DataType::Struct(_) => StructChunked, "Struct")
+
+        self.try_struct()
+            .ok_or_else(|| unpack_chunked_err!(self => "Struct"))
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Null]`
     pub fn null(&self) -> PolarsResult<&NullChunked> {
-        unpack_chunked!(self, DataType::Null => NullChunked, "Null")
+        self.try_null()
+            .ok_or_else(|| unpack_chunked_err!(self => "Null"))
     }
 }

--- a/crates/polars-core/src/series/ops/reshape.rs
+++ b/crates/polars-core/src/series/ops/reshape.rs
@@ -124,8 +124,9 @@ impl Series {
             let len_iter = dimensions[1..]
                 .iter()
                 .map(|d| {
+                    let length = current_length as usize;
                     current_length *= d.get_or_infer(0);
-                    current_length as usize
+                    length
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/polars-core/src/series/ops/reshape.rs
+++ b/crates/polars-core/src/series/ops/reshape.rs
@@ -96,63 +96,89 @@ impl Series {
 
         let mut total_dim_size = 1;
         let mut num_infers = 0;
-        for (index, &dim) in dimensions.iter().enumerate() {
+        for &dim in dimensions {
             match dim {
-                ReshapeDimension::Infer => {
-                    polars_ensure!(
-                        num_infers == 0,
-                        InvalidOperation: "can only specify one inferred dimension"
-                    );
-                    num_infers += 1;
-                },
-                ReshapeDimension::Specified(dim) => {
-                    let dim = dim.get();
-
-                    if dim > 0 {
-                        total_dim_size *= dim as usize
-                    } else {
-                        polars_ensure!(
-                            index == 0,
-                            InvalidOperation: "cannot reshape array into shape containing a zero dimension after the first: {}",
-                            format_tuple!(dimensions)
-                        );
-                        total_dim_size = 0;
-                        // We can early exit here, as empty arrays will error with multiple dimensions,
-                        // and non-empty arrays will error when the first dimension is zero.
-                        break;
-                    }
-                },
+                ReshapeDimension::Infer => num_infers += 1,
+                ReshapeDimension::Specified(dim) => total_dim_size *= dim.get() as usize,
             }
         }
+
+        polars_ensure!(num_infers <= 1, InvalidOperation: "can only specify one inferred dimension");
 
         if size == 0 {
-            if dimensions.len() > 1 || (num_infers == 0 && total_dim_size != 0) {
-                polars_bail!(InvalidOperation: "cannot reshape empty array into shape {}", format_tuple!(dimensions))
-            }
-        } else if total_dim_size == 0 {
-            polars_bail!(InvalidOperation: "cannot reshape non-empty array into shape containing a zero dimension: {}", format_tuple!(dimensions))
-        } else {
             polars_ensure!(
-                size % total_dim_size == 0,
-                InvalidOperation: "cannot reshape array of size {} into shape {}", size, format_tuple!(dimensions)
+                num_infers > 0 || total_dim_size == 0,
+                InvalidOperation: "cannot reshape empty array into shape without zero dimension: {}",
+                format_tuple!(dimensions),
             );
+
+            let mut prev_arrow_dtype = leaf_array
+                .dtype()
+                .to_physical()
+                .to_arrow(CompatLevel::newest());
+            let mut prev_dtype = leaf_array.dtype().clone();
+            let mut prev_array = leaf_array.chunks()[0].clone();
+
+            // @NOTE: We need to collect the iterator here because it is lazily processed.
+            let mut current_length = dimensions[0].get_or_infer(0);
+            let len_iter = dimensions[1..]
+                .iter()
+                .map(|d| {
+                    current_length *= d.get_or_infer(0);
+                    current_length as usize
+                })
+                .collect::<Vec<_>>();
+
+            // We pop the outer dimension as that is the height of the series.
+            for (dim, length) in dimensions[1..].iter().zip(len_iter).rev() {
+                // Infer dimension if needed
+                let dim = dim.get_or_infer(0);
+                prev_arrow_dtype = prev_arrow_dtype.to_fixed_size_list(dim as usize, true);
+                prev_dtype = DataType::Array(Box::new(prev_dtype), dim as usize);
+
+                prev_array =
+                    FixedSizeListArray::new(prev_arrow_dtype.clone(), length, prev_array, None)
+                        .boxed();
+            }
+
+            return Ok(unsafe {
+                Series::from_chunks_and_dtype_unchecked(
+                    leaf_array.name().clone(),
+                    vec![prev_array],
+                    &prev_dtype,
+                )
+            });
         }
 
+        polars_ensure!(
+            total_dim_size > 0,
+            InvalidOperation: "cannot reshape non-empty array into shape containing a zero dimension: {}",
+            format_tuple!(dimensions)
+        );
+
+        polars_ensure!(
+            size % total_dim_size == 0,
+            InvalidOperation: "cannot reshape array of size {} into shape {}", size, format_tuple!(dimensions)
+        );
+
         let leaf_array = leaf_array.rechunk();
+        let mut prev_arrow_dtype = leaf_array
+            .dtype()
+            .to_physical()
+            .to_arrow(CompatLevel::newest());
         let mut prev_dtype = leaf_array.dtype().clone();
         let mut prev_array = leaf_array.chunks()[0].clone();
 
         // We pop the outer dimension as that is the height of the series.
-        for idx in (1..dimensions.len()).rev() {
+        for dim in dimensions[1..].iter().rev() {
             // Infer dimension if needed
-            let dim = dimensions[idx].get_or_infer_with(|| {
-                debug_assert!(num_infers > 0);
-                (size / total_dim_size) as u64
-            });
+            let dim = dim.get_or_infer((size / total_dim_size) as u64);
+            prev_arrow_dtype = prev_arrow_dtype.to_fixed_size_list(dim as usize, true);
             prev_dtype = DataType::Array(Box::new(prev_dtype), dim as usize);
 
             prev_array = FixedSizeListArray::new(
-                prev_dtype.to_arrow(CompatLevel::newest()),
+                prev_arrow_dtype.clone(),
+                prev_array.len() / dim as usize,
                 prev_array,
                 None,
             )

--- a/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/mod.rs
@@ -45,7 +45,7 @@ pub fn create_list(
     nested: &mut NestedState,
     values: Box<dyn Array>,
 ) -> Box<dyn Array> {
-    let (mut offsets, validity) = nested.pop().unwrap();
+    let (length, mut offsets, validity) = nested.pop().unwrap();
     let validity = validity.and_then(freeze_validity);
     match dtype.to_logical_type() {
         ArrowDataType::List(_) => {
@@ -75,7 +75,7 @@ pub fn create_list(
             ))
         },
         ArrowDataType::FixedSizeList(_, _) => {
-            Box::new(FixedSizeListArray::new(dtype, values, validity))
+            Box::new(FixedSizeListArray::new(dtype, length, values, validity))
         },
         _ => unreachable!(),
     }
@@ -87,7 +87,7 @@ pub fn create_map(
     nested: &mut NestedState,
     values: Box<dyn Array>,
 ) -> Box<dyn Array> {
-    let (mut offsets, validity) = nested.pop().unwrap();
+    let (_, mut offsets, validity) = nested.pop().unwrap();
     match dtype.to_logical_type() {
         ArrowDataType::Map(_, _) => {
             offsets.push(values.len() as i64);

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
@@ -403,7 +403,7 @@ pub fn columns_to_iter_recursive(
                 let (mut nested, last_array) =
                     field_to_nested_array(init.clone(), &mut columns, &mut types, last_field)?;
                 debug_assert!(matches!(nested.last().unwrap(), NestedContent::Struct));
-                let (_, struct_validity) = nested.pop().unwrap();
+                let (_, _, struct_validity) = nested.pop().unwrap();
 
                 let mut field_arrays = Vec::<Box<dyn Array>>::with_capacity(fields.len());
                 field_arrays.push(last_array);
@@ -416,7 +416,7 @@ pub fn columns_to_iter_recursive(
                     {
                         debug_assert!(matches!(_nested.last().unwrap(), NestedContent::Struct));
                         debug_assert_eq!(
-                            _nested.pop().unwrap().1.and_then(freeze_validity),
+                            _nested.pop().unwrap().2.and_then(freeze_validity),
                             struct_validity.clone().and_then(freeze_validity),
                         );
                     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -87,12 +87,17 @@ impl Nested {
         }
     }
 
-    fn take(mut self) -> (Vec<i64>, Option<MutableBitmap>) {
+    fn take(mut self) -> (usize, Vec<i64>, Option<MutableBitmap>) {
         if !matches!(self.content, NestedContent::Primitive) {
             if let Some(validity) = self.validity.as_mut() {
                 validity.extend_constant(self.num_valids, true);
                 validity.extend_constant(self.num_invalids, false);
             }
+
+            debug_assert!(self
+                .validity
+                .as_ref()
+                .map_or(true, |v| v.len() == self.length));
         }
 
         self.num_valids = 0;
@@ -101,11 +106,11 @@ impl Nested {
         match self.content {
             NestedContent::Primitive => {
                 debug_assert!(self.validity.map_or(true, |validity| validity.is_empty()));
-                (Vec::new(), None)
+                (self.length, Vec::new(), None)
             },
-            NestedContent::List { offsets } => (offsets, self.validity),
-            NestedContent::FixedSizeList { .. } => (Vec::new(), self.validity),
-            NestedContent::Struct => (Vec::new(), self.validity),
+            NestedContent::List { offsets } => (self.length, offsets, self.validity),
+            NestedContent::FixedSizeList { .. } => (self.length, Vec::new(), self.validity),
+            NestedContent::Struct => (self.length, Vec::new(), self.validity),
         }
     }
 
@@ -254,7 +259,7 @@ impl NestedState {
         Self { nested }
     }
 
-    pub fn pop(&mut self) -> Option<(Vec<i64>, Option<MutableBitmap>)> {
+    pub fn pop(&mut self) -> Option<(usize, Vec<i64>, Option<MutableBitmap>)> {
         Some(self.nested.pop()?.take())
     }
 

--- a/crates/polars-parquet/src/arrow/read/statistics/list.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/list.rs
@@ -64,6 +64,7 @@ impl MutableArray for DynMutableListArray {
             },
             ArrowDataType::FixedSizeList(field, _) => Box::new(FixedSizeListArray::new(
                 ArrowDataType::FixedSizeList(field.clone(), inner.len()),
+                self.len(),
                 inner,
                 None,
             )),

--- a/crates/polars-parquet/src/arrow/read/statistics/list.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/list.rs
@@ -64,7 +64,7 @@ impl MutableArray for DynMutableListArray {
             },
             ArrowDataType::FixedSizeList(field, _) => Box::new(FixedSizeListArray::new(
                 ArrowDataType::FixedSizeList(field.clone(), inner.len()),
-                self.len(),
+                1,
                 inner,
                 None,
             )),

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -392,7 +392,7 @@ pub(super) fn concat(s: &mut [Column]) -> PolarsResult<Option<Column>> {
     let mut first = std::mem::take(&mut s[0]);
     let other = &s[1..];
 
-    let mut first_ca = match first.list().ok() {
+    let mut first_ca = match first.try_list() {
         Some(ca) => ca,
         None => {
             first = first

--- a/crates/polars/tests/it/arrow/array/fixed_size_list/mod.rs
+++ b/crates/polars/tests/it/arrow/array/fixed_size_list/mod.rs
@@ -12,6 +12,7 @@ fn data() -> FixedSizeListArray {
             Box::new(Field::new("a".into(), values.dtype().clone(), true)),
             2,
         ),
+        2,
         values.boxed(),
         Some([true, false].into()),
     )
@@ -87,6 +88,7 @@ fn wrong_size() {
             Box::new(Field::new("a".into(), ArrowDataType::Int32, true)),
             2
         ),
+        2,
         values.boxed(),
         None
     )
@@ -95,12 +97,13 @@ fn wrong_size() {
 
 #[test]
 fn wrong_len() {
-    let values = Int32Array::from_slice([10, 20, 0]);
+    let values = Int32Array::from_slice([10, 20, 0, 0]);
     assert!(FixedSizeListArray::try_new(
         ArrowDataType::FixedSizeList(
             Box::new(Field::new("a".into(), ArrowDataType::Int32, true)),
             2
         ),
+        2,
         values.boxed(),
         Some([true, false, false].into()), // it should be 2
     )
@@ -109,11 +112,12 @@ fn wrong_len() {
 
 #[test]
 fn wrong_dtype() {
-    let values = Int32Array::from_slice([10, 20, 0]);
+    let values = Int32Array::from_slice([10, 20, 0, 0]);
     assert!(FixedSizeListArray::try_new(
         ArrowDataType::Binary,
+        2,
         values.boxed(),
-        Some([true, false, false].into()), // it should be 2
+        Some([true, false, false, false].into()),
     )
     .is_err());
 }

--- a/crates/polars/tests/it/arrow/compute/aggregate/memory.rs
+++ b/crates/polars/tests/it/arrow/compute/aggregate/memory.rs
@@ -27,6 +27,6 @@ fn fixed_size_list() {
         3,
     );
     let values = Box::new(Float32Array::from_slice([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
-    let a = FixedSizeListArray::new(dtype, values, None);
+    let a = FixedSizeListArray::new(dtype, 2, values, None);
     assert_eq!(6 * std::mem::size_of::<f32>(), estimated_bytes_size(&a));
 }

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -9,7 +8,6 @@ import pandas as pd
 import pytest
 
 import polars as pl
-from polars.exceptions import InvalidOperationError
 from polars.testing.asserts.series import assert_series_equal
 
 if TYPE_CHECKING:
@@ -157,11 +155,10 @@ def test_series_init_pandas_timestamp_18127() -> None:
 
 def test_series_init_np_2d_zero_zero_shape() -> None:
     arr = np.array([]).reshape(0, 0)
-    with pytest.raises(
-        InvalidOperationError,
-        match=re.escape("cannot reshape empty array into shape (0, 0)"),
-    ):
-        pl.Series(arr)
+    assert_series_equal(
+        pl.Series("a", arr),
+        pl.Series("a", [], pl.Array(pl.Float64, 0)),
+    )
 
 
 def test_list_null_constructor_schema() -> None:

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -876,9 +876,8 @@ def test_parquet_array_dtype_nulls() -> None:
         ([[1, 2, 3]], pl.Array(pl.Int64, 3)),
         ([[1, None, 3], None, [1, 2, None]], pl.Array(pl.Int64, 3)),
         ([[1, 2], None, [None, 3]], pl.Array(pl.Int64, 2)),
-        # @TODO: Enable when zero-width arrays are enabled
-        # ([[], [], []],                       pl.Array(pl.Int64, 0)),
-        # ([[], None, []],                     pl.Array(pl.Int64, 0)),
+        ([[], [], []], pl.Array(pl.Int64, 0)),
+        ([[], None, []], pl.Array(pl.Int64, 0)),
         (
             [[[1, 5, 2], [42, 13, 37]], [[1, 2, 3], [5, 2, 3]], [[1, 2, 1], [3, 1, 3]]],
             pl.Array(pl.Array(pl.Int8, 3), 2),
@@ -924,7 +923,7 @@ def test_parquet_array_dtype_nulls() -> None:
                 [[]],
                 [[None]],
                 [[[None], None]],
-                [[[None], []]],
+                [[[None], [None]]],
                 [[[[None]], [[[1]]]]],
                 [[[[[None]]]]],
                 [[[[[1]]]]],
@@ -938,12 +937,6 @@ def test_complex_types(series: list[Any], dtype: pl.DataType) -> None:
     df = pl.DataFrame({"x": xs})
 
     test_round_trip(df)
-
-
-@pytest.mark.xfail
-def test_placeholder_zero_array() -> None:
-    # @TODO: if this does not fail anymore please enable the upper test-cases
-    pl.Series([[]], dtype=pl.Array(pl.Int8, 0))
 
 
 @pytest.mark.write_disk

--- a/py-polars/tests/unit/operations/test_reshape.py
+++ b/py-polars/tests/unit/operations/test_reshape.py
@@ -139,6 +139,5 @@ def test_array_ndarray_reshape() -> None:
 )
 def test_reshape_empty(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [], dtype=pl.Int64)
-    print(s.reshape(shape))
     expected_len = max(shape[0], 0)
     assert s.reshape(shape).len() == expected_len

--- a/py-polars/tests/unit/operations/test_reshape.py
+++ b/py-polars/tests/unit/operations/test_reshape.py
@@ -66,7 +66,7 @@ def test_reshape_invalid_zero_dimension() -> None:
     with pytest.raises(
         InvalidOperationError,
         match=re.escape(
-            f"cannot reshape array into shape containing a zero dimension after the first: {display_shape(shape)}"
+            f"cannot reshape non-empty array into shape containing a zero dimension: {display_shape(shape)}"
         ),
     ):
         s.reshape(shape)
@@ -100,24 +100,14 @@ def test_reshape_empty_valid_1d(shape: tuple[int, ...]) -> None:
     assert_series_equal(out, s)
 
 
-@pytest.mark.parametrize("shape", [(0, 1), (1, -1), (-1, 1)])
-def test_reshape_empty_invalid_2d(shape: tuple[int, ...]) -> None:
-    s = pl.Series("a", [], dtype=pl.Int64)
-    with pytest.raises(
-        InvalidOperationError,
-        match=re.escape(
-            f"cannot reshape empty array into shape {display_shape(shape)}"
-        ),
-    ):
-        s.reshape(shape)
-
-
 @pytest.mark.parametrize("shape", [(1,), (2,)])
 def test_reshape_empty_invalid_1d(shape: tuple[int, ...]) -> None:
     s = pl.Series("a", [], dtype=pl.Int64)
     with pytest.raises(
         InvalidOperationError,
-        match=re.escape(f"cannot reshape empty array into shape ({shape[0]})"),
+        match=re.escape(
+            f"cannot reshape empty array into shape without zero dimension: ({shape[0]})"
+        ),
     ):
         s.reshape(shape)
 
@@ -131,3 +121,24 @@ def test_array_ndarray_reshape() -> None:
     n = n[0]
     s = s[0]
     assert (n[0] == s[0].to_numpy()).all()
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (0, 1),
+        (1, 0),
+        (-1, 10, 20, 10),
+        (-1, 1, 0),
+        (10, 1, 0),
+        (10, 0, 1, 0),
+        (10, 0, 1),
+        (42, 2, 3, 4, 0, 2, 3, 4),
+        (42, 1, 1, 1, 0),
+    ],
+)
+def test_reshape_empty(shape: tuple[int, ...]) -> None:
+    s = pl.Series("a", [], dtype=pl.Int64)
+    print(s.reshape(shape))
+    expected_len = max(shape[0], 0)
+    assert s.reshape(shape).len() == expected_len


### PR DESCRIPTION
This PR properly implements `polars.Array(..., 0)`. This does make a few
fundamental changes to how `FixedSizeListArray` works internally. Mainly, it
now keeps a `length` field that actually determines the length instead of
relying on the `values.len() / size`.

Fixes #18921, #16878.