### PR TITLE
fix: Subtraction with underflow on empty FixedSizeBinaryArray

### DIFF
--- a/crates/polars-compute/src/cast/binary_to.rs
+++ b/crates/polars-compute/src/cast/binary_to.rs
@@ -202,12 +202,15 @@ pub fn fixed_size_binary_to_binview(from: &FixedSizeBinaryArray) -> BinaryViewAr
     // This is zero-copy for the buffer since split just increases the data since
     let mut buffer = from.values().clone();
     let mut buffers = Vec::with_capacity(num_buffers);
-    for _ in 0..num_buffers - 1 {
-        let slice;
-        (slice, buffer) = buffer.split_at(split_point);
-        buffers.push(slice);
+
+    if let Some(num_buffers) = num_buffers.checked_sub(1) {
+        for _ in 0..num_buffers {
+            let slice;
+            (slice, buffer) = buffer.split_at(split_point);
+            buffers.push(slice);
+        }
+        buffers.push(buffer);
     }
-    buffers.push(buffer);
 
     let mut iter = from.values_iter();
     let iter = iter.by_ref();


### PR DESCRIPTION
When trying to deserialize an arrow IPC stream with a fixed-size binary array that contains no values, the code currently subtracts with underflow. In the Python package (which uses a release build), this is silently ignored as debug assertions are turned off. Instead, you get a panic about an out-of-bounds offset.
```PanicException: assertion failed: self.check_bound(offset)```

By checking for an underflow, everything works fine.

To reproduce the issue, you can try the following code:
```rust
// [dependencies]
// arrow = "53.3.0"
// polars = { version = "1.16.0", features = ["polars-io", "ipc", "ipc_streaming"] }

use std::sync::Arc;
use arrow::{datatypes::{DataType, Field, Schema}, record_batch::RecordBatch};
use polars::io::{SerReader, ipc::IpcStreamReader};

fn main() {
    let mut buffer = Vec::new();

    let field = Field::new("bin", DataType::FixedSizeBinary(42), false);
    let schema = Arc::new(Schema::new(vec![field]));

    let column = Arc::new(arrow::array::FixedSizeBinaryBuilder::new(42).finish()) as _;
    let batch = RecordBatch::try_new(schema.clone(), vec![column]).unwrap();

    let mut writer = arrow::ipc::writer::StreamWriter::try_new(&mut buffer, &schema).unwrap();
    writer.write(&batch).unwrap();
    writer.finish().unwrap();

    let _ = IpcStreamReader::new(std::io::Cursor::new(&buffer[..]))
        .finish()
        .unwrap();
}

```