### PR TITLE
feat(rust): Pub-licize Expr DSL Function enums

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -77,26 +77,26 @@ use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "dtype-array")]
-pub(crate) use array::ArrayFunction;
+pub use array::ArrayFunction;
 #[cfg(feature = "cov")]
-pub(crate) use correlation::CorrelationMethod;
+pub use correlation::CorrelationMethod;
 #[cfg(feature = "fused")]
-pub(crate) use fused::FusedOperator;
-pub(crate) use list::ListFunction;
-use polars_core::datatypes::ReshapeDimension;
+pub use fused::FusedOperator;
+pub use list::ListFunction;
+pub use polars_core::datatypes::ReshapeDimension;
 use polars_core::prelude::*;
 #[cfg(feature = "random")]
-pub(crate) use random::RandomMethod;
+pub use random::RandomMethod;
 use schema::FieldsMapper;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-pub(crate) use self::binary::BinaryFunction;
+pub use self::binary::BinaryFunction;
 #[cfg(feature = "bitwise")]
 pub use self::bitwise::BitwiseFunction;
 pub use self::boolean::BooleanFunction;
 #[cfg(feature = "business")]
-pub(super) use self::business::BusinessFunction;
+pub use self::business::BusinessFunction;
 #[cfg(feature = "dtype-categorical")]
 pub use self::cat::CategoricalFunction;
 #[cfg(feature = "temporal")]
@@ -113,7 +113,7 @@ pub use self::strings::StringFunction;
 #[cfg(feature = "dtype-struct")]
 pub use self::struct_::StructFunction;
 #[cfg(feature = "trigonometry")]
-pub(super) use self::trigonometry::TrigonometricFunction;
+pub use self::trigonometry::TrigonometricFunction;
 use super::*;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
Changes the visibility of parts of the Expr DSL that I'd like to add support for in OpenDP ([see current docs](https://docs.opendp.org/en/stable/api/user-guide/polars/expressions/index.html)) to `pub`.