### PR TITLE
refactor: Use Column in Row Encoding

### DIFF
--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -320,7 +320,7 @@ impl IntoGroupsProxy for ListChunked {
         sorted: bool,
     ) -> PolarsResult<GroupsProxy> {
         multithreaded &= POOL.current_num_threads() > 1;
-        let by = &[self.clone().into_series()];
+        let by = &[self.clone().into_column()];
         let ca = if multithreaded {
             encode_rows_vertical_par_unordered(by).unwrap()
         } else {

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -76,7 +76,7 @@ impl DataFrame {
             let by = by
                 .iter()
                 .filter(|s| !s.dtype().is_null())
-                .map(|c| c.as_materialized_series().clone())
+                .cloned()
                 .collect::<Vec<_>>();
             if by.is_empty() {
                 let groups = if self.is_empty() {

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -5,7 +5,6 @@ use polars_core::prelude::row_encode::_get_rows_encoded_unordered;
 use polars_core::prelude::PlRandomState;
 use polars_core::series::Series;
 use polars_utils::hashing::HashPartitioner;
-use polars_utils::itertools::Itertools;
 use polars_utils::vec::PushUnchecked;
 use polars_utils::IdxSize;
 
@@ -20,12 +19,8 @@ pub enum HashKeys {
 impl HashKeys {
     pub fn from_df(df: &DataFrame, random_state: PlRandomState, force_row_encoding: bool) -> Self {
         if df.width() > 1 || force_row_encoding {
-            let keys = df
-                .get_columns()
-                .iter()
-                .map(|c| c.as_materialized_series().clone())
-                .collect_vec();
-            let keys_encoded = _get_rows_encoded_unordered(&keys[..]).unwrap().into_array();
+            let keys = df.get_columns();
+            let keys_encoded = _get_rows_encoded_unordered(keys).unwrap().into_array();
             assert!(keys_encoded.len() == df.height());
 
             // TODO: use vechash? Not supported yet for lists.

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -572,9 +572,9 @@ fn prepare_keys_multiple(s: &[Series], join_nulls: bool) -> PolarsResult<BinaryO
         .map(|s| {
             let phys = s.to_physical_repr();
             match phys.dtype() {
-                DataType::Float32 => phys.f32().unwrap().to_canonical().into_series(),
-                DataType::Float64 => phys.f64().unwrap().to_canonical().into_series(),
-                _ => phys.into_owned(),
+                DataType::Float32 => phys.f32().unwrap().to_canonical().into_column(),
+                DataType::Float64 => phys.f64().unwrap().to_canonical().into_column(),
+                _ => phys.into_owned().into_column(),
             }
         })
         .collect::<Vec<_>>();

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -684,7 +684,7 @@ impl PyDataFrame {
     ) -> PyResult<PySeries> {
         py.allow_threads(|| {
             let name = PlSmallStr::from_static("row_enc");
-            let is_unordered = opts.first().map_or(false, |(_, _, v)| *v);
+            let is_unordered = opts.first().is_some_and(|(_, _, v)| *v);
 
             let ca = if is_unordered {
                 _get_rows_encoded_ca_unordered(name, self.df.get_columns())

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -582,17 +582,17 @@ impl PySeries {
             let columns = columns
                 .into_iter()
                 .zip(dtypes)
-                .map(|(arr, (name, dtype))| {
-                    unsafe {
-                        Series::from_chunks_and_dtype_unchecked(
-                            PlSmallStr::from(name),
-                            vec![arr],
-                            &dtype.0,
-                        )
-                    }
+                .map(|(arr, (name, dtype))| unsafe {
+                    Series::from_chunks_and_dtype_unchecked(
+                        PlSmallStr::from(name),
+                        vec![arr],
+                        &dtype.0.to_physical(),
+                    )
                     .into_column()
+                    .from_physical_unchecked(&dtype.0)
                 })
-                .collect::<Vec<_>>();
+                .collect::<PolarsResult<Vec<_>>>()
+                .map_err(PyPolarsErr::from)?;
             Ok(DataFrame::new(columns).map_err(PyPolarsErr::from)?.into())
         })
     }


### PR DESCRIPTION
Now we can use `Column` for unordered Row-Encoding and the python interface now calls the standard functions.