### PR TITLE
refactor(rust): Rename ComputeNode::spawn parameters

### DIFF
--- a/crates/polars-stream/src/nodes/filter.rs
+++ b/crates/polars-stream/src/nodes/filter.rs
@@ -27,14 +27,14 @@ impl ComputeNode for FilterNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.len() == 1 && send.len() == 1);
-        let receivers = recv[0].take().unwrap().parallel();
-        let senders = send[0].take().unwrap().parallel();
+        assert!(recv_ports.len() == 1 && send_ports.len() == 1);
+        let receivers = recv_ports[0].take().unwrap().parallel();
+        let senders = send_ports[0].take().unwrap().parallel();
 
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -264,25 +264,25 @@ impl ComputeNode for GroupByNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(send.len() == 1 && recv.len() == 1);
+        assert!(send_ports.len() == 1 && recv_ports.len() == 1);
         match &mut self.state {
             GroupByState::Sink(sink) => {
-                assert!(send[0].is_none());
+                assert!(send_ports[0].is_none());
                 sink.spawn(
                     scope,
-                    recv[0].take().unwrap().parallel(),
+                    recv_ports[0].take().unwrap().parallel(),
                     state,
                     join_handles,
                 )
             },
             GroupByState::Source(source) => {
-                assert!(recv[0].is_none());
-                source.spawn(scope, &mut [], send, state, join_handles);
+                assert!(recv_ports[0].is_none());
+                source.spawn(scope, &mut [], send_ports, state, join_handles);
             },
             GroupByState::Done => unreachable!(),
         }

--- a/crates/polars-stream/src/nodes/in_memory_map.rs
+++ b/crates/polars-stream/src/nodes/in_memory_map.rs
@@ -86,16 +86,16 @@ impl ComputeNode for InMemoryMapNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         match self {
             Self::Sink { sink_node, .. } => {
-                sink_node.spawn(scope, recv, &mut [], state, join_handles)
+                sink_node.spawn(scope, recv_ports, &mut [], state, join_handles)
             },
-            Self::Source(source) => source.spawn(scope, &mut [], send, state, join_handles),
+            Self::Source(source) => source.spawn(scope, &mut [], send_ports, state, join_handles),
             Self::Done => unreachable!(),
         }
     }

--- a/crates/polars-stream/src/nodes/in_memory_sink.rs
+++ b/crates/polars-stream/src/nodes/in_memory_sink.rs
@@ -45,13 +45,13 @@ impl ComputeNode for InMemorySinkNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.len() == 1 && send.is_empty());
-        let receivers = recv[0].take().unwrap().parallel();
+        assert!(recv_ports.len() == 1 && send_ports.is_empty());
+        let receivers = recv_ports[0].take().unwrap().parallel();
 
         for mut recv in receivers {
             let slf = &*self;

--- a/crates/polars-stream/src/nodes/in_memory_source.rs
+++ b/crates/polars-stream/src/nodes/in_memory_source.rs
@@ -60,13 +60,13 @@ impl ComputeNode for InMemorySourceNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.is_empty() && send.len() == 1);
-        let senders = send[0].take().unwrap().parallel();
+        assert!(recv_ports.is_empty() && send_ports.len() == 1);
+        let senders = send_ports[0].take().unwrap().parallel();
         let source = self.source.as_ref().unwrap();
 
         // TODO: can this just be serial, using the work distributor?

