### PR TITLE
refactor(rust): Reduce memcopy in parquet

### DIFF
--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -191,7 +191,7 @@ impl<'a> CoreReader<'a> {
             if let Some(b) =
                 decompress(&reader_bytes, total_n_rows, separator, quote_char, eol_char)
             {
-                reader_bytes = ReaderBytes::Owned(b);
+                reader_bytes = ReaderBytes::Owned(b.into());
             }
         }
 

--- a/crates/polars-io/src/csv/read/schema_inference.rs
+++ b/crates/polars-io/src/csv/read/schema_inference.rs
@@ -296,7 +296,7 @@ fn infer_file_schema_inner(
         buf.push(eol_char);
 
         return infer_file_schema_inner(
-            &ReaderBytes::Owned(buf),
+            &ReaderBytes::Owned(buf.into()),
             separator,
             max_read_rows,
             has_header,
@@ -481,7 +481,7 @@ fn infer_file_schema_inner(
         rb.extend_from_slice(reader_bytes);
         rb.push(eol_char);
         return infer_file_schema_inner(
-            &ReaderBytes::Owned(rb),
+            &ReaderBytes::Owned(rb.into()),
             separator,
             max_read_rows,
             has_header,

--- a/crates/polars-io/src/mmap.rs
+++ b/crates/polars-io/src/mmap.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::io::{BufReader, Cursor, Read, Seek};
-use std::sync::Arc;
 
 use polars_core::config::verbose;
 use polars_utils::mmap::{MMapSemaphore, MemSlice};
@@ -87,6 +86,11 @@ impl std::ops::Deref for ReaderBytes<'_> {
 /// `MemSlice` from the `ReaderBytes` in a zero-copy manner regardless of the underlying enum
 /// variant.
 impl ReaderBytes<'static> {
+    /// Construct a `MemSlice` in a zero-copy manner from the underlying bytes, with the assumption
+    /// that the underlying bytes have a `'static` lifetime. This is marked as unsafe despite having
+    /// a `'static` inner lifetime, as the `Owned(Vec<u8>)` variant is not covered by the lifetime
+    /// guarantee.
+    ///
     ///  # Safety
     /// `Self` outlives the returned `MemSlice` if this enum variant is an `Owned(Vec<u8>)`.
     pub unsafe fn to_static_slice(&self) -> MemSlice {

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -959,9 +959,9 @@ impl FetchRowGroupsFromMmapReader {
 
     fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
         // @TODO: we can something smarter here with mmap
-        Ok(mmap::ColumnStore::Local(MemSlice::from_vec(
-            self.0.deref().to_vec(),
-        )))
+        Ok(mmap::ColumnStore::Local(MemSlice::from_static(unsafe {
+            std::mem::transmute(self.0.deref())
+        })))
     }
 }
 

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -959,9 +959,7 @@ impl FetchRowGroupsFromMmapReader {
 
     fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
         // @TODO: we can something smarter here with mmap
-        Ok(mmap::ColumnStore::Local(MemSlice::from_static(unsafe {
-            std::mem::transmute(self.0.deref())
-        })))
+        Ok(mmap::ColumnStore::Local(self.0.to_static_slice()))
     }
 }
 

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -957,7 +957,7 @@ impl FetchRowGroupsFromMmapReader {
 
     fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
         // @TODO: we can something smarter here with mmap
-        Ok(mmap::ColumnStore::Local(unsafe { self.0.to_memslice() }))
+        Ok(mmap::ColumnStore::Local(self.0.to_memslice()))
     }
 }
 

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -908,7 +908,7 @@ pub fn read_parquet<R: MmapBytesReader>(
 
     let reader = ReaderBytes::from(&mut reader);
     let store = mmap::ColumnStore::Local(unsafe {
-        std::mem::transmute::<ReaderBytes<'_>, ReaderBytes<'static>>(reader).to_static_slice()
+        std::mem::transmute::<ReaderBytes<'_>, ReaderBytes<'static>>(reader).to_memslice()
     });
 
     let dfs = rg_to_dfs(
@@ -957,9 +957,7 @@ impl FetchRowGroupsFromMmapReader {
 
     fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
         // @TODO: we can something smarter here with mmap
-        Ok(mmap::ColumnStore::Local(unsafe {
-            self.0.to_static_slice()
-        }))
+        Ok(mmap::ColumnStore::Local(unsafe { self.0.to_memslice() }))
     }
 }
 

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -908,10 +908,9 @@ pub fn read_parquet<R: MmapBytesReader>(
     }
 
     let reader = ReaderBytes::from(&mut reader);
-    let store = mmap::ColumnStore::Local(
-        unsafe { std::mem::transmute::<ReaderBytes<'_>, ReaderBytes<'static>>(reader) }
-            .into_mem_slice(),
-    );
+    let store = mmap::ColumnStore::Local(unsafe {
+        std::mem::transmute::<ReaderBytes<'_>, ReaderBytes<'static>>(reader).to_static_slice()
+    });
 
     let dfs = rg_to_dfs(
         &store,
@@ -959,7 +958,9 @@ impl FetchRowGroupsFromMmapReader {
 
     fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
         // @TODO: we can something smarter here with mmap
-        Ok(mmap::ColumnStore::Local(self.0.to_static_slice()))
+        Ok(mmap::ColumnStore::Local(unsafe {
+            self.0.to_static_slice()
+        }))
     }
 }
 

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -15,7 +15,6 @@ use polars_parquet::parquet::statistics::Statistics;
 use polars_parquet::read::{
     self, ColumnChunkMetadata, FileMetadata, Filter, PhysicalType, RowGroupMetadata,
 };
-use polars_utils::mmap::MemSlice;
 use rayon::prelude::*;
 
 #[cfg(feature = "cloud")]

--- a/crates/polars-io/src/utils/other.rs
+++ b/crates/polars-io/src/utils/other.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 use polars_core::prelude::*;
 #[cfg(any(feature = "ipc_streaming", feature = "parquet"))]
 use polars_core::utils::{accumulate_dataframes_vertical_unchecked, split_df_as_ref};
-use polars_utils::mmap::MMapSemaphore;
+use polars_utils::mmap::{MMapSemaphore, MemSlice};
 use regex::{Regex, RegexBuilder};
 
 use crate::mmap::{MmapBytesReader, ReaderBytes};
@@ -23,14 +23,8 @@ pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
     {
         let mut options = memmap::MmapOptions::new();
         options.offset(offset);
-
-        // somehow bck thinks borrows alias
-        // this is sound as file was already bound to 'a
-        use std::fs::File;
-
-        let file = unsafe { std::mem::transmute::<&File, &'a File>(file) };
         let mmap = MMapSemaphore::new_from_file_with_options(file, options)?;
-        Ok(ReaderBytes::Mapped(mmap, file))
+        Ok(ReaderBytes::Owned(MemSlice::from_mmap(Arc::new(mmap))))
     } else {
         // we can get the bytes for free
         if reader.to_bytes().is_some() {
@@ -40,7 +34,7 @@ pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
             // we have to read to an owned buffer to get the bytes.
             let mut bytes = Vec::with_capacity(1024 * 128);
             reader.read_to_end(&mut bytes)?;
-            Ok(ReaderBytes::Owned(bytes))
+            Ok(ReaderBytes::Owned(bytes.into()))
         }
     }
 }

--- a/crates/polars-io/src/utils/other.rs
+++ b/crates/polars-io/src/utils/other.rs
@@ -12,7 +12,7 @@ use regex::{Regex, RegexBuilder};
 use crate::mmap::{MmapBytesReader, ReaderBytes};
 
 pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
-    reader: &'a mut R,
+    reader: &mut R,
 ) -> PolarsResult<ReaderBytes<'a>> {
     // we have a file so we can mmap
     // only seekable files are mmap-able

--- a/crates/polars-io/src/utils/other.rs
+++ b/crates/polars-io/src/utils/other.rs
@@ -12,7 +12,7 @@ use regex::{Regex, RegexBuilder};
 use crate::mmap::{MmapBytesReader, ReaderBytes};
 
 pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
-    reader: &mut R,
+    reader: &'a mut R,
 ) -> PolarsResult<ReaderBytes<'a>> {
     // we have a file so we can mmap
     // only seekable files are mmap-able

--- a/crates/polars-io/src/utils/other.rs
+++ b/crates/polars-io/src/utils/other.rs
@@ -11,9 +11,9 @@ use regex::{Regex, RegexBuilder};
 
 use crate::mmap::{MmapBytesReader, ReaderBytes};
 
-pub fn get_reader_bytes<'a, R: Read + MmapBytesReader + ?Sized>(
-    reader: &'a mut R,
-) -> PolarsResult<ReaderBytes<'a>> {
+pub fn get_reader_bytes<R: Read + MmapBytesReader + ?Sized>(
+    reader: &mut R,
+) -> PolarsResult<ReaderBytes<'_>> {
     // we have a file so we can mmap
     // only seekable files are mmap-able
     if let Some((file, offset)) = reader

--- a/crates/polars-utils/src/mmap.rs
+++ b/crates/polars-utils/src/mmap.rs
@@ -61,6 +61,12 @@ mod private {
         }
     }
 
+    impl From<Vec<u8>> for MemSlice {
+        fn from(value: Vec<u8>) -> Self {
+            Self::from_vec(value)
+        }
+    }
+
     impl MemSlice {
         pub const EMPTY: Self = Self::from_static(&[]);
 


### PR DESCRIPTION
It should be sound since it matches what we did a long time ago https://github.com/pola-rs/polars/blob/04714b933c72cb5f754069bb31f1af7750c0ab6a/crates/polars-io/src/parquet/read/read_impl.rs#L496