### PR TITLE
refactor(rust): Add BytesIndexMap and use in RowEncodedHashGrouper

### DIFF
--- a/crates/polars-expr/src/groups/row_encoded.rs
+++ b/crates/polars-expr/src/groups/row_encoded.rs
@@ -1,87 +1,32 @@
-use hashbrown::hash_table::{Entry, HashTable};
 use polars_row::EncodingField;
 use polars_utils::cardinality_sketch::CardinalitySketch;
+use polars_utils::idx_map::bytes_idx_map::{BytesIndexMap, Entry};
 use polars_utils::vec::PushUnchecked;
 
 use super::*;
 use crate::hash_keys::HashKeys;
 
-const BASE_KEY_DATA_CAPACITY: usize = 1024;
-
-struct Key {
-    key_hash: u64,
-    key_buffer: u32,
-    key_offset: usize,
-    key_length: u32,
-}
-
-impl Key {
-    unsafe fn get<'k>(&self, key_data: &'k [Vec<u8>]) -> &'k [u8] {
-        let buf = key_data.get_unchecked(self.key_buffer as usize);
-        buf.get_unchecked(self.key_offset..self.key_offset + self.key_length as usize)
-    }
-}
-
 #[derive(Default)]
 pub struct RowEncodedHashGrouper {
     key_schema: Arc<Schema>,
-    table: HashTable<IdxSize>,
-    group_keys: Vec<Key>,
-    key_data: Vec<Vec<u8>>,
-
-    // Internal random seed used to keep hash iteration order decorrelated.
-    // We simply store a random odd number and multiply the canonical hash by it.
-    seed: u64,
+    idx_map: BytesIndexMap<()>,
 }
 
 impl RowEncodedHashGrouper {
     pub fn new(key_schema: Arc<Schema>) -> Self {
         Self {
             key_schema,
-            seed: rand::random::<u64>() | 1,
-            key_data: vec![Vec::with_capacity(BASE_KEY_DATA_CAPACITY)],
-            ..Default::default()
+            idx_map: BytesIndexMap::new(),
         }
     }
 
     fn insert_key(&mut self, hash: u64, key: &[u8]) -> IdxSize {
-        let entry = self.table.entry(
-            hash.wrapping_mul(self.seed),
-            |g| unsafe {
-                let gk = self.group_keys.get_unchecked(*g as usize);
-                hash == gk.key_hash && key == gk.get(&self.key_data)
-            },
-            |g| unsafe {
-                let gk = self.group_keys.get_unchecked(*g as usize);
-                gk.key_hash.wrapping_mul(self.seed)
-            },
-        );
-
-        match entry {
-            Entry::Occupied(e) => *e.get(),
-            Entry::Vacant(e) => unsafe {
-                let mut num_buffers = self.key_data.len() as u32;
-                let mut active_buf = self.key_data.last_mut().unwrap_unchecked();
-                let key_len = key.len();
-                if active_buf.len() + key_len > active_buf.capacity() {
-                    let ideal_next_cap = BASE_KEY_DATA_CAPACITY.checked_shl(num_buffers).unwrap();
-                    let next_capacity = std::cmp::max(ideal_next_cap, key_len);
-                    self.key_data.push(Vec::with_capacity(next_capacity));
-                    active_buf = self.key_data.last_mut().unwrap_unchecked();
-                    num_buffers += 1;
-                }
-
-                let group_idx: IdxSize = self.group_keys.len().try_into().unwrap();
-                let group_key = Key {
-                    key_hash: hash,
-                    key_buffer: num_buffers - 1,
-                    key_offset: active_buf.len(),
-                    key_length: key.len().try_into().unwrap(),
-                };
-                self.group_keys.push(group_key);
-                active_buf.extend_from_slice(key);
-                e.insert(group_idx);
-                group_idx
+        match self.idx_map.entry(hash, key) {
+            Entry::Occupied(o) => o.index(),
+            Entry::Vacant(v) => {
+                let index = v.index();
+                v.insert(());
+                index
             },
         }
     }
@@ -117,15 +62,11 @@ impl Grouper for RowEncodedHashGrouper {
     }
 
     fn reserve(&mut self, additional: usize) {
-        self.table.reserve(additional, |g| unsafe {
-            let gk = self.group_keys.get_unchecked(*g as usize);
-            gk.key_hash.wrapping_mul(self.seed)
-        });
-        self.group_keys.reserve(additional);
+        self.idx_map.reserve(additional);
     }
 
     fn num_groups(&self) -> IdxSize {
-        self.table.len() as IdxSize
+        self.idx_map.len()
     }
 
     fn insert_keys(&mut self, keys: HashKeys, group_idxs: &mut Vec<IdxSize>) {
@@ -145,17 +86,13 @@ impl Grouper for RowEncodedHashGrouper {
         let other = other.as_any().downcast_ref::<Self>().unwrap();
 
         // TODO: cardinality estimation.
-        self.table.reserve(other.group_keys.len(), |g| unsafe {
-            let gk = self.group_keys.get_unchecked(*g as usize);
-            gk.key_hash.wrapping_mul(self.seed)
-        });
+        self.idx_map.reserve(other.idx_map.len() as usize);
 
         unsafe {
             group_idxs.clear();
-            group_idxs.reserve(other.table.len());
-            for group_key in &other.group_keys {
-                let new_idx = self.insert_key(group_key.key_hash, group_key.get(&other.key_data));
-                group_idxs.push_unchecked(new_idx);
+            group_idxs.reserve(other.idx_map.len() as usize);
+            for (hash, key) in other.idx_map.iter_hash_keys() {
+                group_idxs.push_unchecked(self.insert_key(hash, key));
             }
         }
     }
@@ -169,31 +106,26 @@ impl Grouper for RowEncodedHashGrouper {
         let other = other.as_any().downcast_ref::<Self>().unwrap();
 
         // TODO: cardinality estimation.
-        self.table.reserve(subset.len(), |g| unsafe {
-            let gk = self.group_keys.get_unchecked(*g as usize);
-            gk.key_hash.wrapping_mul(self.seed)
-        });
-        self.group_keys.reserve(subset.len());
+        self.idx_map.reserve(subset.len());
 
         unsafe {
             group_idxs.clear();
             group_idxs.reserve(subset.len());
             for i in subset {
-                let group_key = other.group_keys.get_unchecked(*i as usize);
-                let new_idx = self.insert_key(group_key.key_hash, group_key.get(&other.key_data));
-                group_idxs.push_unchecked(new_idx);
+                let (hash, key, ()) = other.idx_map.get_index_unchecked(*i);
+                group_idxs.push_unchecked(self.insert_key(hash, key));
             }
         }
     }
 
     fn get_keys_in_group_order(&self) -> DataFrame {
-        let mut key_rows: Vec<&[u8]> = Vec::with_capacity(self.table.len());
         unsafe {
-            for group_key in &self.group_keys {
-                key_rows.push_unchecked(group_key.get(&self.key_data));
+            let mut key_rows: Vec<&[u8]> = Vec::with_capacity(self.idx_map.len() as usize);
+            for (_, key) in self.idx_map.iter_hash_keys() {
+                key_rows.push_unchecked(key);
             }
+            self.finalize_keys(key_rows)
         }
-        self.finalize_keys(key_rows)
     }
 
     fn gen_partition_idxs(
@@ -209,10 +141,10 @@ impl Grouper for RowEncodedHashGrouper {
         // Two-pass algorithm to prevent reallocations.
         let mut partition_sizes = vec![0; num_partitions];
         unsafe {
-            for group_key in &self.group_keys {
-                let p_idx = partitioner.hash_to_partition(group_key.key_hash);
+            for (hash, _key) in self.idx_map.iter_hash_keys() {
+                let p_idx = partitioner.hash_to_partition(hash);
                 *partition_sizes.get_unchecked_mut(p_idx) += 1;
-                sketches.get_unchecked_mut(p_idx).insert(group_key.key_hash);
+                sketches.get_unchecked_mut(p_idx).insert(hash);
             }
         }
 
@@ -222,8 +154,8 @@ impl Grouper for RowEncodedHashGrouper {
         }
 
         unsafe {
-            for (i, group_key) in self.group_keys.iter().enumerate() {
-                let p_idx = partitioner.hash_to_partition(group_key.key_hash);
+            for (i, (hash, _key)) in self.idx_map.iter_hash_keys().enumerate() {
+                let p_idx = partitioner.hash_to_partition(hash);
                 let p = partition_idxs.get_unchecked_mut(p_idx);
                 p.push_unchecked(i as IdxSize);
             }

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -22,6 +22,7 @@ memmap = { workspace = true, optional = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true }
+rand = { workspace = true }
 raw-cpuid = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/crates/polars-utils/src/idx_map/bytes_idx_map.rs
+++ b/crates/polars-utils/src/idx_map/bytes_idx_map.rs
@@ -1,0 +1,173 @@
+use hashbrown::hash_table::{
+    Entry as TEntry, HashTable, OccupiedEntry as TOccupiedEntry, VacantEntry as TVacantEntry,
+};
+
+use crate::IdxSize;
+
+const BASE_KEY_DATA_CAPACITY: usize = 1024;
+
+struct Key {
+    key_hash: u64,
+    key_buffer: u32,
+    key_offset: usize,
+    key_length: u32,
+}
+
+impl Key {
+    unsafe fn get<'k>(&self, key_data: &'k [Vec<u8>]) -> &'k [u8] {
+        let buf = key_data.get_unchecked(self.key_buffer as usize);
+        buf.get_unchecked(self.key_offset..self.key_offset + self.key_length as usize)
+    }
+}
+
+/// An IndexMap where the keys are always [u8] slices which are pre-hashed.
+pub struct BytesIndexMap<V> {
+    table: HashTable<IdxSize>,
+    tuples: Vec<(Key, V)>,
+    key_data: Vec<Vec<u8>>,
+
+    // Internal random seed used to keep hash iteration order decorrelated.
+    // We simply store a random odd number and multiply the canonical hash by it.
+    seed: u64,
+}
+
+impl<V> Default for BytesIndexMap<V> {
+    fn default() -> Self {
+        Self {
+            table: HashTable::new(),
+            tuples: Vec::new(),
+            key_data: vec![Vec::with_capacity(BASE_KEY_DATA_CAPACITY)],
+            seed: rand::random::<u64>() | 1,
+        }
+    }
+}
+
+impl<V> BytesIndexMap<V> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.table.reserve(additional, |i| unsafe {
+            let tuple = self.tuples.get_unchecked(*i as usize);
+            tuple.0.key_hash.wrapping_mul(self.seed)
+        });
+        self.tuples.reserve(additional);
+    }
+
+    pub fn len(&self) -> IdxSize {
+        self.table.len() as IdxSize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    pub fn entry<'k>(&mut self, hash: u64, key: &'k [u8]) -> Entry<'_, 'k, V> {
+        let entry = self.table.entry(
+            hash.wrapping_mul(self.seed),
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                hash == t.0.key_hash && key == t.0.get(&self.key_data)
+            },
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                t.0.key_hash.wrapping_mul(self.seed)
+            },
+        );
+
+        match entry {
+            TEntry::Occupied(o) => Entry::Occupied(OccupiedEntry {
+                entry: o,
+                tuples: &mut self.tuples,
+            }),
+            TEntry::Vacant(v) => Entry::Vacant(VacantEntry {
+                key,
+                hash,
+                entry: v,
+                tuples: &mut self.tuples,
+                key_data: &mut self.key_data,
+            }),
+        }
+    }
+
+    /// Gets the hash, key and value at the given index by insertion order.
+    ///
+    /// # Safety
+    /// The index must be less than len().
+    pub unsafe fn get_index_unchecked(&self, idx: IdxSize) -> (u64, &[u8], &V) {
+        let t = self.tuples.get_unchecked(idx as usize);
+        (t.0.key_hash, t.0.get(&self.key_data), &t.1)
+    }
+
+    /// Iterates over the (hash, key) pairs in insertion order.
+    pub fn iter_hash_keys(&self) -> impl Iterator<Item = (u64, &[u8])> {
+        self.tuples
+            .iter()
+            .map(|t| unsafe { (t.0.key_hash, t.0.get(&self.key_data)) })
+    }
+}
+
+pub enum Entry<'a, 'k, V> {
+    Occupied(OccupiedEntry<'a, V>),
+    Vacant(VacantEntry<'a, 'k, V>),
+}
+
+pub struct OccupiedEntry<'a, V> {
+    entry: TOccupiedEntry<'a, IdxSize>,
+    tuples: &'a mut Vec<(Key, V)>,
+}
+
+impl<'a, V> OccupiedEntry<'a, V> {
+    pub fn index(&self) -> IdxSize {
+        *self.entry.get()
+    }
+
+    pub fn into_mut(self) -> &'a mut V {
+        let idx = self.index();
+        unsafe { &mut self.tuples.get_unchecked_mut(idx as usize).1 }
+    }
+}
+
+pub struct VacantEntry<'a, 'k, V> {
+    hash: u64,
+    key: &'k [u8],
+    entry: TVacantEntry<'a, IdxSize>,
+    tuples: &'a mut Vec<(Key, V)>,
+    key_data: &'a mut Vec<Vec<u8>>,
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a, 'k, V> VacantEntry<'a, 'k, V> {
+    pub fn index(&self) -> IdxSize {
+        self.tuples.len() as IdxSize
+    }
+
+    pub fn insert(self, value: V) -> &'a mut V {
+        unsafe {
+            let tuple_idx: IdxSize = self.tuples.len().try_into().unwrap();
+
+            let mut num_buffers = self.key_data.len() as u32;
+            let mut active_buf = self.key_data.last_mut().unwrap_unchecked();
+            let key_len = self.key.len();
+            if active_buf.len() + key_len > active_buf.capacity() {
+                let ideal_next_cap = BASE_KEY_DATA_CAPACITY.checked_shl(num_buffers).unwrap();
+                let next_capacity = std::cmp::max(ideal_next_cap, key_len);
+                self.key_data.push(Vec::with_capacity(next_capacity));
+                active_buf = self.key_data.last_mut().unwrap_unchecked();
+                num_buffers += 1;
+            }
+
+            let tuple_key = Key {
+                key_hash: self.hash,
+                key_buffer: num_buffers - 1,
+                key_offset: active_buf.len(),
+                key_length: self.key.len().try_into().unwrap(),
+            };
+            self.tuples.push((tuple_key, value));
+            active_buf.extend_from_slice(self.key);
+            self.entry.insert(tuple_idx);
+            &mut self.tuples.last_mut().unwrap_unchecked().1
+        }
+    }
+}

--- a/crates/polars-utils/src/idx_map/mod.rs
+++ b/crates/polars-utils/src/idx_map/mod.rs
@@ -1,0 +1,2 @@
+pub mod bytes_idx_map;
+pub use bytes_idx_map::BytesIndexMap;

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -19,6 +19,7 @@ mod error;
 pub mod floor_divmod;
 pub mod functions;
 pub mod hashing;
+pub mod idx_map;
 pub mod idx_vec;
 pub mod mem;
 pub mod min_max;


### PR DESCRIPTION
This is a very minimal byte-key-only `IndexMap` implementation we can then re-use in both the grouper and join code for strings, bytes and row-encoded keys.

Only the bare minimum for the grouper is implemented, feel free to add methods as needed.