### PR TITLE
fix: Ensure `mean_horizontal` raises on non-numeric input

### DIFF
--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -78,12 +78,6 @@ def test_duration_aggs() -> None:
     }
 
 
-def test_mean_horizontal_with_str_column() -> None:
-    assert pl.DataFrame(
-        {"int": [1, 2, 3], "bool": [True, True, None], "str": ["a", "b", "c"]}
-    ).mean_horizontal().to_list() == [1.0, 1.5, 3.0]
-
-
 def test_list_aggregation_that_filters_all_data_6017() -> None:
     out = (
         pl.DataFrame({"col_to_group_by": [2], "flt": [1672740910.967138], "col3": [1]})

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -397,14 +397,14 @@ def test_horizontal_broadcasting() -> None:
 
 
 def test_mean_horizontal() -> None:
-    # numeric
     lf = pl.LazyFrame({"a": [1, 2, 3], "b": [2.0, 4.0, 6.0], "c": [3, None, 9]})
     result = lf.select(pl.mean_horizontal(pl.all()).alias("mean"))
 
     expected = pl.LazyFrame({"mean": [2.0, 3.0, 6.0]}, schema={"mean": pl.Float64})
     assert_frame_equal(result, expected)
 
-    # boolean
+
+def test_mean_horizontal_bool() -> None:
     df = pl.DataFrame(
         {
             "a": [True, False, False],

--- a/py-polars/tests/unit/operations/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/operations/aggregation/test_horizontal.py
@@ -8,7 +8,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, PolarsError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -397,11 +397,23 @@ def test_horizontal_broadcasting() -> None:
 
 
 def test_mean_horizontal() -> None:
+    # numeric
     lf = pl.LazyFrame({"a": [1, 2, 3], "b": [2.0, 4.0, 6.0], "c": [3, None, 9]})
+    result = lf.select(pl.mean_horizontal(pl.all()).alias("mean"))
 
-    result = lf.select(pl.mean_horizontal(pl.all()))
+    expected = pl.LazyFrame({"mean": [2.0, 3.0, 6.0]}, schema={"mean": pl.Float64})
+    assert_frame_equal(result, expected)
 
-    expected = pl.LazyFrame({"a": [2.0, 3.0, 6.0]}, schema={"a": pl.Float64})
+    # boolean
+    df = pl.DataFrame(
+        {
+            "a": [True, False, False],
+            "b": [None, True, False],
+            "c": [True, False, False],
+        }
+    )
+    expected = pl.DataFrame({"mean": [1.0, 1 / 3, 0.0]}, schema={"mean": pl.Float64})
+    result = df.select(mean=pl.mean_horizontal(pl.all()))
     assert_frame_equal(result, expected)
 
 
@@ -475,3 +487,40 @@ def test_fold_all_schema() -> None:
     # divide because of overflow
     result = df.select(pl.sum_horizontal(pl.all().hash(seed=1) // int(1e8)))
     assert result.dtypes == [pl.UInt64]
+
+
+@pytest.mark.parametrize(
+    "horizontal_func",
+    [
+        pl.all_horizontal,
+        pl.any_horizontal,
+        pl.max_horizontal,
+        pl.min_horizontal,
+        pl.mean_horizontal,
+        pl.sum_horizontal,
+    ],
+)
+def test_expected_horizontal_dtype_errors(horizontal_func: type[pl.Expr]) -> None:
+    from decimal import Decimal as D
+
+    import polars as pl
+
+    df = pl.DataFrame(
+        {
+            "cola": [D("1.5"), D("0.5"), D("5"), D("0"), D("-0.25")],
+            "colb": [[0, 1], [2], [3, 4], [5], [6]],
+            "colc": ["aa", "bb", "cc", "dd", "ee"],
+            "cold": ["bb", "cc", "dd", "ee", "ff"],
+            "cole": [1000, 2000, 3000, 4000, 5000],
+        }
+    )
+    with pytest.raises(PolarsError):
+        df.select(
+            horizontal_func(  # type: ignore[call-arg]
+                pl.col("cola"),
+                pl.col("colb"),
+                pl.col("colc"),
+                pl.col("cold"),
+                pl.col("cole"),
+            )
+        )


### PR DESCRIPTION
The `mean_horizontal` expression was the _only_ specialised horizontal function that wouldn't raise an error on incompatible input - instead it just filtered that input for the numeric/boolean columns, checked there was at least one, and operated on those. 

This is inconsistent; `selectors` can be used to trivially choose numeric columns - the expression shouldn't be doing it silently (and it isn't documented that it would do so).

Incompatible input now raises a clear error.

**Also:** 

Allow `Decimal` in `mean_horizontal` (was omitted by an `.is_numeric()` dtype check).

## Example

* **Catch invalid input**
  ```python
  from decimal import Decimal as D
  import polars as pl
  
  df = pl.DataFrame({
      "cola": [D("1.5"), D("0.5"), D("5"), D("0"), D("-0.25")],
      "colb": [[0,1], [2], [3,4], [5], [6]],
      "colc": ["aa", "bb", "cc", "dd", "ee"],
      "cold": ["bb", "cc", "dd", "ee", "ff"],
      "cole": [1000, 2000, 3000, 4000, 5000],
  })
  df.select(
      pl.mean_horizontal(
          pl.col("cola"),
          pl.col("colb"),
          pl.col("colc"),
          pl.col("cold"),
          pl.col("cole"),
      )
  )
  ```
  Before:
  ```python
  # shape: (5, 1)
  # ┌────────┐
  # │ cola   │
  # │ ---    │
  # │ f64    │
  # ╞════════╡
  # │ 1000.0 │
  # │ 2000.0 │
  # │ 3000.0 │
  # │ 4000.0 │
  # │ 5000.0 │
  # └────────┘
  ```
  After:
  ```python
  # InvalidOperationError: 
  # 'horizontal_mean' expects numeric expressions, found "colb" (dtype=list[i64])
  ```