### PR TITLE
feat: Add `cat.starts_with`/`cat.ends_with`

### DIFF
--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -21,6 +21,7 @@ impl CategoricalNameSpace {
             .map_private(FunctionExpr::Categorical(CategoricalFunction::LenChars))
     }
 
+    #[cfg(feature = "strings")]
     /// Check if a string value starts with the `sub` string.
     pub fn starts_with(self, sub: Expr) -> Expr {
         self.0.map_many_private(
@@ -31,6 +32,7 @@ impl CategoricalNameSpace {
         )
     }
 
+    #[cfg(feature = "strings")]
     /// Check if a string value ends with the `sub` string.
     pub fn ends_with(self, sub: Expr) -> Expr {
         self.0.map_many_private(

--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -20,4 +20,24 @@ impl CategoricalNameSpace {
         self.0
             .map_private(FunctionExpr::Categorical(CategoricalFunction::LenChars))
     }
+
+    /// Check if a string value starts with the `sub` string.
+    pub fn starts_with(self, sub: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::Categorical(CategoricalFunction::StartsWith),
+            &[sub],
+            false,
+            None,
+        )
+    }
+
+    /// Check if a string value ends with the `sub` string.
+    pub fn ends_with(self, sub: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::Categorical(CategoricalFunction::EndsWith),
+            &[sub],
+            false,
+            None,
+        )
+    }
 }

--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -22,24 +22,18 @@ impl CategoricalNameSpace {
     }
 
     #[cfg(feature = "strings")]
-    /// Check if a string value starts with the `sub` string.
-    pub fn starts_with(self, sub: Expr) -> Expr {
-        self.0.map_many_private(
-            FunctionExpr::Categorical(CategoricalFunction::StartsWith),
-            &[sub],
-            false,
-            None,
-        )
+    pub fn starts_with(self, prefix: String) -> Expr {
+        self.0
+            .map_private(FunctionExpr::Categorical(CategoricalFunction::StartsWith(
+                prefix,
+            )))
     }
 
     #[cfg(feature = "strings")]
-    /// Check if a string value ends with the `sub` string.
-    pub fn ends_with(self, sub: Expr) -> Expr {
-        self.0.map_many_private(
-            FunctionExpr::Categorical(CategoricalFunction::EndsWith),
-            &[sub],
-            false,
-            None,
-        )
+    pub fn ends_with(self, suffix: String) -> Expr {
+        self.0
+            .map_private(FunctionExpr::Categorical(CategoricalFunction::EndsWith(
+                suffix,
+            )))
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::map;
+use crate::{map, map_as_slice};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
@@ -9,6 +9,10 @@ pub enum CategoricalFunction {
     LenBytes,
     #[cfg(feature = "strings")]
     LenChars,
+    #[cfg(feature = "strings")]
+    StartsWith,
+    #[cfg(feature = "strings")]
+    EndsWith,
 }
 
 impl CategoricalFunction {
@@ -20,6 +24,10 @@ impl CategoricalFunction {
             LenBytes => mapper.with_dtype(DataType::UInt32),
             #[cfg(feature = "strings")]
             LenChars => mapper.with_dtype(DataType::UInt32),
+            #[cfg(feature = "strings")]
+            StartsWith => mapper.with_dtype(DataType::Boolean),
+            #[cfg(feature = "strings")]
+            EndsWith => mapper.with_dtype(DataType::Boolean),
         }
     }
 }
@@ -33,6 +41,10 @@ impl Display for CategoricalFunction {
             LenBytes => "len_bytes",
             #[cfg(feature = "strings")]
             LenChars => "len_chars",
+            #[cfg(feature = "strings")]
+            StartsWith { .. } => "starts_with",
+            #[cfg(feature = "strings")]
+            EndsWith { .. } => "ends_with",
         };
         write!(f, "cat.{s}")
     }
@@ -47,6 +59,10 @@ impl From<CategoricalFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             LenBytes => map!(len_bytes),
             #[cfg(feature = "strings")]
             LenChars => map!(len_chars),
+            #[cfg(feature = "strings")]
+            StartsWith { .. } => map_as_slice!(starts_with),
+            #[cfg(feature = "strings")]
+            EndsWith { .. } => map_as_slice!(ends_with),
         }
     }
 }
