### PR TITLE
refactor(rust): Use size_of/align_of from prelude

### DIFF
--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -459,8 +459,8 @@ impl<T: NativeType> PrimitiveArray<T> {
 
         // SAFETY: this is fine, we checked size and alignment, and NativeType
         // is always Pod.
-        assert_eq!(std::mem::size_of::<T>(), std::mem::size_of::<U>());
-        assert_eq!(std::mem::align_of::<T>(), std::mem::align_of::<U>());
+        assert_eq!(size_of::<T>(), size_of::<U>());
+        assert_eq!(align_of::<T>(), align_of::<U>());
         let new_values = unsafe { std::mem::transmute::<Buffer<T>, Buffer<U>>(values) };
         PrimitiveArray::new(U::PRIMITIVE.into(), new_values, validity)
     }

--- a/crates/polars-arrow/src/bitmap/aligned.rs
+++ b/crates/polars-arrow/src/bitmap/aligned.rs
@@ -55,7 +55,7 @@ impl<'a, T: BitChunk> AlignedBitmapSlice<'a, T> {
     /// The length (in bits) of the portion of the bitmap found in bulk.
     #[inline(always)]
     pub fn bulk_bitlen(&self) -> usize {
-        8 * std::mem::size_of::<T>() * self.bulk.len()
+        8 * size_of::<T>() * self.bulk.len()
     }
 
     /// The length (in bits) of the portion of the bitmap found in suffix.
@@ -77,7 +77,7 @@ impl<'a, T: BitChunk> AlignedBitmapSlice<'a, T> {
         offset %= 8;
 
         // Fast-path: fits entirely in one chunk.
-        let chunk_len = std::mem::size_of::<T>();
+        let chunk_len = size_of::<T>();
         let chunk_len_bits = 8 * chunk_len;
         if offset + len <= chunk_len_bits {
             let mut prefix = load_chunk_le::<T>(bytes) >> offset;

--- a/crates/polars-arrow/src/bitmap/bitmap_ops.rs
+++ b/crates/polars-arrow/src/bitmap/bitmap_ops.rs
@@ -12,7 +12,7 @@ pub(crate) fn push_bitchunk<T: BitChunk>(buffer: &mut Vec<u8>, value: T) {
 
 /// Creates a [`Vec<u8>`] from a [`TrustedLen`] of [`BitChunk`].
 pub fn chunk_iter_to_vec<T: BitChunk, I: TrustedLen<Item = T>>(iter: I) -> Vec<u8> {
-    let cap = iter.size_hint().0 * std::mem::size_of::<T>();
+    let cap = iter.size_hint().0 * size_of::<T>();
     let mut buffer = Vec::with_capacity(cap);
     for v in iter {
         push_bitchunk(&mut buffer, v)
@@ -24,7 +24,7 @@ fn chunk_iter_to_vec_and_remainder<T: BitChunk, I: TrustedLen<Item = T>>(
     iter: I,
     remainder: T,
 ) -> Vec<u8> {
-    let cap = (iter.size_hint().0 + 1) * std::mem::size_of::<T>();
+    let cap = (iter.size_hint().0 + 1) * size_of::<T>();
     let mut buffer = Vec::with_capacity(cap);
     for v in iter {
         push_bitchunk(&mut buffer, v)

--- a/crates/polars-arrow/src/bitmap/utils/chunk_iterator/chunks_exact.rs
+++ b/crates/polars-arrow/src/bitmap/utils/chunk_iterator/chunks_exact.rs
@@ -17,7 +17,7 @@ impl<'a, T: BitChunk> BitChunksExact<'a, T> {
     #[inline]
     pub fn new(bitmap: &'a [u8], length: usize) -> Self {
         assert!(length <= bitmap.len() * 8);
-        let size_of = std::mem::size_of::<T>();
+        let size_of = size_of::<T>();
 
         let bitmap = &bitmap[..length.saturating_add(7) / 8];
 

--- a/crates/polars-arrow/src/bitmap/utils/chunk_iterator/merge.rs
+++ b/crates/polars-arrow/src/bitmap/utils/chunk_iterator/merge.rs
@@ -23,7 +23,7 @@ where
     // expected = [n5, n6, n7, c0, c1, c2, c3, c4]
 
     // 1. unset most significants of `next` up to `offset`
-    let inverse_offset = std::mem::size_of::<T>() * 8 - offset;
+    let inverse_offset = size_of::<T>() * 8 - offset;
     next <<= inverse_offset;
     // next    =  [n5, n6, n7, 0 , 0 , 0 , 0 , 0 ]
 

--- a/crates/polars-arrow/src/bitmap/utils/chunk_iterator/mod.rs
+++ b/crates/polars-arrow/src/bitmap/utils/chunk_iterator/mod.rs
@@ -44,7 +44,7 @@ fn copy_with_merge<T: BitChunk>(dst: &mut T::Bytes, bytes: &[u8], bit_offset: us
     bytes
         .windows(2)
         .chain(std::iter::once([bytes[bytes.len() - 1], 0].as_ref()))
-        .take(std::mem::size_of::<T>())
+        .take(size_of::<T>())
         .enumerate()
         .for_each(|(i, w)| {
             let val = merge_reversed(w[0], w[1], bit_offset);
@@ -59,7 +59,7 @@ impl<'a, T: BitChunk> BitChunks<'a, T> {
 
         let slice = &slice[offset / 8..];
         let bit_offset = offset % 8;
-        let size_of = std::mem::size_of::<T>();
+        let size_of = size_of::<T>();
 
         let bytes_len = len / 8;
         let bytes_upper_len = (len + bit_offset + 7) / 8;
@@ -120,7 +120,7 @@ impl<'a, T: BitChunk> BitChunks<'a, T> {
                 // all remaining bytes
                 self.remainder_bytes
                     .iter()
-                    .take(std::mem::size_of::<T>())
+                    .take(size_of::<T>())
                     .enumerate()
                     .for_each(|(i, val)| remainder[i] = *val);
 
@@ -137,7 +137,7 @@ impl<'a, T: BitChunk> BitChunks<'a, T> {
 
     /// Returns the remainder bits in [`BitChunks::remainder`].
     pub fn remainder_len(&self) -> usize {
-        self.len - (std::mem::size_of::<T>() * ((self.len / 8) / std::mem::size_of::<T>()) * 8)
+        self.len - (size_of::<T>() * ((self.len / 8) / size_of::<T>()) * 8)
     }
 }
 

--- a/crates/polars-arrow/src/bitmap/utils/chunks_exact_mut.rs
+++ b/crates/polars-arrow/src/bitmap/utils/chunks_exact_mut.rs
@@ -4,7 +4,7 @@ use super::BitChunk;
 ///
 /// # Safety
 /// The slices returned by this iterator are guaranteed to have length equal to
-/// `std::mem::size_of::<T>()`.
+/// `size_of::<T>()`.
 #[derive(Debug)]
 pub struct BitChunksExactMut<'a, T: BitChunk> {
     chunks: std::slice::ChunksExactMut<'a, u8>,
@@ -18,7 +18,7 @@ impl<'a, T: BitChunk> BitChunksExactMut<'a, T> {
     #[inline]
     pub fn new(bitmap: &'a mut [u8], length: usize) -> Self {
         assert!(length <= bitmap.len() * 8);
-        let size_of = std::mem::size_of::<T>();
+        let size_of = size_of::<T>();
 
         let bitmap = &mut bitmap[..length.saturating_add(7) / 8];
 

--- a/crates/polars-arrow/src/bitmap/utils/iterator.rs
+++ b/crates/polars-arrow/src/bitmap/utils/iterator.rs
@@ -176,7 +176,7 @@ impl<'a> BitmapIter<'a> {
         let num_words = n / 64;
 
         if num_words > 0 {
-            assert!(self.bytes.len() >= num_words * std::mem::size_of::<u64>());
+            assert!(self.bytes.len() >= num_words * size_of::<u64>());
 
             bitmap.extend_from_slice(self.bytes, 0, num_words * u64::BITS as usize);
 
@@ -189,7 +189,7 @@ impl<'a> BitmapIter<'a> {
             return;
         }
 
-        assert!(self.bytes.len() >= std::mem::size_of::<u64>());
+        assert!(self.bytes.len() >= size_of::<u64>());
 
         self.word_len = usize::min(self.rest_len, 64);
         self.rest_len -= self.word_len;

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -299,10 +299,10 @@ impl<T: crate::types::NativeType> From<arrow_buffer::Buffer> for Buffer<T> {
 impl<T: crate::types::NativeType> From<Buffer<T>> for arrow_buffer::Buffer {
     fn from(value: Buffer<T>) -> Self {
         let offset = value.offset();
-        value.storage.into_arrow_buffer().slice_with_length(
-            offset * size_of::<T>(),
-            value.length * size_of::<T>(),
-        )
+        value
+            .storage
+            .into_arrow_buffer()
+            .slice_with_length(offset * size_of::<T>(), value.length * size_of::<T>())
     }
 }
 

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -300,8 +300,8 @@ impl<T: crate::types::NativeType> From<Buffer<T>> for arrow_buffer::Buffer {
     fn from(value: Buffer<T>) -> Self {
         let offset = value.offset();
         value.storage.into_arrow_buffer().slice_with_length(
-            offset * std::mem::size_of::<T>(),
-            value.length * std::mem::size_of::<T>(),
+            offset * size_of::<T>(),
+            value.length * size_of::<T>(),
         )
     }
 }

--- a/crates/polars-arrow/src/compute/aggregate/memory.rs
+++ b/crates/polars-arrow/src/compute/aggregate/memory.rs
@@ -18,7 +18,7 @@ macro_rules! dyn_binary {
         let values_end = offsets[offsets.len() - 1] as usize;
 
         values_end - values_start
-            + offsets.len() * std::mem::size_of::<$o>()
+            + offsets.len() * size_of::<$o>()
             + validity_size(array.validity())
     }};
 }
@@ -50,7 +50,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
         },
         Primitive(PrimitiveType::DaysMs) => {
             let array = array.as_any().downcast_ref::<DaysMsArray>().unwrap();
-            array.values().len() * std::mem::size_of::<i32>() * 2 + validity_size(array.validity())
+            array.values().len() * size_of::<i32>() * 2 + validity_size(array.validity())
         },
         Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             let array = array
@@ -58,7 +58,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
                 .downcast_ref::<PrimitiveArray<$T>>()
                 .unwrap();
 
-            array.values().len() * std::mem::size_of::<$T>() + validity_size(array.validity())
+            array.values().len() * size_of::<$T>() + validity_size(array.validity())
         }),
         Binary => dyn_binary!(array, BinaryArray<i32>, i32),
         FixedSizeBinary => {
@@ -74,7 +74,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
         List => {
             let array = array.as_any().downcast_ref::<ListArray<i32>>().unwrap();
             estimated_bytes_size(array.values().as_ref())
-                + array.offsets().len_proxy() * std::mem::size_of::<i32>()
+                + array.offsets().len_proxy() * size_of::<i32>()
                 + validity_size(array.validity())
         },
         FixedSizeList => {
@@ -84,7 +84,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
         LargeList => {
             let array = array.as_any().downcast_ref::<ListArray<i64>>().unwrap();
             estimated_bytes_size(array.values().as_ref())
-                + array.offsets().len_proxy() * std::mem::size_of::<i64>()
+                + array.offsets().len_proxy() * size_of::<i64>()
                 + validity_size(array.validity())
         },
         Struct => {
@@ -99,11 +99,11 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
         },
         Union => {
             let array = array.as_any().downcast_ref::<UnionArray>().unwrap();
-            let types = array.types().len() * std::mem::size_of::<i8>();
+            let types = array.types().len() * size_of::<i8>();
             let offsets = array
                 .offsets()
                 .as_ref()
-                .map(|x| x.len() * std::mem::size_of::<i32>())
+                .map(|x| x.len() * size_of::<i32>())
                 .unwrap_or_default();
             let fields = array
                 .fields()
@@ -124,7 +124,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
         BinaryView => binview_size::<[u8]>(array.as_any().downcast_ref().unwrap()),
         Map => {
             let array = array.as_any().downcast_ref::<MapArray>().unwrap();
-            let offsets = array.offsets().len_proxy() * std::mem::size_of::<i32>();
+            let offsets = array.offsets().len_proxy() * size_of::<i32>();
             offsets + estimated_bytes_size(array.field().as_ref()) + validity_size(array.validity())
         },
     }

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -227,7 +227,7 @@ unsafe fn get_buffer_ptr<T: NativeType>(
 
     if array
         .buffers
-        .align_offset(std::mem::align_of::<*mut *const u8>())
+        .align_offset(align_of::<*mut *const u8>())
         != 0
     {
         polars_bail!( ComputeError:
@@ -294,7 +294,7 @@ unsafe fn create_buffer<T: NativeType>(
 
     // We have to check alignment.
     // This is the zero-copy path.
-    if ptr.align_offset(std::mem::align_of::<T>()) == 0 {
+    if ptr.align_offset(align_of::<T>()) == 0 {
         let storage = SharedStorage::from_internal_arrow_array(ptr, len, owner);
         Ok(Buffer::from_storage(storage).sliced(offset, len - offset))
     }

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -225,11 +225,7 @@ unsafe fn get_buffer_ptr<T: NativeType>(
         );
     }
 
-    if array
-        .buffers
-        .align_offset(align_of::<*mut *const u8>())
-        != 0
-    {
+    if array.buffers.align_offset(align_of::<*mut *const u8>()) != 0 {
         polars_bail!( ComputeError:
             "an ArrowArray of type {dtype:?}
             must have buffer {index} aligned to type {}",

--- a/crates/polars-arrow/src/io/avro/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/avro/read/deserialize.rs
@@ -195,8 +195,7 @@ fn deserialize_value<'a>(
                     array.push(Some(value))
                 },
                 PrimitiveType::Float32 => {
-                    let value =
-                        f32::from_le_bytes(block[..size_of::<f32>()].try_into().unwrap());
+                    let value = f32::from_le_bytes(block[..size_of::<f32>()].try_into().unwrap());
                     block = &block[size_of::<f32>()..];
                     let array = array
                         .as_mut_any()
@@ -205,8 +204,7 @@ fn deserialize_value<'a>(
                     array.push(Some(value))
                 },
                 PrimitiveType::Float64 => {
-                    let value =
-                        f64::from_le_bytes(block[..size_of::<f64>()].try_into().unwrap());
+                    let value = f64::from_le_bytes(block[..size_of::<f64>()].try_into().unwrap());
                     block = &block[size_of::<f64>()..];
                     let array = array
                         .as_mut_any()

--- a/crates/polars-arrow/src/io/avro/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/avro/read/deserialize.rs
@@ -196,8 +196,8 @@ fn deserialize_value<'a>(
                 },
                 PrimitiveType::Float32 => {
                     let value =
-                        f32::from_le_bytes(block[..std::mem::size_of::<f32>()].try_into().unwrap());
-                    block = &block[std::mem::size_of::<f32>()..];
+                        f32::from_le_bytes(block[..size_of::<f32>()].try_into().unwrap());
+                    block = &block[size_of::<f32>()..];
                     let array = array
                         .as_mut_any()
                         .downcast_mut::<MutablePrimitiveArray<f32>>()
@@ -206,8 +206,8 @@ fn deserialize_value<'a>(
                 },
                 PrimitiveType::Float64 => {
                     let value =
-                        f64::from_le_bytes(block[..std::mem::size_of::<f64>()].try_into().unwrap());
-                    block = &block[std::mem::size_of::<f64>()..];
+                        f64::from_le_bytes(block[..size_of::<f64>()].try_into().unwrap());
+                    block = &block[size_of::<f64>()..];
                     let array = array
                         .as_mut_any()
                         .downcast_mut::<MutablePrimitiveArray<f64>>()
@@ -404,10 +404,10 @@ fn skip_item<'a>(
                     let _ = util::zigzag_i64(&mut block)?;
                 },
                 PrimitiveType::Float32 => {
-                    block = &block[std::mem::size_of::<f32>()..];
+                    block = &block[size_of::<f32>()..];
                 },
                 PrimitiveType::Float64 => {
-                    block = &block[std::mem::size_of::<f64>()..];
+                    block = &block[size_of::<f64>()..];
                 },
                 PrimitiveType::MonthDayNano => {
                     block = &block[12..];

--- a/crates/polars-arrow/src/io/ipc/read/read_basic.rs
+++ b/crates/polars-arrow/src/io/ipc/read/read_basic.rs
@@ -17,10 +17,10 @@ fn read_swapped<T: NativeType, R: Read + Seek>(
     is_little_endian: bool,
 ) -> PolarsResult<()> {
     // slow case where we must reverse bits
-    let mut slice = vec![0u8; length * std::mem::size_of::<T>()];
+    let mut slice = vec![0u8; length * size_of::<T>()];
     reader.read_exact(&mut slice)?;
 
-    let chunks = slice.chunks_exact(std::mem::size_of::<T>());
+    let chunks = slice.chunks_exact(size_of::<T>());
     if !is_little_endian {
         // machine is little endian, file is big endian
         buffer
@@ -67,7 +67,7 @@ fn read_uncompressed_buffer<T: NativeType, R: Read + Seek>(
     length: usize,
     is_little_endian: bool,
 ) -> PolarsResult<Vec<T>> {
-    let required_number_of_bytes = length.saturating_mul(std::mem::size_of::<T>());
+    let required_number_of_bytes = length.saturating_mul(size_of::<T>());
     if required_number_of_bytes > buffer_length {
         polars_bail!(
             oos = OutOfSpecKind::InvalidBuffer {

--- a/crates/polars-arrow/src/io/ipc/write/serialize/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write/serialize/mod.rs
@@ -283,7 +283,7 @@ fn _write_buffer_from_iter<T: NativeType, I: TrustedLen<Item = T>>(
     is_little_endian: bool,
 ) {
     let len = buffer.size_hint().0;
-    arrow_data.reserve(len * std::mem::size_of::<T>());
+    arrow_data.reserve(len * size_of::<T>());
     if is_little_endian {
         buffer
             .map(|x| T::to_le_bytes(&x))
@@ -303,7 +303,7 @@ fn _write_compressed_buffer_from_iter<T: NativeType, I: TrustedLen<Item = T>>(
     compression: Compression,
 ) {
     let len = buffer.size_hint().0;
-    let mut swapped = Vec::with_capacity(len * std::mem::size_of::<T>());
+    let mut swapped = Vec::with_capacity(len * size_of::<T>());
     if is_little_endian {
         buffer
             .map(|x| T::to_le_bytes(&x))

--- a/crates/polars-arrow/src/legacy/kernels/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/mod.rs
@@ -59,8 +59,7 @@ impl<'a> MaskedSlicesIterator<'a> {
     pub(crate) fn new(mask: &'a BooleanArray) -> Self {
         let chunks = mask.values().chunks::<u64>();
 
-        let chunk_bits = 8 * size_of::<u64>();
-        let chunk_len = mask.len() / chunk_bits;
+        let chunk_len = mask.len() / 64;
         let remainder_len = chunks.remainder_len();
         let remainder_mask = chunks.remainder();
 

--- a/crates/polars-arrow/src/legacy/kernels/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/mod.rs
@@ -59,7 +59,7 @@ impl<'a> MaskedSlicesIterator<'a> {
     pub(crate) fn new(mask: &'a BooleanArray) -> Self {
         let chunks = mask.values().chunks::<u64>();
 
-        let chunk_bits = 8 * std::mem::size_of::<u64>();
+        let chunk_bits = 8 * size_of::<u64>();
         let chunk_len = mask.len() / chunk_bits;
         let remainder_len = chunks.remainder_len();
         let remainder_mask = chunks.remainder();

--- a/crates/polars-arrow/src/mmap/array.rs
+++ b/crates/polars-arrow/src/mmap/array.rs
@@ -35,7 +35,7 @@ fn check_bytes_len_and_is_aligned<T: NativeType>(
     bytes: &[u8],
     expected_len: usize,
 ) -> PolarsResult<bool> {
-    if bytes.len() < std::mem::size_of::<T>() * expected_len {
+    if bytes.len() < size_of::<T>() * expected_len {
         polars_bail!(ComputeError: "buffer's length is too small in mmap")
     };
 
@@ -281,7 +281,7 @@ fn mmap_primitive<P: NativeType, T: AsRef<[u8]>>(
     let bytes = get_bytes(data_ref, block_offset, buffers)?;
     let is_aligned = check_bytes_len_and_is_aligned::<P>(bytes, num_rows)?;
 
-    let out = if is_aligned || std::mem::size_of::<T>() <= 8 {
+    let out = if is_aligned || size_of::<T>() <= 8 {
         assert!(
             is_aligned,
             "primitive type with size <= 8 bytes should have been aligned"

--- a/crates/polars-arrow/src/storage.rs
+++ b/crates/polars-arrow/src/storage.rs
@@ -100,9 +100,9 @@ impl<T> SharedStorage<T> {
 impl<T: crate::types::NativeType> SharedStorage<T> {
     pub fn from_arrow_buffer(buffer: arrow_buffer::Buffer) -> Self {
         let ptr = buffer.as_ptr();
-        let align_offset = ptr.align_offset(std::mem::align_of::<T>());
+        let align_offset = ptr.align_offset(align_of::<T>());
         assert_eq!(align_offset, 0, "arrow_buffer::Buffer misaligned");
-        let length = buffer.len() / std::mem::size_of::<T>();
+        let length = buffer.len() / size_of::<T>();
 
         let inner = SharedStorageInner {
             ref_count: AtomicU64::new(1),
@@ -119,7 +119,7 @@ impl<T: crate::types::NativeType> SharedStorage<T> {
 
     pub fn into_arrow_buffer(self) -> arrow_buffer::Buffer {
         let ptr = NonNull::new(self.as_ptr() as *mut u8).unwrap();
-        let len = self.len() * std::mem::size_of::<T>();
+        let len = self.len() * size_of::<T>();
         let arc = std::sync::Arc::new(self);
         unsafe { arrow_buffer::Buffer::from_custom_allocation(ptr, len, arc) }
     }

--- a/crates/polars-arrow/src/types/bit_chunk.rs
+++ b/crates/polars-arrow/src/types/bit_chunk.rs
@@ -72,7 +72,7 @@ impl<T: BitChunk> BitChunkIter<T> {
     /// Creates a new [`BitChunkIter`] with `len` bits.
     #[inline]
     pub fn new(value: T, len: usize) -> Self {
-        assert!(len <= std::mem::size_of::<T>() * 8);
+        assert!(len <= size_of::<T>() * 8);
         Self {
             value,
             remaining: len,

--- a/crates/polars-arrow/src/types/native.rs
+++ b/crates/polars-arrow/src/types/native.rs
@@ -60,7 +60,7 @@ macro_rules! native_type {
         impl NativeType for $type {
             const PRIMITIVE: PrimitiveType = $primitive_type;
 
-            type Bytes = [u8; std::mem::size_of::<Self>()];
+            type Bytes = [u8; size_of::<Self>()];
             #[inline]
             fn to_le_bytes(&self) -> Self::Bytes {
                 Self::to_le_bytes(*self)

--- a/crates/polars-compute/src/arity.rs
+++ b/crates/polars-compute/src/arity.rs
@@ -52,9 +52,7 @@ where
     let len = arr.len();
 
     // Reuse memory if possible.
-    if size_of::<I>() == size_of::<O>()
-        && align_of::<I>() == align_of::<O>()
-    {
+    if size_of::<I>() == size_of::<O>() && align_of::<I>() == align_of::<O>() {
         if let Some(values) = arr.get_mut_values() {
             let ptr = values.as_mut_ptr();
             // SAFETY: checked same size & alignment I/O, NativeType is always Pod.
@@ -93,9 +91,7 @@ where
     let validity = combine_validities_and(lhs.validity(), rhs.validity());
 
     // Reuse memory if possible.
-    if size_of::<L>() == size_of::<O>()
-        && align_of::<L>() == align_of::<O>()
-    {
+    if size_of::<L>() == size_of::<O>() && align_of::<L>() == align_of::<O>() {
         if let Some(lv) = lhs.get_mut_values() {
             let lp = lv.as_mut_ptr();
             let rp = rhs.values().as_ptr();
@@ -106,9 +102,7 @@ where
             return lhs.transmute::<O>().with_validity(validity);
         }
     }
-    if size_of::<R>() == size_of::<O>()
-        && align_of::<R>() == align_of::<O>()
-    {
+    if size_of::<R>() == size_of::<O>() && align_of::<R>() == align_of::<O>() {
         if let Some(rv) = rhs.get_mut_values() {
             let lp = lhs.values().as_ptr();
             let rp = rv.as_mut_ptr();

--- a/crates/polars-compute/src/arity.rs
+++ b/crates/polars-compute/src/arity.rs
@@ -52,8 +52,8 @@ where
     let len = arr.len();
 
     // Reuse memory if possible.
-    if std::mem::size_of::<I>() == std::mem::size_of::<O>()
-        && std::mem::align_of::<I>() == std::mem::align_of::<O>()
+    if size_of::<I>() == size_of::<O>()
+        && align_of::<I>() == align_of::<O>()
     {
         if let Some(values) = arr.get_mut_values() {
             let ptr = values.as_mut_ptr();
@@ -93,8 +93,8 @@ where
     let validity = combine_validities_and(lhs.validity(), rhs.validity());
 
     // Reuse memory if possible.
-    if std::mem::size_of::<L>() == std::mem::size_of::<O>()
-        && std::mem::align_of::<L>() == std::mem::align_of::<O>()
+    if size_of::<L>() == size_of::<O>()
+        && align_of::<L>() == align_of::<O>()
     {
         if let Some(lv) = lhs.get_mut_values() {
             let lp = lv.as_mut_ptr();
@@ -106,8 +106,8 @@ where
             return lhs.transmute::<O>().with_validity(validity);
         }
     }
-    if std::mem::size_of::<R>() == std::mem::size_of::<O>()
-        && std::mem::align_of::<R>() == std::mem::align_of::<O>()
+    if size_of::<R>() == size_of::<O>()
+        && align_of::<R>() == align_of::<O>()
     {
         if let Some(rv) = rhs.get_mut_values() {
             let lp = lhs.values().as_ptr();

--- a/crates/polars-compute/src/comparisons/simd.rs
+++ b/crates/polars-compute/src/comparisons/simd.rs
@@ -17,7 +17,7 @@ where
     T: NativeType,
     F: FnMut(&[T; N], &[T; N]) -> M,
 {
-    assert_eq!(N, std::mem::size_of::<M>() * 8);
+    assert_eq!(N, size_of::<M>() * 8);
     assert!(lhs.len() == rhs.len());
     let n = lhs.len();
 
@@ -29,7 +29,7 @@ where
     let rhs_rest = rhs_chunks.remainder();
 
     let num_masks = n.div_ceil(N);
-    let mut v: Vec<u8> = Vec::with_capacity(num_masks * std::mem::size_of::<M>());
+    let mut v: Vec<u8> = Vec::with_capacity(num_masks * size_of::<M>());
     let mut p = v.as_mut_ptr() as *mut M;
     for (l, r) in lhs_chunks.zip(rhs_chunks) {
         unsafe {
@@ -53,7 +53,7 @@ where
     }
 
     unsafe {
-        v.set_len(num_masks * std::mem::size_of::<M>());
+        v.set_len(num_masks * size_of::<M>());
     }
 
     Bitmap::from_u8_vec(v, n)
@@ -64,7 +64,7 @@ where
     T: NativeType,
     F: FnMut(&[T; N]) -> M,
 {
-    assert_eq!(N, std::mem::size_of::<M>() * 8);
+    assert_eq!(N, size_of::<M>() * 8);
     let n = arg.len();
 
     let arg_buf = arg.values().as_slice();
@@ -72,7 +72,7 @@ where
     let arg_rest = arg_chunks.remainder();
 
     let num_masks = n.div_ceil(N);
-    let mut v: Vec<u8> = Vec::with_capacity(num_masks * std::mem::size_of::<M>());
+    let mut v: Vec<u8> = Vec::with_capacity(num_masks * size_of::<M>());
     let mut p = v.as_mut_ptr() as *mut M;
     for a in arg_chunks {
         unsafe {
@@ -91,7 +91,7 @@ where
     }
 
     unsafe {
-        v.set_len(num_masks * std::mem::size_of::<M>());
+        v.set_len(num_masks * size_of::<M>());
     }
 
     Bitmap::from_u8_vec(v, n)

--- a/crates/polars-compute/src/filter/avx512.rs
+++ b/crates/polars-compute/src/filter/avx512.rs
@@ -5,7 +5,7 @@ use core::arch::x86_64::*;
 // structured functions.
 macro_rules! simd_filter {
     ($values: ident, $mask_bytes: ident, $out: ident, |$subchunk: ident, $m: ident: $MaskT: ty| $body:block) => {{
-        const MASK_BITS: usize = $MaskT::BITS as usize;
+        const MASK_BITS: usize = <$MaskT>::BITS as usize;
 
         // Do a 64-element loop for sparse fast path.
         let chunks = $values.chunks_exact(64);

--- a/crates/polars-compute/src/filter/avx512.rs
+++ b/crates/polars-compute/src/filter/avx512.rs
@@ -5,7 +5,7 @@ use core::arch::x86_64::*;
 // structured functions.
 macro_rules! simd_filter {
     ($values: ident, $mask_bytes: ident, $out: ident, |$subchunk: ident, $m: ident: $MaskT: ty| $body:block) => {{
-        const MASK_BITS: usize = size_of::<$MaskT>() * 8;
+        const MASK_BITS: usize = $MaskT::BITS as usize;
 
         // Do a 64-element loop for sparse fast path.
         let chunks = $values.chunks_exact(64);

--- a/crates/polars-compute/src/filter/avx512.rs
+++ b/crates/polars-compute/src/filter/avx512.rs
@@ -5,7 +5,7 @@ use core::arch::x86_64::*;
 // structured functions.
 macro_rules! simd_filter {
     ($values: ident, $mask_bytes: ident, $out: ident, |$subchunk: ident, $m: ident: $MaskT: ty| $body:block) => {{
-        const MASK_BITS: usize = std::mem::size_of::<$MaskT>() * 8;
+        const MASK_BITS: usize = size_of::<$MaskT>() * 8;
 
         // Do a 64-element loop for sparse fast path.
         let chunks = $values.chunks_exact(64);

--- a/crates/polars-compute/src/filter/primitive.rs
+++ b/crates/polars-compute/src/filter/primitive.rs
@@ -19,7 +19,7 @@ fn nop_filter<'a, T: Pod>(
 }
 
 pub fn filter_values<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
-    match (std::mem::size_of::<T>(), std::mem::align_of::<T>()) {
+    match (size_of::<T>(), align_of::<T>()) {
         (1, 1) => cast_vec(filter_values_u8(cast_slice(values), mask)),
         (2, 2) => cast_vec(filter_values_u16(cast_slice(values), mask)),
         (4, 4) => cast_vec(filter_values_u32(cast_slice(values), mask)),

--- a/crates/polars-core/src/chunked_array/object/builder.rs
+++ b/crates/polars-core/src/chunked_array/object/builder.rs
@@ -80,7 +80,7 @@ pub(crate) fn get_object_type<T: PolarsObject>() -> DataType {
         Box::new(ObjectChunkedBuilder::<T>::new(name, capacity)) as Box<dyn AnonymousObjectBuilder>
     });
 
-    let object_size = std::mem::size_of::<T>();
+    let object_size = size_of::<T>();
     let physical_dtype = ArrowDataType::FixedSizeBinary(object_size);
 
     let registry = ObjectRegistry::new(object_builder, physical_dtype);

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -29,7 +29,7 @@ pub fn set_polars_allow_extension(toggle: bool) {
 /// `n_t_vals` must represent the correct number of `T` values in that allocation
 unsafe fn create_drop<T: Sized>(mut ptr: *const u8, n_t_vals: usize) -> Box<dyn FnMut()> {
     Box::new(move || {
-        let t_size = std::mem::size_of::<T>() as isize;
+        let t_size = size_of::<T>() as isize;
         for _ in 0..n_t_vals {
             let _ = std::ptr::read_unaligned(ptr as *const T);
             ptr = ptr.offset(t_size)
@@ -55,7 +55,7 @@ impl Drop for ExtensionSentinel {
 // https://stackoverflow.com/questions/28127165/how-to-convert-struct-to-u8d
 // not entirely sure if padding bytes in T are initialized or not.
 unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
-    std::slice::from_raw_parts((p as *const T) as *const u8, std::mem::size_of::<T>())
+    std::slice::from_raw_parts((p as *const T) as *const u8, size_of::<T>())
 }
 
 /// Create an extension Array that can be sent to arrow and (once wrapped in `[PolarsExtension]` will
@@ -67,8 +67,8 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
     if !(POLARS_ALLOW_EXTENSION.load(Ordering::Relaxed) || std::env::var(env).is_ok()) {
         panic!("creating extension types not allowed - try setting the environment variable {env}")
     }
-    let t_size = std::mem::size_of::<T>();
-    let t_alignment = std::mem::align_of::<T>();
+    let t_size = size_of::<T>();
+    let t_alignment = align_of::<T>();
     let n_t_vals = iter.size_hint().1.unwrap();
 
     let mut buf = Vec::with_capacity(n_t_vals * t_size);

--- a/crates/polars-core/src/chunked_array/object/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/mod.rs
@@ -164,7 +164,7 @@ where
     }
 
     fn dtype(&self) -> &ArrowDataType {
-        &ArrowDataType::FixedSizeBinary(std::mem::size_of::<T>())
+        &ArrowDataType::FixedSizeBinary(size_of::<T>())
     }
 
     fn slice(&mut self, offset: usize, length: usize) {
@@ -275,7 +275,7 @@ impl<T: PolarsObject> StaticArray for ObjectArray<T> {
 
 impl<T: PolarsObject> ParameterFreeDtypeStaticArray for ObjectArray<T> {
     fn get_dtype() -> ArrowDataType {
-        ArrowDataType::FixedSizeBinary(std::mem::size_of::<T>())
+        ArrowDataType::FixedSizeBinary(size_of::<T>())
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -8,8 +8,8 @@ use crate::series::BitRepr;
 fn reinterpret_chunked_array<T: PolarsNumericType, U: PolarsNumericType>(
     ca: &ChunkedArray<T>,
 ) -> ChunkedArray<U> {
-    assert!(std::mem::size_of::<T::Native>() == std::mem::size_of::<U::Native>());
-    assert!(std::mem::align_of::<T::Native>() == std::mem::align_of::<U::Native>());
+    assert!(size_of::<T::Native>() == size_of::<U::Native>());
+    assert!(align_of::<T::Native>() == align_of::<U::Native>());
 
     let chunks = ca.downcast_iter().map(|array| {
         let buf = array.values().clone();
@@ -29,8 +29,8 @@ fn reinterpret_chunked_array<T: PolarsNumericType, U: PolarsNumericType>(
 fn reinterpret_list_chunked<T: PolarsNumericType, U: PolarsNumericType>(
     ca: &ListChunked,
 ) -> ListChunked {
-    assert!(std::mem::size_of::<T::Native>() == std::mem::size_of::<U::Native>());
-    assert!(std::mem::align_of::<T::Native>() == std::mem::align_of::<U::Native>());
+    assert!(size_of::<T::Native>() == size_of::<U::Native>());
+    assert!(align_of::<T::Native>() == align_of::<U::Native>());
 
     let chunks = ca.downcast_iter().map(|array| {
         let inner_arr = array
@@ -105,7 +105,7 @@ where
     T: PolarsNumericType,
 {
     fn to_bit_repr(&self) -> BitRepr {
-        let is_large = std::mem::size_of::<T::Native>() == 8;
+        let is_large = size_of::<T::Native>() == 8;
 
         if is_large {
             if matches!(self.dtype(), DataType::UInt64) {
@@ -118,7 +118,7 @@ where
 
             BitRepr::Large(reinterpret_chunked_array(self))
         } else {
-            BitRepr::Small(if std::mem::size_of::<T::Native>() == 4 {
+            BitRepr::Small(if size_of::<T::Native>() == 4 {
                 if matches!(self.dtype(), DataType::UInt32) {
                     let ca = self.clone();
                     // Convince the compiler we are this type. This preserves flags.

--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -44,8 +44,8 @@ where
             let mut first: Vec<IdxSize> = unsafe { aligned_vec(len) };
 
             // ensure we keep aligned to cache lines
-            let chunk_size = (chunk_size * std::mem::size_of::<T::Native>()).next_multiple_of(64);
-            let chunk_size = chunk_size / std::mem::size_of::<T::Native>();
+            let chunk_size = (chunk_size * size_of::<T::Native>()).next_multiple_of(64);
+            let chunk_size = chunk_size / size_of::<T::Native>();
 
             let mut cache_line_offsets = Vec::with_capacity(n_threads + 1);
             cache_line_offsets.push(0);
@@ -227,8 +227,8 @@ struct AlignTo64([u8; 64]);
 /// There are no guarantees that the [`Vec<T>`] will remain aligned if you reallocate the data.
 /// This means that you cannot reallocate so you will need to know how big to allocate up front.
 unsafe fn aligned_vec<T>(n: usize) -> Vec<T> {
-    assert!(std::mem::align_of::<T>() <= 64);
-    let n_units = (n * std::mem::size_of::<T>() / std::mem::size_of::<AlignTo64>()) + 1;
+    assert!(align_of::<T>() <= 64);
+    let n_units = (n * size_of::<T>() / size_of::<AlignTo64>()) + 1;
 
     let mut aligned: Vec<AlignTo64> = Vec::with_capacity(n_units);
 
@@ -240,6 +240,6 @@ unsafe fn aligned_vec<T>(n: usize) -> Vec<T> {
     Vec::from_raw_parts(
         ptr as *mut T,
         0,
-        cap_units * std::mem::size_of::<AlignTo64>() / std::mem::size_of::<T>(),
+        cap_units * size_of::<AlignTo64>() / size_of::<T>(),
     )
 }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -873,8 +873,7 @@ impl Series {
             DataType::Categorical(Some(rv), _) | DataType::Enum(Some(rv), _) => match &**rv {
                 RevMapping::Local(arr, _) => size += estimated_bytes_size(arr),
                 RevMapping::Global(map, arr, _) => {
-                    size +=
-                        map.capacity() * size_of::<u32>() * 2 + estimated_bytes_size(arr);
+                    size += map.capacity() * size_of::<u32>() * 2 + estimated_bytes_size(arr);
                 },
             },
             _ => {},

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -874,7 +874,7 @@ impl Series {
                 RevMapping::Local(arr, _) => size += estimated_bytes_size(arr),
                 RevMapping::Global(map, arr, _) => {
                     size +=
-                        map.capacity() * std::mem::size_of::<u32>() * 2 + estimated_bytes_size(arr);
+                        map.capacity() * size_of::<u32>() * 2 + estimated_bytes_size(arr);
                 },
             },
             _ => {},

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -1159,7 +1159,7 @@ pub fn coalesce_nulls_columns(a: &Column, b: &Column) -> (Column, Column) {
 }
 
 pub fn operation_exceeded_idxsize_msg(operation: &str) -> String {
-    if core::mem::size_of::<IdxSize>() == core::mem::size_of::<u32>() {
+    if size_of::<IdxSize>() == size_of::<u32>() {
         format!(
             "{} exceeded the maximum supported limit of {} rows. Consider installing 'polars-u64-idx'.",
             operation,

--- a/crates/polars-ops/src/chunked_array/strings/case.rs
+++ b/crates/polars-ops/src/chunked_array/strings/case.rs
@@ -5,7 +5,7 @@ fn convert_while_ascii(b: &[u8], convert: fn(&u8) -> u8, out: &mut Vec<u8>) {
     out.clear();
     out.reserve(b.len());
 
-    const USIZE_SIZE: usize = std::mem::size_of::<usize>();
+    const USIZE_SIZE: usize = size_of::<usize>();
     const MAGIC_UNROLL: usize = 2;
     const N: usize = USIZE_SIZE * MAGIC_UNROLL;
     const NONASCII_MASK: usize = usize::from_ne_bytes([0x80; USIZE_SIZE]);

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
@@ -55,7 +55,7 @@ where
                 let values = split_buffer(page)?.values;
                 Ok(Self::ByteStreamSplit(byte_stream_split::Decoder::try_new(
                     values,
-                    std::mem::size_of::<P>(),
+                    size_of::<P>(),
                 )?))
             },
             _ => Err(utils::not_implemented(page)),

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -58,7 +58,7 @@ where
                 let values = split_buffer(page)?.values;
                 Ok(Self::ByteStreamSplit(byte_stream_split::Decoder::try_new(
                     values,
-                    std::mem::size_of::<P>(),
+                    size_of::<P>(),
                 )?))
             },
             (Encoding::DeltaBinaryPacked, _) => {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/mod.rs
@@ -167,7 +167,7 @@ where
     D: DecoderFunction<P, T>,
 {
     values
-        .chunks_exact(std::mem::size_of::<P>())
+        .chunks_exact(size_of::<P>())
         .map(decode)
         .map(|v| decoder.decode(v))
         .collect::<Vec<_>>()

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils/array_chunks.rs
@@ -16,7 +16,7 @@ impl<'a, P: ParquetNativeType> ArrayChunks<'a, P> {
     ///
     /// This returns null if the `bytes` slice's length is not a multiple of the size of `P::Bytes`.
     pub(crate) fn new(bytes: &'a [u8]) -> Option<Self> {
-        if bytes.len() % std::mem::size_of::<P::Bytes>() != 0 {
+        if bytes.len() % size_of::<P::Bytes>() != 0 {
             return None;
         }
 

--- a/crates/polars-parquet/src/arrow/write/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binary/basic.rs
@@ -30,8 +30,8 @@ pub(crate) fn encode_plain<O: Offset>(
 ) {
     if options.is_optional() && array.validity().is_some() {
         let len_before = buffer.len();
-        let capacity = array.get_values_size()
-            + (array.len() - array.null_count()) * size_of::<u32>();
+        let capacity =
+            array.get_values_size() + (array.len() - array.null_count()) * size_of::<u32>();
         buffer.reserve(capacity);
         encode_non_null_values(array.non_null_values_iter(), buffer);
         // Ensure we allocated properly.

--- a/crates/polars-parquet/src/arrow/write/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binary/basic.rs
@@ -31,14 +31,14 @@ pub(crate) fn encode_plain<O: Offset>(
     if options.is_optional() && array.validity().is_some() {
         let len_before = buffer.len();
         let capacity = array.get_values_size()
-            + (array.len() - array.null_count()) * std::mem::size_of::<u32>();
+            + (array.len() - array.null_count()) * size_of::<u32>();
         buffer.reserve(capacity);
         encode_non_null_values(array.non_null_values_iter(), buffer);
         // Ensure we allocated properly.
         debug_assert_eq!(buffer.len() - len_before, capacity);
     } else {
         let len_before = buffer.len();
-        let capacity = array.get_values_size() + array.len() * std::mem::size_of::<u32>();
+        let capacity = array.get_values_size() + array.len() * size_of::<u32>();
         buffer.reserve(capacity);
         encode_non_null_values(array.values_iter(), buffer);
         // Ensure we allocated properly.

--- a/crates/polars-parquet/src/arrow/write/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binview/basic.rs
@@ -17,7 +17,7 @@ pub(crate) fn encode_plain(
 ) {
     if options.is_optional() && array.validity().is_some() {
         let capacity = array.total_bytes_len()
-            + (array.len() - array.null_count()) * std::mem::size_of::<u32>();
+            + (array.len() - array.null_count()) * size_of::<u32>();
 
         let len_before = buffer.len();
         buffer.reserve(capacity);
@@ -26,7 +26,7 @@ pub(crate) fn encode_plain(
         // Append the non-null values.
         debug_assert_eq!(buffer.len() - len_before, capacity);
     } else {
-        let capacity = array.total_bytes_len() + array.len() * std::mem::size_of::<u32>();
+        let capacity = array.total_bytes_len() + array.len() * size_of::<u32>();
 
         let len_before = buffer.len();
         buffer.reserve(capacity);

--- a/crates/polars-parquet/src/arrow/write/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binview/basic.rs
@@ -16,8 +16,8 @@ pub(crate) fn encode_plain(
     buffer: &mut Vec<u8>,
 ) {
     if options.is_optional() && array.validity().is_some() {
-        let capacity = array.total_bytes_len()
-            + (array.len() - array.null_count()) * size_of::<u32>();
+        let capacity =
+            array.total_bytes_len() + (array.len() - array.null_count()) * size_of::<u32>();
 
         let len_before = buffer.len();
         buffer.reserve(capacity);

--- a/crates/polars-parquet/src/arrow/write/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/basic.rs
@@ -38,7 +38,7 @@ where
                 let mut iter = validity.iter();
                 let values = array.values().as_slice();
 
-                buffer.reserve(std::mem::size_of::<P::Bytes>() * (array.len() - null_count));
+                buffer.reserve(size_of::<P::Bytes>() * (array.len() - null_count));
 
                 let mut offset = 0;
                 let mut remaining_valid = array.len() - null_count;
@@ -61,7 +61,7 @@ where
         }
     }
 
-    buffer.reserve(std::mem::size_of::<P>() * array.len());
+    buffer.reserve(size_of::<P>() * array.len());
     buffer.extend(
         array
             .values()

--- a/crates/polars-parquet/src/parquet/compression.rs
+++ b/crates/polars-parquet/src/parquet/compression.rs
@@ -245,7 +245,7 @@ fn try_decompress_hadoop(input_buf: &[u8], output_buf: &mut [u8]) -> ParquetResu
     // The Hadoop Lz4Codec source code can be found here:
     // https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/Lz4Codec.cc
 
-    const SIZE_U32: usize = std::mem::size_of::<u32>();
+    const SIZE_U32: usize = size_of::<u32>();
     const PREFIX_LEN: usize = SIZE_U32 * 2;
     let mut input_len = input_buf.len();
     let mut input = input_buf;

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/decode.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/decode.rs
@@ -56,7 +56,7 @@ impl<'a, T: Unpackable> Decoder<'a, T> {
         num_bits: usize,
         length: usize,
     ) -> ParquetResult<Self> {
-        let block_size = std::mem::size_of::<T>() * num_bits;
+        let block_size = size_of::<T>() * num_bits;
 
         if packed.len() * 8 < length * num_bits {
             return Err(ParquetError::oos(format!(
@@ -78,7 +78,7 @@ impl<'a, T: Unpackable> Decoder<'a, T> {
 
     /// Returns a [`Decoder`] with `T` encoded in `packed` with `num_bits`.
     pub fn try_new(packed: &'a [u8], num_bits: usize, length: usize) -> ParquetResult<Self> {
-        let block_size = std::mem::size_of::<T>() * num_bits;
+        let block_size = size_of::<T>() * num_bits;
 
         if num_bits == 0 {
             return Err(ParquetError::oos("Bitpacking requires num_bits > 0"));
@@ -181,7 +181,7 @@ impl<'a, T: Unpackable> Decoder<'a, T> {
     }
 
     pub fn take(&mut self) -> Self {
-        let block_size = std::mem::size_of::<T>() * self.num_bits;
+        let block_size = size_of::<T>() * self.num_bits;
         let packed = std::mem::replace(&mut self.packed, [].chunks(block_size));
         let length = self.length;
         self.length = 0;

--- a/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
@@ -63,7 +63,7 @@ mod tests {
     fn encode<T: NativeType>(data: &[T], buffer: &mut Vec<u8>) {
         let element_size = size_of::<T>();
         let num_elements = data.len();
-        let total_length = std::mem::size_of_val(data);
+        let total_length = size_of_val(data);
         buffer.resize(total_length, 0);
 
         for (i, v) in data.iter().enumerate() {

--- a/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/byte_stream_split/mod.rs
@@ -14,7 +14,7 @@ mod tests {
         let mut buffer = vec![];
         encode(&data, &mut buffer);
 
-        let mut decoder = Decoder::try_new(&buffer, std::mem::size_of::<f32>())?;
+        let mut decoder = Decoder::try_new(&buffer, size_of::<f32>())?;
         let values = decoder
             .iter_converted(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
             .collect::<Vec<_>>();
@@ -30,7 +30,7 @@ mod tests {
         let mut buffer = vec![];
         encode(&data, &mut buffer);
 
-        let mut decoder = Decoder::try_new(&buffer, std::mem::size_of::<f64>())?;
+        let mut decoder = Decoder::try_new(&buffer, size_of::<f64>())?;
         let values = decoder
             .iter_converted(|bytes| f64::from_le_bytes(bytes.try_into().unwrap()))
             .collect::<Vec<_>>();
@@ -61,7 +61,7 @@ mod tests {
     }
 
     fn encode<T: NativeType>(data: &[T], buffer: &mut Vec<u8>) {
-        let element_size = std::mem::size_of::<T>();
+        let element_size = size_of::<T>();
         let num_elements = data.len();
         let total_length = std::mem::size_of_val(data);
         buffer.resize(total_length, 0);

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -133,7 +133,7 @@ impl<'a> HybridRleDecoder<'a> {
             if run_length == 0 {
                 0
             } else {
-                let mut bytes = [0u8; std::mem::size_of::<u32>()];
+                let mut bytes = [0u8; size_of::<u32>()];
                 pack.iter().zip(bytes.iter_mut()).for_each(|(src, dst)| {
                     *dst = *src;
                 });
@@ -380,7 +380,7 @@ impl<'a> HybridRleDecoder<'a> {
                 if run_length <= n {
                     run_length
                 } else {
-                    let mut bytes = [0u8; std::mem::size_of::<u32>()];
+                    let mut bytes = [0u8; size_of::<u32>()];
                     pack.iter().zip(bytes.iter_mut()).for_each(|(src, dst)| {
                         *dst = *src;
                     });

--- a/crates/polars-parquet/src/parquet/statistics/boolean.rs
+++ b/crates/polars-parquet/src/parquet/statistics/boolean.rs
@@ -13,14 +13,14 @@ pub struct BooleanStatistics {
 impl BooleanStatistics {
     pub fn deserialize(v: &ParquetStatistics) -> ParquetResult<Self> {
         if let Some(ref v) = v.max_value {
-            if v.len() != std::mem::size_of::<bool>() {
+            if v.len() != size_of::<bool>() {
                 return Err(ParquetError::oos(
                     "The max_value of statistics MUST be plain encoded",
                 ));
             }
         };
         if let Some(ref v) = v.min_value {
-            if v.len() != std::mem::size_of::<bool>() {
+            if v.len() != size_of::<bool>() {
                 return Err(ParquetError::oos(
                     "The min_value of statistics MUST be plain encoded",
                 ));

--- a/crates/polars-parquet/src/parquet/statistics/primitive.rs
+++ b/crates/polars-parquet/src/parquet/statistics/primitive.rs
@@ -20,7 +20,7 @@ impl<T: types::NativeType> PrimitiveStatistics<T> {
     ) -> ParquetResult<Self> {
         if v.max_value
             .as_ref()
-            .is_some_and(|v| v.len() != std::mem::size_of::<T>())
+            .is_some_and(|v| v.len() != size_of::<T>())
         {
             return Err(ParquetError::oos(
                 "The max_value of statistics MUST be plain encoded",
@@ -28,7 +28,7 @@ impl<T: types::NativeType> PrimitiveStatistics<T> {
         };
         if v.min_value
             .as_ref()
-            .is_some_and(|v| v.len() != std::mem::size_of::<T>())
+            .is_some_and(|v| v.len() != size_of::<T>())
         {
             return Err(ParquetError::oos(
                 "The min_value of statistics MUST be plain encoded",

--- a/crates/polars-parquet/src/parquet/types.rs
+++ b/crates/polars-parquet/src/parquet/types.rs
@@ -22,7 +22,7 @@ pub trait NativeType: std::fmt::Debug + Send + Sync + 'static + Copy + Clone {
 macro_rules! native {
     ($type:ty, $physical_type:expr) => {
         impl NativeType for $type {
-            type Bytes = [u8; std::mem::size_of::<Self>()];
+            type Bytes = [u8; size_of::<Self>()];
             #[inline]
             fn to_le_bytes(&self) -> Self::Bytes {
                 Self::to_le_bytes(*self)
@@ -51,7 +51,7 @@ native!(f64, PhysicalType::Double);
 impl NativeType for [u32; 3] {
     const TYPE: PhysicalType = PhysicalType::Int96;
 
-    type Bytes = [u8; std::mem::size_of::<Self>()];
+    type Bytes = [u8; size_of::<Self>()];
     #[inline]
     fn to_le_bytes(&self) -> Self::Bytes {
         let mut bytes = [0; 12];
@@ -137,7 +137,7 @@ pub fn ord_binary<'a>(a: &'a [u8], b: &'a [u8]) -> std::cmp::Ordering {
 
 #[inline]
 pub fn decode<T: NativeType>(chunk: &[u8]) -> T {
-    assert!(chunk.len() >= std::mem::size_of::<<T as NativeType>::Bytes>());
+    assert!(chunk.len() >= size_of::<<T as NativeType>::Bytes>());
     unsafe { decode_unchecked(chunk) }
 }
 

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -208,7 +208,7 @@ where
                 let agg_fn = match logical_dtype.to_physical() {
                     // Boolean is aggregated as the IDX type.
                     DataType::Boolean => {
-                        if std::mem::size_of::<IdxSize>() == 4 {
+                        if size_of::<IdxSize>() == 4 {
                             AggregateFunction::SumU32(SumAgg::<u32>::new())
                         } else {
                             AggregateFunction::SumU64(SumAgg::<u64>::new())

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -272,6 +272,6 @@ mod test {
     #[ignore]
     #[test]
     fn test_alp_size() {
-        assert!(std::mem::size_of::<IR>() <= 152);
+        assert!(size_of::<IR>() <= 152);
     }
 }

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -115,7 +115,7 @@ pub(crate) fn any_value_into_py_object(av: AnyValue, py: Python) -> PyObject {
             let buf = unsafe {
                 std::slice::from_raw_parts(
                     buf.as_slice().as_ptr() as *const u8,
-                    N * std::mem::size_of::<u128>(),
+                    N * size_of::<u128>(),
                 )
             };
             let digits = PyTuple::new_bound(py, buf.iter().take(n_digits));

--- a/crates/polars-python/src/conversion/chunked_array.rs
+++ b/crates/polars-python/src/conversion/chunked_array.rs
@@ -127,7 +127,7 @@ pub(crate) fn decimal_to_pyobject_iter<'a>(
             let buf = unsafe {
                 std::slice::from_raw_parts(
                     buf.as_slice().as_ptr() as *const u8,
-                    N * std::mem::size_of::<u128>(),
+                    N * size_of::<u128>(),
                 )
             };
             let digits = PyTuple::new_bound(py, buf.iter().take(n_digits));

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -59,8 +59,8 @@ unsafe impl<T: Transparent> Transparent for Option<T> {
 }
 
 pub(crate) fn reinterpret_vec<T: Transparent>(input: Vec<T>) -> Vec<T::Target> {
-    assert_eq!(std::mem::size_of::<T>(), std::mem::size_of::<T::Target>());
-    assert_eq!(std::mem::align_of::<T>(), std::mem::align_of::<T::Target>());
+    assert_eq!(size_of::<T>(), size_of::<T::Target>());
+    assert_eq!(align_of::<T>(), align_of::<T::Target>());
     let len = input.len();
     let cap = input.capacity();
     let mut manual_drop_vec = std::mem::ManuallyDrop::new(input);

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -88,7 +88,7 @@ pub fn register_startup_deps() {
             Box::new(object) as Box<dyn Any>
         });
 
-        let object_size = std::mem::size_of::<ObjectValue>();
+        let object_size = size_of::<ObjectValue>();
         let physical_dtype = ArrowDataType::FixedSizeBinary(object_size);
         registry::register_object_builder(object_builder, object_converter, physical_dtype);
         // register SERIES UDF

--- a/crates/polars-python/src/series/numpy_ufunc.rs
+++ b/crates/polars-python/src/series/numpy_ufunc.rs
@@ -1,4 +1,4 @@
-use std::{mem, ptr};
+use std::ptr;
 
 use ndarray::IntoDimension;
 use numpy::npyffi::types::npy_intp;
@@ -30,7 +30,7 @@ unsafe fn aligned_array<T: Element + NativeType>(
     let buffer_ptr = buf.as_mut_ptr();
 
     let mut dims = [len].into_dimension();
-    let strides = [mem::size_of::<T>() as npy_intp];
+    let strides = [size_of::<T>() as npy_intp];
 
     let ptr = PY_ARRAY_API.PyArray_NewFromDescr(
         py,

--- a/crates/polars-row/src/fixed.rs
+++ b/crates/polars-row/src/fixed.rs
@@ -25,7 +25,7 @@ impl<const N: usize> FromSlice for [u8; N] {
 pub trait FixedLengthEncoding: Copy + Debug {
     // 1 is validity 0 or 1
     // bit repr of encoding
-    const ENCODED_LEN: usize = 1 + std::mem::size_of::<Self::Encoded>();
+    const ENCODED_LEN: usize = 1 + size_of::<Self::Encoded>();
 
     type Encoded: Sized + Copy + AsRef<[u8]> + AsMut<[u8]>;
 

--- a/crates/polars-row/src/row.rs
+++ b/crates/polars-row/src/row.rs
@@ -40,8 +40,8 @@ pub struct RowsEncoded {
 
 fn checks(offsets: &[usize]) {
     assert_eq!(
-        std::mem::size_of::<usize>(),
-        std::mem::size_of::<i64>(),
+        size_of::<usize>(),
+        size_of::<i64>(),
         "only supported on 64bit arch"
     );
     assert!(

--- a/crates/polars-utils/src/arena.rs
+++ b/crates/polars-utils/src/arena.rs
@@ -7,11 +7,11 @@ use crate::error::*;
 use crate::slice::GetSaferUnchecked;
 
 unsafe fn index_of_unchecked<T>(slice: &[T], item: &T) -> usize {
-    (item as *const _ as usize - slice.as_ptr() as usize) / std::mem::size_of::<T>()
+    (item as *const _ as usize - slice.as_ptr() as usize) / size_of::<T>()
 }
 
 fn index_of<T>(slice: &[T], item: &T) -> Option<usize> {
-    debug_assert!(std::mem::size_of::<T>() > 0);
+    debug_assert!(size_of::<T>() > 0);
     let ptr = item as *const T;
     unsafe {
         if slice.as_ptr() < ptr && slice.as_ptr().add(slice.len()) > ptr {

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -46,8 +46,8 @@ impl<T> UnitVec<T> {
     pub fn new() -> Self {
         // This is optimized away, all const.
         assert!(
-            std::mem::size_of::<T>() <= std::mem::size_of::<*mut T>()
-                && std::mem::align_of::<T>() <= std::mem::align_of::<*mut T>()
+            size_of::<T>() <= size_of::<*mut T>()
+                && align_of::<T>() <= align_of::<*mut T>()
         );
         Self {
             len: 0,

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -45,10 +45,7 @@ impl<T> UnitVec<T> {
     #[inline]
     pub fn new() -> Self {
         // This is optimized away, all const.
-        assert!(
-            size_of::<T>() <= size_of::<*mut T>()
-                && align_of::<T>() <= align_of::<*mut T>()
-        );
+        assert!(size_of::<T>() <= size_of::<*mut T>() && align_of::<T>() <= align_of::<*mut T>());
         Self {
             len: 0,
             capacity: NonZeroUsize::new(1).unwrap(),

--- a/crates/polars-utils/src/sort.rs
+++ b/crates/polars-utils/src/sort.rs
@@ -90,8 +90,8 @@ where
     Idx: FromPrimitive + Copy,
 {
     // Needed to be able to write back to back in the same buffer.
-    debug_assert_eq!(std::mem::align_of::<T>(), std::mem::align_of::<(T, Idx)>());
-    let size = std::mem::size_of::<(T, Idx)>();
+    debug_assert_eq!(align_of::<T>(), align_of::<(T, Idx)>());
+    let size = size_of::<(T, Idx)>();
     let upper_bound = size * n + size;
     scratch.reserve(upper_bound);
     let scratch_slice = unsafe {

--- a/crates/polars/tests/it/arrow/compute/aggregate/memory.rs
+++ b/crates/polars/tests/it/arrow/compute/aggregate/memory.rs
@@ -5,7 +5,7 @@ use arrow::datatypes::{ArrowDataType, Field};
 #[test]
 fn primitive() {
     let a = Int32Array::from_slice([1, 2, 3, 4, 5]);
-    assert_eq!(5 * std::mem::size_of::<i32>(), estimated_bytes_size(&a));
+    assert_eq!(5 * size_of::<i32>(), estimated_bytes_size(&a));
 }
 
 #[test]
@@ -17,7 +17,7 @@ fn boolean() {
 #[test]
 fn utf8() {
     let a = Utf8Array::<i32>::from_slice(["aaa"]);
-    assert_eq!(3 + 2 * std::mem::size_of::<i32>(), estimated_bytes_size(&a));
+    assert_eq!(3 + 2 * size_of::<i32>(), estimated_bytes_size(&a));
 }
 
 #[test]
@@ -28,5 +28,5 @@ fn fixed_size_list() {
     );
     let values = Box::new(Float32Array::from_slice([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
     let a = FixedSizeListArray::new(dtype, 2, values, None);
-    assert_eq!(6 * std::mem::size_of::<f32>(), estimated_bytes_size(&a));
+    assert_eq!(6 * size_of::<f32>(), estimated_bytes_size(&a));
 }

--- a/crates/polars/tests/it/io/parquet/read/dictionary/primitive.rs
+++ b/crates/polars/tests/it/io/parquet/read/dictionary/primitive.rs
@@ -30,7 +30,7 @@ pub fn read<T: NativeType>(
     num_values: usize,
     _is_sorted: bool,
 ) -> ParquetResult<PrimitivePageDict<T>> {
-    let size_of = std::mem::size_of::<T>();
+    let size_of = size_of::<T>();
 
     let typed_size = num_values.wrapping_mul(size_of);
 

--- a/crates/polars/tests/it/io/parquet/read/primitive_nested.rs
+++ b/crates/polars/tests/it/io/parquet/read/primitive_nested.rs
@@ -10,7 +10,7 @@ use super::dictionary::PrimitivePageDict;
 use super::{hybrid_rle_iter, Array};
 
 fn read_buffer<T: NativeType>(values: &[u8]) -> impl Iterator<Item = T> + '_ {
-    let chunks = values.chunks_exact(std::mem::size_of::<T>());
+    let chunks = values.chunks_exact(size_of::<T>());
     chunks.map(|chunk| {
         // unwrap is infalible due to the chunk size.
         let chunk: T::Bytes = match chunk.try_into() {

--- a/crates/polars/tests/it/io/parquet/read/utils.rs
+++ b/crates/polars/tests/it/io/parquet/read/utils.rs
@@ -197,12 +197,12 @@ pub fn native_cast<T: NativeType>(page: &DataPage) -> ParquetResult<Casted<T>> {
         def: _,
         values,
     } = split_buffer(page)?;
-    if values.len() % std::mem::size_of::<T>() != 0 {
+    if values.len() % size_of::<T>() != 0 {
         panic!("A primitive page data's len must be a multiple of the type");
     }
 
     Ok(values
-        .chunks_exact(std::mem::size_of::<T>())
+        .chunks_exact(size_of::<T>())
         .map(decode::<T>))
 }
 

--- a/crates/polars/tests/it/io/parquet/read/utils.rs
+++ b/crates/polars/tests/it/io/parquet/read/utils.rs
@@ -201,9 +201,7 @@ pub fn native_cast<T: NativeType>(page: &DataPage) -> ParquetResult<Casted<T>> {
         panic!("A primitive page data's len must be a multiple of the type");
     }
 
-    Ok(values
-        .chunks_exact(size_of::<T>())
-        .map(decode::<T>))
+    Ok(values.chunks_exact(size_of::<T>()).map(decode::<T>))
 }
 
 /// The deserialization state of a `DataPage` of `Primitive` parquet primitive type


### PR DESCRIPTION
This has apparently been possible since Rust 1.80.