### PR TITLE
fix(rust,python): Fix predicate pushdown into inequality joins

### DIFF
--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -174,6 +174,10 @@ impl JoinType {
         }
     }
 
+    pub fn is_cross(&self) -> bool {
+        matches!(self, JoinType::Cross)
+    }
+
     pub fn is_ie(&self) -> bool {
         #[cfg(feature = "iejoin")]
         {

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -41,7 +41,7 @@ pub fn resolve_join(
     }
 
     let owned = Arc::unwrap_or_clone;
-    if matches!(options.args.how, JoinType::Cross) {
+    if options.args.how.is_cross() {
         polars_ensure!(left_on.len() + right_on.len() == 0, InvalidOperation: "a 'cross' join doesn't expect any join keys");
     } else {
         polars_ensure!(left_on.len() + right_on.len() > 0, InvalidOperation: "expected join keys/predicates");

--- a/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
@@ -192,7 +192,7 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &mut Arena<AEx
                 left_on,
                 right_on,
                 options,
-            } if matches!(options.args.how, JoinType::Cross) => {
+            } if options.args.how.is_cross() => {
                 if predicates.is_empty() {
                     continue;
                 }

--- a/crates/polars-plan/src/plans/optimizer/collect_members.rs
+++ b/crates/polars-plan/src/plans/optimizer/collect_members.rs
@@ -48,7 +48,7 @@ impl MemberCollector {
             match alp {
                 Join { .. } | Union { .. } => self.has_joins_or_unions = true,
                 Filter { input, .. } => {
-                    self.has_filter_with_join_input |= matches!(lp_arena.get(*input), Join { options, .. } if options.args.how == JoinType::Cross)
+                    self.has_filter_with_join_input |= matches!(lp_arena.get(*input), Join { options, .. } if options.args.how.is_cross())
                 },
                 Cache { .. } => self.has_cache = true,
                 ExtContext { .. } => self.has_ext_context = true,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -149,7 +149,8 @@ pub(super) fn process_join(
 
     for (_, predicate) in acc_predicates {
         // Cross joins produce a cartesian product, so if a predicate combines columns from both tables, we should not push down.
-        if matches!(options.args.how, JoinType::Cross)
+        // Inequality joins logically produce a cartesian product, so the same logic applies.
+        if (options.args.how.is_cross() || options.args.how.is_ie())
             && predicate_applies_to_both_tables(
                 predicate.node(),
                 expr_arena,


### PR DESCRIPTION
Inequality joins are, from the optimizer's point of view, the same as cross joins: they logically produce a cartesian product that is then filtered. Consequently, if a predicate combines columns from both tables, we cannot push the filter into the join.

- Fixes #19580