### PR TITLE
chore(python): Prepare test suite for Python 3.13 support

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -6,7 +6,7 @@ hvplot
 matplotlib
 seaborn
 plotly
-numba
+numba >= 0.54; python_version < '3.13'  # numba does not support Python 3.13
 numpy
 
 mkdocs-material==9.5.27

--- a/docs/source/src/python/user-guide/misc/styling.py
+++ b/docs/source/src/python/user-guide/misc/styling.py
@@ -1,3 +1,13 @@
+# --8<-- [start:setup]
+import warnings
+
+# great-tables throws a Deprecation warning in `as_raw_html` under Python 3.13
+# https://github.com/posit-dev/great-tables/pull/563
+warnings.filterwarnings(
+    "ignore", "'count' is passed as positional argument", category=DeprecationWarning
+)
+# --8<-- [end:setup]
+
 # --8<-- [start:dataframe]
 import polars as pl
 import polars.selectors as cs

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from collections.abc import Sequence
 from datetime import time
 from io import BufferedReader, BytesIO, StringIO, TextIOWrapper
@@ -1010,7 +1011,12 @@ def _read_spreadsheet_xlsx2csv(
     """Use the 'xlsx2csv' library to read data from the given worksheet."""
     csv_buffer = StringIO()
 
-    parser.convert(outfile=csv_buffer, sheetname=sheet_name)
+    with warnings.catch_warnings():
+        # xlsx2csv version 0.8.4 throws a DeprecationWarning in Python 3.13
+        # https://github.com/dilshod/xlsx2csv/pull/287
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        parser.convert(outfile=csv_buffer, sheetname=sheet_name)
+
     read_options.setdefault("truncate_ragged_lines", True)
     if columns:
         read_options["columns"] = columns

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -251,6 +251,9 @@ filterwarnings = [
   # TODO: Excel tests lead to unclosed file warnings
   # https://github.com/pola-rs/polars/issues/14466
   "ignore:unclosed file.*:ResourceWarning",
+  # TODO: Database tests lead to unclosed database warnings
+  # https://github.com/pola-rs/polars/issues/20296
+  "ignore:unclosed database.*:ResourceWarning",
   # Ignore invalid warnings when running earlier versions of SQLAlchemy (we
   # know they are invalid because our standard tests run the latest version)
   "ignore:Deprecated API features detected.*:DeprecationWarning",

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -21,7 +21,6 @@ numba >= 0.54; python_version < '3.13'  # Numba can lag Python releases
 pandas
 pyarrow
 pydantic>=2.0.0
-numba
 # Datetime / time zones
 tzdata; platform_system == 'Windows'
 # Database

--- a/py-polars/tests/docs/test_user_guide.py
+++ b/py-polars/tests/docs/test_user_guide.py
@@ -2,6 +2,7 @@
 
 import os
 import runpy
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -18,6 +19,10 @@ snippet_paths = list(python_snippets_dir.rglob("*.py"))
 
 # Skip visualization snippets
 snippet_paths = [p for p in snippet_paths if "visualization" not in str(p)]
+
+# Skip UDF section on Python 3.13 as numba does not support it yet
+if sys.version_info >= (3, 13):
+    snippet_paths = [p for p in snippet_paths if "user-defined-functions" not in str(p)]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This makes our 'regular' test suite pass on Python 3.13. There are some other things popping up in the parametric tests, will look at those another time.