### PR TITLE
refactor: Use `Column` for the `{try,}_apply_columns{_par,}` functions on `DataFrame`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -233,7 +233,7 @@ fn fill_with_gather<F: Fn(&Bitmap) -> Vec<IdxSize>>(
 
     let idx = bits_to_idx(validity);
 
-    Ok(unsafe { s.take_unchecked_from_slice(&idx) })
+    Ok(unsafe { s.take_slice_unchecked(&idx) })
 }
 
 fn fill_forward_gather(s: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -546,6 +546,7 @@ impl Column {
                     idxs_length,
                 );
 
+                // We need to make sure that null values in `idx` become null values in the result
                 if idxs_null_count == 0 {
                     scalar.into_column()
                 } else if idxs_null_count == idxs_length {

--- a/crates/polars-core/src/frame/column/scalar.rs
+++ b/crates/polars-core/src/frame/column/scalar.rs
@@ -138,7 +138,7 @@ impl ScalarColumn {
     /// This will panic if the value cannot be made static or if the series has length `0`.
     pub fn from_single_value_series(series: Series, length: usize) -> Self {
         debug_assert!(series.len() <= 1);
-        debug_assert!(length > 0 || series.is_empty());
+        debug_assert!(!series.is_empty() || length == 0);
 
         let value = series.get(0).map_or(AnyValue::Null, |av| av.into_static());
         let value = Scalar::new(series.dtype().clone(), value);

--- a/crates/polars-core/src/frame/column/scalar.rs
+++ b/crates/polars-core/src/frame/column/scalar.rs
@@ -279,6 +279,11 @@ impl ScalarColumn {
             self.clone()
         }
     }
+
+    pub fn into_nulls(mut self) -> Self {
+        self.scalar.update(AnyValue::Null);
+        self
+    }
 }
 
 impl IntoColumn for ScalarColumn {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -723,14 +723,6 @@ impl Series {
         }
     }
 
-    /// Take by index if ChunkedArray contains a single chunk.
-    ///
-    /// # Safety
-    /// This doesn't check any bounds. Null validity is checked.
-    pub unsafe fn take_unchecked_from_slice(&self, idx: &[IdxSize]) -> Series {
-        self.take_slice_unchecked(idx)
-    }
-
     /// Traverse and collect every nth element in a new array.
     pub fn gather_every(&self, n: usize, offset: usize) -> Series {
         let idx = ((offset as IdxSize)..self.len() as IdxSize)

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -287,19 +287,27 @@ pub trait SeriesTrait:
     /// Filter by boolean mask. This operation clones data.
     fn filter(&self, _filter: &BooleanChunked) -> PolarsResult<Series>;
 
-    /// Take by index. This operation is clone.
+    /// Take from `self` at the indexes given by `idx`.
+    ///
+    /// Null values in `idx` because null values in the output array.
+    ///
+    /// This operation is clone.
     fn take(&self, _indices: &IdxCa) -> PolarsResult<Series>;
 
-    /// Take by index.
+    /// Take from `self` at the indexes given by `idx`.
+    ///
+    /// Null values in `idx` because null values in the output array.
     ///
     /// # Safety
     /// This doesn't check any bounds.
     unsafe fn take_unchecked(&self, _idx: &IdxCa) -> Series;
 
-    /// Take by index. This operation is clone.
+    /// Take from `self` at the indexes given by `idx`.
+    ///
+    /// This operation is clone.
     fn take_slice(&self, _indices: &[IdxSize]) -> PolarsResult<Series>;
 
-    /// Take by index.
+    /// Take from `self` at the indexes given by `idx`.
     ///
     /// # Safety
     /// This doesn't check any bounds.

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -21,7 +21,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_chunked_unchecked_seq(&self, idx: &[ChunkId], sorted: IsSorted) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_materialized(&|s| s.take_chunked_unchecked(idx, sorted));
+            ._apply_columns(&|s| s.take_chunked_unchecked(idx, sorted));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -32,7 +32,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_opt_chunked_unchecked_seq(&self, idx: &[NullableChunkId]) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_materialized(&|s| s.take_opt_chunked_unchecked(idx));
+            ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -42,7 +42,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_chunked_unchecked(&self, idx: &[ChunkId], sorted: IsSorted) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_materialized_par(&|s| s.take_chunked_unchecked(idx, sorted));
+            ._apply_columns_par(&|s| s.take_chunked_unchecked(idx, sorted));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -54,7 +54,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_opt_chunked_unchecked(&self, idx: &[ChunkId]) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_materialized_par(&|s| s.take_opt_chunked_unchecked(idx));
+            ._apply_columns_par(&|s| s.take_opt_chunked_unchecked(idx));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -86,6 +86,22 @@ fn prepare_series(s: &Series) -> Cow<Series> {
         "implementation error"
     );
     phys
+}
+
+impl TakeChunked for Column {
+    unsafe fn take_chunked_unchecked(&self, by: &[ChunkId], sorted: IsSorted) -> Self {
+        // @scalar-opt
+        let s = self.as_materialized_series();
+        let s = unsafe { s.take_chunked_unchecked(by, sorted) };
+        s.into_column()
+    }
+
+    unsafe fn take_opt_chunked_unchecked(&self, by: &[ChunkId]) -> Self {
+        // @scalar-opt
+        let s = self.as_materialized_series();
+        let s = unsafe { s.take_opt_chunked_unchecked(by) };
+        s.into_column()
+    }
 }
 
 impl TakeChunked for Series {

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -21,7 +21,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_chunked_unchecked_seq(&self, idx: &[ChunkId], sorted: IsSorted) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns(&|s| s.take_chunked_unchecked(idx, sorted));
+            ._apply_columns_materialized(&|s| s.take_chunked_unchecked(idx, sorted));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -32,7 +32,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_opt_chunked_unchecked_seq(&self, idx: &[NullableChunkId]) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx));
+            ._apply_columns_materialized(&|s| s.take_opt_chunked_unchecked(idx));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -42,7 +42,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_chunked_unchecked(&self, idx: &[ChunkId], sorted: IsSorted) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_par(&|s| s.take_chunked_unchecked(idx, sorted));
+            ._apply_columns_materialized_par(&|s| s.take_chunked_unchecked(idx, sorted));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -54,7 +54,7 @@ pub trait DfTake: IntoDf {
     unsafe fn _take_opt_chunked_unchecked(&self, idx: &[ChunkId]) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_par(&|s| s.take_opt_chunked_unchecked(idx));
+            ._apply_columns_materialized_par(&|s| s.take_opt_chunked_unchecked(idx));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }

--- a/crates/polars-ops/src/frame/join/dispatch_left_right.rs
+++ b/crates/polars-ops/src/frame/join/dispatch_left_right.rs
@@ -107,9 +107,7 @@ fn materialize_left_join(
             if let Some((offset, len)) = args.slice {
                 right_idx = slice_slice(right_idx, offset, len);
             }
-            IdxCa::with_nullable_idx(right_idx, |idx| {
-                other.take_unchecked(idx)
-            })
+            IdxCa::with_nullable_idx(right_idx, |idx| other.take_unchecked(idx))
         },
         ChunkJoinOptIds::Right(right_idx) => unsafe {
             let mut right_idx = &*right_idx;

--- a/crates/polars-ops/src/frame/join/dispatch_left_right.rs
+++ b/crates/polars-ops/src/frame/join/dispatch_left_right.rs
@@ -107,7 +107,9 @@ fn materialize_left_join(
             if let Some((offset, len)) = args.slice {
                 right_idx = slice_slice(right_idx, offset, len);
             }
-            IdxCa::with_nullable_idx(right_idx, |idx| other.take_unchecked(idx))
+            IdxCa::with_nullable_idx(right_idx, |idx| {
+                other.take_unchecked(idx)
+            })
         },
         ChunkJoinOptIds::Right(right_idx) => unsafe {
             let mut right_idx = &*right_idx;


### PR DESCRIPTION
This keeps `ScalarColumn` in even more places.