### PR TITLE
perf(python): Much faster `Series` construction from subclasses of standard Python types

### DIFF
--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -152,17 +152,19 @@ def numpy_type_to_constructor(
 if not _DOCUMENTING:
     _PY_TYPE_TO_CONSTRUCTOR = {
         float: PySeries.new_opt_f64,
+        bool: PySeries.new_opt_bool,
         int: PySeries.new_opt_i64,
         str: PySeries.new_str,
-        bool: PySeries.new_opt_bool,
         bytes: PySeries.new_binary,
         PyDecimal: PySeries.new_decimal,
     }
 
 
-def py_type_to_constructor(dtype: type[Any]) -> Callable[..., PySeries]:
+def py_type_to_constructor(py_type: type[Any]) -> Callable[..., PySeries]:
     """Get the right PySeries constructor for the given Python dtype."""
-    try:
-        return _PY_TYPE_TO_CONSTRUCTOR[dtype]
-    except KeyError:
-        return PySeries.new_object
+    py_type = (
+        next((tp for tp in _PY_TYPE_TO_CONSTRUCTOR if issubclass(py_type, tp)), py_type)
+        if py_type not in _PY_TYPE_TO_CONSTRUCTOR
+        else py_type
+    )
+    return _PY_TYPE_TO_CONSTRUCTOR.get(py_type, PySeries.new_object)


### PR DESCRIPTION
Took another look at Series construction following #20157, and found some additional large speedups (though in a more niche context).

Data composed of types that inherit from the standard builtin types (int, float, str, bytes) currently use the generic `new_object` constructor; however, it is actually still valid to use the specialised/fast-path constructors in this case. This PR makes a minor update to `py_type_to_constructor` to detect this and assign the faster constructors.

## Example

```python
import polars as pl
import codecs

class BinaryReprInt(int):
    def __new__(cls, value):
        return super().__new__(cls, value)

    def __repr__(self) -> str:
        v = f"{abs(int(self)):>08b}"
        return f"-{v}" if self < 0 else v

    __str__ = __repr__


bn = BinaryReprInt(12345)
print(bn)
# 11000000111001

bn == 12345
# True
```
```python
int_data = list(range(10_000_000))
custom_int_data = [BinaryReprInt(i) for i in int_data]

with Timer():
    s1 = pl.Series(custom_int_data)
with Timer():
    s2 = pl.Series(int_data)
```

#### Timings
```
Before: 0.2938 secs
 After: 0.0805 secs  (~3½ times faster)  🚀 
```

#### Type comparison

Applying this update shows a different degree of speedup for different base types, but all speedups are significant; the table below shows timings when loading 10,000,000 elements that inherit from the given type:

 | dtype | before (secs) | after (secs) | speedup |
|-------|--------------|-------------|---------|
| bytes | 0.9838           | 0.1071          | 9.2x     |
| float | 0.2554           | 0.0533          | 4.8x    |
| int   | 0.3010           | 0.0816          | 3.7x     |
| str   | 0.5904           | 0.3167          | 1.9x      |
