### PR TITLE
fix: Fix incorrect lazy schema for explode on array columns

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -132,7 +132,7 @@ impl From<ArrayFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "array_count")]
             CountMatches => map_as_slice!(count_matches),
             Shift => map_as_slice!(shift),
-            Explode => unreachable!(),
+            Explode => map_as_slice!(explode),
         }
     }
 }
@@ -252,4 +252,8 @@ pub(super) fn shift(s: &[Column]) -> PolarsResult<Column> {
     let n = &s[1];
 
     ca.array_shift(n.as_materialized_series()).map(Column::from)
+}
+
+fn explode(c: &[Column]) -> PolarsResult<Column> {
+    c[0].explode()
 }

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -85,9 +85,9 @@ impl AExpr {
                     .to_field_impl(schema, ctx, arena, &mut false)?;
 
                 let field = match field.dtype() {
-                    List(inner) | Array(inner, ..) => {
-                        Field::new(field.name().clone(), *inner.clone())
-                    },
+                    List(inner) => Field::new(field.name().clone(), *inner.clone()),
+                    #[cfg(feature = "dtype-array")]
+                    Array(inner, ..) => Field::new(field.name().clone(), *inner.clone()),
                     _ => field,
                 };
 

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -84,11 +84,14 @@ impl AExpr {
                     .get(*expr)
                     .to_field_impl(schema, ctx, arena, &mut false)?;
 
-                if let List(inner) = field.dtype() {
-                    Ok(Field::new(field.name().clone(), *inner.clone()))
-                } else {
-                    Ok(field)
-                }
+                let field = match field.dtype() {
+                    List(inner) | Array(inner, ..) => {
+                        Field::new(field.name().clone(), *inner.clone())
+                    },
+                    _ => field,
+                };
+
+                Ok(field)
             },
             Alias(expr, name) => Ok(Field::new(
                 name.clone(),

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -7,12 +7,6 @@ pub(super) fn optimize_functions(
     expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<Option<AExpr>> {
     let out = match function {
-        #[cfg(feature = "dtype-array")]
-        // arr.explode() -> explode()
-        FunctionExpr::ArrayExpr(ArrayFunction::Explode) => {
-            let input_node = input[0].node();
-            Some(AExpr::Explode(input_node))
-        },
         // is_null().any() -> null_count() > 0
         // is_not_null().any() ->  null_count() < len()
         // CORRECTNESS: we can ignore 'ignore_nulls' since is_null/is_not_null never produces NULLS

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1113,3 +1113,13 @@ def test_join_key_type_coercion_19597() -> None:
         left.join(
             right, left_on=pl.col("a") * 2, right_on=pl.col("a") * 2
         ).collect_schema()
+
+
+def test_array_explode_join_19763() -> None:
+    q = pl.LazyFrame().select(
+        pl.lit(pl.Series([[1], [2]], dtype=pl.Array(pl.Int64, 1))).explode().alias("k")
+    )
+
+    q = q.join(pl.LazyFrame({"k": [1, 2]}), on="k")
+
+    assert_frame_equal(q.collect().sort("k"), pl.DataFrame({"k": [1, 2]}))

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -284,15 +284,15 @@ def test_lf_explode_schema() -> None:
     lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.Array(pl.Int64, 1))})
 
     q = lf.select(pl.col("x").explode())
-    assert q.collect_schema() == q.collect().collect_schema()
+    assert q.collect_schema() == {"x": pl.Int64}
 
     q = lf.select(pl.col("x").arr.explode())
-    assert q.collect_schema() == q.collect().collect_schema()
+    assert q.collect_schema() == {"x": pl.Int64}
 
     lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.List(pl.Int64))})
 
     q = lf.select(pl.col("x").explode())
-    assert q.collect_schema() == q.collect().collect_schema()
+    assert q.collect_schema() == {"x": pl.Int64}
 
     q = lf.select(pl.col("x").list.explode())
-    assert q.collect_schema() == q.collect().collect_schema()
+    assert q.collect_schema() == {"x": pl.Int64}

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -278,3 +278,21 @@ def test_lf_window_schema(expr: pl.Expr, mapping_strategy: str) -> None:
     )
 
     assert q.collect_schema() == q.collect().collect_schema()
+
+
+def test_lf_explode_schema() -> None:
+    lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.Array(pl.Int64, 1))})
+
+    q = lf.select(pl.col("x").explode())
+    assert q.collect_schema() == q.collect().collect_schema()
+
+    q = lf.select(pl.col("x").arr.explode())
+    assert q.collect_schema() == q.collect().collect_schema()
+
+    # lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.List(pl.Int64))})
+
+    # q = lf.select(pl.col("x").explode())
+    # assert q.collect_schema() == q.collect().collect_schema()
+
+    # q = lf.select(pl.col("x").list.explode())
+    # assert q.collect_schema() == q.collect().collect_schema()

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -289,10 +289,10 @@ def test_lf_explode_schema() -> None:
     q = lf.select(pl.col("x").arr.explode())
     assert q.collect_schema() == q.collect().collect_schema()
 
-    # lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.List(pl.Int64))})
+    lf = pl.LazyFrame({"k": [1], "x": pl.Series([[1]], dtype=pl.List(pl.Int64))})
 
-    # q = lf.select(pl.col("x").explode())
-    # assert q.collect_schema() == q.collect().collect_schema()
+    q = lf.select(pl.col("x").explode())
+    assert q.collect_schema() == q.collect().collect_schema()
 
-    # q = lf.select(pl.col("x").list.explode())
-    # assert q.collect_schema() == q.collect().collect_schema()
+    q = lf.select(pl.col("x").list.explode())
+    assert q.collect_schema() == q.collect().collect_schema()


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19763

Our lazy schema for an exploded array column was not correct. I think this was only starting causing issues with joins after https://github.com/pola-rs/polars/pull/19625 because we never used this schema information before then
