### PR TITLE
feat(python): Improved error message on invalid Python `Enum` init

### DIFF
--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -782,7 +782,7 @@ def _from_series_repr(m: re.Match[str]) -> Series:
     else:
         string_values = [
             v.strip()
-            for v in re.findall(r"[\s>#]*(?:\t|\s{4,})([^\n]*)\n", m.groups()[-1])
+            for v in re.findall(r"[\s>#]*(?:\t|\s{2,})([^\n]*)\n", m.groups()[-1])
         ]
         if string_values == ["[", "]"]:
             string_values = []

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -622,10 +622,10 @@ class Enum(DataType):
         )
 
         if isclass(categories) and issubclass(categories, enum.Enum):
-            for enum_subclass in (enum.IntFlag, enum.Flag, enum.IntEnum):
+            for enum_subclass in (enum.Flag, enum.IntEnum):
                 if issubclass(categories, enum_subclass):
-                    enum_type_name = enum_subclass.__name__
-                    msg = f"Enum categories must be strings; Python `enum.{enum_type_name}` values are integers"
+                    enum_type_name = categories.__name__
+                    msg = f"Enum categories must be strings; `{enum_type_name}` values are integers"
                     raise TypeError(msg)
 
             enum_values = [

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -94,11 +94,9 @@ def test_enum_init_from_python_invalid() -> None:
             GREEN = enum.auto()
             BLUE = enum.auto()
 
-        base_name = EnumBase.__name__
-
         with pytest.raises(
             TypeError,
-            match=f"Enum categories must be strings; Python `enum.{base_name}` values are integers",
+            match="Enum categories must be strings; `Color` values are integers",
         ):
             pl.Enum(Color)
 


### PR DESCRIPTION
Improves an error message that could be raised when initialising Polars `Enum` from an unsuitable Python Enum type; instead of using the generic enum class name we now reference the specific enum, eg:

**Also**: minor tweak to `pl.from_repr` Series regex (4 -> 2).
(apparently some IDE configurations can collapse the usual leading four spaces to two).

## Example

```python
import polars as pl
import enum

class Color(enum.IntEnum):
    RED = enum.auto()
    GREEN = enum.auto()
    BLUE = enum.auto()

dtype = pl.Enum(Color)
```
**Before**: ```TypeError: Enum categories must be strings; Python `enum.IntEnum` values are integers```
**After**: ```TypeError: Enum categories must be strings; `Color` values are integers```
