### PR TITLE
fix(python): Properly raise UDF errors

### DIFF
--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -555,14 +555,14 @@ impl PyDataFrame {
             use apply_lambda_with_primitive_out_type as apply;
             #[rustfmt::skip]
             let out = match output_type.map(|dt| dt.0) {
-                Some(DataType::Int32) => apply::<Int32Type>(df, py, lambda, 0, None).into_series(),
-                Some(DataType::Int64) => apply::<Int64Type>(df, py, lambda, 0, None).into_series(),
-                Some(DataType::UInt32) => apply::<UInt32Type>(df, py, lambda, 0, None).into_series(),
-                Some(DataType::UInt64) => apply::<UInt64Type>(df, py, lambda, 0, None).into_series(),
-                Some(DataType::Float32) => apply::<Float32Type>(df, py, lambda, 0, None).into_series(),
-                Some(DataType::Float64) => apply::<Float64Type>(df, py, lambda, 0, None).into_series(),
-                Some(DataType::Date) => apply::<Int32Type>(df, py, lambda, 0, None).into_date().into_series(),
-                Some(DataType::Datetime(tu, tz)) => apply::<Int64Type>(df, py, lambda, 0, None).into_datetime(tu, tz).into_series(),
+                Some(DataType::Int32) => apply::<Int32Type>(df, py, lambda, 0, None)?.into_series(),
+                Some(DataType::Int64) => apply::<Int64Type>(df, py, lambda, 0, None)?.into_series(),
+                Some(DataType::UInt32) => apply::<UInt32Type>(df, py, lambda, 0, None)?.into_series(),
+                Some(DataType::UInt64) => apply::<UInt64Type>(df, py, lambda, 0, None)?.into_series(),
+                Some(DataType::Float32) => apply::<Float32Type>(df, py, lambda, 0, None)?.into_series(),
+                Some(DataType::Float64) => apply::<Float64Type>(df, py, lambda, 0, None)?.into_series(),
+                Some(DataType::Date) => apply::<Int32Type>(df, py, lambda, 0, None)?.into_date().into_series(),
+                Some(DataType::Datetime(tu, tz)) => apply::<Int64Type>(df, py, lambda, 0, None)?.into_datetime(tu, tz).into_series(),
                 Some(DataType::Boolean) => apply_lambda_with_bool_out_type(df, py, lambda, 0, None).into_series(),
                 Some(DataType::String) => apply_lambda_with_string_out_type(df, py, lambda, 0, None).into_series(),
                 _ => return apply_lambda_unknown(df, py, lambda, inference_size),

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -563,8 +563,8 @@ impl PyDataFrame {
                 Some(DataType::Float64) => apply::<Float64Type>(df, py, lambda, 0, None)?.into_series(),
                 Some(DataType::Date) => apply::<Int32Type>(df, py, lambda, 0, None)?.into_date().into_series(),
                 Some(DataType::Datetime(tu, tz)) => apply::<Int64Type>(df, py, lambda, 0, None)?.into_datetime(tu, tz).into_series(),
-                Some(DataType::Boolean) => apply_lambda_with_bool_out_type(df, py, lambda, 0, None).into_series(),
-                Some(DataType::String) => apply_lambda_with_string_out_type(df, py, lambda, 0, None).into_series(),
+                Some(DataType::Boolean) => apply_lambda_with_bool_out_type(df, py, lambda, 0, None)?.into_series(),
+                Some(DataType::String) => apply_lambda_with_string_out_type(df, py, lambda, 0, None)?.into_series(),
                 _ => return apply_lambda_unknown(df, py, lambda, inference_size),
             };
 

--- a/crates/polars-python/src/map/dataframe.rs
+++ b/crates/polars-python/src/map/dataframe.rs
@@ -47,7 +47,7 @@ pub fn apply_lambda_unknown<'a>(
             let first_value = out.extract::<bool>().ok();
             return Ok((
                 PySeries::new(
-                    apply_lambda_with_bool_out_type(df, py, lambda, null_count, first_value)
+                    apply_lambda_with_bool_out_type(df, py, lambda, null_count, first_value)?
                         .into_series(),
                 )
                 .into_py_any(py)?,
@@ -90,7 +90,7 @@ pub fn apply_lambda_unknown<'a>(
             let first_value = out.extract::<PyBackedStr>().ok();
             return Ok((
                 PySeries::new(
-                    apply_lambda_with_string_out_type(df, py, lambda, null_count, first_value)
+                    apply_lambda_with_string_out_type(df, py, lambda, null_count, first_value)?
                         .into_series(),
                 )
                 .into_py_any(py)?,
@@ -194,10 +194,13 @@ pub fn apply_lambda_with_bool_out_type<'a>(
     lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Option<bool>,
-) -> ChunkedArray<BooleanType> {
+) -> PyResult<ChunkedArray<BooleanType>> {
     let skip = usize::from(first_value.is_some());
     if init_null_count == df.height() {
-        ChunkedArray::full_null(PlSmallStr::from_static("map"), df.height())
+        Ok(ChunkedArray::full_null(
+            PlSmallStr::from_static("map"),
+            df.height(),
+        ))
     } else {
         let iter = apply_iter(df, py, lambda, init_null_count, skip);
         iterator_to_bool(
@@ -217,10 +220,13 @@ pub fn apply_lambda_with_string_out_type<'a>(
     lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Option<PyBackedStr>,
-) -> StringChunked {
+) -> PyResult<StringChunked> {
     let skip = usize::from(first_value.is_some());
     if init_null_count == df.height() {
-        ChunkedArray::full_null(PlSmallStr::from_static("map"), df.height())
+        Ok(ChunkedArray::full_null(
+            PlSmallStr::from_static("map"),
+            df.height(),
+        ))
     } else {
         let iter = apply_iter::<PyBackedStr>(df, py, lambda, init_null_count, skip);
         iterator_to_string(

--- a/crates/polars-python/src/map/dataframe.rs
+++ b/crates/polars-python/src/map/dataframe.rs
@@ -64,7 +64,7 @@ pub fn apply_lambda_unknown<'a>(
                         lambda,
                         null_count,
                         first_value,
-                    )
+                    )?
                     .into_series(),
                 )
                 .into_py_any(py)?,
@@ -80,7 +80,7 @@ pub fn apply_lambda_unknown<'a>(
                         lambda,
                         null_count,
                         first_value,
-                    )
+                    )?
                     .into_series(),
                 )
                 .into_py_any(py)?,
@@ -164,14 +164,17 @@ pub fn apply_lambda_with_primitive_out_type<'a, D>(
     lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     first_value: Option<D::Native>,
-) -> ChunkedArray<D>
+) -> PyResult<ChunkedArray<D>>
 where
     D: PyArrowPrimitiveType,
     D::Native: IntoPyObject<'a> + FromPyObject<'a>,
 {
     let skip = usize::from(first_value.is_some());
     if init_null_count == df.height() {
-        ChunkedArray::full_null(PlSmallStr::from_static("map"), df.height())
+        Ok(ChunkedArray::full_null(
+            PlSmallStr::from_static("map"),
+            df.height(),
+        ))
     } else {
         let iter = apply_iter(df, py, lambda, init_null_count, skip);
         iterator_to_primitive(

--- a/crates/polars-python/src/map/dataframe.rs
+++ b/crates/polars-python/src/map/dataframe.rs
@@ -145,7 +145,7 @@ fn apply_iter<'a, T>(
     lambda: Bound<'a, PyAny>,
     init_null_count: usize,
     skip: usize,
-) -> impl Iterator<Item = Option<T>> + 'a
+) -> impl Iterator<Item = PyResult<Option<T>>> + 'a
 where
     T: FromPyObject<'a>,
 {
@@ -153,10 +153,7 @@ where
     ((init_null_count + skip)..df.height()).map(move |_| {
         let iter = iters.iter_mut().map(|it| Wrap(it.next().unwrap()));
         let tpl = (PyTuple::new(py, iter).unwrap(),);
-        match lambda.call1(tpl) {
-            Ok(val) => val.extract::<T>().ok(),
-            Err(e) => panic!("python function failed {e}"),
-        }
+        lambda.call1(tpl).map(|v| v.extract().ok())
     })
 }
 

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -214,7 +214,7 @@ fn iterator_to_object(
     first_value: Option<ObjectValue>,
     name: PlSmallStr,
     capacity: usize,
-) -> ObjectChunked<ObjectValue> {
+) -> PyResult<ObjectChunked<ObjectValue>> {
     let mut error = None;
     // SAFETY: we know the iterators len.
     let ca: ObjectChunked<ObjectValue> = unsafe {
@@ -236,8 +236,11 @@ fn iterator_to_object(
             it.map(|v| catch_err(&mut error, v)).collect()
         }
     };
+    if let Some(err) = error {
+        let _ = err?;
+    }
     debug_assert_eq!(ca.len(), capacity);
-    ca.with_name(name)
+    Ok(ca.with_name(name))
 }
 
 fn catch_err<K>(error: &mut Option<PyResult<Option<K>>>, result: PyResult<Option<K>>) -> Option<K> {

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -285,7 +285,7 @@ fn iterator_to_string<S: AsRef<str>>(
 
 fn iterator_to_list(
     dt: &DataType,
-    it: impl Iterator<Item = Option<Series>>,
+    it: impl Iterator<Item = PyResult<Option<Series>>>,
     init_null_count: usize,
     first_value: Option<&Series>,
     name: PlSmallStr,
@@ -301,7 +301,7 @@ fn iterator_to_list(
             .map_err(PyPolarsErr::from)?;
     }
     for opt_val in it {
-        match opt_val {
+        match opt_val? {
             None => builder.append_null(),
             Some(s) => {
                 if s.len() == 0 && s.dtype() != dt {

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -139,7 +139,7 @@ fn iterator_to_primitive<T>(
     first_value: Option<T::Native>,
     name: PlSmallStr,
     capacity: usize,
-) -> ChunkedArray<T>
+) -> PyResult<ChunkedArray<T>>
 where
     T: PyArrowPrimitiveType,
 {
@@ -165,7 +165,11 @@ where
         }
     };
     debug_assert_eq!(ca.len(), capacity);
-    ca.with_name(name)
+
+    if let Some(err) = error {
+        let _ = err?;
+    }
+    Ok(ca.with_name(name))
 }
 
 fn iterator_to_bool(

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -178,7 +178,7 @@ fn iterator_to_bool(
     first_value: Option<bool>,
     name: PlSmallStr,
     capacity: usize,
-) -> ChunkedArray<BooleanType> {
+) -> PyResult<ChunkedArray<BooleanType>> {
     let mut error = None;
     // SAFETY: we know the iterators len.
     let ca: BooleanChunked = unsafe {
@@ -200,8 +200,11 @@ fn iterator_to_bool(
             it.map(|v| catch_err(&mut error, v)).collect()
         }
     };
+    if let Some(err) = error {
+        let _ = err?;
+    }
     debug_assert_eq!(ca.len(), capacity);
-    ca.with_name(name)
+    Ok(ca.with_name(name))
 }
 
 #[cfg(feature = "object")]
@@ -252,7 +255,7 @@ fn iterator_to_string<S: AsRef<str>>(
     first_value: Option<S>,
     name: PlSmallStr,
     capacity: usize,
-) -> StringChunked {
+) -> PyResult<StringChunked> {
     let mut error = None;
     // SAFETY: we know the iterators len.
     let ca: StringChunked = unsafe {
@@ -274,7 +277,10 @@ fn iterator_to_string<S: AsRef<str>>(
         }
     };
     debug_assert_eq!(ca.len(), capacity);
-    ca.with_name(name)
+    if let Some(err) = error {
+        let _ = err?;
+    }
+    Ok(ca.with_name(name))
 }
 
 fn iterator_to_list(

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -33,7 +33,7 @@ impl PyArrowPrimitiveType for Float64Type {}
 
 fn iterator_to_struct<'a>(
     py: Python,
-    it: impl Iterator<Item = Option<Bound<'a, PyAny>>>,
+    it: impl Iterator<Item = PyResult<Option<Bound<'a, PyAny>>>>,
     init_null_count: usize,
     first_value: AnyValue<'a>,
     name: PlSmallStr,
@@ -72,7 +72,7 @@ fn iterator_to_struct<'a>(
     }
 
     for dict in it {
-        match dict {
+        match dict? {
             None => {
                 for field_items in struct_fields.values_mut() {
                     field_items.push(AnyValue::Null);

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -526,13 +526,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val));
 
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -542,13 +542,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 }
@@ -845,13 +845,13 @@ where
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val));
 
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -861,13 +861,13 @@ where
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 }
@@ -1154,13 +1154,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val));
 
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1170,13 +1170,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 }
@@ -1610,13 +1610,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                     call_lambda_and_extract(py, lambda, python_series_wrapper)
                 });
 
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1636,13 +1636,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 }
@@ -2054,13 +2054,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                     call_lambda_and_extract(py, lambda, python_series_wrapper)
                 });
 
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -2080,13 +2080,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 }
@@ -2360,13 +2360,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val));
 
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -2376,13 +2376,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_object(
+            iterator_to_object(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 }
@@ -2552,12 +2552,12 @@ impl<'a> ApplyLambda<'a> for StructChunked {
             .skip(init_null_count + skip)
             .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)));
 
