### PR TITLE
fix(rust): Fix datetime cast behavior for pre-epoch times

### DIFF
--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -123,12 +123,12 @@ impl DatetimeChunked {
         use TimeUnit::*;
         match (current_unit, tu) {
             (Nanoseconds, Microseconds) => {
-                let ca = (&self.0).wrapping_trunc_div_scalar(1_000);
+                let ca = (&self.0).wrapping_floor_div_scalar(1_000);
                 out.0 = ca;
                 out
             },
             (Nanoseconds, Milliseconds) => {
-                let ca = (&self.0).wrapping_trunc_div_scalar(1_000_000);
+                let ca = (&self.0).wrapping_floor_div_scalar(1_000_000);
                 out.0 = ca;
                 out
             },
@@ -138,7 +138,7 @@ impl DatetimeChunked {
                 out
             },
             (Microseconds, Milliseconds) => {
-                let ca = (&self.0).wrapping_trunc_div_scalar(1_000);
+                let ca = (&self.0).wrapping_floor_div_scalar(1_000);
                 out.0 = ca;
                 out
             },

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2393,3 +2393,23 @@ def test_weekday_vs_stdlib_date(value: date) -> None:
     result = pl.Series([value]).dt.weekday().item()
     expected = value.isoweekday()
     assert result == expected
+
+
+def test_temporal_downcast_construction_19949() -> None:
+    # implicit cast from us to ms upon construction
+    s = pl.Series(
+        [
+            datetime(1969, 1, 1, 0, 0, 0, 1),
+            datetime(1969, 12, 31, 23, 59, 59, 999999),
+            datetime(1970, 1, 1, 0, 0, 0, 0),
+            datetime(1970, 1, 1, 0, 0, 0, 1),
+        ],
+        dtype=pl.Datetime("ms"),
+    )
+
+    assert s.to_list() == [
+        datetime(1969, 1, 1),
+        datetime(1969, 12, 31, 23, 59, 59, 999000),
+        datetime(1970, 1, 1),
+        datetime(1970, 1, 1),
+    ]

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2395,7 +2395,7 @@ def test_weekday_vs_stdlib_date(value: date) -> None:
     assert result == expected
 
 
-def test_temporal_downcast_construction_19949() -> None:
+def test_temporal_downcast_construction_19309() -> None:
     # implicit cast from us to ms upon construction
     s = pl.Series(
         [


### PR DESCRIPTION
Fixes #19309

See also my comment https://github.com/pola-rs/polars/issues/19309#issuecomment-2495681651

Error was introduced with  #14026 

Pre-epoch timestamps are negative, if we trunc div instead of floor div here, we get an incorrect distance to epoch.