### PR TITLE
fix: Fix incorrect lazy schema for `explode()` in `agg()`

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -170,7 +170,7 @@ impl ApplyExpr {
                 // })?
                 let out: ListChunked = POOL.install(|| iter.collect::<PolarsResult<_>>())?;
 
-                debug_assert_eq!(out.dtype(), &dtype);
+                debug_assert_eq!(&dtype, out.dtype());
 
                 out
             } else {

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -170,7 +170,15 @@ impl ApplyExpr {
                 // })?
                 let out: ListChunked = POOL.install(|| iter.collect::<PolarsResult<_>>())?;
 
-                debug_assert_eq!(out.dtype(), &DataType::List(Box::new(dtype)));
+                if cfg!(debug_assertions) {
+                    if self.function_returns_scalar {
+                        // TODO: Not sure whether having this if branch is correct behavior..
+                        // but it makes all the tests green so :^
+                        debug_assert_eq!(out.dtype(), &DataType::List(Box::new(dtype)));
+                    } else {
+                        debug_assert_eq!(out.dtype(), &dtype)
+                    }
+                }
 
                 out
             } else {

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -170,7 +170,11 @@ impl ApplyExpr {
                 // })?
                 let out: ListChunked = POOL.install(|| iter.collect::<PolarsResult<_>>())?;
 
-                debug_assert_eq!(&dtype, out.dtype());
+                if self.function_returns_scalar {
+                    debug_assert_eq!(&DataType::List(Box::new(dtype)), out.dtype());
+                } else {
+                    debug_assert_eq!(&dtype, out.dtype());
+                }
 
                 out
             } else {

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -170,15 +170,7 @@ impl ApplyExpr {
                 // })?
                 let out: ListChunked = POOL.install(|| iter.collect::<PolarsResult<_>>())?;
 
-                if cfg!(debug_assertions) {
-                    if self.function_returns_scalar {
-                        // TODO: Not sure whether having this if branch is correct behavior..
-                        // but it makes all the tests green so :^
-                        debug_assert_eq!(out.dtype(), &DataType::List(Box::new(dtype)));
-                    } else {
-                        debug_assert_eq!(out.dtype(), &dtype)
-                    }
-                }
+                debug_assert_eq!(out.dtype(), &dtype);
 
                 out
             } else {

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -473,13 +473,9 @@ fn create_physical_expr_inner(
             options,
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
-            let mut output_field =
-                expr_arena
-                    .get(expression)
-                    .to_field(schema, Context::Default, expr_arena)?;
-            if let Context::Aggregation = ctxt {
-                output_field.dtype = DataType::List(Box::new(output_field.dtype));
-            }
+            let output_field = expr_arena
+                .get(expression)
+                .to_field(schema, ctxt, expr_arena)?;
 
             let is_reducing_aggregation = options.flags.contains(FunctionFlags::RETURNS_SCALAR)
                 && matches!(options.collect_groups, ApplyOptions::GroupWise);
@@ -514,14 +510,9 @@ fn create_physical_expr_inner(
             options,
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
-            let mut output_field =
-                expr_arena
-                    .get(expression)
-                    .to_field(schema, Context::Default, expr_arena)?;
-            if let Context::Aggregation = ctxt {
-                output_field.dtype = DataType::List(Box::new(output_field.dtype));
-            }
-
+            let output_field = expr_arena
+                .get(expression)
+                .to_field(schema, ctxt, expr_arena)?;
             let is_reducing_aggregation = options.flags.contains(FunctionFlags::RETURNS_SCALAR)
                 && matches!(options.collect_groups, ApplyOptions::GroupWise);
             // Will be reset in the function so get that here.

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -562,10 +562,9 @@ fn create_physical_expr_inner(
                 move |c: &mut [polars_core::frame::column::Column]| c[0].explode().map(Some),
             ) as Arc<dyn ColumnsUdf>);
 
-            let mut field =
-                expr_arena
-                    .get(expression)
-                    .to_field(schema, Context::Default, expr_arena)?;
+            let mut field = expr_arena
+                .get(expression)
+                .to_field(schema, ctxt, expr_arena)?;
 
             if let Context::Aggregation = ctxt {
                 field.dtype = DataType::List(Box::new(field.dtype));

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -571,9 +571,15 @@ fn create_physical_expr_inner(
                 move |c: &mut [polars_core::frame::column::Column]| c[0].explode().map(Some),
             ) as Arc<dyn ColumnsUdf>);
 
-            let field = expr_arena
-                .get(expression)
-                .to_field(schema, ctxt, expr_arena)?;
+            let mut field =
+                expr_arena
+                    .get(expression)
+                    .to_field(schema, Context::Default, expr_arena)?;
+
+            if let Context::Aggregation = ctxt {
+                field.dtype = DataType::List(Box::new(field.dtype));
+            }
+
             Ok(Arc::new(ApplyExpr::new(
                 vec![input],
                 function,

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -239,7 +239,7 @@ fn create_physical_expr_inner(
                     // TODO! Order by
                     let group_by = create_physical_expressions_from_nodes(
                         partition_by,
-                        Context::Default,
+                        ctxt,
                         expr_arena,
                         schema,
                         state,
@@ -473,10 +473,9 @@ fn create_physical_expr_inner(
             options,
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
-            let output_dtype =
-                expr_arena
-                    .get(expression)
-                    .to_field(schema, Context::Default, expr_arena)?;
+            let output_dtype = expr_arena
+                .get(expression)
+                .to_field(schema, ctxt, expr_arena)?;
 
             let is_reducing_aggregation = options.flags.contains(FunctionFlags::RETURNS_SCALAR)
                 && matches!(options.collect_groups, ApplyOptions::GroupWise);
@@ -512,10 +511,9 @@ fn create_physical_expr_inner(
             ..
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
-            let output_field =
-                expr_arena
-                    .get(expression)
-                    .to_field(schema, Context::Default, expr_arena)?;
+            let output_field = expr_arena
+                .get(expression)
+                .to_field(schema, ctxt, expr_arena)?;
             let is_reducing_aggregation = options.flags.contains(FunctionFlags::RETURNS_SCALAR)
                 && matches!(options.collect_groups, ApplyOptions::GroupWise);
             // Will be reset in the function so get that here.

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -562,7 +562,7 @@ fn create_physical_expr_inner(
                 move |c: &mut [polars_core::frame::column::Column]| c[0].explode().map(Some),
             ) as Arc<dyn ColumnsUdf>);
 
-            let mut field = expr_arena
+            let field = expr_arena
                 .get(expression)
                 .to_field(schema, ctxt, expr_arena)?;
 

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -239,7 +239,7 @@ fn create_physical_expr_inner(
                     // TODO! Order by
                     let group_by = create_physical_expressions_from_nodes(
                         partition_by,
-                        ctxt,
+                        Context::Aggregation,
                         expr_arena,
                         schema,
                         state,
@@ -473,9 +473,13 @@ fn create_physical_expr_inner(
             options,
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
-            let output_field = expr_arena
-                .get(expression)
-                .to_field(schema, ctxt, expr_arena)?;
+            let mut output_field =
+                expr_arena
+                    .get(expression)
+                    .to_field(schema, Context::Default, expr_arena)?;
+            if let Context::Aggregation = ctxt {
+                output_field.dtype = DataType::List(Box::new(output_field.dtype));
+            }
 
             let is_reducing_aggregation = options.flags.contains(FunctionFlags::RETURNS_SCALAR)
                 && matches!(options.collect_groups, ApplyOptions::GroupWise);
@@ -508,12 +512,16 @@ fn create_physical_expr_inner(
             input,
             function,
             options,
-            ..
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
-            let output_field = expr_arena
-                .get(expression)
-                .to_field(schema, ctxt, expr_arena)?;
+            let mut output_field =
+                expr_arena
+                    .get(expression)
+                    .to_field(schema, Context::Default, expr_arena)?;
+            if let Context::Aggregation = ctxt {
+                output_field.dtype = DataType::List(Box::new(output_field.dtype));
+            }
+
             let is_reducing_aggregation = options.flags.contains(FunctionFlags::RETURNS_SCALAR)
                 && matches!(options.collect_groups, ApplyOptions::GroupWise);
             // Will be reset in the function so get that here.

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -566,10 +566,6 @@ fn create_physical_expr_inner(
                 .get(expression)
                 .to_field(schema, ctxt, expr_arena)?;
 
-            if let Context::Aggregation = ctxt {
-                field.dtype = DataType::List(Box::new(field.dtype));
-            }
-
             Ok(Arc::new(ApplyExpr::new(
                 vec![input],
                 function,

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -473,7 +473,7 @@ fn create_physical_expr_inner(
             options,
         } => {
             let is_scalar = is_scalar_ae(expression, expr_arena);
-            let output_dtype = expr_arena
+            let output_field = expr_arena
                 .get(expression)
                 .to_field(schema, ctxt, expr_arena)?;
 
@@ -500,7 +500,7 @@ fn create_physical_expr_inner(
                 *options,
                 state.allow_threading,
                 schema.clone(),
-                output_dtype,
+                output_field,
                 is_scalar,
             )))
         },

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -263,8 +263,6 @@ impl AExpr {
                 options,
                 ..
             } => {
-                *nested = nested
-                    .saturating_sub(options.flags.contains(FunctionFlags::RETURNS_SCALAR) as _);
                 let fields = func_args_to_fields(input, schema, arena, nested)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", options.fmt_str);
                 output_type.get_field(schema, Context::Default, &fields)
@@ -274,8 +272,6 @@ impl AExpr {
                 input,
                 options,
             } => {
-                *nested = nested
-                    .saturating_sub(options.flags.contains(FunctionFlags::RETURNS_SCALAR) as _);
                 let fields = func_args_to_fields(input, schema, arena, nested)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", function);
                 function.get_field(schema, Context::Default, &fields)

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -73,6 +73,9 @@ impl AExpr {
             },
             Explode(expr) => {
                 let field = arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
+                // `Explode` is a "flatten" operation, which is not the same as returning a scalar.
+                // Namely, it should be auto-imploded in the aggregation context, so we don't update
+                // the `nested` state here.
 
                 if let List(inner) = field.dtype() {
                     Ok(Field::new(field.name().clone(), *inner.clone()))

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -74,6 +74,8 @@ impl AExpr {
             Explode(expr) => {
                 let field = arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
 
+                dbg!(&field);
+
                 if let List(inner) = field.dtype() {
                     Ok(Field::new(field.name().clone(), *inner.clone()))
                 } else {

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -38,7 +38,7 @@ impl AExpr {
         //      col(foo: i64).sum() -> i64
         // The `nested` keeps track of the nesting we need to add.
         let mut nested = matches!(ctx, Context::Aggregation) as u8;
-        let mut field = self.to_field_impl(schema, arena, &mut nested)?;
+        let mut field = self.to_field_impl(schema, ctx, arena, &mut nested)?;
 
         if nested >= 1 {
             field.coerce(field.dtype().clone().implode());
@@ -51,6 +51,7 @@ impl AExpr {
     pub fn to_field_impl(
         &self,
         schema: &Schema,
+        ctx: Context,
         arena: &Arena<AExpr>,
         nested: &mut u8,
     ) -> PolarsResult<Field> {
@@ -68,10 +69,10 @@ impl AExpr {
                     *nested += matches!(mapping, WindowMapping::Join) as u8;
                 }
                 let e = arena.get(*function);
-                e.to_field_impl(schema, arena, nested)
+                e.to_field_impl(schema, ctx, arena, nested)
             },
             Explode(expr) => {
-                let field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                let field = arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
 
                 if let List(inner) = field.dtype() {
                     Ok(Field::new(field.name().clone(), *inner.clone()))
@@ -81,7 +82,10 @@ impl AExpr {
             },
             Alias(expr, name) => Ok(Field::new(
                 name.clone(),
-                arena.get(*expr).to_field_impl(schema, arena, nested)?.dtype,
+                arena
+                    .get(*expr)
+                    .to_field_impl(schema, ctx, arena, nested)?
+                    .dtype,
             )),
             Column(name) => schema
                 .get_field(name)
@@ -109,20 +113,23 @@ impl AExpr {
                     | Operator::LogicalOr => {
                         let out_field;
                         let out_name = {
-                            out_field = arena.get(*left).to_field_impl(schema, arena, nested)?;
+                            out_field =
+                                arena.get(*left).to_field_impl(schema, ctx, arena, nested)?;
                             out_field.name()
                         };
                         Field::new(out_name.clone(), Boolean)
                     },
                     Operator::TrueDivide => {
-                        return get_truediv_field(*left, *right, arena, schema, nested)
+                        return get_truediv_field(*left, *right, arena, ctx, schema, nested)
                     },
-                    _ => return get_arithmetic_field(*left, *right, arena, *op, schema, nested),
+                    _ => {
+                        return get_arithmetic_field(*left, *right, arena, *op, ctx, schema, nested)
+                    },
                 };
 
                 Ok(field)
             },
-            Sort { expr, .. } => arena.get(*expr).to_field_impl(schema, arena, nested),
+            Sort { expr, .. } => arena.get(*expr).to_field_impl(schema, ctx, arena, nested),
             Gather {
                 expr,
                 returns_scalar,
@@ -131,10 +138,10 @@ impl AExpr {
                 if *returns_scalar {
                     *nested = nested.saturating_sub(1);
                 }
-                arena.get(*expr).to_field_impl(schema, arena, nested)
+                arena.get(*expr).to_field_impl(schema, ctx, arena, nested)
             },
-            SortBy { expr, .. } => arena.get(*expr).to_field_impl(schema, arena, nested),
-            Filter { input, .. } => arena.get(*input).to_field_impl(schema, arena, nested),
+            SortBy { expr, .. } => arena.get(*expr).to_field_impl(schema, ctx, arena, nested),
+            Filter { input, .. } => arena.get(*input).to_field_impl(schema, ctx, arena, nested),
             Agg(agg) => {
                 use IRAggExpr::*;
                 match agg {
@@ -143,11 +150,12 @@ impl AExpr {
                     | First(expr)
                     | Last(expr) => {
                         *nested = nested.saturating_sub(1);
-                        arena.get(*expr).to_field_impl(schema, arena, nested)
+                        arena.get(*expr).to_field_impl(schema, ctx, arena, nested)
                     },
                     Sum(expr) => {
                         *nested = nested.saturating_sub(1);
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         let dt = match field.dtype() {
                             Boolean => Some(IDX_DTYPE),
                             UInt8 | Int8 | Int16 | UInt16 => Some(Int64),
@@ -160,7 +168,8 @@ impl AExpr {
                     },
                     Median(expr) => {
                         *nested = nested.saturating_sub(1);
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         match field.dtype {
                             Date => field.coerce(Datetime(TimeUnit::Milliseconds, None)),
                             _ => float_type(&mut field),
@@ -169,7 +178,8 @@ impl AExpr {
                     },
                     Mean(expr) => {
                         *nested = nested.saturating_sub(1);
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         match field.dtype {
                             Date => field.coerce(Datetime(TimeUnit::Milliseconds, None)),
                             _ => float_type(&mut field),
@@ -177,57 +187,64 @@ impl AExpr {
                         Ok(field)
                     },
                     Implode(expr) => {
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         field.coerce(DataType::List(field.dtype().clone().into()));
                         Ok(field)
                     },
                     Std(expr, _) => {
                         *nested = nested.saturating_sub(1);
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         float_type(&mut field);
                         Ok(field)
                     },
                     Var(expr, _) => {
                         *nested = nested.saturating_sub(1);
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         float_type(&mut field);
                         Ok(field)
                     },
                     NUnique(expr) => {
                         *nested = 0;
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         field.coerce(IDX_DTYPE);
                         Ok(field)
                     },
                     Count(expr, _) => {
                         *nested = 0;
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         field.coerce(IDX_DTYPE);
                         Ok(field)
                     },
                     AggGroups(expr) => {
                         *nested = 1;
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         field.coerce(List(IDX_DTYPE.into()));
                         Ok(field)
                     },
                     Quantile { expr, .. } => {
                         *nested = nested.saturating_sub(1);
-                        let mut field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let mut field =
+                            arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         float_type(&mut field);
                         Ok(field)
                     },
                     #[cfg(feature = "bitwise")]
                     Bitwise(expr, _) => {
                         *nested = nested.saturating_sub(1);
-                        let field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                        let field = arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                         // @Q? Do we need to coerce here?
                         Ok(field)
                     },
                 }
             },
             Cast { expr, dtype, .. } => {
-                let field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
+                let field = arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                 Ok(Field::new(field.name().clone(), dtype.clone()))
             },
             Ternary { truthy, falsy, .. } => {
@@ -241,10 +258,11 @@ impl AExpr {
                 let mut truthy =
                     arena
                         .get(*truthy)
-                        .to_field_impl(schema, arena, &mut nested_truthy)?;
-                let falsy = arena
-                    .get(*falsy)
-                    .to_field_impl(schema, arena, &mut nested_falsy)?;
+                        .to_field_impl(schema, ctx, arena, &mut nested_truthy)?;
+                let falsy =
+                    arena
+                        .get(*falsy)
+                        .to_field_impl(schema, ctx, arena, &mut nested_falsy)?;
 
                 let st = if let DataType::Null = *truthy.dtype() {
                     falsy.dtype().clone()
@@ -263,26 +281,39 @@ impl AExpr {
                 options,
                 ..
             } => {
-                let fields = func_args_to_fields(input, schema, arena, nested)?;
+                let fields = func_args_to_fields(input, ctx, schema, arena, nested)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", options.fmt_str);
-                output_type.get_field(schema, Context::Default, &fields)
+                let out = output_type.get_field(schema, ctx, &fields)?;
+
+                if matches!(ctx, Context::Aggregation) {
+                    *nested += 1;
+                }
+
+                Ok(out)
             },
             Function {
                 function,
                 input,
                 options: _,
             } => {
-                let fields = func_args_to_fields(input, schema, arena, nested)?;
+                let fields = func_args_to_fields(input, ctx, schema, arena, nested)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", function);
-                function.get_field(schema, Context::Default, &fields)
+                let out = function.get_field(schema, ctx, &fields)?;
+
+                if matches!(ctx, Context::Aggregation) {
+                    *nested += 1;
+                }
+
+                Ok(out)
             },
-            Slice { input, .. } => arena.get(*input).to_field_impl(schema, arena, nested),
+            Slice { input, .. } => arena.get(*input).to_field_impl(schema, ctx, arena, nested),
         }
     }
 }
 
 fn func_args_to_fields(
     input: &[ExprIR],
+    ctx: Context,
     schema: &Schema,
     arena: &Arena<AExpr>,
     nested: &mut u8,
@@ -303,7 +334,7 @@ fn func_args_to_fields(
 
             arena
                 .get(e.node())
-                .to_field_impl(schema, arena, nested)
+                .to_field_impl(schema, ctx, arena, nested)
                 .map(|mut field| {
                     field.name = e.output_name().clone();
                     field
@@ -317,6 +348,7 @@ fn get_arithmetic_field(
     right: Node,
     arena: &Arena<AExpr>,
     op: Operator,
+    ctx: Context,
     schema: &Schema,
     nested: &mut u8,
 ) -> PolarsResult<Field> {
@@ -332,11 +364,11 @@ fn get_arithmetic_field(
     // leading to quadratic behavior. # 4736
     //
     // further right_type is only determined when needed.
-    let mut left_field = left_ae.to_field_impl(schema, arena, nested)?;
+    let mut left_field = left_ae.to_field_impl(schema, ctx, arena, nested)?;
 
     let super_type = match op {
         Operator::Minus => {
-            let right_type = right_ae.to_field_impl(schema, arena, nested)?.dtype;
+            let right_type = right_ae.to_field_impl(schema, ctx, arena, nested)?.dtype;
             match (&left_field.dtype, &right_type) {
                 #[cfg(feature = "dtype-struct")]
                 (Struct(_), Struct(_)) => {
@@ -391,7 +423,7 @@ fn get_arithmetic_field(
             }
         },
         Operator::Plus => {
-            let right_type = right_ae.to_field_impl(schema, arena, nested)?.dtype;
+            let right_type = right_ae.to_field_impl(schema, ctx, arena, nested)?.dtype;
             match (&left_field.dtype, &right_type) {
                 (Duration(_), Datetime(_, _))
                 | (Datetime(_, _), Duration(_))
@@ -433,7 +465,7 @@ fn get_arithmetic_field(
             }
         },
         _ => {
-            let right_type = right_ae.to_field_impl(schema, arena, nested)?.dtype;
+            let right_type = right_ae.to_field_impl(schema, ctx, arena, nested)?.dtype;
 
             match (&left_field.dtype, &right_type) {
                 #[cfg(feature = "dtype-struct")]
@@ -517,11 +549,12 @@ fn get_truediv_field(
     left: Node,
     right: Node,
     arena: &Arena<AExpr>,
+    ctx: Context,
     schema: &Schema,
     nested: &mut u8,
 ) -> PolarsResult<Field> {
-    let mut left_field = arena.get(left).to_field_impl(schema, arena, nested)?;
-    let right_field = arena.get(right).to_field_impl(schema, arena, nested)?;
+    let mut left_field = arena.get(left).to_field_impl(schema, ctx, arena, nested)?;
+    let right_field = arena.get(right).to_field_impl(schema, ctx, arena, nested)?;
     use DataType::*;
 
     // TODO: Re-investigate this. A lot of "_" is being used on the RHS match because this code

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -72,10 +72,10 @@ impl AExpr {
                 e.to_field_impl(schema, ctx, arena, nested)
             },
             Explode(expr) => {
-                let field = arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
                 // `Explode` is a "flatten" operation, which is not the same as returning a scalar.
                 // Namely, it should be auto-imploded in the aggregation context, so we don't update
                 // the `nested` state here.
+                let field = arena.get(*expr).to_field_impl(schema, ctx, arena, &mut 0)?;
 
                 if let List(inner) = field.dtype() {
                     Ok(Field::new(field.name().clone(), *inner.clone()))

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -74,8 +74,6 @@ impl AExpr {
             Explode(expr) => {
                 let field = arena.get(*expr).to_field_impl(schema, ctx, arena, nested)?;
 
-                dbg!(&field);
-
                 if let List(inner) = field.dtype() {
                     Ok(Field::new(field.name().clone(), *inner.clone()))
                 } else {

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -72,7 +72,6 @@ impl AExpr {
             },
             Explode(expr) => {
                 let field = arena.get(*expr).to_field_impl(schema, arena, nested)?;
-                *nested = nested.saturating_sub(1);
 
                 if let List(inner) = field.dtype() {
                     Ok(Field::new(field.name().clone(), *inner.clone()))

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -270,7 +270,7 @@ impl AExpr {
             Function {
                 function,
                 input,
-                options,
+                options: _,
             } => {
                 let fields = func_args_to_fields(input, schema, arena, nested)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", function);

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -286,6 +286,7 @@ impl AExpr {
                 let out = output_type.get_field(schema, ctx, &fields)?;
 
                 if matches!(ctx, Context::Aggregation) {
+                    // We always want agg list regardless of inner `nested` value.
                     *nested += 1;
                 }
 
@@ -301,6 +302,7 @@ impl AExpr {
                 let out = function.get_field(schema, ctx, &fields)?;
 
                 if matches!(ctx, Context::Aggregation) {
+                    // We always want agg list regardless of inner `nested` value.
                     *nested += 1;
                 }
 

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -285,8 +285,9 @@ impl AExpr {
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", options.fmt_str);
                 let out = output_type.get_field(schema, ctx, &fields)?;
 
-                if matches!(ctx, Context::Aggregation) {
-                    // We always want agg list regardless of inner `nested` value.
+                if options.flags.contains(FunctionFlags::RETURNS_SCALAR) {
+                    *nested = 0;
+                } else if matches!(ctx, Context::Aggregation) {
                     *nested += 1;
                 }
 
@@ -295,14 +296,15 @@ impl AExpr {
             Function {
                 function,
                 input,
-                options: _,
+                options,
             } => {
                 let fields = func_args_to_fields(input, ctx, schema, arena, nested)?;
                 polars_ensure!(!fields.is_empty(), ComputeError: "expression: '{}' didn't get any inputs", function);
                 let out = function.get_field(schema, ctx, &fields)?;
 
-                if matches!(ctx, Context::Aggregation) {
-                    // We always want agg list regardless of inner `nested` value.
+                if options.flags.contains(FunctionFlags::RETURNS_SCALAR) {
+                    *nested = 0;
+                } else if matches!(ctx, Context::Aggregation) {
                     *nested += 1;
                 }
 

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1424,3 +1424,11 @@ def test_lf_unnest() -> None:
         ]
     )
     assert_frame_equal(lf.unnest("a", "b").collect(), expected)
+
+
+def test_lf_schema_explode_in_agg_19562() -> None:
+    lf = pl.LazyFrame({"a": 1, "b": [[1]]})
+    q = lf.group_by("a").agg(pl.col("b").explode())
+
+    assert q.collect_schema() == {"a": pl.Int32, "b": pl.List(pl.Int64)}
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 1, "b": [[1]]}))

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1424,24 +1424,3 @@ def test_lf_unnest() -> None:
         ]
     )
     assert_frame_equal(lf.unnest("a", "b").collect(), expected)
-
-
-def test_lf_explode_in_agg_schema_19562() -> None:
-    lf = pl.LazyFrame({"a": 1, "b": [[1]]})
-    q = lf.group_by("a").agg(pl.col("b").explode())
-
-    assert q.collect_schema() == {"a": pl.Int32, "b": pl.List(pl.Int64)}
-    assert_frame_equal(q.collect(), pl.DataFrame({"a": 1, "b": [[1]]}))
-
-
-def test_lf_nested_function_expr_agg_schema() -> None:
-    q = (
-        pl.LazyFrame({"k": [1, 1, 2]})
-        .group_by(pl.first(), maintain_order=True)
-        .agg(o=pl.int_range(pl.len()).reverse() < 1)
-    )
-
-    assert q.collect_schema() == {"k": pl.Int64, "o": pl.List(pl.Boolean)}
-    assert_frame_equal(
-        q.collect(), pl.DataFrame({"k": [1, 2], "o": [[False, True], [True]]})
-    )

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -246,4 +246,4 @@ def test_lf_agg_lit_explode() -> None:
 
     schema = {"k": pl.Int64, "o": pl.List(pl.Int64)}
     assert q.collect_schema() == schema
-    assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": [[1]]}, schema=schema))
+    assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": [[1]]}, schema=schema))  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -160,3 +160,25 @@ def test_lf_agg_scalar_return_schema() -> None:
     schema = {"k": pl.Int64, "o": pl.UInt32}
     assert q.collect_schema() == schema
     assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": 0}, schema=schema))
+
+
+def test_lf_agg_nested_expr_schema() -> None:
+    q = (
+        pl.LazyFrame({"k": [1]})
+        .group_by("k")
+        .agg(
+            (
+                (
+                    (pl.col("k").shuffle().shuffle() + 1)
+                    + pl.col("k").shuffle().shuffle()
+                )
+                .shuffle()
+                .sum()
+                * 0
+            ).alias("o")
+        )
+    )
+
+    schema = {"k": pl.Int64, "o": pl.Int64}
+    assert q.collect_schema() == schema
+    assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": 0}, schema=schema))

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -199,7 +199,6 @@ def test_lf_nested_function_expr_agg_schema() -> None:
         .agg(o=pl.int_range(pl.len()).reverse() < 1)
     )
 
-    print(q.collect_schema())
     assert q.collect_schema() == {"k": pl.Int64, "o": pl.List(pl.Boolean)}
     assert_frame_equal(
         q.collect(), pl.DataFrame({"k": [1, 2], "o": [[False, True], [True]]})

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -169,10 +169,11 @@ def test_lf_agg_nested_expr_schema() -> None:
         .agg(
             (
                 (
-                    (pl.col("k").shuffle().shuffle() + 1)
-                    + pl.col("k").shuffle().shuffle()
+                    (pl.col("k").reverse().shuffle() + 1)
+                    + pl.col("k").shuffle().reverse()
                 )
                 .shuffle()
+                .reverse()
                 .sum()
                 * 0
             ).alias("o")

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -235,3 +235,15 @@ def test_lf_agg_nested_expr_schema() -> None:
     schema = {"k": pl.Int64, "o": pl.Int64}
     assert q.collect_schema() == schema
     assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": 0}, schema=schema))
+
+
+def test_lf_agg_lit_explode() -> None:
+    q = (
+        pl.LazyFrame({"k": [1]})
+        .group_by("k")
+        .agg(pl.lit(1, dtype=pl.Int64).explode().alias("o"))
+    )
+
+    schema = {"k": pl.Int64, "o": pl.List(pl.Int64)}
+    assert q.collect_schema() == schema
+    assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": [[1]]}, schema=schema))


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19562

* `Explode` during dtype resolution mistakenly indicated that it did not need auto-imploding (see the `nested` variable in the code)
* Also adjusts the output dtype getting/checking logic for FunctionExpr to adhere to:
  * If the function indicates RETURNS_SCALAR, its output dtype shall always be scalar (i.e. .agg(col(f64).sum()) -> Float64)
  * Otherwise, if we are in a Context::Aggregation, we auto-implode the dtype (i.e. .agg(col(f64).shuffle()) -> list[Float64])
  * Assertion was also adjusted during execution in `ApplyExpr`
  * To do this properly we also propagate the `Context` recursively

