### PR TITLE
refactor(rust): Remove unused IR::Reduce node

### DIFF
--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -212,11 +212,6 @@ pub(crate) fn insert_streaming_nodes(
                 state.operators_sinks.push(PipelineNode::Operator(root));
                 stack.push(StackFrame::new(*input, state, current_idx))
             },
-            Reduce { input, .. } => {
-                state.streamable = true;
-                state.operators_sinks.push(PipelineNode::Sink(root));
-                stack.push(StackFrame::new(*input, state, current_idx))
-            },
             // Rechunks are ignored
             MapFunction {
                 input,

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -426,20 +426,6 @@ fn create_physical_plan_impl(
                 allow_vertical_parallelism,
             }))
         },
-        Reduce {
-            exprs,
-            input,
-            schema,
-        } => {
-            let select = Select {
-                input,
-                expr: exprs,
-                schema,
-                options: Default::default(),
-            };
-            let node = lp_arena.add(select);
-            create_physical_plan(node, lp_arena, expr_arena)
-        },
         DataFrameScan {
             df,
             filter: predicate,

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -333,13 +333,6 @@ where
             let slice = SliceSink::new(*offset as u64, *len as usize, input_schema.into_owned());
             Box::new(slice) as Box<dyn SinkTrait>
         },
-        Reduce {
-            input: _,
-            exprs: _,
-            schema: _,
-        } => {
-            todo!()
-        },
         Sort {
             input,
             by_column,

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -130,15 +130,6 @@ impl IR {
                     options,
                 }
             },
