### PR TITLE
fix(python): Improve export from 2D Array dtype columns to PyTorch Tensors (`to_torch`) and Jax Arrays (`to_jax`)

### DIFF
--- a/py-polars/polars/ml/utilities.py
+++ b/py-polars/polars/ml/utilities.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from polars import DataFrame
+from polars._typing import IndexOrder
+from polars.datatypes import Array, List
+from polars.dependencies import numpy as np
+
+
+def frame_to_numpy(
+    df: DataFrame,
+    *,
+    writable: bool,
+    target: str,
+    order: IndexOrder = "fortran",
+) -> np.ndarray[Any, Any]:
+    """Convert a DataFrame to a NumPy array for use with Jax or PyTorch."""
+    for nm, tp in df.schema.items():
+        if tp == List:
+            msg = f"cannot convert List column {nm!r} to {target} (use Array dtype instead)"
+            raise TypeError(msg) from None
+
+    if df.width == 1 and df.schema.dtypes()[0] == Array:
+        arr = df[df.columns[0]].to_numpy(writable=writable)
+    else:
+        arr = df.to_numpy(writable=writable, order=order)
+
+    if arr.dtype == object:
+        msg = f"cannot convert DataFrame to {target} (mixed type columns result in `object` dtype)\n{df.schema!r}"
+        raise TypeError(msg)
+    return arr

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4431,10 +4431,15 @@ class Series:
             srs = self
 
         # we have to build the tensor from a writable array or PyTorch will complain
-        # about it (as writing to readonly array results in undefined behavior)
+        # about it (writing to a readonly array results in undefined behavior)
         numpy_array = srs.to_numpy(writable=True)
-        tensor = torch.from_numpy(numpy_array)
-
+        try:
+            tensor = torch.from_numpy(numpy_array)
+        except TypeError:
+            if self.dtype == List:
+                msg = "cannot convert List dtype to Tensor (use Array dtype instead)"
+                raise TypeError(msg) from None
+            raise
         # note: named tensors are currently experimental
         # tensor.rename(self.name)
         return tensor

--- a/py-polars/tests/unit/ml/test_to_torch.py
+++ b/py-polars/tests/unit/ml/test_to_torch.py
@@ -167,16 +167,11 @@ def test_to_torch_dataset_with_2D_arrays() -> None:
     )
     ds = df.to_torch("dataset", label="lbl")
 
-    ds_values = list(ds)  # type: ignore[call-overload]
-    assert len(ds_values) == 2
-    assert_tensor_equal(ds_values[0][1], torch.tensor(0, dtype=torch.int64))
-    assert_tensor_equal(ds_values[1][1], torch.tensor(1, dtype=torch.int64))
-    assert_tensor_equal(
-        ds_values[0][0], torch.tensor([[1, 1], [1, 2]], dtype=torch.int32)
-    )
-    assert_tensor_equal(
-        ds_values[1][0], torch.tensor([[2, 2], [2, 3]], dtype=torch.int32)
-    )
+    assert len(ds) == 2
+    assert_tensor_equal(ds[0][1], torch.tensor(0, dtype=torch.int64))
+    assert_tensor_equal(ds[1][1], torch.tensor(1, dtype=torch.int64))
+    assert_tensor_equal(ds[0][0], torch.tensor([[1, 1], [1, 2]], dtype=torch.int32))
+    assert_tensor_equal(ds[1][0], torch.tensor([[2, 2], [2, 3]], dtype=torch.int32))
 
 
 def test_to_torch_dataset_feature_reorder(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/ml/test_to_torch.py
+++ b/py-polars/tests/unit/ml/test_to_torch.py
@@ -104,6 +104,49 @@ def test_to_torch_feature_label_dict(df: pl.DataFrame) -> None:
     )
 
 
