### PR TITLE
feat: Support numerical arrays in `bin.reinterpret`

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -942,7 +942,7 @@ impl DataType {
                         return None;
                     }
                 }
-                return Some(total_size)
+                Some(total_size)
             },
             DataType::Unknown(_) => None,
         }

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -921,7 +921,7 @@ impl DataType {
             DataType::String => None,
             DataType::Binary => None,
             DataType::BinaryOffset => None,
-            DataType::Date => todo!(),
+            DataType::Date => Some(4),
             DataType::Datetime(_, _) => Some(8),
             DataType::Duration(_) => Some(8),
             DataType::Time => Some(8),
@@ -929,10 +929,10 @@ impl DataType {
                 data_type.byte_size().map(|v| v * size)
             }
             DataType::List(_) => None,
-            DataType::Object(_, arc) => None,
+            DataType::Object(_, _) => None,
             DataType::Null => Some(0),
-            DataType::Categorical(arc, categorical_ordering) => None,
-            DataType::Enum(arc, categorical_ordering) => None,
+            DataType::Categorical(_, _) => None,
+            DataType::Enum(_, _) => None,
             DataType::Struct(vec) => {
                 let mut total_size = 0usize;
                 for field in vec.iter() {
@@ -944,7 +944,7 @@ impl DataType {
                 }
                 return Some(total_size)
             },
-            DataType::Unknown(unknown_kind) => None,
+            DataType::Unknown(_) => None,
         }
     }
 }

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -925,9 +925,7 @@ impl DataType {
             DataType::Datetime(_, _) => Some(8),
             DataType::Duration(_) => Some(8),
             DataType::Time => Some(8),
-            DataType::Array(data_type, size) => {
-                data_type.byte_size().map(|v| v * size)
-            }
+            DataType::Array(data_type, size) => data_type.byte_size().map(|v| v * size),
             DataType::List(_) => None,
             DataType::Object(_, _) => None,
             DataType::Null => Some(0),

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -902,6 +902,51 @@ impl DataType {
             },
         }
     }
+
+    pub fn byte_size(&self) -> Option<usize> {
+        match self {
+            DataType::Boolean => Some(1),
+            DataType::UInt8 => Some(1),
+            DataType::UInt16 => Some(2),
+            DataType::UInt32 => Some(4),
+            DataType::UInt64 => Some(8),
+            DataType::Int8 => Some(1),
+            DataType::Int16 => Some(2),
+            DataType::Int32 => Some(4),
+            DataType::Int64 => Some(8),
+            DataType::Int128 => Some(16),
+            DataType::Float32 => Some(4),
+            DataType::Float64 => Some(8),
+            DataType::Decimal(_, _) => Some(16),
+            DataType::String => None,
+            DataType::Binary => None,
+            DataType::BinaryOffset => None,
+            DataType::Date => todo!(),
+            DataType::Datetime(_, _) => Some(8),
+            DataType::Duration(_) => Some(8),
+            DataType::Time => Some(8),
+            DataType::Array(data_type, size) => {
+                data_type.byte_size().map(|v| v * size)
+            }
+            DataType::List(_) => None,
+            DataType::Object(_, arc) => None,
+            DataType::Null => Some(0),
+            DataType::Categorical(arc, categorical_ordering) => None,
+            DataType::Enum(arc, categorical_ordering) => None,
+            DataType::Struct(vec) => {
+                let mut total_size = 0usize;
+                for field in vec.iter() {
+                    if let Some(byte_size) = field.dtype.byte_size() {
+                        total_size += byte_size;
+                    } else {
+                        return None;
+                    }
+                }
+                return Some(total_size)
+            },
+            DataType::Unknown(unknown_kind) => None,
+        }
+    }
 }
 
 impl Display for DataType {

--- a/crates/polars-ops/src/chunked_array/binary/cast_binary_to_numerical.rs
+++ b/crates/polars-ops/src/chunked_array/binary/cast_binary_to_numerical.rs
@@ -1,4 +1,7 @@
-use arrow::array::{Array, BinaryViewArray, FixedSizeListArray, MutableArray, MutableFixedSizeListArray, MutablePrimitiveArray, PrimitiveArray, TryPush};
+use arrow::array::{
+    Array, BinaryViewArray, FixedSizeListArray, MutableArray, MutableFixedSizeListArray,
+    MutablePrimitiveArray, PrimitiveArray, TryPush,
+};
 use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use polars_error::PolarsResult;
@@ -84,7 +87,7 @@ pub(super) fn try_cast_binview_to_array_primitive<T>(
     from: &BinaryViewArray,
     to: &ArrowDataType,
     is_little_endian: bool,
-    element_size: usize
+    element_size: usize,
 ) -> PolarsResult<FixedSizeListArray>
 where
     T: Cast + NativeType,
@@ -96,28 +99,28 @@ where
     };
     let mut result = MutableFixedSizeListArray::new(MutablePrimitiveArray::<T>::new(), size);
 
