### PR TITLE
fix: Only apply string parsing to String dtype

### DIFF
--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -338,16 +338,6 @@ pub fn cast(
                 array.as_any().downcast_ref().unwrap(),
             )
             .boxed()),
-            UInt8 => binview_to_primitive_dyn::<u8>(array, to_type, options),
-            UInt16 => binview_to_primitive_dyn::<u16>(array, to_type, options),
-            UInt32 => binview_to_primitive_dyn::<u32>(array, to_type, options),
-            UInt64 => binview_to_primitive_dyn::<u64>(array, to_type, options),
-            Int8 => binview_to_primitive_dyn::<i8>(array, to_type, options),
-            Int16 => binview_to_primitive_dyn::<i16>(array, to_type, options),
-            Int32 => binview_to_primitive_dyn::<i32>(array, to_type, options),
-            Int64 => binview_to_primitive_dyn::<i64>(array, to_type, options),
-            Float32 => binview_to_primitive_dyn::<f32>(array, to_type, options),
-            Float64 => binview_to_primitive_dyn::<f64>(array, to_type, options),
             LargeList(inner) if matches!(inner.dtype, ArrowDataType::UInt8) => {
                 let bin_array = view_to_binary::<i64>(array.as_any().downcast_ref().unwrap());
                 Ok(binary_to_list(&bin_array, to_type.clone()).boxed())
@@ -404,17 +394,16 @@ pub fn cast(
             match to_type {
                 BinaryView => Ok(arr.to_binview().boxed()),
                 LargeUtf8 => Ok(binview_to::utf8view_to_utf8::<i64>(arr).boxed()),
-                UInt8
-                | UInt16
-                | UInt32
-                | UInt64
-                | Int8
-                | Int16
-                | Int32
-                | Int64
-                | Float32
-                | Float64
-                | Decimal(_, _) => cast(&arr.to_binview(), to_type, options),
+                UInt8 => binview_to_primitive_dyn::<u8>(&arr.to_binview(), to_type, options),
+                UInt16 => binview_to_primitive_dyn::<u16>(&arr.to_binview(), to_type, options),
+                UInt32 => binview_to_primitive_dyn::<u32>(&arr.to_binview(), to_type, options),
+                UInt64 => binview_to_primitive_dyn::<u64>(&arr.to_binview(), to_type, options),
+                Int8 => binview_to_primitive_dyn::<i8>(&arr.to_binview(), to_type, options),
+                Int16 => binview_to_primitive_dyn::<i16>(&arr.to_binview(), to_type, options),
+                Int32 => binview_to_primitive_dyn::<i32>(&arr.to_binview(), to_type, options),
+                Int64 => binview_to_primitive_dyn::<i64>(&arr.to_binview(), to_type, options),
+                Float32 => binview_to_primitive_dyn::<f32>(&arr.to_binview(), to_type, options),
+                Float64 => binview_to_primitive_dyn::<f64>(&arr.to_binview(), to_type, options),
                 Timestamp(time_unit, None) => {
                     utf8view_to_naive_timestamp_dyn(array, time_unit.to_owned())
                 },

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -461,12 +461,6 @@ def test_cast_temporal(
         "expected_value",
     ),
     [
-        (str(2**7 - 1).encode(), pl.Binary, pl.Int8, 2**7 - 1),
-        (str(2**15 - 1).encode(), pl.Binary, pl.Int16, 2**15 - 1),
-        (str(2**31 - 1).encode(), pl.Binary, pl.Int32, 2**31 - 1),
-        (str(2**63 - 1).encode(), pl.Binary, pl.Int64, 2**63 - 1),
-        (b"1.0", pl.Binary, pl.Float32, 1.0),
-        (b"1.0", pl.Binary, pl.Float64, 1.0),
         (str(2**7 - 1), pl.String, pl.Int8, 2**7 - 1),
         (str(2**15 - 1), pl.String, pl.Int16, 2**15 - 1),
         (str(2**31 - 1), pl.String, pl.Int32, 2**31 - 1),
@@ -478,13 +472,9 @@ def test_cast_temporal(
         (str(2**15), pl.String, pl.Int16, None),
         (str(2**31), pl.String, pl.Int32, None),
         (str(2**63), pl.String, pl.Int64, None),
-        (str(2**7).encode(), pl.Binary, pl.Int8, None),
-        (str(2**15).encode(), pl.Binary, pl.Int16, None),
-        (str(2**31).encode(), pl.Binary, pl.Int32, None),
-        (str(2**63).encode(), pl.Binary, pl.Int64, None),
     ],
 )
-def test_cast_string_and_binary(
+def test_cast_string(
     value: int,
     from_dtype: PolarsDataType,
     to_dtype: PolarsDataType,
@@ -522,12 +512,6 @@ def test_cast_string_and_binary(
         "expected_value",
     ),
     [
-        (str(2**7 - 1).encode(), pl.Binary, pl.Int8, True, 2**7 - 1),
-        (str(2**15 - 1).encode(), pl.Binary, pl.Int16, True, 2**15 - 1),
-        (str(2**31 - 1).encode(), pl.Binary, pl.Int32, True, 2**31 - 1),
-        (str(2**63 - 1).encode(), pl.Binary, pl.Int64, True, 2**63 - 1),
-        (b"1.0", pl.Binary, pl.Float32, True, 1.0),
-        (b"1.0", pl.Binary, pl.Float64, True, 1.0),
         (str(2**7 - 1), pl.String, pl.Int8, True, 2**7 - 1),
         (str(2**15 - 1), pl.String, pl.Int16, True, 2**15 - 1),
         (str(2**31 - 1), pl.String, pl.Int32, True, 2**31 - 1),
@@ -539,13 +523,9 @@ def test_cast_string_and_binary(
         (str(2**15), pl.String, pl.Int16, False, None),
         (str(2**31), pl.String, pl.Int32, False, None),
         (str(2**63), pl.String, pl.Int64, False, None),
-        (str(2**7).encode(), pl.Binary, pl.Int8, False, None),
-        (str(2**15).encode(), pl.Binary, pl.Int16, False, None),
-        (str(2**31).encode(), pl.Binary, pl.Int32, False, None),
-        (str(2**63).encode(), pl.Binary, pl.Int64, False, None),
     ],
 )
-def test_strict_cast_string_and_binary(
+def test_strict_cast_string(
     value: int,
     from_dtype: PolarsDataType,
     to_dtype: PolarsDataType,


### PR DESCRIPTION
See https://github.com/pola-rs/polars/issues/18991 for comment and conclusion. This MR is step 1 of proposed solution.
It is technically breaking, but old version of transform `binary -> numerical` can be done via `binary -(decode)> string -> numerical)`.

Note that I wasn't sure what was going on with `Decimal` since it is allowed in string, but not for binary. I removed it, but please let me know if it should be interpreted somehow