### PR TITLE
fix: Ensure type object of inputs for cached any-value conversion functions are kept alive

### DIFF
--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -525,7 +525,7 @@ pub(crate) fn py_object_to_any_value<'py>(
             if !lut.contains_key(&py_type_address) {
                 let k = TypeObjectKey::new(py_type.clone().unbind());
 
-                debug_assert_eq!(k.address, py_type_address);
+                assert_eq!(k.address, py_type_address);
 
                 unsafe {
                     lut.insert_unique_unchecked(k, get_conversion_function(ob, py, allow_object)?);

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -1,4 +1,5 @@
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
+use std::sync::Arc;
 
 #[cfg(feature = "object")]
 use polars::chunked_array::object::PolarsObjectSafe;
@@ -12,7 +13,9 @@ use polars_core::utils::arrow::temporal_conversions::date32_to_date;
 use pyo3::exceptions::{PyOverflowError, PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PySequence, PyString, PyTuple};
+use pyo3::types::{
+    PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PySequence, PyString, PyTuple, PyType,
+};
 
 use super::datetime::{
     elapsed_offset_to_timedelta, nanos_since_midnight_to_naivetime, timestamp_to_naive_datetime,
@@ -152,9 +155,50 @@ fn datetime_to_py_object(
     }
 }
 
-type TypeObjectPtr = usize;
+/// Holds a Python type object and implements hashing / equality based on the pointer address of the
+/// type object. This is used as a hashtable key instead of only the `usize` pointer value, as we
+/// need to hold a ref to the Python type object to keep it alive.
+#[derive(Debug, Clone)]
+pub struct TypeObjectKey {
+    #[allow(unused)]
+    type_object: Arc<Py<PyType>>,
+    /// We need to store this in a field for `Borrow<usize>`
+    address: usize,
+}
+
+impl TypeObjectKey {
+    fn new(type_object: Py<PyType>) -> Self {
+        let address = type_object.as_ptr() as usize;
+        Self {
+            type_object: Arc::new(type_object),
+            address,
+        }
+    }
+}
+
+impl PartialEq for TypeObjectKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.address == other.address
+    }
+}
+
+impl Eq for TypeObjectKey {}
+
+impl std::borrow::Borrow<usize> for TypeObjectKey {
+    fn borrow(&self) -> &usize {
+        &self.address
+    }
+}
+
+impl std::hash::Hash for TypeObjectKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let v: &usize = self.borrow();
+        v.hash(state)
+    }
+}
+
 type InitFn = for<'py> fn(&Bound<'py, PyAny>, bool) -> PyResult<AnyValue<'py>>;
-pub(crate) static LUT: crate::gil_once_cell::GILOnceCell<PlHashMap<TypeObjectPtr, InitFn>> =
+pub(crate) static LUT: crate::gil_once_cell::GILOnceCell<PlHashMap<TypeObjectKey, InitFn>> =
     crate::gil_once_cell::GILOnceCell::new();
 
 /// Convert a Python object to an [`AnyValue`].
@@ -473,16 +517,23 @@ pub(crate) fn py_object_to_any_value<'py>(
         }
     }
 
-    let type_object_ptr = ob.get_type().as_type_ptr() as usize;
+    let py_type = ob.get_type();
+    let py_type_address = py_type.as_ptr() as usize;
 
