### PR TITLE
refactor(rust): Refactor compute kernels in polars-arrow to avoid using gather

### DIFF
--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -214,11 +214,6 @@ where
         let list_validity = list.validity().unwrap();
         let mut growable = make_growable(&[list.values().as_ref()], true, list.len());
 
-        if cfg!(debug_assertions) {
-            let msg = "fn cast_list_to_fixed_size_list < nullable >";
-            dbg!(msg);
-        }
-
         for (outer_idx, x) in offsets.windows(2).enumerate() {
             let [i, j] = x else { unreachable!() };
             let i = i.to_usize();

--- a/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
@@ -11,11 +11,6 @@ pub fn sub_fixed_size_list_get_literal(
     index: i64,
     null_on_oob: bool,
 ) -> PolarsResult<ArrayRef> {
-    if cfg!(debug_assertions) {
-        let msg = "fn sub_fixed_size_list_get_literal";
-        dbg!(msg);
-    }
-
     let ArrowDataType::FixedSizeList(_, width) = arr.dtype() else {
         unreachable!();
     };
@@ -49,11 +44,6 @@ pub fn sub_fixed_size_list_get(
     index: &PrimitiveArray<i64>,
     null_on_oob: bool,
 ) -> PolarsResult<ArrayRef> {
-    if cfg!(debug_assertions) {
-        let msg = "fn sub_fixed_size_list_get";
-        dbg!(msg);
-    }
-
     fn idx_oob_err(index: i64, width: usize) -> PolarsError {
         PolarsError::ComputeError(
             format!(

--- a/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
@@ -1,59 +1,47 @@
-use polars_error::{polars_bail, PolarsResult};
-use polars_utils::index::NullCount;
-use polars_utils::IdxSize;
+use polars_error::{polars_bail, PolarsError, PolarsResult};
 
-use crate::array::{ArrayRef, FixedSizeListArray, PrimitiveArray};
-use crate::compute::take::take_unchecked;
-use crate::legacy::prelude::*;
-use crate::legacy::utils::CustomIterTools;
-
-fn sub_fixed_size_list_get_indexes_literal(width: usize, len: usize, index: i64) -> IdxArr {
-    (0..len)
-        .map(|i| {
-            if index >= width as i64 {
-                return None;
-            }
-
-            index
-                .negative_to_usize(width)
-                .map(|idx| (idx + i * width) as IdxSize)
-        })
-        .collect_trusted()
-}
-
-fn sub_fixed_size_list_get_indexes(width: usize, index: &PrimitiveArray<i64>) -> IdxArr {
-    index
-        .iter()
-        .enumerate()
-        .map(|(i, idx)| {
-            if let Some(idx) = idx {
-                if *idx >= width as i64 {
-                    return None;
-                }
-
-                idx.negative_to_usize(width)
-                    .map(|idx| (idx + i * width) as IdxSize)
-            } else {
-                None
-            }
-        })
-        .collect_trusted()
-}
+use crate::array::growable::make_growable;
+use crate::array::{Array, ArrayRef, FixedSizeListArray, PrimitiveArray};
+use crate::bitmap::BitmapBuilder;
+use crate::compute::utils::combine_validities_and;
+use crate::datatypes::ArrowDataType;
 
 pub fn sub_fixed_size_list_get_literal(
     arr: &FixedSizeListArray,
     index: i64,
     null_on_oob: bool,
 ) -> PolarsResult<ArrayRef> {
-    let take_by = sub_fixed_size_list_get_indexes_literal(arr.size(), arr.len(), index);
-    if !null_on_oob && take_by.null_count() > 0 {
-        polars_bail!(ComputeError: "get index is out of bounds");
+    if cfg!(debug_assertions) {
+        let msg = "fn sub_fixed_size_list_get_literal";
+        dbg!(msg);
+    }
+
+    let ArrowDataType::FixedSizeList(_, width) = arr.dtype() else {
+        unreachable!();
+    };
+
+    let width = *width;
+
+    let index = usize::try_from(index).unwrap();
+
+    if !null_on_oob && index >= width {
+        polars_bail!(
+            ComputeError:
+            "get index {} is out of bounds for array(width={})",
+            index,
+            width
+        );
     }
 
     let values = arr.values();
-    // SAFETY:
-    // the indices we generate are in bounds
-    unsafe { Ok(take_unchecked(&**values, &take_by)) }
+
+    let mut growable = make_growable(&[values.as_ref()], values.validity().is_some(), arr.len());
+
+    for i in 0..arr.len() {
+        unsafe { growable.extend(0, i * width + index, 1) }
+    }
+
+    Ok(growable.as_box())
 }
 
 pub fn sub_fixed_size_list_get(
@@ -61,13 +49,79 @@ pub fn sub_fixed_size_list_get(
     index: &PrimitiveArray<i64>,
     null_on_oob: bool,
 ) -> PolarsResult<ArrayRef> {
-    let take_by = sub_fixed_size_list_get_indexes(arr.size(), index);
-    if !null_on_oob && take_by.null_count() > 0 {
-        polars_bail!(ComputeError: "get index is out of bounds");
+    if cfg!(debug_assertions) {
+        let msg = "fn sub_fixed_size_list_get";
+        dbg!(msg);
     }
 
+    fn idx_oob_err(index: i64, width: usize) -> PolarsError {
+        PolarsError::ComputeError(
+            format!(
+                "get index {} is out of bounds for array(width={})",
+                index, width
+            )
+            .into(),
+        )
+    }
+
+    let ArrowDataType::FixedSizeList(_, width) = arr.dtype() else {
+        unreachable!();
+    };
+
+    let width = *width;
+
+    if arr.is_empty() {
+        if !null_on_oob {
+            if let Some(i) = index.non_null_values_iter().max() {
+                if usize::try_from(i).unwrap() >= width {
+                    return Err(idx_oob_err(i, width));
+                }
+            }
+        }
+
+        let values = arr.values();
+        assert!(values.is_empty());
+        return Ok(values.clone());
+    }
+
+    if !null_on_oob && width == 0 {
+        if let Some(i) = index.non_null_values_iter().next() {
+            return Err(idx_oob_err(i, width));
+        }
+    }
+
+    // Array is non-empty and has non-zero width at this point
     let values = arr.values();
-    // SAFETY:
-    // the indices we generate are in bounds
-    unsafe { Ok(take_unchecked(&**values, &take_by)) }
+
+    let mut growable = make_growable(&[values.as_ref()], values.validity().is_some(), arr.len());
+    let mut output_validity = BitmapBuilder::with_capacity(arr.len());
+    let opt_index_validity = index.validity();
+    let mut exceeded_width_idx = 0;
+
+    for i in 0..arr.len() {
+        let idx = usize::try_from(index.value(i)).unwrap();
+        let idx_is_oob = idx >= width;
+        let idx_is_valid = opt_index_validity.map_or(true, |x| unsafe { x.get_bit_unchecked(i) });
+
+        if idx_is_oob && idx_is_valid && exceeded_width_idx < width {
+            exceeded_width_idx = idx;
+        }
+
+        let idx = if idx_is_oob { 0 } else { idx };
+
+        unsafe {
+            growable.extend(0, i * width + idx, 1);
+            let output_is_valid = idx_is_valid & !idx_is_oob;
+            output_validity.push_unchecked(output_is_valid);
+        }
+    }
+
+    if !null_on_oob && exceeded_width_idx >= width {
+        return Err(idx_oob_err(exceeded_width_idx as i64, width));
+    }
+
+    let output = growable.as_box();
+    let output_validity = combine_validities_and(Some(&output_validity.freeze()), arr.validity());
+
+    Ok(output.with_validity(output_validity))
 }

--- a/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
@@ -2,7 +2,7 @@ use polars_error::{polars_bail, PolarsError, PolarsResult};
 
 use crate::array::growable::make_growable;
 use crate::array::{Array, ArrayRef, FixedSizeListArray, PrimitiveArray};
-use crate::bitmap::BitmapBuilder;
+use crate::bitmap::{Bitmap, BitmapBuilder};
 use crate::compute::utils::combine_validities_and3;
 use crate::datatypes::ArrowDataType;
 
@@ -113,7 +113,10 @@ pub fn sub_fixed_size_list_get(
 
     let mut growable = make_growable(&[values.as_ref()], values.validity().is_some(), arr.len());
     let mut idx_oob_validity = BitmapBuilder::with_capacity(arr.len());
-    let opt_index_validity = index.validity();
+    let index_validity = index
+        .validity()
+        .cloned()
+        .unwrap_or_else(|| Bitmap::new_with_value(true, index.len()));
     let mut exceeded_width_idx = 0;
     let mut current_index_i64 = 0;
 
@@ -132,7 +135,7 @@ pub fn sub_fixed_size_list_get(
         };
 
         let idx_is_oob = idx >= width;
-        let idx_is_valid = opt_index_validity.map_or(true, |x| unsafe { x.get_bit_unchecked(i) });
+        let idx_is_valid = unsafe { index_validity.get_bit_unchecked(i) };
 
         if idx_is_oob && idx_is_valid && exceeded_width_idx < width {
             exceeded_width_idx = idx;

--- a/crates/polars-arrow/src/legacy/kernels/list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/list.rs
@@ -7,11 +7,6 @@ use crate::legacy::trusted_len::TrustedLenPush;
 use crate::offset::{Offsets, OffsetsBuffer};
 
 pub fn sublist_get(arr: &ListArray<i64>, index: i64) -> ArrayRef {
-    if cfg!(debug_assertions) {
-        let msg = "fn sublist_get";
-        dbg!(msg);
-    }
-
     let values = arr.values();
 
     let mut growable = make_growable(&[values.as_ref()], values.validity().is_some(), arr.len());

--- a/crates/polars-arrow/src/legacy/kernels/list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/list.rs
@@ -45,8 +45,8 @@ pub fn sublist_get(arr: &ListArray<i64>, index: i64) -> ArrayRef {
     let values = growable.as_box();
 
     values.with_validity(combine_validities_and(
-        Some(&result_validity.freeze()),
-        values.validity(),
+        values.validity(),               // inner validity
+        Some(&result_validity.freeze()), // outer validity
     ))
 }
 

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -149,8 +149,11 @@ def test_array_get() -> None:
     assert_frame_equal(out_df, expected_df)
 
     # Out-of-bounds index literal.
-    with pytest.raises(ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index 100 is out of bounds"):
         out = s.arr.get(100, null_on_oob=False)
+
+    with pytest.raises(ComputeError, match="get index -3 is out of bounds"):
+        pl.Series([[1, 2]], dtype=pl.Array(pl.Int32, 2)).arr.get(-3)
 
     # Negative index literal.
     out = s.arr.get(-2, null_on_oob=False)
@@ -158,7 +161,7 @@ def test_array_get() -> None:
     assert_series_equal(out, expected)
 
     # Test index expr.
-    with pytest.raises(ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index 100 is out of bounds"):
         out = s.arr.get(pl.Series([1, -2, 100]), null_on_oob=False)
 
     out = s.arr.get(pl.Series([1, -2, 0]), null_on_oob=False)
@@ -175,7 +178,7 @@ def test_array_get() -> None:
         ],
         dtype=pl.Array(pl.Date, 2),
     )
-    with pytest.raises(ComputeError, match="get index is out of bounds"):
+    with pytest.raises(ComputeError, match="get index 4 is out of bounds"):
         out = s.arr.get(pl.Series([1, -2, 4]), null_on_oob=False)
 
 

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -149,10 +149,14 @@ def test_array_get() -> None:
     assert_frame_equal(out_df, expected_df)
 
     # Out-of-bounds index literal.
-    with pytest.raises(ComputeError, match="get index 100 is out of bounds"):
+    with pytest.raises(
+        ComputeError, match=r"get index 100 is out of bounds for array\(width=4\)"
+    ):
         out = s.arr.get(100, null_on_oob=False)
 
-    with pytest.raises(ComputeError, match="get index -3 is out of bounds"):
+    with pytest.raises(
+        ComputeError, match=r"get index -3 is out of bounds for array\(width=2\)"
+    ):
         pl.Series([[1, 2]], dtype=pl.Array(pl.Int32, 2)).arr.get(-3)
 
     # Negative index literal.
@@ -161,7 +165,9 @@ def test_array_get() -> None:
     assert_series_equal(out, expected)
 
     # Test index expr.
-    with pytest.raises(ComputeError, match="get index 100 is out of bounds"):
+    with pytest.raises(
+        ComputeError, match=r"get index 100 is out of bounds for array\(width=4\)"
+    ):
         out = s.arr.get(pl.Series([1, -2, 100]), null_on_oob=False)
 
     out = s.arr.get(pl.Series([1, -2, 0]), null_on_oob=False)

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -694,3 +694,14 @@ def test_cast_list_to_array() -> None:
         ),
         pl.Series([[1], None, [None]], dtype=pl.Array(pl.Int32, 1)),
     )
+
+    assert_series_equal(
+        (
+            pl.Series([[1], [1, 2, 3], [None]], dtype=pl.List(pl.Int32))
+            .to_frame()
+            .select(pl.when(pl.int_range(pl.len()) != 1).then(pl.first()))
+            .to_series()
+            .cast(pl.Array(pl.Int32, 1))
+        ),
+        pl.Series([[1], None, [None]], dtype=pl.Array(pl.Int32, 1)),
+    )

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -680,3 +680,17 @@ def test_cast_int_to_string_unsets_sorted_flag_19424() -> None:
     s = pl.Series([1, 2]).set_sorted()
     assert s.flags["SORTED_ASC"]
     assert not s.cast(pl.String).flags["SORTED_ASC"]
+
+
+def test_cast_list_to_array() -> None:
+    assert_series_equal(
+        pl.Series([[], None], dtype=pl.List(pl.Int32)).cast(pl.Array(pl.Int32, 0)),
+        pl.Series([[], None], dtype=pl.Array(pl.Int32, 0)),
+    )
+
+    assert_series_equal(
+        pl.Series([[1], None, [None]], dtype=pl.List(pl.Int32)).cast(
+            pl.Array(pl.Int32, 1)
+        ),
+        pl.Series([[1], None, [None]], dtype=pl.Array(pl.Int32, 1)),
+    )


### PR DESCRIPTION
Before we can move the gather logic to `polars-compute` we need to remove all uses of it in `polars-arrow`, as it will no longer be accessible in `polars-arrow` after the move.
