### PR TITLE
feat(python): Add Series `.str.escape_regex()` 

### DIFF
--- a/py-polars/docs/source/reference/series/string.rst
+++ b/py-polars/docs/source/reference/series/string.rst
@@ -16,6 +16,7 @@ The following methods are available under the `Series.str` attribute.
     Series.str.decode
     Series.str.encode
     Series.str.ends_with
+    Series.str.escape_regex
     Series.str.explode
     Series.str.extract
     Series.str.extract_all

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -2077,3 +2077,25 @@ class StringNameSpace:
             null
         ]
         """
+
+    def escape_regex(self) -> Series:
+        r"""
+        Returns string values with all regular expression meta characters escaped.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`String`.
+
+        Examples
+        --------
+        >>> pl.Series(["abc", "def", None, "abc(\\w+)"]).str.escape_regex())
+        shape: (4,)
+        Series: '' [str]
+        [
+            "abc"
+            "def"
+            null
+            "abc\(\\w\+\)"
+        ]
+        """

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1806,3 +1806,4 @@ def test_escape_regex() -> None:
     )
 
     assert_frame_equal(result_df, expected_df)
+    assert_series_equal(result_df["escaped"], expected_df["escaped"])


### PR DESCRIPTION
Just noticed the new `Expr.str.escape_regex()` did not yet have an entry In the Series dispatch code.