### PR TITLE
refactor: Divide `ChunkCompare` into `Eq` and `Ineq` variants

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/categorical.rs
+++ b/crates/polars-core/src/chunked_array/comparison/categorical.rs
@@ -96,7 +96,7 @@ where
     }
 }
 
-impl ChunkCompare<&CategoricalChunked> for CategoricalChunked {
+impl ChunkCompareEq<&CategoricalChunked> for CategoricalChunked {
     type Item = PolarsResult<BooleanChunked>;
 
     fn equal(&self, rhs: &CategoricalChunked) -> Self::Item {
@@ -134,6 +134,10 @@ impl ChunkCompare<&CategoricalChunked> for CategoricalChunked {
             UInt32Chunked::not_equal_missing,
         )
     }
+}
+
+impl ChunkCompareIneq<&CategoricalChunked> for CategoricalChunked {
+    type Item = PolarsResult<BooleanChunked>;
 
     fn gt(&self, rhs: &CategoricalChunked) -> Self::Item {
         cat_compare_helper(self, rhs, UInt32Chunked::gt, |l, r| l > r)
@@ -217,7 +221,7 @@ where
     }
 }
 
-impl ChunkCompare<&StringChunked> for CategoricalChunked {
+impl ChunkCompareEq<&StringChunked> for CategoricalChunked {
     type Item = PolarsResult<BooleanChunked>;
 
     fn equal(&self, rhs: &StringChunked) -> Self::Item {
@@ -265,6 +269,10 @@ impl ChunkCompare<&StringChunked> for CategoricalChunked {
             StringChunked::not_equal_missing,
         )
     }
+}
+
+impl ChunkCompareIneq<&StringChunked> for CategoricalChunked {
+    type Item = PolarsResult<BooleanChunked>;
 
     fn gt(&self, rhs: &StringChunked) -> Self::Item {
         cat_str_compare_helper(
@@ -376,7 +384,7 @@ where
     }
 }
 
-impl ChunkCompare<&str> for CategoricalChunked {
+impl ChunkCompareEq<&str> for CategoricalChunked {
     type Item = PolarsResult<BooleanChunked>;
 
     fn equal(&self, rhs: &str) -> Self::Item {
@@ -414,6 +422,10 @@ impl ChunkCompare<&str> for CategoricalChunked {
             UInt32Chunked::equal_missing,
         )
     }
+}
+
+impl ChunkCompareIneq<&str> for CategoricalChunked {
+    type Item = PolarsResult<BooleanChunked>;
 
     fn gt(&self, rhs: &str) -> Self::Item {
         cat_single_str_compare_helper(

--- a/crates/polars-core/src/chunked_array/comparison/scalar.rs
+++ b/crates/polars-core/src/chunked_array/comparison/scalar.rs
@@ -61,13 +61,14 @@ where
     ca
 }
 
-impl<T, Rhs> ChunkCompare<Rhs> for ChunkedArray<T>
+impl<T, Rhs> ChunkCompareEq<Rhs> for ChunkedArray<T>
 where
     T: PolarsNumericType,
     Rhs: ToPrimitive,
     T::Array: TotalOrdKernel<Scalar = T::Native> + TotalEqKernel<Scalar = T::Native>,
 {
     type Item = BooleanChunked;
+
     fn equal(&self, rhs: Rhs) -> BooleanChunked {
         let rhs: T::Native = NumCast::from(rhs).unwrap();
         let fa = Some(|x: T::Native| x.tot_ge(&rhs));
@@ -111,6 +112,15 @@ where
             })
         }
     }
+}
+
+impl<T, Rhs> ChunkCompareIneq<Rhs> for ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    Rhs: ToPrimitive,
+    T::Array: TotalOrdKernel<Scalar = T::Native> + TotalEqKernel<Scalar = T::Native>,
+{
+    type Item = BooleanChunked;
 
     fn gt(&self, rhs: Rhs) -> BooleanChunked {
         let rhs: T::Native = NumCast::from(rhs).unwrap();
@@ -157,7 +167,7 @@ where
     }
 }
 
-impl ChunkCompare<&[u8]> for BinaryChunked {
+impl ChunkCompareEq<&[u8]> for BinaryChunked {
     type Item = BooleanChunked;
 
     fn equal(&self, rhs: &[u8]) -> BooleanChunked {
@@ -175,6 +185,10 @@ impl ChunkCompare<&[u8]> for BinaryChunked {
     fn not_equal_missing(&self, rhs: &[u8]) -> BooleanChunked {
         arity::unary_mut_with_options(self, |arr| arr.tot_ne_missing_kernel_broadcast(rhs).into())
     }
+}
+
+impl ChunkCompareIneq<&[u8]> for BinaryChunked {
+    type Item = BooleanChunked;
 
     fn gt(&self, rhs: &[u8]) -> BooleanChunked {
         arity::unary_mut_values(self, |arr| arr.tot_gt_kernel_broadcast(rhs).into())
@@ -193,7 +207,7 @@ impl ChunkCompare<&[u8]> for BinaryChunked {
     }
 }
 
-impl ChunkCompare<&str> for StringChunked {
+impl ChunkCompareEq<&str> for StringChunked {
     type Item = BooleanChunked;
 
     fn equal(&self, rhs: &str) -> BooleanChunked {
@@ -211,6 +225,10 @@ impl ChunkCompare<&str> for StringChunked {
     fn not_equal_missing(&self, rhs: &str) -> BooleanChunked {
         arity::unary_mut_with_options(self, |arr| arr.tot_ne_missing_kernel_broadcast(rhs).into())
     }
+}
+
+impl ChunkCompareIneq<&str> for StringChunked {
+    type Item = BooleanChunked;
 
     fn gt(&self, rhs: &str) -> BooleanChunked {
         arity::unary_mut_values(self, |arr| arr.tot_gt_kernel_broadcast(rhs).into())

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -38,7 +38,6 @@ pub(crate) mod unique;
 #[cfg(feature = "zip_with")]
 pub mod zip;
 
-use polars_utils::no_call_const;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 pub use sort::options::*;
@@ -312,7 +311,7 @@ pub trait ChunkVar {
 ///     df.filter(&mask)
 /// }
 /// ```
-pub trait ChunkCompare<Rhs> {
+pub trait ChunkCompareEq<Rhs> {
     type Item;
 
     /// Check for equality.
@@ -326,30 +325,24 @@ pub trait ChunkCompare<Rhs> {
 
     /// Check for inequality where `None == None`.
     fn not_equal_missing(&self, rhs: Rhs) -> Self::Item;
+}
+
+/// Compare [`Series`] and [`ChunkedArray`]'s using inequality operators (`<`, `>=`, etc.) and get
+/// a `boolean` mask that can be used to filter rows.
+pub trait ChunkCompareIneq<Rhs> {
+    type Item;
 
     /// Greater than comparison.
-    #[allow(unused_variables)]
-    fn gt(&self, rhs: Rhs) -> Self::Item {
-        no_call_const!()
-    }
+    fn gt(&self, rhs: Rhs) -> Self::Item;
 
     /// Greater than or equal comparison.
-    #[allow(unused_variables)]
-    fn gt_eq(&self, rhs: Rhs) -> Self::Item {
-        no_call_const!()
-    }
+    fn gt_eq(&self, rhs: Rhs) -> Self::Item;
 
     /// Less than comparison.
-    #[allow(unused_variables)]
-    fn lt(&self, rhs: Rhs) -> Self::Item {
-        no_call_const!()
-    }
+    fn lt(&self, rhs: Rhs) -> Self::Item;
 
     /// Less than or equal comparison
-    #[allow(unused_variables)]
-    fn lt_eq(&self, rhs: Rhs) -> Self::Item {
-        no_call_const!()
-    }
+    fn lt_eq(&self, rhs: Rhs) -> Self::Item;
 }
 
 /// Get unique values in a `ChunkedArray`

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -87,7 +87,8 @@ where
     T: PolarsNumericType,
     T::Native: TotalHash + TotalEq + ToTotalOrd,
     <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + Ord,
-    ChunkedArray<T>: IntoSeries + for<'a> ChunkCompare<&'a ChunkedArray<T>, Item = BooleanChunked>,
+    ChunkedArray<T>:
+        IntoSeries + for<'a> ChunkCompareEq<&'a ChunkedArray<T>, Item = BooleanChunked>,
 {
     fn unique(&self) -> PolarsResult<Self> {
         // prevent stackoverflow repeated sorted.unique call

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -992,61 +992,65 @@ impl Column {
     }
 }
 
-impl ChunkCompare<&Column> for Column {
+impl ChunkCompareEq<&Column> for Column {
     type Item = PolarsResult<BooleanChunked>;
 
     /// Create a boolean mask by checking for equality.
     #[inline]
-    fn equal(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn equal(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .equal(rhs.as_materialized_series())
     }
 
     /// Create a boolean mask by checking for equality.
     #[inline]
-    fn equal_missing(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn equal_missing(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .equal_missing(rhs.as_materialized_series())
     }
 
     /// Create a boolean mask by checking for inequality.
     #[inline]
-    fn not_equal(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn not_equal(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .not_equal(rhs.as_materialized_series())
     }
 
     /// Create a boolean mask by checking for inequality.
     #[inline]
-    fn not_equal_missing(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn not_equal_missing(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .not_equal_missing(rhs.as_materialized_series())
     }
+}
+
+impl ChunkCompareIneq<&Column> for Column {
+    type Item = PolarsResult<BooleanChunked>;
 
     /// Create a boolean mask by checking if self > rhs.
     #[inline]
-    fn gt(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn gt(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .gt(rhs.as_materialized_series())
     }
 
     /// Create a boolean mask by checking if self >= rhs.
     #[inline]
-    fn gt_eq(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn gt_eq(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .gt_eq(rhs.as_materialized_series())
     }
 
     /// Create a boolean mask by checking if self < rhs.
     #[inline]
-    fn lt(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn lt(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .lt(rhs.as_materialized_series())
     }
 
     /// Create a boolean mask by checking if self <= rhs.
     #[inline]
-    fn lt_eq(&self, rhs: &Column) -> PolarsResult<BooleanChunked> {
+    fn lt_eq(&self, rhs: &Column) -> Self::Item {
         self.as_materialized_series()
             .lt_eq(rhs.as_materialized_series())
     }

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -4,8 +4,8 @@ use crate::prelude::*;
 use crate::series::arithmetic::coerce_lhs_rhs;
 use crate::series::nulls::replace_non_null;
 
-macro_rules! impl_compare {
-    ($self:expr, $rhs:expr, $method:ident, $struct_function:expr) => {{
+macro_rules! impl_eq_compare {
+    ($self:expr, $rhs:expr, $method:ident) => {{
         use DataType::*;
         let (lhs, rhs) = ($self, $rhs);
         validate_types(lhs.dtype(), rhs.dtype())?;
@@ -70,14 +70,7 @@ macro_rules! impl_compare {
             #[cfg(feature = "dtype-array")]
             Array(_, _) => lhs.array().unwrap().$method(rhs.array().unwrap()),
             #[cfg(feature = "dtype-struct")]
-            Struct(_) => {
-                let lhs = lhs
-                .struct_()
-                .unwrap();
-                let rhs = rhs.struct_().unwrap();
-
-                $struct_function(lhs, rhs)?
-            },
+            Struct(_) => lhs.struct_().unwrap().$method(rhs.struct_().unwrap()),
             #[cfg(feature = "dtype-decimal")]
             Decimal(_, s1) => {
                 let DataType::Decimal(_, s2) = rhs.dtype() else {
@@ -96,14 +89,108 @@ macro_rules! impl_compare {
     }};
 }
 
-#[cfg(feature = "dtype-struct")]
-fn raise_struct(_a: &StructChunked, _b: &StructChunked) -> PolarsResult<BooleanChunked> {
-    polars_bail!(InvalidOperation: "order comparison not support for struct dtype")
+macro_rules! bail_invalid_ineq {
+    ($lhs:expr, $rhs:expr, $op:literal) => {
+        polars_bail!(
+            InvalidOperation: "cannot perform '{}' comparison between series '{}' of dtype: {} and series '{}' of dtype: {}",
+            $op,
+            $lhs.name(), $lhs.dtype(),
+            $rhs.name(), $rhs.dtype(),
+        )
+    };
 }
 
-#[cfg(not(feature = "dtype-struct"))]
-fn raise_struct(_a: &(), _b: &()) -> PolarsResult<BooleanChunked> {
-    unimplemented!()
+macro_rules! impl_ineq_compare {
+    ($self:expr, $rhs:expr, $method:ident, $op:literal) => {{
+        use DataType::*;
+        let (lhs, rhs) = ($self, $rhs);
+        validate_types(lhs.dtype(), rhs.dtype())?;
+
+        polars_ensure!(
+            lhs.len() == rhs.len() ||
+
+            // Broadcast
+            lhs.len() == 1 ||
+            rhs.len() == 1,
+            ShapeMismatch:
+                "could not perform '{}' comparison between series '{}' of length: {} and series '{}' of length: {}, because they have different lengths",
+            $op,
+            lhs.name(), lhs.len(),
+            rhs.name(), rhs.len()
+        );
+
+        #[cfg(feature = "dtype-categorical")]
+        match (lhs.dtype(), rhs.dtype()) {
+            (Categorical(_, _) | Enum(_, _), Categorical(_, _) | Enum(_, _)) => {
+                return Ok(lhs
+                    .categorical()
+                    .unwrap()
+                    .$method(rhs.categorical().unwrap())?
+                    .with_name(lhs.name().clone()));
+            },
+            (Categorical(_, _) | Enum(_, _), String) => {
+                return Ok(lhs
+                    .categorical()
+                    .unwrap()
+                    .$method(rhs.str().unwrap())?
+                    .with_name(lhs.name().clone()));
+            },
+            (String, Categorical(_, _) | Enum(_, _)) => {
+                return Ok(rhs
+                    .categorical()
+                    .unwrap()
+                    .$method(lhs.str().unwrap())?
+                    .with_name(lhs.name().clone()));
+            },
+            _ => (),
+        };
+
+        let (lhs, rhs) = coerce_lhs_rhs(lhs, rhs).map_err(|_|
+            polars_err!(
+                SchemaMismatch: "could not evaluate '{}' comparison between series '{}' of dtype: {} and series '{}' of dtype: {}",
+                $op,
+                lhs.name(), lhs.dtype(),
+                rhs.name(), rhs.dtype()
+            )
+        )?;
+        let lhs = lhs.to_physical_repr();
+        let rhs = rhs.to_physical_repr();
+        let mut out = match lhs.dtype() {
+            Null => lhs.null().unwrap().$method(rhs.null().unwrap()),
+            Boolean => lhs.bool().unwrap().$method(rhs.bool().unwrap()),
+            String => lhs.str().unwrap().$method(rhs.str().unwrap()),
+            Binary => lhs.binary().unwrap().$method(rhs.binary().unwrap()),
+            UInt8 => lhs.u8().unwrap().$method(rhs.u8().unwrap()),
+            UInt16 => lhs.u16().unwrap().$method(rhs.u16().unwrap()),
+            UInt32 => lhs.u32().unwrap().$method(rhs.u32().unwrap()),
+            UInt64 => lhs.u64().unwrap().$method(rhs.u64().unwrap()),
+            Int8 => lhs.i8().unwrap().$method(rhs.i8().unwrap()),
+            Int16 => lhs.i16().unwrap().$method(rhs.i16().unwrap()),
+            Int32 => lhs.i32().unwrap().$method(rhs.i32().unwrap()),
+            Int64 => lhs.i64().unwrap().$method(rhs.i64().unwrap()),
+            Float32 => lhs.f32().unwrap().$method(rhs.f32().unwrap()),
+            Float64 => lhs.f64().unwrap().$method(rhs.f64().unwrap()),
+            List(_) => bail_invalid_ineq!(lhs, rhs, $op),
+            #[cfg(feature = "dtype-array")]
+            Array(_, _) => bail_invalid_ineq!(lhs, rhs, $op),
+            #[cfg(feature = "dtype-struct")]
+            Struct(_) => bail_invalid_ineq!(lhs, rhs, $op),
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(_, s1) => {
+                let DataType::Decimal(_, s2) = rhs.dtype() else {
+                    unreachable!()
+                };
+                let scale = s1.max(s2).unwrap();
+                let lhs = lhs.decimal().unwrap().to_scale(scale).unwrap();
+                let rhs = rhs.decimal().unwrap().to_scale(scale).unwrap();
+                lhs.0.$method(&rhs.0)
+            },
+
+            dt => polars_bail!(InvalidOperation: "could not apply comparison on series of dtype '{}; operand names: '{}', '{}'", dt, lhs.name(), rhs.name()),
+        };
+        out.rename(lhs.name().clone());
+        PolarsResult::Ok(out)
+    }};
 }
 
 fn validate_types(left: &DataType, right: &DataType) -> PolarsResult<()> {
@@ -124,74 +211,61 @@ fn validate_types(left: &DataType, right: &DataType) -> PolarsResult<()> {
     Ok(())
 }
 
-impl ChunkCompare<&Series> for Series {
+impl ChunkCompareEq<&Series> for Series {
     type Item = PolarsResult<BooleanChunked>;
 
     /// Create a boolean mask by checking for equality.
-    fn equal(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(self, rhs, equal, |a: &StructChunked, b: &StructChunked| {
-            PolarsResult::Ok(a.equal(b))
-        })
+    fn equal(&self, rhs: &Series) -> Self::Item {
+        impl_eq_compare!(self, rhs, equal)
     }
 
     /// Create a boolean mask by checking for equality.
-    fn equal_missing(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(
-            self,
-            rhs,
-            equal_missing,
-            |a: &StructChunked, b: &StructChunked| PolarsResult::Ok(a.equal_missing(b))
-        )
+    fn equal_missing(&self, rhs: &Series) -> Self::Item {
+        impl_eq_compare!(self, rhs, equal_missing)
     }
 
     /// Create a boolean mask by checking for inequality.
-    fn not_equal(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(
-            self,
-            rhs,
-            not_equal,
-            |a: &StructChunked, b: &StructChunked| PolarsResult::Ok(a.not_equal(b))
-        )
+    fn not_equal(&self, rhs: &Series) -> Self::Item {
+        impl_eq_compare!(self, rhs, not_equal)
     }
 
     /// Create a boolean mask by checking for inequality.
-    fn not_equal_missing(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(
-            self,
-            rhs,
-            not_equal_missing,
-            |a: &StructChunked, b: &StructChunked| PolarsResult::Ok(a.not_equal_missing(b))
-        )
-    }
-
-    /// Create a boolean mask by checking if self > rhs.
-    fn gt(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(self, rhs, gt, raise_struct)
-    }
-
-    /// Create a boolean mask by checking if self >= rhs.
-    fn gt_eq(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(self, rhs, gt_eq, raise_struct)
-    }
-
-    /// Create a boolean mask by checking if self < rhs.
-    fn lt(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(self, rhs, lt, raise_struct)
-    }
-
-    /// Create a boolean mask by checking if self <= rhs.
-    fn lt_eq(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        impl_compare!(self, rhs, lt_eq, raise_struct)
+    fn not_equal_missing(&self, rhs: &Series) -> Self::Item {
+        impl_eq_compare!(self, rhs, not_equal_missing)
     }
 }
 
-impl<Rhs> ChunkCompare<Rhs> for Series
+impl ChunkCompareIneq<&Series> for Series {
+    type Item = PolarsResult<BooleanChunked>;
+
+    /// Create a boolean mask by checking if self > rhs.
+    fn gt(&self, rhs: &Series) -> Self::Item {
+        impl_ineq_compare!(self, rhs, gt, ">")
+    }
+
+    /// Create a boolean mask by checking if self >= rhs.
+    fn gt_eq(&self, rhs: &Series) -> Self::Item {
+        impl_ineq_compare!(self, rhs, gt_eq, ">=")
+    }
+
+    /// Create a boolean mask by checking if self < rhs.
+    fn lt(&self, rhs: &Series) -> Self::Item {
+        impl_ineq_compare!(self, rhs, lt, "<")
+    }
+
+    /// Create a boolean mask by checking if self <= rhs.
+    fn lt_eq(&self, rhs: &Series) -> Self::Item {
+        impl_ineq_compare!(self, rhs, lt_eq, "<=")
+    }
+}
+
+impl<Rhs> ChunkCompareEq<Rhs> for Series
 where
     Rhs: NumericNative,
 {
     type Item = PolarsResult<BooleanChunked>;
 
-    fn equal(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
+    fn equal(&self, rhs: Rhs) -> Self::Item {
         validate_types(self.dtype(), &DataType::Int8)?;
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, equal, rhs))
@@ -203,7 +277,7 @@ where
         Ok(apply_method_physical_numeric!(&s, equal_missing, rhs))
     }
 
-    fn not_equal(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
+    fn not_equal(&self, rhs: Rhs) -> Self::Item {
         validate_types(self.dtype(), &DataType::Int8)?;
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, not_equal, rhs))
@@ -214,33 +288,40 @@ where
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, not_equal_missing, rhs))
     }
+}
 
-    fn gt(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
+impl<Rhs> ChunkCompareIneq<Rhs> for Series
+where
+    Rhs: NumericNative,
+{
+    type Item = PolarsResult<BooleanChunked>;
+
+    fn gt(&self, rhs: Rhs) -> Self::Item {
         validate_types(self.dtype(), &DataType::Int8)?;
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, gt, rhs))
     }
 
-    fn gt_eq(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
+    fn gt_eq(&self, rhs: Rhs) -> Self::Item {
         validate_types(self.dtype(), &DataType::Int8)?;
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, gt_eq, rhs))
     }
 
-    fn lt(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
+    fn lt(&self, rhs: Rhs) -> Self::Item {
         validate_types(self.dtype(), &DataType::Int8)?;
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, lt, rhs))
     }
 
-    fn lt_eq(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
+    fn lt_eq(&self, rhs: Rhs) -> Self::Item {
         validate_types(self.dtype(), &DataType::Int8)?;
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, lt_eq, rhs))
     }
 }
 
-impl ChunkCompare<&str> for Series {
+impl ChunkCompareEq<&str> for Series {
     type Item = PolarsResult<BooleanChunked>;
 
     fn equal(&self, rhs: &str) -> PolarsResult<BooleanChunked> {
@@ -294,8 +375,12 @@ impl ChunkCompare<&str> for Series {
             _ => Ok(replace_non_null(self.name().clone(), self.0.chunks(), true)),
         }
     }
+}
 
-    fn gt(&self, rhs: &str) -> PolarsResult<BooleanChunked> {
+impl ChunkCompareIneq<&str> for Series {
+    type Item = PolarsResult<BooleanChunked>;
+
+    fn gt(&self, rhs: &str) -> Self::Item {
         validate_types(self.dtype(), &DataType::String)?;
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().gt(rhs)),

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1,5 +1,5 @@
 //! Type agnostic columnar data structure.
-pub use crate::prelude::ChunkCompare;
+pub use crate::prelude::ChunkCompareEq;
 use crate::prelude::*;
 use crate::{HEAD_DEFAULT_LENGTH, TAIL_DEFAULT_LENGTH};
 

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -614,12 +614,12 @@ impl ApplyExpr {
 
                     if max.get(0).unwrap() == min.get(0).unwrap() {
                         let one_equals =
-                            |value: &Series| Some(ChunkCompare::equal(input, value).ok()?.any());
+                            |value: &Series| Some(ChunkCompareEq::equal(input, value).ok()?.any());
                         return one_equals(min);
                     }
 
-                    let smaller = ChunkCompare::lt(input, min).ok()?;
-                    let bigger = ChunkCompare::gt(input, max).ok()?;
+                    let smaller = ChunkCompareIneq::lt(input, min).ok()?;
+                    let bigger = ChunkCompareIneq::gt(input, max).ok()?;
 
                     Some(!(smaller | bigger).all())
                 };
@@ -662,7 +662,7 @@ impl ApplyExpr {
                     // don't read the row_group anyways as
                     // the condition will evaluate to false.
                     // e.g. in_between(10, 5)
-                    if ChunkCompare::gt(&left, &right).ok()?.all() {
+                    if ChunkCompareIneq::gt(&left, &right).ok()?.all() {
                         return Some(false);
                     }
 
@@ -674,15 +674,15 @@ impl ApplyExpr {
                     };
                     // check the right limit of the interval.
                     // if the end is open, we should be stricter (lt_eq instead of lt).
-                    if right_open && ChunkCompare::lt_eq(&right, min).ok()?.all()
-                        || !right_open && ChunkCompare::lt(&right, min).ok()?.all()
+                    if right_open && ChunkCompareIneq::lt_eq(&right, min).ok()?.all()
+                        || !right_open && ChunkCompareIneq::lt(&right, min).ok()?.all()
                     {
                         return Some(false);
                     }
                     // we couldn't conclude anything using the right limit,
                     // check the left limit of the interval
-                    if left_open && ChunkCompare::gt_eq(&left, max).ok()?.all()
-                        || !left_open && ChunkCompare::gt(&left, max).ok()?.all()
+                    if left_open && ChunkCompareIneq::gt_eq(&left, max).ok()?.all()
+                        || !left_open && ChunkCompareIneq::gt(&left, max).ok()?.all()
                     {
                         return Some(false);
                     }

--- a/crates/polars-ops/src/chunked_array/array/count.rs
+++ b/crates/polars-ops/src/chunked_array/array/count.rs
@@ -11,7 +11,7 @@ pub fn array_count_matches(ca: &ArrayChunked, value: AnyValue) -> PolarsResult<S
     let value = Series::new(PlSmallStr::EMPTY, [value]);
 
     let ca = ca.apply_to_inner(&|s| {
-        ChunkCompare::<&Series>::equal_missing(&s, &value).map(|ca| ca.into_series())
+        ChunkCompareEq::<&Series>::equal_missing(&s, &value).map(|ca| ca.into_series())
     })?;
     let out = count_boolean_bits(&ca);
     Ok(out.into_series())

--- a/crates/polars-ops/src/chunked_array/list/count.rs
+++ b/crates/polars-ops/src/chunked_array/list/count.rs
@@ -45,7 +45,7 @@ pub fn list_count_matches(ca: &ListChunked, value: AnyValue) -> PolarsResult<Ser
     let value = Series::new(PlSmallStr::EMPTY, [value]);
 
     let ca = ca.apply_to_inner(&|s| {
-        ChunkCompare::<&Series>::equal_missing(&s, &value).map(|ca| ca.into_series())
+        ChunkCompareEq::<&Series>::equal_missing(&s, &value).map(|ca| ca.into_series())
     })?;
     let out = count_boolean_bits(&ca);
     Ok(out.into_series())

--- a/crates/polars-ops/src/chunked_array/peaks.rs
+++ b/crates/polars-ops/src/chunked_array/peaks.rs
@@ -4,7 +4,7 @@ use polars_core::prelude::*;
 /// Get a boolean mask of the local maximum peaks.
 pub fn peak_max<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> BooleanChunked
 where
-    ChunkedArray<T>: for<'a> ChunkCompare<&'a ChunkedArray<T>, Item = BooleanChunked>,
+    ChunkedArray<T>: for<'a> ChunkCompareIneq<&'a ChunkedArray<T>, Item = BooleanChunked>,
 {
     let shift_left = ca.shift_and_fill(1, Some(Zero::zero()));
     let shift_right = ca.shift_and_fill(-1, Some(Zero::zero()));
@@ -14,7 +14,7 @@ where
 /// Get a boolean mask of the local minimum peaks.
 pub fn peak_min<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> BooleanChunked
 where
-    ChunkedArray<T>: for<'a> ChunkCompare<&'a ChunkedArray<T>, Item = BooleanChunked>,
+    ChunkedArray<T>: for<'a> ChunkCompareIneq<&'a ChunkedArray<T>, Item = BooleanChunked>,
 {
     let shift_left = ca.shift_and_fill(1, Some(Zero::zero()));
     let shift_right = ca.shift_and_fill(-1, Some(Zero::zero()));


### PR DESCRIPTION
Divide the `ChunkCompare` trait into two traits `ChunkCompareEq` and `ChunkCompareIneq`, which allows us to statistically verify that there are no calls to the inequality methods when these are not available (e.g. for `List`, `Array` and `Struct`). This makes error handling a lot better as well.

For example, the following was a panic exception before.

```python
import polars as pl

a = pl.Series('a', [[1]], pl.Array(pl.Int8, 1))
b = pl.Series('b', [[1]], pl.Array(pl.Int8, 1))

c = a < b
```

Now, it returns:

```
polars.exceptions.InvalidOperationError: cannot perform '<' comparison between series 'a' of dtype: array[i8, 1] and series 'b' of dtype: array[i8, 1]
```

Fixes #18938.