### PR TITLE
docs: Link to main website from banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <h1 align="center">
-  <img src="https://raw.githubusercontent.com/pola-rs/polars-static/master/banner/polars_github_banner.svg" alt="Polars logo">
-  <br>
+  <a href="https://pola.rs">
+    <img src="https://raw.githubusercontent.com/pola-rs/polars-static/master/banner/polars_github_banner.svg" alt="Polars logo">
+  </a>
 </h1>
 
 <div align="center">


### PR DESCRIPTION
Very minor tweak to `README.md`: the large Polars banner on the [main github page](https://github.com/pola-rs/polars) currently links to the svg file, which is probably not desirable. This links to https://pola.rs, so when users click on the banner they are brought to the main polars page.

[See the update here](https://github.com/mcrumiller/polars/tree/header-link).