### PR TITLE
docs: Tiny correction post dask-expr

### DIFF
--- a/docs/source/user-guide/migration/pandas.md
+++ b/docs/source/user-guide/migration/pandas.md
@@ -50,8 +50,7 @@ eager evaluation. The lazy evaluation mode is powerful because Polars carries ou
 automatic query optimization when it examines the query plan and looks for ways to
 accelerate the query or reduce memory usage.
 
-`Dask` also supports lazy evaluation when it generates a query plan. However, `Dask`
-does not carry out query optimization on the query plan.
+`Dask` also supports lazy evaluation when it generates a query plan.
 
 ## Key syntax differences
 


### PR DESCRIPTION
Hi 👋 I've been getting into polars recently and it's absolutely mind blowing- thanks for building/maintaining such an awesome tool!

As I was reading through the documentation I came across a bit saying something like "dask also performs lazy evaluation but does not optimise queries" which was probably true when this was written. Dask since something like April this year has a ('dask-expr')[https://github.com/dask/dask-expr] library as it's backend which does optimise queries, so I thought I'd be a helpful and put in a tiny PR to update/remove that bit.