### PR TITLE
feat: Allow for `to_datetime` / `strftime` to automatically parse dates with single-digit hour/minute/second

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/infer.rs
+++ b/crates/polars-time/src/chunkedarray/string/infer.rs
@@ -21,12 +21,12 @@ const DATETIME_DMY_PATTERN: &str = r#"(?x)
         (?:\d{4,})                   # year
         (?:
             [T\ ]                    # separator
-            (?:\d{1,2})                # hour
+            (?:\d{1,2})              # hour
             :?                       # separator
-            (?:\d{1,2})                # minute
+            (?:\d{1,2})              # minute
             (?:
                 :?                   # separator
-                (?:\d{1,2})            # second
+                (?:\d{1,2})          # second
                 (?:
                     \.(?:\d{1,9})    # subsecond
                 )?
@@ -47,12 +47,12 @@ const DATETIME_YMD_PATTERN: &str = r#"(?x)
         (?:\d{1,2})                # day
         (?:
             [T\ ]                  # separator
-            (?:\d{1,2})              # hour
+            (?:\d{1,2})            # hour
             :?                     # separator
-            (?:\d{1,2})              # minute
+            (?:\d{1,2})            # minute
             (?:
                 :?                 # separator
-                (?:\d{1,2})          # seconds
+                (?:\d{1,2})        # seconds
                 (?:
                     \.(?:\d{1,9})  # subsecond
                 )?

--- a/crates/polars-time/src/chunkedarray/string/infer.rs
+++ b/crates/polars-time/src/chunkedarray/string/infer.rs
@@ -47,12 +47,12 @@ const DATETIME_YMD_PATTERN: &str = r#"(?x)
         (?:\d{1,2})                # day
         (?:
             [T\ ]                  # separator
-            (?:\d{2})              # hour
+            (?:\d{1,2})              # hour
             :?                     # separator
-            (?:\d{2})              # minute
+            (?:\d{1,2})              # minute
             (?:
                 :?                 # separator
-                (?:\d{2})          # seconds
+                (?:\d{1,2})          # seconds
                 (?:
                     \.(?:\d{1,9})  # subsecond
                 )?

--- a/crates/polars-time/src/chunkedarray/string/infer.rs
+++ b/crates/polars-time/src/chunkedarray/string/infer.rs
@@ -21,12 +21,12 @@ const DATETIME_DMY_PATTERN: &str = r#"(?x)
         (?:\d{4,})                   # year
         (?:
             [T\ ]                    # separator
-            (?:\d{2})                # hour
+            (?:\d{1,2})                # hour
             :?                       # separator
-            (?:\d{2})                # minute
+            (?:\d{1,2})                # minute
             (?:
                 :?                   # separator
-                (?:\d{2})            # second
+                (?:\d{1,2})            # second
                 (?:
                     \.(?:\d{1,9})    # subsecond
                 )?

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -152,6 +152,20 @@ def test_to_date_all_inferred_date_patterns(time_string: str, expected: date) ->
 
 
 @pytest.mark.parametrize(
+    ("time_string", "expected"),
+    [
+        ("2024-12-04 09:08:00", datetime(2024, 12, 4, 9, 8, 0)),
+        ("2024-12-4 9:8:0", datetime(2024, 12, 4, 9, 8, 0)),
+        ("2024/12/04 9:8", datetime(2024, 12, 4, 9, 8, 0)),
+        ("4/12/2024 9:8", datetime(2024, 12, 4, 9, 8, 0)),
+    ],
+)
+def test_to_datetime_infer_missing_digit_in_time(time_string: str, expected: datetime) -> None:
+    result = pl.Series([time_string]).str.to_datetime()
+    assert result[0] == expected
+
+
+@pytest.mark.parametrize(
     ("value", "attr"),
     [
         ("a", "to_date"),

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -160,7 +160,9 @@ def test_to_date_all_inferred_date_patterns(time_string: str, expected: date) ->
         ("4/12/2024 9:8", datetime(2024, 12, 4, 9, 8, 0)),
     ],
 )
-def test_to_datetime_infer_missing_digit_in_time(time_string: str, expected: datetime) -> None:
+def test_to_datetime_infer_missing_digit_in_time(
+    time_string: str, expected: datetime
+) -> None:
     result = pl.Series([time_string]).str.to_datetime()
     assert result[0] == expected
 

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -160,7 +160,7 @@ def test_to_date_all_inferred_date_patterns(time_string: str, expected: date) ->
         ("4/12/2024 9:8", datetime(2024, 12, 4, 9, 8, 0)),
     ],
 )
-def test_to_datetime_infer_missing_digit_in_time(
+def test_to_datetime_infer_missing_digit_in_time_16092(
     time_string: str, expected: datetime
 ) -> None:
     result = pl.Series([time_string]).str.to_datetime()


### PR DESCRIPTION
To accommodate the default datetime format used by Excel in certain regional settings (e.g., China), as discussed in #16092 

closes #16092

The format mentioned in the original issue is actually H:m, with seconds omitted. However, since the seconds component is already optional in the current pattern, adding support for single-digit seconds shouldn't cause any issues.