### PR TITLE
feat(python): Add lazy support for `pl.select`

### DIFF
--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -70,6 +70,12 @@ def test_int_range_eager() -> None:
     assert_series_equal(result, expected)
 
 
+def test_int_range_lazy() -> None:
+    lf = pl.select(n=pl.int_range(8, 0, -2), eager=False)
+    expected = pl.LazyFrame({"n": [8, 6, 4, 2]})
+    assert_frame_equal(lf, expected)
+
+
 def test_int_range_schema() -> None:
     result = pl.LazyFrame().select(int=pl.int_range(-3, 3))
 


### PR DESCRIPTION
Minor extension to `pl.select`, adding "eager" parameter so it can also operate in lazy mode and produce LazyFrames.

## Example
```python
import polars as pl

lf = pl.select(pl.int_range(10, 0, -3), eager=False)
lf.collect()
# shape: (4, 1)
# ┌─────────┐
# │ literal │
# │ ---     │
# │ i64     │
# ╞═════════╡
# │ 10      │
# │ 7       │
# │ 4       │
# │ 1       │
# └─────────┘
```