### PR TITLE
perf: Improve hive partition pruning with datetime predicates from SQL

### DIFF
--- a/crates/polars-expr/src/expressions/alias.rs
+++ b/crates/polars-expr/src/expressions/alias.rs
@@ -33,6 +33,13 @@ impl PhysicalExpr for AliasExpr {
         Ok(self.finish(series))
     }
 
+    fn evaluate_inline_impl(&self, depth_limit: u8) -> Option<Column> {
+        let depth_limit = depth_limit.checked_sub(1)?;
+        self.physical_expr
+            .evaluate_inline_impl(depth_limit)
+            .map(|s| self.finish(s))
+    }
+
     #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups<'a>(
         &self,

--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -396,8 +396,19 @@ mod stats {
                 use Operator::*;
 
                 match self.op {
+                    // These don't result in a boolean output
                     Multiply | Divide | TrueDivide | FloorDivide | Modulus => return Ok(true),
                     _ => {},
+                }
+
+                let Expr::BinaryExpr { left, right, .. } = &self.expr else {
+                    unreachable!()
+                };
+
+                match (left.as_ref(), right.as_ref()) {
+                    // The logic below assumes one side is a column
+                    (Expr::Column(_), _) | (_, Expr::Column(_)) => {},
+                    _ => return Ok(true),
                 }
             }
 

--- a/crates/polars-expr/src/expressions/cast.rs
+++ b/crates/polars-expr/src/expressions/cast.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::prelude::*;
 