@@ -83,15 +99,14 @@ fn _get_cat_phys_map(ca: &CategoricalChunked) -> (StringChunked, Series) {
     (categories, phys)
 }
 
-/// Apply a function to the categories of a categorical column and broadcast the result back to the
-/// array.
-fn apply_to_cats<F, T>(s: &Column, mut op: F) -> PolarsResult<Column>
+/// Fast path: apply a string function to the categories of a categorical column and broadcast the
+/// result back to the array.
+fn apply_to_cats<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
 where
     F: FnMut(&StringChunked) -> ChunkedArray<T>,
     ChunkedArray<T>: IntoSeries,
     T: PolarsDataType<HasViews = FalseT, IsStruct = FalseT, IsNested = FalseT>,
 {
-    let ca = s.categorical()?;
     let (categories, phys) = _get_cat_phys_map(ca);
     let result = op(&categories);
     // SAFETY: physical idx array is valid.
@@ -99,12 +114,85 @@ where
     Ok(out.into_column())
 }
 
+/// Fast path: apply a binary function to the categories of a categorical column and broadcast the
+/// result back to the array.
+fn apply_to_cats_binary<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
+where
+    F: FnMut(&BinaryChunked) -> ChunkedArray<T>,
+    ChunkedArray<T>: IntoSeries,
+    T: PolarsDataType<HasViews = FalseT, IsStruct = FalseT, IsNested = FalseT>,
+{
+    let (categories, phys) = _get_cat_phys_map(ca);
+    let result = op(&categories.as_binary());
+    // SAFETY: physical idx array is valid.
+    let out = unsafe { result.take_unchecked(phys.idx().unwrap()) };
+    Ok(out.into_column())
+}
+
+/// Slow path: cast the array to String, then apply result.
+fn apply_with_cast<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
+where
+    F: FnMut(&StringChunked) -> ChunkedArray<T>,
+    ChunkedArray<T>: IntoSeries,
+    T: PolarsDataType<HasViews = FalseT, IsStruct = FalseT, IsNested = FalseT>,
+{
+    let ca_s = ca.cast(&DataType::String)?;
+    let out = op(ca_s.str()?);
+    Ok(out.into_column())
+}
+
+/// Slow path: cast the array to Binary, then apply result.
+fn apply_with_cast_binary<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
+where
+    F: FnMut(&BinaryChunked) -> ChunkedArray<T>,
+    ChunkedArray<T>: IntoSeries,
+    T: PolarsDataType<HasViews = FalseT, IsStruct = FalseT, IsNested = FalseT>,
+{
+    let ca_s = ca.cast(&DataType::String)?;
+    let out = op(&ca_s.str()?.as_binary());
+    Ok(out.into_column())
+}
+
 #[cfg(feature = "strings")]
 fn len_bytes(s: &Column) -> PolarsResult<Column> {
-    apply_to_cats(s, |s| s.str_len_bytes())
+    let ca = s.categorical()?;
+    apply_to_cats(ca, |s| s.str_len_bytes())
 }
 
 #[cfg(feature = "strings")]
 fn len_chars(s: &Column) -> PolarsResult<Column> {
-    apply_to_cats(s, |s| s.str_len_chars())
+    let ca = s.categorical()?;
+    apply_to_cats(ca, |s| s.str_len_chars())
+}
+
+#[cfg(feature = "strings")]
+fn starts_with(s: &[Column]) -> PolarsResult<Column> {
+    let ca = s[0].categorical()?;
+    // Because we disable supercast in map_many_private, we may end up with Null dtype here.
+    let prefix = match &s[1].dtype() {
+        DataType::Null => &s[1].cast(&DataType::String)?,
+        _ => &s[1],
+    };
+    let prefix_str = prefix.str()?;
+    match prefix {
+        Column::Scalar(_) => apply_to_cats(ca, |s| s.starts_with_chunked(prefix_str)),
+        _ => apply_with_cast(ca, |s| s.starts_with_chunked(prefix_str)),
+    }
+}
+
+#[cfg(feature = "strings")]
+fn ends_with(s: &[Column]) -> PolarsResult<Column> {
+    let ca = s[0].categorical()?;
+    // Because we disable supercast in map_many_private, we may end up with Null dtype here.
+    let suffix = match &s[1].dtype() {
+        DataType::Null => &s[1].cast(&DataType::String)?,
+        _ => &s[1],
+    };
+    let suffix_str = suffix.str()?.as_binary();
+    match suffix {
+        Column::Scalar(_) => {
+            apply_to_cats_binary(ca, |s| s.as_binary().ends_with_chunked(&suffix_str))
+        },
+        _ => apply_with_cast_binary(ca, |s| s.as_binary().ends_with_chunked(&suffix_str)),
+    }
 }

