### PR TITLE
feat: Streamline use of predicates connected by `&` with IEJoin (`join_where`)

### DIFF
--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -172,7 +172,7 @@ fn resolve_join_where(
         {
             comparison_count += 1;
             if comparison_count > 1 {
-                polars_bail!(InvalidOperation: "only one binary comparison allowed in each 'join_where' predicate, found: {:?}", expr);
+                polars_bail!(InvalidOperation: "only one binary comparison allowed in each 'join_where' predicate; found {:?}", expr);
             }
         }
 

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -69,7 +69,9 @@ def test_basic_ie_join() -> None:
     )
 
     actual = east.join_where(
-        west, pl.col("dur") < pl.col("time"), pl.col("rev") > pl.col("cost")
+        west,
+        pl.col("dur") < pl.col("time"),
+        pl.col("rev") > pl.col("cost"),
     )
 
     expected = pl.DataFrame(
@@ -111,7 +113,9 @@ def test_ie_join_with_slice(offset: int, length: int) -> None:
 
     actual = (
         east.join_where(
-            west, pl.col("dur") < pl.col("time"), pl.col("rev") < pl.col("cost")
+            west,
+            pl.col("dur") < pl.col("time"),
+            pl.col("rev") < pl.col("cost"),
         )
         .slice(offset, length)
         .collect()
@@ -260,7 +264,9 @@ def test_join_where_predicates(range_constraint: list[pl.Expr]) -> None:
     q = (
         left.lazy()
         .join_where(
-            right.lazy(), pl.col("group") != pl.col("group_right"), *range_constraint
+            right.lazy(),
+            pl.col("group") != pl.col("group_right"),
+            *range_constraint,
         )
         .select("id", "id_right", "group")
         .sort("id")
@@ -405,7 +411,7 @@ def test_ie_join(east: pl.DataFrame, west: pl.DataFrame, op1: str, op2: str) -> 
     expr0 = _inequality_expression("dur", op1, "time")
     expr1 = _inequality_expression("rev", op2, "cost")
 
-    actual = east.join_where(west, expr0, expr1)
+    actual = east.join_where(west, expr0 & expr1)
 
     expected = east.join(west, how="cross").filter(expr0 & expr1)
     assert_frame_equal(actual, expected, check_row_order=False, check_exact=True)
@@ -423,7 +429,7 @@ def test_ie_join_with_nulls(
     expr0 = _inequality_expression("dur", op1, "time")
     expr1 = _inequality_expression("rev", op2, "cost")
 
-    actual = east.join_where(west, expr0, expr1)
+    actual = east.join_where(west, expr0 & expr1)
 
     expected = east.join(west, how="cross").filter(expr0 & expr1)
     assert_frame_equal(actual, expected, check_row_order=False, check_exact=True)
@@ -460,7 +466,7 @@ def test_raise_on_multiple_binary_comparisons() -> None:
     df = pl.DataFrame({"id": [1, 2]})
     with pytest.raises(
         pl.exceptions.InvalidOperationError,
-        match="only one binary comparison allowed in each 'join_where' predicate, found: ",
+        match="only one binary comparison allowed in each 'join_where' predicate; found ",
     ):
         df.join_where(
             df, (pl.col("id") < pl.col("id")) ^ (pl.col("id") >= pl.col("id"))


### PR DESCRIPTION
Following on from #19547.

Small ease of use improvement for predicate conjunctions passed to `join_where`. 

Decomposes `And` conjunctions internally, rather than raise an unnecessary error (as it does now), so the caller can create and pass a single expression (instead of `n` expressions). Handles nested `And` (eg: `p1 & ((p2 & p3) & p4)`)

## Example

The following are all now allowed, and equivalent: 
```python
df1.join_where(
    df2,
    predicate1,
    predicate2,
    predicate3,
    predicate4,
)
```
```python
df1.join_where(
    df2,
    predicate1 & predicate2,
    predicate3 & predicate4,
)
```
```python
df1.join_where(
    df2,
    predicate1 & predicate2 & predicate3 & predicate4
)
```