### PR TITLE
fix: Fix filter incorrectly pushed past struct unnest when unnested column name matches upper column name

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -577,7 +577,7 @@ impl<'a> PredicatePushDown<'a> {
                             ))
                         },
                         FunctionIR::Unnest { columns } => {
-                            let exclude = columns.iter().collect::<PlHashSet<_>>();
+                            let exclude = columns.iter().cloned().collect::<PlHashSet<_>>();
 
                             let local_predicates =
                                 transfer_to_local_by_name(expr_arena, &mut acc_predicates, |x| {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -576,6 +576,28 @@ impl<'a> PredicatePushDown<'a> {
                                 expr_arena,
                             ))
                         },
+                        FunctionIR::Unnest { columns } => {
+                            let exclude = columns.iter().collect::<PlHashSet<_>>();
+
+                            let local_predicates =
+                                transfer_to_local_by_name(expr_arena, &mut acc_predicates, |x| {
+                                    exclude.contains(x)
+                                });
+
+                            let lp = self.pushdown_and_continue(
+                                lp,
+                                acc_predicates,
+                                lp_arena,
+                                expr_arena,
+                                false,
+                            )?;
+                            Ok(self.optional_apply_predicate(
+                                lp,
+                                local_predicates,
+                                lp_arena,
+                                expr_arena,
+                            ))
+                        },
                         _ => self.pushdown_and_continue(
                             lp,
                             acc_predicates,

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -514,6 +514,34 @@ def test_predicate_push_down_list_gather_17492() -> None:
 
 
 def test_predicate_pushdown_struct_unnest_19632() -> None:
+    lf = pl.LazyFrame({"a": [{"a": 1, "b": 2}]}).unnest("a")
+
+    q = lf.filter(pl.col("a") == 1)
+    plan = q.explain()
+
+    assert "FILTER" in plan
+    assert plan.index("FILTER") < plan.index("UNNEST")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"a": 1, "b": 2}),
+    )
+
+    # With `pl.struct()`
+    lf = pl.LazyFrame({"a": 1, "b": 2}).select(pl.struct(pl.all())).unnest("a")
+
+    q = lf.filter(pl.col("a") == 1)
+    plan = q.explain()
+
+    assert "FILTER" in plan
+    assert plan.index("FILTER") < plan.index("UNNEST")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"a": 1, "b": 2}),
+    )
+
+    # With `value_counts()`
     lf = pl.LazyFrame({"a": [1]}).select(pl.col("a").value_counts()).unnest("a")
 
     q = lf.filter(pl.col("a") == 1)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19632
