### PR TITLE
fix(python): Fix return type for `add_business_days`, `millennium`, `century` and `combine` methods in `Series.dt` namespace

### DIFF
--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -373,7 +373,7 @@ class DateTimeNameSpace:
         """
         return self.to_string(format)
 
-    def millennium(self) -> Expr:
+    def millennium(self) -> Series:
         """
         Extract the millennium from underlying representation.
 
@@ -383,8 +383,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Expr
-            Expression of data type :class:`Int32`.
+        Series
+            Series of data type :class:`Int32`.
 
         Examples
         --------
@@ -411,7 +411,7 @@ class DateTimeNameSpace:
         ]
         """
 
-    def century(self) -> Expr:
+    def century(self) -> Series:
         """
         Extract the century from underlying representation.
 
@@ -421,8 +421,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Expr
-            Expression of data type :class:`Int32`.
+        Series
+            Series of data type :class:`Int32`.
 
         Examples
         --------
@@ -1924,7 +1924,7 @@ class DateTimeNameSpace:
         ]
         """
 
-    def combine(self, time: dt.time | Series, time_unit: TimeUnit = "us") -> Expr:
+    def combine(self, time: dt.time | Series, time_unit: TimeUnit = "us") -> Series:
         """
         Create a naive Datetime from an existing Date/Datetime expression and a Time.
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -79,7 +79,7 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Expr
+        Series
             Data type is preserved.
 
         Examples


### PR DESCRIPTION
Return type for `Series.dt.add_business_days`'s type annotation was fixed in https://github.com/pola-rs/polars/pull/20402, but not its docstring. This PR fixes the docstring.

This PR also fixes the return types for `millennium`, `century` and `combine` in the `Series.dt` namespace.