### PR TITLE
perf: Fix cloud download speed regression

### DIFF
--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -319,12 +319,12 @@ fn merge_ranges(ranges: &[Range<usize>]) -> impl Iterator<Item = (Range<usize>, 
                 };
 
                 let should_merge = is_overlapping || {
-                    let le_existing_chunk_size_dist = new_merged.len().abs_diff(chunk_size)
+                    let leq_existing_chunk_size_dist = new_merged.len().abs_diff(chunk_size)
                         <= current_merged_range.len().abs_diff(chunk_size);
                     let gap_tolerance =
                         (current_n_bytes.max(range.len()) / 8).clamp(1024 * 1024, 8 * 1024 * 1024);
 
-                    le_existing_chunk_size_dist && distance <= gap_tolerance
+                    leq_existing_chunk_size_dist && distance <= gap_tolerance
                 };
 
                 if should_merge {

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -322,13 +322,8 @@ fn merge_ranges(ranges: &[Range<usize>]) -> impl Iterator<Item = (Range<usize>, 
                 let should_merge =
                     is_overlapping // Always merge if overlapping
                     || (
-                        (
-                            // Either one range is extremely small compared to the other, with a limit of 8MiB..
-                            range.len().min(current_merged_range.len())
-                                < (range.len().max(current_merged_range.len()) / 128).min(8 * 1024 * 1024)
-                            // ..or the new size is closer to the chunk_size
-                            || new_merged.len().abs_diff(chunk_size) < current_merged_range.len().abs_diff(chunk_size)
-                        )
+                        // Don't merge if the result size is not closer to the `chunk_size`
+                        new_merged.len().abs_diff(chunk_size) < current_merged_range.len().abs_diff(chunk_size)
                         && (
                             // Either the gap is less than 1MiB..
                             distance <= 1024 * 1024
@@ -442,27 +437,6 @@ mod tests {
         assert_eq!(
             merge_ranges(&[0..1, 1..127 * 1024 * 1024]).collect::<Vec<_>>(),
             [(0..66584576, 0), (66584576..133169152, 2)]
-        );
-
-        assert_eq!(
-            merge_ranges(&[
-                0..1,
-                1..128 * 1024 * 1024,
-                1 + 128 * 1024 * 1024..2 + 128 * 1024 * 1024,
-                2 + 128 * 1024 * 1024..256 * 1024 * 1024
-            ])
-            .collect::<Vec<_>>(),
-            [
-                (0..67108865, 0),
-                (67108865..134217730, 3),
-                (134217730..201326593, 0),
-                (201326593..268435456, 4)
-            ]
-        );
-
-        assert_eq!(
-            merge_ranges(&[0..1, 1..128 * 1024 * 1024]).collect::<Vec<_>>(),
-            [(0..67108864, 0), (67108864..134217728, 2)]
         );
 
         // <= 1MiB gap, merge

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -319,12 +319,12 @@ fn merge_ranges(ranges: &[Range<usize>]) -> impl Iterator<Item = (Range<usize>, 
                 };
 
                 let should_merge = is_overlapping || {
-                    let is_closer_to_chunk_size = new_merged.len().abs_diff(chunk_size)
+                    let le_existing_chunk_size_dist = new_merged.len().abs_diff(chunk_size)
                         <= current_merged_range.len().abs_diff(chunk_size);
                     let gap_tolerance =
                         (current_n_bytes.max(range.len()) / 8).clamp(1024 * 1024, 8 * 1024 * 1024);
 
-                    is_closer_to_chunk_size && distance <= gap_tolerance
+                    le_existing_chunk_size_dist && distance <= gap_tolerance
                 };
 
                 if should_merge {

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -319,12 +319,12 @@ fn merge_ranges(ranges: &[Range<usize>]) -> impl Iterator<Item = (Range<usize>, 
                 };
 
                 let should_merge = is_overlapping || {
-                    let leq_current_dist_to_chunk_size = new_merged.len().abs_diff(chunk_size)
+                    let leq_current_len_dist_to_chunk_size = new_merged.len().abs_diff(chunk_size)
                         <= current_merged_range.len().abs_diff(chunk_size);
                     let gap_tolerance =
                         (current_n_bytes.max(range.len()) / 8).clamp(1024 * 1024, 8 * 1024 * 1024);
 
-                    leq_current_dist_to_chunk_size && distance <= gap_tolerance
+                    leq_current_len_dist_to_chunk_size && distance <= gap_tolerance
                 };
 
                 if should_merge {

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -319,12 +319,12 @@ fn merge_ranges(ranges: &[Range<usize>]) -> impl Iterator<Item = (Range<usize>, 
                 };
 
                 let should_merge = is_overlapping || {
-                    let leq_existing_chunk_size_dist = new_merged.len().abs_diff(chunk_size)
+                    let leq_current_dist_to_chunk_size = new_merged.len().abs_diff(chunk_size)
                         <= current_merged_range.len().abs_diff(chunk_size);
                     let gap_tolerance =
                         (current_n_bytes.max(range.len()) / 8).clamp(1024 * 1024, 8 * 1024 * 1024);
 
-                    leq_existing_chunk_size_dist && distance <= gap_tolerance
+                    leq_current_dist_to_chunk_size && distance <= gap_tolerance
                 };
 
                 if should_merge {


### PR DESCRIPTION
Reverts https://github.com/pola-rs/polars/pull/19730 - from benchmarking it performed worse.

In hindsight it's not worth adding that rule - even without it we will only have up to half of our requests being tiny in the worst case (in this worst case they would be interleaved).

