### PR TITLE
feat: Allow substraction of time dtype columns

### DIFF
--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -88,15 +88,14 @@ impl private::PrivateSeries for SeriesWrap<TimeChunked> {
     }
 
     fn subtract(&self, rhs: &Series) -> PolarsResult<Series> {
-        match rhs.dtype() {
-            DataType::Time => {
-                let dt = DataType::Duration(TimeUnit::Nanoseconds);
-                let lhs = self.cast(&dt, CastOptions::NonStrict)?;
-                let rhs = rhs.cast(&dt)?;
-                lhs.subtract(&rhs)
-            },
-            dtr => polars_bail!(opq = sub, DataType::Time, dtr),
-        }
+        let rhs = rhs.time().map_err(|_| polars_err!(InvalidOperation: "cannot subtract a {} dtype with a series of type: {}", self.dtype(), rhs.dtype()))?;
+
+        let phys = self
+            .0
+            .physical()
+            .subtract(&rhs.physical().clone().into_series())?;
+
+        Ok(phys.into_duration(TimeUnit::Nanoseconds))
     }
 
     fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -88,7 +88,15 @@ impl private::PrivateSeries for SeriesWrap<TimeChunked> {
     }
 
     fn subtract(&self, rhs: &Series) -> PolarsResult<Series> {
-        polars_bail!(opq = sub, DataType::Time, rhs.dtype());
+        match rhs.dtype() {
+            DataType::Time => {
+                let dt = DataType::Duration(TimeUnit::Nanoseconds);
+                let lhs = self.cast(&dt, CastOptions::NonStrict)?;
+                let rhs = rhs.cast(&dt)?;
+                lhs.subtract(&rhs)
+            },
+            dtr => polars_bail!(opq = sub, DataType::Time, dtr),
+        }
     }
 
     fn add_to(&self, rhs: &Series) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -467,9 +467,7 @@ fn get_arithmetic_field(
                 (_, Duration(_)) | (Duration(_), _) => {
                     polars_bail!(InvalidOperation: "{} not allowed on {} and {}", op, left_field.dtype, right_type)
                 },
-                (_, Time) | (Time, _) => {
-                    polars_bail!(InvalidOperation: "{} not allowed on {} and {}", op, left_field.dtype, right_type)
-                },
+                (_, Time) | (Time, _) => Duration(TimeUnit::Nanoseconds),
                 (l @ List(a), r @ List(b))
                     if ![a, b]
                         .into_iter()

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -467,7 +467,10 @@ fn get_arithmetic_field(
                 (_, Duration(_)) | (Duration(_), _) => {
                     polars_bail!(InvalidOperation: "{} not allowed on {} and {}", op, left_field.dtype, right_type)
                 },
-                (_, Time) | (Time, _) => Duration(TimeUnit::Nanoseconds),
+                (Time, Time) => Duration(TimeUnit::Nanoseconds),
+                (_, Time) | (Time, _) => {
+                    polars_bail!(InvalidOperation: "{} not allowed on {} and {}", op, left_field.dtype, right_type)
+                },
                 (l @ List(a), r @ List(b))
                     if ![a, b]
                         .into_iter()

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -790,6 +790,7 @@ def test_date_datetime_sub() -> None:
         "bar": [timedelta(days=4)],
     }
 
+
 def test_time_time_sub() -> None:
     df = pl.DataFrame(
         {
@@ -813,6 +814,7 @@ def test_time_time_sub() -> None:
             timedelta(microseconds=-9),
         ],
     }
+
 
 def test_raise_invalid_shape() -> None:
     with pytest.raises(InvalidOperationError):

--- a/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_arithmetic.py
@@ -790,6 +790,29 @@ def test_date_datetime_sub() -> None:
         "bar": [timedelta(days=4)],
     }
 
+def test_time_time_sub() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": pl.Series([-1, 0, 10]).cast(pl.Datetime("us")),
+            "bar": pl.Series([1, 0, 1]).cast(pl.Datetime("us")),
+        }
+    )
+
+    assert df.select(
+        pl.col("foo").dt.time() - pl.col("bar").dt.time(),
+        pl.col("bar").dt.time() - pl.col("foo").dt.time(),
+    ).to_dict(as_series=False) == {
+        "foo": [
+            timedelta(days=1, microseconds=-2),
+            timedelta(0),
+            timedelta(microseconds=9),
+        ],
+        "bar": [
+            timedelta(days=-1, microseconds=2),
+            timedelta(0),
+            timedelta(microseconds=-9),
+        ],
+    }
 
 def test_raise_invalid_shape() -> None:
     with pytest.raises(InvalidOperationError):


### PR DESCRIPTION
Closes #19720 

Since the documentation specifies the Time dtype as
> The underlying representation of this type is a 64-bit signed integer. The integer indicates the number of nanoseconds since midnight.

we can specify the result of a substraction as a duration with nanosecond time unit.