### PR TITLE
refactor: Improve makefile build commands

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -194,7 +194,7 @@ jobs:
           command: build
           target: ${{ steps.target.outputs.target }}
           args: >
-            --release
+            --profile dist-release
             --manifest-path py-polars/Cargo.toml
             --out dist
           manylinux: ${{ matrix.architecture == 'aarch64' && '2_24' || 'auto' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,16 +136,16 @@ features = [
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
 
-[profile.opt-dev]
-inherits = "dev"
-opt-level = 1
+[profile.release]
+lto = "thin"
+
+[profile.profile-release]
+inherits = "release"
+debug = "line-tables-only"
 
 [profile.debug-release]
 inherits = "release"
 debug = true
-
-[profile.release]
-lto = "thin"
 
 [profile.dist-release]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,10 +138,11 @@ features = [
 
 [profile.release]
 lto = "thin"
-
-[profile.profile-release]
-inherits = "release"
 debug = "line-tables-only"
+
+[profile.nodebug-release]
+inherits = "release"
+debug = false
 
 [profile.debug-release]
 inherits = "release"
@@ -150,4 +151,5 @@ debug = true
 [profile.dist-release]
 inherits = "release"
 codegen-units = 1
+debug = false
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,10 +143,11 @@ opt-level = 1
 [profile.debug-release]
 inherits = "release"
 debug = true
-incremental = true
-codegen-units = 16
-lto = "thin"
 
 [profile.release]
+lto = "thin"
+
+[profile.dist-release]
+inherits = "release"
 codegen-units = 1
 lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -89,19 +89,19 @@ build: .venv  ## Compile and install Python Polars for development
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-release
-build-release: .venv  ## Compile and install Python Polars binary with optimizations, without debug symbols
+build-release: .venv  ## Compile and install Python Polars binary with optimizations, with minimal debug symbols
 	@unset CONDA_PREFIX \
 	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --release $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
-.PHONY: build-profile-release
-build-profile-release: .venv  ## Same as build-release, but with minimal debug symbols turned on needed for profiling
+.PHONY: build-nodebug-release
+build-nodebug-release: .venv  ## Same as build-release, but without any debug symbols at all (a bit faster to build)
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile profile-release $(ARGS) \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile nodebug-release $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-release
-build-debug-release: .venv  ## Same as build-release, but with full debug symbols turned on
+build-debug-release: .venv  ## Same as build-release, but with full debug symbols turned on (a bit slower to build)
 	@unset CONDA_PREFIX \
 	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile debug-release $(ARGS) \
 	$(FILTER_PIP_WARNINGS)

--- a/Makefile
+++ b/Makefile
@@ -88,22 +88,22 @@ build: .venv  ## Compile and install Python Polars for development
 	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
-.PHONY: build-opt
-build-opt: .venv  ## Compile and install Python Polars with minimal optimizations for development
-	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile opt-dev $(ARGS) \
-	$(FILTER_PIP_WARNINGS)
-
-.PHONY: build-debug-release
-build-debug-release: .venv  ## Compile and install Python Polars with optimizations on and debug assertions turned off, but with debug symbols on
-	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile debug-release $(ARGS) \
-	$(FILTER_PIP_WARNINGS)
-
 .PHONY: build-release
 build-release: .venv  ## Compile and install Python Polars binary with optimizations, without debug symbols
 	@unset CONDA_PREFIX \
 	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --release $(ARGS) \
+	$(FILTER_PIP_WARNINGS)
+
+.PHONY: build-profile-release
+build-profile-release: .venv  ## Same as build-release, but with minimal debug symbols turned on needed for profiling
+	@unset CONDA_PREFIX \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile profile-release $(ARGS) \
+	$(FILTER_PIP_WARNINGS)
+
+.PHONY: build-debug-release
+build-debug-release: .venv  ## Same as build-release, but with full debug symbols turned on
+	@unset CONDA_PREFIX \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile debug-release $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-dist-release

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,56 @@ else
 	VENV_BIN=$(VENV)/bin
 endif
 
+# Detect CPU architecture.
+ifeq ($(OS),Windows_NT)
+    ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+		ARCH := amd64
+	else ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+		ARCH := x86
+	else ifeq ($(PROCESSOR_ARCHITECTURE),ARM64)
+		ARCH := arm64
+	else
+		ARCH := unknown
+    endif
+else
+    UNAME_P := $(shell uname -p)
+    ifeq ($(UNAME_P),x86_64)
+		ARCH := amd64
+	else ifneq ($(filter %86,$(UNAME_P)),)
+		ARCH := x86
+	else ifneq ($(filter arm%,$(UNAME_P)),)
+		ARCH := arm64
+	else
+		ARCH := unknown
+    endif
+endif
+
+# Ensure boolean arguments are normalized to 1/0 to prevent surprises.
+ifdef LTS_CPU
+	ifeq ($(LTS_CPU),0)
+	else ifeq ($(LTS_CPU),1)
+	else
+$(error LTS_CPU must be 0 or 1 (or undefined, default to 0))
+	endif
+endif
+
+# Define RUSTFLAGS and CFLAGS appropriate for the architecture.
+# Keep synchronized with .github/workflows/release-python.yml.
+ifeq ($(ARCH),amd64)
+	ifeq ($(LTS_CPU),1)
+		FEAT_RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b
+		FEAT_CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16
+	else
+		FEAT_RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe -Z tune-cpu=skylake
+		FEAT_CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe -mtune=skylake
+	endif
+endif
+
+override RUSTFLAGS+=$(FEAT_RUSTFLAGS)
+override CFLAGS+=$(FEAT_CFLAGS)
+export RUSTFLAGS
+export CFLAGS
+
 # Define command to filter pip warnings when running maturin
 FILTER_PIP_WARNINGS=| grep -v "don't match your environment"; test $${PIPESTATUS[0]} -eq 0
 
@@ -35,55 +85,31 @@ requirements-all: .venv  ## Install/refresh all Python requirements (including t
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml \
-	$(FILTER_PIP_WARNINGS)
-
-.PHONY: build-debug-opt
-build-debug-opt: .venv  ## Compile and install Python Polars with minimal optimizations turned on
-	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile opt-dev \
-	$(FILTER_PIP_WARNINGS)
-
-.PHONY: build-debug-opt-subset
-build-debug-opt-subset: .venv  ## Compile and install Python Polars with minimal optimizations turned on and no default features
-	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --no-default-features --profile opt-dev \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-opt
-build-opt: .venv  ## Compile and install Python Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
+build-opt: .venv  ## Compile and install Python Polars with minimal optimizations for development
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile debug-release \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile opt-dev $(ARGS) \
+	$(FILTER_PIP_WARNINGS)
+
+.PHONY: build-debug-release
+build-debug-release: .venv  ## Compile and install Python Polars with optimizations on and debug assertions turned off, but with debug symbols on
+	@unset CONDA_PREFIX \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile debug-release $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-release
-build-release: .venv  ## Compile and install a faster Python Polars binary with full optimizations
+build-release: .venv  ## Compile and install Python Polars binary with optimizations, without debug symbols
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --release \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --release $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
-.PHONY: build-native
-build-native: .venv  ## Same as build, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && RUSTFLAGS='-C target-cpu=native' \
-	$(VENV_BIN)/maturin develop -m py-polars/Cargo.toml \
-	$(FILTER_PIP_WARNINGS)
-
-.PHONY: build-debug-opt-native
-build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && RUSTFLAGS='-C target-cpu=native' \
-	$(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile opt-dev \
-	$(FILTER_PIP_WARNINGS)
-
-.PHONY: build-opt-native
-build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && RUSTFLAGS='-C target-cpu=native' \
-	$(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile debug-release \
-	$(FILTER_PIP_WARNINGS)
-
-.PHONY: build-release-native
-build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && RUSTFLAGS='-C target-cpu=native' \
-	$(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --release \
+.PHONY: build-dist-release
+build-dist-release: .venv  ## Compile and install Python Polars binary with super slow extra optimization turned on, for distribution
+	@unset CONDA_PREFIX \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile dist-release $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: check
@@ -121,3 +147,6 @@ clean:  ## Clean up caches, build artifacts, and the venv
 help:  ## Display this help screen
 	@echo -e "\033[1mAvailable commands:\033[0m"
 	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}' | sort
+	@echo
+	@echo The build commands support LTS_CPU=1 for building for older CPUs, and ARGS which is passed through to maturin.
+	@echo 'For example to build without default features use: make build ARGS="--no-default-features".'

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ This can be done by going through the following steps in sequence:
 2. Install [maturin](https://maturin.rs/): `pip install maturin`
 3. `cd py-polars` and choose one of the following:
    - `make build`, slow binary with debug assertions and symbols, fast compile times
-   - `make build-release`, fast binary without debug assertions or debug symbols, long compile times
-   - `make build-profile-release`, fast binary with minimal debug symbols for profiling (but no debug assertions), very long compile times
-   - `make build-debug-release`, fast binary with full debug symbols (but no debug assertions), even longer compile times
+   - `make build-release`, fast binary without debug assertions, minimal debug symbols, long compile times
+   - `make build-nodebug-release`, same as build-release but without any debug symbols, slightly faster to compile
+   - `make build-debug-release`, same as build-release but with full debug symbols, slightly slower to compile
    - `make build-dist-release`, fastest binary, extreme compile times
 
   By default the binary is compiled with optimizations turned on for a modern CPU. Specify `LTS_CPU=1`

--- a/README.md
+++ b/README.md
@@ -233,13 +233,14 @@ This can be done by going through the following steps in sequence:
 1. Install the latest [Rust compiler](https://www.rust-lang.org/tools/install)
 2. Install [maturin](https://maturin.rs/): `pip install maturin`
 3. `cd py-polars` and choose one of the following:
-   - `make build-release`, fastest binary, very long compile times
-   - `make build-opt`, fast binary with debug symbols, long compile times
-   - `make build-debug-opt`, medium-speed binary with debug assertions and symbols, medium compile times
    - `make build`, slow binary with debug assertions and symbols, fast compile times
+   - `make build-opt`, medium-speed binary with debug assertions and symbols, medium compile times
+   - `make build-release`, fast binary, long compile times
+   - `make build-debug-release`, fast binary with debug symbols (but no debug assertions), very long compile times
+   - `make build-dist-release`, fastest binary, extreme compile times
 
-   Append `-native` (e.g. `make build-release-native`) to enable further optimizations specific to
-   your CPU. This produces a non-portable binary/wheel however.
+  By default the binary is compiled with optimizations turned on for a modern CPU. Specify `LTS_CPU=1`
+  with the command if your CPU is older and does not support e.g. AVX2.
 
 Note that the Rust crate implementing the Python bindings is called `py-polars` to distinguish from the wrapped
 Rust crate `polars` itself. However, both the Python package and the Python module are named `polars`, so you

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ This can be done by going through the following steps in sequence:
    - `make build-debug-release`, same as build-release but with full debug symbols, slightly slower to compile
    - `make build-dist-release`, fastest binary, extreme compile times
 
-  By default the binary is compiled with optimizations turned on for a modern CPU. Specify `LTS_CPU=1`
-  with the command if your CPU is older and does not support e.g. AVX2.
+By default the binary is compiled with optimizations turned on for a modern CPU. Specify `LTS_CPU=1`
+with the command if your CPU is older and does not support e.g. AVX2.
 
 Note that the Rust crate implementing the Python bindings is called `py-polars` to distinguish from the wrapped
 Rust crate `polars` itself. However, both the Python package and the Python module are named `polars`, so you

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ This can be done by going through the following steps in sequence:
 2. Install [maturin](https://maturin.rs/): `pip install maturin`
 3. `cd py-polars` and choose one of the following:
    - `make build`, slow binary with debug assertions and symbols, fast compile times
-   - `make build-opt`, medium-speed binary with debug assertions and symbols, medium compile times
-   - `make build-release`, fast binary, long compile times
-   - `make build-debug-release`, fast binary with debug symbols (but no debug assertions), very long compile times
+   - `make build-release`, fast binary without debug assertions or debug symbols, long compile times
+   - `make build-profile-release`, fast binary with minimal debug symbols for profiling (but no debug assertions), very long compile times
+   - `make build-debug-release`, fast binary with full debug symbols (but no debug assertions), even longer compile times
    - `make build-dist-release`, fastest binary, extreme compile times
 
   By default the binary is compiled with optimizations turned on for a modern CPU. Specify `LTS_CPU=1`

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -23,39 +23,23 @@ requirements-all: .venv  ## Install/refresh all Python requirements (including t
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build
-build: .venv  ## Compile and install Polars for development
-	@$(MAKE) -s -C .. $@
-
-.PHONY: build-debug-opt
-build-debug-opt: .venv  ## Compile and install Polars with minimal optimizations turned on
-	@$(MAKE) -s -C .. $@
-
-.PHONY: build-debug-opt-subset
-build-debug-opt-subset: .venv  ## Compile and install Polars with minimal optimizations turned on and no default features
+build: .venv  ## Compile and install Python Polars for development
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-opt
-build-opt: .venv  ## Compile and install Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
+build-opt: .venv  ## Compile and install Python Polars with minimal optimizations for development
+	@$(MAKE) -s -C .. $@
+
+.PHONY: build-debug-release
+build-debug-release: .venv  ## Compile and install Python Polars with optimizations on and debug assertions turned off, but with debug symbols on
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-release
-build-release: .venv  ## Compile and install a faster Polars binary with full optimizations
+build-release: .venv  ## Compile and install Python Polars binary with optimizations, without debug symbols
 	@$(MAKE) -s -C .. $@
 
-.PHONY: build-native
-build-native: .venv  ## Same as build, except with native CPU optimizations turned on
-	@$(MAKE) -s -C .. $@
-
-.PHONY: build-debug-opt-native
-build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
-	@$(MAKE) -s -C .. $@
-
-.PHONY: build-opt-native
-build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
-	@$(MAKE) -s -C .. $@
-
-.PHONY: build-release-native
-build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
+.PHONY: build-dist-release
+build-dist-release: .venv  ## Compile and install Python Polars binary with super slow extra optimization turned on, for distribution
 	@$(MAKE) -s -C .. $@
 
 .PHONY: lint

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -26,16 +26,16 @@ requirements-all: .venv  ## Install/refresh all Python requirements (including t
 build: .venv  ## Compile and install Python Polars for development
 	@$(MAKE) -s -C .. $@
 
-.PHONY: build-profile-release
-build-profile-release: .venv  ## Same as build-release, but with minimal debug symbols turned on needed for profiling
+.PHONY: build-release
+build-release: .venv  ## Compile and install Python Polars binary with optimizations, with minimal debug symbols
+	@$(MAKE) -s -C .. $@
+
+.PHONY: build-nodebug-release
+build-nodebug-release: .venv  ## Same as build-release, but without any debug symbols at all (a bit faster to build)
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-debug-release
-build-debug-release: .venv  ## Same as build-release, but with full debug symbols turned on
-	@$(MAKE) -s -C .. $@
-
-.PHONY: build-release
-build-release: .venv  ## Compile and install Python Polars binary with optimizations, without debug symbols or assertions
+build-debug-release: .venv  ## Same as build-release, but with full debug symbols turned on (a bit slower to build)
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-dist-release

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -26,16 +26,16 @@ requirements-all: .venv  ## Install/refresh all Python requirements (including t
 build: .venv  ## Compile and install Python Polars for development
 	@$(MAKE) -s -C .. $@
 
-.PHONY: build-opt
-build-opt: .venv  ## Compile and install Python Polars with minimal optimizations for development
+.PHONY: build-profile-release
+build-profile-release: .venv  ## Same as build-release, but with minimal debug symbols turned on needed for profiling
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-debug-release
-build-debug-release: .venv  ## Compile and install Python Polars with optimizations on and debug assertions turned off, but with debug symbols on
+build-debug-release: .venv  ## Same as build-release, but with full debug symbols turned on
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-release
-build-release: .venv  ## Compile and install Python Polars binary with optimizations, without debug symbols
+build-release: .venv  ## Compile and install Python Polars binary with optimizations, without debug symbols or assertions
 	@$(MAKE) -s -C .. $@
 
 .PHONY: build-dist-release


### PR DESCRIPTION
This does a couple things:

1. We now properly match the CPU flags to that of our release. Specify `LTS_CPU=1` e.g. `make build-release LTS_CPU=1` to build a lts-cpu variant.
2. You can now pass along arguments to maturin through the makefile commands, e.g. `make build ARGS="--no-default-features"`.
3. I redefined the build profiles. We now have (ordered by compilation speed):

| Name  | Optimization | Debug assertions | Debug symbols | Compilation Speed |
| - | - | - | - | - |
| `debug` | No | Yes | Yes | Fastest |
| `nodebug-release` | Yes | No | No | Slow |
| `release` | Yes | No | Minimal | Slower |
| `debug-release` | Yes | No | Yes | Slower still |
| `dist-release` | Extreme | No | No | Slowest |

Almost all the time you want `debug`, which is just `make build`. If you are investigating performance, you want `make build-release`.

The remaining profiles are more niche. Use `dist-release` to exactly match the optimization we use when distributing, which is not necessary most of the time. The `nodebug`/`debug` variants of `release` exist  because I found it adds significant (30-60 sec) compile time between them (all fresh compiles):

```
Apple M2
make build 1:50
make nodebug-release 4:51
make release 5:33
make debug-release 6:39
make dist-release ~20 (couldn't be bothered to run it)
```

Use `nodebug` if you are iterating on something performance-sensitive but you've already done profiling so you know what to improve without needing further profiling. Use `debug` when hunting down a bug with a debugger that only occurs in release mode.
