### PR TITLE
feat: Support use of `is_between` range predicate with IEJoin operations (`join_where`)

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -35,6 +35,7 @@ use polars_expr::{create_physical_expr, ExpressionConversionState};
 use polars_io::RowIndex;
 use polars_mem_engine::{create_physical_plan, Executor};
 use polars_ops::frame::JoinCoalesce;
+#[cfg(feature = "is_between")]
 use polars_ops::prelude::ClosedInterval;
 pub use polars_plan::frame::{AllowedOptimizations, OptFlags};
 use polars_plan::global::FETCH_ROWS;
@@ -2162,11 +2163,11 @@ impl JoinBuilder {
         }
 
         // Decompose `is_between` predicates to allow for cleaner expression of range joins
+        #[cfg(feature = "is_between")]
         let predicates: Vec<Expr> = predicates
             .clone()
             .into_iter()
             .flat_map(|predicate| {
-                #[cfg(feature = "is_between")]
                 if let Expr::Function {
                     function: FunctionExpr::Boolean(BooleanFunction::IsBetween { closed }),
                     input,

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -164,15 +164,15 @@ fn resolve_join_where(
         .schema(ctxt.lp_arena)
         .into_owned();
 
-    for e in &predicates {
+    for expr in &predicates {
         let mut comparison_count = 0;
-        for e in e
+        for _e in expr
             .into_iter()
             .filter(|e| matches!(e, Expr::BinaryExpr { op, .. } if op.is_comparison()))
         {
             comparison_count += 1;
             if comparison_count > 1 {
-                polars_bail!(InvalidOperation: "only one binary comparison allowed in each 'join_where' predicate, found: {:?}", e);
+                polars_bail!(InvalidOperation: "only one binary comparison allowed in each 'join_where' predicate, found: {:?}", expr);
             }
         }
 
@@ -189,7 +189,7 @@ fn resolve_join_where(
             })
         }
 
-        let valid = e.into_iter().all(|e| match e {
+        let valid = expr.into_iter().all(|e| match e {
             Expr::BinaryExpr { left, op, right } if op.is_comparison() => {
                 !(all_in_schema(&schema_left, None, left, right)
                     || all_in_schema(&schema_right, Some(&schema_left), left, right))

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -449,21 +449,30 @@ def test_ie_join_with_floats(
 
 def test_raise_on_ambiguous_name() -> None:
     df = pl.DataFrame({"id": [1, 2]})
-    with pytest.raises(pl.exceptions.InvalidOperationError):
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="'join_where' predicate only refers to columns from a single table",
+    ):
         df.join_where(df, pl.col("id") >= pl.col("id"))
 
 
 def test_raise_on_multiple_binary_comparisons() -> None:
     df = pl.DataFrame({"id": [1, 2]})
-    with pytest.raises(pl.exceptions.InvalidOperationError):
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="only one binary comparison allowed in each 'join_where' predicate, found: ",
+    ):
         df.join_where(
-            df, (pl.col("id") < pl.col("id")) & (pl.col("id") >= pl.col("id"))
+            df, (pl.col("id") < pl.col("id")) ^ (pl.col("id") >= pl.col("id"))
         )
 
 
 def test_raise_invalid_input_join_where() -> None:
     df = pl.DataFrame({"id": [1, 2]})
-    with pytest.raises(pl.exceptions.InvalidOperationError):
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="expected join keys/predicates",
+    ):
         df.join_where(df)
 
 
@@ -571,7 +580,10 @@ def test_raise_invalid_predicate() -> None:
     left = pl.LazyFrame({"a": [1, 2]}).with_row_index()
     right = pl.LazyFrame({"b": [1, 2]}).with_row_index()
 
-    with pytest.raises(pl.exceptions.InvalidOperationError):
+    with pytest.raises(
+        pl.exceptions.InvalidOperationError,
+        match="'join_where' predicate only refers to columns from a single table",
+    ):
         left.join_where(right, pl.col.index >= pl.col.a).collect()
 
 


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/pull/18365

One of the most useful applications of `join_where` is range joins, and the `is_between` expression is a natural way to express such ranges. This PR allows for use of such in the list of join predicates, streamlining these queries.

Also improved several related error messages, providing more detail if a given predicate is not suitable for use with `join_where` (such as actually including that predicate in the error).

### Example

Setup:
```python
import polars as pl

df1 = pl.DataFrame({
    "id": ["aa", "bb", "cc"],
    "start": [date(2020,1,1), date(2022,10,10), date(2024,7,5)],
    "end": [date(2022,12,31), date(2024,10,1), date(2024,12,31)],
})
df2 = pl.DataFrame({
    "id": ["aa", "cc", "bb"],
    "dt": [date(2022,12,31), date(2024,2,21), date(2024,8,8)],
    "price": [100, 200, 300],
})
```
The following two formulations are now equivalent:
```python
df1.join_where(
    df2,
    pl.col("id") == pl.col("id_right"),
    pl.col("dt") >= pl.col("start"),
    pl.col("dt") <= pl.col("end")
)
```
```python
df1.join_where(
    df2,
    pl.col("id") == pl.col("id_right"),
    pl.col("dt").is_between("start","end")
)
```
```
shape: (2, 5)
┌─────┬────────────┬────────────┬────────────┬───────┐
│ id  ┆ start      ┆ end        ┆ dt         ┆ price │
│ --- ┆ ---        ┆ ---        ┆ ---        ┆ ---   │
│ str ┆ date       ┆ date       ┆ date       ┆ i64   │
╞═════╪════════════╪════════════╪════════════╪═══════╡
│ aa  ┆ 2020-01-01 ┆ 2022-12-31 ┆ 2022-12-31 ┆ 100   │
│ bb  ┆ 2022-10-10 ┆ 2024-10-01 ┆ 2024-08-08 ┆ 300   │
└─────┴────────────┴────────────┴────────────┴───────┘
```