### PR TITLE
fix: Don't use RLE encoding for Parquet Boolean

### DIFF
--- a/crates/polars-arrow/src/bitmap/bitmask.rs
+++ b/crates/polars-arrow/src/bitmap/bitmask.rs
@@ -94,6 +94,10 @@ impl<'a> BitMask<'a> {
         Self::new(bytes, offset, len)
     }
 
+    pub fn inner(&self) -> (&[u8], usize, usize) {
+        (self.bytes, self.offset, self.len)
+    }
+
     pub fn new(bytes: &'a [u8], offset: usize, len: usize) -> Self {
         // Check length so we can use unsafe access in our get.
         assert!(bytes.len() * 8 >= len + offset);

--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -3,6 +3,7 @@ use std::hint::unreachable_unchecked;
 use polars_error::{polars_bail, PolarsResult};
 use polars_utils::vec::PushUnchecked;
 
+use super::bitmask::BitMask;
 use super::utils::{count_zeros, fmt, BitChunk, BitChunks, BitChunksExactMut, BitmapIter};
 use super::{intersects_with_mut, Bitmap};
 use crate::bitmap::utils::{get_bit_unchecked, merge_reversed, set_bit_in_byte};
@@ -798,6 +799,12 @@ impl MutableBitmap {
         assert!(offset + length <= slice.len() * 8);
         // SAFETY: invariant is asserted
         unsafe { self.extend_from_slice_unchecked(slice, offset, length) }
+    }
+
+    #[inline]
+    pub fn extend_from_bitmask(&mut self, bitmask: BitMask<'_>) {
+        let (slice, offset, length) = bitmask.inner();
+        self.extend_from_slice(slice, offset, length)
     }
 
     /// Extends the [`MutableBitmap`] from a [`Bitmap`].

--- a/crates/polars-io/src/parquet/write/writer.rs
+++ b/crates/polars-io/src/parquet/write/writer.rs
@@ -145,7 +145,6 @@ fn encoding_map(dtype: &ArrowDataType) -> Encoding {
         | PhysicalType::LargeUtf8
         | PhysicalType::Utf8View
         | PhysicalType::BinaryView => Encoding::RleDictionary,
-        PhysicalType::Boolean => Encoding::Rle,
         PhysicalType::Primitive(dt) => {
             use arrow::types::PrimitiveType::*;
             match dt {

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
@@ -105,10 +105,7 @@ pub(crate) fn constrain_page_validity(
 ) -> Option<Bitmap> {
     let num_unfiltered_rows = match (filter.as_ref(), page_validity) {
         (None, None) => values_len,
-        (None, Some(pv)) => {
-            debug_assert!(pv.len() >= values_len);
-            pv.len()
-        },
+        (None, Some(pv)) => pv.len(),
         (Some(f), v) => {
             if cfg!(debug_assertions) {
                 if let Some(v) = v {


### PR DESCRIPTION
This is not really ready yet unless we have compatibility profiles.

Fixes #18819.