### PR TITLE
docs(python): Update bokeh to use cdn to avoid Bokeh Error

### DIFF
--- a/docs/source/src/python/user-guide/misc/visualization.py
+++ b/docs/source/src/python/user-guide/misc/visualization.py
@@ -28,7 +28,7 @@ plot = df.hvplot.scatter(
     by="species",
     width=650,
 )
-hvplot.save(plot, "docs/assets/images/hvplot_scatter.html")
+hvplot.save(plot, "docs/assets/images/hvplot_scatter.html", resources="cdn")
 with open("docs/assets/images/hvplot_scatter.html", "r") as f:
     chart_html = f.read()
     print(f"{chart_html}")


### PR DESCRIPTION
Previously bokeh charts where saved as html with inline resources. This seems to have led to charts not appearing on first load and bokeh errors on subsequent loads as it tries to re-load resources. Now bokeh resources are instead loaded from CDN each time and the error disappears when I render in gh-pages.

Closes #19722 