### PR TITLE
perf: Increase default async thread count for low core count systems

### DIFF
--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -262,7 +262,7 @@ impl RuntimeManager {
     fn new() -> Self {
         let n_threads = std::env::var("POLARS_ASYNC_THREAD_COUNT")
             .map(|x| x.parse::<usize>().expect("integer"))
-            .unwrap_or((POOL.current_num_threads() / 4).clamp(1, 4));
+            .unwrap_or(POOL.current_num_threads().clamp(1, 4));
 
         if polars_core::config::verbose() {
             eprintln!("Async thread count: {}", n_threads);


### PR DESCRIPTION
Removes the division by 4 before clamping when calculating the async thread pool size.

This may benefit low core count systems, specifically those with less than 16 cores. Any potential performance gains may be observed particularly in systems with up to 7 cores, as the difference between having 1 vs 2 async threads is the most substantial.

| rayon threadpool size | old async thread count | new async thread count |
|-----------------------|------------------------|------------------------|
| 1                     | 1                      | 1                      |
| 2                     | 1                      | 2                      |
| 3                     | 1                      | 3                      |
| 4                     | 1                      | 4                      |
| 5                     | 1                      | 4                      |
| 6                     | 1                      | 4                      |
| 7                     | 1                      | 4                      |
| 8                     | 2                      | 4                      |
| 9                     | 2                      | 4                      |
| 10                    | 2                      | 4                      |
| 11                    | 2                      | 4                      |
| 12                    | 3                      | 4                      |
| 13                    | 3                      | 4                      |
| 14                    | 3                      | 4                      |
| 15                    | 3                      | 4                      |

