### PR TITLE
feat: Add `cat.len_chars` and `cat.len_bytes`

### DIFF
--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -8,4 +8,16 @@ impl CategoricalNameSpace {
         self.0
             .apply_private(CategoricalFunction::GetCategories.into())
     }
+
+    #[cfg(feature = "strings")]
+    pub fn len_bytes(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::Categorical(CategoricalFunction::LenBytes))
+    }
+
+    #[cfg(feature = "strings")]
+    pub fn len_chars(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::Categorical(CategoricalFunction::LenChars))
+    }
 }

--- a/crates/polars-python/src/expr/categorical.rs
+++ b/crates/polars-python/src/expr/categorical.rs
@@ -7,4 +7,12 @@ impl PyExpr {
     fn cat_get_categories(&self) -> Self {
         self.inner.clone().cat().get_categories().into()
     }
+
+    fn cat_len_bytes(&self) -> Self {
+        self.inner.clone().cat().len_bytes().into()
+    }
+
+    fn cat_len_chars(&self) -> Self {
+        self.inner.clone().cat().len_chars().into()
+    }
 }

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -8,7 +8,7 @@ use polars_ops::series::InterpolationMethod;
 use polars_ops::series::SearchSortedSide;
 use polars_plan::dsl::function_expr::rolling::RollingFunction;
 use polars_plan::dsl::function_expr::rolling_by::RollingFunctionBy;
