### PR TITLE
fix: Allow `.struct.with_fields` inside `list.eval`

### DIFF
--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -105,7 +105,7 @@ impl StructNameSpace {
             function: FunctionExpr::StructExpr(StructFunction::WithFields),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ElementWise,
-                flags: FunctionFlags::default() & !FunctionFlags::ALLOW_GROUP_AWARE
+                flags: FunctionFlags::default()
                     | FunctionFlags::PASS_NAME_TO_APPLY
                     | FunctionFlags::INPUT_WILDCARD_EXPANSION,
                 ..Default::default()

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1186,3 +1186,31 @@ def test_struct_eq_missing_outer_validity_19156(
 
     assert_series_equal(l.eq_missing(r), pl.Series([True, False]))
     assert_series_equal(l.ne_missing(r), pl.Series([False, True]))
+
+
+def test_struct_field_list_eval_17356() -> None:
+    df = pl.DataFrame(
+        {
+            "items": [
+                [
+                    {"name": "John", "age": 30, "car": None},
+                ],
+                [
+                    {"name": "Alice", "age": 65, "car": "Volvo"},
+                ],
+            ]
+        }
+    )
+
+    assert df.select(
+        pl.col("items").list.eval(
+            pl.element().struct.with_fields(
+                pl.field("name").str.to_uppercase(), pl.field("car").fill_null("Mazda")
+            )
+        )
+    ).to_dict(as_series=False) == {
+        "items": [
+            [{"name": "JOHN", "age": 30, "car": "Mazda"}],
+            [{"name": "ALICE", "age": 65, "car": "Mazda"}],
+        ],
+    }


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/17356

```python
df = pl.DataFrame({
    "x": [[{"a": 1, "b": 2}], [{"a": 3, "b": 4}]]
})

df.with_columns(
    pl.col.x.list.eval(pl.element().struct.with_fields(c = pl.field("a") + 10))
)    

# shape: (2, 1)
# ┌─────────────────┐
# │ x               │
# │ ---             │
# │ list[struct[3]] │
# ╞═════════════════╡
# │ [{1,2,11}]      │
# │ [{3,4,13}]      │
# └─────────────────┘
```

All tests still pass - but I'm not sure if there may be a reason why the flag is currently disabled.