-    from.iter().try_for_each(
-        |x| {
-            if let Some(x) = x {
-                if x.len() % element_size != 0 {
-                    todo!("Return error here.")
-                }
+    from.iter().try_for_each(|x| {
+        if let Some(x) = x {
+            if x.len() % element_size != 0 {
+                todo!("Return error here.")
+            }
 
-                result.try_push(
-                    Some(x.chunks_exact(element_size).map(|val|
+            result.try_push(Some(
+                x.chunks_exact(element_size)
+                    .map(|val| {
                         if is_little_endian {
                             T::cast_le(val)
                         } else {
                             T::cast_be(val)
                         }
-                    ).collect::<Vec<_>>())
-                )
-            } else {
-                result.push_null();
-                Ok(())
-            }
+                    })
+                    .collect::<Vec<_>>(),
+            ))
+        } else {
+            result.push_null();
+            Ok(())
         }
-    )?;
+    })?;
 
     Ok(result.into())
 }
@@ -126,12 +129,17 @@ pub(super) fn cast_binview_to_array_primitive_dyn<T>(
     from: &dyn Array,
     to: &ArrowDataType,
     is_little_endian: bool,
-    element_size: usize
+    element_size: usize,
 ) -> PolarsResult<Box<dyn Array>>
 where
     T: Cast + NativeType,
 {
     let from = from.as_any().downcast_ref().unwrap();
 
-    Ok(Box::new(try_cast_binview_to_array_primitive::<T>(from, to, is_little_endian, element_size)?))
+    Ok(Box::new(try_cast_binview_to_array_primitive::<T>(
+        from,
+        to,
+        is_little_endian,
+        element_size,
+    )?))
 }

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -141,7 +141,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
         unsafe {
             Ok(Series::from_chunks_and_dtype_unchecked(
                 self.as_binary().name().clone(),
-                self._from_buffer_inner(&dtype, is_little_endian)?,
+                self._from_buffer_inner(dtype, is_little_endian)?,
                 dtype,
             ))
         }

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -190,44 +190,6 @@ pub trait BinaryNameSpaceImpl: AsBinary {
                         }).collect()
                     }
                 })
