### PR TITLE
perf: Improve cloud scan performance

### DIFF
--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -49,10 +49,6 @@ impl PolarsObjectStore {
                 .await
                 .map_err(to_compute_err)
         } else {
-            dbg!(&range);
-            dbg!(parts.len());
-            dbg!(parts.clone().take(10).collect::<Vec<_>>());
-
             let parts = tune_with_concurrency_budget(
                 parts.len().clamp(0, MAX_BUDGET_PER_REQUEST) as u32,
                 || {
@@ -96,15 +92,6 @@ impl PolarsObjectStore {
         ranges.sort_unstable_by_key(|x| x.start);
 
         let (merged_ranges, merged_ends): (Vec<_>, Vec<_>) = merge_ranges(ranges).unzip();
-
-        dbg!(ranges.len());
-        dbg!(ranges.iter().take(10).collect::<Vec<_>>());
-        dbg!(merged_ranges.len());
-        dbg!(merged_ranges
-            .iter()
-            .zip(merged_ends.iter())
-            .take(10)
-            .collect::<Vec<_>>());
 
         let mut stream = self.get_buffered_ranges_stream(path, merged_ranges.iter().cloned());
 
@@ -252,7 +239,7 @@ impl PolarsObjectStore {
 
 /// Splits a single range into multiple smaller ranges, which can be downloaded concurrently for
 /// much higher throughput.
-fn split_range(range: Range<usize>) -> impl ExactSizeIterator<Item = Range<usize>> + Clone {
+fn split_range(range: Range<usize>) -> impl ExactSizeIterator<Item = Range<usize>> {
     let chunk_size = get_download_chunk_size();
 
     // Calculate n_parts such that we are as close as possible to the `chunk_size`.

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -2,14 +2,16 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};
-use polars_error::{to_compute_err, PolarsResult};
+use polars_core::prelude::{InitHashMaps, PlHashMap};
+use polars_error::{to_compute_err, PolarsError, PolarsResult};
 use tokio::io::AsyncWriteExt;
 
 use crate::pl_async::{
-    self, tune_with_concurrency_budget, with_concurrency_budget, MAX_BUDGET_PER_REQUEST,
+    self, get_concurrency_limit, get_download_chunk_size, tune_with_concurrency_budget,
+    with_concurrency_budget, MAX_BUDGET_PER_REQUEST,
 };
 
 /// Polars specific wrapper for `Arc<dyn ObjectStore>` that limits the number of
@@ -23,63 +25,197 @@ impl PolarsObjectStore {
         Self(store)
     }
 
-    pub async fn get(&self, path: &Path) -> PolarsResult<Bytes> {
-        tune_with_concurrency_budget(1, || async {
-            self.0
-                .get(path)
-                .await
-                .map_err(to_compute_err)?
-                .bytes()
-                .await
-                .map_err(to_compute_err)
-        })
-        .await
+    /// Returns a buffered stream that downloads concurrently up to the concurrency limit.
+    fn get_buffered_ranges_stream<'a, T: Iterator<Item = Range<usize>>>(
+        &'a self,
+        path: &'a Path,
+        ranges: T,
+    ) -> impl StreamExt<Item = PolarsResult<Bytes>>
+           + TryStreamExt<Ok = Bytes, Error = PolarsError, Item = PolarsResult<Bytes>>
+           + use<'a, T> {
+        futures::stream::iter(
+            ranges
+                .map(|range| async { self.0.get_range(path, range).await.map_err(to_compute_err) }),
+        )
+        // Add a limit locally as this gets run inside a single `tune_with_concurrency_budget`.
+        .buffered(get_concurrency_limit() as usize)
     }
 
     pub async fn get_range(&self, path: &Path, range: Range<usize>) -> PolarsResult<Bytes> {
-        tune_with_concurrency_budget(1, || self.0.get_range(path, range))
-            .await
-            .map_err(to_compute_err)
-    }
+        let parts = split_range(range.clone());
 
-    pub async fn get_ranges(
-        &self,
-        path: &Path,
-        ranges: &[Range<usize>],
-    ) -> PolarsResult<Vec<Bytes>> {
-        tune_with_concurrency_budget(
-            (ranges.len() as u32).clamp(0, MAX_BUDGET_PER_REQUEST as u32),
-            || self.0.get_ranges(path, ranges),
-        )
-        .await
-        .map_err(to_compute_err)
-    }
-
-    pub async fn download<F: tokio::io::AsyncWrite + std::marker::Unpin>(
-        &self,
-        path: &Path,
-        file: &mut F,
-    ) -> PolarsResult<()> {
-        tune_with_concurrency_budget(1, || async {
-            let mut stream = self
-                .0
-                .get(path)
+        if parts.len() == 1 {
+            tune_with_concurrency_budget(1, || self.0.get_range(path, range))
                 .await
-                .map_err(to_compute_err)?
-                .into_stream();
+                .map_err(to_compute_err)
+        } else {
+            dbg!(&range);
+            dbg!(parts.len());
+            dbg!(parts.clone().take(10).collect::<Vec<_>>());
 
-            let mut len = 0;
-            while let Some(bytes) = stream.next().await {
-                let bytes = bytes.map_err(to_compute_err)?;
-                len += bytes.len();
-                file.write_all(bytes.as_ref())
-                    .await
-                    .map_err(to_compute_err)?;
+            let parts = tune_with_concurrency_budget(
+                parts.len().clamp(0, MAX_BUDGET_PER_REQUEST) as u32,
+                || {
+                    self.get_buffered_ranges_stream(path, parts)
+                        .try_collect::<Vec<Bytes>>()
+                },
+            )
+            .await?;
+
+            let mut combined = Vec::with_capacity(range.len());
+
+            for part in parts {
+                combined.extend_from_slice(&part)
             }
 
-            PolarsResult::Ok(pl_async::Size::from(len as u64))
-        })
+            assert_eq!(combined.len(), range.len());
+
+            PolarsResult::Ok(Bytes::from(combined))
+        }
+    }
+
+    /// Fetch byte ranges into a HashMap keyed by the range start. This will mutably sort the
+    /// `ranges` slice for coalescing.
+    ///
+    /// # Panics
+    /// Panics if the same range start is used by more than 1 range.
+    pub async fn get_ranges_sort<
+        K: TryFrom<usize, Error = impl std::fmt::Debug> + std::hash::Hash + Eq,
+        T: From<Bytes>,
+    >(
+        &self,
+        path: &Path,
+        ranges: &mut [Range<usize>],
+    ) -> PolarsResult<PlHashMap<K, T>> {
+        if ranges.is_empty() {
+            return Ok(Default::default());
+        }
+
+        let mut out = PlHashMap::with_capacity(ranges.len());
+
+        ranges.sort_unstable_by_key(|x| x.start);
+
+        let (merged_ranges, merged_ends): (Vec<_>, Vec<_>) = merge_ranges(ranges).unzip();
+
+        dbg!(ranges.len());
+        dbg!(ranges.iter().take(10).collect::<Vec<_>>());
+        dbg!(merged_ranges.len());
+        dbg!(merged_ranges
+            .iter()
+            .zip(merged_ends.iter())
+            .take(10)
+            .collect::<Vec<_>>());
+
+        let mut stream = self.get_buffered_ranges_stream(path, merged_ranges.iter().cloned());
+
+        tune_with_concurrency_budget(
+            merged_ranges.len().clamp(0, MAX_BUDGET_PER_REQUEST) as u32,
+            || async {
+                let mut len = 0;
+                let mut current_offset = 0;
+                let mut ends_iter = merged_ends.iter();
+
+                let mut splitted_parts = vec![];
+
+                while let Some(bytes) = stream.try_next().await? {
+                    len += bytes.len();
+                    let end = *ends_iter.next().unwrap();
+
+                    if end == 0 {
+                        splitted_parts.push(bytes);
+                        continue;
+                    }
+
+                    let full_range = ranges[current_offset..end]
+                        .iter()
+                        .cloned()
+                        .reduce(|l, r| l.start.min(r.start)..l.end.max(r.end))
+                        .unwrap();
+
+                    let bytes = if splitted_parts.is_empty() {
+                        bytes
+                    } else {
+                        let mut out = Vec::with_capacity(full_range.len());
+
+                        for x in splitted_parts.drain(..) {
+                            out.extend_from_slice(&x);
+                        }
+
+                        out.extend_from_slice(&bytes);
+                        Bytes::from(out)
+                    };
+
+                    assert_eq!(bytes.len(), full_range.len());
+
+                    for range in &ranges[current_offset..end] {
+                        let v = out.insert(
+                            K::try_from(range.start).unwrap(),
+                            T::from(bytes.slice(
+                                range.start - full_range.start..range.end - full_range.start,
+                            )),
+                        );
+
+                        assert!(v.is_none()); // duplicate range start
+                    }
+
+                    current_offset = end;
+                }
+
+                assert!(splitted_parts.is_empty());
+
+                PolarsResult::Ok(pl_async::Size::from(len as u64))
+            },
+        )
         .await?;
+
+        Ok(out)
+    }
+
+    pub async fn download(&self, path: &Path, file: &mut tokio::fs::File) -> PolarsResult<()> {
+        let opt_size = self.head(path).await.ok().map(|x| x.size);
+        let parts = opt_size.map(|x| split_range(0..x)).filter(|x| x.len() > 1);
+
+        if let Some(parts) = parts {
+            tune_with_concurrency_budget(
+                parts.len().clamp(0, MAX_BUDGET_PER_REQUEST) as u32,
+                || async {
+                    let mut stream = self.get_buffered_ranges_stream(path, parts);
+                    let mut len = 0;
+                    while let Some(bytes) = stream.try_next().await? {
+                        len += bytes.len();
+                        file.write_all(&bytes).await.map_err(to_compute_err)?;
+                    }
+
+                    assert_eq!(len, opt_size.unwrap());
+
+                    PolarsResult::Ok(pl_async::Size::from(len as u64))
+                },
+            )
+            .await?
+        } else {
+            tune_with_concurrency_budget(1, || async {
+                let mut stream = self
+                    .0
+                    .get(path)
+                    .await
+                    .map_err(to_compute_err)?
+                    .into_stream();
+
+                let mut len = 0;
+                while let Some(bytes) = stream.try_next().await? {
+                    len += bytes.len();
+                    file.write_all(&bytes).await.map_err(to_compute_err)?;
+                }
+
+                PolarsResult::Ok(pl_async::Size::from(len as u64))
+            })
+            .await?
+        };
+
+        // Dropping is delayed for tokio async files so we need to explicitly
+        // flush here (https://github.com/tokio-rs/tokio/issues/2307#issuecomment-596336451).
+        file.sync_all().await.map_err(PolarsError::from)?;
+
         Ok(())
     }
 
@@ -111,5 +247,240 @@ impl PolarsObjectStore {
         })
         .await
         .map_err(to_compute_err)
+    }
+}
+
+/// Splits a single range into multiple smaller ranges, which can be downloaded concurrently for
+/// much higher throughput.
+fn split_range(range: Range<usize>) -> impl ExactSizeIterator<Item = Range<usize>> + Clone {
+    let chunk_size = get_download_chunk_size();
+
+    // Calculate n_parts such that we are as close as possible to the `chunk_size`.
+    let n_parts = [
+        (range.len().div_ceil(chunk_size)).max(1),
+        (range.len() / chunk_size).max(1),
+    ]
+    .into_iter()
+    .min_by_key(|x| (range.len() / *x).abs_diff(chunk_size))
+    .unwrap();
+
+    let chunk_size = (range.len() / n_parts).max(1);
+
+    assert_eq!(n_parts, (range.len() / chunk_size).max(1));
+    let bytes_rem = range.len() % chunk_size;
+
+    (0..n_parts).map(move |part_no| {
+        let (start, end) = if part_no == 0 {
+            // Download remainder length in the first chunk since it starts downloading first.
+            let end = range.start + chunk_size + bytes_rem;
+            let end = if end > range.end { range.end } else { end };
+            (range.start, end)
+        } else {
+            let start = bytes_rem + range.start + part_no * chunk_size;
+            (start, start + chunk_size)
+        };
+
+        start..end
+    })
+}
+
+/// Note: For optimal performance, `ranges` should be sorted. More generally,
+/// ranges placed next to each other should also be close in range value.
+///
+/// # Returns
+/// `[(range1, end1), (range2, end2)]`, where:
+/// * `range1` contains bytes for the ranges from `ranges[0..end1]`
+/// * `range2` contains bytes for the ranges from `ranges[end1..end2]`
+/// * etc..
+///
+/// Note that if an end value is 0, it means the range is a splitted part and should be combined.
+fn merge_ranges(ranges: &[Range<usize>]) -> impl Iterator<Item = (Range<usize>, usize)> + '_ {
+    let chunk_size = get_download_chunk_size();
+
+    let mut current_merged_range = ranges.first().map_or(0..0, Clone::clone);
+    // Number of fetched bytes excluding excess.
+    let mut current_n_bytes = 0;
+
+    (0..ranges.len())
+        .filter_map(move |current_idx| {
+            let current_idx = 1 + current_idx;
+
+            if current_idx == ranges.len() {
+                // No more items - flush current state.
+                Some((current_merged_range.clone(), current_idx))
+            } else {
+                let range = ranges[current_idx].clone();
+
+                let new_merged = current_merged_range.start.min(range.start)
+                    ..current_merged_range.end.max(range.end);
+
+                // E.g.:
+                // |--------|
+                //  oo        // range1
+                //       oo   // range2
+                //    ^^^     // distance = 3, is_overlapping = false
+                // E.g.:
+                // |--------|
+                //  ooooo     // range1
+                //     ooooo  // range2
+                //     ^^     // distance = 2, is_overlapping = true
+                let (distance, is_overlapping) = {
+                    let l = current_merged_range.end.min(range.end);
+                    let r = current_merged_range.start.max(range.start);
+
+                    (r.abs_diff(l), r < l)
+                };
+
+                #[rustfmt::skip]
+                let should_merge =
+                    is_overlapping // Always merge if overlapping
+                    || (
+                        // Don't merge if the result size is not closer to the `chunk_size`
+                        new_merged.len().abs_diff(chunk_size) < current_merged_range.len().abs_diff(chunk_size)
+                        && (
+                            // Either the gap is less than 1MiB..
+                            distance <= 1024 * 1024
+                            || (
+                                // ..or, the gap is less than 12.5% of the largest between `current_n_bytes`
+                                // and the new `range`, capped at 8MiB.
+                                distance <= current_n_bytes.max(range.len()) / 8
+                                && distance <= 8 * 1024 * 1024
+                            )
+                        )
+                    );
+
+                if should_merge {
+                    // Merge to existing range
+                    current_merged_range = new_merged;
+                    current_n_bytes += if is_overlapping {
+                        range.len() - distance
+                    } else {
+                        range.len()
+                    };
+                    None
+                } else {
+                    let v = current_merged_range.clone();
+                    current_merged_range = range;
+                    current_n_bytes = 0;
+                    Some((v, current_idx))
+                }
+            }
+        })
+        .flat_map(|x| {
+            // Split large individual ranges within the list of ranges.
+            let (range, end) = x;
+            let split = split_range(range.clone());
+            let len = split.len();
+
+            split
+                .enumerate()
+                .map(move |(i, range)| (range, if 1 + i == len { end } else { 0 }))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_split_range() {
+        use super::{get_download_chunk_size, split_range};
+
+        let chunk_size = get_download_chunk_size();
+
+        assert_eq!(chunk_size, 64 * 1024 * 1024);
+
+        #[allow(clippy::single_range_in_vec_init)]
+        {
+            // Round-trip empty ranges.
+            assert_eq!(split_range(0..0).collect::<Vec<_>>(), [0..0]);
+            assert_eq!(split_range(3..3).collect::<Vec<_>>(), [3..3]);
+        }
+
+        // Threshold to start splitting to 2 ranges
+        //
+        // n - chunk_size == chunk_size - n / 2
+        // n + n / 2 == 2 * chunk_size
+        // 3 * n == 4 * chunk_size
+        // n = 4 * chunk_size / 3
+        let n = 4 * chunk_size / 3;
+
+        #[allow(clippy::single_range_in_vec_init)]
+        {
+            assert_eq!(split_range(0..n).collect::<Vec<_>>(), [0..89478485]);
+        }
+
+        assert_eq!(
+            split_range(0..n + 1).collect::<Vec<_>>(),
+            [0..44739243, 44739243..89478486]
+        );
+
+        // Threshold to start splitting to 3 ranges
+        //
+        // n / 2 - chunk_size == chunk_size - n / 3
+        // n / 2 + n / 3 == 2 * chunk_size
+        // 5 * n == 12 * chunk_size
+        // n == 12 * chunk_size / 5
+        let n = 12 * chunk_size / 5;
+
+        assert_eq!(
+            split_range(0..n).collect::<Vec<_>>(),
+            [0..80530637, 80530637..161061273]
+        );
+
+        assert_eq!(
+            split_range(0..n + 1).collect::<Vec<_>>(),
+            [0..53687092, 53687092..107374183, 107374183..161061274]
+        );
+    }
+
+    #[test]
+    fn test_merge_ranges() {
+        use super::{get_download_chunk_size, merge_ranges};
+
+        let chunk_size = get_download_chunk_size();
+
+        assert_eq!(chunk_size, 64 * 1024 * 1024);
+
+        // Round-trip empty slice
+        assert_eq!(merge_ranges(&[]).collect::<Vec<_>>(), []);
+
+        // We have 1 tiny request followed by 1 huge request. They are combined as it reduces the
+        // `abs_diff()` to the `chunk_size`, but afterwards they are split to 2 evenly sized
+        // requests.
+        assert_eq!(
+            merge_ranges(&[0..1, 1..127 * 1024 * 1024]).collect::<Vec<_>>(),
+            [(0..66584576, 0), (66584576..133169152, 2)]
+        );
+
+        // <= 1MiB gap, merge
+        assert_eq!(
+            merge_ranges(&[0..1, 1024 * 1024 + 1..1024 * 1024 + 2]).collect::<Vec<_>>(),
+            [(0..1048578, 2)]
+        );
+
+        // > 1MiB gap, do not merge
+        assert_eq!(
+            merge_ranges(&[0..1, 1024 * 1024 + 2..1024 * 1024 + 3]).collect::<Vec<_>>(),
+            [(0..1, 1), (1048578..1048579, 2)]
+        );
+
+        // <= 12.5% gap, merge
+        assert_eq!(
+            merge_ranges(&[0..8, 10..11]).collect::<Vec<_>>(),
+            [(0..11, 2)]
+        );
+
+        // <= 12.5% gap relative to RHS, merge
+        assert_eq!(
+            merge_ranges(&[0..1, 3..11]).collect::<Vec<_>>(),
+            [(0..11, 2)]
+        );
+
+        // Overlapping range, merge
+        assert_eq!(
+            merge_ranges(&[0..80 * 1024 * 1024, 10 * 1024 * 1024..70 * 1024 * 1024])
+                .collect::<Vec<_>>(),
+            [(0..80 * 1024 * 1024, 2)]
+        );
     }
 }

--- a/crates/polars-io/src/file_cache/file_fetcher.rs
+++ b/crates/polars-io/src/file_cache/file_fetcher.rs
@@ -116,12 +116,7 @@ impl FileFetcher for CloudFileFetcher {
                 .await
                 .map_err(PolarsError::from)?;
 
-            self.object_store.download(&self.cloud_path, file).await?;
-            // Dropping is delayed for tokio async files so we need to explicitly
-            // flush here (https://github.com/tokio-rs/tokio/issues/2307#issuecomment-596336451).
-            file.sync_all().await.map_err(PolarsError::from)?;
-            PolarsResult::Ok(())
-        })?;
-        Ok(())
+            self.object_store.download(&self.cloud_path, file).await
+        })
     }
 }

