### PR TITLE
docs: Assorted fixes to Rust API docs

### DIFF
--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -357,8 +357,8 @@ impl BooleanArray {
         (dtype, values, validity)
     }
 
-    /// Creates a `[BooleanArray]` from its internal representation.
-    /// This is the inverted from `[BooleanArray::into_inner]`
+    /// Creates a [`BooleanArray`] from its internal representation.
+    /// This is the inverted from [`BooleanArray::into_inner`]
     ///
     /// # Safety
     /// Callers must ensure all invariants of this struct are upheld.

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -8,7 +8,7 @@
 //! * [`BooleanArray`] and [`MutableBooleanArray`], an array of boolean values (stored as a bitmap)
 //! * [`Utf8Array`] and [`MutableUtf8Array`], an array of variable length utf8 values
 //! * [`BinaryArray`] and [`MutableBinaryArray`], an array of opaque variable length values
-//! * [`ListArray`] and [`MutableListArray`], an array of arrays (e.g. )
+//! * [`ListArray`] and [`MutableListArray`], an array of arrays (e.g. `[[1, 2], None, [], [None]]`)
 //! * [`StructArray`] and [`MutableStructArray`], an array of arrays identified by a string (e.g. `{"a": [1, 2], "b": [true, false]}`)
 //!
 //! All immutable arrays implement the trait object [`Array`] and that can be downcasted

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -8,7 +8,7 @@
 //! * [`BooleanArray`] and [`MutableBooleanArray`], an array of boolean values (stored as a bitmap)
 //! * [`Utf8Array`] and [`MutableUtf8Array`], an array of variable length utf8 values
 //! * [`BinaryArray`] and [`MutableBinaryArray`], an array of opaque variable length values
-//! * [`ListArray`] and [`MutableListArray`], an array of arrays (e.g. `[[1, 2], None, [], [None]]`)
+//! * [`ListArray`] and [`MutableListArray`], an array of arrays (e.g. )
 //! * [`StructArray`] and [`MutableStructArray`], an array of arrays identified by a string (e.g. `{"a": [1, 2], "b": [true, false]}`)
 //!
 //! All immutable arrays implement the trait object [`Array`] and that can be downcasted

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -311,8 +311,8 @@ impl<T: NativeType> PrimitiveArray<T> {
         (dtype, values, validity)
     }
 
-    /// Creates a `[PrimitiveArray]` from its internal representation.
-    /// This is the inverted from `[PrimitiveArray::into_inner]`
+    /// Creates a [`PrimitiveArray`] from its internal representation.
+    /// This is the inverted from [`PrimitiveArray::into_inner`]
     pub fn from_inner(
         dtype: ArrowDataType,
         values: Buffer<T>,
@@ -322,8 +322,8 @@ impl<T: NativeType> PrimitiveArray<T> {
         Ok(unsafe { Self::from_inner_unchecked(dtype, values, validity) })
     }
 
-    /// Creates a `[PrimitiveArray]` from its internal representation.
-    /// This is the inverted from `[PrimitiveArray::into_inner]`
+    /// Creates a [`PrimitiveArray`] from its internal representation.
+    /// This is the inverted from [`PrimitiveArray::into_inner`]
     ///
     /// # Safety
     /// Callers must ensure all invariants of this struct are upheld.

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -472,8 +472,8 @@ impl Bitmap {
         }
     }
 
-    /// Creates a `[Bitmap]` from its internal representation.
-    /// This is the inverted from `[Bitmap::into_inner]`
+    /// Creates a [`Bitmap`] from its internal representation.
+    /// This is the inverted from [`Bitmap::into_inner`]
     ///
     /// # Safety
     /// Callers must ensure all invariants of this struct are upheld.

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -317,7 +317,7 @@ impl CategoricalChunked {
         }
     }
 
-    /// Create an `[Iterator]` that iterates over the `&str` values of the `[CategoricalChunked]`.
+    /// Create an [`Iterator`] that iterates over the `&str` values of the [`CategoricalChunked`].
     pub fn iter_str(&self) -> CatIter<'_> {
         let iter = self.physical().into_iter();
         CatIter {

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -58,7 +58,7 @@ unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
     std::slice::from_raw_parts((p as *const T) as *const u8, size_of::<T>())
 }
 
