### PR TITLE
feat: Series.index_of() - Request for initial comments on design

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -241,7 +241,7 @@ pub trait ChunkApply<'a, T> {
 /// Search for an item.
 pub trait ChunkSearch<'a, T> {
     /// Return the index of the given value within self, or `None` if not found.
-    fn index_of(&'a self, value: T) -> Option<usize>;
+    fn index_of(&'a self, value: Option<T>) -> Option<usize>;
 }
 
 /// Aggregation operations.

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod nulls;
 mod reverse;
 #[cfg(feature = "rolling_window")]
 pub(crate) mod rolling_window;
+mod search;
 pub mod search_sorted;
 mod set;
 mod shift;
@@ -235,6 +236,12 @@ pub trait ChunkApply<'a, T> {
     // (value of chunkedarray, value of slice) -> value of slice
     where
         F: Fn(Option<T>, &S) -> S;
+}
+
+/// Search for an item.
+pub trait ChunkSearch<'a, T> {
+    /// Return the index of the given value within self, or `None` if not found.
+    fn index_of(&'a self, value: T) -> Option<usize>;
 }
 
 /// Aggregation operations.

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -14,6 +14,7 @@ where
                 .iter()
                 .position(|opt_val| opt_val.map(|v| v.is_nan()) == Some(true));
         }
+
         return self.iter().position(|opt_val| opt_val == value);
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -29,3 +29,15 @@ impl ChunkSearch<'_, &Series> for ListChunked {
             })
     }
 }
