### PR TITLE
perf: Add fast paths for series.arg_sort and dataframe.sort

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
@@ -28,7 +28,7 @@ where
     let mut current_end: IdxSize = 0;
     let mut rev_idx: Vec<IdxSize> = Vec::with_capacity(len);
     let mut i: IdxSize;
-    // We traverse the array , comparing consecutive elements.
+    // We traverse the array, comparing consecutive elements.
     // We maintain the start and end indice of elements with same value.
     // When we see a new element we push the previous indices in reverse order.
     // We do a final reverse to get stable reverse index.
@@ -220,13 +220,9 @@ where
         } else if (options.descending && is_sorted_flag == IsSorted::Ascending)
             || (!options.descending && is_sorted_flag == IsSorted::Descending)
         {
-            return ChunkedArray::with_chunk(
-                name,
-                IdxArr::from_data_default(
-                    Buffer::from((reverse_stable_no_nulls(iters, len)[..len_final]).to_vec()),
-                    None,
-                ),
-            );
+            let idx = reverse_stable_no_nulls(iters, len);
+            let idx = Buffer::from(idx).sliced(0, len_final);
+            return ChunkedArray::with_chunk(name, IdxArr::from_data_default(idx, None));
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
@@ -290,7 +290,7 @@ mod test {
                 Some(4), // 6
             ],
         );
-        let idx = reverse_stable_no_nulls(a.into_iter(), 7);
+        let idx = reverse_stable_no_nulls(&a, 7);
         let expected = [6, 3, 4, 5, 1, 2, 0];
         assert_eq!(idx, expected);
 
@@ -306,7 +306,7 @@ mod test {
                 Some(7), // 6
             ],
         );
-        let idx = reverse_stable_no_nulls(a.into_iter(), 7);
+        let idx = reverse_stable_no_nulls(&a, 7);
         let expected = [6, 5, 4, 3, 2, 1, 0];
         assert_eq!(idx, expected);
 
@@ -316,13 +316,13 @@ mod test {
                 Some(1), // 0
             ],
         );
-        let idx = reverse_stable_no_nulls(a.into_iter(), 1);
+        let idx = reverse_stable_no_nulls(&a, 1);
         let expected = [0];
         assert_eq!(idx, expected);
 
         let empty_array: [i32; 0] = [];
         let a = Int32Chunked::new(PlSmallStr::from_static("a"), &empty_array);
-        let idx = reverse_stable_no_nulls(a.into_iter(), 0);
+        let idx = reverse_stable_no_nulls(&a, 0);
         assert_eq!(idx.len(), 0);
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
@@ -15,6 +15,43 @@ where
         options.multithreaded,
     );
 }
