### PR TITLE
docs: Alter examples for round_sig_figs to make behaviour clearer

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4967,14 +4967,14 @@ class Series:
 
         Examples
         --------
-        >>> s = pl.Series([0.01234, 3.333, 1234.0])
+        >>> s = pl.Series([0.01234, 3.333, 3450.0])
         >>> s.round_sig_figs(2)
         shape: (3,)
         Series: '' [f64]
         [
                 0.012
                 3.3
-                1200.0
+                3500.0
         ]
         """
 


### PR DESCRIPTION
I wondered about the rounding behaviour and ended up putting in a script to test it myself. If I'd seen this example it would have cleared it up for me very quickly!