### PR TITLE
fix: Fix error writing on Windows to locations outside of C drive

### DIFF
--- a/crates/polars-io/src/utils/file.rs
+++ b/crates/polars-io/src/utils/file.rs
@@ -70,10 +70,13 @@ pub fn try_get_writeable(
     } else {
         let path = resolve_homedir(&path);
         std::fs::File::create(&path).map_err(PolarsError::from)?;
-        let path = std::fs::canonicalize(&path)?;
 
         if verbose {
-            eprintln!("try_get_writeable: local: {}", path.to_str().unwrap())
+            eprintln!(
+                "try_get_writeable: local: {} (canonicalize: {:?})",
+                path.to_str().unwrap(),
+                std::fs::canonicalize(&path)
+            )
         }
 
         Ok(Box::new(polars_utils::open_file_write(&path)?))


### PR DESCRIPTION
This should fix https://github.com/pola-rs/polars/issues/20231. I couldn't reproduce the issue so this is just a guess based on the fact that we were apparently able to at least create the file.