+fn reverse_stable_no_nulls<I, J, T>(iters: I, len: usize) -> Vec<u32>
+where
+    I: IntoIterator<Item = J>,
+    J: IntoIterator<Item = T>,
+    T: TotalOrd + Send + Sync,
+{
+    let mut current_start = 0;
+    let mut current_end = 1;
+    let mut flattened_iter = iters.into_iter().flatten();
+    let first_element = flattened_iter.next();
+    let mut rev_idx = Vec::with_capacity(len);
+    let mut i: IdxSize;
+    match first_element {
+        Some(value) => {
+            let mut previous_element = value;
+            while let Some(current_element) = flattened_iter.next() {
+                if current_element.tot_cmp(&previous_element) == Ordering::Equal {
+                    current_end += 1;
+                } else {
+                    //rev_idx.extend((current_start..current_end).rev());
+                    i = current_end;
+                    while i > current_start {
+                        i = i - 1;
+                        unsafe { rev_idx.push_unchecked(i) };
+                    }
+                    current_start = current_end;
+                    current_end = current_end + 1;
+                }
+                previous_element = current_element;
+            }
+            rev_idx.extend((current_start..current_end).rev());
+            rev_idx.reverse();
+            return rev_idx;
+        },
+        None => return rev_idx,
+    }
+}
 
 pub(super) fn arg_sort<I, J, T>(
     name: PlSmallStr,
@@ -22,6 +59,9 @@ pub(super) fn arg_sort<I, J, T>(
     options: SortOptions,
     null_count: usize,
     mut len: usize,
+    is_sorted_descending_flag: bool,
+    is_sorted_ascending_flag: bool,
+    first_element_null: bool,
 ) -> IdxCa
 where
     I: IntoIterator<Item = J>,
@@ -29,10 +69,23 @@ where
     T: TotalOrd + Send + Sync,
 {
     let nulls_last = options.nulls_last;
+    let null_cap = if nulls_last { null_count } else { len };
+
+    if (options.descending && is_sorted_descending_flag)
+        || (!options.descending && is_sorted_ascending_flag)
+    {
+        if (nulls_last && !first_element_null) || (!nulls_last && first_element_null) {
+            return ChunkedArray::with_chunk(
+                name,
+                IdxArr::from_data_default(
+                    Buffer::from((0..(len as IdxSize)).collect::<Vec<IdxSize>>()),
+                    None,
+                ),
+            );
+        }
+    }
 
     let mut vals = Vec::with_capacity(len - null_count);
-
-    let null_cap = if nulls_last { null_count } else { len };
     let mut nulls_idx = Vec::with_capacity(null_cap);
     let mut count: IdxSize = 0;
 
@@ -108,12 +161,33 @@ pub(super) fn arg_sort_no_nulls<I, J, T>(
     iters: I,
     options: SortOptions,
     len: usize,
+    is_sorted_descending_flag: bool,
+    is_sorted_ascending_flag: bool,
 ) -> IdxCa
 where
     I: IntoIterator<Item = J>,
     J: IntoIterator<Item = T>,
     T: TotalOrd + Send + Sync,
 {
+    if (options.descending && is_sorted_descending_flag)
+        || (!options.descending && is_sorted_ascending_flag)
+    {
+        return ChunkedArray::with_chunk(
+            name,
+            IdxArr::from_data_default(
+                Buffer::from((0..(len as IdxSize)).collect::<Vec<IdxSize>>()),
+                None,
+            ),
+        );
+    } else if (options.descending && is_sorted_ascending_flag)
+        || (!options.descending && is_sorted_descending_flag)
+    {
+        return ChunkedArray::with_chunk(
+            name,
+            IdxArr::from_data_default(Buffer::from(reverse_stable_no_nulls(iters, len)), None),
+        );
+    }
+
     let mut vals = Vec::with_capacity(len);
 
     let mut count: IdxSize = 0;

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -67,6 +67,9 @@ impl CategoricalChunked {
                 options,
                 self.physical().null_count(),
                 self.len(),
+                false,
+                false,
+                false,
             )
         } else {
             self.physical().arg_sort(options)

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -67,8 +67,7 @@ impl CategoricalChunked {
                 options,
                 self.physical().null_count(),
                 self.len(),
-                false,
-                false,
+                IsSorted::Not,
                 false,
             )
         } else {

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -162,7 +162,8 @@ macro_rules! sort_with_fast_path {
 macro_rules! arg_sort_fast_path {
     ($ca:ident,  $options:expr) => {{
         // if already sorted in required order we can just return 0..len
-        if $options.descending && $ca.is_sorted_descending_flag() || ($ca.is_sorted_ascending_flag() && !$options.descending) {
+        if $options.limit.is_none() &&
+        ($options.descending && $ca.is_sorted_descending_flag() || ($ca.is_sorted_ascending_flag() && !$options.descending)) {
             // there are nulls
             if $ca.null_count() > 0 {
                 // if the nulls are already last we can return 0..len

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -261,8 +261,7 @@ where
             iter,
             options,
             ca.len(),
-            ca.is_sorted_descending_flag(),
-            ca.is_sorted_ascending_flag(),
+            ca.is_sorted_flag(),
         )
     } else {
         let iter = ca
@@ -274,8 +273,7 @@ where
             options,
             ca.null_count(),
             ca.len(),
-            ca.is_sorted_descending_flag(),
-            ca.is_sorted_ascending_flag(),
+            ca.is_sorted_flag(),
             ca.get(0).is_none(),
         )
     }
@@ -463,8 +461,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
                 self.downcast_iter().map(|arr| arr.values_iter()),
                 options,
                 self.len(),
-                self.is_sorted_descending_flag(),
-                self.is_sorted_ascending_flag(),
+                self.is_sorted_flag(),
             )
         } else {
             arg_sort::arg_sort(
@@ -473,8 +470,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
                 options,
                 self.null_count(),
                 self.len(),
-                self.is_sorted_descending_flag(),
-                self.is_sorted_ascending_flag(),
+                self.is_sorted_flag(),
                 self.get(0).is_none(),
             )
         }
@@ -737,8 +733,7 @@ impl ChunkSort<BooleanType> for BooleanChunked {
                 self.downcast_iter().map(|arr| arr.values_iter()),
                 options,
                 self.len(),
-                self.is_sorted_descending_flag(),
-                self.is_sorted_ascending_flag(),
+                self.is_sorted_flag(),
             )
         } else {
             arg_sort::arg_sort(
@@ -747,8 +742,7 @@ impl ChunkSort<BooleanType> for BooleanChunked {
                 options,
                 self.null_count(),
                 self.len(),
-                self.is_sorted_descending_flag(),
-                self.is_sorted_ascending_flag(),
+                self.is_sorted_flag(),
                 self.get(0).is_none(),
             )
         }

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -139,7 +139,7 @@ macro_rules! sort_with_fast_path {
                 // if the nulls are already last we can clone
                 if ($options.nulls_last && $ca.get($ca.len() - 1).is_none())  ||
                 // if the nulls are already first we can clone
-                (!$options.nulls_last && $ca.get(0).is_none())
+                $ca.get(0).is_none()
                 {
                     return $ca.clone();
                 }

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -137,9 +137,9 @@ macro_rules! sort_with_fast_path {
             // there are nulls
             if $ca.null_count() > 0 {
                 // if the nulls are already last we can clone
-                if ($options.nulls_last && $ca.get($ca.len() - 1).is_none())  ||
+                if $options.nulls_last && $ca.get($ca.len() - 1).is_none()  ||
                 // if the nulls are already first we can clone
-                $ca.get(0).is_none()
+                (!$options.nulls_last && $ca.get(0).is_none())
                 {
                     return $ca.clone();
                 }

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -159,6 +159,79 @@ macro_rules! sort_with_fast_path {
     }}
 }
 
+// macro_rules! arg_sort_fast_path {
+//     ($ca:ident,  $options:expr) => {{
+//         // we can clone if we sort in same order
+//         if $options.descending && $ca.is_sorted_descending_flag() || ($ca.is_sorted_ascending_flag() && !$options.descending) {
+//             // there are nulls
+//             if $ca.null_count() > 0 {
+//                 // if the nulls are already last we can clone
+//                 if ($options.nulls_last && $ca.get($ca.len() - 1).is_none() ) ||
+//                 // if the nulls are already first we can clone
+//                 (! $options.nulls_last && $ca.get(0).is_none())
+//                 {
+//                    return ChunkedArray::with_chunk($ca.name().clone(),
+//                     IdxArr::from_data_default(Buffer::from((0..($ca.len() as IdxSize)).collect::<Vec<IdxSize>>()), None));
+//                 }
+//                 // nulls are not at the right place
+//                 // continue w/ sorting
+//                 // TODO: we can optimize here and just put the null at the correct place
+//             } else {
+//                 return ChunkedArray::with_chunk($ca.name().clone(),
+//                 IdxArr::from_data_default(Buffer::from((0..($ca.len() as IdxSize )).collect::<Vec<IdxSize>>()), None));
+//             }
+//         }
+//         // we can reverse if we sort in other order
+//         else if ($options.descending && $ca.is_sorted_ascending_flag() || $ca.is_sorted_descending_flag()) && $ca.null_count() == 0 {
+//         //     if !$options.maintain_order
+//         //   { return ChunkedArray::with_chunk($ca.name().clone(),
+//         //      IdxArr::from_data_default(Buffer::from(((0..($ca.len() as IdxSize)).rev()).collect::<Vec<IdxSize>>()), None));
+//         //   }
+//         //   else
+//         // {
+//             let mut vals = Vec::with_capacity($ca.len());
+//             let mut equal_elements = Vec::with_capacity($ca.len());
+
+//             ($ca:BooleanChunked) => {
+//                 let iters = $ca
+//                 .downcast_iter()
+//                 .map(|arr| arr.values_iter.copied());
+//             }
+            
+
+//             let mut count: IdxSize = 0;
+//             for arr_iter in iters {
+//                 vals.extend(arr_iter.into_iter().map(|v| {
+//                     let idx = count;
+//                     count += 1;
+//                     (idx, v)
+//                 }));
+//             }
+//             let mut current_start=0;            
+//             let mut current_end=1;
+
+//             for i in 0..vals.len()-1{
+//                 if vals[i].1==vals[i+1].1 {
+//                     current_end=vals[i+1].0 +1;
+//                 }
+//                 else
+//                 {
+//                     equal_elements.push(current_start..current_end);
+//                     current_start=vals[i+1].0;
+//                     current_end=vals[i+1].0 +1;
+//                 }
+//             }
+//             equal_elements.push(current_start..current_end);
+//             let mut rev_idx = Vec::with_capacity($ca.len());
+
+//             for equal_elements_range in equal_elements.iter().rev() {
+//                 rev_idx.extend(equal_elements_range.clone().collect::<Vec<IdxSize>>());
+//         }
+//         return ChunkedArray::with_chunk($ca.name().clone(),
+//         IdxArr::from_data_default(Buffer::from(rev_idx), None));
+//         };
+//     }}}
+
 fn sort_with_numeric<T>(ca: &ChunkedArray<T>, options: SortOptions) -> ChunkedArray<T>
 where
     T: PolarsNumericType,
@@ -225,16 +298,17 @@ where
     T: PolarsNumericType,
 {
     options.multithreaded &= POOL.current_num_threads() > 1;
+    //arg_sort_fast_path!(ca, options);
     if ca.null_count() == 0 {
         let iter = ca
             .downcast_iter()
             .map(|arr| arr.values().as_slice().iter().copied());
-        arg_sort::arg_sort_no_nulls(ca.name().clone(), iter, options, ca.len())
+         arg_sort::arg_sort_no_nulls(ca.name().clone(), iter, options, ca.len(),ca.is_sorted_descending_flag(),ca.is_sorted_ascending_flag())
     } else {
         let iter = ca
             .downcast_iter()
             .map(|arr| arr.iter().map(|opt| opt.copied()));
-        arg_sort::arg_sort(ca.name().clone(), iter, options, ca.null_count(), ca.len())
+        arg_sort::arg_sort(ca.name().clone(), iter, options, ca.null_count(), ca.len(),ca.is_sorted_descending_flag(),ca.is_sorted_ascending_flag(),ca.get(0).is_none())
     }
 }
 
@@ -413,12 +487,14 @@ impl ChunkSort<BinaryType> for BinaryChunked {
     }
 
     fn arg_sort(&self, options: SortOptions) -> IdxCa {
+        //arg_sort_fast_path!(self, options);
         if self.null_count() == 0 {
             arg_sort::arg_sort_no_nulls(
                 self.name().clone(),
                 self.downcast_iter().map(|arr| arr.values_iter()),
                 options,
                 self.len(),
+                self.is_sorted_descending_flag(),self.is_sorted_ascending_flag()
             )
         } else {
             arg_sort::arg_sort(
@@ -427,6 +503,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
                 options,
                 self.null_count(),
                 self.len(),
+                self.is_sorted_descending_flag(),self.is_sorted_ascending_flag(),self.get(0).is_none()
             )
         }
     }
@@ -687,6 +764,7 @@ impl ChunkSort<BooleanType> for BooleanChunked {
                 self.downcast_iter().map(|arr| arr.values_iter()),
                 options,
                 self.len(),
+                self.is_sorted_descending_flag(),self.is_sorted_ascending_flag()
             )
         } else {
             arg_sort::arg_sort(
@@ -695,6 +773,7 @@ impl ChunkSort<BooleanType> for BooleanChunked {
                 options,
                 self.null_count(),
                 self.len(),
+                self.is_sorted_descending_flag(),self.is_sorted_ascending_flag(),self.get(0).is_none()
             )
         }
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2039,11 +2039,16 @@ impl DataFrame {
         // Check if the required column is already sorted; if so we can exit early
         // We can do so when there is only one column to sort by, for multiple columns
         // it will be complicated to do so
+        #[cfg(feature = "dtype-categorical")]
+        let is_not_categorical_enum =
+            !(matches!(by_column[0].dtype(), DataType::Categorical(_, _))
+                || matches!(by_column[0].dtype(), DataType::Enum(_, _)));
 
-        if by_column.len() == 1
-            && !(matches!(by_column[0].dtype(), DataType::Categorical(_, _))
-                || matches!(by_column[0].dtype(), DataType::Enum(_, _)))
-        {
+        #[cfg(not(feature = "dtype-categorical"))]
+        #[allow(non_upper_case_globals)]
+        const is_not_categorical_enum: bool = true;
+
+        if by_column.len() == 1 && is_not_categorical_enum {
             let required_sorting = if sort_options.descending[0] {
                 IsSorted::Descending
             } else {
@@ -2064,6 +2069,7 @@ impl DataFrame {
                 };
             }
         }
+
         #[cfg(feature = "dtype-struct")]
         let has_struct = by_column
             .iter()

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2039,7 +2039,11 @@ impl DataFrame {
         // Check if the required column is already sorted; if so we can exit early
         // We can do so when there is only one column to sort by, for multiple columns
         // it will be complicated to do so
-        if by_column.len() == 1 {
+
+        if by_column.len() == 1
+            && !(matches!(by_column[0].dtype(), DataType::Categorical(_, _))
+                || matches!(by_column[0].dtype(), DataType::Enum(_, _)))
+        {
             let required_sorting = if sort_options.descending[0] {
                 IsSorted::Descending
             } else {

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -227,7 +227,6 @@ def test_arg_sort_nulls(
     assert res == [1.0, 2.0, 3.0, None, None]
 
 
-
 @pytest.mark.parametrize(
     ("nulls_last", "expected"),
     [

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -253,7 +253,6 @@ def test_expr_arg_sort_nulls_last(
         .to_series()
         .to_list()
     )
-    print(out)
     assert out == expected
 
 

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -195,30 +195,11 @@ def test_sort_by_exprs() -> None:
     assert out.to_list() == [1, -1, 2, -2]
 
 
-@pytest.mark.parametrize(
-    ("sort_function", "expected"),
-    [
-        (lambda x: x, ([0, 1, 2, 3, 4], [3, 4, 0, 1, 2])),
-        (
-            lambda x: x.sort(descending=False, nulls_last=True),
-            ([0, 1, 2, 3, 4], [3, 4, 0, 1, 2]),
-        ),
-        (
-            lambda x: x.sort(descending=False, nulls_last=False),
-            ([2, 3, 4, 0, 1], [0, 1, 2, 3, 4]),
-        ),
-    ],
-)
-def test_arg_sort_nulls(
-    sort_function: Callable[[pl.Series], pl.Series],
-    expected: tuple[list[int], list[int]],
-) -> None:
+def test_arg_sort_nulls() -> None:
     a = pl.Series("a", [1.0, 2.0, 3.0, None, None])
 
-    a = sort_function(a)
-
-    assert a.arg_sort(nulls_last=True).to_list() == expected[0]
-    assert a.arg_sort(nulls_last=False).to_list() == expected[1]
+    assert a.arg_sort(nulls_last=True).to_list() == [0, 1, 2, 3, 4]
+    assert a.arg_sort(nulls_last=False).to_list() == [3, 4, 0, 1, 2]
 
     res = a.to_frame().sort(by="a", nulls_last=False).to_series().to_list()
     assert res == [None, None, 1.0, 2.0, 3.0]

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -76,36 +76,67 @@ def test_sort_dates_multiples() -> None:
     assert out["values"].to_list() == expected
 
 
-def test_sort_by() -> None:
+@pytest.mark.parametrize(
+    ("sort_function", "expected"),
+    [
+        (
+            lambda x: x,
+            ([3, 1, 2, 5, 4], [4, 5, 2, 1, 3], [5, 4, 3, 1, 2], [1, 2, 3, 4, 5]),
+        ),
+        (
+            lambda x: x.sort("b", descending=True, maintain_order=True),
+            ([3, 1, 2, 5, 4], [4, 5, 2, 1, 3], [5, 4, 3, 1, 2], [1, 2, 3, 4, 5]),
+        ),
+        (
+            lambda x: x.sort("b", "c", descending=False, maintain_order=True),
+            ([3, 1, 2, 5, 4], [4, 5, 2, 1, 3], [5, 4, 3, 1, 2], [3, 1, 2, 5, 4]),
+        ),
+    ],
+)
+def test_sort_by(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame], expected: tuple[list[int]]
+) -> None:
     df = pl.DataFrame(
         {"a": [1, 2, 3, 4, 5], "b": [1, 1, 1, 2, 2], "c": [2, 3, 1, 2, 1]}
     )
-
+    df = sort_function(df)
     by: list[pl.Expr | str]
     for by in [["b", "c"], [pl.col("b"), "c"]]:  # type: ignore[assignment]
         out = df.select(pl.col("a").sort_by(by))
-        assert out["a"].to_list() == [3, 1, 2, 5, 4]
+        assert out["a"].to_list() == expected[0]
 
     # Columns as positional arguments are also accepted
     out = df.select(pl.col("a").sort_by("b", "c"))
-    assert out["a"].to_list() == [3, 1, 2, 5, 4]
+    assert out["a"].to_list() == expected[0]
 
     out = df.select(pl.col("a").sort_by(by, descending=False))
-    assert out["a"].to_list() == [3, 1, 2, 5, 4]
+    assert out["a"].to_list() == expected[0]
 
     out = df.select(pl.col("a").sort_by(by, descending=True))
-    assert out["a"].to_list() == [4, 5, 2, 1, 3]
+    assert out["a"].to_list() == expected[1]
 
     out = df.select(pl.col("a").sort_by(by, descending=[True, False]))
-    assert out["a"].to_list() == [5, 4, 3, 1, 2]
+    assert out["a"].to_list() == expected[2]
 
     # by can also be a single column
     out = df.select(pl.col("a").sort_by("b", descending=[False]))
-    assert out["a"].to_list() == [1, 2, 3, 4, 5]
+    assert out["a"].to_list() == expected[3]
 
 
-def test_expr_sort_by_nulls_last() -> None:
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("a", descending=False, maintain_order=True),
+        lambda x: x.sort("a", descending=True, maintain_order=True),
+        lambda x: x.sort("a", descending=False, nulls_last=True),
+    ],
+)
+def test_expr_sort_by_nulls_last(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
     df = pl.DataFrame({"a": [1, 2, None, None, 5], "b": [None, 1, 1, 2, None]})
+    df = sort_function(df)
 
     # nulls last
     expected = pl.DataFrame({"a": [1, 2, 5, None, None], "b": [None, 1, None, 1, 2]})
@@ -214,16 +245,30 @@ def test_expr_arg_sort_nulls_last(
             "c": [2, 3, 1, 2, 1],
         },
     )
+
     out = (
         df.select(pl.arg_sort_by("a", "b", nulls_last=nulls_last, maintain_order=True))
         .to_series()
         .to_list()
     )
+    print(out)
     assert out == expected
 
 
-def test_arg_sort_window_functions() -> None:
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("Id", descending=False, maintain_order=True),
+        lambda x: x.sort("Id", descending=True, maintain_order=True),
+    ],
+)
+def test_arg_sort_window_functions(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
     df = pl.DataFrame({"Id": [1, 1, 2, 2, 3, 3], "Age": [1, 2, 3, 4, 5, 6]})
+    df = sort_function(df)
+
     out = df.select(
         pl.col("Age").arg_sort().over("Id").alias("arg_sort"),
         pl.arg_sort_by("Age").over("Id").alias("arg_sort_by"),
@@ -233,18 +278,38 @@ def test_arg_sort_window_functions() -> None:
     )
 
 
-def test_sort_nans_3740() -> None:
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("val", descending=False, maintain_order=True),
+        lambda x: x.sort("val", descending=True, maintain_order=True),
+    ],
+)
+def test_sort_nans_3740(sort_function: Callable[[pl.DataFrame], pl.DataFrame]) -> None:
     df = pl.DataFrame(
         {
             "key": [1, 2, 3, 4, 5],
             "val": [0.0, None, float("nan"), float("-inf"), float("inf")],
         }
     )
+    df = sort_function(df)
     assert df.sort("val")["key"].to_list() == [2, 4, 1, 5, 3]
 
 
-def test_sort_by_exps_nulls_last() -> None:
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("a", descending=False, maintain_order=True),
+        lambda x: x.sort("a", descending=True, maintain_order=True),
+    ],
+)
+def test_sort_by_exps_nulls_last(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
     df = pl.DataFrame({"a": [1, 3, -2, None, 1]}).with_row_index()
+    df = sort_function(df)
 
     assert df.sort(pl.col("a") ** 2, nulls_last=True).to_dict(as_series=False) == {
         "index": [0, 4, 2, 1, 3],
@@ -335,18 +400,41 @@ def test_sorted_fast_paths() -> None:
     assert rev.sort().to_list() == [None, 1, 2, 3]
 
 
-def test_arg_sort_rank_nans() -> None:
+def test_sorted_arg_sort_fast_paths() -> None:
+    s = pl.Series([1, 2, 3]).sort()
+    rev = s.sort(descending=True)
+
+    assert rev.to_list() == [3, 2, 1]
+    assert s.sort().to_list() == [1, 2, 3]
+
+    s = pl.Series([None, 1, 2, 3]).sort()
+    rev = s.sort(descending=True)
+    assert rev.to_list() == [None, 3, 2, 1]
+    assert rev.sort(descending=True).to_list() == [None, 3, 2, 1]
+    assert rev.sort().to_list() == [None, 1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("val", descending=False, maintain_order=True),
+    ],
+)
+def test_arg_sort_rank_nans(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
+    df = pl.DataFrame(
+        {
+            "val": [1.0, float("nan")],
+        }
+    )
+    df = sort_function(df)
     assert (
-        pl.DataFrame(
-            {
-                "val": [1.0, float("nan")],
-            }
-        )
-        .with_columns(
+        df.with_columns(
             pl.col("val").rank().alias("rank"),
             pl.col("val").arg_sort().alias("arg_sort"),
-        )
-        .select(["rank", "arg_sort"])
+        ).select(["rank", "arg_sort"])
     ).to_dict(as_series=False) == {"rank": [1.0, 2.0], "arg_sort": [0, 1]}
 
 
@@ -359,13 +447,24 @@ def test_set_sorted_schema() -> None:
     ) == {"A": pl.Int64}
 
 
-def test_sort_slice_fast_path_5245() -> None:
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("foo", descending=False, maintain_order=True),
+        lambda x: x.sort("foo", descending=True, maintain_order=True),
+    ],
+)
+def test_sort_slice_fast_path_5245(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
     df = pl.DataFrame(
         {
             "foo": ["f", "c", "b", "a"],
             "bar": [1, 2, 3, 4],
         }
     ).lazy()
+    df = sort_function(df)
 
     assert df.sort("foo").limit(1).select("foo").collect().to_dict(as_series=False) == {
         "foo": ["a"]
@@ -568,14 +667,35 @@ def test_sort_by_logical() -> None:
     ).to_dict(as_series=False) == {"name": ["a", "b"], "num": [[3, 1], [4]]}
 
 
-def test_limit_larger_than_sort() -> None:
-    assert pl.LazyFrame({"a": [1]}).sort("a").limit(30).collect().to_dict(
-        as_series=False
-    ) == {"a": [1]}
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("a", descending=False),
+        lambda x: x.sort("a", descending=True),
+    ],
+)
+def test_limit_larger_than_sort(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
+    df = pl.LazyFrame({"a": [1]})
+    df = sort_function(df)
+    assert df.sort("a").limit(30).collect().to_dict(as_series=False) == {"a": [1]}
 
 
-def test_sort_by_struct() -> None:
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("st", descending=False),
+        lambda x: x.sort("st", descending=True),
+    ],
+)
+def test_sort_by_struct(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
     df = pl.Series([{"a": 300}, {"a": 20}, {"a": 55}]).to_frame("st").with_row_index()
+    df = sort_function(df)
     assert df.sort("st").to_dict(as_series=False) == {
         "index": [1, 2, 0],
         "st": [{"a": 20}, {"a": 55}, {"a": 300}],
@@ -668,14 +788,26 @@ def test_sort_by_11653() -> None:
     ).sort("id").to_dict(as_series=False) == {"id": [0, 1], "sort_by": [1.0, 1.0]}
 
 
-def test_sort_with_null_12139() -> None:
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("bool", descending=False, nulls_last=True),
+        lambda x: x.sort("bool", descending=True, nulls_last=True),
+        lambda x: x.sort("bool", descending=False, nulls_last=False),
+        lambda x: x.sort("bool", descending=True, nulls_last=False),
+    ],
+)
+def test_sort_with_null_12139(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+) -> None:
     df = pl.DataFrame(
         {
             "bool": [True, False, None, True, False],
             "float": [1.0, 2.0, 3.0, 4.0, 5.0],
         }
     )
-
+    df = sort_function(df)
     assert df.sort("bool", descending=False, nulls_last=False).to_dict(
         as_series=False
     ) == {
@@ -734,11 +866,25 @@ def test_sort_series_nulls_last(input: list[Any], expected: list[Any]) -> None:
     assert pl.Series(input).sort(nulls_last=True).to_list() == expected
 
 
+@pytest.mark.parametrize(
+    ("sort_function"),
+    [
+        lambda x: x,
+        lambda x: x.sort("x", descending=False, nulls_last=True),
+        lambda x: x.sort("x", descending=True, nulls_last=True),
+        lambda x: x.sort("x", descending=False, nulls_last=False),
+        lambda x: x.sort("x", descending=True, nulls_last=False),
+    ],
+)
 @pytest.mark.parametrize("descending", [True, False])
 @pytest.mark.parametrize("nulls_last", [True, False])
-def test_sort_descending_nulls_last(descending: bool, nulls_last: bool) -> None:
+def test_sort_descending_nulls_last(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame],
+    descending: bool,
+    nulls_last: bool,
+) -> None:
     df = pl.DataFrame({"x": [1, 3, None, 2, None], "y": [1, 3, 0, 2, 0]})
-
+    df = sort_function(df)
     null_sentinel = 100 if descending ^ nulls_last else -100
     ref_x = [1, 3, None, 2, None]
     ref_x.sort(key=lambda k: null_sentinel if k is None else k, reverse=descending)
@@ -768,16 +914,22 @@ def test_sort_nan_1942() -> None:
     assert (end - start) < 1.0
 
 
-def test_sort_chunked_no_nulls() -> None:
+@pytest.mark.parametrize(
+    ("sort_function", "expected"),
+    [
+        (lambda x: x, [1, 3, 0, 2]),
+        (lambda x: x.sort("values", descending=False), [0, 1, 2, 3]),
+        (lambda x: x.sort("values", descending=True), [2, 3, 0, 1]),
+    ],
+)
+def test_sort_chunked_no_nulls(
+    sort_function: Callable[[pl.DataFrame], pl.DataFrame], expected: list[int]
+) -> None:
     df = pl.DataFrame({"values": [3.0, 2.0]})
     df = pl.concat([df, df], rechunk=False)
+    df = sort_function(df)
 
-    assert df.with_columns(pl.col("values").arg_sort())["values"].to_list() == [
-        1,
-        3,
-        0,
-        2,
-    ]
+    assert df.with_columns(pl.col("values").arg_sort())["values"].to_list() == expected
 
 
 def test_sort_string_nulls() -> None:


### PR DESCRIPTION
Add fast paths for series.arg_sort and dataframe.sort(single column) in the following cases -
1) Key column has no nulls and is sorted in the required order 
2) Key column has no nulls and is sorted in the opposite order 
3) Key column has nulls ,is sorted in the required order and has nulls in the correct place

