### PR TITLE
feat: Add SQL support for `RIGHT JOIN`, fix an issue with wildcard aliasing

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -1156,6 +1156,24 @@ pub(crate) fn adjust_one_indexed_param(idx: Expr, null_if_zero: bool) -> Expr {
     }
 }
 
+fn resolve_column<'a>(
+    ctx: &'a mut SQLContext,
+    ident_root: &'a Ident,
+    name: &'a str,
+    dtype: &'a DataType,
+) -> PolarsResult<(Expr, Option<&'a DataType>)> {
+    let resolved = ctx.resolve_name(&ident_root.value, name);
+    let resolved = resolved.as_str();
+    Ok((
+        if name != resolved {
+            col(resolved).alias(name)
+        } else {
+            col(name)
+        },
+        Some(dtype),
+    ))
+}
+
 pub(crate) fn resolve_compound_identifier(
     ctx: &mut SQLContext,
     idents: &[Ident],
@@ -1182,20 +1200,11 @@ pub(crate) fn resolve_compound_identifier(
         let name = &remaining_idents.next().unwrap().value;
         if lf.is_some() && name == "*" {
             return Ok(schema
-                .iter_names()
-                .map(|name| col(name.clone()))
+                .iter_names_and_dtypes()
+                .map(|(name, dtype)| resolve_column(ctx, ident_root, name, dtype).unwrap().0)
                 .collect::<Vec<_>>());
         } else if let Some((_, name, dtype)) = schema.get_full(name) {
-            let resolved = ctx.resolve_name(&ident_root.value, name);
-            let resolved = resolved.as_str();
-            Ok((
-                if name != resolved {
-                    col(resolved).alias(name.clone())
-                } else {
-                    col(name.clone())
-                },
-                Some(dtype),
-            ))
+            resolve_column(ctx, ident_root, name, dtype)
         } else if lf.is_none() {
             remaining_idents = idents.iter().skip(1);
             Ok((

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -295,10 +296,11 @@ def test_join_misc_16255() -> None:
 )
 def test_non_equi_joins(constraint: str) -> None:
     # no support (yet) for non equi-joins in polars joins
+    # TODO: integrate awareness of new IEJoin
     with (
         pytest.raises(
             SQLInterfaceError,
-            match=r"only equi-join constraints are supported",
+            match=r"only equi-join constraints are currently supported",
         ),
         pl.SQLContext({"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2]})}) as ctx,
     ):
@@ -333,6 +335,109 @@ def test_implicit_joins() -> None:
             WHERE t1.a = t2.b
             """
         )
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        # INNER joins
+        (
+            "SELECT df1.* FROM df1 INNER JOIN df2 USING (a)",
+            {"a": [1, 3], "b": ["x", "z"], "c": [100, 300]},
+        ),
+        (
+            "SELECT df2.* FROM df1 INNER JOIN df2 USING (a)",
+            {"a": [1, 3], "b": ["qq", "pp"], "c": [400, 500]},
+        ),
+        (
+            "SELECT df1.* FROM df2 INNER JOIN df1 USING (a)",
+            {"a": [1, 3], "b": ["x", "z"], "c": [100, 300]},
+        ),
+        (
+            "SELECT df2.* FROM df2 INNER JOIN df1 USING (a)",
+            {"a": [1, 3], "b": ["qq", "pp"], "c": [400, 500]},
+        ),
+        # LEFT joins
+        (
+            "SELECT df1.* FROM df1 LEFT JOIN df2 USING (a)",
+            {"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [100, 200, 300]},
+        ),
+        (
+            "SELECT df2.* FROM df1 LEFT JOIN df2 USING (a)",
+            {"a": [1, 3, None], "b": ["qq", "pp", None], "c": [400, 500, None]},
+        ),
+        (
+            "SELECT df1.* FROM df2 LEFT JOIN df1 USING (a)",
+            {"a": [1, 3, None], "b": ["x", "z", None], "c": [100, 300, None]},
+        ),
+        (
+            "SELECT df2.* FROM df2 LEFT JOIN df1 USING (a)",
+            {"a": [1, 3, 4], "b": ["qq", "pp", "oo"], "c": [400, 500, 600]},
+        ),
+        # RIGHT joins
+        (
+            "SELECT df1.* FROM df1 RIGHT JOIN df2 USING (a)",
+            {"a": [1, 3, None], "b": ["x", "z", None], "c": [100, 300, None]},
+        ),
+        (
+            "SELECT df2.* FROM df1 RIGHT JOIN df2 USING (a)",
+            {"a": [1, 3, 4], "b": ["qq", "pp", "oo"], "c": [400, 500, 600]},
+        ),
+        (
+            "SELECT df1.* FROM df2 RIGHT JOIN df1 USING (a)",
+            {"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [100, 200, 300]},
+        ),
+        (
+            "SELECT df2.* FROM df2 RIGHT JOIN df1 USING (a)",
+            {"a": [1, 3, None], "b": ["qq", "pp", None], "c": [400, 500, None]},
+        ),
+        # FULL joins
+        (
+            "SELECT df1.* FROM df1 FULL JOIN df2 USING (a)",
+            {
+                "a": [1, 2, 3, None],
+                "b": ["x", "y", "z", None],
+                "c": [100, 200, 300, None],
+            },
+        ),
+        (
+            "SELECT df2.* FROM df1 FULL JOIN df2 USING (a)",
+            {
+                "a": [1, 3, 4, None],
+                "b": ["qq", "pp", "oo", None],
+                "c": [400, 500, 600, None],
+            },
+        ),
+        (
+            "SELECT df1.* FROM df2 FULL JOIN df1 USING (a)",
+            {
+                "a": [1, 2, 3, None],
+                "b": ["x", "y", "z", None],
+                "c": [100, 200, 300, None],
+            },
+        ),
+        (
+            "SELECT df2.* FROM df2 FULL JOIN df1 USING (a)",
+            {
+                "a": [1, 3, 4, None],
+                "b": ["qq", "pp", "oo", None],
+                "c": [400, 500, 600, None],
+            },
+        ),
+    ],
+)
+def test_wildcard_resolution_and_join_order(
+    query: str, expected: dict[str, Any]
+) -> None:
+    df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [100, 200, 300]})  # noqa: F841
+    df2 = pl.DataFrame({"a": [1, 3, 4], "b": ["qq", "pp", "oo"], "c": [400, 500, 600]})  # noqa: F841
+
+    res = pl.sql(query).collect()
+    assert_frame_equal(
+        res,
+        pl.DataFrame(expected),
+        check_row_order=False,
+    )
 
 
 def test_natural_joins_01() -> None:
@@ -481,8 +586,15 @@ def test_natural_joins_02(cols_constraint: str, expect_data: list[tuple[int]]) -
 @pytest.mark.parametrize(
     "join_clause",
     [
-        "df2 INNER JOIN df3 ON df2.CharacterID=df3.CharacterID",
-        "df2 INNER JOIN (df3 INNDER JOIN df4 ON df3.CharacterID=df4.CharacterID) ON df2.CharacterID=df3.CharacterID",
+        """
+        df2 JOIN df3 ON
+        df2.CharacterID = df3.CharacterID
+        """,
+        """
+        df2 INNER JOIN (
+          df3 JOIN df4 ON df3.CharacterID = df4.CharacterID
+        ) ON df2.CharacterID = df3.CharacterID
+        """,
     ],
 )
 def test_nested_join(join_clause: str) -> None:


### PR DESCRIPTION
* Exposes the `right join` support added in #17441 up to the SQL interface.
* Fixes #17552, where a SELECT on a single `alias.*` wildcard would _always_ select from the left-most frame; the columns are now resolved with respect to the alias in all cases.
* Additional test coverage for these cases, and join aliasing in general.


## Examples

Establish some test frames:
```python
import polars as pl

df1 = pl.DataFrame({
  "a": [1, 2, 3],
  "b": ["x", "y", "z"],
  "c": [100, 200, 300],
})
df2 = pl.DataFrame({
  "a": [1, 3, 2],
  "b": ["qq", "pp", "oo"],
  "c": [400, 500, 600],
})
```
Apply a `RIGHT JOIN` (new feature)...
...returning all cols from the _right-most_ frame (bugfix):
```python
pl.sql("""
  SELECT df2.*
  FROM df1 RIGHT JOIN df2 USING (a) ORDER BY a
""").collect()

# shape: (3, 3)
# ┌─────┬─────┬─────┐
# │ a   ┆ b   ┆ c   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ str ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 1   ┆ qq  ┆ 400 │
# │ 2   ┆ oo  ┆ 600 │
# │ 3   ┆ pp  ┆ 500 │
# └─────┴─────┴─────┘
```
