### PR TITLE
feat: Improve `read_database` typing

### DIFF
--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -25,10 +25,12 @@ if TYPE_CHECKING:
     except ImportError:
         Selectable: TypeAlias = Any  # type: ignore[no-redef]
 
+    from sqlalchemy.sql.elements import TextClause
+
 
 @overload
 def read_database(
-    query: str | Selectable,
+    query: str | TextClause | Selectable,
     connection: ConnectionOrCursor | str,
     *,
     iter_batches: Literal[False] = ...,
@@ -41,7 +43,7 @@ def read_database(
 
 @overload
 def read_database(
-    query: str | Selectable,
+    query: str | TextClause | Selectable,
     connection: ConnectionOrCursor | str,
     *,
     iter_batches: Literal[True],
@@ -54,7 +56,7 @@ def read_database(
 
 @overload
 def read_database(
-    query: str | Selectable,
+    query: str | TextClause | Selectable,
     connection: ConnectionOrCursor | str,
     *,
     iter_batches: bool,
@@ -66,7 +68,7 @@ def read_database(
 
 
 def read_database(
-    query: str | Selectable,
+    query: str | TextClause | Selectable,
     connection: ConnectionOrCursor | str,
     *,
     iter_batches: bool = False,

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 import pyarrow as pa
 import pytest
 import sqlalchemy
-from sqlalchemy import Integer, MetaData, Table, create_engine, func, select
+from sqlalchemy import Integer, MetaData, Table, create_engine, func, select, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import cast as alchemy_cast
 
@@ -374,6 +374,39 @@ def test_read_database_alchemy_selectable(tmp_sqlite_db: Path) -> None:
     batches = list(
         pl.read_database(
             selectable_query,
+            connection=conn,
+            iter_batches=True,
+            batch_size=1,
+        )
+    )
+    assert len(batches) == 1
+    assert_frame_equal(batches[0], expected)
+
+
+def test_read_database_alchemy_textclause(tmp_sqlite_db: Path) -> None:
+    # various flavours of alchemy connection
+    alchemy_engine = create_engine(f"sqlite:///{tmp_sqlite_db}")
+    alchemy_session: ConnectionOrCursor = sessionmaker(bind=alchemy_engine)()
+    alchemy_conn: ConnectionOrCursor = alchemy_engine.connect()
+
+    # establish sqlalchemy "textclause" and validate usage
+    textclause_query = text("""
+        SELECT CAST(STRFTIME('%Y',"date") AS INT) as "year", name, value
+        FROM test_data
+        WHERE value < 0
+    """)
+
+    expected = pl.DataFrame({"year": [2021], "name": ["other"], "value": [-99.5]})
+
+    for conn in (alchemy_session, alchemy_engine, alchemy_conn):
+        assert_frame_equal(
+            pl.read_database(textclause_query, connection=conn),
+            expected,
+        )
+
+    batches = list(
+        pl.read_database(
+            textclause_query,
             connection=conn,
             iter_batches=True,
             batch_size=1,


### PR DESCRIPTION
## Purpose

This pull request aims to improve type hints in the codebase.

- The `query` parameter in `read_database` currently [accepts only `str` and `Selectable` types](https://github.com/pola-rs/polars/blob/425e251fa3fed25f1956fb5486ed1e41f51ce170/py-polars/polars/io/database/functions.py#L31), but `execute` [can handle `str | TextClause | Selectable`](https://github.com/pola-rs/polars/blob/425e251fa3fed25f1956fb5486ed1e41f51ce170/py-polars/polars/io/database/_executor.py#L476).
- In practice, `read_database` can execute successfully with a `TextClause` argument.
- However, mypy flags this as an error, causing issues during type-checking as in https://github.com/pola-rs/polars/actions/runs/11515095096/job/32055062473?pr=19444

## Changes Made

- Added a test case that uses SQLAlchemy's `text` to validate that `read_database` executes properly with a `TextClause`: https://github.com/pola-rs/polars/commit/4e87f0145027edd737f242ddb77649ee80d2a2f8
- Updated the type hint for the `query` parameter in `read_database` to include `TextClause`: https://github.com/pola-rs/polars/pull/19444/commits/edd7e1d220403e0de432968e1d7db5aac10b6bfc