### PR TITLE
feat(rust): Speed up starts_with for small prefixes

### DIFF
--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -141,11 +141,17 @@ impl View {
     pub fn starts_with<'a>(&self, prefix: &str, buffers: &'a [Buffer<u8>]) -> bool {
         unsafe {
             if self.length <= View::MAX_INLINE_SIZE {
-                self.get_inlined_slice_unchecked().starts_with(prefix.as_bytes())
+                self.get_inlined_slice_unchecked()
+                    .starts_with(prefix.as_bytes())
             } else {
-                let starts = self.prefix.to_le_bytes().starts_with(&prefix.as_bytes()[0..4]);
+                let starts = self
+                    .prefix
+                    .to_le_bytes()
+                    .starts_with(&prefix.as_bytes()[0..4]);
                 if starts {
-                    return self.get_slice_unchecked(buffers).starts_with(prefix.as_bytes());
+                    return self
+                        .get_slice_unchecked(buffers)
+                        .starts_with(prefix.as_bytes());
                 }
                 false
             }

--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -136,6 +136,22 @@ impl View {
         }
     }
 
+    /// Checks if the string starts with the prefix
+    /// When the prefix is smaller than View::MAX_INLINE_SIZE then this will be very fast
+    pub fn starts_with<'a>(&self, prefix: &str, buffers: &'a [Buffer<u8>]) -> bool {
+        unsafe {
+            if self.length <= View::MAX_INLINE_SIZE {
+                self.get_inlined_slice_unchecked().starts_with(prefix.as_bytes())
+            } else {
+                let starts = self.prefix.to_le_bytes().starts_with(&prefix.as_bytes()[0..4]);
+                if starts {
+                    return self.get_slice_unchecked(buffers).starts_with(prefix.as_bytes());
+                }
+                false
+            }
+        }
+    }
+
     /// Constructs a byteslice from this view.
     ///
     /// # Safety

--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -136,28 +136,6 @@ impl View {
         }
     }
 
-    /// Checks if the string starts with the prefix
-    /// When the prefix is smaller than View::MAX_INLINE_SIZE then this will be very fast
-    pub fn starts_with(&self, prefix: &str, buffers: &[Buffer<u8>]) -> bool {
-        unsafe {
-            if self.length <= View::MAX_INLINE_SIZE {
-                self.get_inlined_slice_unchecked()
-                    .starts_with(prefix.as_bytes())
-            } else {
-                let starts = self
-                    .prefix
-                    .to_le_bytes()
-                    .starts_with(&prefix.as_bytes()[0..4]);
-                if starts {
-                    return self
-                        .get_slice_unchecked(buffers)
-                        .starts_with(prefix.as_bytes());
-                }
-                false
-            }
-        }
-    }
-
     /// Constructs a byteslice from this view.
     ///
     /// # Safety

