### PR TITLE
build(rust): More feature flag fixes

### DIFF
--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -17,8 +17,10 @@ use polars_io::csv::read::{
 use polars_io::parquet::read::ParquetAsyncReader;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::read::ParquetReader;
-#[cfg(all(feature = "parquet", feature = "async"))]
-use polars_io::pl_async::{get_runtime, with_concurrency_budget};
+#[cfg(feature = "cloud")]
+use polars_io::pl_async::get_runtime;
+#[cfg(feature = "async")]
+use polars_io::pl_async::with_concurrency_budget;
 #[cfg(any(feature = "json", feature = "parquet"))]
 use polars_io::SerReader;
 

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -16,7 +16,7 @@ futures = { workspace = true }
 memmap = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
-polars-io = { workspace = true, features = ["async", "cloud", "aws"] }
+polars-io = { workspace = true, features = ["cloud"] }
 polars-utils = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
@@ -26,11 +26,11 @@ tokio = { workspace = true }
 
 polars-core = { workspace = true }
 polars-error = { workspace = true }
-polars-expr = { workspace = true, features = ["dtype-full"] }
+polars-expr = { workspace = true }
 # TODO: feature gate
-polars-mem-engine = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud", "dtype-categorical", "dtype-i8", "dtype-i16", "dtype-u8", "dtype-u16", "dtype-decimal", "dtype-struct", "object"] }
+polars-mem-engine = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud"] }
 polars-parquet = { workspace = true }
-polars-plan = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud", "serde", "dtype-categorical", "dtype-i8", "dtype-i16", "dtype-u8", "dtype-u16", "dtype-decimal", "dtype-struct", "object"] }
+polars-plan = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud"] }
 
 [build-dependencies]
 version_check = { workspace = true }

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -28,9 +28,9 @@ polars-core = { workspace = true }
 polars-error = { workspace = true }
 polars-expr = { workspace = true, features = ["dtype-full"] }
 # TODO: feature gate
-polars-mem-engine = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud", "python", "dtype-categorical", "dtype-i8", "dtype-i16", "dtype-u8", "dtype-u16", "dtype-decimal", "dtype-struct", "object"] }
+polars-mem-engine = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud", "dtype-categorical", "dtype-i8", "dtype-i16", "dtype-u8", "dtype-u16", "dtype-decimal", "dtype-struct", "object"] }
 polars-parquet = { workspace = true }
-polars-plan = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud", "python", "serde", "dtype-categorical", "dtype-i8", "dtype-i16", "dtype-u8", "dtype-u16", "dtype-decimal", "dtype-struct", "object"] }
+polars-plan = { workspace = true, features = ["parquet", "csv", "json", "ipc", "cloud", "serde", "dtype-categorical", "dtype-i8", "dtype-i16", "dtype-u8", "dtype-u16", "dtype-decimal", "dtype-struct", "object"] }
 
 [build-dependencies]
 version_check = { workspace = true }
@@ -42,6 +42,8 @@ merge_sorted = ["polars-plan/merge_sorted"]
 dynamic_group_by = []
 strings = []
 
+python = ["polars-plan/python", "polars-mem-engine/python"]
+
 # We need to specify default features here to match workspace defaults.
 # Otherwise we get warnings with cargo check/clippy.
-default = ["bitwise"]
+default = ["bitwise", "python"]

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -331,7 +331,7 @@ pub fn lower_ir(
                 file_options,
             }
         },
-
+        #[cfg(feature = "python")]
         IR::PythonScan { .. } => todo!(),
         IR::Reduce { .. } => todo!(),
         IR::Cache { .. } => todo!(),


### PR DESCRIPTION
This makes sure that Python-related code is no longer required for building `polars-stream`.