+def test_2D_array_cols_to_torch() -> None:
+    # 2D array
+    df1 = pl.DataFrame(
+        {"data": [[1, 1], [1, 2], [2, 2]]},
+        schema_overrides={"data": pl.Array(pl.Int32, shape=(2,))},
+    )
+    arr1 = df1.to_torch()
+    assert_tensor_equal(
+        arr1,
+        torch.tensor([[1, 1], [1, 2], [2, 2]], dtype=torch.int32),
+    )
+
+    # nested 2D array
+    df2 = pl.DataFrame(
+        {"data": [[[1, 1], [1, 2]], [[2, 2], [2, 3]]]},
+        schema_overrides={"data": pl.Array(pl.Array(pl.Int32, shape=(2,)), shape=(2,))},
+    )
+    arr2 = df2.to_torch()
+    assert_tensor_equal(
+        arr2,
+        torch.tensor([[[1, 1], [1, 2]], [[2, 2], [2, 3]]], dtype=torch.int32),
+    )
+
+    # dict with 2D array
+    df3 = df2.insert_column(0, pl.Series("lbl", [0, 1], dtype=pl.Int32))
+    lbl_feat_dict = df3.to_torch("dict")
+    assert_tensor_equal(
+        lbl_feat_dict["lbl"],
+        torch.tensor([0, 1], dtype=torch.int32),
+    )
+    assert_tensor_equal(
+        lbl_feat_dict["data"],
+        torch.tensor([[[1, 1], [1, 2]], [[2, 2], [2, 3]]], dtype=torch.int32),
+    )
+
+    # no support for list (yet? could add if ragged arrays are valid)
+    with pytest.raises(
+        TypeError,
+        match=r"cannot convert List column 'data' to Tensor \(use Array dtype instead\)",
+    ):
+        pl.DataFrame({"data": [[1, 1], [1, 2], [2, 2]]}).to_torch()
+
+
 def test_to_torch_dataset(df: pl.DataFrame) -> None:
     ds = df.to_torch("dataset", dtype=pl.Float64)
 
@@ -115,6 +158,25 @@ def test_to_torch_dataset(df: pl.DataFrame) -> None:
     assert isinstance(ts, tuple)
     assert len(ts) == 1
     assert_tensor_equal(ts[0], torch.tensor([1.0, 1.0, 1.5], dtype=torch.float64))
+
+
+def test_to_torch_dataset_with_2D_arrays() -> None:
+    df = pl.DataFrame(
+        {"lbl": [0, 1], "data": [[[1, 1], [1, 2]], [[2, 2], [2, 3]]]},
+        schema_overrides={"data": pl.Array(pl.Array(pl.Int32, shape=(2,)), shape=(2,))},
+    )
+    ds = df.to_torch("dataset", label="lbl")
+
+    ds_values = list(ds)  # type: ignore[call-overload]
+    assert len(ds_values) == 2
+    assert_tensor_equal(ds_values[0][1], torch.tensor(0, dtype=torch.int64))
+    assert_tensor_equal(ds_values[1][1], torch.tensor(1, dtype=torch.int64))
+    assert_tensor_equal(
+        ds_values[0][0], torch.tensor([[1, 1], [1, 2]], dtype=torch.int32)
+    )
+    assert_tensor_equal(
+        ds_values[1][0], torch.tensor([[2, 2], [2, 3]], dtype=torch.int32)
+    )
 
 
 def test_to_torch_dataset_feature_reorder(df: pl.DataFrame) -> None:


### PR DESCRIPTION
Closes #19092.

This addresses some issues exporting 2D `pl.Array` data to PyTorch/Jax.

(Assuming support for ragged Tensors/Arrays is present in the target library we could consider supporting export from List data as an enhancement - for now List raises a `TypeError` suggesting use of Array 🤔)

## Example

Establish a test frame containing some 2D Array data:
```python
import polars as pl
import numpy as np

df = pl.DataFrame({
    "sample": [1, 1, 1, 2, 2, 2],
    "seq_pos": [2, 0, 1, 0, 1, 2],
    "f1": np.random.rand(6),
    "f2": np.random.rand(6),
}).sort(
    by=["seq_pos"]
).group_by("sample").agg(
    pl.concat_list("f1", "f2").alias("features")
).with_columns(
    pl.col("features").cast(pl.Array(pl.Float64, (3,2)))
)
# shape: (2, 2)
# ┌────────┬─────────────────────────────────┐
# │ sample ┆ features                        │
# │ ---    ┆ ---                             │
# │ i64    ┆ array[f64, (3, 2)]              │
# ╞════════╪═════════════════════════════════╡
# │ 1      ┆ [[0.644683, 0.217759], [0.2951… │
# │ 2      ┆ [[0.294134, 0.683678], [0.8695… │
# └────────┴─────────────────────────────────┘
```
Export to PyTorch `Dataset`:
```python
ds = df.to_torch("dataset", label="sample")

ds.labels
# tensor([1, 2])

ds.features
# tensor([[[0.6447, 0.2178],
#          [0.2952, 0.4262],
#          [0.8459, 0.1967]],
#         [[0.2941, 0.6837],
#          [0.8696, 0.9194],
#          [0.4777, 0.1374]]], dtype=torch.float64)
```
Export to dict of Jax `Array`:
```python
df.to_jax("dict")
# {
#   "sample": Array([1, 2], dtype=int32),
#   "features": Array(
#     [[[0.64468336, 0.21775946],
#       [0.29518905, 0.426187  ],
#       [0.8459465 , 0.19667272]],
#      [[0.2941337 , 0.68367827],
#       [0.869574  , 0.91941637],
#       [0.4776729 , 0.13742302]]], dtype=float32),
# }
```