--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -138,7 +138,7 @@ impl View {
 
     /// Checks if the string starts with the prefix
     /// When the prefix is smaller than View::MAX_INLINE_SIZE then this will be very fast
-    pub fn starts_with<'a>(&self, prefix: &str, buffers: &'a [Buffer<u8>]) -> bool {
+    pub fn starts_with(&self, prefix: &str, buffers: &[Buffer<u8>]) -> bool {
         unsafe {
             if self.length <= View::MAX_INLINE_SIZE {
                 self.get_inlined_slice_unchecked()

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -19,6 +19,8 @@ mod reverse;
 #[cfg(feature = "strings")]
 mod split;
 #[cfg(feature = "strings")]
+mod starts_with;
+#[cfg(feature = "strings")]
 mod strip;
 #[cfg(feature = "strings")]
 mod substring;

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -220,18 +220,16 @@ pub trait StringNameSpaceImpl: AsString {
     fn starts_with(&self, sub: &str) -> BooleanChunked {
         let ca = self.as_string();
 
-        unsafe {
-            let iter = ca.downcast_iter().map(|arr| {
-                let out: <BooleanType as PolarsDataType>::Array = arr
-                    .views()
-                    .iter()
-                    .map(|view| view.starts_with(sub, arr.data_buffers()))
-                    .collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()));
-                out.with_validity_typed(arr.validity().cloned())
-            });
+        let iter = ca.downcast_iter().map(|arr| {
+            let out: <BooleanType as PolarsDataType>::Array = arr
+                .views()
+                .iter()
+                .map(|view| view.starts_with(sub, arr.data_buffers()))
+                .collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()));
+            out.with_validity_typed(arr.validity().cloned())
+        });
 
-            ChunkedArray::from_chunk_iter(ca.name().clone(), iter)
-        }
+        ChunkedArray::from_chunk_iter(ca.name().clone(), iter)
     }
 
     /// This is more performant than the BinaryChunked version because we use the inline prefix

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -220,7 +220,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Check if strings starts with a substring
     fn starts_with(&self, sub: &str) -> BooleanChunked {
         let ca = self.as_string();
-        let iter = ca.downcast_iter().map(|arr| unsafe {
+        let iter = ca.downcast_iter().map(|arr| {
             let out: <BooleanType as PolarsDataType>::Array = arr
                 .views()
                 .iter()

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -9,12 +9,12 @@ use polars_core::export::num::Num;
 use polars_core::export::regex::Regex;
 use polars_core::prelude::arity::*;
 use polars_utils::cache::FastFixedCache;
-use polars_utils::slice::SliceAble;
 use regex::escape;
 
 use super::*;
 #[cfg(feature = "binary_encoding")]
 use crate::chunked_array::binary::BinaryNameSpaceImpl;
+use crate::prelude::strings::starts_with::starts_with;
 
 // We need this to infer the right lifetimes for the match closure.
 #[inline(always)]
@@ -225,7 +225,7 @@ pub trait StringNameSpaceImpl: AsString {
             let out: <BooleanType as PolarsDataType>::Array = arr
                 .views()
                 .iter()
-                .map(|view| view.starts_with(sub, arr.data_buffers()))
+                .map(|view| starts_with(*view, sub, arr.data_buffers()))
                 .collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()));
             out.with_validity_typed(arr.validity().cloned())
         });

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -9,6 +9,7 @@ use polars_core::export::num::Num;
 use polars_core::export::regex::Regex;
 use polars_core::prelude::arity::*;
 use polars_utils::cache::FastFixedCache;
+use polars_utils::slice::SliceAble;
 use regex::escape;
 
 use super::*;

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -10,6 +10,7 @@ use polars_core::export::regex::Regex;
 use polars_core::prelude::arity::*;
 use polars_utils::cache::FastFixedCache;
 use regex::escape;
+
 use super::*;
 #[cfg(feature = "binary_encoding")]
 use crate::chunked_array::binary::BinaryNameSpaceImpl;
@@ -221,9 +222,11 @@ pub trait StringNameSpaceImpl: AsString {
 
         unsafe {
             let iter = ca.downcast_iter().map(|arr| {
-                let out: <BooleanType as PolarsDataType>::Array = arr.views().iter().map(|view| {
-                    view.starts_with(sub, arr.data_buffers())
-                }).collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()));
+                let out: <BooleanType as PolarsDataType>::Array = arr
+                    .views()
+                    .iter()
+                    .map(|view| view.starts_with(sub, arr.data_buffers()))
+                    .collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()));
                 out.with_validity_typed(arr.validity().cloned())
             });
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -1,4 +1,5 @@
 use arrow::array::{Array, ValueSize};
+use arrow::compute::utils::combine_validities_and;
 use arrow::legacy::kernels::string::*;
 #[cfg(feature = "string_encoding")]
 use base64::engine::general_purpose;
@@ -8,13 +9,14 @@ use base64::Engine as _;
 use polars_core::export::num::Num;
 use polars_core::export::regex::Regex;
 use polars_core::prelude::arity::*;
+use polars_core::utils::align_chunks_binary;
 use polars_utils::cache::FastFixedCache;
 use regex::escape;
 
 use super::*;
 #[cfg(feature = "binary_encoding")]
 use crate::chunked_array::binary::BinaryNameSpaceImpl;
-use crate::prelude::strings::starts_with::starts_with;
+use crate::prelude::strings::starts_with::{starts_with_str, starts_with_view};
 
 // We need this to infer the right lifetimes for the match closure.
 #[inline(always)]
@@ -221,12 +223,22 @@ pub trait StringNameSpaceImpl: AsString {
     fn starts_with(&self, sub: &str) -> BooleanChunked {
         let ca = self.as_string();
 
-        let iter = ca.downcast_iter().map(|arr| {
-            let out: <BooleanType as PolarsDataType>::Array = arr
-                .views()
-                .iter()
-                .map(|view| starts_with(*view, sub, arr.data_buffers()))
-                .collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()));
+        let iter = ca.downcast_iter().map(|arr| unsafe {
+            // If the buffer is empty then all strings are inlined and we can avoid a branch which might result in vectorization
+            let out: <BooleanType as PolarsDataType>::Array = if arr.data_buffers().is_empty() {
+                arr.views()
+                    .iter()
+                    .map(|view| {
+                        view.get_inlined_slice_unchecked()
+                            .starts_with(sub.as_bytes())
+                    })
+                    .collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()))
+            } else {
+                arr.views()
+                    .iter()
+                    .map(|view| starts_with_str(*view, sub, arr.data_buffers()))
+                    .collect_arr_with_dtype(DataType::Boolean.to_arrow(CompatLevel::newest()))
+            };
             out.with_validity_typed(arr.validity().cloned())
         });
 
@@ -242,7 +254,34 @@ pub trait StringNameSpaceImpl: AsString {
                 Some(s) => self.starts_with(s),
                 None => BooleanChunked::full_null(ca.name().clone(), ca.len()),
             },
-            _ => broadcast_binary_elementwise_values(ca, prefix, |s, sub| s.starts_with(sub)),
+            _ => {
+                let (lhs, rhs) = align_chunks_binary(ca, prefix);
+
+                let iter =
+                    lhs.downcast_iter()
+                        .zip(rhs.downcast_iter())
+                        .map(|(lhs_arr, rhs_arr)| {
+                            let validity =
+                                combine_validities_and(lhs_arr.validity(), rhs_arr.validity());
+
+                            let element_iter =
+                                lhs_arr.views().iter().zip(rhs_arr.views().iter()).map(
+                                    |(lhs_val, rhs_val)| {
+                                        starts_with_view(
+                                            *lhs_val,
+                                            *rhs_val,
+                                            lhs_arr.data_buffers(),
+                                            rhs_arr.data_buffers(),
+                                        )
+                                    },
+                                );
+
+                            let array: <BooleanType as PolarsDataType>::Array =
+                                element_iter.collect_arr();
+                            array.with_validity_typed(validity)
+                        });
+                ChunkedArray::from_chunk_iter(lhs.name().clone(), iter)
+            },
         }
     }
 

