### PR TITLE
fix(rust): Using same division in scalar and not for floats

### DIFF
--- a/crates/polars-compute/src/arithmetic/float.rs
+++ b/crates/polars-compute/src/arithmetic/float.rs
@@ -105,7 +105,7 @@ macro_rules! impl_float_arith_kernel {
             }
 
             fn prim_true_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<Self::TrueDivT> {
-                Self::prim_wrapping_mul_scalar(lhs, 1.0 / rhs)
+                prim_unary_values(lhs, |x| x / rhs)
             }
 
             fn prim_true_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<Self::TrueDivT> {


### PR DESCRIPTION
Fixes #20038

Let me know if this change is wanted before I add tests