### PR TITLE
refactor: Implement nested row encoding / decoding

### DIFF
--- a/crates/polars-arrow/src/array/dictionary/typed_iterator.rs
+++ b/crates/polars-arrow/src/array/dictionary/typed_iterator.rs
@@ -181,6 +181,7 @@ impl<'a, K: DictionaryKey, V: DictValue> Iterator for DictionaryIterTyped<'a, K,
 
 unsafe impl<K: DictionaryKey, V: DictValue> TrustedLen for DictionaryIterTyped<'_, K, V> {}
 
+impl<K: DictionaryKey, V: DictValue> ExactSizeIterator for DictionaryIterTyped<'_, K, V> {}
 impl<K: DictionaryKey, V: DictValue> DoubleEndedIterator for DictionaryIterTyped<'_, K, V> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -1,5 +1,5 @@
 use super::{new_empty_array, new_null_array, Array, ArrayRef, Splitable};
-use crate::bitmap::Bitmap;
+use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::datatypes::{ArrowDataType, Field};
 
 mod ffi;
@@ -224,6 +224,32 @@ impl FixedSizeListArray {
             prev_array = &a.values;
         }
         dims
+    }
+
+    pub fn propagate_nulls(&self) -> Self {
+        let Some(validity) = self.validity() else {
+            return self.clone();
+        };
+
+        let propagated_validity = if self.size == 1 {
+            validity.clone()
+        } else {
+            Bitmap::from_trusted_len_iter(
+                (0..self.size * validity.len())
+                    .map(|i| unsafe { validity.get_bit_unchecked(i / self.size) }),
+            )
+        };
+
+        let propagated_validity = match self.values.validity() {
+            None => propagated_validity,
+            Some(val) => val & &propagated_validity,
+        };
+        Self::new(
+            self.dtype().clone(),
+            self.length.clone(),
+            self.values.with_validity(Some(propagated_validity)),
+            self.validity.clone(),
+        )
     }
 }
 

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -1,5 +1,5 @@
 use super::{new_empty_array, new_null_array, Array, ArrayRef, Splitable};
-use crate::bitmap::{Bitmap, MutableBitmap};
+use crate::bitmap::Bitmap;
 use crate::datatypes::{ArrowDataType, Field};
 
 mod ffi;
@@ -246,7 +246,7 @@ impl FixedSizeListArray {
         };
         Self::new(
             self.dtype().clone(),
-            self.length.clone(),
+            self.length,
             self.values.with_validity(Some(propagated_validity)),
             self.validity.clone(),
         )