For the second case, if maintain_order is false, technically we can simply return the reverse of 0..len. However current behavior is that we still do a stable sort on it, maintaining order of elements. This is also the expectation in some unrelated test cases. To maintain this behavior, I have implemented a linear algorithm to do a stable reverse sort. This is faster than the current implementation which is also linear for sorting already sorted data, but takes more time due to creating a copy of the data.

Closes #19364
### Benchmarks
**dataframe.sort**
<details>
<summary>Code </summary>

```
import numpy as np
import polars as pl
n = 1_000_000
df = pl.DataFrame({
    "a": np.random.rand(n),
    "b": np.random.rand(n),
})

# -- One column
print("A unsorted")
df2 = df.select("a")
%timeit df2.sort("a")

print("A sorted")
df2 = df.select("a").sort("a")
%timeit df2.sort("a")

# -- Two columns
print("A unsorted, B unsorted")
df2 = df.clone()
%timeit df2.sort("a")

print("A sorted, B unsorted")
df2 = df.sort("a")
%timeit df2.sort("a")

print("A sorted reverse, B unsorted")
df2 = df.sort("a",descending=True)
%timeit df2.sort("a")


df_nulls = pl.DataFrame({
    "a": np.random.rand(n).tolist()+[None],
    "b": np.random.rand(n).tolist()+[None],
})
print("A sorted, with null")
df2_nulls = df_nulls.sort("a")
%timeit df2_nulls.sort("a")
```
</details>

