### PR TITLE
docs(python): Remove note about guaranteed left join order

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7106,8 +7106,6 @@ class DataFrame:
             * *anti*
                 Returns rows from the left table that have no match in the right table.
 
-            .. note::
-                A left join preserves the row order of the left DataFrame.
         left_on
             Name(s) of the left join column(s).
         right_on

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4418,8 +4418,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             * *anti*
                 Returns rows from the left table that have no match in the right table.
 
-            .. note::
-                A left join preserves the row order of the left DataFrame.
         left_on
             Join column of the left DataFrame.
         right_on


### PR DESCRIPTION
We currently guarantee preserving the order on a left join. In the future, we will no longer guarantee this by default and add a `maintain_order` argument to control this, as guaranteeing the order can be expensive under certain conditions.

