### PR TITLE
feat: Check Python version when deserializing UDFs

### DIFF
--- a/crates/polars-plan/src/dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_udf.rs
@@ -61,7 +61,7 @@ impl Serialize for PythonFunction {
         Python::with_gil(|py| {
             let pickle = PyModule::import_bound(py, "cloudpickle")
                 .or_else(|_| PyModule::import_bound(py, "pickle"))
-                .expect("Unable to import 'cloudpickle' or 'pickle'")
+                .expect("unable to import 'cloudpickle' or 'pickle'")
                 .getattr("dumps")
                 .unwrap();
 
@@ -87,9 +87,8 @@ impl<'a> Deserialize<'a> for PythonFunction {
         let bytes = Vec::<u8>::deserialize(deserializer)?;
 
         Python::with_gil(|py| {
-            let pickle = PyModule::import_bound(py, "cloudpickle")
-                .or_else(|_| PyModule::import_bound(py, "pickle"))
-                .expect("Unable to import 'pickle'")
+            let pickle = PyModule::import_bound(py, "pickle")
+                .expect("unable to import 'pickle'")
                 .getattr("loads")
                 .unwrap();
             let arg = (PyBytes::new_bound(py, &bytes),);
@@ -139,16 +138,17 @@ impl PythonUdfExpression {
         );
         let buf = &buf[MAGIC_BYTE_MARK.len() + 1..];
 
+        // Load metadata
         let mut reader = Cursor::new(buf);
         let (output_type, is_elementwise, returns_scalar): (Option<DataType>, bool, bool) =
             ciborium::de::from_reader(&mut reader).map_err(map_err)?;
 
         let remainder = &buf[reader.position() as usize..];
 
+        // Load UDF
         Python::with_gil(|py| {
-            let pickle = PyModule::import_bound(py, "cloudpickle")
-                .or_else(|_| PyModule::import_bound(py, "pickle"))
-                .expect("Unable to import 'pickle'")
+            let pickle = PyModule::import_bound(py, "pickle")
+                .expect("unable to import 'pickle'")
                 .getattr("loads")
                 .unwrap();
             let arg = (PyBytes::new_bound(py, remainder),);
@@ -219,7 +219,7 @@ impl ColumnsUdf for PythonUdfExpression {
         Python::with_gil(|py| {
             let pickle = PyModule::import_bound(py, "cloudpickle")
                 .or_else(|_| PyModule::import_bound(py, "pickle"))
-                .expect("Unable to import 'pickle'")
+                .expect("unable to import 'pickle'")
                 .getattr("dumps")
                 .unwrap();
             let dumped = pickle

--- a/py-polars/tests/unit/lazyframe/test_serde.py
+++ b/py-polars/tests/unit/lazyframe/test_serde.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import io
-import sys
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING
 
 import pytest
 from hypothesis import example, given
 
 import polars as pl
-from polars.exceptions import ComputeError, InvalidOperationError
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
@@ -119,36 +118,16 @@ def test_lf_serde_scan(tmp_path: Path) -> None:
     assert_frame_equal(result.collect(), df)
 
 
-class MockVersionInfo(NamedTuple):
-    """Version info with different minor version."""
-
-    major: int = sys.version_info.major
-    minor: int = sys.version_info.minor + 1
-    micro: int = sys.version_info.micro
-
-
 @pytest.mark.filterwarnings("ignore::polars.exceptions.PolarsInefficientMapWarning")
-def test_lf_serde_lambda_version_specific(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_lf_serde_version_specific_lambda(monkeypatch: pytest.MonkeyPatch) -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3]}).select(
         pl.col("a").map_elements(lambda x: x + 1, return_dtype=pl.Int64)
     )
     ser = lf.serialize()
 
-    # Same version
     result = pl.LazyFrame.deserialize(io.BytesIO(ser))
     expected = pl.LazyFrame({"a": [2, 3, 4]})
     assert_frame_equal(result, expected)
-
-    # Different version
-    monkeypatch.setattr(sys, "version_info", MockVersionInfo())
-
-    with pytest.raises(
-        InvalidOperationError,
-        match="does not match the Python version used to serialize the UDF",
-    ):
-        pl.LazyFrame.deserialize(io.BytesIO(ser)).collect()
 
 
 def custom_function(x: pl.Series) -> pl.Series:
@@ -156,7 +135,7 @@ def custom_function(x: pl.Series) -> pl.Series:
 
 
 @pytest.mark.filterwarnings("ignore::polars.exceptions.PolarsInefficientMapWarning")
-def test_lf_serde_function_version_specific(
+def test_lf_serde_version_specific_named_function(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3]}).select(
@@ -164,13 +143,6 @@ def test_lf_serde_function_version_specific(
     )
     ser = lf.serialize()
 
-    # Same version
     result = pl.LazyFrame.deserialize(io.BytesIO(ser))
     expected = pl.LazyFrame({"a": [2, 3, 4]})
-    assert_frame_equal(result, expected)
-
-    # Different version
-    monkeypatch.setattr(sys, "version_info", MockVersionInfo())
-
-    result = pl.LazyFrame.deserialize(io.BytesIO(ser))
     assert_frame_equal(result, expected)


### PR DESCRIPTION
[cloudpickle](https://github.com/cloudpipe/cloudpickle) does not support serde across Python versions:

> Cloudpickle can only be used to send objects between **the exact same version of Python**.

Currently, failing to adhere to this restriction can cause code execution to hang.

So we should only use `cloudpickle` when necessary, and when we do, we should encode the Python version during serialization and check it during deserialization. I chose to only encode the **minor** version, as we only support Python 3 anyway and the patch version doesn't seem to matter.