### PR TITLE
perf(python): Construct `Series` for bytes/binary data 10x faster when dtype not explicitly set

### DIFF
--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -155,6 +155,7 @@ if not _DOCUMENTING:
         int: PySeries.new_opt_i64,
         str: PySeries.new_str,
         bool: PySeries.new_opt_bool,
+        bytes: PySeries.new_binary,
         PyDecimal: PySeries.new_decimal,
     }
 


### PR DESCRIPTION
Can still detect/use the fast-path binary constructor rather than the generic object constructor even when the dtype was not explicitly set (as `pl.Binary`). 

Not a bad return on a one-line update ;)

## Example
```python
from codetiming import Timer
import polars as pl

binary_data = [str(n).encode("utf8") for n in range(50_000_000)]

with Timer():
    s = pl.Series(binary_data)
```
**Timings**  
```
Before: 5.6219 secs  (new_object)
 After: 0.5609 secs  (new_binary) 🚀
```
