### PR TITLE
refactor: Move hive partitioning/multi-file handling outside of readers

### DIFF
--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -468,6 +468,10 @@ impl PhysicalExpr for AggregationExpr {
         }
     }
 
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.input.collect_live_columns(lv);
+    }
+
     fn is_scalar(&self) -> bool {
         true
     }
@@ -755,6 +759,11 @@ impl PhysicalExpr for AggQuantileExpr {
             AggregatedScalar(agg),
             Cow::Borrowed(groups),
         ))
+    }
+
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.input.collect_live_columns(lv);
+        self.quantile.collect_live_columns(lv);
     }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-expr/src/expressions/alias.rs
+++ b/crates/polars-expr/src/expressions/alias.rs
@@ -59,6 +59,11 @@ impl PhysicalExpr for AliasExpr {
         Ok(ac)
     }
 
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.physical_expr.collect_live_columns(lv);
+        lv.insert(self.name.clone());
+    }
+
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         Ok(Field::new(
             self.name.clone(),

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -447,7 +447,7 @@ impl PhysicalExpr for ApplyExpr {
                         new_inputs.extend(self.inputs[..i].iter().cloned());
                         new_inputs.push(new);
                         break;
-                    }
+                    },
                 }
             }
 

--- a/crates/polars-expr/src/expressions/cast.rs
+++ b/crates/polars-expr/src/expressions/cast.rs
@@ -87,6 +87,10 @@ impl PhysicalExpr for CastExpr {
         Ok(ac)
     }
 
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.input.collect_live_columns(lv);
+    }
+
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.input.to_field(input_schema).map(|mut fld| {
             fld.coerce(self.dtype.clone());

--- a/crates/polars-expr/src/expressions/count.rs
+++ b/crates/polars-expr/src/expressions/count.rs
@@ -36,6 +36,8 @@ impl PhysicalExpr for CountExpr {
         Ok(AggregationContext::new(c, Cow::Borrowed(groups), true))
     }
 
+    fn collect_live_columns(&self, _lv: &mut PlIndexSet<PlSmallStr>) {}
+
     fn to_field(&self, _input_schema: &Schema) -> PolarsResult<Field> {
         Ok(Field::new(PlSmallStr::from_static(LEN), IDX_DTYPE))
     }

--- a/crates/polars-expr/src/expressions/filter.rs
+++ b/crates/polars-expr/src/expressions/filter.rs
@@ -24,6 +24,7 @@ impl PhysicalExpr for FilterExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let s_f = || self.input.evaluate(df, state);
         let predicate_f = || self.by.evaluate(df, state);
@@ -143,6 +144,11 @@ impl PhysicalExpr for FilterExpr {
             ac_s.with_groups(groups).set_original_len(false);
             Ok(ac_s)
         }
+    }
+
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.input.collect_live_columns(lv);
+        self.by.collect_live_columns(lv);
     }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -18,6 +18,7 @@ impl PhysicalExpr for GatherExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let series = self.phys_expr.evaluate(df, state)?;
         self.finish(df, state, series)
@@ -86,6 +87,11 @@ impl PhysicalExpr for GatherExpr {
         ac.with_values(taken.into_column(), true, Some(&self.expr))?;
         ac.with_update_groups(UpdateGroups::WithSeriesLen);
         Ok(ac)
+    }
+
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.phys_expr.collect_live_columns(lv);
+        self.idx.collect_live_columns(lv);
     }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -121,6 +121,7 @@ impl PhysicalExpr for LiteralExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.1)
     }
+
     fn evaluate(&self, _df: &DataFrame, _state: &ExecutionState) -> PolarsResult<Column> {
         self.as_column()
     }
@@ -147,6 +148,8 @@ impl PhysicalExpr for LiteralExpr {
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
         Some(self)
     }
+    
+    fn collect_live_columns(&self, _lv: &mut PlIndexSet<PlSmallStr>) {}
 
     fn to_field(&self, _input_schema: &Schema) -> PolarsResult<Field> {
         let dtype = self.0.get_datatype();

--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -148,7 +148,7 @@ impl PhysicalExpr for LiteralExpr {
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
         Some(self)
     }
-    
+
     fn collect_live_columns(&self, _lv: &mut PlIndexSet<PlSmallStr>) {}
 
     fn to_field(&self, _input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-expr/src/expressions/rolling.rs
+++ b/crates/polars-expr/src/expressions/rolling.rs
@@ -59,6 +59,10 @@ impl PhysicalExpr for RollingExpr {
         polars_bail!(InvalidOperation: "rolling expression not allowed in aggregation");
     }
 
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.phys_function.collect_live_columns(lv);
+    }
+
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.function.to_field(input_schema, Context::Default)
     }

--- a/crates/polars-expr/src/expressions/slice.rs
+++ b/crates/polars-expr/src/expressions/slice.rs
@@ -268,6 +268,12 @@ impl PhysicalExpr for SliceExpr {
         Ok(ac)
     }
 
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.input.collect_live_columns(lv);
+        self.offset.collect_live_columns(lv);
+        self.length.collect_live_columns(lv);
+    }
+
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.input.to_field(input_schema)
     }

--- a/crates/polars-expr/src/expressions/sort.rs
+++ b/crates/polars-expr/src/expressions/sort.rs
@@ -46,6 +46,7 @@ impl PhysicalExpr for SortExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let series = self.physical_expr.evaluate(df, state)?;
         series.sort_with(self.options)
@@ -102,6 +103,10 @@ impl PhysicalExpr for SortExpr {
         }
 
         Ok(ac)
