### PR TITLE
feat(python): Allow `insert_column` to take expressions

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4575,8 +4575,14 @@ class DataFrame:
         │ 4   ┆ 13.0 ┆ true  ┆ 0.0  │
         └─────┴──────┴───────┴──────┘
         """
-        if index < 0:
+        if (original_index := index) < 0:
             index = len(self.columns) + index
+            if index < 0:
+                msg = f"column index {original_index} is out of range (frame has {len(self.columns)} columns)"
+                raise IndexError(msg)
+        elif index > len(self.columns):
+            msg = f"column index {original_index} is out of range (frame has {len(self.columns)} columns)"
+            raise IndexError(msg)
 
         if isinstance(column, pl.Series):
             self._df.insert_column(index, column._s)

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -489,6 +489,17 @@ def test_insert_column() -> None:
     )
     assert_frame_equal(df, expected)
 
+    # check that we raise suitable index errors
+    for idx, column in (
+        (10, pl.col("v1").sqrt().alias("v1_sqrt")),
+        (-10, pl.Series("foo", [1, 2, 3])),
+    ):
+        with pytest.raises(
+            IndexError,
+            match=rf"column index {idx} is out of range \(frame has 5 columns\)",
+        ):
+            df.insert_column(idx, column)
+
 
 def test_replace_column() -> None:
     df = (

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -458,6 +458,7 @@ def test_assignment() -> None:
 
 
 def test_insert_column() -> None:
+    # insert series
     df = (
         pl.DataFrame({"z": [3, 4, 5]})
         .insert_column(0, pl.Series("x", [1, 2, 3]))
@@ -465,6 +466,28 @@ def test_insert_column() -> None:
     )
     expected_df = pl.DataFrame({"x": [1, 2, 3], "y": [2, 3, 4], "z": [3, 4, 5]})
     assert_frame_equal(expected_df, df)
+
+    # insert expressions
+    df = pl.DataFrame(
+        {
+            "id": ["xx", "yy", "zz"],
+            "v1": [5, 4, 6],
+            "v2": [7, 3, 3],
+        }
+    )
+    df.insert_column(3, (pl.col("v1") * pl.col("v2")).alias("v3"))
+    df.insert_column(1, (pl.col("v2") - pl.col("v1")).alias("v0"))
+
+    expected = pl.DataFrame(
+        {
+            "id": ["xx", "yy", "zz"],
+            "v0": [2, -1, -3],
+            "v1": [5, 4, 6],
+            "v2": [7, 3, 3],
+            "v3": [35, 12, 18],
+        }
+    )
+    assert_frame_equal(df, expected)
 
 
 def test_replace_column() -> None:


### PR DESCRIPTION
Closes #18406.

Streamlines insertion of an Expr at an arbitrary index in a DataFrame; currently `insert_column` only supports this for Series, but it's straightforward to allow Expr too.

Without this affordance the user has to make two calls - one to add the new Expr (typically via `with_columns`), and then a second call to explicitly reorder the columns. 

More ergonomic to allow this in a single call, and it's consistent with `with_columns`, which also supports both Expr and Series input.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "id": ["xx", "yy", "zz"],
    "v1": [5, 4, 6],
    "v2": [7, 3, 3],
})

df.insert_column(3, (pl.col("v1") * pl.col("v2")).alias("v3"))
df.insert_column(1, (pl.col("v2") - pl.col("v1")).alias("v0"))

# shape: (3, 5)
# ┌─────┬─────┬─────┬─────┬─────┐
# │ id  ┆ v0  ┆ v1  ┆ v2  ┆ v3  │
# │ --- ┆ --- ┆ --- ┆ --- ┆ --- │
# │ str ┆ i64 ┆ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╪═════╪═════╡
# │ xx  ┆ 2   ┆ 5   ┆ 7   ┆ 35  │
# │ yy  ┆ -1  ┆ 4   ┆ 3   ┆ 12  │
# │ zz  ┆ -3  ┆ 6   ┆ 3   ┆ 18  │
# └─────┴─────┴─────┴─────┴─────┘
```