### PR TITLE
fix(python): Replace spaces with &nbsp; to support showing multiple spaces in HTML repr

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -119,7 +119,9 @@ class HTMLFormatter:
                             else:
                                 series = self.df[:, c]
                                 self.elements.append(
-                                    html.escape(series._s.get_fmt(r, str_len_limit))
+                                    html.escape(
+                                        series._s.get_fmt(r, str_len_limit)
+                                    ).replace(" ", "&nbsp;")
                                 )
 
     def write(self, inner: str) -> None:

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -77,3 +77,22 @@ def test_series_repr_html_max_rows_default() -> None:
 
     expected_rows = 10
     assert html.count("<td>") - 2 == expected_rows
+
+
+def test_html_representation_multiple_spaces() -> None:
+    df = pl.DataFrame(
+        {"string_col": ["multiple   spaces", "  trailing and leading   "]}
+    )
+    html_repr = df._repr_html_()
+
+    assert (
+        html_repr
+        == """<div><style>
+.dataframe > thead > tr,
+.dataframe > tbody > tr {
+  text-align: right;
+  white-space: pre-wrap;
+}
+</style>
+<small>shape: (2, 1)</small><table border="1" class="dataframe"><thead><tr><th>string_col</th></tr><tr><td>str</td></tr></thead><tbody><tr><td>&quot;multiple&nbsp;&nbsp;&nbsp;spaces&quot;</td></tr><tr><td>&quot;&nbsp;&nbsp;trailing&nbsp;and&nbsp;leading&nbsp;&nbsp;&nbsp;&quot;</td></tr></tbody></table></div>"""
+    )


### PR DESCRIPTION
Fixes #19665

Before:
![image](https://github.com/user-attachments/assets/942002e2-3692-4b98-ba66-3f41f7560648)

After:
![image](https://github.com/user-attachments/assets/819307a5-94c9-48d4-b5a0-7ccbc729d62a)

I've added a small unit test that checks for a right output for the repr in `test_repr_html.py`, not sure if it's the correct location. Please let me know.