### PR TITLE
fix: Raise informative error instead of panicking for list arithmetic on some invalid dtypes

### DIFF
--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -489,7 +489,7 @@ impl Add for &Series {
                 _struct_arithmetic(self, rhs, |a, b| a.add(b))
             },
             (DataType::List(_), _) | (_, DataType::List(_)) => {
-                list_borrowed::NumericListOp::add().execute(self, rhs)
+                list::NumericListOp::add().execute(self, rhs)
             },
             #[cfg(feature = "dtype-array")]
             (DataType::Array(..), _) | (_, DataType::Array(..)) => {
@@ -514,7 +514,7 @@ impl Sub for &Series {
                 _struct_arithmetic(self, rhs, |a, b| a.sub(b))
             },
             (DataType::List(_), _) | (_, DataType::List(_)) => {
-                list_borrowed::NumericListOp::sub().execute(self, rhs)
+                list::NumericListOp::sub().execute(self, rhs)
             },
             #[cfg(feature = "dtype-array")]
             (DataType::Array(..), _) | (_, DataType::Array(..)) => {
@@ -555,7 +555,7 @@ impl Mul for &Series {
                 Ok(out.with_name(self.name().clone()))
             },
             (DataType::List(_), _) | (_, DataType::List(_)) => {
-                list_borrowed::NumericListOp::mul().execute(self, rhs)
+                list::NumericListOp::mul().execute(self, rhs)
             },
             #[cfg(feature = "dtype-array")]
             (DataType::Array(..), _) | (_, DataType::Array(..)) => {
@@ -592,7 +592,7 @@ impl Div for &Series {
             | (_, Date)
             | (_, Datetime(_, _)) => polars_bail!(opq = div, self.dtype(), rhs.dtype()),
             (DataType::List(_), _) | (_, DataType::List(_)) => {
-                list_borrowed::NumericListOp::div().execute(self, rhs)
+                list::NumericListOp::div().execute(self, rhs)
             },
             #[cfg(feature = "dtype-array")]
             (DataType::Array(..), _) | (_, DataType::Array(..)) => {
@@ -622,7 +622,7 @@ impl Rem for &Series {
                 _struct_arithmetic(self, rhs, |a, b| a.rem(b))
             },
             (DataType::List(_), _) | (_, DataType::List(_)) => {
-                list_borrowed::NumericListOp::rem().execute(self, rhs)
+                list::NumericListOp::rem().execute(self, rhs)
             },
             #[cfg(feature = "dtype-array")]
             (DataType::Array(..), _) | (_, DataType::Array(..)) => {

--- a/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
+++ b/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
@@ -55,8 +55,6 @@ impl NumericFixedSizeListOp {
 }
 
 impl NumericFixedSizeListOp {
-    /// # Panics
-    /// Panics if one side is not an `Array` type.
     #[cfg_attr(not(feature = "array_arithmetic"), allow(unused))]
     pub fn execute(&self, lhs: &Series, rhs: &Series) -> PolarsResult<Series> {
         feature_gated!("array_arithmetic", {

--- a/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
+++ b/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
@@ -55,6 +55,8 @@ impl NumericFixedSizeListOp {
 }
 
 impl NumericFixedSizeListOp {
+    /// # Panics
+    /// Panics if one side is not an `Array` type.
     #[cfg_attr(not(feature = "array_arithmetic"), allow(unused))]
     pub fn execute(&self, lhs: &Series, rhs: &Series) -> PolarsResult<Series> {
         feature_gated!("array_arithmetic", {

--- a/crates/polars-core/src/series/arithmetic/list.rs
+++ b/crates/polars-core/src/series/arithmetic/list.rs
@@ -58,8 +58,6 @@ impl NumericListOp {
 }
 
 impl NumericListOp {
-    /// # Panics
-    /// Panics if one side is not a `List` type.
     #[cfg_attr(not(feature = "list_arithmetic"), allow(unused))]
     pub fn execute(&self, lhs: &Series, rhs: &Series) -> PolarsResult<Series> {
         feature_gated!("list_arithmetic", {

--- a/crates/polars-core/src/series/arithmetic/mod.rs
+++ b/crates/polars-core/src/series/arithmetic/mod.rs
@@ -1,6 +1,6 @@
 mod bitops;
 mod borrowed;
-mod list_borrowed;
+mod list;
 mod owned;
 
 use std::borrow::Cow;
@@ -9,7 +9,7 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 pub use borrowed::*;
 #[cfg(feature = "dtype-array")]
 pub use fixed_size_list::NumericFixedSizeListOp;
-pub use list_borrowed::NumericListOp;
+pub use list::NumericListOp;
 use num_traits::{Num, NumCast};
 #[cfg(feature = "dtype-array")]
 mod fixed_size_list;

--- a/py-polars/tests/unit/operations/arithmetic/test_array.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_array.py
@@ -434,3 +434,8 @@ def test_array_arithmetic_dtype_mismatch(
         InvalidOperationError, match="dtype was not array on all nesting levels"
     ):
         exec_op(a, b, op.add)
+
+    with pytest.raises(
+        InvalidOperationError, match="dtype was not array on all nesting levels"
+    ):
+        exec_op(b, a, op.add)

--- a/py-polars/tests/unit/operations/arithmetic/test_array.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_array.py
@@ -422,15 +422,15 @@ def test_array_arithmetic_dtype_mismatch(
     with pytest.raises(InvalidOperationError, match="differing dtypes"):
         exec_op(a, b, op.add)
 
-    s = pl.Series([[[1]], [[1]]], dtype=pl.Array(pl.List(pl.Int64), 1))
-    p = pl.Series([1], dtype=pl.Int64)
+    a = pl.Series([[[1]], [[1]]], dtype=pl.Array(pl.List(pl.Int64), 1))
+    b = pl.Series([1], dtype=pl.Int64)
 
     with pytest.raises(
         InvalidOperationError, match="dtype was not array on all nesting levels"
     ):
-        exec_op(s, s, op.add)
+        exec_op(a, a, op.add)
 
     with pytest.raises(
         InvalidOperationError, match="dtype was not array on all nesting levels"
     ):
-        exec_op(s, p, op.add)
+        exec_op(a, b, op.add)

--- a/py-polars/tests/unit/operations/arithmetic/test_list.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_list.py
@@ -569,6 +569,11 @@ def test_list_arithmetic_invalid_dtypes(
     ):
         exec_op(a, b, op.add)
 
+    with pytest.raises(
+        InvalidOperationError, match="dtype was not list on all nesting levels"
+    ):
+        exec_op(b, a, op.add)
+
 
 @pytest.mark.parametrize(
     ("expected", "expr", "column_names"),


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19839

We didn't validate that the `list` side of an arithmetic operation between `list<->primitive` columns has a `list` type at all nesting levels. This causes a panic when we later attempt to downcast to a numeric array type.

```python
# Before
pyo3_runtime.PanicException: not implemented for dtype Struct([Field { name: "a", dtype: Int64 }])
# After
polars.exceptions.InvalidOperationError: cannot add columns: dtype was not list on all nesting levels: (left: list[struct[1]], right: i64)
```

Some drive-bys:
* Rename `arithmetic/list_borrowed.rs -> arithmetic/list.rs` (under `polars-core`)
* Rename `arithmetic/test_list_arithmetic.py -> arithmetic/test_list.py` (under `py-polars/tests`)