--- a/crates/polars-python/src/expr/categorical.rs
+++ b/crates/polars-python/src/expr/categorical.rs
@@ -15,4 +15,12 @@ impl PyExpr {
     fn cat_len_chars(&self) -> Self {
         self.inner.clone().cat().len_chars().into()
     }
+
+    fn cat_starts_with(&self, sub: Self) -> Self {
+        self.inner.clone().cat().starts_with(sub.inner).into()
+    }
+
+    fn cat_ends_with(&self, sub: Self) -> Self {
+        self.inner.clone().cat().ends_with(sub.inner).into()
+    }
 }

--- a/crates/polars-python/src/expr/categorical.rs
+++ b/crates/polars-python/src/expr/categorical.rs
@@ -16,11 +16,11 @@ impl PyExpr {
         self.inner.clone().cat().len_chars().into()
     }
 
-    fn cat_starts_with(&self, sub: Self) -> Self {
-        self.inner.clone().cat().starts_with(sub.inner).into()
+    fn cat_starts_with(&self, prefix: String) -> Self {
+        self.inner.clone().cat().starts_with(prefix).into()
     }
 
-    fn cat_ends_with(&self, sub: Self) -> Self {
-        self.inner.clone().cat().ends_with(sub.inner).into()
+    fn cat_ends_with(&self, suffix: String) -> Self {
+        self.inner.clone().cat().ends_with(suffix).into()
     }
 }

--- a/py-polars/docs/source/reference/expressions/categories.rst
+++ b/py-polars/docs/source/reference/expressions/categories.rst
@@ -9,6 +9,8 @@ The following methods are available under the `expr.cat` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Expr.cat.ends_with
     Expr.cat.get_categories
     Expr.cat.len_bytes
     Expr.cat.len_chars
+    Expr.cat.starts_with

--- a/py-polars/docs/source/reference/series/categories.rst
+++ b/py-polars/docs/source/reference/series/categories.rst
@@ -9,9 +9,11 @@ The following methods are available under the `Series.cat` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Series.cat.ends_with
     Series.cat.get_categories
     Series.cat.is_local
     Series.cat.len_bytes
     Series.cat.len_chars
+    Series.cat.starts_with
     Series.cat.to_local
     Series.cat.uses_lexical_ordering

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -168,29 +168,6 @@ class ExprCatNameSpace:
         │ null   ┆ null       │
         └────────┴────────────┘
 
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "fruits": pl.Series(
-        ...             ["apple", "mango", "banana"],
-        ...             dtype=pl.Categorical,
-        ...         ),
-        ...         "prefix": ["app", "na", "ba"],
-        ...     }
-        ... )
-        >>> df.with_columns(
-        ...     pl.col("fruits").cat.starts_with(pl.col("prefix")).alias("has_prefix"),
-        ... )
-        shape: (3, 3)
-        ┌────────┬────────┬────────────┐
-        │ fruits ┆ prefix ┆ has_prefix │
-        │ ---    ┆ ---    ┆ ---        │
-        │ cat    ┆ str    ┆ bool       │
-        ╞════════╪════════╪════════════╡
-        │ apple  ┆ app    ┆ true       │
-        │ mango  ┆ na     ┆ false      │
-        │ banana ┆ ba     ┆ true       │
-        └────────┴────────┴────────────┘
-
         Using `starts_with` as a filter condition:
 
         >>> df.filter(pl.col("fruits").cat.starts_with("app"))
