### PR TITLE
fix: Use of `HAVING` outside of `GROUP BY` should raise a suitable SQLSyntaxError

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -709,6 +709,11 @@ impl SQLContext {
         };
 
         lf = if group_by_keys.is_empty() {
+            // The 'having' clause is only valid inside 'group by'
+            if select_stmt.having.is_some() {
+                polars_bail!(SQLSyntax: "HAVING clause not valid outside of GROUP BY; found:\n{:?}", select_stmt.having);
+            };
+
             // Final/selected cols, accounting for 'SELECT *' modifiers
             let mut retained_cols = Vec::with_capacity(projections.len());
             let have_order_by = query.order_by.is_some();

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -238,3 +238,9 @@ def test_group_by_errors() -> None:
         match=r"'a' should participate in the GROUP BY clause or an aggregate function",
     ):
         df.sql("SELECT a, SUM(b) FROM self GROUP BY b")
+
+    with pytest.raises(
+        SQLSyntaxError,
+        match=r"HAVING clause not valid outside of GROUP BY",
+    ):
+        df.sql("SELECT a, COUNT(a) AS n FROM self HAVING n > 1")


### PR DESCRIPTION
Ref #19310.

While some (but not all) SQL dialects allow a bare HAVING (eg: outside of GROUP BY context) it is usually clearer to implement such constraints using a WHERE. However, currently we are silently ignoring such HAVING clauses :\

We should raise a syntax error here for now (can consider allowing such clauses in the future, though use of HAVING outside of GROUP BY is pretty niche - it requires _implicitly_ treating all rows as a single group, _and_ the presence of aggregate functions in the SELECT, but in the meantime can easily be written with a follow-on WHERE clause, without any ambiguity).

## Example
```python
import polars as pl

df = pl.DataFrame({
    "key": ["aaa", "aaa", "bbb", "bbb", "bbb"],
    "value": [100, 25, -200, 50, 135],
})
```
Bare HAVING clause now raises a SQLSyntaxError:
```python
df.sql("""
  SELECT
    key,
    SUM(value) AS total, 
    COUNT(key) AS n_keys
  FROM self
  HAVING n_keys > 2
""")

# SQLSyntaxError: HAVING clause not valid outside of GROUP BY
```
In this case the caller can add the missing GROUP BY to fix the query:
```python
df.sql("""
  SELECT 
    key,
    SUM(value) AS total, 
    COUNT(key) AS n_keys
  FROM self
  GROUP BY key
  HAVING n_keys > 2
""")

# shape: (1, 3)
# ┌─────┬───────┬────────┐
# │ key ┆ total ┆ n_keys │
# │ --- ┆ ---   ┆ ---    │
# │ str ┆ i64   ┆ u32    │
# ╞═════╪═══════╪════════╡
# │ bbb ┆ -15   ┆ 3      │
# └─────┴───────┴────────┘
```