### PR TITLE
fix: Altair tooltip was being incorrectly applied to plots which did not accept it

### DIFF
--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Callable, Union
 
 from polars.dependencies import altair as alt
@@ -239,9 +240,17 @@ class DataFramePlot:
         if method is None:
             msg = "Altair has no method 'mark_{attr}'"
             raise AttributeError(msg)
-        encodings: Encodings = {}
 
-        def func(**kwargs: EncodeKwds) -> alt.Chart:
-            return method(tooltip=True).encode(**encodings, **kwargs).interactive()
+        accepts_tooltip_argument = "tooltip" in {
+            value.name for value in inspect.signature(method).parameters.values()
+        }
+        if accepts_tooltip_argument:
+
+            def func(**kwargs: EncodeKwds) -> alt.Chart:
+                return method(tooltip=True).encode(**kwargs).interactive()
+        else:
+
+            def func(**kwargs: EncodeKwds) -> alt.Chart:
+                return method().encode(**kwargs).interactive()
 
         return func

--- a/py-polars/polars/series/plotting.py
+++ b/py-polars/polars/series/plotting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Callable
 
 from polars.dependencies import altair as alt
@@ -175,7 +176,16 @@ class SeriesPlot:
             raise AttributeError(msg)
         encodings: Encodings = {"x": "index", "y": self._series_name}
 
-        def func(**kwargs: EncodeKwds) -> alt.Chart:
-            return method(tooltip=True).encode(**encodings, **kwargs).interactive()
+        accepts_tooltip_argument = "tooltip" in {
+            value.name for value in inspect.signature(method).parameters.values()
+        }
+        if accepts_tooltip_argument:
+
+            def func(**kwargs: EncodeKwds) -> alt.Chart:
+                return method(tooltip=True).encode(**encodings, **kwargs).interactive()
+        else:
+
+            def func(**kwargs: EncodeKwds) -> alt.Chart:
+                return method().encode(**encodings, **kwargs).interactive()
 
         return func

--- a/py-polars/tests/unit/operations/namespaces/test_plot.py
+++ b/py-polars/tests/unit/operations/namespaces/test_plot.py
@@ -67,3 +67,11 @@ def test_x_with_axis_18830() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     result = df.plot.line(x=alt.X("a", axis=alt.Axis(labelAngle=-90))).to_dict()
     assert result["mark"]["tooltip"] is True
+
+
+def test_errorbar_19787() -> None:
+    df = pl.DataFrame({"A": [0, 1, 2], "B": [10, 11, 12], "C": [1, 2, 3]})
+    result = df.plot.errorbar(x="A", y="B", yError="C").to_dict()
+    assert "tooltip" not in result["encoding"]
+    result = df["A"].plot.errorbar().to_dict()
+    assert "tooltip" not in result["encoding"]


### PR DESCRIPTION
closes #19787

An alternative would be to just never pass `tooltip` in the generic case, but I think `inspect.signature` is safe enough