### PR TITLE
perf: Explicit transpose in new-streaming equi-join finalize

### DIFF
--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -202,7 +202,7 @@ impl BuildState {
     }
 
     fn finalize(&mut self, params: &EquiJoinParams, table: &dyn ChunkedIdxTable) -> ProbeState {
-        // Tranpose.
+        // Transpose.
         let num_workers = self.partitions_per_worker.len();
         let num_partitions = self.partitions_per_worker[0].len();
         let mut results_per_partition = (0..num_partitions)


### PR DESCRIPTION
This ensures the `Drop` happens in parallel and reduces clones which were bottlenecks.