### PR TITLE
feat(python): Support DataFrame init from raw SQLAlchemy rows

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -17,6 +17,7 @@ from polars._utils.construction.utils import (
     is_namedtuple,
     is_pydantic_model,
     is_simple_numpy_backed_pandas_series,
+    is_sqlalchemy,
 )
 from polars._utils.various import (
     range_to_series,
@@ -105,6 +106,7 @@ def sequence_to_pyseries(
             dataclasses.is_dataclass(value)
             or is_pydantic_model(value)
             or is_namedtuple(value.__class__)
+            or is_sqlalchemy(value)
         ) and dtype != Object:
             return pl.DataFrame(values).to_struct(name)._s
         elif isinstance(value, range) and dtype is None:

--- a/py-polars/polars/_utils/construction/utils.py
+++ b/py-polars/polars/_utils/construction/utils.py
@@ -67,6 +67,11 @@ def is_pydantic_model(value: Any) -> bool:
     return _check_for_pydantic(value) and isinstance(value, pydantic.BaseModel)
 
 
+def is_sqlalchemy(value: Any) -> bool:
+    """Check whether value is an instance of a SQLAlchemy object."""
+    return getattr(value, "__module__", "").startswith("sqlalchemy.")
+
+
 def get_first_non_none(values: Sequence[Any | None]) -> Any:
     """
     Return the first value from a sequence that isn't None.


### PR DESCRIPTION
Closes #19816.

* With a trivial extension to the existing Sequence checks we can support direct DataFrame/Series init from a list of SQLAlchemy Row objects, as they intentionally mimic namedtuple in various ways[^1].

* This allows for a _**very** small_ (low single-digit percentage) speedup ingesting SQLAlchemy results via `read_database`, so I've taken advantage of that (against a 50000x10 row test dataset I was seeing ~1-2% gains, so it's extremely marginal - but it's not zero, so...)


[^1]: [sqlalchemy.engine.Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row)