### PR TITLE
fix: Incorrect aggregation of empty groups after slice

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -657,7 +657,8 @@ impl Column {
                 let mut s = scalar_col.take_materialized_series().rechunk();
                 // SAFETY: We perform a compute_len afterwards.
                 let chunks = unsafe { s.chunks_mut() };
-                chunks[0].with_validity(Some(validity));
+                let arr = &mut chunks[0];
+                *arr = arr.with_validity(Some(validity));
                 s.compute_len();
 
                 s.into_column()

--- a/crates/polars-expr/src/expressions/slice.rs
+++ b/crates/polars-expr/src/expressions/slice.rs
@@ -110,6 +110,11 @@ impl PhysicalExpr for SliceExpr {
                 .collect::<PolarsResult<Vec<_>>>()
         })?;
         let mut ac = results.pop().unwrap();
+
+        if ac.is_aggregated() {
+            polars_bail!(InvalidOperation: "cannot slice() an aggregated value")
+        }
+
         let mut ac_length = results.pop().unwrap();
         let mut ac_offset = results.pop().unwrap();
 

--- a/crates/polars-expr/src/expressions/slice.rs
+++ b/crates/polars-expr/src/expressions/slice.rs
@@ -111,8 +111,8 @@ impl PhysicalExpr for SliceExpr {
         })?;
         let mut ac = results.pop().unwrap();
 
-        if ac.is_aggregated() {
-            polars_bail!(InvalidOperation: "cannot slice() an aggregated value")
+        if let AggState::AggregatedScalar(_) = ac.agg_state() {
+            polars_bail!(InvalidOperation: "cannot slice() an aggregated scalar value")
         }
 
         let mut ac_length = results.pop().unwrap();

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -748,7 +748,7 @@ def test_slice_after_agg_raises() -> None:
     with pytest.raises(
         InvalidOperationError, match=r"cannot slice\(\) an aggregated value"
     ):
-        pl.select(a=1, b=1).group_by("a").agg(pl.col("b").first().slice(1, 1))
+        pl.select(a=1, b=1).group_by("a").agg(pl.col("b").first().slice(999, 0))
 
 
 def test_agg_scalar_empty_groups_20115() -> None:

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -742,3 +742,21 @@ def test_sort_by_over_multiple_nulls_last() -> None:
         }
     )
     assert_frame_equal(out, expected)
+
+
+def test_slice_after_agg_raises() -> None:
+    with pytest.raises(
+        InvalidOperationError, match=r"cannot slice\(\) an aggregated value"
+    ):
+        pl.select(a=1, b=1).group_by("a").agg(pl.col("b").first().slice(1, 1))
+
+
+def test_agg_scalar_empty_groups_20115() -> None:
+    assert_frame_equal(
+        (
+            pl.DataFrame({"key": [123], "value": [456]})
+            .group_by("key")
+            .agg(pl.col("value").slice(1, 1).first())
+        ),
+        pl.select(key=pl.lit(123, pl.Int64), value=pl.lit(None, pl.Int64)),
+    )

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -746,9 +746,9 @@ def test_sort_by_over_multiple_nulls_last() -> None:
 
 def test_slice_after_agg_raises() -> None:
     with pytest.raises(
-        InvalidOperationError, match=r"cannot slice\(\) an aggregated value"
+        InvalidOperationError, match=r"cannot slice\(\) an aggregated scalar value"
     ):
-        pl.select(a=1, b=1).group_by("a").agg(pl.col("b").first().slice(999, 0))
+        pl.select(a=1, b=1).group_by("a").agg(pl.col("b").first().slice(99, 0))
 
 
 def test_agg_scalar_empty_groups_20115() -> None:


### PR DESCRIPTION
Returned previously filtered values instead of NULL.

Fixes https://github.com/pola-rs/polars/issues/20115