-        Ok(iterator_to_object(
+        iterator_to_object(
             it,
             init_null_count,
             first_value,
             self.name().clone(),
             self.len(),
-        ))
+        )
     }
 }

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -524,7 +524,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val));
 
             Ok(iterator_to_object(
                 it,
@@ -538,7 +538,9 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_object(
                 it,
@@ -841,7 +843,7 @@ where
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val));
 
             Ok(iterator_to_object(
                 it,
@@ -855,7 +857,9 @@ where
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_object(
                 it,
@@ -1148,7 +1152,7 @@ impl<'a> ApplyLambda<'a> for StringChunked {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val));
 
             Ok(iterator_to_object(
                 it,
@@ -1162,7 +1166,9 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_object(
                 it,
@@ -1601,7 +1607,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper)
                 });
 
             Ok(iterator_to_object(
@@ -1616,17 +1622,19 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_object(
                 it,
@@ -2043,7 +2051,7 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper)
                 });
 
             Ok(iterator_to_object(
@@ -2058,17 +2066,19 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_object(
                 it,
@@ -2348,7 +2358,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val));
 
             Ok(iterator_to_object(
                 it,
@@ -2362,7 +2372,9 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_object(
                 it,
@@ -2538,7 +2550,7 @@ impl<'a> ApplyLambda<'a> for StructChunked {
         let skip = usize::from(first_value.is_some());
         let it = iter_struct(self)
             .skip(init_null_count + skip)
-            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).ok());
+            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)));
 
         Ok(iterator_to_object(
             it,

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -358,13 +358,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -374,13 +374,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -403,13 +403,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                         .map(Some)
                 });
 
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -419,13 +419,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -676,13 +676,13 @@ where
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -692,13 +692,13 @@ where
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -718,13 +718,13 @@ where
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
 
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -734,13 +734,13 @@ where
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -982,13 +982,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -998,13 +998,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -1024,13 +1024,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
 
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1040,13 +1040,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
     fn apply_lambda_with_list_out_type(
@@ -1383,13 +1383,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         .unwrap();
                     call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1409,13 +1409,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -1448,13 +1448,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                     call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
 
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1474,13 +1474,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
     fn apply_lambda_with_list_out_type(
@@ -1820,13 +1820,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         .unwrap();
                     call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1846,13 +1846,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -1885,13 +1885,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                     call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
 
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1911,13 +1911,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
     fn apply_lambda_with_list_out_type(
@@ -2175,13 +2175,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -2191,13 +2191,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_bool(
+            iterator_to_bool(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -2217,13 +2217,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
 
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -2233,13 +2233,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_string(
+            iterator_to_string(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -2442,13 +2442,13 @@ impl<'a> ApplyLambda<'a> for StructChunked {
             .skip(init_null_count + skip)
             .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).map(Some));
 
-        Ok(iterator_to_bool(
+        iterator_to_bool(
             it,
             init_null_count,
             first_value,
             self.name().clone(),
             self.len(),
-        ))
+        )
     }
 
     fn apply_lambda_with_string_out_type(
@@ -2463,13 +2463,13 @@ impl<'a> ApplyLambda<'a> for StructChunked {
             .skip(init_null_count + skip)
             .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).map(Some));
 
-        Ok(iterator_to_string(
+        iterator_to_string(
             it,
             init_null_count,
             first_value,
             self.name().clone(),
             self.len(),
-        ))
+        )
     }
     fn apply_lambda_with_list_out_type(
         &'a self,

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -316,7 +316,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_primitive(
                 it,
                 init_null_count,
@@ -329,7 +329,9 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -355,7 +357,7 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_bool(
                 it,
                 init_null_count,
@@ -368,7 +370,9 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_bool(
                 it,
@@ -395,7 +399,8 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| {
-                    call_lambda_and_extract::<_, pyo3::pybacked::PyBackedStr>(py, lambda, val).ok()
+                    call_lambda_and_extract::<_, pyo3::pybacked::PyBackedStr>(py, lambda, val)
+                        .map(Some)
                 });
 
             Ok(iterator_to_string(
@@ -410,7 +415,9 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_string(
                 it,
@@ -627,7 +634,7 @@ where
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_primitive(
                 it,
                 init_null_count,
@@ -640,7 +647,9 @@ where
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -666,7 +675,7 @@ where
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_bool(
                 it,
                 init_null_count,
@@ -679,7 +688,9 @@ where
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_bool(
                 it,
@@ -705,7 +716,7 @@ where
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
 
             Ok(iterator_to_string(
                 it,
@@ -719,7 +730,9 @@ where
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_string(
                 it,
@@ -927,7 +940,7 @@ impl<'a> ApplyLambda<'a> for StringChunked {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_primitive(
                 it,
                 init_null_count,
@@ -940,7 +953,9 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -966,7 +981,7 @@ impl<'a> ApplyLambda<'a> for StringChunked {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_bool(
                 it,
                 init_null_count,
@@ -979,7 +994,9 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_bool(
                 it,
@@ -1005,7 +1022,7 @@ impl<'a> ApplyLambda<'a> for StringChunked {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
 
             Ok(iterator_to_string(
                 it,
@@ -1019,7 +1036,9 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_string(
                 it,
@@ -1298,7 +1317,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -1312,17 +1331,19 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -1358,7 +1379,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
             Ok(iterator_to_bool(
                 it,
@@ -1372,17 +1393,19 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_bool(
                 it,
@@ -1420,7 +1443,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
 
             Ok(iterator_to_string(
@@ -1435,17 +1458,19 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_string(
                 it,
@@ -1727,7 +1752,7 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -1741,17 +1766,19 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -1787,7 +1814,7 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
             Ok(iterator_to_bool(
                 it,
@@ -1801,17 +1828,19 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_bool(
                 it,
@@ -1849,7 +1878,7 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         .unwrap()
                         .call1((pyseries,))
                         .unwrap();
-                    call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
+                    call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
 
             Ok(iterator_to_string(
@@ -1864,17 +1893,19 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| {
-                        // create a PySeries struct/object for Python
-                        let pyseries = PySeries::new(val);
-                        // Wrap this PySeries object in the python side Series wrapper
-                        let python_series_wrapper = pypolars
-                            .getattr("wrap_s")
-                            .unwrap()
-                            .call1((pyseries,))
-                            .unwrap();
-                        call_lambda_and_extract(py, lambda, python_series_wrapper).ok()
-                    })
+                    opt_val
+                        .map(|val| {
+                            // create a PySeries struct/object for Python
+                            let pyseries = PySeries::new(val);
+                            // Wrap this PySeries object in the python side Series wrapper
+                            let python_series_wrapper = pypolars
+                                .getattr("wrap_s")
+                                .unwrap()
+                                .call1((pyseries,))
+                                .unwrap();
+                            call_lambda_and_extract(py, lambda, python_series_wrapper)
+                        })
+                        .transpose()
                 });
             Ok(iterator_to_string(
                 it,
@@ -2101,7 +2132,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_primitive(
                 it,
                 init_null_count,
@@ -2114,7 +2145,9 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_primitive(
                 it,
@@ -2140,7 +2173,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
             Ok(iterator_to_bool(
                 it,
                 init_null_count,
@@ -2153,7 +2186,9 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_bool(
                 it,
@@ -2179,7 +2214,7 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
             let it = self
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
-                .map(|val| call_lambda_and_extract(py, lambda, val).ok());
+                .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
 
             Ok(iterator_to_string(
                 it,
@@ -2193,7 +2228,9 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .into_iter()
                 .skip(init_null_count + skip)
                 .map(|opt_val| {
-                    opt_val.and_then(|val| call_lambda_and_extract(py, lambda, val).ok())
+                    opt_val
+                        .map(|val| call_lambda_and_extract(py, lambda, val))
+                        .transpose()
                 });
             Ok(iterator_to_string(
                 it,
@@ -2381,7 +2418,7 @@ impl<'a> ApplyLambda<'a> for StructChunked {
         let skip = usize::from(first_value.is_some());
         let it = iter_struct(self)
             .skip(init_null_count + skip)
-            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).ok());
+            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).map(Some));
 
         Ok(iterator_to_primitive(
             it,
@@ -2402,7 +2439,7 @@ impl<'a> ApplyLambda<'a> for StructChunked {
         let skip = usize::from(first_value.is_some());
         let it = iter_struct(self)
             .skip(init_null_count + skip)
-            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).ok());
+            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).map(Some));
 
         Ok(iterator_to_bool(
             it,
@@ -2423,7 +2460,7 @@ impl<'a> ApplyLambda<'a> for StructChunked {
         let skip = usize::from(first_value.is_some());
         let it = iter_struct(self)
             .skip(init_null_count + skip)
-            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).ok());
+            .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).map(Some));
 
         Ok(iterator_to_string(
             it,

--- a/crates/polars-python/src/map/series.rs
+++ b/crates/polars-python/src/map/series.rs
@@ -317,13 +317,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -333,13 +333,13 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -635,13 +635,13 @@ where
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -651,13 +651,13 @@ where
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -941,13 +941,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -957,13 +957,13 @@ impl<'a> ApplyLambda<'a> for StringChunked {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -1321,13 +1321,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         .unwrap();
                     call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1347,13 +1347,13 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -1758,13 +1758,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         .unwrap();
                     call_lambda_and_extract(py, lambda, python_series_wrapper).map(Some)
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -1784,13 +1784,13 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                         })
                         .transpose()
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -2134,13 +2134,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                 .into_no_null_iter()
                 .skip(init_null_count + skip)
                 .map(|val| call_lambda_and_extract(py, lambda, val).map(Some));
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         } else {
             let it = self
                 .into_iter()
@@ -2150,13 +2150,13 @@ impl<'a> ApplyLambda<'a> for ObjectChunked<ObjectValue> {
                         .map(|val| call_lambda_and_extract(py, lambda, val))
                         .transpose()
                 });
-            Ok(iterator_to_primitive(
+            iterator_to_primitive(
                 it,
                 init_null_count,
                 first_value,
                 self.name().clone(),
                 self.len(),
-            ))
+            )
         }
     }
 
@@ -2421,13 +2421,13 @@ impl<'a> ApplyLambda<'a> for StructChunked {
             .skip(init_null_count + skip)
             .map(|val| call_lambda_and_extract(py, lambda, Wrap(val)).map(Some));
 
-        Ok(iterator_to_primitive(
+        iterator_to_primitive(
             it,
             init_null_count,
             first_value,
             self.name().clone(),
             self.len(),
-        ))
+        )
     }
 
     fn apply_lambda_with_bool_out_type(

--- a/py-polars/tests/unit/expr/test_udfs.py
+++ b/py-polars/tests/unit/expr/test_udfs.py
@@ -20,7 +20,18 @@ def test_pass_name_alias_18914() -> None:
     ).to_dict(as_series=False) == {"id": [1], "value": [2]}
 
 
-@pytest.mark.parametrize("dtype", [pl.String, pl.Int64, pl.Boolean])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.String,
+        pl.Int64,
+        pl.Boolean,
+        pl.List(pl.Int32),
+        pl.Array(pl.Boolean, 2),
+        pl.Struct({"a": pl.Int8}),
+        pl.Enum(["a"]),
+    ],
+)
 def test_raises_udf(dtype: pl.DataType) -> None:
     def raise_f(item: Any) -> None:
         raise ValueError

--- a/py-polars/tests/unit/expr/test_udfs.py
+++ b/py-polars/tests/unit/expr/test_udfs.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+import pytest
+
 import polars as pl
 
 
@@ -14,3 +18,17 @@ def test_pass_name_alias_18914() -> None:
         )
         .over("id")
     ).to_dict(as_series=False) == {"id": [1], "value": [2]}
+
+
+@pytest.mark.parametrize("dtype", [pl.String, pl.Int64, pl.Boolean])
+def test_raises_udf(dtype: pl.DataType) -> None:
+    def raise_f(item: Any) -> None:
+        raise ValueError
+
+    with pytest.raises(pl.exceptions.ComputeError):
+        pl.select(
+            pl.lit(1).map_elements(
+                raise_f,
+                return_dtype=dtype,
+            )
+        )


### PR DESCRIPTION
Always raise the errors instead of silently ignoring them. Also removes a panics.

fixes #19315
fixes #17499
fixes #11823
fixes #12675


And I assume a few other panic related issues.