### PR TITLE
perf: Improve `DataFrame.sort().limit/top_k` performance

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
@@ -40,8 +40,7 @@ pub fn _arg_bottom_k(
     _broadcast_bools(by_column.len(), &mut sort_options.nulls_last);
 
     // Don't go into row encoding.
-    if by_column.len() == 1 {
-        sort_options.limit = Some(k as IdxSize);
+    if by_column.len() == 1 && sort_options.limit.is_some() && !sort_options.maintain_order {
         return Ok(NoNull::new(by_column[0].arg_sort((&*sort_options).into())));
     }
 

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_bottom_k.rs
@@ -39,6 +39,12 @@ pub fn _arg_bottom_k(
     _broadcast_bools(by_column.len(), &mut sort_options.descending);
     _broadcast_bools(by_column.len(), &mut sort_options.nulls_last);
 
+    // Don't go into row encoding.
+    if by_column.len() == 1 {
+        sort_options.limit = Some(k as IdxSize);
+        return Ok(NoNull::new(by_column[0].arg_sort((&*sort_options).into())));
+    }
+
     let encoded = _get_rows_encoded(
         by_column,
         &sort_options.descending,

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
@@ -18,7 +18,7 @@ pub(super) fn arg_sort<I, J, T>(
     iters: I,
     options: SortOptions,
     null_count: usize,
-    len: usize,
+    mut len: usize,
 ) -> IdxCa
 where
     I: IntoIterator<Item = J>,
@@ -49,13 +49,36 @@ where
         vals.extend(iter);
     }
 
-    sort_impl(vals.as_mut_slice(), options);
+    let vals = if let (Some(limit), true) = (options.limit, nulls_last) {
+        let limit = limit as usize;
+        let out = if limit >= vals.len() {
+            vals.as_mut_slice()
+        } else {
+            // Overwrite output len.
+            len = limit;
+            let vals = vals.as_mut_slice();
+            let (lower, _el, _upper) = vals.select_nth_unstable_by(limit, |a, b| a.1.tot_cmp(&b.1));
+            lower
+        };
 
-    let iter = vals.into_iter().map(|(idx, _v)| idx);
+        sort_impl(out, options);
+        out
+    } else {
+        sort_impl(vals.as_mut_slice(), options);
+        vals.as_slice()
+    };
+
+    let iter = vals.iter().map(|(idx, _v)| idx).copied();
     let idx = if nulls_last {
         let mut idx = Vec::with_capacity(len);
         idx.extend(iter);
-        idx.extend(nulls_idx);
+
+        let nulls_idx = if options.limit.is_some() {
+            &nulls_idx[..len - idx.len()]
+        } else {
+            &nulls_idx
+        };
+        idx.extend_from_slice(nulls_idx);
         idx
     } else {
         let ptr = nulls_idx.as_ptr() as usize;
@@ -90,9 +113,24 @@ where
         }));
     }
 
-    sort_impl(vals.as_mut_slice(), options);
+    let vals = if let Some(limit) = options.limit {
+        let limit = limit as usize;
+        let out = if limit >= vals.len() {
+            vals.as_mut_slice()
+        } else {
+            let (lower, _el, _upper) = vals
+                .as_mut_slice()
+                .select_nth_unstable_by(limit, |a, b| a.1.tot_cmp(&b.1));
+            lower
+        };
+        sort_impl(out, options);
+        out
+    } else {
+        sort_impl(vals.as_mut_slice(), options);
+        vals.as_slice()
+    };
 
-    let iter = vals.into_iter().map(|(idx, _v)| idx);
+    let iter = vals.iter().map(|(idx, _v)| idx).copied();
     let idx: Vec<_> = iter.collect_trusted();
 
     ChunkedArray::with_chunk(name, IdxArr::from_data_default(Buffer::from(idx), None))

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -53,6 +53,7 @@ impl CategoricalChunked {
             descending,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         })
     }
 

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -335,6 +335,7 @@ impl ChunkSort<StringType> for StringChunked {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         })
     }
 
@@ -406,6 +407,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         })
     }
 
