### PR TITLE
perf: Rolling 'iter_lookbehind' breeze through duplicates

### DIFF
--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -259,11 +259,21 @@ pub(crate) fn group_by_values_iter_lookbehind(
         0
     };
     let mut end = start;
+    let mut last = time[start_offset];
     Ok(time[start_offset..upper_bound]
         .iter()
         .enumerate()
         .map(move |(mut i, t)| {
             i += start_offset;
+
+            // Fast path for duplicates.
+            if *t == last && i > start_offset {
+                let len = end - start;
+                let offset = start as IdxSize;
+                return Ok((offset, len as IdxSize));
+            }
+            last = *t;
+
             let lower = add(&offset, *t, tz.as_ref())?;
             let upper = *t;
 


### PR DESCRIPTION
Adds a small branch that ensures we skip very expensive computations on duplicates.

closes #19912