-use polars_plan::dsl::{BooleanFunction, CategoricalFunction, StringFunction, TemporalFunction};
+use polars_plan::dsl::{BooleanFunction, StringFunction, TemporalFunction};
 use polars_plan::prelude::{
     AExpr, FunctionExpr, GroupbyOptions, IRAggExpr, LiteralValue, Operator, PowFunction,
     WindowMapping, WindowType,
@@ -166,21 +166,6 @@ pub enum PyStringFunction {
 
 #[pymethods]
 impl PyStringFunction {
-    fn __hash__(&self) -> isize {
-        *self as isize
-    }
-}
-
-#[pyclass(name = "CategoricalFunction", eq)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum PyCategoricalFunction {
-    GetCategories,
-    LenBytes,
-    LenChars,
-}
-
-#[pymethods]
-impl PyCategoricalFunction {
     fn __hash__(&self) -> isize {
         *self as isize
     }
@@ -808,16 +793,8 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::BinaryExpr(_) => {
                     return Err(PyNotImplementedError::new_err("binary expr"))
                 },
-                FunctionExpr::Categorical(catfun) => match catfun {
-                    CategoricalFunction::GetCategories => {
-                        (PyCategoricalFunction::GetCategories.into_py(py),).to_object(py)
-                    },
-                    CategoricalFunction::LenBytes => {
-                        (PyCategoricalFunction::LenBytes.into_py(py),).to_object(py)
-                    },
-                    CategoricalFunction::LenChars => {
-                        (PyCategoricalFunction::LenChars.into_py(py),).to_object(py)
-                    },
+                FunctionExpr::Categorical(_) => {
+                    return Err(PyNotImplementedError::new_err("categorical expr"))
                 },
                 FunctionExpr::ListExpr(_) => {
                     return Err(PyNotImplementedError::new_err("list expr"))

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -8,7 +8,7 @@ use polars_ops::series::InterpolationMethod;
 use polars_ops::series::SearchSortedSide;
 use polars_plan::dsl::function_expr::rolling::RollingFunction;
 use polars_plan::dsl::function_expr::rolling_by::RollingFunctionBy;
-use polars_plan::dsl::{BooleanFunction, StringFunction, TemporalFunction};
+use polars_plan::dsl::{BooleanFunction, CategoricalFunction, StringFunction, TemporalFunction};
 use polars_plan::prelude::{
     AExpr, FunctionExpr, GroupbyOptions, IRAggExpr, LiteralValue, Operator, PowFunction,
     WindowMapping, WindowType,
@@ -166,6 +166,21 @@ pub enum PyStringFunction {
 
 #[pymethods]
 impl PyStringFunction {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
+#[pyclass(name = "CategoricalFunction", eq)]
+#[derive(Copy, Clone, PartialEq)]
+pub enum PyCategoricalFunction {
+    GetCategories,
+    LenBytes,
+    LenChars,
+}
+
+#[pymethods]
+impl PyCategoricalFunction {
     fn __hash__(&self) -> isize {
         *self as isize
     }
@@ -793,8 +808,16 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::BinaryExpr(_) => {
                     return Err(PyNotImplementedError::new_err("binary expr"))
                 },
-                FunctionExpr::Categorical(_) => {
-                    return Err(PyNotImplementedError::new_err("categorical expr"))
+                FunctionExpr::Categorical(catfun) => match catfun {
+                    CategoricalFunction::GetCategories => {
+                        (PyCategoricalFunction::GetCategories.into_py(py),).to_object(py)
+                    },
+                    CategoricalFunction::LenBytes => {
+                        (PyCategoricalFunction::LenBytes.into_py(py),).to_object(py)
+                    },
+                    CategoricalFunction::LenChars => {
+                        (PyCategoricalFunction::LenChars.into_py(py),).to_object(py)
+                    },
                 },
                 FunctionExpr::ListExpr(_) => {
                     return Err(PyNotImplementedError::new_err("list expr"))

--- a/py-polars/docs/source/reference/expressions/categories.rst
+++ b/py-polars/docs/source/reference/expressions/categories.rst
@@ -10,3 +10,5 @@ The following methods are available under the `expr.cat` attribute.
    :template: autosummary/accessor_method.rst
 
     Expr.cat.get_categories
+    Expr.cat.len_bytes
+    Expr.cat.len_chars

--- a/py-polars/docs/source/reference/series/categories.rst
+++ b/py-polars/docs/source/reference/series/categories.rst
@@ -11,5 +11,7 @@ The following methods are available under the `Series.cat` attribute.
 
     Series.cat.get_categories
     Series.cat.is_local
+    Series.cat.len_bytes
+    Series.cat.len_chars
     Series.cat.to_local
     Series.cat.uses_lexical_ordering

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -38,3 +38,94 @@ class ExprCatNameSpace:
         └──────┘
         """
         return wrap_expr(self._pyexpr.cat_get_categories())
+
+    def len_bytes(self) -> Expr:
+        """
+        Return the byte-length of the string representation of each value.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`UInt32`.
+
+        See Also
+        --------
+        len_chars
+
+        Notes
+        -----
+        When working with non-ASCII text, the length in bytes is not the same as the
+        length in characters. You may want to use :func:`len_chars` instead.
+        Note that :func:`len_bytes` is much more performant (_O(1)_) than
+        :func:`len_chars` (_O(n)_).
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {"a": pl.Series(["Café", "345", "東京", None], dtype=pl.Categorical)}
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("a").cat.len_bytes().alias("n_bytes"),
+        ...     pl.col("a").cat.len_chars().alias("n_chars"),
+        ... )
+        shape: (4, 3)
+        ┌──────┬─────────┬─────────┐
+        │ a    ┆ n_bytes ┆ n_chars │
+        │ ---  ┆ ---     ┆ ---     │
+        │ cat  ┆ u32     ┆ u32     │
+        ╞══════╪═════════╪═════════╡
+        │ Café ┆ 5       ┆ 4       │
+        │ 345  ┆ 3       ┆ 3       │
+        │ 東京 ┆ 6       ┆ 2       │
+        │ null ┆ null    ┆ null    │
+        └──────┴─────────┴─────────┘
+        """
+        return wrap_expr(self._pyexpr.cat_len_bytes())
+
+    def len_chars(self) -> Expr:
+        """
+        Return the number of characters of the string representation of each value.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`UInt32`.
+
+        See Also
+        --------
+        len_bytes
+
+        Notes
+        -----
+        When working with ASCII text, use :func:`len_bytes` instead to achieve
+        equivalent output with much better performance:
+        :func:`len_bytes` runs in _O(1)_, while :func:`len_chars` runs in (_O(n)_).
+
+        A character is defined as a `Unicode scalar value`_. A single character is
+        represented by a single byte when working with ASCII text, and a maximum of
+        4 bytes otherwise.
+
+        .. _Unicode scalar value: https://www.unicode.org/glossary/#unicode_scalar_value
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {"a": pl.Series(["Café", "345", "東京", None], dtype=pl.Categorical)}
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("a").cat.len_chars().alias("n_chars"),
+        ...     pl.col("a").cat.len_bytes().alias("n_bytes"),
+        ... )
+        shape: (4, 3)
+        ┌──────┬─────────┬─────────┐
+        │ a    ┆ n_chars ┆ n_bytes │
+        │ ---  ┆ ---     ┆ ---     │
+        │ cat  ┆ u32     ┆ u32     │
+        ╞══════╪═════════╪═════════╡
+        │ Café ┆ 4       ┆ 5       │
+        │ 345  ┆ 3       ┆ 3       │
+        │ 東京 ┆ 2       ┆ 6       │
+        │ null ┆ null    ┆ null    │
+        └──────┴─────────┴─────────┘
+        """
+        return wrap_expr(self._pyexpr.cat_len_chars())

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -112,3 +112,76 @@ class CatNameSpace:
         True
         """
         return self._s.cat_uses_lexical_ordering()
+
+    def len_bytes(self) -> Series:
+        """
+        Return the byte-length of the string representation of each value.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`UInt32`.
+
+        See Also
+        --------
+        len_chars
+
+        Notes
+        -----
+        When working with non-ASCII text, the length in bytes is not the same as the
+        length in characters. You may want to use :func:`len_chars` instead.
+        Note that :func:`len_bytes` is much more performant (_O(1)_) than
+        :func:`len_chars` (_O(n)_).
+
+        Examples
+        --------
+        >>> s = pl.Series(["Café", "345", "東京", None], dtype=pl.Categorical)
+        >>> s.cat.len_bytes()
+        shape: (4,)
+        Series: '' [u32]
+        [
+            5
+            3
+            6
+            null
+        ]
+        """
+
+    def len_chars(self) -> Series:
+        """
+        Return the number of characters of the string representation of each value.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`UInt32`.
+
+        See Also
+        --------
+        len_bytes
+
+        Notes
+        -----
+        When working with ASCII text, use :func:`len_bytes` instead to achieve
+        equivalent output with much better performance:
+        :func:`len_bytes` runs in _O(1)_, while :func:`len_chars` runs in (_O(n)_).
+
+        A character is defined as a `Unicode scalar value`_. A single character is
+        represented by a single byte when working with ASCII text, and a maximum of
+        4 bytes otherwise.
+
+        .. _Unicode scalar value: https://www.unicode.org/glossary/#unicode_scalar_value
+
+        Examples
+        --------
+        >>> s = pl.Series(["Café", "345", "東京", None], dtype=pl.Categorical)
+        >>> s.cat.len_chars()
+        shape: (4,)
+        Series: '' [u32]
+        [
+            4
+            3
+            2
+            null
+        ]
+        """

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -1,7 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import Any
+
+    FixtureRequest = Any
+
+
+@pytest.fixture(params=[True, False])
+def test_global_and_local(
+    request: FixtureRequest,
+) -> Generator[Any, Any, Any]:
+    """Setup fixture which runs each test with and without global string cache."""
+    use_global = request.param
+    if use_global:
+        with pl.StringCache():
+            # Pre-fill some global items to ensure physical repr isn't 0..n.
+            pl.Series(["a", "b", "c"], dtype=pl.Categorical)
+            yield
+    else:
+        yield
 
 
 def test_categorical_lexical_sort() -> None:
@@ -148,3 +173,41 @@ def test_cat_uses_lexical_ordering() -> None:
 
     s = s.cast(pl.Categorical("physical"))
     assert s.cat.uses_lexical_ordering() is False
+
+
+@pytest.mark.usefixtures("test_global_and_local")
+def test_cat_len_bytes() -> None:
+    # test Series
+    s = pl.Series("a", ["Café", None, "Café", "345", "東京"], dtype=pl.Categorical)
+    result = s.cat.len_bytes()
+    expected = pl.Series("a", [5, None, 5, 3, 6], dtype=pl.UInt32)
+    assert_series_equal(result, expected)
+
+    # test DataFrame expr
+    df = pl.DataFrame(s)
+    result_df = df.select(pl.col("a").cat.len_bytes())
+    expected_df = pl.DataFrame(expected)
+    assert_frame_equal(result_df, expected_df)
+
+    # test LazyFrame expr
+    result_lf = df.lazy().select(pl.col("a").cat.len_bytes()).collect()
+    assert_frame_equal(result_lf, expected_df)
+
+
+@pytest.mark.usefixtures("test_global_and_local")
+def test_cat_len_chars() -> None:
+    # test Series
+    s = pl.Series("a", ["Café", None, "Café", "345", "東京"], dtype=pl.Categorical)
+    result = s.cat.len_chars()
+    expected = pl.Series("a", [4, None, 4, 3, 2], dtype=pl.UInt32)
+    assert_series_equal(result, expected)
+
+    # test DataFrame expr
+    df = pl.DataFrame(s)
+    result_df = df.select(pl.col("a").cat.len_chars())
+    expected_df = pl.DataFrame(expected)
+    assert_frame_equal(result_df, expected_df)
+
+    # test LazyFrame expr
+    result_lf = df.lazy().select(pl.col("a").cat.len_chars()).collect()
+    assert_frame_equal(result_lf, expected_df)

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -193,6 +193,24 @@ def test_cat_len_bytes() -> None:
     result_lf = df.lazy().select(pl.col("a").cat.len_bytes()).collect()
     assert_frame_equal(result_lf, expected_df)
 
+    # test GroupBy
+    result_df = (
+        pl.LazyFrame({"key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2], "value": s.extend(s)})
+        .group_by("key", maintain_order=True)
+        .agg(pl.col("value").cat.len_bytes().alias("len_bytes"))
+        .explode("len_bytes")
+        .collect()
+    )
+    expected_df = pl.DataFrame(
+        {
+            "key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
+            "len_bytes": pl.Series(
+                [5, None, 5, 3, 6, 5, None, 5, 3, 6], dtype=pl.get_index_type()
+            ),
+        }
+    )
+    assert_frame_equal(result_df, expected_df)
+
 
 @pytest.mark.usefixtures("test_global_and_local")
 def test_cat_len_chars() -> None:
@@ -211,3 +229,21 @@ def test_cat_len_chars() -> None:
     # test LazyFrame expr
     result_lf = df.lazy().select(pl.col("a").cat.len_chars()).collect()
     assert_frame_equal(result_lf, expected_df)
+
+    # test GroupBy
+    result_df = (
+        pl.LazyFrame({"key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2], "value": s.extend(s)})
+        .group_by("key", maintain_order=True)
+        .agg(pl.col("value").cat.len_chars().alias("len_bytes"))
+        .explode("len_bytes")
+        .collect()
+    )
+    expected_df = pl.DataFrame(
+        {
+            "key": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
+            "len_bytes": pl.Series(
+                [4, None, 4, 3, 2, 4, None, 4, 3, 2], dtype=pl.get_index_type()
+            ),
+        }
+    )
+    assert_frame_equal(result_df, expected_df)


### PR DESCRIPTION
This adds a fast path for operations that can be performed on the categories of a categorical series. I've added `len_bytes` and `len_chars` for now. If desired, it would be trivial to add a few others such as `starts_with` and `ends_with`.

```python
import polars as pl

with pl.StringCache():
    pl.Series(["a", "b"], dtype=pl.Categorical)  # fill some cache
    df = pl.DataFrame({
        "a": pl.Series(["Café", "345", "Café", "東京", None], dtype=pl.Categorical)
    })

df.with_columns(
    pl.col("a").cat.len_bytes().alias("n_bytes"),
    pl.col("a").cat.len_chars().alias("n_chars"),
)
# shape: (5, 3)
# ┌──────┬─────────┬─────────┐
# │ a    ┆ n_bytes ┆ n_chars │
# │ ---  ┆ ---     ┆ ---     │
# │ cat  ┆ u32     ┆ u32     │
# ╞══════╪═════════╪═════════╡
# │ Café ┆ 5       ┆ 4       │
# │ 345  ┆ 3       ┆ 3       │
# │ Café ┆ 5       ┆ 4       │
# │ 東京 ┆ 6       ┆ 2       │
# │ null ┆ null    ┆ null    │
# └──────┴─────────┴─────────┘
```

These require the `strings` feature because they dispatch to `str.len_bytes` and `str.len_chars`.