-
-                // // unwrap is safe since all lists have inner type
-                // // let inner_dtype = dtype.inner_dtype().unwrap();
-                // let size  = if let DataType::Array(inner_dtype, size) = dtype {
-                //     *size
-                // } else {
-                //     todo!("alfafldasd")
-                // };
-
-                // let (inner_dtype, offsets): (_, OffsetsBuffer<i64>) = if let DataType::Array(inner_dtype, size) = dtype {
-                //     // TODO: Nicer way of doing this when I'm online
-                //     let mut offsets = Vec::with_capacity(*size);
-                //     let mut idx = 0;
-                //     let type_size = inner_dtype.byte_size().unwrap();
-                //     while idx < *size {
-                //         offsets.push((idx * type_size) as i64);
-                //         idx += 1
-                //     }
-                //     (
-                //         inner_dtype,
-                //         offsets.try_into().unwrap()
-                //     )
-                // } else {
-                //     todo!("Some reasonable error here.")
-                // };
-                // // ChunkedArray::as_list()
-                // self._from_buffer_inner(inner_dtype, is_little_endian).map(|arr_vec| {
-                //     arr_vec.into_iter().map(|arr| {
-                //         println!("Array dtype: {:?}", arr.dtype());
-                //         println!("Values: {arr:?}");
-                //         FixedSizeListArray::new(
-                //             arrow_data_type.clone(),
-                //             size,
-                //             arr,
-                //             None,
-                //         ).boxed()
-                //     }).collect()
-                // })
             },
             _ => Err(
                 polars_err!(InvalidOperation:"unsupported data type in from_buffer. Only numerical types are allowed."),

--- a/crates/polars-plan/src/dsl/binary.rs
+++ b/crates/polars-plan/src/dsl/binary.rs
@@ -71,12 +71,16 @@ impl BinaryNameSpace {
         let shape = to_type.get_shape();
 
         let call_to_type = if let Some(ref shape) = shape {
-            DataType::Array(Box::new(leaf_type.clone()), shape.iter().fold(1, |a, b| a * b))
+            DataType::Array(
+                Box::new(leaf_type.clone()),
+                shape.iter().fold(1, |a, b| a * b),
+            )
         } else {
             to_type
         };
 
-        let result = self.0
+        let result = self
+            .0
             .map_private(FunctionExpr::BinaryExpr(BinaryFunction::FromBuffer(
                 call_to_type,
                 is_little_endian,
@@ -89,9 +93,7 @@ impl BinaryNameSpace {
                 .collect();
             dimensions.insert(0, ReshapeDimension::Infer);
 
-
-            result
-                .apply_private(FunctionExpr::Reshape(dimensions))
+            result.apply_private(FunctionExpr::Reshape(dimensions))
         } else {
             result
         }

--- a/crates/polars-plan/src/dsl/binary.rs
+++ b/crates/polars-plan/src/dsl/binary.rs
@@ -73,7 +73,7 @@ impl BinaryNameSpace {
         let call_to_type = if let Some(ref shape) = shape {
             DataType::Array(
                 Box::new(leaf_type.clone()),
-                shape.iter().fold(1, |a, b| a * b),
+                shape.iter().product(),
             )
         } else {
             to_type

--- a/py-polars/tests/unit/operations/namespaces/test_binary.py
+++ b/py-polars/tests/unit/operations/namespaces/test_binary.py
@@ -257,7 +257,7 @@ def test_reinterpret_list(
             vals = [
                 struct.unpack_from(
                     f"{struct_endianness}{struct_type}",
-                    elem_bytes[idx:idx + inner_type_size],
+                    elem_bytes[idx : idx + inner_type_size],
                 )[0]
                 for idx in range(0, type_size, inner_type_size)
             ]

--- a/py-polars/tests/unit/operations/namespaces/test_binary.py
+++ b/py-polars/tests/unit/operations/namespaces/test_binary.py
@@ -256,7 +256,8 @@ def test_reinterpret_list(
         for elem_bytes in byte_arr:
             vals = [
                 struct.unpack_from(
-                    f"{struct_endianness}{struct_type}", elem_bytes[idx:idx + inner_type_size]
+                    f"{struct_endianness}{struct_type}",
+                    elem_bytes[idx:idx + inner_type_size],
                 )[0]
                 for idx in range(0, type_size, inner_type_size)
             ]

--- a/py-polars/tests/unit/operations/namespaces/test_binary.py
+++ b/py-polars/tests/unit/operations/namespaces/test_binary.py
@@ -209,6 +209,64 @@ def test_reinterpret(
 
         assert_frame_equal(result, expected_df)
 
+@pytest.mark.parametrize(
+    ("dtype", "inner_type_size", "struct_type"),
+    [
+        (pl.Array(pl.Int8, 2), 1, "b"),
+        # (pl.UInt8, 1, "B"),
+        # (pl.Int16, 2, "h"),
+        # (pl.UInt16, 2, "H"),
+        # (pl.Int32, 4, "i"),
+        # (pl.UInt32, 4, "I"),
+        # (pl.Int64, 8, "q"),
+        # (pl.UInt64, 8, "Q"),
+        # (pl.Float32, 4, "f"),
+        # (pl.Float64, 8, "d"),
+    ],
+)
+def test_reinterpret_list(
+    dtype: pl.Array,
+    inner_type_size: int,
+    struct_type: str,
+) -> None:
+    # Make test reproducible
+    random.seed(42)
+
+    type_size = inner_type_size
+    shape = dtype.shape
+    if isinstance(shape, int):
+        shape = (shape,)
+    for dim_size in dtype.shape:
+        type_size *= dim_size
+
+    print(shape)
+    print(type_size)
+
+    byte_arr = [random.randbytes(type_size) for _ in range(3)]
+    df = pl.DataFrame({"x": byte_arr})
+
+    for endianness in ["little", "big"]:
+        result = df.select(
+            pl.col("x").bin.reinterpret(dtype=dtype, endianness=endianness)  # type: ignore[arg-type]
+        )
+
+        # So that mypy doesn't complain
+        struct_endianness = "<" if endianness == "little" else ">"
+        expected = []
+        for elem_bytes in byte_arr:
+            print(elem_bytes)
+            vals = [
+                struct.unpack_from(f"{struct_endianness}{struct_type}", elem_bytes[idx:idx + inner_type_size])[0]
+                for idx in range(0, type_size, inner_type_size)
+            ]
+            print(vals)
+            expected.append(vals)
+        print(expected)
+        expected_df = pl.DataFrame({"x": expected}, schema={"x": dtype})
+
+
+        assert_frame_equal(result, expected_df)
+
 
 @pytest.mark.parametrize(
     ("dtype", "type_size"),

--- a/py-polars/tests/unit/operations/namespaces/test_binary.py
+++ b/py-polars/tests/unit/operations/namespaces/test_binary.py
@@ -212,16 +212,16 @@ def test_reinterpret(
 @pytest.mark.parametrize(
     ("dtype", "inner_type_size", "struct_type"),
     [
-        (pl.Array(pl.Int8, 2), 1, "b"),
-        # (pl.UInt8, 1, "B"),
-        # (pl.Int16, 2, "h"),
-        # (pl.UInt16, 2, "H"),
-        # (pl.Int32, 4, "i"),
-        # (pl.UInt32, 4, "I"),
-        # (pl.Int64, 8, "q"),
-        # (pl.UInt64, 8, "Q"),
-        # (pl.Float32, 4, "f"),
-        # (pl.Float64, 8, "d"),
+        (pl.Array(pl.Int8, 3), 1, "b"),
+        (pl.Array(pl.UInt8, 3), 1, "B"),
+        (pl.Array(pl.Int16, 3), 2, "h"),
+        (pl.Array(pl.UInt16, 3), 2, "H"),
+        (pl.Array(pl.Int32, 3), 4, "i"),
+        (pl.Array(pl.UInt32, 3), 4, "I"),
+        (pl.Array(pl.Int64, 3), 8, "q"),
+        (pl.Array(pl.UInt64, 3), 8, "Q"),
+        (pl.Array(pl.Float32, 3), 4, "f"),
+        (pl.Array(pl.Float64, 3), 8, "d"),
     ],
 )
 def test_reinterpret_list(
@@ -239,11 +239,8 @@ def test_reinterpret_list(
     for dim_size in dtype.shape:
         type_size *= dim_size
 
-    print(shape)
-    print(type_size)
-
     byte_arr = [random.randbytes(type_size) for _ in range(3)]
-    df = pl.DataFrame({"x": byte_arr})
+    df = pl.DataFrame({"x": byte_arr}, orient="row")
 
     for endianness in ["little", "big"]:
         result = df.select(
@@ -254,16 +251,12 @@ def test_reinterpret_list(
         struct_endianness = "<" if endianness == "little" else ">"
         expected = []
         for elem_bytes in byte_arr:
-            print(elem_bytes)
             vals = [
                 struct.unpack_from(f"{struct_endianness}{struct_type}", elem_bytes[idx:idx + inner_type_size])[0]
                 for idx in range(0, type_size, inner_type_size)
             ]
-            print(vals)
             expected.append(vals)
-        print(expected)
         expected_df = pl.DataFrame({"x": expected}, schema={"x": dtype})
-
 
         assert_frame_equal(result, expected_df)
 

--- a/py-polars/tests/unit/operations/namespaces/test_binary.py
+++ b/py-polars/tests/unit/operations/namespaces/test_binary.py
@@ -4,6 +4,7 @@ import random
 import struct
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -214,6 +215,7 @@ def test_reinterpret(
     [
         (pl.Array(pl.Int8, 3), 1, "b"),
         (pl.Array(pl.UInt8, 3), 1, "B"),
+        (pl.Array(pl.UInt8, (3, 4, 5)), 1, "B"),
         (pl.Array(pl.Int16, 3), 2, "h"),
         (pl.Array(pl.UInt16, 3), 2, "H"),
         (pl.Array(pl.Int32, 3), 4, "i"),
@@ -255,6 +257,8 @@ def test_reinterpret_list(
                 struct.unpack_from(f"{struct_endianness}{struct_type}", elem_bytes[idx:idx + inner_type_size])[0]
                 for idx in range(0, type_size, inner_type_size)
             ]
+            if len(shape) > 1:
+                vals = np.reshape(vals, shape).tolist()
             expected.append(vals)
         expected_df = pl.DataFrame({"x": expected}, schema={"x": dtype})
 

--- a/py-polars/tests/unit/operations/namespaces/test_binary.py
+++ b/py-polars/tests/unit/operations/namespaces/test_binary.py
@@ -210,6 +210,7 @@ def test_reinterpret(
 
         assert_frame_equal(result, expected_df)
 
+
 @pytest.mark.parametrize(
     ("dtype", "inner_type_size", "struct_type"),
     [
@@ -254,7 +255,9 @@ def test_reinterpret_list(
         expected = []
         for elem_bytes in byte_arr:
             vals = [
-                struct.unpack_from(f"{struct_endianness}{struct_type}", elem_bytes[idx:idx + inner_type_size])[0]
+                struct.unpack_from(
+                    f"{struct_endianness}{struct_type}", elem_bytes[idx:idx + inner_type_size]
+                )[0]
                 for idx in range(0, type_size, inner_type_size)
             ]
             if len(shape) > 1:


### PR DESCRIPTION
Follow-up to: https://github.com/pola-rs/polars/pull/20263 Related to: https://github.com/pola-rs/polars/issues/18991

Adds support for casting binary into arrays of known size. This includes nested shapes (using flattening and reshaping).

Note that unknown size arrays (i.e. lists) are not supported. I think this is fine, since in majority of cases array size is known.
