### PR TITLE
fix: Properly handle `from_physical` for List/Array

### DIFF
--- a/crates/polars-core/src/chunked_array/array/mod.rs
+++ b/crates/polars-core/src/chunked_array/array/mod.rs
@@ -29,6 +29,51 @@ impl ArrayChunked {
         fld.coerce(DataType::Array(Box::new(inner_dtype), width))
     }
 
+    /// Convert a non-logical [`ArrayChunked`] back into a logical [`ArrayChunked`] without casting.
+    ///
+    /// # Safety
+    ///
+    /// This can lead to invalid memory access in downstream code.
+    pub unsafe fn from_physical_unchecked(&self, to_inner_dtype: DataType) -> PolarsResult<Self> {
+        debug_assert!(!self.inner_dtype().is_logical());
+
+        let chunks = self
+            .downcast_iter()
+            .map(|chunk| chunk.values())
+            .cloned()
+            .collect();
+
+        let inner = unsafe {
+            Series::from_chunks_and_dtype_unchecked(PlSmallStr::EMPTY, chunks, self.inner_dtype())
+        };
+        let inner = unsafe { inner.from_physical_unchecked(&to_inner_dtype) }?;
+
+        let chunks: Vec<_> = self
+            .downcast_iter()
+            .zip(inner.into_chunks())
+            .map(|(chunk, values)| {
+                FixedSizeListArray::new(
+                    ArrowDataType::FixedSizeList(
+                        Box::new(ArrowField::new(
+                            PlSmallStr::from_static("item"),
+                            values.dtype().clone(),
+                            true,
+                        )),
+                        self.width(),
+                    ),
+                    chunk.len(),
+                    values,
+                    chunk.validity().cloned(),
+                )
+                .to_boxed()
+            })
+            .collect();
+
+        let name = self.name().clone();
+        let dtype = DataType::Array(Box::new(to_inner_dtype), self.width());
+        Ok(unsafe { Self::from_chunks_and_dtype_unchecked(name, chunks, dtype) })
+    }
+
     /// Get the inner values as `Series`
     pub fn get_inner(&self) -> Series {
         let chunks: Vec<_> = self.downcast_iter().map(|c| c.values().clone()).collect();

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1195,6 +1195,25 @@ mod test {
     }
 
     #[test]
+    fn roundtrip_list_logical_20311() {
+        let list = ListChunked::from_chunk_iter(
+            PlSmallStr::from_static("a"),
+            [ListArray::new(
+                ArrowDataType::LargeList(Box::new(ArrowField::new(
+                    PlSmallStr::from_static("item"),
+                    ArrowDataType::Int32,
+                    true,
+                ))),
+                unsafe { Offsets::new_unchecked(vec![0, 1]) }.into(),
+                PrimitiveArray::new(ArrowDataType::Int32, vec![1i32].into(), None).to_boxed(),
+                None,
+            )],
+        );
+        let list = unsafe { list.from_physical_unchecked(DataType::Date) }.unwrap();
+        assert_eq!(list.dtype(), &DataType::List(Box::new(DataType::Date)));
+    }
+
+    #[test]
     #[cfg(feature = "dtype-struct")]
     fn new_series_from_empty_structs() {
         let dtype = DataType::Struct(vec![]);

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1195,6 +1195,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "dtype-date")]
     fn roundtrip_list_logical_20311() {
         let list = ListChunked::from_chunk_iter(
             PlSmallStr::from_static("a"),


### PR DESCRIPTION
This fixes the following snippet panicking.

```python
dtype = pl.List(pl.Datetime)
df = pl.Series('a', [[date(1996, 10, 5)]], dtype).to_frame()

print(df)
re = df._row_encode([(False, False, False)])
rt = re._row_decode([('a', dtype)], [(False, False, False)])
print(rt)
```