### PR TITLE
docs: Add missing deprecation notice to `str.concat`

### DIFF
--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -243,7 +243,7 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         Err(polars_err!(
             op = "`sum`",
             DataType::String,
-            hint = "you may mean to call `str.concat` or `list.join`"
+            hint = "you may mean to call `str.join` or `list.join`"
         ))
     }
     fn max_reduce(&self) -> PolarsResult<Scalar> {

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2724,6 +2724,11 @@ class ExprStringNameSpace:
         """
         return wrap_expr(self._pyexpr.str_join(delimiter, ignore_nulls=ignore_nulls))
 
+    @deprecate_function(
+        "Use `str.join` instead. Note that the default `delimiter` for `str.join`"
+        " is an empty string instead of a hyphen.",
+        version="1.0.0",
+    )
     def concat(
         self, delimiter: str | None = None, *, ignore_nulls: bool = True
     ) -> Expr:


### PR DESCRIPTION
https://github.com/pola-rs/polars/issues/19144

Would it make sense to take out the deprecation notice further down as part of this? I guess it wouldn't change for `str.concat` now if it's been deprecated?

https://github.com/pola-rs/polars/blob/133bf47a6083dd72b991d0c72dacb30ebd3195f2/py-polars/polars/expr/string.py#L2776-L2780