### PR TITLE
chore: Add `mindebug-dev` rust profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,10 @@ features = [
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
 
+[profile.mindebug-dev]
+inherits = "dev"
+debug = "line-tables-only"
+
 [profile.release]
 lto = "thin"
 debug = "line-tables-only"

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,12 @@ build: .venv  ## Compile and install Python Polars for development
 	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml $(ARGS) \
 	$(FILTER_PIP_WARNINGS)
 
+.PHONY: build-mindebug
+build-mindebug: .venv  ## Same as build, but don't include full debug information
+	@unset CONDA_PREFIX \
+	&& $(VENV_BIN)/maturin develop -m py-polars/Cargo.toml --profile mindebug-dev $(ARGS) \
+	$(FILTER_PIP_WARNINGS)
+
 .PHONY: build-release
 build-release: .venv  ## Compile and install Python Polars binary with optimizations, with minimal debug symbols
 	@unset CONDA_PREFIX \


### PR DESCRIPTION
This adds a profile that forgoes full debug information to more quickly iterate on code.

Clean compile times:

```
mindebug-dev: 3m42s
debug: 4m13s
```