### PR TITLE
fix(python): Don't fail test if e.g. jax has been used first, since jax installs a fork handler that warns

### DIFF
--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -105,6 +105,7 @@ def run_in_child() -> pl.Series:
     return pl.Series([1, 2, 3])
 
 
+@pytest.mark.filterwarnings("ignore")
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="Requires fork()")
 def test_fork_safety() -> None:
     # Using fork()-based multiprocessing shouldn't work:


### PR DESCRIPTION
@stinodego 