### PR TITLE
fix: Fix `Expr.over` with `order_by` did not take effect if group keys were sorted

### DIFF
--- a/crates/polars-core/src/frame/group_by/proxy.rs
+++ b/crates/polars-core/src/frame/group_by/proxy.rs
@@ -395,7 +395,7 @@ impl GroupsProxy {
         }
     }
 
-    pub fn is_sorted_flag(&self) -> bool {
+    pub(crate) fn is_sorted_flag(&self) -> bool {
         match self {
             GroupsProxy::Idx(groups) => groups.is_sorted_flag(),
             GroupsProxy::Slice { .. } => true,

--- a/crates/polars-core/src/frame/group_by/proxy.rs
+++ b/crates/polars-core/src/frame/group_by/proxy.rs
@@ -395,7 +395,7 @@ impl GroupsProxy {
         }
     }
 
-    pub(crate) fn is_sorted_flag(&self) -> bool {
+    pub fn is_sorted_flag(&self) -> bool {
         match self {
             GroupsProxy::Idx(groups) => groups.is_sorted_flag(),
             GroupsProxy::Slice { .. } => true,

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -335,7 +335,11 @@ impl WindowExpr {
             (WindowMapping::GroupsToRows, AggState::AggregatedList(_))
                 if gb.get_groups().is_sorted_flag() =>
             {
-                Ok(MapStrategy::Explode)
+                if let GroupsProxy::Idx(_) = gb.get_groups() {
+                    Ok(MapStrategy::Map)
+                } else {
+                    Ok(MapStrategy::Explode)
+                }
             },
             (WindowMapping::GroupsToRows, AggState::AggregatedList(_)) => Ok(MapStrategy::Map),
             // no aggregations, just return column

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -498,7 +498,7 @@ impl PhysicalExpr for WindowExpr {
         // to make sure that the caches align we sort
         // the groups, so that the cached groups and join keys
         // are consistent among all windows
-        if self.order_by.is_none() && (sort_groups || state.cache_window()) {
+        if sort_groups || state.cache_window() {
             groups.sort()
         }
         let gb = GroupBy::new(df, group_by_columns.clone(), groups, Some(apply_columns));

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -150,9 +150,7 @@ fn test_sort_by_in_groups() -> PolarsResult<()> {
             col("cars"),
             col("A")
                 .sort_by([col("B")], SortMultipleOptions::default())
-                .implode()
                 .over([col("cars")])
-                .explode()
                 .alias("sorted_A_by_B"),
         ])
         .collect()?;

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -518,3 +518,21 @@ def test_lit_window_broadcast() -> None:
     assert pl.DataFrame({"a": [1, 1, 2]}).select(pl.lit(0).over("a").alias("a"))[
         "a"
     ].to_list() == [0, 0, 0]
+
+
+def test_order_by_sorted_keys_18943() -> None:
+    df = pl.DataFrame(
+        {
+            "g": [1, 1, 1, 1],
+            "t": [4, 3, 2, 1],
+            "x": [10, 20, 30, 40],
+        }
+    )
+
+    expect = pl.DataFrame({"x": [100, 90, 70, 40]})
+
+    out = df.select(pl.col("x").cum_sum().over("g", order_by="t"))
+    assert_frame_equal(out, expect)
+
+    out = df.set_sorted("g").select(pl.col("x").cum_sum().over("g", order_by="t"))
+    assert_frame_equal(out, expect)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/18943