### PR TITLE
feat: Add credential provider utility classes for AWS, GCP

### DIFF
--- a/crates/polars-io/src/cloud/credential_provider.rs
+++ b/crates/polars-io/src/cloud/credential_provider.rs
@@ -415,7 +415,7 @@ impl<C: Clone> FetchedCredentialsCache<C> {
 
             if verbose {
                 eprintln!(
-                    "[FetchedCredentialsCache]: Finish update_func: {}",
+                    "[FetchedCredentialsCache]: Finish update_func: new {}",
                     expiry_msg(
                         *last_fetched_expiry,
                         SystemTime::now()

--- a/crates/polars-io/src/cloud/credential_provider.rs
+++ b/crates/polars-io/src/cloud/credential_provider.rs
@@ -296,8 +296,8 @@ impl Debug for CredentialProviderFunction {
 impl Eq for CredentialProviderFunction {}
 
 impl PartialEq for CredentialProviderFunction {
-    fn eq(&self, _other: &Self) -> bool {
-        false
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 
@@ -456,7 +456,7 @@ mod python_impl {
 
     use super::IntoCredentialProvider;
 
-    #[derive(Clone, Debug, PartialEq, Eq)]
+    #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct PythonCredentialProvider(pub(super) Arc<PythonFunction>);
 
@@ -648,8 +648,20 @@ mod python_impl {
         }
     }
 
+    impl Eq for PythonCredentialProvider {}
+
+    impl PartialEq for PythonCredentialProvider {
+        fn eq(&self, other: &Self) -> bool {
+            Arc::ptr_eq(&self.0, &other.0)
+        }
+    }
+
     impl Hash for PythonCredentialProvider {
         fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            // # Safety
+            // * Inner is an `Arc`
+            // * Visibility is limited to super
+            // * No code in `mod python_impl` or `super` mutates the Arc inner.
             state.write_usize(Arc::as_ptr(&self.0) as *const () as usize)
         }
     }

--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -117,3 +117,14 @@ Connect to pyarrow datasets.
    :toctree: api/
 
    scan_pyarrow_dataset
+
+Cloud Credentials
+~~~~~~~~~~~~~~~~~
+Configuration for cloud credential provisioning.
+
+.. autosummary::
+   :toctree: api/
+
+   CredentialProvider
+   CredentialProviderAWS
+   CredentialProviderGCP

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -176,6 +176,13 @@ from polars.io import (
     scan_parquet,
     scan_pyarrow_dataset,
 )
+from polars.io.cloud import (
+    CredentialProvider,
+    CredentialProviderAWS,
+    CredentialProviderFunction,
+    CredentialProviderFunctionReturn,
+    CredentialProviderGCP,
+)
 from polars.lazyframe import GPUEngine, LazyFrame
 from polars.meta import (
     build_info,
@@ -266,6 +273,12 @@ __all__ = [
     "scan_ndjson",
     "scan_parquet",
     "scan_pyarrow_dataset",
+    # polars.io.cloud
+    "CredentialProvider",
+    "CredentialProviderAWS",
+    "CredentialProviderFunction",
+    "CredentialProviderFunctionReturn",
+    "CredentialProviderGCP",
     # polars.stringcache
     "StringCache",
     "disable_string_cache",

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -298,12 +298,5 @@ MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, Boole
 EngineType: TypeAlias = Union[Literal["cpu", "gpu"], "GPUEngine"]
 
 ScanSource: TypeAlias = Union[
-    str
-    | Path
-    | IO[bytes]
-    | bytes
-    | list[str]
-    | list[Path]
-    | list[IO[bytes]]
-    | list[bytes]
+    str, Path, IO[bytes], bytes, list[str], list[Path], list[IO[bytes]], list[bytes]
 ]

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Mapping, Sequence
+from pathlib import Path
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
-    Callable,
     Literal,
-    Optional,
     Protocol,
     TypedDict,
     TypeVar,
@@ -297,6 +297,13 @@ MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, Boole
 # LazyFrame engine selection
 EngineType: TypeAlias = Union[Literal["cpu", "gpu"], "GPUEngine"]
 
-CredentialProviderFunction: TypeAlias = Callable[
-    [], tuple[dict[str, Optional[str]], Optional[int]]
+ScanSource: TypeAlias = Union[
+    str
+    | Path
+    | IO[bytes]
+    | bytes
+    | list[str]
+    | list[Path]
+    | list[IO[bytes]]
+    | list[bytes]
 ]

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -7,7 +7,11 @@ from io import BytesIO, StringIO
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, overload
 
-from polars._utils.various import is_int_sequence, is_str_sequence, normalize_filepath
+from polars._utils.various import (
+    is_int_sequence,
+    is_str_sequence,
+    normalize_filepath,
+)
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
 

--- a/py-polars/polars/io/cloud/__init__.py
+++ b/py-polars/polars/io/cloud/__init__.py
@@ -1,0 +1,15 @@
+from polars.io.cloud.credential_provider import (
+    CredentialProvider,
+    CredentialProviderAWS,
+    CredentialProviderFunction,
+    CredentialProviderFunctionReturn,
+    CredentialProviderGCP,
+)
+
+__all__ = [
+    "CredentialProvider",
+    "CredentialProviderAWS",
+    "CredentialProviderFunction",
+    "CredentialProviderFunctionReturn",
+    "CredentialProviderGCP",
+]

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from polars._utils.various import is_path_or_str_sequence
+
+if TYPE_CHECKING:
+    from polars._typing import ScanSource
+
+
+def _first_scan_path(
+    source: ScanSource,
+) -> str | Path | None:
+    if isinstance(source, (str, Path)):
+        return source
+    elif is_path_or_str_sequence(source) and source:
+        return source[0]
+
+    return None
+
+
+def _infer_cloud_type(
+    source: ScanSource,
+) -> Literal["aws", "azure", "gcp", "file", "http", "hf"] | None:
+    if (path := _first_scan_path(source)) is None:
+        return None
+
+    splitted = str(path).split("://", maxsplit=1)
+
+    # Fast path - local file
+    if not splitted:
+        return None
+
+    scheme = splitted[0]
+
+    if scheme == "file":
+        return "file"
+
+    if any(scheme == x for x in ["s3", "s3a"]):
+        return "aws"
+
+    if any(scheme == x for x in ["az", "azure", "adl", "abfs", "abfss"]):
+        return "azure"
+
+    if any(scheme == x for x in ["gs", "gcp", "gcs"]):
+        return "gcp"
+
+    if any(scheme == x for x in ["http", "https"]):
+        return "http"
+
+    if scheme == "hf":
+        return "hf"
+
+    return None

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import abc
+import importlib.util
+import os
+import sys
+import zoneinfo
+from typing import TYPE_CHECKING, Callable, Optional, TypeAlias, Union
+
+from polars._utils.unstable import issue_unstable_warning
+
+if TYPE_CHECKING:
+    from polars._typing import ScanSource
+
+
+# These typedefs are here to avoid circular import issues
+CredentialProviderFunctionReturn: TypeAlias = tuple[
+    dict[str, Optional[str]], Optional[int]
+]
+
+CredentialProviderFunction: TypeAlias = Union[
+    Callable[[], CredentialProviderFunctionReturn], "CredentialProvider"
+]
+
+
+class CredentialProvider(abc.ABC):
+    """
+    Base class for credential providers.
+
+    .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+    """
+
+    @abc.abstractmethod
+    def __call__(self) -> CredentialProviderFunctionReturn:
+        """Fetches the credentials."""
+
+
+class CredentialProviderAWS(CredentialProvider):
+    """
+    AWS Credential Provider.
+
+    Using this requires the `boto3` Python package to be installed.
+
+    .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+    """
+
+    def __init__(self, *, profile_name: str = "default") -> None:
+        """
+        Initialize a credential provider for AWS.
+
+        Parameters
+        ----------
+        profile_name : str
+            Profile name to use from credentials file.
+        """
+        msg = "`CredentialProviderAWS` functionality is considered unstable"
+        issue_unstable_warning(msg)
+
+        self._check_module_availability()
+        self.profile_name = profile_name
+
+    def __call__(self) -> CredentialProviderFunctionReturn:
+        """Fetch the credentials for the configured profile name."""
+        import boto3
+
+        session = boto3.Session(profile_name=self.profile_name)
+        creds = session.get_credentials()
+
+        if creds is None:
+            msg = "unexpected None value returned from boto3.Session.get_credentials()"
+            raise ValueError(msg)
+
+        return {
+            "aws_access_key_id": creds.access_key,
+            "aws_secret_access_key": creds.secret_key,
+            "aws_session_token": creds.token,
+        }, None
+
+    @classmethod
+    def _check_module_availability(cls) -> None:
+        if importlib.util.find_spec("boto3") is None:
+            msg = "boto3 must be installed to use `CredentialProviderAWS`"
+            raise ImportError(msg)
+
+
+class CredentialProviderGCP(CredentialProvider):
+    """
+    GCP Credential Provider.
+
+    Using this requires the `gcloud` Python package to be installed.
+
+    .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+    """
+
+    def __init__(self) -> None:
+        """Initialize a credential provider for Google Cloud (GCP)."""
+        msg = "`CredentialProviderAWS` functionality is considered unstable"
+        issue_unstable_warning(msg)
+
+        self._check_module_availability()
+
+        import google.auth
+        import google.auth.credentials
+
+        creds, _ = google.auth.default()  # type: ignore[no-untyped-call]
+        self.creds: google.auth.credentials.Credentials = creds
+
+    def __call__(self) -> CredentialProviderFunctionReturn:
+        """Fetch the credentials for the configured profile name."""
+        import google.auth.transport.requests
+
+        self.creds.refresh(google.auth.transport.requests.Request())  # type: ignore[no-untyped-call]
+
+        return {"bearer_token": self.creds.token}, (
+            int(
+                expiry.replace(
+                    # Google auth does not set this properly
+                    tzinfo=zoneinfo.ZoneInfo("UTC")
+                ).timestamp()
+            )
+            if (expiry := self.creds.expiry) is not None
+            else None
+        )
+
+    @classmethod
+    def _check_module_availability(cls) -> None:
+        if importlib.util.find_spec("google") is None:
+            msg = "gcloud must be installed to use `CredentialProviderGCP`"
+            raise ImportError(msg)
+
+
+def _auto_select_credential_provider(
+    source: ScanSource,
+) -> CredentialProvider | None:
+    from polars.io.cloud._utils import _infer_cloud_type
+
+    verbose = os.getenv("POLARS_VERBOSE") == "1"
+    cloud_type = _infer_cloud_type(source)
+
+    provider = None
+
+    try:
+        provider = (
+            None
+            if cloud_type is None
+            else CredentialProviderAWS()
+            if cloud_type == "aws"
+            else CredentialProviderGCP()
+            if cloud_type == "gcp"
+            else None
+        )
+    except ImportError as e:
+        if verbose:
+            msg = f"Unable to auto-select credential provider: {e}"
+            print(msg, file=sys.stderr)
+
+    if provider is not None and verbose:
+        msg = f"Auto-selected credential provider: {type(provider).__name__}"
+        print(msg, file=sys.stderr)
+
+    return provider

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -55,7 +55,7 @@ class CredentialProviderAWS(CredentialProvider):
             at any point without it being considered a breaking change.
     """
 
-    def __init__(self, *, profile_name: str = "default") -> None:
+    def __init__(self, *, profile_name: str | None = None) -> None:
         """
         Initialize a credential provider for AWS.
 

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -98,7 +98,7 @@ class CredentialProviderGCP(CredentialProvider):
     """
     GCP Credential Provider.
 
-    Using this requires the `gcloud` Python package to be installed.
+    Using this requires the `google-auth` Python package to be installed.
 
     .. warning::
             This functionality is considered **unstable**. It may be changed
@@ -137,8 +137,8 @@ class CredentialProviderGCP(CredentialProvider):
 
     @classmethod
     def _check_module_availability(cls) -> None:
-        if importlib.util.find_spec("google") is None:
-            msg = "gcloud must be installed to use `CredentialProviderGCP`"
+        if importlib.util.find_spec("google.auth") is None:
+            msg = "google-auth must be installed to use `CredentialProviderGCP`"
             raise ImportError(msg)
 
 

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -5,7 +5,13 @@ import importlib.util
 import os
 import sys
 import zoneinfo
-from typing import TYPE_CHECKING, Callable, Optional, TypeAlias, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
+
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 from polars._utils.unstable import issue_unstable_warning
 
@@ -13,7 +19,8 @@ if TYPE_CHECKING:
     from polars._typing import ScanSource
 
 
-# These typedefs are here to avoid circular import issues
+# These typedefs are here to avoid circular import issues, as
+# `CredentialProviderFunction` specifies "CredentialProvider"
 CredentialProviderFunctionReturn: TypeAlias = tuple[
     dict[str, Optional[str]], Optional[int]
 ]

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -115,14 +115,14 @@ class CredentialProviderGCP(CredentialProvider):
         import google.auth
         import google.auth.credentials
 
-        creds, _ = google.auth.default()  # type: ignore[no-untyped-call]
+        creds, _ = google.auth.default()
         self.creds = creds
 
     def __call__(self) -> CredentialProviderFunctionReturn:
         """Fetch the credentials for the configured profile name."""
         import google.auth.transport.requests
 
-        self.creds.refresh(google.auth.transport.requests.Request())  # type: ignore[no-untyped-call]
+        self.creds.refresh(google.auth.transport.requests.Request())
 
         return {"bearer_token": self.creds.token}, (
             int(

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -116,7 +116,7 @@ class CredentialProviderGCP(CredentialProvider):
         import google.auth.credentials
 
         creds, _ = google.auth.default()  # type: ignore[no-untyped-call]
-        self.creds: google.auth.credentials.Credentials = creds
+        self.creds = creds
 
     def __call__(self) -> CredentialProviderFunctionReturn:
         """Fetch the credentials for the configured profile name."""

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -115,20 +115,22 @@ class CredentialProviderGCP(CredentialProvider):
         import google.auth
         import google.auth.credentials
 
-        # CI runs with both `mypy` and `mypy --allow-untyped-calls` depending on Python version.
-        # If we add a `type: ignore[no-untyped-call]`, then the check that runs with
-        # `--allow-untyped-calls` will complain about an unused "type: ignore" comment. And if
-        # we don't add the ignore, then the check that runs `mypy` will complain.
+        # CI runs with both `mypy` and `mypy --allow-untyped-calls` depending on
+        # Python version. If we add a `type: ignore[no-untyped-call]`, then the
+        # check that runs with `--allow-untyped-calls` will complain about an
+        # unused "type: ignore" comment. And if we don't add the ignore, then
+        # he check that runs `mypy` will complain.
         #
-        # So we just bypass it with a getattr :|
-        creds, _ = getattr(google.auth, "default")()
+        # So we just bypass it with a __dict__[] (because ruff complains about
+        # getattr) :|
+        creds, _ = google.auth.__dict__["default"]()
         self.creds = creds
 
     def __call__(self) -> CredentialProviderFunctionReturn:
         """Fetch the credentials for the configured profile name."""
         import google.auth.transport.requests
 
-        self.creds.refresh(getattr(google.auth.transport.requests, "Request")())
+        self.creds.refresh(google.auth.transport.requests.__dict__["Request"]())
 
         return {"bearer_token": self.creds.token}, (
             int(

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -336,7 +336,7 @@ def scan_parquet(
     low_memory: bool = False,
     cache: bool = True,
     storage_options: dict[str, Any] | None = None,
-    credential_provider: CredentialProviderFunction | Literal["auto"] | None = "auto",
+    credential_provider: CredentialProviderFunction | Literal["auto"] | None = None,
     retries: int = 2,
     include_file_paths: str | None = None,
     allow_missing_columns: bool = False,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -486,7 +486,11 @@ def scan_parquet(
         issue_unstable_warning(msg)
 
         if credential_provider == "auto":
-            credential_provider = _auto_select_credential_provider(source)
+            credential_provider = (
+                _auto_select_credential_provider(source)
+                if storage_options is None
+                else None
+            )
 
     return _scan_parquet_impl(
         source,  # type: ignore[arg-type]

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -21,27 +21,24 @@ from polars.io._utils import (
     parse_row_index_args,
     prepare_file_arg,
 )
+from polars.io.cloud.credential_provider import _auto_select_credential_provider
 
 with contextlib.suppress(ImportError):
     from polars.polars import PyLazyFrame
     from polars.polars import read_parquet_schema as _read_parquet_schema
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from polars import DataFrame, DataType, LazyFrame
-    from polars._typing import CredentialProviderFunction, ParallelStrategy, SchemaDict
+    from polars._typing import ParallelStrategy, ScanSource, SchemaDict
+    from polars.io.cloud import CredentialProviderFunction
 
 
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
 def read_parquet(
-    source: str
-    | Path
-    | IO[bytes]
-    | bytes
-    | list[str]
-    | list[Path]
-    | list[IO[bytes]]
-    | list[bytes],
+    source: ScanSource,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
@@ -203,6 +200,7 @@ def read_parquet(
             rechunk=rechunk,
         )
 
+    # TODO: FIXME: Move this to `scan_parquet`
     # Read file and bytes inputs using `read_parquet`
     if isinstance(source, bytes):
         source = io.BytesIO(source)
@@ -212,7 +210,7 @@ def read_parquet(
 
     # For other inputs, defer to `scan_parquet`
     lf = scan_parquet(
-        source,  # type: ignore[arg-type]
+        source,
         n_rows=n_rows,
         row_index_name=row_index_name,
         row_index_offset=row_index_offset,
@@ -322,7 +320,7 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
 def scan_parquet(
-    source: str | Path | IO[bytes] | list[str] | list[Path] | list[IO[bytes]],
+    source: ScanSource,
     *,
     n_rows: int | None = None,
     row_index_name: str | None = None,
@@ -338,7 +336,7 @@ def scan_parquet(
     low_memory: bool = False,
     cache: bool = True,
     storage_options: dict[str, Any] | None = None,
-    credential_provider: CredentialProviderFunction | None = None,
+    credential_provider: CredentialProviderFunction | Literal["auto"] | None = "auto",
     retries: int = 2,
     include_file_paths: str | None = None,
     allow_missing_columns: bool = False,
@@ -476,16 +474,19 @@ def scan_parquet(
         msg = "The `hive_schema` parameter of `scan_parquet` is considered unstable."
         issue_unstable_warning(msg)
 
-    if credential_provider is not None:
-        msg = "The `credential_provider` parameter of `scan_parquet` is considered unstable."
-        issue_unstable_warning(msg)
-
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source, check_not_directory=False)
     elif is_path_or_str_sequence(source):
         source = [
             normalize_filepath(source, check_not_directory=False) for source in source
         ]
+
+    if credential_provider is not None:
+        msg = "The `credential_provider` parameter of `scan_parquet` is considered unstable."
+        issue_unstable_warning(msg)
+
+        if credential_provider == "auto":
+            credential_provider = _auto_select_credential_provider(source)
 
     return _scan_parquet_impl(
         source,  # type: ignore[arg-type]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -74,3 +74,4 @@ flask-cors
 # Stub files
 pandas-stubs
 boto3-stubs
+google-auth-stubs

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -74,4 +74,3 @@ flask-cors
 # Stub files
 pandas-stubs
 boto3-stubs
-google-auth-stubs

--- a/py-polars/tests/unit/io/cloud/test_cloud.py
+++ b/py-polars/tests/unit/io/cloud/test_cloud.py
@@ -39,6 +39,9 @@ def test_scan_credential_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     # Passing `None` should disable the automatic instantiation of
     # `CredentialProviderAWS`
     pl.scan_parquet("s3://bucket/path", credential_provider=None)
+    # Passing `storage_options` should disable the automatic instantiation of
+    # `CredentialProviderAWS`
+    pl.scan_parquet("s3://bucket/path", credential_provider="auto", storage_options={})
 
     err_magic = "err_magic_7"
 

--- a/py-polars/tests/unit/io/cloud/test_cloud.py
+++ b/py-polars/tests/unit/io/cloud/test_cloud.py
@@ -33,9 +33,8 @@ def test_scan_credential_provider(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(pl.CredentialProviderAWS, "__init__", raises)
 
-    # By default `credential_provider="auto"`
     with pytest.raises(AssertionError, match=err_magic):
-        pl.scan_parquet("s3://bucket/path")
+        pl.scan_parquet("s3://bucket/path", credential_provider="auto")
 
     # Passing `None` should disable the automatic instantiation of
     # `CredentialProviderAWS`


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/pull/19271#discussion_r1804601805

* Adds `CredentialProviderAWS`, `CredentialProviderGCP`

`CredentialProviderAWS` can be used to select a different AWS profile:

```python
lf = pl.scan_parquet(
    "s3://...",
    credential_provider=pl.CredentialProviderAWS(profile_name="..."),
)

# `CredentialProviderAWS()` will also pick up `AWS_PROFILE` from the environment
import os
os.environ['AWS_PROFILE'] = 'dummy'

lf = pl.scan_parquet(
    "s3://...",
    credential_provider=pl.CredentialProviderAWS(),
)
```

Todos:
* In local testing, GCP is not being cached properly