@@ -536,6 +538,7 @@ impl ChunkSort<BinaryOffsetType> for BinaryOffsetChunked {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         })
     }
 
@@ -672,6 +675,7 @@ impl ChunkSort<BooleanType> for BooleanChunked {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         })
     }
 
@@ -797,6 +801,7 @@ mod test {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         });
         assert_eq!(
             Vec::from(&out),
@@ -816,6 +821,7 @@ mod test {
             nulls_last: true,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         });
         assert_eq!(
             Vec::from(&out),
@@ -925,6 +931,7 @@ mod test {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         });
         let expected = &[None, None, Some("a"), Some("b"), Some("c")];
         assert_eq!(Vec::from(&out), expected);
@@ -934,6 +941,7 @@ mod test {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         });
 
         let expected = &[None, None, Some("c"), Some("b"), Some("a")];
@@ -944,6 +952,7 @@ mod test {
             nulls_last: true,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         });
         let expected = &[Some("a"), Some("b"), Some("c"), None, None];
         assert_eq!(Vec::from(&out), expected);
@@ -953,6 +962,7 @@ mod test {
             nulls_last: true,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         });
         let expected = &[Some("c"), Some("b"), Some("a"), None, None];
         assert_eq!(Vec::from(&out), expected);

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -41,6 +41,8 @@ pub struct SortOptions {
     /// If true maintain the order of equal elements.
     /// Default `false`.
     pub maintain_order: bool,
+    /// Limit a sort output, this is for optimization purposes and might be ignored.
+    pub limit: Option<IdxSize>,
 }
 
 /// Sort options for multi-series sorting.
@@ -96,6 +98,8 @@ pub struct SortMultipleOptions {
     pub multithreaded: bool,
     /// Whether maintain the order of equal elements. Default `false`.
     pub maintain_order: bool,
+    /// Limit a sort output, this is for optimization purposes and might be ignored.
+    pub limit: Option<IdxSize>,
 }
 
 impl Default for SortOptions {
@@ -105,6 +109,7 @@ impl Default for SortOptions {
             nulls_last: false,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         }
     }
 }
@@ -116,6 +121,7 @@ impl Default for SortMultipleOptions {
             nulls_last: vec![false],
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         }
     }
 }
@@ -224,6 +230,7 @@ impl From<&SortOptions> for SortMultipleOptions {
             nulls_last: vec![value.nulls_last],
             multithreaded: value.multithreaded,
             maintain_order: value.maintain_order,
+            limit: value.limit,
         }
     }
 }
@@ -235,6 +242,7 @@ impl From<&SortMultipleOptions> for SortOptions {
             nulls_last: value.nulls_last.first().copied().unwrap_or(false),
             multithreaded: value.multithreaded,
             maintain_order: value.maintain_order,
+            limit: value.limit,
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/options.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/options.rs
@@ -42,7 +42,9 @@ pub struct SortOptions {
     /// Default `false`.
     pub maintain_order: bool,
     /// Limit a sort output, this is for optimization purposes and might be ignored.
-    pub limit: Option<IdxSize>,
+    /// - Len
+    /// - Descending
+    pub limit: Option<(IdxSize, bool)>,
 }
 
 /// Sort options for multi-series sorting.
@@ -99,7 +101,9 @@ pub struct SortMultipleOptions {
     /// Whether maintain the order of equal elements. Default `false`.
     pub maintain_order: bool,
     /// Limit a sort output, this is for optimization purposes and might be ignored.
-    pub limit: Option<IdxSize>,
+    /// - Len
+    /// - Descending
+    pub limit: Option<(IdxSize, bool)>,
 }
 
 impl Default for SortOptions {

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1989,6 +1989,7 @@ impl DataFrame {
             return Ok(out);
         }
         if let Some((0, k)) = slice {
+            sort_options.limit = Some(k as IdxSize);
             return self.bottom_k_impl(k, by_column, sort_options);
         }
 
@@ -2012,6 +2013,7 @@ impl DataFrame {
                     nulls_last: sort_options.nulls_last[0],
                     multithreaded: sort_options.multithreaded,
                     maintain_order: sort_options.maintain_order,
+                    limit: sort_options.limit,
                 };
                 // fast path for a frame with a single series
                 // no need to compute the sort indices and then take by these indices

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1989,7 +1989,12 @@ impl DataFrame {
             return Ok(out);
         }
         if let Some((0, k)) = slice {
-            sort_options.limit = Some(k as IdxSize);
+            let desc = if sort_options.descending.len() == 1 {
+                sort_options.descending[0]
+            } else {
+                false
+            };
+            sort_options.limit = Some((k as IdxSize, desc));
             return self.bottom_k_impl(k, by_column, sort_options);
         }
 

--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -160,6 +160,7 @@ fn sort_by_groups_multiple_by(
                 nulls_last: nulls_last.to_owned(),
                 multithreaded,
                 maintain_order,
+                limit: None,
             };
 
             let sorted_idx = groups[0]
@@ -180,6 +181,7 @@ fn sort_by_groups_multiple_by(
                 nulls_last: nulls_last.to_owned(),
                 multithreaded,
                 maintain_order,
+                limit: None,
             };
             let sorted_idx = groups[0]
                 .as_materialized_series()

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -450,6 +450,7 @@ fn take_aggregations() -> PolarsResult<()> {
                             nulls_last: false,
                             multithreaded: true,
                             maintain_order: false,
+                            limit: None,
                         })
                         .head(Some(2)),
                 )
