### PR TITLE
chore: Migrate to PyO3 0.22 and released verion of rust-numpy crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,8 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.21.0"
-source = "git+https://github.com/stinodego/rust-numpy.git?rev=9ba9962ae57ba26e35babdce6f179edf5fe5b9c8#9ba9962ae57ba26e35babdce6f179edf5fe5b9c8"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf314fca279e6e6ac2126a4ff98f26d88aa4ad06bc68fb6ae5cf4bd706758311"
 dependencies = [
  "libc",
  "ndarray",
@@ -3499,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "15ee168e30649f7f234c3d49ef5a7a6cbf5134289bc46c29ff3155fa3221c225"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -3509,7 +3510,7 @@ dependencies = [
  "inventory",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -3519,9 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "e61cef80755fe9e46bb8a0b8f20752ca7676dcc07a5277d8b7768c6172e529b3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3529,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "67ce096073ec5405f5ee2b8b31f03a68e02aa10d5d4f565eca04acc41931fa1c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3539,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "2440c6d12bc8f3ae39f1e775266fa5122fd0c8891ce7520fa6048e683ad3de28"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3551,11 +3552,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "1be962f0e06da8f8465729ea2cb71a416d2257dff56cbe40a70d3e62a93ae5d1"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,13 @@ memmap = { package = "memmap2", version = "0.7" }
 multiversion = "0.7"
 ndarray = { version = "0.15", default-features = false }
 num-traits = "0.2"
+numpy = "0.22"
 object_store = { version = "0.10", default-features = false }
 once_cell = "1"
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pin-project-lite = "0.2"
-pyo3 = "0.21"
+pyo3 = "0.22"
 rand = "0.8"
 rand_distr = "0.4"
 raw-cpuid = "11"

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -22,7 +22,7 @@ fn cum_fold_dtype() -> GetOutput {
 /// Accumulate over multiple columns horizontally / row wise.
 pub fn fold_exprs<F, E>(acc: Expr, f: F, exprs: E) -> Expr
 where
-    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync + Clone,
+    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync,
     E: AsRef<[Expr]>,
 {
     let mut exprs = exprs.as_ref().to_vec();
@@ -62,7 +62,7 @@ where
 /// `collect` is called.
 pub fn reduce_exprs<F, E>(f: F, exprs: E) -> Expr
 where
-    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync + Clone,
+    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync,
     E: AsRef<[Expr]>,
 {
     let exprs = exprs.as_ref().to_vec();
@@ -104,7 +104,7 @@ where
 #[cfg(feature = "dtype-struct")]
 pub fn cum_reduce_exprs<F, E>(f: F, exprs: E) -> Expr
 where
-    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync + Clone,
+    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync,
     E: AsRef<[Expr]>,
 {
     let exprs = exprs.as_ref().to_vec();
@@ -152,7 +152,7 @@ where
 #[cfg(feature = "dtype-struct")]
 pub fn cum_fold_exprs<F, E>(acc: Expr, f: F, exprs: E, include_init: bool) -> Expr
 where
-    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync + Clone,
+    F: 'static + Fn(Column, Column) -> PolarsResult<Option<Column>> + Send + Sync,
     E: AsRef<[Expr]>,
 {
     let mut exprs = exprs.as_ref().to_vec();

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -32,11 +32,9 @@ itoa = { workspace = true }
 libc = { workspace = true }
 ndarray = { workspace = true }
 num-traits = { workspace = true }
-# TODO: Pin to released version once NumPy 2.0 support is merged
-# https://github.com/PyO3/rust-numpy/issues/409
-numpy = { git = "https://github.com/stinodego/rust-numpy.git", rev = "9ba9962ae57ba26e35babdce6f179edf5fe5b9c8", default-features = false }
+numpy = { workspace = true, default-features = false }
 once_cell = { workspace = true }
-pyo3 = { workspace = true, features = ["abi3-py38", "chrono", "multiple-pymethods"] }
+pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "multiple-pymethods", "py-clone"] }
 recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -32,7 +32,7 @@ itoa = { workspace = true }
 libc = { workspace = true }
 ndarray = { workspace = true }
 num-traits = { workspace = true }
-numpy = { workspace = true, default-features = false }
+numpy = { workspace = true }
 once_cell = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "multiple-pymethods"] }
 recursive = { workspace = true }

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -34,7 +34,7 @@ ndarray = { workspace = true }
 num-traits = { workspace = true }
 numpy = { workspace = true, default-features = false }
 once_cell = { workspace = true }
-pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "multiple-pymethods", "py-clone"] }
+pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "multiple-pymethods"] }
 recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -98,12 +98,12 @@ pub(crate) fn any_value_into_py_object(av: AnyValue, py: Python) -> PyObject {
         #[cfg(feature = "object")]
         AnyValue::Object(v) => {
             let object = v.as_any().downcast_ref::<ObjectValue>().unwrap();
-            object.inner.clone()
+            object.inner.clone_ref(py)
         },
         #[cfg(feature = "object")]
         AnyValue::ObjectOwned(v) => {
             let object = v.0.as_any().downcast_ref::<ObjectValue>().unwrap();
-            object.inner.clone()
+            object.inner.clone_ref(py)
         },
         AnyValue::Binary(v) => PyBytes::new_bound(py, v).into_py(py),
         AnyValue::BinaryOwned(v) => PyBytes::new_bound(py, &v).into_py(py),

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -425,8 +425,8 @@ pub(crate) fn py_object_to_any_value<'py>(
             Ok(get_struct)
         } else {
             let ob_type = ob.get_type();
-            let type_name = ob_type.qualname().unwrap();
-            match &*type_name {
+            let type_name = ob_type.qualname().unwrap().to_string();
+            match type_name.as_str() {
                 // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
                 // so need this workaround instead of `isinstance(ob, datetime)`.
                 "date" => Ok(get_date as InitFn),

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -604,10 +604,18 @@ impl IntoPy<PyObject> for Wrap<&Schema> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct ObjectValue {
     pub inner: PyObject,
+}
+
+impl Clone for ObjectValue {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| Self {
+            inner: self.inner.clone_ref(py),
+        })
+    }
 }
 
 impl Hash for ObjectValue {
@@ -689,8 +697,8 @@ impl From<&dyn PolarsObjectSafe> for &ObjectValue {
 }
 
 impl ToPyObject for ObjectValue {
-    fn to_object(&self, _py: Python) -> PyObject {
-        self.inner.clone()
+    fn to_object(&self, py: Python) -> PyObject {
+        self.inner.clone_ref(py)
     }
 }
 

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -336,7 +336,7 @@ impl<'py> FromPyObject<'py> for Wrap<Field> {
 impl<'py> FromPyObject<'py> for Wrap<DataType> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
-        let type_name = ob.get_type().qualname()?;
+        let type_name = ob.get_type().qualname()?.to_string();
 
         let dtype = match &*type_name {
             "DataTypeClass" => {

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -12,6 +12,7 @@ use crate::interop;
 #[pymethods]
 impl PyDataFrame {
     #[staticmethod]
+    #[pyo3(signature = (data, schema=None, infer_schema_length=None))]
     pub fn from_rows(
         py: Python,
         data: Vec<Wrap<Row>>,

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -95,6 +95,7 @@ impl PyDataFrame {
         Ok(df.into())
     }
 
+    #[pyo3(signature = (n, with_replacement, shuffle, seed=None))]
     pub fn sample_n(
         &self,
         n: &PySeries,
@@ -109,6 +110,7 @@ impl PyDataFrame {
         Ok(df.into())
     }
 
+    #[pyo3(signature = (frac, with_replacement, shuffle, seed=None))]
     pub fn sample_frac(
         &self,
         frac: &PySeries,
@@ -294,6 +296,7 @@ impl PyDataFrame {
         Ok(())
     }
 
+    #[pyo3(signature = (offset, length=None))]
     pub fn slice(&self, offset: i64, length: Option<usize>) -> Self {
         let df = self
             .df
@@ -329,6 +332,7 @@ impl PyDataFrame {
         }
     }
 
+    #[pyo3(signature = (name, offset=None))]
     pub fn with_row_index(&self, name: &str, offset: Option<IdxSize>) -> PyResult<Self> {
         let df = self
             .df
@@ -391,6 +395,7 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "pivot")]
+    #[pyo3(signature = (on, index, value_name=None, variable_name=None))]
     pub fn unpivot(
         &self,
         on: Vec<PyBackedStr>,

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -188,6 +188,7 @@ impl PyDataFrame {
 
     #[staticmethod]
     #[cfg(feature = "json")]
+    #[pyo3(signature = (py_f, infer_schema_length=None, schema=None, schema_overrides=None))]
     pub fn read_json(
         py: Python,
         mut py_f: Bound<PyAny>,
@@ -220,6 +221,7 @@ impl PyDataFrame {
 
     #[staticmethod]
     #[cfg(feature = "json")]
+    #[pyo3(signature = (py_f, ignore_errors, schema=None, schema_overrides=None))]
     pub fn read_ndjson(
         py: Python,
         mut py_f: Bound<PyAny>,
@@ -337,6 +339,7 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "csv")]
+    #[pyo3(signature = (py_f, include_bom, include_header, separator, line_terminator, quote_char, batch_size, datetime_format=None, date_format=None, time_format=None, float_scientific=None, float_precision=None, null_value=None, quote_style=None))]
     pub fn write_csv(
         &mut self,
         py: Python,

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use polars::prelude::*;
 use polars_io::mmap::ReaderBytes;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
 
 use super::PyDataFrame;
@@ -25,11 +26,11 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "ipc_streaming")]
-    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+    fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
         // Used in pickle/pickling
-        match state.extract::<&PyBytes>(py) {
+        match state.extract::<PyBackedBytes>() {
             Ok(s) => {
-                let c = Cursor::new(s.as_bytes());
+                let c = Cursor::new(&*s);
                 let reader = IpcStreamReader::new(c);
 
                 reader

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -361,6 +361,7 @@ impl PyExpr {
         self.inner.clone().forward_fill(limit).into()
     }
 
+    #[pyo3(signature = (n, fill_value=None))]
     fn shift(&self, n: Self, fill_value: Option<Self>) -> Self {
         let expr = self.inner.clone();
         let out = match fill_value {
@@ -470,6 +471,7 @@ impl PyExpr {
         self.inner.clone().ceil().into()
     }
 
+    #[pyo3(signature = (min=None, max=None))]
     fn clip(&self, min: Option<Self>, max: Option<Self>) -> Self {
         let expr = self.inner.clone();
         let out = match (min, max) {
@@ -739,6 +741,7 @@ impl PyExpr {
         self.inner.clone().upper_bound().into()
     }
 
+    #[pyo3(signature = (method, descending, seed=None))]
     fn rank(&self, method: Wrap<RankMethod>, descending: bool, seed: Option<u64>) -> Self {
         let options = RankOptions {
             method: method.0,
@@ -896,6 +899,7 @@ impl PyExpr {
         self.inner.clone().replace(old.inner, new.inner).into()
     }
 
+    #[pyo3(signature = (old, new, default=None, return_dtype=None))]
     fn replace_strict(
         &self,
         old: PyExpr,

--- a/crates/polars-python/src/expr/list.rs
+++ b/crates/polars-python/src/expr/list.rs
@@ -118,6 +118,7 @@ impl PyExpr {
         self.inner.clone().list().shift(periods.inner).into()
     }
 
+    #[pyo3(signature = (offset, length=None))]
     fn list_slice(&self, offset: PyExpr, length: Option<PyExpr>) -> Self {
         let length = match length {
             Some(i) => i.inner,
@@ -152,6 +153,7 @@ impl PyExpr {
     }
 
     #[cfg(feature = "list_sample")]
+    #[pyo3(signature = (n, with_replacement, shuffle, seed=None))]
     fn list_sample_n(
         &self,
         n: PyExpr,
@@ -167,6 +169,7 @@ impl PyExpr {
     }
 
     #[cfg(feature = "list_sample")]
+    #[pyo3(signature = (fraction, with_replacement, shuffle, seed=None))]
     fn list_sample_fraction(
         &self,
         fraction: PyExpr,

--- a/crates/polars-python/src/expr/serde.rs
+++ b/crates/polars-python/src/expr/serde.rs
@@ -21,9 +21,9 @@ impl PyExpr {
         Ok(PyBytes::new_bound(py, &writer).to_object(py))
     }
 
-    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+    fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
         // Used in pickle/pickling
-        match state.extract::<PyBackedBytes>(py) {
+        match state.extract::<PyBackedBytes>() {
             Ok(s) => {
                 let cursor = Cursor::new(&*s);
                 self.inner = ciborium::de::from_reader(cursor)

--- a/crates/polars-python/src/expr/string.rs
+++ b/crates/polars-python/src/expr/string.rs
@@ -226,6 +226,7 @@ impl PyExpr {
     }
 
     #[cfg(feature = "extract_jsonpath")]
+    #[pyo3(signature = (dtype=None, infer_schema_len=None))]
     fn str_json_decode(
         &self,
         dtype: Option<Wrap<DataType>>,

--- a/crates/polars-python/src/file.rs
+++ b/crates/polars-python/src/file.rs
@@ -17,9 +17,16 @@ use pyo3::types::{PyBytes, PyString, PyStringMethods};
 use crate::error::PyPolarsErr;
 use crate::prelude::resolve_homedir;
 
-#[derive(Clone)]
 pub struct PyFileLikeObject {
     inner: PyObject,
+}
+
+impl Clone for PyFileLikeObject {
+    fn clone(&self) -> Self {
+        Python::with_gil(|py| Self {
+            inner: self.inner.clone_ref(py),
+        })
+    }
 }
 
 /// Wraps a `PyObject`, and implements read, seek, and write for it.

--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -466,7 +466,7 @@ pub fn lit(value: &Bound<'_, PyAny>, allow_object: bool, is_scalar: bool) -> PyR
                 format!(
                     "cannot create expression literal for value of type {}.\
                     \n\nHint: Pass `allow_object=True` to accept any value and create a literal of type Object.",
-                    value.get_type().qualname().unwrap_or("unknown".to_owned()),
+                    value.get_type().qualname().map(|s|s.to_string()).unwrap_or("unknown".to_owned()),
                 )
             )
         })?;

--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -517,6 +517,7 @@ pub fn reduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
+#[pyo3(signature = (value, n, dtype=None))]
 pub fn repeat(value: PyExpr, n: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResult<PyExpr> {
     let mut value = value.inner;
     let n = n.inner;

--- a/crates/polars-python/src/functions/meta.rs
+++ b/crates/polars-python/src/functions/meta.rs
@@ -41,6 +41,7 @@ pub fn get_float_fmt() -> PyResult<String> {
 }
 
 #[pyfunction]
+#[pyo3(signature = (precision=None))]
 pub fn set_float_precision(precision: Option<usize>) -> PyResult<()> {
     use polars_core::fmt::set_float_precision;
     set_float_precision(precision);
@@ -54,6 +55,7 @@ pub fn get_float_precision() -> PyResult<Option<usize>> {
 }
 
 #[pyfunction]
+#[pyo3(signature = (sep=None))]
 pub fn set_thousands_separator(sep: Option<char>) -> PyResult<()> {
     use polars_core::fmt::set_thousands_separator;
     set_thousands_separator(sep);
@@ -67,6 +69,7 @@ pub fn get_thousands_separator() -> PyResult<Option<String>> {
 }
 
 #[pyfunction]
+#[pyo3(signature = (sep=None))]
 pub fn set_decimal_separator(sep: Option<char>) -> PyResult<()> {
     use polars_core::fmt::set_decimal_separator;
     set_decimal_separator(sep);
@@ -80,6 +83,7 @@ pub fn get_decimal_separator() -> PyResult<Option<char>> {
 }
 
 #[pyfunction]
+#[pyo3(signature = (trim=None))]
 pub fn set_trim_decimal_zeros(trim: Option<bool>) -> PyResult<()> {
     use polars_core::fmt::set_trim_decimal_zeros;
     set_trim_decimal_zeros(trim);

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -94,6 +94,7 @@ pub fn date_ranges(
 }
 
 #[pyfunction]
+#[pyo3(signature = (start, end, every, closed, time_unit=None, time_zone=None))]
 pub fn datetime_range(
     start: PyExpr,
     end: PyExpr,
@@ -112,6 +113,7 @@ pub fn datetime_range(
 }
 
 #[pyfunction]
+#[pyo3(signature = (start, end, every, closed, time_unit=None, time_zone=None))]
 pub fn datetime_ranges(
     start: PyExpr,
     end: PyExpr,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -575,6 +575,7 @@ impl PyLazyFrame {
         Ok((df.into(), time_df.into()))
     }
 
+    #[pyo3(signature = (lambda_post_opt=None))]
     fn collect(&self, py: Python, lambda_post_opt: Option<PyObject>) -> PyResult<PyDataFrame> {
         // if we don't allow threads and we have udfs trying to acquire the gil from different
         // threads we deadlock.
@@ -913,6 +914,7 @@ impl PyLazyFrame {
             .into())
     }
 
+    #[pyo3(signature = (other, left_on, right_on, allow_parallel, force_parallel, join_nulls, how, suffix, validate, coalesce=None))]
     fn join(
         &self,
         other: Self,
@@ -992,6 +994,7 @@ impl PyLazyFrame {
         ldf.reverse().into()
     }
 
+    #[pyo3(signature = (n, fill_value=None))]
     fn shift(&self, n: PyExpr, fill_value: Option<PyExpr>) -> Self {
         let lf = self.ldf.clone();
         let out = match fill_value {
@@ -1081,12 +1084,14 @@ impl PyLazyFrame {
         .into()
     }
 
+    #[pyo3(signature = (subset=None))]
     fn drop_nulls(&self, subset: Option<Vec<PyExpr>>) -> Self {
         let ldf = self.ldf.clone();
         let subset = subset.map(|e| e.to_exprs());
         ldf.drop_nulls(subset).into()
     }
 
+    #[pyo3(signature = (offset, len=None))]
     fn slice(&self, offset: i64, len: Option<IdxSize>) -> Self {
         let ldf = self.ldf.clone();
         ldf.slice(offset, len.unwrap_or(IdxSize::MAX)).into()
@@ -1116,6 +1121,7 @@ impl PyLazyFrame {
         ldf.unpivot(args).into()
     }
 
+    #[pyo3(signature = (name, offset=None))]
     fn with_row_index(&self, name: &str, offset: Option<IdxSize>) -> Self {
         let ldf = self.ldf.clone();
         ldf.with_row_index(name, offset).into()

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -56,8 +56,8 @@ impl IntoPy<PyObject> for Wrap<ClosedInterval> {
     }
 }
 
-#[pyclass(name = "Operator")]
-#[derive(Copy, Clone)]
+#[pyclass(name = "Operator", eq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum PyOperator {
     Eq,
     EqValidity,
@@ -129,8 +129,8 @@ impl IntoPy<PyObject> for Wrap<InequalityOperator> {
     }
 }
 
-#[pyclass(name = "StringFunction")]
-#[derive(Copy, Clone)]
+#[pyclass(name = "StringFunction", eq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum PyStringFunction {
     ConcatHorizontal,
     ConcatVertical,
@@ -183,8 +183,8 @@ impl PyStringFunction {
     }
 }
 
-#[pyclass(name = "BooleanFunction")]
-#[derive(Copy, Clone)]
+#[pyclass(name = "BooleanFunction", eq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum PyBooleanFunction {
     Any,
     All,
@@ -212,8 +212,8 @@ impl PyBooleanFunction {
     }
 }
 
-#[pyclass(name = "TemporalFunction")]
-#[derive(Copy, Clone)]
+#[pyclass(name = "TemporalFunction", eq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum PyTemporalFunction {
     Millennium,
     Century,

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -273,7 +273,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                     options
                         .scan_fn
                         .as_ref()
-                        .map_or_else(|| py.None(), |s| s.0.clone()),
+                        .map_or_else(|| py.None(), |s| s.0.clone_ref(py)),
                     options.with_columns.as_ref().map_or_else(
                         || py.None(),
                         |cols| {

--- a/crates/polars-python/src/lazygroupby.rs
+++ b/crates/polars-python/src/lazygroupby.rs
@@ -34,6 +34,7 @@ impl PyLazyGroupBy {
         lgb.tail(Some(n)).into()
     }
 
+    #[pyo3(signature = (lambda, schema=None))]
     fn map_groups(
         &mut self,
         lambda: PyObject,

--- a/crates/polars-python/src/series/buffers.rs
+++ b/crates/polars-python/src/series/buffers.rs
@@ -251,6 +251,7 @@ fn get_boolean_buffer_length_in_bytes(length: usize, offset: usize) -> usize {
 impl PySeries {
     /// Construct a PySeries from information about its underlying buffers.
     #[staticmethod]
+    #[pyo3(signature = (dtype, data, validity=None))]
     unsafe fn _from_buffers(
         dtype: Wrap<DataType>,
         data: Vec<PySeries>,

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -497,6 +497,7 @@ impl PySeries {
         Ok(out.into())
     }
 
+    #[pyo3(signature = (offset, length=None))]
     fn slice(&self, offset: i64, length: Option<usize>) -> Self {
         let length = length.unwrap_or_else(|| self.series.len());
         self.series.slice(offset, length).into()
@@ -523,6 +524,7 @@ macro_rules! impl_set_with_mask {
 
         #[pymethods]
         impl PySeries {
+            #[pyo3(signature = (filter, value))]
             fn $name(&self, filter: &PySeries, value: Option<$native>) -> PyResult<Self> {
                 let series = $name(&self.series, filter, value).map_err(PyPolarsErr::from)?;
                 Ok(Self::new(series))

--- a/crates/polars-python/src/series/map.rs
+++ b/crates/polars-python/src/series/map.rs
@@ -232,7 +232,7 @@ impl PySeries {
                         PyCFunction::new_closure_bound(py, None, None, move |args, _kwargs| {
                             Python::with_gil(|py| {
                                 let out = function_owned.call1(py, args)?;
-                                SERIES.call1(py, ("", out, dtype_py.clone()))
+                                SERIES.call1(py, ("", out, dtype_py.clone_ref(py)))
                             })
                         })?
                         .to_object(py);


### PR DESCRIPTION
Closes #17273 

This also tweaks the abi3 in the `polars-python` crate to match what was in py-polars (3.9), since Python 3.8 is now EOL.

The commits are a commit per category of change I made.