### PR TITLE
fix: Compilation error missing use JsonLineReader

### DIFF
--- a/crates/polars-mem-engine/src/executors/scan/ndjson.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ndjson.rs
@@ -1,6 +1,7 @@
 use polars_core::config;
 use polars_core::utils::accumulate_dataframes_vertical;
 use polars_io::utils::compression::maybe_decompress_bytes;
+use polars_io::prelude::{JsonLineReader,SerReader};
 
 use super::*;
 

--- a/crates/polars-mem-engine/src/executors/scan/ndjson.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ndjson.rs
@@ -1,7 +1,7 @@
 use polars_core::config;
 use polars_core::utils::accumulate_dataframes_vertical;
+use polars_io::prelude::{JsonLineReader, SerReader};
 use polars_io::utils::compression::maybe_decompress_bytes;
-use polars_io::prelude::{JsonLineReader,SerReader};
 
 use super::*;
 


### PR DESCRIPTION
fixes:
```
error[E0433]: failed to resolve: use of undeclared type `JsonLineReader`
  --> /polars/crates/polars-mem-engine/src/executors/scan/ndjson.rs:88:30
   |
88 |                 let reader = JsonLineReader::new(curs);
   |                              ^^^^^^^^^^^^^^ use of undeclared type `JsonLineReader`
   |
help: consider importing this struct
   |
1  + use polars_io::prelude::JsonLineReader;
   |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `polars-mem-engine` (lib) due to 1 previous error
```