### PR TITLE
chore(python): Clean up some remnants of Python 3.8 support

### DIFF
--- a/.github/workflows/test-bytecode-parser.yml
+++ b/.github/workflows/test-bytecode-parser.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # Only the versions that are not already run as part of the regular test suite
-        python-version: ['3.9', '3.10']
+        python-version: ['3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/source/user-guide/installation.md
+++ b/docs/source/user-guide/installation.md
@@ -155,7 +155,7 @@ pip install 'polars[numpy,fsspec]'
 | style       | Style dataframes through the `style` namespace. |
 | timezone    | Timezone support[^note].                        |
 
-[^note]: Only needed if you are on Python < 3.9 or you are on Windows.
+[^note]: Only needed if you are on Windows.
 
 ### Rust
 

--- a/py-polars/polars/_utils/convert.py
+++ b/py-polars/polars/_utils/convert.py
@@ -8,7 +8,6 @@ from typing import (
     Any,
     Callable,
     NoReturn,
-    no_type_check,
     overload,
 )
 
@@ -171,26 +170,14 @@ def to_py_datetime(
 
 def _localize_datetime(dt: datetime, time_zone: str) -> datetime:
     # zone info installation should already be checked
+    tz: zoneinfo.ZoneInfo | tzinfo
     try:
-        tz = string_to_zoneinfo(time_zone)
+        tz = zoneinfo.ZoneInfo(time_zone)
     except zoneinfo.ZoneInfoNotFoundError:
         # try fixed offset, which is not supported by ZoneInfo
         tz = _parse_fixed_tz_offset(time_zone)
 
     return dt.astimezone(tz)
-
-
-@no_type_check
-@lru_cache(None)
-def string_to_zoneinfo(key: str) -> Any:
-    """
-    Convert a time zone string to a Python ZoneInfo object.
-
-    This is a simple wrapper for the zoneinfo.ZoneInfo constructor.
-    The wrapper is useful because zoneinfo is not available on Python 3.8
-    and the backports module may not be installed.
-    """
-    return zoneinfo.ZoneInfo(key)
 
 
 # cache here as we have a single tz per column

--- a/py-polars/polars/_utils/convert.py
+++ b/py-polars/polars/_utils/convert.py
@@ -10,6 +10,7 @@ from typing import (
     NoReturn,
     overload,
 )
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from polars._utils.constants import (
     EPOCH,
@@ -21,7 +22,6 @@ from polars._utils.constants import (
     SECONDS_PER_HOUR,
     US_PER_SECOND,
 )
-from polars.dependencies import _ZONEINFO_AVAILABLE, zoneinfo
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -160,20 +160,17 @@ def to_py_datetime(
 
     if time_zone is None:
         return EPOCH + td
-    elif _ZONEINFO_AVAILABLE:
+    else:
         dt = EPOCH_UTC + td
         return _localize_datetime(dt, time_zone)
-    else:
-        msg = "install polars[timezone] to handle datetimes with time zone information"
-        raise ImportError(msg)
 
 
 def _localize_datetime(dt: datetime, time_zone: str) -> datetime:
     # zone info installation should already be checked
-    tz: zoneinfo.ZoneInfo | tzinfo
+    tz: ZoneInfo | tzinfo
     try:
-        tz = zoneinfo.ZoneInfo(time_zone)
-    except zoneinfo.ZoneInfoNotFoundError:
+        tz = ZoneInfo(time_zone)
+    except ZoneInfoNotFoundError:
         # try fixed offset, which is not supported by ZoneInfo
         tz = _parse_fixed_tz_offset(time_zone)
 

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -20,7 +20,6 @@ _PANDAS_AVAILABLE = True
 _PYARROW_AVAILABLE = True
 _PYDANTIC_AVAILABLE = True
 _PYICEBERG_AVAILABLE = True
-_ZONEINFO_AVAILABLE = True
 
 
 class _LazyModule(ModuleType):
@@ -150,7 +149,6 @@ if TYPE_CHECKING:
     import json
     import pickle
     import subprocess
-    import zoneinfo
 
     import altair
     import deltalake
@@ -182,11 +180,6 @@ else:
     pyarrow, _PYARROW_AVAILABLE = _lazy_import("pyarrow")
     pydantic, _PYDANTIC_AVAILABLE = _lazy_import("pydantic")
     pyiceberg, _PYICEBERG_AVAILABLE = _lazy_import("pyiceberg")
-    zoneinfo, _ZONEINFO_AVAILABLE = (
-        _lazy_import("zoneinfo")
-        if sys.version_info >= (3, 9)
-        else _lazy_import("backports.zoneinfo")
-    )
     gevent, _GEVENT_AVAILABLE = _lazy_import("gevent")
 
 
@@ -308,7 +301,6 @@ __all__ = [
     "pydantic",
     "pyiceberg",
     "pyarrow",
-    "zoneinfo",
     # lazy utilities
     "_check_for_numpy",
     "_check_for_pandas",
@@ -324,5 +316,4 @@ __all__ = [
     "_NUMPY_AVAILABLE",
     "_PANDAS_AVAILABLE",
     "_PYARROW_AVAILABLE",
-    "_ZONEINFO_AVAILABLE",
 ]

--- a/py-polars/polars/testing/parametric/strategies/data.py
+++ b/py-polars/polars/testing/parametric/strategies/data.py
@@ -6,6 +6,7 @@ import decimal
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal
+from zoneinfo import ZoneInfo
 
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument
@@ -25,7 +26,6 @@ from polars._utils.constants import (
     U32_MAX,
     U64_MAX,
 )
-from polars._utils.convert import string_to_zoneinfo
 from polars.datatypes import (
     Array,
     Binary,
@@ -167,7 +167,7 @@ def datetimes(
     if time_zone is None:
         return st.datetimes(min_value, max_value)
 
-    time_zone_info = string_to_zoneinfo(time_zone)
+    time_zone_info = ZoneInfo(time_zone)
 
     # Make sure time zone offsets do not cause out-of-bound datetimes
     if time_unit == "ns":

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -70,7 +70,7 @@ cloudpickle = ["cloudpickle"]
 graph = ["matplotlib"]
 plot = ["altair >= 5.4.0"]
 style = ["great-tables >= 0.8.0"]
-timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_system == 'Windows'"]
+timezone = ["tzdata; platform_system == 'Windows'"]
 
 # GPU Engine
 gpu = ["cudf-polars-cu12"]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -23,12 +23,11 @@ pyarrow
 pydantic>=2.0.0
 numba
 # Datetime / time zones
-backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 # Database
 sqlalchemy
-adbc-driver-manager; python_version >= '3.9' and platform_system != 'Windows'
-adbc-driver-sqlite; python_version >= '3.9' and platform_system != 'Windows'
+adbc-driver-manager; platform_system != 'Windows'
+adbc-driver-sqlite; platform_system != 'Windows'
 aiosqlite
 connectorx
 kuzu
@@ -49,7 +48,7 @@ zstandard
 # Plotting
 altair>=5.4.0
 # Styling
-great-tables>=0.8.0; python_version >= '3.9'
+great-tables>=0.8.0
 # Async
 gevent
 # Graph

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from random import shuffle
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -23,7 +24,6 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     import sys
     from collections.abc import Callable
-    from zoneinfo import ZoneInfo
 
     from polars._typing import PolarsDataType
 
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
         from typing import Self
     else:
         from typing_extensions import Self
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 # -----------------------------------------------------------------------------------

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from io import BytesIO
 from operator import floordiv, truediv
 from typing import TYPE_CHECKING, Any, Callable, cast
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pyarrow as pa
@@ -34,12 +35,9 @@ from tests.unit.conftest import INTEGER_DTYPES
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
-    from zoneinfo import ZoneInfo
 
     from polars import Expr
     from polars._typing import JoinStrategy, UniqueKeepStrategy
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 def test_version() -> None:

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -11,11 +12,8 @@ from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from datetime import timezone
-    from zoneinfo import ZoneInfo
 
     from polars._typing import FillNullStrategy, PolarsIntegerType
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
 
 import hypothesis.strategies as st
 import numpy as np
@@ -27,15 +28,11 @@ from polars.testing import (
 from tests.unit.conftest import DATETIME_DTYPES, TEMPORAL_DTYPES
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars._typing import (
         Ambiguous,
         PolarsTemporalType,
         TimeUnit,
     )
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 def test_fill_null() -> None:

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta, timezone
 from itertools import permutations
 from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -18,11 +19,7 @@ from tests.unit.conftest import (
 )
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars._typing import PolarsDataType
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 def test_arg_true() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -10,11 +11,7 @@ from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars._typing import TimeUnit
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 def test_date_datetime() -> None:

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import hypothesis.strategies as st
 import pytest
@@ -13,11 +14,7 @@ from polars.exceptions import ComputeError, InvalidOperationError, SchemaError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars._typing import ClosedInterval, PolarsDataType, TimeUnit
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 def test_datetime_range() -> None:

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -72,10 +71,6 @@ def test_to_dataframe_pyarrow_zero_copy_parametric(df: pl.DataFrame) -> None:
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="The correct `from_dataframe` implementation for pandas is not available before Python 3.9",
-)
 @pytest.mark.filterwarnings(
     "ignore:.*PEP3118 format string that does not match its itemsize:RuntimeWarning"
 )
@@ -92,10 +87,6 @@ def test_to_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
     assert_frame_equal(result, df, categorical_as_str=True)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="The correct `from_dataframe` implementation for pandas is not available before Python 3.9",
-)
 @pytest.mark.filterwarnings(
     "ignore:.*PEP3118 format string that does not match its itemsize:RuntimeWarning"
 )
@@ -158,10 +149,6 @@ def test_from_dataframe_pyarrow_zero_copy_parametric(df: pl.DataFrame) -> None:
         ],
     )
 )
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="Older versions of pandas do not implement the required conversions",
-)
 def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas(use_pyarrow_extension_array=True)
     result = pl.from_dataframe(df_pd)
@@ -184,10 +171,6 @@ def test_from_dataframe_pandas_parametric(df: pl.DataFrame) -> None:
         allow_chunks=False,
     )
 )
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="Older versions of pandas do not implement the required conversions",
-)
 def test_from_dataframe_pandas_zero_copy_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas(use_pyarrow_extension_array=True)
     result = pl.from_dataframe(df_pd, allow_copy=False)
