### PR TITLE
docs(python): Add storage_options hint for azure

### DIFF
--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1145,7 +1145,10 @@ def scan_csv(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+          to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1145,7 +1145,7 @@ def scan_csv(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1145,9 +1145,9 @@ def scan_csv(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
-          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1146,7 +1146,8 @@ def scan_csv(
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
         * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}`
+          to use the underlying azure infrastructure identity,
           `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -401,7 +401,10 @@ def scan_ipc(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+          to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -401,9 +401,9 @@ def scan_ipc(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
-          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -401,7 +401,7 @@ def scan_ipc(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -402,7 +402,8 @@ def scan_ipc(
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
         * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}`
+          to use the underlying azure infrastructure identity,
           `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -90,7 +90,7 @@ def read_ndjson(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 
@@ -243,7 +243,7 @@ def scan_ndjson(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -90,7 +90,10 @@ def read_ndjson(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+          to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 
@@ -243,7 +246,10 @@ def scan_ndjson(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+          to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -91,7 +91,8 @@ def read_ndjson(
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
         * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}`
+          to use the underlying azure infrastructure identity,
           `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
@@ -247,7 +248,8 @@ def scan_ndjson(
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
         * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}`
+          to use the underlying azure infrastructure identity,
           `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -90,9 +90,9 @@ def read_ndjson(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
-          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
@@ -246,9 +246,9 @@ def scan_ndjson(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
-          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -123,7 +123,10 @@ def read_parquet(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+          to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 
@@ -387,7 +390,10 @@ def scan_parquet(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+          to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -124,7 +124,8 @@ def read_parquet(
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
         * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}`
+          to use the underlying azure infrastructure identity,
           `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
@@ -391,7 +392,8 @@ def scan_parquet(
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
         * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}`
+          to use the underlying azure infrastructure identity,
           `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -123,9 +123,9 @@ def read_parquet(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
-          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
@@ -390,9 +390,9 @@ def scan_parquet(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ 
-          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, 
-          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` 
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+          (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity,
+          `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}`
           to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -123,7 +123,7 @@ def read_parquet(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 
@@ -387,7 +387,7 @@ def scan_parquet(
 
         * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
         * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_ (hint: `{"account_name": "<ACCOUNT_NAME>"}` to use the underlying azure infrastructure identity, `{"account_name": "<ACCOUNT_NAME>", "use_azure_cli": "True"}` to use the identity specified in `az login`)
         * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
           `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
 


### PR DESCRIPTION
Following issue https://github.com/pola-rs/polars/issues/18931.

I've tried to find a good place to put some hints in the documentation, but I can't find a good place in the polars documentation without ruining the nice minimalist style.

I am trying with a PR to add it in the only place I consider acceptable.