### PR TITLE
fix: Improve binning in `Series.hist` with `bin_count` when all values are the same

### DIFF
--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -69,8 +69,14 @@ where
                 // Determine outer bin edges from the data itself
                 let min_value = ca.min().unwrap().to_f64().unwrap();
                 let max_value = ca.max().unwrap().to_f64().unwrap();
-                pad_lower = true;
-                (min_value, (max_value - min_value) / bin_count as f64)
+
+                // All data points are identical--use unit interval.
+                if min_value == max_value {
+                    (min_value - 0.5, 1.0 / bin_count as f64)
+                } else {
+                    pad_lower = true;
+                    (min_value, (max_value - min_value) / bin_count as f64)
+                }
             };
             let out = (0..bin_count + 1)
                 .map(|x| (x as f64 * width) + offset)


### PR DESCRIPTION
Closes #20030.

I added a skip condition to the `test_hist_rand` to address "flaky failure" in the same-value case, since including it would increase the complexity of the test. It's easier to just include the separate test.

New behavior uses a unit interval, as it does in the single-value case:

```pycon
>>> pl.Series([1, 1]).hist(bin_count=2)
shape: (2, 3)
┌────────────┬────────────┬───────┐
│ breakpoint ┆ category   ┆ count │
│ ---        ┆ ---        ┆ ---   │
│ f64        ┆ cat        ┆ u32   │
╞════════════╪════════════╪═══════╡
│ 1.0        ┆ (0.5, 1.0] ┆ 2     │
│ 1.5        ┆ (1.0, 1.5] ┆ 0     │
└────────────┴────────────┴───────┘
```

I think this could use a further improvement and should probably only have a single bin, but that can be a different discussion.