### PR TITLE
docs(python): Include parquet options in BigQuery I/O write sample

### DIFF
--- a/docs/source/src/python/user-guide/io/bigquery.py
+++ b/docs/source/src/python/user-guide/io/bigquery.py
@@ -25,12 +25,15 @@ client = bigquery.Client()
 with io.BytesIO() as stream:
     df.write_parquet(stream)
     stream.seek(0)
+    parquet_options = bigquery.ParquetOptions()
+    parquet_options.enable_list_inference = True
     job = client.load_table_from_file(
         stream,
         destination='tablename',
         project='projectname',
         job_config=bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.PARQUET,
+            parquet_options=parquet_options,
         ),
     )
 job.result()  # Waits for the job to complete


### PR DESCRIPTION
This ensures lists are interpreted correctly by BigQuery.

See also: https://github.com/googleapis/python-bigquery/issues/2008#issuecomment-2541921785 where I test this with a sample DataFrame. That issue discusses the possibility of google-cloud-bigquery automatically setting such an option in future.

Fixes #16938 