### PR TITLE
fix: Allow nested `is_in()` in `when()/then()` for full-streaming

### DIFF
--- a/crates/polars-mem-engine/src/executors/projection.rs
+++ b/crates/polars-mem-engine/src/executors/projection.rs
@@ -13,7 +13,7 @@ pub struct ProjectionExec {
     pub(crate) schema: SchemaRef,
     pub(crate) options: ProjectionOptions,
     // Can run all operations elementwise
-    pub(crate) streamable: bool,
+    pub(crate) allow_vertical_parallelism: bool,
 }
 
 impl ProjectionExec {
@@ -23,7 +23,7 @@ impl ProjectionExec {
         mut df: DataFrame,
     ) -> PolarsResult<DataFrame> {
         // Vertical and horizontal parallelism.
-        let df = if self.streamable
+        let df = if self.allow_vertical_parallelism
             && df.first_col_n_chunks() > 1
             && df.height() > POOL.current_num_threads() * 2
             && self.options.run_parallel

--- a/crates/polars-mem-engine/src/executors/stack.rs
+++ b/crates/polars-mem-engine/src/executors/stack.rs
@@ -11,7 +11,7 @@ pub struct StackExec {
     pub(crate) output_schema: SchemaRef,
     pub(crate) options: ProjectionOptions,
     // Can run all operations elementwise
-    pub(crate) streamable: bool,
+    pub(crate) allow_vertical_parallelism: bool,
 }
 
 impl StackExec {
@@ -23,7 +23,7 @@ impl StackExec {
         let schema = &*self.output_schema;
 
         // Vertical and horizontal parallelism.
-        let df = if self.streamable
+        let df = if self.allow_vertical_parallelism
             && df.first_col_n_chunks() > 1
             && df.height() > 0
             && self.options.run_parallel

--- a/crates/polars-plan/src/plans/aexpr/traverse.rs
+++ b/crates/polars-plan/src/plans/aexpr/traverse.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl AExpr {
     /// Push nodes at this level to a pre-allocated stack.
-    pub(crate) fn nodes<C: PushNode>(&self, container: &mut C) {
+    pub(crate) fn nodes(&self, container: &mut impl PushNode) {
         use AExpr::*;
 
         match self {

--- a/crates/polars-plan/src/plans/aexpr/utils.rs
+++ b/crates/polars-plan/src/plans/aexpr/utils.rs
@@ -1,8 +1,11 @@
+use polars_utils::idx_vec::UnitVec;
+use polars_utils::unitvec;
+
 use super::*;
 
 /// Checks if the top-level expression node is elementwise. If this is the case, then `stack` will
 /// be extended further with any nested expression nodes.
-pub fn is_elementwise(stack: &mut Vec<Node>, ae: &AExpr, expr_arena: &Arena<AExpr>) -> bool {
+pub fn is_elementwise(stack: &mut UnitVec<Node>, ae: &AExpr, expr_arena: &Arena<AExpr>) -> bool {
     use AExpr::*;
 
     if !ae.is_elementwise_top_level() {
@@ -38,7 +41,7 @@ pub fn is_elementwise(stack: &mut Vec<Node>, ae: &AExpr, expr_arena: &Arena<AExp
 
 /// Recursive variant of `is_elementwise`
 pub fn is_elementwise_rec<'a>(mut ae: &'a AExpr, expr_arena: &'a Arena<AExpr>) -> bool {
-    let mut stack = vec![];
+    let mut stack = unitvec![];
 
     loop {
         if !is_elementwise(&mut stack, ae, expr_arena) {
@@ -58,7 +61,7 @@ pub fn is_elementwise_rec<'a>(mut ae: &'a AExpr, expr_arena: &'a Arena<AExpr>) -
 /// Recursive variant of `is_elementwise` that also forbids casting to categoricals. This function
 /// is used to determine if an expression evaluation can be vertically parallelized.
 pub fn is_elementwise_rec_no_cat_cast<'a>(mut ae: &'a AExpr, expr_arena: &'a Arena<AExpr>) -> bool {
-    let mut stack = vec![];
+    let mut stack = unitvec![];
 
     loop {
         if !is_elementwise(&mut stack, ae, expr_arena) {
@@ -97,7 +100,7 @@ pub fn is_elementwise_rec_no_cat_cast<'a>(mut ae: &'a AExpr, expr_arena: &'a Are
 /// Note that this  function is not recursive - the caller should repeatedly
 /// call this function with the `stack` to perform a recursive check.
 pub(crate) fn permits_filter_pushdown(
-    stack: &mut Vec<Node>,
+    stack: &mut UnitVec<Node>,
     ae: &AExpr,
     expr_arena: &Arena<AExpr>,
 ) -> bool {
@@ -129,7 +132,7 @@ pub(crate) fn permits_filter_pushdown(
 }
 
 pub fn permits_filter_pushdown_rec<'a>(mut ae: &'a AExpr, expr_arena: &'a Arena<AExpr>) -> bool {
-    let mut stack = vec![];
+    let mut stack = unitvec![];
 
     loop {
         if !permits_filter_pushdown(&mut stack, ae, expr_arena) {

--- a/crates/polars-plan/src/plans/aexpr/utils.rs
+++ b/crates/polars-plan/src/plans/aexpr/utils.rs
@@ -1,121 +1,147 @@
-use bitflags::bitflags;
-
 use super::*;
 
-fn has_series_or_range(ae: &AExpr) -> bool {
-    matches!(
-        ae,
-        AExpr::Literal(LiteralValue::Series(_) | LiteralValue::Range { .. })
-    )
-}
+/// Checks if the top-level expression node is elementwise. If this is the case, then `stack` will
+/// be extended further with any nested expression nodes.
+pub fn is_elementwise(stack: &mut Vec<Node>, ae: &AExpr, expr_arena: &Arena<AExpr>) -> bool {
+    use AExpr::*;
 
-bitflags! {
-        #[derive(Default, Copy, Clone)]
-        struct StreamableFlags: u8 {
-          const ALLOW_CAST_CATEGORICAL = 1;
-        }
-}
-
-#[derive(Copy, Clone)]
-pub struct IsStreamableContext {
-    flags: StreamableFlags,
-    context: Context,
-}
-
-impl Default for IsStreamableContext {
-    fn default() -> Self {
-        Self {
-            flags: StreamableFlags::all(),
-            context: Default::default(),
-        }
-    }
-}
-
-impl IsStreamableContext {
-    pub fn new(ctx: Context) -> Self {
-        Self {
-            flags: StreamableFlags::all(),
-            context: ctx,
-        }
+    if !ae.is_elementwise_top_level() {
+        return false;
     }
 
-    pub fn with_allow_cast_categorical(mut self, allow_cast_categorical: bool) -> Self {
-        self.flags.set(
-            StreamableFlags::ALLOW_CAST_CATEGORICAL,
-            allow_cast_categorical,
-        );
-        self
-    }
-}
-
-pub fn is_streamable(node: Node, expr_arena: &Arena<AExpr>, ctx: IsStreamableContext) -> bool {
-    // check whether leaf column is Col or Lit
-    let mut seen_column = false;
-    let mut seen_lit_range = false;
-    let all = expr_arena.iter(node).all(|(_, ae)| match ae {
-        AExpr::Function {
-            function: FunctionExpr::SetSortedFlag(_),
+    match ae {
+        // Literals that aren't being projected are allowed to be non-scalar, so we don't add them
+        // for inspection. (e.g. `is_in(<literal>)`).
+        #[cfg(feature = "is_in")]
+        Function {
+            function: FunctionExpr::Boolean(BooleanFunction::IsIn),
+            input,
             ..
-        } => true,
-        AExpr::Function { options, .. } | AExpr::AnonymousFunction { options, .. } => {
-            match ctx.context {
-                Context::Default => matches!(
-                    options.collect_groups,
-                    ApplyOptions::ElementWise | ApplyOptions::ApplyList
-                ),
-                Context::Aggregation => matches!(options.collect_groups, ApplyOptions::ElementWise),
-            }
-        },
-        AExpr::Column(_) => {
-            seen_column = true;
-            true
-        },
-        AExpr::BinaryExpr { left, right, .. } => {
-            !has_aexpr(*left, expr_arena, has_series_or_range)
-                && !has_aexpr(*right, expr_arena, has_series_or_range)
-        },
-        AExpr::Ternary {
-            truthy,
-            falsy,
-            predicate,
-        } => {
-            !has_aexpr(*truthy, expr_arena, has_series_or_range)
-                && !has_aexpr(*falsy, expr_arena, has_series_or_range)
-                && !has_aexpr(*predicate, expr_arena, has_series_or_range)
-        },
-        #[cfg(feature = "dtype-categorical")]
-        AExpr::Cast { dtype, .. } if matches!(dtype, DataType::Categorical(_, _)) => {
-            ctx.flags.contains(StreamableFlags::ALLOW_CAST_CATEGORICAL)
-        },
-        AExpr::Alias(_, _) | AExpr::Cast { .. } => true,
-        AExpr::Literal(lv) => match lv {
-            LiteralValue::Series(_) | LiteralValue::Range { .. } => {
-                seen_lit_range = true;
-                true
-            },
-            _ => true,
-        },
-        _ => false,
-    });
+        } => (|| {
+            if let Some(rhs) = input.get(1) {
+                assert_eq!(input.len(), 2); // A.is_in(B)
+                let rhs = rhs.node();
 
-    if all {
-        // adding a range or literal series to chunks will fail because sizes don't match
-        // if column is a leaf column then it is ok
-        // - so we want to block `with_column(lit(Series))`
-        // - but we want to allow `with_column(col("foo").is_in(Series))`
-        // that means that IFF we seen a lit_range, we only allow if we also seen a `column`.
-        return if seen_lit_range { seen_column } else { true };
+                if matches!(expr_arena.get(rhs), AExpr::Literal { .. }) {
+                    stack.push_node(input[0].node());
+                    return;
+                }
+            };
+
+            ae.nodes(stack);
+        })(),
+        _ => ae.nodes(stack),
     }
 
-    false
+    true
 }
 
-pub fn all_streamable(
-    exprs: &[ExprIR],
+/// Recursive variant of `is_elementwise`
+pub fn is_elementwise_rec<'a>(mut ae: &'a AExpr, expr_arena: &'a Arena<AExpr>) -> bool {
+    let mut stack = vec![];
+
+    loop {
+        if !is_elementwise(&mut stack, ae, expr_arena) {
+            return false;
+        }
+
+        let Some(node) = stack.pop() else {
+            break;
+        };
+
+        ae = expr_arena.get(node);
+    }
+
+    true
+}
+
+/// Recursive variant of `is_elementwise` that also forbids casting to categoricals. This function
+/// is used to determine if an expression evaluation can be vertically parallelized.
+pub fn is_elementwise_rec_no_cat_cast<'a>(mut ae: &'a AExpr, expr_arena: &'a Arena<AExpr>) -> bool {
+    let mut stack = vec![];
+
+    loop {
+        if !is_elementwise(&mut stack, ae, expr_arena) {
+            return false;
+        }
+
+        #[cfg(feature = "dtype-categorical")]
+        {
+            if let AExpr::Cast {
+                dtype: DataType::Categorical(..),
+                ..
+            } = ae
+            {
+                return false;
+            }
+        }
+
+        let Some(node) = stack.pop() else {
+            break;
+        };
+
+        ae = expr_arena.get(node);
+    }
+
+    true
+}
+
+/// Check whether filters can be pushed past this expression.
+///
+/// A query, `with_columns(C).filter(P)` can be re-ordered as `filter(P).with_columns(C)`, iff
+/// both P and C permit filter pushdown.
+///
+/// If filter pushdown is permitted, `stack` is extended with any input expression nodes that this
+/// expression may have.
+///
+/// Note that this  function is not recursive - the caller should repeatedly
+/// call this function with the `stack` to perform a recursive check.
+pub(crate) fn permits_filter_pushdown(
+    stack: &mut Vec<Node>,
+    ae: &AExpr,
     expr_arena: &Arena<AExpr>,
-    ctx: IsStreamableContext,
 ) -> bool {
-    exprs
-        .iter()
-        .all(|e| is_streamable(e.node(), expr_arena, ctx))
+    // This is a subset of an `is_elementwise` check that also blocks exprs that raise errors
+    // depending on the data. The idea is that, although the success value of these functions
+    // are elementwise, their error behavior is non-elementwise. Their error behavior is essentially
+    // performing an aggregation `ANY(evaluation_result_was_error)`, and if this is the case then
+    // the query result should be an error.
+    match ae {
+        // Rows that go OOB on get/gather may be filtered out in earlier operations,
+        // so we don't push these down.
+        AExpr::Function {
+            function: FunctionExpr::ListExpr(ListFunction::Get(false)),
+            ..
+        } => false,
+        #[cfg(feature = "list_gather")]
+        AExpr::Function {
+            function: FunctionExpr::ListExpr(ListFunction::Gather(false)),
+            ..
+        } => false,
+        #[cfg(feature = "dtype-array")]
+        AExpr::Function {
+            function: FunctionExpr::ArrayExpr(ArrayFunction::Get(false)),
+            ..
+        } => false,
+        // TODO: There are a lot more functions that should be caught here.
+        ae => is_elementwise(stack, ae, expr_arena),
+    }
+}
+
+pub fn permits_filter_pushdown_rec<'a>(mut ae: &'a AExpr, expr_arena: &'a Arena<AExpr>) -> bool {
+    let mut stack = vec![];
+
+    loop {
+        if !permits_filter_pushdown(&mut stack, ae, expr_arena) {
+            return false;
+        }
+
+        let Some(node) = stack.pop() else {
+            break;
+        };
+
+        ae = expr_arena.get(node);
+    }
+
+    true
 }

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -406,7 +406,11 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
 
             let predicate_ae = to_expr_ir(predicate.clone(), ctxt.expr_arena)?;
 
-            return if is_streamable(predicate_ae.node(), ctxt.expr_arena, Default::default()) {
+            // TODO: We could do better here by using `pushdown_eligibility()`
+            return if permits_filter_pushdown_rec(
+                ctxt.expr_arena.get(predicate_ae.node()),
+                ctxt.expr_arena,
+            ) {
                 // Split expression that are ANDed into multiple Filter nodes as the optimizer can then
                 // push them down independently. Especially if they refer columns from different tables
                 // this will be more performant.

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -134,12 +134,17 @@ pub fn resolve_join(
     }
     // Every expression must be elementwise so that we are
     // guaranteed the keys for a join are all the same length.
-    let all_elementwise =
-        |aexprs: &[ExprIR]| all_streamable(aexprs, &*ctxt.expr_arena, Default::default());
+    let all_elementwise = |aexprs: &[ExprIR]| {
+        aexprs
+            .iter()
+            .all(|e| is_elementwise_rec(ctxt.expr_arena.get(e.node()), ctxt.expr_arena))
+    };
+
     polars_ensure!(
         all_elementwise(&left_on) && all_elementwise(&right_on),
-        InvalidOperation: "All join key expressions must be elementwise."
+        InvalidOperation: "all join key expressions must be elementwise."
     );
+
     let lp = IR::Join {
         input_left,
         input_right,

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -98,10 +98,16 @@ impl LiteralValue {
         }
     }
 
+    pub fn is_scalar(&self) -> bool {
+        !matches!(self, LiteralValue::Series(_) | LiteralValue::Range { .. })
+    }
+
+    /// Less-strict `is_scalar` check - generally used for internal functionality such as our
+    /// optimizers.
     pub(crate) fn projects_as_scalar(&self) -> bool {
         match self {
-            LiteralValue::Range { low, high, .. } => high.saturating_sub(*low) == 1,
             LiteralValue::Series(s) => s.len() == 1,
+            LiteralValue::Range { low, high, .. } => high.saturating_sub(*low) == 1,
             _ => true,
         }
     }
@@ -229,10 +235,6 @@ impl LiteralValue {
         {
             LiteralValue::UInt32(value)
         }
-    }
-
-    pub fn is_scalar(&self) -> bool {
-        !matches!(self, LiteralValue::Series(_) | LiteralValue::Range { .. })
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cache_states.rs
@@ -290,7 +290,7 @@ pub(super) fn set_cache_states(
     // back to the cache node again
     if !cache_schema_and_children.is_empty() {
         let mut proj_pd = ProjectionPushDown::new();
-        let pred_pd = PredicatePushDown::new(expr_eval).block_at_cache(false);
+        let mut pred_pd = PredicatePushDown::new(expr_eval).block_at_cache(false);
         for (_cache_id, v) in cache_schema_and_children {
             // # CHECK IF WE NEED TO REMOVE CACHES
             // If we encounter multiple predicates we remove the cache nodes completely as we don't

--- a/crates/polars-plan/src/plans/optimizer/cse/cse_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cse_expr.rs
@@ -350,11 +350,11 @@ impl ExprIdentifierVisitor<'_> {
                 // other operations we cannot add to the state as they have the output size of the
                 // groups, not the original dataframe
                 if self.is_group_by {
-                    if ae.groups_sensitive() {
+                    if !ae.is_elementwise_top_level() {
                         return REFUSE_NO_MEMBER;
                     }
                     match ae {
-                        AExpr::AnonymousFunction { .. } | AExpr::Filter { .. } => REFUSE_NO_MEMBER,
+                        AExpr::AnonymousFunction { .. } => REFUSE_NO_MEMBER,
                         AExpr::Cast { .. } => REFUSE_ALLOW_MEMBER,
                         _ => ACCEPT,
                     }

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -157,7 +157,7 @@ pub fn optimize(
     }
 
     if predicate_pushdown {
-        let predicate_pushdown_opt = PredicatePushDown::new(expr_eval);
+        let mut predicate_pushdown_opt = PredicatePushDown::new(expr_eval);
         let alp = lp_arena.take(lp_top);
         let alp = predicate_pushdown_opt.optimize(alp, lp_arena, expr_arena)?;
         lp_arena.replace(lp_top, alp);
@@ -182,7 +182,7 @@ pub fn optimize(
     }
 
     if slice_pushdown {
-        let slice_pushdown_opt = SlicePushDown::new(streaming, new_streaming);
+        let mut slice_pushdown_opt = SlicePushDown::new(streaming, new_streaming);
         let alp = lp_arena.take(lp_top);
         let alp = slice_pushdown_opt.optimize(alp, lp_arena, expr_arena)?;
 

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/group_by.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_group_by(
-    opt: &PredicatePushDown,
+    opt: &mut PredicatePushDown,
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
     input: Node,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -121,7 +121,7 @@ fn predicate_applies_to_both_tables(
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_join(
-    opt: &PredicatePushDown,
+    opt: &mut PredicatePushDown,
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
     input_left: Node,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -19,28 +19,47 @@ use crate::utils::{check_input_node, has_aexpr};
 pub type ExprEval<'a> =
     Option<&'a dyn Fn(&ExprIR, &Arena<AExpr>, &SchemaRef) -> Option<Arc<dyn PhysicalIoExpr>>>;
 
-pub struct PredicatePushDown<'a> {
-    expr_eval: ExprEval<'a>,
-    verbose: bool,
-    block_at_cache: bool,
-}
+/// The struct is wrapped in a mod to prevent direct member access of `nodes_scratch`
+mod inner {
+    use polars_core::config::verbose;
+    use polars_utils::arena::Node;
 
-impl<'a> PredicatePushDown<'a> {
-    pub fn new(expr_eval: ExprEval<'a>) -> Self {
-        Self {
-            expr_eval,
-            verbose: verbose(),
-            block_at_cache: true,
-        }
+    use super::ExprEval;
+
+    pub struct PredicatePushDown<'a> {
+        pub(super) expr_eval: ExprEval<'a>,
+        pub(super) verbose: bool,
+        pub(super) block_at_cache: bool,
+        nodes_scratch: Vec<Node>,
     }
 
+    impl<'a> PredicatePushDown<'a> {
+        pub fn new(expr_eval: ExprEval<'a>) -> Self {
+            Self {
+                expr_eval,
+                verbose: verbose(),
+                block_at_cache: true,
+                nodes_scratch: vec![],
+            }
+        }
+
+        pub(super) fn nodes_scratch_mut(&mut self) -> &mut Vec<Node> {
+            self.nodes_scratch.clear();
+            &mut self.nodes_scratch
+        }
+    }
+}
+
+pub use inner::PredicatePushDown;
+
+impl PredicatePushDown<'_> {
     pub(crate) fn block_at_cache(mut self, toggle: bool) -> Self {
         self.block_at_cache = toggle;
         self
     }
 
     fn optional_apply_predicate(
-        &self,
+        &mut self,
         lp: IR,
         local_predicates: Vec<ExprIR>,
         lp_arena: &mut Arena<IR>,
@@ -57,7 +76,7 @@ impl<'a> PredicatePushDown<'a> {
     }
 
     fn pushdown_and_assign(
-        &self,
+        &mut self,
         input: Node,
         acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
@@ -71,7 +90,7 @@ impl<'a> PredicatePushDown<'a> {
 
     /// Filter will be pushed down.
     fn pushdown_and_continue(
-        &self,
+        &mut self,
         lp: IR,
         mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
@@ -89,8 +108,13 @@ impl<'a> PredicatePushDown<'a> {
             }
             let input = inputs[inputs.len() - 1];
 
-            let (eligibility, alias_rename_map) =
-                pushdown_eligibility(&exprs, &[], &acc_predicates, expr_arena)?;
+            let (eligibility, alias_rename_map) = pushdown_eligibility(
+                &exprs,
+                &[],
+                &acc_predicates,
+                expr_arena,
+                self.nodes_scratch_mut(),
+            )?;
 
             let local_predicates = match eligibility {
                 PushdownEligibility::Full => vec![],
@@ -186,7 +210,7 @@ impl<'a> PredicatePushDown<'a> {
 
     /// Filter will be done at this node, but we continue optimization
     fn no_pushdown_restart_opt(
-        &self,
+        &mut self,
         lp: IR,
         acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
@@ -217,7 +241,7 @@ impl<'a> PredicatePushDown<'a> {
     }
 
     fn no_pushdown(
-        &self,
+        &mut self,
         lp: IR,
         acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
@@ -241,7 +265,7 @@ impl<'a> PredicatePushDown<'a> {
     /// * `expr_arena` - The local memory arena for the expressions.
     #[recursive]
     fn push_down(
-        &self,
+        &mut self,
         lp: IR,
         mut acc_predicates: PlHashMap<PlSmallStr, ExprIR>,
         lp_arena: &mut Arena<IR>,
@@ -267,9 +291,10 @@ impl<'a> PredicatePushDown<'a> {
 
                 let local_predicates = match pushdown_eligibility(
                     &[],
-                    &[(tmp_key.clone(), predicate.clone())],
+                    &[predicate.clone()],
                     &acc_predicates,
                     expr_arena,
+                    self.nodes_scratch_mut(),
                 )?
                 .0
                 {
@@ -632,34 +657,32 @@ impl<'a> PredicatePushDown<'a> {
                 acc_predicates,
             ),
             lp @ Union { .. } => {
-                let mut local_predicates = vec![];
-
-                // a count is influenced by a Union/Vstack
-                acc_predicates.retain(|_, predicate| {
-                    if has_aexpr(predicate.node(), expr_arena, |ae| matches!(ae, AExpr::Len)) {
-                        local_predicates.push(predicate.clone());
-                        false
-                    } else {
-                        true
+                if cfg!(debug_assertions) {
+                    for v in acc_predicates.values() {
+                        let ae = expr_arena.get(v.node());
+                        assert!(permits_filter_pushdown(
+                            self.nodes_scratch_mut(),
+                            ae,
+                            expr_arena
+                        ));
                     }
-                });
-                let lp =
-                    self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)?;
-                Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
+                }
+
+                self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
             },
             lp @ Sort { .. } => {
-                let mut local_predicates = vec![];
-                acc_predicates.retain(|_, predicate| {
-                    if predicate_is_sort_boundary(predicate.node(), expr_arena) {
-                        local_predicates.push(predicate.clone());
-                        false
-                    } else {
-                        true
+                if cfg!(debug_assertions) {
+                    for v in acc_predicates.values() {
+                        let ae = expr_arena.get(v.node());
+                        assert!(permits_filter_pushdown(
+                            self.nodes_scratch_mut(),
+                            ae,
+                            expr_arena
+                        ));
                     }
-                });
-                let lp =
-                    self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)?;
-                Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
+                }
+
+                self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, true)
             },
             // Pushed down passed these nodes
             lp @ Sink { .. } => {
@@ -694,7 +717,7 @@ impl<'a> PredicatePushDown<'a> {
                 if let Some(predicate) = predicate {
                     // For IO plugins we only accept streamable expressions as
                     // we want to apply the predicates to the batches.
-                    if !is_streamable(predicate.node(), expr_arena, Default::default())
+                    if !is_elementwise_rec(expr_arena.get(predicate.node()), expr_arena)
                         && matches!(options.python_source, PythonScanSource::IOPlugin)
                     {
                         let lp = PythonScan { options };
@@ -715,7 +738,7 @@ impl<'a> PredicatePushDown<'a> {
     }
 
     pub(crate) fn optimize(
-        &self,
+        &mut self,
         logical_plan: IR,
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -23,6 +23,8 @@ pub type ExprEval<'a> =
 mod inner {
     use polars_core::config::verbose;
     use polars_utils::arena::Node;
+    use polars_utils::idx_vec::UnitVec;
+    use polars_utils::unitvec;
 
     use super::ExprEval;
 
@@ -30,7 +32,7 @@ mod inner {
         pub(super) expr_eval: ExprEval<'a>,
         pub(super) verbose: bool,
         pub(super) block_at_cache: bool,
-        nodes_scratch: Vec<Node>,
+        nodes_scratch: UnitVec<Node>,
     }
 
     impl<'a> PredicatePushDown<'a> {
@@ -39,11 +41,11 @@ mod inner {
                 expr_eval,
                 verbose: verbose(),
                 block_at_cache: true,
-                nodes_scratch: vec![],
+                nodes_scratch: unitvec![],
             }
         }
 
-        pub(super) fn nodes_scratch_mut(&mut self) -> &mut Vec<Node> {
+        pub(super) fn nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
             self.nodes_scratch.clear();
             &mut self.nodes_scratch
         }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -79,34 +79,6 @@ pub(super) fn predicate_at_scan(
     }
 }
 
-fn shifts_elements(node: Node, expr_arena: &Arena<AExpr>) -> bool {
-    let matches = |e: &AExpr| {
-        matches!(
-            e,
-            AExpr::Function {
-                function: FunctionExpr::Shift | FunctionExpr::ShiftAndFill,
-                ..
-            }
-        )
-    };
-    has_aexpr(node, expr_arena, matches)
-}
-
-pub(super) fn predicate_is_sort_boundary(node: Node, expr_arena: &Arena<AExpr>) -> bool {
-    let matches = |e: &AExpr| match e {
-        AExpr::Window { function, .. } => shifts_elements(*function, expr_arena),
-        AExpr::Function { options, .. } | AExpr::AnonymousFunction { options, .. } => {
-            // this check for functions that are
-            // group sensitive and doesn't auto-explode (e.g. is a reduction/aggregation
-            // like sum, min, etc).
-            // function that match this are `cum_sum`, `shift`, `sort`, etc.
-            options.is_groups_sensitive() && !options.flags.contains(FunctionFlags::RETURNS_SCALAR)
-        },
-        _ => false,
-    };
-    has_aexpr(node, expr_arena, matches)
-}
-
 /// Evaluates a condition on the column name inputs of every predicate, where if
 /// the condition evaluates to true on any column name the predicate is
 /// transferred to local.
@@ -136,73 +108,6 @@ where
         }
     }
     local_predicates
-}
-
-/// Extends a stack of nodes with new nodes from `ae` (with some filtering), to support traversing
-/// an expression tree to check predicate PD eligibility. Generally called repeatedly with the same
-/// stack until all nodes are exhausted.
-fn check_and_extend_predicate_pd_nodes(
-    stack: &mut Vec<Node>,
-    ae: &AExpr,
-    expr_arena: &Arena<AExpr>,
-) -> bool {
-    if match ae {
-        // These literals do not come from the RHS of an is_in, meaning that
-        // they are projected as either columns or predicates, both of which
-        // rely on the height of the dataframe at this level and thus need
-        // to block pushdown.
-        AExpr::Literal(lit) => !lit.projects_as_scalar(),
-        // Rows that go OOB on get/gather may be filtered out in earlier operations,
-        // so we don't push these down.
-        AExpr::Function {
-            function: FunctionExpr::ListExpr(ListFunction::Get(false)),
-            ..
-        } => true,
-        #[cfg(feature = "list_gather")]
-        AExpr::Function {
-            function: FunctionExpr::ListExpr(ListFunction::Gather(false)),
-            ..
-        } => true,
-        #[cfg(feature = "dtype-array")]
-        AExpr::Function {
-            function: FunctionExpr::ArrayExpr(ArrayFunction::Get(false)),
-            ..
-        } => true,
-        ae => ae.groups_sensitive(),
-    } {
-        false
-    } else {
-        match ae {
-            #[cfg(feature = "is_in")]
-            AExpr::Function {
-                function: FunctionExpr::Boolean(BooleanFunction::IsIn),
-                input,
-                ..
-            } => {
-                // Handles a special case where the expr contains a series, but it is being
-                // used as part the RHS of an `is_in`, so it can be pushed down as it is not
-                // being projected.
-                let mut transferred_local_nodes = false;
-                if let Some(rhs) = input.get(1) {
-                    let rhs = rhs.node();
-                    if matches!(expr_arena.get(rhs), AExpr::Literal { .. }) {
-                        let mut local_nodes = Vec::<Node>::with_capacity(4);
-                        ae.nodes(&mut local_nodes);
-
-                        stack.extend(local_nodes.into_iter().filter(|node| *node != rhs));
-                        transferred_local_nodes = true;
-                    }
-                };
-                if !transferred_local_nodes {
-                    ae.nodes(stack);
-                }
-            },
-            ae => {
-                ae.nodes(stack);
-            },
-        };
-        true
-    }
 }
 
 /// * `col(A).alias(B).alias(C) => (C, A)`
@@ -235,11 +140,13 @@ pub enum PushdownEligibility {
 #[allow(clippy::type_complexity)]
 pub fn pushdown_eligibility(
     projection_nodes: &[ExprIR],
-    new_predicates: &[(PlSmallStr, ExprIR)],
+    new_predicates: &[ExprIR],
     acc_predicates: &PlHashMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
+    scratch: &mut Vec<Node>,
 ) -> PolarsResult<(PushdownEligibility, PlHashMap<PlSmallStr, PlSmallStr>)> {
-    let mut ae_nodes_stack = Vec::<Node>::with_capacity(4);
+    assert!(scratch.is_empty());
+    let ae_nodes_stack = scratch;
 
     let mut alias_to_col_map =
         optimizer::init_hashmap::<PlSmallStr, PlSmallStr>(Some(projection_nodes.len()));
@@ -259,6 +166,8 @@ pub fn pushdown_eligibility(
          common_window_inputs: &mut PlHashSet<PlSmallStr>| {
             debug_assert_eq!(ae_nodes_stack.len(), 1);
 
+            let mut partition_by_names = PlHashSet::<PlSmallStr>::new();
+
             while let Some(node) = ae_nodes_stack.pop() {
                 let ae = expr_arena.get(node);
 
@@ -276,8 +185,8 @@ pub fn pushdown_eligibility(
                             return false;
                         };
 
-                        let mut partition_by_names =
-                            PlHashSet::<PlSmallStr>::with_capacity(partition_by.len());
+                        partition_by_names.clear();
+                        partition_by_names.reserve(partition_by.len());
 
                         for node in partition_by.iter() {
                             // Only accept col()
@@ -295,7 +204,7 @@ pub fn pushdown_eligibility(
                         }
 
                         if !*has_window {
-                            for name in partition_by_names.into_iter() {
+                            for name in partition_by_names.drain() {
                                 common_window_inputs.insert(name);
                             }
 
@@ -313,7 +222,7 @@ pub fn pushdown_eligibility(
                         }
                     },
                     _ => {
-                        if !check_and_extend_predicate_pd_nodes(ae_nodes_stack, ae, expr_arena) {
+                        if !permits_filter_pushdown(ae_nodes_stack, ae, expr_arena) {
                             return false;
                         }
                     },
@@ -340,7 +249,7 @@ pub fn pushdown_eligibility(
         ae_nodes_stack.push(e.node());
 
         if !process_projection_or_predicate(
-            &mut ae_nodes_stack,
+            ae_nodes_stack,
             &mut has_window,
             &mut common_window_inputs,
         ) {
@@ -372,12 +281,12 @@ pub fn pushdown_eligibility(
         common_window_inputs = new;
     }
 
-    for (_, e) in new_predicates.iter() {
+    for e in new_predicates.iter() {
         debug_assert!(ae_nodes_stack.is_empty());
         ae_nodes_stack.push(e.node());
 
         if !process_projection_or_predicate(
-            &mut ae_nodes_stack,
+            ae_nodes_stack,
             &mut has_window,
             &mut common_window_inputs,
         ) {
@@ -417,7 +326,7 @@ pub fn pushdown_eligibility(
                     can_use_column(name)
                 } else {
                     // May still contain window expressions that need to be blocked.
-                    check_and_extend_predicate_pd_nodes(&mut ae_nodes_stack, ae, expr_arena)
+                    permits_filter_pushdown(ae_nodes_stack, ae, expr_arena)
                 };
 
                 if !can_pushdown {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -1,4 +1,5 @@
 use polars_core::prelude::*;
+use polars_utils::idx_vec::UnitVec;
 
 use super::keys::*;
 use crate::prelude::*;
@@ -143,7 +144,7 @@ pub fn pushdown_eligibility(
     new_predicates: &[ExprIR],
     acc_predicates: &PlHashMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
-    scratch: &mut Vec<Node>,
+    scratch: &mut UnitVec<Node>,
 ) -> PolarsResult<(PushdownEligibility, PlHashMap<PlSmallStr, PlSmallStr>)> {
     assert!(scratch.is_empty());
     let ae_nodes_stack = scratch;
@@ -161,7 +162,7 @@ pub fn pushdown_eligibility(
     // all non-aliased.
     // This function returns false if pushdown cannot be performed.
     let process_projection_or_predicate =
-        |ae_nodes_stack: &mut Vec<Node>,
+        |ae_nodes_stack: &mut UnitVec<Node>,
          has_window: &mut bool,
          common_window_inputs: &mut PlHashSet<PlSmallStr>| {
             debug_assert_eq!(ae_nodes_stack.len(), 1);

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -31,7 +31,7 @@ impl OptimizationRule for SlicePushDown {
                     let ae = ae.clone();
                     self.scratch.clear();
                     ae.nodes(&mut self.scratch);
-                    let input = self.scratch[0];
+                    let input = self.scratch.drain(..).next().unwrap();
                     let new_input = pushdown(input, offset, length, expr_arena);
                     Some(ae.replace_inputs(&[new_input]))
                 },

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -29,9 +29,9 @@ impl OptimizationRule for SlicePushDown {
             let out = match expr_arena.get(*input) {
                 ae @ Alias(..) | ae @ Cast { .. } => {
                     let ae = ae.clone();
-                    self.scratch.clear();
-                    ae.nodes(&mut self.scratch);
-                    let input = self.scratch.drain(..).next().unwrap();
+                    let scratch = self.nodes_scratch_mut();
+                    ae.nodes(scratch);
+                    let input = scratch[0];
                     let new_input = pushdown(input, offset, length, expr_arena);
                     Some(ae.replace_inputs(&[new_input]))
                 },

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -106,13 +106,13 @@ pub struct DistinctOptionsIR {
 pub enum ApplyOptions {
     /// Collect groups to a list and apply the function over the groups.
     /// This can be important in aggregation context.
-    // e.g. [g1, g1, g2] -> [[g1, g1], g2]
+    /// e.g. [g1, g1, g2] -> [[g1, g1], g2]
     GroupWise,
-    // collect groups to a list and then apply
-    // e.g. [g1, g1, g2] -> list([g1, g1, g2])
+    /// collect groups to a list and then apply
+    /// e.g. [g1, g1, g2] -> list([g1, g1, g2])
     ApplyList,
-    // do not collect before apply
-    // e.g. [g1, g1, g2] -> [g1, g1, g2]
+    /// do not collect before apply
+    /// e.g. [g1, g1, g2] -> [g1, g1, g2]
     ElementWise,
 }
 
@@ -200,14 +200,6 @@ pub struct FunctionOptions {
 }
 
 impl FunctionOptions {
-    /// Any function that is sensitive to the number of elements in a group
-    /// - Aggregations
-    /// - Sorts
-    /// - Counts
-    pub fn is_groups_sensitive(&self) -> bool {
-        matches!(self.collect_groups, ApplyOptions::GroupWise)
-    }
-
     #[cfg(feature = "fused")]
     pub(crate) unsafe fn no_check_lengths(&mut self) {
         self.check_lengths = UnsafeBool(false);
@@ -217,10 +209,12 @@ impl FunctionOptions {
     }
 
     pub fn is_elementwise(&self) -> bool {
-        self.collect_groups == ApplyOptions::ElementWise
-            && !self
-                .flags
-                .contains(FunctionFlags::CHANGES_LENGTH | FunctionFlags::RETURNS_SCALAR)
+        matches!(
+            self.collect_groups,
+            ApplyOptions::ElementWise | ApplyOptions::ApplyList
+        ) && !self
+            .flags
+            .contains(FunctionFlags::CHANGES_LENGTH | FunctionFlags::RETURNS_SCALAR)
     }
 }
 

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -40,6 +40,7 @@ pub(crate) fn fmt_column_delimited<S: AsRef<str>>(
     write!(f, "{container_end}")
 }
 
+// TODO: Remove this and use `Extend<Node>` instead.
 pub trait PushNode {
     fn push_node(&mut self, value: Node);
 

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -12,9 +12,9 @@ use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::plans::AExpr;
 use polars_plan::prelude::*;
 use polars_utils::arena::{Arena, Node};
-use polars_utils::format_pl_smallstr;
 use polars_utils::itertools::Itertools;
 use polars_utils::pl_str::PlSmallStr;
+use polars_utils::{format_pl_smallstr, unitvec};
 use slotmap::SlotMap;
 
 use super::{PhysNode, PhysNodeKey, PhysNodeKind};
@@ -57,7 +57,7 @@ pub(crate) fn is_elementwise_rec_cached(
             expr_key,
             (|| {
                 let mut expr_key = expr_key;
-                let mut stack = vec![];
+                let mut stack = unitvec![];
 
                 loop {
                     let ae = arena.get(expr_key);

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -9,7 +9,7 @@ use polars_expr::planner::get_expr_depth_limit;
 use polars_expr::state::ExecutionState;
 use polars_expr::{create_physical_expr, ExpressionConversionState};
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
-use polars_plan::plans::{AExpr, LiteralValue};
+use polars_plan::plans::AExpr;
 use polars_plan::prelude::*;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::format_pl_smallstr;
@@ -47,73 +47,36 @@ struct LowerExprContext<'a> {
     cache: &'a mut ExprCache,
 }
 
-#[recursive::recursive]
-pub(crate) fn is_elementwise(
+pub(crate) fn is_elementwise_rec_cached(
     expr_key: IRNodeKey,
     arena: &Arena<AExpr>,
     cache: &mut ExprCache,
 ) -> bool {
-    if let Some(ret) = cache.is_elementwise.get(&expr_key) {
-        return *ret;
+    if !cache.is_elementwise.contains_key(&expr_key) {
+        cache.is_elementwise.insert(
+            expr_key,
+            (|| {
+                let mut expr_key = expr_key;
+                let mut stack = vec![];
+
+                loop {
+                    if !polars_plan::plans::is_elementwise(&mut stack, arena.get(expr_key), arena) {
+                        return false;
+                    }
+
+                    let Some(next_key) = stack.pop() else {
+                        break;
+                    };
+
+                    expr_key = next_key;
+                }
+
+                true
+            })(),
+        );
     }
 
-    let ret = match arena.get(expr_key) {
-        AExpr::Explode(_) => false,
-        AExpr::Alias(inner, _) => is_elementwise(*inner, arena, cache),
-        AExpr::Column(_) => true,
-        AExpr::Literal(lit) => !matches!(lit, LiteralValue::Series(_) | LiteralValue::Range { .. }),
-        AExpr::BinaryExpr { left, op: _, right } => {
-            is_elementwise(*left, arena, cache) && is_elementwise(*right, arena, cache)
-        },
-        AExpr::Cast {
-            expr,
-            dtype: _,
-            options: _,
-        } => is_elementwise(*expr, arena, cache),
-        AExpr::Sort { .. } | AExpr::SortBy { .. } | AExpr::Gather { .. } => false,
-        AExpr::Filter { .. } => false,
-        AExpr::Agg(_) => false,
-        AExpr::Ternary {
-            predicate,
-            truthy,
-            falsy,
-        } => {
-            is_elementwise(*predicate, arena, cache)
-                && is_elementwise(*truthy, arena, cache)
-                && is_elementwise(*falsy, arena, cache)
-        },
-        AExpr::AnonymousFunction {
-            input,
-            function: _,
-            output_type: _,
-            options,
-        } => {
-            options.is_elementwise() && input.iter().all(|e| is_elementwise(e.node(), arena, cache))
-        },
-        AExpr::Function {
-            input,
-            function,
-            options,
-        } => {
-            match function {
-                // Non-strict strptime must be done in-memory to ensure the format
-                // is consistent across the entire dataframe.
-                #[cfg(feature = "strings")]
-                FunctionExpr::StringExpr(StringFunction::Strptime(_, opts)) => opts.strict,
-                _ => {
-                    options.is_elementwise()
-                        && input.iter().all(|e| is_elementwise(e.node(), arena, cache))
-                },
-            }
-        },
-
-        AExpr::Window { .. } => false,
-        AExpr::Slice { .. } => false,
-        AExpr::Len => false,
-    };
-
-    cache.is_elementwise.insert(expr_key, ret);
-    ret
+    *cache.is_elementwise.get(&expr_key).unwrap()
 }
 
 #[recursive::recursive]
@@ -403,7 +366,7 @@ fn lower_exprs_with_ctx(
     let mut transformed_exprs = Vec::with_capacity(exprs.len());
 
     for expr in exprs.iter().copied() {
-        if is_elementwise(expr, ctx.expr_arena, ctx.cache) {
+        if is_elementwise_rec_cached(expr, ctx.expr_arena, ctx.cache) {
             if !is_input_independent(expr, ctx) {
                 input_nodes.insert(input);
             }

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -4,15 +4,11 @@ use std::cmp::Reverse;
 use polars_core::prelude::*;
 use polars_core::POOL;
 use polars_expr::planner::{create_physical_expr, get_expr_depth_limit, ExpressionConversionState};
-use polars_plan::plans::{Context, IRPlan, IsStreamableContext, IR};
+use polars_plan::plans::{Context, IRPlan, IR};
 use polars_plan::prelude::expr_ir::ExprIR;
 use polars_plan::prelude::AExpr;
 use polars_utils::arena::{Arena, Node};
 use slotmap::{SecondaryMap, SlotMap};
-
-fn is_streamable(node: Node, arena: &Arena<AExpr>) -> bool {
-    polars_plan::plans::is_streamable(node, arena, IsStreamableContext::new(Context::Default))
-}
 
 pub fn run_query(
     node: Node,

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -155,9 +155,18 @@ def test_is_in_null() -> None:
     assert_series_equal(result, expected)
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_is_in_invalid_shape() -> None:
     with pytest.raises(ComputeError):
         pl.Series("a", [1, 2, 3]).is_in([[]])
+
+
+@pytest.mark.may_fail_auto_streaming
+def test_is_in_list_rhs() -> None:
+    assert_series_equal(
+        pl.Series([1, 2, 3, 4, 5]).is_in([[1], [2, 9], [None], None, None]),
+        pl.Series([True, True, False, False, False]),
+    )
 
 
 @pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -369,3 +369,22 @@ def test_streaming_with_hconcat(tmp_path: Path) -> None:
     )
 
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.write_disk
+def test_elementwise_identification_in_ternary_15767(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    (
+        pl.LazyFrame({"a": pl.Series([1])})
+        .with_columns(b=pl.col("a").is_in(pl.Series([1, 2, 3])))
+        .sink_parquet(tmp_path / "1")
+    )
+
+    (
+        pl.LazyFrame({"a": pl.Series([1])})
+        .with_columns(
+            b=pl.when(pl.col("a").is_in(pl.Series([1, 2, 3]))).then(pl.col("a"))
+        )
+        .sink_parquet(tmp_path / "1")
+    )

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
@@ -497,7 +498,7 @@ def test_predicate_push_down_with_alias_15442() -> None:
     assert output.to_dict(as_series=False) == {"a": [1]}
 
 
-def test_predicate_push_down_list_gather_17492() -> None:
+def test_predicate_slice_pushdown_list_gather_17492() -> None:
     lf = pl.LazyFrame({"val": [[1], [1, 1]], "len": [1, 2]})
 
     assert_frame_equal(
@@ -511,6 +512,12 @@ def test_predicate_push_down_list_gather_17492() -> None:
         .filter(pl.col("val").list.get(1, null_on_oob=True) == 1)
         .explain()
     )
+
+    # Also check slice pushdown
+    q = lf.with_columns(pl.col("val").list.get(1).alias("b")).slice(1, 1)
+
+    with pytest.raises(ComputeError, match="get index is out of bounds"):
+        q.collect()
 
 
 def test_predicate_pushdown_struct_unnest_19632() -> None:


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/15767

This PR also does some refactoring to consolidate and improve the way we identify expressions as elementwise.

#### Replacing `streamable` with `is_elementwise`

A lot of places where we currently use the `streamable` terminology actually needed to use an even stricter `elementwise` requirement (e.g. filter / slice pushdown. `streamable` expressions include all elementwise expressions and more. For example, `filter()` / `explode()` expressions are streamable, but they are not elementwise.

Where this matters is if the result of a streamable expression needs to be projected next to other result columns, which is almost always the case. The existing in-memory engine and evaluators cannot do this properly as it projects the result columns independently within every chunk, which could lead to height mismatches. The only place that properly supports this is the new-streaming engine, where the `ZipNode` performs the projection properly.
