### PR TITLE
fix(python): Fix typing for SchemaDefinition

### DIFF
--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -72,7 +72,7 @@ PythonDataType: TypeAlias = Union[
 ]
 
 SchemaDefinition: TypeAlias = Union[
-    Mapping[str, Union[PolarsDataType, PythonDataType]],
+    Mapping[str, Union[PolarsDataType, PythonDataType, None]],
     Sequence[Union[str, tuple[str, Union[PolarsDataType, PythonDataType, None]]]],
 ]
 SchemaDict: TypeAlias = Mapping[str, PolarsDataType]


### PR DESCRIPTION
According to the docs you can map a column name to `None` to let Polars infer the data type of the given column. If you use `None`, that's what happens, but typing complains because it's not expecting the value `None`, only an explicit data type.