+
+#[cfg(feature="dtype-array")]
+impl ChunkSearch<'_, &Series> for ArrayChunked {
+    fn index_of(&self, value: Option<&Series>) -> Option<usize> {
+        self.amortized_iter()
+            .position(|opt_val| match (opt_val, value) {
+                (Some(in_series), Some(value)) => in_series.as_ref() == value,
+                (None, None) => true,
+                _ => false,
+            })
+    }
+}

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -6,12 +6,12 @@ impl<'a, T> ChunkSearch<'a, T::Native> for ChunkedArray<T>
 where
     T: PolarsNumericType,
 {
-    fn index_of(&'a self, value: T::Native) -> Option<usize> {
-        if value.is_nan() {
+    fn index_of(&'a self, value: Option<T::Native>) -> Option<usize> {
+        if value.map(|v| v.is_nan()) == Some(true) {
             return self
                 .iter()
                 .position(|opt_val| opt_val.map(|v| v.is_nan()) == Some(true));
         }
-        return self.iter().position(|opt_val| opt_val == Some(value));
+        return self.iter().position(|opt_val| opt_val == value);
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -7,6 +7,8 @@ where
     T: PolarsNumericType,
 {
     fn index_of(&'a self, value: Option<T::Native>) -> Option<usize> {
+        // A NaN is never equal to anything, including itself. But we still want
+        // to be able to search for NaNs, so we handle them specially.
         if value.map(|v| v.is_nan()) == Some(true) {
             return self
                 .iter()

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -15,6 +15,17 @@ where
                 .position(|opt_val| opt_val.map(|v| v.is_nan()) == Some(true));
         }
 
-        return self.iter().position(|opt_val| opt_val == value);
+        self.iter().position(|opt_val| opt_val == value)
+    }
+}
+
+impl ChunkSearch<'_, &Series> for ListChunked {
+    fn index_of(&self, value: Option<&Series>) -> Option<usize> {
+        self.amortized_iter()
+            .position(|opt_val| match (opt_val, value) {
+                (Some(in_series), Some(value)) => in_series.as_ref() == value,
+                (None, None) => true,
+                _ => false,
+            })
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -1,3 +1,5 @@
+use polars_utils::float::IsFloat;
+
 use crate::prelude::*;
 
 impl<'a, T> ChunkSearch<'a, T::Native> for ChunkedArray<T>
@@ -5,11 +7,19 @@ where
     T: PolarsNumericType,
 {
     fn index_of(&'a self, value: T::Native) -> Option<usize> {
-        // TODO handle NaN
+        if value.is_nan() {
+            let mut index = 0;
+            for opt_val in self.iter() {
+                if opt_val.map(|v| v.is_nan()) == Some(true) {
+                    return Some(index);
+                };
+                index += 1;
+            }
+            return None;
+        }
         let mut index = 0;
-        for opt_val in self.downcast_iter().map(|arr| arr.into_iter()).flatten() {
-            println!("{value} {opt_val:?}, {index}");
-            if Some(&value) == opt_val {
+        for opt_val in self.iter() {//self.downcast_iter().map(|arr| arr.into_iter()).flatten() {
+            if Some(value) == opt_val {
                 return Some(index);
             };
             index += 1;

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -8,22 +8,10 @@ where
 {
     fn index_of(&'a self, value: T::Native) -> Option<usize> {
         if value.is_nan() {
-            let mut index = 0;
-            for opt_val in self.iter() {
-                if opt_val.map(|v| v.is_nan()) == Some(true) {
-                    return Some(index);
-                };
-                index += 1;
-            }
-            return None;
+            return self
+                .iter()
+                .position(|opt_val| opt_val.map(|v| v.is_nan()) == Some(true));
         }
-        let mut index = 0;
-        for opt_val in self.iter() {//self.downcast_iter().map(|arr| arr.into_iter()).flatten() {
-            if Some(value) == opt_val {
-                return Some(index);
-            };
-            index += 1;
-        }
-        None
+        return self.iter().position(|opt_val| opt_val == Some(value));
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/search.rs
+++ b/crates/polars-core/src/chunked_array/ops/search.rs
@@ -1,0 +1,19 @@
+use crate::prelude::*;
+
+impl<'a, T> ChunkSearch<'a, T::Native> for ChunkedArray<T>
+where
+    T: PolarsNumericType,
+{
+    fn index_of(&'a self, value: T::Native) -> Option<usize> {
+        // TODO handle NaN
+        let mut index = 0;
+        for opt_val in self.downcast_iter().map(|arr| arr.into_iter()).flatten() {
+            println!("{value} {opt_val:?}, {index}");
+            if Some(&value) == opt_val {
+                return Some(index);
+            };
+            index += 1;
+        }
+        None
+    }
+}

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -1,5 +1,6 @@
 use polars::export::arrow::array::Array;
 use polars::prelude::*;
+use polars_core::downcast_as_macro_arg_physical;
 use pyo3::prelude::*;
 
 use super::PySeries;
@@ -150,23 +151,56 @@ impl PySeries {
     }
 }
 
-fn index_of(series: &Series, value: &Series) -> PolarsResult<Option<usize>> {
-    let dtype = value.dtype();
-    let value = if dtype.is_null() {
-        // Should be able to cast null dtype to anything.
-        &value.cast(series.dtype())?
+/// Try casting the value to the correct type, then call index_of().
+macro_rules! try_index_of {
+    ($self:expr, $value:expr) => {{
+        let cast_value = $value.map(|v| AnyValue::from(v).strict_cast($self.dtype()));
+        if cast_value == Some(None) {
+            // We can can't cast the searched-for value to a valid data point
+            // within the dtype of the Series we're searching, that means we
+            // will never find that value.
+            None
+        } else {
+            let cast_value = cast_value.flatten();
+            $self.index_of(cast_value.map(|v| v.extract().unwrap()))
+        }
+    }};
+}
+
+fn index_of(series: &Series, value_series: &Series) -> PolarsResult<Option<usize>> {
+    let value_series = if value_series.dtype().is_null() {
+        // Should be able to cast null dtype to anything, so cast it to dtype of
+        // Series we're searching.
+        &value_series.cast(series.dtype())?
     } else {
-        value
+        value_series
     };
-    match value.dtype() {
-        DataType::Int64 => {
-            let value = value.i64()?.get(0);
-            Ok(series.i64()?.index_of(value))
-        },
+    let value_dtype = value_series.dtype();
+
+    if value_dtype.is_signed_integer() {
+        let value = value_series
+            .cast(&DataType::Int64)?
+            .i64()
+            .unwrap()
+            .get(0);
+        return Ok(downcast_as_macro_arg_physical!(series, try_index_of, value));
+    }
+    if value_dtype.is_unsigned_integer() {
+        let value = value_series
+            .cast(&DataType::UInt64)?
+            .u64()
+            .unwrap()
+            .get(0);
+        return Ok(downcast_as_macro_arg_physical!(series, try_index_of, value));
+    }
+    match value_series.dtype() {
         DataType::Float64 => {
-            let value = value.f64()?.get(0);
+            let value = value_series.f64()?.get(0);
             Ok(series.f64()?.index_of(value))
         },
+        // TODO if it's DataType::Null, that means both are null, so it's either
+        // Some(0) if series length >= 1, otherwise None. Implement after tests
+        // are written?
         _ => unimplemented!("TODO"),
     }
 }

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -139,3 +139,25 @@ fn scatter_impl(
 
     s.and_then(|s| s.cast(&logical_dtype))
 }
+
+#[pymethods]
+impl PySeries {
+    /// Given a `PySeries` of length 0, find the index of the first value within
+    /// self.
+    fn index_of(&self, value: PySeries) -> PyResult<Option<usize>> {
+        // TODO assert length of value is 1?
+        index_of(&self.series, &value.series).map_err(|e| PyErr::from(PyPolarsErr::from(e)))
+    }
+}
+
+fn index_of(series: &Series, value: &Series) -> PolarsResult<Option<usize>> {
+    match series.dtype() {
+        DataType::Int64 => {
+            let Some(value) = value.i64()?.get(0) else {
+                unimplemented!("TODO")
+            };
+            Ok(series.i64()?.index_of(value))
+        },
+        _ => unimplemented!("TODO"),
+    }
+}

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -158,6 +158,12 @@ fn index_of(series: &Series, value: &Series) -> PolarsResult<Option<usize>> {
             };
             Ok(series.i64()?.index_of(value))
         },
+        DataType::Float64 => {
+            let Some(value) = value.f64()?.get(0) else {
+                unimplemented!("TODO")
+            };
+            Ok(series.f64()?.index_of(value))
+        },
         _ => unimplemented!("TODO"),
     }
 }

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -199,6 +199,15 @@ fn index_of(series: &Series, value_series: &Series) -> PolarsResult<Option<usize
                 .map(|arr| Series::from_arrow("".into(), arr).unwrap());
             Ok(series.list()?.index_of(value.as_ref()))
         },
+        #[cfg(feature="dtype-array")]
+        DataType::Array(_, _) => {
+            let value = value_series
+                .array()
+                .unwrap()
+                .get(0)
+                .map(|arr| Series::from_arrow("".into(), arr).unwrap());
+            Ok(series.array()?.index_of(value.as_ref()))
+        },
         _ => unimplemented!("TODO"),
     }
 }

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -157,7 +157,7 @@ macro_rules! try_index_of {
         let cast_value = $value.map(|v| AnyValue::from(v).strict_cast($self.dtype()));
         if cast_value == Some(None) {
             // We can can't cast the searched-for value to a valid data point
-            // within the dtype of the Series we're searching, that means we
+            // within the dtype of the Series we're searching, which means we
             // will never find that value.
             None
         } else {
@@ -178,29 +178,27 @@ fn index_of(series: &Series, value_series: &Series) -> PolarsResult<Option<usize
     let value_dtype = value_series.dtype();
 
     if value_dtype.is_signed_integer() {
-        let value = value_series
-            .cast(&DataType::Int64)?
-            .i64()
-            .unwrap()
-            .get(0);
+        let value = value_series.cast(&DataType::Int64)?.i64().unwrap().get(0);
         return Ok(downcast_as_macro_arg_physical!(series, try_index_of, value));
     }
     if value_dtype.is_unsigned_integer() {
-        let value = value_series
-            .cast(&DataType::UInt64)?
-            .u64()
-            .unwrap()
-            .get(0);
+        let value = value_series.cast(&DataType::UInt64)?.u64().unwrap().get(0);
         return Ok(downcast_as_macro_arg_physical!(series, try_index_of, value));
     }
+    if value_dtype.is_float() {
+        let value = value_series.cast(&DataType::Float64)?.f64().unwrap().get(0);
+        return Ok(downcast_as_macro_arg_physical!(series, try_index_of, value));
+    }
+    // At this point we're done handling integers and floats.
     match value_series.dtype() {
-        DataType::Float64 => {
-            let value = value_series.f64()?.get(0);
-            Ok(series.f64()?.index_of(value))
+        DataType::List(_) => {
+            let value = value_series
+                .list()
+                .unwrap()
+                .get(0)
+                .map(|arr| Series::from_arrow("".into(), arr).unwrap());
+            Ok(series.list()?.index_of(value.as_ref()))
         },
-        // TODO if it's DataType::Null, that means both are null, so it's either
-        // Some(0) if series length >= 1, otherwise None. Implement after tests
-        // are written?
         _ => unimplemented!("TODO"),
     }
 }

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -151,17 +151,20 @@ impl PySeries {
 }
 
 fn index_of(series: &Series, value: &Series) -> PolarsResult<Option<usize>> {
-    match series.dtype() {
+    let dtype = value.dtype();
+    let value = if dtype.is_null() {
+        // Should be able to cast null dtype to anything.
+        &value.cast(series.dtype())?
+    } else {
+        value
+    };
+    match value.dtype() {
         DataType::Int64 => {
-            let Some(value) = value.i64()?.get(0) else {
-                unimplemented!("TODO")
-            };
+            let value = value.i64()?.get(0);
             Ok(series.i64()?.index_of(value))
         },
         DataType::Float64 => {
-            let Some(value) = value.f64()?.get(0) else {
-                unimplemented!("TODO")
-            };
+            let value = value.f64()?.get(0);
             Ok(series.f64()?.index_of(value))
         },
         _ => unimplemented!("TODO"),

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4749,11 +4749,13 @@ class Series:
         TODO
         """
         if isinstance(value, Series):
-            # Searching for lists...
-            # TODO what about searching for arrays?
+            # Searching for lists or arrays:
             value = value.implode()
         else:
             value = Series(values=[value])
+
+        if isinstance(self.dtype, Array):
+            value = value.cast(Array(self.dtype.inner, len(value[0])))
 
         return self._s.index_of(value._s)
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4732,6 +4732,31 @@ class Series:
         self._s.scatter(indices._s, values._s)
         return self
 
+    def index_of(
+        self,
+        value: Series | Iterable[PythonLiteral] | PythonLiteral | None,
+    ) -> int | None:
+        """
+        Get the first index of a value, or ``None`` if it's not found.
+
+        Parameters
+        ----------
+        value
+            Value to find.
+
+        Examples
+        --------
+        TODO
+        """
+        if isinstance(value, Series):
+            # Searching for lists...
+            # TODO what about searching for arrays?
+            value = value.implode()
+        else:
+            value = Series(values=[value])
+
+        return self._s.index_of(value._s)
+
     def clear(self, n: int = 0) -> Series:
         """
         Create an empty copy of the current Series, with zero to 'n' elements.


### PR DESCRIPTION
This is the first half of #5503, just adding a method to Series.

It's not done, obviously, the code needs to be cleaned up, logical types aren't supported, and there are no unit tests, but I figured I'd ask for feedback at this point.

Only thing I'm not quite sure about is how to deal with structs.

I made the decision to treat a `Series` input as the list (or array) to search for, there's no special "if it's a Series of length 1 search for its first value" in the Python API exposed to users.

Here's the test script I've been using:

```python
import polars as pl
import numpy as np

ints = pl.Series([6, 2, None, 71, 5], dtype=pl.Int64())
print(ints)
print(71, ints.index_of(71))
print(None, ints.index_of(None))

ints32 = pl.Series([6, 2, None, 71, 5], dtype=pl.Int32())
print("int32 71", ints.index_of(np.int32(71)))
print("int64 71", ints.index_of(np.int64(71)))
print("uint8 71", ints.index_of(np.uint8(71)))
print("int64 2 ** 33", ints.index_of(np.int64(2**33)))

floats = pl.Series([2.0, float("nan"), 3.2])
print(floats)
print(2.0, floats.index_of(2.0))
print("NaN", floats.index_of(float("nan")))
print(3.2, floats.index_of(3.2))

floats32 = pl.Series([2.0, float("nan"), 3.2], dtype=pl.Float32())
print(3.2, floats32.index_of(np.float32(3.2)))
print(3.2, floats32.index_of(np.float64(3.2)))
print(2, floats32.index_of(np.int64(2)))
print("large", floats32.index_of(np.float64(2**35)))

lists = pl.Series([[1, 2], [3, 4]], dtype=pl.List(pl.Int32()))
print("lists:", lists)
print([1, 2], lists.index_of([1, 2]))
print([3, 6], lists.index_of([3, 6]))
print("[1, 2] as int32 series", lists.index_of(pl.Series([1, 2], dtype=pl.Int32())))
print("[1, 2] as int64 series", lists.index_of(pl.Series([1, 2], dtype=pl.Int64())))
print("[3, 4] as int64", lists.index_of([np.int64(3), np.int64(4)]))
print()

arrays = pl.Series([[1, 2], [3, 4]], dtype=pl.Array(pl.Int32(), 2))
print("arrays:", arrays)
print([1, 2], arrays.index_of([1, 2]))
print([3, 6], arrays.index_of([3, 6]))
print("[1, 2] as int32 series", arrays.index_of(pl.Series([1, 2], dtype=pl.Int32())))
print("[1, 2] as int64 series", arrays.index_of(pl.Series([1, 2], dtype=pl.Int64())))
print("[3, 4] as int64", arrays.index_of([np.int64(3), np.int64(4)]))
```