### PR TITLE
refactor: Remove debug asserts on scratch space

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -45,6 +45,7 @@ mod inner {
             }
         }
 
+        /// Returns shared scratch space after clearing.
         pub(super) fn empty_nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
             self.nodes_scratch.clear();
             &mut self.nodes_scratch

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -45,7 +45,7 @@ mod inner {
             }
         }
 
-        pub(super) fn nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
+        pub(super) fn empty_nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
             self.nodes_scratch.clear();
             &mut self.nodes_scratch
         }
@@ -115,7 +115,7 @@ impl PredicatePushDown<'_> {
                 &[],
                 &acc_predicates,
                 expr_arena,
-                self.nodes_scratch_mut(),
+                self.empty_nodes_scratch_mut(),
             )?;
 
             let local_predicates = match eligibility {
@@ -296,7 +296,7 @@ impl PredicatePushDown<'_> {
                     &[predicate.clone()],
                     &acc_predicates,
                     expr_arena,
-                    self.nodes_scratch_mut(),
+                    self.empty_nodes_scratch_mut(),
                 )?
                 .0
                 {
@@ -663,7 +663,7 @@ impl PredicatePushDown<'_> {
                     for v in acc_predicates.values() {
                         let ae = expr_arena.get(v.node());
                         assert!(permits_filter_pushdown(
-                            self.nodes_scratch_mut(),
+                            self.empty_nodes_scratch_mut(),
                             ae,
                             expr_arena
                         ));
@@ -677,7 +677,7 @@ impl PredicatePushDown<'_> {
                     for v in acc_predicates.values() {
                         let ae = expr_arena.get(v.node());
                         assert!(permits_filter_pushdown(
-                            self.nodes_scratch_mut(),
+                            self.empty_nodes_scratch_mut(),
                             ae,
                             expr_arena
                         ));

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -146,7 +146,6 @@ pub fn pushdown_eligibility(
     expr_arena: &mut Arena<AExpr>,
     scratch: &mut UnitVec<Node>,
 ) -> PolarsResult<(PushdownEligibility, PlHashMap<PlSmallStr, PlSmallStr>)> {
-    debug_assert!(scratch.is_empty());
     scratch.clear();
     let ae_nodes_stack = scratch;
 

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -29,7 +29,7 @@ impl OptimizationRule for SlicePushDown {
             let out = match expr_arena.get(*input) {
                 ae @ Alias(..) | ae @ Cast { .. } => {
                     let ae = ae.clone();
-                    let scratch = self.nodes_scratch_mut();
+                    let scratch = self.empty_nodes_scratch_mut();
                     ae.nodes(scratch);
                     let input = scratch[0];
                     let new_input = pushdown(input, offset, length, expr_arena);

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -496,8 +496,9 @@ impl SlicePushDown {
             // [Pushdown]
             // these nodes will be pushed down.
             // State is None, we can continue
-            m @(Select {..}, None) |
-            m @ (SimpleProjection {..}, _)
+            m @ (Select {..}, None)
+            | m @ (HStack{..}, None)
+            | m @ (SimpleProjection {..}, _)
             => {
                 let (lp, state) = m;
                 self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
@@ -514,7 +515,7 @@ impl SlicePushDown {
                     self.no_pushdown_restart_opt(lp, state, lp_arena, expr_arena)
                 }
             }
-            (HStack {input, exprs, schema, options}, _) => {
+            (HStack {input, exprs, schema, options}, Some(_)) => {
                 let (can_pushdown, can_pushdown_and_any_expr_has_column) = can_pushdown_slice_past_projections(&exprs, expr_arena, self.empty_nodes_scratch_mut());
 
                 if can_pushdown_and_any_expr_has_column || (

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -24,7 +24,7 @@ mod inner {
             }
         }
 
-        pub fn nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
+        pub fn empty_nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
             self.scratch.clear();
             &mut self.scratch
         }
@@ -50,7 +50,6 @@ fn can_pushdown_slice_past_projections(
     arena: &Arena<AExpr>,
     scratch: &mut UnitVec<Node>,
 ) -> (bool, bool) {
-    debug_assert!(scratch.is_empty());
     scratch.clear();
 
     let mut can_pushdown_and_any_expr_has_column = false;
@@ -504,7 +503,7 @@ impl SlicePushDown {
             }
             // there is state, inspect the projection to determine how to deal with it
             (Select {input, expr, schema, options}, Some(_)) => {
-                if can_pushdown_slice_past_projections(&expr, expr_arena, self.nodes_scratch_mut()).1 {
+                if can_pushdown_slice_past_projections(&expr, expr_arena, self.empty_nodes_scratch_mut()).1 {
                     let lp = Select {input, expr, schema, options};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
                 }
@@ -515,7 +514,7 @@ impl SlicePushDown {
                 }
             }
             (HStack {input, exprs, schema, options}, _) => {
-                let (can_pushdown, can_pushdown_and_any_expr_has_column) = can_pushdown_slice_past_projections(&exprs, expr_arena, self.nodes_scratch_mut());
+                let (can_pushdown, can_pushdown_and_any_expr_has_column) = can_pushdown_slice_past_projections(&exprs, expr_arena, self.empty_nodes_scratch_mut());
 
                 if can_pushdown_and_any_expr_has_column || (
                     // If the schema length is greater then an input column is being projected, so

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -497,7 +497,7 @@ impl SlicePushDown {
             // these nodes will be pushed down.
             // State is None, we can continue
             m @ (Select {..}, None)
-            | m @ (HStack{..}, None)
+            | m @ (HStack {..}, None)
             | m @ (SimpleProjection {..}, _)
             => {
                 let (lp, state) = m;

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -24,6 +24,7 @@ mod inner {
             }
         }
 
+        /// Returns shared scratch space after clearing.
         pub fn empty_nodes_scratch_mut(&mut self) -> &mut UnitVec<Node> {
             self.scratch.clear();
             &mut self.scratch

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -515,7 +515,7 @@ impl SlicePushDown {
                     self.no_pushdown_restart_opt(lp, state, lp_arena, expr_arena)
                 }
             }
-            (HStack {input, exprs, schema, options}, Some(_)) => {
+            (HStack {input, exprs, schema, options}, _) => {
                 let (can_pushdown, can_pushdown_and_any_expr_has_column) = can_pushdown_slice_past_projections(&exprs, expr_arena, self.empty_nodes_scratch_mut());
 
                 if can_pushdown_and_any_expr_has_column || (

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -304,10 +304,9 @@ def test_slice_after_sort_with_nulls_20079() -> None:
 def test_slice_pushdown_panic_20216() -> None:
     col = pl.col("A")
 
-    df = pl.LazyFrame({"A": "1/1"})
-    df = df.with_columns(col.str.split("/"))
-    df = df.with_columns(
-        pl.when(col.is_not_null()).then(col.list.get(0)).otherwise(None)
-    ).slice(0, 1)
+    q = pl.LazyFrame({"A": "1/1"})
+    q = q.with_columns(col.str.split("/"))
+    q = q.with_columns(pl.when(col.is_not_null()).then(col.list.get(0)).otherwise(None))
 
-    assert_frame_equal(df.collect(), pl.DataFrame({"A": ["1"]}))
+    assert_frame_equal(q.collect(), pl.DataFrame({"A": ["1"]}))
+    assert_frame_equal(q.slice(0, 1).collect(), pl.DataFrame({"A": ["1"]}))

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -308,5 +308,5 @@ def test_slice_pushdown_panic_20216() -> None:
     q = q.with_columns(col.str.split("/"))
     q = q.with_columns(pl.when(col.is_not_null()).then(col.list.get(0)).otherwise(None))
 
-    assert_frame_equal(q.collect(), pl.DataFrame({"A": ["1"]}))
     assert_frame_equal(q.slice(0, 1).collect(), pl.DataFrame({"A": ["1"]}))
+    assert_frame_equal(q.collect(), pl.DataFrame({"A": ["1"]}))

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -308,6 +308,6 @@ def test_slice_pushdown_panic_20216() -> None:
     df = df.with_columns(col.str.split("/"))
     df = df.with_columns(
         pl.when(col.is_not_null()).then(col.list.get(0)).otherwise(None)
-    )
+    ).slice(0, 1)
 
     assert_frame_equal(df.collect(), pl.DataFrame({"A": ["1"]}))


### PR DESCRIPTION
Always `clear()` instead

* Also adds a change to skip checking projections when there is no slice for `with_columns()`