@@ -240,29 +217,6 @@ class ExprCatNameSpace:
         │ mango  ┆ true       │
         │ null   ┆ null       │
         └────────┴────────────┘
-
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "fruits": pl.Series(
-        ...             ["apple", "mango", "banana"],
-        ...             dtype=pl.Categorical,
-        ...         ),
-        ...         "suffix": ["le", "go", "nu"],
-        ...     }
-        ... )
-        >>> df.with_columns(
-        ...     pl.col("fruits").cat.ends_with(pl.col("suffix")).alias("has_suffix")
-        ... )
-        shape: (3, 3)
-        ┌────────┬────────┬────────────┐
-        │ fruits ┆ suffix ┆ has_suffix │
-        │ ---    ┆ ---    ┆ ---        │
-        │ cat    ┆ str    ┆ bool       │
-        ╞════════╪════════╪════════════╡
-        │ apple  ┆ le     ┆ true       │
-        │ mango  ┆ go     ┆ true       │
-        │ banana ┆ nu     ┆ false      │
-        └────────┴────────┴────────────┘
 
         Using `ends_with` as a filter condition:
 

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -180,6 +180,9 @@ class ExprCatNameSpace:
         │ apple  │
         └────────┘
         """
+        if not isinstance(prefix, str):
+            msg = f"'prefix' must be a string; found {type(prefix)!r}"
+            raise TypeError(msg)
         return wrap_expr(self._pyexpr.cat_starts_with(prefix))
 
     def ends_with(self, suffix: str | None) -> Expr:
@@ -230,4 +233,7 @@ class ExprCatNameSpace:
         │ mango  │
         └────────┘
         """
+        if not isinstance(suffix, str):
+            msg = f"'suffix' must be a string; found {type(suffix)!r}"
+            raise TypeError(msg)
         return wrap_expr(self._pyexpr.cat_ends_with(suffix))

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -185,7 +185,7 @@ class ExprCatNameSpace:
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.cat_starts_with(prefix))
 
-    def ends_with(self, suffix: str | None) -> Expr:
+    def ends_with(self, suffix: str) -> Expr:
         """
         Check if string representations of values end with a substring.
 

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars._utils.parse import parse_into_expression
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
@@ -131,7 +130,7 @@ class ExprCatNameSpace:
         """
         return wrap_expr(self._pyexpr.cat_len_chars())
 
-    def starts_with(self, prefix: str | Expr | None) -> Expr:
+    def starts_with(self, prefix: str) -> Expr:
         """
         Check if string representations of values start with a substring.
 
@@ -144,6 +143,11 @@ class ExprCatNameSpace:
         --------
         contains : Check if string repr contains a substring that matches a pattern.
         ends_with : Check if string repr end with a substring.
+
+        Notes
+        -----
+        Whereas `str.starts_with` allows expression inputs, `cat.starts_with` requires
+        a literal string value.
 
         Examples
         --------
@@ -199,10 +203,9 @@ class ExprCatNameSpace:
         │ apple  ┆ app    │
         └────────┴────────┘
         """
-        prefix = parse_into_expression(prefix, str_as_lit=True)
         return wrap_expr(self._pyexpr.cat_starts_with(prefix))
 
-    def ends_with(self, suffix: str | Expr | None) -> Expr:
+    def ends_with(self, suffix: str | None) -> Expr:
         """
         Check if string representations of values end with a substring.
 
@@ -215,6 +218,11 @@ class ExprCatNameSpace:
         --------
         contains : Check if string reprs contains a substring that matches a pattern.
         starts_with : Check if string reprs start with a substring.
+
+        Notes
+        -----
+        Whereas `str.ends_with` allows expression inputs, `cat.ends_with` requires a
+        literal string value.
 
         Examples
         --------
@@ -268,5 +276,4 @@ class ExprCatNameSpace:
         │ mango  ┆ go     │
         └────────┴────────┘
         """
