### PR TITLE
docs(python): Mention `row_by_keys` in the `to_dict` documentation

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1627,6 +1627,10 @@ class DataFrame:
             True -> Values are Series
             False -> Values are List[Any]
 
+        See Also
+        --------
+        rows_by_key
+
         Examples
         --------
         >>> df = pl.DataFrame(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1630,6 +1630,7 @@ class DataFrame:
         See Also
         --------
         rows_by_key
+        to_dicts
 
         Examples
         --------
@@ -10387,6 +10388,7 @@ class DataFrame:
         --------
         rows : Materialize all frame data as a list of rows (potentially expensive).
         iter_rows : Row iterator over frame data (does not materialize all rows).
+        to_dict : Convert DataFrame to a dictionary mapping column name to values.
 
         Examples
         --------


### PR DESCRIPTION
User coming from pandas will try to get the equivalent of `df.set_index([key1, key2]).to_dict()` but can easily miss `row_by_keys`. I think adding `row_by_keys` in the "see also" section of `to_dict` is a good addition