### PR TITLE
refactor(rust): Add tracking of async task wait time statistics

### DIFF
--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -1,4 +1,6 @@
 #![allow(unused)] // TODO: remove me
+use std::cmp::Reverse;
+
 use polars_core::prelude::*;
 use polars_core::POOL;
 use polars_expr::planner::{create_physical_expr, get_expr_depth_limit, ExpressionConversionState};
@@ -35,6 +37,16 @@ pub fn run_query(
     }
     let (mut graph, phys_to_graph) =
         crate::physical_plan::physical_plan_to_graph(root, &phys_sm, expr_arena)?;
+    crate::async_executor::clear_task_wait_statistics();
     let mut results = crate::execute::execute_graph(&mut graph)?;
+    if std::env::var("POLARS_TRACK_WAIT_STATS").as_deref() == Ok("1") {
+        let mut stats = crate::async_executor::get_task_wait_statistics();
+        stats.sort_by_key(|(_l, w)| Reverse(*w));
+        eprintln!("Time spent waiting for async tasks:");
+        for (loc, wait_time) in stats {
+            eprintln!("{}:{} - {:?}", loc.file(), loc.line(), wait_time);
+        }
+    }
+
     Ok(results.remove(phys_to_graph[root]).unwrap())
 }


### PR DESCRIPTION
A profiler is useless in an async engine if something is a blocking bottleneck - all threads will just show spending a lot of time in condvar waiting inside the executor loop.

With this PR if you set `POLARS_TRACK_WAIT_STATS=1` we track the time between right before we park a thread, and when that thread finds a new task, and adds the time spent blocked to that tasks metadata. After a new streaming query we print these stats, which can look like this:

```
Time spent waiting for async tasks:
crates/polars-stream/src/nodes/parquet_source/mod.rs:230 - 971.347764ms
crates/polars-stream/src/nodes/parquet_source/init.rs:179 - 493.140887ms
crates/polars-stream/src/nodes/in_memory_source.rs:75 - 16.806251ms
crates/polars-stream/src/nodes/in_memory_sink.rs:58 - 4.832292ms
crates/polars-stream/src/nodes/parquet_source/metadata_fetch.rs:123 - 0ns
crates/polars-stream/src/nodes/group_by.rs:47 - 0ns
crates/polars-stream/src/nodes/parquet_source/mod.rs:259 - 0ns
```

In this case you know that waiting for the parquet source was the bottleneck for the execution engine.