### PR TITLE
fix(python): Parse uppercase config keys

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -122,6 +122,7 @@ where
 {
     Ok(config
         .into_iter()
+        // Silenty ignores custom upstream storage_options
         .filter_map(|(key, val)| {
             T::from_str(key.as_ref().to_ascii_lowercase().as_str())
                 .ok()

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -605,7 +605,9 @@ impl CloudOptions {
 #[cfg(feature = "cloud")]
 #[cfg(test)]
 mod tests {
-    use super::parse_url;
+    use hashbrown::HashMap;
+
+    use super::{parse_url, parsed_untyped_config};
 
     #[test]
     fn test_parse_url() {
@@ -679,5 +681,40 @@ mod tests {
                 .as_str()
             );
         }
+    }
+    #[cfg(feature = "aws")]
+    #[test]
+    fn test_parse_untyped_config() {
+        use object_store::aws::AmazonS3ConfigKey;
+
+        let aws_config = [
+            ("aws_secret_access_key", "a_key"),
+            ("aws_s3_allow_unsafe_rename", "true"),
+        ]
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+        let aws_keys = parsed_untyped_config::<AmazonS3ConfigKey, _>(aws_config)
+            .expect("Parsing keys shouldn't have thrown an error");
+
+        assert_eq!(
+            aws_keys.get(0).unwrap().0,
+            AmazonS3ConfigKey::SecretAccessKey
+        );
+        assert_eq!(aws_keys.len(), 1);
+
+        let aws_config = [
+            ("AWS_SECRET_ACCESS_KEY", "a_key"),
+            ("aws_s3_allow_unsafe_rename", "true"),
+        ]
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+        let aws_keys = parsed_untyped_config::<AmazonS3ConfigKey, _>(aws_config)
+            .expect("Parsing keys shouldn't have thrown an error");
+
+        assert_eq!(
+            aws_keys.get(0).unwrap().0,
+            AmazonS3ConfigKey::SecretAccessKey
+        );
+        assert_eq!(aws_keys.len(), 1);
     }
 }

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -697,7 +697,7 @@ mod tests {
             .expect("Parsing keys shouldn't have thrown an error");
 
         assert_eq!(
-            aws_keys.get(0).unwrap().0,
+            aws_keys.first().unwrap().0,
             AmazonS3ConfigKey::SecretAccessKey
         );
         assert_eq!(aws_keys.len(), 1);
@@ -712,7 +712,7 @@ mod tests {
             .expect("Parsing keys shouldn't have thrown an error");
 
         assert_eq!(
-            aws_keys.get(0).unwrap().0,
+            aws_keys.first().unwrap().0,
             AmazonS3ConfigKey::SecretAccessKey
         );
         assert_eq!(aws_keys.len(), 1);

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -122,7 +122,7 @@ where
 {
     Ok(config
         .into_iter()
-        // Silenty ignores custom upstream storage_options
+        // Silently ignores custom upstream storage_options
         .filter_map(|(key, val)| {
             T::from_str(key.as_ref().to_ascii_lowercase().as_str())
                 .ok()

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -123,7 +123,8 @@ where
     Ok(config
         .into_iter()
         .filter_map(|(key, val)| {
-            T::from_str(key.as_ref().to_ascii_lowercase().as_str()).ok()
+            T::from_str(key.as_ref().to_ascii_lowercase().as_str())
+                .ok()
                 .map(|typed_key| (typed_key, val.into()))
         })
         .collect::<Configs<T>>())

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -120,16 +120,13 @@ fn parsed_untyped_config<T, I: IntoIterator<Item = (impl AsRef<str>, impl Into<S
 where
     T: FromStr + Eq + std::hash::Hash,
 {
-    config
+    Ok(config
         .into_iter()
-        .map(|(key, val)| {
-            T::from_str(key.as_ref())
-                .map_err(
-                    |_| polars_err!(ComputeError: "unknown configuration key: {}", key.as_ref()),
-                )
+        .filter_map(|(key, val)| {
+            T::from_str(key.as_ref().to_ascii_lowercase().as_str()).ok()
                 .map(|typed_key| (typed_key, val.into()))
         })
-        .collect::<PolarsResult<Configs<T>>>()
+        .collect::<Configs<T>>())
 }
 
 #[derive(PartialEq)]


### PR DESCRIPTION
In delta-rs we also parse config keys that are uppercase, this provides more flexibility and allows people to use same storage options for delta-rs and pola-rs.

Additionally instead of raising for non existing config keys, we just filter them out. This would make it easier to keep engine specific keys in the storage options in python, since delta-rs has some of those to handle mounted storage.

- closes https://github.com/pola-rs/polars/issues/19849
