### PR TITLE
feat: Expose LTS CPU in show_versions()

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -137,7 +137,6 @@ jobs:
         if: matrix.architecture == 'x86-64'
         env:
           IS_LTS_CPU: ${{ matrix.package == 'polars-lts-cpu' }}
-          IS_MACOS: ${{ matrix.os == 'macos-13' }}
         # IMPORTANT: All features enabled here should also be included in py-polars/polars/_cpu_check.py
         run: |
           if [[ "$IS_LTS_CPU" = true ]]; then
@@ -175,7 +174,7 @@ jobs:
       - name: Set variables in CPU check module - LTS_CPU
         if: matrix.package == 'polars-lts-cpu'
         run: |
-          sed $SED_INPLACE 's/^_LTS_CPU = False$/_LTS_CPU = True/g' $CPU_CHECK_MODULE
+          sed $SED_INPLACE 's/^_POLARS_LTS_CPU = False$/_POLARS_LTS_CPU = True/g' $CPU_CHECK_MODULE
 
       - name: Set Rust target for aarch64
         if: matrix.architecture == 'aarch64'

--- a/py-polars/polars/_cpu_check.py
+++ b/py-polars/polars/_cpu_check.py
@@ -44,11 +44,14 @@ _POLARS_ARCH = "unknown"
 _POLARS_FEATURE_FLAGS = ""
 
 # Set to True during the build process if we are building a LTS CPU version.
-# The risk of the CPU check failing is then higher than a CPU not being supported.
 _POLARS_LTS_CPU = False
 
 _IS_WINDOWS = os.name == "nt"
 _IS_64BIT = ctypes.sizeof(ctypes.c_void_p) == 8
+
+
+def get_lts_cpu() -> bool:
+    return _POLARS_LTS_CPU
 
 
 def _open_posix_libc() -> ctypes.CDLL:
@@ -234,11 +237,7 @@ def _read_cpu_flags() -> dict[str, bool]:
 
 
 def check_cpu_flags() -> None:
-    if (
-        not _POLARS_FEATURE_FLAGS
-        or _POLARS_LTS_CPU
-        or os.environ.get("POLARS_SKIP_CPU_CHECK")
-    ):
+    if not _POLARS_FEATURE_FLAGS or os.environ.get("POLARS_SKIP_CPU_CHECK"):
         return
 
     expected_cpu_flags = [f.lstrip("+") for f in _POLARS_FEATURE_FLAGS.split(",")]

--- a/py-polars/polars/meta/versions.py
+++ b/py-polars/polars/meta/versions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 
+from polars._cpu_check import get_lts_cpu
 from polars._utils.polars_version import get_polars_version
 from polars.meta.index_type import get_index_type
 
@@ -18,6 +19,7 @@ def show_versions() -> None:
     Index type:           UInt32
     Platform:             macOS-14.4.1-arm64-arm-64bit
     Python:               3.11.8 (main, Feb  6 2024, 21:21:21) [Clang 15.0.0 (clang-1500.1.0.2.5)]
+    LTS CPU:              False
     ----Optional dependencies----
     adbc_driver_manager:  0.11.0
     altair:               5.4.0
@@ -45,7 +47,7 @@ def show_versions() -> None:
     import platform
 
     deps = _get_dependency_list()
-    core_properties = ("Polars", "Index type", "Platform", "Python")
+    core_properties = ("Polars", "Index type", "Platform", "Python", "LTS CPU")
     keylen = max(len(x) for x in [*core_properties, *deps]) + 1
 
     print("--------Version info---------")
@@ -53,6 +55,7 @@ def show_versions() -> None:
     print(f"{'Index type:':{keylen}s} {get_index_type()}")
     print(f"{'Platform:':{keylen}s} {platform.platform()}")
     print(f"{'Python:':{keylen}s} {sys.version}")
+    print(f"{'LTS CPU:':{keylen}s} {get_lts_cpu()}")
 
     print("\n----Optional dependencies----")
     for name in deps:

--- a/py-polars/tests/unit/meta/test_versions.py
+++ b/py-polars/tests/unit/meta/test_versions.py
@@ -12,4 +12,5 @@ def test_show_versions(capsys: Any) -> None:
     out, _ = capsys.readouterr()
     assert "Python" in out
     assert "Polars" in out
+    assert "LTS CPU" in out
     assert "Optional dependencies" in out

--- a/py-polars/tests/unit/test_cpu_check.py
+++ b/py-polars/tests/unit/test_cpu_check.py
@@ -60,18 +60,6 @@ def test_check_cpu_flags_skipped_no_flags(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.usefixtures("_feature_flags")
-def test_check_cpu_flags_skipped_lts_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(_cpu_check, "_POLARS_LTS_CPU", True)
-
-    mock_read_cpu_flags = Mock()
-    monkeypatch.setattr(_cpu_check, "_read_cpu_flags", mock_read_cpu_flags)
-
-    check_cpu_flags()
-
-    assert mock_read_cpu_flags.call_count == 0
-
-
-@pytest.mark.usefixtures("_feature_flags")
 def test_check_cpu_flags_skipped_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLARS_SKIP_CPU_CHECK", "1")
 


### PR DESCRIPTION
closes #19109

This PR both exposes LTS CPU in `show_versions()` and fixes an issue in the release workflow where the `_POLARS_LTS_CPU` wasn't set correctly.

The LTS CPU was originally supposed to be taken into account by `check_cpu_flags` however, because of the mentioned issue it was practically always False and so we can deem it safe to remove it from that check