### PR TITLE
fix(python): DataFrame descending sorting by single list element

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -629,10 +629,3 @@ def re_escape(s: str) -> str:
     # escapes _only_ those metachars with meaning to the rust regex crate
     re_rust_metachars = r"\\?()|\[\]{}^$#&~.+*-"
     return re.sub(f"([{re_rust_metachars}])", r"\\\1", s)
-
-
-def try_head(seq: Sequence[Any] | Any, default: Any) -> Any:
-    try:
-        return seq[0]
-    except TypeError:
-        return default

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -629,3 +629,10 @@ def re_escape(s: str) -> str:
     # escapes _only_ those metachars with meaning to the rust regex crate
     re_rust_metachars = r"\\?()|\[\]{}^$#&~.+*-"
     return re.sub(f"([{re_rust_metachars}])", r"\\\1", s)
+
+
+def try_head(seq: Sequence[Any] | Any, default: Any) -> Any:
+    try:
+        return seq[0]
+    except TypeError:
+        return default

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1370,6 +1370,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         # Fast path for sorting by a single existing column
         if isinstance(by, str) and not more_by:
+            if isinstance(descending, list):
+                descending = descending[0]
             return self._from_pyldf(
                 self._ldf.sort(
                     by, descending, nulls_last, maintain_order, multithreaded

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -45,7 +45,6 @@ from polars._utils.various import (
     issue_warning,
     normalize_filepath,
     parse_percentiles,
-    try_head,
 )
 from polars._utils.wrap import wrap_df, wrap_expr
 from polars.datatypes import (
@@ -1370,9 +1369,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └──────┴─────┴─────┘
         """
         # Fast path for sorting by a single existing column
-        if isinstance(by, str) and not more_by:
-            descending = try_head(descending, descending)
-            nulls_last = try_head(nulls_last, nulls_last)
+        if (
+            isinstance(by, str)
+            and not more_by
+            and isinstance(descending, bool)
+            and isinstance(nulls_last, bool)
+        ):
             return self._from_pyldf(
                 self._ldf.sort(
                     by, descending, nulls_last, maintain_order, multithreaded

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1370,12 +1370,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         # Fast path for sorting by a single existing column
         if isinstance(by, str) and not more_by:
-            if not all([isinstance(descending, bool), isinstance(nulls_last, bool)]):
+            if (isinstance(descending, list) and len(descending) != 1) or (
+                isinstance(nulls_last, list) and len(nulls_last) != 1
+            ):
                 msg = (
-                    "type of `descending` or `nulls_last` "
-                    "must be `bool` when sorting by one column"
+                    "size of `descending` or `nulls_last` "
+                    "must be 1 when defined as list"
                 )
-                raise TypeError(msg)
+                raise ValueError(msg)
+            if isinstance(descending, list):
+                descending = descending[0]
+            if isinstance(nulls_last, list):
+                nulls_last = nulls_last[0]
             return self._from_pyldf(
                 self._ldf.sort(
                     by, descending, nulls_last, maintain_order, multithreaded

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1370,8 +1370,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         # Fast path for sorting by a single existing column
         if isinstance(by, str) and not more_by:
-            if isinstance(descending, list):
-                descending = descending[0]
+            if not all([isinstance(descending, bool), isinstance(nulls_last, bool)]):
+                msg = (
+                    "type of `descending` or `nulls_last` "
+                    "must be `bool` when sorting by one column"
+                )
+                raise TypeError(msg)
             return self._from_pyldf(
                 self._ldf.sort(
                     by, descending, nulls_last, maintain_order, multithreaded

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -45,6 +45,7 @@ from polars._utils.various import (
     issue_warning,
     normalize_filepath,
     parse_percentiles,
+    try_head,
 )
 from polars._utils.wrap import wrap_df, wrap_expr
 from polars.datatypes import (
@@ -1370,18 +1371,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         # Fast path for sorting by a single existing column
         if isinstance(by, str) and not more_by:
-            if (isinstance(descending, list) and len(descending) != 1) or (
-                isinstance(nulls_last, list) and len(nulls_last) != 1
-            ):
-                msg = (
-                    "size of `descending` or `nulls_last` "
-                    "must be 1 when defined as list"
-                )
-                raise ValueError(msg)
-            if isinstance(descending, list):
-                descending = descending[0]
-            if isinstance(nulls_last, list):
-                nulls_last = nulls_last[0]
+            descending = try_head(descending, descending)
+            nulls_last = try_head(nulls_last, nulls_last)
             return self._from_pyldf(
                 self._ldf.sort(
                     by, descending, nulls_last, maintain_order, multithreaded

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -307,6 +307,9 @@ def test_sort() -> None:
     assert_frame_equal(
         df.sort(["a", "b"]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
     )
+    assert_frame_equal(
+        df.sort(["a"], descending=[False]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
+    )
 
 
 def test_sort_multi_output_exprs_01() -> None:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -308,7 +308,7 @@ def test_sort() -> None:
         df.sort(["a", "b"]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
     )
     assert_frame_equal(
-        df.sort("a", descending=[False]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
+        df.sort("a", descending=False), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
     )
 
 
@@ -363,6 +363,15 @@ def test_sort_multi_output_exprs_01() -> None:
         match=r"the length of `nulls_last` \(3\) does not match the length of `by` \(2\)",
     ):
         df.sort("dts", "strs", nulls_last=[True, False, True])
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "type of `descending` or `nulls_last` "
+            "must be `bool` when sorting by one column"
+        ),
+    ):
+        df.sort(by="dts", descending=[True])
 
     # No columns selected - return original input.
     assert_frame_equal(df, df.sort(pl.col("^xxx$")))

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -308,7 +308,7 @@ def test_sort() -> None:
         df.sort(["a", "b"]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
     )
     assert_frame_equal(
-        df.sort(["a"], descending=[False]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
+        df.sort("a", descending=[False]), pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
     )
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -364,17 +364,13 @@ def test_sort_multi_output_exprs_01() -> None:
 
     with pytest.raises(
         ValueError,
-        match=(
-            "size of `descending` or `nulls_last` must be 1 when defined as list"
-        ),
+        match="size of `descending` or `nulls_last` must be 1 when defined as list",
     ):
         df.sort(by="dts", descending=[True, False])
 
     with pytest.raises(
         ValueError,
-        match=(
-            "size of `descending` or `nulls_last` must be 1 when defined as list"
-        ),
+        match="size of `descending` or `nulls_last` must be 1 when defined as list",
     ):
         df.sort(by="dts", nulls_last=[True, False])
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -306,8 +306,6 @@ def test_sort() -> None:
     expected = pl.DataFrame({"a": [1, 2, 3], "b": [2, 1, 3]})
     assert_frame_equal(df.sort("a"), expected)
     assert_frame_equal(df.sort(["a", "b"]), expected)
-    assert_frame_equal(df.sort("a", descending=[False]), expected)
-    assert_frame_equal(df.sort("a", nulls_last=[False]), expected)
 
 
 def test_sort_multi_output_exprs_01() -> None:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -362,18 +362,6 @@ def test_sort_multi_output_exprs_01() -> None:
     ):
         df.sort("dts", "strs", nulls_last=[True, False, True])
 
-    with pytest.raises(
-        ValueError,
-        match="size of `descending` or `nulls_last` must be 1 when defined as list",
-    ):
-        df.sort(by="dts", descending=[True, False])
-
-    with pytest.raises(
-        ValueError,
-        match="size of `descending` or `nulls_last` must be 1 when defined as list",
-    ):
-        df.sort(by="dts", nulls_last=[True, False])
-
     # No columns selected - return original input.
     assert_frame_equal(df, df.sort(pl.col("^xxx$")))
 


### PR DESCRIPTION
When calling sort with single `str` column and list of single `descending` parameter it fails with error:  
```
ldf = pl.DataFrame({
    "age": [2, 5, 1],
    "names": ["Alice", "Cob", "Bob"]
}).lazy()

sorted_df = ldf.sort("age", descending=[False])
print(sorted_df)
```
```
  File "..../site-packages/polars/lazyframe/frame.py", line 1378, in sort
    self._ldf.sort(
TypeError: argument 'descending': 'list' object cannot be converted to 'PyBool'
```

It checks for types and avoids path that does not use list.