### PR TITLE
fix: Updates error message in csv parser to recommend schema_overrides instead of deprecated dtypes argument

### DIFF
--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -835,7 +835,7 @@ pub(super) fn parse_lines(
                                         \n\
                                         You might want to try:\n\
                                         - increasing `infer_schema_length` (e.g. `infer_schema_length=10000`),\n\
-                                        - specifying correct dtype with the `dtypes` argument\n\
+                                        - specifying correct dtype with the `schema_overrides` argument\n\
                                         - setting `ignore_errors` to `True`,\n\
                                         - adding `{}` to the `null_values` list.\n\n\
                                         Original error: ```{}```",


### PR DESCRIPTION
Very small PR. I found it a little annoying that the error message recommends using an argument that has been deprecated and gives a warning, instead of recommending the updated argument. So I decided to try and fix it :smile: 