### PR TITLE
fix(python): Fix filter on dataframe containing object

### DIFF
--- a/crates/polars-mem-engine/src/executors/filter.rs
+++ b/crates/polars-mem-engine/src/executors/filter.rs
@@ -74,10 +74,14 @@ impl FilterExec {
     ) -> PolarsResult<DataFrame> {
         let n_partitions = POOL.current_num_threads();
 
+        #[cfg(feature = "object")]
         let has_object_cols = df
             .get_columns()
             .iter()
             .any(|s| matches!(s.dtype(), DataType::Object(_, _)));
+
+        #[cfg(not(feature = "object"))]
+        let has_object_cols = false;
 
         // Vertical parallelism.
         if self.streamable && df.height() > 0 && !has_object_cols {

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -199,3 +199,8 @@ def test_object_null_slice() -> None:
     assert_series_equal(s.slice(0, 2).is_null(), pl.Series("x", [False, True]))
     assert_series_equal(s.slice(1, 1).is_null(), pl.Series("x", [True]))
     assert_series_equal(s.slice(2, 1).is_null(), pl.Series("x", [False]))
+
+
+def test_filter_with_object_18665() -> None:
+    df = pl.DataFrame([{f"c{i}": 0 for i in range(11)} | {"c": object()}] * 12)
+    assert df.filter((pl.col("c0") == 0) & (pl.col("c1") == 0)).height == 12


### PR DESCRIPTION
Fixes: #18665

I know that this is just a patch, and this should be implemented properly here: polars/polars/crates/polars-core/src/chunked_array/ops/chunkops.rs:146:17 

But I though that this PR is better than the current behaviour, not being able to filter a dataframe that contains Object make the use of object really close to zero IMO 