### PR TITLE
fix: Allow more than one dictionary encoded data page per column chunk in parquet

### DIFF
--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -418,7 +418,7 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
 
 impl<K: DictionaryKey> Splitable for DictionaryArray<K> {
     fn check_bound(&self, offset: usize) -> bool {
-        offset < self.len()
+        offset <= self.len()
     }
 
     unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -232,7 +232,7 @@ impl Array for FixedSizeBinaryArray {
 
 impl Splitable for FixedSizeBinaryArray {
     fn check_bound(&self, offset: usize) -> bool {
-        offset < self.len()
+        offset <= self.len()
     }
 
     unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {

--- a/crates/polars-parquet/src/arrow/write/file.rs
+++ b/crates/polars-parquet/src/arrow/write/file.rs
@@ -61,6 +61,7 @@ impl<W: Write> FileWriter<W> {
                 parquet_schema,
                 FileWriteOptions {
                     version: options.version,
+                    write_indexes: false,
                     write_statistics: options.has_statistics(),
                 },
                 created_by,

--- a/crates/polars-parquet/src/arrow/write/sink.rs
+++ b/crates/polars-parquet/src/arrow/write/sink.rs
@@ -58,6 +58,7 @@ where
             parquet_schema.clone(),
             ParquetWriteOptions {
                 version: options.version,
+                write_indexes: false,
                 write_statistics: options.has_statistics(),
             },
             created_by,

--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -250,13 +250,6 @@ impl Page {
             Self::Dict(page) => page.buffer.to_mut(),
         }
     }
-
-    pub(crate) fn unwrap_data(self) -> DataPage {
-        match self {
-            Self::Data(page) => page,
-            _ => panic!(),
-        }
-    }
 }
 
 /// A [`CompressedPage`] is a compressed, encoded representation of a Parquet page. It holds actual data

--- a/crates/polars-parquet/src/parquet/write/file.rs
+++ b/crates/polars-parquet/src/parquet/write/file.rs
@@ -188,7 +188,7 @@ impl<W: Write> FileWriter<W> {
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();
 
-        if self.options.write_statistics {
+        if self.options.write_indexes {
             // write column indexes (require page statistics)
             self.row_groups
                 .iter_mut()

--- a/crates/polars-parquet/src/parquet/write/mod.rs
+++ b/crates/polars-parquet/src/parquet/write/mod.rs
@@ -28,8 +28,10 @@ pub type RowGroupIter<'a, E> = DynIter<'a, RowGroupIterColumns<'a, E>>;
 /// Write options of different interfaces on this crate
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WriteOptions {
-    /// Whether to write statistics, including indexes
+    /// Whether to write statistics
     pub write_statistics: bool,
+    /// Whether to write indexes
+    pub write_indexes: bool,
     /// Which Parquet version to use
     pub version: Version,
 }

--- a/crates/polars/tests/it/io/parquet/write/mod.rs
+++ b/crates/polars/tests/it/io/parquet/write/mod.rs
@@ -52,6 +52,7 @@ fn test_column(column: &str, compression: CompressionOptions) -> ParquetResult<(
 
     let options = WriteOptions {
         write_statistics: true,
+        write_indexes: false,
         version: Version::V1,
     };
 
@@ -177,6 +178,7 @@ fn basic() -> ParquetResult<()> {
 
     let options = WriteOptions {
         write_statistics: false,
+        write_indexes: false,
         version: Version::V1,
     };
 

--- a/crates/polars/tests/it/io/parquet/write/sidecar.rs
+++ b/crates/polars/tests/it/io/parquet/write/sidecar.rs
@@ -20,6 +20,7 @@ fn basic() -> Result<(), ParquetError> {
             schema.clone(),
             WriteOptions {
                 write_statistics: true,
+                write_indexes: false,
                 version: Version::V2,
             },
             None,


### PR DESCRIPTION
Fixes #20141.