### PR TITLE
fix: Fix parsing of bytes to work for any valid numbers. For now fixed to low endianness

### DIFF
--- a/crates/polars-arrow/src/compute/cast/binary_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binary_to.rs
@@ -19,7 +19,7 @@ macro_rules! impl_parse {
     ($primitive_type:ident) => {
         impl Parse for $primitive_type {
             fn parse(val: &[u8]) -> Option<Self> {
-                atoi_simd::parse_skipped(val).ok()
+                Some(Self::from_le_bytes(val.try_into().ok()?))
             }
         }
     };


### PR DESCRIPTION
See: https://github.com/pola-rs/polars/issues/18991 for more details.

One potential regression is that binary of exact size is required for parsing to work, which is not necessarily that can with previous function. I do think introducing this requirement makes sense though.
I was also unsure whether it's ok to remove dependency or not, so feel free to lmk if I should adjust Cargo.toml as well.