### PR TITLE
build: Bump Rust toolchain to `nightly-2024-09-29`

### DIFF
--- a/crates/polars-arrow/src/legacy/kernels/take_agg/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/take_agg/mod.rs
@@ -107,7 +107,7 @@ pub unsafe fn take_agg_bin_iter_unchecked<
     indices: I,
     f: F,
     len: IdxSize,
-) -> Option<&[u8]> {
+) -> Option<&'a [u8]> {
     let mut null_count = 0 as IdxSize;
     let validity = arr.validity().unwrap();
 
@@ -147,7 +147,7 @@ pub unsafe fn take_agg_bin_iter_unchecked_no_null<
     arr: &'a BinaryViewArray,
     indices: I,
     f: F,
-) -> Option<&[u8]> {
+) -> Option<&'a [u8]> {
     indices
         .into_iter()
         .map(|idx| arr.value_unchecked(idx))

--- a/crates/polars-arrow/src/legacy/kernels/take_agg/var.rs
+++ b/crates/polars-arrow/src/legacy/kernels/take_agg/var.rs
@@ -8,7 +8,6 @@ use super::*;
 /// and:
 /// Ling, Robert F. (1974). "Comparison of Several Algorithms for Computing Sample Means and Variances".
 /// Journal of the American Statistical Association. 69 (348): 859–866. doi:10.2307/2286154. JSTOR 2286154.
-
 pub fn online_variance<I>(
     // iterator producing values
     iter: I,

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -91,7 +91,7 @@ macro_rules! impl_signed_arith_kernel {
                     lhs.fill_with(0)
                 } else if rhs == 1 {
                     lhs
-                } else if scalar_u & (scalar_u - 1) == 0 {
+                } else if scalar_u.is_power_of_two() {
                     // Power of two.
                     let shift = scalar_u.trailing_zeros();
                     if rhs > 0 {

--- a/crates/polars-compute/src/arithmetic/unsigned.rs
+++ b/crates/polars-compute/src/arithmetic/unsigned.rs
@@ -74,7 +74,7 @@ macro_rules! impl_unsigned_arith_kernel {
                     lhs.fill_with(0)
                 } else if rhs == 1 {
                     lhs
-                } else if rhs & (rhs - 1) == 0 {
+                } else if rhs.is_power_of_two() {
                     // Power of two.
                     let shift = rhs.trailing_zeros();
                     prim_unary_values(lhs, |x| x << shift)

--- a/crates/polars-core/src/chunked_array/binary.rs
+++ b/crates/polars-core/src/chunked_array/binary.rs
@@ -12,7 +12,7 @@ fn fill_bytes_hashes<'a, T>(
     ca: &'a ChunkedArray<T>,
     null_h: u64,
     hb: PlRandomState,
-) -> Vec<BytesHash>
+) -> Vec<BytesHash<'a>>
 where
     T: PolarsDataType,
     <<T as PolarsDataType>::Array as StaticArray>::ValueT<'a>: AsRef<[u8]>,

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -72,8 +72,7 @@ impl CategoricalChunked {
         }
     }
 
-    /// Retrieve the indexes need to sort this and the other arrays.
-
+    /// Retrieve the indices needed to sort this and the other arrays.
     pub(crate) fn arg_sort_multiple(
         &self,
         by: &[Column],

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -426,7 +426,7 @@ impl PhysicalExpr for ApplyExpr {
                         }
                     }
                     if has_agg_list || (has_agg_scalar && has_not_agg) {
-                        return self.apply_multiple_group_aware(acs, df);
+                        self.apply_multiple_group_aware(acs, df)
                     } else {
                         apply_multiple_elementwise(
                             acs,

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -163,7 +163,7 @@ impl Matcher {
             return true;
         }
         let last = &key[self.prefix.len()..];
-        return self.re.as_ref().unwrap().is_match(last.as_ref());
+        self.re.as_ref().unwrap().is_match(last.as_ref())
     }
 }
 

--- a/crates/polars-io/src/csv/write/write_impl/serializer.rs
+++ b/crates/polars-io/src/csv/write/write_impl/serializer.rs
@@ -264,7 +264,7 @@ fn decimal_serializer(array: &PrimitiveArray<i128>, scale: usize) -> impl Serial
 fn callback_serializer<'a, T: NativeType, const QUOTE_NON_NULL: bool>(
     array: &'a PrimitiveArray<T>,
     mut callback: impl FnMut(T, &mut Vec<u8>) + 'a,
-) -> impl Serializer + 'a {
+) -> impl Serializer<'a> {
     let f = move |&item, buf: &mut Vec<u8>, _options: &SerializeOptions| {
         callback(item, buf);
     };

