### PR TITLE
fix: Fix starts_with out of bounds

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/starts_with.rs
+++ b/crates/polars-ops/src/chunked_array/strings/starts_with.rs
@@ -12,8 +12,8 @@ pub(crate) fn starts_with_str(view: View, prefix: &str, buffers: &[Buffer<u8>]) 
         } else {
             let starts = view
                 .prefix
-                .to_le_bytes()
-                .starts_with(prefix.as_bytes().slice_unchecked(0..4));
+                .to_ne_bytes()
+                .starts_with(prefix.as_bytes().slice_unchecked(0..4.min(prefix.len())));
             if starts {
                 return view
                     .get_slice_unchecked(buffers)

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1335,7 +1335,7 @@ def test_extract_groups() -> None:
 def test_starts_ends_with() -> None:
     df = pl.DataFrame(
         {
-            "a": ["hamburger", "nuts", "lollypop", None],
+            "a": ["hamburger_with_tomatoes", "nuts", "lollypop", None],
             "sub": ["ham", "ts", None, "anything"],
         }
     )


### PR DESCRIPTION
Fixes #20003 

If the prefix is shorter than 4 bytes then the slicing should be bounded.