### PR TITLE
fix: Implement to_arrow functionality properly for Arrays

### DIFF
--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -79,6 +79,39 @@ impl Series {
                 );
                 Box::new(arr)
             },
+            DataType::Array(inner, width) => {
+                let ca = self.array().unwrap();
+                let arr = ca.chunks[chunk_idx].clone();
+                let arr = arr.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+
+                let new_values = if let DataType::Null = &**inner {
+                    arr.values().clone()
+                } else {
+                    let s = unsafe {
+                        Series::from_chunks_and_dtype_unchecked(
+                            PlSmallStr::EMPTY,
+                            vec![arr.values().clone()],
+                            &inner.to_physical(),
+                        )
+                        .cast_unchecked(inner)
+                        .unwrap()
+                    };
+
+                    s.to_arrow(0, compat_level)
+                };
+
+                let dtype = FixedSizeListArray::default_datatype(
+                    inner.to_arrow(compat_level),
+                    width.clone(),
+                );
+                let arr = FixedSizeListArray::new(
+                    dtype,
+                    arr.len().clone(),
+                    new_values,
+                    arr.validity().cloned(),
+                );
+                Box::new(arr)
+            },
             #[cfg(feature = "dtype-categorical")]
             dt @ (DataType::Categorical(_, ordering) | DataType::Enum(_, ordering)) => {
                 let ca = self.categorical().unwrap();

--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -100,16 +100,10 @@ impl Series {
                     s.to_arrow(0, compat_level)
                 };
 
-                let dtype = FixedSizeListArray::default_datatype(
-                    inner.to_arrow(compat_level),
-                    width.clone(),
-                );
-                let arr = FixedSizeListArray::new(
-                    dtype,
-                    arr.len().clone(),
-                    new_values,
-                    arr.validity().cloned(),
-                );
+                let dtype =
+                    FixedSizeListArray::default_datatype(inner.to_arrow(compat_level), *width);
+                let arr =
+                    FixedSizeListArray::new(dtype, arr.len(), new_values, arr.validity().cloned());
                 Box::new(arr)
             },
             #[cfg(feature = "dtype-categorical")]

--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -79,6 +79,7 @@ impl Series {
                 );
                 Box::new(arr)
             },
+            #[cfg(feature = "dtype-array")]
             DataType::Array(inner, width) => {
                 let ca = self.array().unwrap();
                 let arr = ca.chunks[chunk_idx].clone();

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -78,6 +78,7 @@ def test_arrow_list_chunked_array() -> None:
     s = cast(pl.Series, pl.from_arrow(ca))
     assert s.dtype == pl.List
 
+
 # Test that polars convert Arrays of logical types correctly to arrow
 def test_arrow_array_logical() -> None:
     # cast to large string and uint32 indices because polars converts to those
@@ -102,6 +103,7 @@ def test_arrow_array_logical() -> None:
         dtype=pl.Array(pl.Date, shape=1),
     )
     assert s2.to_arrow() == pa_array_logical2
+
 
 def test_from_dict() -> None:
     data = {"a": [1, 2], "b": [3, 4]}


### PR DESCRIPTION
Fixes #18810 

Currently there is no special branch to handle to_arrow conversion for Arrays, due to which Array of logical types are not converted properly. This fix implements this branch, similar to the one for Lists.

While converting to pickle, to_arrow is used, hence converting to arrow properly also fixes the above issue.