+    }
+
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.physical_expr.collect_live_columns(lv);
     }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -201,6 +201,7 @@ impl PhysicalExpr for SortByExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
         let series_f = || self.input.evaluate(df, state);
         if self.by.is_empty() {
@@ -372,6 +373,13 @@ impl PhysicalExpr for SortByExpr {
 
         ac_in.with_groups(groups);
         Ok(ac_in)
+    }
+
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.input.collect_live_columns(lv);
+        for i in &self.by {
+            i.collect_live_columns(lv);
+        }
     }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -328,6 +328,12 @@ impl PhysicalExpr for TernaryExpr {
         Some(self)
     }
 
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        self.predicate.collect_live_columns(lv);
+        self.truthy.collect_live_columns(lv);
+        self.falsy.collect_live_columns(lv);
+    }
+
     fn is_scalar(&self) -> bool {
         self.returns_scalar
     }

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -640,6 +640,16 @@ impl PhysicalExpr for WindowExpr {
     fn is_scalar(&self) -> bool {
         false
     }
+    
+    fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
+        for i in &self.group_by {
+            i.collect_live_columns(lv);
+        }
+        if let Some((i, _)) = &self.order_by {
+            i.collect_live_columns(lv);
+        }
+        self.phys_function.collect_live_columns(lv);
+    }
 
     #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups<'a>(

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -640,7 +640,7 @@ impl PhysicalExpr for WindowExpr {
     fn is_scalar(&self) -> bool {
         false
     }
-    
+
     fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
         for i in &self.group_by {
             i.collect_live_columns(lv);

--- a/crates/polars-io/src/parquet/read/mod.rs
+++ b/crates/polars-io/src/parquet/read/mod.rs
@@ -31,10 +31,10 @@ consider compiling with polars-bigidx feature (polars-u64-idx package on python)
 or set 'streaming'",
 ));
 
-use arrow::datatypes::ArrowSchema;
 pub use options::{ParallelStrategy, ParquetOptions};
-use polars_error::{ErrString, PolarsError, PolarsResult};
-use polars_parquet::read::FileMetadata;
+use polars_error::{ErrString, PolarsError};
+pub use polars_parquet::arrow::read::infer_schema;
+pub use polars_parquet::read::FileMetadata;
 pub use read_impl::{create_sorting_map, try_set_sorted_flag};
 #[cfg(feature = "cloud")]
 pub use reader::ParquetAsyncReader;
@@ -46,8 +46,4 @@ pub mod _internal {
     pub use super::predicates::read_this_row_group;
     pub use super::read_impl::{calc_prefilter_cost, PrefilterMaskSetting};
     pub use super::utils::ensure_matching_dtypes_if_found;
-}
-
-pub fn infer_schema(metadata: &FileMetadata) -> PolarsResult<ArrowSchema> {
-    Ok(polars_parquet::arrow::read::infer_schema(metadata)?)
 }

--- a/crates/polars-io/src/parquet/read/mod.rs
+++ b/crates/polars-io/src/parquet/read/mod.rs
@@ -31,8 +31,10 @@ consider compiling with polars-bigidx feature (polars-u64-idx package on python)
 or set 'streaming'",
 ));
 
+use arrow::datatypes::ArrowSchema;
 pub use options::{ParallelStrategy, ParquetOptions};
-use polars_error::{ErrString, PolarsError};
+use polars_error::{ErrString, PolarsError, PolarsResult};
+use polars_parquet::read::FileMetadata;
 pub use read_impl::{create_sorting_map, try_set_sorted_flag};
 #[cfg(feature = "cloud")]
 pub use reader::ParquetAsyncReader;
@@ -44,4 +46,8 @@ pub mod _internal {
     pub use super::predicates::read_this_row_group;
     pub use super::read_impl::{calc_prefilter_cost, PrefilterMaskSetting};
     pub use super::utils::ensure_matching_dtypes_if_found;
+}
+
+pub fn infer_schema(metadata: &FileMetadata) -> PolarsResult<ArrowSchema> {
+    Ok(polars_parquet::arrow::read::infer_schema(metadata)?)
 }

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::ops::{Deref, Range};
+use std::ops::Range;
 
 use arrow::array::BooleanArray;
 use arrow::bitmap::MutableBitmap;
