### PR TITLE
fix(python): More accurate `from_dicts` typing/signature

### DIFF
--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -98,7 +98,7 @@ def from_dict(
 
 
 def from_dicts(
-    data: Sequence[dict[str, Any]],
+    data: Iterable[dict[str, Any]],
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,


### PR DESCRIPTION
Closes #19234.

We actually accept an `Iterable` for the "data" param, not just a `Sequence`.