### PR TITLE
fix: Properly handle Zero-Field Structs in row encoding

### DIFF
--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/eval.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/eval.rs
@@ -85,6 +85,7 @@ impl Eval {
         }
 
         polars_row::convert_columns_amortized(
+            keys_columns[0].len(), // @NOTE: does not work for ZFS
             keys_columns,
             &self.key_fields,
             &mut self.rows_encoded,

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
@@ -141,7 +141,11 @@ impl<K: ExtraPayload> GenericBuild<K> {
             let arr = s.to_physical_repr().rechunk().array_ref(0).clone();
             self.join_columns.push(arr);
         }
-        let rows_encoded = polars_row::convert_columns_no_order(&self.join_columns).into_array();
+        let rows_encoded = polars_row::convert_columns_no_order(
+            self.join_columns[0].len(), // @NOTE: does not work for ZFS
+            &self.join_columns,
+        )
+        .into_array();
         self.materialized_join_cols.push(rows_encoded);
         Ok(self.materialized_join_cols.last().unwrap())
     }

--- a/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
@@ -74,6 +74,7 @@ impl RowValues {
             self.join_column_idx = Some(idx);
         }
         polars_row::convert_columns_amortized_no_order(
+            self.join_columns_material[0].len(), // @NOTE: does not work for ZFS
             &self.join_columns_material,
             &mut self.current_rows,
         );

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -233,7 +233,11 @@ impl SortSinkMultiple {
         let column = if chunk.data.height() == 0 && chunk.data.width() > 0 {
             Column::new_empty(name, &DataType::BinaryOffset)
         } else {
-            let rows_encoded = polars_row::convert_columns(&self.sort_column, &self.sort_fields);
+            let rows_encoded = polars_row::convert_columns(
+                self.sort_column[0].len(), // @NOTE: does not work for ZFS
+                &self.sort_column,
+                &self.sort_fields,
+            );
             let series = unsafe {
                 Series::from_chunks_and_dtype_unchecked(
                     name,

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -740,7 +740,7 @@ impl PyDataFrame {
                 )
                 .collect::<Vec<_>>();
 
-            let rows = polars_row::convert_columns(&chunks, &fields);
+            let rows = polars_row::convert_columns(df.height(), &chunks, &fields);
 
             Ok(unsafe {
                 Series::from_chunks_and_dtype_unchecked(

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -134,13 +134,16 @@ def test_str(field: tuple[bool, bool, bool]) -> None:
     )
 
 
-# def test_struct() -> None:
-#     # @TODO: How do we deal with zero-field structs?
-#     # roundtrip_re(pl.Series('a', [], pl.Struct({})).to_frame())
-#     # roundtrip_re(pl.Series('a', [{}], pl.Struct({})).to_frame())
-#     roundtrip_re(pl.Series("a", [{"x": 1}], pl.Struct({"x": pl.Int32})).to_frame())
-#     roundtrip_re(
-#         pl.Series(
-#             "a", [{"x": 1}, {"y": 2}], pl.Struct({"x": pl.Int32, "y": pl.Int32})
-#         ).to_frame()
-#     )
+@pytest.mark.parametrize("field", FIELD_COMBS)
+def test_struct(field: tuple[bool, bool, bool]) -> None:
+    roundtrip_re(pl.Series("a", [], pl.Struct({})).to_frame())
+    roundtrip_re(pl.Series("a", [{}], pl.Struct({})).to_frame())
+    roundtrip_re(
+        pl.Series("a", [{"x": 1}], pl.Struct({"x": pl.Int32})).to_frame(), [field]
+    )
+    roundtrip_re(
+        pl.Series(
+            "a", [{"x": 1}, {"y": 2}], pl.Struct({"x": pl.Int32, "y": pl.Int32})
+        ).to_frame(),
+        [field],
+    )


### PR DESCRIPTION
Follow up to #19843.