@@ -9,6 +11,7 @@ pub struct CastExpr {
     pub(crate) dtype: DataType,
     pub(crate) expr: Expr,
     pub(crate) options: CastOptions,
+    pub(crate) inlined_eval: OnceLock<Option<Column>>,
 }
 
 impl CastExpr {
@@ -25,6 +28,18 @@ impl PhysicalExpr for CastExpr {
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let column = self.input.evaluate(df, state)?;
         self.finish(&column)
+    }
+
+    fn evaluate_inline_impl(&self, depth_limit: u8) -> Option<Column> {
+        self.inlined_eval
+            .get_or_init(|| {
+                let depth_limit = depth_limit.checked_sub(1)?;
+                self.input
+                    .evaluate_inline_impl(depth_limit)
+                    .filter(|x| x.len() == 1)
+                    .and_then(|x| self.finish(&x).ok())
+            })
+            .clone()
     }
 
     #[allow(clippy::ptr_arg)]

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -538,6 +538,20 @@ pub trait PhysicalExpr: Send + Sync {
     /// Take a DataFrame and evaluate the expression.
     fn evaluate(&self, df: &DataFrame, _state: &ExecutionState) -> PolarsResult<Column>;
 
+    /// Attempt to cheaply evaluate this expression in-line without a DataFrame context.
+    /// This is used by StatsEvaluator when skipping files / row groups using a predicate.
+    /// TODO: Maybe in the future we can do this evaluation in-line at the optimizer stage?
+    ///
+    /// Do not implement this directly - instead implement `evaluate_inline_impl`
+    fn evaluate_inline(&self) -> Option<Column> {
+        self.evaluate_inline_impl(4)
+    }
+
+    /// Implementation of `evaluate_inline`
+    fn evaluate_inline_impl(&self, _depth_limit: u8) -> Option<Column> {
+        None
+    }
+
     /// Some expression that are not aggregations can be done per group
     /// Think of sort, slice, filter, shift, etc.
     /// defaults to ignoring the group

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -438,6 +438,7 @@ fn create_physical_expr_inner(
                 dtype: dtype.clone(),
                 expr: node_to_expr(expression, expr_arena),
                 options: *options,
+                inlined_eval: Default::default(),
             }))
         },
         Ternary {

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -159,6 +159,7 @@ impl ColumnStats {
     ///
     /// Returns `None` if no maximum value is available.
     pub fn to_min(&self) -> Option<&Series> {
+        // @scalar-opt
         let min_val = self.min_value.as_ref()?;
         let dtype = min_val.dtype();
 
@@ -177,6 +178,7 @@ impl ColumnStats {
     ///
     /// Returns `None` if no maximum value is available.
     pub fn to_max(&self) -> Option<&Series> {
+        // @scalar-opt
         let max_val = self.max_value.as_ref()?;
         let dtype = max_val.dtype();
 

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -900,12 +900,10 @@ def test_predicate_stats_eval_nested_binary() -> None:
     assert_frame_equal(
         (
             pl.scan_parquet(bufs)
-            .filter(
-                pl.col("x")
-                % pl.lit("222").str.slice(0, 2).str.slice(0, 1).cast(pl.Int64)
-                == 0
-            )
+            # The literal eval depth limit is 4 -
+            # * crates/polars-expr/src/expressions/mod.rs::PhysicalExpr::evaluate_inline
+            .filter(pl.col("x") == pl.lit("222").str.slice(0, 1).cast(pl.Int64))
             .collect()
         ),
-        pl.DataFrame({"x": [0, 2, 4, 6, 8]}),
+        pl.DataFrame({"x": [2]}),
     )

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -880,8 +880,6 @@ def test_predicate_hive_pruning_with_cast(tmp_path: Path) -> None:
 
 
 def test_predicate_stats_eval_nested_binary() -> None:
-    n = 10
-
     bufs: list[bytes] = []
 
     for i in range(10):

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -882,13 +882,13 @@ def test_predicate_hive_pruning_with_cast(tmp_path: Path) -> None:
 def test_predicate_stats_eval_nested_binary() -> None:
     n = 10
 
-    bufs = [io.BytesIO() for _ in range(n)]
+    bufs: list[bytes] = []
 
-    for i, b in enumerate(bufs):
+    for i in range(10):
+        b = io.BytesIO()
         pl.DataFrame({"x": i}).write_parquet(b)
-
-    for b in bufs:
         b.seek(0)
+        bufs.append(b.read())
 
     assert_frame_equal(
         (
@@ -898,9 +898,6 @@ def test_predicate_stats_eval_nested_binary() -> None:
         ),
         pl.DataFrame({"x": [0, 2, 4, 6, 8]}),
     )
-
-    for b in bufs:
-        b.seek(0)
 
     assert_frame_equal(
         (

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -860,7 +860,7 @@ def test_predicate_hive_pruning_with_cast(tmp_path: Path) -> None:
 
     lf = pl.scan_parquet(tmp_path)
 
-    q = lf.filter(pl.col("date") < datetime(2024, 1, 2))
+    q = lf.filter(pl.col("date") < datetime(2024, 1, 2).date())
 
     assert_frame_equal(q.collect(), expect)
 

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -850,7 +850,11 @@ def test_predicate_hive_pruning_with_cast(tmp_path: Path) -> None:
 
     (p := (tmp_path / "date=2024-01-02")).mkdir()
 
-    (p / "1").write_text("invalid file")
+    # Write an invalid parquet file that will cause errors if polars attempts to
+    # read it.
+    # This works because `scan_parquet()` only looks at the first file during
+    # schema inference.
+    (p / "1").write_text("not a parquet file")
 
     expect = pl.DataFrame({"x": 1, "date": datetime(2024, 1, 1).date()})
 


### PR DESCRIPTION
`StatsEvaluator` currently only works if the inputs are literals as it directly takes from the `Expr` - 

* `col('A') < lit(1)` - [ok]
* `col('A') < lit('2024-01-01').str.strptime(..)` - [err]
  * This type of predicate is created by `LazyFrame.sql()` - as it does not have access to the IR context / schema during creation.

This PR adds an `evaluate_inline` to `PhysicalExpr` with some basic support for literals, casting and `FuntionExpr`s. The function is intended to evaluate to `Some(column)` only if we consider the operation to be cheap:

* `Cast` / `FunctionExpr` will only evaluate if the input is of length 1, which is generally the case with literals in predicate expressions
* A depth_limit is used to protect against highly nested expressions
* Some PhysicalExprs also cache the result in a `OnceLock` - as they can be called multiple times from the stats evaluator

With this change the folllowing query should now be able to prune files on hive partitions:

* `scan_parquet(...).sql("select * from self where hive_date1 < '2024-01-02'")`