### PR TITLE
fix(python): Ensure that `read_database` takes advantage of Arrow return from a `duckdb_engine` connection when using a SQLAlchemy `Selectable`

### DIFF
--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -505,7 +505,7 @@ class ConnectionExecutor:
             )
             result = cursor_execute(query, *positional_options)
 
-        # note: some cursors execute in-place, some access results via an additional property
+        # note: some cursors execute in-place, some access results via a property
         result = self.cursor if result is None else result
         if self.driver_name == "duckdb":
             result = result.cursor

--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -392,7 +392,7 @@ class ConnectionExecutor:
                     return conn.engine.raw_connection().cursor()
                 elif conn.engine.driver == "duckdb_engine":
                     self.driver_name = "duckdb"
-                    return conn.engine.raw_connection().driver_connection
+                    return conn
                 elif self._is_alchemy_engine(conn):
                     # note: if we create it, we can close it
                     self.can_close_cursor = True
@@ -505,8 +505,11 @@ class ConnectionExecutor:
             )
             result = cursor_execute(query, *positional_options)
 
-        # note: some cursors execute in-place
+        # note: some cursors execute in-place, some access results via an additional property
         result = self.cursor if result is None else result
+        if self.driver_name == "duckdb":
+            result = result.cursor
+
         self.result = result
         return self
 


### PR DESCRIPTION
Closes #19221.

Improves `read_database` integration with DuckDB, when using a SQLAlchemy-based `duckdb_engine` connection. 

Previously we accessed the raw connection directly in order to take advantage of native Arrow return, but this didn't work when using a SQLAlchemy `Selectable` as the query.

Now we handle this case properly, as it turns out that `duckdb_engine` supports transparent pass-through to the underlying raw connection via `__getitem__`, allowing us to take advantage of DuckDB Arrow return in _all_ cases, for maximum performance, _without_ having to interact with the raw connection ourselves.

## Example

Setup (assuming `duckdb_engine` installed):
```python
import polars as pl
from sqlalchemy import MetaData, Table, create_engine, select

df_test_data = pl.DataFrame({
    "key": ["aa", "bb", None, "cc", "dd"], 
    "value": range(5),
})
engine = create_engine("duckdb:///:memory:")
metadata = MetaData()
table_name = "tbl"

with engine.connect() as conn:
    df_test_data.write_database(table_name, connection=conn)
    conn.commit()
    
metadata.reflect(engine)
table = Table(table_name, metadata)
```
Provide `read_database` query as a SQLAlchemy `Selectable` object:
_(previously this raised an error - now it returns data to Polars via Arrow)_
```python
with engine.connect() as conn:
    stmt = select(table).where(table.c.key.is_not(None))
    df = pl.read_database(stmt, connection=conn)
    
    # shape: (4, 2)
    # ┌─────┬───────┐
    # │ key ┆ value │
    # │ --- ┆ ---   │
    # │ str ┆ i64   │
    # ╞═════╪═══════╡
    # │ aa  ┆ 0     │
    # │ bb  ┆ 1     │
    # │ cc  ┆ 3     │
    # │ dd  ┆ 4     │
    # └─────┴───────┘
```