### PR TITLE
feat(python): Add `credential_provider` argument to more read functions

### DIFF
--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -41,7 +41,7 @@ impl PyLazyFrame {
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
         source, sources, infer_schema_length, schema, schema_overrides, batch_size, n_rows, low_memory, rechunk,
-        row_index, ignore_errors, include_file_paths, cloud_options, retries, file_cache_ttl
+        row_index, ignore_errors, include_file_paths, cloud_options, credential_provider, retries, file_cache_ttl
     ))]
     fn new_from_ndjson(
         source: Option<PyObject>,
@@ -57,9 +57,11 @@ impl PyLazyFrame {
         ignore_errors: bool,
         include_file_paths: Option<String>,
         cloud_options: Option<Vec<(String, String)>>,
+        credential_provider: Option<PyObject>,
         retries: usize,
         file_cache_ttl: Option<u64>,
     ) -> PyResult<Self> {
+        use cloud::credential_provider::PlCredentialProvider;
         let row_index = row_index.map(|(name, offset)| RowIndex {
             name: name.into(),
             offset,
@@ -79,7 +81,11 @@ impl PyLazyFrame {
 
             let mut cloud_options =
                 parse_cloud_options(&first_path_url, cloud_options.unwrap_or_default())?;
-            cloud_options = cloud_options.with_max_retries(retries);
+            cloud_options = cloud_options
+                .with_max_retries(retries)
+                .with_credential_provider(
+                    credential_provider.map(PlCredentialProvider::from_python_func_object),
+                );
 
             if let Some(file_cache_ttl) = file_cache_ttl {
                 cloud_options.file_cache_ttl = file_cache_ttl;
@@ -111,7 +117,7 @@ impl PyLazyFrame {
         low_memory, comment_prefix, quote_char, null_values, missing_utf8_is_empty_string,
         infer_schema_length, with_schema_modify, rechunk, skip_rows_after_header,
         encoding, row_index, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines, decimal_comma, glob, schema,
-        cloud_options, retries, file_cache_ttl, include_file_paths
+        cloud_options, credential_provider, retries, file_cache_ttl, include_file_paths
     )
     )]
     fn new_from_csv(
@@ -143,10 +149,13 @@ impl PyLazyFrame {
         glob: bool,
         schema: Option<Wrap<Schema>>,
         cloud_options: Option<Vec<(String, String)>>,
+        credential_provider: Option<PyObject>,
         retries: usize,
         file_cache_ttl: Option<u64>,
         include_file_paths: Option<String>,
     ) -> PyResult<Self> {
+        use cloud::credential_provider::PlCredentialProvider;
+
         let null_values = null_values.map(|w| w.0);
         let quote_char = quote_char
             .map(|s| {
@@ -198,7 +207,11 @@ impl PyLazyFrame {
             if let Some(file_cache_ttl) = file_cache_ttl {
                 cloud_options.file_cache_ttl = file_cache_ttl;
             }
-            cloud_options = cloud_options.with_max_retries(retries);
+            cloud_options = cloud_options
+                .with_max_retries(retries)
+                .with_credential_provider(
+                    credential_provider.map(PlCredentialProvider::from_python_func_object),
+                );
             r = r.with_cloud_options(Some(cloud_options));
         }
 

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -298,5 +298,12 @@ MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, Boole
 EngineType: TypeAlias = Union[Literal["cpu", "gpu"], "GPUEngine"]
 
 ScanSource: TypeAlias = Union[
-    str, Path, IO[bytes], bytes, list[str], list[Path], list[IO[bytes]], list[bytes]
+    str,
+    Path,
+    IO[bytes],
+    bytes,
+    list[str],
+    list[Path],
+    list[IO[bytes]],
+    list[bytes],
 ]

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import IO
 
 from polars._utils.various import is_path_or_str_sequence
 
-if TYPE_CHECKING:
-    from polars._typing import ScanSource
-
 
 def _first_scan_path(
-    source: ScanSource,
+    source: str
+    | Path
+    | IO[str]
+    | IO[bytes]
+    | bytes
+    | list[str]
+    | list[Path]
+    | list[IO[str]]
+    | list[IO[bytes]]
+    | list[bytes],
 ) -> str | Path | None:
     if isinstance(source, (str, Path)):
         return source

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 import polars._reexport as pl
 import polars.functions as F
@@ -23,6 +23,9 @@ from polars.io._utils import (
     prepare_file_arg,
 )
 
+from polars.io.cloud.credential_provider import _maybe_init_credential_provider
+
+
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame, PyLazyFrame
     from polars.polars import read_ipc_schema as _read_ipc_schema
@@ -32,6 +35,7 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, DataType, LazyFrame
     from polars._typing import SchemaDict
+    from polars.io.cloud import CredentialProviderFunction
 
 
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
@@ -362,6 +366,7 @@ def scan_ipc(
     row_index_name: str | None = None,
     row_index_offset: int = 0,
     storage_options: dict[str, Any] | None = None,
+    credential_provider: CredentialProviderFunction | Literal["auto"] | None = None,
     memory_map: bool = True,
     retries: int = 2,
     file_cache_ttl: int | None = None,
@@ -407,6 +412,15 @@ def scan_ipc(
 
         If `storage_options` is not provided, Polars will try to infer the information
         from environment variables.
+    credential_provider
+        Provide a function that can be called to provide cloud storage
+        credentials. The function is expected to return a dictionary of
+        credential keys along with an optional credential expiry time.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+
     memory_map
         Try to memory map the file. This can greatly improve performance on repeated
         queries as the OS may cache pages.
@@ -451,6 +465,16 @@ def scan_ipc(
     # Memory Mapping is now a no-op
     _ = memory_map
 
+    credential_provider = _maybe_init_credential_provider(
+        credential_provider, source, storage_options, "scan_parquet"
+    )
+
+    if storage_options:
+        storage_options = list(storage_options.items())  # type: ignore[assignment]
+    else:
+        # Handle empty dict input
+        storage_options = None
+
     pylf = PyLazyFrame.new_from_ipc(
         source,
         sources,
@@ -459,6 +483,7 @@ def scan_ipc(
         rechunk,
         parse_row_index_args(row_index_name, row_index_offset),
         cloud_options=storage_options,
+        credential_provider=credential_provider,
         retries=retries,
         file_cache_ttl=file_cache_ttl,
         hive_partitioning=hive_partitioning,

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -22,9 +22,7 @@ from polars.io._utils import (
     parse_row_index_args,
     prepare_file_arg,
 )
-
 from polars.io.cloud.credential_provider import _maybe_init_credential_provider
-
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame, PyLazyFrame

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -4,13 +4,14 @@ import contextlib
 from collections.abc import Sequence
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import is_path_or_str_sequence, normalize_filepath
 from polars._utils.wrap import wrap_df, wrap_ldf
 from polars.datatypes import N_INFER_DEFAULT
 from polars.io._utils import parse_row_index_args
+from polars.io.cloud.credential_provider import _maybe_init_credential_provider
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame, PyLazyFrame
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, LazyFrame
     from polars._typing import SchemaDefinition
+    from polars.io.cloud import CredentialProviderFunction
 
 
 def read_ndjson(
@@ -36,6 +38,7 @@ def read_ndjson(
     row_index_offset: int = 0,
     ignore_errors: bool = False,
     storage_options: dict[str, Any] | None = None,
+    credential_provider: CredentialProviderFunction | Literal["auto"] | None = None,
     retries: int = 2,
     file_cache_ttl: int | None = None,
     include_file_paths: str | None = None,
@@ -96,6 +99,14 @@ def read_ndjson(
 
         If `storage_options` is not provided, Polars will try to infer the information
         from environment variables.
+    credential_provider
+        Provide a function that can be called to provide cloud storage
+        credentials. The function is expected to return a dictionary of
+        credential keys along with an optional credential expiry time.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
     retries
         Number of retries if accessing a cloud instance fails.
     file_cache_ttl
@@ -147,6 +158,10 @@ def read_ndjson(
 
         return df
 
+    credential_provider = _maybe_init_credential_provider(
+        credential_provider, source, storage_options, "read_ndjson"
+    )
+
     return scan_ndjson(
         source,
         schema=schema,
@@ -162,6 +177,7 @@ def read_ndjson(
         include_file_paths=include_file_paths,
         retries=retries,
         storage_options=storage_options,
+        credential_provider=credential_provider,
         file_cache_ttl=file_cache_ttl,
     ).collect()
 
@@ -190,6 +206,7 @@ def scan_ndjson(
     row_index_offset: int = 0,
     ignore_errors: bool = False,
     storage_options: dict[str, Any] | None = None,
+    credential_provider: CredentialProviderFunction | Literal["auto"] | None = None,
     retries: int = 2,
     file_cache_ttl: int | None = None,
     include_file_paths: str | None = None,
@@ -249,6 +266,14 @@ def scan_ndjson(
 
         If `storage_options` is not provided, Polars will try to infer the information
         from environment variables.
+    credential_provider
+        Provide a function that can be called to provide cloud storage
+        credentials. The function is expected to return a dictionary of
+        credential keys along with an optional credential expiry time.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
     retries
         Number of retries if accessing a cloud instance fails.
     file_cache_ttl
@@ -276,6 +301,10 @@ def scan_ndjson(
         msg = "'infer_schema_length' should be positive"
         raise ValueError(msg)
 
+    credential_provider = _maybe_init_credential_provider(
+        credential_provider, source, storage_options, "scan_ndjson"
+    )
+
     if storage_options:
         storage_options = list(storage_options.items())  # type: ignore[assignment]
     else:
@@ -297,6 +326,7 @@ def scan_ndjson(
         include_file_paths=include_file_paths,
         retries=retries,
         cloud_options=storage_options,
+        credential_provider=credential_provider,
         file_cache_ttl=file_cache_ttl,
     )
     return wrap_ldf(pylf)

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -21,7 +21,7 @@ from polars.io._utils import (
     parse_row_index_args,
     prepare_file_arg,
 )
-from polars.io.cloud.credential_provider import _auto_select_credential_provider
+from polars.io.cloud.credential_provider import _maybe_init_credential_provider
 
 with contextlib.suppress(ImportError):
     from polars.polars import PyLazyFrame
@@ -54,6 +54,7 @@ def read_parquet(
     rechunk: bool = False,
     low_memory: bool = False,
     storage_options: dict[str, Any] | None = None,
+    credential_provider: CredentialProviderFunction | Literal["auto"] | None = None,
     retries: int = 2,
     use_pyarrow: bool = False,
     pyarrow_options: dict[str, Any] | None = None,
@@ -136,6 +137,14 @@ def read_parquet(
 
         If `storage_options` is not provided, Polars will try to infer the information
         from environment variables.
+    credential_provider
+        Provide a function that can be called to provide cloud storage
+        credentials. The function is expected to return a dictionary of
+        credential keys along with an optional credential expiry time.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
     retries
         Number of retries if accessing a cloud instance fails.
     use_pyarrow
@@ -216,6 +225,7 @@ def read_parquet(
         low_memory=low_memory,
         cache=False,
         storage_options=storage_options,
+        credential_provider=credential_provider,
         retries=retries,
         glob=glob,
         include_file_paths=include_file_paths,
@@ -473,16 +483,9 @@ def scan_parquet(
             normalize_filepath(source, check_not_directory=False) for source in source
         ]
 
-    if credential_provider is not None:
-        msg = "The `credential_provider` parameter of `scan_parquet` is considered unstable."
-        issue_unstable_warning(msg)
-
-        if credential_provider == "auto":
-            credential_provider = (
-                _auto_select_credential_provider(source)
-                if storage_options is None
-                else None
-            )
+    credential_provider = _maybe_init_credential_provider(
+        credential_provider, source, storage_options, "scan_parquet"
+    )
 
     return _scan_parquet_impl(
         source,  # type: ignore[arg-type]

--- a/py-polars/tests/unit/io/cloud/test_cloud.py
+++ b/py-polars/tests/unit/io/cloud/test_cloud.py
@@ -35,6 +35,7 @@ def test_scan_nonexistent_cloud_path_17444(format: str) -> None:
         *[pl.scan_parquet, pl.read_parquet],
         pl.scan_csv,
         *[pl.scan_ndjson, pl.read_ndjson],
+        pl.scan_ipc,
     ],
 )
 def test_scan_credential_provider(

--- a/py-polars/tests/unit/io/cloud/test_cloud.py
+++ b/py-polars/tests/unit/io/cloud/test_cloud.py
@@ -51,6 +51,8 @@ def test_scan_credential_provider(
     with pytest.raises(AssertionError, match=err_magic):
         io_func("s3://bucket/path", credential_provider="auto")
 
+    # We can't test these with the `read_` functions as they end up executing
+    # the query
     if io_func.__name__.startswith("scan_"):
         # Passing `None` should disable the automatic instantiation of
         # `CredentialProviderAWS`

--- a/py-polars/tests/unit/io/cloud/test_cloud.py
+++ b/py-polars/tests/unit/io/cloud/test_cloud.py
@@ -1,5 +1,6 @@
 import io
 import sys
+from typing import Any
 
 import pytest
 
@@ -28,7 +29,17 @@ def test_scan_nonexistent_cloud_path_17444(format: str) -> None:
         result.collect()
 
 
-def test_scan_credential_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    "io_func",
+    [
+        *[pl.scan_parquet, pl.read_parquet],
+        pl.scan_csv,
+        *[pl.scan_ndjson, pl.read_ndjson],
+    ],
+)
+def test_scan_credential_provider(
+    io_func: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     err_magic = "err_magic_3"
 
     def raises(*_: None, **__: None) -> None:
@@ -37,14 +48,15 @@ def test_scan_credential_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pl.CredentialProviderAWS, "__init__", raises)
 
     with pytest.raises(AssertionError, match=err_magic):
-        pl.scan_parquet("s3://bucket/path", credential_provider="auto")
+        io_func("s3://bucket/path", credential_provider="auto")
 
-    # Passing `None` should disable the automatic instantiation of
-    # `CredentialProviderAWS`
-    pl.scan_parquet("s3://bucket/path", credential_provider=None)
-    # Passing `storage_options` should disable the automatic instantiation of
-    # `CredentialProviderAWS`
-    pl.scan_parquet("s3://bucket/path", credential_provider="auto", storage_options={})
+    if io_func.__name__.startswith("scan_"):
+        # Passing `None` should disable the automatic instantiation of
+        # `CredentialProviderAWS`
+        io_func("s3://bucket/path", credential_provider=None)
+        # Passing `storage_options` should disable the automatic instantiation of
+        # `CredentialProviderAWS`
+        io_func("s3://bucket/path", credential_provider="auto", storage_options={})
 
     err_magic = "err_magic_7"
 
@@ -54,7 +66,7 @@ def test_scan_credential_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     # Note to reader: It is converted to a ComputeError as it is being called
     # from Rust.
     with pytest.raises(ComputeError, match=err_magic):
-        pl.scan_parquet("s3://bucket/path", credential_provider=raises_2).collect()
+        io_func("s3://bucket/path", credential_provider=raises_2).collect()
 
 
 def test_scan_credential_provider_serialization() -> None:


### PR DESCRIPTION
* read_parquet
* scan_csv
* scan_ndjson
* read_ndjson
* scan_ipc

Was not added to `read_csv` and `read_ipc` as they use fsspec