### PR TITLE
fix: Incorrect explode schema for `LazyFrame.explode()`

### DIFF
--- a/crates/polars-plan/src/plans/functions/schema.rs
+++ b/crates/polars-plan/src/plans/functions/schema.rs
@@ -132,10 +132,17 @@ fn explode_schema<'a>(
 
     // columns to string
     columns.iter().try_for_each(|name| {
-        if let DataType::List(inner) = schema.try_get(name)? {
-            let inner = *inner.clone();
-            schema.with_column(name.clone(), inner);
-        };
+        match schema.try_get(name)? {
+            DataType::List(inner) => {
+                schema.with_column(name.clone(), inner.as_ref().clone());
+            },
+            #[cfg(feature = "dtype-array")]
+            DataType::Array(inner, _) => {
+                schema.with_column(name.clone(), inner.as_ref().clone());
+            },
+            _ => {},
+        }
+
         PolarsResult::Ok(())
     })?;
     let schema = Arc::new(schema);

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -297,6 +297,17 @@ def test_lf_explode_schema() -> None:
     q = lf.select(pl.col("x").list.explode())
     assert q.collect_schema() == {"x": pl.Int64}
 
+    lf = pl.LazyFrame().with_columns(
+        pl.Series([[1]], dtype=pl.List(pl.Int64)).alias("list"),
+        pl.Series([[1]], dtype=pl.Array(pl.Int64, 1)).alias("array"),
+    )
+
+    q = lf.explode("*")
+    assert q.collect_schema() == {"list": pl.Int64, "array": pl.Int64}
+
+    q = lf.explode("list")
+    assert q.collect_schema() == {"list": pl.Int64, "array": pl.Array(pl.Int64, 1)}
+
 
 def test_raise_subnodes_18787() -> None:
     df = pl.DataFrame({"a": [1], "b": [2]})


### PR DESCRIPTION
This goes through a different codepath than the `Expr` explode. We will be correct in both `Expr` and `LazyFrame` explode after this PR 🙂

Fixes https://github.com/pola-rs/polars/issues/19763
