### PR TITLE
fix(python): Series construct with large nested `u64`

### DIFF
--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2172,3 +2172,12 @@ def test_series_from_numpy_with_dtype() -> None:
 def test_raise_invalid_is_between() -> None:
     with pytest.raises(pl.exceptions.InvalidOperationError):
         pl.select(pl.lit(2).is_between(pl.lit("11"), pl.lit("33")))
+
+
+def test_construction_large_nested_u64_17231() -> None:
+    import polars as pl
+
+    values = [{"f0": [9223372036854775808]}]
+    dtype = pl.Struct({"f0": pl.List(pl.UInt64)})
+
+    assert pl.Series(values, dtype=dtype).to_list() == values


### PR DESCRIPTION
Fixes #17231.