@@ -236,7 +236,9 @@ fn rg_to_dfs(
 
     if parallel == S::Prefiltered {
         if let Some(predicate) = predicate {
-            if let Some(live_variables) = predicate.live_variables() {
+            let mut live_columns = PlIndexSet::new();
+            predicate.collect_live_columns(&mut live_columns);
+            if !live_columns.is_empty() {
                 return rg_to_dfs_prefiltered(
                     store,
                     previous_row_count,
@@ -244,7 +246,7 @@ fn rg_to_dfs(
                     row_group_end,
                     file_metadata,
                     schema,
-                    live_variables,
+                    live_columns,
                     predicate,
                     row_index,
                     projection,
@@ -308,7 +310,7 @@ fn rg_to_dfs_prefiltered(
     row_group_end: usize,
     file_metadata: &FileMetadata,
     schema: &ArrowSchemaRef,
-    live_variables: Vec<PlSmallStr>,
+    live_columns: PlIndexSet<PlSmallStr>,
     predicate: &dyn PhysicalIoExpr,
     row_index: Option<RowIndex>,
     projection: &[usize],
@@ -335,14 +337,8 @@ fn rg_to_dfs_prefiltered(
             .collect(),
     };
 
-    // Deduplicate the live variables
-    let live_variables = live_variables
-        .iter()
-        .map(Deref::deref)
-        .collect::<PlHashSet<_>>();
-
     // Get the number of live columns
-    let num_live_columns = live_variables.len();
+    let num_live_columns = live_columns.len();
     let num_dead_columns =
         projection.len() + hive_partition_columns.map_or(0, |x| x.len()) - num_live_columns;
 
@@ -358,7 +354,7 @@ fn rg_to_dfs_prefiltered(
     for &i in projection.iter() {
         let name = schema.get_at_index(i).unwrap().0.as_str();
 
-        if live_variables.contains(name) {
+        if live_columns.contains(name) {
             live_idx_to_col_idx.push(i);
         } else {
             dead_idx_to_col_idx.push(i);
@@ -899,7 +895,9 @@ pub fn read_parquet<R: MmapBytesReader>(
         let prefilter_env = std::env::var("POLARS_PARQUET_PREFILTER");
         let prefilter_env = prefilter_env.as_deref();
 
-        let num_live_variables = predicate.live_variables().map_or(0, |v| v.len());
+        let mut live_columns = PlIndexSet::new();
+        predicate.collect_live_columns(&mut live_columns);
+        let num_live_variables = live_columns.len();
         let mut do_prefilter = false;
 
         do_prefilter |= prefilter_env == Ok("1"); // Force enable

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -9,7 +9,7 @@ pub trait PhysicalIoExpr: Send + Sync {
 
     /// Get the variables that are used in the expression i.e. live variables.
     /// This can contain duplicates.
-    fn live_variables(&self) -> Option<Vec<PlSmallStr>>;
+    fn collect_live_columns(&self, live_columns: &mut PlIndexSet<PlSmallStr>);
 
     /// Can take &dyn Statistics and determine of a file should be
     /// read -> `true`
@@ -212,6 +212,16 @@ pub struct BatchStats {
     stats: Vec<ColumnStats>,
     // This might not be available, as when pruning hive partitions.
     num_rows: Option<usize>,
+}
+
+impl Default for BatchStats {
+    fn default() -> Self {
+        Self {
+            schema: Arc::new(Schema::default()),
+            stats: Vec::new(),
+            num_rows: None,
+        }
+    }
 }
 
 impl BatchStats {

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -26,9 +26,8 @@ impl PhysicalIoExpr for Wrap {
         };
         h.evaluate_io(df)
     }
-    fn live_variables(&self) -> Option<Vec<PlSmallStr>> {
-        // @TODO: This should not unwrap
-        Some(expr_to_leaf_column_names(self.0.as_expression()?))
+    fn collect_live_columns(&self, live_columns: &mut PlIndexSet<PlSmallStr>) {
+        self.0.collect_live_columns(live_columns);
     }
     fn as_stats_evaluator(&self) -> Option<&dyn StatsEvaluator> {
         self.0.as_stats_evaluator()

--- a/crates/polars-mem-engine/src/executors/hive_scan.rs
+++ b/crates/polars-mem-engine/src/executors/hive_scan.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::cell::LazyCell;
 
 use hive::HivePartitions;
 use polars_core::frame::column::ScalarColumn;
@@ -75,6 +74,159 @@ impl HiveExec {
             scan_type,
         }
     }
+
+    pub fn read(&mut self) -> PolarsResult<DataFrame> {
+        let include_file_paths = self.file_options.include_file_paths.take();
+        let predicate = self.predicate.take();
+        let stats_evaluator = predicate.as_ref().and_then(|p| p.as_stats_evaluator());
+        let mut row_index = self.file_options.row_index.take();
+        let mut slice = self.file_options.slice.take();
+
+        assert_eq!(self.sources.len(), self.hive_parts.len());
+
+        assert!(!self.file_options.allow_missing_columns, "NYI");
+        assert!(slice.is_none_or(|s| s.0 >= 0), "NYI");
+
+        #[cfg(feature = "parquet")]
+        {
+            let FileScan::Parquet {
+                options,
+                cloud_options,
+                metadata,
+            } = self.scan_type.clone()
+            else {
+                todo!()
+            };
+
+            let stats_evaluator = stats_evaluator.filter(|_| options.use_statistics);
+
+            let mut dfs = Vec::with_capacity(self.sources.len());
+
+            for (source, hive_part) in self.sources.iter().zip(self.hive_parts.iter()) {
+                if slice.is_some_and(|s| s.1 == 0) {
+                    break;
+                }
+
+                let part_source = match source {
+                    ScanSourceRef::Path(path) => ScanSources::Paths([path.to_path_buf()].into()),
+                    ScanSourceRef::File(_) | ScanSourceRef::Buffer(_) => {
+                        ScanSources::Buffers([source.to_memslice()?].into())
+                    },
+                };
+
+                let mut file_options = self.file_options.clone();
+                file_options.row_index = row_index.clone();
+
+                // @TODO: There are cases where we can ignore reading. E.g. no row index + empty with columns + no predicate
+                let mut exec = ParquetExec::new(
+                    part_source,
+                    self.file_info.clone(),
+                    None,
+                    None, // @TODO: add predicate with hive columns replaced
+                    options.clone(),
+                    cloud_options.clone(),
+                    file_options,
+                    metadata.clone(),
+                );
+
+                let mut num_unfiltered_rows = LazyTryCell::new(|| exec.num_unfiltered_rows());
+
+                let mut do_skip_file = false;
+                if let Some(slice) = &slice {
+                    do_skip_file |= slice.0 >= num_unfiltered_rows.get()? as i64;
+                }
+                if let Some(stats_evaluator) = stats_evaluator {
+                    do_skip_file |= !stats_evaluator
+                        .should_read(hive_part.get_statistics())
+                        .unwrap_or(true);
+                }
+
+                // Update the row_index to the proper offset.
+                if let Some(row_index) = row_index.as_mut() {
+                    row_index.offset += num_unfiltered_rows.get()?;
+                }
+
+                if do_skip_file {
+                    // Update the row_index to the proper offset.
+                    if let Some(row_index) = row_index.as_mut() {
+                        row_index.offset += num_unfiltered_rows.get()?;
+                    }
+                    // Update the slice offset.
+                    if let Some(slice) = slice.as_mut() {
+                        slice.0 = slice.0.saturating_sub(num_unfiltered_rows.get()? as i64);
+                    }
+
+                    continue;
+                }
+
+                // Read the DataFrame and needed metadata.
+                // @TODO: these should be merged into one call
+                let num_unfiltered_rows = num_unfiltered_rows.get()?;
+                let mut df = exec.read()?;
+
+                // Update the row_index to the proper offset.
+                if let Some(row_index) = row_index.as_mut() {
+                    row_index.offset += num_unfiltered_rows;
+                }
+                // Update the slice.
+                if let Some(slice) = slice.as_mut() {
+                    slice.0 = slice.0.saturating_sub(num_unfiltered_rows as i64);
+                    slice.1 = slice.1.saturating_sub(num_unfiltered_rows as usize);
+                }
+
+                if let Some(with_columns) = &self.file_options.with_columns {
+                    df = match &row_index {
+                        None => df.select(with_columns.iter().cloned())?,
+                        Some(ri) => df.select(
+                            std::iter::once(ri.name.clone()).chain(with_columns.iter().cloned()),
+                        )?,
+                    }
+                }
+
+                // Materialize the hive columns and add them basic in.
+                let hive_df: DataFrame = hive_part
+                    .get_statistics()
+                    .column_stats()
+                    .iter()
+                    .map(|hive_col| {
+                        ScalarColumn::from_single_value_series(
+                            hive_col
+                                .to_min()
+                                .unwrap()
+                                .clone()
+                                .with_name(hive_col.field_name().clone()),
+                            df.height(),
+                        )
+                        .into_column()
+                    })
+                    .collect();
+                let mut df = hive_df.hstack(df.get_columns())?;
+
+                if let Some(include_file_paths) = &include_file_paths {
+                    df.with_column(ScalarColumn::new(
+                        include_file_paths.clone(),
+                        PlSmallStr::from_str(source.to_include_path_name()).into(),
+                        df.height(),
+                    ))?;
+                }
+
+                dfs.push(df);
+            }
+
+            let out = if cfg!(debug_assertions) {
+                accumulate_dataframes_vertical(dfs)?
+            } else {
+                accumulate_dataframes_vertical_unchecked(dfs)
+            };
+
+            Ok(out)
+        }
+
+        #[cfg(not(feature = "parquet"))]
+        {
+            todo!()
+        }
+    }
 }
 
 impl Executor for HiveExec {
@@ -90,164 +242,6 @@ impl Executor for HiveExec {
             Cow::Borrowed("")
         };
 
-        state.record(
-            || {
-                let include_file_paths = self.file_options.include_file_paths.take();
-                let predicate = self.predicate.take();
-                let stats_evaluator = predicate.as_ref().and_then(|p| p.as_stats_evaluator());
-                let mut row_index = self.file_options.row_index.take();
-                let mut slice = self.file_options.slice.take();
-
-                assert_eq!(self.sources.len(), self.hive_parts.len());
-
-                assert!(!self.file_options.allow_missing_columns, "NYI");
-                assert!(slice.is_none_or(|s| s.0 >= 0), "NYI");
-
-                #[cfg(feature = "parquet")]
-                {
-                    let FileScan::Parquet {
-                        options,
-                        cloud_options,
-                        metadata,
-                    } = self.scan_type.clone()
-                    else {
-                        todo!()
-                    };
-
-                    let stats_evaluator = stats_evaluator.filter(|_| options.use_statistics);
-
-                    let mut dfs = Vec::with_capacity(self.sources.len());
-
-                    for (source, hive_part) in self.sources.iter().zip(self.hive_parts.iter()) {
-                        if slice.is_some_and(|s| s.1 == 0) {
-                            break;
-                        }
-
-                        let part_source = match source {
-                            ScanSourceRef::Path(path) => {
-                                ScanSources::Paths([path.to_path_buf()].into())
-                            },
-                            ScanSourceRef::File(_) | ScanSourceRef::Buffer(_) => {
-                                ScanSources::Buffers([source.to_memslice()?].into())
-                            },
-                        };
-
-                        let mut file_options = self.file_options.clone();
-                        file_options.row_index = row_index.clone();
-
-                        // @TODO: There are cases where we can ignore reading. E.g. no row index + empty with columns + no predicate
-                        let mut exec = ParquetExec::new(
-                            part_source,
-                            self.file_info.clone(),
-                            None,
-                            None, // @TODO: add predicate with hive columns replaced
-                            options.clone(),
-                            cloud_options.clone(),
-                            file_options,
-                            metadata.clone(),
-                        );
-
-                        let mut num_unfiltered_rows =
-                            LazyTryCell::new(|| exec.num_unfiltered_rows());
-
-                        let mut do_skip_file = false;
-                        if let Some(slice) = &slice {
-                            do_skip_file |= slice.0 >= num_unfiltered_rows.get()? as i64;
-                        }
-                        if let Some(stats_evaluator) = stats_evaluator {
-                            do_skip_file |= !stats_evaluator
-                                .should_read(hive_part.get_statistics())
-                                .unwrap_or(true);
-                        }
-
-                        // Update the row_index to the proper offset.
-                        if let Some(row_index) = row_index.as_mut() {
-                            row_index.offset += num_unfiltered_rows.get()?;
-                        }
-
-                        if do_skip_file {
-                            // Update the row_index to the proper offset.
-                            if let Some(row_index) = row_index.as_mut() {
-                                row_index.offset += num_unfiltered_rows.get()?;
-                            }
-                            // Update the slice offset.
-                            if let Some(slice) = slice.as_mut() {
-                                slice.0 = slice.0.saturating_sub(num_unfiltered_rows.get()? as i64);
-                            }
-
-                            continue;
-                        }
-
-                        // Read the DataFrame and needed metadata.
-                        // @TODO: these should be merged into one call
-                        let num_unfiltered_rows = num_unfiltered_rows.get()?;
-                        let mut df = exec.read()?;
-
-                        // Update the row_index to the proper offset.
-                        if let Some(row_index) = row_index.as_mut() {
-                            row_index.offset += num_unfiltered_rows;
-                        }
-                        // Update the slice.
-                        if let Some(slice) = slice.as_mut() {
-                            slice.0 = slice.0.saturating_sub(num_unfiltered_rows as i64);
-                            slice.1 = slice.1.saturating_sub(num_unfiltered_rows as usize);
-                        }
-
-                        if let Some(with_columns) = &self.file_options.with_columns {
-                            df = match &row_index {
-                                None => df.select(with_columns.iter().cloned())?,
-                                Some(ri) => df.select(
-                                    std::iter::once(ri.name.clone())
-                                        .chain(with_columns.iter().cloned()),
-                                )?,
-                            }
-                        }
-
-                        // Materialize the hive columns and add them basic in.
-                        let hive_df: DataFrame = hive_part
-                            .get_statistics()
-                            .column_stats()
-                            .iter()
-                            .map(|hive_col| {
-                                ScalarColumn::from_single_value_series(
-                                    hive_col
-                                        .to_min()
-                                        .unwrap()
-                                        .clone()
-                                        .with_name(hive_col.field_name().clone()),
-                                    df.height(),
-                                )
-                                .into_column()
-                            })
-                            .collect();
-                        let mut df = hive_df.hstack(df.get_columns())?;
-
-                        if let Some(include_file_paths) = &include_file_paths {
-                            df.with_column(ScalarColumn::new(
-                                include_file_paths.clone(),
-                                PlSmallStr::from_str(source.to_include_path_name()).into(),
-                                df.height(),
-                            ))?;
-                        }
-
-                        dfs.push(df);
-                    }
-
-                    let out = if cfg!(debug_assertions) {
-                        accumulate_dataframes_vertical(dfs)?
-                    } else {
-                        accumulate_dataframes_vertical_unchecked(dfs)
-                    };
-
-                    Ok(out)
-                }
-
-                #[cfg(not(feature = "parquet"))]
-                {
-                    todo!()
-                }
-            },
-            profile_name,
-        )
+        state.record(|| self.read(), profile_name)
     }
 }

--- a/crates/polars-mem-engine/src/executors/hive_scan.rs
+++ b/crates/polars-mem-engine/src/executors/hive_scan.rs
@@ -11,7 +11,7 @@ use polars_io::predicates::BatchStats;
 use polars_io::prelude::FileMetadata;
 use polars_io::RowIndex;
 
-use super::Executor;
+use super::{CsvExec, Executor};
 use crate::executors::ParquetExec;
 use crate::prelude::*;
 
@@ -88,6 +88,13 @@ fn source_to_scan_exec(
                     .clone()
             }),
         )) as _,
+        FileScan::Csv { options, .. } => Box::new(CsvExec {
+            sources: source,
+            file_info: file_info.clone(),
+            options: options.clone(),
+            file_options: file_options.clone(),
+            predicate: None,
+        }),
         _ => todo!(),
     })
 }

--- a/crates/polars-mem-engine/src/executors/hive_scan.rs
+++ b/crates/polars-mem-engine/src/executors/hive_scan.rs
@@ -21,6 +21,25 @@ pub trait IOFileMetadata: Send + Sync {
     fn schema(&self) -> PolarsResult<Schema>;
 }
 
+pub(super) struct BasicFileMetadata {
+    pub schema: Schema,
+    pub num_rows: IdxSize,
+}
+
+impl IOFileMetadata for BasicFileMetadata {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn num_rows(&self) -> PolarsResult<IdxSize> {
+        Ok(self.num_rows)
+    }
+
+    fn schema(&self) -> PolarsResult<Schema> {
+        Ok(self.schema.clone())
+    }
+}
+
 pub trait ScanExec {
     fn read(
         &mut self,

--- a/crates/polars-mem-engine/src/executors/hive_scan.rs
+++ b/crates/polars-mem-engine/src/executors/hive_scan.rs
@@ -1,0 +1,182 @@
+use std::borrow::Cow;
+
+use hive::HivePartitions;
+use polars_core::frame::column::ScalarColumn;
+use polars_core::utils::{
+    accumulate_dataframes_vertical, accumulate_dataframes_vertical_unchecked,
+};
+
+use super::Executor;
+use crate::executors::ParquetExec;
+use crate::prelude::*;
+
+pub trait ScanExec {
+    fn read(&mut self) -> PolarsResult<DataFrame>;
+}
+
+pub struct HiveExec {
+    sources: ScanSources,
+    file_info: FileInfo,
+    hive_parts: Arc<Vec<HivePartitions>>,
+    predicate: Option<Arc<dyn PhysicalExpr>>,
+    file_options: FileScanOptions,
+    scan_type: FileScan,
+}
+
+impl HiveExec {
+    pub fn new(
+        sources: ScanSources,
+        file_info: FileInfo,
+        hive_parts: Arc<Vec<HivePartitions>>,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+        file_options: FileScanOptions,
+        scan_type: FileScan,
+    ) -> Self {
+        Self {
+            sources,
+            file_info,
+            hive_parts,
+            predicate,
+            file_options,
+            scan_type,
+        }
+    }
+}
+
+impl Executor for HiveExec {
+    fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        let profile_name = if state.has_node_timer() {
+            let mut ids = vec![self.sources.id()];
+            if self.predicate.is_some() {
+                ids.push("predicate".into())
+            }
+            let name = comma_delimited("hive".to_string(), &ids);
+            Cow::Owned(name)
+        } else {
+            Cow::Borrowed("")
+        };
+
+        state.record(
+            || {
+                let include_file_paths = self.file_options.include_file_paths.take();
+                let mut row_index = self.file_options.row_index.take();
+
+                assert_eq!(self.sources.len(), self.hive_parts.len());
+
+                assert!(!self.file_options.allow_missing_columns, "NYI");
+                assert!(self.file_options.slice.is_none(), "NYI");
+
+                #[cfg(feature = "parquet")]
+                {
+                    let FileScan::Parquet {
+                        options,
+                        cloud_options,
+                        metadata,
+                    } = self.scan_type.clone()
+                    else {
+                        todo!()
+                    };
+
+                    let mut dfs = Vec::with_capacity(self.sources.len());
+
+                    for (source, hive_part) in self.sources.iter().zip(self.hive_parts.iter()) {
+                        let part_source = match source {
+                            ScanSourceRef::Path(path) => {
+                                ScanSources::Paths([path.to_path_buf()].into())
+                            },
+                            ScanSourceRef::File(_) | ScanSourceRef::Buffer(_) => {
+                                ScanSources::Buffers([source.to_memslice()?].into())
+                            },
+                        };
+
+                        let mut file_options = self.file_options.clone();
+                        if let Some(row_index) = &row_index {
+                            file_options.row_index = Some(row_index.clone());
+                        }
+
+                        // @TODO: There are cases where we can ignore reading. E.g. no row index + empty with columns + no predicate
+                        let mut exec = ParquetExec::new(
+                            part_source,
+                            self.file_info.clone(),
+                            None,
+                            self.predicate.clone(),
+                            options.clone(),
+                            cloud_options.clone(),
+                            file_options,
+                            metadata.clone(),
+                        );
+
+                        let mut df = exec.read()?;
+
+                        // Update the row_index to the proper offset.
+                        if let Some(row_index) = row_index.as_mut() {
+                            // @Q? Is this always index = 0
+                            let ri = &df.get_columns()[0];
+                            let ri_offset = ri.get(ri.len() - 1).unwrap();
+
+                            // @TODO: Use bigint feature
+                            row_index.offset = match ri_offset {
+                                AnyValue::UInt32(v) => v as IdxSize,
+                                AnyValue::UInt64(v) => v as IdxSize,
+                                _ => unreachable!(),
+                            } + 1;
+                        }
+
+                        if let Some(with_columns) = &self.file_options.with_columns {
+                            df = match &row_index {
+                                None => df.select(with_columns.iter().cloned())?,
+                                Some(ri) => df.select(
+                                    std::iter::once(ri.name.clone())
+                                        .chain(with_columns.iter().cloned()),
+                                )?,
+                            }
+                        }
+
+                        // Materialize the hive columns and add them basic in.
+                        let hive_df: DataFrame = hive_part
+                            .get_statistics()
+                            .column_stats()
+                            .iter()
+                            .map(|hive_col| {
+                                ScalarColumn::from_single_value_series(
+                                    hive_col
+                                        .to_min()
+                                        .unwrap()
+                                        .clone()
+                                        .with_name(hive_col.field_name().clone()),
+                                    df.height(),
+                                )
+                                .into_column()
+                            })
+                            .collect();
+                        let mut df = hive_df.hstack(df.get_columns())?;
+
+                        if let Some(include_file_paths) = &include_file_paths {
+                            df.with_column(ScalarColumn::new(
+                                include_file_paths.clone(),
+                                PlSmallStr::from_str(source.to_include_path_name()).into(),
+                                df.height(),
+                            ))?;
+                        }
+
+                        dfs.push(df);
+                    }
+
+                    let out = if cfg!(debug_assertions) {
+                        accumulate_dataframes_vertical(dfs)?
+                    } else {
+                        accumulate_dataframes_vertical_unchecked(dfs)
+                    };
+
+                    Ok(out)
+                }
+
+                #[cfg(not(feature = "parquet"))]
+                {
+                    todo!()
+                }
+            },
+            profile_name,
+        )
+    }
+}

--- a/crates/polars-mem-engine/src/executors/mod.rs
+++ b/crates/polars-mem-engine/src/executors/mod.rs
@@ -7,6 +7,7 @@ mod group_by_dynamic;
 mod group_by_partitioned;
 pub(super) mod group_by_rolling;
 mod hconcat;
+mod hive_scan;
 mod join;
 mod projection;
 mod projection_simple;
@@ -38,6 +39,7 @@ pub(super) use self::group_by_partitioned::*;
 #[cfg(feature = "dynamic_group_by")]
 pub(super) use self::group_by_rolling::GroupByRollingExec;
 pub(super) use self::hconcat::*;
+pub(super) use self::hive_scan::*;
 pub(super) use self::join::*;
 pub(super) use self::projection::*;
 pub(super) use self::projection_simple::*;

--- a/crates/polars-mem-engine/src/executors/scan/csv.rs
+++ b/crates/polars-mem-engine/src/executors/scan/csv.rs
@@ -224,10 +224,9 @@ impl ScanExec for CsvExec {
         self.predicate = predicate;
         self.file_options.row_index = row_index;
 
-        self.file_info.reader_schema = Some(arrow::Either::Left(Arc::new(
-            schema.to_arrow(CompatLevel::newest()),
-        )));
-        self.file_info.schema = Arc::new(schema);
+        let schema = Arc::new(schema);
+        self.file_info.reader_schema = Some(arrow::Either::Right(schema.clone()));
+        self.file_info.schema = schema.clone();
 
         self.options.schema.take();
         // self.options.schema_overwrite.take();
@@ -260,20 +259,15 @@ impl ScanExec for CsvExec {
         )? as IdxSize;
         let schema = infer_file_schema(
             &get_reader_bytes(&mut std::io::Cursor::new(bytes))?,
-            popt.separator,
+            self.options.parse_options.as_ref(),
             self.options.infer_schema_length,
             self.options.has_header,
             self.options.schema_overwrite.as_deref(),
             self.options.skip_rows,
+            self.options.skip_lines,
             self.options.skip_rows_after_header,
-            popt.comment_prefix.as_ref(),
-            popt.quote_char,
-            popt.eol_char,
-            popt.null_values.as_ref(),
-            popt.try_parse_dates,
             self.options.raise_if_empty,
             &mut self.options.n_threads,
-            popt.decimal_comma,
         )?
         .0;
 

--- a/crates/polars-mem-engine/src/executors/scan/csv.rs
+++ b/crates/polars-mem-engine/src/executors/scan/csv.rs
@@ -254,7 +254,7 @@ impl ScanExec for CsvExec {
             popt.separator,
             popt.quote_char,
             popt.comment_prefix.as_ref(),
-            popt.eol_char.clone(),
+            popt.eol_char,
             self.options.has_header,
         )? as IdxSize;
         let schema = infer_file_schema(

--- a/crates/polars-mem-engine/src/executors/scan/csv.rs
+++ b/crates/polars-mem-engine/src/executors/scan/csv.rs
@@ -17,7 +17,7 @@ pub struct CsvExec {
 }
 
 impl CsvExec {
-    fn read(&self) -> PolarsResult<DataFrame> {
+    fn read_impl(&self) -> PolarsResult<DataFrame> {
         let with_columns = self
             .file_options
             .with_columns
@@ -209,6 +209,78 @@ impl CsvExec {
     }
 }
 
+impl ScanExec for CsvExec {
+    fn read(
+        &mut self,
+        with_columns: Option<Arc<[PlSmallStr]>>,
+        slice: Option<(usize, usize)>,
+        predicate: Option<Arc<dyn PhysicalExpr>>,
+        row_index: Option<polars_io::RowIndex>,
+        metadata: Option<Box<dyn IOFileMetadata>>,
+        schema: Schema,
+    ) -> PolarsResult<DataFrame> {
+        self.file_options.with_columns = with_columns;
+        self.file_options.slice = slice.map(|(o, l)| (o as i64, l));
+        self.predicate = predicate;
+        self.file_options.row_index = row_index;
+
+        self.file_info.reader_schema = Some(arrow::Either::Left(Arc::new(
+            schema.to_arrow(CompatLevel::newest()),
+        )));
+        self.file_info.schema = Arc::new(schema);
+
+        self.options.schema.take();
+        // self.options.schema_overwrite.take();
+
+        // Use the metadata somehow
+        _ = metadata;
+
+        self.read_impl()
+    }
+
+    fn metadata(&mut self) -> PolarsResult<Box<dyn IOFileMetadata>> {
+        let force_async = config::force_async();
+        let run_async = (self.sources.is_paths() && force_async) || self.sources.is_cloud_url();
+
+        let source = self.sources.at(0);
+        let owned = &mut vec![];
+
+        let memslice = source.to_memslice_async_assume_latest(run_async)?;
+
+        let popt = self.options.parse_options.as_ref();
+
+        let bytes = maybe_decompress_bytes(&memslice, owned)?;
+        let num_rows = count_rows_from_slice(
+            bytes,
+            popt.separator,
+            popt.quote_char,
+            popt.comment_prefix.as_ref(),
+            popt.eol_char.clone(),
+            self.options.has_header,
+        )? as IdxSize;
+        let schema = infer_file_schema(
+            &get_reader_bytes(&mut std::io::Cursor::new(bytes))?,
+            popt.separator,
+            self.options.infer_schema_length,
+            self.options.has_header,
+            self.options.schema_overwrite.as_deref(),
+            self.options.skip_rows,
+            self.options.skip_rows_after_header,
+            popt.comment_prefix.as_ref(),
+            popt.quote_char,
+            popt.eol_char,
+            popt.null_values.as_ref(),
+            popt.try_parse_dates,
+            self.options.raise_if_empty,
+            &mut self.options.n_threads,
+            popt.decimal_comma,
+        )?
+        .0;
+
+        Ok(Box::new(BasicFileMetadata { schema, num_rows }) as _)
+    }
+}
+
 impl Executor for CsvExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
         let profile_name = if state.has_node_timer() {
@@ -222,6 +294,6 @@ impl Executor for CsvExec {
             Cow::Borrowed("")
         };
 
-        state.record(|| self.read(), profile_name)
+        state.record(|| self.read_impl(), profile_name)
     }
 }

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -528,6 +528,7 @@ impl ParquetExec {
         }) as _)
     }
 
+    #[cfg(feature = "cloud")]
     async fn metadata_async(&mut self) -> PolarsResult<Box<dyn IOFileMetadata>> {
         let ScanSourceRef::Path(path) = self.sources.get(0).unwrap() else {
             unreachable!();
@@ -599,11 +600,12 @@ impl ScanExec for ParquetExec {
     }
 
     fn metadata(&mut self) -> PolarsResult<Box<dyn IOFileMetadata>> {
+        #[cfg(feature = "cloud")]
         if self.sources.is_cloud_url() {
-            pl_async::get_runtime().block_on_potential_spawn(self.metadata_async())
-        } else {
-            self.metadata_sync()
+            return pl_async::get_runtime().block_on_potential_spawn(self.metadata_async());
         }
+
+        self.metadata_sync()
     }
 }
 

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -528,8 +528,6 @@ impl ScanExec for ParquetExec {
     }
 
     fn read(&mut self) -> PolarsResult<DataFrame> {
-        assert_eq!(self.sources.len(), 1);
-
         self.read_with_num_unfiltered_rows().map(|(_, df)| df)
     }
 

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -472,7 +472,9 @@ impl ParquetExec {
 
         Ok(result)
     }
+}
 
+impl ScanExec for ParquetExec {
     fn read(&mut self) -> PolarsResult<DataFrame> {
         // FIXME: The row index implementation is incorrect when a predicate is
         // applied. This code mitigates that by applying the predicate after the

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -472,13 +472,6 @@ impl ParquetExec {
 
         Ok(result)
     }
-}
-
-impl ScanExec for ParquetExec {
-    fn num_unfiltered_rows(&mut self) -> PolarsResult<IdxSize> {
-        // @FIXME! This is extremely inefficient.
-        self.read_with_num_unfiltered_rows().map(|(n, _)| n)
-    }
 
     fn read_with_num_unfiltered_rows(&mut self) -> PolarsResult<(IdxSize, DataFrame)> {
         // FIXME: The row index implementation is incorrect when a predicate is
@@ -517,6 +510,17 @@ impl ScanExec for ParquetExec {
             out.as_single_chunk_par();
         }
         Ok((num_unfiltered_rows, out))
+    }
+}
+
+impl ScanExec for ParquetExec {
+    fn num_unfiltered_rows(&mut self) -> PolarsResult<IdxSize> {
+        // @FIXME! This is extremely inefficient.
+        self.read_with_num_unfiltered_rows().map(|(n, _)| n)
+    }
+
+    fn read(&mut self) -> PolarsResult<DataFrame> {
+        self.read_with_num_unfiltered_rows().map(|(_, df)| df)
     }
 }
 

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -14,7 +14,9 @@ use super::*;
 pub struct ParquetExec {
     sources: ScanSources,
     file_info: FileInfo,
+
     hive_parts: Option<Arc<Vec<HivePartitions>>>,
+
     predicate: Option<Arc<dyn PhysicalExpr>>,
     options: ParquetOptions,
     #[allow(dead_code)]
@@ -39,7 +41,9 @@ impl ParquetExec {
         ParquetExec {
             sources,
             file_info,
+
             hive_parts,
+
             predicate,
             options,
             cloud_options,

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use hive::HivePartitions;
 use polars_core::config;
 #[cfg(feature = "cloud")]

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -7,7 +7,7 @@ use polars_error::feature_gated;
 use polars_io::cloud::CloudOptions;
 use polars_io::parquet::metadata::FileMetadataRef;
 use polars_io::utils::slice::split_slice_at_file;
-use polars_io::{pl_async, RowIndex};
+use polars_io::RowIndex;
 
 use super::*;
 
@@ -602,7 +602,8 @@ impl ScanExec for ParquetExec {
     fn metadata(&mut self) -> PolarsResult<Box<dyn IOFileMetadata>> {
         #[cfg(feature = "cloud")]
         if self.sources.is_cloud_url() {
-            return pl_async::get_runtime().block_on_potential_spawn(self.metadata_async());
+            return polars_io::pl_async::get_runtime()
+                .block_on_potential_spawn(self.metadata_async());
         }
 
         self.metadata_sync()

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -332,7 +332,7 @@ fn create_physical_plan_impl(
                     if sources.len() > 1
                         && std::env::var("POLARS_NEW_MULTIFILE").as_deref() == Ok("1")
                     {
-                        Ok(Box::new(executors::HiveExec::new(
+                        Ok(Box::new(executors::MultiScanExec::new(
                             sources,
                             file_info,
                             hive_parts,

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -329,10 +329,9 @@ fn create_physical_plan_impl(
                     cloud_options,
                     metadata,
                 } => {
-                    if hive_parts.is_some()
-                        && std::env::var("POLARS_NEW_HIVE").as_deref() == Ok("1")
+                    if sources.len() > 1
+                        && std::env::var("POLARS_NEW_MULTIFILE").as_deref() == Ok("1")
                     {
-                        let hive_parts = hive_parts.unwrap();
                         Ok(Box::new(executors::HiveExec::new(
                             sources,
                             file_info,

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use polars_core::datatypes::Field;
 use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{DataType, SchemaRef, Series, IDX_DTYPE};
+use polars_core::prelude::{DataType, PlIndexSet, SchemaRef, Series, IDX_DTYPE};
 use polars_core::schema::Schema;
 use polars_expr::state::ExecutionState;
 use polars_io::predicates::PhysicalIoExpr;
@@ -32,9 +32,7 @@ impl PhysicalIoExpr for Len {
         unimplemented!()
     }
 
-    fn live_variables(&self) -> Option<Vec<PlSmallStr>> {
-        Some(vec![])
-    }
+    fn collect_live_columns(&self, _live_columns: &mut PlIndexSet<PlSmallStr>) {}
 }
 impl PhysicalPipedExpr for Len {
     fn evaluate(&self, chunk: &DataChunk, _lazy_state: &ExecutionState) -> PolarsResult<Series> {

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -137,8 +137,8 @@ where
                                     self.p.evaluate_io(df)
                                 }
 
-                                fn live_variables(&self) -> Option<Vec<PlSmallStr>> {
-                                    None
+                                fn collect_live_columns(&self, live_columns: &mut PlIndexSet<PlSmallStr>) {
+                                    self.p.collect_live_columns(live_columns);
                                 }
 
                                 fn as_stats_evaluator(&self) -> Option<&dyn StatsEvaluator> {

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -137,7 +137,10 @@ where
                                     self.p.evaluate_io(df)
                                 }
 
-                                fn collect_live_columns(&self, live_columns: &mut PlIndexSet<PlSmallStr>) {
+                                fn collect_live_columns(
+                                    &self,
+                                    live_columns: &mut PlIndexSet<PlSmallStr>,
+                                ) {
                                     self.p.collect_live_columns(live_columns);
                                 }
 

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -233,7 +233,7 @@ impl LiteralValue {
         }
     }
 
-    pub(crate) fn new_idxsize(value: IdxSize) -> Self {
+    pub fn new_idxsize(value: IdxSize) -> Self {
         #[cfg(feature = "bigidx")]
         {
             LiteralValue::UInt64(value)

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -285,6 +285,26 @@ impl<D> Schema<D> {
 
         Ok(i)
     }
+
+    /// Compare the fields between two schema returning the additional columns that each schema has.
+    pub fn field_compare<'a, 'b>(
+        &'a self,
+        other: &'b Self,
+        self_extra: &mut Vec<(usize, (&'a PlSmallStr, &'a D))>,
+        other_extra: &mut Vec<(usize, (&'b PlSmallStr, &'b D))>,
+    ) {
+        self_extra.extend(
+            self.iter()
+                .enumerate()
+                .filter(|(_, (n, _))| !other.contains(n)),
+        );
+        other_extra.extend(
+            other
+                .iter()
+                .enumerate()
+                .filter(|(_, (n, _))| !self.contains(n)),
+        );
+    }
 }
 
 impl<D> Schema<D>

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -270,19 +270,21 @@ impl ParquetSourceNode {
                 .as_ref()
                 .unwrap()
                 .collect_live_columns(&mut live_columns);
-            let v = (!live_columns.is_empty()).then(|| {
-                let out = live_columns
-                    .iter()
-                    // Can be `None` - if the column is e.g. a hive column, or the row index column.
-                    .filter_map(|x| projected_arrow_schema.index_of(x))
-                    .collect::<Vec<_>>();
+            let v = (!live_columns.is_empty())
+                .then(|| {
+                    let out = live_columns
+                        .iter()
+                        // Can be `None` - if the column is e.g. a hive column, or the row index column.
+                        .filter_map(|x| projected_arrow_schema.index_of(x))
+                        .collect::<Vec<_>>();
 
-                // There is at least one non-predicate column, or pre-filtering was
-                // explicitly requested (only useful for testing).
-                (out.len() < projected_arrow_schema.len()
-                    || matches!(self.options.parallel, ParallelStrategy::Prefiltered))
-                .then_some(out)
-            }).flatten();
+                    // There is at least one non-predicate column, or pre-filtering was
+                    // explicitly requested (only useful for testing).
+                    (out.len() < projected_arrow_schema.len()
+                        || matches!(self.options.parallel, ParallelStrategy::Prefiltered))
+                    .then_some(out)
+                })
+                .flatten();
 
             use_prefiltered &= v.is_some();
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use polars_core::frame::DataFrame;
+use polars_core::prelude::PlIndexSet;
 use polars_error::PolarsResult;
 use polars_io::prelude::ParallelStrategy;
 use polars_io::prelude::_internal::PrefilterMaskSetting;
@@ -264,25 +265,24 @@ impl ParquetSourceNode {
             );
 
         let predicate_arrow_field_indices = if use_prefiltered {
-            let v = physical_predicate
+            let mut live_columns = PlIndexSet::default();
+            physical_predicate
                 .as_ref()
                 .unwrap()
-                .live_variables()
-                .and_then(|x| {
-                    let mut out = x
-                        .iter()
-                        // Can be `None` - if the column is e.g. a hive column, or the row index column.
-                        .filter_map(|x| projected_arrow_schema.index_of(x))
-                        .collect::<Vec<_>>();
+                .collect_live_columns(&mut live_columns);
+            let v = (!live_columns.is_empty()).then(|| {
+                let out = live_columns
+                    .iter()
+                    // Can be `None` - if the column is e.g. a hive column, or the row index column.
+                    .filter_map(|x| projected_arrow_schema.index_of(x))
+                    .collect::<Vec<_>>();
 
-                    out.sort_unstable();
-                    out.dedup();
-                    // There is at least one non-predicate column, or pre-filtering was
-                    // explicitly requested (only useful for testing).
-                    (out.len() < projected_arrow_schema.len()
-                        || matches!(self.options.parallel, ParallelStrategy::Prefiltered))
-                    .then_some(out)
-                });
+                // There is at least one non-predicate column, or pre-filtering was
+                // explicitly requested (only useful for testing).
+                (out.len() < projected_arrow_schema.len()
+                    || matches!(self.options.parallel, ParallelStrategy::Prefiltered))
+                .then_some(out)
+            }).flatten();
 
             use_prefiltered &= v.is_some();
 


### PR DESCRIPTION
This is a very early stage PR exploring whether it is possible to take the multi-file handling and hive partitioning out of the readers. This will also make the multi-file and hive partitioning completely file type agnostic.

Currently, this PR does not do anything unless `POLARS_NEW_MULTIFILE` is set to `1`.

Here is a rough todo list.

- [x] Row Indexes
- [x] Include File Paths
- [x] Projection Pushdown
- [x] Slicing
  - [x] Positive
  - [x] Negative
- [x] Hive Predicates
- [x] Non hive predicates
- [ ] Lazy Loading of Non-Hive data
- [x] Allow Missing Columns
- [ ] All file types
   - [x] Parquet
   - [x] CSV
   - [ ] IPC
   - [ ] NDJson
- [ ] New streaming engine sink

ping @ritchie46, @nameexhaustion