### PR TITLE
docs(rust): Fix "forcolumnar" typo in docs

### DIFF
--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Polars is a DataFrame library for Rust. It is based on [Apache Arrow](https://arrow.apache.org/)'s memory model.
 //! Apache Arrow provides very cache efficient columnar data structures and is becoming the defacto
-//! standard forcolumnar data.
+//! standard for columnar data.
 //!
 //! ## Quickstart
 //! We recommend building queries directly with [polars-lazy]. This allows you to combine


### PR DESCRIPTION
There was a missing space in between "for" and "columnar"