### PR TITLE
feat: Serialize DataFrame/Series using IPC in serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,9 @@ name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -3390,7 +3393,6 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "ciborium",
  "either",
  "futures",
  "hashbrown 0.15.2",
@@ -3425,10 +3427,11 @@ version = "0.45.1"
 dependencies = [
  "ahash",
  "arboard",
+ "bincode",
  "bytemuck",
  "bytes",
- "ciborium",
  "either",
+ "flate2",
  "itoa",
  "libc",
  "ndarray",
@@ -3552,9 +3555,11 @@ name = "polars-utils"
 version = "0.45.1"
 dependencies = [
  "ahash",
+ "bincode",
  "bytemuck",
  "bytes",
  "compact_str",
+ "flate2",
  "hashbrown 0.15.2",
  "indexmap",
  "libc",
@@ -3567,6 +3572,7 @@ dependencies = [
  "raw-cpuid",
  "rayon",
  "serde",
+ "serde_json",
  "stacker",
  "sysinfo",
  "version_check",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ atoi_simd = "0.16"
 atomic-waker = "1"
 avro-schema = { version = "0.3" }
 base64 = "0.22.0"
+bincode = "1.3.3"
 bitflags = "2"
 bytemuck = { version = "1.11", features = ["derive", "extern_crate_alloc"] }
 bytes = { version = "1.7" }
 chrono = { version = "0.4.31", default-features = false, features = ["std"] }
 chrono-tz = "0.10"
-ciborium = "0.2"
 compact_str = { version = "0.8.0", features = ["serde"] }
 crossbeam-channel = "0.5.8"
 crossbeam-deque = "0.8.5"

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -111,10 +111,6 @@ pub enum ArrowDataType {
     LargeList(Box<Field>),
     /// A nested [`ArrowDataType`] with a given number of [`Field`]s.
     Struct(Vec<Field>),
-    /// A nested datatype that can represent slots of differing types.
-    /// Third argument represents mode
-    #[cfg_attr(feature = "serde", serde(skip))]
-    Union(Vec<Field>, Option<Vec<i32>>, UnionMode),
     /// A nested type that is represented as
     ///
     /// List<entries: Struct<key: K, value: V>>
@@ -176,6 +172,10 @@ pub enum ArrowDataType {
     Utf8View,
     /// A type unknown to Arrow.
     Unknown,
+    /// A nested datatype that can represent slots of differing types.
+    /// Third argument represents mode
+    #[cfg_attr(feature = "serde", serde(skip))]
+    Union(Vec<Field>, Option<Vec<i32>>, UnionMode),
 }
 
 /// Mode of [`ArrowDataType::Union`]

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -129,6 +129,7 @@ serde = [
   "polars-schema/serde",
   "polars-utils/serde",
   "arrow/io_ipc",
+  "arrow/io_ipc_compression",
   "serde_json",
 ]
 serde-lazy = ["serde", "arrow/serde", "indexmap/serde", "chrono/serde"]

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -151,6 +151,7 @@ docs-selection = [
   "row_hash",
   "rolling_window",
   "rolling_window_by",
+  "serde",
   "dtype-categorical",
   "dtype-decimal",
   "diagonal_concat",

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = { workspace = true }
 xxhash-rust = { workspace = true }
 
 [dev-dependencies]
-bincode = { version = "1" }
+bincode = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]
@@ -123,7 +123,14 @@ dtype-struct = []
 bigidx = ["arrow/bigidx", "polars-utils/bigidx"]
 python = []
 
-serde = ["dep:serde", "bitflags/serde", "polars-schema/serde", "polars-utils/serde"]
+serde = [
+  "dep:serde",
+  "bitflags/serde",
+  "polars-schema/serde",
+  "polars-utils/serde",
+  "arrow/io_ipc",
+  "serde_json",
+]
 serde-lazy = ["serde", "arrow/serde", "indexmap/serde", "chrono/serde"]
 
 docs-selection = [

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -37,8 +37,6 @@ mod series;
 /// 2. A [`ScalarColumn`] that repeats a single [`Scalar`]
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(from = "Series"))]
-#[cfg_attr(feature = "serde", serde(into = "_SerdeSeries"))]
 pub enum Column {
     Series(SeriesColumn),
     Partitioned(PartitionedColumn),

--- a/crates/polars-core/src/frame/column/partitioned.rs
+++ b/crates/polars-core/src/frame/column/partitioned.rs
@@ -12,12 +12,14 @@ use crate::frame::Scalar;
 use crate::series::IsSorted;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PartitionedColumn {
     name: PlSmallStr,
 
     values: Series,
     ends: Arc<[IdxSize]>,
 
+    #[cfg_attr(feature = "serde", serde(skip))]
     materialized: OnceLock<Series>,
 }
 

--- a/crates/polars-core/src/frame/column/series.rs
+++ b/crates/polars-core/src/frame/column/series.rs
@@ -7,10 +7,12 @@ use super::Series;
 /// At the moment this just conditionally tracks where it was created so that materialization
 /// problems can be tracked down.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SeriesColumn {
     inner: Series,
 
     #[cfg(debug_assertions)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     materialized_at: Option<std::sync::Arc<std::backtrace::Backtrace>>,
 }
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3562,4 +3562,41 @@ mod test {
         assert_eq!(df.get_column_names(), &["a", "b", "c"]);
         Ok(())
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_deserialize_height_validation_8751() {
+        // Construct an invalid directly from the inner fields as the `new_unchecked_*` functions
+        // have debug assertions
+
+        use polars_utils::pl_serialize;
+
+        let df = DataFrame {
+            height: 2,
+            columns: vec![
+                Int64Chunked::full("a".into(), 1, 2).into_column(),
+                Int64Chunked::full("b".into(), 1, 1).into_column(),
+            ],
+            cached_schema: OnceLock::new(),
+        };
+
+        // We rely on the fact that the serialization doesn't check the heights of all columns
+        let serialized = serde_json::to_string(&df).unwrap();
+        let err = serde_json::from_str::<DataFrame>(&serialized).unwrap_err();
+
+        assert!(err.to_string().contains(
+            "successful parse invalid data: lengths don't match: could not create a new DataFrame:",
+        ));
+
+        let serialized = pl_serialize::SerializeOptions::new(true)
+            .serialize_to_bytes(&df)
+            .unwrap();
+        let err = pl_serialize::SerializeOptions::new(true)
+            .deserialize_from_reader::<DataFrame, _>(serialized.as_slice())
+            .unwrap_err();
+
+        assert!(err.to_string().contains(
+            "successful parse invalid data: lengths don't match: could not create a new DataFrame:",
+        ));
+    }
 }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3588,10 +3588,10 @@ mod test {
             "successful parse invalid data: lengths don't match: could not create a new DataFrame:",
         ));
 
-        let serialized = pl_serialize::SerializeOptions::default_outer()
+        let serialized = pl_serialize::SerializeOptions::default()
             .serialize_to_bytes(&df)
             .unwrap();
-        let err = pl_serialize::SerializeOptions::default_outer()
+        let err = pl_serialize::SerializeOptions::default()
             .deserialize_from_reader::<DataFrame, _>(serialized.as_slice())
             .unwrap_err();
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3588,10 +3588,10 @@ mod test {
             "successful parse invalid data: lengths don't match: could not create a new DataFrame:",
         ));
 
-        let serialized = pl_serialize::SerializeOptions::new(true)
+        let serialized = pl_serialize::SerializeOptions::default_outer()
             .serialize_to_bytes(&df)
             .unwrap();
-        let err = pl_serialize::SerializeOptions::new(true)
+        let err = pl_serialize::SerializeOptions::default_outer()
             .deserialize_from_reader::<DataFrame, _>(serialized.as_slice())
             .unwrap_err();
 

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -12,14 +12,14 @@ mod test {
     fn test_serde() -> PolarsResult<()> {
         let ca = UInt32Chunked::new("foo".into(), &[Some(1), None, Some(2)]);
 
-        let json = serde_json::to_string(&ca).unwrap();
+        let json = serde_json::to_string(&ca.clone().into_series()).unwrap();
 
         let out = serde_json::from_str::<Series>(&json).unwrap();
         assert!(ca.into_series().equals_missing(&out));
 
         let ca = StringChunked::new("foo".into(), &[Some("foo"), None, Some("bar")]);
 
-        let json = serde_json::to_string(&ca).unwrap();
+        let json = serde_json::to_string(&ca.clone().into_series()).unwrap();
 
         let out = serde_json::from_str::<Series>(&json).unwrap(); // uses `Deserialize<'de>`
         assert!(ca.into_series().equals_missing(&out));
@@ -32,7 +32,7 @@ mod test {
     fn test_serde_owned() {
         let ca = UInt32Chunked::new("foo".into(), &[Some(1), None, Some(2)]);
 
-        let json = serde_json::to_string(&ca).unwrap();
+        let json = serde_json::to_string(&ca.clone().into_series()).unwrap();
 
         let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap(); // uses `DeserializeOwned`
         assert!(ca.into_series().equals_missing(&out));
@@ -54,7 +54,7 @@ mod test {
         for mut column in df.columns {
             column.set_sorted_flag(IsSorted::Descending);
             let json = serde_json::to_string(&column).unwrap();
-            let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap();
+            let out = serde_json::from_reader::<_, Column>(json.as_bytes()).unwrap();
             let f = out.get_flags();
             assert_ne!(f, MetadataFlags::empty());
             assert_eq!(column.get_flags(), out.get_flags());

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -1,16 +1,18 @@
-use std::borrow::Cow;
 use std::fmt::Formatter;
 
-use serde::de::{Error as DeError, MapAccess, Visitor};
-#[cfg(feature = "object")]
-use serde::ser::Error as SerError;
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use arrow::datatypes::Metadata;
+use arrow::io::ipc::read::{read_stream_metadata, StreamReader, StreamState};
+use arrow::io::ipc::write::WriteOptions;
+use serde::de::{Error as DeError, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "dtype-array")]
-use crate::chunked_array::builder::get_fixed_size_list_builder;
-use crate::chunked_array::builder::AnonymousListBuilder;
 use crate::chunked_array::metadata::MetadataFlags;
+use crate::config;
 use crate::prelude::*;
+use crate::utils::accumulate_dataframes_vertical;
+
+const FLAGS_KEY: PlSmallStr = PlSmallStr::from_static("_PL_FLAGS");
+const DTYPE_KEY: PlSmallStr = PlSmallStr::from_static("_PL_DTYPE");
 
 impl Serialize for Series {
     fn serialize<S>(
@@ -20,78 +22,63 @@ impl Serialize for Series {
     where
         S: Serializer,
     {
-        match self.dtype() {
-            DataType::Binary => {
-                let ca = self.binary().unwrap();
-                ca.serialize(serializer)
-            },
-            DataType::List(_) => {
-                let ca = self.list().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-array")]
-            DataType::Array(_, _) => {
-                let ca = self.array().unwrap();
-                ca.serialize(serializer)
-            },
-            DataType::Boolean => {
-                let ca = self.bool().unwrap();
-                ca.serialize(serializer)
-            },
-            DataType::String => {
-                let ca = self.str().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-struct")]
-            DataType::Struct(_) => {
-                let ca = self.struct_().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-date")]
-            DataType::Date => {
-                let ca = self.date().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-datetime")]
-            DataType::Datetime(_, _) => {
-                let ca = self.datetime().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
-                let ca = self.categorical().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-duration")]
-            DataType::Duration(_) => {
-                let ca = self.duration().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-time")]
-            DataType::Time => {
-                let ca = self.time().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "dtype-decimal")]
-            DataType::Decimal(_, _) => {
-                let ca = self.decimal().unwrap();
-                ca.serialize(serializer)
-            },
-            DataType::Null => {
-                let ca = self.null().unwrap();
-                ca.serialize(serializer)
-            },
-            #[cfg(feature = "object")]
-            DataType::Object(_, _) => Err(S::Error::custom(
+        use serde::ser::Error;
+
+        if self.dtype().is_object() {
+            return Err(polars_err!(
+                ComputeError:
                 "serializing data of type Object is not supported",
-            )),
-            dt => {
-                with_match_physical_numeric_polars_type!(dt, |$T| {
-                    let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
-                    ca.serialize(serializer)
-                })
-            },
+            ))
+            .map_err(S::Error::custom);
         }
+
+        let bytes = vec![];
+        let mut bytes = std::io::Cursor::new(bytes);
+        let mut ipc_writer = arrow::io::ipc::write::StreamWriter::new(
+            &mut bytes,
+            WriteOptions {
+                // Compression should be done on an outer level
+                compression: None,
+            },
+        );
+
+        let df = unsafe {
+            DataFrame::new_no_checks_height_from_first(vec![self.rechunk().into_column()])
+        };
+
+        ipc_writer.set_custom_schema_metadata(Arc::new(Metadata::from([
+            (
+                FLAGS_KEY,
+                PlSmallStr::from(std::str::from_utf8(&[self.get_flags().bits()]).unwrap()),
+            ),
+            (
+                // Post-deserialize cast for:
+                // * Categorical ordering physical / lexical
+                // * Decimal precision of "None"
+                DTYPE_KEY,
+                serde_json::to_string(self.dtype())
+                    .map_err(S::Error::custom)?
+                    .into(),
+            ),
+        ])));
+
+        ipc_writer
+            .start(
+                &ArrowSchema::from_iter([ArrowField::new(
+                    self.name().clone(),
+                    self.dtype().to_arrow(CompatLevel::newest()),
+                    true, // is_nullable
+                )]),
+                None,
+            )
+            .map_err(S::Error::custom)?;
+
+        for batch in df.iter_chunks(CompatLevel::newest(), false) {
+            ipc_writer.write(&batch, None).map_err(S::Error::custom)?;
+        }
+
+        ipc_writer.finish().map_err(S::Error::custom)?;
+        serializer.serialize_bytes(bytes.into_inner().as_slice())
     }
 }
 
@@ -100,233 +87,95 @@ impl<'de> Deserialize<'de> for Series {
     where
         D: Deserializer<'de>,
     {
-        const FIELDS: &[&str] = &["name", "datatype", "bit_settings", "length", "values"];
-
         struct SeriesVisitor;
 
         impl<'de> Visitor<'de> for SeriesVisitor {
             type Value = Series;
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-                formatter
-                    .write_str("struct {name: <name>, datatype: <dtype>, bit_settings?: <settings>, length?: <length>, values: <values array>}")
+                formatter.write_str("bytes (IPC)")
             }
 
-            fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>
+            fn visit_bytes<E>(self, mut v: &[u8]) -> Result<Self::Value, E>
             where
-                A: MapAccess<'de>,
+                E: DeError,
             {
-                let mut name: Option<Cow<'de, str>> = None;
-                let mut dtype = None;
-                let mut length = None;
-                let mut bit_settings: Option<MetadataFlags> = None;
-                let mut values_set = false;
-                while let Some(key) = map.next_key::<Cow<str>>().unwrap() {
-                    match key.as_ref() {
-                        "name" => {
-                            name = match map.next_value::<Cow<str>>() {
-                                Ok(s) => Some(s),
-                                Err(_) => Some(Cow::Owned(map.next_value::<String>()?)),
-                            };
+                let mut md = read_stream_metadata(&mut v).map_err(E::custom)?;
+                let arrow_schema = md.schema.clone();
+
+                let custom_metadata = md.custom_schema_metadata.take();
+
+                let reader = StreamReader::new(v, md, None);
+                let dfs = reader
+                    .into_iter()
+                    .map_while(|batch| match batch {
+                        Ok(StreamState::Some(batch)) => {
+                            Some(DataFrame::try_from((batch, &arrow_schema)))
                         },
-                        "datatype" => {
-                            dtype = Some(map.next_value()?);
-                        },
-                        "bit_settings" => {
-                            bit_settings = Some(map.next_value()?);
-                        },
-                        // length is only used for struct at the moment
-                        "length" => length = Some(map.next_value()?),
-                        "values" => {
-                            // we delay calling next_value until we know the dtype
-                            values_set = true;
-                            break;
-                        },
-                        fld => return Err(de::Error::unknown_field(fld, FIELDS)),
+                        Ok(StreamState::Waiting) => None,
+                        Err(e) => Some(Err(e)),
+                    })
+                    .collect::<PolarsResult<Vec<DataFrame>>>()
+                    .map_err(E::custom)?;
+
+                let df = accumulate_dataframes_vertical(dfs).map_err(E::custom)?;
+
+                if df.width() != 1 {
+                    return Err(polars_err!(
+                        ShapeMismatch:
+                        "expected only 1 column when deserializing Series from IPC, got columns: {:?}",
+                        df.schema().iter_names().collect::<Vec<_>>()
+                    )).map_err(E::custom);
+                }
+
+                let mut s = df.take_columns().swap_remove(0).take_materialized_series();
+
+                if let Some(custom_metadata) = custom_metadata {
+                    if let Some(flags) = custom_metadata.get(&FLAGS_KEY) {
+                        if let [v] = flags.as_bytes() {
+                            if let Some(flags) = MetadataFlags::from_bits(*v) {
+                                s.set_flags(flags);
+                            }
+                        } else if config::verbose() {
+                            eprintln!(
+                                "Series::Deserialize: Expected length-1 for flags, got: {:?}",
+                                flags
+                            )
+                        }
+                    }
+
+                    if let Some(dtype_json) = custom_metadata.get(&DTYPE_KEY) {
+                        // Ensure we round-trip `ordering` of the Categorical type
+                        match serde_json::from_str::<DataType>(dtype_json).map_err(E::custom) {
+                            Ok(dtype) => s = s.cast(&dtype).map_err(E::custom)?,
+                            Err(e) => {
+                                if config::verbose() {
+                                    eprintln!(
+                                        "Series::Deserialize: Couldn't deserialize dtype string \
+                                        {:?} (err = {})",
+                                        dtype_json, e
+                                    )
+                                }
+                            },
+                        }
                     }
                 }
-                if !values_set {
-                    return Err(de::Error::missing_field("values"));
-                }
-                let name = name.ok_or_else(|| de::Error::missing_field("name"))?;
-                let name = PlSmallStr::from_str(name.as_ref());
-                let dtype = dtype.ok_or_else(|| de::Error::missing_field("datatype"))?;
 
-                let mut s = match dtype {
-                    #[cfg(feature = "dtype-i8")]
-                    DataType::Int8 => {
-                        let values: Vec<Option<i8>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    #[cfg(feature = "dtype-u8")]
-                    DataType::UInt8 => {
-                        let values: Vec<Option<u8>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    #[cfg(feature = "dtype-i16")]
-                    DataType::Int16 => {
-                        let values: Vec<Option<i16>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    #[cfg(feature = "dtype-u16")]
-                    DataType::UInt16 => {
-                        let values: Vec<Option<u16>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::Int32 => {
-                        let values: Vec<Option<i32>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::UInt32 => {
-                        let values: Vec<Option<u32>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::Int64 => {
-                        let values: Vec<Option<i64>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::UInt64 => {
-                        let values: Vec<Option<u64>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    #[cfg(feature = "dtype-date")]
-                    DataType::Date => {
-                        let values: Vec<Option<i32>> = map.next_value()?;
-                        Ok(Series::new(name, values).cast(&DataType::Date).unwrap())
-                    },
-                    #[cfg(feature = "dtype-datetime")]
-                    DataType::Datetime(tu, tz) => {
-                        let values: Vec<Option<i64>> = map.next_value()?;
-                        Ok(Series::new(name, values)
-                            .cast(&DataType::Datetime(tu, tz))
-                            .unwrap())
-                    },
-                    #[cfg(feature = "dtype-duration")]
-                    DataType::Duration(tu) => {
-                        let values: Vec<Option<i64>> = map.next_value()?;
-                        Ok(Series::new(name, values)
-                            .cast(&DataType::Duration(tu))
-                            .unwrap())
-                    },
-                    #[cfg(feature = "dtype-time")]
-                    DataType::Time => {
-                        let values: Vec<Option<i64>> = map.next_value()?;
-                        Ok(Series::new(name, values).cast(&DataType::Time).unwrap())
-                    },
-                    #[cfg(feature = "dtype-decimal")]
-                    DataType::Decimal(precision, Some(scale)) => {
-                        let values: Vec<Option<i128>> = map.next_value()?;
-                        Ok(ChunkedArray::from_slice_options(name, &values)
-                            .into_decimal_unchecked(precision, scale)
-                            .into_series())
-                    },
-                    DataType::Boolean => {
-                        let values: Vec<Option<bool>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::Float32 => {
-                        let values: Vec<Option<f32>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::Float64 => {
-                        let values: Vec<Option<f64>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::String => {
-                        let values: Vec<Option<Cow<str>>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    DataType::List(inner) => {
-                        let values: Vec<Option<Series>> = map.next_value()?;
-                        let mut lb = AnonymousListBuilder::new(name, values.len(), Some(*inner));
-                        for value in &values {
-                            lb.append_opt_series(value.as_ref()).map_err(|e| {
-                                de::Error::custom(format!("could not append series to list: {e}"))
-                            })?;
-                        }
-                        Ok(lb.finish().into_series())
-                    },
-                    #[cfg(feature = "dtype-array")]
-                    DataType::Array(inner, width) => {
-                        let values: Vec<Option<Series>> = map.next_value()?;
-                        let mut builder =
-                            get_fixed_size_list_builder(&inner, values.len(), width, name)
-                                .map_err(|e| {
-                                    de::Error::custom(format!(
-                                        "could not get supported list builder: {e}"
-                                    ))
-                                })?;
-                        for value in &values {
-                            if let Some(s) = value {
-                                // we only have one chunk per series as we serialize it in this way.
-                                let arr = &s.chunks()[0];
-                                // SAFETY, we are within bounds
-                                unsafe {
-                                    builder.push_unchecked(arr.as_ref(), 0);
-                                }
-                            } else {
-                                // SAFETY, we are within bounds
-                                unsafe {
-                                    builder.push_null();
-                                }
-                            }
-                        }
-                        Ok(builder.finish().into_series())
-                    },
-                    DataType::Binary => {
-                        let values: Vec<Option<Cow<[u8]>>> = map.next_value()?;
-                        Ok(Series::new(name, values))
-                    },
-                    #[cfg(feature = "dtype-struct")]
-                    DataType::Struct(fields) => {
-                        let length = length.ok_or_else(|| de::Error::missing_field("length"))?;
-                        let values: Vec<Series> = map.next_value()?;
-
-                        if fields.len() != values.len() {
-                            let expected = format!("expected {} value series", fields.len());
-                            let expected = expected.as_str();
-                            return Err(de::Error::invalid_length(values.len(), &expected));
-                        }
-
-                        for (f, v) in fields.iter().zip(values.iter()) {
-                            if f.dtype() != v.dtype() {
-                                let err = format!(
-                                    "type mismatch for struct. expected: {}, given: {}",
-                                    f.dtype(),
-                                    v.dtype()
-                                );
-                                return Err(de::Error::custom(err));
-                            }
-                        }
-
-                        let ca = StructChunked::from_series(name.clone(), length, values.iter())
-                            .unwrap();
-                        let mut s = ca.into_series();
-                        s.rename(name);
-                        Ok(s)
-                    },
-                    #[cfg(feature = "dtype-categorical")]
-                    dt @ (DataType::Categorical(_, _) | DataType::Enum(_, _)) => {
-                        let values: Vec<Option<Cow<str>>> = map.next_value()?;
-                        Ok(Series::new(name, values).cast(&dt).unwrap())
-                    },
-                    DataType::Null => {
-                        let values: Vec<usize> = map.next_value()?;
-                        let len = values.first().unwrap();
-                        Ok(Series::new_null(name, *len))
-                    },
-                    dt => Err(A::Error::custom(format!(
-                        "deserializing data of type {dt} is not supported"
-                    ))),
-                }?;
-
-                if let Some(f) = bit_settings {
-                    s.set_flags(f)
-                }
                 Ok(s)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                // This is not ideal, but we hit here if the serialization format is JSON.
+                let bytes = std::iter::from_fn(|| seq.next_element::<u8>().transpose())
+                    .collect::<Result<Vec<_>, A::Error>>()?;
+
+                self.visit_bytes(&bytes)
             }
         }
 
-        deserializer.deserialize_map(SeriesVisitor)
+        deserializer.deserialize_bytes(SeriesVisitor)
     }
 }

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -53,6 +53,7 @@ version_check = { workspace = true }
 debugging = []
 python = ["dep:pyo3", "polars-utils/python"]
 serde = [
+  "ir_serde",
   "dep:serde",
   "polars-core/serde-lazy",
   "polars-time/serde",

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -27,10 +27,9 @@ ahash = { workspace = true }
 arrow = { workspace = true }
 bitflags = { workspace = true }
 bytemuck = { workspace = true }
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
-ciborium = { workspace = true, optional = true }
 either = { workspace = true }
 futures = { workspace = true, optional = true }
 hashbrown = { workspace = true }
@@ -52,7 +51,7 @@ version_check = { workspace = true }
 [features]
 # debugging utility
 debugging = []
-python = ["dep:pyo3", "ciborium", "polars-utils/python"]
+python = ["dep:pyo3", "polars-utils/python"]
 serde = [
   "dep:serde",
   "polars-core/serde-lazy",
@@ -189,7 +188,7 @@ month_end = ["polars-time/month_end"]
 offset_by = ["polars-time/offset_by"]
 
 bigidx = ["polars-core/bigidx", "polars-utils/bigidx"]
-polars_cloud = ["serde", "ciborium"]
+polars_cloud = ["serde"]
 ir_serde = ["serde", "polars-utils/ir_serde"]
 
 panic_on_schema = []
@@ -279,7 +278,6 @@ features = [
   "replace",
   "dtype-u16",
   "regex",
-  "ciborium",
   "dtype-decimal",
   "arg_where",
   "business",

--- a/crates/polars-plan/src/client/mod.rs
+++ b/crates/polars-plan/src/client/mod.rs
@@ -12,7 +12,9 @@ pub fn prepare_cloud_plan(dsl: DslPlan) -> PolarsResult<Vec<u8>> {
 
     // Serialize the plan.
     let mut writer = Vec::new();
-    pl_serialize::serialize_into_writer(&mut writer, &dsl)?;
+    pl_serialize::SerializeOptions::default()
+        .with_compression(true)
+        .serialize_into_writer(&mut writer, &dsl)?;
 
     Ok(writer)
 }

--- a/crates/polars-plan/src/client/mod.rs
+++ b/crates/polars-plan/src/client/mod.rs
@@ -1,7 +1,7 @@
 mod check;
 
-use arrow::legacy::error::to_compute_err;
 use polars_core::error::PolarsResult;
+use polars_utils::pl_serialize;
 
 use crate::plans::DslPlan;
 
@@ -12,7 +12,7 @@ pub fn prepare_cloud_plan(dsl: DslPlan) -> PolarsResult<Vec<u8>> {
 
     // Serialize the plan.
     let mut writer = Vec::new();
-    ciborium::into_writer(&dsl, &mut writer).map_err(to_compute_err)?;
+    pl_serialize::serialize_into_writer(&mut writer, &dsl)?;
 
     Ok(writer)
 }

--- a/crates/polars-plan/src/dsl/expr_dyn_fn.rs
+++ b/crates/polars-plan/src/dsl/expr_dyn_fn.rs
@@ -31,31 +31,7 @@ impl Serialize for SpecialEq<Arc<dyn ColumnsUdf>> {
         self.0
             .try_serialize(&mut buf)
             .map_err(|e| S::Error::custom(format!("{e}")))?;
-        serializer.serialize_bytes(&buf)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T: Serialize + Clone> Serialize for LazySerde<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            Self::Deserialized(t) => t.serialize(serializer),
-            Self::Bytes(b) => serializer.serialize_bytes(b),
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'a, T: Deserialize<'a> + Clone> Deserialize<'a> for LazySerde<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        let buf = Vec::<u8>::deserialize(deserializer)?;
-        Ok(Self::Bytes(bytes::Bytes::from(buf)))
+        Vec::<u8>::serialize(&buf, serializer)
     }
 }
 
@@ -72,8 +48,12 @@ impl<'a> Deserialize<'a> for SpecialEq<Arc<dyn ColumnsUdf>> {
             let buf = Vec::<u8>::deserialize(deserializer)?;
 
             if buf.starts_with(python_udf::PYTHON_SERDE_MAGIC_BYTE_MARK) {
-                let udf = python_udf::PythonUdfExpression::try_deserialize(&buf)
-                    .map_err(|e| D::Error::custom(format!("{e}")))?;
+                let udf = python_udf::PythonUdfExpression::try_deserialize(&buf).map_err(|e| {
+                    D::Error::custom(format!(
+                        "error @ SpecialEq<Arc<dyn ColumnsUdf>>::deserialize: {e}"
+                    ))
+                })?;
+
                 Ok(SpecialEq::new(udf))
             } else {
                 Err(D::Error::custom(
@@ -88,6 +68,55 @@ impl<'a> Deserialize<'a> for SpecialEq<Arc<dyn ColumnsUdf>> {
             Err(D::Error::custom(
                 "deserialization not supported for this 'opaque' function",
             ))
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::LazySerde;
+
+    #[derive(Serialize, Deserialize)]
+    enum LazySerdeWrap<T: Clone + Serialize> {
+        Deserialized(T),
+        Bytes(bytes::Bytes),
+    }
+
+    impl<T: Clone + Serialize> From<LazySerde<T>> for LazySerdeWrap<T> {
+        fn from(value: LazySerde<T>) -> Self {
+            match value {
+                LazySerde::Deserialized(v) => Self::Deserialized(v),
+                LazySerde::Bytes(v) => Self::Bytes(v),
+            }
+        }
+    }
+
+    impl<T: Clone + Serialize> From<LazySerdeWrap<T>> for LazySerde<T> {
+        fn from(value: LazySerdeWrap<T>) -> Self {
+            match value {
+                LazySerdeWrap::Deserialized(v) => Self::Deserialized(v),
+                LazySerdeWrap::Bytes(v) => Self::Bytes(v),
+            }
+        }
+    }
+
+    impl<T: Serialize + Clone> Serialize for LazySerde<T> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            LazySerdeWrap::from(self.clone()).serialize(serializer)
+        }
+    }
+
+    impl<'a, T: Deserialize<'a> + Clone + Serialize> Deserialize<'a> for LazySerde<T> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'a>,
+        {
+            LazySerdeWrap::deserialize(deserializer).map(|x| x.into())
         }
     }
 }
@@ -195,7 +224,8 @@ impl Serialize for SpecialEq<Arc<DslPlan>> {
     where
         S: Serializer,
     {
-        self.0.serialize(serializer)
+        let v: &DslPlan = self.0.as_ref();
+        DslPlan::serialize(v, serializer)
     }
 }
 
@@ -384,7 +414,7 @@ impl Serialize for GetOutput {
         self.0
             .try_serialize(&mut buf)
             .map_err(|e| S::Error::custom(format!("{e}")))?;
-        serializer.serialize_bytes(&buf)
+        Vec::<u8>::serialize(&buf, serializer)
     }
 }
 

--- a/crates/polars-plan/src/plans/file_scan.rs
+++ b/crates/polars-plan/src/plans/file_scan.rs
@@ -19,6 +19,11 @@ pub enum FileScan {
         options: CsvReadOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
     },
+    #[cfg(feature = "json")]
+    NDJson {
+        options: NDJsonReadOptions,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
+    },
     #[cfg(feature = "parquet")]
     Parquet {
         options: ParquetOptions,
@@ -32,11 +37,6 @@ pub enum FileScan {
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         #[cfg_attr(feature = "serde", serde(skip))]
         metadata: Option<arrow::io::ipc::read::FileMetadata>,
-    },
-    #[cfg(feature = "json")]
-    NDJson {
-        options: NDJsonReadOptions,
-        cloud_options: Option<polars_io::cloud::CloudOptions>,
     },
     #[cfg_attr(feature = "serde", serde(skip))]
     Anonymous {

--- a/crates/polars-plan/src/plans/functions/dsl.rs
+++ b/crates/polars-plan/src/plans/functions/dsl.rs
@@ -21,9 +21,10 @@ pub struct OpaquePythonUdf {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum DslFunction {
-    // Function that is already converted to IR.
-    #[cfg_attr(feature = "serde", serde(skip))]
-    FunctionIR(FunctionIR),
+    RowIndex {
+        name: PlSmallStr,
+        offset: Option<IdxSize>,
+    },
     // This is both in DSL and IR because we want to be able to serialize it.
     #[cfg(feature = "python")]
     OpaquePython(OpaquePythonUdf),
@@ -35,10 +36,6 @@ pub enum DslFunction {
     Unpivot {
         args: UnpivotArgsDSL,
     },
-    RowIndex {
-        name: PlSmallStr,
-        offset: Option<IdxSize>,
-    },
     Rename {
         existing: Arc<[PlSmallStr]>,
         new: Arc<[PlSmallStr]>,
@@ -49,6 +46,9 @@ pub enum DslFunction {
     /// FillValue
     FillNan(Expr),
     Drop(DropFunction),
+    // Function that is already converted to IR.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    FunctionIR(FunctionIR),
 }
 
 #[derive(Clone)]

--- a/crates/polars-plan/src/plans/functions/mod.rs
+++ b/crates/polars-plan/src/plans/functions/mod.rs
@@ -31,32 +31,22 @@ use crate::prelude::*;
 #[derive(Clone, IntoStaticStr)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum FunctionIR {
+    RowIndex {
+        name: PlSmallStr,
+        offset: Option<IdxSize>,
+        // Might be cached.
+        #[cfg_attr(feature = "ir_serde", serde(skip))]
+        schema: CachedSchema,
+    },
     #[cfg(feature = "python")]
     OpaquePython(OpaquePythonUdf),
-    #[cfg_attr(feature = "ir_serde", serde(skip))]
-    Opaque {
-        function: Arc<dyn DataFrameUdf>,
-        schema: Option<Arc<dyn UdfSchema>>,
-        ///  allow predicate pushdown optimizations
-        predicate_pd: bool,
-        ///  allow projection pushdown optimizations
-        projection_pd: bool,
-        streamable: bool,
-        // used for formatting
-        fmt_str: PlSmallStr,
-    },
+
     FastCount {
         sources: ScanSources,
         scan_type: FileScan,
         alias: Option<PlSmallStr>,
     },
-    /// Streaming engine pipeline
-    #[cfg_attr(feature = "ir_serde", serde(skip))]
-    Pipeline {
-        function: Arc<Mutex<dyn DataFrameUdfMut>>,
-        schema: SchemaRef,
-        original: Option<Arc<IRPlan>>,
-    },
+
     Unnest {
         columns: Arc<[PlSmallStr]>,
     },
@@ -89,12 +79,24 @@ pub enum FunctionIR {
         #[cfg_attr(feature = "ir_serde", serde(skip))]
         schema: CachedSchema,
     },
-    RowIndex {
-        name: PlSmallStr,
-        // Might be cached.
-        #[cfg_attr(feature = "ir_serde", serde(skip))]
-        schema: CachedSchema,
-        offset: Option<IdxSize>,
+    #[cfg_attr(feature = "ir_serde", serde(skip))]
+    Opaque {
+        function: Arc<dyn DataFrameUdf>,
+        schema: Option<Arc<dyn UdfSchema>>,
+        ///  allow predicate pushdown optimizations
+        predicate_pd: bool,
+        ///  allow projection pushdown optimizations
+        projection_pd: bool,
+        streamable: bool,
+        // used for formatting
+        fmt_str: PlSmallStr,
+    },
+    /// Streaming engine pipeline
+    #[cfg_attr(feature = "ir_serde", serde(skip))]
+    Pipeline {
+        function: Arc<Mutex<dyn DataFrameUdfMut>>,
+        schema: SchemaRef,
+        original: Option<Arc<IRPlan>>,
     },
 }
 

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -112,10 +112,10 @@ pub enum IR {
         keys: Vec<ExprIR>,
         aggs: Vec<ExprIR>,
         schema: SchemaRef,
-        #[cfg_attr(feature = "ir_serde", serde(skip))]
-        apply: Option<Arc<dyn DataFrameUdf>>,
         maintain_order: bool,
         options: Arc<GroupbyOptions>,
+        #[cfg_attr(feature = "ir_serde", serde(skip))]
+        apply: Option<Arc<dyn DataFrameUdf>>,
     },
     Join {
         input_left: Node,

--- a/crates/polars-plan/src/plans/mod.rs
+++ b/crates/polars-plan/src/plans/mod.rs
@@ -97,10 +97,10 @@ pub enum DslPlan {
         input: Arc<DslPlan>,
         keys: Vec<Expr>,
         aggs: Vec<Expr>,
-        #[cfg_attr(feature = "serde", serde(skip))]
-        apply: Option<(Arc<dyn DataFrameUdf>, SchemaRef)>,
         maintain_order: bool,
         options: Arc<GroupbyOptions>,
+        #[cfg_attr(feature = "serde", serde(skip))]
+        apply: Option<(Arc<dyn DataFrameUdf>, SchemaRef)>,
     },
     /// Join operation
     Join {
@@ -162,11 +162,11 @@ pub enum DslPlan {
         payload: SinkType,
     },
     IR {
-        #[cfg_attr(feature = "serde", serde(skip))]
-        node: Option<Node>,
-        version: u32,
         // Keep the original Dsl around as we need that for serialization.
         dsl: Arc<DslPlan>,
+        version: u32,
+        #[cfg_attr(feature = "serde", serde(skip))]
+        node: Option<Node>,
     },
 }
 

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -212,9 +212,6 @@ pub struct FunctionOptions {
     /// Collect groups to a list and apply the function over the groups.
     /// This can be important in aggregation context.
     pub collect_groups: ApplyOptions,
-    // used for formatting, (only for anonymous functions)
-    #[cfg_attr(feature = "serde", serde(skip_deserializing))]
-    pub fmt_str: &'static str,
 
     /// Options used when deciding how to cast the arguments of the function.
     pub cast_options: FunctionCastOptions,
@@ -223,6 +220,10 @@ pub struct FunctionOptions {
     // this should always be true or we could OOB
     pub check_lengths: UnsafeBool,
     pub flags: FunctionFlags,
+
+    // used for formatting, (only for anonymous functions)
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub fmt_str: &'static str,
 }
 
 impl FunctionOptions {
@@ -281,11 +282,10 @@ pub struct PythonOptions {
     pub with_columns: Option<Arc<[PlSmallStr]>>,
     // Which interface is the python function.
     pub python_source: PythonScanSource,
-    /// Optional predicate the reader must apply.
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub predicate: PythonPredicate,
     /// A `head` call passed to the reader.
     pub n_rows: Option<usize>,
+    /// Optional predicate the reader must apply.
+    pub predicate: PythonPredicate,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
@@ -298,6 +298,7 @@ pub enum PythonScanSource {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PythonPredicate {
     // A pyarrow predicate python expression
     // can be evaluated with python.eval

--- a/crates/polars-plan/src/plans/python/predicate.rs
+++ b/crates/polars-plan/src/plans/python/predicate.rs
@@ -1,5 +1,5 @@
-use polars_core::error::polars_err;
 use polars_core::prelude::PolarsResult;
+use polars_utils::pl_serialize;
 
 use crate::prelude::*;
 
@@ -62,8 +62,7 @@ pub fn serialize(expr: &Expr) -> PolarsResult<Option<Vec<u8>>> {
         return Ok(None);
     }
     let mut buf = vec![];
-    ciborium::into_writer(expr, &mut buf)
-        .map_err(|_| polars_err!(ComputeError: "could not serialize: {}", expr))?;
+    pl_serialize::serialize_into_writer(&mut buf, expr)?;
 
     Ok(Some(buf))
 }

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -27,10 +27,11 @@ polars-utils = { workspace = true }
 
 ahash = { workspace = true }
 arboard = { workspace = true, optional = true }
+bincode = { workspace = true }
 bytemuck = { workspace = true }
 bytes = { workspace = true }
-ciborium = { workspace = true }
 either = { workspace = true }
+flate2 = { workspace = true }
 itoa = { workspace = true }
 libc = { workspace = true }
 ndarray = { workspace = true }

--- a/crates/polars-python/src/cloud.rs
+++ b/crates/polars-python/src/cloud.rs
@@ -1,10 +1,9 @@
-use std::io::Cursor;
-
-use polars_core::error::{polars_err, to_compute_err, PolarsResult};
+use polars_core::error::{polars_err, PolarsResult};
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_plan::plans::{AExpr, IRPlan, IR};
 use polars_plan::prelude::{Arena, Node};
+use polars_utils::pl_serialize;
 use pyo3::intern;
 use pyo3::prelude::{PyAnyMethods, PyModule, Python, *};
 use pyo3::types::{IntoPyDict, PyBytes};
@@ -28,10 +27,8 @@ pub fn prepare_cloud_plan(lf: PyLazyFrame, py: Python<'_>) -> PyResult<Bound<'_,
 #[pyfunction]
 pub fn _execute_ir_plan_with_gpu(ir_plan_ser: Vec<u8>, py: Python) -> PyResult<PyDataFrame> {
     // Deserialize into IRPlan.
-    let reader = Cursor::new(ir_plan_ser);
-    let mut ir_plan = ciborium::from_reader::<IRPlan, _>(reader)
-        .map_err(to_compute_err)
-        .map_err(PyPolarsErr::from)?;
+    let mut ir_plan: IRPlan =
+        pl_serialize::deserialize_from_reader(ir_plan_ser.as_slice()).map_err(PyPolarsErr::from)?;
 
     // Edit for use with GPU engine.
     gpu_post_opt(

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -20,9 +20,8 @@ impl PyDataFrame {
         // Used in pickle/pickling
         PyBytes::new(
             py,
-            &pl_serialize::SerializeOptions::new(true)
+            &pl_serialize::SerializeOptions::default_outer()
                 .serialize_to_bytes(&self.df)
-                .map_err(|e| PyPolarsErr::from(e))
                 .unwrap(),
         )
     }
@@ -31,7 +30,7 @@ impl PyDataFrame {
     fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
         // Used in pickle/pickling
         match state.extract::<PyBackedBytes>() {
-            Ok(s) => pl_serialize::SerializeOptions::new(true)
+            Ok(s) => pl_serialize::SerializeOptions::default_outer()
                 .deserialize_from_reader(&*s)
                 .map(|df| {
                     self.df = df;
@@ -45,7 +44,7 @@ impl PyDataFrame {
     fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        pl_serialize::SerializeOptions::new(true)
+        pl_serialize::SerializeOptions::default_outer()
             .serialize_into_writer(writer, &self.df)
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
@@ -64,7 +63,7 @@ impl PyDataFrame {
     fn deserialize_binary(py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let file = BufReader::new(file);
-        let df: DataFrame = pl_serialize::SerializeOptions::new(true)
+        let df: DataFrame = pl_serialize::SerializeOptions::default_outer()
             .deserialize_from_reader(file)
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(df.into())

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -20,7 +20,8 @@ impl PyDataFrame {
         // Used in pickle/pickling
         PyBytes::new(
             py,
-            &pl_serialize::SerializeOptions::default_outer()
+            &pl_serialize::SerializeOptions::default()
+                .with_compression(true)
                 .serialize_to_bytes(&self.df)
                 .unwrap(),
         )
@@ -30,7 +31,8 @@ impl PyDataFrame {
     fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
         // Used in pickle/pickling
         match state.extract::<PyBackedBytes>() {
-            Ok(s) => pl_serialize::SerializeOptions::default_outer()
+            Ok(s) => pl_serialize::SerializeOptions::default()
+                .with_compression(true)
                 .deserialize_from_reader(&*s)
                 .map(|df| {
                     self.df = df;
@@ -44,7 +46,8 @@ impl PyDataFrame {
     fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        pl_serialize::SerializeOptions::default_outer()
+        pl_serialize::SerializeOptions::default()
+            .with_compression(true)
             .serialize_into_writer(writer, &self.df)
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
@@ -63,7 +66,8 @@ impl PyDataFrame {
     fn deserialize_binary(py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let file = BufReader::new(file);
-        let df: DataFrame = pl_serialize::SerializeOptions::default_outer()
+        let df: DataFrame = pl_serialize::SerializeOptions::default()
+            .with_compression(true)
             .deserialize_from_reader(file)
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(df.into())

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -1,8 +1,9 @@
-use std::io::{BufReader, BufWriter, Cursor};
+use std::io::{BufReader, BufWriter};
 use std::ops::Deref;
 
 use polars::prelude::*;
 use polars_io::mmap::ReaderBytes;
+use polars_utils::pl_serialize;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
@@ -17,29 +18,25 @@ impl PyDataFrame {
     #[cfg(feature = "ipc_streaming")]
     fn __getstate__<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
         // Used in pickle/pickling
-        let mut buf: Vec<u8> = vec![];
-        IpcStreamWriter::new(&mut buf)
-            .with_compat_level(CompatLevel::newest())
-            .finish(&mut self.df.clone())
-            .expect("ipc writer");
-        PyBytes::new(py, &buf)
+        PyBytes::new(
+            py,
+            &pl_serialize::SerializeOptions::new(true)
+                .serialize_to_bytes(&self.df)
+                .map_err(|e| PyPolarsErr::from(e))
+                .unwrap(),
+        )
     }
 
     #[cfg(feature = "ipc_streaming")]
     fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
         // Used in pickle/pickling
         match state.extract::<PyBackedBytes>() {
-            Ok(s) => {
-                let c = Cursor::new(&*s);
-                let reader = IpcStreamReader::new(c);
-
-                reader
-                    .finish()
-                    .map(|df| {
-                        self.df = df;
-                    })
-                    .map_err(|e| PyPolarsErr::from(e).into())
-            },
+            Ok(s) => pl_serialize::SerializeOptions::new(true)
+                .deserialize_from_reader(&*s)
+                .map(|df| {
+                    self.df = df;
+                })
+                .map_err(|e| PyPolarsErr::from(e).into()),
             Err(e) => Err(e),
         }
     }
@@ -48,7 +45,8 @@ impl PyDataFrame {
     fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        ciborium::into_writer(&self.df, writer)
+        pl_serialize::SerializeOptions::new(true)
+            .serialize_into_writer(writer, &self.df)
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
 
@@ -65,8 +63,9 @@ impl PyDataFrame {
     #[staticmethod]
     fn deserialize_binary(py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
-        let reader = BufReader::new(file);
-        let df = ciborium::from_reader::<DataFrame, _>(reader)
+        let file = BufReader::new(file);
+        let df: DataFrame = pl_serialize::SerializeOptions::new(true)
+            .deserialize_from_reader(file)
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(df.into())
     }

--- a/crates/polars-python/src/expr/serde.rs
+++ b/crates/polars-python/src/expr/serde.rs
@@ -1,6 +1,7 @@
 use std::io::{BufReader, BufWriter, Cursor};
 
 use polars::lazy::prelude::Expr;
+use polars_utils::pl_serialize;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::PyBytes;
@@ -15,7 +16,7 @@ impl PyExpr {
     fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
         // Used in pickle/pickling
         let mut writer: Vec<u8> = vec![];
-        ciborium::ser::into_writer(&self.inner, &mut writer)
+        pl_serialize::serialize_into_writer(&mut writer, &self.inner)
             .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
 
         Ok(PyBytes::new(py, &writer))
@@ -23,10 +24,12 @@ impl PyExpr {
 
     fn __setstate__(&mut self, state: &Bound<PyAny>) -> PyResult<()> {
         // Used in pickle/pickling
+
         let bytes = state.extract::<PyBackedBytes>()?;
         let cursor = Cursor::new(&*bytes);
-        self.inner =
-            ciborium::de::from_reader(cursor).map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
+        self.inner = pl_serialize::SerializeOptions::new(true)
+            .deserialize_from_reader(cursor)
+            .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
         Ok(())
     }
 
@@ -34,7 +37,8 @@ impl PyExpr {
     fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        ciborium::into_writer(&self.inner, writer)
+        pl_serialize::SerializeOptions::new(true)
+            .serialize_into_writer(writer, &self.inner)
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
 
@@ -52,7 +56,8 @@ impl PyExpr {
     fn deserialize_binary(py_f: PyObject) -> PyResult<PyExpr> {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
-        let expr = ciborium::from_reader::<Expr, _>(reader)
+        let expr: Expr = pl_serialize::SerializeOptions::new(true)
+            .deserialize_from_reader(reader)
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(expr.into())
     }

--- a/crates/polars-python/src/expr/serde.rs
+++ b/crates/polars-python/src/expr/serde.rs
@@ -27,7 +27,7 @@ impl PyExpr {
 
         let bytes = state.extract::<PyBackedBytes>()?;
         let cursor = Cursor::new(&*bytes);
-        self.inner = pl_serialize::SerializeOptions::new(true)
+        self.inner = pl_serialize::SerializeOptions::default_outer()
             .deserialize_from_reader(cursor)
             .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
         Ok(())
@@ -37,7 +37,7 @@ impl PyExpr {
     fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        pl_serialize::SerializeOptions::new(true)
+        pl_serialize::SerializeOptions::default_outer()
             .serialize_into_writer(writer, &self.inner)
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
@@ -56,7 +56,7 @@ impl PyExpr {
     fn deserialize_binary(py_f: PyObject) -> PyResult<PyExpr> {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
-        let expr: Expr = pl_serialize::SerializeOptions::new(true)
+        let expr: Expr = pl_serialize::SerializeOptions::default_outer()
             .deserialize_from_reader(reader)
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(expr.into())

--- a/crates/polars-python/src/file.rs
+++ b/crates/polars-python/src/file.rs
@@ -386,8 +386,7 @@ fn read_if_bytesio(py_f: Bound<PyAny>) -> Bound<PyAny> {
     py_f
 }
 
-/// Create reader from PyBytes or a file-like object. To get BytesIO to have
-/// better performance, use read_if_bytesio() before calling this.
+/// Create reader from PyBytes or a file-like object.
 pub fn get_mmap_bytes_reader(py_f: &Bound<PyAny>) -> PyResult<Box<dyn MmapBytesReader>> {
     get_mmap_bytes_reader_and_path(py_f).map(|t| t.0)
 }

--- a/crates/polars-python/src/lazyframe/serde.rs
+++ b/crates/polars-python/src/lazyframe/serde.rs
@@ -18,7 +18,7 @@ impl PyLazyFrame {
         // Used in pickle/pickling
         let mut writer: Vec<u8> = vec![];
 
-        pl_serialize::SerializeOptions::new(true)
+        pl_serialize::SerializeOptions::default_outer()
             .serialize_into_writer(&mut writer, &self.ldf.logical_plan)
             .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
 
@@ -29,7 +29,7 @@ impl PyLazyFrame {
         // Used in pickle/pickling
         match state.extract::<PyBackedBytes>(py) {
             Ok(s) => {
-                let lp: DslPlan = pl_serialize::SerializeOptions::new(true)
+                let lp: DslPlan = pl_serialize::SerializeOptions::default_outer()
                     .deserialize_from_reader(&*s)
                     .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
                 self.ldf = LazyFrame::from(lp);
@@ -43,7 +43,7 @@ impl PyLazyFrame {
     fn serialize_binary(&self, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        pl_serialize::SerializeOptions::new(true)
+        pl_serialize::SerializeOptions::default_outer()
             .serialize_into_writer(writer, &self.ldf.logical_plan)
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
@@ -62,7 +62,7 @@ impl PyLazyFrame {
     fn deserialize_binary(py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
-        let lp: DslPlan = pl_serialize::SerializeOptions::new(true)
+        let lp: DslPlan = pl_serialize::SerializeOptions::default_outer()
             .deserialize_from_reader(reader)
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(LazyFrame::from(lp).into())

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -392,7 +392,8 @@ impl PySeries {
         // Used in pickle/pickling
         let mut buf: Vec<u8> = vec![];
 
-        pl_serialize::SerializeOptions::default_outer()
+        pl_serialize::SerializeOptions::default()
+            .with_compression(true)
             .serialize_into_writer(&mut buf, &self.series)
             .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
 
@@ -405,7 +406,8 @@ impl PySeries {
         use pyo3::pybacked::PyBackedBytes;
         match state.extract::<PyBackedBytes>(py) {
             Ok(s) => {
-                let s: Series = pl_serialize::SerializeOptions::default_outer()
+                let s: Series = pl_serialize::SerializeOptions::default()
+                    .with_compression(true)
                     .deserialize_from_reader(&*s)
                     .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
                 self.series = s;

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -12,9 +12,11 @@ description = "Private utils for the Polars DataFrame library"
 polars-error = { workspace = true }
 
 ahash = { workspace = true }
+bincode = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 bytes = { workspace = true }
 compact_str = { workspace = true }
+flate2 = { workspace = true, default-features = true, optional = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
 libc = { workspace = true }
@@ -26,6 +28,7 @@ rand = { workspace = true }
 raw-cpuid = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 stacker = { workspace = true }
 sysinfo = { version = "0.32", default-features = false, features = ["system"], optional = true }
 
@@ -40,5 +43,5 @@ mmap = ["memmap"]
 bigidx = []
 nightly = []
 ir_serde = ["serde"]
-serde = ["dep:serde", "serde/derive"]
+serde = ["dep:serde", "serde/derive", "dep:bincode", "dep:flate2", "dep:serde_json"]
 python = ["pyo3"]

--- a/crates/polars-utils/src/config.rs
+++ b/crates/polars-utils/src/config.rs
@@ -1,0 +1,3 @@
+pub(crate) fn verbose() -> bool {
+    std::env::var("POLARS_VERBOSE").as_deref().unwrap_or("") == "1"
+}

--- a/crates/polars-utils/src/io.rs
+++ b/crates/polars-utils/src/io.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 
 use polars_error::*;
 
-fn verbose() -> bool {
-    std::env::var("POLARS_VERBOSE").as_deref().unwrap_or("") == "1"
-}
+use crate::config::verbose;
 
 pub fn _limit_path_len_io_err(path: &Path, err: io::Error) -> PolarsError {
     let path = path.to_string_lossy();

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cardinality_sketch;
 pub mod cell;
 pub mod chunks;
 pub mod clmul;
+mod config;
 pub mod cpuid;
 mod error;
 pub mod floor_divmod;
@@ -57,3 +58,6 @@ pub use io::*;
 
 #[cfg(feature = "python")]
 pub mod python_function;
+
+#[cfg(feature = "serde")]
+pub mod pl_serialize;

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -66,6 +66,7 @@ impl SerializeOptions {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for SerializeOptions {
     fn default() -> Self {
         Self { compression: false }

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -24,8 +24,9 @@ pub struct SerializeOptions {
 }
 
 impl SerializeOptions {
-    pub fn new(compression: bool) -> Self {
-        Self { compression }
+    /// Defaults for the final level of serialization
+    pub fn default_outer() -> Self {
+        Self { compression: false }
     }
 
     pub fn serialize_into_writer<W, T>(&self, writer: W, value: &T) -> PolarsResult<()>
@@ -120,10 +121,10 @@ mod tests {
         assert_eq!(r, v);
 
         let v = Enum::A;
-        let b = super::SerializeOptions::new(true)
+        let b = super::SerializeOptions::default_outer()
             .serialize_to_bytes(&v)
             .unwrap();
-        let r: Enum = super::SerializeOptions::new(true)
+        let r: Enum = super::SerializeOptions::default_outer()
             .deserialize_from_reader(b.as_slice())
             .unwrap();
 

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -1,0 +1,132 @@
+use polars_error::{to_compute_err, PolarsResult};
+
+fn serialize_impl<W, T>(writer: W, value: &T) -> PolarsResult<()>
+where
+    W: std::io::Write,
+    T: serde::ser::Serialize,
+{
+    bincode::serialize_into(writer, value).map_err(to_compute_err)
+}
+
+pub fn deserialize_impl<T, R>(reader: R) -> PolarsResult<T>
+where
+    T: serde::de::DeserializeOwned,
+    R: std::io::Read,
+{
+    bincode::deserialize_from(reader).map_err(to_compute_err)
+}
+
+/// Mainly used to enable compression when serializing the final outer value.
+/// For intermediate serialization steps, the function in the module should
+/// be used instead.
+pub struct SerializeOptions {
+    compression: bool,
+}
+
+impl SerializeOptions {
+    pub fn new(compression: bool) -> Self {
+        Self { compression }
+    }
+
+    pub fn serialize_into_writer<W, T>(&self, writer: W, value: &T) -> PolarsResult<()>
+    where
+        W: std::io::Write,
+        T: serde::ser::Serialize,
+    {
+        if self.compression {
+            let writer = flate2::write::ZlibEncoder::new(writer, flate2::Compression::fast());
+            serialize_impl(writer, value)
+        } else {
+            serialize_impl(writer, value)
+        }
+    }
+
+    pub fn deserialize_from_reader<T, R>(&self, reader: R) -> PolarsResult<T>
+    where
+        T: serde::de::DeserializeOwned,
+        R: std::io::Read,
+    {
+        if self.compression {
+            deserialize_impl(flate2::read::ZlibDecoder::new(reader))
+        } else {
+            deserialize_impl(reader)
+        }
+    }
+
+    pub fn serialize_to_bytes<T>(&self, value: &T) -> PolarsResult<Vec<u8>>
+    where
+        T: serde::ser::Serialize,
+    {
+        let mut v = vec![];
+
+        self.serialize_into_writer(&mut v, value)?;
+
+        Ok(v)
+    }
+}
+
+pub fn serialize_into_writer<W, T>(writer: W, value: &T) -> PolarsResult<()>
+where
+    W: std::io::Write,
+    T: serde::ser::Serialize,
+{
+    serialize_impl(writer, value)
+}
+
+pub fn deserialize_from_reader<T, R>(reader: R) -> PolarsResult<T>
+where
+    T: serde::de::DeserializeOwned,
+    R: std::io::Read,
+{
+    deserialize_impl(reader)
+}
+
+pub fn serialize_to_bytes<T>(value: &T) -> PolarsResult<Vec<u8>>
+where
+    T: serde::ser::Serialize,
+{
+    let mut v = vec![];
+
+    serialize_into_writer(&mut v, value)?;
+
+    Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_serde_skip_enum() {
+        #[derive(Default, Debug, PartialEq)]
+        struct MyType(Option<usize>);
+
+        // Note: serde(skip) must be at the end of enums
+        #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+        enum Enum {
+            A,
+            #[serde(skip)]
+            B(MyType),
+        }
+
+        impl Default for Enum {
+            fn default() -> Self {
+                Self::B(MyType(None))
+            }
+        }
+
+        let v = Enum::A;
+        let b = super::serialize_to_bytes(&v).unwrap();
+        let r: Enum = super::deserialize_from_reader(b.as_slice()).unwrap();
+
+        assert_eq!(r, v);
+
+        let v = Enum::A;
+        let b = super::SerializeOptions::new(true)
+            .serialize_to_bytes(&v)
+            .unwrap();
+        let r: Enum = super::SerializeOptions::new(true)
+            .deserialize_from_reader(b.as_slice())
+            .unwrap();
+
+        assert_eq!(r, v);
+    }
+}

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -24,11 +24,9 @@ pub struct SerializeOptions {
 }
 
 impl SerializeOptions {
-    /// Defaults for the final level of serialization
-    pub fn default_outer() -> Self {
-        // We already compress DataFrames inside their serialization using the IpcWriter. This
-        // assumes the plan itself isn't that big compared to the DataFrame.
-        Self { compression: false }
+    pub fn with_compression(mut self, compression: bool) -> Self {
+        self.compression = compression;
+        self
     }
 
     pub fn serialize_into_writer<W, T>(&self, writer: W, value: &T) -> PolarsResult<()>
@@ -65,6 +63,12 @@ impl SerializeOptions {
         self.serialize_into_writer(&mut v, value)?;
 
         Ok(v)
+    }
+}
+
+impl Default for SerializeOptions {
+    fn default() -> Self {
+        Self { compression: false }
     }
 }
 
@@ -123,10 +127,10 @@ mod tests {
         assert_eq!(r, v);
 
         let v = Enum::A;
-        let b = super::SerializeOptions::default_outer()
+        let b = super::SerializeOptions::default()
             .serialize_to_bytes(&v)
             .unwrap();
-        let r: Enum = super::SerializeOptions::default_outer()
+        let r: Enum = super::SerializeOptions::default()
             .deserialize_from_reader(b.as_slice())
             .unwrap();
 

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -26,6 +26,8 @@ pub struct SerializeOptions {
 impl SerializeOptions {
     /// Defaults for the final level of serialization
     pub fn default_outer() -> Self {
+        // We already compress DataFrames inside their serialization using the IpcWriter. This
+        // assumes the plan itself isn't that big compared to the DataFrame.
         Self { compression: false }
     }
 

--- a/crates/polars-utils/src/python_function.rs
+++ b/crates/polars-utils/src/python_function.rs
@@ -45,11 +45,11 @@ impl serde::Serialize for PythonFunction {
         S: serde::Serializer,
     {
         use serde::ser::Error;
-        serializer.serialize_bytes(
-            self.try_serialize_to_bytes()
-                .map_err(|e| S::Error::custom(e.to_string()))?
-                .as_slice(),
-        )
+        let bytes = self
+            .try_serialize_to_bytes()
+            .map_err(|e| S::Error::custom(e.to_string()))?;
+
+        Vec::<u8>::serialize(&bytes, serializer)
     }
 }
 
@@ -61,7 +61,9 @@ impl<'a> serde::Deserialize<'a> for PythonFunction {
     {
         use serde::de::Error;
         let bytes = Vec::<u8>::deserialize(deserializer)?;
-        Self::try_deserialize_bytes(bytes.as_slice()).map_err(|e| D::Error::custom(e.to_string()))
+        let v = Self::try_deserialize_bytes(bytes.as_slice())
+            .map_err(|e| D::Error::custom(e.to_string()));
+        v
     }
 }
 

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -64,7 +64,7 @@ default = [
 ]
 ndarray = ["polars-core/ndarray"]
 # serde support for dataframes and series
-serde = ["polars-core/serde", "polars-utils/serde"]
+serde = ["polars-core/serde", "polars-utils/serde", "polars-plan/ir_serde"]
 serde-lazy = [
   "polars-core/serde-lazy",
   "polars-lazy?/serde",

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -64,7 +64,7 @@ default = [
 ]
 ndarray = ["polars-core/ndarray"]
 # serde support for dataframes and series
-serde = ["polars-core/serde", "polars-utils/serde", "polars-plan/ir_serde"]
+serde = ["polars-core/serde", "polars-utils/serde", "ir_serde"]
 serde-lazy = [
   "polars-core/serde-lazy",
   "polars-lazy?/serde",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2636,7 +2636,7 @@ class DataFrame:
         ... )
         >>> bytes = df.serialize()
         >>> bytes  # doctest: +ELLIPSIS
-        b'\xa1gcolumns\x82\xa4dnamecfoohdatatypeeInt64lbit_settings\x00fvalues\x83...'
+        b'\x02\x00\x00\x00\x00\x00...'
 
         The bytes can later be deserialized back into a DataFrame.
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2636,7 +2636,7 @@ class DataFrame:
         ... )
         >>> bytes = df.serialize()
         >>> bytes  # doctest: +ELLIPSIS
-        b'\x02\x00\x00\x00\x00\x00...'
+        b'x\x01bb@\x80\x15...'
 
         The bytes can later be deserialized back into a DataFrame.
 

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -332,7 +332,7 @@ class ExprMetaNameSpace:
         >>> expr = pl.col("foo").sum().over("bar")
         >>> bytes = expr.meta.serialize()
         >>> bytes  # doctest: +ELLIPSIS
-        b'\xa1fWindow\xa4hfunction\xa1cAgg\xa1cSum\xa1fColumncfoolpartition_by\x81...'
+        b'x\x01\x02L\x80\x81...'
 
         The bytes can later be deserialized back into an `Expr` object.
 

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -34,6 +34,7 @@ def test_df_serde_roundtrip_json(df: pl.DataFrame) -> None:
 
     if isinstance(dt := df.to_series(0).dtype, pl.Decimal):
         if dt.precision is None:
+            # This gets converted to precision 38 upon `to_arrow()`
             pytest.skip("precision None")
 
     assert_frame_equal(result, df, categorical_as_str=True)

--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -19,11 +19,6 @@ if TYPE_CHECKING:
     from polars._typing import SerializationFormat
 
 
-@given(
-    df=dataframes(
-        excluded_dtypes=[pl.Struct],  # Outer nullability not supported
-    )
-)
 def test_df_serde_roundtrip_binary(df: pl.DataFrame) -> None:
     serialized = df.serialize()
     result = pl.DataFrame.deserialize(io.BytesIO(serialized), format="binary")
@@ -64,9 +59,12 @@ def test_df_serde_json_stringio(df: pl.DataFrame) -> None:
 def test_df_serialize_json() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [9, 5, 6]}).sort("a")
     result = df.serialize(format="json")
-    expected = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":"SORTED_ASC","values":[1,2,3]},{"name":"b","datatype":"Int64","bit_settings":"","values":[9,5,6]}]}'
-    print(result)
-    assert result == expected
+
+    assert isinstance(result, str)
+
+    f = io.StringIO(result)
+
+    assert_frame_equal(pl.DataFrame.deserialize(f, format="json"), df)
 
 
 @pytest.mark.parametrize(
@@ -193,40 +191,11 @@ def test_df_serde_array_logical_inner_type(data: Any, dtype: pl.DataType) -> Non
     assert_frame_equal(result, df)
 
 
-@pytest.mark.xfail(reason="Bug: https://github.com/pola-rs/polars/issues/17211")
 def test_df_serde_float_inf_nan() -> None:
     df = pl.DataFrame({"a": [1.0, float("inf"), float("-inf"), float("nan")]})
     ser = df.serialize(format="json")
     result = pl.DataFrame.deserialize(io.StringIO(ser), format="json")
     assert_frame_equal(result, df)
-
-
-def test_df_deserialize_validation() -> None:
-    f = io.StringIO(
-        """
-    {
-      "columns": [
-        {
-          "name": "a",
-          "datatype": "Int64",
-          "values": [
-            1,
-            2
-          ]
-        },
-        {
-          "name": "b",
-          "datatype": "Int64",
-          "values": [
-            1
-          ]
-        }
-      ]
-    }
-    """
-    )
-    with pytest.raises(ComputeError, match=r"lengths don't match"):
-        pl.DataFrame.deserialize(f, format="json")
 
 
 def test_df_serialize_invalid_type() -> None:

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -71,11 +71,14 @@ def test_scan_credential_provider_serialization() -> None:
 
 
 def test_scan_credential_provider_serialization_pyversion() -> None:
+    import zlib
+
     lf = pl.scan_parquet(
         "s3://bucket/path", credential_provider=pl.CredentialProviderAWS()
     )
 
     serialized = lf.serialize()
+    serialized = zlib.decompress(serialized)
     serialized = bytearray(serialized)
 
     # We can't monkeypatch sys.python_version so we just mutate the output
@@ -89,6 +92,8 @@ def test_scan_credential_provider_serialization_pyversion() -> None:
     # Note: These are loaded as u8's
     serialized[i] = 255
     serialized[i + 1] = 254
+
+    serialized = zlib.compress(serialized)
 
     with pytest.raises(ComputeError, match=r"python version.*(3, 255, 254).*differs.*"):
         lf = pl.LazyFrame.deserialize(io.BytesIO(serialized))


### PR DESCRIPTION
We currently use custom serialization code, this PR streamlines the implementation to instead use IPC, which has support for more types, and can also be faster in some cases.

I've also swapped the serialization from `ciborium` to `bincode`, mainly due to an issue deserializing large byte data (https://github.com/enarx/ciborium/issues/96), but `bincode` also appears to do better in benchmarks and has more downloads.

`serialize(binary)` benchmarks:
| column                                                      | size_before | size_after | %size   | time_before(s) | time_after(s) | runtime speedup |
|-------------------------------------------------------------|-------------|------------|---------|----------------|---------------|-----------------|
| pl.select(pl.int_range(0, 30_000_000, dtype=pl.UInt64))     | 150.0MB     | 0.61MB     | 0.4%    | 1.143455       | 0.623622      | 1.8x            |
| pl.select(pl.repeat(1, 30_000_000, dtype=pl.UInt64))        | 30.0MB      | 0.00054MB  | 0.0018% | 1.087035       | 0.087299      | 12.0x           |
| pl.read_csv('.env/data/yellow_tripdata_2015-01_head1m.csv') | 110.0MB     | 25.0MB     | 23.0%   | 0.811681       | 0.785048      | 1.0x            |
| pl.read_csv('.env/iris/iris.csv')                           | 6.3KB       | 1.7KB      | 27.0%   | 0.001379       | 0.001247      | 1.1x            |

Note:
* Time measurements are sum of both serialization and deserialization time

Note that there may be some degradations for the `serialize(format="json")` - this tradeoff is acceptable since it's deprecated functionality.

<details>
<summary>Exploratory benchmark testing</summary>

* File: `yellow_tripdata_2015-01_head1M.csv` (1M rows)
* Sorted by sum of serialization and deserialization time
* Performed on EC2 c7i.4xlarge
* Note: The compression here is applied only at the final serialization stage, the latest approach is to compress both during IPC writing and the final output data.

| row_nr                | COLUMN_SERIALIZER | SERIALIZER | COMPRESSION | serialized_size | serialize_time | deserialize_time |
|-----------------------|-------------------|------------|-------------|-----------------|----------------|------------------|
| 1                     | LEGACY            | BINCODE    | NONE        | 210.0MB         | 0.135096       | 0.364147         |
| 2                     | IPC               | BINCODE    | NONE        | 214.01MB        | 0.399154       | 0.222068         |
| 3 (proposed (binary)) | IPC               | BINCODE    | ZSTD        | 43.46MB         | 0.64739        | 0.372755         |
| 4 (current (json))    | LEGACY            | SERDE_JSON | NONE        | 162.91MB        | 0.556199       | 0.694452         |
| 5 (current (binary))  | LEGACY            | CIBORIUM   | NONE        | 108.73MB        | 0.234633       | 1.309476         |
| 6 (proposed (json))   | IPC               | SERDE_JSON | NONE        | 556.59MB        | 1.141087       | 2.623377         |
| 7                     | LEGACY            | CIBORIUM   | ZSTD        | 33.2MB          | 6.108194       | 2.157196         |
| 8                     | LEGACY            | BINCODE    | ZSTD        | 38.15MB         | 7.217784       | 1.753814         |
| 9                     | LEGACY            | SERDE_JSON | ZSTD        | 54.7MB          | 8.413706       | 4.899252         |
| 10                    | IPC               | SERDE_JSON | ZSTD        | 71.3MB          | 71.410487      | 16.191857        |
| 11                    | IPC               | CIBORIUM   | ZSTD        | 43.46MB         | 0.644313       | failed             |
| 12                    | IPC               | CIBORIUM   | NONE        | 214.01MB        | 0.399962       | failed             |

Photo
![image](https://github.com/user-attachments/assets/f4302ed4-3d22-4943-8fdd-76ce9b9348d9)

Results CSV

[bench_serialize_processed_results.csv](https://github.com/user-attachments/files/18124994/bench_serialize_processed_results.csv)

<details>
<summary>Benchmark code</summary>

```python
import polars as pl
import os
import io
from itertools import product
from time import perf_counter

FILES_ROOT = ".env/data"
print(f"{FILES_ROOT = }")

out_path = ".env/bench_serialize_results.csv"


class Matrix:
    FILES = ["iris.csv", "yellow_tripdata_2015-01_head1M.csv"]
    POLARS_SERIALIZE_COMPRESSION = ["ZSTD", "NONE"]
    POLARS_COLUMN_SERIALIZER = ["LEGACY", "IPC"]
    POLARS_SERIALIZER = ["BINCODE", "CIBORIUM", "SERDE_JSON"]


def get_serialize_stats(value):
    r = {}
    t = perf_counter()
    b = getattr(value, "serialize")()
    r["serialize_time"] = perf_counter() - t
    r["serialized_size"] = len(b)
    r["serialized_prefix"] = repr(b)

    # Deserialization may fail
    r["deserialize_time"] = None

    try:
        t = perf_counter()
        getattr(value, "deserialize")(io.BytesIO(b))
        r["deserialize_time"] = perf_counter() - t
    except Exception:
        pass

    return r


results = []

combinations = [
    *product(
        Matrix.POLARS_SERIALIZE_COMPRESSION,
        Matrix.POLARS_COLUMN_SERIALIZER,
        Matrix.POLARS_SERIALIZER,
    )
]


def iter_targets():
    for fname in Matrix.FILES:
        path = f"{FILES_ROOT}/{fname}"
        df = pl.read_csv(path)

        yield fname, df

    yield (
        "q1_plan",
        (
            pl.LazyFrame(
                schema={
                    "l_orderkey": pl.Int64,
                    "l_partkey": pl.Int64,
                    "l_suppkey": pl.Int64,
                    "l_linenumber": pl.Int64,
                    "l_quantity": pl.Int64,
                    "l_extendedprice": pl.Float64,
                    "l_discount": pl.Float64,
                    "l_tax": pl.Float64,
                    "l_returnflag": pl.String,
                    "l_linestatus": pl.String,
                    "l_shipdate": pl.String,
                    "l_commitdate": pl.String,
                    "l_receiptdate": pl.String,
                    "l_shipinstruct": pl.String,
                    "l_shipmode": pl.String,
                    "comments": pl.String,
                }
            )
            .filter(pl.col("l_shipdate") <= pl.mean("l_shipdate"))
            .group_by("l_returnflag", "l_linestatus")
            .agg(
                pl.sum("l_quantity").alias("sum_qty"),
                pl.sum("l_extendedprice").alias("sum_base_price"),
                (pl.col("l_extendedprice") * (1.0 - pl.col("l_discount")))
                .sum()
                .alias("sum_disc_price"),
                (
                    pl.col("l_extendedprice")
                    * (1.0 - pl.col("l_discount"))
                    * (1.0 + pl.col("l_tax"))
                )
                .sum()
                .alias("sum_charge"),
                pl.mean("l_quantity").alias("avg_qty"),
                pl.mean("l_extendedprice").alias("avg_price"),
                pl.mean("l_discount").alias("avg_disc"),
                pl.len().alias("count_order"),
            )
            .sort("l_returnflag", "l_linestatus")
        ),
    )


for fname, value in iter_targets():
    raw_ipc_size = None

    if isinstance(value, pl.DataFrame):
        f = io.BytesIO()
        value.write_ipc(f)
        raw_ipc_size = f.tell()
        del f

    for compression, col_serializer, serializer in combinations:
        print(fname, col_serializer, serializer, compression)

        r = {
            "file": fname,
            "POLARS_COLUMN_SERIALIZER": col_serializer,
            "POLARS_SERIALIZER": serializer,
            "POLARS_SERIALIZE_COMPRESSION": compression,
        }

        for k, v in r.items():
            os.environ[k] = v

        r.update(get_serialize_stats(value))
        r["raw_ipc_size"] = raw_ipc_size
        results.append(r)


df = pl.from_records(results).with_columns(
    pl.format(
        "{}-{}",
        pl.col("serialized_prefix").str.slice(2, 10),
        pl.col("serialized_prefix").hash(),
    )
)

with pl.Config(
    fmt_str_lengths=99,
    tbl_cols=99,
    tbl_rows=99,
    tbl_formatting="ASCII_MARKDOWN",
    tbl_hide_column_data_types=True,
):
    print(df)


print(df.write_csv())

df.write_csv(out_path)

if (
    v := df.filter(pl.col("serialized_prefix").is_duplicated()).sort(
        "serialized_prefix", maintain_order=True
    )
).height > 0:
    print("WARN: Duplicated serialized values:")
    print(v)
else:
    print("OK")

```
</details>

</details>

Fixes https://github.com/pola-rs/polars/issues/17211
