### PR TITLE
fix(python): Remove incorrect warning when using an `IO[bytes]` instance

### DIFF
--- a/crates/polars-python/src/file.rs
+++ b/crates/polars-python/src/file.rs
@@ -9,7 +9,7 @@ use std::os::fd::{FromRawFd, RawFd};
 use std::path::PathBuf;
 
 use polars::io::mmap::MmapBytesReader;
-use polars_error::{polars_err, polars_warn};
+use polars_error::polars_err;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString, PyStringMethods};
@@ -284,14 +284,6 @@ pub fn get_python_scan_source_input(
                 }));
             }
 
-            // BytesIO / StringIO is relatively fast, and some code relies on it.
-            if !py_f.is_exact_instance(&io.getattr("BytesIO").unwrap())
-                && !py_f.is_exact_instance(&io.getattr("StringIO").unwrap())
-            {
-                polars_warn!("Polars found a filename. \
-                Ensure you pass a path to the file instead of a python file object when possible for best \
-                performance.");
-            }
             // Unwrap TextIOWrapper
             // Allow subclasses to allow things like pytest.capture.CaptureIO
             let py_f = if py_f
@@ -397,14 +389,6 @@ fn get_either_buffer_or_path(
                 ));
             }
 
-            // BytesIO / StringIO is relatively fast, and some code relies on it.
-            if !py_f.is_exact_instance(&io.getattr("BytesIO").unwrap())
-                && !py_f.is_exact_instance(&io.getattr("StringIO").unwrap())
-            {
-                polars_warn!("Polars found a filename. \
-                Ensure you pass a path to the file instead of a python file object when possible for best \
-                performance.");
-            }
             // Unwrap TextIOWrapper
             // Allow subclasses to allow things like pytest.capture.CaptureIO
             let py_f = if py_f


### PR DESCRIPTION
Fixes #18417 

When passing something like a `gzip.GzipFile` or `zipfile.ZipExtFile`, it's not possible to pass a file path instead. And since #17315, Polars will extract the underlying fileno for faster IO performance if possible, so it doesn't appear that this warning is useful any more.