--- a/crates/polars-ops/src/chunked_array/strings/starts_with.rs
+++ b/crates/polars-ops/src/chunked_array/strings/starts_with.rs
@@ -23,25 +23,3 @@ pub(crate) fn starts_with_str(view: View, prefix: &str, buffers: &[Buffer<u8>]) 
         }
     }
 }
-
-/// Checks if the string starts with the prefix
-/// If you call this in a loop and the prefix doesn't change then prefer starts_with_str()
-pub(crate) fn starts_with_view(
-    view: View,
-    prefix: View,
-    left_buffers: &[Buffer<u8>],
-    right_buffers: &[Buffer<u8>],
-) -> bool {
-    unsafe {
-        if !view.prefix.to_le_bytes()[0..view.length.min(4) as usize]
-            .starts_with(&prefix.prefix.to_le_bytes()[..view.length.min(4) as usize])
-        {
-            return false;
-        }
-
-        let left_buffer = view.get_slice_unchecked(left_buffers);
-        let right_buffer = prefix.get_slice_unchecked(right_buffers);
-
-        left_buffer.starts_with(right_buffer)
-    }
-}

--- a/crates/polars-ops/src/chunked_array/strings/starts_with.rs
+++ b/crates/polars-ops/src/chunked_array/strings/starts_with.rs
@@ -4,7 +4,7 @@ use polars_utils::slice::SliceAble;
 
 /// Checks if the string starts with the prefix
 /// When the prefix is smaller than View::MAX_INLINE_SIZE then this will be very fast
