### PR TITLE
fix: Fix lazy frame join expression

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
@@ -20,9 +20,16 @@ fn add_keys_to_accumulated_state(
     // the JOIN executor
     if add_local {
         // return the left most name as output name
-        let names = aexpr_to_leaf_names_iter(expr, expr_arena).collect::<Vec<_>>();
-        let output_name = names.first().cloned();
+        let names = aexpr_to_leaf_names_iter(expr, expr_arena);
+
+        let mut first = true;
+        let mut output_name = None;
         for name in names {
+            if first {
+                output_name = Some(name.clone());
+                first = false;
+            }
+
             let node = expr_arena.add(AExpr::Column(name));
             local_projection.push(ColumnNode(node));
         }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/joins.rs
@@ -20,16 +20,9 @@ fn add_keys_to_accumulated_state(
     // the JOIN executor
     if add_local {
         // return the left most name as output name
-        let names = aexpr_to_leaf_names_iter(expr, expr_arena);
-
-        let mut first = true;
-        let mut output_name = None;
+        let names = aexpr_to_leaf_names_iter(expr, expr_arena).collect::<Vec<_>>();
+        let output_name = names.first().cloned();
         for name in names {
-            if first {
-                output_name = Some(name.clone());
-                first = false;
-            }
-
             let node = expr_arena.add(AExpr::Column(name));
             local_projection.push(ColumnNode(node));
         }

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -171,7 +171,7 @@ def test_join_lazy_frame_on_expression() -> None:
         .collect()
     )
 
-    eager_join = (df.join(df, left_on=pl.coalesce('b', 'a'), right_on='a').select('a'))
+    eager_join = df.join(df, left_on=pl.coalesce('b', 'a'), right_on='a').select('a')
 
     assert lazy_join.shape == eager_join.shape
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -158,6 +158,36 @@ def test_join_on_expressions() -> None:
     ).to_dict(as_series=False) == {"a": [1, 2, 3, 3], "b": [1, 4, 9, 9]}
 
 
+def test_join_lazy_frame_on_expression() -> None:
+    # Tests a lazy frame projection pushdown bug
+    # https://github.com/pola-rs/polars/issues/19822
+
+    df = pl.DataFrame(data={"a": [0, 1], "b": [2, 3]})
+
+    lazy_join = (df.lazy()
+                 .join(df.lazy(),
+                       left_on=pl.coalesce('b', 'a'),
+                       right_on='a'
+                       )
+                 .select('a')
+                 .collect()
+                 )
+
+    print(lazy_join)
+
+    eager_join = (df
+                  .join(df,
+                        left_on=pl.coalesce('b', 'a'),
+                        right_on='a'
+                        )
+                  .select('a')
+                  )
+
+    print(eager_join)
+
+    assert lazy_join.shape == eager_join.shape
+
+
 def test_join() -> None:
     df_left = pl.DataFrame(
         {

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -171,7 +171,7 @@ def test_join_lazy_frame_on_expression() -> None:
         .collect()
     )
 
-    eager_join = df.join(df, left_on=pl.coalesce('b', 'a'), right_on='a').select('a')
+    eager_join = df.join(df, left_on=pl.coalesce("b", "a"), right_on="a").select("a")
 
     assert lazy_join.shape == eager_join.shape
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -164,26 +164,14 @@ def test_join_lazy_frame_on_expression() -> None:
 
     df = pl.DataFrame(data={"a": [0, 1], "b": [2, 3]})
 
-    lazy_join = (df.lazy()
-                 .join(df.lazy(),
-                       left_on=pl.coalesce('b', 'a'),
-                       right_on='a'
-                       )
-                 .select('a')
-                 .collect()
-                 )
+    lazy_join = (
+        df.lazy()
+        .join(df.lazy(), left_on=pl.coalesce("b", "a"), right_on="a")
+        .select("a")
+        .collect()
+    )
 
-    print(lazy_join)
-
-    eager_join = (df
-                  .join(df,
-                        left_on=pl.coalesce('b', 'a'),
-                        right_on='a'
-                        )
-                  .select('a')
-                  )
-
-    print(eager_join)
+    eager_join = (df.join(df, left_on=pl.coalesce('b', 'a'), right_on='a').select('a'))
 
     assert lazy_join.shape == eager_join.shape
 


### PR DESCRIPTION
Fixes #19822 

Previously only the first column was added to the local projections while all of the columns in the sub expression should be added.