--- a/crates/polars-stream/src/nodes/parquet_source/row_group_data_fetch.rs
+++ b/crates/polars-stream/src/nodes/parquet_source/row_group_data_fetch.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use polars_core::prelude::{ArrowSchema, InitHashMaps, PlHashMap};
+use polars_core::prelude::{ArrowSchema, PlHashMap};
 use polars_core::series::IsSorted;
 use polars_core::utils::operation_exceeded_idxsize_msg;
 use polars_error::{polars_err, PolarsResult};
@@ -197,46 +197,32 @@ impl RowGroupDataFetcher {
                             mem_slice,
                         }
                     } else if let Some(columns) = projection.as_ref() {
-                        let ranges = get_row_group_byte_ranges_for_projection(
+                        let mut ranges = get_row_group_byte_ranges_for_projection(
                             &row_group_metadata,
                             columns.as_ref(),
                         )
                         .collect::<Vec<_>>();
 
-                        let bytes = current_byte_source.get_ranges(ranges.as_ref()).await?;
+                        let n_ranges = ranges.len();
 
-                        assert_eq!(bytes.len(), ranges.len());
+                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
 
-                        let mut bytes_map = PlHashMap::with_capacity(ranges.len());
-
-                        for (range, bytes) in ranges.iter().zip(bytes) {
-                            memory_prefetch_func(bytes.as_ref());
-                            let v = bytes_map.insert(range.start, bytes);
-                            debug_assert!(v.is_none(), "duplicate range start {}", range.start);
-                        }
+                        assert_eq!(bytes_map.len(), n_ranges);
 
                         FetchedBytes::BytesMap(bytes_map)
                     } else {
-                        // We have a dedicated code-path for a full projection that performs a
-                        // single range request for the entire row group. During testing this
-                        // provided much higher throughput from cloud than making multiple range
-                        // request with `get_ranges()`.
-                        let full_range = row_group_metadata.full_byte_range();
-                        let full_range = full_range.start as usize..full_range.end as usize;
+                        let mut ranges = row_group_metadata
+                            .byte_ranges_iter()
+                            .map(|x| x.start as usize..x.end as usize)
+                            .collect::<Vec<_>>();
 
-                        let mem_slice = {
-                            let full_range_2 = full_range.clone();
-                            task_handles_ext::AbortOnDropHandle(io_runtime.spawn(async move {
-                                current_byte_source.get_range(full_range_2).await
-                            }))
-                            .await
-                            .unwrap()?
-                        };
+                        let n_ranges = ranges.len();
 
-                        FetchedBytes::MemSlice {
-                            offset: full_range.start,
-                            mem_slice,
-                        }
+                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+
+                        assert_eq!(bytes_map.len(), n_ranges);
+
+                        FetchedBytes::BytesMap(bytes_map)
                     };
 
                     PolarsResult::Ok(RowGroupData {

--- a/crates/polars-utils/src/mmap.rs
+++ b/crates/polars-utils/src/mmap.rs
@@ -130,6 +130,12 @@ mod private {
             out
         }
     }
+
+    impl From<bytes::Bytes> for MemSlice {
+        fn from(value: bytes::Bytes) -> Self {
+            Self::from_bytes(value)
+        }
+    }
 }
 
 use memmap::MmapOptions;


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/issues/18443

We were previously slow either due to making a single very large request, or making thousands of tiny requests. This PR splits/combines the range requests to make them evenly distributed with a reasonable chunk size.

| query                                                                    | time (1.12.0, seconds) | time (this PR) | speedup |
| ------------------------------------------------------------------------ | ---------------------- | -------------- | ------- |
| pl.read_parquet(path)                                                    | 29.020907              | 2.771221       | 10.5x   |
| pl.scan_parquet(path).select(cs.by_index(range(6_000))).collect()        | 14.717146              | 1.75916        | 8.4x    |
| pl.scan_parquet(path).select(cs.by_index(range(0, 12_000, 5))).collect() | 28.716227              | 2.414139       | 11.9x   |
| pl.scan_parquet(path).select(cs.by_index(range(0, 12_000, 3))).collect() | 28.815121              | 2.515088       | 11.5x   |
| pl.scan_parquet(path).collect(new_streaming=True)                        | 28.939848              | 3.001616       | 9.6x    |
