### PR TITLE
feat(python): Add support for python builtin `round`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -150,6 +150,9 @@ class Expr:
     def __abs__(self) -> Expr:
         return self.abs()
 
+    def __round__(self, decimals: int = 0) -> Expr:
+        return self.round(decimals)
+
     # operators
     def __add__(self, other: IntoExpr) -> Expr:
         other = parse_into_expression(other, str_as_lit=True)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1221,6 +1221,9 @@ class Series:
     def __abs__(self) -> Series:
         return self.abs()
 
+    def __round__(self, decimals: int = 0) -> Series:
+        return self.round(decimals)
+
     def __copy__(self) -> Self:
         return self.clone()
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2844,6 +2844,12 @@ def test_round() -> None:
     assert_series_equal(col_a_rounded, pl.Series("a", [2, 1, 3]).cast(pl.Float64))
 
 
+def test_round_builtin() -> None:
+    df = pl.DataFrame({"a": [1.8, 1.2, 3.0]})
+    col_a_rounded = df.select(round(pl.col("a"), ndigits=0))["a"]
+    assert_series_equal(col_a_rounded, pl.Series("a", [2, 1, 3]).cast(pl.Float64))
+
+
 def test_dot() -> None:
     df = pl.DataFrame({"a": [1.8, 1.2, 3.0], "b": [3.2, 1, 2]})
     assert df.select(pl.col("a").dot(pl.col("b"))).item() == 12.96

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -942,6 +942,15 @@ def test_round() -> None:
     assert b.to_list() == [1.0, 2.0]
 
 
+def test_round_builtin() -> None:
+    a = pl.Series("f", [1.003, 2.003])
+    b = round(a, 2)
+    assert b.to_list() == [1.00, 2.00]
+
+    b = round(a)
+    assert b.to_list() == [1.0, 2.0]
+
+
 @pytest.mark.parametrize(
     ("series", "digits", "expected_result"),
     [


### PR DESCRIPTION
Hello polars maintainers,

This is a PR to add support for builtin `round` by implementing `__round__` in Expr and Series;
It is already possible to call `abs(e)` and `e.abs()` on series and expressions;
this change enables calling `round(e)` or `round(e, 3)` in addition to `e.round()` or `e.round(3)`

Let me know if you'd like to support this feature and whether I can contribute further by implementing it in other areas

resolves https://github.com/pola-rs/polars/issues/19942

Thank you !