### PR TITLE
fix(rust): Add `ScanSources` in prelude

### DIFF
--- a/crates/polars-lazy/src/prelude.rs
+++ b/crates/polars-lazy/src/prelude.rs
@@ -14,7 +14,7 @@ pub use polars_ops::prelude::{RankMethod, RankOptions};
 pub use polars_plan::client::prepare_cloud_plan;
 pub use polars_plan::plans::{
     AnonymousScan, AnonymousScanArgs, AnonymousScanOptions, DslPlan, Literal, LiteralValue, Null,
-    NULL,
+    ScanSources, NULL,
 };
 pub use polars_plan::prelude::UnionArgs;
 pub(crate) use polars_plan::prelude::*;


### PR DESCRIPTION
`polars_plan::plan::ScanSources` should be part of `polars_lazy::prelude` because it is a parameter of `polars_lazy::prelude::LazyCsvReader::new_with_sources`.

AFAIK the only way to use it now ina  third party project is to add a direct dependency on `polars_plan`.