| case  | Time taken Before| Time taken After |
| ------------- | ------------- | ------------- |
| A unsorted| 32.7 ms ± 651 μs | 32 ms ± 1.33 ms |
| A sorted| 11.6 ms ± 52.6 μs | **6.08 μs ± 24.2 ns** |
| A sorted reverse| 17.6 ms ± 1.43 ms | **4.75 ms ± 244 μs** |
| A sorted, with null| 14.1 ms ± 560 μs| **6.14 μs ± 43.5 ns** |

**series.arg_sort**
<details>
<summary> Code </summary>

```
import numpy as np
#import polars as pl
n = 1_000_000
df = pl.DataFrame({
    "a": np.random.rand(n),
    "b": np.random.rand(n),
})
s=df["a"]
%timeit s.arg_sort()

s=df.sort("a")["a"]
%timeit s.arg_sort()
%timeit s.arg_sort(descending=True)
df_nulls = pl.DataFrame({
    "a": np.random.rand(n).tolist()+[None],
    "b": np.random.rand(n).tolist()+[None],
})
s_nulls=df_nulls.sort("a")["a"]
%timeit s_nulls.arg_sort()
```
</details>

| case  | Time taken Before| Time taken After |
| ------------- | ------------- | ------------- |
| A unsorted| 27.2 ms ± 715 μs| 27.5 ms ± 472 μs |
| A sorted| 9.85 ms ± 51.2 μs | **71.2 μs ± 362 ns** |
| A sorted reverse| 12.7 ms ± 298 μs | **1.99 ms ± 9.96 μs** |
| A sorted, with null| 11 ms ± 67.7 μs | **69.8 μs ± 744 ns** |

### Testing

We need to ensure that even if we take fast path we do not change the final array. I have modified some pre existing tests to also test for fast path. I have added an additional test which checks for correctness of sorting.

