### PR TITLE
fix: Ensure pl.datetime returns empty column when input columns are empty

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -81,9 +81,11 @@ pub(super) fn datetime(
     use polars_core::export::chrono::NaiveDate;
     use polars_core::utils::CustomIterTools;
 
+    let col_name = PlSmallStr::from_static("datetime");
+
     if s.iter().any(|s| s.is_empty()) {
         return Ok(Column::new_empty(
-            PlSmallStr::from_static("datetime"),
+            col_name,
             &DataType::Datetime(
                 time_unit.to_owned(),
                 match time_zone {
@@ -93,9 +95,9 @@ pub(super) fn datetime(
                         Some(PlSmallStr::from_str(time_zone))
                     },
                     _ => {
-                        polars_ensure!(
+                        assert!(
                             time_zone.is_none(),
-                            ComputeError: "cannot make use of the `time_zone` argument without the 'timezones' feature enabled."
+                            "cannot make use of the `time_zone` argument without the 'timezones' feature enabled."
                         );
                         None
                     },
@@ -195,16 +197,16 @@ pub(super) fn datetime(
             ca
         },
         _ => {
-            polars_ensure!(
+            assert!(
                 time_zone.is_none(),
-                ComputeError: "cannot make use of the `time_zone` argument without the 'timezones' feature enabled."
+                "cannot make use of the `time_zone` argument without the 'timezones' feature enabled."
             );
             ca.into_datetime(*time_unit, None)
         },
     };
 
     let mut s = ca.into_column();
-    s.rename(PlSmallStr::from_static("datetime"));
+    s.rename(col_name);
     Ok(s)
 }
 

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -81,3 +81,21 @@ def test_datetime_wildcard_expansion() -> None:
         "a": [datetime(1, 1, 1, 0, 0)],
         "b": [datetime(2, 2, 2, 0, 0)],
     }
+
+
+def test_datetime_invalid_time_zone() -> None:
+    df1 = pl.DataFrame({"year": []}, schema={"year": pl.Int32})
+    df2 = pl.DataFrame({"year": [2024]})
+
+    with pytest.raises(ComputeError, match="unable to parse time zone: 'foo'"):
+        df1.select(pl.datetime("year", 1, 1, time_zone="foo"))
+
+    with pytest.raises(ComputeError, match="unable to parse time zone: 'foo'"):
+        df2.select(pl.datetime("year", 1, 1, time_zone="foo"))
+
+
+def test_datetime_from_empty_column() -> None:
+    df = pl.DataFrame({"year": []}, schema={"year": pl.Int32})
+
+    assert df.select(datetime=pl.datetime("year", 1, 1)).shape == (0, 1)
+    assert df.with_columns(datetime=pl.datetime("year", 1, 1)).shape == (0, 2)


### PR DESCRIPTION
Fixes #19696 

In the new code, the returned column is named as "datetime" for consistency. The column name issue of `pl.datetime` is tracked by #18808.