### PR TITLE
feat: Add `mean_horizontal` for temporal dtypes

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -385,7 +385,7 @@ jobs:
           merge-multiple: true
 
       - name: Remove Emscripten wheel
-        run: rm -f dist/*emscripten-wasm32*.whl
+        run: rm -f dist/*emscripten*.whl
 
       - name: Publish to PyPI
         if: inputs.dry-run == false

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -385,7 +385,7 @@ jobs:
           merge-multiple: true
 
       - name: Remove Emscripten wheel
-        run: rm -f dist/*emscripten*.whl
+        run: rm -f dist/*emscripten-wasm32*.whl
 
       - name: Publish to PyPI
         if: inputs.dry-run == false

--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -286,7 +286,7 @@ pub fn mean_horizontal(
 
         // Convert to physical
         columns
-            .into_iter()
+            .iter()
             .map(|c| c.cast(&DataType::Int64).unwrap())
             .collect::<Vec<_>>()
     } else if first_dtype.is_numeric()
@@ -314,7 +314,7 @@ pub fn mean_horizontal(
             }
         }
         columns
-            .into_iter()
+            .iter()
             .map(|s| s.cast(&DataType::Int64).unwrap().into_column())
             .collect::<Vec<_>>()
     } else {
@@ -386,7 +386,7 @@ pub fn mean_horizontal(
                                 .cast(&DataType::Datetime(TimeUnit::Milliseconds, None))
                         } else {
                             // Cast to original
-                            value.cast(&first_dtype)
+                            value.cast(first_dtype)
                         }
                     } else {
                         Ok(value)


### PR DESCRIPTION
Closes #20313. Adds a path in `mean_horizontal` for temporals. A bit of logic update:

1. Checks to ensure that if we have numeric columns, all columns are numeric (includes bool/null).
2. Checks to ensure that if we have a temporal column, all columns have the same temporal dtype.

This implementation doesn't allow taking the mean of mixed time-unit dtypes that are otherwise the same. I am not sure if I should update logic to include this or not. In other words:

```python
from datetime import datetime
import polars as pl

dates = [datetime(2025, 1, 1), datetime(2025, 1, 2)]

df = pl.DataFrame({
    "ms": pl.Series(dates, dtype=pl.Datetime(time_unit="ms")),
    "us1": pl.Series(dates, dtype=pl.Datetime(time_unit="us")),
    "us2": pl.Series(dates, dtype=pl.Datetime(time_unit="us")),
})

df.with_columns(
    pl.mean_horizontal("ms", "us1"),   # error--dtypes are not compatible
    pl.mean_horizontal("us1", "us2"),  # ok
)
```
