### PR TITLE
feat: Polars build for Pyodide

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -355,7 +355,6 @@ jobs:
         with:
           command: build
           target: wasm32-unknown-emscripten
-          rust-toolchain: nightly-2024-12-19
           args: >
             --profile dist-release
             --manifest-path py-polars/Cargo.toml

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -304,6 +304,71 @@ jobs:
           name: wheel-${{ matrix.package }}-${{ matrix.os }}-${{ matrix.architecture }}
           path: dist/*.whl
 
+  build-wheel-pyodide:
+    name: build-wheels (polars, pyodide, wasm32)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      # Avoid potential out-of-memory errors
+      - name: Set swap space for Linux
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Disable incompatible features
+        env:
+            FEATURES: parquet|async|json|extract_jsonpath|cloud|polars_cloud|tokio|clipboard|decompress|new_streaming
+        run: |
+          sed -i 's/^  "json",$/  "serde_json",/' crates/polars-python/Cargo.toml
+          sed -E -i "/^  \"(${FEATURES})\",$/d" crates/polars-python/Cargo.toml py-polars/Cargo.toml
+
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          # This should match the exact version of Emscripten used by Pyodide
+          version: 3.1.58
+
+      - name: Install LLVM
+        # This should match the major version of LLVM expected by Emscripten
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19
+          echo "EM_LLVM_ROOT=/usr/lib/llvm-19/bin" >> $GITHUB_ENV
+
+      - name: Set CFLAGS and RUSTFLAGS for wasm32
+        run: |
+            echo "CFLAGS=-fPIC" >> $GITHUB_ENV
+            echo "RUSTFLAGS=-C link-self-contained=no" >> $GITHUB_ENV
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: wasm32-unknown-emscripten
+          rust-toolchain: nightly-2024-12-19
+          args: >
+            --profile dist-release
+            --manifest-path py-polars/Cargo.toml
+            --interpreter python3.10
+            --out wasm-dist
+          maturin-version: 1.7.4
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-polars-emscripten-wasm32
+          path: wasm-dist/*.whl
+
   publish-to-pypi:
     needs: [create-sdist, build-wheels]
     environment:
@@ -327,7 +392,7 @@ jobs:
           verbose: true
 
   publish-to-github:
-    needs: publish-to-pypi
+    needs: [publish-to-pypi, build-wheel-pyodide]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -339,6 +404,12 @@ jobs:
         with:
           name: sdist-polars
           path: dist
+
+      - name: Download Pyodide wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-polars-emscripten-wasm32
+          path: wasm-dist
 
       - name: Get version from Cargo.toml
         id: version
@@ -372,7 +443,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.github-release.outputs.tag_name }}
-          FILES: dist/polars-*.tar.gz
+          FILES: dist/polars-*.tar.gz wasm-dist/polars-*.whl
 
       - name: Publish GitHub release
         if: inputs.dry-run == false

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           command: build
           target: wasm32-unknown-emscripten
-          rust-toolchain: nightly-2024-12-19
           args: >
             --profile dev
             --manifest-path py-polars/Cargo.toml

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -1,0 +1,71 @@
+name: Test Pyodide
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - py-polars/**
+      - docs/source/src/python/**
+      - crates/**
+      - .github/workflows/test-pyodide.yml
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.lock
+      - crates/**
+      - docs/source/src/python/**
+      - py-polars/**
+      - .github/workflows/test-pyodide.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUSTFLAGS: -C link-self-contained=no -C debuginfo=0
+  CFLAGS: -fPIC
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test-pyodide:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Disable incompatible features
+        env:
+            FEATURES: parquet|async|json|extract_jsonpath|cloud|polars_cloud|tokio|clipboard|decompress|new_streaming
+        run: |
+          sed -i 's/^  "json",$/  "serde_json",/' crates/polars-python/Cargo.toml
+          sed -E -i "/^  \"(${FEATURES})\",$/d" crates/polars-python/Cargo.toml py-polars/Cargo.toml
+
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          # This should match the exact version of Emscripten used by Pyodide
+          version: 3.1.58
+
+      - name: Install LLVM
+        # This should match the major version of LLVM expected by Emscripten
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19
+          echo "EM_LLVM_ROOT=/usr/lib/llvm-19/bin" >> $GITHUB_ENV
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: wasm32-unknown-emscripten
+          rust-toolchain: nightly-2024-12-19
+          args: >
+            --profile dev
+            --manifest-path py-polars/Cargo.toml
+            --interpreter python3.10
+          maturin-version: 1.7.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,9 +2115,12 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inventory"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+checksum = "e5d80fade88dd420ce0d9ab6f7c58ef2272dde38db874657950f827d4982c817"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ipnet"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "apache-avro"
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.10"
+version = "1.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b49afaa341e8dd8577e1a2200468f98956d6eda50bcf4a53246cc00174ba924"
+checksum = "a5d1c2c88936a73c699225d0bc00684a534166b0cebc2659c3cdf08de8edc64c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+checksum = "300a12520b4e6d08b73f77680f12c16e8ae43250d55100e0b2be46d78da16a48"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.64.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fe5e7f71b1cc6274e905d3bcc7daf94099ac2d4cba83447ffb959b5b27b3c1"
+checksum = "154488d16ab0d627d15ab2832b57e68a16684c8c902f14cb8a75ec933fc94852"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.49.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09677244a9da92172c8dc60109b4a9658597d4d298b188dd0018b6a66b410ca4"
+checksum = "74995133da38f109a0eb8e8c886f9e80c713b6e9f2e6e5a6a1ba4450ce2ffc46"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fea2f3a8bb3bd10932ae7ad59cc59f65f270fc9183a7e91f501dc5efbef7ee"
+checksum = "e7062a779685cbf3b2401eb36151e2c6589fd5f3569b8a6bc2d199e5aaa1d059"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.50.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ada54e5f26ac246dc79727def52f7f8ed38915cb47781e2a72213957dc3a7d5"
+checksum = "299dae7b1dc0ee50434453fa5a229dc4b22bd3ee50409ff16becf1f7346e0193"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.5"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -449,7 +449,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "once_cell",
  "p256",
  "percent-encoding",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+checksum = "8aa8ff1492fd9fb99ae28e8467af0dbbb7c31512b16fabf1a0f10d7bb6ef78bb"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.7"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.3"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+checksum = "431a10d0e07e09091284ef04453dae4069283aa108d209974d67e77ae1caa658"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -561,7 +561,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -581,7 +581,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -590,16 +590,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
+checksum = "8ecbf4d5dfb169812e2b240a4350f15ad3c6b03a54074e5712818801615f2dc5"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -688,9 +688,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f850665a0385e070b64c38d2354e6c104c8479c59868d1e48a0c13ee2c7a1c1"
+checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
 dependencies = [
  "autocfg",
  "libm",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
  "jobserver",
  "libc",
@@ -870,9 +870,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -931,18 +931,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clipboard-win"
@@ -1126,18 +1126,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1154,18 +1154,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -1391,9 +1391,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1433,9 +1433,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -1652,7 +1652,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http 1.2.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1760,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1787,7 +1787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1823,9 +1823,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1847,15 +1847,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1873,7 +1873,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -1883,19 +1883,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "f6884a48c6826ec44f524c7456b163cebe9e55a18d7b5e307cb4f100371cc767"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.5.1",
+ "http 1.2.0",
+ "hyper 1.5.2",
  "hyper-util",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tower-service",
 ]
 
@@ -1907,7 +1907,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1924,9 +1924,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2227,9 +2227,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libflate"
@@ -2437,9 +2437,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -2707,7 +2707,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "itertools 0.13.0",
  "md-5",
  "parking_lot",
@@ -3088,7 +3088,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum_macros",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
  "version_check",
  "xxhash-rust",
 ]
@@ -3130,7 +3130,7 @@ dependencies = [
  "polars-arrow-format",
  "regex",
  "simdutf8",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -3457,7 +3457,7 @@ dependencies = [
  "pyo3",
  "recursive",
  "serde_json",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
  "version_check",
 ]
 
@@ -3622,9 +3622,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -3778,9 +3778,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
  "tokio",
  "tracing",
 ]
@@ -3796,10 +3796,10 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3807,9 +3807,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3944,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -4024,11 +4024,11 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.7",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
- "hyper-rustls 0.27.3",
+ "hyper 1.5.2",
+ "hyper-rustls 0.27.4",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -4040,7 +4040,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -4050,7 +4050,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -4116,15 +4116,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4141,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "once_cell",
  "ring",
@@ -4174,7 +4174,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework 3.1.0",
 ]
 
 [[package]]
@@ -4197,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -4346,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.0",
@@ -4359,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4369,15 +4369,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
@@ -4393,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4751,11 +4751,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -4771,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4782,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4802,9 +4802,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4847,9 +4847,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4895,20 +4895,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.19",
- "rustls-pki-types",
+ "rustls 0.23.20",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5138,9 +5137,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5149,13 +5148,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -5164,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5177,9 +5175,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5187,9 +5185,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5200,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-streams"
@@ -5219,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5536,9 +5534,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "a08fd76779ae1883bbf1e46c2c46a75a0c4e37c445e68a24b01479d438f26ae6"
 
 [[package]]
 name = "yoke"

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -174,7 +174,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
             // }
 
             for (i, view) in views.iter().enumerate() {
-                let is_valid = validity.as_ref().map_or(true, |v| v.get_bit(i));
+                let is_valid = validity.as_ref().is_none_or(|v| v.get_bit(i));
 
                 if !is_valid {
                     continue;
@@ -600,7 +600,7 @@ impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         debug_assert!(
-            validity.as_ref().map_or(true, |v| v.len() == self.len()),
+            validity.as_ref().is_none_or(|v| v.len() == self.len()),
             "{} != {}",
             validity.as_ref().unwrap().len(),
             self.len()

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -89,7 +89,7 @@ impl FixedSizeListArray {
         let has_valid_validity = self
             .validity
             .as_ref()
-            .map_or(true, |v| v.len() == self.length);
+            .is_none_or(|v| v.len() == self.length);
 
         has_valid_length && has_valid_validity
     }

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -735,7 +735,7 @@ pub type ArrayRef = Box<dyn Array>;
 impl Splitable for Option<Bitmap> {
     #[inline(always)]
     fn check_bound(&self, offset: usize) -> bool {
-        self.as_ref().map_or(true, |v| offset <= v.len())
+        self.as_ref().is_none_or(|v| offset <= v.len())
     }
 
     unsafe fn _split_at_unchecked(&self, offset: usize) -> (Self, Self) {

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -376,7 +376,7 @@ impl<O: Offset> Utf8Array<O> {
         debug_assert!(
             validity
                 .as_ref()
-                .map_or(true, |validity| validity.len() == offsets.len_proxy()),
+                .is_none_or(|validity| validity.len() == offsets.len_proxy()),
             "validity mask length must match the number of values"
         );
         debug_assert!(

--- a/crates/polars-arrow/src/compute/take/fixed_size_list.rs
+++ b/crates/polars-arrow/src/compute/take/fixed_size_list.rs
@@ -114,7 +114,7 @@ fn arr_no_validities_recursive(arr: &dyn Array) -> bool {
         && arr
             .as_any()
             .downcast_ref::<FixedSizeListArray>()
-            .map_or(true, |x| arr_no_validities_recursive(x.values().as_ref()))
+            .is_none_or(|x| arr_no_validities_recursive(x.values().as_ref()))
 }
 
 /// `take` implementation for FixedSizeListArrays

--- a/crates/polars-compute/src/cast/utf8_to.rs
+++ b/crates/polars-compute/src/cast/utf8_to.rs
@@ -76,8 +76,10 @@ type OffsetType = i8;
 // chunks so that we don't overflow the offset u32.
 fn truncate_buffer(buf: &Buffer<u8>) -> Buffer<u8> {
     // * 2, as it must be able to hold u32::MAX offset + u32::MAX len.
-    buf.clone()
-        .sliced(0, std::cmp::min(buf.len(), OffsetType::MAX as usize * 2))
+    buf.clone().sliced(
+        0,
+        std::cmp::min(buf.len(), ((OffsetType::MAX as u64) * 2) as usize),
+    )
 }
 
 pub fn binary_to_binview<O: Offset>(arr: &BinaryArray<O>) -> BinaryViewArray {

--- a/crates/polars-compute/src/comparisons/dictionary.rs
+++ b/crates/polars-compute/src/comparisons/dictionary.rs
@@ -13,8 +13,8 @@ impl<K: DictionaryKey> TotalEqKernel for DictionaryArray<K> {
         let mut bitmap = MutableBitmap::with_capacity(self.len());
 
         for i in 0..self.len() {
-            let lval = self.validity().map_or(true, |v| v.get(i).unwrap());
-            let rval = other.validity().map_or(true, |v| v.get(i).unwrap());
+            let lval = self.validity().is_none_or(|v| v.get(i).unwrap());
+            let rval = other.validity().is_none_or(|v| v.get(i).unwrap());
 
             if !lval || !rval {
                 bitmap.push(true);
@@ -42,8 +42,8 @@ impl<K: DictionaryKey> TotalEqKernel for DictionaryArray<K> {
         let mut bitmap = MutableBitmap::with_capacity(self.len());
 
         for i in 0..self.len() {
-            let lval = self.validity().map_or(true, |v| v.get(i).unwrap());
-            let rval = other.validity().map_or(true, |v| v.get(i).unwrap());
+            let lval = self.validity().is_none_or(|v| v.get(i).unwrap());
+            let rval = other.validity().is_none_or(|v| v.get(i).unwrap());
 
             if !lval || !rval {
                 bitmap.push(false);

--- a/crates/polars-compute/src/comparisons/list.rs
+++ b/crates/polars-compute/src/comparisons/list.rs
@@ -27,8 +27,8 @@ macro_rules! compare {
 
                 (0..$lhs.len())
                     .map(|i| {
-                        let lval = $lhs.validity().map_or(true, |v| v.get(i).unwrap());
-                        let rval = $rhs.validity().map_or(true, |v| v.get(i).unwrap());
+                        let lval = $lhs.validity().is_none_or(|v| v.get(i).unwrap());
+                        let rval = $rhs.validity().is_none_or(|v| v.get(i).unwrap());
 
                         if !lval || !rval {
                             return $invalid_rv;
@@ -126,7 +126,7 @@ macro_rules! compare_broadcast {
 
                 (0..length)
                     .map(move |i| {
-                        let v = $validity.map_or(true, |v| v.get(i).unwrap());
+                        let v = $validity.is_none_or(|v| v.get(i).unwrap());
 
                         if !v {
                             return $invalid_rv;

--- a/crates/polars-compute/src/comparisons/struct_.rs
+++ b/crates/polars-compute/src/comparisons/struct_.rs
@@ -27,7 +27,7 @@ impl TotalEqKernel for StructArray {
         for i in 0..lhs.len() {
             let mut is_equal = true;
 
-            if !ln.map_or(true, |v| v.get(i).unwrap()) || !rn.map_or(true, |v| v.get(i).unwrap()) {
+            if !ln.is_none_or(|v| v.get(i).unwrap()) || !rn.is_none_or(|v| v.get(i).unwrap()) {
                 bitmap.push(true);
                 continue;
             }
@@ -74,7 +74,7 @@ impl TotalEqKernel for StructArray {
         for i in 0..lhs.len() {
             let mut is_equal = true;
 
-            if !ln.map_or(true, |v| v.get(i).unwrap()) || !rn.map_or(true, |v| v.get(i).unwrap()) {
+            if !ln.is_none_or(|v| v.get(i).unwrap()) || !rn.is_none_or(|v| v.get(i).unwrap()) {
                 bitmap.push(false);
                 continue;
             }

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -660,7 +660,7 @@ where
                 .downcast_ref::<ListArray<i64>>()
                 .unwrap();
 
-            if !right.validity().map_or(true, |v| v.get(0).unwrap()) {
+            if !right.validity().is_none_or(|v| v.get(0).unwrap()) {
                 if missing {
                     if is_ne {
                         return lhs.is_not_null();
@@ -692,7 +692,7 @@ where
                 .downcast_ref::<ListArray<i64>>()
                 .unwrap();
 
-            if !left.validity().map_or(true, |v| v.get(0).unwrap()) {
+            if !left.validity().is_none_or(|v| v.get(0).unwrap()) {
                 if missing {
                     if is_ne {
                         return rhs.is_not_null();
@@ -912,7 +912,7 @@ where
                 .downcast_ref::<FixedSizeListArray>()
                 .unwrap();
 
-            if !right.validity().map_or(true, |v| v.get(0).unwrap()) {
+            if !right.validity().is_none_or(|v| v.get(0).unwrap()) {
                 if missing {
                     if is_ne {
                         return lhs.is_not_null();
@@ -939,7 +939,7 @@ where
                 .downcast_ref::<FixedSizeListArray>()
                 .unwrap();
 
-            if !left.validity().map_or(true, |v| v.get(0).unwrap()) {
+            if !left.validity().is_none_or(|v| v.get(0).unwrap()) {
                 if missing {
                     if is_ne {
                         return rhs.is_not_null();

--- a/crates/polars-core/src/lib.rs
+++ b/crates/polars-core/src/lib.rs
@@ -64,7 +64,16 @@ pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
         .expect("could not spawn threads")
 });
 
-#[cfg(target_family = "wasm")] // instead use this on wasm targets
+#[cfg(all(target_os = "emscripten", target_family = "wasm"))] // Use 1 rayon thread on emscripten
+pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
+    ThreadPoolBuilder::new()
+        .num_threads(1)
+        .use_current_thread()
+        .build()
+        .expect("could not create pool")
+});
+
+#[cfg(all(not(target_os = "emscripten"), target_family = "wasm"))] // use this on other wasm targets
 pub static POOL: Lazy<polars_utils::wasm::Pool> = Lazy::new(|| polars_utils::wasm::Pool);
 
 // utility for the tests to ensure a single thread can execute

--- a/crates/polars-core/src/series/ops/reshape.rs
+++ b/crates/polars-core/src/series/ops/reshape.rs
@@ -239,7 +239,7 @@ impl Series {
         match dimensions.len() {
             1 => {
                 polars_ensure!(
-                    dimensions[0].get().map_or(true, |dim| dim as usize == s_ref.len()),
+                    dimensions[0].get().is_none_or( |dim| dim as usize == s_ref.len()),
                     InvalidOperation: "cannot reshape len {} into shape {:?}", s_ref.len(), dimensions,
                 );
                 Ok(s_ref.clone())

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -94,7 +94,7 @@ impl Nested {
             debug_assert!(self
                 .validity
                 .as_ref()
-                .map_or(true, |v| v.len() == self.length));
+                .is_none_or(|v| v.len() == self.length));
         }
 
         self.num_valids = 0;
@@ -102,7 +102,7 @@ impl Nested {
 
         match self.content {
             NestedContent::Primitive => {
-                debug_assert!(self.validity.map_or(true, |validity| validity.is_empty()));
+                debug_assert!(self.validity.is_none_or(|validity| validity.is_empty()));
                 (self.length, Vec::new(), None)
             },
             NestedContent::List { offsets } => (self.length, offsets, self.validity),

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -72,10 +72,10 @@ where
             )));
         };
         let s = match exponent_value.to_f64().unwrap() {
-            a if a == 1.0 => base.clone().into_column(),
+            1.0 => base.clone().into_column(),
             // specialized sqrt will ensure (-inf)^0.5 = NaN
             // and will likely be faster as well.
-            a if a == 0.5 => base.apply_values(|v| v.sqrt()).into_column(),
+            0.5 => base.apply_values(|v| v.sqrt()).into_column(),
             a if a.fract() == 0.0 && a < 10.0 && a > 1.0 => {
                 let mut out = base.clone();
 

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -296,7 +296,7 @@ fn resolve_join_where(
             let mut iter =
                 expr_to_leaf_column_names_iter(left).chain(expr_to_leaf_column_names_iter(right));
             iter.all(|name| {
-                schema.contains(name.as_str()) && other.map_or(true, |s| !s.contains(name.as_str()))
+                schema.contains(name.as_str()) && other.is_none_or(|s| !s.contains(name.as_str()))
             })
         }
 

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -3,6 +3,7 @@ use std::io::BufWriter;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+#[cfg(feature = "cloud")]
 use cloud::credential_provider::PlCredentialProvider;
 #[cfg(feature = "avro")]
 use polars::io::avro::AvroCompression;
@@ -22,7 +23,9 @@ use crate::file::{
     get_either_file, get_file_like, get_mmap_bytes_reader, get_mmap_bytes_reader_and_path,
     EitherRustPythonFile,
 };
-use crate::prelude::{parse_cloud_options, PyCompatLevel};
+#[cfg(feature = "cloud")]
+use crate::prelude::parse_cloud_options;
+use crate::prelude::PyCompatLevel;
 
 #[pymethods]
 impl PyDataFrame {
@@ -365,6 +368,7 @@ impl PyDataFrame {
     ) -> PyResult<()> {
         let null = null_value.unwrap_or_default();
 
+        #[cfg(feature = "cloud")]
         let cloud_options = if let Ok(path) = py_f.extract::<Cow<str>>(py) {
             let cloud_options = parse_cloud_options(&path, cloud_options.unwrap_or_default())?;
             Some(
@@ -377,6 +381,9 @@ impl PyDataFrame {
         } else {
             None
         };
+
+        #[cfg(not(feature = "cloud"))]
+        let cloud_options = None;
 
         let f = crate::file::try_get_writeable(py_f, cloud_options.as_ref())?;
 
@@ -450,6 +457,7 @@ impl PyDataFrame {
             return Ok(());
         };
 
+        #[cfg(feature = "cloud")]
         let cloud_options = if let Ok(path) = py_f.extract::<Cow<str>>(py) {
             let cloud_options = parse_cloud_options(&path, cloud_options.unwrap_or_default())?;
             Some(
@@ -462,6 +470,9 @@ impl PyDataFrame {
         } else {
             None
         };
+
+        #[cfg(not(feature = "cloud"))]
+        let cloud_options = None;
 
         let f = crate::file::try_get_writeable(py_f, cloud_options.as_ref())?;
 
@@ -518,6 +529,7 @@ impl PyDataFrame {
         credential_provider: Option<PyObject>,
         retries: usize,
     ) -> PyResult<()> {
+        #[cfg(feature = "cloud")]
         let cloud_options = if let Ok(path) = py_f.extract::<Cow<str>>(py) {
             let cloud_options = parse_cloud_options(&path, cloud_options.unwrap_or_default())?;
             Some(
@@ -530,6 +542,9 @@ impl PyDataFrame {
         } else {
             None
         };
+
+        #[cfg(not(feature = "cloud"))]
+        let cloud_options = None;
 
         let f = crate::file::try_get_writeable(py_f, cloud_options.as_ref())?;
 

--- a/crates/polars-python/src/lazyframe/exitable.rs
+++ b/crates/polars-python/src/lazyframe/exitable.rs
@@ -6,6 +6,7 @@ use crate::error::PyPolarsErr;
 use crate::PyDataFrame;
 
 #[pymethods]
+#[cfg(not(target_arch = "wasm32"))]
 impl PyLazyFrame {
     fn collect_concurrently(&self, py: Python) -> PyResult<PyInProcessQuery> {
         let ipq = py.allow_threads(|| {
@@ -17,6 +18,7 @@ impl PyLazyFrame {
 }
 
 #[pyclass]
+#[cfg(not(target_arch = "wasm32"))]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyInProcessQuery {
@@ -24,6 +26,7 @@ pub struct PyInProcessQuery {
 }
 
 #[pymethods]
+#[cfg(not(target_arch = "wasm32"))]
 impl PyInProcessQuery {
     pub fn cancel(&self, py: Python) {
         py.allow_threads(|| self.ipq.cancel())

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -155,6 +155,7 @@ impl PyLazyFrame {
         file_cache_ttl: Option<u64>,
         include_file_paths: Option<String>,
     ) -> PyResult<Self> {
+        #[cfg(feature = "cloud")]
         use cloud::credential_provider::PlCredentialProvider;
 
         let null_values = null_values.map(|w| w.0);
@@ -371,6 +372,7 @@ impl PyLazyFrame {
         file_cache_ttl: Option<u64>,
         include_file_paths: Option<String>,
     ) -> PyResult<Self> {
+        #[cfg(feature = "cloud")]
         use cloud::credential_provider::PlCredentialProvider;
         let row_index = row_index.map(|(name, offset)| RowIndex {
             name: name.into(),
@@ -389,7 +391,6 @@ impl PyLazyFrame {
             cache,
             rechunk,
             row_index,
-            #[cfg(feature = "cloud")]
             cloud_options: None,
             hive_options,
             include_file_paths: include_file_paths.map(|x| x.into()),
@@ -740,6 +741,7 @@ impl PyLazyFrame {
             maintain_order,
         };
 
+        #[cfg(feature = "cloud")]
         let cloud_options = {
             let cloud_options =
                 parse_cloud_options(path.to_str().unwrap(), cloud_options.unwrap_or_default())?;
@@ -751,6 +753,9 @@ impl PyLazyFrame {
                     ),
             )
         };
+
+        #[cfg(not(feature = "cloud"))]
+        let cloud_options = None;
 
         // if we don't allow threads and we have udfs trying to acquire the gil from different
         // threads we deadlock.
@@ -814,6 +819,7 @@ impl PyLazyFrame {
             serialize_options,
         };
 
+        #[cfg(feature = "cloud")]
         let cloud_options = {
             let cloud_options =
                 parse_cloud_options(path.to_str().unwrap(), cloud_options.unwrap_or_default())?;
@@ -825,6 +831,9 @@ impl PyLazyFrame {
                     ),
             )
         };
+
+        #[cfg(not(feature = "cloud"))]
+        let cloud_options = None;
 
         // if we don't allow threads and we have udfs trying to acquire the gil from different
         // threads we deadlock.

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -6,6 +6,7 @@ mod serde;
 pub mod visit;
 pub mod visitor;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use exitable::PyInProcessQuery;
 use polars::prelude::LazyFrame;
 use pyo3::pyclass;

--- a/crates/polars-python/src/series/numpy_ufunc.rs
+++ b/crates/polars-python/src/series/numpy_ufunc.rs
@@ -56,11 +56,11 @@ unsafe fn aligned_array<T: Element + NativeType>(
 ///   - For PyPy: Reference counters for a live PyPy object = refcnt + 2 << 60.
 fn get_refcnt<T>(pyarray: &Bound<'_, PyArray1<T>>) -> isize {
     let refcnt = pyarray.get_refcnt();
+    #[cfg(target_pointer_width = "64")]
     if refcnt >= (2 << 60) {
-        refcnt - (2 << 60)
-    } else {
-        refcnt
+        return refcnt - (2 << 60);
     }
+    refcnt
 }
 
 macro_rules! impl_ufuncs {

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1117,7 +1117,7 @@ impl SQLContext {
         order_by: &Option<OrderBy>,
         selected: Option<&[Expr]>,
     ) -> PolarsResult<LazyFrame> {
-        if order_by.as_ref().map_or(true, |ob| ob.exprs.is_empty()) {
+        if order_by.as_ref().is_none_or(|ob| ob.exprs.is_empty()) {
             return Ok(lf);
         }
         let schema = self.get_frame_schema(&mut lf)?;

--- a/crates/polars-utils/src/sort.rs
+++ b/crates/polars-utils/src/sort.rs
@@ -20,7 +20,7 @@ use crate::IdxSize;
 ///
 /// # Safety
 /// The caller must ensure that the right indexes for `&[(_, IdxSize)]` are integers ranging from `0..idx.len`
-#[cfg(not(target_family = "wasm"))]
+#[cfg(any(target_os = "emscripten", not(target_family = "wasm")))]
 pub unsafe fn perfect_sort(pool: &ThreadPool, idx: &[(IdxSize, IdxSize)], out: &mut Vec<IdxSize>) {
     let chunk_size = std::cmp::max(
         idx.len() / pool.current_num_threads(),
@@ -47,7 +47,7 @@ pub unsafe fn perfect_sort(pool: &ThreadPool, idx: &[(IdxSize, IdxSize)], out: &
 }
 
 // wasm alternative with different signature
-#[cfg(target_family = "wasm")]
+#[cfg(all(not(target_os = "emscripten"), target_family = "wasm"))]
 pub unsafe fn perfect_sort(
     pool: &crate::wasm::Pool,
     idx: &[(IdxSize, IdxSize)],

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -14,11 +14,11 @@ polars = { workspace = true }
 polars-python = { workspace = true, features = ["pymethods", "iejoin"] }
 pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "extension-module", "multiple-pymethods"] }
 
-[target.'cfg(all(any(not(target_family = "unix"), allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
+[target.'cfg(all(any(not(target_family = "unix"), target_os = "emscripten", allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 
 # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).
-[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
+[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
 jemallocator = { version = "0.5", features = ["disable_initial_exec_tls", "background_threads"] }
 
 [target.'cfg(all(target_family = "unix", target_os = "macos", not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]

--- a/py-polars/src/allocator.rs
+++ b/py-polars/src/allocator.rs
@@ -1,5 +1,6 @@
 #[cfg(all(
     target_family = "unix",
+    not(target_os = "emscripten"),
     not(allocator = "default"),
     not(allocator = "mimalloc"),
 ))]
@@ -7,13 +8,18 @@ use jemallocator::Jemalloc;
 #[cfg(all(
     not(debug_assertions),
     not(allocator = "default"),
-    any(not(target_family = "unix"), allocator = "mimalloc"),
+    any(
+        not(target_family = "unix"),
+        target_os = "emscripten",
+        allocator = "mimalloc"
+    ),
 ))]
 use mimalloc::MiMalloc;
 
 #[cfg(all(
     debug_assertions,
     target_family = "unix",
+    not(target_os = "emscripten"),
     not(allocator = "default"),
     not(allocator = "mimalloc"),
 ))]
@@ -25,6 +31,7 @@ use crate::memory::TracemallocAllocator;
     not(allocator = "mimalloc"),
     not(allocator = "default"),
     target_family = "unix",
+    not(target_os = "emscripten"),
 ))]
 static ALLOC: Jemalloc = Jemalloc;
 
@@ -32,7 +39,11 @@ static ALLOC: Jemalloc = Jemalloc;
 #[cfg(all(
     not(debug_assertions),
     not(allocator = "default"),
-    any(not(target_family = "unix"), allocator = "mimalloc"),
+    any(
+        not(target_family = "unix"),
+        target_os = "emscripten",
+        allocator = "mimalloc"
+    ),
 ))]
 static ALLOC: MiMalloc = MiMalloc;
 
@@ -44,6 +55,7 @@ static ALLOC: MiMalloc = MiMalloc;
 #[cfg(all(
     debug_assertions,
     target_family = "unix",
+    not(target_os = "emscripten"),
     not(allocator = "default"),
     not(allocator = "mimalloc"),
 ))]

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -15,7 +15,9 @@ use polars_python::cloud;
 use polars_python::dataframe::PyDataFrame;
 use polars_python::expr::PyExpr;
 use polars_python::functions::PyStringCacheHolder;
-use polars_python::lazyframe::{PyInProcessQuery, PyLazyFrame};
+#[cfg(not(target_arch = "wasm32"))]
+use polars_python::lazyframe::PyInProcessQuery;
+use polars_python::lazyframe::PyLazyFrame;
 use polars_python::lazygroupby::PyLazyGroupBy;
 use polars_python::series::PySeries;
 #[cfg(feature = "sql")]
@@ -87,6 +89,7 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PySeries>().unwrap();
     m.add_class::<PyDataFrame>().unwrap();
     m.add_class::<PyLazyFrame>().unwrap();
+    #[cfg(not(target_arch = "wasm32"))]
     m.add_class::<PyInProcessQuery>().unwrap();
     m.add_class::<PyLazyGroupBy>().unwrap();
     m.add_class::<PyExpr>().unwrap();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-11-28"
+channel = "nightly-2024-12-19"


### PR DESCRIPTION
Hi @ritchie46 , it was nice chatting to you recently.

As discussed, here is all the work so far for building a Polars wheel for Pyodide. As an update from when we spoke last: the required changes to LLVM have now hit nightly Rust and the `inventory` crate, so this should work from LLVM 19.1.6 and Rust `nightly-2024-12-19` onwards. In the new CI for this PR, I have fixed the version of Rust nightly, but I believe after the next `stable` Rust release the pin can be dropped.

The PR makes a few changes, summarised below:

1) A couple of modifications have been made to deal with `wasm32`'s native 32bit pointer width and using `mimalloc` under the `emscripten` OS (corresponding to Pyodide).

2) For the `emscripten` OS I setup the thread pool to use a single thread. Use of threads on Emscripten in combination with dynamic libraries is still a little shaky/experimental, and so this keeps things simple for now.

2b. For related reasons `PyInProcessQuery` is disabled for now when running under Pyodide.

3. I added a new "Test Pyodide" CI workflow. Currently it just "tests" by attempting to build the Pyodide wheel. Eventually we might want to load the wheel into Pyodide using `node` and run some real tests. I also added a new step in the "Release Python" workflow that builds the Pyodide wheel and adds it to a GitHub release. I would have just uploaded to PyPI with the other binaries but my understanding is that this does not work yet for Pyodide wheels.

3a. A set of features has been disabled when building for Pyodide in CI. Eventually we'd like to bring these back, but at the moment they pull in Rust dependencies that break the build. I expect this can all be improved except for the `cloud` related features, which might be difficult to get working in the Wasm sandbox.

3b. In a few places `#[cfg(feature = "cloud")]` has been added to conditionally compile some cloud-related code.

3c. In CI I disable the features using a janky `sed`, this might be doable entirely using `Cargo.toml` but I wasn't able to figure it out.

I have another copy of this branch, so if you'd like to make any further changes before merging please feel absolutely free to push extra commits directly to this PR branch.

If you'd like to experiment with the resulting Pyodide wheel, there's a copy available at https://github.com/georgestagg/polars/releases/tag/py-1.17.1 on my fork.