@@ -489,6 +490,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             })
             .get(lit(0))])
         .collect()?;
@@ -507,6 +509,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             })
             .get(lit(0))])
         .collect()?;
@@ -526,6 +529,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                     nulls_last: false,
                     multithreaded: true,
                     maintain_order: false,
+                    limit: None,
                 })
                 .get(lit(0))
                 .alias("1"),
@@ -537,6 +541,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                             nulls_last: false,
                             multithreaded: true,
                             maintain_order: false,
+                            limit: None,
                         })
                         .get(lit(0)),
                 )

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1666,6 +1666,7 @@ fn test_single_group_result() -> PolarsResult<()> {
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             })
             .over([col("a")])])
         .collect()?;

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -285,6 +285,7 @@ fn top_k_by_impl(
         nulls_last: vec![true; by.len()],
         multithreaded,
         maintain_order: false,
+        limit: None,
     };
 
     let idx = _arg_bottom_k(k, by, &mut sort_options)?;

--- a/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
@@ -225,6 +225,7 @@ pub(crate) fn _sort_or_hash_inner(
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             });
             let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(s_left, &s_right);
@@ -252,6 +253,7 @@ pub(crate) fn _sort_or_hash_inner(
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             });
             let s_left = unsafe { s_left.take_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(&s_left, s_right);
@@ -323,6 +325,7 @@ pub(crate) fn sort_or_hash_left(
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             });
             let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
 

--- a/crates/polars-pipe/src/executors/sinks/sort/source.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/source.rs
@@ -101,6 +101,7 @@ impl SortSource {
                     nulls_last: self.nulls_last,
                     multithreaded: true,
                     maintain_order: false,
+                    limit: None,
                 },
             ),
             Some((offset, len)) => {
@@ -119,6 +120,7 @@ impl SortSource {
                             nulls_last: self.nulls_last,
                             multithreaded: true,
                             maintain_order: false,
+                            limit: None,
                         },
                     );
                     *len = len.saturating_sub(df_len);

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -260,6 +260,7 @@ impl PyExpr {
                 nulls_last,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             })
             .into()
     }
@@ -272,6 +273,7 @@ impl PyExpr {
                 nulls_last,
                 multithreaded: true,
                 maintain_order: false,
+                limit: None,
             })
             .into()
     }
@@ -349,6 +351,7 @@ impl PyExpr {
                     nulls_last,
                     multithreaded,
                     maintain_order,
+                    limit: None,
                 },
             )
             .into()

--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -75,6 +75,7 @@ pub fn arg_sort_by(
             nulls_last,
             multithreaded,
             maintain_order,
+            limit: None,
         },
     )
     .into()

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -539,6 +539,7 @@ impl PyLazyFrame {
                 nulls_last: vec![nulls_last],
                 multithreaded,
                 maintain_order,
+                limit: None,
             },
         )
         .into()