@@ -207,10 +190,6 @@ def test_from_dataframe_pandas_zero_copy_parametric(df: pl.DataFrame) -> None:
         min_size=1,
         allow_null=False,  # Bug: https://github.com/pola-rs/polars/issues/16190
     )
-)
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="Older versions of pandas do not implement the required conversions",
 )
 def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas()
@@ -234,10 +213,6 @@ def test_from_dataframe_pandas_native_parametric(df: pl.DataFrame) -> None:
         allow_chunks=False,
         allow_null=False,  # Bug: https://github.com/pola-rs/polars/issues/16190
     )
-)
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="Older versions of pandas do not implement the required conversions",
 )
 def test_from_dataframe_pandas_native_zero_copy_parametric(df: pl.DataFrame) -> None:
     df_pd = df.to_pandas()

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -463,8 +463,7 @@ def test_read_database_parameterised(tmp_sqlite_db: Path) -> None:
     ],
 )
 @pytest.mark.skipif(
-    sys.version_info < (3, 9) or sys.platform == "win32",
-    reason="adbc_driver_sqlite not available on py3.8/windows",
+    sys.platform == "win32", reason="adbc_driver_sqlite not available on Windows"
 )
 def test_read_database_parameterised_uri(
     param: str, param_value: Any, tmp_sqlite_db: Path

--- a/py-polars/tests/unit/io/database/test_read.py
+++ b/py-polars/tests/unit/io/database/test_read.py
@@ -190,8 +190,8 @@ class ExceptionTestParams(NamedTuple):
                 schema_overrides={"id": pl.UInt8},
             ),
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
-                reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
+                sys.platform == "win32",
+                reason="adbc_driver_sqlite not available on Windows",
             ),
             id="uri: adbc",
         ),
