### PR TITLE
fix(python): Use `cls` for `to_python`

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -91,7 +91,7 @@ class DataTypeClass(type):
         ...
 
     @classmethod
-    def to_python(self) -> PythonDataType:  # noqa: D102
+    def to_python(cls) -> PythonDataType:  # noqa: D102
         ...
 
 


### PR DESCRIPTION
`cls` should be taken for this class method.