### PR TITLE
refactor(rust): Use HashKeys abstraction

### DIFF
--- a/crates/polars-arrow/src/compute/take/binary.rs
+++ b/crates/polars-arrow/src/compute/take/binary.rs
@@ -21,6 +21,8 @@ use crate::array::{Array, BinaryArray, PrimitiveArray};
 use crate::offset::Offset;
 
 /// `take` implementation for utf8 arrays
+/// # Safety
+/// The indices must be in-bounds.
 pub unsafe fn take_unchecked<O: Offset, I: Index>(
     values: &BinaryArray<O>,
     indices: &PrimitiveArray<I>,

--- a/crates/polars-arrow/src/compute/take/boolean.rs
+++ b/crates/polars-arrow/src/compute/take/boolean.rs
@@ -59,6 +59,8 @@ unsafe fn take_values_indices_validity(
 }
 
 /// `take` implementation for boolean arrays
+/// # Safety
+/// The indices must be in-bounds.
 pub unsafe fn take_unchecked(
     values: &BooleanArray,
     indices: &PrimitiveArray<IdxSize>,

--- a/crates/polars-arrow/src/compute/take/mod.rs
+++ b/crates/polars-arrow/src/compute/take/mod.rs
@@ -25,15 +25,15 @@ use crate::compute::take::binview::take_binview_unchecked;
 use crate::datatypes::{ArrowDataType, IdxArr};
 use crate::types::Index;
 
-mod binary;
-mod binview;
-mod bitmap;
-mod boolean;
-mod fixed_size_list;
-mod generic_binary;
-mod list;
-mod primitive;
-mod structure;
+pub mod binary;
+pub mod binview;
+pub mod bitmap;
+pub mod boolean;
+pub mod fixed_size_list;
+pub mod generic_binary;
+pub mod list;
+pub mod primitive;
+pub mod structure;
 
 use crate::with_match_primitive_type_full;
 

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -454,7 +454,7 @@ pub fn _df_rows_to_hashes_threaded_vertical(
     Ok((hashes, hasher_builder))
 }
 
-pub(crate) fn columns_to_hashes(
+pub fn columns_to_hashes(
     keys: &[Column],
     build_hasher: Option<PlRandomState>,
     hashes: &mut Vec<u64>,

--- a/crates/polars-expr/src/groups/mod.rs
+++ b/crates/polars-expr/src/groups/mod.rs
@@ -2,10 +2,11 @@ use std::any::Any;
 use std::path::Path;
 
 use polars_core::prelude::*;
-use polars_utils::aliases::PlRandomState;
 use polars_utils::cardinality_sketch::CardinalitySketch;
 use polars_utils::hashing::HashPartitioner;
 use polars_utils::IdxSize;
+
+use crate::hash_keys::HashKeys;
 
 mod row_encoded;
 
@@ -22,7 +23,7 @@ pub trait Grouper: Any + Send + Sync {
 
     /// Inserts the given keys into this Grouper, mutating groups_idxs such
     /// that group_idxs[i] is the group index of keys[..][i].
-    fn insert_keys(&mut self, keys: &DataFrame, group_idxs: &mut Vec<IdxSize>);
+    fn insert_keys(&mut self, keys: HashKeys, group_idxs: &mut Vec<IdxSize>);
 
     /// Adds the given Grouper into this one, mutating groups_idxs such that
     /// the ith group of other now has group index group_idxs[i] in self.
@@ -69,9 +70,6 @@ pub trait Grouper: Any + Send + Sync {
     fn as_any(&self) -> &dyn Any;
 }
 
-pub fn new_hash_grouper(key_schema: Arc<Schema>, random_state: PlRandomState) -> Box<dyn Grouper> {
-    Box::new(row_encoded::RowEncodedHashGrouper::new(
-        key_schema,
-        random_state,
-    ))
+pub fn new_hash_grouper(key_schema: Arc<Schema>) -> Box<dyn Grouper> {
+    Box::new(row_encoded::RowEncodedHashGrouper::new(key_schema))
 }

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -1,7 +1,6 @@
 use arrow::array::BinaryArray;
 use arrow::compute::take::binary::take_unchecked;
 use polars_core::frame::DataFrame;
-use polars_core::hashing::columns_to_hashes;
 use polars_core::prelude::row_encode::_get_rows_encoded_unordered;
 use polars_core::prelude::PlRandomState;
 use polars_core::series::Series;
@@ -29,8 +28,11 @@ impl HashKeys {
             let keys_encoded = _get_rows_encoded_unordered(&keys[..]).unwrap().into_array();
             assert!(keys_encoded.len() == df.height());
 
-            let mut hashes = Vec::with_capacity(df.height());
-            columns_to_hashes(df.get_columns(), Some(random_state), &mut hashes).unwrap();
+            // TODO: use vechash? Not supported yet for lists.
+            // let mut hashes = Vec::with_capacity(df.height());
+            // columns_to_hashes(df.get_columns(), Some(random_state), &mut hashes).unwrap();
+            
+            let hashes = keys_encoded.values_iter().map(|k| random_state.hash_one(k)).collect();
             Self::RowEncoded(RowEncodedKeys {
                 hashes,
                 keys: keys_encoded,

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -31,8 +31,11 @@ impl HashKeys {
             // TODO: use vechash? Not supported yet for lists.
             // let mut hashes = Vec::with_capacity(df.height());
             // columns_to_hashes(df.get_columns(), Some(random_state), &mut hashes).unwrap();
-            
-            let hashes = keys_encoded.values_iter().map(|k| random_state.hash_one(k)).collect();
+
+            let hashes = keys_encoded
+                .values_iter()
+                .map(|k| random_state.hash_one(k))
+                .collect();
             Self::RowEncoded(RowEncodedKeys {
                 hashes,
                 keys: keys_encoded,

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -1,0 +1,137 @@
+use arrow::array::BinaryArray;
+use arrow::compute::take::binary::take_unchecked;
+use polars_core::frame::DataFrame;
+use polars_core::hashing::columns_to_hashes;
+use polars_core::prelude::row_encode::_get_rows_encoded_unordered;
+use polars_core::prelude::PlRandomState;
+use polars_core::series::Series;
+use polars_utils::hashing::HashPartitioner;
+use polars_utils::itertools::Itertools;
+use polars_utils::vec::PushUnchecked;
+use polars_utils::IdxSize;
+
+/// Represents a DataFrame plus a hash per row, intended for keys in grouping
+/// or joining. The hashes may or may not actually be physically pre-computed,
+/// this depends per type.
+pub enum HashKeys {
+    RowEncoded(RowEncodedKeys),
+    Single(SingleKeys),
+}
+
+impl HashKeys {
+    pub fn from_df(df: &DataFrame, random_state: PlRandomState, force_row_encoding: bool) -> Self {
+        if df.width() > 1 || force_row_encoding {
+            let keys = df
+                .get_columns()
+                .iter()
+                .map(|c| c.as_materialized_series().clone())
+                .collect_vec();
+            let keys_encoded = _get_rows_encoded_unordered(&keys[..]).unwrap().into_array();
+            assert!(keys_encoded.len() == df.height());
+
+            let mut hashes = Vec::with_capacity(df.height());
+            columns_to_hashes(df.get_columns(), Some(random_state), &mut hashes).unwrap();
+            Self::RowEncoded(RowEncodedKeys {
+                hashes,
+                keys: keys_encoded,
+            })
+        } else {
+            todo!()
+            // Self::Single(SingleKeys {
+            //     random_state,
+            //     hashes: todo!(),
+            //     keys: df[0].as_materialized_series().clone(),
+            // })
+        }
+    }
+
+    pub fn gen_partition_idxs(
+        &self,
+        partitioner: &HashPartitioner,
+        partition_idxs: &mut [Vec<IdxSize>],
+    ) {
+        match self {
+            Self::RowEncoded(s) => s.gen_partition_idxs(partitioner, partition_idxs),
+            Self::Single(s) => s.gen_partition_idxs(partitioner, partition_idxs),
+        }
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn gather(&self, idxs: &[IdxSize]) -> Self {
+        match self {
+            Self::RowEncoded(s) => Self::RowEncoded(s.gather(idxs)),
+            Self::Single(s) => Self::Single(s.gather(idxs)),
+        }
+    }
+}
+
+pub struct RowEncodedKeys {
+    pub hashes: Vec<u64>,
+    pub keys: BinaryArray<i64>,
+}
+
+impl RowEncodedKeys {
+    pub fn gen_partition_idxs(
+        &self,
+        partitioner: &HashPartitioner,
+        partition_idxs: &mut [Vec<IdxSize>],
+    ) {
+        assert!(partitioner.num_partitions() == partition_idxs.len());
+        for (i, h) in self.hashes.iter().enumerate() {
+            unsafe {
+                // SAFETY: we assured the number of partitions matches.
+                let p = partitioner.hash_to_partition(*h);
+                partition_idxs.get_unchecked_mut(p).push(i as IdxSize);
+            }
+        }
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn gather(&self, idxs: &[IdxSize]) -> Self {
+        let mut hashes = Vec::with_capacity(idxs.len());
+        for idx in idxs {
+            hashes.push_unchecked(*self.hashes.get_unchecked(*idx as usize));
+        }
+        let idx_arr = arrow::ffi::mmap::slice(idxs);
+        let keys = take_unchecked(&self.keys, &idx_arr);
+        Self { hashes, keys }
+    }
+}
+
+/// Single keys. Does not pre-hash for boolean & integer types, only for strings
+/// and nested types.
+pub struct SingleKeys {
+    pub random_state: PlRandomState,
+    pub hashes: Option<Vec<u64>>,
+    pub keys: Series,
+}
+
+impl SingleKeys {
+    pub fn gen_partition_idxs(
+        &self,
+        partitioner: &HashPartitioner,
+        partition_idxs: &mut [Vec<IdxSize>],
+    ) {
+        assert!(partitioner.num_partitions() == partition_idxs.len());
+        todo!()
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn gather(&self, idxs: &[IdxSize]) -> Self {
+        let hashes = self.hashes.as_ref().map(|hashes| {
+            let mut out = Vec::with_capacity(idxs.len());
+            for idx in idxs {
+                out.push_unchecked(*hashes.get_unchecked(*idx as usize));
+            }
+            out
+        });
+        Self {
+            random_state: self.random_state.clone(),
+            hashes,
+            keys: self.keys.take_slice_unchecked(idxs),
+        }
+    }
+}

--- a/crates/polars-expr/src/lib.rs
+++ b/crates/polars-expr/src/lib.rs
@@ -1,5 +1,6 @@
 mod expressions;
 pub mod groups;
+pub mod hash_keys;
 pub mod planner;
 pub mod prelude;
 pub mod reduce;

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
+use polars_core::prelude::PlRandomState;
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::PolarsResult;
 use polars_expr::groups::new_hash_grouper;
@@ -395,8 +396,7 @@ fn to_graph_rec<'a>(
             let input_schema = &ctx.phys_sm[*input].output_schema;
             let key_schema = compute_output_schema(input_schema, key, ctx.expr_arena)?
                 .materialize_unknown_dtypes()?;
-            let random_state = Default::default();
-            let grouper = new_hash_grouper(Arc::new(key_schema), random_state);
+            let grouper = new_hash_grouper(Arc::new(key_schema));
 
             let key_selectors = key
                 .iter()
@@ -424,6 +424,7 @@ fn to_graph_rec<'a>(
                     grouped_reductions,
                     grouper,
                     node.output_schema.clone(),
+                    PlRandomState::new(),
                 ),
                 [input_key],
             )


### PR DESCRIPTION
This will be used in both the join / reduce interfaces to abstract over a key dataframe which may or may not be pre-hashed.