### PR TITLE
feat(rust): Allow specification of `chunk_size` on `LazyCsvReader.read_options`

### DIFF
--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -117,6 +117,13 @@ impl LazyCsvReader {
         self
     }
 
+    /// Sets the chunk size used by the parser. This influences performance.
+    /// This can be used as a way to reduce memory usage during the parsing at the cost of performance.
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.read_options.chunk_size = chunk_size;
+        self
+    }
+
     /// Set the CSV file's column separator as a byte character
     #[must_use]
     pub fn with_separator(self, separator: u8) -> Self {


### PR DESCRIPTION
The `LazyCsvReader` appears to consume significant memory for certain inputs. This is primarily due to the large default `chunk_size` (262144) in the `CsvReadOptions`. While the `low_memory` option can help in some cases, it may not be sufficient for all use cases, introducing a way to control the amount of data that will be read and stored in memory can mitigate potential out-of-memory (OOM) issues at the cost of performance.

Related issues:
- https://github.com/pola-rs/polars/issues/17714