### PR TITLE
feat(python): Drop python 3.8 support

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.12']
+        python-version: ['3.9', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -63,4 +63,4 @@ jobs:
       # Allow untyped calls for older Python versions
       - name: Run mypy
         working-directory: py-polars
-        run: mypy ${{ (matrix.python-version == '3.8') && '--allow-untyped-calls' || '' }}
+        run: mypy ${{ (matrix.python-version == '3.9') && '--allow-untyped-calls' || '' }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.8'
+  PYTHON_VERSION: '3.9'
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.11', '3.12']
+        python-version: ['3.9', '3.12']
         include:
           - os: windows-latest
             python-version: '3.12'

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -12,7 +12,7 @@ libc = { workspace = true }
 # Explicit dependency is needed to add bigidx in CI during release
 polars = { workspace = true }
 polars-python = { workspace = true, features = ["pymethods", "iejoin"] }
-pyo3 = { workspace = true, features = ["abi3-py38", "chrono", "extension-module", "multiple-pymethods"] }
+pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "extension-module", "multiple-pymethods"] }
 
 [build-dependencies]
 built = { version = "0.7", features = ["chrono", "git2", "cargo-lock"], optional = true }

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -4,11 +4,8 @@ from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    List,
     Literal,
     Protocol,
-    Tuple,
-    Type,
     TypedDict,
     TypeVar,
     Union,
@@ -52,29 +49,29 @@ class ArrowStreamExportable(Protocol):
 
 # Data types
 PolarsDataType: TypeAlias = Union["DataTypeClass", "DataType"]
-PolarsTemporalType: TypeAlias = Union[Type["TemporalType"], "TemporalType"]
-PolarsIntegerType: TypeAlias = Union[Type["IntegerType"], "IntegerType"]
+PolarsTemporalType: TypeAlias = Union[type["TemporalType"], "TemporalType"]
+PolarsIntegerType: TypeAlias = Union[type["IntegerType"], "IntegerType"]
 OneOrMoreDataTypes: TypeAlias = Union[PolarsDataType, Iterable[PolarsDataType]]
 PythonDataType: TypeAlias = Union[
-    Type[int],
-    Type[float],
-    Type[bool],
-    Type[str],
-    Type["date"],
-    Type["time"],
-    Type["datetime"],
-    Type["timedelta"],
-    Type[List[Any]],
-    Type[Tuple[Any, ...]],
-    Type[bytes],
-    Type[object],
-    Type["Decimal"],
-    Type[None],
+    type[int],
+    type[float],
+    type[bool],
+    type[str],
+    type["date"],
+    type["time"],
+    type["datetime"],
+    type["timedelta"],
+    type[list[Any]],
+    type[tuple[Any, ...]],
+    type[bytes],
+    type[object],
+    type["Decimal"],
+    type[None],
 ]
 
 SchemaDefinition: TypeAlias = Union[
     Mapping[str, Union[PolarsDataType, PythonDataType]],
-    Sequence[Union[str, Tuple[str, Union[PolarsDataType, PythonDataType, None]]]],
+    Sequence[Union[str, tuple[str, Union[PolarsDataType, PythonDataType, None]]]],
 ]
 SchemaDict: TypeAlias = Mapping[str, PolarsDataType]
 
@@ -82,7 +79,7 @@ NumericLiteral: TypeAlias = Union[int, float, "Decimal"]
 TemporalLiteral: TypeAlias = Union["date", "time", "datetime", "timedelta"]
 NonNestedLiteral: TypeAlias = Union[NumericLiteral, TemporalLiteral, str, bool, bytes]
 # Python literal types (can convert into a `lit` expression)
-PythonLiteral: TypeAlias = Union[NonNestedLiteral, List[Any]]
+PythonLiteral: TypeAlias = Union[NonNestedLiteral, list[Any]]
 # Inputs that can convert into a `col` expression
 IntoExprColumn: TypeAlias = Union["Expr", "Series", str]
 # Inputs that can convert into an expression