--- a/crates/polars-lazy/src/frame/exitable.rs
+++ b/crates/polars-lazy/src/frame/exitable.rs
@@ -37,7 +37,7 @@ impl InProcessQuery {
     }
 
     /// Fetch the result.
-
+    ///
     /// If it is ready, a materialized DataFrame is returned.
     /// If it is not ready it will return `None`.
     pub fn fetch(&self) -> Option<PolarsResult<DataFrame>> {

--- a/crates/polars-ops/src/chunked_array/list/dispersion.rs
+++ b/crates/polars-ops/src/chunked_array/list/dispersion.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(super) fn median_with_nulls(ca: &ListChunked) -> Series {
-    return match ca.inner_dtype() {
+    match ca.inner_dtype() {
         DataType::Float32 => {
             let out: Float32Chunked = ca
                 .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().median().map(|v| v as f32)))
@@ -21,11 +21,11 @@ pub(super) fn median_with_nulls(ca: &ListChunked) -> Series {
                 .with_name(ca.name().clone());
             out.into_series()
         },
-    };
+    }
 }
 
 pub(super) fn std_with_nulls(ca: &ListChunked, ddof: u8) -> Series {
-    return match ca.inner_dtype() {
+    match ca.inner_dtype() {
         DataType::Float32 => {
             let out: Float32Chunked = ca
                 .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().std(ddof).map(|v| v as f32)))
@@ -45,11 +45,11 @@ pub(super) fn std_with_nulls(ca: &ListChunked, ddof: u8) -> Series {
                 .with_name(ca.name().clone());
             out.into_series()
         },
-    };
+    }
 }
 
 pub(super) fn var_with_nulls(ca: &ListChunked, ddof: u8) -> Series {
-    return match ca.inner_dtype() {
+    match ca.inner_dtype() {
         DataType::Float32 => {
             let out: Float32Chunked = ca
                 .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().var(ddof).map(|v| v as f32)))
@@ -82,5 +82,5 @@ pub(super) fn var_with_nulls(ca: &ListChunked, ddof: u8) -> Series {
                 .with_name(ca.name().clone());
             out.into_series()
         },
-    };
+    }
 }

--- a/crates/polars-ops/src/chunked_array/list/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/list/sum_mean.rs
@@ -175,7 +175,7 @@ pub(super) fn mean_list_numerical(ca: &ListChunked, inner_type: &DataType) -> Se
 }
 
 pub(super) fn mean_with_nulls(ca: &ListChunked) -> Series {
-    return match ca.inner_dtype() {
+    match ca.inner_dtype() {
         DataType::Float32 => {
             let out: Float32Chunked = ca
                 .apply_amortized_generic(|s| s.and_then(|s| s.as_ref().mean().map(|v| v as f32)))
@@ -188,5 +188,5 @@ pub(super) fn mean_with_nulls(ca: &ListChunked) -> Series {
                 .with_name(ca.name().clone());
             out.into_series()
         },
-    };
+    }
 }

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -430,7 +430,7 @@ pub trait StringNameSpaceImpl: AsString {
     fn strip_chars_start(&self, pat: &Column) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_start())));
+            Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_start())))
         } else {
             Ok(strip_chars_start(ca, pat.str()?))
         }
@@ -439,7 +439,7 @@ pub trait StringNameSpaceImpl: AsString {
     fn strip_chars_end(&self, pat: &Column) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_end())));
+            Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_end())))
         } else {
             Ok(strip_chars_end(ca, pat.str()?))
         }