@@ -256,8 +256,8 @@ class ExceptionTestParams(NamedTuple):
                 expected_dates=["2020-01-01", "2021-12-31"],
             ),
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
-                reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
+                sys.platform == "win32",
+                reason="adbc_driver_sqlite not available on Windows",
             ),
             id="conn: adbc (fetchall)",
         ),
@@ -275,8 +275,8 @@ class ExceptionTestParams(NamedTuple):
                 batch_size=1,
             ),
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 9) or sys.platform == "win32",
-                reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
+                sys.platform == "win32",
+                reason="adbc_driver_sqlite not available on Windows",
             ),
             id="conn: adbc (batched)",
         ),

--- a/py-polars/tests/unit/io/database/test_write.py
+++ b/py-polars/tests/unit/io/database/test_write.py
@@ -320,10 +320,7 @@ def test_write_database_sa_commit(tmp_path: str, pass_connection: bool) -> None:
     assert_frame_equal(result, df)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9) or sys.platform == "win32",
-    reason="adbc not available on Windows or <= Python 3.8",
-)
+@pytest.mark.skipif(sys.platform == "win32", reason="adbc not available on Windows")
 def test_write_database_adbc_temporary_table() -> None:
     """Confirm that execution_options are passed along to create temporary tables."""
     df = pl.DataFrame({"colx": [1, 2, 3]})

