### PR TITLE
fix: Also split on forward slashes during hive path inference on Windows

### DIFF
--- a/crates/polars-plan/src/plans/hive.rs
+++ b/crates/polars-plan/src/plans/hive.rs
@@ -231,19 +231,16 @@ pub fn hive_partitions_from_paths(
 }
 
 /// Determine the path separator for identifying Hive partitions.
-#[cfg(target_os = "windows")]
-fn separator(url: &Path) -> char {
-    if polars_io::path_utils::is_cloud_url(url) {
-        '/'
+fn separator(url: &Path) -> &[char] {
+    if cfg!(target_family = "windows") {
+        if polars_io::path_utils::is_cloud_url(url) {
+            &['/']
+        } else {
+            &['/', '\\']
+        }
     } else {
-        '\\'
+        &['/']
     }
-}
-
-/// Determine the path separator for identifying Hive partitions.
-#[cfg(not(target_os = "windows"))]
-fn separator(_url: &Path) -> char {
-    '/'
 }
 
 /// Parse a Hive partition string (e.g. "column=1.5") into a name and value part.

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -783,7 +783,8 @@ def test_hive_predicate_dates_14712(
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows paths")
 @pytest.mark.write_disk
-def test_hive_windows_path_separator(tmp_path: Path) -> None:
+def test_hive_windows_splits_on_forward_slashes(tmp_path: Path) -> None:
+    # Note: This needs to be an absolute path.
     tmp_path = tmp_path.resolve()
     path = f"{tmp_path}/a=1/b=1/c=1/d=1/e=1"
     Path(path).mkdir(exist_ok=True, parents=True)

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -779,3 +779,43 @@ def test_hive_predicate_dates_14712(
     )
     pl.scan_parquet(tmp_path).filter(pl.col("a") != datetime(2024, 1, 1)).collect()
     assert "hive partitioning: skipped 1 files" in capfd.readouterr().err
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows paths")
+@pytest.mark.write_disk
+def test_hive_windows_path_separator(tmp_path: Path) -> None:
+    path = f"{tmp_path}/a=1/b=1\\c=1\\d=1/e=1"
+    Path(path).mkdir(exist_ok=True, parents=True)
+
+    df = pl.DataFrame({"x": "x"})
+    df.write_parquet(f"{path}/data.parquet")
+
+    expect = pl.DataFrame(
+        [
+            s.new_from_index(0, 5)
+            for s in pl.DataFrame(
+                {
+                    "x": "x",
+                    "a": 1,
+                    "b": 1,
+                    "c": 1,
+                    "d": 1,
+                    "e": 1,
+                }
+            )
+        ]
+    )
+
+    assert_frame_equal(
+        pl.scan_parquet(
+            [
+                f"{tmp_path}/a=1/b=1/c=1/d=1/e=1/*",
+                f"{tmp_path}\\a=1\\b=1\\c=1\\d=1\\e=1/*",
+                f"{tmp_path}\\a=1/b=1/c=1/d=1/**/*",
+                f"{tmp_path}/a=1/b=1\\c=1/d=1/**/*",
+                f"{tmp_path}/a=1/b=1/c=1/d=1\\e=1/*",
+            ],
+            hive_partitioning=True,
+        ).collect(),
+        expect,
+    )

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -784,6 +784,7 @@ def test_hive_predicate_dates_14712(
 @pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows paths")
 @pytest.mark.write_disk
 def test_hive_windows_path_separator(tmp_path: Path) -> None:
+    tmp_path = tmp_path.resolve()
     path = f"{tmp_path}/a=1/b=1\\c=1\\d=1/e=1"
     Path(path).mkdir(exist_ok=True, parents=True)
 
@@ -809,8 +810,8 @@ def test_hive_windows_path_separator(tmp_path: Path) -> None:
     assert_frame_equal(
         pl.scan_parquet(
             [
-                f"{tmp_path}/a=1/b=1/c=1/d=1/e=1/*",
-                f"{tmp_path}\\a=1\\b=1\\c=1\\d=1\\e=1/*",
+                f"{tmp_path}/a=1/b=1/c=1/d=1/e=1/data.parquet",
+                f"{tmp_path}\\a=1\\b=1\\c=1\\d=1\\e=1\\data.parquet",
                 f"{tmp_path}\\a=1/b=1/c=1/d=1/**/*",
                 f"{tmp_path}/a=1/b=1\\c=1/d=1/**/*",
                 f"{tmp_path}/a=1/b=1/c=1/d=1\\e=1/*",

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -785,7 +785,7 @@ def test_hive_predicate_dates_14712(
 @pytest.mark.write_disk
 def test_hive_windows_path_separator(tmp_path: Path) -> None:
     tmp_path = tmp_path.resolve()
-    path = f"{tmp_path}/a=1/b=1\\c=1\\d=1/e=1"
+    path = f"{tmp_path}/a=1/b=1/c=1/d=1/e=1"
     Path(path).mkdir(exist_ok=True, parents=True)
 
     df = pl.DataFrame({"x": "x"})


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/pull/19103#issuecomment-2395009937

We currently only split on backslashes, but Windows paths can use both forwards and backwards slashes as separators

This should fix the test