### PR TITLE
refactor: Test Python docs build

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -119,6 +119,8 @@ class Expr:
 
     @classmethod
     def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:
+        v: int = 1
+        assert v == 1
         expr = cls.__new__(cls)
         expr._pyexpr = pyexpr
         return expr


### PR DESCRIPTION
`build-python-docs` is failing on `main` - 

<details>
<summary>Log output AttributeError: 'function' object has no attribute '__arrow_c_stream__'</summary>

```python
Warning, treated as error:
autodoc: failed to import method 'DataFrame.__arrow_c_stream__' from module 'polars'; the following exception was raised:
Traceback (most recent call last):
  File "/home/runner/work/polars/polars/.venv/lib/python3.12/site-packages/sphinx/util/inspect.py", line 374, in safe_getattr
    return getattr(obj, name, *defargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'function' object has no attribute '__arrow_c_stream__'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/work/polars/polars/.venv/lib/python3.12/site-packages/sphinx/ext/autodoc/importer.py", line 209, in import_object
    obj = attrgetter(obj, mangled_name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/polars/polars/.venv/lib/python3.12/site-packages/sphinx/ext/autodoc/__init__.py", line 329, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/polars/polars/.venv/lib/python3.12/site-packages/sphinx/ext/autodoc/__init__.py", line 2844, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/polars/polars/.venv/lib/python3.12/site-packages/sphinx/util/inspect.py", line 390, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: __arrow_c_stream__

make: *** [Makefile:27: html] Error 2
Error: Process completed with exit code 2.
```
</details>

