### PR TITLE
fix: Correct categorical namespace error message

### DIFF
--- a/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
@@ -74,7 +74,7 @@ fn check_namespace(function: &FunctionExpr, first_dtype: &DataType) -> PolarsRes
         },
         #[cfg(feature = "dtype-categorical")]
         FunctionExpr::Categorical(_) => {
-            polars_ensure!(matches!(first_dtype, DataType::Categorical(_, _)), InvalidOperation: "expected Struct type, got: {}", first_dtype)
+            polars_ensure!(matches!(first_dtype, DataType::Categorical(_, _)), InvalidOperation: "expected Categorical type, got: {}", first_dtype)
         },
         _ => {},
     }

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -837,7 +837,7 @@ def test_cat_append_lexical_sorted_flag() -> None:
 def test_get_cat_categories_multiple_chunks() -> None:
     df = pl.DataFrame(
         [
-            pl.Series("e", ["a", "b"], pl.Enum(["a", "b"])),
+            pl.Series("e", ["a", "b"], pl.Categorical),
         ]
     )
     df = pl.concat(


### PR DESCRIPTION
While trying to enforce type validation on all namespace functions, I encountered a lot of type erros inside the tests