### PR TITLE
docs(python): Change `eq_missing` comparison to wrong method 

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -869,7 +869,7 @@ class Series:
         """
         Method equivalent of equality operator `series == other` where `None == None`.
 
-        This differs from the standard `ne` where null values are propagated.
+        This differs from the standard `eq` where null values are propagated.
 
         Parameters
         ----------


### PR DESCRIPTION
Now docstring references `eq` instead of `ne`.
Closes #18976. 