### PR TITLE
chore: Allow PR titles to start with a backtick

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,7 +4,7 @@
     "color": "FF0000"
   },
   "CHECKS": {
-    "regexp": "^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\\((python|rust)\\!?(,(python|rust)\\!?)?\\))?\\!?\\: [A-Z].*[^\\.\\!\\?,… ]$",
+    "regexp": "^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\\((python|rust)\\!?(,(python|rust)\\!?)?\\))?\\!?\\: [A-Z`].*[^\\.\\!\\?,… ]$",
     "ignoreLabels": ["skip changelog"]
   },
   "MESSAGES": {


### PR DESCRIPTION
@stinodego I won't un-draft this unless you think this is acceptable. I had a PR title fail because it was:

> fix: `Series.hist` with `bin_count` produces wrong result if all values are the same

The [PR checker regex](https://github.com/pola-rs/polars/blob/main/.github/pr-title-checker-config.json#L7) does not allow for the PR title to begin with a backtick after the `: ` section. This simply adds a backtick to the list of first-acceptable characters.