### PR TITLE
feat: Raise informative error on Unknown unnest

### DIFF
--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -347,7 +347,9 @@ This means there was an operation of which the output data type could not be det
 Try setting the output data type for that operation.",
                 );
                 for e in input[0].into_iter() {
+                    #[allow(clippy::single_match)]
                     match e {
+                        #[cfg(feature = "list_to_struct")]
                         Expr::Function {
                             input: _,
                             function,

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -337,8 +337,41 @@ fn expand_struct_fields(
             unreachable!()
         };
         let field = input[0].to_field(schema, Context::Default)?;
-        let DataType::Struct(fields) = field.dtype() else {
-            polars_bail!(InvalidOperation: "expected 'struct'")
+        let dtype = field.dtype();
+        let DataType::Struct(fields) = dtype else {
+            if !dtype.is_known() {
+                let mut msg = String::from(
+                    "expected 'struct' got an unknown data type
+
+This means there was an operation of which the output data type could not be determined statically.
+Try setting the output data type for that operation.",
+                );
+                for e in input[0].into_iter() {
+                    match e {
+                        Expr::Function {
+                            input: _,
+                            function,
+                            options: _,
+                        } => {
+                            if matches!(
+                                function,
+                                FunctionExpr::ListExpr(ListFunction::ToStruct(..))
+                            ) {
+                                msg.push_str(
+                                    "
+
+Hint: set 'upper_bound' for 'list.to_struct'.",
+                                );
+                            }
+                        },
+                        _ => {},
+                    }
+                }
+
+                polars_bail!(InvalidOperation: msg)
+            } else {
+                polars_bail!(InvalidOperation: "expected 'struct' got {}", field.dtype())
+            }
         };
 
         // Wildcard.

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1125,6 +1125,11 @@ class ExprListNameSpace:
 
         Notes
         -----
+        It is recommended to set 'upper_bound' to the correct output size of the struct.
+        If this is not set, Polars will not know the output type of this operation and
+        will set it to 'Unknown' which can lead to errors because Polars is not able
+        to resolve the query.
+
         For performance reasons, the length of the first non-null sublist is used
         to determine the number of output fields. If the sublists can be of different
         lengths then `n_field_strategy="max_width"` must be used to obtain the expected


### PR DESCRIPTION
closes #19812

 ```python
>>> df = pl.DataFrame({"a": [[1, 2, 3]]})
>>> df.select(pl.col("a").list.to_struct().struct.unnest()
---------------------------------------------------------------------------
InvalidOperationError                     Traceback (most recent call last)
Cell In[3], line 2
      1 df = pl.DataFrame({"a": [[1, 2, 3]]})
----> 2 df.select(pl.col("a").list.to_struct().struct.unnest())

File ~/code/polars/py-polars/polars/dataframe/frame.py:9029, in DataFrame.select(self, *exprs, **named_exprs)
   8929 def select(
   8930     self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
   8931 ) -> DataFrame:
   8932     """
   8933     Select columns from this DataFrame.
   8934 
   (...)
   9027     └──────────────┘
   9028     """
-> 9029     return self.lazy().select(*exprs, **named_exprs).collect(_eager=True)

File ~/code/polars/py-polars/polars/lazyframe/frame.py:2029, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, slice_pushdown, comm_subplan_elim, comm_subexpr_elim, cluster_with_columns, collapse_joins, no_optimization, streaming, engine, background, _eager, **_kwargs)
   2027 # Only for testing purposes
   2028 callback = _kwargs.get("post_opt_callback", callback)
-> 2029 return wrap_df(ldf.collect(callback))

InvalidOperationError: expected 'struct' got an unknown data type

This means there was an operation of which the output data type could not be determined statically.
Try setting the output data type for that operation.

Hint: set 'upper_bound' for 'list.to_struct'.

Resolved plan until failure:

	---> FAILED HERE RESOLVING 'select' <---
DF ["a"]; PROJECT */1 COLUMNS; SELECTION: None
 ```