### PR TITLE
build(python): Add `project.dynamic = ["version"]` to pyproject.toml

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Rust",
   "Topic :: Scientific/Engineering",
 ]
+dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://www.pola.rs/"


### PR DESCRIPTION
This fixes installing using the latest version of `uv`, which otherwise
fails with

```
TOML parse error at line 5, column 1
        |
      5 | [project]
        | ^^^^^^^^^
      `pyproject.toml` is using the `[project]` table, but the required
      `project.version` field is neither set nor present in the
      `project.dynamic` list
```

CC: @ritchie46 https://github.com/astral-sh/uv/issues/9989
