### PR TITLE
fix: Fix incorrect `(eq|ne)_missing` on List/Array types

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -674,7 +674,11 @@ where
                 right.offsets().range().try_into().unwrap(),
             );
 
-            arity::unary_mut_values(lhs, |a| broadcast_op(a, &values).into())
+            if missing {
+                arity::unary_mut_with_options(lhs, |a| broadcast_op(a, &values).into())
+            } else {
+                arity::unary_mut_values(lhs, |a| broadcast_op(a, &values).into())
+            }
         },
         (1, _) => {
             let left = lhs.chunks()[0]
@@ -699,9 +703,19 @@ where
                 left.offsets().range().try_into().unwrap(),
             );
 
-            arity::unary_mut_values(rhs, |a| broadcast_op(a, &values).into())
+            if missing {
+                arity::unary_mut_with_options(rhs, |a| broadcast_op(a, &values).into())
+            } else {
+                arity::unary_mut_values(rhs, |a| broadcast_op(a, &values).into())
+            }
         },
-        _ => arity::binary_mut_values(lhs, rhs, |a, b| op(a, b).into(), PlSmallStr::EMPTY),
+        _ => {
+            if missing {
+                arity::binary_mut_with_options(lhs, rhs, |a, b| op(a, b).into(), PlSmallStr::EMPTY)
+            } else {
+                arity::binary_mut_values(lhs, rhs, |a, b| op(a, b).into(), PlSmallStr::EMPTY)
+            }
+        },
     }
 }
 
@@ -874,7 +888,11 @@ where
                 }
             }
 
-            arity::unary_mut_values(lhs, |a| broadcast_op(a, right.values()).into())
+            if missing {
+                arity::unary_mut_with_options(lhs, |a| broadcast_op(a, right.values()).into())
+            } else {
+                arity::unary_mut_values(lhs, |a| broadcast_op(a, right.values()).into())
+            }
         },
         (1, _) => {
             let left = lhs.chunks()[0]
@@ -894,9 +912,19 @@ where
                 }
             }
 
-            arity::unary_mut_values(rhs, |a| broadcast_op(a, left.values()).into())
+            if missing {
+                arity::unary_mut_with_options(rhs, |a| broadcast_op(a, left.values()).into())
+            } else {
+                arity::unary_mut_values(rhs, |a| broadcast_op(a, left.values()).into())
+            }
         },
-        _ => arity::binary_mut_values(lhs, rhs, |a, b| op(a, b).into(), PlSmallStr::EMPTY),
+        _ => {
+            if missing {
+                arity::binary_mut_with_options(lhs, rhs, |a, b| op(a, b).into(), PlSmallStr::EMPTY)
+            } else {
+                arity::binary_mut_values(lhs, rhs, |a, b| op(a, b).into(), PlSmallStr::EMPTY)
+            }
+        },
     }
 }
 

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -405,14 +405,14 @@ def test_fast_explode_merge_left_16923() -> None:
 @pytest.mark.parametrize(
     ("values", "exploded"),
     [
-        (["foobar", None], ["f", "o", "o", "b", "a", "r", ""]),
-        ([None, "foo", "bar"], ["", "f", "o", "o", "b", "a", "r"]),
+        (["foobar", None], ["f", "o", "o", "b", "a", "r", None]),
+        ([None, "foo", "bar"], [None, "f", "o", "o", "b", "a", "r"]),
         (
             [None, "foo", "bar", None, "ham"],
-            ["", "f", "o", "o", "b", "a", "r", "", "h", "a", "m"],
+            [None, "f", "o", "o", "b", "a", "r", None, "h", "a", "m"],
         ),
         (["foo", "bar", "ham"], ["f", "o", "o", "b", "a", "r", "h", "a", "m"]),
-        (["", None, "foo", "bar"], ["", "", "f", "o", "o", "b", "a", "r"]),
+        (["", None, "foo", "bar"], ["", None, "f", "o", "o", "b", "a", "r"]),
         (["", "foo", "bar"], ["", "f", "o", "o", "b", "a", "r"]),
     ],
 )

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -421,9 +421,6 @@ def test_series_str_explode_deprecated(
 ) -> None:
     with pytest.deprecated_call():
         result = pl.Series(values).str.explode()
-    if result.to_list() != exploded:
-        print(result.to_list())
-        print(exploded)
     assert result.to_list() == exploded
 
 


### PR DESCRIPTION
Regression causing `eq/ne_missing` to incorrectly give NULL when comparing NULLs instead of True/False

Fixes https://github.com/pola-rs/polars/issues/19153

Adds
* `test_eq_lists_arrays` for `==` / `!=`
* `test_eq_missing_lists_arrays_19153` for `eq_missing` / `ne_missing`
---
Tests are parametrized to test both lists and arrays