### PR TITLE
fix: Fix panic with empty delta scan, or empty parquet scan with a provided schema

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -77,9 +77,9 @@ pub fn expanded_from_single_directory<P: AsRef<std::path::Path>>(
             !is_cloud_url(paths[0].as_ref()) && paths[0].as_ref().is_dir()
         )
         || (
-            // Otherwise we check the output path is different from the input path, so that we also
-            // handle the case of a directory containing a single file.
-            !expanded_paths.is_empty() && (paths[0].as_ref() != expanded_paths[0].as_ref())
+            // For cloud paths, we determine that the input path isn't a file by checking that the
+            // output path differs.
+            expanded_paths.is_empty() || (paths[0].as_ref() != expanded_paths[0].as_ref())
         )
     }
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -244,7 +244,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 {
                     polars_bail!(
                         ComputeError:
-                        "a hive schema was given but hive_partitioning was not enabled"
+                        "a hive schema was given but hive_partitioning was disabled"
                     )
                 }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -235,7 +235,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 };
 
                 if file_options.hive_options.enabled.is_none() {
-                    // TODO: Auto-enable this based on whether we received a hive schema.
+                    // TODO: Auto-enable this if `hive_options.schema` was given.
                     file_options.hive_options.enabled = Some(false);
                 }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -328,7 +328,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         .unwrap();
                 }
 
