### PR TITLE
fix(python): Respect schema_overrides in batched csv reader

### DIFF
--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -59,13 +59,13 @@ class BatchedCsvReader:
     ) -> None:
         path = normalize_filepath(source, check_not_directory=False)
 
-        schema_overrides: Sequence[tuple[str, PolarsDataType]] | None = None
+        dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
         dtype_slice: Sequence[PolarsDataType] | None = None
         if schema_overrides is not None:
             if isinstance(schema_overrides, dict):
-                schema_overrides = []
+                dtype_list = []
                 for k, v in schema_overrides.items():
-                    schema_overrides.append((k, parse_into_dtype(v)))
+                    dtype_list.append((k, parse_into_dtype(v)))
             elif isinstance(schema_overrides, Sequence):
                 dtype_slice = schema_overrides
             else:
@@ -89,7 +89,7 @@ class BatchedCsvReader:
             encoding=encoding,
             n_threads=n_threads,
             path=path,
-            schema_overrides=schema_overrides,
+            schema_overrides=dtype_list,
             overwrite_dtype_slice=dtype_slice,
             low_memory=low_memory,
             comment_prefix=comment_prefix,

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -59,13 +59,13 @@ class BatchedCsvReader:
     ) -> None:
         path = normalize_filepath(source, check_not_directory=False)
 
-        dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
+        schema_overrides: Sequence[tuple[str, PolarsDataType]] | None = None
         dtype_slice: Sequence[PolarsDataType] | None = None
         if schema_overrides is not None:
             if isinstance(schema_overrides, dict):
-                dtype_list = []
+                schema_overrides = []
                 for k, v in schema_overrides.items():
-                    dtype_list.append((k, parse_into_dtype(v)))
+                    schema_overrides.append((k, parse_into_dtype(v)))
             elif isinstance(schema_overrides, Sequence):
                 dtype_slice = schema_overrides
             else:
@@ -89,7 +89,7 @@ class BatchedCsvReader:
             encoding=encoding,
             n_threads=n_threads,
             path=path,
-            overwrite_dtype=dtype_list,
+            schema_overrides=schema_overrides,
             overwrite_dtype_slice=dtype_slice,
             low_memory=low_memory,
             comment_prefix=comment_prefix,

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2346,3 +2346,11 @@ time
         ),
         df,
     )
+
+
+def test_batched_csv_schema_overrides(io_files_path: Path) -> None:
+    foods = io_files_path / "foods1.csv"
+    batched = pl.read_csv_batched(foods, schema_overrides={"calories": pl.String})
+    b = batched.next_batches(1)[0]
+    assert b["calories"].dtype == pl.String
+    assert b.width == 4

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2351,6 +2351,8 @@ time
 def test_batched_csv_schema_overrides(io_files_path: Path) -> None:
     foods = io_files_path / "foods1.csv"
     batched = pl.read_csv_batched(foods, schema_overrides={"calories": pl.String})
-    b = batched.next_batches(1)[0]
+    res = batched.next_batches(1)
+    assert res is not None
+    b = res[0]
     assert b["calories"].dtype == pl.String
     assert b.width == 4


### PR DESCRIPTION
fixes #19685