### PR TITLE
feat(python): Use a contravariant typevar for df.cast

### DIFF
--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -92,6 +92,7 @@ ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq
 # selector type, and related collection/sequence
 SelectorType: TypeAlias = "_selector_proxy_"
 ColumnNameOrSelector: TypeAlias = Union[str, SelectorType]
+ColumnNameOrSelectorOrDataType = TypeVar("ColumnNameOrSelectorOrDataType", bound=ColumnNameOrSelector | PolarsDataType, contravariant=True)
 
 # User-facing string literal types
 # The following all have an equivalent Rust enum with the same name

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -139,6 +139,7 @@ if TYPE_CHECKING:
         ClosedInterval,
         ColumnFormatDict,
         ColumnNameOrSelector,
+        ColumnNameOrSelectorOrDataType,
         ColumnTotalsDefinition,
         ColumnWidthsDefinition,
         ComparisonOperator,
@@ -7620,7 +7621,7 @@ class DataFrame:
     def cast(
         self,
         dtypes: (
-            Mapping[ColumnNameOrSelector | PolarsDataType, PolarsDataType]
+            Mapping[ColumnNameOrSelectorOrDataType, PolarsDataType]
             | PolarsDataType
         ),
         *,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
         AsofJoinStrategy,
         ClosedInterval,
         ColumnNameOrSelector,
+        ColumnNameOrSelectorOrDataType,
         CsvQuoteStyle,
         EngineType,
         ExplainFormat,
@@ -2932,7 +2933,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def cast(
         self,
         dtypes: (
-            Mapping[ColumnNameOrSelector | PolarsDataType, PolarsDataType]
+            Mapping[ColumnNameOrSelectorOrDataType, PolarsDataType]
             | PolarsDataType
         ),
         *,

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -674,6 +674,13 @@ def test_cast_consistency() -> None:
     ).to_dict(as_series=False) == {"a": [0.0], "b": ["0.0"], "c": ["0.0"]}
 
 
+def test_cast_schema() -> None:
+    schema = pl.Schema({"v": pl.UInt8()})
+    df = pl.DataFrame({"v": [1, 2, 3]}).cast(schema)
+    assert df.collect_schema() == schema
+    assert df["v"].eq(pl.Series("v", [1, 2, 3], dtype=pl.UInt8())).all()
+
+
 def test_cast_int_to_string_unsets_sorted_flag_19424() -> None:
     s = pl.Series([1, 2]).set_sorted()
     assert s.flags["SORTED_ASC"]


### PR DESCRIPTION
Adjust the typing annotations for the `DataFrame.cast` and `LazyFrame.cast` methods such that mypy/ruff do complain about passing an instance of pl.Schema, which already works in practice.