### PR TITLE
feat(python): Respect `include_index` for pandas series

### DIFF
--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -4,7 +4,7 @@ import io
 import itertools
 import re
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import polars._reexport as pl
 from polars import functions as F
@@ -487,13 +487,24 @@ def from_pandas(
 
 @overload
 def from_pandas(
-    data: pd.Series[Any] | pd.Index[Any],
+    data: pd.Series[Any] | pd.Index[Any] | pd.DatetimeIndex,
     *,
     schema_overrides: SchemaDict | None = ...,
     rechunk: bool = ...,
     nan_to_null: bool = ...,
-    include_index: bool = ...,
+    include_index: Literal[False] = ...,
 ) -> Series: ...
+
+
+@overload
+def from_pandas(
+    data: pd.Series[Any],
+    *,
+    schema_overrides: SchemaDict | None = ...,
+    rechunk: bool = ...,
+    nan_to_null: bool = ...,
+    include_index: Literal[True] = ...,
+) -> DataFrame: ...
 
 
 def from_pandas(
@@ -525,8 +536,8 @@ def from_pandas(
         Load any non-default pandas indexes as columns.
 
         .. note::
-            If the input is a pandas ``Series`` or ``DataFrame`` and has a nameless
-            index which just enumerates the rows, then it will not be included in the
+            If the input is a pandas ``DataFrame`` and has a nameless index
+            which just enumerates the rows, then it will not be included in the
             result, regardless of this parameter. If you want to be sure to include it,
             please call ``.reset_index()`` prior to calling this function.
 
@@ -566,6 +577,9 @@ def from_pandas(
         3
     ]
     """
+    if include_index and isinstance(data, pd.Series):
+        data = data.reset_index()
+
     if isinstance(data, (pd.Series, pd.Index, pd.DatetimeIndex)):
         return wrap_s(pandas_to_pyseries("", data, nan_to_null=nan_to_null))
     elif isinstance(data, pd.DataFrame):

--- a/py-polars/tests/unit/interop/test_from_pandas.py
+++ b/py-polars/tests/unit/interop/test_from_pandas.py
@@ -190,6 +190,18 @@ def test_from_pandas_include_indexes() -> None:
     assert df.to_dict(as_series=False) == data
 
 
+def test_from_pandas_series_include_indexes() -> None:
+    # no default index
+    pd_series = pd.Series({"a": 1, "b": 2}, name="number").rename_axis(["letter"])
+    df = pl.from_pandas(pd_series, include_index=True)
+    assert df.to_dict(as_series=False) == {"letter": ["a", "b"], "number": [1, 2]}
+
+    # default index
+    pd_series = pd.Series(range(2))
+    df = pl.from_pandas(pd_series, include_index=True)
+    assert df.to_dict(as_series=False) == {"index": [0, 1], "0": [0, 1]}
+
+
 def test_duplicate_cols_diff_types() -> None:
     df = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=["0", 0, "1", 1])
     with pytest.raises(


### PR DESCRIPTION
Fixes: #18859
For `pd.Series` I don't think it is a good idea to ignore the `include_index` argument if the index is the default index. Otherwise, the resulting type depends of the data. 