### PR TITLE
test(python): Adjust flaky `with_columns` test

### DIFF
--- a/py-polars/tests/benchmark/test_with_columns.py
+++ b/py-polars/tests/benchmark/test_with_columns.py
@@ -1,21 +1,39 @@
-import time
+from time import perf_counter
 
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 
 
 # TODO: this is slow in streaming
 @pytest.mark.may_fail_auto_streaming
+@pytest.mark.slow
 def test_with_columns_quadratic_19503() -> None:
-    num_columns = 2000
+    num_columns = 10_000
     data1 = {f"col_{i}": [0] for i in range(num_columns)}
     df1 = pl.DataFrame(data1)
 
     data2 = {f"feature_{i}": [0] for i in range(num_columns)}
     df2 = pl.DataFrame(data2)
 
-    t0 = time.time()
-    df1.with_columns(df2)
-    t1 = time.time()
-    assert t1 - t0 < 0.2
+    df3 = df2.select(cs.by_index(range(num_columns // 1000)))
+
+    times = []  # [slow, fast]
+
+    class _:
+        t = perf_counter()
+        df1.with_columns(df2)
+        times.append(perf_counter() - t)
+
+    class _:  # type: ignore[no-redef]
+        t = perf_counter()
+        df1.with_columns(df3)
+        times.append(perf_counter() - t)
+
+    # Assert the relative rather than exact runtime to avoid flakiness in CI
+    # From local testing, the fixed version was roughly 20x, while the quadratic
+    # version was roughly 200x.
+
+    factor = times[0] / times[1]
+    assert factor < 30

--- a/py-polars/tests/benchmark/test_with_columns.py
+++ b/py-polars/tests/benchmark/test_with_columns.py
@@ -38,7 +38,7 @@ def test_with_columns_quadratic_19503() -> None:
     # negatives.
     #                    1.12.0 | 1.14.0
     #   M3 Pro 11-core |   200x |    20x
-    #  EC2 47i.4xlarge |   150x |    13x
+    #  EC2 c7i.4xlarge |   150x |    13x
     # GitHub CI runner |        |    50x
     if ratio > 80:
         raise AssertionError(ratio)

--- a/py-polars/tests/benchmark/test_with_columns.py
+++ b/py-polars/tests/benchmark/test_with_columns.py
@@ -34,6 +34,8 @@ def test_with_columns_quadratic_19503() -> None:
     factor = times[0] / times[1]
 
     # Assert the relative rather than exact runtime to avoid flakiness in CI
+    # We pick a threshold just low enough to pass CI without any false
+    # negatives.
     #                    1.12.0 | 1.14.0
     #   M3 Pro 11-core |   200x |    20x
     #  EC2 47i.4xlarge |   150x |    13x

--- a/py-polars/tests/benchmark/test_with_columns.py
+++ b/py-polars/tests/benchmark/test_with_columns.py
@@ -36,4 +36,6 @@ def test_with_columns_quadratic_19503() -> None:
     # version was roughly 200x.
 
     factor = times[0] / times[1]
-    assert factor < 30
+
+    if factor > 30:
+        raise AssertionError(factor)

--- a/py-polars/tests/benchmark/test_with_columns.py
+++ b/py-polars/tests/benchmark/test_with_columns.py
@@ -31,7 +31,7 @@ def test_with_columns_quadratic_19503() -> None:
         df1.with_columns(rhs)
         times.append(perf_counter() - t)
 
-    factor = times[0] / times[1]
+    ratio = times[0] / times[1]
 
     # Assert the relative rather than exact runtime to avoid flakiness in CI
     # We pick a threshold just low enough to pass CI without any false
@@ -40,5 +40,5 @@ def test_with_columns_quadratic_19503() -> None:
     #   M3 Pro 11-core |   200x |    20x
     #  EC2 47i.4xlarge |   150x |    13x
     # GitHub CI runner |        |    50x
-    if factor > 80:
-        raise AssertionError(factor)
+    if ratio > 80:
+        raise AssertionError(ratio)

--- a/py-polars/tests/benchmark/test_with_columns.py
+++ b/py-polars/tests/benchmark/test_with_columns.py
@@ -17,25 +17,26 @@ def test_with_columns_quadratic_19503() -> None:
     data2 = {f"feature_{i}": [0] for i in range(num_columns)}
     df2 = pl.DataFrame(data2)
 
-    df3 = df2.select(cs.by_index(range(num_columns // 1000)))
-
     times = []  # [slow, fast]
 
     class _:
+        rhs = df2
         t = perf_counter()
-        df1.with_columns(df2)
+        df1.with_columns(rhs)
         times.append(perf_counter() - t)
 
     class _:  # type: ignore[no-redef]
+        rhs = df2.select(cs.by_index(range(num_columns // 1_000)))
         t = perf_counter()
-        df1.with_columns(df3)
+        df1.with_columns(rhs)
         times.append(perf_counter() - t)
-
-    # Assert the relative rather than exact runtime to avoid flakiness in CI
-    # From local testing, the fixed version was roughly 20x, while the quadratic
-    # version was roughly 200x.
 
     factor = times[0] / times[1]
 
-    if factor > 30:
+    # Assert the relative rather than exact runtime to avoid flakiness in CI
+    #                    1.12.0 | 1.14.0
+    #   M3 Pro 11-core |   200x |    20x
+    #  EC2 47i.4xlarge |   150x |    13x
+    # GitHub CI runner |        |    50x
+    if factor > 80:
         raise AssertionError(factor)


### PR DESCRIPTION
I think this fails in CI a bit more often than we'd want - to address this, I've increased `num_columns` from 2,000 to 10,000. I've also updated the assertion to check the runtime relative to the time taken for applying calling `with_columns` on 10 columns rather than an exact time.
