### PR TITLE
fix(rust): Too-strict SQL UDF schema validation

### DIFF
--- a/crates/polars-plan/src/dsl/udf.rs
+++ b/crates/polars-plan/src/dsl/udf.rs
@@ -1,7 +1,7 @@
 use polars_utils::pl_str::PlSmallStr;
 
 use super::{ColumnsUdf, Expr, GetOutput, OpaqueColumnUdf};
-use crate::prelude::{new_column_udf, FunctionOptions};
+use crate::prelude::{FunctionOptions, new_column_udf};
 
 /// Represents a user-defined function
 #[derive(Clone)]

--- a/crates/polars-plan/src/dsl/udf.rs
+++ b/crates/polars-plan/src/dsl/udf.rs
@@ -1,18 +1,13 @@
-use arrow::legacy::error::{PolarsResult, polars_bail};
-use polars_core::prelude::Field;
-use polars_core::schema::Schema;
 use polars_utils::pl_str::PlSmallStr;
 
 use super::{ColumnsUdf, Expr, GetOutput, OpaqueColumnUdf};
-use crate::prelude::{Context, FunctionOptions, new_column_udf};
+use crate::prelude::{new_column_udf, FunctionOptions};
 
 /// Represents a user-defined function
 #[derive(Clone)]
 pub struct UserDefinedFunction {
     /// name
     pub name: PlSmallStr,
-    /// The function signature.
-    pub input_fields: Vec<Field>,
     /// The function output type.
     pub return_type: GetOutput,
     /// The function implementation.
@@ -25,7 +20,6 @@ impl std::fmt::Debug for UserDefinedFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("UserDefinedFunction")
             .field("name", &self.name)
-            .field("signature", &self.input_fields)
             .field("fun", &"<FUNC>")
             .field("options", &self.options)
             .finish()
@@ -34,15 +28,9 @@ impl std::fmt::Debug for UserDefinedFunction {
 
 impl UserDefinedFunction {
     /// Create a new UserDefinedFunction
-    pub fn new(
-        name: PlSmallStr,
-        input_fields: Vec<Field>,
-        return_type: GetOutput,
-        fun: impl ColumnsUdf + 'static,
-    ) -> Self {
+    pub fn new(name: PlSmallStr, return_type: GetOutput, fun: impl ColumnsUdf + 'static) -> Self {
         Self {
             name,
-            input_fields,
             return_type,
             fun: new_column_udf(fun),
             options: FunctionOptions::default(),
@@ -50,37 +38,7 @@ impl UserDefinedFunction {
     }
 
     /// creates a logical expression with a call of the UDF
-    /// This utility allows using the UDF without requiring access to the registry.
-    /// The schema is validated and the query will fail if the schema is invalid.
-    pub fn call(self, args: Vec<Expr>) -> PolarsResult<Expr> {
-        if args.len() != self.input_fields.len() {
-            polars_bail!(InvalidOperation: "expected {} arguments, got {}", self.input_fields.len(), args.len())
-        }
-        let schema = Schema::from_iter(self.input_fields);
-
-        if args
-            .iter()
-            .map(|e| e.to_field(&schema, Context::Default))
-            .collect::<PolarsResult<Vec<_>>>()
-            .is_err()
-        {
-            polars_bail!(InvalidOperation: "unexpected field in UDF \nexpected: {:?}\n received {:?}", schema, args)
-        };
-
-        Ok(Expr::AnonymousFunction {
-            input: args,
-            function: self.fun,
-            output_type: self.return_type,
-            options: self.options,
-        })
-    }
-
-    /// creates a logical expression with a call of the UDF
-    /// This does not do any schema validation and is therefore faster.
-    ///
-    /// Only use this if you are certain that the schema is correct.
-    /// If the schema is invalid, the query will fail at runtime.
-    pub fn call_unchecked(self, args: Vec<Expr>) -> Expr {
+    pub fn call(self, args: Vec<Expr>) -> Expr {
         Expr::AnonymousFunction {
             input: args,
             function: self.fun,

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1500,7 +1500,7 @@ impl SQLFunctionVisitor<'_> {
             .function_registry
             .get_udf(func_name)?
             .ok_or_else(|| polars_err!(SQLInterface: "UDF {} not found", func_name))?
-            .call_unchecked(args))
+            .call(args))
     }
 
     /// Window specs without partition bys are essentially cumulative functions

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1495,7 +1495,8 @@ impl SQLFunctionVisitor<'_> {
             })
             .collect::<PolarsResult<Vec<_>>>()?;
 
-        Ok(self.ctx
+        Ok(self
+            .ctx
             .function_registry
             .get_udf(func_name)?
             .ok_or_else(|| polars_err!(SQLInterface: "UDF {} not found", func_name))?

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1495,11 +1495,11 @@ impl SQLFunctionVisitor<'_> {
             })
             .collect::<PolarsResult<Vec<_>>>()?;
 
-        self.ctx
+        Ok(self.ctx
             .function_registry
             .get_udf(func_name)?
             .ok_or_else(|| polars_err!(SQLInterface: "UDF {} not found", func_name))?
-            .call(args)
+            .call_unchecked(args))
     }
 
     /// Window specs without partition bys are essentially cumulative functions

--- a/crates/polars-sql/tests/udf.rs
+++ b/crates/polars-sql/tests/udf.rs
@@ -34,10 +34,6 @@ impl FunctionRegistry for MyFunctionRegistry {
 fn test_udfs() -> PolarsResult<()> {
     let my_custom_sum = UserDefinedFunction::new(
         "my_custom_sum".into(),
-        vec![
-            Field::new("a".into(), DataType::Int32),
-            Field::new("b".into(), DataType::Int32),
-        ],
         GetOutput::same_type(),
         move |c: &mut [Column]| {
             let first = c[0].as_materialized_series().clone();
@@ -64,10 +60,6 @@ fn test_udfs() -> PolarsResult<()> {
     // create a new UDF to be registered on the context
     let my_custom_divide = UserDefinedFunction::new(
         "my_custom_divide".into(),
-        vec![
-            Field::new("a".into(), DataType::Int32),
-            Field::new("b".into(), DataType::Int32),
-        ],
         GetOutput::same_type(),
         move |c: &mut [Column]| {
             let first = c[0].as_materialized_series().clone();

--- a/crates/polars-sql/tests/udf.rs
+++ b/crates/polars-sql/tests/udf.rs
@@ -61,12 +61,6 @@ fn test_udfs() -> PolarsResult<()> {
     let res = ctx.execute("SELECT a, b, my_custom_sum(a, b) FROM foo");
     assert!(res.is_ok());
 
-    // schema is invalid so it will fail
-    assert!(
-        ctx.execute("SELECT a, b, my_custom_sum(c) as invalid FROM foo")
-            .is_err()
-    );
-
     // create a new UDF to be registered on the context
     let my_custom_divide = UserDefinedFunction::new(
         "my_custom_divide".into(),

--- a/crates/polars-sql/tests/udf.rs
+++ b/crates/polars-sql/tests/udf.rs
@@ -34,7 +34,16 @@ impl FunctionRegistry for MyFunctionRegistry {
 fn test_udfs() -> PolarsResult<()> {
     let my_custom_sum = UserDefinedFunction::new(
         "my_custom_sum".into(),
-        GetOutput::same_type(),
+        GetOutput::map_dtypes(|dtypes| {
+            // UDF is responsible for schema validation
+            let Ok([first, second]) = <[&DataType; 2]>::try_from(dtypes) else {
+                polars_bail!(SchemaMismatch: "expected two arguments")
+            };
+            if first != second {
+                polars_bail!(SchemaMismatch: "mismatched types")
+            }
+            Ok(first.clone())
+        }),
         move |c: &mut [Column]| {
             let first = c[0].as_materialized_series().clone();
             let second = c[1].as_materialized_series().clone();
@@ -57,10 +66,25 @@ fn test_udfs() -> PolarsResult<()> {
     let res = ctx.execute("SELECT a, b, my_custom_sum(a, b) FROM foo");
     assert!(res.is_ok());
 
+    // schema is invalid so it will fail
+    assert!(matches!(
+        ctx.execute("SELECT a, b, my_custom_sum(c) as invalid FROM foo"),
+        Err(PolarsError::SchemaMismatch(_))
+    ));
+
     // create a new UDF to be registered on the context
     let my_custom_divide = UserDefinedFunction::new(
         "my_custom_divide".into(),
-        GetOutput::same_type(),
+        GetOutput::map_dtypes(|dtypes| {
+            // UDF is responsible for schema validation
+            let Ok([first, second]) = <[&DataType; 2]>::try_from(dtypes) else {
+                polars_bail!(SchemaMismatch: "expected two arguments")
+            };
+            if first != second {
+                polars_bail!(SchemaMismatch: "mismatched types")
+            }
+            Ok(first.clone())
+        }),
         move |c: &mut [Column]| {
             let first = c[0].as_materialized_series().clone();
             let second = c[1].as_materialized_series().clone();


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/15155

Over-eager schema validation is unfortunately rendering user-defined SQL functions unusable. Not sure why registered UDFs need to hardcode/pre-specify the names and dtypes of prospective arguments-- the plugin can handle invalid calling patterns much more flexibly. Reducing the strictness also allows SQL plugins to be variadic, just like Python plugins are.

I wrote this PR with a different and simpler approach because the original PR from @uhlarmarek has stalled: https://github.com/pola-rs/polars/pull/15159

The SQL functionality seems useful, but we can't move forward with it until we can register UDFs. Thanks for the great work as always!
