### PR TITLE
fix(python): Fix plotting f-strings and docstrings

### DIFF
--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -114,6 +114,7 @@ class DataFramePlot:
         Polars does not implement plotting logic itself but instead defers to
         `Altair <https://altair-viz.github.io/>`_.
 
+        `df.plot.line(**kwargs)` is shorthand for
         `alt.Chart(df).mark_line().encode(**kwargs).interactive()`,
         and is provided for convenience - for full customisatibility, use a plotting
         library directly.
@@ -238,7 +239,7 @@ class DataFramePlot:
     def __getattr__(self, attr: str) -> Callable[..., alt.Chart]:
         method = getattr(self._chart, f"mark_{attr}", None)
         if method is None:
-            msg = "Altair has no method 'mark_{attr}'"
+            msg = f"Altair has no method 'mark_{attr}'"
             raise AttributeError(msg)
 
         accepts_tooltip_argument = "tooltip" in {

--- a/py-polars/polars/series/plotting.py
+++ b/py-polars/polars/series/plotting.py
@@ -150,7 +150,7 @@ class SeriesPlot:
         Examples
         --------
         >>> s = pl.Series("price", [1, 3, 3, 3, 5, 2, 6, 5, 5, 5, 7])
-        >>> s.plot.kde()  # doctest: +SKIP
+        >>> s.plot.line()  # doctest: +SKIP
         """  # noqa: W505
         if self._series_name == "index":
             msg = "Cannot call `plot.line` when Series name is 'index'"
@@ -165,14 +165,14 @@ class SeriesPlot:
 
     def __getattr__(self, attr: str) -> Callable[..., alt.Chart]:
         if self._series_name == "index":
-            msg = "Cannot call `plot.{attr}` when Series name is 'index'"
+            msg = f"Cannot call `plot.{attr}` when Series name is 'index'"
             raise ValueError(msg)
         if attr == "scatter":
             # alias `scatter` to `point` because of how common it is
             attr = "point"
         method = getattr(alt.Chart(self._df.with_row_index()), f"mark_{attr}", None)
         if method is None:
-            msg = "Altair has no method 'mark_{attr}'"
+            msg = f"Altair has no method 'mark_{attr}'"
             raise AttributeError(msg)
         encodings: Encodings = {"x": "index", "y": self._series_name}
 


### PR DESCRIPTION
- Add missing `f` prefixes for f-strings
- Add missing line in docstring of `DataFrame.plot.line`
- Fix typo in docstring of `Series.plot.line` examples section

Closes #18475