### PR TITLE
Python Polars 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "jemallocator",
  "libc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "1.8.2"
+version = "1.9.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
`build_info` has been commented out. This failed due to https://github.com/lukaslueg/built/issues/71