### PR TITLE
feat(python): Streamline creation of empty frame from `Schema`

### DIFF
--- a/py-polars/polars/schema.py
+++ b/py-polars/polars/schema.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeAlias
 
-
 if sys.version_info >= (3, 10):
 
     def _required_init_args(tp: DataTypeClass) -> bool:
@@ -36,7 +35,6 @@ else:
 
 BaseSchema = OrderedDict[str, DataType]
 SchemaInitDataType: TypeAlias = Union[DataType, DataTypeClass, PythonDataType]
-
 
 __all__ = ["Schema"]
 
@@ -155,12 +153,12 @@ class Schema(BaseSchema):
         return list(self.values())
 
     @overload
-    def empty_frame(self, *, eager: Literal[False] = ...) -> LazyFrame: ...
+    def to_frame(self, *, eager: Literal[False] = ...) -> LazyFrame: ...
 
     @overload
-    def empty_frame(self, *, eager: Literal[True]) -> DataFrame: ...
+    def to_frame(self, *, eager: Literal[True]) -> DataFrame: ...
 
-    def empty_frame(self, *, eager: bool = True) -> DataFrame | LazyFrame:
+    def to_frame(self, *, eager: bool = True) -> DataFrame | LazyFrame:
         """
         Create an empty DataFrame (or LazyFrame) from this Schema.
 
@@ -172,7 +170,7 @@ class Schema(BaseSchema):
         Examples
         --------
         >>> s = pl.Schema({"x": pl.Int32(), "y": pl.String()})
-        >>> s.empty_frame()
+        >>> s.to_frame()
         shape: (0, 2)
         ┌─────┬─────┐
         │ x   ┆ y   │
@@ -180,7 +178,7 @@ class Schema(BaseSchema):
         │ i32 ┆ str │
         ╞═════╪═════╡
         └─────┴─────┘
-        >>> s.empty_frame(eager=False)  # doctest: +IGNORE_RESULT
+        >>> s.to_frame(eager=False)  # doctest: +IGNORE_RESULT
         <LazyFrame at 0x11BC0AD80>
         """
         from polars import DataFrame, LazyFrame

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -41,7 +41,7 @@ def test_schema() -> None:
 )
 def test_schema_empty_frame(schema: pl.Schema) -> None:
     assert_frame_equal(
-        schema.empty_frame(),
+        schema.to_frame(),
         pl.DataFrame(schema=schema),
     )
 
@@ -270,13 +270,15 @@ def test_lazy_agg_lit_explode() -> None:
     assert_frame_equal(q.collect(), pl.DataFrame({"k": 1, "o": [[1]]}, schema=schema))  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("expr_op", [
-    "approx_n_unique", "arg_max", "arg_min", "bitwise_and", "bitwise_or",
-    "bitwise_xor", "count", "entropy", "first", "has_nulls", "implode", "kurtosis",
-    "last", "len", "lower_bound", "max", "mean", "median", "min", "n_unique", "nan_max",
-    "nan_min", "null_count", "product", "sample", "skew", "std", "sum", "upper_bound",
-    "var"
-])  # fmt: skip
+@pytest.mark.parametrize(
+    "expr_op", [
+        "approx_n_unique", "arg_max", "arg_min", "bitwise_and", "bitwise_or",
+        "bitwise_xor", "count", "entropy", "first", "has_nulls", "implode", "kurtosis",
+        "last", "len", "lower_bound", "max", "mean", "median", "min", "n_unique", "nan_max",
+        "nan_min", "null_count", "product", "sample", "skew", "std", "sum", "upper_bound",
+        "var"
+    ]
+)  # fmt: skip
 @pytest.mark.parametrize("lhs", [pl.col("b"), pl.lit(1, dtype=pl.Int64).alias("b")])
 def test_lazy_agg_to_scalar_schema_19752(lhs: pl.Expr, expr_op: str) -> None:
     op = getattr(pl.Expr, expr_op)

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -24,6 +24,28 @@ def test_schema() -> None:
         pl.Schema({"foo": pl.String, "bar": pl.List})
 
 
+@pytest.mark.parametrize(
+    "schema",
+    [
+        pl.Schema(),
+        pl.Schema({"foo": pl.Int8()}),
+        pl.Schema({"foo": pl.Datetime("us"), "bar": pl.String()}),
+        pl.Schema(
+            {
+                "foo": pl.UInt32(),
+                "bar": pl.Categorical("physical"),
+                "baz": pl.Struct({"x": pl.Int64(), "y": pl.Float64()}),
+            }
+        ),
+    ],
+)
+def test_schema_empty_frame(schema: pl.Schema) -> None:
+    assert_frame_equal(
+        schema.empty_frame(),
+        pl.DataFrame(schema=schema),
+    )
+
+
 def test_schema_equality() -> None:
     s1 = pl.Schema({"foo": pl.Int8(), "bar": pl.Float64()})
     s2 = pl.Schema({"foo": pl.Int8(), "bar": pl.String()})


### PR DESCRIPTION
Closes #20262.

Simple, but useful...

## Example
```python
import polars as pl

s = pl.Schema({"x": pl.Int32(), "y": pl.String()})
s.to_frame()
# shape: (0, 2)
# ┌─────┬─────┐
# │ x   ┆ y   │
# │ --- ┆ --- │
# │ i32 ┆ str │
# ╞═════╪═════╡
# └─────┴─────┘
```