-                let ir = if sources.is_empty() {
+                let ir = if sources.is_empty() && !matches!(scan_type, FileScan::Anonymous { .. }) {
                     IR::DataFrameScan {
                         df: Arc::new(DataFrame::empty_with_schema(&file_info.schema)),
                         schema: file_info.schema,

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -238,7 +238,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     file_options.hive_options.enabled = Some(false);
                 }
 
-                if file_options.hive_options.enabled == Some(false)
+                if file_options.hive_options.enabled.unwrap() == false
                     && file_options.hive_options.schema.is_some()
                 {
                     polars_bail!(

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -235,11 +235,12 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 };
 
                 if file_options.hive_options.enabled.is_none() {
+                    // TODO: Auto-enable this based on whether we received a hive schema.
                     file_options.hive_options.enabled = Some(false);
                 }
 
-                if file_options.hive_options.enabled.unwrap() == false
-                    && file_options.hive_options.schema.is_some()
+                if file_options.hive_options.schema.is_some()
+                    && !file_options.hive_options.enabled.unwrap()
                 {
                     polars_bail!(
                         ComputeError:

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -234,18 +234,19 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     },
                 };
 
-                if file_options.hive_options.enabled.is_none() {
-                    // TODO: Auto-enable this if `hive_options.schema` was given.
-                    file_options.hive_options.enabled = Some(false);
-                }
-
                 if file_options.hive_options.schema.is_some()
-                    && !file_options.hive_options.enabled.unwrap()
+                    && file_options.hive_options.enabled == Some(false)
                 {
+                    // hive_partitioning was explicitly disabled
                     polars_bail!(
                         ComputeError:
                         "a hive schema was given but hive_partitioning was disabled"
                     )
+                }
+
+                if file_options.hive_options.enabled.is_none() {
+                    // TODO: Auto-enable this if `hive_options.schema` was given.
+                    file_options.hive_options.enabled = Some(false);
                 }
 
                 let hive_parts = if file_options.hive_options.enabled.unwrap()

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -279,6 +279,9 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     let hive_schema = hive_parts[0].schema();
                     file_info.update_schema_with_hive_schema(hive_schema.clone());
                 } else if let Some(hive_schema) = file_options.hive_options.schema.clone() {
+                    // We hit here if we are passed the `hive_schema` to `scan_parquet` but end up with an empty file
+                    // list during path expansion. In this case we still want to return an empty DataFrame with this
+                    // schema.
                     file_info.update_schema_with_hive_schema(hive_schema);
                 }
 

--- a/crates/polars-plan/src/plans/ir/scan_sources.rs
+++ b/crates/polars-plan/src/plans/ir/scan_sources.rs
@@ -54,7 +54,7 @@ pub struct ScanSourceIter<'a> {
 
 impl Default for ScanSources {
     fn default() -> Self {
-        Self::Buffers(Arc::default())
+        Self::Paths(Arc::default())
     }
 }
 
@@ -106,6 +106,8 @@ impl ScanSources {
         }
     }
 
+    /// This will update `file_options.hive_options.enabled` to `true` if the existing value is `None`
+    /// and the paths are expanded from a single directory. Otherwise the existing value is maintained.
     #[cfg(any(feature = "ipc", feature = "parquet"))]
     pub fn expand_paths_with_hive_update(
         &self,
@@ -114,26 +116,23 @@ impl ScanSources {
     ) -> PolarsResult<Self> {
         match self {
             Self::Paths(paths) => {
-                let hive_enabled = file_options.hive_options.enabled;
                 let (expanded_paths, hive_start_idx) = expand_paths_hive(
                     paths,
                     file_options.glob,
                     cloud_options,
-                    hive_enabled.unwrap_or(false),
+                    file_options.hive_options.enabled.unwrap_or(false),
                 )?;
-                let inferred_hive_enabled = hive_enabled.unwrap_or_else(|| {
-                    expanded_from_single_directory(paths, expanded_paths.as_ref())
-                });
 
-                file_options.hive_options.enabled = Some(inferred_hive_enabled);
+                if file_options.hive_options.enabled.is_none()
+                    && expanded_from_single_directory(paths, expanded_paths.as_ref())
+                {
+                    file_options.hive_options.enabled = Some(true);
+                }
                 file_options.hive_options.hive_start_idx = hive_start_idx;
 
                 Ok(Self::Paths(expanded_paths))
             },
-            v => {
-                file_options.hive_options.enabled = Some(false);
-                Ok(v.clone())
-            },
+            v => Ok(v.clone()),
         }
     }
 

--- a/crates/polars-plan/src/plans/ir/scan_sources.rs
+++ b/crates/polars-plan/src/plans/ir/scan_sources.rs
@@ -54,6 +54,8 @@ pub struct ScanSourceIter<'a> {
 
 impl Default for ScanSources {
     fn default() -> Self {
+        // We need to use `Paths` here to avoid erroring when doing hive-partitioned scans of empty
+        // file lists.
         Self::Paths(Arc::default())
     }
 }

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -341,7 +341,7 @@ def scan_delta(
     return scan_parquet(
         dl_tbl.file_uris(),
         schema=main_schema,
-        hive_schema=hive_schema,
+        hive_schema=hive_schema if len(partition_columns) > 0 else None,
         allow_missing_columns=True,
         hive_partitioning=len(partition_columns) > 0,
         storage_options=storage_options,

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -264,8 +264,8 @@ def test_init_structured_objects() -> None:
 def test_init_pydantic_2x() -> None:
     class PageView(BaseModel):
         user_id: str
-        ts: datetime = Field(alias=["ts", "$date"])  # type: ignore[literal-required, arg-type]
-        path: str = Field("?", alias=["url", "path"])  # type: ignore[literal-required, arg-type]
+        ts: datetime = Field(alias=["ts", "$date"])  # type: ignore[literal-required, call-overload]
+        path: str = Field("?", alias=["url", "path"])  # type: ignore[literal-required, call-overload]
         referer: str = Field("?", alias="referer")
         event: Literal["leave", "enter"] = Field("enter")
         time_on_page: int = Field(0, serialization_alias="top")

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -489,18 +489,10 @@ def test_scan_delta_DT_input(delta_table_path: Path) -> None:
     assert_frame_equal(expected, ldf.collect(), check_dtypes=False)
 
 
-@pytest.mark.skip(
-    reason="""\
-Upstream bug writing empty tables \
-"_internal.DeltaError: Generic error: No data source supplied to write command"
-Note this works if we downgrade to deltalake==0.18.2
-"""
-)
 @pytest.mark.write_disk
 def test_read_delta_empty(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
     path = str(tmp_path)
-    df = pl.DataFrame({}, [("p", pl.Int64)])
-    df.write_delta(path)
 
-    assert_frame_equal(pl.read_delta(path), pl.DataFrame(schema={"p": pl.Int64}))
+    DeltaTable.create(path, pl.DataFrame(schema={"x": pl.Int64}).to_arrow().schema)
+    assert_frame_equal(pl.read_delta(path), pl.DataFrame(schema={"x": pl.Int64}))

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -499,8 +499,8 @@ Note this works if we downgrade to deltalake==0.18.2
 @pytest.mark.write_disk
 def test_read_delta_empty(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
-    tmp_path = str(tmp_path)
+    path = str(tmp_path)
     df = pl.DataFrame({}, [("p", pl.Int64)])
-    df.write_delta(tmp_path)
+    df.write_delta(path)
 
-    assert_frame_equal(pl.read_delta(tmp_path), pl.DataFrame(schema={"p": pl.Int64}))
+    assert_frame_equal(pl.read_delta(path), pl.DataFrame(schema={"p": pl.Int64}))

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -487,3 +487,20 @@ def test_scan_delta_DT_input(delta_table_path: Path) -> None:
 
     expected = pl.DataFrame({"name": ["Joey", "Ivan"], "age": [14, 32]})
     assert_frame_equal(expected, ldf.collect(), check_dtypes=False)
+
+
+@pytest.mark.skip(
+    reason="""\
+Upstream bug writing empty tables \
+"_internal.DeltaError: Generic error: No data source supplied to write command"
+Note this works if we downgrade to deltalake==0.18.2
+"""
+)
+@pytest.mark.write_disk
+def test_read_delta_empty(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    tmp_path = str(tmp_path)
+    df = pl.DataFrame({}, [("p", pl.Int64)])
+    df.write_delta(tmp_path)
+
+    assert_frame_equal(pl.read_delta(tmp_path), pl.DataFrame(schema={"p": pl.Int64}))

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -13,7 +13,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import polars as pl
-from polars.exceptions import SchemaFieldNotFoundError
+from polars.exceptions import ComputeError, SchemaFieldNotFoundError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -847,3 +847,19 @@ def test_hive_windows_splits_on_forward_slashes(tmp_path: Path) -> None:
         ).collect(),
         expect,
     )
+
+
+@pytest.mark.write_disk
+def test_passing_hive_schema_with_hive_partitioning_disabled_raises(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(
+        ComputeError,
+        match="a hive schema was given but hive_partitioning was not enabled",
+    ):
+        pl.scan_parquet(
+            tmp_path,
+            schema={"x": pl.Int64},
+            hive_schema={"h": pl.String},
+            hive_partitioning=False,
+        ).collect()

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -855,7 +855,7 @@ def test_passing_hive_schema_with_hive_partitioning_disabled_raises(
 ) -> None:
     with pytest.raises(
         ComputeError,
-        match="a hive schema was given but hive_partitioning was not enabled",
+        match="a hive schema was given but hive_partitioning was disabled",
     ):
         pl.scan_parquet(
             tmp_path,

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -343,7 +343,7 @@ def test_hive_partition_directory_scan(
     ).collect()
     assert_frame_equal(out, df)
 
-    out = scan(tmp_path, hive_partitioning=False).collect()
+    out = scan(tmp_path, hive_partitioning=False, hive_schema=None).collect()
     assert_frame_equal(out, df.drop("a", "b"))
 
     out = scan(
@@ -352,10 +352,7 @@ def test_hive_partition_directory_scan(
     ).collect()
     assert_frame_equal(out, df.filter(a=1).drop("a"))
 
-    out = scan(
-        tmp_path / "a=1",
-        hive_partitioning=False,
-    ).collect()
+    out = scan(tmp_path / "a=1", hive_partitioning=False, hive_schema=None).collect()
     assert_frame_equal(out, df.filter(a=1).drop("a", "b"))
 
     path = tmp_path / "a=1/b=1/data.bin"
@@ -363,7 +360,7 @@ def test_hive_partition_directory_scan(
     out = scan(path, hive_partitioning=True).collect()
     assert_frame_equal(out, dfs[0])
 
-    out = scan(path, hive_partitioning=False).collect()
+    out = scan(path, hive_partitioning=False, hive_schema=None).collect()
     assert_frame_equal(out, dfs[0].drop("a", "b"))
 
     # Test default behavior with `hive_partitioning=None`, which should only
@@ -429,14 +426,18 @@ def test_hive_partition_directory_scan(
     )
 
     # Test `hive_partitioning=False`
-    out = scan(tmp_path, hive_partitioning=False).collect()
+    out = scan(tmp_path, hive_partitioning=False, hive_schema=None).collect()
     assert_frame_equal(out, df.drop("a", "b"))
 
     if glob:
-        out = scan(tmp_path / "**/*.bin", hive_partitioning=False).collect()
+        out = scan(
+            tmp_path / "**/*.bin", hive_partitioning=False, hive_schema=None
+        ).collect()
         assert_frame_equal(out, df.drop("a", "b"))
 
-    out = scan(tmp_path / "a=1/b=1/data.bin", hive_partitioning=False).collect()
+    out = scan(
+        tmp_path / "a=1/b=1/data.bin", hive_partitioning=False, hive_schema=None
+    ).collect()
     assert_frame_equal(out, df.filter(a=1, b=1).drop("a", "b"))
 
 

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -773,6 +773,30 @@ def test_parquet_schema_arg(
         lf.collect(streaming=streaming)
 
 
+def test_scan_parquet_schema_specified_with_empty_files_list(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    assert_frame_equal(
+        pl.scan_parquet(tmp_path, schema={"x": pl.Int64}).collect(),
+        pl.DataFrame(schema={"x": pl.Int64}),
+    )
+
+    assert_frame_equal(
+        pl.scan_parquet(
+            tmp_path, schema={"x": pl.Int64}, hive_schema={"h": pl.String}
+        ).collect(),
+        pl.DataFrame(schema={"x": pl.Int64, "h": pl.String}),
+    )
+
+    with pytest.raises(ComputeError, match="hive_partitioning was not enabled"):
+        pl.scan_parquet(
+            tmp_path,
+            schema={"x": pl.Int64},
+            hive_schema={"h": pl.String},
+            hive_partitioning=False,
+        ).collect()
+
+
 @pytest.mark.parametrize("streaming", [True, False])
 @pytest.mark.parametrize("allow_missing_columns", [True, False])
 @pytest.mark.write_disk

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -782,19 +782,27 @@ def test_scan_parquet_schema_specified_with_empty_files_list(tmp_path: Path) -> 
     )
 
     assert_frame_equal(
+        pl.scan_parquet(tmp_path, schema={"x": pl.Int64}).with_row_index().collect(),
+        pl.DataFrame(schema={"x": pl.Int64}).with_row_index(),
+    )
+
+    assert_frame_equal(
         pl.scan_parquet(
             tmp_path, schema={"x": pl.Int64}, hive_schema={"h": pl.String}
         ).collect(),
         pl.DataFrame(schema={"x": pl.Int64, "h": pl.String}),
     )
 
-    with pytest.raises(ComputeError, match="hive_partitioning was not enabled"):
-        pl.scan_parquet(
-            tmp_path,
-            schema={"x": pl.Int64},
-            hive_schema={"h": pl.String},
-            hive_partitioning=False,
-        ).collect()
+    assert_frame_equal(
+        (
+            pl.scan_parquet(
+                tmp_path, schema={"x": pl.Int64}, hive_schema={"h": pl.String}
+            )
+            .with_row_index()
+            .collect()
+        ),
+        pl.DataFrame(schema={"x": pl.Int64, "h": pl.String}).with_row_index(),
+    )
 
 
 @pytest.mark.parametrize("streaming", [True, False])


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19876
Fixes https://github.com/pola-rs/polars/issues/19854
Fixes https://github.com/pola-rs/polars/issues/19890

For the case when `scan_parquet` is done on an empty directory and `schema` was given, we should return an empty DataFrame. Currently this case isn't accounted for in some areas of the code causing some errors / panics.

Also fixes a mypy lint issue due to a new pydantic release
