### PR TITLE
feat: Support both "iso" and "iso:strict" format options for `dt.to_string`

### DIFF
--- a/crates/polars-core/src/chunked_array/temporal/date.rs
+++ b/crates/polars-core/src/chunked_array/temporal/date.rs
@@ -33,7 +33,11 @@ impl DateChunked {
     /// Convert from Date into String with the given format.
     /// See [chrono strftime/strptime](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
     pub fn to_string(&self, format: &str) -> PolarsResult<StringChunked> {
-        let format = if format == "iso" { "%F" } else { format };
+        let format = if format == "iso" || format == "iso:strict" {
+            "%F"
+        } else {
+            format
+        };
         let datefmt_f = |ndt: NaiveDate| ndt.format(format);
         self.try_apply_into_string_amortized(|val, buf| {
             let ndt = date32_to_date(val);

--- a/crates/polars-core/src/chunked_array/temporal/duration.rs
+++ b/crates/polars-core/src/chunked_array/temporal/duration.rs
@@ -67,7 +67,7 @@ impl DurationChunked {
         // the duration string functions below can reuse this string buffer
         let mut s = String::with_capacity(32);
         match format {
-            "iso" => {
+            "iso" | "iso:strict" => {
                 let out: StringChunked =
                     self.0
                         .apply_nonnull_values_generic(DataType::String, |v: i64| {

--- a/crates/polars-core/src/chunked_array/temporal/time.rs
+++ b/crates/polars-core/src/chunked_array/temporal/time.rs
@@ -23,7 +23,11 @@ impl TimeChunked {
     pub fn to_string(&self, format: &str) -> StringChunked {
         let mut ca: StringChunked = self.apply_kernel_cast(&|arr| {
             let mut buf = String::new();
-            let format = if format == "iso" { "%T%.9f" } else { format };
+            let format = if format == "iso" || format == "iso:strict" {
+                "%T%.9f"
+            } else {
+                format
+            };
             let mut mutarr = MutablePlString::with_capacity(arr.len());
 
             for opt in arr.into_iter() {

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -480,7 +480,8 @@ class ExprDateTimeNameSpace:
           format strings. The difference is in the inclusion of a "T" separator
           between the date and time components ("iso" results in ISO compliant
           date and time components, separated with a space; "iso:strict" returns
-          the same components separated with a "T").
+          the same components separated with a "T"). All other temporal types
+          return the same value for both format strings.
 
         * Duration dtype expressions cannot be formatted with `strftime`. Instead,
           only "iso" and "polars" are supported as format strings. The "iso" format

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -237,7 +237,8 @@ class DateTimeNameSpace:
           format strings. The difference is in the inclusion of a "T" separator
           between the date and time components ("iso" results in ISO compliant
           date and time components, separated with a space; "iso:strict" returns
-          the same components separated with a "T").
+          the same components separated with a "T"). All other temporal types
+          return the same value for both format strings.
 
         * Duration dtype expressions cannot be formatted with `strftime`. Instead,
           only "iso" and "polars" are supported as format strings. The "iso" format

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -207,16 +207,25 @@ class DateTimeNameSpace:
         """
         return self._s.mean()
 
-    def to_string(self, format: str) -> Series:
+    def to_string(self, format: str | None = None) -> Series:
         """
         Convert a Date/Time/Datetime column into a String column with the given format.
+
+        .. versionchanged:: 1.15.0
+            Added support for the use of "iso:strict" as a format string.
+        .. versionchanged:: 1.14.0
+            Added support for the `Duration` dtype, and use of "iso" as a format string.
 
         Parameters
         ----------
         format
-            Format to use, refer to the `chrono strftime documentation
-            <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
-            for specification. Example: `"%y-%m-%d"`.
+            * Format to use, refer to the `chrono strftime documentation
+              <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>`_
+              for specification. Example: `"%y-%m-%d"`.
+
+            * If no format is provided, the appropriate ISO format for the underlying
+              data type is used. This can be made explicit by passing `"iso"` or
+              `"iso:strict"` as the format string (see notes below for details).
 
         Notes
         -----
@@ -224,39 +233,62 @@ class DateTimeNameSpace:
           the formatting of the resulting string; if no format is provided, the
           appropriate ISO format for the underlying data type is used.
 
-        * Duration dtype Series cannot be formatted with `strftime`. Instead,
+        * Datetime dtype expressions distinguish between "iso" and "iso:strict"
+          format strings. The difference is in the inclusion of a "T" separator
+          between the date and time components ("iso" results in ISO compliant
+          date and time components, separated with a space; "iso:strict" returns
+          the same components separated with a "T").
+
+        * Duration dtype expressions cannot be formatted with `strftime`. Instead,
           only "iso" and "polars" are supported as format strings. The "iso" format
           string results in ISO8601 duration string output, and "polars" results
           in the same form seen in the frame `repr`.
 
         Examples
         --------
-        >>> from datetime import date
+        >>> from datetime import datetime
         >>> s = pl.Series(
-        ...     "datetime",
-        ...     [date(2020, 3, 1), date(2020, 4, 1), date(2020, 5, 1)],
+        ...     "dtm",
+        ...     [
+        ...         datetime(1999, 12, 31, 6, 12, 30, 800),
+        ...         datetime(2020, 7, 5, 10, 20, 45, 12345),
+        ...         datetime(2077, 10, 20, 18, 25, 10, 999999),
+        ...     ],
         ... )
 
         Default for temporal dtypes (if not specifying a format string) is ISO8601:
 
-        >>> s.dt.to_string()
+        >>> s.dt.to_string()  # or s.dt.to_string("iso")
         shape: (3,)
-        Series: 'datetime' [str]
+        Series: 'dtm' [str]
         [
-            "2020-03-01"
-            "2020-04-01"
-            "2020-05-01"
+            "1999-12-31 06:12:30.000800"
+            "2020-07-05 10:20:45.012345"
+            "2077-10-20 18:25:10.999999"
+        ]
+
+        For `Datetime` specifically you can choose between "iso" (where the date and
+        time components are ISO, separated by a space) and "iso:strict" (where these
+        components are separated by a "T"):
+
+        >>> s.dt.to_string("iso:strict")
+        shape: (3,)
+        Series: 'dtm' [str]
+        [
+            "1999-12-31T06:12:30.000800"
+            "2020-07-05T10:20:45.012345"
+            "2077-10-20T18:25:10.999999"
         ]
 
         The output can be customized by using a strftime-compatible format string:
 
         >>> s.dt.to_string("%d/%m/%y")
         shape: (3,)
-        Series: 'datetime' [str]
+        Series: 'dtm' [str]
         [
-            "01/03/20"
-            "01/04/20"
-            "01/05/20"
+            "31/12/99"
+            "05/07/20"
+            "20/10/77"
         ]
 
         If you're interested in using day or month names, you can use
@@ -264,20 +296,20 @@ class DateTimeNameSpace:
 
         >>> s.dt.to_string("%A")
         shape: (3,)
-        Series: 'datetime' [str]
+        Series: 'dtm' [str]
         [
-                "Sunday"
-                "Wednesday"
-                "Friday"
+            "Friday"
+            "Sunday"
+            "Wednesday"
         ]
 
         >>> s.dt.to_string("%B")
         shape: (3,)
-        Series: 'datetime' [str]
+        Series: 'dtm' [str]
         [
-                "March"
-                "April"
-                "May"
+            "December"
+            "July"
+            "October"
         ]
         """
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1093,6 +1093,28 @@ def test_datetime_string_casts() -> None:
             "2022-08-30 10:30:45.123456789",
         )
     ]
+    assert df.select(
+        pl.col("x").dt.to_string("iso").name.suffix(":iso"),
+        pl.col("y").dt.to_string("iso").name.suffix(":iso"),
+        pl.col("z").dt.to_string("iso").name.suffix(":iso"),
+    ).rows() == [
+        (
+            "2022-08-30 10:30:45.123",
+            "2022-08-30 10:30:45.123456",
+            "2022-08-30 10:30:45.123456789",
+        )
+    ]
+    assert df.select(
+        pl.col("x").dt.to_string("iso:strict").name.suffix(":iso:strict"),
+        pl.col("y").dt.to_string("iso:strict").name.suffix(":iso:strict"),
+        pl.col("z").dt.to_string("iso:strict").name.suffix(":iso:strict"),
+    ).rows() == [
+        (
+            "2022-08-30T10:30:45.123",
+            "2022-08-30T10:30:45.123456",
+            "2022-08-30T10:30:45.123456789",
+        )
+    ]
 
 
 def test_temporal_to_string_iso_default() -> None:
@@ -1122,7 +1144,9 @@ def test_temporal_to_string_iso_default() -> None:
     ).with_columns(dtm_tz=pl.col("dtm").dt.replace_time_zone("Asia/Kathmandu"))
 
     df_stringified = df.select(
-        pl.col("td").dt.to_string("polars").alias("td_pl"), cs.temporal().dt.to_string()
+        pl.col("td").dt.to_string("polars").alias("td_pl"),
+        cs.temporal().dt.to_string().name.suffix(":iso"),
+        cs.datetime().dt.to_string("iso:strict").name.suffix(":iso:strict"),
     )
     assert df_stringified.to_dict(as_series=False) == {
         "td_pl": [
@@ -1130,30 +1154,40 @@ def test_temporal_to_string_iso_default() -> None:
             "13d 14h 1001µs",
             "0µs",
         ],
-        "td": [
+        "td:iso": [
             "-P1DT42S",
             "P13DT14H0.001001S",
             "PT0S",
         ],
-        "tm": [
+        "tm:iso": [
             "01:02:03.456789",
             "23:59:09.000101",
             "00:00:00",
         ],
-        "dt": [
+        "dt:iso": [
             "1999-03-01",
             "2020-05-03",
             "2077-07-05",
         ],
-        "dtm": [
+        "dtm:iso": [
             "1980-08-10 00:10:20.000000",
             "2010-10-20 08:25:35.000000",
             "2040-12-30 16:40:50.000000",
         ],
-        "dtm_tz": [
+        "dtm_tz:iso": [
             "1980-08-10 00:10:20.000000+05:30",
             "2010-10-20 08:25:35.000000+05:45",
             "2040-12-30 16:40:50.000000+05:45",
+        ],
+        "dtm:iso:strict": [
+            "1980-08-10T00:10:20.000000",
+            "2010-10-20T08:25:35.000000",
+            "2040-12-30T16:40:50.000000",
+        ],
+        "dtm_tz:iso:strict": [
+            "1980-08-10T00:10:20.000000+05:30",
+            "2010-10-20T08:25:35.000000+05:45",
+            "2040-12-30T16:40:50.000000+05:45",
         ],
     }
 


### PR DESCRIPTION
A follow-up to enable stricter ISO formatting for `dt.to_string()` with Datetime.
See https://github.com/pola-rs/polars/pull/19697#discussion_r1845979731 for the rationale/details 🤔

### TLDR
* `"iso"`: (what we have now) each _component_ is ISO, joined with a space (this was valid ISO 8601 for the majority of the spec's lifetime, but now falls under RFC 3339 - see the comments below for more explanation/details, and the "Spec Arcana" section).
* `"iso:strict"`: (new) same as the above, but with a "T" separator between date/time instead of a space; this conforms to the latest ISO spec amendment, ISO 8601-1:2019).

### Spec Arcana

Making the "T" mandatory for Datetimes was an amendment made (around five years ago) in ISO 8601-1:2019. Consequently you will see _both_ forms (with a space or with a "T") used widely, with both being referred to as "ISO", depending on the date of implementation and which version of the spec was being targeted.

### Also
* Updated the `to_string` docstring for Series and DataFrame with additional explanation and examples.
* Additional/updated unit tests.

## Example

```python
from datetime import datetime
import polars as pl

df = pl.DataFrame({
   "dtm": [
       datetime(1980, 8, 10, 0, 10, 20),
       datetime(2010, 10, 20, 8, 25, 35),
       datetime(2040, 12, 30, 16, 40, 50),
   ]
})

df.select(
    pl.col("dtm").dt.to_string("iso").name.suffix(":iso"),
    pl.col("dtm").dt.to_string("iso:strict").name.suffix(":iso_strict"),
)
# shape: (3, 2)
# ┌────────────────────────────┬────────────────────────────┐
# │ dtm:iso                    ┆ dtm:iso_strict             │
# │ ---                        ┆ ---                        │
# │ str                        ┆ str                        │
# ╞════════════════════════════╪════════════════════════════╡
# │ 1980-08-10 00:10:20.000000 ┆ 1980-08-10T00:10:20.000000 │
# │ 2010-10-20 08:25:35.000000 ┆ 2010-10-20T08:25:35.000000 │
# │ 2040-12-30 16:40:50.000000 ┆ 2040-12-30T16:40:50.000000 │
# └────────────────────────────┴────────────────────────────┘
```