### PR TITLE
build: Bump Rust toolchain to `nightly-2024-11-28`

### DIFF
--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -79,7 +79,7 @@ impl<O: Offset> BinaryArray<O> {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len_proxy())
+            .is_some_and(|validity| validity.len() != offsets.len_proxy())
         {
             polars_bail!(ComputeError: "validity mask length must match the number of values")
         }

--- a/crates/polars-arrow/src/array/binary/mutable.rs
+++ b/crates/polars-arrow/src/array/binary/mutable.rs
@@ -65,7 +65,7 @@ impl<O: Offset> MutableBinaryArray<O> {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != values.len())
+            .is_some_and(|validity| validity.len() != values.len())
         {
             polars_bail!(ComputeError: "validity's length must be equal to the number of values")
         }

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -61,7 +61,7 @@ impl BooleanArray {
     ) -> PolarsResult<Self> {
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != values.len())
+            .is_some_and(|validity| validity.len() != values.len())
         {
             polars_bail!(ComputeError: "validity mask length must match the number of values")
         }

--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -61,7 +61,7 @@ impl MutableBooleanArray {
     ) -> PolarsResult<Self> {
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != values.len())
+            .is_some_and(|validity| validity.len() != values.len())
         {
             polars_bail!(ComputeError:
                 "validity mask length must match the number of values",

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -46,7 +46,7 @@ impl FixedSizeBinaryArray {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != len)
+            .is_some_and(|validity| validity.len() != len)
         {
             polars_bail!(ComputeError: "validity mask length must be equal to the number of values divided by size")
         }

--- a/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
@@ -56,7 +56,7 @@ impl MutableFixedSizeBinaryArray {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != len)
+            .is_some_and(|validity| validity.len() != len)
         {
             polars_bail!(ComputeError: "validity mask length must be equal to the number of values divided by size")
         }

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -66,7 +66,7 @@ impl FixedSizeListArray {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != length)
+            .is_some_and(|validity| validity.len() != length)
         {
             polars_bail!(ComputeError: "validity mask length must be equal to the number of values divided by size")
         }

--- a/crates/polars-arrow/src/array/list/mod.rs
+++ b/crates/polars-arrow/src/array/list/mod.rs
@@ -43,7 +43,7 @@ impl<O: Offset> ListArray<O> {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len_proxy())
+            .is_some_and(|validity| validity.len() != offsets.len_proxy())
         {
             polars_bail!(ComputeError: "validity mask length must match the number of values")
         }

--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -51,7 +51,7 @@ impl MapArray {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len_proxy())
+            .is_some_and(|validity| validity.len() != offsets.len_proxy())
         {
             polars_bail!(ComputeError: "validity mask length must match the number of values")
         }

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -59,7 +59,7 @@ pub(super) fn check<T: NativeType>(
     values: &[T],
     validity_len: Option<usize>,
 ) -> PolarsResult<()> {
-    if validity_len.map_or(false, |len| len != values.len()) {
+    if validity_len.is_some_and(|len| len != values.len()) {
         polars_bail!(ComputeError: "validity mask length must match the number of values")
     }
 

--- a/crates/polars-arrow/src/array/struct_/mod.rs
+++ b/crates/polars-arrow/src/array/struct_/mod.rs
@@ -89,7 +89,7 @@ impl StructArray {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != length)
+            .is_some_and(|validity| validity.len() != length)
         {
             polars_bail!(ComputeError:"The validity length of a StructArray must match its number of elements")
         }

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -90,7 +90,7 @@ impl<O: Offset> Utf8Array<O> {
         try_check_utf8(&offsets, &values)?;
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len_proxy())
+            .is_some_and(|validity| validity.len() != offsets.len_proxy())
         {
             polars_bail!(ComputeError: "validity mask length must match the number of values");
         }

--- a/crates/polars-arrow/src/array/utf8/mutable.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable.rs
@@ -65,7 +65,7 @@ impl<O: Offset> MutableUtf8Array<O> {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != values.len())
+            .is_some_and(|validity| validity.len() != values.len())
         {
             polars_bail!(ComputeError: "validity's length must be equal to the number of values")
         }

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -220,7 +220,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                     .unwrap()
                     .as_ref()
                     .validity()
-                    .map_or(false, |bm| bm.get(0).unwrap());
+                    .is_some_and(|bm| bm.get(0).unwrap());
 
             if !has_nulls_at_start {
                 let can_copy_min_value = !has_nulls_at_start && is_ascending;
@@ -237,7 +237,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                     .unwrap()
                     .as_ref()
                     .validity()
-                    .map_or(false, |bm| bm.get(bm.len() - 1).unwrap());
+                    .is_some_and(|bm| bm.get(bm.len() - 1).unwrap());
 
             if !has_nulls_at_end {
                 let can_copy_min_value = !has_nulls_at_end && is_descending;
@@ -285,7 +285,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                             .unwrap()
                             .as_ref()
                             .validity()
-                            .map_or(false, |bm| bm.get(0).unwrap());
+                            .is_some_and(|bm| bm.get(0).unwrap());
 
                     can_copy_min_value |= !has_nulls_at_start && is_ascending;
                     can_copy_max_value |= !has_nulls_at_start && is_descending;
@@ -300,7 +300,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                             .unwrap()
                             .as_ref()
                             .validity()
-                            .map_or(false, |bm| bm.get(bm.len() - 1).unwrap());
+                            .is_some_and(|bm| bm.get(bm.len() - 1).unwrap());
 
                     can_copy_min_value |= !has_nulls_at_end && is_descending;
                     can_copy_max_value |= !has_nulls_at_end && is_ascending;

--- a/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
+++ b/crates/polars-core/src/series/arithmetic/fixed_size_list.rs
@@ -304,11 +304,11 @@ mod inner {
                 || (matches!(
                     &op_apply_type,
                     BinaryOpApplyType::ListToList | BinaryOpApplyType::ListToPrimitive
-                ) && lhs.rechunk_validity().map_or(false, |x| x.set_bits() == 0))
+                ) && lhs.rechunk_validity().is_some_and(|x| x.set_bits() == 0))
                 || (matches!(
                     &op_apply_type,
                     BinaryOpApplyType::ListToList | BinaryOpApplyType::PrimitiveToList
-                ) && rhs.rechunk_validity().map_or(false, |x| x.set_bits() == 0))
+                ) && rhs.rechunk_validity().is_some_and(|x| x.set_bits() == 0))
             {
                 let DataType::Array(inner_dtype, width) = output_dtype else {
                     unreachable!()

--- a/crates/polars-core/src/series/arithmetic/list.rs
+++ b/crates/polars-core/src/series/arithmetic/list.rs
@@ -256,11 +256,11 @@ mod inner {
                 || (matches!(
                     &op_apply_type,
                     BinaryOpApplyType::ListToList | BinaryOpApplyType::ListToPrimitive
-                ) && validity_lhs.as_ref().map_or(false, |x| x.set_bits() == 0))
+                ) && validity_lhs.as_ref().is_some_and(|x| x.set_bits() == 0))
                 || (matches!(
                     &op_apply_type,
                     BinaryOpApplyType::ListToList | BinaryOpApplyType::PrimitiveToList
-                ) && validity_rhs.as_ref().map_or(false, |x| x.set_bits() == 0))
+                ) && validity_rhs.as_ref().is_some_and(|x| x.set_bits() == 0))
             {
                 return Ok(Either::Right(ListChunked::full_null_with_dtype(
                     output_name.clone(),

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -564,7 +564,7 @@ impl ApplyExpr {
                         Some(null_count)
                             if stats
                                 .num_rows()
-                                .map_or(false, |num_rows| num_rows == null_count) =>
+                                .is_some_and(|num_rows| num_rows == null_count) =>
                         {
                             Ok(false)
                         },

--- a/crates/polars-io/src/file_cache/cache_lock.rs
+++ b/crates/polars-io/src/file_cache/cache_lock.rs
@@ -125,7 +125,7 @@ impl GlobalLock {
         if let Ok(mut this) = self.inner.try_write() {
             if Arc::strong_count(&self.access_tracker.0) <= 2 {
                 return if this.state.take().is_some() {
-                    this.file.unlock().unwrap();
+                    FileExt::unlock(&this.file).unwrap();
                     Some(true)
                 } else {
                     Some(false)
@@ -156,7 +156,7 @@ impl GlobalLock {
             let mut this = self.inner.write().unwrap();
 
             if this.state.is_none() {
-                this.file.lock_shared().unwrap();
+                FileExt::lock_shared(&this.file).unwrap();
                 this.state = Some(LockedState::Shared);
             }
         }
@@ -200,7 +200,7 @@ impl GlobalLock {
             }
 
             if this.state.take().is_some() {
-                this.file.unlock().unwrap();
+                FileExt::unlock(&this.file).unwrap();
             }
 
             if this.file.try_lock_exclusive().is_ok() {

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -353,7 +353,7 @@ fn finish_open<F: FileLockAnyGuard>(data_file_path: &Path, _metadata_guard: &F) 
         }
     };
     update_last_accessed(&file);
-    if file.try_lock_shared().is_err() {
+    if FileExt::try_lock_shared(&file).is_err() {
         panic!(
             "finish_open: could not acquire shared lock on data file at {}",
             data_file_path.to_str().unwrap()

--- a/crates/polars-io/src/file_cache/file_lock.rs
+++ b/crates/polars-io/src/file_cache/file_lock.rs
@@ -36,7 +36,7 @@ impl<T: AsRef<Path>> FileLock<T> {
             .read(true)
             .write(true)
             .open(self.0.as_ref())?;
-        file.lock_shared().map(|_| FileLockSharedGuard(file))
+        FileExt::lock_shared(&file).map(|_| FileLockSharedGuard(file))
     }
 
     pub(super) fn acquire_exclusive(&self) -> Result<FileLockExclusiveGuard, std::io::Error> {
@@ -66,7 +66,7 @@ impl std::ops::DerefMut for FileLockSharedGuard {
 
 impl Drop for FileLockSharedGuard {
     fn drop(&mut self) {
-        self.0.unlock().unwrap();
+        FileExt::unlock(&self.0).unwrap();
     }
 }
 
@@ -86,6 +86,6 @@ impl std::ops::DerefMut for FileLockExclusiveGuard {
 
 impl Drop for FileLockExclusiveGuard {
     fn drop(&mut self) {
-        self.0.unlock().unwrap();
+        FileExt::unlock(&self.0).unwrap();
     }
 }

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -329,7 +329,7 @@ pub trait ListNameSpaceImpl: AsList {
 
         let ca_validity = ca.rechunk_validity();
 
-        if ca_validity.as_ref().map_or(false, |x| x.set_bits() == 0) {
+        if ca_validity.as_ref().is_some_and(|x| x.set_bits() == 0) {
             return IdxCa::full_null(ca.name().clone(), ca.len());
         }
 

--- a/crates/polars-ops/src/series/ops/concat_arr.rs
+++ b/crates/polars-ops/src/series/ops/concat_arr.rs
@@ -46,7 +46,7 @@ pub fn concat_arr(args: &[Column], dtype: &DataType) -> PolarsResult<Column> {
                     let arr = c.array().unwrap().rechunk();
 
                     return_all_null |=
-                        arr.len() == 1 && arr.rechunk_validity().map_or(false, |x| !x.get_bit(0));
+                        arr.len() == 1 && arr.rechunk_validity().is_some_and(|x| !x.get_bit(0));
 
                     (arr.rechunk().downcast_into_array().values().clone(), *width)
                 },

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -535,7 +535,7 @@ impl ProjectionPushDown {
                 if let Some(RowIndex { ref name, .. }) = file_options.row_index {
                     if output_schema
                         .as_ref()
-                        .map_or(false, |schema| !schema.contains(name))
+                        .is_some_and(|schema| !schema.contains(name))
                     {
                         // Need to remove it from the input schema so
                         // that projection indices are correct.
@@ -549,7 +549,7 @@ impl ProjectionPushDown {
                 if let Some(col_name) = &file_options.include_file_paths {
                     if output_schema
                         .as_ref()
-                        .map_or(false, |schema| !schema.contains(col_name))
+                        .is_some_and(|schema| !schema.contains(col_name))
                     {
                         // Need to remove it from the input schema so
                         // that projection indices are correct.

--- a/crates/polars-python/src/exceptions.rs
+++ b/crates/polars-python/src/exceptions.rs
@@ -1,5 +1,9 @@
 //! Define the Polars exception hierarchy.
 
+// TODO: Remove this directive when upgrading to PyO3 version 0.23.
+// https://github.com/PyO3/pyo3/issues/4743
+#![allow(unexpected_cfgs)]
+
 use pyo3::create_exception;
 use pyo3::exceptions::{PyException, PyWarning};
 

--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -30,6 +30,10 @@ strum_macros = { workspace = true }
 polars-ops = { workspace = true, features = ["abs"] }
 
 [features]
+dtype-i8 = ["polars-core/dtype-i8"]
+dtype-i16 = ["polars-core/dtype-i16"]
+dtype-u8 = ["polars-core/dtype-u8"]
+dtype-u16 = ["polars-core/dtype-u16"]
 dtype-date = ["polars-core/dtype-date", "temporal"]
 dtype-datetime = ["polars-core/dtype-datetime", "temporal"]
 dtype-time = ["polars-core/dtype-time", "temporal"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-11-29"
+channel = "nightly-2024-11-28"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-11-01"
+channel = "nightly-2024-11-29"


### PR DESCRIPTION
Two new lints that affect us:
- Unnecessary `map_or`: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
- Unstable name collisions: https://github.com/rust-lang/rust/issues/48919

And an update to the config flag checks in external macros: https://github.com/rust-lang/rust/pull/132577