### PR TITLE
feat: Add env var to ignore file cache allocate error

### DIFF
--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -151,14 +151,6 @@ impl Inner {
                 .truncate(true)
                 .open(data_file_path)
                 .map_err(PolarsError::from)?;
-            file.lock_exclusive().unwrap();
-            if file.allocate(remote_metadata.size).is_err() {
-                polars_bail!(
-                    ComputeError: "failed to allocate {} bytes to download uri = {}",
-                    remote_metadata.size,
-                    self.uri.as_ref()
-                );
-            }
         }
         self.file_fetcher.fetch(data_file_path)?;
 

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -145,7 +145,7 @@ impl Inner {
         // This could be left from an aborted process.
         let _ = std::fs::remove_file(data_file_path);
         if !self.file_fetcher.fetches_as_symlink() {
-            let _ = std::fs::OpenOptions::new()
+            std::fs::OpenOptions::new()
                 .write(true)
                 .create(true)
                 .truncate(true)

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -171,7 +171,7 @@ impl Inner {
             file.lock_exclusive().unwrap();
             if let Err(e) = file.allocate(remote_metadata.size) {
                 let msg = format!(
-                    "failed to allocate {} bytes to download uri = {}: {:?}",
+                    "failed to reserve {} bytes on disk to download uri = {}: {:?}",
                     remote_metadata.size,
                     self.uri.as_ref(),
                     e

--- a/crates/polars-io/src/file_cache/entry.rs
+++ b/crates/polars-io/src/file_cache/entry.rs
@@ -145,7 +145,7 @@ impl Inner {
         // This could be left from an aborted process.
         let _ = std::fs::remove_file(data_file_path);
         if !self.file_fetcher.fetches_as_symlink() {
-            let file = std::fs::OpenOptions::new()
+            let _ = std::fs::OpenOptions::new()
                 .write(true)
                 .create(true)
                 .truncate(true)


### PR DESCRIPTION
Adds a flag `POLARS_IGNORE_FILE_CACHE_ALLOCATE_ERROR` to ignore any allocation errors from the `std::fs::File::allocate` call. May help with:

* https://github.com/pola-rs/polars/issues/17946

There is a chance this allocate is incorrectly failing. I've also adjusted the print to include the IO error itself.
