### PR TITLE
perf: fast path to generate group idxs for vanilla int_range in group_by_dynamic

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1138,6 +1138,18 @@ impl LazyFrame {
         if let Expr::Column(name) = index_column {
             options.index_column = name;
         } else {
+            fn is_int_range(expr: &Expr) -> bool {
+                match expr {
+                    Expr::Alias(input, _) => is_int_range(input),
+                    Expr::Function {
+                        input, function, ..
+                    } => {
+                        matches!(function, FunctionExpr::Range(f) if f.to_string() == "int_range")
+                    },
+                    _ => false,
+                }
+            }
+            options.int_range = is_int_range(&index_column);
             let output_field = index_column
                 .to_field(&self.collect_schema().unwrap(), Context::Default)
                 .unwrap();


### PR DESCRIPTION
Performance optimization of `group_by_dynamic` when passing a vanilla`int_range` (i.e., start=0, step=1) as `index_column`. 
If we know that the index column for the dynamic group by is an int range, we can generate the group indices (as there is a fixed step between the index values) and can thus avoid the slow `group_by_windows` function. 

Any feedback to improve this PR is welcome :)

Further enhancements (that could? be done):
- [ ] support non-vanilla int-ranges (i.e., step != 1 and/or start !=0)
- [ ] do not materialize the int_range (as indices can be generated)

---

Using the updated code, I observe ~10x performance improvements on my machine