### PR TITLE
refactor(rust): Add capability to transmute to SharedStorage

### DIFF
--- a/crates/polars-arrow/src/storage.rs
+++ b/crates/polars-arrow/src/storage.rs
@@ -85,6 +85,7 @@ unsafe impl<T: Sync + Send> Sync for SharedStorage<T> {}
 
 impl<T> SharedStorage<T> {
     pub fn from_static(slice: &'static [T]) -> Self {
+        #[expect(clippy::manual_slice_size_calculation)]
         let length_in_bytes = slice.len() * size_of::<T>();
         let ptr = slice.as_ptr().cast_mut();
         let inner = SharedStorageInner {

--- a/crates/polars-arrow/src/storage.rs
+++ b/crates/polars-arrow/src/storage.rs
@@ -214,19 +214,19 @@ impl<T> SharedStorage<T> {
 impl<T: Pod> SharedStorage<T> {
     fn try_transmute<U: Pod>(self) -> Result<SharedStorage<U>, Self> {
         let inner = self.inner();
-        
+
         // The length of the array in bytes must be a multiple of the target size.
         // We can skip this check if the size of U divides the size of T.
         if size_of::<T>() % size_of::<U>() != 0 && inner.length_in_bytes % size_of::<U>() != 0 {
             return Err(self);
         }
-        
+
         // The pointer must be properly aligned for U.
         // We can skip this check if the alignment of U divides the alignment of T.
         if align_of::<T>() % align_of::<U>() != 0 && !inner.ptr.cast::<U>().is_aligned() {
             return Err(self);
         }
-        
+
         Ok(SharedStorage {
             inner: self.inner.cast(),
             phantom: PhantomData,


### PR DESCRIPTION
This will come in handy in the future, this lets us safely transmute between `SharedStorage`s.