### PR TITLE
feat(python): Improve dtype inference and load for `DataFrame` cols constructed from Python Enums

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 from collections.abc import Generator, Iterator
 from datetime import date, datetime, time, timedelta
+from enum import Enum as PyEnum
 from itertools import islice
 from typing import (
     TYPE_CHECKING,
@@ -123,6 +124,14 @@ def sequence_to_pyseries(
                 dtype in pl_temporal_types or type(dtype) in pl_temporal_types
             ) and not isinstance(value, int):
                 python_dtype = dtype_to_py_type(dtype)  # type: ignore[arg-type]
+
+    # if values are enums, infer and load the appropriate dtype/values
+    if issubclass(type(value), PyEnum):
+        if dtype is None and python_dtype is None:
+            with contextlib.suppress(TypeError):
+                dtype = Enum(type(value))
+        if not isinstance(value, (str, int)):
+            values = [v.value for v in values]
 
     # physical branch
     # flat data

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -629,8 +629,7 @@ class Enum(DataType):
                     raise TypeError(msg)
 
             enum_values = [
-                (v if isinstance(v, str) else v.value)
-                for v in categories.__members__.values()
+                getattr(v, "value", v) for v in categories.__members__.values()
             ]
             categories = pl.Series(values=enum_values)
         elif not isinstance(categories, pl.Series):

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
 from polars._utils.wrap import wrap_expr
-from polars.datatypes import Date, Datetime, Duration, Enum
+from polars.datatypes import Date, Datetime, Duration
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 
@@ -150,10 +150,7 @@ def lit(
         )
 
     elif isinstance(value, enum.Enum):
-        lit_value = value.value
-        if dtype is None and isinstance(value, str):
-            dtype = Enum(m.value for m in type(value))
-        return lit(lit_value, dtype=dtype)
+        return lit(value.value, dtype=dtype)
 
     if dtype:
         return wrap_expr(plr.lit(value, allow_object, is_scalar=True)).cast(dtype)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="redundant-expr"
 from __future__ import annotations
 
 import enum
@@ -20,6 +21,13 @@ from polars.exceptions import (
     SchemaError,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+
+    PyStrEnum: type[enum.Enum] | None = StrEnum
+else:
+    PyStrEnum = None
 
 
 def test_enum_creation() -> None:
@@ -628,13 +636,8 @@ def test_roundtrip_enum_parquet() -> None:
     "EnumBase",
     [
         (enum.Enum,),
-        (enum.StrEnum,),
         (str, enum.Enum),
-    ]
-    if sys.version_info >= (3, 11)
-    else [
-        (enum.Enum,),
-        (str, enum.Enum),
+        *([(PyStrEnum,)] if PyStrEnum is not None else []),
     ],
 )
 def test_init_frame_from_enums(EnumBase: tuple[type, ...]) -> None:

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="redundant-expr"
 from __future__ import annotations
 
 import enum
@@ -17,6 +18,14 @@ from polars.testing.parametric.strategies.data import datetimes
 
 if TYPE_CHECKING:
     from polars._typing import PolarsDataType
+
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+
+    PyStrEnum: type[enum.Enum] | None = StrEnum
+else:
+    PyStrEnum = None
 
 
 @pytest.mark.parametrize(
@@ -110,13 +119,8 @@ def test_lit_unsupported_type() -> None:
     "EnumBase",
     [
         (enum.Enum,),
-        (enum.StrEnum,),
         (str, enum.Enum),
-    ]
-    if sys.version_info >= (3, 11)
-    else [
-        (enum.Enum,),
-        (str, enum.Enum),
+        *([(PyStrEnum,)] if PyStrEnum is not None else []),
     ],
 )
 def test_lit_enum_input_16668(EnumBase: tuple[type, ...]) -> None:

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import sys
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
@@ -105,32 +106,67 @@ def test_lit_unsupported_type() -> None:
         pl.lit(pl.LazyFrame({"a": [1, 2, 3]}))
 
 
-def test_lit_enum_input_16668() -> None:
+@pytest.mark.parametrize(
+    "EnumBase",
+    [
+        (enum.Enum,),
+        (enum.StrEnum,),
+        (str, enum.Enum),
+    ]
+    if sys.version_info >= (3, 11)
+    else [
+        (enum.Enum,),
+        (str, enum.Enum),
+    ],
+)
+def test_lit_enum_input_16668(EnumBase: tuple[type, ...]) -> None:
     # https://github.com/pola-rs/polars/issues/16668
 
-    class State(str, enum.Enum):
-        VIC = "victoria"
-        NSW = "new south wales"
+    class State(*EnumBase):  # type: ignore[misc]
+        NSW = "New South Wales"
+        QLD = "Queensland"
+        VIC = "Victoria"
 
+    # validate that frame schema has inferred the enum
+    df = pl.DataFrame({"state": [State.NSW, State.VIC]})
+    assert df.schema == {
+        "state": pl.Enum(["New South Wales", "Queensland", "Victoria"])
+    }
+
+    # check use of enum as lit/constraint
     value = State.VIC
+    expected = "Victoria"
 
-    result = pl.lit(value)
-    assert pl.select(result).dtypes[0] == pl.Enum(["victoria", "new south wales"])
-    assert pl.select(result).item() == "victoria"
+    for lit_value in (
+        pl.lit(value),
+        pl.lit(value.value),  # type: ignore[attr-defined]
+    ):
+        assert pl.select(lit_value).item() == expected
+        assert df.filter(state=value).item() == expected
+        assert df.filter(state=lit_value).item() == expected
 
-    result = pl.lit(value, dtype=pl.String)
-    assert pl.select(result).dtypes[0] == pl.String
-    assert pl.select(result).item() == "victoria"
+    assert df.filter(pl.col("state") == State.QLD).is_empty()
+    assert df.filter(pl.col("state") != State.QLD).height == 2
 
 
-def test_lit_enum_input_non_string() -> None:
+@pytest.mark.parametrize(
+    "EnumBase",
+    [
+        (enum.Enum,),
+        (enum.Flag,),
+        (enum.IntEnum,),
+        (enum.IntFlag,),
+        (int, enum.Enum),
+    ],
+)
+def test_lit_enum_input_non_string(EnumBase: tuple[type, ...]) -> None:
     # https://github.com/pola-rs/polars/issues/16668
 
-    class State(int, enum.Enum):
+    class Number(*EnumBase):  # type: ignore[misc]
         ONE = 1
         TWO = 2
 
-    value = State.ONE
+    value = Number.ONE
 
     result = pl.lit(value)
     assert pl.select(result).dtypes[0] == pl.Int32


### PR DESCRIPTION
Improved detection and loading of Python Enum values from _all_ flavours of Python Enum base class. Lots of new Enum-related unit tests to extend coverage for this.

## Examples

Ingest/inference for Python string-valued Enums:
```python
import polars as pl
import enum

for EnumBase in (
    (enum.Enum,),
    (enum.StrEnum,),
    (str, enum.Enum),
):
    class Portfolio(*EnumBase):  # type: ignore[misc]
        TECH = "Technology"
        RETAIL = "Retail"
        OTHER = "Other"

    df = pl.DataFrame({
        "trade_id": [123, 456], 
        "portfolio": [Portfolio.OTHER, Portfolio.TECH],
    })
    # shape: (2, 2)
    # ┌──────────┬────────────┐
    # │ trade_id ┆ portfolio  │
    # │ ---      ┆ ---        │
    # │ i64      ┆ enum       │
    # ╞══════════╪════════════╡
    # │ 123      ┆ Other      │
    # │ 456      ┆ Technology │
    # └──────────┴────────────┘

    df.schema["portfolio"]
    # Enum(categories=['Technology', 'Retail', 'Other'])
```
We don't support Python integer-valued Enums _as_ Polars Enums, but we do expect to be able to load them by value:
```python
for EnumBase in (
    (enum.Enum,),
    (enum.Flag,),
    (enum.IntEnum,),
    (enum.IntFlag,),
    (int, enum.Enum),
):
    class Number(*EnumBases):  # type: ignore[misc]
        ONE = 1
        TWO = 2
        FOUR = 4
        EIGHT = 8
    
    s = pl.Series(values=[Number.EIGHT, Number.TWO, Number.FOUR])

    shape: (3,)
    # Series: '' [i64]
    # [
    #     8
    #     2
    #     4
    # ]
```

## Miscellaneous

Following https://github.com/pola-rs/polars/pull/20166, string-based enum values load roughly 50% faster than before (as they are now ingested via the `new_str` constructor instead of `new_object`).