### PR TITLE
fix: Flip order on right join

### DIFF
--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -82,7 +82,7 @@ pub enum MaintainOrderJoin {
 }
 
 impl MaintainOrderJoin {
-    pub fn flip(&self) -> Self {
+    pub(super) fn flip(&self) -> Self {
         match self {
             MaintainOrderJoin::None => MaintainOrderJoin::None,
             MaintainOrderJoin::Left => MaintainOrderJoin::Right,

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -81,6 +81,18 @@ pub enum MaintainOrderJoin {
     RightLeft,
 }
 
+impl MaintainOrderJoin {
+    pub fn flip(&self) -> Self {
+        match self {
+            MaintainOrderJoin::None => MaintainOrderJoin::None,
+            MaintainOrderJoin::Left => MaintainOrderJoin::Right,
+            MaintainOrderJoin::Right => MaintainOrderJoin::Left,
+            MaintainOrderJoin::LeftRight => MaintainOrderJoin::RightLeft,
+            MaintainOrderJoin::RightLeft => MaintainOrderJoin::LeftRight,
+        }
+    }
+}
+
 impl Default for JoinArgs {
     fn default() -> Self {
         Self {

--- a/crates/polars-ops/src/frame/join/dispatch_left_right.rs
+++ b/crates/polars-ops/src/frame/join/dispatch_left_right.rs
@@ -21,11 +21,12 @@ pub(super) fn right_join_from_series(
     right: DataFrame,
     s_left: &Series,
     s_right: &Series,
-    args: JoinArgs,
+    mut args: JoinArgs,
     verbose: bool,
     drop_names: Option<Vec<PlSmallStr>>,
 ) -> PolarsResult<DataFrame> {
     // Swap the order of tables to do a right join.
+    args.maintain_order = args.maintain_order.flip();
     let (df_right, df_left) = materialize_left_join_from_series(
         right, left, s_right, s_left, &args, verbose, drop_names,
     )?;

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1243,6 +1243,29 @@ def test_join_preserve_order_left() -> None:
         5,
     ]
 
+    right_left = left.join(
+        right, on="a", how="right", maintain_order="left"
+    ).collect()
+    print(right_left)
+    assert right_left.get_column("a").cast(pl.UInt32).to_list() == [
+        2,
+        1,
+        1,
+        None,
+        6
+    ]
+
+    right_right = left.join(
+        right, on="a", how="right", maintain_order="right"
+    ).collect()
+    assert right_right.get_column("a").cast(pl.UInt32).to_list() == [
+        1,
+        1,
+        None,
+        2,
+        6,
+    ]
+
 
 def test_join_preserve_order_full() -> None:
     left = pl.LazyFrame({"a": [None, 2, 1, 1, 5]})

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1247,13 +1247,7 @@ def test_join_preserve_order_left() -> None:
         right, on="a", how="right", maintain_order="left"
     ).collect()
     print(right_left)
-    assert right_left.get_column("a").cast(pl.UInt32).to_list() == [
-        2,
-        1,
-        1,
-        None,
-        6
-    ]
+    assert right_left.get_column("a").cast(pl.UInt32).to_list() == [2, 1, 1, None, 6]
 
     right_right = left.join(
         right, on="a", how="right", maintain_order="right"

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1243,10 +1243,7 @@ def test_join_preserve_order_left() -> None:
         5,
     ]
 
-    right_left = left.join(
-        right, on="a", how="right", maintain_order="left"
-    ).collect()
-    print(right_left)
+    right_left = left.join(right, on="a", how="right", maintain_order="left").collect()
     assert right_left.get_column("a").cast(pl.UInt32).to_list() == [2, 1, 1, None, 6]
 
     right_right = left.join(


### PR DESCRIPTION
Fixes #20350

When doing a right join the dataframes were swapped and a left join was done. For this the maintain_order argument also needs to be flipped. Thanks @rodrigogiraoserrao for catching this.