-        suffix = parse_into_expression(suffix, str_as_lit=True)
         return wrap_expr(self._pyexpr.cat_ends_with(suffix))

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -171,14 +171,14 @@ class ExprCatNameSpace:
         Using `starts_with` as a filter condition:
 
         >>> df.filter(pl.col("fruits").cat.starts_with("app"))
-        shape: (1, 2)
-        ┌────────┬────────┐
-        │ fruits ┆ prefix │
-        │ ---    ┆ ---    │
-        │ cat    ┆ str    │
-        ╞════════╪════════╡
-        │ apple  ┆ app    │
-        └────────┴────────┘
+        shape: (1, 1)
+        ┌────────┐
+        │ fruits │
+        │ ---    │
+        │ cat    │
+        ╞════════╡
+        │ apple  │
+        └────────┘
         """
         return wrap_expr(self._pyexpr.cat_starts_with(prefix))
 
@@ -221,13 +221,13 @@ class ExprCatNameSpace:
         Using `ends_with` as a filter condition:
 
         >>> df.filter(pl.col("fruits").cat.ends_with("go"))
-        shape: (1, 2)
-        ┌────────┬────────┐
-        │ fruits ┆ suffix │
-        │ ---    ┆ ---    │
-        │ cat    ┆ str    │
-        ╞════════╪════════╡
-        │ mango  ┆ go     │
-        └────────┴────────┘
+        shape: (1, 1)
+        ┌────────┐
+        │ fruits │
+        │ ---    │
+        │ cat    │
+        ╞════════╡
+        │ mango  │
+        └────────┘
         """
         return wrap_expr(self._pyexpr.cat_ends_with(suffix))

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polars._utils.parse import parse_into_expression
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
@@ -129,3 +130,143 @@ class ExprCatNameSpace:
         └──────┴─────────┴─────────┘
         """
         return wrap_expr(self._pyexpr.cat_len_chars())
+
+    def starts_with(self, prefix: str | Expr | None) -> Expr:
+        """
+        Check if string representations of values start with a substring.
+
+        Parameters
+        ----------
+        prefix
+            Prefix substring.
+
+        See Also
+        --------
+        contains : Check if string repr contains a substring that matches a pattern.
+        ends_with : Check if string repr end with a substring.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {"fruits": pl.Series(["apple", "mango", None], dtype=pl.Categorical)}
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("fruits").cat.starts_with("app").alias("has_prefix"),
+        ... )
+        shape: (3, 2)
+        ┌────────┬────────────┐
+        │ fruits ┆ has_prefix │
+        │ ---    ┆ ---        │
+        │ cat    ┆ bool       │
+        ╞════════╪════════════╡
+        │ apple  ┆ true       │
+        │ mango  ┆ false      │
+        │ null   ┆ null       │
+        └────────┴────────────┘
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "fruits": pl.Series(
+        ...             ["apple", "mango", "banana"],
+        ...             dtype=pl.Categorical,
+        ...         ),
+        ...         "prefix": ["app", "na", "ba"],
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("fruits").cat.starts_with(pl.col("prefix")).alias("has_prefix"),
+        ... )
+        shape: (3, 3)
+        ┌────────┬────────┬────────────┐
+        │ fruits ┆ prefix ┆ has_prefix │
+        │ ---    ┆ ---    ┆ ---        │
+        │ cat    ┆ str    ┆ bool       │
+        ╞════════╪════════╪════════════╡
+        │ apple  ┆ app    ┆ true       │
+        │ mango  ┆ na     ┆ false      │
+        │ banana ┆ ba     ┆ true       │
+        └────────┴────────┴────────────┘
+
+        Using `starts_with` as a filter condition:
+
+        >>> df.filter(pl.col("fruits").cat.starts_with("app"))
+        shape: (1, 2)
+        ┌────────┬────────┐
+        │ fruits ┆ prefix │
+        │ ---    ┆ ---    │
+        │ cat    ┆ str    │
+        ╞════════╪════════╡
+        │ apple  ┆ app    │
+        └────────┴────────┘
+        """
+        prefix = parse_into_expression(prefix, str_as_lit=True)
+        return wrap_expr(self._pyexpr.cat_starts_with(prefix))
+
+    def ends_with(self, suffix: str | Expr | None) -> Expr:
+        """
+        Check if string representations of values end with a substring.
+
+        Parameters
+        ----------
+        suffix
+            Suffix substring.
+
+        See Also
+        --------
+        contains : Check if string reprs contains a substring that matches a pattern.
+        starts_with : Check if string reprs start with a substring.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {"fruits": pl.Series(["apple", "mango", None], dtype=pl.Categorical)}
+        ... )
+        >>> df.with_columns(pl.col("fruits").cat.ends_with("go").alias("has_suffix"))
+        shape: (3, 2)
+        ┌────────┬────────────┐
+        │ fruits ┆ has_suffix │
+        │ ---    ┆ ---        │
+        │ cat    ┆ bool       │
+        ╞════════╪════════════╡
+        │ apple  ┆ false      │
+        │ mango  ┆ true       │
+        │ null   ┆ null       │
+        └────────┴────────────┘
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "fruits": pl.Series(
+        ...             ["apple", "mango", "banana"],
+        ...             dtype=pl.Categorical,
+        ...         ),
+        ...         "suffix": ["le", "go", "nu"],
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("fruits").cat.ends_with(pl.col("suffix")).alias("has_suffix")
+        ... )
+        shape: (3, 3)
+        ┌────────┬────────┬────────────┐
+        │ fruits ┆ suffix ┆ has_suffix │
+        │ ---    ┆ ---    ┆ ---        │
+        │ cat    ┆ str    ┆ bool       │
+        ╞════════╪════════╪════════════╡
+        │ apple  ┆ le     ┆ true       │
+        │ mango  ┆ go     ┆ true       │
+        │ banana ┆ nu     ┆ false      │
+        └────────┴────────┴────────────┘
+
+        Using `ends_with` as a filter condition:
+
+        >>> df.filter(pl.col("fruits").cat.ends_with("go"))
+        shape: (1, 2)
+        ┌────────┬────────┐
+        │ fruits ┆ suffix │
+        │ ---    ┆ ---    │
+        │ cat    ┆ str    │
+        ╞════════╪════════╡
+        │ mango  ┆ go     │
+        └────────┴────────┘
+        """
+        suffix = parse_into_expression(suffix, str_as_lit=True)
+        return wrap_expr(self._pyexpr.cat_ends_with(suffix))

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -7,7 +7,7 @@ from polars._utils.wrap import wrap_s
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from polars import Series
+    from polars import Expr, Series
     from polars.polars import PySeries
 
 
@@ -182,6 +182,60 @@ class CatNameSpace:
             4
             3
             2
+            null
+        ]
+        """
+
+    def starts_with(self, prefix: str | Expr | None) -> Series:
+        """
+        Check if string representations of values start with a substring.
+
+        Parameters
+        ----------
+        prefix
+            Prefix substring.
+
+        See Also
+        --------
+        contains : Check if the string repr contains a substring that matches a pattern.
+        ends_with : Check if string repr ends with a substring.
+
+        Examples
+        --------
+        >>> s = pl.Series("fruits", ["apple", "mango", None], dtype=pl.Categorical)
+        >>> s.cat.starts_with("app")
+        shape: (3,)
+        Series: 'fruits' [bool]
+        [
+            true
+            false
+            null
+        ]
+        """
+
+    def ends_with(self, suffix: str | Expr | None) -> Series:
+        """
+        Check if string representations of values end with a substring.
+
+        Parameters
+        ----------
+        suffix
+            Suffix substring.
+
+        See Also
+        --------
+        contains : Check if the string repr contains a substring that matches a pattern.
+        starts_with : Check if string repr starts with a substring.
+
+        Examples
+        --------
+        >>> s = pl.Series("fruits", ["apple", "mango", None], dtype=pl.Categorical)
+        >>> s.cat.ends_with("go")
+        shape: (3,)
+        Series: 'fruits' [bool]
+        [
+            false
+            true
             null
         ]
         """

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -186,7 +186,7 @@ class CatNameSpace:
         ]
         """
 
-    def starts_with(self, prefix: str | None) -> Series:
+    def starts_with(self, prefix: str) -> Series:
         """
         Check if string representations of values start with a substring.
 
