### PR TITLE
ci: Configure grouped Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     commit-message:
       prefix: ci
     labels: ['skip changelog']
+    groups:
+      ci:
+        patterns:
+          - '*'
 
   # Rust Polars
   - package-ecosystem: cargo
@@ -24,6 +28,10 @@ updates:
       prefix: build
       prefix-development: chore(rust)
     labels: ['skip changelog']
+    groups:
+      rust:
+        patterns:
+          - '*'
 
   # Python Polars
   - package-ecosystem: pip
@@ -36,6 +44,10 @@ updates:
     commit-message:
       prefix: chore(python)
     labels: ['skip changelog']
+    groups:
+      python:
+        patterns:
+          - '*'
 
   # Documentation
   - package-ecosystem: pip
@@ -48,3 +60,7 @@ updates:
     commit-message:
       prefix: chore(python)
     labels: ['skip changelog']
+    groups:
+      documentation:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
     commit-message:
-      prefix: build(rust)
+      prefix: build
       prefix-development: chore(rust)
     labels: ['skip changelog']
 
@@ -35,18 +35,6 @@ updates:
         update-types: ['version-update:semver-patch']
     commit-message:
       prefix: chore(python)
-    labels: ['skip changelog']
-
-  - package-ecosystem: cargo
-    directory: py-polars
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-patch']
-    commit-message:
-      prefix: build(python)
-      prefix-development: chore(python)
     labels: ['skip changelog']
 
   # Documentation


### PR DESCRIPTION
Relevant docs here:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

This functionality was introduced about a year ago - it wasn't available yet when I set up dependabot for this repo.

This should drastically reduce the number of PRs opened by dependabot each month.