### PR TITLE
fix(python): Fix return type of `Series.dt.add_business_days`

### DIFF
--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -44,7 +44,7 @@ class DateTimeNameSpace:
         week_mask: Iterable[bool] = (True, True, True, True, True, False, False),
         holidays: Iterable[dt.date] = (),
         roll: Roll = "raise",
-    ) -> Expr:
+    ) -> Series:
         """
         Offset by `n` business days.
 


### PR DESCRIPTION
The return type of `Series.dt.add_business_days` should be `Series`, not `Expr`

```python
>>> import polars as pl
>>> import datetime

>>> type(
    pl.Series("date", [datetime.date(2024, 12, 23)]).dt.add_business_days(
        1, roll="forward"
    )
)
<class 'polars.series.series.Series'>
```