-    Python::with_gil(|py| {
-        let conversion_function = get_conversion_function(ob, py, allow_object)?;
+    Python::with_gil(move |py| {
+        LUT.with_gil(py, move |lut| {
+            if !lut.contains_key(&py_type_address) {
+                let k = TypeObjectKey::new(py_type.clone().unbind());
 
-        LUT.with_gil(py, |lut| {
-            let convert_fn = lut
-                .entry(type_object_ptr)
-                .or_insert_with(|| conversion_function);
-            convert_fn(ob, strict)
+                debug_assert_eq!(k.address, py_type_address);
+
+                unsafe {
+                    lut.insert_unique_unchecked(k, get_conversion_function(ob, py, allow_object)?);
+                }
+            }
+
+            let conversion_func = lut.get(&py_type_address).unwrap();
+            conversion_func(ob, strict)
         })
     })
 }

--- a/crates/polars-python/src/conversion/any_value.rs
+++ b/crates/polars-python/src/conversion/any_value.rs
@@ -1,5 +1,4 @@
 use std::borrow::{Borrow, Cow};
-use std::sync::Arc;
 
 #[cfg(feature = "object")]
 use polars::chunked_array::object::PolarsObjectSafe;
@@ -158,10 +157,10 @@ fn datetime_to_py_object(
 /// Holds a Python type object and implements hashing / equality based on the pointer address of the
 /// type object. This is used as a hashtable key instead of only the `usize` pointer value, as we
 /// need to hold a ref to the Python type object to keep it alive.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TypeObjectKey {
     #[allow(unused)]
-    type_object: Arc<Py<PyType>>,
+    type_object: Py<PyType>,
     /// We need to store this in a field for `Borrow<usize>`
     address: usize,
 }
@@ -170,7 +169,7 @@ impl TypeObjectKey {
     fn new(type_object: Py<PyType>) -> Self {
         let address = type_object.as_ptr() as usize;
         Self {
-            type_object: Arc::new(type_object),
+            type_object,
             address,
         }
     }

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -312,7 +312,6 @@ def test_date_ranges_datetime_input() -> None:
     assert_series_equal(result, expected)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_date_range_with_subclass_18470_18447() -> None:
     class MyAmazingDate(date):
         pass


### PR DESCRIPTION
Fixes a non-deterministic bug in AnyValue conversion from Python, where the incorrect object conversion function would be used when constructing from a Python object. This occurs when there are multiple dynamically created classes being used.

We have a cache `static LUT` for `get_conversion_function` keyed by the `usize` pointer address of the Python type class. This didn't account for dynamically constructed type objects that may be freed during execution. If a different type object gets allocated to the same location as a previously freed type object, we would incorrectly use the conversion_function meant for the previous type object.

<details>
<summary>Traceback</summary>

This is a traceback that I believe to be caused by the bug:

```shell
2024-11-19T11:31:25.2828286Z ================================== FAILURES ===================================
2024-11-19T11:31:25.2829036Z __________________________ test_err_transpose_object __________________________
2024-11-19T11:31:25.2830362Z [gw1] win32 -- Python 3.12.7 D:\a\polars\polars\py-polars\.venv\Scripts\python.exe
2024-11-19T11:31:25.2831180Z tests\unit\operations\test_transpose.py:207: in test_err_transpose_object
2024-11-19T11:31:25.2831788Z     pl.DataFrame([CustomObject()]).transpose()
2024-11-19T11:31:25.2832264Z polars\dataframe\frame.py:375: in __init__
2024-11-19T11:31:25.2832703Z     self._df = sequence_to_pydf(
2024-11-19T11:31:25.2833235Z polars\_utils\construction\dataframe.py:461: in sequence_to_pydf
2024-11-19T11:31:25.2833795Z     return _sequence_to_pydf_dispatcher(
2024-11-19T11:31:25.2834395Z C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\functools.py:907: in wrapper
2024-11-19T11:31:25.2835180Z     return dispatch(args[0].__class__)(*args, **kw)
2024-11-19T11:31:25.2835882Z polars\_utils\construction\dataframe.py:534: in _sequence_to_pydf_dispatcher
2024-11-19T11:31:25.2836493Z     return to_pydf(**common_params)
2024-11-19T11:31:25.2837416Z polars\_utils\construction\dataframe.py:749: in _sequence_of_elements_to_pydf
2024-11-19T11:31:25.2838539Z     pl.Series(
2024-11-19T11:31:25.2839362Z polars\series\series.py:289: in __init__
2024-11-19T11:31:25.2839822Z     self._s = sequence_to_pyseries(
2024-11-19T11:31:25.2840576Z polars\_utils\construction\series.py:285: in sequence_to_pyseries
2024-11-19T11:31:25.2841192Z     srs = PySeries.new_from_any_values(name, values, strict)
2024-11-19T11:31:25.2843104Z E   pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'AttributeError'>, value: AttributeError("'CustomObject' object has no attribute 'tzinfo'"), traceback: Some(<traceback object at 0x00000192592C8940>) }
2024-11-19T11:31:25.2844496Z ---------------------------- Captured stderr call -----------------------------
2024-11-19T11:31:25.2845236Z thread '<unnamed>' panicked at crates\polars-python\src\conversion\any_value.rs:231:18:
2024-11-19T11:31:25.2846649Z called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'AttributeError'>, value: AttributeError("'CustomObject' object has no attribute 'tzinfo'"), traceback: Some(<traceback object at 0x00000192592C8940>) }
2024-11-19T11:31:25.2847697Z stack backtrace:
2024-11-19T11:31:25.2848202Z note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2024-11-19T11:31:25.2848867Z =========================== short test summary info ===========================
2024-11-19T11:31:25.2850669Z FAILED tests/unit/operations/test_transpose.py::test_err_transpose_object - pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'AttributeError'>, value: AttributeError("'CustomObject' object has no attribute 'tzinfo'"), traceback: Some(<traceback object at 0x00000192592C8940>) }
2024-11-19T11:31:25.2852293Z ===== 1 failed, 13563 passed, 40 skipped, 2 xfailed in 254.30s (0:04:14) ======
2024-11-19T11:31:25.6771944Z ##[error]Process completed with exit code 1.
2024-11-19T11:31:25.6996072Z Post job cleanup.
2024-11-19T11:31:25.9725140Z [command]"C:\Program Files\Git\bin\git.exe" version
2024-11-19T11:31:25.9968353Z git version 2.47.0.windows.1
2024-11-19T11:31:26.0032882Z Temporarily overriding HOME='D:\a\_temp\09b7a1b4-b0e1-44b1-b48b-64a41195c908' before making global git config changes
2024-11-19T11:31:26.0034380Z Adding repository directory to the temporary git global config as a safe directory
2024-11-19T11:31:26.0044176Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\polars\polars
2024-11-19T11:31:26.0352376Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
2024-11-19T11:31:26.0574454Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
2024-11-19T11:31:26.5085175Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2024-11-19T11:31:26.5274100Z http.https://github.com/.extraheader
2024-11-19T11:31:26.5309604Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
2024-11-19T11:31:26.5537462Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
2024-11-19T11:31:26.9699703Z Cleaning up orphan processes
2024-11-19T11:31:27.0051797Z Terminate orphan process: pid (1268) (vctip)
2024-11-19T11:31:27.0203632Z Terminate orphan process: pid (7152) (MSBuild)
2024-11-19T11:31:27.0339223Z Terminate orphan process: pid (5824) (conhost)

```
</details>