--- a/crates/polars-pipe/src/executors/sinks/group_by/ooc_state.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/ooc_state.rs
@@ -7,9 +7,8 @@ use crate::executors::sinks::io::IOThread;
 use crate::executors::sinks::memory::MemTracker;
 use crate::pipeline::morsels_per_sink;
 
-/// THIS CODE DOESN'T MAKE SENSE
-/// it is a remnant of OOC, but will be rewritten to use the generic OOC
-/// Table
+// THIS CODE DOESN'T MAKE SENSE
+// It is a remnant of OOC, but will be rewritten to use the generic OOC Table.
 
 pub(super) struct OocState {
     // OOC

--- a/crates/polars-pipe/src/executors/sinks/group_by/primitive/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/primitive/mod.rs
@@ -500,7 +500,7 @@ fn insert_and_get<T>(
     h: u64,
     opt_v: Option<T>,
     pre_agg_len: usize,
-    pre_agg_partitions: &mut Vec<PlIdHashMap<Key<Option<T>>, IdxSize>>,
+    pre_agg_partitions: &mut [PlIdHashMap<Key<Option<T>>, IdxSize>],
     current_aggregators: &mut Vec<AggregateFunction>,
     agg_fns: &Vec<AggregateFunction>,
 ) -> IdxSize
@@ -536,7 +536,7 @@ fn try_insert_and_get<T>(
     h: u64,
     opt_v: Option<T>,
     pre_agg_len: usize,
-    pre_agg_partitions: &mut Vec<PlIdHashMap<Key<Option<T>>, IdxSize>>,
+    pre_agg_partitions: &mut [PlIdHashMap<Key<Option<T>>, IdxSize>],
 ) -> Option<IdxSize>
 where
     T: NumericNative + Hash,

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -113,7 +113,7 @@ impl DateLikeNameSpace {
 
     /// Extract the week from the underlying Date representation.
     /// Can be performed on Date and Datetime
-
+    ///
     /// Returns the ISO week number starting from 1.
     /// The return value ranges from 1 to 53. (The last week of year differs by years.)
     pub fn week(self) -> Expr {
@@ -123,7 +123,7 @@ impl DateLikeNameSpace {
 
     /// Extract the ISO week day from the underlying Date representation.
     /// Can be performed on Date and Datetime.
-
+    ///
     /// Returns the weekday number where monday = 1 and sunday = 7
     pub fn weekday(self) -> Expr {
         self.0

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -287,7 +287,7 @@ impl ToPyObject for Wrap<DataType> {
                     Series::from_arrow(PlSmallStr::from_static("category"), categories.to_boxed())
                         .unwrap();
                 let series = to_series(py, s.into());
-                return class.call1((series,)).unwrap().into();
+                class.call1((series,)).unwrap().into()
             },
             DataType::Time => pl.getattr(intern!(py, "Time")).unwrap().into(),
             DataType::Struct(fields) => {

--- a/crates/polars-stream/src/nodes/parquet_source/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/parquet_source/row_group_decode.rs
@@ -457,9 +457,7 @@ pub(super) struct SharedFileState {
     file_path_series: Option<Column>,
 }
 
-///
-/// Pre-filtered
-///
+// Pre-filtered
 
 impl RowGroupDecoder {
     async fn row_group_data_to_df_prefiltered(

--- a/crates/polars-time/src/windows/window.rs
+++ b/crates/polars-time/src/windows/window.rs
@@ -177,7 +177,7 @@ impl Window {
         tu: TimeUnit,
         tz: Option<&'a Tz>,
         start_by: StartBy,
-    ) -> PolarsResult<BoundsIter> {
+    ) -> PolarsResult<BoundsIter<'a>> {
         BoundsIter::new(*self, closed_window, boundary, tu, tz, start_by)
     }
 }

--- a/crates/polars-utils/src/pl_str.rs
+++ b/crates/polars-utils/src/pl_str.rs
@@ -54,7 +54,7 @@ impl Default for PlSmallStr {
     }
 }
 
-/// AsRef, Deref and Borrow impls to &str
+// AsRef, Deref and Borrow impls to &str
 
 impl AsRef<str> for PlSmallStr {
     #[inline(always)]
@@ -79,7 +79,7 @@ impl core::borrow::Borrow<str> for PlSmallStr {
     }
 }
 
-/// AsRef impls for other types
+// AsRef impls for other types
 
 impl AsRef<std::path::Path> for PlSmallStr {
     #[inline(always)]
@@ -102,7 +102,7 @@ impl AsRef<std::ffi::OsStr> for PlSmallStr {
     }
 }
 
-/// From impls
+// From impls
 
 impl From<&str> for PlSmallStr {
     #[inline(always)]
@@ -132,7 +132,7 @@ impl From<Inner> for PlSmallStr {
     }
 }
 
-/// FromIterator impls
+// FromIterator impls
 
 impl FromIterator<PlSmallStr> for PlSmallStr {
     #[inline(always)]
@@ -190,7 +190,7 @@ impl<'a> FromIterator<std::borrow::Cow<'a, str>> for PlSmallStr {
     }
 }
 
-/// PartialEq impls
+// PartialEq impls
 
 impl<T> PartialEq<T> for PlSmallStr
 where
@@ -216,7 +216,7 @@ impl PartialEq<PlSmallStr> for String {
     }
 }
 
-/// Write
+// Write
 
 impl core::fmt::Write for PlSmallStr {
     #[inline(always)]
@@ -235,7 +235,7 @@ impl core::fmt::Write for PlSmallStr {
     }
 }
 
-/// Debug, Display
+// Debug, Display
 
 impl core::fmt::Debug for PlSmallStr {
     #[inline(always)]

--- a/crates/polars/tests/it/io/avro/read_async.rs
+++ b/crates/polars/tests/it/io/avro/read_async.rs
@@ -26,16 +26,25 @@ async fn test(codec: Codec) -> PolarsResult<()> {
     Ok(())
 }
 
+// Issue with clippy interacting with tokio. See:
+// https://github.com/rust-lang/rust-clippy/issues/13458
+#[allow(clippy::needless_return)]
 #[tokio::test]
 async fn read_without_codec() -> PolarsResult<()> {
     test(Codec::Null).await
 }
 
+// Issue with clippy interacting with tokio. See:
+// https://github.com/rust-lang/rust-clippy/issues/13458
+#[allow(clippy::needless_return)]
 #[tokio::test]
 async fn read_deflate() -> PolarsResult<()> {
     test(Codec::Deflate).await
 }
 
+// Issue with clippy interacting with tokio. See:
+// https://github.com/rust-lang/rust-clippy/issues/13458
+#[allow(clippy::needless_return)]
 #[tokio::test]
 async fn read_snappy() -> PolarsResult<()> {
     test(Codec::Snappy).await

--- a/crates/polars/tests/it/io/avro/write_async.rs
+++ b/crates/polars/tests/it/io/avro/write_async.rs
@@ -42,6 +42,9 @@ async fn roundtrip(compression: Option<Compression>) -> PolarsResult<()> {
     Ok(())
 }
 
+// Issue with clippy interacting with tokio. See:
+// https://github.com/rust-lang/rust-clippy/issues/13458
+#[allow(clippy::needless_return)]
 #[tokio::test]
 async fn no_compression() -> PolarsResult<()> {
     roundtrip(None).await

--- a/docs/source/src/rust/user-guide/io/cloud-storage.rs
+++ b/docs/source/src/rust/user-guide/io/cloud-storage.rs
@@ -1,3 +1,7 @@
+// Issue with clippy interacting with tokio. See:
+// https://github.com/rust-lang/rust-clippy/issues/13458
+#![allow(clippy::needless_return)]
+
 // --8<-- [start:read_parquet]
 use aws_config::BehaviorVersion;
 use polars::prelude::*;

--- a/py-polars/build.rs
+++ b/py-polars/build.rs
@@ -1,4 +1,4 @@
-/// Build script using 'built' crate to generate build info.
+//! Build script using 'built' crate to generate build info.
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(allocator, values(\"default\", \"mimalloc\"))");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-08-26"
+channel = "nightly-2024-09-29"


### PR DESCRIPTION
You can check commit by commit for the newly added lints.

There's an issue with one of the new lints that requires a few ignores. See:
https://github.com/rust-lang/rust-clippy/issues/13458