### PR TITLE
fix: Raise InvalidOperationError for invalid float to decimal casts (e.g. Inf, NaN)

### DIFF
--- a/crates/polars-arrow/src/compute/cast/primitive_to.rs
+++ b/crates/polars-arrow/src/compute/cast/primitive_to.rs
@@ -233,7 +233,7 @@ where
 
     let values = from.iter().map(|x| {
         x.and_then(|x| {
-            let x = (*x * multiplier).to_i128().unwrap();
+            let x = (*x * multiplier).to_i128()?;
             if x > max_for_precision || x < min_for_precision {
                 None
             } else {

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -628,6 +628,16 @@ def test_cast_decimal_to_decimal_high_precision() -> None:
     assert result.to_list() == values
 
 
+@pytest.mark.parametrize("value", [float("inf"), float("nan")])
+def test_invalid_cast_float_to_decimal(value: float) -> None:
+    s = pl.Series([value], dtype=pl.Float64)
+    with pytest.raises(
+        InvalidOperationError,
+        match="conversion from `f64` to `decimal\\[38,0\\]` failed",
+    ):
+        s.cast(pl.Decimal)
+
+
 def test_err_on_time_datetime_cast() -> None:
     s = pl.Series([time(10, 0, 0), time(11, 30, 59)])
     with pytest.raises(


### PR DESCRIPTION
closes #19934