### PR TITLE
docs: Fix example of `as_struct`

### DIFF
--- a/crates/polars/src/docs/lazy.rs
+++ b/crates/polars/src/docs/lazy.rs
@@ -257,7 +257,7 @@
 //!         "b" => [3.0f32, 5.1, 0.3]
 //!     ]?
 //!     .lazy()
-//!     .select([as_struct(&[col("a"), col("b")]).map(
+//!     .select([as_struct(vec![col("a"), col("b")]).map(
 //!         |s| {
 //!             let ca = s.struct_()?;
 //!


### PR DESCRIPTION
Hi, since `as_struct` no longer accepts slices and now only accepts a `Vec`, I've updated the documentation.