### PR TITLE
perf(rust): Drop probe tables in parallel in new-streaming equi-join

### DIFF
--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -516,6 +516,13 @@ impl ProbeState {
     }
 }
 
+impl Drop for ProbeState {
+    fn drop(&mut self) {
+        // Parallel drop as the state might be quite big.
+        self.table_per_partition.par_drain(..).for_each(drop);
+    }
+}
+
 struct EmitUnmatchedState {
     partitions: Vec<ProbeTable>,
     active_partition_idx: usize,


### PR DESCRIPTION
This was a partial single-threaded bottleneck.