### PR TITLE
refactor: Add a `TypeCheckRule` to the optimizer

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -172,6 +172,12 @@ impl LazyFrame {
         self
     }
 
+    /// Toggle type check optimization.
+    pub fn with_type_check(mut self, toggle: bool) -> Self {
+        self.opt_state.set(OptFlags::TYPE_CHECK, toggle);
+        self
+    }
+
     /// Toggle expression simplification optimization on or off.
     pub fn with_simplify_expr(mut self, toggle: bool) -> Self {
         self.opt_state.set(OptFlags::SIMPLIFY_EXPR, toggle);

--- a/crates/polars-plan/src/dsl/expr_dyn_fn.rs
+++ b/crates/polars-plan/src/dsl/expr_dyn_fn.rs
@@ -295,6 +295,12 @@ impl GetOutput {
         Default::default()
     }
 
+    pub fn first() -> Self {
+        SpecialEq::new(Arc::new(
+            |_input_schema: &Schema, _cntxt: Context, fields: &[Field]| Ok(fields[0].clone()),
+        ))
+    }
+
     pub fn from_type(dt: DataType) -> Self {
         SpecialEq::new(Arc::new(move |_: &Schema, _: Context, flds: &[Field]| {
             Ok(Field::new(flds[0].name().clone(), dt.clone()))

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -38,12 +38,14 @@ bitflags! {
         /// Check if operations are order dependent and unset maintaining_order if
         /// the order would not be observed.
         const CHECK_ORDER_OBSERVE = 1 << 16;
+        /// Do type checking of the IR.
+        const TYPE_CHECK = 1 << 17;
     }
 }
 
 impl OptFlags {
     pub fn schema_only() -> Self {
-        Self::TYPE_COERCION
+        Self::TYPE_COERCION | Self::TYPE_CHECK
     }
 }
 

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -63,12 +63,13 @@ pub fn to_alp(
     lp: DslPlan,
     expr_arena: &mut Arena<AExpr>,
     lp_arena: &mut Arena<IR>,
-    // Only `SIMPLIFY_EXPR` and `TYPE_COERCION` are respected.
+    // Only `SIMPLIFY_EXPR`, `TYPE_COERCION`, `TYPE_CHECK` are respected.
     opt_flags: &mut OptFlags,
 ) -> PolarsResult<Node> {
     let conversion_optimizer = ConversionOptimizer::new(
         opt_flags.contains(OptFlags::SIMPLIFY_EXPR),
         opt_flags.contains(OptFlags::TYPE_COERCION),
+        opt_flags.contains(OptFlags::TYPE_CHECK),
     );
 
     let mut ctxt = DslConversionContext {

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -120,6 +120,9 @@ pub fn resolve_join(
         .coerce_types(ctxt.expr_arena, ctxt.lp_arena, input_right)
         .map_err(|e| e.context("'join' failed".into()))?;
 
+    let schema_left = ctxt.lp_arena.get(input_left).schema(ctxt.lp_arena);
+    let schema_right = ctxt.lp_arena.get(input_right).schema(ctxt.lp_arena);
+
     // Not a closure to avoid borrow issues because we mutate expr_arena as well.
     macro_rules! get_dtype {
         ($expr:expr, $schema:expr) => {

--- a/crates/polars-plan/src/plans/conversion/type_check/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_check/mod.rs
@@ -1,0 +1,48 @@
+use polars_core::error::{polars_ensure, PolarsResult};
+use polars_core::prelude::DataType;
+use polars_utils::arena::{Arena, Node};
+
+use super::{AExpr, OptimizationRule, IR};
+use crate::plans::conversion::get_schema;
+use crate::plans::Context;
+
+pub struct TypeCheckRule;
+
+impl OptimizationRule for TypeCheckRule {
+    fn optimize_plan(
+        &mut self,
+        ir_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+        node: Node,
+    ) -> PolarsResult<Option<IR>> {
+        let ir = ir_arena.get(node);
+        match ir {
+            IR::Scan {
+                predicate: Some(predicate),
+                ..
+            } => {
+                let input_schema = get_schema(ir_arena, node);
+                let dtype = predicate.dtype(input_schema.as_ref(), Context::Default, expr_arena)?;
+
+                polars_ensure!(
+                    matches!(dtype, DataType::Boolean | DataType::Unknown(_)),
+                    InvalidOperation: "filter predicate must be of type `Boolean`, got `{dtype:?}`"
+                );
+
+                Ok(None)
+            },
+            IR::Filter { predicate, .. } => {
+                let input_schema = get_schema(ir_arena, node);
+                let dtype = predicate.dtype(input_schema.as_ref(), Context::Default, expr_arena)?;
+
+                polars_ensure!(
+                    matches!(dtype, DataType::Boolean | DataType::Unknown(_)),
+                    InvalidOperation: "filter predicate must be of type `Boolean`, got `{dtype:?}`"
+                );
+
+                Ok(None)
+            },
+            _ => Ok(None),
+        }
+    }
+}

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -106,6 +106,10 @@ impl ExprIR {
         self
     }
 
+    pub(crate) fn set_dtype(&mut self, dtype: DataType) {
+        self.output_dtype = OnceLock::from(dtype);
+    }
+
     pub fn from_node(node: Node, arena: &Arena<AExpr>) -> Self {
         let mut out = Self {
             node,

--- a/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_and_project.rs
@@ -33,7 +33,7 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
         node: Node,
-    ) -> Option<IR> {
+    ) -> PolarsResult<Option<IR>> {
         use IR::*;
         let lp = lp_arena.get(node);
 
@@ -47,22 +47,25 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                         matches!(expr_arena.get(e.node()), AExpr::Column(_)) && !e.has_alias()
                     }) {
                         self.processed.insert(node);
-                        return None;
+                        return Ok(None);
                     }
 
                     let exprs = expr
                         .iter()
                         .map(|e| e.output_name().clone())
                         .collect::<Vec<_>>();
-                    let alp = IRBuilder::new(*input, expr_arena, lp_arena)
+                    let Some(alp) = IRBuilder::new(*input, expr_arena, lp_arena)
                         .project_simple(exprs.iter().cloned())
-                        .ok()?
-                        .build();
+                        .ok()
+                    else {
+                        return Ok(None);
+                    };
+                    let alp = alp.build();
 
-                    Some(alp)
+                    Ok(Some(alp))
                 } else {
                     self.processed.insert(node);
-                    None
+                    Ok(None)
                 }
             },
             SimpleProjection { columns, input } if !self.eager => {
@@ -70,10 +73,10 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                     // If there are 2 subsequent fast projections, flatten them and only take the last
                     SimpleProjection {
                         input: prev_input, ..
-                    } => Some(SimpleProjection {
+                    } => Ok(Some(SimpleProjection {
                         input: *prev_input,
                         columns: columns.clone(),
-                    }),
+                    })),
                     // Cleanup projections set in projection pushdown just above caches
                     // they are not needed.
                     cache_lp @ Cache { .. } if self.processed.contains(&node) => {
@@ -83,9 +86,9 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                                 |(left_name, right_name)| left_name.as_str() == right_name.as_str(),
                             )
                         {
-                            Some(cache_lp.clone())
+                            Ok(Some(cache_lp.clone()))
                         } else {
-                            None
+                            Ok(None)
                         }
                     },
                     // If a projection does nothing, remove it.
@@ -93,10 +96,10 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                         let input_schema = other.schema(lp_arena);
                         // This will fail fast if lengths are not equal
                         if *input_schema.as_ref() == *columns {
-                            Some(other.clone())
+                            Ok(Some(other.clone()))
                         } else {
                             self.processed.insert(node);
-                            None
+                            Ok(None)
                         }
                     },
                 }
@@ -113,17 +116,17 @@ impl OptimizationRule for SimpleProjectionAndCollapse {
                     cache_hits,
                 } = lp_arena.get(*input)
                 {
-                    Some(Cache {
+                    Ok(Some(Cache {
                         input: *prev_input,
                         id: *id,
                         // ensure the counts are updated
                         cache_hits: cache_hits.saturating_add(*outer_cache_hits),
-                    })
+                    }))
                 } else {
-                    None
+                    Ok(None)
                 }
             },
-            _ => None,
+            _ => Ok(None),
         }
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/count_star.rs
+++ b/crates/polars-plan/src/plans/optimizer/count_star.rs
@@ -19,30 +19,32 @@ impl OptimizationRule for CountStar {
         lp_arena: &mut Arena<IR>,
         expr_arena: &mut Arena<AExpr>,
         node: Node,
-    ) -> Option<IR> {
-        visit_logical_plan_for_scan_paths(node, lp_arena, expr_arena, false).map(
-            |count_star_expr| {
-                // MapFunction needs a leaf node, hence we create a dummy placeholder node
-                let placeholder = IR::DataFrameScan {
-                    df: Arc::new(Default::default()),
-                    schema: Arc::new(Default::default()),
-                    output_schema: None,
-                    filter: None,
-                };
-                let placeholder_node = lp_arena.add(placeholder);
+    ) -> PolarsResult<Option<IR>> {
+        Ok(
+            visit_logical_plan_for_scan_paths(node, lp_arena, expr_arena, false).map(
+                |count_star_expr| {
+                    // MapFunction needs a leaf node, hence we create a dummy placeholder node
+                    let placeholder = IR::DataFrameScan {
+                        df: Arc::new(Default::default()),
+                        schema: Arc::new(Default::default()),
+                        output_schema: None,
+                        filter: None,
+                    };
+                    let placeholder_node = lp_arena.add(placeholder);
 
-                let alp = IR::MapFunction {
-                    input: placeholder_node,
-                    function: FunctionIR::FastCount {
-                        sources: count_star_expr.sources,
-                        scan_type: count_star_expr.scan_type,
-                        alias: count_star_expr.alias,
-                    },
-                };
+                    let alp = IR::MapFunction {
+                        input: placeholder_node,
+                        function: FunctionIR::FastCount {
+                            sources: count_star_expr.sources,
+                            scan_type: count_star_expr.scan_type,
+                            alias: count_star_expr.alias,
+                        },
+                    };
 
-                lp_arena.replace(count_star_expr.node, alp.clone());
-                alp
-            },
+                    lp_arena.replace(count_star_expr.node, alp.clone());
+                    alp
+                },
+            ),
         )
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/delay_rechunk.rs
+++ b/crates/polars-plan/src/plans/optimizer/delay_rechunk.rs
@@ -19,14 +19,14 @@ impl OptimizationRule for DelayRechunk {
         lp_arena: &mut Arena<IR>,
         _expr_arena: &mut Arena<AExpr>,
         node: Node,
-    ) -> Option<IR> {
+    ) -> PolarsResult<Option<IR>> {
         match lp_arena.get(node) {
             // An aggregation can be partitioned, its wasteful to rechunk before that partition.
             #[allow(unused_mut)]
             IR::GroupBy { input, keys, .. } => {
                 // Multiple keys on multiple chunks is much slower, so rechunk.
                 if !self.processed.insert(node.0) || keys.len() > 1 {
-                    return None;
+                    return Ok(None);
                 };
 
                 use IR::*;
@@ -62,9 +62,9 @@ impl OptimizationRule for DelayRechunk {
                     }
                 };
 
-                None
+                Ok(None)
             },
-            _ => None,
+            _ => Ok(None),
         }
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/flatten_union.rs
+++ b/crates/polars-plan/src/plans/optimizer/flatten_union.rs
@@ -1,3 +1,4 @@
+use polars_core::error::PolarsResult;
 use polars_utils::arena::{Arena, Node};
 use IR::*;
 
@@ -19,7 +20,7 @@ impl OptimizationRule for FlattenUnionRule {
         lp_arena: &mut polars_utils::arena::Arena<IR>,
         _expr_arena: &mut polars_utils::arena::Arena<crate::prelude::AExpr>,
         node: polars_utils::arena::Node,
-    ) -> Option<IR> {
+    ) -> PolarsResult<Option<IR>> {
         let lp = lp_arena.get(node);
 
         match lp {
@@ -41,12 +42,12 @@ impl OptimizationRule for FlattenUnionRule {
                 }
                 options.flattened_by_opt = true;
 
-                Some(Union {
+                Ok(Some(Union {
                     inputs: new_inputs,
                     options,
-                })
+                }))
             },
-            _ => None,
+            _ => Ok(None),
         }
     }
 }

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -161,7 +161,7 @@ pub fn optimize(
 
         if projection_pushdown_opt.is_count_star {
             let mut count_star_opt = CountStar::new();
-            count_star_opt.optimize_plan(lp_arena, expr_arena, lp_top);
+            count_star_opt.optimize_plan(lp_arena, expr_arena, lp_top)?;
         }
     }
 

--- a/crates/polars-plan/src/plans/optimizer/stack_opt.rs
+++ b/crates/polars-plan/src/plans/optimizer/stack_opt.rs
@@ -31,7 +31,7 @@ impl StackOptimizer {
                 // Apply rules
                 for rule in rules.iter_mut() {
                     // keep iterating over same rule
-                    while let Some(x) = rule.optimize_plan(lp_arena, expr_arena, current_node) {
+                    while let Some(x) = rule.optimize_plan(lp_arena, expr_arena, current_node)? {
                         lp_arena.replace(current_node, x);
                         changed = true;
                     }
@@ -93,8 +93,8 @@ pub trait OptimizationRule {
         _lp_arena: &mut Arena<IR>,
         _expr_arena: &mut Arena<AExpr>,
         _node: Node,
-    ) -> Option<IR> {
-        None
+    ) -> PolarsResult<Option<IR>> {
+        Ok(None)
     }
     fn optimize_expr(
         &mut self,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -484,6 +484,7 @@ impl PyLazyFrame {
     fn optimization_toggle(
         &self,
         type_coercion: bool,
+        type_check: bool,
         predicate_pushdown: bool,
         projection_pushdown: bool,
         simplify_expression: bool,
@@ -500,6 +501,7 @@ impl PyLazyFrame {
         let ldf = self.ldf.clone();
         let mut ldf = ldf
             .with_type_coercion(type_coercion)
+            .with_type_check(type_check)
             .with_predicate_pushdown(predicate_pushdown)
             .with_simplify_expr(simplify_expression)
             .with_slice_pushdown(slice_pushdown)

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1619,7 +1619,7 @@ def collect_all(
     lazy_frames: Iterable[LazyFrame],
     *,
     type_coercion: bool = True,
-    type_check: bool = True,
+    _type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1643,8 +1643,6 @@ def collect_all(
         A list of LazyFrames to collect.
     type_coercion
         Do type coercion optimization.
-    type_check
-        Do type checking of the intermediate representation.
     predicate_pushdown
         Do predicate pushdown optimization.
     projection_pushdown
@@ -1699,7 +1697,7 @@ def collect_all(
     for lf in lazy_frames:
         ldf = lf._ldf.optimization_toggle(
             type_coercion,
-            type_check,
+            _type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1729,7 +1727,7 @@ def collect_all_async(
     *,
     gevent: Literal[True],
     type_coercion: bool = True,
-    type_check: bool = True,
+    _type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1749,7 +1747,7 @@ def collect_all_async(
     *,
     gevent: Literal[False] = False,
     type_coercion: bool = True,
-    type_check: bool = True,
+    _type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1769,7 +1767,7 @@ def collect_all_async(
     *,
     gevent: bool = False,
     type_coercion: bool = True,
-    type_check: bool = True,
+    _type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1804,8 +1802,6 @@ def collect_all_async(
         Return wrapper to `gevent.event.AsyncResult` instead of Awaitable
     type_coercion
         Do type coercion optimization.
-    type_check
-        Do type checking of the intermediate representation.
     predicate_pushdown
         Do predicate pushdown optimization.
     projection_pushdown
@@ -1872,7 +1868,7 @@ def collect_all_async(
     for lf in lazy_frames:
         ldf = lf._ldf.optimization_toggle(
             type_coercion,
-            type_check,
+            _type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1619,6 +1619,7 @@ def collect_all(
     lazy_frames: Iterable[LazyFrame],
     *,
     type_coercion: bool = True,
+    type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1642,6 +1643,8 @@ def collect_all(
         A list of LazyFrames to collect.
     type_coercion
         Do type coercion optimization.
+    type_check
+        Do type checking of the intermediate representation.
     predicate_pushdown
         Do predicate pushdown optimization.
     projection_pushdown
@@ -1696,6 +1699,7 @@ def collect_all(
     for lf in lazy_frames:
         ldf = lf._ldf.optimization_toggle(
             type_coercion,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1725,6 +1729,7 @@ def collect_all_async(
     *,
     gevent: Literal[True],
     type_coercion: bool = True,
+    type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1744,6 +1749,7 @@ def collect_all_async(
     *,
     gevent: Literal[False] = False,
     type_coercion: bool = True,
+    type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1763,6 +1769,7 @@ def collect_all_async(
     *,
     gevent: bool = False,
     type_coercion: bool = True,
+    type_check: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
     simplify_expression: bool = True,
@@ -1797,6 +1804,8 @@ def collect_all_async(
         Return wrapper to `gevent.event.AsyncResult` instead of Awaitable
     type_coercion
         Do type coercion optimization.
+    type_check
+        Do type checking of the intermediate representation.
     predicate_pushdown
         Do predicate pushdown optimization.
     projection_pushdown
@@ -1863,6 +1872,7 @@ def collect_all_async(
     for lf in lazy_frames:
         ldf = lf._ldf.optimization_toggle(
             type_coercion,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1695,9 +1695,10 @@ def collect_all(
     prepared = []
 
     for lf in lazy_frames:
+        type_check = _type_check
         ldf = lf._ldf.optimization_toggle(
             type_coercion,
-            _type_check,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1866,9 +1867,10 @@ def collect_all_async(
     prepared = []
 
     for lf in lazy_frames:
+        type_check = _type_check
         ldf = lf._ldf.optimization_toggle(
             type_coercion,
-            _type_check,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2398,7 +2398,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=_type_check,
+            _type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2539,7 +2539,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=_type_check,
+            _type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2726,7 +2726,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=_type_check,
+            _type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2854,7 +2854,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=_type_check,
+            _type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2904,7 +2904,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._ldf.optimization_toggle(
             type_coercion=type_coercion,
-            type_check=_type_check,
+            _type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2964,7 +2964,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         return self._fetch(
             n_rows=n_rows,
             type_coercion=type_coercion,
-            type_check=_type_check,
+            _type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1013,6 +1013,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         format: ExplainFormat = "plain",
         optimized: bool = True,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1041,6 +1042,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             run.
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -1098,6 +1101,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if optimized:
             ldf = self._ldf.optimization_toggle(
                 type_coercion,
+                type_check,
                 predicate_pushdown,
                 projection_pushdown,
                 simplify_expression,
@@ -1130,6 +1134,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         raw_output: bool = False,
         figsize: tuple[float, float] = (16.0, 12.0),
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1161,6 +1166,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Passed to matplotlib if `show == True`.
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -1195,6 +1202,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         _ldf = self._ldf.optimization_toggle(
             type_coercion,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1602,6 +1610,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1630,6 +1639,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -1701,6 +1712,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         ldf = self._ldf.optimization_toggle(
             type_coercion,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1761,6 +1773,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1782,6 +1795,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1802,6 +1816,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1828,6 +1843,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2005,6 +2022,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         ldf = self._ldf.optimization_toggle(
             type_coercion,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -2048,6 +2066,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         gevent: Literal[True],
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2066,6 +2085,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         gevent: Literal[False] = False,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2083,6 +2103,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         gevent: bool = False,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2115,6 +2136,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Return wrapper to `gevent.event.AsyncResult` instead of Awaitable
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2205,6 +2228,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         ldf = self._ldf.optimization_toggle(
             type_coercion,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -2269,6 +2293,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         data_page_size: int | None = None,
         maintain_order: bool = True,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2335,6 +2360,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2383,6 +2410,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
+            type_check=type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2441,6 +2469,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         compression: str | None = "zstd",
         maintain_order: bool = True,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2474,6 +2503,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2522,6 +2553,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
+            type_check=type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2571,6 +2603,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         quote_style: CsvQuoteStyle | None = None,
         maintain_order: bool = True,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2652,6 +2685,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2707,6 +2742,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
+            type_check=type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2755,6 +2791,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         maintain_order: bool = True,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2785,6 +2822,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2833,6 +2872,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
+            type_check=type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2865,6 +2905,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2881,6 +2922,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._ldf.optimization_toggle(
             type_coercion=type_coercion,
+            type_check=type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2905,6 +2947,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         n_rows: int = 500,
         *,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2939,6 +2982,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         return self._fetch(
             n_rows=n_rows,
             type_coercion=type_coercion,
+            type_check=type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2956,6 +3000,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         n_rows: int = 500,
         *,
         type_coercion: bool = True,
+        type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2980,6 +3025,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Collect n_rows from the data sources.
         type_coercion
             Run type coercion optimization.
+        type_check
+            Do type checking of the intermediate representation.
         predicate_pushdown
             Run predicate pushdown optimization.
         projection_pushdown
@@ -3057,6 +3104,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         lf = self._ldf.optimization_toggle(
             type_coercion,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1013,7 +1013,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         format: ExplainFormat = "plain",
         optimized: bool = True,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1042,8 +1042,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             run.
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -1101,7 +1099,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if optimized:
             ldf = self._ldf.optimization_toggle(
                 type_coercion,
-                type_check,
+                _type_check,
                 predicate_pushdown,
                 projection_pushdown,
                 simplify_expression,
@@ -1134,7 +1132,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         raw_output: bool = False,
         figsize: tuple[float, float] = (16.0, 12.0),
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1166,8 +1164,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Passed to matplotlib if `show == True`.
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -1202,7 +1198,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         _ldf = self._ldf.optimization_toggle(
             type_coercion,
-            type_check,
+            _type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1610,7 +1606,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1639,8 +1635,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -1712,7 +1706,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         ldf = self._ldf.optimization_toggle(
             type_coercion,
-            type_check,
+            _type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1773,7 +1767,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1795,7 +1789,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1816,7 +1810,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -1843,8 +1837,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2022,7 +2014,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         ldf = self._ldf.optimization_toggle(
             type_coercion,
-            type_check,
+            _type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -2066,7 +2058,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         gevent: Literal[True],
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2085,7 +2077,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         gevent: Literal[False] = False,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2103,7 +2095,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         gevent: bool = False,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2136,8 +2128,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Return wrapper to `gevent.event.AsyncResult` instead of Awaitable
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2228,7 +2218,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         ldf = self._ldf.optimization_toggle(
             type_coercion,
-            type_check,
+            _type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -2293,7 +2283,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         data_page_size: int | None = None,
         maintain_order: bool = True,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2360,8 +2350,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2410,7 +2398,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=type_check,
+            type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2469,7 +2457,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         compression: str | None = "zstd",
         maintain_order: bool = True,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2503,8 +2491,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2553,7 +2539,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=type_check,
+            type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2603,7 +2589,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         quote_style: CsvQuoteStyle | None = None,
         maintain_order: bool = True,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2685,8 +2671,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2742,7 +2726,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=type_check,
+            type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2791,7 +2775,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         maintain_order: bool = True,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2822,8 +2806,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Do predicate pushdown optimization.
         projection_pushdown
@@ -2872,7 +2854,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         lf = self._set_sink_optimizations(
             type_coercion=type_coercion,
-            type_check=type_check,
+            type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2905,7 +2887,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         *,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2922,7 +2904,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._ldf.optimization_toggle(
             type_coercion=type_coercion,
-            type_check=type_check,
+            type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -2947,7 +2929,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         n_rows: int = 500,
         *,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -2982,7 +2964,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         return self._fetch(
             n_rows=n_rows,
             type_coercion=type_coercion,
-            type_check=type_check,
+            type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -3000,7 +2982,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         n_rows: int = 500,
         *,
         type_coercion: bool = True,
-        type_check: bool = True,
+        _type_check: bool = True,
         predicate_pushdown: bool = True,
         projection_pushdown: bool = True,
         simplify_expression: bool = True,
@@ -3025,8 +3007,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Collect n_rows from the data sources.
         type_coercion
             Run type coercion optimization.
-        type_check
-            Do type checking of the intermediate representation.
         predicate_pushdown
             Run predicate pushdown optimization.
         projection_pushdown
@@ -3104,7 +3084,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         lf = self._ldf.optimization_toggle(
             type_coercion,
-            type_check,
+            _type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1097,9 +1097,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             issue_unstable_warning("Streaming mode is considered unstable.")
 
         if optimized:
+            type_check = _type_check
             ldf = self._ldf.optimization_toggle(
                 type_coercion,
-                _type_check,
+                type_check,
                 predicate_pushdown,
                 projection_pushdown,
                 simplify_expression,
@@ -1196,9 +1197,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     "a"
         ... ).show_graph()  # doctest: +SKIP
         """
+        type_check = _type_check
         _ldf = self._ldf.optimization_toggle(
             type_coercion,
-            _type_check,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -1704,9 +1706,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             cluster_with_columns = False
             collapse_joins = False
 
+        type_check = _type_check
         ldf = self._ldf.optimization_toggle(
             type_coercion,
-            _type_check,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -2012,9 +2015,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Don't run on GPU in _eager mode (but don't warn)
             is_gpu = False
 
+        type_check = _type_check
         ldf = self._ldf.optimization_toggle(
             type_coercion,
-            _type_check,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -2216,9 +2220,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if streaming:
             issue_unstable_warning("Streaming mode is considered unstable.")
 
+        type_check = _type_check
         ldf = self._ldf.optimization_toggle(
             type_coercion,
-            _type_check,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,
@@ -2904,7 +2909,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._ldf.optimization_toggle(
             type_coercion=type_coercion,
-            _type_check=_type_check,
+            type_check=_type_check,
             predicate_pushdown=predicate_pushdown,
             projection_pushdown=projection_pushdown,
             simplify_expression=simplify_expression,
@@ -3082,9 +3087,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if streaming:
             issue_unstable_warning("Streaming mode is considered unstable.")
 
+        type_check = _type_check
         lf = self._ldf.optimization_toggle(
             type_coercion,
-            _type_check,
+            type_check,
             predicate_pushdown,
             projection_pushdown,
             simplify_expression,

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -233,7 +233,7 @@ def test_error_on_double_agg() -> None:
 def test_filter_not_of_type_bool() -> None:
     df = pl.DataFrame({"json_val": ['{"a":"hello"}', None, '{"a":"world"}']})
     with pytest.raises(
-        ComputeError, match="filter predicate must be of type `Boolean`, got"
+        InvalidOperationError, match="filter predicate must be of type `Boolean`, got"
     ):
         df.filter(pl.col("json_val").str.json_path_match("$.a"))
 


### PR DESCRIPTION
This PR fixes #17391 by properly adding a `TypeCheckRule` to the `ConversionOptimizer` that will verify that `filters` have a `Boolean` datatype.

This already caught #20424.

In the future, this can be expanded to type check additional parts of the IR such as arithmetic operators.