@@ -213,7 +213,7 @@ class CatNameSpace:
         ]
         """
 
-    def ends_with(self, suffix: str | None) -> Series:
+    def ends_with(self, suffix: str) -> Series:
         """
         Check if string representations of values end with a substring.
 

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -7,7 +7,7 @@ from polars._utils.wrap import wrap_s
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from polars import Expr, Series
+    from polars import Series
     from polars.polars import PySeries
 
 
@@ -186,7 +186,7 @@ class CatNameSpace:
         ]
         """
 
-    def starts_with(self, prefix: str | Expr | None) -> Series:
+    def starts_with(self, prefix: str | None) -> Series:
         """
         Check if string representations of values start with a substring.
 
@@ -213,7 +213,7 @@ class CatNameSpace:
         ]
         """
 
-    def ends_with(self, suffix: str | Expr | None) -> Series:
+    def ends_with(self, suffix: str | None) -> Series:
         """
         Check if string representations of values end with a substring.
 

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -528,7 +528,7 @@ class StringNameSpace:
         ]
         """
 
-    def ends_with(self, suffix: str | Expr) -> Series:
+    def ends_with(self, suffix: str | Expr | None) -> Series:
         """
         Check if string values end with a substring.
 

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -284,3 +284,9 @@ def test_starts_ends_with() -> None:
         ).to_dict(as_series=False)
         == expected
     )
