### PR TITLE
fix(python): Fixes empty table delta reading and missing columns within nested structs

### DIFF
--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -13,6 +13,7 @@ from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.io.parquet import scan_parquet
 from polars.io.pyarrow_dataset.functions import scan_pyarrow_dataset
 from polars.schema import Schema
+from polars import concat
 
 if TYPE_CHECKING:
     from deltalake import DeltaTable

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+from polars import concat
 from polars.convert import from_arrow
 from polars.datatypes import Null, Time
 from polars.datatypes.convert import unpack_dtypes
@@ -13,7 +14,6 @@ from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
 from polars.io.parquet import scan_parquet
 from polars.io.pyarrow_dataset.functions import scan_pyarrow_dataset
 from polars.schema import Schema
-from polars import concat
 
 if TYPE_CHECKING:
     from deltalake import DeltaTable
@@ -317,7 +317,7 @@ def scan_delta(
     # Requires conversion through pyarrow table because there is no direct way yet to
     # convert a delta schema into a polars schema
     delta_schema = dl_tbl.schema().to_pyarrow(as_large_types=True)
-    empty_delta_schema_lf : pl.LazyFrame = from_arrow(pa.Table.from_pylist([], delta_schema)).lazy() # type: ignore
+    empty_delta_schema_lf : LazyFrame = from_arrow(pa.Table.from_pylist([], delta_schema)).lazy() # type: ignore
     polars_schema = empty_delta_schema_lf.collect_schema()  # type: ignore[union-attr]
     partition_columns = dl_tbl.metadata().partition_columns
 

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -320,7 +320,7 @@ def scan_delta(
     empty_delta_schema_lf: LazyFrame = from_arrow(
         pa.Table.from_pylist([], delta_schema)
     ).lazy()  # type: ignore[union-attr]
-    polars_schema = empty_delta_schema_lf.collect_schema()  # type: ignore[union-attr]
+    polars_schema = empty_delta_schema_lf.collect_schema()
     partition_columns = dl_tbl.metadata().partition_columns
 
     def _split_schema(schema: Schema, partition_columns: list[str]) -> Schema:

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -317,15 +317,15 @@ def scan_delta(
     # Requires conversion through pyarrow table because there is no direct way yet to
     # convert a delta schema into a polars schema
     delta_schema = dl_tbl.schema().to_pyarrow(as_large_types=True)
-    empty_delta_schema_lf : LazyFrame = from_arrow(pa.Table.from_pylist([], delta_schema)).lazy() # type: ignore
+    empty_delta_schema_lf: LazyFrame = from_arrow(
+        pa.Table.from_pylist([], delta_schema)
+    ).lazy()  # type: ignore
     polars_schema = empty_delta_schema_lf.collect_schema()  # type: ignore[union-attr]
     partition_columns = dl_tbl.metadata().partition_columns
 
-    def _split_schema(
-        schema: Schema, partition_columns: list[str]
-    ) -> Schema:
+    def _split_schema(schema: Schema, partition_columns: list[str]) -> Schema:
         if len(partition_columns) == 0:
-            return  Schema([])
+            return Schema([])
         hive_schema = []
 
         for name, dtype in schema.items():
@@ -337,7 +337,7 @@ def scan_delta(
     hive_schema = _split_schema(polars_schema, partition_columns)
 
     if dl_tbl.file_uris():
-        parquet_df= scan_parquet(
+        parquet_df = scan_parquet(
             dl_tbl.file_uris(),
             schema=None,
             hive_schema=hive_schema,

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -319,7 +319,7 @@ def scan_delta(
     delta_schema = dl_tbl.schema().to_pyarrow(as_large_types=True)
     empty_delta_schema_lf: LazyFrame = from_arrow(
         pa.Table.from_pylist([], delta_schema)
-    ).lazy()  # type: ignore
+    ).lazy()  # type: ignore[union-attr]
     polars_schema = empty_delta_schema_lf.collect_schema()  # type: ignore[union-attr]
     partition_columns = dl_tbl.metadata().partition_columns
 


### PR DESCRIPTION
Draft to fix issue https://github.com/pola-rs/polars/issues/19854 (+ additional issues), I want to see if any CI/CD / automation runs. Pending tests


Fixes:
1. The issue with empty tables not fully complying to the schema + also parquet files not FULLY complying to the delta schema
2. Issues with fields missing in nested structs of the parquet files, but added to the delta schema, now they will succeed

Questions:
1. I'm not sure if diagonal_relaxed is what you want as "polars" (it works for me locally of course), as it might have side-effects on data sizes... they should be minor though, as in theory the parquet files within a delta table should be compatible with the schema
2. Should we rechunk also in the concat? I think its not needed as its just an empty_dataframe + the real already-rechunked dataframe
3. I think rather than a "diagonal_relaxed", allow_missing_columns=True should be fixed on rust side of the code to allow nested missing columns (this would help parquet aswell)