### PR TITLE
perf: Reduce the size of row encoding UTF-8

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/row_encode.rs
+++ b/crates/polars-core/src/chunked_array/ops/row_encode.rs
@@ -13,7 +13,7 @@ pub(crate) fn convert_series_for_row_encoding(s: &Series) -> PolarsResult<Series
         Categorical(_, _) | Enum(_, _) => s.rechunk(),
         Binary | Boolean => s.clone(),
         BinaryOffset => s.clone(),
-        String => s.str().unwrap().as_binary().into_series(),
+        String => s.clone(),
         #[cfg(feature = "dtype-struct")]
         Struct(_) => {
             let ca = s.struct_().unwrap();

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/eval.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/eval.rs
@@ -75,11 +75,7 @@ impl Eval {
         }
         for phys_e in self.key_columns_expr.iter() {
             let s = phys_e.evaluate(chunk, &context.execution_state)?;
-            let s = match s.dtype() {
-                // todo! add binary to physical repr?
-                DataType::String => unsafe { s.cast_unchecked(&DataType::Binary).unwrap() },
-                _ => s.to_physical_repr().into_owned(),
-            };
+            let s = s.to_physical_repr().into_owned();
             let s = prepare_key(&s, chunk);
             keys_columns.push(s.to_arrow(0, CompatLevel::newest()));
         }

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -8,7 +8,7 @@ use self::fixed::get_null_sentinel;
 use self::variable::decode_strview;
 use super::*;
 use crate::fixed::{decode_bool, decode_primitive};
-use crate::variable::{decode_binary, decode_binview};
+use crate::variable::decode_binview;
 
 /// Decode `rows` into a arrow format
 /// # Safety
@@ -196,7 +196,7 @@ unsafe fn decode(rows: &mut [&[u8]], field: &EncodingField, dtype: &ArrowDataTyp
     match dtype {
         ArrowDataType::Null => NullArray::new(ArrowDataType::Null, rows.len()).to_boxed(),
         ArrowDataType::Boolean => decode_bool(rows, field).to_boxed(),
-        ArrowDataType::BinaryView | ArrowDataType::LargeBinary => {
+        ArrowDataType::Binary | ArrowDataType::LargeBinary | ArrowDataType::BinaryView => {
             decode_binview(rows, field).to_boxed()
         },
         ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 | ArrowDataType::Utf8View => {

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -897,24 +897,9 @@ pub fn fixed_size(dtype: &ArrowDataType) -> Option<usize> {
 
 #[cfg(test)]
 mod test {
-    use arrow::array::Int32Array;
-
     use super::*;
     use crate::decode::decode_rows_from_binary;
     use crate::variable::{decode_binview, BLOCK_SIZE, EMPTY_SENTINEL, NON_EMPTY_SENTINEL};
-
-    #[test]
-    fn test_fixed_and_variable_encode() {
-        let a = Int32Array::from_vec(vec![1, 2, 3]);
-        let b = Int32Array::from_vec(vec![213, 12, 12]);
-        let c = Utf8ViewArray::from_slice([Some("a"), Some(""), Some("meep")]);
-
-        let encoded = convert_columns_no_order(a.len(), &[Box::new(a), Box::new(b), Box::new(c)]);
-        assert_eq!(encoded.offsets, &[0, 44, 55, 99]);
-        assert_eq!(encoded.values.len(), 99);
-        assert!(encoded.values.ends_with(&[0, 0, 0, 4]));
-        assert!(encoded.values.starts_with(&[1, 128, 0, 0, 1, 1, 128]));
-    }
 
     #[test]
     fn test_str_encode() {

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -477,39 +477,75 @@ fn get_encoder(array: &dyn Array, field: &EncodingField, row_widths: &mut RowWid
 
         D::Utf8View => {
             let dc_array = array.as_any().downcast_ref::<Utf8ViewArray>().unwrap();
-            striter_num_column_bytes(
-                array,
-                dc_array.views().iter().map(|v| v.length as usize),
-                dc_array.validity(),
-                field,
-                row_widths,
-            )
+            if field.no_order {
+                biniter_num_column_bytes(
+                    array,
+                    dc_array.views().iter().map(|v| v.length as usize),
+                    dc_array.validity(),
+                    field,
+                    row_widths,
+                )
+            } else {
+                striter_num_column_bytes(
+                    array,
+                    dc_array.views().iter().map(|v| v.length as usize),
+                    dc_array.validity(),
+                    field,
+                    row_widths,
+                )
+            }
         },
         D::Utf8 => {
             let dc_array = array.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
-            striter_num_column_bytes(
-                array,
-                dc_array
-                    .offsets()
-                    .windows(2)
-                    .map(|vs| (vs[1] - vs[0]) as usize),
-                dc_array.validity(),
-                field,
-                row_widths,
-            )
+            if field.no_order {
+                biniter_num_column_bytes(
+                    array,
+                    dc_array
+                        .offsets()
+                        .windows(2)
+                        .map(|vs| (vs[1] - vs[0]) as usize),
+                    dc_array.validity(),
+                    field,
+                    row_widths,
+                )
+            } else {
+                striter_num_column_bytes(
+                    array,
+                    dc_array
+                        .offsets()
+                        .windows(2)
+                        .map(|vs| (vs[1] - vs[0]) as usize),
+                    dc_array.validity(),
+                    field,
+                    row_widths,
+                )
+            }
         },
         D::LargeUtf8 => {
             let dc_array = array.as_any().downcast_ref::<Utf8Array<i64>>().unwrap();
-            striter_num_column_bytes(
-                array,
-                dc_array
-                    .offsets()
-                    .windows(2)
-                    .map(|vs| (vs[1] - vs[0]) as usize),
-                dc_array.validity(),
-                field,
-                row_widths,
-            )
+            if field.no_order {
+                biniter_num_column_bytes(
+                    array,
+                    dc_array
+                        .offsets()
+                        .windows(2)
+                        .map(|vs| (vs[1] - vs[0]) as usize),
+                    dc_array.validity(),
+                    field,
+                    row_widths,
+                )
+            } else {
+                striter_num_column_bytes(
+                    array,
+                    dc_array
+                        .offsets()
+                        .windows(2)
+                        .map(|vs| (vs[1] - vs[0]) as usize),
+                    dc_array.validity(),
+                    field,
+                    row_widths,
+                )
+            }
         },
 
         D::Dictionary(_, _, _) => {
@@ -591,15 +627,42 @@ unsafe fn encode_flat_array(
         },
         D::Utf8 => {
             let array = array.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
-            crate::variable::encode_str_iter(buffer, array.iter(), field, offsets);
+            if field.no_order {
+                crate::variable::encode_iter(
+                    buffer,
+                    array.iter().map(|v| v.map(str::as_bytes)),
+                    field,
+                    offsets,
+                );
+            } else {
+                crate::variable::encode_str_iter(buffer, array.iter(), field, offsets);
+            }
         },
         D::LargeUtf8 => {
             let array = array.as_any().downcast_ref::<Utf8Array<i64>>().unwrap();
-            crate::variable::encode_str_iter(buffer, array.iter(), field, offsets);
+            if field.no_order {
+                crate::variable::encode_iter(
+                    buffer,
+                    array.iter().map(|v| v.map(str::as_bytes)),
+                    field,
+                    offsets,
+                );
+            } else {
+                crate::variable::encode_str_iter(buffer, array.iter(), field, offsets);
+            }
         },
         D::Utf8View => {
             let array = array.as_any().downcast_ref::<Utf8ViewArray>().unwrap();
-            crate::variable::encode_str_iter(buffer, array.iter(), field, offsets);
+            if field.no_order {
+                crate::variable::encode_iter(
+                    buffer,
+                    array.iter().map(|v| v.map(str::as_bytes)),
+                    field,
+                    offsets,
+                );
+            } else {
+                crate::variable::encode_str_iter(buffer, array.iter(), field, offsets);
+            }
         },
         D::Dictionary(_, _, _) => {
             let dc_array = array

--- a/crates/polars-row/src/row.rs
+++ b/crates/polars-row/src/row.rs
@@ -19,6 +19,8 @@ pub struct EncodingField {
 }
 
 const LIST_CONTINUATION_TOKEN: u8 = 0xFE;
+const EMPTY_STR_TOKEN: u8 = 0x01;
+const NON_EMPTY_STR_TOKEN: u8 = 0x02;
 
 impl EncodingField {
     pub fn new_sorted(descending: bool, nulls_last: bool) -> Self {
@@ -66,6 +68,21 @@ impl EncodingField {
 
     pub fn list_termination_token(self) -> u8 {
         !self.list_continuation_token()
+    }
+
+    pub fn empty_str_token(self) -> u8 {
+        if self.descending {
+            !EMPTY_STR_TOKEN
+        } else {
+            EMPTY_STR_TOKEN
+        }
+    }
+    pub fn non_empty_str_token(self) -> u8 {
+        if self.descending {
+            !NON_EMPTY_STR_TOKEN
+        } else {
+            NON_EMPTY_STR_TOKEN
+        }
     }
 }
 

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -418,6 +418,68 @@ def test_order_uint() -> None:
     assert_order_series([None], [1], dtype, ["gt"], nulls_last=True)
 
 
+def test_order_str() -> None:
+    dtype = pl.String
+    assert_order_series(["a", "b", "c"], ["c", "b", "a"], dtype, ["lt", "eq", "gt"])
+    assert_order_series(
+        ["a", "b", "c"], ["c", "b", "a"], dtype, ["lt", "eq", "gt"], descending=True
+    )
+    assert_order_series(
+        ["a", "aa", "aaa"], ["aaa", "aa", "a"], dtype, ["lt", "eq", "gt"]
+    )
+    assert_order_series(
+        ["a", "aa", "aaa"],
+        ["aaa", "aa", "a"],
+        dtype,
+        ["lt", "eq", "gt"],
+        descending=True,
+    )
+    assert_order_series(["", "a", "aa"], ["aa", "a", ""], dtype, ["lt", "eq", "gt"])
+    assert_order_series(
+        ["", "a", "aa"], ["aa", "a", ""], dtype, ["lt", "eq", "gt"], descending=True
+    )
+    assert_order_series([None], [None], dtype, ["eq"])
+    assert_order_series([None], ["a"], dtype, ["lt"])
+    assert_order_series([None], ["a"], dtype, ["gt"], nulls_last=True)
+
+
+def test_order_bin() -> None:
+    dtype = pl.Binary
+    assert_order_series(
+        [b"a", b"b", b"c"], [b"c", b"b", b"a"], dtype, ["lt", "eq", "gt"]
+    )
+    assert_order_series(
+        [b"a", b"b", b"c"],
+        [b"c", b"b", b"a"],
+        dtype,
+        ["lt", "eq", "gt"],
+        descending=True,
+    )
+    assert_order_series(
+        [b"a", b"aa", b"aaa"], [b"aaa", b"aa", b"a"], dtype, ["lt", "eq", "gt"]
+    )
+    assert_order_series(
+        [b"a", b"aa", b"aaa"],
+        [b"aaa", b"aa", b"a"],
+        dtype,
+        ["lt", "eq", "gt"],
+        descending=True,
+    )
+    assert_order_series(
+        [b"", b"a", b"aa"], [b"aa", b"a", b""], dtype, ["lt", "eq", "gt"]
+    )
+    assert_order_series(
+        [b"", b"a", b"aa"],
+        [b"aa", b"a", b""],
+        dtype,
+        ["lt", "eq", "gt"],
+        descending=True,
+    )
+    assert_order_series([None], [None], dtype, ["eq"])
+    assert_order_series([None], [b"a"], dtype, ["lt"])
+    assert_order_series([None], [b"a"], dtype, ["gt"], nulls_last=True)
+
+
 def test_order_list() -> None:
     dtype = pl.List(pl.Int32)
     assert_order_series([[1, 2, 3]], [[3, 2, 1]], dtype, ["lt"])


### PR DESCRIPTION
Before, row encoding and decoding would use the variable row encoding. Now, we use the fact that `0xFF` is always an invalid UTF-8 character. To encode, the string with bytes `b1, ..., bn` becomes `b1 + 2, ..., bn + 2, 0x01`. This way, we can just scan for the `0x01` when we want to know where to end. Nulls are encoded as `0x00`. Everything is bitwise inverted for descending.

This is always a size improvement and in particular saves massively for small strings. For example, encoding "a" went from 33 bytes to 2 bytes.

This is a continuation of #19874.