### PR TITLE
perf: Reorder conditions in is_leap_year

### DIFF
--- a/crates/polars-time/src/windows/calendar.rs
+++ b/crates/polars-time/src/windows/calendar.rs
@@ -5,7 +5,7 @@ pub(crate) const DAYS_PER_MONTH: [[i64; 12]; 2] = [
 ];
 
 pub(crate) const fn is_leap_year(year: i32) -> bool {
-    year % 400 == 0 || (year % 4 == 0 && year % 100 != 0)
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 }
 /// nanoseconds per unit
 pub const NS_MICROSECOND: i64 = 1_000;


### PR DESCRIPTION
This is a completely random shot as I was just reading polars source code for fun and have no insights into it. I can imagine the rust compiler optimises this anyway but I'd rule out 75 % of cases in the first check rather than 0.25 %.