### PR TITLE
test(python): Fix typo in assertion in datatype copy test

### DIFF
--- a/py-polars/tests/unit/datatypes/test_datatype.py
+++ b/py-polars/tests/unit/datatypes/test_datatype.py
@@ -7,5 +7,5 @@ import polars as pl
 def test_datatype_copy() -> None:
     dtype = pl.Int64()
     result = copy.deepcopy(dtype)
-    assert dtype == dtype
+    assert dtype == result
     assert isinstance(result, pl.Int64)


### PR DESCRIPTION
Spotted while poking around.
Did a quick check on main for any other instances of `assert {self} == {self}` and there were none.