-pub fn starts_with(view: View, prefix: &str, buffers: &[Buffer<u8>]) -> bool {
+pub(crate) fn starts_with_str(view: View, prefix: &str, buffers: &[Buffer<u8>]) -> bool {
     unsafe {
         if view.length <= View::MAX_INLINE_SIZE {
             view.get_inlined_slice_unchecked()
@@ -21,5 +21,27 @@ pub fn starts_with(view: View, prefix: &str, buffers: &[Buffer<u8>]) -> bool {
             }
             false
         }
+    }
+}
+
+/// Checks if the string starts with the prefix
+/// If you call this in a loop and the prefix doesn't change then prefer starts_with_str()
+pub(crate) fn starts_with_view(
+    view: View,
+    prefix: View,
+    left_buffers: &[Buffer<u8>],
+    right_buffers: &[Buffer<u8>],
+) -> bool {
+    unsafe {
+        if !view.prefix.to_le_bytes()[0..view.length.min(4) as usize]
+            .starts_with(&prefix.prefix.to_le_bytes()[..view.length.min(4) as usize])
+        {
+            return false;
+        }
+
+        let left_buffer = view.get_slice_unchecked(left_buffers);
+        let right_buffer = prefix.get_slice_unchecked(right_buffers);
+
+        left_buffer.starts_with(right_buffer)
     }
 }

--- a/crates/polars-ops/src/chunked_array/strings/starts_with.rs
+++ b/crates/polars-ops/src/chunked_array/strings/starts_with.rs
@@ -1,0 +1,25 @@
+use arrow::array::View;
+use arrow::buffer::Buffer;
+use polars_utils::slice::SliceAble;
+
+/// Checks if the string starts with the prefix
+/// When the prefix is smaller than View::MAX_INLINE_SIZE then this will be very fast
+pub fn starts_with(view: View, prefix: &str, buffers: &[Buffer<u8>]) -> bool {
+    unsafe {
+        if view.length <= View::MAX_INLINE_SIZE {
+            view.get_inlined_slice_unchecked()
+                .starts_with(prefix.as_bytes())
+        } else {
+            let starts = view
+                .prefix
+                .to_le_bytes()
+                .starts_with(&prefix.as_bytes().slice_unchecked(0..4));
+            if starts {
+                return view
+                    .get_slice_unchecked(buffers)
+                    .starts_with(prefix.as_bytes());
+            }
+            false
+        }
+    }
+}

--- a/crates/polars-ops/src/chunked_array/strings/starts_with.rs
+++ b/crates/polars-ops/src/chunked_array/strings/starts_with.rs
@@ -13,7 +13,7 @@ pub fn starts_with(view: View, prefix: &str, buffers: &[Buffer<u8>]) -> bool {
             let starts = view
                 .prefix
                 .to_le_bytes()
-                .starts_with(&prefix.as_bytes().slice_unchecked(0..4));
+                .starts_with(prefix.as_bytes().slice_unchecked(0..4));
             if starts {
                 return view
                     .get_slice_unchecked(buffers)

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -502,9 +502,8 @@ pub(super) fn ends_with(s: &[Column]) -> PolarsResult<Column> {
 }
 
 pub(super) fn starts_with(s: &[Column]) -> PolarsResult<Column> {
-    let ca = &s[0].str()?.as_binary();
-    let prefix = &s[1].str()?.as_binary();
-
+    let ca = s[0].str()?;
+    let prefix = s[1].str()?;
     Ok(ca.starts_with_chunked(prefix).into_column())
 }
 


### PR DESCRIPTION
The string view type has a small (4 or <12 bytes) prefix inlined that we can use for comparisons. From a small test this is about the same speed on a worst case (search prefix > 12 bytes, string not inlined) and more than twice as fast on a best case (string <12 bytes so entirely inlined).