+
+    with pytest.raises(TypeError, match="'prefix' must be a string; found"):
+        df.select(pl.col("a").cat.starts_with(None))
+
+    with pytest.raises(TypeError, match="'suffix' must be a string; found"):
+        df.select(pl.col("a").cat.ends_with(None))

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -262,10 +262,6 @@ def test_starts_ends_with() -> None:
     assert_series_equal(
         s.cat.starts_with("nu"), pl.Series("a", [False, True, True, False, None])
     )
-    assert_series_equal(
-        s.cat.starts_with(None),
-        pl.Series("a", [None, None, None, None, None], dtype=pl.Boolean),
-    )
 
     df = pl.DataFrame(
         {
@@ -273,42 +269,18 @@ def test_starts_ends_with() -> None:
                 ["hamburger_with_tomatoes", "nuts", "nuts", "lollypop", None],
                 dtype=pl.Categorical,
             ),
-            "sub": ["ham", "ts", "nu", None, "anything"],
         }
     )
 
     expected = {
         "ends_pop": [False, False, False, True, None],
-        "ends_None": [None, None, None, None, None],
-        "ends_sub": [False, True, False, None, None],
         "starts_ham": [True, False, False, False, None],
-        "starts_None": [None, None, None, None, None],
-        "starts_sub": [True, False, True, None, None],
     }
 
     assert (
         df.select(
             pl.col("a").cat.ends_with("pop").alias("ends_pop"),
-            pl.col("a").cat.ends_with(pl.lit(None)).alias("ends_None"),
-            pl.col("a").cat.ends_with(pl.col("sub")).alias("ends_sub"),
             pl.col("a").cat.starts_with("ham").alias("starts_ham"),
-            pl.col("a").cat.starts_with(pl.lit(None)).alias("starts_None"),
-            pl.col("a").cat.starts_with(pl.col("sub")).alias("starts_sub"),
         ).to_dict(as_series=False)
-        == expected
-    )
-
-    assert (
-        df.lazy()
-        .select(
-            pl.col("a").cat.ends_with("pop").alias("ends_pop"),
-            pl.col("a").cat.ends_with(pl.lit(None)).alias("ends_None"),
-            pl.col("a").cat.ends_with(pl.col("sub")).alias("ends_sub"),
-            pl.col("a").cat.starts_with("ham").alias("starts_ham"),
-            pl.col("a").cat.starts_with(pl.lit(None)).alias("starts_None"),
-            pl.col("a").cat.starts_with(pl.col("sub")).alias("starts_sub"),
-        )
-        .collect()
-        .to_dict(as_series=False)
         == expected
     )

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -263,6 +263,12 @@ def test_starts_ends_with() -> None:
         s.cat.starts_with("nu"), pl.Series("a", [False, True, True, False, None])
     )
 
