### PR TITLE
feat: Add rolling_(min/max/sum), rolling_(min/max/sum)_by for `pl.Boolean`

### DIFF
--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -195,7 +195,11 @@ pub trait SeriesOpsTime: AsSeries {
         by: &Series,
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
-        let s = self.as_series().clone();
+        let mut s = self.as_series().clone();
+        if s.dtype().is_bool() {
+            s = s.cast(&DataType::UInt32)?;
+        }
+
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
             rolling_agg_by(
@@ -213,6 +217,8 @@ pub trait SeriesOpsTime: AsSeries {
         let mut s = self.as_series().clone();
         if options.weights.is_some() {
             s = s.to_float()?;
+        } else if s.dtype().is_bool() {
+            s = s.cast(&DataType::UInt32)?;
         }
 
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
@@ -267,34 +273,52 @@ pub trait SeriesOpsTime: AsSeries {
         by: &Series,
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
-        let s = self.as_series().clone();
+        let original_type = self.as_series().dtype();
+        let mut s = self.as_series().clone();
+        if s.dtype().is_bool() {
+            s = s.cast(&DataType::UInt32)?;
+        }
+
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg_by(
+            let out = rolling_agg_by(
                 ca,
                 by,
                 options,
                 &super::rolling_kernels::no_nulls::rolling_min,
-            )
+            )?;
+            if original_type.is_bool() {
+                out.cast(original_type)
+            } else {
+                Ok(out)
+            }
         })
     }
 
     /// Apply a rolling min to a Series.
     #[cfg(feature = "rolling_window")]
     fn rolling_min(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
+        let original_type = self.as_series().dtype();
         let mut s = self.as_series().clone();
         if options.weights.is_some() {
             s = s.to_float()?;
+        } else if s.dtype().is_bool() {
+            s = s.cast(&DataType::UInt32)?;
         }
 
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg(
+            let out = rolling_agg(
                 ca,
                 options,
                 &rolling::no_nulls::rolling_min,
                 &rolling::nulls::rolling_min,
-            )
+            )?;
+            if original_type.is_bool() {
+                out.cast(original_type)
+            } else {
+                Ok(out)
+            }
         })
     }
 
@@ -305,34 +329,52 @@ pub trait SeriesOpsTime: AsSeries {
         by: &Series,
         options: RollingOptionsDynamicWindow,
     ) -> PolarsResult<Series> {
-        let s = self.as_series().clone();
+        let original_type = self.as_series().dtype();
+        let mut s = self.as_series().clone();
+        if s.dtype().is_bool() {
+            s = s.cast(&DataType::UInt32)?;
+        }
+
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg_by(
+            let out = rolling_agg_by(
                 ca,
                 by,
                 options,
                 &super::rolling_kernels::no_nulls::rolling_max,
-            )
+            )?;
+            if original_type.is_bool() {
+                out.cast(original_type)
+            } else {
+                Ok(out)
+            }
         })
     }
 
     /// Apply a rolling max to a Series.
     #[cfg(feature = "rolling_window")]
     fn rolling_max(&self, options: RollingOptionsFixedWindow) -> PolarsResult<Series> {
+        let original_type = self.as_series().dtype();
         let mut s = self.as_series().clone();
         if options.weights.is_some() {
             s = s.to_float()?;
+        } else if s.dtype().is_bool() {
+            s = s.cast(&DataType::UInt32)?;
         }
 
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-            rolling_agg(
+            let out = rolling_agg(
                 ca,
                 options,
                 &rolling::no_nulls::rolling_max,
                 &rolling::nulls::rolling_max,
-            )
+            )?;
+            if original_type.is_bool() {
+                out.cast(original_type)
+            } else {
+                Ok(out)
+            }
         })
     }
 


### PR DESCRIPTION
On version 1.9.0, `rolling_(min/max/sum)`, `rolling_(min/max/sum)_by` operations are not implemented for dtype `pl.Boolean`.

Before:
```python
>>> import polars as pl
>>> pl.DataFrame(
...     {"a": [-10, 34, 20, -30, -20, -45, 30]},
... ).with_columns(
...     true_cnt_in_2_win=pl.col("a").gt(0).rolling_sum(2),
...     all_true_in_2_win=pl.col("a").gt(0).rolling_min(2),
...     any_true_in_2_win=pl.col("a").gt(0).rolling_max(2),
... )
thread 'polars-0' panicked at /home/runner/work/polars/polars/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs:209:9:
not implemented for dtype Boolean
thread 'polars-1' panicked at /home/runner/work/polars/polars/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs:281:9:
not implemented for dtype Boolean
thread 'polars-2' panicked at /home/runner/work/polars/polars/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs:319:9:
not implemented for dtype Boolean
```

After:
```python
>>> import polars as pl
>>> pl.DataFrame(
...     {"a": [-10, 34, 20, -30, -20, -45, 30]},
... ).with_columns(
...     true_cnt_in_2_win=pl.col("a").gt(0).rolling_sum(2),
...     all_true_in_2_win=pl.col("a").gt(0).rolling_min(2),
...     any_true_in_2_win=pl.col("a").gt(0).rolling_max(2),
... )
shape: (7, 4)
┌─────┬───────────────────┬───────────────────┬───────────────────┐
│ a   ┆ true_cnt_in_2_win ┆ all_true_in_2_win ┆ any_true_in_2_win │
│ --- ┆ ---               ┆ ---               ┆ ---               │
│ i64 ┆ u32               ┆ bool              ┆ bool              │
╞═════╪═══════════════════╪═══════════════════╪═══════════════════╡
│ -10 ┆ null              ┆ null              ┆ null              │
│ 34  ┆ 1                 ┆ false             ┆ true              │
│ 20  ┆ 2                 ┆ true              ┆ true              │
│ -30 ┆ 1                 ┆ false             ┆ true              │
│ -20 ┆ 0                 ┆ false             ┆ false             │
│ -45 ┆ 0                 ┆ false             ┆ false             │
│ 30  ┆ 1                 ┆ false             ┆ true              │
└─────┴───────────────────┴───────────────────┴───────────────────┘
```

Note:
Other `rolling_*` operations, such as `rolling_mean`, already support the `pl.Boolean` dtype via `to_float()`, if I’m not mistaken.