### PR TITLE
fix: Make Array arithmetic ops fully elementwise

### DIFF
--- a/crates/polars-core/src/chunked_array/array/mod.rs
+++ b/crates/polars-core/src/chunked_array/array/mod.rs
@@ -81,4 +81,13 @@ impl ArrayChunked {
 
         ArrayChunked::try_from_chunk_iter(self.name().clone(), chunks)
     }
+
+    /// Recurse nested types until we are at the leaf array.
+    pub fn get_leaf_array(&self) -> Series {
+        let mut current = self.get_inner();
+        while let Some(child_array) = current.try_array() {
+            current = child_array.get_inner();
+        }
+        current
+    }
 }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -110,48 +110,18 @@ macro_rules! impl_dyn_series {
             }
 
             fn subtract(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = sub,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::subtract(&self.0, rhs)
             }
             fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = add,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::add_to(&self.0, rhs)
             }
             fn multiply(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = mul,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::multiply(&self.0, rhs)
             }
             fn divide(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = div,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::divide(&self.0, rhs)
             }
             fn remainder(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = rem,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::remainder(&self.0, rhs)
             }
             #[cfg(feature = "algorithm_group_by")]

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -183,48 +183,18 @@ macro_rules! impl_dyn_series {
             }
 
             fn subtract(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = sub,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::subtract(&self.0, rhs)
             }
             fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = add,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::add_to(&self.0, rhs)
             }
             fn multiply(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = mul,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::multiply(&self.0, rhs)
             }
             fn divide(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = div,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::divide(&self.0, rhs)
             }
             fn remainder(&self, rhs: &Series) -> PolarsResult<Series> {
-                polars_ensure!(
-                    self.dtype() == rhs.dtype(),
-                    opq = rem,
-                    self.dtype(),
-                    rhs.dtype()
-                );
                 NumOpsDispatch::remainder(&self.0, rhs)
             }
             #[cfg(feature = "algorithm_group_by")]

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -383,3 +383,16 @@ def test_zero_width_array(fn: str) -> None:
 
                 df = pl.concat([a.to_frame(), b.to_frame()], how="horizontal")
                 df.select(c=expr_f(pl.col.a, pl.col.b))
+
+
+def test_elementwise_arithmetic_19682() -> None:
+    dt = pl.Array(pl.Int64, (2, 3))
+
+    a = pl.Series("a", [[[1, 2, 3], [4, 5, 6]]], dt)
+    sc = pl.Series("a", [1])
+    zfa = pl.Series("a", [[]], pl.Array(pl.Int64, 0))
+
+    assert_series_equal(a + a, pl.Series("a", [[[2, 4, 6], [8, 10, 12]]], dt))
+    assert_series_equal(a + sc, pl.Series("a", [[[2, 3, 4], [5, 6, 7]]], dt))
+    assert_series_equal(sc + a, pl.Series("a", [[[2, 3, 4], [5, 6, 7]]], dt))
+    assert_series_equal(zfa + zfa, pl.Series("a", [[]], pl.Array(pl.Int64, 0)))


### PR DESCRIPTION
Fixes #19679.

Along side two other issues.

Issue 1:

```python
import polars as pl

a = pl.Series('a', [[[1, 2, 3], [4, 5, 6]]], pl.Array(pl.Int64, (2, 3)))

print(a + pl.Series([1]))
print(pl.Series([1]) + a)
```

```console
shape: (1,)
Series: 'a' [array[i64, (2, 3)]]
[
    [[2, 3, 4], [5, 6, 7]]
]
Traceback (most recent call last):
  File "/home/johndoe/Projects/polars/array_elementwise_bug.py", line 6, in <module>
    print(pl.Series([1]) + a)
          ~~~~~~~~~~~~~~~^~~
  File "/home/johndoe/Projects/polars/py-polars/polars/series/series.py", line 1045, in __add__
    return self._arithmetic(other, "add", "add_<>")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johndoe/Projects/polars/py-polars/polars/series/series.py", line 994, in _arithmetic
    return self._from_pyseries(getattr(self._s, op_s)(other._s))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.InvalidOperationError: add operation not supported for dtypes `i64` and `array[i64, (2, 3)]`
```

Issue 2:

```python
import polars as pl

a = pl.Series('a', [[[1, 2, 3], [4, 5, 6]]], pl.Array(pl.Int64, (2, 3)))
print(a + a)
```

```console
shape: (3,)
Series: 'a' [array[i64, 2]]
[
    [2, 4]
    [6, 8]
    [10, 12]
]
```