### PR TITLE
fix: Only validate UTF-8 for selected items when all below len 128

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binview.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview.rs
@@ -410,7 +410,7 @@ pub fn decode_plain_generic(
         // only a valid first byte of a UTF-8 code-point and (L, 0, 0, 0) is valid UTF-8.
         // Consequently, it is valid to just check the whole buffer.
         } else if all_len_below_128 {
-            if simdutf8::basic::from_utf8(values).is_err() {
+            if simdutf8::basic::from_utf8(&values[..values.len() - mvalues.len()]).is_err() {
                 return Err(invalid_utf8_err());
             }
         } else {

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -2579,3 +2579,13 @@ c0,c9,c3
 1,1,1
 """),
     )
+
+
+def test_utf8_verification_with_slice_20174() -> None:
+    f = io.BytesIO()
+    pq.write_table(
+        pl.Series("s", ["a", "a" * 128]).to_frame().to_arrow(), f, use_dictionary=False
+    )
+
+    f.seek(0)
+    pl.scan_parquet(f).head(1).collect()


### PR DESCRIPTION
Fixes #20174.