### PR TITLE
docs: Fix `Expr.all` description of Kleene logic

### DIFF
--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1801,7 +1801,7 @@ impl Expr {
     /// Returns whether all values in the column are `true`.
     ///
     /// If `ignore_nulls` is `False`, [Kleene logic] is used to deal with nulls:
-    /// if the column contains any null values and no `true` values, the output
+    /// if the column contains any null values and no `false` values, the output
     /// is null.
     ///
     /// [Kleene logic]: https://en.wikipedia.org/wiki/Three-valued_logic

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -516,7 +516,7 @@ class Expr:
             Ignore null values (default).
 
             If set to `False`, `Kleene logic`_ is used to deal with nulls:
-            if the column contains any null values and no `True` values,
+            if the column contains any null values and no `False` values,
             the output is null.
 
             .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic


### PR DESCRIPTION
closes #17373