### PR TITLE
refactor: Add `FunctionCastOptions` and conservative IR-level cast type-checking

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -345,7 +345,9 @@ impl DataType {
 
             (D::Boolean, dt) | (dt, D::Boolean) => match dt {
                 dt if dt.is_numeric() => true,
-                D::Decimal(_, _) | D::String | D::Binary => true,
+                #[cfg(feature = "dtype-decimal")]
+                D::Decimal(_, _) => true,
+                D::String | D::Binary => true,
                 _ => false,
             },
 

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -320,6 +320,55 @@ impl DataType {
         }
     }
 
+    /// Return whether the cast to `to` makes sense.
+    ///
+    /// This will never be precise but gives an initial estimate.
+    pub fn can_cast_to(&self, to: &DataType) -> bool {
+        if self == to {
+            return true;
+        }
+
+        if self.is_numeric() && to.is_numeric() {
+            return true;
+        }
+
+        use DataType as D;
+        match (self, to) {
+            #[cfg(feature = "dtype-categorical")]
+            (D::Categorical(_, _) | D::Enum(_, _), D::Binary)
+            | (D::Binary, D::Categorical(_, _) | D::Enum(_, _)) => false,
+
+            #[cfg(feature = "object")]
+            (D::Object(_, _), D::Object(_, _)) => true,
+            #[cfg(feature = "object")]
+            (D::Object(_, _), _) | (_, D::Object(_, _)) => false,
+
+            (D::Boolean, dt) | (dt, D::Boolean) => match dt {
+                dt if dt.is_numeric() => true,
+                D::Decimal(_, _) | D::String | D::Binary => true,
+                _ => false,
+            },
+
+            (D::List(from), D::List(to)) => from.can_cast_to(to),
+            #[cfg(feature = "dtype-array")]
+            (D::Array(from, l_width), D::Array(to, r_width)) => {
+                l_width == r_width && from.can_cast_to(to)
+            },
+            #[cfg(feature = "dtype-struct")]
+            (D::Struct(l_fields), D::Struct(r_fields)) => {
+                l_fields.is_empty()
+                    || (l_fields.len() == r_fields.len()
+                        && l_fields
+                            .iter()
+                            .zip(r_fields)
+                            .all(|(l, r)| l.dtype().can_cast_to(r.dtype())))
+            },
+
+            // @NOTE: we are being conversative
+            _ => true,
+        }
+    }
+
     pub fn implode(self) -> DataType {
         DataType::List(Box::new(self))
     }

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -571,10 +571,7 @@ fn create_physical_expr_inner(
                 node_to_expr(expression, expr_arena),
                 FunctionOptions {
                     collect_groups: ApplyOptions::GroupWise,
-                    fmt_str: "",
-                    cast_to_supertypes: None,
-                    check_lengths: Default::default(),
-                    flags: Default::default(),
+                    ..Default::default()
                 },
                 state.allow_threading,
                 schema.clone(),

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -99,7 +99,7 @@ pub fn concat_expr<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
             flags: FunctionFlags::default() | FunctionFlags::INPUT_WILDCARD_EXPANSION,
-            cast_to_supertypes: Some(Default::default()),
+            cast_options: FunctionCastOptions::cast_to_supertypes(),
             ..Default::default()
         },
     })

--- a/crates/polars-plan/src/dsl/functions/correlation.rs
+++ b/crates/polars-plan/src/dsl/functions/correlation.rs
@@ -11,7 +11,7 @@ pub fn cov(a: Expr, b: Expr, ddof: u8) -> Expr {
         function,
         options: FunctionOptions {
             collect_groups: ApplyOptions::GroupWise,
-            cast_to_supertypes: Some(Default::default()),
+            cast_options: FunctionCastOptions::cast_to_supertypes(),
             flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
             ..Default::default()
         },
@@ -29,7 +29,7 @@ pub fn pearson_corr(a: Expr, b: Expr) -> Expr {
         function,
         options: FunctionOptions {
             collect_groups: ApplyOptions::GroupWise,
-            cast_to_supertypes: Some(Default::default()),
+            cast_options: FunctionCastOptions::cast_to_supertypes(),
             flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
             ..Default::default()
         },
@@ -54,7 +54,7 @@ pub fn spearman_rank_corr(a: Expr, b: Expr, propagate_nans: bool) -> Expr {
         function,
         options: FunctionOptions {
             collect_groups: ApplyOptions::GroupWise,
-            cast_to_supertypes: Some(Default::default()),
+            cast_options: FunctionCastOptions::cast_to_supertypes(),
             flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
             ..Default::default()
         },

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -285,7 +285,6 @@ pub fn sum_horizontal<E: AsRef<[Expr]>>(exprs: E, ignore_nulls: bool) -> PolarsR
             collect_groups: ApplyOptions::ElementWise,
             flags: FunctionFlags::default()
                 | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR,
-            cast_to_supertypes: None,
             ..Default::default()
         },
     })
