### PR TITLE
refactor: Get `Column` into `polars-expr`

### DIFF
--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -152,6 +152,15 @@ where
     }
 }
 
+impl FromIterator<Option<Column>> for ListChunked {
+    fn from_iter<T: IntoIterator<Item = Option<Column>>>(iter: T) -> Self {
+        ListChunked::from_iter(
+            iter.into_iter()
+                .map(|c| c.map(|c| c.take_materialized_series())),
+        )
+    }
+}
+
 impl FromIterator<Option<Series>> for ListChunked {
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<Series>>>(iter: I) -> Self {

--- a/crates/polars-core/src/frame/column/arithmetic.rs
+++ b/crates/polars-core/src/frame/column/arithmetic.rs
@@ -1,70 +1,7 @@
 use num_traits::{Num, NumCast};
-use polars_error::{polars_bail, PolarsResult};
+use polars_error::PolarsResult;
 
 use super::{Column, ScalarColumn, Series};
-use crate::utils::Container;
-
-fn output_length(a: &Column, b: &Column) -> PolarsResult<usize> {
-    match (a.len(), b.len()) {
-        // broadcasting
-        (1, o) | (o, 1) => Ok(o),
-        // equal
-        (a, b) if a == b => Ok(a),
-        // unequal
-        (a, b) => {
-            polars_bail!(InvalidOperation: "cannot do arithmetic operation on series of different lengths: got {} and {}", a, b)
-        },
-    }
-}
-
-fn unit_series_op<F: Fn(&Series, &Series) -> PolarsResult<Series>>(
-    l: &Series,
-    r: &Series,
-    op: F,
-    length: usize,
-) -> PolarsResult<Column> {
-    debug_assert!(l.len() <= 1);
-    debug_assert!(r.len() <= 1);
-
-    op(l, r)
-        .map(|s| ScalarColumn::from_single_value_series(s, length))
-        .map(Column::from)
-}
-
-fn op_with_broadcast<F: Fn(&Series, &Series) -> PolarsResult<Series>>(
-    l: &Column,
-    r: &Column,
-    op: F,
-) -> PolarsResult<Column> {
-    // Here we rely on the underlying broadcast operations.
-
-    let length = output_length(l, r)?;
-    match (l, r) {
-        (Column::Series(l), Column::Scalar(r)) => {
-            let r = r.as_single_value_series();
-            if l.len() == 1 {
-                unit_series_op(l, &r, op, length)
-            } else {
-                op(l, &r).map(Column::from)
-            }
-        },
-        (Column::Scalar(l), Column::Series(r)) => {
-            let l = l.as_single_value_series();
-            if r.len() == 1 {
-                unit_series_op(&l, r, op, length)
-            } else {
-                op(&l, r).map(Column::from)
-            }
-        },
-        (Column::Scalar(l), Column::Scalar(r)) => unit_series_op(
-            &l.as_single_value_series(),
-            &r.as_single_value_series(),
-            op,
-            length,
-        ),
-        (l, r) => op(l.as_materialized_series(), r.as_materialized_series()).map(Column::from),
-    }
-}
 
 fn num_op_with_broadcast<T: Num + NumCast, F: Fn(&Series, T) -> Series>(
     c: &'_ Column,
@@ -90,7 +27,7 @@ macro_rules! broadcastable_ops {
 
             #[inline]
             fn $op(self, rhs: Self) -> Self::Output {
-                op_with_broadcast(&self, &rhs, |l, r| l.$op(r))
+                self.try_apply_broadcasting_binary_elementwise(&rhs, |l, r| l.$op(r))
             }
         }
 
@@ -99,7 +36,7 @@ macro_rules! broadcastable_ops {
 
             #[inline]
             fn $op(self, rhs: Self) -> Self::Output {
-                op_with_broadcast(self, rhs, |l, r| l.$op(r))
+                self.try_apply_broadcasting_binary_elementwise(rhs, |l, r| l.$op(r))
             }
         }
         )+

--- a/crates/polars-core/src/frame/column/partitioned.rs
+++ b/crates/polars-core/src/frame/column/partitioned.rs
@@ -274,4 +274,19 @@ impl PartitionedColumn {
     pub fn clear(&self) -> Self {
         Self::new_empty(self.name.clone(), self.values.dtype().clone())
     }
+
+    pub fn partitions(&self) -> &Series {
+        &self.values
+    }
+    pub fn partition_ends(&self) -> &[IdxSize] {
+        &self.ends
+    }
+
+    pub fn or_reduce(&self) -> PolarsResult<Scalar> {
+        self.values.or_reduce()
+    }
+
+    pub fn and_reduce(&self) -> PolarsResult<Scalar> {
+        self.values.and_reduce()
+    }
 }

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -15,7 +15,7 @@ impl Series {
     }
 
     #[doc(hidden)]
-    pub fn agg_valid_count(&self, groups: &GroupsProxy) -> Series {
+    pub unsafe fn agg_valid_count(&self, groups: &GroupsProxy) -> Series {
         // Prevent a rechunk for every individual group.
         let s = if groups.len() > 1 && self.null_count() > 0 {
             self.rechunk()

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -317,7 +317,7 @@ impl PhysicalExpr for ApplyExpr {
         Some(&self.expr)
     }
 
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let f = |e: &Arc<dyn PhysicalExpr>| e.evaluate(df, state);
         let mut inputs = if self.allow_threading && self.inputs.len() > 1 {
             POOL.install(|| {
@@ -337,14 +337,9 @@ impl PhysicalExpr for ApplyExpr {
 
         if self.allow_rename {
             self.eval_and_flatten(&mut inputs)
-                .map(|c| c.as_materialized_series().clone())
         } else {
             let in_name = inputs[0].name().clone();
-            Ok(self
-                .eval_and_flatten(&mut inputs)?
-                .as_materialized_series()
-                .clone()
-                .with_name(in_name))
+            Ok(self.eval_and_flatten(&mut inputs)?.with_name(in_name))
         }
     }
 
@@ -677,29 +672,24 @@ impl PartitionedAggregation for ApplyExpr {
         df: &DataFrame,
         groups: &GroupsProxy,
         state: &ExecutionState,
-    ) -> PolarsResult<Series> {
+    ) -> PolarsResult<Column> {
         let a = self.inputs[0].as_partitioned_aggregator().unwrap();
-        let s = a.evaluate_partitioned(df, groups, state)?.into();
+        let s = a.evaluate_partitioned(df, groups, state)?;
 
         if self.allow_rename {
             self.eval_and_flatten(&mut [s])
-                .map(|c| c.as_materialized_series().clone())
         } else {
             let in_name = s.name().clone();
-            Ok(self
-                .eval_and_flatten(&mut [s])?
-                .as_materialized_series()
-                .clone()
-                .with_name(in_name))
+            Ok(self.eval_and_flatten(&mut [s])?.with_name(in_name))
         }
     }
 
     fn finalize(
         &self,
-        partitioned: Series,
+        partitioned: Column,
         _groups: &GroupsProxy,
         _state: &ExecutionState,
-    ) -> PolarsResult<Series> {
+    ) -> PolarsResult<Column> {
         Ok(partitioned)
     }
 }

--- a/crates/polars-expr/src/expressions/cast.rs
+++ b/crates/polars-expr/src/expressions/cast.rs
@@ -12,7 +12,7 @@ pub struct CastExpr {
 }
 
 impl CastExpr {
-    fn finish(&self, input: &Series) -> PolarsResult<Series> {
+    fn finish(&self, input: &Column) -> PolarsResult<Column> {
         input.cast_with_options(&self.dtype, self.options)
     }
 }
@@ -22,9 +22,9 @@ impl PhysicalExpr for CastExpr {
         Some(&self.expr)
     }
 
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
-        let series = self.input.evaluate(df, state)?;
-        self.finish(&series)
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
+        let column = self.input.evaluate(df, state)?;
+        self.finish(&column)
     }
 
     #[allow(clippy::ptr_arg)]
@@ -40,15 +40,18 @@ impl PhysicalExpr for CastExpr {
             // this will not explode and potentially increase memory due to overlapping groups
             AggState::AggregatedList(s) => {
                 let ca = s.list().unwrap();
-                let casted = ca.apply_to_inner(&|s| self.finish(&s))?;
+                let casted = ca.apply_to_inner(&|s| {
+                    self.finish(&s.into_column())
+                        .map(|c| c.take_materialized_series())
+                })?;
                 ac.with_series(casted.into_series(), true, None)?;
             },
             AggState::AggregatedScalar(s) => {
-                let s = self.finish(s)?;
+                let s = self.finish(&s.clone().into_column())?;
                 if ac.is_literal() {
-                    ac.with_literal(s);
+                    ac.with_literal(s.take_materialized_series());
                 } else {
-                    ac.with_series(s, true, None)?;
+                    ac.with_series(s.take_materialized_series(), true, None)?;
                 }
             },
             _ => {
@@ -56,12 +59,12 @@ impl PhysicalExpr for CastExpr {
                 ac.groups();
 
                 let s = ac.flat_naive();
-                let s = self.finish(s.as_ref())?;
+                let s = self.finish(&s.as_ref().clone().into_column())?;
 
                 if ac.is_literal() {
-                    ac.with_literal(s);
+                    ac.with_literal(s.take_materialized_series());
                 } else {
-                    ac.with_series(s, false, None)?;
+                    ac.with_series(s.take_materialized_series(), false, None)?;
                 }
             },
         }
@@ -91,17 +94,17 @@ impl PartitionedAggregation for CastExpr {
         df: &DataFrame,
         groups: &GroupsProxy,
         state: &ExecutionState,
-    ) -> PolarsResult<Series> {
+    ) -> PolarsResult<Column> {
         let e = self.input.as_partitioned_aggregator().unwrap();
         self.finish(&e.evaluate_partitioned(df, groups, state)?)
     }
 
     fn finalize(
         &self,
-        partitioned: Series,
+        partitioned: Column,
         groups: &GroupsProxy,
         state: &ExecutionState,
-    ) -> PolarsResult<Series> {
+    ) -> PolarsResult<Column> {
         let agg = self.input.as_partitioned_aggregator().unwrap();
         agg.finalize(partitioned, groups, state)
     }

--- a/crates/polars-expr/src/expressions/filter.rs
+++ b/crates/polars-expr/src/expressions/filter.rs
@@ -24,7 +24,7 @@ impl PhysicalExpr for FilterExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let s_f = || self.input.evaluate(df, state);
         let predicate_f = || self.by.evaluate(df, state);
 

--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -18,7 +18,7 @@ impl PhysicalExpr for GatherExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let series = self.phys_expr.evaluate(df, state)?;
         self.finish(df, state, series)
     }
@@ -102,10 +102,10 @@ impl GatherExpr {
         &self,
         df: &DataFrame,
         state: &ExecutionState,
-        series: Series,
-    ) -> PolarsResult<Series> {
+        series: Column,
+    ) -> PolarsResult<Column> {
         let idx = self.idx.evaluate(df, state)?;
-        let idx = convert_to_unsigned_index(&idx, series.len())?;
+        let idx = convert_to_unsigned_index(idx.as_materialized_series(), series.len())?;
         series.take(&idx)
     }
 

--- a/crates/polars-expr/src/expressions/rolling.rs
+++ b/crates/polars-expr/src/expressions/rolling.rs
@@ -19,7 +19,7 @@ pub(crate) struct RollingExpr {
 }
 
 impl PhysicalExpr for RollingExpr {
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let groups_key = format!("{:?}", &self.options);
 
         let groups_map = state.group_tuples.read().unwrap();
@@ -47,7 +47,7 @@ impl PhysicalExpr for RollingExpr {
         if let Some(name) = &self.out_name {
             out.rename(name.clone());
         }
-        Ok(out)
+        Ok(out.into_column())
     }
 
     fn evaluate_on_groups<'a>(

--- a/crates/polars-expr/src/expressions/sort.rs
+++ b/crates/polars-expr/src/expressions/sort.rs
@@ -46,7 +46,7 @@ impl PhysicalExpr for SortExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let series = self.physical_expr.evaluate(df, state)?;
         series.sort_with(self.options)
     }

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -79,7 +79,7 @@ impl PhysicalExpr for TernaryExpr {
         Some(&self.expr)
     }
 
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let mut state = state.split();
         // Don't cache window functions as they run in parallel.
         state.remove_cache_window_flag();
@@ -337,7 +337,7 @@ impl PartitionedAggregation for TernaryExpr {
         df: &DataFrame,
         groups: &GroupsProxy,
         state: &ExecutionState,
-    ) -> PolarsResult<Series> {
+    ) -> PolarsResult<Column> {
         let truthy = self.truthy.as_partitioned_aggregator().unwrap();
         let falsy = self.falsy.as_partitioned_aggregator().unwrap();
         let mask = self.predicate.as_partitioned_aggregator().unwrap();
@@ -352,10 +352,10 @@ impl PartitionedAggregation for TernaryExpr {
 
     fn finalize(
         &self,
-        partitioned: Series,
+        partitioned: Column,
         _groups: &GroupsProxy,
         _state: &ExecutionState,
-    ) -> PolarsResult<Series> {
+    ) -> PolarsResult<Column> {
         Ok(partitioned)
     }
 }

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -69,7 +69,7 @@ fn run_per_sublist(
                     let df = s.into_frame();
                     let out = phys_expr.evaluate(&df, &state);
                     match out {
-                        Ok(s) => Some(s),
+                        Ok(s) => Some(s.take_materialized_series()),
                         Err(e) => {
                             *m_err.lock().unwrap() = Some(e);
                             None
@@ -90,7 +90,7 @@ fn run_per_sublist(
                     let out = phys_expr.evaluate(&df_container, &state);
                     df_container.clear_columns();
                     match out {
-                        Ok(s) => Some(s),
+                        Ok(s) => Some(s.take_materialized_series()),
                         Err(e) => {
                             err = Some(e);
                             None

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -36,7 +36,9 @@ impl PhysicalIoExpr for Wrap {
 }
 impl PhysicalPipedExpr for Wrap {
     fn evaluate(&self, chunk: &DataChunk, state: &ExecutionState) -> PolarsResult<Series> {
-        self.0.evaluate(&chunk.data, state)
+        self.0
+            .evaluate(&chunk.data, state)
+            .map(|c| c.take_materialized_series())
     }
     fn field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.0.to_field(input_schema)

--- a/crates/polars-mem-engine/src/executors/filter.rs
+++ b/crates/polars-mem-engine/src/executors/filter.rs
@@ -45,7 +45,7 @@ impl FilterExec {
         if self.has_window {
             state.clear_window_expr_cache()
         }
-        df.filter(series_to_mask(&s)?)
+        df.filter(series_to_mask(s.as_materialized_series())?)
     }
 
     fn execute_chunks(
@@ -55,7 +55,7 @@ impl FilterExec {
     ) -> PolarsResult<DataFrame> {
         let iter = chunks.into_par_iter().map(|df| {
             let s = self.predicate.evaluate(&df, state)?;
-            df.filter(series_to_mask(&s)?)
+            df.filter(series_to_mask(s.as_materialized_series())?)
         });
         let df = POOL.install(|| iter.collect::<PolarsResult<Vec<_>>>())?;
         Ok(accumulate_dataframes_vertical_unchecked(df))

--- a/crates/polars-mem-engine/src/executors/group_by_partitioned.rs
+++ b/crates/polars-mem-engine/src/executors/group_by_partitioned.rs
@@ -332,11 +332,7 @@ impl PartitionGroupByExec {
                 .map(|(expr, partitioned_s)| {
                     let agg_expr = expr.as_partitioned_aggregator().unwrap();
                     agg_expr
-                        .finalize(
-                            partitioned_s.as_materialized_series().clone(),
-                            groups,
-                            state,
-                        )
+                        .finalize(partitioned_s.clone(), groups, state)
                         .map(Column::from)
                 })
                 .collect();

--- a/crates/polars-mem-engine/src/executors/join.rs
+++ b/crates/polars-mem-engine/src/executors/join.rs
@@ -139,8 +139,8 @@ impl Executor for JoinExec {
 
             let df = df_left._join_impl(
                 &df_right,
-                left_on_series,
-                right_on_series,
+                left_on_series.into_iter().map(|c| c.take_materialized_series()).collect(),
+                right_on_series.into_iter().map(|c| c.take_materialized_series()).collect(),
                 self.args.clone(),
                 true,
                 state.verbose(),

--- a/crates/polars-mem-engine/src/executors/stack.rs
+++ b/crates/polars-mem-engine/src/executors/stack.rs
@@ -37,7 +37,12 @@ impl StackExec {
                     self.options.run_parallel,
                 )?;
                 // We don't have to do a broadcast check as cse is not allowed to hit this.
-                df._add_series(res, schema)?;
+                df._add_series(
+                    res.into_iter()
+                        .map(|c| c.take_materialized_series())
+                        .collect(),
+                    schema,
+                )?;
                 Ok(df)
             });
 
@@ -94,7 +99,12 @@ impl StackExec {
                         }
                     }
                 }
-                df._add_series(res, schema)?;
+                df._add_series(
+                    res.into_iter()
+                        .map(|v| v.take_materialized_series())
+                        .collect(),
+                    schema,
+                )?;
             }
             df
         };

--- a/crates/polars-stream/src/expression.rs
+++ b/crates/polars-stream/src/expression.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars_core::frame::DataFrame;
-use polars_core::prelude::Series;
+use polars_core::prelude::Column;
 use polars_error::PolarsResult;
 use polars_expr::prelude::{ExecutionState, PhysicalExpr};
 
@@ -21,7 +21,7 @@ impl StreamExpr {
         }
     }
 
-    pub async fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+    pub async fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         if self.reentrant {
             let state = state.clone();
             let phys_expr = self.inner.clone();

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -85,7 +85,10 @@ impl GroupBySinkState {
                             // SAFETY: we resize the reduction to the number of groups beforehand.
                             reduction.resize(local.grouper.num_groups());
                             reduction.update_groups(
-                                &selector.evaluate(&df, state).await?,
+                                selector
+                                    .evaluate(&df, state)
+                                    .await?
+                                    .as_materialized_series(),
                                 &group_idxs,
                             )?;
                         }

--- a/crates/polars-stream/src/nodes/reduce.rs
+++ b/crates/polars-stream/src/nodes/reduce.rs
@@ -64,7 +64,7 @@ impl ReduceNode {
                     while let Ok(morsel) = recv.recv().await {
                         for (reducer, selector) in local_reducers.iter_mut().zip(selectors) {
                             let input = selector.evaluate(morsel.df(), state).await?;
-                            reducer.update_group(&input, 0)?;
+                            reducer.update_group(input.as_materialized_series(), 0)?;
                         }
                     }
 


### PR DESCRIPTION
This starts the moving of `Column` into `polars-expr`. I tried to keep this PR to a minimal, and will do the follow-up in other PRs.

For example, what this PR allows:
```python
import polars as pl
print(
    pl.select(pl.repeat(pl.lit(1), 10))
        ._to_metadata(stats='repr')
)
```

```console
shape: (1, 2)
┌─────────────┬────────┐
│ column_name ┆ repr   │
│ ---         ┆ ---    │
│ str         ┆ str    │
╞═════════════╪════════╡
│ repeat      ┆ scalar │
└─────────────┴────────┘
```

This can now finally produce a `Column::Scalar` instead of having to materialize to a `Column::Series`.