+    with pytest.raises(TypeError, match="'prefix' must be a string; found"):
+        s.cat.starts_with(None)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="'suffix' must be a string; found"):
+        s.cat.ends_with(None)  # type: ignore[arg-type]
+
     df = pl.DataFrame(
         {
             "a": pl.Series(
@@ -286,7 +292,7 @@ def test_starts_ends_with() -> None:
     )
 
     with pytest.raises(TypeError, match="'prefix' must be a string; found"):
-        df.select(pl.col("a").cat.starts_with(None))
+        df.select(pl.col("a").cat.starts_with(None))  # type: ignore[arg-type]
 
     with pytest.raises(TypeError, match="'suffix' must be a string; found"):
-        df.select(pl.col("a").cat.ends_with(None))
+        df.select(pl.col("a").cat.ends_with(None))  # type: ignore[arg-type]

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -277,14 +277,7 @@ def test_starts_ends_with() -> None:
         }
     )
 
-    assert df.select(
-        pl.col("a").cat.ends_with("pop").alias("ends_pop"),
-        pl.col("a").cat.ends_with(pl.lit(None)).alias("ends_None"),
-        pl.col("a").cat.ends_with(pl.col("sub")).alias("ends_sub"),
-        pl.col("a").cat.starts_with("ham").alias("starts_ham"),
-        pl.col("a").cat.starts_with(pl.lit(None)).alias("starts_None"),
-        pl.col("a").cat.starts_with(pl.col("sub")).alias("starts_sub"),
-    ).to_dict(as_series=False) == {
+    expected = {
         "ends_pop": [False, False, False, True, None],
         "ends_None": [None, None, None, None, None],
         "ends_sub": [False, True, False, None, None],
@@ -292,3 +285,30 @@ def test_starts_ends_with() -> None:
         "starts_None": [None, None, None, None, None],
         "starts_sub": [True, False, True, None, None],
     }
+
+    assert (
+        df.select(
+            pl.col("a").cat.ends_with("pop").alias("ends_pop"),
+            pl.col("a").cat.ends_with(pl.lit(None)).alias("ends_None"),
+            pl.col("a").cat.ends_with(pl.col("sub")).alias("ends_sub"),
+            pl.col("a").cat.starts_with("ham").alias("starts_ham"),
+            pl.col("a").cat.starts_with(pl.lit(None)).alias("starts_None"),
+            pl.col("a").cat.starts_with(pl.col("sub")).alias("starts_sub"),
+        ).to_dict(as_series=False)
+        == expected
+    )
+
+    assert (
+        df.lazy()
+        .select(
+            pl.col("a").cat.ends_with("pop").alias("ends_pop"),
+            pl.col("a").cat.ends_with(pl.lit(None)).alias("ends_None"),
+            pl.col("a").cat.ends_with(pl.col("sub")).alias("ends_sub"),
+            pl.col("a").cat.starts_with("ham").alias("starts_ham"),
+            pl.col("a").cat.starts_with(pl.lit(None)).alias("starts_None"),
+            pl.col("a").cat.starts_with(pl.col("sub")).alias("starts_sub"),
+        )
+        .collect()
+        .to_dict(as_series=False)
+        == expected
+    )


### PR DESCRIPTION
Follow up to #20211.

**Edit 2024-12-18**: expression implementation has been removed, along with the slow path. `cat.starts_with` and `cat.ends_with` now require `str` inputs and do not except expressions.