### PR TITLE
fix: Fix panic on schema merge for prefiltering

### DIFF
--- a/crates/polars-io/src/hive.rs
+++ b/crates/polars-io/src/hive.rs
@@ -75,15 +75,14 @@ pub(crate) fn merge_sorted_to_schema_order<D>(
 ) {
     // Safety: Both `df_columns` and `hive_columns` are non-empty.
     let mut series_arr = [df_columns, hive_columns];
-    let mut schema_idx_arr = [
-        // `unwrap_or(0)`: The first column could be a row_index column that doesn't exist in the `schema`.
-        schema.index_of(series_arr[0][0].name()).unwrap_or(0),
-        schema
-            .index_of(series_arr[1][0].name())
-            .unwrap_or(usize::MAX),
-    ];
 
-    if schema_idx_arr[1] != usize::MAX {
+    if let Some(i) = schema.index_of(series_arr[1][0].name()) {
+        let mut schema_idx_arr = [
+            // `unwrap_or(0)`: The first column could be a row_index column that doesn't exist in the `schema`.
+            schema.index_of(series_arr[0][0].name()).unwrap_or(0),
+            i,
+        ];
+
         loop {
             // Take from the side whose next column appears earlier in the `schema`.
             let arg_min = if schema_idx_arr[1] < schema_idx_arr[0] {

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -558,11 +558,8 @@ fn rg_to_dfs_prefiltered(
                 // We re-use `hive::merge_sorted_to_schema_order()` as it performs most of the merge operation we want.
                 // But we take out the `row_index` column as it isn't on the right side.
 
-                let live_columns = if row_index.is_some() {
+                if row_index.is_some() {
                     merged.push(live_columns[0].clone());
-                    &live_columns[1..]
-                } else {
-                    &live_columns
                 };
 
                 if live_columns.is_empty() {
@@ -570,8 +567,8 @@ fn rg_to_dfs_prefiltered(
                 } else {
                     assert!(!dead_columns.is_empty());
                     hive::merge_sorted_to_schema_order(
-                        &dead_columns, // df_columns
-                        live_columns,  // hive_columns
+                        &mut dead_columns.into_iter(), // df_columns
+                        &mut live_columns.into_iter().skip(row_index.is_some() as usize), // hive_columns
                         schema,
                         &mut merged,
                     );


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/19968

Panic caused by assuming that hive columns were always in the file in the merge for prefiltering
