### PR TITLE
fix: Don't produce duplicate column names in Series.to_dummies

### DIFF
--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -46,7 +46,8 @@ impl ToDummies for Series {
             })
             .collect::<Vec<_>>();
 
-        Ok(unsafe { DataFrame::new_no_checks_height_from_first(sort_columns(columns)) })
+        // SAFETY: `dummies_helper` functions preserve `self.len()` length
+        unsafe { DataFrame::new_no_length_checks(sort_columns(columns)) }
     }
 }
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -23,6 +23,7 @@ from polars.datatypes import (
     Unknown,
 )
 from polars.exceptions import (
+    DuplicateError,
     InvalidOperationError,
     PolarsInefficientMapWarning,
     ShapeError,
@@ -1354,6 +1355,13 @@ def test_to_dummies_drop_first() -> None:
         schema={"a_2": pl.UInt8, "a_3": pl.UInt8},
     )
     assert_frame_equal(result, expected)
+
+
+def test_to_dummies_null_clash_19096() -> None:
+    with pytest.raises(
+        DuplicateError, match="column with name '_null' has more than one occurrence"
+    ):
+        pl.Series([None, "null"]).to_dummies()
 
 
 def test_chunk_lengths() -> None:


### PR DESCRIPTION
closes #19096