### PR TITLE
fix(rust): Run join type coercion with correct schemas active

### DIFF
--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -110,7 +110,13 @@ pub fn resolve_join(
     ctxt.conversion_optimizer
         .fill_scratch(&left_on, ctxt.expr_arena);
     ctxt.conversion_optimizer
+        .coerce_types(ctxt.expr_arena, ctxt.lp_arena, input_left)
+        .map_err(|e| e.context("'join' failed".into()))?;
+    ctxt.conversion_optimizer
         .fill_scratch(&right_on, ctxt.expr_arena);
+    ctxt.conversion_optimizer
+        .coerce_types(ctxt.expr_arena, ctxt.lp_arena, input_right)
+        .map_err(|e| e.context("'join' failed".into()))?;
 
     // Every expression must be elementwise so that we are
     // guaranteed the keys for a join are all the same length.
@@ -128,7 +134,7 @@ pub fn resolve_join(
         right_on,
         options,
     };
-    run_conversion(lp, ctxt, "join")
+    Ok(ctxt.lp_arena.add(lp))
 }
 
 #[cfg(feature = "iejoin")]

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -141,7 +141,7 @@ def test_join_asof_mismatched_dtypes() -> None:
     )
 
     with pytest.raises(
-        pl.exceptions.ComputeError, match="datatypes of join keys don't match"
+        pl.exceptions.SchemaError, match="datatypes of join keys don't match"
     ):
         df1.join_asof(df2, on="a", strategy="forward")
 


### PR DESCRIPTION
We previously ran type coercion for the left (respectively right) key expressions with the schema of the output join node active. This is incorrect since the keys may not even refer to column names in the output (if the expressions do not refer to columns). Instead, the left (right) key expressions must be coerced with the left (right) inputs active.

With this done, we now no longer need to run type coercion on the resulting Join node, and instead must just add it to the arena.

- Fixes #19597