@@ -303,7 +302,6 @@ pub fn mean_horizontal<E: AsRef<[Expr]>>(exprs: E, ignore_nulls: bool) -> Polars
             collect_groups: ApplyOptions::ElementWise,
             flags: FunctionFlags::default()
                 | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR,
-            cast_to_supertypes: None,
             ..Default::default()
         },
     })
@@ -319,8 +317,8 @@ pub fn coalesce(exprs: &[Expr]) -> Expr {
         function: FunctionExpr::Coalesce,
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
-            cast_to_supertypes: Some(Default::default()),
             flags: FunctionFlags::default() | FunctionFlags::INPUT_WILDCARD_EXPANSION,
+            cast_options: FunctionCastOptions::cast_to_supertypes(),
             ..Default::default()
         },
     }

--- a/crates/polars-plan/src/dsl/functions/range.rs
+++ b/crates/polars-plan/src/dsl/functions/range.rs
@@ -89,7 +89,7 @@ pub fn datetime_range(
         }),
         options: FunctionOptions {
             collect_groups: ApplyOptions::GroupWise,
-            cast_to_supertypes: Some(Default::default()),
+            cast_options: FunctionCastOptions::cast_to_supertypes(),
             flags: FunctionFlags::default() | FunctionFlags::ALLOW_RENAME,
             ..Default::default()
         },
