### PR TITLE
feat(python): Improve Polars `Enum` dtype init from standard Python enums

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -582,7 +582,7 @@ class Categorical(DataType):
 
 class Enum(DataType):
     """
-    A fixed set categorical encoding of a set of strings.
+    A fixed categorical encoding of a unique set of strings.
 
     .. warning::
         This functionality is considered **unstable**.
@@ -592,8 +592,22 @@ class Enum(DataType):
     Parameters
     ----------
     categories
-        The categories in the dataset. Categories must be strings.
-    """
+        The categories in the dataset; must be a unique set of strings, or an
+        existing Python string-valued enum.
+
+    Examples
+    --------
+    Explicitly define enumeration categories:
+
+    >>> pl.Enum(["north", "south", "east", "west"])
+    Enum(categories=['north', 'south', 'east', 'west'])
+
+    Initialise from an existing Python enumeration:
+
+    >>> from http import HTTPMethod
+    >>> pl.Enum(HTTPMethod)
+    Enum(categories=['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE'])
+    """  # noqa: W505
 
     categories: Series
 
@@ -608,7 +622,17 @@ class Enum(DataType):
         )
 
         if isclass(categories) and issubclass(categories, enum.Enum):
-            categories = pl.Series(values=categories.__members__.values())
+            for enum_subclass in (enum.IntFlag, enum.Flag, enum.IntEnum):
+                if issubclass(categories, enum_subclass):
+                    enum_type_name = enum_subclass.__name__
+                    msg = f"Enum categories must be strings; Python `enum.{enum_type_name}` values are integers"
+                    raise TypeError(msg)
+
+            enum_values = [
+                (v if isinstance(v, str) else v.value)
+                for v in categories.__members__.values()
+            ]
+            categories = pl.Series(values=enum_values)
         elif not isinstance(categories, pl.Series):
             categories = pl.Series(values=categories)
 

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import operator
 import re
+import sys
 from datetime import date
 from textwrap import dedent
 from typing import Any, Callable
@@ -42,32 +43,70 @@ def test_enum_init_empty(categories: pl.Series | list[str] | None) -> None:
     assert_series_equal(dtype.categories, expected)
 
 
-def test_enum_init_python_enum_19724() -> None:
-    class PythonEnum(str, enum.Enum):
-        CAT1 = "A"
-        CAT2 = "B"
-        CAT3 = "C"
+def test_enum_init_from_python() -> None:
+    # standard string enum
+    class Color1(str, enum.Enum):
+        RED = "red"
+        GREEN = "green"
+        BLUE = "blue"
 
-    result = pl.Enum(PythonEnum)
-    assert result == pl.Enum(["A", "B", "C"])
+    dtype = pl.Enum(Color1)
+    assert dtype == pl.Enum(["red", "green", "blue"])
+
+    # standard generic enum
+    class Color2(enum.Enum):
+        RED = "red"
+        GREEN = "green"
+        BLUE = "blue"
+
+    dtype = pl.Enum(Color2)
+    assert dtype == pl.Enum(["red", "green", "blue"])
+
+    # specialised string enum
+    if sys.version_info >= (3, 11):
+
+        class Color3(enum.Enum):
+            RED = "red"
+            GREEN = "green"
+            BLUE = "blue"
+
+        dtype = pl.Enum(Color3)
+        assert dtype == pl.Enum(["red", "green", "blue"])
 
 
-def test_enum_init_python_enum_ints_19724() -> None:
-    class PythonEnum(int, enum.Enum):
-        CAT1 = 1
-        CAT2 = 2
-        CAT3 = 3
+def test_enum_init_from_python_invalid() -> None:
+    class Color(int, enum.Enum):
+        RED = 1
+        GREEN = 2
+        BLUE = 3
 
-    with pytest.raises(TypeError, match="Enum categories must be strings"):
-        pl.Enum(PythonEnum)
+    with pytest.raises(
+        TypeError,
+        match="Enum categories must be strings",
+    ):
+        pl.Enum(Color)
+
+    # flag/int enums
+    for EnumBase in (enum.Flag, enum.IntFlag, enum.IntEnum):
+
+        class Color(EnumBase):  # type: ignore[no-redef,misc,valid-type]
+            RED = enum.auto()
+            GREEN = enum.auto()
+            BLUE = enum.auto()
+
+        base_name = EnumBase.__name__
+
+        with pytest.raises(
+            TypeError,
+            match=f"Enum categories must be strings; Python `enum.{base_name}` values are integers",
+        ):
+            pl.Enum(Color)
 
 
 def test_enum_non_existent() -> None:
     with pytest.raises(
         InvalidOperationError,
-        match=re.escape(
-            "conversion from `str` to `enum` failed in column '' for 1 out of 4 values: [\"c\"]"
-        ),
+        match="conversion from `str` to `enum` failed in column '' for 1 out of 4 values: \\[\"c\"\\]",
     ):
         pl.Series([None, "a", "b", "c"], dtype=pl.Enum(categories=["a", "b"]))
 


### PR DESCRIPTION
Extends #19926.

* Seamless init from all types of string-valued Python Enums. This means that the caller's Enum definition doesn't _have_ to be explicitly declared as `SomeEnum(str, Enum)` _(py < 3.11)_ or `SomeEnum(StrEnum)` _(py >=3.11)_, as long as the referenced values are strings.
* More specific error message on attempt to initialise from unsupported Python enum types (eg: `Flag`, `IntEnum`, etc...)

## Example

```python
import polars as pl
import enum

class PolarsURL(enum.Enum):
    HOMEPAGE = "https://pola.rs"
    BLOG = "https://pola.rs/posts/"
    USER_GUIDE = "https://docs.pola.rs/"
    PYTHON_API = "https://docs.pola.rs/py-polars/html/reference/"
    RUST_API = "https://docs.rs/polars/latest/polars/"
    SERVICES = "https://pola.rs/our-services/"
```
**Before:**
```python
pl.Enum(PolarsURL)
# TypeError: Enum categories must be strings; found data of type Object
```
**After:**
```python
pl.Enum(PolarsURL)
# Enum(categories=[
#     'https://pola.rs', 
#     'https://pola.rs/posts/', 
#     'https://docs.pola.rs/', 
#     'https://docs.pola.rs/py-polars/html/reference/', 
#     'https://docs.rs/polars/latest/polars/',
#     'https://pola.rs/our-services/',
# ])
```