### PR TITLE
fix: Fix incorrectly added sorted flag after append for lexically ordered categorical series

### DIFF
--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -833,6 +833,15 @@ def test_cat_append_lexical_sorted_flag() -> None:
 
     assert not (df2["y"].is_sorted())
 
+    s = pl.Series("a", ["z", "k", "a"], pl.Categorical("lexical"))
+    s1 = s[[0]]
+    s2 = s[[1]]
+    s3 = s[[2]]
+    s1.append(s2)
+    s1.append(s3)
+
+    assert not (s1.is_sorted())
+
 
 def test_get_cat_categories_multiple_chunks() -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
After doing merge operation, the physical representation might get the sorted flag set. For lexical ordering we should not be setting this flag at all. Have added a small check which ensures that this flag is not set.
Fixes #19900 .