### PR TITLE
feat(python): AssumeRole support for AWS Credential Provider

### DIFF
--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -26,30 +26,54 @@ def _infer_cloud_type(
     if (path := _first_scan_path(source)) is None:
         return None
 
-    splitted = str(path).split("://", maxsplit=1)
+    scheme = _get_path_scheme(path)
 
     # Fast path - local file
-    if not splitted:
+    if not scheme:
         return None
-
-    scheme = splitted[0]
 
     if scheme == "file":
         return "file"
 
-    if any(scheme == x for x in ["s3", "s3a"]):
+    if _is_aws_cloud(scheme):
         return "aws"
 
-    if any(scheme == x for x in ["az", "azure", "adl", "abfs", "abfss"]):
+    if _is_azure_cloud(scheme):
         return "azure"
 
-    if any(scheme == x for x in ["gs", "gcp", "gcs"]):
+    if _is_gcp_cloud(scheme):
         return "gcp"
 
-    if any(scheme == x for x in ["http", "https"]):
+    if _is_http_cloud(scheme):
         return "http"
 
-    if scheme == "hf":
+    if _is_hf_cloud(scheme):
         return "hf"
 
     return None
+
+
+def _get_path_scheme(path: str | Path) -> str | None:
+    splitted = str(path).split("://", maxsplit=1)
+
+    return None if not splitted else splitted[0]
+
+
+def _is_aws_cloud(scheme: str) -> bool:
+    return any(scheme == x for x in ["s3", "s3a"])
+
+
+def _is_azure_cloud(scheme: str) -> bool:
+    return any(scheme == x for x in ["az", "azure", "adl", "abfs", "abfss"])
+
+
+def _is_gcp_cloud(scheme: str) -> bool:
+    return any(scheme == x for x in ["gs", "gcp", "gcs"])
+
+
+def _is_http_cloud(scheme: str) -> bool:
+    return any(scheme == x for x in ["http", "https"])
+
+
+def _is_hf_cloud(scheme: str) -> bool:
+    return scheme == "hf"

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -20,39 +20,6 @@ def _first_scan_path(
     return None
 
 
-def _infer_cloud_type(
-    source: ScanSource,
-) -> Literal["aws", "azure", "gcp", "file", "http", "hf"] | None:
-    if (path := _first_scan_path(source)) is None:
-        return None
-
-    scheme = _get_path_scheme(path)
-
-    # Fast path - local file
-    if not scheme:
-        return None
-
-    if scheme == "file":
-        return "file"
-
-    if _is_aws_cloud(scheme):
-        return "aws"
-
-    if _is_azure_cloud(scheme):
-        return "azure"
-
-    if _is_gcp_cloud(scheme):
-        return "gcp"
-
-    if _is_http_cloud(scheme):
-        return "http"
-
-    if _is_hf_cloud(scheme):
-        return "hf"
-
-    return None
-
-
 def _get_path_scheme(path: str | Path) -> str | None:
     splitted = str(path).split("://", maxsplit=1)
 
@@ -63,17 +30,5 @@ def _is_aws_cloud(scheme: str) -> bool:
     return any(scheme == x for x in ["s3", "s3a"])
 
 
-def _is_azure_cloud(scheme: str) -> bool:
-    return any(scheme == x for x in ["az", "azure", "adl", "abfs", "abfss"])
-
-
 def _is_gcp_cloud(scheme: str) -> bool:
     return any(scheme == x for x in ["gs", "gcp", "gcs"])
-
-
-def _is_http_cloud(scheme: str) -> bool:
-    return any(scheme == x for x in ["http", "https"])
-
-
-def _is_hf_cloud(scheme: str) -> bool:
-    return scheme == "hf"

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from polars._utils.various import is_path_or_str_sequence
 

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -118,11 +118,6 @@ class CredentialProviderAWS(CredentialProvider):
         }, None
 
     def _finish_assume_role(self, session: Any) -> CredentialProviderFunctionReturn:
-        if TYPE_CHECKING:
-            import boto3
-
-            session: boto3.Session
-
         client = session.client("sts")
 
         sts_response = client.assume_role(**self.assume_role)

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -125,6 +125,10 @@ class CredentialProviderAWS(CredentialProvider):
 
         expiry = creds["Expiration"]
 
+        if expiry.tzinfo is None:
+            msg = "expiration time in STS response did not contain timezone information"
+            raise ValueError(msg)
+
         return {
             "aws_access_key_id": creds["AccessKeyId"],
             "aws_secret_access_key": creds["SecretAccessKey"],

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -85,7 +85,7 @@ class CredentialProviderAWS(CredentialProvider):
         ----------
         profile_name : str
             Profile name to use from credentials file.
-        assume_role : dict[AWSAssumeRoleKWArgs, Any] | None
+        assume_role : AWSAssumeRoleKWArgs | None
             Configure a role to assume. These are passed as kwarg parameters to
             [STS.client.assume_role()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role.html#STS.Client.assume_role)
         """

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -5,7 +5,7 @@ import importlib.util
 import os
 import sys
 import zoneinfo
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypedDict, Union
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 10):
@@ -28,6 +28,23 @@ CredentialProviderFunctionReturn: TypeAlias = tuple[
 CredentialProviderFunction: TypeAlias = Union[
     Callable[[], CredentialProviderFunctionReturn], "CredentialProvider"
 ]
+
+
+class AWSAssumeRoleKWArgs(TypedDict):
+    """Parameters for [STS.Client.assume_role()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role.html#STS.Client.assume_role)."""
+
+    RoleArn: str
+    RoleSessionName: str
+    PolicyArns: list[dict[str, str]]
+    Policy: str
+    DurationSeconds: int
+    Tags: list[dict[str, str]]
+    TransitiveTagKeys: list[str]
+    ExternalId: str
+    SerialNumber: str
+    TokenCode: str
+    SourceIdentity: str
+    ProvidedContexts: list[dict[str, str]]
 
 
 class CredentialProvider(abc.ABC):
@@ -55,7 +72,12 @@ class CredentialProviderAWS(CredentialProvider):
             at any point without it being considered a breaking change.
     """
 
-    def __init__(self, *, profile_name: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        profile_name: str | None = None,
+        assume_role: AWSAssumeRoleKWArgs | None = None,
+    ) -> None:
         """
         Initialize a credential provider for AWS.
 
@@ -63,18 +85,26 @@ class CredentialProviderAWS(CredentialProvider):
         ----------
         profile_name : str
             Profile name to use from credentials file.
+        assume_role : dict[AWSAssumeRoleKWArgs, Any] | None
+            Configure a role to assume. These are passed as kwarg parameters to
+            [STS.client.assume_role()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role.html#STS.Client.assume_role)
         """
         msg = "`CredentialProviderAWS` functionality is considered unstable"
         issue_unstable_warning(msg)
 
         self._check_module_availability()
         self.profile_name = profile_name
+        self.assume_role = assume_role
 
     def __call__(self) -> CredentialProviderFunctionReturn:
         """Fetch the credentials for the configured profile name."""
         import boto3
 
         session = boto3.Session(profile_name=self.profile_name)
+
+        if self.assume_role is not None:
+            return self._finish_assume_role(session)
+
         creds = session.get_credentials()
 
         if creds is None:
@@ -86,6 +116,25 @@ class CredentialProviderAWS(CredentialProvider):
             "aws_secret_access_key": creds.secret_key,
             "aws_session_token": creds.token,
         }, None
+
+    def _finish_assume_role(self, session: Any) -> CredentialProviderFunctionReturn:
+        if TYPE_CHECKING:
+            import boto3
+
+            session: boto3.Session
+
+        client = session.client("sts")
+
+        sts_response = client.assume_role(**self.assume_role)
+        creds = sts_response["Credentials"]
+
+        expiry = creds["Expiration"]
+
+        return {
+            "aws_access_key_id": creds["AccessKeyId"],
+            "aws_secret_access_key": creds["SecretAccessKey"],
+            "aws_session_token": creds["SessionToken"],
+        }, int(expiry.timestamp())
 
     @classmethod
     def _check_module_availability(cls) -> None:
@@ -134,9 +183,10 @@ class CredentialProviderGCP(CredentialProvider):
 
         return {"bearer_token": self.creds.token}, (
             int(
-                expiry.replace(
-                    # Google auth does not set this properly
-                    tzinfo=zoneinfo.ZoneInfo("UTC")
+                (
+                    expiry.replace(tzinfo=zoneinfo.ZoneInfo("UTC"))
+                    if expiry.tzinfo is None
+                    else expiry
                 ).timestamp()
             )
             if (expiry := self.creds.expiry) is not None
@@ -153,21 +203,29 @@ class CredentialProviderGCP(CredentialProvider):
 def _auto_select_credential_provider(
     source: ScanSource,
 ) -> CredentialProvider | None:
-    from polars.io.cloud._utils import _infer_cloud_type
+    from polars.io.cloud._utils import (
+        _first_scan_path,
+        _get_path_scheme,
+        _is_aws_cloud,
+        _is_gcp_cloud,
+    )
 
     verbose = os.getenv("POLARS_VERBOSE") == "1"
-    cloud_type = _infer_cloud_type(source)
+
+    if (path := _first_scan_path(source)) is None:
+        return None
+
+    if (scheme := _get_path_scheme(path)) is None:
+        return None
 
     provider = None
 
     try:
         provider = (
-            None
-            if cloud_type is None
-            else CredentialProviderAWS()
-            if cloud_type == "aws"
+            CredentialProviderAWS()
+            if _is_aws_cloud(scheme)
             else CredentialProviderGCP()
-            if cloud_type == "gcp"
+            if _is_gcp_cloud(scheme)
             else None
         )
     except ImportError as e:


### PR DESCRIPTION
Adds support for using an assumed role to `CredentialProviderAWS`

```python
pl.scan_parquet(
    "s3://.../...",
    credential_provider=pl.CredentialProviderAWS(
        assume_role={
            "RoleArn": "arn:aws:iam::0000000:role/ExampleRole",
            "RoleSessionName": "example",
        }
    ),
)
```

ref https://github.com/pola-rs/polars/issues/18979
ref https://github.com/pola-rs/polars/issues/15838