### PR TITLE
fix: Preserve Series name in __rpow__ operation

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1194,7 +1194,11 @@ class Series:
         return self.pow(exponent)
 
     def __rpow__(self, other: Any) -> Series:
-        return self.to_frame().select_seq(other ** F.col(self.name)).to_series()
+        return (
+            self.to_frame()
+            .select_seq((other ** F.col(self.name)).alias(self.name))
+            .to_series()
+        )
 
     def __matmul__(self, other: Any) -> float | Series | None:
         if isinstance(other, Sequence) or (

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -549,14 +549,20 @@ def test_power_series() -> None:
     assert_series_equal(a**j, pl.Series([1, 4], dtype=Int64))
 
     # rpow
-    assert_series_equal(2.0**a, pl.Series("literal", [2.0, 4.0], dtype=Float64))
-    assert_series_equal(2**b, pl.Series("literal", [None, 4.0], dtype=Float64))
+    assert_series_equal(2.0**a, pl.Series(None, [2.0, 4.0], dtype=Float64))
+    assert_series_equal(2**b, pl.Series(None, [None, 4.0], dtype=Float64))
 
     with pytest.raises(ColumnNotFoundError):
         "hi" ** a
 
     # Series.pow() method
     assert_series_equal(a.pow(2), pl.Series([1, 4], dtype=Int64))
+
+
+def test_rpow_name_20071() -> None:
+    result = 1 ** pl.Series("a", [1, 2])
+    expected = pl.Series("a", [1, 1], pl.Int32)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #20071 