### PR TITLE
fix: Ensure sorted flag is unset after Int->String cast

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -206,10 +206,9 @@ where
                 // - remain signed
                 // - unsigned -> signed
                 // this may still fail with overflow?
-                let dtype = self.dtype();
-
                 let to_signed = dtype.is_signed_integer();
-                let unsigned2unsigned = dtype.is_unsigned_integer() && dtype.is_unsigned_integer();
+                let unsigned2unsigned =
+                    self.dtype().is_unsigned_integer() && dtype.is_unsigned_integer();
                 let allowed = to_signed || unsigned2unsigned;
 
                 if (allowed)

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -672,3 +672,8 @@ def test_cast_consistency() -> None:
     assert pl.DataFrame().with_columns(a=pl.lit(0.0)).with_columns(
         b=pl.col("a").cast(pl.String), c=pl.lit(0.0).cast(pl.String)
     ).to_dict(as_series=False) == {"a": [0.0], "b": ["0.0"], "c": ["0.0"]}
+
+
+def test_cast_int_to_string_unsets_sorted_flag_19424() -> None:
+    s = pl.Series([1, 2]).set_sorted()
+    assert not s.cast(pl.String).flags["SORTED_ASC"]

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -676,4 +676,5 @@ def test_cast_consistency() -> None:
 
 def test_cast_int_to_string_unsets_sorted_flag_19424() -> None:
     s = pl.Series([1, 2]).set_sorted()
+    assert s.flags["SORTED_ASC"]
     assert not s.cast(pl.String).flags["SORTED_ASC"]


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19424

Regression from https://github.com/pola-rs/polars/commit/f562b13dc6b775fd5bc8fe066598b5ed4a6efb92?diff=split&w=0#diff-2fa673dd53f64440ab23998a2ab3c26a2e465abdf3599c339db7072d110cfe9bR203-R224