### PR TITLE
fix: Capture groups should be ignored in replace_all when literal=True

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+
 use arrow::legacy::utils::CustomIterTools;
 #[cfg(feature = "timezones")]
 use once_cell::sync::Lazy;
@@ -8,7 +9,7 @@ use polars_core::utils::handle_casting_failures;
 #[cfg(feature = "dtype-struct")]
 use polars_utils::format_pl_smallstr;
 #[cfg(feature = "regex")]
-use regex::{escape, Regex, NoExpand};
+use regex::{escape, NoExpand, Regex};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -900,9 +901,9 @@ fn replace_all<'a>(
                 // According to the docs for replace_all
                 // when literal = True then capture groups are ignored.
                 if literal {
-                    return reg.replace_all(s, NoExpand(val))
+                    reg.replace_all(s, NoExpand(val))
                 } else {
-                    return reg.replace_all(s, val)
+                    reg.replace_all(s, val)
                 }
             };
 

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1005,19 +1005,34 @@ def test_replace_all() -> None:
         == "(.)(\\?)(\\?)"
     )
 
+
 def test_replace_literal_no_caputures() -> None:
     # When using literal = True, capture groups should be disabled
 
     # Single row code path in Rust
-    df = pl.DataFrame({'text': ["I found <amt> yesterday."], 'amt': ["$1"]})
-    df = df.with_columns(pl.col("text").str.replace_all(f"<amt>", pl.col('amt'), literal=True).alias("text2"))
-    assert(df.get_column("text2")[0] == "I found $1 yesterday.")
+    df = pl.DataFrame({"text": ["I found <amt> yesterday."], "amt": ["$1"]})
+    df = df.with_columns(
+        pl.col("text")
+        .str.replace_all("<amt>", pl.col("amt"), literal=True)
+        .alias("text2")
+    )
+    assert df.get_column("text2")[0] == "I found $1 yesterday."
 
     # Multi-row code path in Rust
-    df2 = pl.DataFrame({'text': ["I found <amt> yesterday.", "I lost <amt> yesterday."], 'amt': ["$1", "$2"]})
-    df2 = df2.with_columns(pl.col("text").str.replace_all(f"<amt>", pl.col('amt'), literal=True).alias("text2"))
-    assert (df2.get_column("text2")[0] == "I found $1 yesterday.")
-    assert (df2.get_column("text2")[1] == "I lost $2 yesterday.")
+    df2 = pl.DataFrame(
+        {
+            "text": ["I found <amt> yesterday.", "I lost <amt> yesterday."],
+            "amt": ["$1", "$2"],
+        }
+    )
+    df2 = df2.with_columns(
+        pl.col("text")
+        .str.replace_all("<amt>", pl.col("amt"), literal=True)
+        .alias("text2")
+    )
+    assert df2.get_column("text2")[0] == "I found $1 yesterday."
+    assert df2.get_column("text2")[1] == "I lost $2 yesterday."
+
 
 def test_replace_expressions() -> None:
     df = pl.DataFrame({"foo": ["123 bla 45 asd", "xyz 678 910t"], "value": ["A", "B"]})

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1005,6 +1005,19 @@ def test_replace_all() -> None:
         == "(.)(\\?)(\\?)"
     )
 
+def test_replace_literal_no_caputures() -> None:
+    # When using literal = True, capture groups should be disabled
+
+    # Single row code path in Rust
+    df = pl.DataFrame({'text': ["I found <amt> yesterday."], 'amt': ["$1"]})
+    df = df.with_columns(pl.col("text").str.replace_all(f"<amt>", pl.col('amt'), literal=True).alias("text2"))
+    assert(df.get_column("text2")[0] == "I found $1 yesterday.")
+
+    # Multi-row code path in Rust
+    df2 = pl.DataFrame({'text': ["I found <amt> yesterday.", "I lost <amt> yesterday."], 'amt': ["$1", "$2"]})
+    df2 = df2.with_columns(pl.col("text").str.replace_all(f"<amt>", pl.col('amt'), literal=True).alias("text2"))
+    assert (df2.get_column("text2")[0] == "I found $1 yesterday.")
+    assert (df2.get_column("text2")[1] == "I lost $2 yesterday.")
 
 def test_replace_expressions() -> None:
     df = pl.DataFrame({"foo": ["123 bla 45 asd", "xyz 678 910t"], "value": ["A", "B"]})


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/18238.
From the docs, (https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.str.replace_all.html#polars-expr-str-replace-all), when literal=True, then capture groups should be ignored. As the docs say:
```
The dollar sign ($) is a special character related to capture groups. To refer to a literal dollar sign, use $$ instead or set literal to True.
```

Fix the Rust logic which did not apply this logic for multi-row replacement.