### PR TITLE
fix: Incorrect gather for FixedSizeList with outer validity but no inner validities

### DIFF
--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -154,7 +154,7 @@ timezones = [
 ]
 dtype-array = []
 dtype-decimal = ["atoi", "itoap"]
-bigidx = []
+bigidx = ["polars-utils/bigidx"]
 nightly = []
 performant = []
 strings = []

--- a/crates/polars-arrow/src/compute/take/fixed_size_list.rs
+++ b/crates/polars-arrow/src/compute/take/fixed_size_list.rs
@@ -230,7 +230,7 @@ pub(super) unsafe fn take_unchecked<O: Index>(
             outer_validity.as_ref(),
             values
                 .validity()
-                // We need at least 1 element as we do `take(i.unwrap_or(0))`
+                // We need at least 1 element as we do `get_bit(i.unwrap_or(0))`
                 .filter(|x| !x.is_empty())
                 .map(|x| {
                     if indices.has_nulls() {
@@ -266,7 +266,7 @@ pub(super) unsafe fn take_unchecked<O: Index>(
 
 #[cfg(test)]
 mod tests {
-
+    /// Test gather for FixedSizeListArray with outer validity but no inner validities.
     #[test]
     fn test_arr_gather_nulls_outer_validity_19482() {
         use polars_utils::IdxSize;

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -258,7 +258,7 @@ replace = ["polars-plan/replace"]
 binary_encoding = ["polars-plan/binary_encoding"]
 string_encoding = ["polars-plan/string_encoding"]
 
-bigidx = ["polars-plan/bigidx"]
+bigidx = ["polars-plan/bigidx", "polars-utils/bigidx"]
 polars_cloud = ["polars-plan/polars_cloud"]
 
 panic_on_schema = ["polars-plan/panic_on_schema", "polars-expr/panic_on_schema"]

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -186,7 +186,7 @@ month_start = ["polars-time/month_start"]
 month_end = ["polars-time/month_end"]
 offset_by = ["polars-time/offset_by"]
 
-bigidx = ["polars-core/bigidx"]
+bigidx = ["polars-core/bigidx", "polars-utils/bigidx"]
 polars_cloud = ["serde", "ciborium"]
 ir_serde = ["serde", "polars-utils/ir_serde"]
 

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -235,7 +235,7 @@ true_div = ["polars-lazy?/true_div"]
 unique_counts = ["polars-ops/unique_counts", "polars-lazy?/unique_counts"]
 zip_with = ["polars-core/zip_with"]
 
-bigidx = ["polars-core/bigidx", "polars-lazy?/bigidx", "polars-ops/big_idx"]
+bigidx = ["polars-core/bigidx", "polars-lazy?/bigidx", "polars-ops/big_idx", "polars-utils/bigidx"]
 polars_cloud = ["polars-lazy?/polars_cloud"]
 ir_serde = ["polars-plan/ir_serde"]
 

--- a/py-polars/tests/unit/operations/test_gather.py
+++ b/py-polars/tests/unit/operations/test_gather.py
@@ -188,3 +188,16 @@ def test_gather_array() -> None:
 
     v = s[[0, 1, None, 3]]  # type: ignore[list-item]
     assert v[2] is None
+
+
+def test_gather_array_outer_validity_19482() -> None:
+    s = (
+        pl.Series([[1], [1]], dtype=pl.Array(pl.Int64, 1))
+        .to_frame()
+        .select(pl.when(pl.int_range(pl.len()) == 0).then(pl.first()))
+        .to_series()
+    )
+
+    expect = pl.Series([[1], None], dtype=pl.Array(pl.Int64, 1))
+    assert_series_equal(s, expect)
+    assert_series_equal(s.gather([0, 1]), expect)


### PR DESCRIPTION
Outer validity of the array was not accounted for in the fast-path, causing outer NULLs to be unmasked.

Fixes https://github.com/pola-rs/polars/issues/19482