### PR TITLE
fix: Fix `include_file_paths` and `with_row_index` for streaming CSV scan

### DIFF
--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -216,18 +216,11 @@ impl Source for CsvSource {
                 };
 
                 for data_chunk in &mut out {
-                    // The batched reader creates the column containing all nulls because the schema it
-                    // gets passed contains the column.
-                    //
+                    let n = data_chunk.data.height();
                     // SAFETY: Columns are only replaced with columns
                     // 1. of the same name, and
                     // 2. of the same length.
-                    for s in unsafe { data_chunk.data.get_columns_mut() } {
-                        if s.name() == ca.name() {
-                            *s = ca.slice(0, s.len()).into_column();
-                            break;
-                        }
-                    }
+                    unsafe { data_chunk.data.get_columns_mut() }.push(ca.slice(0, n).into_column())
                 }
             }
 

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -109,7 +109,7 @@ where
                 FileScan::Csv { options, .. } => {
                     let src = sources::CsvSource::new(
                         sources,
-                        file_info.schema,
+                        file_info.reader_schema.clone().unwrap().unwrap_right(),
                         options,
                         file_options,
                         verbose,

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/hstack.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/hstack.rs
@@ -63,7 +63,7 @@ pub(super) fn process_hstack(
         acc_projections,
         &lp_arena.get(input).schema(lp_arena),
         expr_arena,
-        false,
+        true, // expands_schema
     );
 
     proj_pd.pushdown_and_assign(

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -809,3 +809,29 @@ def test_scan_include_file_paths_respects_projection_pushdown() -> None:
     )
 
     assert_frame_equal(q.collect(), pl.DataFrame({"a": "a1", "b": "b1"}))
+
+
+def test_streaming_scan_csv_include_file_paths_18257(io_files_path: Path) -> None:
+    lf = pl.scan_csv(
+        io_files_path / "foods1.csv",
+        include_file_paths="path",
+    ).select("category", "path")
+
+    assert lf.collect(streaming=True).columns == ["category", "path"]
+
+
+def test_streaming_scan_csv_with_row_index_19172(io_files_path: Path) -> None:
+    lf = (
+        pl.scan_csv(io_files_path / "foods1.csv", infer_schema=False)
+        .with_row_index()
+        .select("calories", "index")
+        .head(1)
+    )
+
+    assert_frame_equal(
+        lf.collect(streaming=True),
+        pl.DataFrame(
+            {"calories": "45", "index": 0},
+            schema={"calories": pl.String, "index": pl.UInt32},
+        ),
+    )


### PR DESCRIPTION
Was a challenging puzzle as it turned out to be a combination of different bugs in different places from where I thought the issue was.

Fixes https://github.com/pola-rs/polars/issues/19172 : Wrong columns shifting during scan with row index
* Caused by accidentally passing full schema instead of `reader_schema`

Fixes https://github.com/pola-rs/polars/issues/19397 : include_file_paths for streaming CSV causes PanicException: index out of bounds: the len is 5 but the index is 5
* Caused by accidentally passing full schema instead of `reader_schema`

Fixes https://github.com/pola-rs/polars/issues/19395 : `with_columns` may not push down projections if schema length remains unchanged

