### PR TITLE
docs(python): Update GPU engine installation instructions to remove `--extra-index-url` from CUDA 12 packages

### DIFF
--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -20,12 +20,12 @@ You can install the GPU backend for Polars with a feature flag as part of a norm
 === ":fontawesome-brands-python: Python"
 
 ```bash
-pip install --extra-index-url=https://pypi.nvidia.com polars[gpu]
+pip install polars[gpu]
 ```
 
 !!! note Installation on a CUDA 11 system
 
-    If you have CUDA 11, the installation line is slightly more complicated: the relevant GPU package must be requested by hand.
+    If you have CUDA 11, the installation line is slightly more complicated: the relevant GPU package must be requested by hand using the NVIDIA PyPI index.
 
     === ":fontawesome-brands-python: Python"
     ```bash

--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -25,7 +25,7 @@ pip install polars[gpu]
 
 !!! note Installation on a CUDA 11 system
 
-    If you have CUDA 11, the installation line is slightly more complicated: the relevant GPU package must be requested by hand using the NVIDIA package index.
+    If you have CUDA 11, the installation line also needs the NVIDIA package index to get the CUDA 11 package.
 
     === ":fontawesome-brands-python: Python"
     ```bash

--- a/docs/source/user-guide/gpu-support.md
+++ b/docs/source/user-guide/gpu-support.md
@@ -25,7 +25,7 @@ pip install polars[gpu]
 
 !!! note Installation on a CUDA 11 system
 
-    If you have CUDA 11, the installation line is slightly more complicated: the relevant GPU package must be requested by hand using the NVIDIA PyPI index.
+    If you have CUDA 11, the installation line is slightly more complicated: the relevant GPU package must be requested by hand using the NVIDIA package index.
 
     === ":fontawesome-brands-python: Python"
     ```bash

--- a/docs/source/user-guide/installation.md
+++ b/docs/source/user-guide/installation.md
@@ -98,9 +98,7 @@ pip install 'polars[numpy,fsspec]'
 
 !!! note
 
-    To install the GPU engine, you need to pass
-    `--extra-index-url=https://pypi.nvidia.com` to `pip`. See [GPU
-    support](gpu-support.md) for more detailed instructions and
+    See [GPU support](gpu-support.md) for more detailed instructions and
     prerequisites.
 
 #### Interoperability

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2019,7 +2019,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 err_prefix="GPU engine requested, but required package",
                 install_message=(
                     "Please install using the command "
-                    "`pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu12` "
+                    "`pip install cudf-polars-cu12` "
                     "(or `pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11` "
                     "if your system has a CUDA 11 driver)."
                 ),


### PR DESCRIPTION
This PR updates the GPU engine installation instructions to reflect that CUDA 12 packages can now be installed without using the `--extra-index-url=https://pypi.nvidia.com` because the relevant packages are now available via PyPI.

`pip install polars[gpu]` will now work for CUDA 12. For CUDA 11, the extra index will still be required.