### PR TITLE
fix: Fix invalid list collection in expression engine

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/mod.rs
@@ -19,6 +19,7 @@ pub use null::*;
 pub use primitive::*;
 
 use super::*;
+use crate::chunked_array::object::registry::get_object_builder;
 
 pub trait ListBuilderTrait {
     fn append_opt_series(&mut self, opt_s: Option<&Series>) -> PolarsResult<()> {
@@ -115,7 +116,14 @@ pub fn get_list_builder(
 
     match &physical_type {
         #[cfg(feature = "object")]
-        DataType::Object(_, _) => polars_bail!(opq = list_builder, &physical_type),
+        DataType::Object(_, _) => {
+            let builder = get_object_builder(PlSmallStr::EMPTY, 0).get_list_builder(
+                name,
+                value_capacity,
+                list_capacity,
+            );
+            Ok(Box::new(builder))
+        },
         #[cfg(feature = "dtype-struct")]
         DataType::Struct(_) => Ok(Box::new(AnonymousOwnedListBuilder::new(
             name,

--- a/crates/polars-core/src/chunked_array/builder/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/mod.rs
@@ -19,6 +19,7 @@ pub use null::*;
 pub use primitive::*;
 
 use super::*;
+#[cfg(feature = "object")]
 use crate::chunked_array::object::registry::get_object_builder;
 
 pub trait ListBuilderTrait {

--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -199,42 +199,24 @@ impl FromIterator<Option<Series>> for ListChunked {
                     }
                     builder.finish()
                 } else {
-                    match first_s.dtype() {
-                        #[cfg(feature = "object")]
-                        DataType::Object(_, _) => {
-                            let mut builder =
-                                first_s.get_list_builder(PlSmallStr::EMPTY, capacity * 5, capacity);
-                            for _ in 0..init_null_count {
-                                builder.append_null();
-                            }
-                            builder.append_series(first_s).unwrap();
+                    // We don't know the needed capacity. We arbitrarily choose an average of 5 elements per series.
+                    let mut builder = get_list_builder(
+                        first_s.dtype(),
+                        capacity * 5,
+                        capacity,
+                        PlSmallStr::EMPTY,
+                    )
+                    .unwrap();
 
-                            for opt_s in it {
-                                builder.append_opt_series(opt_s.as_ref()).unwrap();
-                            }
-                            builder.finish()
-                        },
-                        _ => {
-                            // We don't know the needed capacity. We arbitrarily choose an average of 5 elements per series.
-                            let mut builder = get_list_builder(
-                                first_s.dtype(),
-                                capacity * 5,
-                                capacity,
-                                PlSmallStr::EMPTY,
-                            )
-                            .unwrap();
-
-                            for _ in 0..init_null_count {
-                                builder.append_null();
-                            }
-                            builder.append_series(first_s).unwrap();
-
-                            for opt_s in it {
-                                builder.append_opt_series(opt_s.as_ref()).unwrap();
-                            }
-                            builder.finish()
-                        },
+                    for _ in 0..init_null_count {
+                        builder.append_null();
                     }
+                    builder.append_series(first_s).unwrap();
+
+                    for opt_s in it {
+                        builder.append_opt_series(opt_s.as_ref()).unwrap();
+                    }
+                    builder.finish()
                 }
             },
         }

--- a/crates/polars-core/src/chunked_array/from_iterator_par.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator_par.rs
@@ -177,33 +177,13 @@ fn materialize_list(
     value_capacity: usize,
     list_capacity: usize,
 ) -> ListChunked {
-    match &dtype {
-        #[cfg(feature = "object")]
-        DataType::Object(_, _) => {
-            let s = vectors
-                .iter()
-                .flatten()
-                .find_map(|opt_s| opt_s.as_ref())
-                .unwrap();
-            let mut builder = s.get_list_builder(name, value_capacity, list_capacity);
-
-            for v in vectors {
-                for val in v {
-                    builder.append_opt_series(val.as_ref()).unwrap();
-                }
-            }
-            builder.finish()
-        },
-        dtype => {
-            let mut builder = get_list_builder(dtype, value_capacity, list_capacity, name).unwrap();
-            for v in vectors {
-                for val in v {
-                    builder.append_opt_series(val.as_ref()).unwrap();
-                }
-            }
-            builder.finish()
-        },
+    let mut builder = get_list_builder(&dtype, value_capacity, list_capacity, name).unwrap();
+    for v in vectors {
+        for val in v {
+            builder.append_opt_series(val.as_ref()).unwrap();
+        }
     }
+    builder.finish()
 }
 
 impl FromParallelIterator<Option<Series>> for ListChunked {

--- a/crates/polars-core/src/chunked_array/object/extension/list.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/list.rs
@@ -18,7 +18,7 @@ impl<T: PolarsObject> ObjectChunked<T> {
     }
 }
 
-struct ExtensionListBuilder<T: PolarsObject> {
+pub(crate) struct ExtensionListBuilder<T: PolarsObject> {
     values_builder: ObjectChunkedBuilder<T>,
     offsets: Vec<i64>,
     fast_explode: bool,

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod drop;
-mod list;
+pub(super) mod list;
 pub(crate) mod polars_extension;
 
 use std::mem;

--- a/crates/polars-core/src/chunked_array/object/registry.rs
+++ b/crates/polars-core/src/chunked_array/object/registry.rs
@@ -13,7 +13,7 @@ use polars_utils::pl_str::PlSmallStr;
 
 use crate::chunked_array::object::builder::ObjectChunkedBuilder;
 use crate::datatypes::AnyValue;
-use crate::prelude::PolarsObject;
+use crate::prelude::{ListBuilderTrait, PolarsObject};
 use crate::series::{IntoSeries, Series};
 
 /// Takes a `name` and `capacity` and constructs a new builder.
@@ -71,6 +71,13 @@ pub trait AnonymousObjectBuilder {
     /// Take the current state and materialize as a [`Series`]
     /// the builder should not be used after that.
     fn to_series(&mut self) -> Series;
+
+    fn get_list_builder(
+        &self,
+        name: PlSmallStr,
+        values_capacity: usize,
+        list_capacity: usize,
+    ) -> Box<dyn ListBuilderTrait>;
 }
 
 impl<T: PolarsObject> AnonymousObjectBuilder for ObjectChunkedBuilder<T> {
@@ -86,6 +93,18 @@ impl<T: PolarsObject> AnonymousObjectBuilder for ObjectChunkedBuilder<T> {
     fn to_series(&mut self) -> Series {
         let builder = std::mem::take(self);
         builder.finish().into_series()
+    }
+    fn get_list_builder(
+        &self,
+        name: PlSmallStr,
+        values_capacity: usize,
+        list_capacity: usize,
+    ) -> Box<dyn ListBuilderTrait> {
+        Box::new(super::extension::list::ExtensionListBuilder::<T>::new(
+            name,
+            values_capacity,
+            list_capacity,
+        ))
     }
 }
 

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -72,13 +72,6 @@ impl AggState {
             AggState::NotAggregated(s) => AggState::NotAggregated(func(s)?),
         })
     }
-
-    fn map<F>(&self, func: F) -> Self
-    where
-        F: FnOnce(&Series) -> Series,
-    {
-        self.try_map(|s| Ok(func(s))).unwrap()
-    }
 }
 
 // lazy update strategy

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1146,3 +1146,10 @@ def test_positional_by_with_list_or_tuple_17540() -> None:
         pl.DataFrame({"a": [1, 2, 3]}).group_by(by=["a"])
     with pytest.raises(TypeError, match="Hint: if you"):
         pl.LazyFrame({"a": [1, 2, 3]}).group_by(by=["a"])
+
+
+def test_group_by_agg_19173() -> None:
+    df = pl.DataFrame({"x": [1.0], "g": [0]})
+    out = df.head(0).group_by("g").agg((pl.col.x - pl.col.x.sum() * pl.col.x) ** 2)
+    assert out.to_dict(as_series=False) == {"g": [], "x": []}
+    assert out.schema == pl.Schema([("g", pl.Int64), ("x", pl.List(pl.Float64))])


### PR DESCRIPTION
fixes #19173

Also makes `get_list_builder` work for `Object` types and thus is now infallible.

I can get rid of the extra `if len == 0` branch, but must fix some IR bugs to do that. Will follow up.