### PR TITLE
feat: Auto-enable hive partitioning if hive_schema was given

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -250,6 +250,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 };
 
                 if file_options.hive_options.enabled.is_none() {
+                    // We expect this to be `Some(_)` after this point. If it hasn't been auto-enabled
+                    // we explicitly set it to disabled.
                     file_options.hive_options.enabled = Some(false);
                 }
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -369,17 +369,19 @@ def test_hive_partition_directory_scan(
     assert_frame_equal(out, df)
 
     # Otherwise, hive partitioning is not enabled automatically:
-    out = scan(tmp_path / "a=1/b=1/data.bin").collect()
+    out = scan(tmp_path / "a=1/b=1/data.bin", hive_schema=None).collect()
     assert out.columns == ["x"]
 
-    out = scan([tmp_path / "a=1/", tmp_path / "a=22/"]).collect()
+    out = scan([tmp_path / "a=1/", tmp_path / "a=22/"], hive_schema=None).collect()
     assert out.columns == ["x"]
 
-    out = scan([tmp_path / "a=1/", tmp_path / "a=22/b=1/data.bin"]).collect()
+    out = scan(
+        [tmp_path / "a=1/", tmp_path / "a=22/b=1/data.bin"], hive_schema=None
+    ).collect()
     assert out.columns == ["x"]
 
     if glob:
-        out = scan(tmp_path / "a=1/**/*.bin").collect()
+        out = scan(tmp_path / "a=1/**/*.bin", hive_schema=None).collect()
         assert out.columns == ["x"]
 
     # Test `hive_partitioning=True`

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -877,12 +877,13 @@ def test_hive_auto_enables_when_unspecified_and_hive_schema_passed(
 
     pl.DataFrame({"x": 1}).write_parquet(tmp_path / "a=1/1")
 
-    lf = pl.scan_parquet(tmp_path / "a=1/1", hive_schema={"a": pl.UInt8})
+    for path in [tmp_path / "a=1/1", tmp_path / "**/*"]:
+        lf = pl.scan_parquet(path, hive_schema={"a": pl.UInt8})
 
-    assert_frame_equal(
-        lf.collect(),
-        pl.select(
-            pl.Series("x", [1]),
-            pl.Series("a", [1], dtype=pl.UInt8),
-        ),
-    )
+        assert_frame_equal(
+            lf.collect(),
+            pl.select(
+                pl.Series("x", [1]),
+                pl.Series("a", [1], dtype=pl.UInt8),
+            ),
+        )


### PR DESCRIPTION
This is more of a quality-of-life change. After this PR if users do `scan_parquet(<glob or file path>, hive_schema={...})`, we will automatically enable hive partitioning instead of silently ignoring the `hive_schema`.