--- a/crates/polars-arrow/src/offset.rs
+++ b/crates/polars-arrow/src/offset.rs
@@ -514,7 +514,7 @@ impl<O: Offset> OffsetsBuffer<O> {
 
     /// Returns `(offset, len)` pairs.
     #[inline]
-    pub fn offset_and_length_iter(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+    pub fn offset_and_length_iter(&self) -> impl ExactSizeIterator<Item = (usize, usize)> + '_ {
         self.windows(2).map(|x| {
             let [l, r] = x else { unreachable!() };
             let l = l.to_usize();

--- a/crates/polars-arrow/src/trusted_len.rs
+++ b/crates/polars-arrow/src/trusted_len.rs
@@ -1,6 +1,6 @@
 //! Declares [`TrustedLen`].
 use std::iter::Scan;
-use std::slice::Iter;
+use std::slice::{Iter, IterMut};
 
 /// An iterator of known, fixed size.
 ///
@@ -14,6 +14,7 @@ use std::slice::Iter;
 pub unsafe trait TrustedLen: Iterator {}
 
 unsafe impl<T> TrustedLen for Iter<'_, T> {}
+unsafe impl<T> TrustedLen for IterMut<'_, T> {}
 
 unsafe impl<'a, I, T: 'a> TrustedLen for std::iter::Copied<I>
 where

--- a/crates/polars-core/src/chunked_array/ops/row_encode.rs
+++ b/crates/polars-core/src/chunked_array/ops/row_encode.rs
@@ -144,20 +144,8 @@ pub fn _get_rows_encoded_unordered(by: &[Series]) -> PolarsResult<RowsEncoded> {
 
         let arr = _get_rows_encoded_compat_array(by)?;
         let field = EncodingField::new_unsorted();
-        match arr.dtype() {
-            // Flatten the struct fields.
-            ArrowDataType::Struct(_) => {
-                let arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
-                for arr in arr.values() {
-                    cols.push(arr.clone() as ArrayRef);
-                    fields.push(field)
-                }
-            },
-            _ => {
-                cols.push(arr);
-                fields.push(field)
-            },
-        }
+        cols.push(arr);
+        fields.push(field);
     }
     Ok(convert_columns(num_rows, &cols, &fields))
 }
@@ -187,21 +175,8 @@ pub fn _get_rows_encoded(
             nulls_last: *null_last,
             no_order: false,
         };
-        match arr.dtype() {
-            // Flatten the struct fields.
-            ArrowDataType::Struct(_) => {
-                let arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
-                let arr = arr.propagate_nulls();
-                for value_arr in arr.values() {
-                    cols.push(value_arr.clone() as ArrayRef);
-                    fields.push(sort_field);
-                }
-            },
-            _ => {
-                cols.push(arr);
-                fields.push(sort_field);
-            },
-        }
+        cols.push(arr);
+        fields.push(sort_field);
     }
     Ok(convert_columns(num_rows, &cols, &fields))
 }

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -66,6 +66,9 @@ unsafe fn decode(rows: &mut [&[u8]], field: &EncodingField, dtype: &ArrowDataTyp
                 .collect();
             StructArray::new(dtype.clone(), rows.len(), values, None).to_boxed()
         },
+        ArrowDataType::FixedSizeList(fsl_field, width) => {
+            decode(rows, field, fsl_field.dtype())
+        }
         ArrowDataType::List { .. } | ArrowDataType::LargeList { .. } => {
             todo!("list decoding is not yet supported in polars' row encoding")
         },

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -1,8 +1,10 @@
+use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::buffer::Buffer;
 use arrow::datatypes::ArrowDataType;
 use arrow::offset::OffsetsBuffer;
 
 use self::encode::fixed_size;
+use self::fixed::get_null_sentinel;
 use super::*;
 use crate::fixed::{decode_bool, decode_primitive};
 use crate::variable::{decode_binary, decode_binview};
@@ -39,6 +41,113 @@ pub unsafe fn decode_rows(
         .zip(fields)
         .map(|(dtype, field)| decode(rows, field, dtype))
         .collect()
+}
+
+unsafe fn decode_validity(
+    rows: &mut [&[u8]],
+    field: &EncodingField,
+) -> Option<Bitmap> {
+    let mut i = 0;
+    let mut bm = MutableBitmap::new();
+    let null_sentinel = get_null_sentinel(field);
+    while i < rows.len() {
+        let v;
+        (v, rows[i]) = rows[i].split_at_unchecked(1);
+        if v[0] == null_sentinel {
+            bm.reserve(rows.len());
+            bm.extend_constant(i, true);
+            bm.push(false);
+            i += 1;
+            break;
+        }
+        i += 1;
+    }
+
+    if i == rows.len() {
+        return None;
+    }
+
+    bm.extend_from_trusted_len_iter(rows[i..].iter_mut().map(|row| {
+        let v;
+        (v, *row) = row.split_at_unchecked(1);
+        v[0] != null_sentinel
+    }));
+
+    Some(bm.freeze())
+}
+
+fn rows_for_fixed_size_list<'a>(
+    dtype: &ArrowDataType,
+    field: &EncodingField,
+    width: usize,
+    rows: &mut [&'a [u8]],
+    nested_rows: &mut Vec<&'a [u8]>,
+) {
+    nested_rows.clear();
+    nested_rows.reserve(rows.len() * width);
+
+    // Fast path: if the size is fixed, we can just divide.
+    if let Some(size) = fixed_size(dtype) {
+        for r in 0..rows.len() {
+            for i in 0..width {
+                nested_rows.push(&rows[r][(i * size)..][..size]);
+            }
+            rows[r] = &rows[r][size * width..];
+        }
+        return;
+    }
+
+    use ArrowDataType as D;
+    match dtype {
+        D::FixedSizeBinary(_) => todo!(),
+        D::BinaryView
+        | D::Utf8View
+        | D::Binary
+        | D::LargeBinary
+        | D::Utf8
+        | D::LargeUtf8
+        | D::List(_)
+        | D::LargeList(_) => {
+            let (non_empty_sentinel, continuation_token) = if field.descending {
+                (
+                    !variable::NON_EMPTY_SENTINEL,
+                    !variable::BLOCK_CONTINUATION_TOKEN,
+                )
+            } else {
+                (
+                    variable::NON_EMPTY_SENTINEL,
+                    variable::BLOCK_CONTINUATION_TOKEN,
+                )
+            };
+
+            for r in 0..rows.len() {
+                for i in 0..width {
+                    let length = unsafe {
+                        crate::variable::encoded_item_len(
+                            rows[r],
+                            non_empty_sentinel,
+                            continuation_token,
+                        )
+                    };
+                    let v;
+                    (v, rows[r]) = rows[r].split_at(length);
+                    nested_rows.push(v);
+                }
+            }
+        },
+        D::FixedSizeList(field, _) => todo!(),
+        D::Struct(vec) => todo!(),
+        D::Dictionary(integer_type, arrow_data_type, _) => todo!(),
+        D::Extension(pl_small_str, arrow_data_type, pl_small_str1) => todo!(),
+        D::Unknown => todo!(),
+
+        D::Union(_, _, _) => todo!(),
+        D::Map(_, _) => todo!(),
+        D::Decimal(_, _) => todo!(),
+        D::Decimal256(_, _) => todo!(),
+
+        _ => unreachable!(),
+    }
 }
 
 fn offsets_from_dtype_and_data<'a>(
@@ -82,11 +191,10 @@ fn offsets_from_dtype_and_data<'a>(
             let mut offset = 0;
             while !data.is_empty() {
                 let length = unsafe {
-                    crate::variable::decoded_len(
+                    crate::variable::encoded_item_len(
                         data,
                         non_empty_sentinel,
                         continuation_token,
-                        field.descending,
                     )
                 };
                 offsets.push(offset);
@@ -94,10 +202,10 @@ fn offsets_from_dtype_and_data<'a>(
                 offset += length;
             }
         },
-        D::FixedSizeList(field, _) => todo!(),
-        D::Struct(vec) => todo!(),
-        D::Dictionary(integer_type, arrow_data_type, _) => todo!(),
-        D::Extension(pl_small_str, arrow_data_type, pl_small_str1) => todo!(),
+        D::FixedSizeList(_, _) => todo!(),
+        D::Struct(_) => todo!(),
+        D::Dictionary(_, _, _) => todo!(),
+        D::Extension(_, _, _) => todo!(),
         D::Unknown => todo!(),
 
         D::Union(_, _, _) => todo!(),
@@ -131,13 +239,23 @@ unsafe fn decode(rows: &mut [&[u8]], field: &EncodingField, dtype: &ArrowDataTyp
             .to_boxed()
         },
         ArrowDataType::Struct(fields) => {
+            let validity = decode_validity(rows, field);
             let values = fields
                 .iter()
                 .map(|struct_fld| decode(rows, field, struct_fld.dtype()))
                 .collect();
-            StructArray::new(dtype.clone(), rows.len(), values, None).to_boxed()
+            StructArray::new(dtype.clone(), rows.len(), values, validity).to_boxed()
         },
-        ArrowDataType::FixedSizeList(fsl_field, width) => decode(rows, field, fsl_field.dtype()),
+        ArrowDataType::FixedSizeList(fsl_field, width) => {
+            let validity = decode_validity(rows, field);
+
+            // @TODO: scratchpad
+            let mut nested_rows = Vec::new();
+            rows_for_fixed_size_list(fsl_field.dtype(), field, *width, rows, &mut nested_rows);
+            let values = decode(&mut nested_rows, field, fsl_field.dtype());
+
+            FixedSizeListArray::new(dtype.clone(), rows.len(), values, validity).to_boxed()
+        },
         ArrowDataType::List(list_field) | ArrowDataType::LargeList(list_field) => {
             let arr = decode_binary(rows, field);
 

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -97,14 +97,16 @@ fn dtype_and_data_to_encoded_item_len(
 
     use ArrowDataType as D;
     match dtype {
-        D::Binary |
-        D::LargeBinary |
-        D::Utf8 |
-        D::LargeUtf8 |
-        D::List(_) |
-        D::LargeList(_) |
-        D::BinaryView |
-        D::Utf8View => unsafe { crate::variable::encoded_item_len(data, non_empty_sentinel, continuation_token) },
+        D::Binary
+        | D::LargeBinary
+        | D::Utf8
+        | D::LargeUtf8
+        | D::List(_)
+        | D::LargeList(_)
+        | D::BinaryView
+        | D::Utf8View => unsafe {
+            crate::variable::encoded_item_len(data, non_empty_sentinel, continuation_token)
+        },
 
         D::FixedSizeBinary(_) => todo!(),
         D::FixedSizeList(fsl_field, width) => {
@@ -112,7 +114,7 @@ fn dtype_and_data_to_encoded_item_len(
             let mut item_len = 1; // validity byte
 
             for _ in 0..*width {
-                let len =  dtype_and_data_to_encoded_item_len(fsl_field.dtype(), data, field);
+                let len = dtype_and_data_to_encoded_item_len(fsl_field.dtype(), data, field);
                 data = &data[len..];
                 item_len += len;
             }
@@ -123,7 +125,7 @@ fn dtype_and_data_to_encoded_item_len(
             let mut item_len = 1; // validity byte
 
             for struct_field in struct_fields {
-                let len =  dtype_and_data_to_encoded_item_len(struct_field.dtype(), data, field);
+                let len = dtype_and_data_to_encoded_item_len(struct_field.dtype(), data, field);
                 data = &data[len..];
                 item_len += len;
             }
@@ -137,7 +139,7 @@ fn dtype_and_data_to_encoded_item_len(
         D::Decimal256(_, _) => todo!(),
         D::Extension(_, _, _) => todo!(),
         D::Unknown => todo!(),
-        
+
         _ => unreachable!(),
     }
 }
@@ -211,7 +213,7 @@ fn rows_for_fixed_size_list<'a>(
                     nested_rows.push(v);
                 }
             }
-        }
+        },
     }
 }
 
