### PR TITLE
fix: Correct wildcard and input expansion for some more functions

### DIFF
--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -144,17 +144,12 @@ impl ArrayNameSpace {
     pub fn count_matches<E: Into<Expr>>(self, element: E) -> Expr {
         let other = element.into();
 
-        self.0
-            .map_many_private(
-                FunctionExpr::ArrayExpr(ArrayFunction::CountMatches),
-                &[other],
-                false,
-                None,
-            )
-            .with_function_options(|mut options| {
-                options.flags |= FunctionFlags::INPUT_WILDCARD_EXPANSION;
-                options
-            })
+        self.0.map_many_private(
+            FunctionExpr::ArrayExpr(ArrayFunction::CountMatches),
+            &[other],
+            false,
+            None,
+        )
     }
 
     #[cfg(feature = "array_to_struct")]

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -217,9 +217,7 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
             }),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ElementWise,
-                flags: FunctionFlags::default()
-                    | FunctionFlags::INPUT_WILDCARD_EXPANSION
-                    | FunctionFlags::ALLOW_RENAME,
+                flags: FunctionFlags::default() | FunctionFlags::ALLOW_RENAME,
                 fmt_str: "datetime",
                 ..Default::default()
             },

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -318,8 +318,7 @@ impl ListNameSpace {
                 cast_to_supertypes: Some(SuperTypeOptions {
                     flags: SuperTypeFlags::default() | SuperTypeFlags::ALLOW_IMPLODE_LIST,
                 }),
-                flags: FunctionFlags::default()
-                    | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR,
+                flags: FunctionFlags::default() & !FunctionFlags::RETURNS_SCALAR,
                 ..Default::default()
             },
         }

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -71,3 +71,13 @@ def test_datetime_ambiguous_time_zone_earliest() -> None:
     expected = datetime(2018, 10, 28, 2, 30, tzinfo=ZoneInfo("Europe/Brussels"))
     assert result == expected
     assert result.fold == 0
