### PR TITLE
docs: Fix sign in pandas example of column assignment

### DIFF
--- a/docs/source/user-guide/migration/pandas.md
+++ b/docs/source/user-guide/migration/pandas.md
@@ -175,7 +175,7 @@ the values in column `a` based on a condition. When the value in column `c` is e
 In pandas this would be:
 
 ```python
-df.assign(a=lambda df_: df_.a.where(df_.c != 2, df_.b))
+df.assign(a=lambda df_: df_.a.where(df_.c == 2, df_.b))
 ```
 
 while in Polars this would be:


### PR DESCRIPTION
In the docs on coming from pandas, under column assignment, the example says:

> When the value in column c is equal to 2 then we replace the value in a with the value in b.

But the pandas example shown is:

```python
df.assign(a=lambda df_: df_.a.where(df_.c != 2, df_.b))
```

This just changes the sign so it's actually when `c` is equal to `2`, rather than not equal.