### PR TITLE
docs: Fix docstrings for ATAN2 and ATAN2D SQL functions

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -237,7 +237,7 @@ pub(crate) enum PolarsSQLFunctions {
     /// ```
     Atan,
     /// SQL 'atan2' function
-    /// Compute the inverse tangent of column_2/column_1 (in radians).
+    /// Compute the inverse tangent of column_1/column_2 (in radians).
     /// ```sql
     /// SELECT ATAN2(column_1, column_2) FROM df;
     /// ```
@@ -261,7 +261,7 @@ pub(crate) enum PolarsSQLFunctions {
     /// ```
     AtanD,
     /// SQL 'atan2d' function
-    /// Compute the inverse tangent of column_2/column_1 (in degrees).
+    /// Compute the inverse tangent of column_1/column_2 (in degrees).
     /// ```sql
     /// SELECT ATAN2D(column_1) FROM df;
     /// ```

--- a/py-polars/docs/source/reference/sql/functions/trigonometry.rst
+++ b/py-polars/docs/source/reference/sql/functions/trigonometry.rst
@@ -18,9 +18,9 @@ Trigonometry
    * - :ref:`ATAND <atand>`
      - Compute inverse tangent of the input column (in degrees).
    * - :ref:`ATAN2 <atan2>`
-     - Compute the inverse tangent of column_2/column_1 (in radians).
+     - Compute the inverse tangent of column_1/column_2 (in radians).
    * - :ref:`ATAN2D <atan2d>`
-     - Compute the inverse tangent of column_2/column_1 (in degrees).
+     - Compute the inverse tangent of column_1/column_2 (in degrees).
    * - :ref:`COT <cot>`
      - Compute the cotangent of the input column (in radians).
    * - :ref:`COTD <cotd>`
@@ -187,7 +187,7 @@ Compute inverse tangent of the input column (in degrees).
 
 ATAN2
 -----
-Compute the inverse tangent of column_2/column_1 (in radians).
+Compute the inverse tangent of column_1/column_2 (in radians).
 
 **Example:**
 
@@ -216,7 +216,7 @@ Compute the inverse tangent of column_2/column_1 (in radians).
 
 ATAN2D
 ------
-Compute the inverse tangent of column_2/column_1 (in degrees).
+Compute the inverse tangent of column_1/column_2 (in degrees).
 
 **Example:**
 
@@ -224,22 +224,22 @@ Compute the inverse tangent of column_2/column_1 (in degrees).
 
     df = pl.DataFrame(
         {
-            "a": [0, 90, 180, 360],
-            "b": [360, 270, 180, 90],
+            "a": [-1.0, 0.0, 1.0, 1.0],
+            "b": [1.0, 1.0, 0.0, -1.0],
         }
     )
     df.sql("SELECT a, b, ATAN2D(a, b) AS atan2d_ab FROM self")
     # shape: (4, 3)
-    # ┌─────┬─────┬───────────┐
-    # │ a   ┆ b   ┆ atan2d_ab │
-    # │ --- ┆ --- ┆ ---       │
-    # │ i64 ┆ i64 ┆ f64       │
-    # ╞═════╪═════╪═══════════╡
-    # │ 0   ┆ 360 ┆ 0.0       │
-    # │ 90  ┆ 270 ┆ 18.434949 │
-    # │ 180 ┆ 180 ┆ 45.0      │
-    # │ 360 ┆ 90  ┆ 75.963757 │
-    # └─────┴─────┴───────────┘
+    # ┌──────┬──────┬───────────┐
+    # │ a    ┆ b    ┆ atan2d_ab │
+    # │ ---  ┆ ---  ┆ ---       │
+    # │ f64  ┆ f64  ┆ f64       │
+    # ╞══════╪══════╪═══════════╡
+    # │ -1   ┆  1.0 ┆   135.0   │
+    # │ 0.0  ┆  1.0 ┆    90.0   │
+    # │ 1.0  ┆  0.0 ┆     0.0   │
+    # │ 1.0  ┆ -1.0 ┆   -45.0   │
+    # └──────┴──────┴───────────┘
 
 .. _cot:
 


### PR DESCRIPTION
The docs for `ATAN2` and `ATAN2D` (SQL functions) were incorrect because they claimed to be dividing `arg2/arg1` where it is actually the other way around. 

Alternatively, one could swap the arguments in the implementation, but I like the implementation and it follows `numpy`. 

Also, I changed the example in the docstring so that it uses lengths of 0, 1, or 2, and not the ambiguous "lengths" of 90, 360 etc. 