### PR TITLE
Fix typo in custom expressions docs

### DIFF
--- a/docs/source/user-guide/expressions/plugins.md
+++ b/docs/source/user-guide/expressions/plugins.md
@@ -37,7 +37,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 polars = { version = "*" }
-pyo3 = { version = "*", features = ["extension-module", "abi-py38"] }
+pyo3 = { version = "*", features = ["extension-module", "abi3-py38"] }
 pyo3-polars = { version = "*", features = ["derive"] }
 serde = { version = "*", features = ["derive"] }
 ```


### PR DESCRIPTION
This PR fixes a typo introduced in https://github.com/pola-rs/polars/pull/14621.
The comments in that PR correctly mention teaching about using `abi3-py38` but the actual docs missed a `3`, leading to beginners like me to struggle with what is happening :sweat_smile: 

The specific error when running `maturin develop` was:
```
error: failed to select a version for `pyo3-polars`. The change above seems to have resolved the problem.
```