### PR TITLE
fix(rust): Fix index out of bounds in uniform_hist_count

### DIFF
--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::fmt::Write;
 
 use num_traits::ToPrimitive;
@@ -111,7 +112,9 @@ where
                 } else {
                     idx_floor
                 };
-                count[idx as usize] += 1;
+                /* idx > (num_bins - 1) may happen due to floating point representation imprecision */
+                let idx = cmp::min(idx as usize, num_bins - 1);
+                count[idx] += 1;
             } else if include_lower && item == min_break {
                 count[0] += 1;
             }

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -428,7 +428,7 @@ def test_hist_max_boundary_19998() -> None:
     assert result["count"].sum() == 4
 
 
-def test_hist_max_boundary_5_000000000000001() -> None:
+def test_hist_max_boundary_20133() -> None:
     # Given a set of values that result in bin index to be a floating point number that
     # is represented as 5.000000000000001
     s = pl.Series(

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -428,6 +428,24 @@ def test_hist_max_boundary_19998() -> None:
     assert result["count"].sum() == 4
 
 
+def test_hist_max_boundary_5_000000000000001() -> None:
+    # Given a set of values that result in bin index to be a floating point number that
+    # is represented as 5.000000000000001
+    s = pl.Series(
+        [
+            6.197601318359375,
+            83.5203145345052,
+        ]
+    )
+
+    # When histogram is calculated
+    result = s.hist(bin_count=5)
+
+    # Then there is no exception (previously was possible to get index out of bounds
+    # here) and all the numbers fit into at least one of the bins
+    assert result["count"].sum() == 2
+
+
 def test_hist_same_values_20030() -> None:
     out = pl.Series([1, 1]).hist(bin_count=2)
     expected = pl.DataFrame(


### PR DESCRIPTION
Sometimes, index out of bounds happened in uniform_hist_count in cases when due to floating point representation imprecision idx value went over the maximum index (num_bins - 1). Example error message:

```
thread 'polars-4' panicked at crates/polars-ops/src/chunked_array/hist.rs:112:22:
index out of bounds: the len is 5 but the index is 5
```

To work around the issue, add an explicit check that forces value into expected number of intervals. I am not entirely sure this is mathematically correct solution, but it seems to work well.

I added a test that fails on current main branch on my machine just in case, but I know for sure it does not fail with error in other environments (like google colab, for example) .