--- a/crates/polars-stream/src/nodes/input_independent_select.rs
+++ b/crates/polars-stream/src/nodes/input_independent_select.rs
@@ -36,13 +36,13 @@ impl ComputeNode for InputIndependentSelectNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.is_empty() && send.len() == 1);
-        let mut sender = send[0].take().unwrap().serial();
+        assert!(recv_ports.is_empty() && send_ports.len() == 1);
+        let mut sender = send_ports[0].take().unwrap().serial();
 
         join_handles.push(scope.spawn_task(TaskPriority::Low, async move {
             let empty_df = DataFrame::empty();

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -61,14 +61,14 @@ impl ComputeNode for IpcSinkNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(send.is_empty());
-        assert!(recv.len() == 1);
-        let mut receiver = recv[0].take().unwrap().serial();
+        assert!(send_ports.is_empty());
+        assert!(recv_ports.len() == 1);
+        let mut receiver = recv_ports[0].take().unwrap().serial();
 
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             while let Ok(morsel) = receiver.recv().await {

--- a/crates/polars-stream/src/nodes/map.rs
+++ b/crates/polars-stream/src/nodes/map.rs
@@ -29,14 +29,14 @@ impl ComputeNode for MapNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.len() == 1 && send.len() == 1);
-        let receivers = recv[0].take().unwrap().parallel();
-        let senders = send[0].take().unwrap().parallel();
+        assert!(recv_ports.len() == 1 && send_ports.len() == 1);
+        let receivers = recv_ports[0].take().unwrap().parallel();
+        let senders = send_ports[0].take().unwrap().parallel();
 
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -63,8 +63,8 @@ pub trait ComputeNode: Send {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     );

--- a/crates/polars-stream/src/nodes/ordered_union.rs
+++ b/crates/polars-stream/src/nodes/ordered_union.rs
@@ -52,15 +52,15 @@ impl ComputeNode for OrderedUnionNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        let ready_count = recv.iter().filter(|r| r.is_some()).count();
-        assert!(ready_count == 1 && send.len() == 1);
-        let receivers = recv[self.cur_input_idx].take().unwrap().parallel();
-        let senders = send[0].take().unwrap().parallel();
+        let ready_count = recv_ports.iter().filter(|r| r.is_some()).count();
+        assert!(ready_count == 1 && send_ports.len() == 1);
+        let receivers = recv_ports[self.cur_input_idx].take().unwrap().parallel();
+        let senders = send_ports[0].take().unwrap().parallel();
 
         let mut inner_handles = Vec::new();
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {

--- a/crates/polars-stream/src/nodes/parquet_source/mod.rs
+++ b/crates/polars-stream/src/nodes/parquet_source/mod.rs
@@ -202,18 +202,18 @@ impl ComputeNode for ParquetSourceNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         use std::sync::atomic::Ordering;
 
-        assert!(recv.is_empty());
-        assert_eq!(send.len(), 1);
+        assert!(recv_ports.is_empty());
+        assert_eq!(send_ports.len(), 1);
         assert!(!self.is_finished.load(Ordering::Relaxed));
 
-        let morsel_senders = send[0].take().unwrap().parallel();
+        let morsel_senders = send_ports[0].take().unwrap().parallel();
 
         let mut async_task_data_guard = self.async_task_data.try_lock().unwrap();
         let (raw_morsel_receivers, _) = async_task_data_guard.as_mut().unwrap();

--- a/crates/polars-stream/src/nodes/reduce.rs
+++ b/crates/polars-stream/src/nodes/reduce.rs
@@ -162,24 +162,24 @@ impl ComputeNode for ReduceNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(send.len() == 1 && recv.len() == 1);
+        assert!(send_ports.len() == 1 && recv_ports.len() == 1);
         match &mut self.state {
             ReduceState::Sink {
                 selectors,
                 reductions,
             } => {
-                assert!(send[0].is_none());
-                let recv_port = recv[0].take().unwrap();
+                assert!(send_ports[0].is_none());
+                let recv_port = recv_ports[0].take().unwrap();
                 Self::spawn_sink(selectors, reductions, scope, recv_port, state, join_handles)
             },
             ReduceState::Source(df) => {
-                assert!(recv[0].is_none());
-                let send_port = send[0].take().unwrap();
+                assert!(recv_ports[0].is_none());
+                let send_port = send_ports[0].take().unwrap();
                 Self::spawn_source(df, scope, send_port, join_handles)
             },
             ReduceState::Done => unreachable!(),

--- a/crates/polars-stream/src/nodes/select.rs
+++ b/crates/polars-stream/src/nodes/select.rs
@@ -36,14 +36,14 @@ impl ComputeNode for SelectNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.len() == 1 && send.len() == 1);
-        let receivers = recv[0].take().unwrap().parallel();
-        let senders = send[0].take().unwrap().parallel();
+        assert!(recv_ports.len() == 1 && send_ports.len() == 1);
+        let receivers = recv_ports[0].take().unwrap().parallel();
+        let senders = send_ports[0].take().unwrap().parallel();
 
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;

--- a/crates/polars-stream/src/nodes/simple_projection.rs
+++ b/crates/polars-stream/src/nodes/simple_projection.rs
@@ -33,14 +33,14 @@ impl ComputeNode for SimpleProjectionNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.len() == 1 && send.len() == 1);
-        let receivers = recv[0].take().unwrap().parallel();
-        let senders = send[0].take().unwrap().parallel();
+        assert!(recv_ports.len() == 1 && send_ports.len() == 1);
+        let receivers = recv_ports[0].take().unwrap().parallel();
+        let senders = send_ports[0].take().unwrap().parallel();
 
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;

--- a/crates/polars-stream/src/nodes/streaming_slice.rs
+++ b/crates/polars-stream/src/nodes/streaming_slice.rs
@@ -43,14 +43,14 @@ impl ComputeNode for StreamingSliceNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.len() == 1 && send.len() == 1);
-        let mut recv = recv[0].take().unwrap().serial();
-        let mut send = send[0].take().unwrap().serial();
+        assert!(recv_ports.len() == 1 && send_ports.len() == 1);
+        let mut recv = recv_ports[0].take().unwrap().serial();
+        let mut send = send_ports[0].take().unwrap().serial();
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             let stop_offset = self.start_offset + self.length;
 

--- a/crates/polars-stream/src/nodes/with_row_index.rs
+++ b/crates/polars-stream/src/nodes/with_row_index.rs
@@ -35,14 +35,14 @@ impl ComputeNode for WithRowIndexNode {
     fn spawn<'env, 's>(
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
-        recv: &mut [Option<RecvPort<'_>>],
-        send: &mut [Option<SendPort<'_>>],
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
         _state: &'s ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
-        assert!(recv.len() == 1 && send.len() == 1);
-        let mut receiver = recv[0].take().unwrap().serial();
-        let senders = send[0].take().unwrap().parallel();
+        assert!(recv_ports.len() == 1 && send_ports.len() == 1);
+        let mut receiver = recv_ports[0].take().unwrap().serial();
+        let senders = send_ports[0].take().unwrap().parallel();
 
         let (mut distributor, distr_receivers) =
             distributor_channel(senders.len(), DEFAULT_DISTRIBUTOR_BUFFER_SIZE);


### PR DESCRIPTION
Just a bit more readable, `recv` and `send` was being shadowed a lot.