-/// Create an extension Array that can be sent to arrow and (once wrapped in `[PolarsExtension]` will
+/// Create an extension Array that can be sent to arrow and (once wrapped in [`PolarsExtension`] will
 /// also call drop on `T`, when the array is dropped.
 pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Sized + Default>(
     iter: I,

--- a/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
@@ -23,7 +23,7 @@ impl PolarsExtension {
         Self { array: Some(array) }
     }
 
-    /// Take the Array hold by `[PolarsExtension]` and forget polars extension,
+    /// Take the Array hold by [`PolarsExtension`] and forget polars extension,
     /// so that drop is not called
     pub(crate) fn take_and_forget(self) -> FixedSizeBinaryArray {
         let mut md = ManuallyDrop::new(self);
@@ -57,15 +57,15 @@ impl PolarsExtension {
         }
     }
 
-    /// Calls the heap allocated function in the `[ExtensionSentinel]` that knows
-    /// how to convert the `[FixedSizeBinaryArray]` to a `Series` of type `[ObjectChunked<T>]`
+    /// Calls the heap allocated function in the [`ExtensionSentinel`] that knows
+    /// how to convert the [`FixedSizeBinaryArray`] to a `Series` of type [`ObjectChunked<T>`]
     pub(crate) unsafe fn get_series(&self, name: &PlSmallStr) -> Series {
         self.with_sentinel(|sent| {
             (sent.to_series_fn.as_ref().unwrap())(self.array.as_ref().unwrap(), name)
         })
     }
 
-    // heap allocates a function that converts the binary array to a Series of `[ObjectChunked<T>]`
+    // heap allocates a function that converts the binary array to a Series of [`ObjectChunked<T>`]
     // the `name` will be the `name` of the output `Series` when this function is called (later).
     pub(crate) unsafe fn set_to_series_fn<T: PolarsObject>(&mut self) {
         let f = Box::new(move |arr: &FixedSizeBinaryArray, name: &PlSmallStr| {

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -380,7 +380,7 @@ impl StructChunked {
         unsafe { DataFrame::new_no_checks(self.len(), columns) }
     }
 
-    /// Get access to one of this `[StructChunked]`'s fields
+    /// Get access to one of this [`StructChunked`]'s fields
     pub fn field_by_name(&self, name: &str) -> PolarsResult<Series> {
         self.fields_as_series()
             .into_iter()

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -18,7 +18,7 @@ fn get_exploded(series: &Series) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
     }
 }
 
-/// Arguments for [`DataFrame::unpivot`] function
+/// Arguments for `LazyFrame::unpivot` function
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UnpivotArgsIR {

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -18,7 +18,7 @@ fn get_exploded(series: &Series) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
     }
 }
 
-/// Arguments for `[DataFrame::unpivot]` function
+/// Arguments for [`DataFrame::unpivot`] function
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UnpivotArgsIR {

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -233,7 +233,7 @@ impl<'df> GroupBy<'df> {
     ///     Where second value in the tuple is a vector with all matching indexes.
     ///
     /// # Safety
-    /// Groups should always be in bounds of the `DataFrame` hold by this `[GroupBy]`.
+    /// Groups should always be in bounds of the `DataFrame` hold by this [`GroupBy`].
     /// If you mutate it, you must hold that invariant.
     pub unsafe fn get_groups_mut(&mut self) -> &mut GroupsProxy {
         &mut self.groups

--- a/crates/polars-core/src/series/amortized_iter.rs
+++ b/crates/polars-core/src/series/amortized_iter.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use crate::prelude::*;
 
-/// A `[Series]` that amortizes a few allocations during iteration.
+/// A [`Series`] that amortizes a few allocations during iteration.
 #[derive(Clone)]
 pub struct AmortSeries {
     container: Rc<Series>,
@@ -31,7 +31,7 @@ impl AmortSeries {
         }
     }
 
-    /// Creates a new `[UnsafeSeries]`
+    /// Creates a new [`UnsafeSeries`]
     ///
     /// # Safety
     /// Inner chunks must be from `Series` otherwise the dtype may be incorrect and lead to UB.

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -372,7 +372,7 @@ impl Series {
         self.cast_with_options(dtype, CastOptions::NonStrict)
     }
 
-    /// Cast `[Series]` to another `[DataType]`.
+    /// Cast [`Series`] to another [`DataType`].
     pub fn cast_with_options(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Self> {
         use DataType as D;
 

--- a/crates/polars-core/src/series/ops/downcast.rs
+++ b/crates/polars-core/src/series/ops/downcast.rs
@@ -27,12 +27,12 @@ macro_rules! try_unpack_chunked {
 }
 
 impl Series {
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int8]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int8`]
     pub fn try_i8(&self) -> Option<&Int8Chunked> {
         try_unpack_chunked!(self, DataType::Int8 => Int8Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int16]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int16`]
     pub fn try_i16(&self) -> Option<&Int16Chunked> {
         try_unpack_chunked!(self, DataType::Int16 => Int16Chunked)
     }
@@ -51,91 +51,91 @@ impl Series {
     ///         }
     /// }).collect();
     /// ```
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int32]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int32`]
     pub fn try_i32(&self) -> Option<&Int32Chunked> {
         try_unpack_chunked!(self, DataType::Int32 => Int32Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int64]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int64`]
     pub fn try_i64(&self) -> Option<&Int64Chunked> {
         try_unpack_chunked!(self, DataType::Int64 => Int64Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float32]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Float32`]
     pub fn try_f32(&self) -> Option<&Float32Chunked> {
         try_unpack_chunked!(self, DataType::Float32 => Float32Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float64]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Float64`]
     pub fn try_f64(&self) -> Option<&Float64Chunked> {
         try_unpack_chunked!(self, DataType::Float64 => Float64Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt8]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt8`]
     pub fn try_u8(&self) -> Option<&UInt8Chunked> {
         try_unpack_chunked!(self, DataType::UInt8 => UInt8Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt16]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt16`]
     pub fn try_u16(&self) -> Option<&UInt16Chunked> {
         try_unpack_chunked!(self, DataType::UInt16 => UInt16Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt32]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt32`]
     pub fn try_u32(&self) -> Option<&UInt32Chunked> {
         try_unpack_chunked!(self, DataType::UInt32 => UInt32Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt64]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt64`]
     pub fn try_u64(&self) -> Option<&UInt64Chunked> {
         try_unpack_chunked!(self, DataType::UInt64 => UInt64Chunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Boolean]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Boolean`]
     pub fn try_bool(&self) -> Option<&BooleanChunked> {
         try_unpack_chunked!(self, DataType::Boolean => BooleanChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::String]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::String`]
     pub fn try_str(&self) -> Option<&StringChunked> {
         try_unpack_chunked!(self, DataType::String => StringChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Binary`]
     pub fn try_binary(&self) -> Option<&BinaryChunked> {
         try_unpack_chunked!(self, DataType::Binary => BinaryChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Binary`]
     pub fn try_binary_offset(&self) -> Option<&BinaryOffsetChunked> {
         try_unpack_chunked!(self, DataType::BinaryOffset => BinaryOffsetChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Time]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Time`]
     #[cfg(feature = "dtype-time")]
     pub fn try_time(&self) -> Option<&TimeChunked> {
         try_unpack_chunked!(self, DataType::Time => TimeChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Date]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Date`]
     #[cfg(feature = "dtype-date")]
     pub fn try_date(&self) -> Option<&DateChunked> {
         try_unpack_chunked!(self, DataType::Date => DateChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Datetime]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Datetime`]
     #[cfg(feature = "dtype-datetime")]
     pub fn try_datetime(&self) -> Option<&DatetimeChunked> {
         try_unpack_chunked!(self, DataType::Datetime(_, _) => DatetimeChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Duration]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Duration`]
     #[cfg(feature = "dtype-duration")]
     pub fn try_duration(&self) -> Option<&DurationChunked> {
         try_unpack_chunked!(self, DataType::Duration(_) => DurationChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Decimal]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Decimal`]
     #[cfg(feature = "dtype-decimal")]
     pub fn try_decimal(&self) -> Option<&DecimalChunked> {
         try_unpack_chunked!(self, DataType::Decimal(_, _) => DecimalChunked)
@@ -146,19 +146,19 @@ impl Series {
         try_unpack_chunked!(self, DataType::List(_) => ListChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Array]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Array`]
     #[cfg(feature = "dtype-array")]
     pub fn try_array(&self) -> Option<&ArrayChunked> {
         try_unpack_chunked!(self, DataType::Array(_, _) => ArrayChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Categorical]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Categorical`]
     #[cfg(feature = "dtype-categorical")]
     pub fn try_categorical(&self) -> Option<&CategoricalChunked> {
         try_unpack_chunked!(self, DataType::Categorical(_, _) | DataType::Enum(_, _) => CategoricalChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Struct]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Struct`]
     #[cfg(feature = "dtype-struct")]
     pub fn try_struct(&self) -> Option<&StructChunked> {
         #[cfg(debug_assertions)]
@@ -171,17 +171,17 @@ impl Series {
         try_unpack_chunked!(self, DataType::Struct(_) => StructChunked)
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Null]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Null`]
     pub fn try_null(&self) -> Option<&NullChunked> {
         try_unpack_chunked!(self, DataType::Null => NullChunked)
     }
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int8]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int8`]
     pub fn i8(&self) -> PolarsResult<&Int8Chunked> {
         self.try_i8()
             .ok_or_else(|| unpack_chunked_err!(self => "Int8"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int16]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int16`]
     pub fn i16(&self) -> PolarsResult<&Int16Chunked> {
         self.try_i16()
             .ok_or_else(|| unpack_chunked_err!(self => "Int16"))
@@ -201,107 +201,107 @@ impl Series {
     ///         }
     /// }).collect();
     /// ```
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int32]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int32`]
     pub fn i32(&self) -> PolarsResult<&Int32Chunked> {
         self.try_i32()
             .ok_or_else(|| unpack_chunked_err!(self => "Int32"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int64]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Int64`]
     pub fn i64(&self) -> PolarsResult<&Int64Chunked> {
         self.try_i64()
             .ok_or_else(|| unpack_chunked_err!(self => "Int64"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float32]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Float32`]
     pub fn f32(&self) -> PolarsResult<&Float32Chunked> {
         self.try_f32()
             .ok_or_else(|| unpack_chunked_err!(self => "Float32"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float64]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Float64`]
     pub fn f64(&self) -> PolarsResult<&Float64Chunked> {
         self.try_f64()
             .ok_or_else(|| unpack_chunked_err!(self => "Float64"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt8]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt8`]
     pub fn u8(&self) -> PolarsResult<&UInt8Chunked> {
         self.try_u8()
             .ok_or_else(|| unpack_chunked_err!(self => "UInt8"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt16]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt16`]
     pub fn u16(&self) -> PolarsResult<&UInt16Chunked> {
         self.try_u16()
             .ok_or_else(|| unpack_chunked_err!(self => "UInt16"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt32]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt32`]
     pub fn u32(&self) -> PolarsResult<&UInt32Chunked> {
         self.try_u32()
             .ok_or_else(|| unpack_chunked_err!(self => "UInt32"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt64]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::UInt64`]
     pub fn u64(&self) -> PolarsResult<&UInt64Chunked> {
         self.try_u64()
             .ok_or_else(|| unpack_chunked_err!(self => "UInt64"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Boolean]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Boolean`]
     pub fn bool(&self) -> PolarsResult<&BooleanChunked> {
         self.try_bool()
             .ok_or_else(|| unpack_chunked_err!(self => "Boolean"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::String]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::String`]
     pub fn str(&self) -> PolarsResult<&StringChunked> {
         self.try_str()
             .ok_or_else(|| unpack_chunked_err!(self => "String"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Binary`]
     pub fn binary(&self) -> PolarsResult<&BinaryChunked> {
         self.try_binary()
             .ok_or_else(|| unpack_chunked_err!(self => "Binary"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Binary`]
     pub fn binary_offset(&self) -> PolarsResult<&BinaryOffsetChunked> {
         self.try_binary_offset()
             .ok_or_else(|| unpack_chunked_err!(self => "BinaryOffset"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Time]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Time`]
     #[cfg(feature = "dtype-time")]
     pub fn time(&self) -> PolarsResult<&TimeChunked> {
         self.try_time()
             .ok_or_else(|| unpack_chunked_err!(self => "Time"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Date]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Date`]
     #[cfg(feature = "dtype-date")]
     pub fn date(&self) -> PolarsResult<&DateChunked> {
         self.try_date()
             .ok_or_else(|| unpack_chunked_err!(self => "Date"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Datetime]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Datetime`]
     #[cfg(feature = "dtype-datetime")]
     pub fn datetime(&self) -> PolarsResult<&DatetimeChunked> {
         self.try_datetime()
             .ok_or_else(|| unpack_chunked_err!(self => "Datetime"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Duration]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Duration`]
     #[cfg(feature = "dtype-duration")]
     pub fn duration(&self) -> PolarsResult<&DurationChunked> {
         self.try_duration()
             .ok_or_else(|| unpack_chunked_err!(self => "Duration"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Decimal]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Decimal`]
     #[cfg(feature = "dtype-decimal")]
     pub fn decimal(&self) -> PolarsResult<&DecimalChunked> {
         self.try_decimal()
@@ -314,21 +314,21 @@ impl Series {
             .ok_or_else(|| unpack_chunked_err!(self => "List"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Array]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Array`]
     #[cfg(feature = "dtype-array")]
     pub fn array(&self) -> PolarsResult<&ArrayChunked> {
         self.try_array()
             .ok_or_else(|| unpack_chunked_err!(self => "FixedSizeList"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Categorical]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Categorical`]
     #[cfg(feature = "dtype-categorical")]
     pub fn categorical(&self) -> PolarsResult<&CategoricalChunked> {
         self.try_categorical()
             .ok_or_else(|| unpack_chunked_err!(self => "Enum | Categorical"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Struct]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Struct`]
     #[cfg(feature = "dtype-struct")]
     pub fn struct_(&self) -> PolarsResult<&StructChunked> {
         #[cfg(debug_assertions)]
@@ -343,7 +343,7 @@ impl Series {
             .ok_or_else(|| unpack_chunked_err!(self => "Struct"))
     }
 
-    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Null]`
+    /// Unpack to [`ChunkedArray`] of dtype [`DataType::Null`]
     pub fn null(&self) -> PolarsResult<&NullChunked> {
         self.try_null()
             .ok_or_else(|| unpack_chunked_err!(self => "Null"))

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -428,7 +428,7 @@ pub trait SeriesTrait:
     /// Count the null values.
     fn null_count(&self) -> usize;
 
-    /// Return if any the chunks in this `[ChunkedArray]` have nulls.
+    /// Return if any the chunks in this [`ChunkedArray`] have nulls.
     fn has_nulls(&self) -> bool;
 
     /// Get unique values in the Series.

--- a/crates/polars-io/src/csv/read/options.rs
+++ b/crates/polars-io/src/csv/read/options.rs
@@ -298,7 +298,7 @@ impl CsvParseOptions {
     }
 
     /// Automatically try to parse dates/datetimes and time. If parsing fails,
-    /// columns remain of dtype `[DataType::String]`.
+    /// columns remain of dtype [`DataType::String`].
     pub fn with_try_parse_dates(mut self, try_parse_dates: bool) -> Self {
         self.try_parse_dates = try_parse_dates;
         self

--- a/crates/polars-io/src/shared.rs
+++ b/crates/polars-io/src/shared.rs
@@ -13,7 +13,7 @@ pub trait SerReader<R>
 where
     R: Read,
 {
-    /// Create a new instance of the `[SerReader]`
+    /// Create a new instance of the [`SerReader`]
     fn new(reader: R) -> Self;
 
     /// Make sure that all columns are contiguous in memory by

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -137,7 +137,7 @@ impl LazyCsvReader {
         })
     }
 
-    /// Set the `char` used as quote char. The default is `b'"'`. If set to `[None]` quoting is disabled.
+    /// Set the `char` used as quote char. The default is `b'"'`. If set to [`None`] quoting is disabled.
     #[must_use]
     pub fn with_quote_char(self, quote_char: Option<u8>) -> Self {
         self.map_parse_options(|opts| opts.with_quote_char(quote_char))
@@ -181,7 +181,7 @@ impl LazyCsvReader {
     }
 
     /// Automatically try to parse dates/datetimes and time.
-    /// If parsing fails, columns remain of dtype `[DataType::String]`.
+    /// If parsing fails, columns remain of dtype [`DataType::String`].
     #[cfg(feature = "temporal")]
     pub fn with_try_parse_dates(self, try_parse_dates: bool) -> Self {
         self.map_parse_options(|opts| opts.with_try_parse_dates(try_parse_dates))

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1822,6 +1822,7 @@ impl Expr {
     #[cfg(feature = "dtype-struct")]
     /// Count all unique values and create a struct mapping value to count.
     /// (Note that it is better to turn parallel off in the aggregation context).
+    /// The name of the struct field with the counts is given by the parameter `name`.
     pub fn value_counts(self, sort: bool, parallel: bool, name: &str, normalize: bool) -> Self {
         self.apply_private(FunctionExpr::ValueCounts {
             sort,
@@ -1837,7 +1838,7 @@ impl Expr {
 
     #[cfg(feature = "unique_counts")]
     /// Returns a count of the unique values in the order of appearance.
-    /// This method differs from [`Expr::value_counts]` in that it does not return the
+    /// This method differs from [`Expr::value_counts`] in that it does not return the
     /// values, only the counts and might be faster.
     pub fn unique_counts(self) -> Self {
         self.apply_private(FunctionExpr::UniqueCounts)
@@ -1967,10 +1968,10 @@ impl Expr {
 
 /// Apply a function/closure over multiple columns once the logical plan get executed.
 ///
-/// This function is very similar to `[apply_mul]`, but differs in how it handles aggregations.
+/// This function is very similar to [`apply_multiple`], but differs in how it handles aggregations.
 ///
-///  * `map_mul` should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
-///  * `apply_mul` should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
+///  * [`map_multiple`] should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
+///  * [`apply_multiple`] should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
 ///
 /// It is the responsibility of the caller that the schema is correct by giving
 /// the correct output_type. If None given the output type of the input expr is used.
@@ -1995,11 +1996,11 @@ where
 
 /// Apply a function/closure over multiple columns once the logical plan get executed.
 ///
-/// This function is very similar to `[apply_mul]`, but differs in how it handles aggregations.
+/// This function is very similar to [`apply_multiple`], but differs in how it handles aggregations.
 ///
-///  * `map_mul` should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
-///  * `apply_mul` should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
-///  * `map_list_mul` should be used when the function expects a list aggregated series.
+///  * [`map_multiple`] should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
+///  * [`apply_multiple`] should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
+///  * [`map_list_multiple`] should be used when the function expects a list aggregated series.
 pub fn map_list_multiple<F, E>(function: F, expr: E, output_type: GetOutput) -> Expr
 where
     F: Fn(&mut [Column]) -> PolarsResult<Option<Column>> + 'static + Send + Sync,
@@ -2025,10 +2026,10 @@ where
 /// It is the responsibility of the caller that the schema is correct by giving
 /// the correct output_type. If None given the output type of the input expr is used.
 ///
-/// This difference with `[map_mul]` is that `[apply_mul]` will create a separate `[Series]` per group.
+/// This difference with [`map_multiple`] is that [`apply_multiple`] will create a separate [`Series`] per group.
 ///
-/// * `[map_mul]` should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
-/// * `[apply_mul]` should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
+/// * [`map_multiple`] should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
+/// * [`apply_multiple`] should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
 pub fn apply_multiple<F, E>(
     function: F,
     expr: E,

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -192,7 +192,7 @@ pub enum AExpr {
         /// Function arguments
         /// Some functions rely on aliases,
         /// for instance assignment of struct fields.
-        /// Therefor we need `[ExprIr]`.
+        /// Therefor we need [`ExprIr`].
         input: Vec<ExprIR>,
         /// function to apply
         function: FunctionExpr,

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -311,7 +311,6 @@ dtype-array = [
   "polars-core/dtype-array",
   "polars-lazy?/dtype-array",
   "polars-ops/dtype-array",
-  "polars-plan?/dtype-array",
 ]
 dtype-i8 = [
   "polars-core/dtype-i8",
@@ -415,6 +414,8 @@ docs-selection = [
   "dynamic_group_by",
   "extract_groups",
   "replace",
+  "approx_unique",
+  "unique_counts",
 ]
 
 bench = [

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -311,6 +311,7 @@ dtype-array = [
   "polars-core/dtype-array",
   "polars-lazy?/dtype-array",
   "polars-ops/dtype-array",
+  "polars-plan?/dtype-array",
 ]
 dtype-i8 = [
   "polars-core/dtype-i8",


### PR DESCRIPTION
I added two feature flags to make sure they're included in the docs and when I was adding a bit of detail to a docstring I noticed a link was formatted in the wrong way. Ended up using a regex to find all such poorly formatted links across the Rust API docs.