--- a/py-polars/tests/unit/ml/test_to_jax.py
+++ b/py-polars/tests/unit/ml/test_to_jax.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -143,10 +142,6 @@ def test_to_jax_dict(df: pl.DataFrame) -> None:
         assert_array_equal(a, jxn.array(expected_data, dtype=jxn.float32))
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="jax.numpy.bool requires Python >= 3.9",
-)
 def test_to_jax_feature_label_dict(df: pl.DataFrame) -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import pytest
 from hypothesis import given
@@ -14,11 +15,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric import series
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars._typing import PolarsDataType, TemporalLiteral, TimeUnit
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 @pytest.fixture

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_round.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_round.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import hypothesis.strategies as st
 import pytest
@@ -12,13 +13,7 @@ from polars._utils.convert import parse_as_duration_string
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars.type_aliases import TimeUnit
-
-
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 @pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu"])

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -16,11 +17,7 @@ from polars.exceptions import ChronoFormatWarning, ComputeError, InvalidOperatio
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars._typing import PolarsTemporalType, TimeUnit
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 def test_str_strptime() -> None:

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pytest
@@ -11,11 +12,7 @@ from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
     from polars._typing import Label, StartBy
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import pytest
 from hypothesis import given
@@ -11,12 +11,6 @@ from polars.exceptions import PanicException
 from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 from tests.unit.conftest import NUMERIC_DTYPES
-
-if TYPE_CHECKING:
-    from zoneinfo import ZoneInfo
-
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 @given(

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -33,11 +34,8 @@ from tests.unit.utils.pycapsule_utils import PyCapsuleStreamHolder
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from zoneinfo import ZoneInfo
 
     from polars._typing import EpochTimeUnit, PolarsDataType, TimeUnit
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 def test_cum_agg() -> None:

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pytest
@@ -26,11 +27,8 @@ from polars._utils.various import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from zoneinfo import ZoneInfo
 
     from polars._typing import TimeUnit
-else:
-    from polars._utils.convert import string_to_zoneinfo as ZoneInfo
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There was still a bunch of logic specific to Python 3.8 in the code base.