### PR TITLE
fix: Separate temporal tests

### DIFF
--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -197,21 +197,37 @@ def test_lit_decimal_parametric(s: pl.Series) -> None:
     assert result == value
 
 
-@pytest.mark.parametrize(
-    ("dt_class", "input"),
-    [
-        (date, (2024, 1, 1)),
-        (datetime, (2024, 1, 1)),
-        (timedelta, (1,)),
-        (time, (1,)),
-    ],
-)
-def test_lit_temporal_subclass_w_allow_object(
-    dt_class: type, input: tuple[int]
-) -> None:
-    class MyClass(dt_class):  # type: ignore[misc]
+def test_lit_date_subclass() -> None:
+    class SubDate(date):
         pass
 
-    result = pl.select(a=pl.lit(MyClass(*input)))
-    expected = pl.DataFrame({"a": [dt_class(*input)]})
+    result = pl.select(a=pl.lit(SubDate(2024, 1, 1)))
+    expected = pl.DataFrame({"a": [date(2024, 1, 1)]})
+    assert_frame_equal(result, expected)
+
+
+def test_lit_datetime_subclass() -> None:
+    class SubDatetime(datetime):
+        pass
+
+    result = pl.select(a=pl.lit(SubDatetime(2024, 1, 1)))
+    expected = pl.DataFrame({"a": [datetime(2024, 1, 1)]})
+    assert_frame_equal(result, expected)
+
+
+def test_lit_time_subclass() -> None:
+    class SubTime(time):
+        pass
+
+    result = pl.select(a=pl.lit(SubTime(1)))
+    expected = pl.DataFrame({"a": [time(1)]})
+    assert_frame_equal(result, expected)
+
+
+def test_lit_timedelta_subclass() -> None:
+    class SubTimedelta(timedelta):
+        pass
+
+    result = pl.select(a=pl.lit(SubTimedelta(1)))
+    expected = pl.DataFrame({"a": [timedelta(1)]})
     assert_frame_equal(result, expected)


### PR DESCRIPTION
I'm not 100% sure why the new temporal literal tests were sometimes failing. It appears as though sometimes the `to_datetime` anyvalue converter was being called when the input was a `time` or `timedelta`.

My theory is that because the superclass types were parametrized in `pytest`, and because the tests are run in parallel, the `MyClass` classes were somehow colliding across threads. Thus, the `MyClass(datetime)` subclass defined in the test function would be defined in one thread while the `lit(MyClass(time_input))` was being run in another, and the class ancestry lookup on the rust side would find the wrong superclass. I've split the tests and given the subclasses separate names so I *hope* this fixes it. However, all tests have passed before, so all tests passing now doesn't necessarily mean the issue is fixed.