### PR TITLE
feat: Implement `str.slice/str.head/str.tail` for categoricals

### DIFF
--- a/crates/polars-ops/src/chunked_array/categorical/mod.rs
+++ b/crates/polars-ops/src/chunked_array/categorical/mod.rs
@@ -1,0 +1,6 @@
+use polars_core::prelude::*;
+
+#[cfg(feature = "strings")]
+mod string_namespace;
+#[cfg(feature = "strings")]
+pub use string_namespace::*;

--- a/crates/polars-ops/src/chunked_array/categorical/string_namespace.rs
+++ b/crates/polars-ops/src/chunked_array/categorical/string_namespace.rs
@@ -1,0 +1,96 @@
+use super::*;
+use crate::chunked_array::strings::*;
+#[allow(unused_imports)]
+use crate::prelude::*;
+
+pub trait CategoricalStringNameSpace: Sized {
+    fn str_slice(&self, offset: &Column, length: &Column) -> PolarsResult<Self>;
+    fn str_head(&self, n: &Column) -> PolarsResult<Self>;
+    fn str_tail(&self, n: &Column) -> PolarsResult<Self>;
+}
+
+/// Apply operation to categories of a CategoricalChunked and remap physical & rev map.
+fn fast_remap_ca<F>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<CategoricalChunked>
+where
+    F: FnMut(&StringChunked) -> PolarsResult<StringChunked>,
+{
+    // Determine physical and categories.
+    let rev_map = &**ca.get_rev_map();
+    let (categories, old_phys) = match rev_map {
+        RevMapping::Local(c, _) => (c, (0..c.len() as u32).collect::<Vec<u32>>()),
+        RevMapping::Global(m, c, _) => {
+            let mut idx = m.iter().collect::<Vec<(&u32, &u32)>>();
+            // Set index to same ordering as categories.
+            idx.sort_by_key(|&(_, key)| key);
+            let idx = idx.iter().map(|v| *v.0).collect::<Vec<u32>>();
+            (c, idx)
+        },
+    };
+    let categories = StringChunked::with_chunk(PlSmallStr::EMPTY, categories.clone());
+
+    // Apply function and retrieve new physical.
+    let new_categories = op(&categories)?;
+    let mapped = new_categories.cast(&DataType::Categorical(None, Default::default()))?;
+    let new_phys = mapped.cast(&DataType::UInt32)?.u32()?.to_vec();
+
+    // Create mapping from old physical => new physical.
+    // Some values may map to null if the op returns null.
+    let phys_mapper = old_phys
+        .iter()
+        .zip(new_phys.iter())
+        .collect::<PlHashMap<&u32, &Option<u32>>>();
+
+    // Apply mapping to physical.
+    let new_phys = ca
+        .physical()
+        .apply(|opt| opt.and_then(|idx| phys_mapper.get(&idx).and_then(|&mapped| *mapped)));
+    let new_rev_map = mapped.categorical()?.get_rev_map();
+
+    // SAFETY: new rev_map is valid.
+    let out = unsafe {
+        CategoricalChunked::from_cats_and_rev_map_unchecked(
+            new_phys,
+            new_rev_map.clone(),
+            ca.is_enum(),
+            Default::default(),
+        )
+    };
+    Ok(out)
+}
+
+/// Apply function to a categorical array by casting to String and back.
+fn slow_remap_ca<F>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<CategoricalChunked>
+where
+    F: FnMut(&StringChunked) -> PolarsResult<StringChunked>,
+{
+    let s = ca.cast(&DataType::String).unwrap();
+    let s = op(s.str()?)?;
+    let out = s.cast(&DataType::Categorical(None, Default::default()))?;
+    let out = out.categorical()?;
+    Ok(out.clone())
+}
+
+impl CategoricalStringNameSpace for CategoricalChunked {
+    fn str_slice(&self, offset: &Column, length: &Column) -> PolarsResult<Self> {
+        match (offset, length) {
+            (Column::Scalar(_), Column::Scalar(_)) => {
+                fast_remap_ca(self, |ca| ca.str_slice(offset, length))
+            },
+            _ => slow_remap_ca(self, |ca| ca.str_slice(offset, length)),
+        }
+    }
+
+    fn str_head(&self, n: &Column) -> PolarsResult<Self> {
+        match n {
+            Column::Scalar(_) => fast_remap_ca(self, |ca| ca.str_head(n)),
+            _ => slow_remap_ca(self, |ca| ca.str_head(n)),
+        }
+    }
+
+    fn str_tail(&self, n: &Column) -> PolarsResult<Self> {
+        match n {
+            Column::Scalar(_) => fast_remap_ca(self, |ca| ca.str_tail(n)),
+            _ => slow_remap_ca(self, |ca| ca.str_tail(n)),
+        }
+    }
+}

