### PR TITLE
refactor(rust): Pin hashbrown to 0.14 until migrated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ fallible-streaming-iterator = "0.1.9"
 fast-float = { version = "0.2" }
 flate2 = { version = "1", default-features = false }
 futures = "0.3.25"
-hashbrown = { version = "0.14", features = ["rayon", "ahash", "serde"] }
+hashbrown = { version = "=0.14.5", features = ["rayon", "ahash", "serde"] }
 hex = "0.4.3"
 indexmap = { version = "2", features = ["std", "serde"] }
 itoa = "1.0.6"


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19063.

Hashbrown 0.15 has backwards-incompatible changes we need to migrate to manually.