### PR TITLE
fix(rust): Add temporal feature gate in `is_elementwise_top_level`

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -229,7 +229,7 @@ impl AExpr {
 
             // Non-strict strptime must be done in-memory to ensure the format
             // is consistent across the entire dataframe.
-            #[cfg(feature = "strings")]
+            #[cfg(all(feature = "strings", feature = "temporal"))]
             Function {
                 options,
                 function: FunctionExpr::StringExpr(StringFunction::Strptime(_, opts)),


### PR DESCRIPTION
`StringFunction::Strptime` is only available with `feature = "temporal"`.