### PR TITLE
docs(python): Fix link to Graphviz download

### DIFF
--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -402,7 +402,10 @@ class ExprMetaNameSpace:
         figsize: tuple[float, float] = (16.0, 12.0),
     ) -> str | None:
         """
-        Format the expression as a GraphViz.
+        Format the expression as a Graphviz graph.
+
+        Note that Graphviz must be installed to render the visualization (if not
+        already present, you can download it here: `<https://graphviz.org/download>`_).
 
         Parameters
         ----------
@@ -413,7 +416,7 @@ class ExprMetaNameSpace:
         raw_output
             Return dot syntax. This cannot be combined with `show` and/or `output_path`.
         figsize
-            Passed to matplotlib if `show` == True.
+            Passed to matplotlib if `show == True`.
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1138,8 +1138,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Show a plot of the query plan.
 
-        Note that graphviz must be installed to render the visualization (if not
-        already present you can download it here: <https://graphviz.org/download>`_).
+        Note that Graphviz must be installed to render the visualization (if not
+        already present, you can download it here: `<https://graphviz.org/download>`_).
 
         Parameters
         ----------
@@ -1152,7 +1152,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         raw_output
             Return dot syntax. This cannot be combined with `show` and/or `output_path`.
         figsize
-            Passed to matplotlib if `show` == True.
+            Passed to matplotlib if `show == True`.
         type_coercion
             Do type coercion optimization.
         predicate_pushdown
@@ -1168,11 +1168,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         comm_subexpr_elim
             Common subexpressions will be cached and reused.
         cluster_with_columns
-            Combine sequential independent calls to with_columns
+            Combine sequential independent calls to with_columns.
         collapse_joins
-            Collapse a join and filters into a faster join
+            Collapse a join and filters into a faster join.
         streaming
-            Run parts of the query in a streaming fashion (this is in an alpha state)
+            Run parts of the query in a streaming fashion (this is in an alpha state).
 
         Examples
         --------


### PR DESCRIPTION
Link to Graphviz download is now formatted correctly ([see the docs](https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.show_graph.html#polars.LazyFrame.show_graph)). Fixed a couple of other tiny formatting issues while I was in the area.