### PR TITLE
feat(python): Support StrEnums for `pl.Enum` Construction

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -28,8 +28,6 @@ if TYPE_CHECKING:
         TimeUnit,
     )
 
-_STR_ENUMS_SUPPORTED: Final = sys.version_info >= (3, 11)
-
 
 class classinstmethod(classmethod):  # type: ignore[type-arg]
     """Decorator that allows a method to be called from the class OR instance."""
@@ -561,7 +559,7 @@ class Enum(DataType):
 
     categories: Series
 
-    if _STR_ENUMS_SUPPORTED:
+    if sys.version_info >= (3, 11):
 
         @overload
         def __init__(  # type: ignore[overload]
@@ -579,7 +577,8 @@ class Enum(DataType):
         )
 
         if (
-            _STR_ENUMS_SUPPORTED
+            # Supported in Python 3.11+
+            sys.version_info >= (3, 11)
             and isinstance(categories, type)
             and issubclass(categories, enum.StrEnum)
         ):

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from datetime import timezone
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, Final, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import polars._reexport as pl
 import polars.datatypes

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -561,8 +561,8 @@ class Enum(DataType):
 
     if sys.version_info >= (3, 11):
 
-        @overload
-        def __init__(  # type: ignore[overload]
+        @overload  # type: ignore[overload]
+        def __init__(
             self, categories: Series | Iterable[str] | type[enum.StrEnum]
         ) -> None: ...
 

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from datetime import timezone
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
 import polars.datatypes
@@ -558,13 +558,6 @@ class Enum(DataType):
     """
 
     categories: Series
-
-    if sys.version_info >= (3, 11):
-
-        @overload  # type: ignore[overload]
-        def __init__(
-            self, categories: Series | Iterable[str] | type[enum.StrEnum]
-        ) -> None: ...
 
     def __init__(self, categories: Series | Iterable[str]) -> None:
         # Issuing the warning on `__init__` does not trigger when the class is used

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import enum
 import operator
 import re
+import sys
 from datetime import date
 from textwrap import dedent
 from typing import Any, Callable
@@ -30,8 +32,19 @@ def test_enum_creation() -> None:
     e = pl.Enum(f"x{i}" for i in range(5))
     assert e.categories.to_list() == ["x0", "x1", "x2", "x3", "x4"]
 
+    # From iterable of strings
     e = pl.Enum("abcde")
     assert e.categories.to_list() == ["a", "b", "c", "d", "e"]
+
+    # StrEnums added in Python 3.11
+    if sys.version_info >= (3, 11):
+        # From StrEnum
+        class MyEnum(enum.StrEnum):
+            A = "a"
+            B = "b"
+
+        e = pl.Enum(MyEnum)
+        assert e.categories.to_list() == ["a", "b"]
 
 
 @pytest.mark.parametrize("categories", [[], pl.Series("foo", dtype=pl.Int16), None])


### PR DESCRIPTION
This PR fixes https://github.com/pola-rs/polars/issues/19724, adding support for `StrEnum` in `pl.Enum` construction, if this is a feature we're interested in adding.