--- a/crates/polars-ops/src/chunked_array/mod.rs
+++ b/crates/polars-ops/src/chunked_array/mod.rs
@@ -17,6 +17,8 @@ mod top_k;
 #[cfg(feature = "mode")]
 pub mod mode;
 
+#[cfg(feature = "dtype-categorical")]
+mod categorical;
 #[cfg(feature = "cov")]
 pub mod cov;
 pub(crate) mod gather;
@@ -28,6 +30,8 @@ mod hist;
 mod repeat_by;
 
 pub use binary::*;
+#[cfg(feature = "dtype-categorical")]
+pub use categorical::*;
 #[cfg(feature = "timezones")]
 pub use datetime::*;
 #[cfg(feature = "chunked_ids")]

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -23,7 +23,7 @@ mod starts_with;
 #[cfg(feature = "strings")]
 mod strip;
 #[cfg(feature = "strings")]
-mod substring;
+pub mod substring;
 #[cfg(all(not(feature = "nightly"), feature = "strings"))]
 mod unicode_internals;
 
@@ -42,6 +42,8 @@ use polars_core::prelude::*;
 pub use split::*;
 #[cfg(feature = "strings")]
 pub use strip::*;
+#[cfg(feature = "strings")]
+pub use substring::*;
 
 pub trait AsString {
     fn as_string(&self) -> &StringChunked;

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -153,7 +153,7 @@ fn update_view(mut view: View, start: usize, end: usize, val: &str) -> View {
     }
 }
 
