### PR TITLE
chore(python): Set delta version check higher

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4449,7 +4449,7 @@ class DataFrame:
         if isinstance(target, (str, Path)):
             target = _resolve_delta_lake_uri(str(target), strict=False)
 
-        if Version(delta_version) >= Version("0.22.3"):
+        if Version(delta_version) >= Version("0.23.0"):
             data = self.to_arrow(compat_level=CompatLevel.newest())
         else:
             data = self.to_arrow()


### PR DESCRIPTION
We have to push some changes in delta-rs that fixes some regressions first in 0.22.3, unfortunately we couldn't add the delta-kernel-rs update in there yet that would add the final bits and pieces for the view types inference.

I changed it to 0.23.0 so we have some leeway here for delta-rs to some more bugfix releases. I'll include the bumped delta-kernel-rs in the 0.23 release