-            IR::Reduce { exprs, input, .. } => {
-                let i = convert_to_lp(input, lp_arena);
-                let expr = expr_irs_to_exprs(exprs, expr_arena);
-                DslPlan::Select {
-                    expr,
-                    input: Arc::new(i),
-                    options: Default::default(),
-                }
-            },
             IR::SimpleProjection { input, columns } => {
                 let input = convert_to_lp(input, lp_arena);
                 let expr = columns

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -199,11 +199,6 @@ impl<'a> IRDotDisplay<'a> {
                 self.with_root(*input)._format(f, Some(id), last)?;
                 write_label(f, id, |f| write!(f, "WITH COLUMNS {exprs}"))?;
             },
-            Reduce { input, exprs, .. } => {
-                let exprs = self.display_exprs(exprs);
-                self.with_root(*input)._format(f, Some(id), last)?;
-                write_label(f, id, |f| write!(f, "REDUCE {exprs}"))?;
-            },
             Slice { input, offset, len } => {
                 self.with_root(*input)._format(f, Some(id), last)?;
                 write_label(f, id, |f| write!(f, "SLICE offset: {offset}; len: {len}"))?;

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -284,13 +284,6 @@ impl<'a> IRDisplay<'a> {
                     selection,
                 )
             },
-            Reduce { input, exprs, .. } => {
-                // @NOTE: Maybe there should be a clear delimiter here?
-                let default_exprs = self.display_expr_slice(exprs);
-
-                write!(f, "{:indent$} REDUCE {default_exprs} FROM", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
             Select { expr, input, .. } => {
                 // @NOTE: Maybe there should be a clear delimiter here?
                 let exprs = self.display_expr_slice(expr);

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -30,11 +30,6 @@ impl IR {
                 input: inputs[0],
                 predicate: exprs.pop().unwrap(),
             },
-            Reduce { schema, .. } => Reduce {
-                input: inputs[0],
-                exprs,
-                schema: schema.clone(),
-            },
             Select {
                 schema, options, ..
             } => Select {
@@ -169,7 +164,6 @@ impl IR {
             Slice { .. } | Cache { .. } | Distinct { .. } | Union { .. } | MapFunction { .. } => {},
             Sort { by_column, .. } => container.extend_from_slice(by_column),
             Filter { predicate, .. } => container.push(predicate.clone()),
-            Reduce { exprs, .. } => container.extend_from_slice(exprs),
             Select { expr, .. } => container.extend_from_slice(expr),
             GroupBy { keys, aggs, .. } => {
                 let iter = keys.iter().cloned().chain(aggs.iter().cloned());
@@ -229,7 +223,6 @@ impl IR {
             Slice { input, .. } => *input,
             Filter { input, .. } => *input,
             Select { input, .. } => *input,
-            Reduce { input, .. } => *input,
             SimpleProjection { input, .. } => *input,
             Sort { input, .. } => *input,
             Cache { input, .. } => *input,

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -81,12 +81,6 @@ pub enum IR {
         input: Node,
         columns: SchemaRef,
     },
-    // Special case of `select` where all operations reduce to a single row.
-    Reduce {
-        input: Node,
-        exprs: Vec<ExprIR>,
-        schema: SchemaRef,
-    },
     // Polars' `select` operation. This may access full materialized data.
     Select {
         input: Node,

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -25,7 +25,6 @@ impl IR {
             Filter { .. } => "selection",
             DataFrameScan { .. } => "df",
             Select { .. } => "projection",
-            Reduce { .. } => "reduce",
             Sort { .. } => "sort",
             Cache { .. } => "cache",
             GroupBy { .. } => "aggregate",
@@ -83,7 +82,6 @@ impl IR {
             } => output_schema.as_ref().unwrap_or(schema),
             Filter { input, .. } => return arena.get(*input).schema(arena),
             Select { schema, .. } => schema,
-            Reduce { schema, .. } => schema,
             SimpleProjection { columns, .. } => columns,
             GroupBy { schema, .. } => schema,
             Join { schema, .. } => schema,
@@ -144,7 +142,6 @@ impl IR {
                 ..
             } => output_schema.as_ref().unwrap_or(schema).clone(),
             Select { schema, .. }
-            | Reduce { schema, .. }
             | GroupBy { schema, .. }
             | Join { schema, .. }
             | HStack { schema, .. }

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -312,14 +312,6 @@ impl<'a> TreeFmtNode<'a> {
                             .chain([self.lp_node(None, *input)])
                             .collect(),
                     ),
-                    Reduce { input, exprs, .. } => ND(
-                        wh(h, "REDUCE"),
-                        exprs
-                            .iter()
-                            .map(|expr| self.expr_node(Some("expression:".to_string()), expr))
-                            .chain([self.lp_node(None, *input)])
-                            .collect(),
-                    ),
                     Distinct { input, options } => ND(
                         wh(
                             h,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -693,7 +693,6 @@ impl PredicatePushDown<'_> {
             },
             lp @ HStack { .. }
             | lp @ Select { .. }
-            | lp @ Reduce { .. }
             | lp @ SimpleProjection { .. }
             | lp @ ExtContext { .. } => {
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, true)

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -334,8 +334,6 @@ impl ProjectionPushDown {
         use IR::*;
 
         match logical_plan {
-            // Should not yet be here
-            Reduce { .. } => unreachable!(),
             Select { expr, input, .. } => process_projection(
                 self,
                 input,

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -110,13 +110,6 @@ impl Hash for HashableEqLP<'_> {
                 hash_exprs(expr, self.expr_arena, state);
                 options.hash(state);
             },
-            IR::Reduce {
-                input: _,
-                exprs,
-                schema: _,
-            } => {
-                hash_exprs(exprs, self.expr_arena, state);
-            },
             IR::Sort {
                 input: _,
                 by_column,

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -504,15 +504,6 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             should_broadcast: options.should_broadcast,
         }
         .into_py_any(py),
-        IR::Reduce {
-            input,
-            exprs,
-            schema: _,
-        } => Reduce {
-            input: input.0,
-            exprs: exprs.iter().map(|e| e.into()).collect(),
-        }
-        .into_py_any(py),
         IR::Distinct { input, options } => Distinct {
             input: input.0,
             options: (

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -431,7 +431,6 @@ pub fn lower_ir(
 
         #[cfg(feature = "python")]
         IR::PythonScan { .. } => todo!(),
-        IR::Reduce { .. } => todo!(),
         IR::Cache { .. } => todo!(),
         IR::GroupBy {
             input,


### PR DESCRIPTION
This was intended as a special case for `select` which only returns a single row but physical planners can already inspect the expressions in a `select` to determine whether this is the case regardless.