@@ -201,7 +198,7 @@ FrameInitTypes: TypeAlias = Union[
 # Excel IO
 ColumnFormatDict: TypeAlias = Mapping[
     # dict of colname(s) or selector(s) to format string or dict
-    Union[ColumnNameOrSelector, Tuple[ColumnNameOrSelector, ...]],
+    Union[ColumnNameOrSelector, tuple[ColumnNameOrSelector, ...]],
     Union[str, Mapping[str, str]],
 ]
 ConditionalFormatDict: TypeAlias = Mapping[
@@ -211,12 +208,12 @@ ConditionalFormatDict: TypeAlias = Mapping[
 ]
 ColumnTotalsDefinition: TypeAlias = Union[
     # dict of colname(s) to str, a collection of str, or a boolean
-    Mapping[Union[ColumnNameOrSelector, Tuple[ColumnNameOrSelector]], str],
+    Mapping[Union[ColumnNameOrSelector, tuple[ColumnNameOrSelector]], str],
     Sequence[str],
     bool,
 ]
 ColumnWidthsDefinition: TypeAlias = Union[
-    Mapping[ColumnNameOrSelector, Union[Tuple[str, ...], int]], int
+    Mapping[ColumnNameOrSelector, Union[tuple[str, ...], int]], int
 ]
 RowTotalsDefinition: TypeAlias = Union[
     # dict of colname to str(s), a collection of str, or a boolean
@@ -231,7 +228,7 @@ ParametricProfileNames: TypeAlias = Literal["fast", "balanced", "expensive"]
 # typevars for core polars types
 PolarsType = TypeVar("PolarsType", "DataFrame", "LazyFrame", "Series", "Expr")
 FrameType = TypeVar("FrameType", "DataFrame", "LazyFrame")
-BufferInfo: TypeAlias = Tuple[int, int, int]
+BufferInfo: TypeAlias = tuple[int, int, int]
 
 # type alias for supported spreadsheet engines
 ExcelSpreadsheetEngine: TypeAlias = Literal["xlsx2csv", "openpyxl", "calamine"]

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Collection,
-    Iterable,
     List,
     Literal,
-    Mapping,
     Protocol,
-    Sequence,
     Tuple,
     Type,
     TypedDict,

--- a/py-polars/polars/_utils/async_.py
+++ b/py-polars/polars/_utils/async_.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Generator
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from polars._utils.wrap import wrap_df
@@ -8,6 +8,7 @@ from polars.dependencies import _GEVENT_AVAILABLE
 
 if TYPE_CHECKING:
     from asyncio.futures import Future
+    from collections.abc import Generator
 
     from polars.polars import PyDataFrame
 

--- a/py-polars/polars/_utils/async_.py
+++ b/py-polars/polars/_utils/async_.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Awaitable, Generator, Generic, TypeVar
+from collections.abc import Awaitable, Generator
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from polars._utils.wrap import wrap_df
 from polars.dependencies import _GEVENT_AVAILABLE

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Generator, Iterable, Mapping, MutableMapping, Sequence
 from datetime import date, datetime, time, timedelta
 from functools import singledispatch
 from itertools import islice, zip_longest
@@ -9,11 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Generator,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    Sequence,
 )
 
 import polars._reexport as pl

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Generator, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Generator, Mapping
 from datetime import date, datetime, time, timedelta
 from functools import singledispatch
 from itertools import islice, zip_longest
@@ -59,6 +59,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, MutableMapping, Sequence
+
     from polars import DataFrame, Expr, Series
     from polars._typing import (
         Orientation,

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Generator, Iterable, Iterator, Sequence
 from datetime import date, datetime, time, timedelta
 from itertools import islice
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Generator,
-    Iterable,
-    Iterator,
-    Sequence,
 )
 
 import polars._reexport as pl

--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Generator, Iterable, Iterator, Sequence
+from collections.abc import Generator, Iterator
 from datetime import date, datetime, time, timedelta
 from itertools import islice
 from typing import (
@@ -62,6 +62,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import PySeries
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     from polars import DataFrame, Series
     from polars._typing import PolarsDataType
     from polars.dependencies import pandas as pd

--- a/py-polars/polars/_utils/construction/utils.py
+++ b/py-polars/polars/_utils/construction/utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Sequence
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, Sequence, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, get_type_hints
 
 from polars.dependencies import _check_for_pydantic, pydantic
 

--- a/py-polars/polars/_utils/construction/utils.py
+++ b/py-polars/polars/_utils/construction/utils.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, get_type_hints
 
 from polars.dependencies import _check_for_pydantic, pydantic
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import pandas as pd
 
 PANDAS_SIMPLE_NUMPY_DTYPES = {

--- a/py-polars/polars/_utils/convert.py
+++ b/py-polars/polars/_utils/convert.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import datetime, time, timedelta, timezone
 from decimal import Context
 from functools import lru_cache
@@ -26,6 +25,7 @@ from polars._utils.constants import (
 from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import date, tzinfo
     from decimal import Decimal
 

--- a/py-polars/polars/_utils/convert.py
+++ b/py-polars/polars/_utils/convert.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, time, timedelta, timezone
 from decimal import Context
 from functools import lru_cache
@@ -8,7 +9,6 @@ from typing import (
     Any,
     Callable,
     NoReturn,
-    Sequence,
     no_type_check,
     overload,
 )

--- a/py-polars/polars/_utils/deprecation.py
+++ b/py-polars/polars/_utils/deprecation.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Sequence
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Sequence, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 from polars._utils.various import issue_warning
 
 if TYPE_CHECKING:
     import sys
-    from typing import Mapping
+    from collections.abc import Mapping
 
     from polars._typing import Ambiguous
 

--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NoReturn, overload
 
 import polars._reexport as pl
@@ -23,6 +23,8 @@ from polars.dependencies import numpy as np
 from polars.meta.index_type import get_index_type
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars import DataFrame, Series
     from polars._typing import (
         MultiColSelector,

--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, NoReturn, Sequence, overload
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any, NoReturn, overload
 
 import polars._reexport as pl
 import polars.functions as F

--- a/py-polars/polars/_utils/parse/expr.py
+++ b/py-polars/polars/_utils/parse/expr.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
 from polars import functions as F

--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -10,6 +10,7 @@ import sys
 import warnings
 from bisect import bisect_left
 from collections import defaultdict
+from collections.abc import Iterator
 from dis import get_instructions
 from inspect import signature
 from itertools import count, zip_longest
@@ -20,7 +21,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Iterator,
     Literal,
     NamedTuple,
     Union,

--- a/py-polars/polars/_utils/udfs.py
+++ b/py-polars/polars/_utils/udfs.py
@@ -10,14 +10,12 @@ import sys
 import warnings
 from bisect import bisect_left
 from collections import defaultdict
-from collections.abc import Iterator
 from dis import get_instructions
 from inspect import signature
 from itertools import count, zip_longest
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    AbstractSet,
     Any,
     Callable,
     ClassVar,
@@ -29,6 +27,8 @@ from typing import (
 from polars._utils.various import re_escape
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from collections.abc import Set as AbstractSet
     from dis import Instruction
 
     if sys.version_info >= (3, 10):

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -5,18 +5,21 @@ import os
 import re
 import sys
 import warnings
-from collections.abc import MappingView, Sized
+from collections.abc import (
+    Collection,
+    Generator,
+    Iterable,
+    MappingView,
+    Sequence,
+    Sized,
+)
 from enum import Enum
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Collection,
-    Generator,
-    Iterable,
     Literal,
-    Sequence,
     TypeVar,
     overload,
 )

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import itertools
 import re
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, overload
 
 import polars._reexport as pl
@@ -25,6 +25,8 @@ from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from polars import DataFrame, Series
     from polars._typing import Orientation, SchemaDefinition, SchemaDict
     from polars.dependencies import numpy as np

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import io
 import itertools
 import re
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, overload
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, overload
 
 import polars._reexport as pl
 from polars import functions as F

--- a/py-polars/polars/convert/normalize.py
+++ b/py-polars/polars/convert/normalize.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from collections import abc
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from polars._utils.unstable import unstable
@@ -12,20 +11,13 @@ from polars.dataframe import DataFrame
 from polars.datatypes.constants import N_INFER_DEFAULT
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from polars.schema import Schema
 
-import sys
 
-if sys.version_info >= (3, 9):
-
-    def _remove_prefix(text: str, prefix: str) -> str:
-        return text.removeprefix(prefix)
-else:
-
-    def _remove_prefix(text: str, prefix: str) -> str:
-        if text.startswith(prefix):
-            return text[len(prefix) :]
-        return text
+def _remove_prefix(text: str, prefix: str) -> str:
+    return text.removeprefix(prefix)
 
 
 def _simple_json_normalize(

--- a/py-polars/polars/convert/normalize.py
+++ b/py-polars/polars/convert/normalize.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 from collections import abc
-from typing import TYPE_CHECKING, Any, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 from polars._utils.unstable import unstable
 from polars.dataframe import DataFrame

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from textwrap import dedent
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from polars.dependencies import html
 

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
 from polars.dependencies import html
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from types import TracebackType
 
     from polars import DataFrame

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7,11 +7,8 @@ import os
 import random
 from collections import defaultdict
 from collections.abc import (
-    Collection,
     Generator,
     Iterable,
-    Iterator,
-    Mapping,
     Sequence,
     Sized,
 )
@@ -117,6 +114,11 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import (
+        Collection,
+        Iterator,
+        Mapping,
+    )
     from datetime import timedelta
     from io import IOBase
     from typing import Literal
@@ -3975,8 +3977,9 @@ class DataFrame:
                 else (connection, False)
             )
             with (
-                conn if can_close_conn else contextlib.nullcontext()
-            ), conn.cursor() as cursor:
+                conn if can_close_conn else contextlib.nullcontext(),
+                conn.cursor() as cursor,
+            ):
                 catalog, db_schema, unpacked_table_name = unpack_table_name(table_name)
                 n_rows: int
                 if adbc_version >= (0, 7):

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6,7 +6,15 @@ import contextlib
 import os
 import random
 from collections import defaultdict
-from collections.abc import Sized
+from collections.abc import (
+    Collection,
+    Generator,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+    Sized,
+)
 from io import BytesIO, StringIO
 from operator import itemgetter
 from pathlib import Path
@@ -16,13 +24,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Collection,
-    Generator,
-    Iterable,
-    Iterator,
-    Mapping,
     NoReturn,
-    Sequence,
     TypeVar,
     get_args,
     overload,

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
@@ -9,6 +8,7 @@ from polars._utils.deprecation import deprecate_renamed_function
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Iterable
     from datetime import timedelta
 
     from polars import DataFrame

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
 from polars._utils.convert import parse_as_duration_string

--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Dict, Union
+from typing import TYPE_CHECKING, Callable, Union
 
 from polars.dependencies import altair as alt
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
         from typing_extensions import Unpack
 
     Encoding: TypeAlias = Union[X, Y, Color, Order, Size, Tooltip]
-    Encodings: TypeAlias = Dict[str, Encoding]
+    Encodings: TypeAlias = dict[str, Encoding]
 
 
 def _maybe_extract_shorthand(encoding: Encoding) -> Encoding:

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from collections import OrderedDict
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Mapping
 from datetime import timezone
 from inspect import isclass
 from typing import TYPE_CHECKING, Any
@@ -15,6 +15,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import dtype_str_repr as _dtype_str_repr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
     from polars import Series
     from polars._typing import (
         CategoricalOrdering,

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import contextlib
 from collections import OrderedDict
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from datetime import timezone
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
 import polars.datatypes

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Sequence
 from decimal import Decimal as PyDecimal
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -17,6 +16,8 @@ except ImportError:
     _DOCUMENTING = True
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from polars._typing import PolarsDataType
 
 if not _DOCUMENTING:

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import functools
+from collections.abc import Sequence
 from decimal import Decimal as PyDecimal
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 from polars import datatypes as dt
 from polars.dependencies import numpy as np

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -4,9 +4,10 @@ import contextlib
 import functools
 import re
 import sys
+from collections.abc import Collection
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
-from typing import TYPE_CHECKING, Any, Collection, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from polars.datatypes.classes import (
     Array,

--- a/py-polars/polars/datatypes/group.py
+++ b/py-polars/polars/datatypes/group.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 from polars.datatypes.classes import (
     Array,

--- a/py-polars/polars/datatypes/group.py
+++ b/py-polars/polars/datatypes/group.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from polars.datatypes.classes import (
@@ -28,6 +27,7 @@ from polars.datatypes.classes import (
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Iterable
 
     from polars._typing import (
         PolarsDataType,

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -150,6 +150,7 @@ if TYPE_CHECKING:
     import json
     import pickle
     import subprocess
+    import zoneinfo
 
     import altair
     import deltalake
@@ -162,11 +163,6 @@ if TYPE_CHECKING:
     import pyarrow
     import pydantic
     import pyiceberg
-
-    if sys.version_info >= (3, 9):
-        import zoneinfo
-    else:
-        from backports import zoneinfo
 else:
     # infrequently-used builtins
     dataclasses, _ = _lazy_import("dataclasses")

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import re
 import sys
-from functools import lru_cache
+from collections.abc import Hashable
+from functools import cache
 from importlib import import_module
 from importlib.util import find_spec
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, ClassVar, Hashable, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 _ALTAIR_AVAILABLE = True
 _DELTALAKE_AVAILABLE = True
@@ -193,7 +194,7 @@ else:
     gevent, _GEVENT_AVAILABLE = _lazy_import("gevent")
 
 
-@lru_cache(maxsize=None)
+@cache
 def _might_be(cls: type, type_: str) -> bool:
     # infer whether the given class "might" be associated with the given
     # module (in which case it's reasonable to do a real isinstance check;

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Callable
 
 from polars._utils.parse import parse_into_expression
 from polars._utils.wrap import wrap_expr

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
@@ -14,6 +13,8 @@ from polars._utils.wrap import wrap_expr
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars import Expr
     from polars._typing import (
         Ambiguous,

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars import functions as F

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4,6 +4,7 @@ import contextlib
 import math
 import operator
 import warnings
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import timedelta
 from functools import reduce
 from io import BytesIO, StringIO
@@ -13,12 +14,8 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Collection,
     FrozenSet,
-    Iterable,
-    Mapping,
     NoReturn,
-    Sequence,
     Set,
     TypeVar,
 )

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4,7 +4,7 @@ import contextlib
 import math
 import operator
 import warnings
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from datetime import timedelta
 from functools import reduce
 from io import BytesIO, StringIO
@@ -14,9 +14,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    FrozenSet,
     NoReturn,
-    Set,
     TypeVar,
 )
 
@@ -66,6 +64,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Iterable
     from io import IOBase
 
     from polars import DataFrame, LazyFrame, Series
@@ -5768,7 +5767,7 @@ class Expr:
         └───────────┴──────────────────┴──────────┘
         """
         if isinstance(other, Collection) and not isinstance(other, str):
-            if isinstance(other, (Set, FrozenSet)):
+            if isinstance(other, (set, frozenset)):
                 other = list(other)
             other = F.lit(pl.Series(other))._pyexpr
         else:

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 import polars._reexport as pl
 from polars import functions as F

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Mapping
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars import functions as F

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Iterable, Sequence
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
 
 from polars._utils.parse import parse_into_list_of_expressions
 from polars._utils.wrap import wrap_expr

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING
 
 from polars._utils.parse import parse_into_list_of_expressions
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     from polars import Expr
     from polars._typing import IntoExpr
 

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 import polars.functions as F
 from polars._utils.parse import (

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import polars.functions as F
@@ -12,6 +11,8 @@ from polars._utils.wrap import wrap_expr
 from polars.expr.expr import Expr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars._typing import IntoExpr
     from polars.polars import PyExpr
 

--- a/py-polars/polars/functions/aggregation/horizontal.py
+++ b/py-polars/polars/functions/aggregation/horizontal.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 import polars.functions as F
@@ -13,6 +12,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars import Expr
     from polars._typing import IntoExpr
 

--- a/py-polars/polars/functions/aggregation/horizontal.py
+++ b/py-polars/polars/functions/aggregation/horizontal.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import polars.functions as F
 from polars._utils.parse import parse_into_list_of_expressions

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, overload
 
 from polars import functions as F
@@ -17,6 +16,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from typing import Literal
 
     from polars import Expr, Series

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Iterable, overload
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, overload
 
 from polars import functions as F
 from polars._utils.parse import (

--- a/py-polars/polars/functions/business.py
+++ b/py-polars/polars/functions/business.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable
 from datetime import date
 from typing import TYPE_CHECKING
 
@@ -12,6 +11,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars import Expr
     from polars._typing import IntoExprColumn
 

--- a/py-polars/polars/functions/business.py
+++ b/py-polars/polars/functions/business.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterable
 from datetime import date
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from polars._utils.parse import parse_into_expression
 from polars._utils.wrap import wrap_expr

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from polars._utils.wrap import wrap_expr
 from polars.datatypes import is_polars_dtype

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterable, Sequence
 from functools import reduce
 from itertools import chain
-from typing import TYPE_CHECKING, Iterable, Sequence, get_args
+from typing import TYPE_CHECKING, get_args
 
 import polars._reexport as pl
 from polars import functions as F

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from functools import reduce
 from itertools import chain
 from typing import TYPE_CHECKING, get_args
@@ -17,6 +17,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars import DataFrame, Expr, LazyFrame, Series
     from polars._typing import FrameType, JoinStrategy, PolarsType
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, overload
 
 import polars._reexport as pl
 import polars.functions as F
@@ -20,7 +21,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
-    from typing import Awaitable, Collection, Literal
+    from collections.abc import Awaitable, Collection
+    from typing import Literal
 
     from polars import DataFrame, Expr, LazyFrame, Series
     from polars._typing import (

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable, overload
 
 import polars._reexport as pl
@@ -21,7 +21,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Collection
+    from collections.abc import Awaitable, Collection, Iterable
     from typing import Literal
 
     from polars import DataFrame, Expr, LazyFrame, Series

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
@@ -11,6 +10,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars._typing import IntoExprColumn
 
 

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
 from polars._utils.parse import parse_predicates_constraints_into_expression

--- a/py-polars/polars/interchange/protocol.py
+++ b/py-polars/polars/interchange/protocol.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
 from enum import IntEnum
 from typing import (
     TYPE_CHECKING,
@@ -8,7 +7,6 @@ from typing import (
     ClassVar,
     Literal,
     Protocol,
-    Tuple,
     TypedDict,
 )
 
@@ -16,6 +14,7 @@ from polars._utils.unstable import issue_unstable_warning
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Iterable, Sequence
 
     from polars.interchange.buffer import PolarsBuffer
     from polars.interchange.column import PolarsColumn
@@ -70,7 +69,7 @@ class DtypeKind(IntEnum):
     CATEGORICAL = 23
 
 
-Dtype: TypeAlias = Tuple[DtypeKind, int, str, str]  # see Column.dtype
+Dtype: TypeAlias = tuple[DtypeKind, int, str, str]  # see Column.dtype
 
 
 class ColumnNullType(IntEnum):

--- a/py-polars/polars/interchange/protocol.py
+++ b/py-polars/polars/interchange/protocol.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from enum import IntEnum
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
-    Iterable,
     Literal,
     Protocol,
-    Sequence,
     Tuple,
     TypedDict,
 )

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import glob
 import re
-from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import IO, Any, ContextManager, overload
+from typing import IO, TYPE_CHECKING, Any, overload
 
 from polars._utils.various import is_int_sequence, is_str_sequence, normalize_filepath
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+    from contextlib import AbstractContextManager as ContextManager
 
 
 def parse_columns_arg(

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import glob
 import re
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import IO, Any, ContextManager, Iterator, Sequence, overload
+from typing import IO, Any, ContextManager, overload
 
 from polars._utils.various import is_int_sequence, is_str_sequence, normalize_filepath
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec

--- a/py-polars/polars/io/csv/_utils.py
+++ b/py-polars/polars/io/csv/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from polars import DataFrame

--- a/py-polars/polars/io/csv/_utils.py
+++ b/py-polars/polars/io/csv/_utils.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from polars import DataFrame
 
 

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from polars._utils.various import (
     _process_null_values,

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import contextlib
 import os
+from collections.abc import Mapping, Sequence
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Callable, Mapping, Sequence
+from typing import IO, TYPE_CHECKING, Any, Callable
 
 import polars._reexport as pl
 import polars.functions as F

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Callable
@@ -31,6 +31,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import PyDataFrame, PyLazyFrame
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from polars import DataFrame, LazyFrame
     from polars._typing import CsvEncoding, PolarsDataType, SchemaDict
 

--- a/py-polars/polars/io/database/_cursor_proxies.py
+++ b/py-polars/polars/io/database/_cursor_proxies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
 
 from polars.io.database._utils import _run_async
 

--- a/py-polars/polars/io/database/_cursor_proxies.py
+++ b/py-polars/polars/io/database/_cursor_proxies.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from polars.io.database._utils import _run_async
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Coroutine
+    from collections.abc import Coroutine, Iterable
 
     import pyarrow as pa
 

--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Iterable, Sequence
 from contextlib import suppress
 from inspect import Parameter, signature
-from typing import TYPE_CHECKING, Any, Iterable, Sequence
+from typing import TYPE_CHECKING, Any
 
 from polars import functions as F
 from polars._utils.various import parse_version

--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Coroutine, Iterable, Sequence
+from collections.abc import Coroutine, Sequence
 from contextlib import suppress
 from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any
@@ -22,7 +22,7 @@ from polars.io.database._utils import _run_async
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from types import TracebackType
 
     import pyarrow as pa

--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 from polars.datatypes import N_INFER_DEFAULT
@@ -11,6 +10,7 @@ from polars.io.database._executor import ConnectionExecutor
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Iterable
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias

--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Iterable, Literal, overload
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from polars.datatypes import N_INFER_DEFAULT
 from polars.dependencies import import_optional

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-from collections.abc import Sequence
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any
 
@@ -29,6 +28,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import read_ipc_schema as _read_ipc_schema
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from polars import DataFrame, DataType, LazyFrame
     from polars._typing import SchemaDict
 

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import os
+from collections.abc import Sequence
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Sequence
+from typing import IO, TYPE_CHECKING, Any
 
 import polars._reexport as pl
 import polars.functions as F

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Sequence
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Sequence
+from typing import IO, TYPE_CHECKING, Any
 
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import is_path_or_str_sequence, normalize_filepath

--- a/py-polars/polars/io/plugins.py
+++ b/py-polars/polars/io/plugins.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import TYPE_CHECKING, Callable, Iterator
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Callable
 
 import polars._reexport as pl
 from polars._utils.unstable import unstable
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterator
+    from collections.abc import Iterator
+    from typing import Callable
 
     from polars import DataFrame, Expr, LazyFrame
     from polars._typing import SchemaDict

--- a/py-polars/polars/io/spreadsheet/_utils.py
+++ b/py-polars/polars/io/spreadsheet/_utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator, cast
+from typing import Any, cast
 
 
 @contextmanager

--- a/py-polars/polars/io/spreadsheet/_utils.py
+++ b/py-polars/polars/io/spreadsheet/_utils.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @contextmanager

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
@@ -22,6 +22,7 @@ from polars.exceptions import DuplicateError
 from polars.selectors import _expand_selector_dicts, _expand_selectors, numeric
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from typing import Literal
 
     from xlsxwriter import Workbook

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Sequence, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from polars import functions as F
 from polars.datatypes import (

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from datetime import time
 from io import BufferedReader, BytesIO, StringIO, TextIOWrapper
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Callable, NoReturn, Sequence, overload
+from typing import IO, TYPE_CHECKING, Any, Callable, NoReturn, overload
 
 import polars._reexport as pl
 from polars import from_arrow

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import warnings
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Collection, Mapping
 from datetime import date, datetime, time, timedelta
 from functools import lru_cache, partial, reduce
 from io import BytesIO, StringIO
@@ -88,7 +88,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Iterable, Sequence
     from io import IOBase
     from typing import Literal
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import warnings
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from datetime import date, datetime, time, timedelta
 from functools import lru_cache, partial, reduce
 from io import BytesIO, StringIO
@@ -13,11 +14,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Collection,
-    Iterable,
-    Mapping,
     NoReturn,
-    Sequence,
     TypeVar,
     overload,
 )
@@ -91,8 +88,9 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Awaitable
     from io import IOBase
-    from typing import Awaitable, Literal
+    from typing import Literal
 
     import pyarrow as pa
 

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
@@ -9,6 +8,8 @@ from polars._utils.parse import parse_into_list_of_expressions
 from polars._utils.wrap import wrap_ldf
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars import DataFrame, LazyFrame
     from polars._typing import IntoExpr, RollingInterpolationMethod, SchemaDict
     from polars.polars import PyLazyGroupBy

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
 from polars._utils.deprecation import deprecate_renamed_function

--- a/py-polars/polars/ml/torch.py
+++ b/py-polars/polars/ml/torch.py
@@ -1,7 +1,6 @@
 # mypy: disable-error-code="unused-ignore"
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from polars._utils.unstable import issue_unstable_warning
@@ -11,6 +10,7 @@ from polars.selectors import exclude
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Sequence
 
     from torch import Tensor, memory_format
 

--- a/py-polars/polars/ml/torch.py
+++ b/py-polars/polars/ml/torch.py
@@ -1,7 +1,8 @@
 # mypy: disable-error-code="unused-ignore"
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from polars._utils.unstable import issue_unstable_warning
 from polars.dataframe import DataFrame

--- a/py-polars/polars/plugins.py
+++ b/py-polars/polars/plugins.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 from polars._utils.parse import parse_into_list_of_expressions
 from polars._utils.wrap import wrap_expr

--- a/py-polars/polars/plugins.py
+++ b/py-polars/polars/plugins.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -13,6 +12,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars import Expr
     from polars._typing import IntoExpr
 

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from polars.datatypes import DataType
@@ -10,6 +10,8 @@ from polars.datatypes._parse import parse_into_dtype
 BaseSchema = OrderedDict[str, DataType]
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from polars._typing import PythonDataType
 
 

--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING
 
+from polars.datatypes import DataType
 from polars.datatypes._parse import parse_into_dtype
+
+BaseSchema = OrderedDict[str, DataType]
 
 if TYPE_CHECKING:
     from polars._typing import PythonDataType
-    from polars.datatypes import DataType
 
-    BaseSchema = OrderedDict[str, DataType]
-else:
-    # Python 3.8 does not support generic OrderedDict at runtime
-    BaseSchema = OrderedDict
 
 __all__ = ["Schema"]
 

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping, Sequence
 from datetime import timezone
 from functools import reduce
 from operator import or_
 from typing import (
     TYPE_CHECKING,
     Any,
-    Collection,
     Literal,
-    Mapping,
     NoReturn,
-    Sequence,
     overload,
 )
 

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
 from polars._utils.wrap import wrap_s

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
@@ -8,6 +7,7 @@ from polars._utils.wrap import wrap_s
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import date, datetime, time
 
     from polars import Series

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from polars._utils.deprecation import deprecate_function
@@ -10,6 +9,7 @@ from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
     import datetime as dt
+    from collections.abc import Iterable
 
     from polars import Expr, Series
     from polars._typing import (

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from polars._utils.deprecation import deprecate_function
 from polars._utils.unstable import unstable

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 from polars import functions as F
 from polars._utils.wrap import wrap_s

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
 from polars import functions as F
@@ -8,6 +7,7 @@ from polars._utils.wrap import wrap_s
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import date, datetime, time
 
     from polars import Expr, Series

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import math
 import os
+from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
 from contextlib import nullcontext
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
@@ -11,13 +12,8 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Collection,
-    Generator,
-    Iterable,
     Literal,
-    Mapping,
     NoReturn,
-    Sequence,
     Union,
     overload,
 )

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import math
 import os
-from collections.abc import Collection, Generator, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from contextlib import nullcontext
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal as PyDecimal
@@ -110,6 +110,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Collection, Generator, Mapping
 
     import jax
     import numpy.typing as npt

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from polars._utils.deprecation import deprecate_function
@@ -10,6 +9,8 @@ from polars.datatypes.constants import N_INFER_DEFAULT
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from polars import Expr, Series
     from polars._typing import (
         Ambiguous,

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Mapping
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 from polars._utils.deprecation import deprecate_function
 from polars._utils.unstable import unstable

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from polars._utils.various import BUILDING_SPHINX_DOCS, sphinx_accessor
 from polars._utils.wrap import wrap_df

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from polars._utils.various import BUILDING_SPHINX_DOCS, sphinx_accessor
@@ -9,6 +8,8 @@ from polars.schema import Schema
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from polars import DataFrame, Series
     from polars.polars import PySeries
 elif BUILDING_SPHINX_DOCS:

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import re
-from collections.abc import Collection, Mapping
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -29,6 +28,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Collection, Mapping
     from types import TracebackType
     from typing import Any, Final, Literal
 

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import contextlib
 import re
+from collections.abc import Collection, Mapping
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Collection,
     Generic,
-    Mapping,
     Union,
     overload,
 )

--- a/py-polars/polars/testing/parametric/strategies/core.py
+++ b/py-polars/polars/testing/parametric/strategies/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
@@ -17,6 +17,7 @@ from polars.testing.parametric.strategies.data import data
 from polars.testing.parametric.strategies.dtype import _instantiate_dtype, dtypes
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
     from typing import Literal
 
     from hypothesis.strategies import DrawFn, SearchStrategy

--- a/py-polars/polars/testing/parametric/strategies/core.py
+++ b/py-polars/polars/testing/parametric/strategies/core.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Collection, Mapping, Sequence, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument

--- a/py-polars/polars/testing/parametric/strategies/data.py
+++ b/py-polars/polars/testing/parametric/strategies/data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import decimal
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -61,6 +61,7 @@ from polars.testing.parametric.strategies.dtype import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import date, time
 
     from hypothesis.strategies import SearchStrategy

--- a/py-polars/polars/testing/parametric/strategies/data.py
+++ b/py-polars/polars/testing/parametric/strategies/data.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import decimal
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Literal, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument

--- a/py-polars/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/polars/testing/parametric/strategies/dtype.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Sequence
+from collections.abc import Collection, Sequence
+from typing import TYPE_CHECKING
 
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument

--- a/py-polars/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/polars/testing/parametric/strategies/dtype.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING
 
 import hypothesis.strategies as st
@@ -36,6 +35,8 @@ from polars.datatypes import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
+
     from hypothesis.strategies import DrawFn, SearchStrategy
 
     from polars._typing import CategoricalOrdering, PolarsDataType, TimeUnit

--- a/py-polars/polars/testing/parametric/strategies/legacy.py
+++ b/py-polars/polars/testing/parametric/strategies/legacy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name = "Ritchie Vink", email = "ritchie46@gmail.com" },
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 keywords = ["dataframe", "arrow", "out-of-core"]
 classifiers = [
@@ -22,7 +22,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -35,7 +35,6 @@ import re
 import sys
 import unittest
 import warnings
-from collections.abc import Iterator
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
@@ -43,6 +42,7 @@ from typing import TYPE_CHECKING, Any
 import polars as pl
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from types import ModuleType
 
 

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -35,9 +35,10 @@ import re
 import sys
 import unittest
 import warnings
+from collections.abc import Iterator
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 

--- a/py-polars/tests/docs/test_user_guide.py
+++ b/py-polars/tests/docs/test_user_guide.py
@@ -2,8 +2,8 @@
 
 import os
 import runpy
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 
 import matplotlib as mpl
 import pytest

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -6,7 +6,8 @@ import random
 import string
 import sys
 import tracemalloc
-from typing import Any, Generator, List, cast
+from collections.abc import Generator
+from typing import Any, List, cast
 
 import numpy as np
 import pytest

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -6,14 +6,16 @@ import random
 import string
 import sys
 import tracemalloc
-from collections.abc import Generator
-from typing import Any, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pytest
 
 import polars as pl
 from polars.testing.parametric import load_profile
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 load_profile(
     profile=os.environ.get("POLARS_HYPOTHESIS_PROFILE", "fast"),  # type: ignore[arg-type]
@@ -129,7 +131,7 @@ for T in ["T", " "]:
 
 @pytest.fixture(params=ISO8601_FORMATS_DATETIME)
 def iso8601_format_datetime(request: pytest.FixtureRequest) -> list[str]:
-    return cast(List[str], request.param)
+    return cast(list[str], request.param)
 
 
 ISO8601_TZ_AWARE_FORMATS_DATETIME = []
@@ -152,7 +154,7 @@ for T in ["T", " "]:
 
 @pytest.fixture(params=ISO8601_TZ_AWARE_FORMATS_DATETIME)
 def iso8601_tz_aware_format_datetime(request: pytest.FixtureRequest) -> list[str]:
-    return cast(List[str], request.param)
+    return cast(list[str], request.param)
 
 
 ISO8601_FORMATS_DATE = []
@@ -164,7 +166,7 @@ for date_sep in ("/", "-"):
 
 @pytest.fixture(params=ISO8601_FORMATS_DATE)
 def iso8601_format_date(request: pytest.FixtureRequest) -> list[str]:
-    return cast(List[str], request.param)
+    return cast(list[str], request.param)
 
 
 class MemoryUsage:

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -4,7 +4,7 @@ from collections import OrderedDict, namedtuple
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from random import shuffle
-from typing import TYPE_CHECKING, Any, List, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -280,7 +280,7 @@ def test_init_pydantic_2x() -> None:
         "top": 123
     }]
     """
-    adapter: TypeAdapter[Any] = TypeAdapter(List[PageView])
+    adapter: TypeAdapter[Any] = TypeAdapter(list[PageView])
     models = adapter.validate_json(data_json)
 
     result = pl.DataFrame(models)

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -22,7 +22,6 @@ from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
     from zoneinfo import ZoneInfo
 
     from polars._typing import PolarsDataType

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import sys
 from collections import OrderedDict
-from typing import Any, Iterator, Mapping
+from collections.abc import Iterator, Mapping
+from typing import Any
 
 import pytest
 

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import sys
 from collections import OrderedDict
-from collections.abc import Iterator, Mapping
-from typing import Any
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars.exceptions import DataOrientationWarning, InvalidOperationError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def test_df_mixed_dtypes_string() -> None:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import sys
 import typing
 from collections import OrderedDict
+from collections.abc import Iterator, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from io import BytesIO
 from operator import floordiv, truediv
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import numpy as np
 import pyarrow as pa

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sys
 import typing
 from collections import OrderedDict
-from collections.abc import Iterator, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from io import BytesIO
@@ -33,6 +32,7 @@ from polars.testing import (
 from tests.unit.conftest import INTEGER_DTYPES
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
     from zoneinfo import ZoneInfo
 
     from polars import Expr

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -11,7 +11,6 @@ from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from datetime import timezone
-
     from zoneinfo import ZoneInfo
 
     from polars._typing import FillNullStrategy, PolarsIntegerType

--- a/py-polars/tests/unit/datatypes/test_parse.py
+++ b/py-polars/tests/unit/datatypes/test_parse.py
@@ -4,12 +4,9 @@ from datetime import date, datetime
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     ForwardRef,
-    List,
     NamedTuple,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -63,9 +60,9 @@ def test_parse_py_type_into_dtype(input: Any, expected: PolarsDataType) -> None:
 @pytest.mark.parametrize(
     ("input", "expected"),
     [
-        (List[int], pl.List(pl.Int64())),
-        (Tuple[str, ...], pl.List(pl.String())),
-        (Tuple[datetime, datetime], pl.List(pl.Datetime("us"))),
+        (list[int], pl.List(pl.Int64())),
+        (tuple[str, ...], pl.List(pl.String())),
+        (tuple[datetime, datetime], pl.List(pl.Datetime("us"))),
     ],
 )
 def test_parse_generic_into_dtype(input: Any, expected: PolarsDataType) -> None:
@@ -76,9 +73,9 @@ def test_parse_generic_into_dtype(input: Any, expected: PolarsDataType) -> None:
 @pytest.mark.parametrize(
     "input",
     [
-        Dict[str, float],
-        Tuple[int, str],
-        Tuple[int, float, float],
+        dict[str, float],
+        tuple[int, str],
+        tuple[int, float, float],
     ],
 )
 def test_parse_generic_into_dtype_invalid(input: Any) -> None:

--- a/py-polars/tests/unit/io/cloud/test_aws.py
+++ b/py-polars/tests/unit/io/cloud/test_aws.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import multiprocessing
-from typing import TYPE_CHECKING, Any, Callable, Iterator
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Callable
 
 import boto3
 import pytest

--- a/py-polars/tests/unit/io/cloud/test_aws.py
+++ b/py-polars/tests/unit/io/cloud/test_aws.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import multiprocessing
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Callable
 
 import boto3
@@ -12,6 +11,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 pytestmark = [

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from math import ceil
-from typing import TYPE_CHECKING, Any, Iterable, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import pytest
 import sqlalchemy

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
 from math import ceil
 from typing import TYPE_CHECKING, Any, overload
 
@@ -14,6 +13,7 @@ from polars._utils.various import parse_version
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 SURREAL_MOCK_DATA: list[dict[str, Any]] = [

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 
 def adbc_sqlite_connect(*args: Any, **kwargs: Any) -> Any:
-    with suppress(ModuleNotFoundError):  # not available on 3.8/windows
+    with suppress(ModuleNotFoundError):  # not available on windows
         from adbc_driver_sqlite.dbapi import connect
 
         args = tuple(str(a) if isinstance(a, Path) else a for a in args)

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize(
     ("engine", "uri_connection"),
     [
-        [("sqlalchemy", True), ("sqlalchemy", False), ("adbc", True), ("adbc", False)],
         ("sqlalchemy", True),
         ("sqlalchemy", False),
         pytest.param(

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -24,22 +24,8 @@ if TYPE_CHECKING:
     [
         ("sqlalchemy", True),
         ("sqlalchemy", False),
-        pytest.param(
-            "adbc",
-            True,
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
-                reason="adbc not available on Windows or <= Python 3.8",
-            ),
-        ),
-        pytest.param(
-            "adbc",
-            False,
-            marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
-                reason="adbc not available on Windows or <= Python 3.8",
-            ),
-        ),
+        ("adbc", True),
+        ("adbc", False)
     ],
 )
 class TestWriteDatabase:

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -21,7 +21,27 @@ if TYPE_CHECKING:
 @pytest.mark.write_disk
 @pytest.mark.parametrize(
     ("engine", "uri_connection"),
-    [("sqlalchemy", True), ("sqlalchemy", False), ("adbc", True), ("adbc", False)],
+    [
+        [("sqlalchemy", True), ("sqlalchemy", False), ("adbc", True), ("adbc", False)],
+        ("sqlalchemy", True),
+        ("sqlalchemy", False),
+        pytest.param(
+            "adbc",
+            True,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32",
+                reason="adbc not available on Windows",
+            ),
+        ),
+        pytest.param(
+            "adbc",
+            False,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32",
+                reason="adbc not available on Windows",
+            ),
+        ),
+    ],
 )
 class TestWriteDatabase:
     """Database write tests that share common pytest/parametrize options."""

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -21,12 +21,7 @@ if TYPE_CHECKING:
 @pytest.mark.write_disk
 @pytest.mark.parametrize(
     ("engine", "uri_connection"),
-    [
-        ("sqlalchemy", True),
-        ("sqlalchemy", False),
-        ("adbc", True),
-        ("adbc", False)
-    ],
+    [("sqlalchemy", True), ("sqlalchemy", False), ("adbc", True), ("adbc", False)],
 )
 class TestWriteDatabase:
     """Database write tests that share common pytest/parametrize options."""

--- a/py-polars/tests/unit/io/test_plugins.py
+++ b/py-polars/tests/unit/io/test_plugins.py
@@ -7,7 +7,7 @@ from polars.io.plugins import register_io_source
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from typing import Iterator
+    from collections.abc import Iterator
 
 
 # A simple python source. But this can dispatch into a rust IO source as well.

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import warnings
 from collections import OrderedDict
+from collections.abc import Sequence
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 import pytest
 

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import warnings
 from collections import OrderedDict
-from collections.abc import Sequence
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
@@ -18,6 +17,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.conftest import FLOAT_DTYPES, NUMERIC_DTYPES
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from polars._typing import ExcelSpreadsheetEngine, SelectorType
 
 pytestmark = pytest.mark.slow()

--- a/py-polars/tests/unit/io/test_utils.py
+++ b/py-polars/tests/unit/io/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import pytest
 

--- a/py-polars/tests/unit/io/test_utils.py
+++ b/py-polars/tests/unit/io/test_utils.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import pytest
 
 from polars.io._utils import looks_like_url, parse_columns_arg, parse_row_index_args
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -340,9 +340,10 @@ def test_map_elements_chunked_14390() -> None:
 
 def test_cabbage_strategy_14396() -> None:
     df = pl.DataFrame({"x": [1, 2, 3]})
-    with pytest.raises(
-        ValueError, match="strategy 'cabbage' is not supported"
-    ), pytest.warns(PolarsInefficientMapWarning):
+    with (
+        pytest.raises(ValueError, match="strategy 'cabbage' is not supported"),
+        pytest.warns(PolarsInefficientMapWarning),
+    ):
         df.select(pl.col("x").map_elements(lambda x: 2 * x, strategy="cabbage"))  # type: ignore[arg-type]
 
 

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import pytest

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -9,6 +8,9 @@ import pytest
 import polars as pl
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def test_map_groups() -> None:

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_add_business_days.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import sys
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -11,19 +10,13 @@ import pytest
 from hypothesis import assume, given
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
     from polars._typing import Roll, TimeUnit
 
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 
 def test_add_business_days() -> None:

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_to_datetime.py
@@ -1,24 +1,16 @@
 from __future__ import annotations
 
-import sys
 from datetime import date, datetime
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_series_equal
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
     from hypothesis.strategies import DrawFn

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Any, ContextManager
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -11,6 +11,8 @@ from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager as ContextManager
+
     from polars._typing import PolarsDataType
 
 

--- a/py-polars/tests/unit/operations/test_cross_join.py
+++ b/py-polars/tests/unit/operations/test_cross_join.py
@@ -1,16 +1,7 @@
-import sys
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
-
-from polars.dependencies import _ZONEINFO_AVAILABLE
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 import polars as pl
 

--- a/py-polars/tests/unit/operations/test_ewm_by.py
+++ b/py-polars/tests/unit/operations/test_ewm_by.py
@@ -1,25 +1,18 @@
 from __future__ import annotations
 
-import sys
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import pytest
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
     from polars._typing import PolarsIntegerType, TimeUnit
 
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize("sort", [True, False])

--- a/py-polars/tests/unit/operations/test_interpolate.py
+++ b/py-polars/tests/unit/operations/test_interpolate.py
@@ -1,24 +1,17 @@
 from __future__ import annotations
 
-import sys
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from polars._typing import PolarsDataType, PolarsTemporalType
 
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -1,6 +1,6 @@
 import io
+from collections.abc import Iterator
 from datetime import date, datetime
-from typing import Iterator
 
 import pytest
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Iterator
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
@@ -32,6 +31,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.utils.pycapsule_utils import PyCapsuleStreamHolder
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from zoneinfo import ZoneInfo
 
     from polars._typing import EpochTimeUnit, PolarsDataType, TimeUnit

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Iterator
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Iterator, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -295,10 +295,13 @@ def test_join_misc_16255() -> None:
 )
 def test_non_equi_joins(constraint: str) -> None:
     # no support (yet) for non equi-joins in polars joins
-    with pytest.raises(
-        SQLInterfaceError,
-        match=r"only equi-join constraints are supported",
-    ), pl.SQLContext({"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2]})}) as ctx:
+    with (
+        pytest.raises(
+            SQLInterfaceError,
+            match=r"only equi-join constraints are supported",
+        ),
+        pl.SQLContext({"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2]})}) as ctx,
+    ):
         ctx.execute(
             f"""
             SELECT *
@@ -310,12 +313,19 @@ def test_non_equi_joins(constraint: str) -> None:
 
 def test_implicit_joins() -> None:
     # no support for this yet; ensure we catch it
-    with pytest.raises(
-        SQLInterfaceError,
-        match=r"not currently supported .* use explicit JOIN syntax instead",
-    ), pl.SQLContext(
-        {"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2], "c": ["x", "y", "z"]})}
-    ) as ctx:
+    with (
+        pytest.raises(
+            SQLInterfaceError,
+            match=r"not currently supported .* use explicit JOIN syntax instead",
+        ),
+        pl.SQLContext(
+            {
+                "tbl": pl.DataFrame(
+                    {"a": [1, 2, 3], "b": [4, 3, 2], "c": ["x", "y", "z"]}
+                )
+            }
+        ) as ctx,
+    ):
         ctx.execute(
             """
             SELECT t1.*

--- a/py-polars/tests/unit/test_config.py
+++ b/py-polars/tests/unit/test_config.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -11,6 +10,9 @@ import polars as pl
 import polars.polars as plr
 from polars._utils.unstable import issue_unstable_warning
 from polars.config import _POLARS_CFG_ENV_VARS
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @pytest.fixture(autouse=True)

--- a/py-polars/tests/unit/test_config.py
+++ b/py-polars/tests/unit/test_config.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import pytest
 

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import string
+from collections.abc import Iterator
 from decimal import Decimal as D
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any
 
 import pytest
 

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import string
-from collections.abc import Iterator
 from decimal import Decimal as D
 from typing import TYPE_CHECKING, Any
 
@@ -11,6 +10,8 @@ import polars as pl
 from polars.exceptions import InvalidOperationError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from polars._typing import PolarsDataType
 
 
@@ -291,8 +292,9 @@ def test_fmt_float_full() -> None:
 
 def test_fmt_list_12188() -> None:
     # set max_items to 1 < 4(size of failed list) to touch the testing branch.
-    with pl.Config(fmt_table_cell_list_len=1), pytest.raises(
-        InvalidOperationError, match="from `i64` to `u8` failed"
+    with (
+        pl.Config(fmt_table_cell_list_len=1),
+        pytest.raises(InvalidOperationError, match="from `i64` to `u8` failed"),
     ):
         pl.DataFrame(
             {

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -1,25 +1,17 @@
-import sys
 from collections import OrderedDict
 from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import pytest
 
 import polars as pl
 import polars.selectors as cs
 from polars._typing import SelectorType
-from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ColumnNotFoundError, InvalidOperationError
 from polars.selectors import expand_selector, is_selector
 from polars.testing import assert_frame_equal
 from tests.unit.conftest import INTEGER_DTYPES, TEMPORAL_DTYPES
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 def assert_repr_equals(item: Any, expected: str) -> None:

--- a/py-polars/tests/unit/test_string_cache.py
+++ b/py-polars/tests/unit/test_string_cache.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from collections.abc import Iterator
 
 import pytest
 

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +25,7 @@ from polars._utils.various import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from zoneinfo import ZoneInfo
 
     from polars._typing import TimeUnit


### PR DESCRIPTION
@itamarst I believe there were some py39 ABI's we wanted to call, but couldn't until we dropped py3.8. The moment is here.