### PR TITLE
refactor(rust): Temporarily disable common subplan elim for new-streaming

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -601,11 +601,15 @@ impl LazyFrame {
             opt_state &= !OptFlags::COMM_SUBPLAN_ELIM;
         }
 
-        // The new streaming engine can't deal with the way the common
-        // subexpression elimination adds length-incorrect with_columns.
         #[cfg(feature = "cse")]
         if new_streaming {
+            // The new streaming engine can't deal with the way the common
+            // subexpression elimination adds length-incorrect with_columns.
             opt_state &= !OptFlags::COMM_SUBEXPR_ELIM;
+
+            // The new streaming engine can't yet deal with the cache nodes
+            // introduced by common subplan elimination.
+            opt_state &= !OptFlags::COMM_SUBPLAN_ELIM;
         }
 
         let lp_top = optimize(

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -195,23 +195,27 @@ def test_join_lazy_frame_on_expression() -> None:
 def test_join() -> None:
     df_left = pl.DataFrame(
         {
-            "a": ["a", "b", "c", "z"],
+            "a": ["a", "b", "a", "z"],
             "b": [1, 2, 3, 4],
             "c": [6, 5, 4, 3],
         }
     )
     df_right = pl.DataFrame(
         {
-            "a": ["b", "c", "d", "a"],
+            "a": ["b", "c", "b", "a"],
             "k": [0, 3, 9, 6],
             "c": [1, 0, 2, 1],
         }
     )
 
-    joined = df_left.join(df_right, left_on="a", right_on="a").sort("a")
+    joined = df_left.join(
+        df_right, left_on="a", right_on="a", maintain_order="left_right"
+    ).sort("a")
     assert_series_equal(joined["b"], pl.Series("b", [1, 3, 2, 2]))
 
-    joined = df_left.join(df_right, left_on="a", right_on="a", how="left").sort("a")
+    joined = df_left.join(
+        df_right, left_on="a", right_on="a", how="left", maintain_order="left_right"
+    ).sort("a")
     assert joined["c_right"].is_null().sum() == 1
     assert_series_equal(joined["b"], pl.Series("b", [1, 3, 2, 2, 4]))
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -195,14 +195,14 @@ def test_join_lazy_frame_on_expression() -> None:
 def test_join() -> None:
     df_left = pl.DataFrame(
         {
-            "a": ["a", "b", "a", "z"],
+            "a": ["a", "b", "c", "z"],
             "b": [1, 2, 3, 4],
             "c": [6, 5, 4, 3],
         }
     )
     df_right = pl.DataFrame(
         {
-            "a": ["b", "c", "b", "a"],
+            "a": ["b", "c", "d", "a"],
             "k": [0, 3, 9, 6],
             "c": [1, 0, 2, 1],
         }

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -113,12 +113,15 @@ def test_join_cross_11927() -> None:
 def test_join_inner(foods_ipc_path: Path, join_clause: str) -> None:
     foods1 = pl.scan_ipc(foods_ipc_path)
     foods2 = foods1  # noqa: F841
+    schema = foods1.collect_schema()
 
+    sort_clause = ", ".join(f'{c} ASC, "{c}:foods2" DESC' for c in schema)
     out = pl.sql(
         f"""
         SELECT *
         FROM foods1
         INNER JOIN foods2 {join_clause}
+        ORDER BY {sort_clause}
         LIMIT 2
         """,
         eager=True,
@@ -128,18 +131,17 @@ def test_join_inner(foods_ipc_path: Path, join_clause: str) -> None:
         out,
         pl.DataFrame(
             {
-                "category": ["vegetables", "vegetables"],
-                "calories": [45, 20],
-                "fats_g": [0.5, 0.0],
-                "sugars_g": [2, 2],
-                "category:foods2": ["vegetables", "vegetables"],
-                "calories:foods2": [45, 45],
-                "fats_g:foods2": [0.5, 0.5],
-                "sugars_g:foods2": [2, 2],
+                "category": ["fruit", "fruit"],
+                "calories": [30, 30],
+                "fats_g": [0.0, 0.0],
+                "sugars_g": [3, 5],
+                "category:foods2": ["fruit", "fruit"],
+                "calories:foods2": [130, 130],
+                "fats_g:foods2": [0.0, 0.0],
+                "sugars_g:foods2": [25, 25],
             }
         ),
         check_dtypes=False,
-        check_row_order=False,
     )
 
 

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -124,16 +124,23 @@ def test_join_inner(foods_ipc_path: Path, join_clause: str) -> None:
         eager=True,
     )
 
-    assert out.to_dict(as_series=False) == {
-        "category": ["vegetables", "vegetables"],
-        "calories": [45, 20],
-        "fats_g": [0.5, 0.0],
-        "sugars_g": [2, 2],
-        "category:foods2": ["vegetables", "vegetables"],
-        "calories:foods2": [45, 45],
-        "fats_g:foods2": [0.5, 0.5],
-        "sugars_g:foods2": [2, 2],
-    }
+    assert_frame_equal(
+        out,
+        pl.DataFrame(
+            {
+                "category": ["vegetables", "vegetables"],
+                "calories": [45, 20],
+                "fats_g": [0.5, 0.0],
+                "sugars_g": [2, 2],
+                "category:foods2": ["vegetables", "vegetables"],
+                "calories:foods2": [45, 45],
+                "fats_g:foods2": [0.5, 0.5],
+                "sugars_g:foods2": [2, 2],
+            }
+        ),
+        check_dtypes=False,
+        check_row_order=False,
+    )
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -647,6 +647,7 @@ def test_cse_and_schema_update_projection_pd() -> None:
 
 
 @pytest.mark.debug
+@pytest.mark.may_fail_auto_streaming
 def test_cse_predicate_self_join(capfd: Any, monkeypatch: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     y = pl.LazyFrame({"a": [1], "b": [2], "y": [3]})


### PR DESCRIPTION
The goal is to re-enable this ASAP by translating the cache nodes to multiplexer nodes (or something else), but this fixes a `todo!()` branch for now.