### PR TITLE
feat(python): Try to support native SAP HANA driver via `read_database`

### DIFF
--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -511,7 +511,7 @@ class ConnectionExecutor:
             result = cursor_execute(query, *positional_options)
 
         # note: some cursors execute in-place, some access results via a property
-        result = self.cursor if result is None else result
+        result = self.cursor if (result is None or result is True) else result
         if self.driver_name == "duckdb":
             result = result.cursor
 


### PR DESCRIPTION
Closes #19729 (hopefully).

I do not have access to an SAP HANA instance to validate the fix, but some investigation and careful reading of [their docs](https://help.sap.com/docs/SAP_HANA_CLIENT/f1b440ded6144a54ada97ff95dac7adf/3b89755ceec042e5919313b40acf8794.html?locale=en-US#example) and the associated examples shows that they return a non-standard value from `Cursor.execute` - boolean "True" instead of the usual "None" or a ResultSet object of some kind. Accounting for this is a one-liner that won't impact anything else, and I'm _fairly_ optimistic that it'll work 🤔