-pub(super) fn substring(
+pub fn substring(
     ca: &StringChunked,
     offset: &Int64Chunked,
     length: &UInt64Chunked,

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -1012,10 +1012,21 @@ pub(super) fn str_slice(s: &[Column]) -> PolarsResult<Column> {
         _ensure_lengths(s),
         ComputeError: "all series in `str_slice` should have equal or unit length",
     );
-    let ca = s[0].str()?;
+    let ca = &s[0];
     let offset = &s[1];
     let length = &s[2];
-    Ok(ca.str_slice(offset, length)?.into_column())
+    match ca.dtype() {
+        DataType::String => {
+            let ca = ca.str()?;
+            Ok(ca.str_slice(offset, length)?.into_column())
+        },
+        #[cfg(feature = "dtype-categorical")]
+        DataType::Categorical(_, _) => {
+            let ca = ca.categorical()?;
+            Ok(ca.str_slice(offset, length)?.into_column())
+        },
+        dt => panic!("`slice` not supported for {:?}", dt),
+    }
 }
 
 pub(super) fn str_head(s: &[Column]) -> PolarsResult<Column> {
@@ -1023,9 +1034,20 @@ pub(super) fn str_head(s: &[Column]) -> PolarsResult<Column> {
         _ensure_lengths(s),
         ComputeError: "all series in `str_head` should have equal or unit length",
     );
-    let ca = s[0].str()?;
+    let ca = &s[0];
     let n = &s[1];
-    Ok(ca.str_head(n)?.into_column())
+    match ca.dtype() {
+        DataType::String => {
+            let ca = ca.str()?;
+            Ok(ca.str_head(n)?.into_column())
+        },
+        #[cfg(feature = "dtype-categorical")]
+        DataType::Categorical(_, _) => {
+            let ca = ca.categorical()?;
+            Ok(ca.str_head(n)?.into_column())
+        },
+        dt => panic!("`head` not supported for {:?}", dt),
+    }
 }
 
 pub(super) fn str_tail(s: &[Column]) -> PolarsResult<Column> {
@@ -1033,9 +1055,20 @@ pub(super) fn str_tail(s: &[Column]) -> PolarsResult<Column> {
         _ensure_lengths(s),
         ComputeError: "all series in `str_tail` should have equal or unit length",
     );
-    let ca = s[0].str()?;
+    let ca = &s[0];
     let n = &s[1];
-    Ok(ca.str_tail(n)?.into_column())
+    match ca.dtype() {
+        DataType::String => {
+            let ca = ca.str()?;
+            Ok(ca.str_tail(n)?.into_column())
+        },
+        #[cfg(feature = "dtype-categorical")]
+        DataType::Categorical(_, _) => {
+            let ca = ca.categorical()?;
+            Ok(ca.str_tail(n)?.into_column())
+        },
+        dt => panic!("`tail` not supported for {:?}", dt),
+    }
 }
 
 #[cfg(feature = "string_encoding")]

--- a/py-polars/tests/unit/operations/namespaces/string/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_categorical.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+from polars.exceptions import (
+    InvalidOperationError,
+)
+from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Sequence
+    from typing import Any
+
+    from polars import Series
+
+    FixtureRequest = Any
+
+
+def _cat(values: Sequence[str | None]) -> Series:
+    return pl.Series(values, dtype=pl.Categorical)
+
+
+@pytest.fixture(params=[True, False], autouse=True)
+def _setup_string_cache(
+    request: FixtureRequest,
+) -> Generator[Any, Any, Any]:
+    """Setup fixture which runs each test with and without global string cache."""
+    use_global = request.param
+    if use_global:
+        with pl.StringCache():
+            yield
+    else:
+        yield
+
+
+def test_str_slice() -> None:
+    df = pl.DataFrame({"a": _cat(["foobar", "barfoo"])})
+    assert df["a"].str.slice(-3).to_list() == ["bar", "foo"]
+    assert df.select([pl.col("a").str.slice(2, 4)])["a"].to_list() == ["obar", "rfoo"]
+
+
+def test_str_slice_expr() -> None:
+    df = pl.DataFrame(
+        {
+            "a": _cat(["foobar", None, "barfoo", "abcd", ""]),
+            "offset": [1, 3, None, -3, 2],
+            "length": [3, 4, 2, None, 2],
+        }
+    )
+    out = df.select(
+        all_expr=pl.col("a").str.slice("offset", "length"),
+        offset_expr=pl.col("a").str.slice("offset", 2),
+        length_expr=pl.col("a").str.slice(0, "length"),
+        length_none=pl.col("a").str.slice("offset", None),
+        offset_length_lit=pl.col("a").str.slice(-3, 3),
+        str_lit=pl.lit("qwert", dtype=pl.Categorical).str.slice("offset", "length"),
+    )
+    expected = pl.DataFrame(
+        {
+            "all_expr": _cat(["oob", None, None, "bcd", ""]),
+            "offset_expr": _cat(["oo", None, None, "bc", ""]),
+            "length_expr": _cat(["foo", None, "ba", "abcd", ""]),
+            "length_none": _cat(["oobar", None, None, "bcd", ""]),
+            "offset_length_lit": _cat(["bar", None, "foo", "bcd", ""]),
+            "str_lit": _cat(["wer", "rt", None, "ert", "er"]),
+        }
+    )
+    if pl.using_string_cache():
+        assert_frame_equal(out, expected)
+    else:
+        assert out.schema == expected.schema
+        assert_frame_equal(out, expected, categorical_as_str=True)
+
+    # negative length is not allowed
+    with pytest.raises(InvalidOperationError):
+        df.select(pl.col("a").str.slice(0, -1))
+
+
+@pytest.mark.parametrize(
+    ("input", "n", "output"),
+    [
+        ("你好世界", 0, ""),
+        ("你好世界", 2, "你好"),
+        ("你好世界", 999, "你好世界"),
+        ("你好世界", -1, "你好世"),
+        ("你好世界", -2, "你好"),
+        ("你好世界", -999, ""),
+    ],
+)
+def test_str_head_codepoints(input: str, n: int, output: str) -> None:
+    assert _cat([input]).str.head(n).to_list() == [output]
+
+
+def test_str_head_expr() -> None:
+    s = "012345"
+    df = pl.DataFrame(
+        {
+            "a": _cat([s, s, s, s, s, s, "", None]),
+            "n": [0, 2, -2, 100, -100, None, 3, -2],
+        }
+    )
+    out = df.select(
+        n_expr=pl.col("a").str.head("n"),
+        n_pos2=pl.col("a").str.head(2),
+        n_neg2=pl.col("a").str.head(-2),
+        n_pos100=pl.col("a").str.head(100),
+        n_pos_neg100=pl.col("a").str.head(-100),
+        n_pos_0=pl.col("a").str.head(0),
+        str_lit=pl.col("a").str.head(pl.lit(2)),
+        lit_expr=pl.lit(s, dtype=pl.Categorical).str.head("n"),
+        lit_n=pl.lit(s, dtype=pl.Categorical).str.head(2),
+    )
+    expected = pl.DataFrame(
+        {
+            "n_expr": _cat(["", "01", "0123", "012345", "", None, "", None]),
+            "n_pos2": _cat(["01", "01", "01", "01", "01", "01", "", None]),
+            "n_neg2": _cat(["0123", "0123", "0123", "0123", "0123", "0123", "", None]),
+            "n_pos100": _cat([s, s, s, s, s, s, "", None]),
+            "n_pos_neg100": _cat(["", "", "", "", "", "", "", None]),
+            "n_pos_0": _cat(["", "", "", "", "", "", "", None]),
+            "str_lit": _cat(["01", "01", "01", "01", "01", "01", "", None]),
+            "lit_expr": _cat(["", "01", "0123", "012345", "", None, "012", "0123"]),
+            "lit_n": _cat(["01", "01", "01", "01", "01", "01", "01", "01"]),
+        }
+    )
+    if pl.using_string_cache():
+        assert_frame_equal(out, expected)
+    else:
+        assert out.schema == expected.schema
+        assert_frame_equal(out, expected, categorical_as_str=True)
+
+
+@pytest.mark.parametrize(
+    ("input", "n", "output"),
+    [
+        (["012345", "", None], 0, ["", "", None]),
+        (["012345", "", None], 2, ["45", "", None]),
+        (["012345", "", None], -2, ["2345", "", None]),
+        (["012345", "", None], 100, ["012345", "", None]),
+        (["012345", "", None], -100, ["", "", None]),
+    ],
+)
+def test_str_tail(input: list[str], n: int, output: list[str]) -> None:
+    assert _cat(input).str.tail(n).to_list() == output
+
+
+@pytest.mark.parametrize(
+    ("input", "n", "output"),
+    [
+        ("你好世界", 0, ""),
+        ("你好世界", 2, "世界"),
+        ("你好世界", 999, "你好世界"),
+        ("你好世界", -1, "好世界"),
+        ("你好世界", -2, "世界"),
+        ("你好世界", -999, ""),
+    ],
+)
+def test_str_tail_codepoints(input: str, n: int, output: str) -> None:
+    assert _cat([input]).str.tail(n).to_list() == [output]
+
+
+def test_str_tail_expr() -> None:
+    s = "012345"
+    df = pl.DataFrame(
+        {
+            "a": _cat([s, s, s, s, s, s, "", None]),
+            "n": [0, 2, -2, 100, -100, None, 3, -2],
+        }
+    )
+    out = df.select(
+        n_expr=pl.col("a").str.tail("n"),
+        n_pos2=pl.col("a").str.tail(2),
+        n_neg2=pl.col("a").str.tail(-2),
+        n_pos100=pl.col("a").str.tail(100),
+        n_pos_neg100=pl.col("a").str.tail(-100),
+        n_pos_0=pl.col("a").str.tail(0),
+        str_lit=pl.col("a").str.tail(pl.lit(2)),
+        lit_expr=pl.lit(s, dtype=pl.Categorical).str.tail("n"),
+        lit_n=pl.lit(s, dtype=pl.Categorical).str.tail(2),
+    )
+    expected = pl.DataFrame(
+        {
+            "n_expr": _cat(["", "45", "2345", "012345", "", None, "", None]),
+            "n_pos2": _cat(["45", "45", "45", "45", "45", "45", "", None]),
+            "n_neg2": _cat(["2345", "2345", "2345", "2345", "2345", "2345", "", None]),
+            "n_pos100": _cat([s, s, s, s, s, s, "", None]),
+            "n_pos_neg100": _cat(["", "", "", "", "", "", "", None]),
+            "n_pos_0": _cat(["", "", "", "", "", "", "", None]),
+            "str_lit": _cat(["45", "45", "45", "45", "45", "45", "", None]),
+            "lit_expr": _cat(["", "45", "2345", "012345", "", None, "345", "2345"]),
+            "lit_n": _cat(["45", "45", "45", "45", "45", "45", "45", "45"]),
+        }
+    )
+    if pl.using_string_cache():
+        assert_frame_equal(out, expected)
+    else:
+        assert out.schema == expected.schema
+        assert_frame_equal(out, expected, categorical_as_str=True)
+
+
+def test_str_slice_multibyte() -> None:
+    ref = "你好世界"
+    s = _cat([ref])
+
+    # Pad the string to simplify (negative) offsets starting before/after the string.
+    npad = 20
+    padref = "_" * npad + ref + "_" * npad
+    for start in range(-5, 6):
+        for length in range(6):
+            offset = npad + start if start >= 0 else npad + start + len(ref)
+            correct = padref[offset : offset + length].strip("_")
+            result = s.str.slice(start, length)
+            expected = _cat([correct])
+            if pl.using_string_cache():
+                assert_series_equal(result, expected)
+            else:
+                assert result.dtype == expected.dtype
+                assert_series_equal(result, expected, categorical_as_str=True)


### PR DESCRIPTION
Provides a start for addressing #9773.

This implements a fast-path for `str` namespace operations on categorical data. Since categoricals represent strings, string operations should be applicable. The fast path applies the string operation on the categories themselves, and then re-maps the underlying physical to the new categories.

For cases where input arguments are expressions from other columns and not scalars, the slow path is taken where the column is cast to string, the operation applied, and the column cast back to categorical.

I think the implementation makes it fairly easy to add many of the remaining string namespace functions if this gets approved.