### PR TITLE
refactor: Streamline internal SQL join condition processing

### DIFF
--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -604,14 +604,11 @@ fn test_join_utf8() {
 }
 
 #[test]
-fn test_table() {}
-
-#[test]
 #[should_panic]
 fn test_compound_invalid_1() {
     let mut ctx = prepare_compound_join_context();
     let sql = "SELECT * FROM df1 OUTER JOIN df2 ON a AND b";
-    ctx.execute(sql).unwrap().collect().unwrap();
+    let _ = ctx.execute(sql).unwrap();
 }
 
 #[test]
@@ -619,7 +616,7 @@ fn test_compound_invalid_1() {
 fn test_compound_invalid_2() {
     let mut ctx = prepare_compound_join_context();
     let sql = "SELECT * FROM df1 LEFT JOIN df2 ON df1.a = df2.a AND b = b";
-    ctx.execute(sql).unwrap().collect().unwrap();
+    let _ = ctx.execute(sql).unwrap();
 }
 
 #[test]
@@ -627,5 +624,5 @@ fn test_compound_invalid_2() {
 fn test_compound_invalid_3() {
     let mut ctx = prepare_compound_join_context();
     let sql = "SELECT * FROM df1 INNER JOIN df2 ON df1.a = df2.a AND b";
-    ctx.execute(sql).unwrap().collect().unwrap();
+    let _ = ctx.execute(sql).unwrap();
 }

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -300,7 +300,7 @@ def test_non_equi_joins(constraint: str) -> None:
     with (
         pytest.raises(
             SQLInterfaceError,
-            match=r"only equi-join constraints are currently supported",
+            match=r"only equi-join constraints \(combined with 'AND'\) are currently supported",
         ),
         pl.SQLContext({"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2]})}) as ctx,
     ):


### PR DESCRIPTION
Improved SQL "JOIN ON" constraint resolution; there was a lot of redundant code in  `process_join_constraint` - now delegates properly to `process_join_on`, noticeably streamlining it (and making it easier to integrate some other upcoming fixes).