### PR TITLE
fix: Raise exception for illegal `explode` usage

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -528,13 +528,13 @@ impl Series {
         Ok(max)
     }
 
-    /// Explode a list Series. This expands every item to a new row..
+    /// Explode a list/array Series. This expands every item to a new row.
     pub fn explode(&self) -> PolarsResult<Series> {
         match self.dtype() {
             DataType::List(_) => self.list().unwrap().explode(),
             #[cfg(feature = "dtype-array")]
             DataType::Array(_, _) => self.array().unwrap().explode(),
-            _ => Ok(self.clone()),
+            dt => polars_bail!(opq = explode, dt),
         }
     }
 

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -467,7 +467,11 @@ impl<'a> AggregationContext<'a> {
             AggState::AggregatedScalar(s) => (s, groups),
             AggState::Literal(s) => (s, groups),
             AggState::AggregatedList(s) => {
-                let flattened = s.explode().unwrap();
+                // flat only if we have a list
+                let flattened = match s.dtype() {
+                    DataType::List(_) => s.explode().unwrap(),
+                    _ => s.clone(),
+                };
                 let groups = groups.into_owned();
                 // unroll the possible flattened state
                 // say we have groups with overlapping windows:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -621,6 +621,14 @@ def test_explode() -> None:
     assert out["nrs"].to_list() == [1, 2, 1, 3]
 
 
+def test_illegal_explode_19049() -> None:
+    df = pl.DataFrame({"a": [0]}, schema={"a": pl.Int64})
+    with pytest.raises(
+        InvalidOperationError, match="`explode` operation not supported for dtype `i64`"
+    ):
+        df.select(pl.col.a.explode())
+
+
 @pytest.mark.parametrize(
     ("stack", "exp_shape", "exp_columns"),
     [

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -163,7 +163,7 @@ def test_time_range_lit_eager() -> None:
         ).alias("tm")
     )
     if not eager:
-        tm = tm.select(pl.col("tm").explode())
+        tm = tm.select(pl.col("tm"))
     assert tm["tm"].to_list() == [
         time(6, 47, 13, 333000),
         time(12, 32, 23, 666000),
@@ -178,7 +178,7 @@ def test_time_range_lit_eager() -> None:
         ).alias("tm")
     )
     if not eager:
-        tm = tm.select(pl.col("tm").explode())
+        tm = tm.select(pl.col("tm"))
     assert tm["tm"].to_list() == [
         time(0, 0),
         time(5, 45, 10, 333000),
@@ -194,7 +194,7 @@ def test_time_range_lit_eager() -> None:
             eager=eager,
         ).alias("tm")
     )
-    tm = tm.select(pl.col("tm").explode())
+    tm = tm.select(pl.col("tm"))
     assert tm["tm"].to_list() == [
         time(23, 59, 59, 999980),
         time(23, 59, 59, 999990),


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19049.

I am not sure if it's the right fix, since I think it is better to be caught earlier.