### PR TITLE
test(python): Fix `test_rolling_by_integer` not using parameterized dtype

### DIFF
--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -822,7 +822,11 @@ def test_rolling_by_date() -> None:
 
 @pytest.mark.parametrize("dtype", [pl.Int64, pl.Int32, pl.UInt64, pl.UInt32])
 def test_rolling_by_integer(dtype: PolarsDataType) -> None:
-    df = pl.DataFrame({"val": [1, 2, 3]}).with_row_index()
+    df = (
+        pl.DataFrame({"val": [1, 2, 3]})
+        .with_row_index()
+        .with_columns(pl.col("index").cast(dtype))
+    )
     result = df.with_columns(roll=pl.col("val").rolling_sum_by("index", "2i"))
     expected = df.with_columns(roll=pl.Series([1, 3, 5]))
     assert_frame_equal(result, expected)


### PR DESCRIPTION
This PR is for fixing a small issue in the test `test_rolling_by_integer`.

This was noticed here: https://github.com/pola-rs/polars/pull/19071#discussion_r1824515876