### PR TITLE
perf: Half the size of Booleans in row encoding

### DIFF
--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -553,7 +553,7 @@ unsafe fn encode_flat_array(
         },
         D::Boolean => {
             let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
-            crate::fixed::encode_iter(buffer, array.iter(), field, offsets);
+            crate::fixed::encode_bool_iter(buffer, array.iter(), field, offsets);
         },
         dt if dt.is_numeric() => with_match_arrow_primitive_type!(dt, |$T| {
             let array = array.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
@@ -815,7 +815,7 @@ pub fn fixed_size(dtype: &ArrowDataType) -> Option<usize> {
         Decimal(_, _) => i128::ENCODED_LEN,
         Float32 => f32::ENCODED_LEN,
         Float64 => f64::ENCODED_LEN,
-        Boolean => bool::ENCODED_LEN,
+        Boolean => 1,
         FixedSizeList(f, width) => 1 + width * fixed_size(f.dtype())?,
         Struct(fs) => {
             let mut sum = 0;

--- a/crates/polars-row/src/row.rs
+++ b/crates/polars-row/src/row.rs
@@ -4,6 +4,9 @@ use arrow::datatypes::ArrowDataType;
 use arrow::ffi::mmap;
 use arrow::offset::{Offsets, OffsetsBuffer};
 
+const BOOLEAN_TRUE_SENTINEL: u8 = 0x03;
+const BOOLEAN_FALSE_SENTINEL: u8 = 0x02;
+
 #[derive(Clone, Default, Copy)]
 pub struct EncodingField {
     /// Whether to sort in descending order
@@ -28,6 +31,22 @@ impl EncodingField {
         EncodingField {
             no_order: true,
             ..Default::default()
+        }
+    }
+
+    pub(crate) fn bool_true_sentinel(self) -> u8 {
+        if self.descending {
+            !BOOLEAN_TRUE_SENTINEL
+        } else {
+            BOOLEAN_TRUE_SENTINEL
+        }
+    }
+
+    pub(crate) fn bool_false_sentinel(self) -> u8 {
+        if self.descending {
+            !BOOLEAN_FALSE_SENTINEL
+        } else {
+            BOOLEAN_FALSE_SENTINEL
         }
     }
 }

--- a/py-polars/tests/unit/test_row_encoding.py
+++ b/py-polars/tests/unit/test_row_encoding.py
@@ -373,6 +373,34 @@ def test_parametric_binary_order(df: pl.DataFrame) -> None:
     parametric_order_base(df)
 
 
+def test_order_bool() -> None:
+    dtype = pl.Boolean
+    assert_order_series(
+        [None, False, True], [True, False, None], dtype, ["lt", "eq", "gt"]
+    )
+    assert_order_series(
+        [None, False, True],
+        [True, False, None],
+        dtype,
+        ["gt", "eq", "lt"],
+        nulls_last=True,
+    )
+
+    assert_order_series(
+        [False, False, True, True],
+        [True, False, True, False],
+        dtype,
+        ["lt", "eq", "eq", "gt"],
+    )
+    assert_order_series(
+        [False, False, True, True],
+        [True, False, True, False],
+        dtype,
+        ["lt", "eq", "eq", "gt"],
+        descending=True,
+    )
+
+
 def test_order_int() -> None:
     dtype = pl.Int32
     assert_order_series([1, 2, 3], [3, 2, 1], dtype, ["lt", "eq", "gt"])


### PR DESCRIPTION
This changes the encoding of `pl.Boolean` in the row encoding from needing 2 bytes (1 for validity, 1 for value) to 1 byte. Now, the encoding of Boolean values is as follows:

| Value   | Encoding |
|---------|----------|
| `None`  | `0x00`   |
| `False` | `0x20`   |
| `True`  | `0x30`   |

The null is bitwise inverted for `nulls_last=True` and `False` / `True` are inverted for `descending=True`.

This is a continuation of #19874.