### PR TITLE
fix: Raise proper error message when too small interval is passed to datetime_range

### DIFF
--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -126,9 +126,7 @@ pub(crate) fn datetime_range_i64(
         let step: usize = duration.try_into().map_err(
             |_err| polars_err!(ComputeError: "Could not convert {:?} to usize", duration),
         )?;
-        if step == 0 {
-            polars_bail!(InvalidOperation: "interval {} is too small for time unit {} and got rounded down to zero", interval, time_unit)
-        }
+        polars_ensure!(step != 0, InvalidOperation: "interval {} is too small for time unit {} and got rounded down to zero", interval, time_unit);
         return match closed {
             ClosedWindow::Both => Ok((start..=end).step_by(step).collect::<Vec<i64>>()),
             ClosedWindow::None => Ok((start + duration..end).step_by(step).collect::<Vec<i64>>()),

--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -126,7 +126,12 @@ pub(crate) fn datetime_range_i64(
         let step: usize = duration.try_into().map_err(
             |_err| polars_err!(ComputeError: "Could not convert {:?} to usize", duration),
         )?;
-        polars_ensure!(step != 0, InvalidOperation: "interval {} is too small for time unit {} and got rounded down to zero", interval, time_unit);
+        polars_ensure!(
+            step != 0,
+            InvalidOperation: "interval {} is too small for time unit {} and got rounded down to zero",
+            interval,
+            time_unit,
+        );
         return match closed {
             ClosedWindow::Both => Ok((start..=end).step_by(step).collect::<Vec<i64>>()),
             ClosedWindow::None => Ok((start + duration..end).step_by(step).collect::<Vec<i64>>()),

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -620,3 +620,17 @@ def test_datetime_range_fast_slow_paths(
         eager=True,
     )
     assert_series_equal(result_slow, result_fast)
+
+
+def test_dt_range_with_nanosecond_interval_19931() -> None:
+    with pytest.raises(
+        InvalidOperationError, match="interval 1ns is too small for time unit ms"
+    ):
+        pl.datetime_range(
+            pl.date(2022, 1, 1),
+            pl.date(2022, 1, 1),
+            time_zone="Asia/Kathmandu",
+            interval="1ns",
+            time_unit="ms",
+            eager=True,
+        )


### PR DESCRIPTION
closes #19931

~~🤔 or maybe it should produce an empty range~~ `interval='0ns'` raises that the interval must be positive, so I think it's right to raise