+
+
+def test_datetime_wildcard_expansion() -> None:
+    df = pl.DataFrame({"a": [1], "b": [2]})
+    assert df.select(
+        pl.datetime(year=pl.all(), month=pl.all(), day=pl.all()).name.keep()
+    ).to_dict(as_series=False) == {
+        "a": [datetime(1, 1, 1, 0, 0)],
+        "b": [datetime(2, 2, 2, 0, 0)],
+    }

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -393,6 +393,17 @@ def test_array_count_matches(
     assert out.to_dict(as_series=False) == {"count_matches": expected}
 
 
+def test_array_count_matches_wildcard_expansion() -> None:
+    df = pl.DataFrame(
+        {"a": [[1, 2]], "b": [[3, 4]]},
+        schema={"a": pl.Array(pl.Int64, 2), "b": pl.Array(pl.Int64, 2)},
+    )
+    assert df.select(pl.all().arr.count_matches(3)).to_dict(as_series=False) == {
+        "a": [0],
+        "b": [1],
+    }
+
+
 def test_array_to_struct() -> None:
     df = pl.DataFrame(
         {"a": [[1, 2, 3], [4, 5, None]]}, schema={"a": pl.Array(pl.Int8, 3)}

--- a/py-polars/tests/unit/operations/namespaces/list/test_set_operations.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_set_operations.py
@@ -40,7 +40,11 @@ def test_list_set_operations_float() -> None:
 
 def test_list_set_operations() -> None:
     df = pl.DataFrame(
-        {"a": [[1, 2, 3], [1, 1, 1], [4]], "b": [[4, 2, 1], [2, 1, 12], [4]]}
+        {
+            "a": [[1, 2, 3], [1, 1, 1], [4]],
+            "b": [[4, 2, 1], [2, 1, 12], [4]],
+            "c": [[1, 2], [2, 1, 76], [8, 9]],
+        }
     )
 
     assert df.select(pl.col("a").list.set_union("b"))["a"].to_list() == [
@@ -63,6 +67,24 @@ def test_list_set_operations() -> None:
         [2, 12],
         [],
     ]
+
+    # check expansion of columns
+    assert df.select(pl.col("a", "b").list.set_intersection("c")).to_dict(
+        as_series=False
+    ) == {"a": [[1, 2], [1], []], "b": [[2, 1], [2, 1], []]}
+
+    assert df.select(pl.col("a", "b").list.set_union("c")).to_dict(as_series=False) == {
+        "a": [[1, 2, 3], [1, 2, 76], [4, 8, 9]],
+        "b": [[4, 2, 1], [2, 1, 12, 76], [4, 8, 9]],
+    }
+
+    assert df.select(pl.col("a", "b").list.set_difference("c")).to_dict(
+        as_series=False
+    ) == {"a": [[3], [], [4]], "b": [[4], [12], [4]]}
+
+    assert df.select(pl.col("a", "b").list.set_symmetric_difference("c")).to_dict(
+        as_series=False
+    ) == {"a": [[3], [2, 76], [4, 8, 9]], "b": [[4], [12, 76], [4, 8, 9]]}
 
     # check logical types
     dtype = pl.List(pl.Date)


### PR DESCRIPTION
Fixes #18795 

Continuing from the previous PR (#19449), have fixed wildcard/input expansion for a few more functions by removing INPUT_WILDCARD_EXPANSION  - 

### pl.datetime

Before -
```
df = pl.DataFrame({"a": [1], "b": [2]})
print(df.select(pl.datetime(year=pl.all(),month=pl.all(),day=pl.all()).name.keep() ))
shape: (1, 1)
┌─────────────────────┐
│ a                   │
│ ---                 │
│ datetime[μs]        │
╞═════════════════════╡
│ 0001-02-01 02:01:02 │
└─────────────────────┘
```
After - 
```
df = pl.DataFrame({"a": [1], "b": [2]})
print(df.select(pl.datetime(year=pl.all(),month=pl.all(),day=pl.all()).name.keep() ))
shape: (1, 2)
┌─────────────────────┬─────────────────────┐
│ a                   ┆ b                   │
│ ---                 ┆ ---                 │
│ datetime[μs]        ┆ datetime[μs]        │
╞═════════════════════╪═════════════════════╡
│ 0001-01-01 00:00:00 ┆ 0002-02-02 00:00:00 │
└─────────────────────┴─────────────────────┘
```
### arr.count_matches

Before - 
```
df = pl.DataFrame({"a": [[1, 2]], "b": [[3, 4]]},schema={"a": pl.Array(pl.Int64, 2),"b": pl.Array(pl.Int64, 2)})
print(df.select(pl.all().arr.count_matches(3)))
PanicException: called `Result::unwrap()` on an `Err` value: SchemaMismatch(ErrString("invalid series dtype: expected `Int64`, got `array[i64, 2]`"))
```
After - 
```
df = pl.DataFrame({"a": [[1, 2]], "b": [[3, 4]]},schema={"a": pl.Array(pl.Int64, 2),"b": pl.Array(pl.Int64, 2)})
print(df.select(pl.all().arr.count_matches(3)))
shape: (1, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ u32 ┆ u32 │
╞═════╪═════╡
│ 0   ┆ 1   │
└─────┴─────┘
```

### list.set_*

Before - 
```
df = pl.DataFrame(
    {"a": [[1, 2, 3], [1, 1, 1], [4]], "b": [[4, 2, 1], [2, 1, 12], [4]],"c":[[1,2],[2,1,76],[8,9]]}
)
print(df.select(pl.col("a", "b").list.set_intersection("c")) )
shape: (3, 1)
┌───────────┐
│ a         │
│ ---       │
│ list[i64] │
╞═══════════╡
│ [1, 2]    │
│ [1]       │
│ [4]       │
└───────────┘
```
After - 
```
df = pl.DataFrame(
    {"a": [[1, 2, 3], [1, 1, 1], [4]], "b": [[4, 2, 1], [2, 1, 12], [4]],"c":[[1,2],[2,1,76],[8,9]]}
)
print(df.select(pl.col("a", "b").list.set_intersection("c")) )
shape: (3, 2)
┌───────────┬───────────┐
│ a         ┆ b         │
│ ---       ┆ ---       │
│ list[i64] ┆ list[i64] │
╞═══════════╪═══════════╡
│ [1, 2]    ┆ [2, 1]    │
│ [1]       ┆ [2, 1]    │
│ []        ┆ []        │
└───────────┴───────────┘
```
Similar changes for other `.list.set_*` functions



Notes 

- One thing I noticed in the code was that the `INPUT_WILDCARD_EXPANSION` flag is used not only for specifying wildcard expansion but also for specifying how to deal with multiple input columns. Perhaps the name of the flag needs to be changed( `INPUT_EXPANSION` ? ) or atleast we can document it.
- There are still a couple of places where `INPUT_WILDCARD_EXPANSION`  might be wrongly set , but I was not able to figure out how to deal with those -
- 1) `.list.concat` - here the code is shared with `pl.concat_list`, for the former we should remove the flag but we need it for the latter
- 2) `.struct.with_fields` - Not sure how to deal with cases like `pl.col(a,b).struct.with_fields(c,d)` where there are multiple input columns on both sides.




