### PR TITLE
fix(python): Address incorrect `selector & col` expansion

### DIFF
--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -182,10 +182,16 @@ def test_selector_by_name(df: pl.DataFrame) -> None:
 
     # check "by_name & col"
     for selector_expr, expected in (
-        (cs.by_name("abc", "cde") & pl.col("ghi"), ["abc", "cde", "ghi"]),
-        (pl.col("ghi") & cs.by_name("cde", "abc"), ["ghi", "cde", "abc"]),
+        (cs.by_name("abc", "cde") & pl.col("ghi"), []),
+        (cs.by_name("abc", "cde") & pl.col("cde"), ["cde"]),
+        (pl.col("cde") & cs.by_name("cde", "abc"), ["cde"]),
     ):
         assert df.select(selector_expr).columns == expected
+
+    # check "by_name & by_name"
+    assert df.select(
+        cs.by_name("abc", "cde", "def", "eee") & cs.by_name("cde", "eee", "fgg")
+    ).columns == ["cde", "eee"]
 
     # expected errors
     with pytest.raises(ColumnNotFoundError, match="xxx"):


### PR DESCRIPTION
Closes #19740.

Should resolve as an intersection, not a union.

## Example

```python
import polars.selectors as cs
import polars as pl

df = pl.DataFrame({
    "a": [1],
    "b": [2]
})
```
**Before**
```python
df.select(cs.by_name("a") & pl.col("b"))
# shape: (1, 2)
# ┌─────┬─────┐
# │ a   ┆ b   │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 1   ┆ 2   │
# └─────┴─────┘
```
**After**
```python
df.select(cs.by_name("a") & pl.col("b"))
# shape: (0, 0)
# ┌┐
# ╞╡
# └┘
```