@@ -272,7 +274,7 @@ fn offsets_from_dtype_and_data<'a>(
                 data = &data[length..];
                 offset += length;
             }
-        }
+        },
     }
 }
 

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -63,7 +63,7 @@ unsafe fn decode_validity(
         i += 1;
     }
 
-    if i == rows.len() {
+    if bm.is_empty() {
         return None;
     }
 

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -278,7 +278,14 @@ fn offsets_from_dtype_and_data(
 
 unsafe fn decode(rows: &mut [&[u8]], field: &EncodingField, dtype: &ArrowDataType) -> ArrayRef {
     match dtype {
-        ArrowDataType::Null => NullArray::new(ArrowDataType::Null, rows.len()).to_boxed(),
+        ArrowDataType::Null => {
+            // Temporary: remove when list encoding is better.
+            for row in rows.iter_mut() {
+                *row = &row[1..];
+            }
+
+            NullArray::new(ArrowDataType::Null, rows.len()).to_boxed()
+        },
         ArrowDataType::Boolean => decode_bool(rows, field).to_boxed(),
         ArrowDataType::BinaryView | ArrowDataType::LargeBinary => {
             decode_binview(rows, field).to_boxed()

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -1,5 +1,8 @@
+use arrow::buffer::Buffer;
 use arrow::datatypes::ArrowDataType;
+use arrow::offset::OffsetsBuffer;
 
+use self::encode::fixed_size;
 use super::*;
 use crate::fixed::{decode_bool, decode_primitive};
 use crate::variable::{decode_binary, decode_binview};
@@ -38,6 +41,74 @@ pub unsafe fn decode_rows(
         .collect()
 }
 
+fn offsets_from_dtype_and_data<'a>(
+    dtype: &ArrowDataType,
+    field: &EncodingField,
+    data: &'a [u8],
+    offsets: &mut Vec<usize>,
+) {
+    offsets.clear();
+
+    // Fast path: if the size is fixed, we can just divide.
+    if let Some(size) = fixed_size(dtype) {
+        assert!(size == 0 || data.len() % size == 0);
+        offsets.extend((0..data.len() / size).map(|i| i * size));
+        return;
+    }
+
+    use ArrowDataType as D;
+    match dtype {
+        D::FixedSizeBinary(_) => todo!(),
+        D::BinaryView
+        | D::Utf8View
+        | D::Binary
+        | D::LargeBinary
+        | D::Utf8
+        | D::LargeUtf8
+        | D::List(_)
+        | D::LargeList(_) => {
+            let mut data = data;
+            let (non_empty_sentinel, continuation_token) = if field.descending {
+                (
+                    !variable::NON_EMPTY_SENTINEL,
+                    !variable::BLOCK_CONTINUATION_TOKEN,
+                )
+            } else {
+                (
+                    variable::NON_EMPTY_SENTINEL,
+                    variable::BLOCK_CONTINUATION_TOKEN,
+                )
+            };
+            let mut offset = 0;
+            while !data.is_empty() {
+                let length = unsafe {
+                    crate::variable::decoded_len(
+                        data,
+                        non_empty_sentinel,
+                        continuation_token,
+                        field.descending,
+                    )
+                };
+                offsets.push(offset);
+                data = &data[length..];
+                offset += length;
+            }
+        },
+        D::FixedSizeList(field, _) => todo!(),
+        D::Struct(vec) => todo!(),
+        D::Dictionary(integer_type, arrow_data_type, _) => todo!(),
+        D::Extension(pl_small_str, arrow_data_type, pl_small_str1) => todo!(),
+        D::Unknown => todo!(),
+
+        D::Union(_, _, _) => todo!(),
+        D::Map(_, _) => todo!(),
+        D::Decimal(_, _) => todo!(),
+        D::Decimal256(_, _) => todo!(),
+
+        _ => unreachable!(),
+    }
+}
+
 unsafe fn decode(rows: &mut [&[u8]], field: &EncodingField, dtype: &ArrowDataType) -> ArrayRef {
     match dtype {
         ArrowDataType::Null => NullArray::new(ArrowDataType::Null, rows.len()).to_boxed(),
@@ -66,11 +137,47 @@ unsafe fn decode(rows: &mut [&[u8]], field: &EncodingField, dtype: &ArrowDataTyp
                 .collect();
             StructArray::new(dtype.clone(), rows.len(), values, None).to_boxed()
         },
-        ArrowDataType::FixedSizeList(fsl_field, width) => {
-            decode(rows, field, fsl_field.dtype())
-        }
-        ArrowDataType::List { .. } | ArrowDataType::LargeList { .. } => {
-            todo!("list decoding is not yet supported in polars' row encoding")
+        ArrowDataType::FixedSizeList(fsl_field, width) => decode(rows, field, fsl_field.dtype()),
+        ArrowDataType::List(list_field) | ArrowDataType::LargeList(list_field) => {
+            let arr = decode_binary(rows, field);
+
+            let mut offsets = Vec::with_capacity(rows.len());
+            // @TODO: Make into scratchpad
+            let mut nested_offsets = Vec::new();
+            offsets_from_dtype_and_data(
+                list_field.dtype(),
+                field,
+                arr.values().as_ref(),
+                &mut nested_offsets,
+            );
+            // @TODO: This might cause realloc, fix.
+            nested_offsets.push(arr.values().len());
+            let mut nested_rows = nested_offsets
+                .windows(2)
+                .map(|vs| &arr.values()[vs[0]..vs[1]])
+                .collect::<Vec<_>>();
+
+            let mut i = 0;
+            for offset in arr.offsets().iter() {
+                while nested_offsets[i] != offset.as_usize() {
+                    i += 1;
+                }
+
+                offsets.push(i as i64);
+            }
+            assert_eq!(offsets.len(), rows.len() + 1);
+
+            let values = decode(&mut nested_rows, field, list_field.dtype());
+            let (_, _, _, validity) = arr.into_inner();
+
+            // @TODO: Handle validity
+            ListArray::<i64>::new(
+                dtype.clone(),
+                unsafe { OffsetsBuffer::new_unchecked(Buffer::from(offsets)) },
+                values,
+                validity,
+            )
+            .to_boxed()
         },
         dt => {
             with_match_arrow_primitive_type!(dt, |$T| {

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -43,10 +43,7 @@ pub unsafe fn decode_rows(
         .collect()
 }
 
-unsafe fn decode_validity(
-    rows: &mut [&[u8]],
-    field: &EncodingField,
-) -> Option<Bitmap> {
+unsafe fn decode_validity(rows: &mut [&[u8]], field: &EncodingField) -> Option<Bitmap> {
     let mut i = 0;
     let mut bm = MutableBitmap::new();
     let null_sentinel = get_null_sentinel(field);
@@ -191,11 +188,7 @@ fn offsets_from_dtype_and_data<'a>(
             let mut offset = 0;
             while !data.is_empty() {
                 let length = unsafe {
-                    crate::variable::encoded_item_len(
-                        data,
-                        non_empty_sentinel,
-                        continuation_token,
-                    )
+                    crate::variable::encoded_item_len(data, non_empty_sentinel, continuation_token)
                 };
                 offsets.push(offset);
                 data = &data[length..];

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -792,17 +792,12 @@ unsafe fn encode_primitive<T: NativeType + FixedLengthEncoding>(
     buffer: &mut [MaybeUninit<u8>],
     arr: &PrimitiveArray<T>,
     field: &EncodingField,
-    row_starts: &mut [usize],
+    offsets: &mut [usize],
 ) {
     if arr.null_count() == 0 {
-        crate::fixed::encode_slice(buffer, arr.values().as_slice(), field, row_starts)
+        crate::fixed::encode_slice(buffer, arr.values().as_slice(), field, offsets)
     } else {
-        crate::fixed::encode_iter(
-            buffer,
-            arr.into_iter().map(|v| v.copied()),
-            field,
-            row_starts,
-        )
+        crate::fixed::encode_iter(buffer, arr.into_iter().map(|v| v.copied()), field, offsets)
     }
 }
 

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -41,10 +41,10 @@ pub fn convert_columns_amortized_no_order(
     );
 }
 
-pub fn convert_columns_amortized<'a, I: IntoIterator<Item = &'a EncodingField> + Clone>(
+pub fn convert_columns_amortized<'a>(
     num_rows: usize,
-    columns: &'a [ArrayRef],
-    fields: I,
+    columns: &[ArrayRef],
+    fields: impl IntoIterator<Item = &'a EncodingField> + Clone,
     rows: &mut RowsEncoded,
 ) {
     let mut row_widths = RowWidths::new(num_rows);
@@ -712,7 +712,6 @@ unsafe fn encode_array(
         EncoderState::Struct(arrays) => {
             encode_validity(buffer, encoder.array.validity(), field, offsets);
 
-
             if arrays.is_empty() {
                 return;
             }
@@ -797,11 +796,7 @@ pub fn fixed_size(dtype: &ArrowDataType) -> Option<usize> {
         Float32 => f32::ENCODED_LEN,
         Float64 => f64::ENCODED_LEN,
         Boolean => bool::ENCODED_LEN,
-<<<<<<< HEAD
-       FixedSizeList(f, width) => width * fixed_size(f.dtype())?,
-=======
         FixedSizeList(f, width) => 1 + width * fixed_size(f.dtype())?,
->>>>>>> 5cbb72759b (working arrays and struct validity)
         Struct(fs) => {
             let mut sum = 0;
             for f in fs {

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -593,13 +593,8 @@ unsafe fn encode_flat_array(
                 .iter_typed::<Utf8ViewArray>()
                 .unwrap()
                 .map(|opt_s| opt_s.map(|s| s.as_bytes()));
-            crate::variable::encode_iter(
-                buffer,
-                iter,
-                field,
-                offsets,
-            );
-        }
+            crate::variable::encode_iter(buffer, iter, field, offsets);
+        },
 
         D::FixedSizeBinary(_) => todo!(),
         D::Decimal(_, _) => todo!(),

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -712,6 +712,7 @@ unsafe fn encode_array(
         EncoderState::Struct(arrays) => {
             encode_validity(buffer, encoder.array.validity(), field, offsets);
 
+
             if arrays.is_empty() {
                 return;
             }
@@ -724,12 +725,14 @@ unsafe fn encode_array(
         },
     }
 
-    match &encoder.widths {
-        RowWidths::Constant { width, .. } => offsets.iter_mut().for_each(|v| *v += *width),
-        RowWidths::Variable { widths, .. } => offsets
-            .iter_mut()
-            .zip(widths.iter())
-            .for_each(|(v, w)| *v += *w),
+    if !matches!(encoder.state, EncoderState::Stateless) {
+        match &encoder.widths {
+            RowWidths::Constant { width, .. } => offsets.iter_mut().for_each(|v| *v += *width),
+            RowWidths::Variable { widths, .. } => offsets
+                .iter_mut()
+                .zip(widths.iter())
+                .for_each(|(v, w)| *v += *w),
+        }
     }
 }
 

--- a/crates/polars-row/src/variable.rs
+++ b/crates/polars-row/src/variable.rs
@@ -197,7 +197,7 @@ unsafe fn has_nulls(rows: &[&[u8]], null_sentinel: u8) -> bool {
         .any(|row| *row.get_unchecked(0) == null_sentinel)
 }
 
-unsafe fn decoded_len(
+pub(crate) unsafe fn decoded_len(
     row: &[u8],
     non_empty_sentinel: u8,
     continuation_token: u8,

--- a/crates/polars-row/src/variable.rs
+++ b/crates/polars-row/src/variable.rs
@@ -47,20 +47,11 @@ fn padded_length(a: usize) -> usize {
 }
 
 #[inline]
-pub fn encoded_len(a: Option<&[u8]>, field: &EncodingField) -> usize {
-    if field.no_order {
-        4 + a.map(|v| v.len()).unwrap_or(0)
-    } else {
-        a.map(|v| padded_length(v.len())).unwrap_or(1)
-    }
-}
-
-#[inline]
 pub fn encoded_len_from_len(a: Option<usize>, field: &EncodingField) -> usize {
     if field.no_order {
         4 + a.unwrap_or(0)
     } else {
-        a.map_or(1, |v| padded_length(v))
+        a.map_or(1, padded_length)
     }
 }
 

--- a/crates/polars-row/src/variable.rs
+++ b/crates/polars-row/src/variable.rs
@@ -19,7 +19,6 @@ use arrow::offset::Offsets;
 use polars_utils::slice::Slice2Uninit;
 
 use crate::fixed::{decode_nulls, get_null_sentinel};
-use crate::row::RowsEncoded;
 use crate::EncodingField;
 
 /// The block size of the variable length encoding
@@ -53,6 +52,15 @@ pub fn encoded_len(a: Option<&[u8]>, field: &EncodingField) -> usize {
         4 + a.map(|v| v.len()).unwrap_or(0)
     } else {
         a.map(|v| padded_length(v.len())).unwrap_or(1)
+    }
+}
+
+#[inline]
+pub fn encoded_len_from_len(a: Option<usize>, field: &EncodingField) -> usize {
+    if field.no_order {
+        4 + a.unwrap_or(0)
+    } else {
+        a.map_or(1, |v| padded_length(v))
     }
 }
 
@@ -162,32 +170,26 @@ unsafe fn encode_one(
         },
     }
 }
-pub(crate) unsafe fn encode_iter<'a, I: Iterator<Item = Option<&'a [u8]>>>(
-    input: I,
-    out: &mut RowsEncoded,
-    field: &EncodingField,
-) {
-    out.values.set_len(0);
-    let values = out.values.spare_capacity_mut();
 
+pub(crate) unsafe fn encode_iter<'a, I: Iterator<Item = Option<&'a [u8]>>>(
+    buffer: &mut [MaybeUninit<u8>],
+    input: I,
+    field: &EncodingField,
+    row_starts: &mut [usize],
+) {
     if field.no_order {
-        for (offset, opt_value) in out.offsets.iter_mut().skip(1).zip(input) {
-            let dst = values.get_unchecked_mut(*offset..);
+        for (offset, opt_value) in row_starts.iter_mut().zip(input) {
+            let dst = buffer.get_unchecked_mut(*offset..);
             let written_len = encode_one_no_order(dst, opt_value.map(|v| v.as_uninit()), field);
             *offset += written_len;
         }
     } else {
-        for (offset, opt_value) in out.offsets.iter_mut().skip(1).zip(input) {
-            let dst = values.get_unchecked_mut(*offset..);
+        for (offset, opt_value) in row_starts.iter_mut().zip(input) {
+            let dst = buffer.get_unchecked_mut(*offset..);
             let written_len = encode_one(dst, opt_value.map(|v| v.as_uninit()), field);
             *offset += written_len;
         }
     }
-    let offset = out.offsets.last().unwrap();
-    let dst = values.get_unchecked_mut(*offset..);
-    // write remainder as zeros
-    dst.fill(MaybeUninit::new(0));
-    out.values.set_len(out.values.capacity())
 }
 
 unsafe fn has_nulls(rows: &[&[u8]], null_sentinel: u8) -> bool {

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -31,7 +31,6 @@ def roundtrip_re(
 @given(
     df=dataframes(
         excluded_dtypes=[
-            pl.List,
             pl.Array,
             pl.Struct,
             pl.Categorical,
@@ -147,3 +146,23 @@ def test_struct(field: tuple[bool, bool, bool]) -> None:
         ).to_frame(),
         [field],
     )
+
+
+@pytest.mark.parametrize("field", FIELD_COMBS)
+def test_list(field: tuple[bool, bool, bool]) -> None:
+    dtype = pl.List(pl.Int32)
+    roundtrip_re(pl.Series("a", [], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[1], [2]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[1, 2], [3]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[1, 2], [], [3]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [None, [1, 2], None, [], [3]], dtype).to_frame(), [field])
+
+    dtype = pl.List(pl.String)
+    roundtrip_re(pl.Series("a", [], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[""], [""]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["abc"], ["xyzw"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["x", "yx"], ["abc"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["wow", "this is"], [], ["cool"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [None, ["very", "very"], None, [], ["cool"]], dtype).to_frame(), [field])

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -257,6 +257,17 @@ def test_list_struct_arr(field: tuple[bool, bool, bool]) -> None:
     roundtrip_series_re([[{"x": ["a", "xyz"], "y": [1, 7, 3]}], []], dtype, field)
 
 
+@pytest.mark.parametrize("field", FIELD_COMBS)
+def test_list_nulls(field: tuple[bool, bool, bool]) -> None:
+    dtype = pl.List(pl.Null)
+    roundtrip_series_re([], dtype, field)
+    roundtrip_series_re([[]], dtype, field)
+    roundtrip_series_re([None], dtype, field)
+    roundtrip_series_re([[None]], dtype, field)
+    roundtrip_series_re([[None, None, None]], dtype, field)
+    roundtrip_series_re([[None], [None, None], [None, None, None]], dtype, field)
+
+
 def assert_order_dataframe(
     lhs: pl.DataFrame,
     rhs: pl.DataFrame,

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -268,6 +268,18 @@ def test_list_nulls(field: tuple[bool, bool, bool]) -> None:
     roundtrip_series_re([[None], [None, None], [None, None, None]], dtype, field)
 
 
+def test_int_after_null() -> None:
+    roundtrip_re(
+        pl.DataFrame(
+            [
+                pl.Series("a", [None], pl.Null),
+                pl.Series("b", [None], pl.Int8),
+            ]
+        ),
+        [(False, True, False), (False, True, False)],
+    )
+
+
 def assert_order_dataframe(
     lhs: pl.DataFrame,
     rhs: pl.DataFrame,

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -12,12 +12,11 @@ from polars.testing.parametric import column, dataframes
 if TYPE_CHECKING:
     from polars._typing import PolarsDataType
 
-# @TODO: Deal with no_order
 FIELD_COMBS = [
     (descending, nulls_last, False)
     for descending in [False, True]
     for nulls_last in [False, True]
-]
+] + [(False, False, True)]
 
 
 def roundtrip_re(
@@ -27,6 +26,9 @@ def roundtrip_re(
         fields = [(False, False, False)] * df.width
 
     row_encoded = df._row_encode(fields)
+    if any(map(lambda f: f[2], fields)):
+        return
+
     dtypes = [(c, df.get_column(c).dtype) for c in df.columns]
     result = row_encoded._row_decode(dtypes, fields)
 

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import pytest
-from hypothesis import given
 from typing import TYPE_CHECKING
 
+import pytest
+from hypothesis import given
+
 import polars as pl
-from polars.series.series import ArrayLike
 from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
@@ -32,10 +32,14 @@ def roundtrip_re(
 
     assert_frame_equal(df, result)
 
+
 def roundtrip_series_re(
-    values: ArrayLike, dtype: PolarsDataType, field: tuple[bool, bool, bool]
+    values: pl.series.series.ArrayLike,
+    dtype: PolarsDataType,
+    field: tuple[bool, bool, bool],
 ) -> None:
-    roundtrip_re(pl.Series('series', values, dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("series", values, dtype).to_frame(), [field])
+
 
 @given(
     df=dataframes(
@@ -131,11 +135,13 @@ def test_str(field: tuple[bool, bool, bool]) -> None:
     roundtrip_series_re(["", "a", "b", "c"], dtype, field)
 
     roundtrip_series_re(
-        ["different", "length", "strings"], dtype,
+        ["different", "length", "strings"],
+        dtype,
         field,
     )
     roundtrip_series_re(
-            ["different", "", "length", "", "strings"], dtype,
+        ["different", "", "length", "", "strings"],
+        dtype,
         field,
     )
 
@@ -150,50 +156,39 @@ def test_struct(field: tuple[bool, bool, bool]) -> None:
     roundtrip_series_re([{}, None, {}], dtype, field)
 
     dtype = pl.Struct({"x": pl.Int32})
-    roundtrip_series_re(
-        [{"x": 1}], dtype, field
-    )
-    roundtrip_series_re(
-         [None], dtype, field
-    )
-    roundtrip_series_re(
-         [{"x": 1}] * 3, dtype, field
-    )
+    roundtrip_series_re([{"x": 1}], dtype, field)
+    roundtrip_series_re([None], dtype, field)
+    roundtrip_series_re([{"x": 1}] * 3, dtype, field)
 
     dtype = pl.Struct({"x": pl.Int32, "y": pl.Int32})
     roundtrip_series_re(
-            [{"x": 1}, {"y": 2}], 
-            dtype,
+        [{"x": 1}, {"y": 2}],
+        dtype,
         field,
     )
-    roundtrip_series_re(
-         [None], dtype, field
-    )
+    roundtrip_series_re([None], dtype, field)
 
 
 @pytest.mark.parametrize("field", FIELD_COMBS)
 def test_list(field: tuple[bool, bool, bool]) -> None:
     dtype = pl.List(pl.Int32)
-    roundtrip_series_re( [], dtype, field)
-    roundtrip_series_re( [[]], dtype, field)
-    roundtrip_series_re( [[1], [2]], dtype, field)
-    roundtrip_series_re( [[1, 2], [3]], dtype, field)
-    roundtrip_series_re( [[1, 2], [], [3]], dtype, field)
-    roundtrip_series_re(
-         [None, [1, 2], None, [], [3]], dtype, field
-    )
+    roundtrip_series_re([], dtype, field)
+    roundtrip_series_re([[]], dtype, field)
+    roundtrip_series_re([[1], [2]], dtype, field)
+    roundtrip_series_re([[1, 2], [3]], dtype, field)
+    roundtrip_series_re([[1, 2], [], [3]], dtype, field)
+    roundtrip_series_re([None, [1, 2], None, [], [3]], dtype, field)
 
     dtype = pl.List(pl.String)
-    roundtrip_series_re( [], dtype, field)
-    roundtrip_series_re( [[]], dtype, field)
-    roundtrip_series_re( [[""], [""]], dtype, field)
-    roundtrip_series_re( [["abc"], ["xyzw"]], dtype, field)
-    roundtrip_series_re( [["x", "yx"], ["abc"]], dtype, field)
+    roundtrip_series_re([], dtype, field)
+    roundtrip_series_re([[]], dtype, field)
+    roundtrip_series_re([[""], [""]], dtype, field)
+    roundtrip_series_re([["abc"], ["xyzw"]], dtype, field)
+    roundtrip_series_re([["x", "yx"], ["abc"]], dtype, field)
+    roundtrip_series_re([["wow", "this is"], [], ["cool"]], dtype, field)
     roundtrip_series_re(
-         [["wow", "this is"], [], ["cool"]], dtype, field
-    )
-    roundtrip_series_re(
-         [None, ["very", "very"], None, [], ["cool"]], dtype,
+        [None, ["very", "very"], None, [], ["cool"]],
+        dtype,
         field,
     )
 
@@ -201,39 +196,37 @@ def test_list(field: tuple[bool, bool, bool]) -> None:
 @pytest.mark.parametrize("field", FIELD_COMBS)
 def test_array(field: tuple[bool, bool, bool]) -> None:
     dtype = pl.Array(pl.Int32, 0)
-    roundtrip_series_re( [], dtype, field)
-    roundtrip_series_re( [[]], dtype, field)
-    roundtrip_series_re( [None, [], None], dtype, field)
-    roundtrip_series_re( [None], dtype, field)
+    roundtrip_series_re([], dtype, field)
+    roundtrip_series_re([[]], dtype, field)
+    roundtrip_series_re([None, [], None], dtype, field)
+    roundtrip_series_re([None], dtype, field)
 
     dtype = pl.Array(pl.Int32, 2)
-    roundtrip_series_re( [], dtype, field)
-    roundtrip_series_re( [[5, 6]], dtype, field)
-    roundtrip_series_re( [[1, 2], [2, 3]], dtype, field)
-    roundtrip_series_re( [[1, 2], [3, 7]], dtype, field)
-    roundtrip_series_re( [[1, 2], [13, 11], [3, 7]], dtype, field)
+    roundtrip_series_re([], dtype, field)
+    roundtrip_series_re([[5, 6]], dtype, field)
+    roundtrip_series_re([[1, 2], [2, 3]], dtype, field)
+    roundtrip_series_re([[1, 2], [3, 7]], dtype, field)
+    roundtrip_series_re([[1, 2], [13, 11], [3, 7]], dtype, field)
     roundtrip_series_re(
-         [None, [1, 2], None, [13, 11], [5, 7]], dtype,
+        [None, [1, 2], None, [13, 11], [5, 7]],
+        dtype,
         field,
     )
 
     dtype = pl.Array(pl.String, 2)
-    roundtrip_series_re( [], dtype, field)
-    roundtrip_series_re( [["a", "b"]], dtype, field)
-    roundtrip_series_re( [["", ""], ["", "a"]], dtype, field)
+    roundtrip_series_re([], dtype, field)
+    roundtrip_series_re([["a", "b"]], dtype, field)
+    roundtrip_series_re([["", ""], ["", "a"]], dtype, field)
+    roundtrip_series_re([["abc", "def"], ["ghi", "xyzw"]], dtype, field)
+    roundtrip_series_re([["x", "yx"], ["abc", "xxx"]], dtype, field)
     roundtrip_series_re(
-         [["abc", "def"], ["ghi", "xyzw"]], dtype, field
-    )
-    roundtrip_series_re(
-         [["x", "yx"], ["abc", "xxx"]], dtype, field
-    )
-    roundtrip_series_re(
-            [["wow", "this is"], ["soo", "so"], ["veryyy", "cool"]], dtype,
+        [["wow", "this is"], ["soo", "so"], ["veryyy", "cool"]],
+        dtype,
         field,
     )
     roundtrip_series_re(
-            [None, ["very", "very"], None, [None, None], ["verryy",
-                                                               "cool"]], dtype,
+        [None, ["very", "very"], None, [None, None], ["verryy", "cool"]],
+        dtype,
         field,
     )
 
@@ -249,16 +242,16 @@ def test_list_arr(field: tuple[bool, bool, bool]) -> None:
     roundtrip_series_re([[["a", "b"], ["xyz", "wowie"]]], dtype, field)
     roundtrip_series_re([[["a", "b"]], None, [None, None]], dtype, field)
 
+
 @pytest.mark.parametrize("field", FIELD_COMBS)
 def test_list_struct_arr(field: tuple[bool, bool, bool]) -> None:
-    dtype = pl.List(pl.Struct({
-        'x': pl.Array(pl.String, 2),
-        'y': pl.Array(pl.Int64, 3)
-    }))
+    dtype = pl.List(
+        pl.Struct({"x": pl.Array(pl.String, 2), "y": pl.Array(pl.Int64, 3)})
+    )
     roundtrip_series_re([], dtype, field)
     roundtrip_series_re([None], dtype, field)
     roundtrip_series_re([[None]], dtype, field)
-    roundtrip_series_re([[{ 'x': None, 'y': None }]], dtype, field)
-    roundtrip_series_re([[{ 'x': ["a", None], 'y': [1, None, 3] }]], dtype, field)
-    roundtrip_series_re([[{ 'x': ["a", "xyz"], 'y': [1, 7, 3] }]], dtype, field)
-    roundtrip_series_re([[{ 'x': ["a", "xyz"], 'y': [1, 7, 3] }], []], dtype, field)
+    roundtrip_series_re([[{"x": None, "y": None}]], dtype, field)
+    roundtrip_series_re([[{"x": ["a", None], "y": [1, None, 3]}]], dtype, field)
+    roundtrip_series_re([[{"x": ["a", "xyz"], "y": [1, 7, 3]}]], dtype, field)
+    roundtrip_series_re([[{"x": ["a", "xyz"], "y": [1, 7, 3]}], []], dtype, field)

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -135,16 +135,33 @@ def test_str(field: tuple[bool, bool, bool]) -> None:
 
 @pytest.mark.parametrize("field", FIELD_COMBS)
 def test_struct(field: tuple[bool, bool, bool]) -> None:
-    roundtrip_re(pl.Series("a", [], pl.Struct({})).to_frame())
-    roundtrip_re(pl.Series("a", [{}], pl.Struct({})).to_frame())
+    dtype = pl.Struct({})
+    roundtrip_re(pl.Series("a", [], dtype).to_frame())
+    roundtrip_re(pl.Series("a", [None], dtype).to_frame())
+    roundtrip_re(pl.Series("a", [{}], dtype).to_frame())
+    roundtrip_re(pl.Series("a", [{}, {}, {}], dtype).to_frame())
+    roundtrip_re(pl.Series("a", [{}, None, {}], dtype).to_frame())
+
+    dtype = pl.Struct({"x": pl.Int32})
     roundtrip_re(
-        pl.Series("a", [{"x": 1}], pl.Struct({"x": pl.Int32})).to_frame(), [field]
+        pl.Series("a", [{"x": 1}], dtype).to_frame(), [field]
     )
     roundtrip_re(
+        pl.Series("a", [None], dtype).to_frame(), [field]
+    )
+    roundtrip_re(
+        pl.Series("a", [{"x": 1}] * 3, dtype).to_frame(), [field]
+    )
+
+    dtype = pl.Struct({"x": pl.Int32, "y": pl.Int32})
+    roundtrip_re(
         pl.Series(
-            "a", [{"x": 1}, {"y": 2}], pl.Struct({"x": pl.Int32, "y": pl.Int32})
+            "a", [{"x": 1}, {"y": 2}], 
         ).to_frame(),
         [field],
+    )
+    roundtrip_re(
+        pl.Series("a", [None], dtype).to_frame(), [field]
     )
 
 
@@ -156,7 +173,9 @@ def test_list(field: tuple[bool, bool, bool]) -> None:
     roundtrip_re(pl.Series("a", [[1], [2]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [[1, 2], [3]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [[1, 2], [], [3]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [None, [1, 2], None, [], [3]], dtype).to_frame(), [field])
+    roundtrip_re(
+        pl.Series("a", [None, [1, 2], None, [], [3]], dtype).to_frame(), [field]
+    )
 
     dtype = pl.List(pl.String)
     roundtrip_re(pl.Series("a", [], dtype).to_frame(), [field])
@@ -164,8 +183,13 @@ def test_list(field: tuple[bool, bool, bool]) -> None:
     roundtrip_re(pl.Series("a", [[""], [""]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [["abc"], ["xyzw"]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [["x", "yx"], ["abc"]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [["wow", "this is"], [], ["cool"]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [None, ["very", "very"], None, [], ["cool"]], dtype).to_frame(), [field])
+    roundtrip_re(
+        pl.Series("a", [["wow", "this is"], [], ["cool"]], dtype).to_frame(), [field]
+    )
+    roundtrip_re(
+        pl.Series("a", [None, ["very", "very"], None, [], ["cool"]], dtype).to_frame(),
+        [field],
+    )
 
 
 @pytest.mark.parametrize("field", FIELD_COMBS)
@@ -182,13 +206,30 @@ def test_array(field: tuple[bool, bool, bool]) -> None:
     roundtrip_re(pl.Series("a", [[1, 2], [2, 3]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [[1, 2], [3, 7]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [[1, 2], [13, 11], [3, 7]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [None, [1, 2], None, [13, 11], [5, 7]], dtype).to_frame(), [field])
+    roundtrip_re(
+        pl.Series("a", [None, [1, 2], None, [13, 11], [5, 7]], dtype).to_frame(),
+        [field],
+    )
 
     dtype = pl.Array(pl.String, 2)
     roundtrip_re(pl.Series("a", [], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [["a", "b"]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [["", ""], ["", "a"]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [["abc", "def"], ["ghi", "xyzw"]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [["x", "yx"], ["abc", "xxx"]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [["wow", "this is"], ["soo", "so"], ["veryyy", "cool"]], dtype).to_frame(), [field])
-    roundtrip_re(pl.Series("a", [None, ["very", "very"], None, [None, None], ["verryy", "cool"]], dtype).to_frame(), [field])
+    roundtrip_re(
+        pl.Series("a", [["abc", "def"], ["ghi", "xyzw"]], dtype).to_frame(), [field]
+    )
+    roundtrip_re(
+        pl.Series("a", [["x", "yx"], ["abc", "xxx"]], dtype).to_frame(), [field]
+    )
+    roundtrip_re(
+        pl.Series(
+            "a", [["wow", "this is"], ["soo", "so"], ["veryyy", "cool"]], dtype
+        ).to_frame(),
+        [field],
+    )
+    roundtrip_re(
+        pl.Series(
+            "a", [None, ["very", "very"], None, [None, None], ["verryy", "cool"]], dtype
+        ).to_frame(),
+        [field],
+    )

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -26,7 +26,7 @@ def roundtrip_re(
         fields = [(False, False, False)] * df.width
 
     row_encoded = df._row_encode(fields)
-    if any(map(lambda f: f[2], fields)):
+    if any(f[2] for f in fields):
         return
 
     dtypes = [(c, df.get_column(c).dtype) for c in df.columns]

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -166,3 +166,29 @@ def test_list(field: tuple[bool, bool, bool]) -> None:
     roundtrip_re(pl.Series("a", [["x", "yx"], ["abc"]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [["wow", "this is"], [], ["cool"]], dtype).to_frame(), [field])
     roundtrip_re(pl.Series("a", [None, ["very", "very"], None, [], ["cool"]], dtype).to_frame(), [field])
+
+
+@pytest.mark.parametrize("field", FIELD_COMBS)
+def test_array(field: tuple[bool, bool, bool]) -> None:
+    dtype = pl.Array(pl.Int32, 0)
+    roundtrip_re(pl.Series("a", [], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [None, [], None], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [None], dtype).to_frame(), [field])
+
+    dtype = pl.Array(pl.Int32, 2)
+    roundtrip_re(pl.Series("a", [], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[5, 6]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[1, 2], [2, 3]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[1, 2], [3, 7]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [[1, 2], [13, 11], [3, 7]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [None, [1, 2], None, [13, 11], [5, 7]], dtype).to_frame(), [field])
+
+    dtype = pl.Array(pl.String, 2)
+    roundtrip_re(pl.Series("a", [], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["a", "b"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["", ""], ["", "a"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["abc", "def"], ["ghi", "xyzw"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["x", "yx"], ["abc", "xxx"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [["wow", "this is"], ["soo", "so"], ["veryyy", "cool"]], dtype).to_frame(), [field])
+    roundtrip_re(pl.Series("a", [None, ["very", "very"], None, [None, None], ["verryy", "cool"]], dtype).to_frame(), [field])


### PR DESCRIPTION
This adds row encoding and decoding for nested types.

It is now possible to properly roundtrip `pl.List`, `pl.Array` and `pl.Struct` including their outer and inner validities through the row encoding en decoding.

Fixes #10747.