### PR TITLE
docs: Recommend targetDir for rust-analyzer

### DIFF
--- a/docs/source/development/contributing/ide.md
+++ b/docs/source/development/contributing/ide.md
@@ -19,7 +19,8 @@ For it to work well for the Polars code base, add the following settings to your
 
 ```json
 {
-  "rust-analyzer.cargo.features": "all"
+  "rust-analyzer.cargo.features": "all",
+  "rust-analyzer.cargo.targetDir": true
 }
 ```
 


### PR DESCRIPTION
This prevents PyO3 from constantly recompiling, at least until https://github.com/PyO3/pyo3/issues/1708 is fixed. It also prevents annoying 'waiting for lock' issues, so it might be a good idea regardless.

The downside is that your build directory becomes even bigger as you now store artifacts twice, but it's honestly already a lost cause trying to get the artifact size small during development.