@@ -561,6 +562,7 @@ impl PyLazyFrame {
                 nulls_last,
                 maintain_order,
                 multithreaded,
+                limit: None,
             },
         )
         .into()

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -457,6 +457,7 @@ impl PySeries {
             nulls_last,
             multithreaded: true,
             maintain_order: false,
+            limit: None,
         };
         Ok(self.series.is_sorted(options).map_err(PyPolarsErr::from)?)
     }

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -397,3 +397,37 @@ def test_bottom_k_nulls(s: pl.Series, should_sort: bool) -> None:
 def test_top_k_descending_deprecated() -> None:
     with pytest.deprecated_call():
         pl.col("a").top_k_by("b", descending=True)  # type: ignore[call-arg]
+
+
+def test_top_k_df() -> None:
+    df = pl.LazyFrame({"a": [3, 4, 1, 2, 5]})
+    expected = [5, 4, 3]
+    assert df.sort("a", descending=True).limit(3).collect()["a"].to_list() == expected
+    assert df.top_k(3, by="a").collect()["a"].to_list() == expected
+    expected = [1, 2, 3]
+    assert df.sort("a", descending=False).limit(3).collect()["a"].to_list() == expected
+    assert df.bottom_k(3, by="a").collect()["a"].to_list() == expected
+
+    df = pl.LazyFrame({"a": [1, None, None, 4, 5]})
+    expected = [5, 4, 1, None]
+    assert (
+        df.sort("a", descending=True, nulls_last=True).limit(4).collect()["a"].to_list()
+        == expected
+    )
+    assert df.top_k(4, by="a").collect()["a"].to_list() == expected
+    expected = [1, 4, 5, None]
+    assert (
+        df.sort("a", descending=False, nulls_last=True)
+        .limit(4)
+        .collect()["a"]
+        .to_list()
+        == expected
+    )
+    assert df.bottom_k(4, by="a").collect()["a"].to_list() == expected
+
+    assert df.sort("a", descending=False, nulls_last=False).limit(4).collect()[
+        "a"
+    ].to_list() == [None, None, 1, 4]
+    assert df.sort("a", descending=True, nulls_last=False).limit(4).collect()[
+        "a"
+    ].to_list() == [None, None, 5, 4]

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -409,21 +409,21 @@ def test_top_k_df() -> None:
     assert df.bottom_k(3, by="a").collect()["a"].to_list() == expected
 
     df = pl.LazyFrame({"a": [1, None, None, 4, 5]})
-    expected = [5, 4, 1, None]
+    expected2 = [5, 4, 1, None]
     assert (
         df.sort("a", descending=True, nulls_last=True).limit(4).collect()["a"].to_list()
         == expected
     )
-    assert df.top_k(4, by="a").collect()["a"].to_list() == expected
-    expected = [1, 4, 5, None]
+    assert df.top_k(4, by="a").collect()["a"].to_list() == expected2
+    expected2 = [1, 4, 5, None]
     assert (
         df.sort("a", descending=False, nulls_last=True)
         .limit(4)
         .collect()["a"]
         .to_list()
-        == expected
+        == expected2
     )
-    assert df.bottom_k(4, by="a").collect()["a"].to_list() == expected
+    assert df.bottom_k(4, by="a").collect()["a"].to_list() == expected2
 
     assert df.sort("a", descending=False, nulls_last=False).limit(4).collect()[
         "a"

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -412,7 +412,7 @@ def test_top_k_df() -> None:
     expected2 = [5, 4, 1, None]
     assert (
         df.sort("a", descending=True, nulls_last=True).limit(4).collect()["a"].to_list()
-        == expected
+        == expected2
     )
     assert df.top_k(4, by="a").collect()["a"].to_list() == expected2
     expected2 = [1, 4, 5, None]


### PR DESCRIPTION
Closes #19281

We went into row-encoding. This dispatches to primitives and thus saves an expensive encoding and a very expensive comparison function (strcmp).