### PR TITLE
feat: Add `.list.json_encode()`

### DIFF
--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -406,4 +406,11 @@ impl ListNameSpace {
         let other = other.into();
         self.set_operation(other, SetOperation::SymmetricDifference)
     }
+
+    /// TODO(moritz)
+    #[cfg(feature = "json")]
+    pub fn to_json(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ListExpr(ListFunction::JsonEncode))
+    }
 }

--- a/crates/polars-python/src/expr/list.rs
+++ b/crates/polars-python/src/expr/list.rs
@@ -256,4 +256,9 @@ impl PyExpr {
         }
         .into()
     }
+
+    #[cfg(feature = "json")]
+    fn list_to_json(&self) -> Self {
+        self.inner.clone().list().to_json().into()
+    }
 }

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1359,3 +1359,7 @@ class ExprListNameSpace:
         """  # noqa: W505.
         other = parse_into_expression(other, str_as_lit=False)
         return wrap_expr(self._pyexpr.list_set_operation(other, "symmetric_difference"))
+
+    def to_json(self) -> Expr:
+        """TODO(moritz)."""
+        return wrap_expr(self._pyexpr.list_to_json())

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -900,3 +900,20 @@ def test_list_concat_struct_19279() -> None:
             [{"s": "d", "i": 3}],
         ]
     }
+    assert df.select(
+        pl.col("a").list.eval(pl.element().cast(pl.String)).alias("a_str")
+    ).schema == {"a_str": pl.List(pl.String)}
+
+
+def test_list_to_json() -> None:
+    df = pl.DataFrame(
+        {
+            "intcol": [[1, -10, 999]],
+            "floatcol": [[1.234, 0.0, -0.123]],
+            "strcol": [["a", "b", "c"]],
+            "boolcol": [[True, False, True]],
+        }
+    )
+
+    breakpoint()
+    df.select(pl.col("boolcol").list.to_json()).item(0, 0)


### PR DESCRIPTION
fixes #14029

adds `json_encode()` to the `.list.` namespace to serialize lists to JSON strings.

There are previous discussion about adding this to the root name space but I can't tell how much more work that would be and I'm not rustacean. 

**ToDo**
- [ ] rename to `json_encode` for consistency
- [ ] docs
- [ ] `Series.list` namespace?
- [ ] test w/ complex types (objects, structs, nested lists)
- [ ] test round trip encode decode
- [ ] consolidate with #18396