@@ -118,7 +118,7 @@ pub fn datetime_ranges(
         }),
         options: FunctionOptions {
             collect_groups: ApplyOptions::GroupWise,
-            cast_to_supertypes: Some(Default::default()),
+            cast_options: FunctionCastOptions::cast_to_supertypes(),
             flags: FunctionFlags::default() | FunctionFlags::ALLOW_RENAME,
             ..Default::default()
         },

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -329,9 +329,12 @@ impl ListNameSpace {
             function: FunctionExpr::ListExpr(ListFunction::SetOperation(set_operation)),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ElementWise,
-                cast_to_supertypes: Some(SuperTypeOptions {
-                    flags: SuperTypeFlags::default() | SuperTypeFlags::ALLOW_IMPLODE_LIST,
-                }),
+                cast_options: FunctionCastOptions {
+                    supertype: Some(SuperTypeOptions {
+                        flags: SuperTypeFlags::default() | SuperTypeFlags::ALLOW_IMPLODE_LIST,
+                    }),
+                    ..Default::default()
+                },
                 flags: FunctionFlags::default() & !FunctionFlags::RETURNS_SCALAR,
                 ..Default::default()
             },

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -388,9 +388,13 @@ impl Expr {
                 collect_groups: ApplyOptions::GroupWise,
                 flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
                 fmt_str: "search_sorted",
-                cast_to_supertypes: Some(
-                    (SuperTypeFlags::default() & !SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING).into(),
-                ),
+                cast_options: FunctionCastOptions {
+                    supertype: Some(
+                        (SuperTypeFlags::default() & !SuperTypeFlags::ALLOW_PRIMITIVE_TO_STRING)
+                            .into(),
+                    ),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         }
@@ -709,7 +713,7 @@ impl Expr {
         input.push(self);
         input.extend_from_slice(arguments);
 
-        let cast_to_supertypes = if cast_to_supertypes {
+        let supertype = if cast_to_supertypes {
             Some(Default::default())
         } else {
             None
@@ -726,7 +730,10 @@ impl Expr {
             options: FunctionOptions {
                 collect_groups: ApplyOptions::GroupWise,
                 flags,
-                cast_to_supertypes,
+                cast_options: FunctionCastOptions {
+                    supertype,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         }
@@ -754,7 +761,10 @@ impl Expr {
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ElementWise,
                 flags,
-                cast_to_supertypes,
+                cast_options: FunctionCastOptions {
+                    supertype: cast_to_supertypes,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         }
@@ -1053,7 +1063,7 @@ impl Expr {
             function: FunctionExpr::FillNull,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ElementWise,
-                cast_to_supertypes: Some(Default::default()),
+                cast_options: FunctionCastOptions::cast_to_supertypes(),
                 ..Default::default()
             },
         }

--- a/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
@@ -11,7 +11,7 @@ pub(super) fn get_function_dtypes(
 ) -> PolarsResult<Either<Vec<DataType>, AExpr>> {
     let mut early_return = move || {
         // Next iteration this will not hit anymore as options is updated.
-        options.cast_to_supertypes = None;
+        options.cast_options.supertype = None;
         Ok(Either::Right(AExpr::Function {
             function: function.clone(),
             input: input.to_vec(),

--- a/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
@@ -1,29 +1,19 @@
-use either::Either;
-
 use super::*;
 
+/// Get the datatypes of function arguments.
+///
+/// If all arguments give the same datatype or a datatype cannot be found, `Ok(None)` is returned.
 pub(super) fn get_function_dtypes(
     input: &[ExprIR],
     expr_arena: &Arena<AExpr>,
     input_schema: &Schema,
     function: &FunctionExpr,
-    mut options: FunctionOptions,
-) -> PolarsResult<Either<Vec<DataType>, AExpr>> {
-    let mut early_return = move || {
-        // Next iteration this will not hit anymore as options is updated.
-        options.cast_options.supertype = None;
-        Ok(Either::Right(AExpr::Function {
-            function: function.clone(),
-            input: input.to_vec(),
-            options,
-        }))
-    };
-
+) -> PolarsResult<Option<Vec<DataType>>> {
     let mut dtypes = Vec::with_capacity(input.len());
     let mut first = true;
     for e in input {
         let Some((_, dtype)) = get_aexpr_and_type(expr_arena, e.node(), input_schema) else {
-            return early_return();
+            return Ok(None);
         };
 
         if first {
@@ -34,16 +24,16 @@ pub(super) fn get_function_dtypes(
         // We will raise if we cannot find the supertype later.
         match dtype {
             DataType::Unknown(UnknownKind::Any) => {
-                return early_return();
+                return Ok(None);
             },
             _ => dtypes.push(dtype),
         }
     }
 
     if dtypes.iter().all_equal() {
-        return early_return();
+        return Ok(None);
     }
-    Ok(Either::Left(dtypes))
+    return Ok(Some(dtypes));
 }
 
 // `str` namespace belongs to `String`

--- a/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/functions.rs
@@ -33,7 +33,7 @@ pub(super) fn get_function_dtypes(
     if dtypes.iter().all_equal() {
         return Ok(None);
     }
-    return Ok(Some(dtypes));
+    Ok(Some(dtypes))
 }
 
 // `str` namespace belongs to `String`

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -272,7 +272,7 @@ impl OptimizationRule for TypeCoercionRule {
                 ref function,
                 ref input,
                 mut options,
-            } if options.cast_to_supertypes.is_some() => {
+            } if options.cast_options.supertype.is_some() => {
                 let input_schema = get_schema(lp_arena, lp_node);
 
                 let dtypes = match functions::get_function_dtypes(
@@ -299,7 +299,7 @@ impl OptimizationRule for TypeCoercionRule {
                     let Some(new_st) = get_supertype_with_options(
                         &super_type,
                         &type_other,
-                        options.cast_to_supertypes.unwrap(),
+                        options.cast_options.supertype.unwrap(),
                     ) else {
                         raise_supertype(function, input, &input_schema, expr_arena)?;
                         unreachable!()
@@ -356,7 +356,7 @@ impl OptimizationRule for TypeCoercionRule {
                     .collect::<Vec<_>>();
 
                 // Ensure we don't go through this on next iteration.
-                options.cast_to_supertypes = None;
+                options.cast_options.supertype = None;
                 Some(AExpr::Function {
                     function,
                     input,

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -506,7 +506,10 @@ fn cast_expr_ir(
 }
 
 fn check_cast(from: &DataType, to: &DataType) -> PolarsResult<()> {
-    polars_ensure!(from.can_cast_to(to), InvalidOperation: "casting from {from:?} to {to:?} not supported");
+    polars_ensure!(
+        from.can_cast_to(to) != Some(false),
+        InvalidOperation: "casting from {from:?} to {to:?} not supported"
+    );
     Ok(())
 }
 

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -330,12 +330,7 @@ impl OptimizationRule for TypeCoercionRule {
                             },
                             _ => {
                                 if dtype != super_type {
-                                    let n = expr_arena.add(AExpr::Cast {
-                                        expr: e.node(),
-                                        dtype: super_type.clone(),
-                                        options: CastOptions::NonStrict,
-                                    });
-                                    e.set_node(n);
+                                    cast_expr_ir(e, &super_type, expr_arena, false)?;
                                 }
                             },
                         }
@@ -377,15 +372,12 @@ fn inline_or_prune_cast(
     if !dtype.is_known() {
         return Ok(None);
     }
-    let lv = match (aexpr, dtype) {
+    let lv = match aexpr {
         // PRUNE
-        (
-            AExpr::BinaryExpr {
-                op: Operator::LogicalOr | Operator::LogicalAnd,
-                ..
-            },
-            _,
-        ) => {
+        AExpr::BinaryExpr {
+            op: Operator::LogicalOr | Operator::LogicalAnd,
+            ..
+        } => {
             if let Some(schema) = lp_arena.get(lp_node).input_schema(lp_arena) {
                 let field = aexpr.to_field(&schema, Context::Default, expr_arena)?;
                 if field.dtype == *dtype {
@@ -395,75 +387,119 @@ fn inline_or_prune_cast(
             return Ok(None);
         },
         // INLINE
-        (AExpr::Literal(lv), _) => match lv {
-            LiteralValue::Series(s) => {
-                let s = if strict {
-                    s.strict_cast(dtype)
-                } else {
-                    s.cast(dtype)
-                }?;
-                LiteralValue::Series(SpecialEq::new(s))
-            },
-            LiteralValue::StrCat(s) => {
-                let av = AnyValue::String(s).strict_cast(dtype);
-                return Ok(av.map(|av| AExpr::Literal(av.into())));
-            },
-            // We generate casted literal datetimes, so ensure we cast upon conversion
-            // to create simpler expr trees.
-            #[cfg(feature = "dtype-datetime")]
-            LiteralValue::DateTime(ts, tu, None) if dtype.is_date() => {
-                let from_size = time_unit_multiple(tu.to_arrow()) * SECONDS_IN_DAY;
-                LiteralValue::Date((*ts / from_size) as i32)
-            },
-            lv @ (LiteralValue::Int(_) | LiteralValue::Float(_)) => {
-                let av = lv.to_any_value().ok_or_else(|| polars_err!(InvalidOperation: "literal value: {:?} too large for Polars", lv))?;
-                let av = av.strict_cast(dtype);
-                return Ok(av.map(|av| AExpr::Literal(av.into())));
-            },
-            LiteralValue::Null => match dtype {
-                DataType::Unknown(UnknownKind::Float | UnknownKind::Int(_) | UnknownKind::Str) => {
-                    return Ok(Some(AExpr::Literal(LiteralValue::Null)))
-                },
-                _ => return Ok(None),
-            },
-            _ => {
-                let Some(av) = lv.to_any_value() else {
-                    return Ok(None);
-                };
-                if dtype == &av.dtype() {
-                    return Ok(Some(aexpr.clone()));
-                }
-                match (av, dtype) {
-                    // casting null always remains null
-                    (AnyValue::Null, _) => return Ok(None),
-                    // series cast should do this one
-                    #[cfg(feature = "dtype-datetime")]
-                    (AnyValue::Datetime(_, _, _), DataType::Datetime(_, _)) => return Ok(None),
-                    #[cfg(feature = "dtype-duration")]
-                    (AnyValue::Duration(_, _), _) => return Ok(None),
-                    #[cfg(feature = "dtype-categorical")]
-                    (AnyValue::Categorical(_, _, _), _) | (_, DataType::Categorical(_, _)) => {
-                        return Ok(None)
-                    },
-                    #[cfg(feature = "dtype-categorical")]
-                    (AnyValue::Enum(_, _, _), _) | (_, DataType::Enum(_, _)) => return Ok(None),
-                    #[cfg(feature = "dtype-struct")]
-                    (_, DataType::Struct(_)) => return Ok(None),
-                    (av, _) => {
-                        let out = {
-                            match av.strict_cast(dtype) {
-                                Some(out) => out,
-                                None => return Ok(None),
-                            }
-                        };
-                        out.into()
-                    },
-                }
-            },
+        AExpr::Literal(lv) => match try_inline_literal_cast(lv, dtype, strict)? {
+            None => return Ok(None),
+            Some(lv) => lv,
         },
         _ => return Ok(None),
     };
     Ok(Some(AExpr::Literal(lv)))
+}
+
+fn try_inline_literal_cast(
+    lv: &LiteralValue,
+    dtype: &DataType,
+    strict: bool,
+) -> PolarsResult<Option<LiteralValue>> {
+    let lv = match lv {
+        LiteralValue::Series(s) => {
+            let s = if strict {
+                s.strict_cast(dtype)
+            } else {
+                s.cast(dtype)
+            }?;
+            LiteralValue::Series(SpecialEq::new(s))
+        },
+        LiteralValue::StrCat(s) => {
+            let av = AnyValue::String(s).strict_cast(dtype);
+
+            match av {
+                None => return Ok(None),
+                Some(av) => av.into(),
+            }
+        },
+        // We generate casted literal datetimes, so ensure we cast upon conversion
+        // to create simpler expr trees.
+        #[cfg(feature = "dtype-datetime")]
+        LiteralValue::DateTime(ts, tu, None) if dtype.is_date() => {
+            let from_size = time_unit_multiple(tu.to_arrow()) * SECONDS_IN_DAY;
+            LiteralValue::Date((*ts / from_size) as i32)
+        },
+        lv @ (LiteralValue::Int(_) | LiteralValue::Float(_)) => {
+            let av = lv.to_any_value().ok_or_else(
+                || polars_err!(InvalidOperation: "literal value: {:?} too large for Polars", lv),
+            )?;
+            let av = av.strict_cast(dtype);
+
+            match av {
+                None => return Ok(None),
+                Some(av) => av.into(),
+            }
+        },
+        LiteralValue::Null => match dtype {
+            DataType::Unknown(UnknownKind::Float | UnknownKind::Int(_) | UnknownKind::Str) => {
+                LiteralValue::Null
+            },
+            _ => return Ok(None),
+        },
+        _ => {
+            let Some(av) = lv.to_any_value() else {
+                return Ok(None);
+            };
+            if dtype == &av.dtype() {
+                return Ok(Some(lv.clone()));
+            }
+            match (av, dtype) {
+                // casting null always remains null
+                (AnyValue::Null, _) => return Ok(None),
+                // series cast should do this one
+                #[cfg(feature = "dtype-datetime")]
+                (AnyValue::Datetime(_, _, _), DataType::Datetime(_, _)) => return Ok(None),
+                #[cfg(feature = "dtype-duration")]
+                (AnyValue::Duration(_, _), _) => return Ok(None),
+                #[cfg(feature = "dtype-categorical")]
+                (AnyValue::Categorical(_, _, _), _) | (_, DataType::Categorical(_, _)) => {
+                    return Ok(None)
+                },
+                #[cfg(feature = "dtype-categorical")]
+                (AnyValue::Enum(_, _, _), _) | (_, DataType::Enum(_, _)) => return Ok(None),
+                #[cfg(feature = "dtype-struct")]
+                (_, DataType::Struct(_)) => return Ok(None),
+                (av, _) => {
+                    let out = {
+                        match av.strict_cast(dtype) {
+                            Some(out) => out,
+                            None => return Ok(None),
+                        }
+                    };
+                    out.into()
+                },
+            }
+        },
+    };
+
+    Ok(Some(lv))
+}
+
+fn cast_expr_ir(
+    e: &mut ExprIR,
+    dtype: &DataType,
+    expr_arena: &mut Arena<AExpr>,
+    strict: bool,
+) -> PolarsResult<()> {
+    if let AExpr::Literal(lv) = expr_arena.get(e.node()) {
+        if let Some(literal) = try_inline_literal_cast(lv, dtype, strict)? {
+            e.set_node(expr_arena.add(AExpr::Literal(literal)));
+            return Ok(());
+        }
+    }
+
+    e.set_node(expr_arena.add(AExpr::Cast {
+        expr: e.node(),
+        dtype: dtype.clone(),
+        options: CastOptions::Strict,
+    }));
+    Ok(())
 }
 
 fn early_escape(type_self: &DataType, type_other: &DataType) -> Option<()> {

--- a/crates/polars-plan/src/plans/optimizer/fused.rs
+++ b/crates/polars-plan/src/plans/optimizer/fused.rs
@@ -10,7 +10,7 @@ fn get_expr(input: &[Node], op: FusedOperator, expr_arena: &Arena<AExpr>) -> AEx
         .collect();
     let mut options = FunctionOptions {
         collect_groups: ApplyOptions::ElementWise,
-        cast_to_supertypes: Some(Default::default()),
+        cast_options: FunctionCastOptions::cast_to_supertypes(),
         ..Default::default()
     };
     // order of operations change because of FMA

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -12,10 +12,8 @@ fn new_null_count(input: &[ExprIR]) -> AExpr {
         function: FunctionExpr::NullCount,
         options: FunctionOptions {
             collect_groups: ApplyOptions::GroupWise,
-            fmt_str: "",
-            cast_to_supertypes: None,
-            check_lengths: UnsafeBool::default(),
             flags: FunctionFlags::ALLOW_GROUP_AWARE | FunctionFlags::RETURNS_SCALAR,
+            ..Default::default()
         },
     }
 }

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -179,6 +179,33 @@ impl Default for FunctionFlags {
     }
 }
 
+bitflags::bitflags! {
+    #[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Hash)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct FunctionCastFlags: u8 {}
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct FunctionCastOptions {
+    pub flags: FunctionCastFlags,
+
+    // if the expression and its inputs should be cast to supertypes
+    // `None` -> Don't cast.
+    // `Some` -> cast with given options.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub supertype: Option<SuperTypeOptions>,
+}
+
+impl FunctionCastOptions {
+    pub fn cast_to_supertypes() -> FunctionCastOptions {
+        Self {
+            supertype: Some(Default::default()),
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FunctionOptions {
@@ -188,11 +215,10 @@ pub struct FunctionOptions {
     // used for formatting, (only for anonymous functions)
     #[cfg_attr(feature = "serde", serde(skip_deserializing))]
     pub fmt_str: &'static str,
-    // if the expression and its inputs should be cast to supertypes
-    // `None` -> Don't cast.
-    // `Some` -> cast with given options.
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub cast_to_supertypes: Option<SuperTypeOptions>,
+
+    /// Options used when deciding how to cast the arguments of the function.
+    pub cast_options: FunctionCastOptions,
+
     // Validate the output of a `map`.
     // this should always be true or we could OOB
     pub check_lengths: UnsafeBool,
@@ -222,9 +248,9 @@ impl Default for FunctionOptions {
     fn default() -> Self {
         FunctionOptions {
             collect_groups: ApplyOptions::GroupWise,
-            fmt_str: "",
-            cast_to_supertypes: None,
             check_lengths: UnsafeBool(true),
+            fmt_str: Default::default(),
+            cast_options: Default::default(),
             flags: Default::default(),
         }
     }

--- a/crates/polars-python/src/functions/misc.rs
+++ b/crates/polars-python/src/functions/misc.rs
@@ -56,7 +56,10 @@ pub fn register_plugin_function(
         },
         options: FunctionOptions {
             collect_groups,
-            cast_to_supertypes,
+            cast_options: FunctionCastOptions {
+                supertype: cast_to_supertypes,
+                ..Default::default()
+            },
             flags,
             ..Default::default()
         },


### PR DESCRIPTION
This changes three main things:
1. Refactor `FunctionsOptions::cast_to_supertypes` to `FunctionOptions::cast_options` in preparation for #19894.
2. Immediately prune casts when they are added into the IR through function upcasting
3. Do some conservative cast type-checking in the IR. For instance, if you try to cast from a `Boolean` to a `DateTime`, it is now rejected in the `type_coercion` stage.