### PR TITLE
feat(python): Support querying specific snapshot by id in scan_iceberg

### DIFF
--- a/py-polars/polars/io/iceberg.py
+++ b/py-polars/polars/io/iceberg.py
@@ -42,6 +42,7 @@ _temporal_conversions: dict[str, Callable[..., datetime | date]] = {
 def scan_iceberg(
     source: str | Table,
     *,
+    snapshot_id: int | None = None,
     storage_options: dict[str, Any] | None = None,
 ) -> LazyFrame:
     """
@@ -54,6 +55,8 @@ def scan_iceberg(
 
         Note: For Local filesystem, absolute and relative paths are supported but
         for the supported object storages - GCS, Azure and S3 full URI must be provided.
+    snapshot_id
+        The snapshot ID to scan from.
     storage_options
         Extra options for the storage backends supported by `pyiceberg`.
         For cloud storages, this may include configurations for authentication etc.
@@ -126,6 +129,12 @@ def scan_iceberg(
     >>> pl.scan_iceberg(
     ...     table_path, storage_options=storage_options
     ... ).collect()  # doctest: +SKIP
+
+    Creates a scan for an Iceberg table using a specific snapshot ID.
+
+    >>> table_path = "/path/to/iceberg-table/metadata.json"
+    >>> snapshot_id = 7051579356916758811
+    >>> pl.scan_iceberg(table_path, snapshot_id=snapshot_id).collect()  # doctest: +SKIP
     """
     from pyiceberg.io.pyarrow import schema_to_pyarrow
     from pyiceberg.table import StaticTable
@@ -135,7 +144,13 @@ def scan_iceberg(
             metadata_location=source, properties=storage_options or {}
         )
 
-    func = partial(_scan_pyarrow_dataset_impl, source)
+    if snapshot_id is not None:
+        snapshot = source.snapshot_by_id(snapshot_id)
+        if snapshot is None:
+            msg = f"Snapshot ID not found: {snapshot_id}"
+            raise ValueError(msg)
+
+    func = partial(_scan_pyarrow_dataset_impl, source, snapshot_id=snapshot_id)
     arrow_schema = schema_to_pyarrow(source.schema())
     return pl.LazyFrame._scan_python_function(arrow_schema, func, pyarrow=True)
 
@@ -145,6 +160,7 @@ def _scan_pyarrow_dataset_impl(
     with_columns: list[str] | None = None,
     predicate: str = "",
     n_rows: int | None = None,
+    snapshot_id: int | None = None,
     **kwargs: Any,
 ) -> DataFrame | Series:
     """
@@ -160,6 +176,8 @@ def _scan_pyarrow_dataset_impl(
         pyarrow expression that can be evaluated with eval
     n_rows:
         Materialize only n rows from the arrow dataset.
+    snapshot_id:
+        The snapshot ID to scan from.
     batch_size
         The maximum row count for scanned pyarrow record batches.
     kwargs:
@@ -171,7 +189,7 @@ def _scan_pyarrow_dataset_impl(
     """
     from polars import from_arrow
 
-    scan = tbl.scan(limit=n_rows)
+    scan = tbl.scan(limit=n_rows, snapshot_id=snapshot_id)
 
     if with_columns is not None:
         scan = scan.select(*with_columns)

--- a/py-polars/tests/unit/io/test_iceberg.py
+++ b/py-polars/tests/unit/io/test_iceberg.py
@@ -44,6 +44,19 @@ class TestIcebergScanIO:
             "ts": pl.Datetime(time_unit="us", time_zone=None),
         }
 
+    def test_scan_iceberg_snapshot_id(self, iceberg_path: str) -> None:
+        df = pl.scan_iceberg(iceberg_path, snapshot_id=7051579356916758811)
+        assert len(df.collect()) == 3
+        assert df.collect_schema() == {
+            "id": pl.Int32,
+            "str": pl.String,
+            "ts": pl.Datetime(time_unit="us", time_zone=None),
+        }
+
+    def test_scan_iceberg_snapshot_id_not_found(self, iceberg_path: str) -> None:
+        with pytest.raises(ValueError, match="Snapshot ID not found"):
+            pl.scan_iceberg(iceberg_path, snapshot_id=1234567890)
+
     def test_scan_iceberg_filter_on_partition(self, iceberg_path: str) -> None:
         ts1 = datetime(2023, 3, 1, 18, 15)
         ts2 = datetime(2023, 3, 1, 19, 25)


### PR DESCRIPTION
This PR adds support for querying historical table snapshots when using `scan_iceberg` by adding an optional "snapshot_id" argument that is propagated to the underlying pyiceberg DataScan.