### PR TITLE
perf: Remove predicate from `IR::DataFrame`

### DIFF
--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -247,7 +247,6 @@ fn get_pipeline_node(
         df: Arc::new(DataFrame::empty()),
         schema: Arc::new(Schema::default()),
         output_schema: None,
-        filter: None,
     });
 
     IR::MapFunction {

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -336,25 +336,11 @@ fn create_physical_plan_impl(
             }))
         },
         DataFrameScan {
+            df, output_schema, ..
+        } => Ok(Box::new(executors::DataFrameExec {
             df,
-            filter: predicate,
-            schema,
-            output_schema,
-            ..
-        } => {
-            let mut state = ExpressionConversionState::new(true, state.expr_depth);
-            let selection = predicate
-                .map(|pred| {
-                    create_physical_expr(&pred, Context::Default, expr_arena, &schema, &mut state)
-                })
-                .transpose()?;
-            Ok(Box::new(executors::DataFrameExec {
-                df,
-                projection: output_schema.map(|s| s.iter_names_cloned().collect()),
-                filter: selection,
-                predicate_has_windows: state.has_windows,
-            }))
-        },
+            projection: output_schema.map(|s| s.iter_names_cloned().collect()),
+        })),
         Sort {
             input,
             by_column,

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -52,22 +52,13 @@ where
     use IR::*;
     match source {
         DataFrameScan {
-            df,
-            filter: selection,
-            output_schema,
-            ..
+            df, output_schema, ..
         } => {
             let mut df = (*df).clone();
             let schema = output_schema
                 .clone()
                 .unwrap_or_else(|| Arc::new(df.schema()));
             if push_predicate {
-                if let Some(predicate) = selection {
-                    let predicate = to_physical(&predicate, expr_arena, &schema)?;
-                    let op = operators::FilterOperator { predicate };
-                    let op = Box::new(op) as Box<dyn Operator>;
-                    operator_objects.push(op)
-                }
                 // projection is free
                 if let Some(schema) = output_schema {
                     let columns = schema.iter_names_cloned().collect::<Vec<_>>();

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -24,7 +24,6 @@ fn empty_df() -> IR {
         df: Arc::new(Default::default()),
         schema: Arc::new(Default::default()),
         output_schema: None,
-        filter: None,
     }
 }
 
@@ -342,7 +341,6 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         df: Arc::new(DataFrame::empty_with_schema(&file_info.schema)),
                         schema: file_info.schema,
                         output_schema: None,
-                        filter: None,
                     }
                 } else {
                     IR::Scan {
@@ -471,7 +469,6 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             df,
             schema,
             output_schema: None,
-            filter: None,
         },
         DslPlan::Select {
             expr,

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -118,7 +118,6 @@ impl IR {
                 df,
                 schema,
                 output_schema: _,
-                filter: _,
             } => DslPlan::DataFrameScan { df, schema },
             IR::Select {
                 expr,

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -229,16 +229,13 @@ impl<'a> IRDotDisplay<'a> {
             DataFrameScan {
                 schema,
                 output_schema,
-                filter: selection,
                 ..
             } => {
                 let num_columns = NumColumnsSchema(output_schema.as_ref().map(|p| p.as_ref()));
-                let selection = selection.as_ref().map(|e| self.display_expr(e));
-                let selection = OptionExprIRDisplay(selection);
                 let total_columns = schema.len();
 
                 write_label(f, id, |f| {
-                    write!(f, "TABLE\nπ {num_columns}/{total_columns};\nσ {selection}")
+                    write!(f, "TABLE\nπ {num_columns}/{total_columns}")
                 })?;
             },
             Scan {
@@ -339,7 +336,6 @@ pub struct PathsDisplay<'a>(pub &'a [PathBuf]);
 pub struct ScanSourcesDisplay<'a>(pub &'a ScanSources);
 struct NumColumns<'a>(Option<&'a [PlSmallStr]>);
 struct NumColumnsSchema<'a>(Option<&'a Schema>);
-struct OptionExprIRDisplay<'a>(Option<ExprIRDisplay<'a>>);
 
 impl fmt::Display for ScanSourceRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -397,15 +393,6 @@ impl fmt::Display for NumColumnsSchema<'_> {
         match self.0 {
             None => f.write_str("*"),
             Some(columns) => columns.len().fmt(f),
-        }
-    }
-}
-
-impl fmt::Display for OptionExprIRDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
-            None => f.write_str("None"),
-            Some(expr) => expr.fmt(f),
         }
     }
 }

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 
 use polars_core::datatypes::AnyValue;
@@ -260,7 +259,6 @@ impl<'a> IRDisplay<'a> {
             DataFrameScan {
                 schema,
                 output_schema,
-                filter: selection,
                 ..
             } => {
                 let total_columns = schema.len();
@@ -269,18 +267,13 @@ impl<'a> IRDisplay<'a> {
                 } else {
                     "*".to_string()
                 };
-                let selection = match selection {
-                    Some(s) => Cow::Owned(self.display_expr(s).to_string()),
-                    None => Cow::Borrowed("None"),
-                };
                 write!(
                     f,
-                    "{:indent$}DF {:?}; PROJECT {}/{} COLUMNS; SELECTION: {}",
+                    "{:indent$}DF {:?}; PROJECT {}/{} COLUMNS",
                     "",
                     schema.iter_names().take(4).collect::<Vec<_>>(),
                     n_columns,
                     total_columns,
-                    selection,
                 )
             },
             Select { expr, input, .. } => {

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -122,19 +122,10 @@ impl IR {
                 df,
                 schema,
                 output_schema,
-                filter: selection,
-            } => {
-                let mut new_selection = None;
-                if selection.is_some() {
-                    new_selection = exprs.pop()
-                }
-
-                DataFrameScan {
-                    df: df.clone(),
-                    schema: schema.clone(),
-                    output_schema: output_schema.clone(),
-                    filter: new_selection,
-                }
+            } => DataFrameScan {
+                df: df.clone(),
+                schema: schema.clone(),
+                output_schema: output_schema.clone(),
             },
             MapFunction { function, .. } => MapFunction {
                 input: inputs[0],
@@ -181,13 +172,7 @@ impl IR {
                     container.push(pred.clone())
                 }
             },
-            DataFrameScan {
-                filter: selection, ..
-            } => {
-                if let Some(expr) = selection {
-                    container.push(expr.clone())
-                }
-            },
+            DataFrameScan { .. } => {},
             #[cfg(feature = "python")]
             PythonScan { .. } => {},
             HConcat { .. } => {},

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -71,9 +71,6 @@ pub enum IR {
         // Schema of the projected file
         // If `None`, no projection is applied
         output_schema: Option<SchemaRef>,
-        // Predicate to apply on the DataFrame
-        // All the columns required for the predicate are projected.
-        filter: Option<ExprIR>,
     },
     // Only selects columns (semantically only has row access).
     // This is a more restricted operation than `Select`.

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -189,7 +189,6 @@ impl<'a> TreeFmtNode<'a> {
                     DataFrameScan {
                         schema,
                         output_schema,
-                        filter: selection,
                         ..
                     } => ND(
                         wh(
@@ -205,11 +204,7 @@ impl<'a> TreeFmtNode<'a> {
                                 schema.len()
                             ),
                         ),
-                        if let Some(expr) = selection {
-                            vec![self.expr_node(Some("SELECTION:".to_string()), expr)]
-                        } else {
-                            vec![]
-                        },
+                        vec![],
                     ),
                     Union { inputs, .. } => ND(
                         wh(

--- a/crates/polars-plan/src/plans/optimizer/count_star.rs
+++ b/crates/polars-plan/src/plans/optimizer/count_star.rs
@@ -28,7 +28,6 @@ impl OptimizationRule for CountStar {
                         df: Arc::new(Default::default()),
                         schema: Arc::new(Default::default()),
                         output_schema: None,
-                        filter: None,
                     };
                     let placeholder_node = lp_arena.add(placeholder);
 

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -363,7 +363,6 @@ impl ProjectionPushDown {
                 df,
                 schema,
                 mut output_schema,
-                filter: selection,
                 ..
             } => {
                 if !acc_projections.is_empty() {
@@ -378,7 +377,6 @@ impl ProjectionPushDown {
                     df,
                     schema,
                     output_schema,
-                    filter: selection,
                 };
                 Ok(lp)
             },

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -318,13 +318,12 @@ impl SlicePushDown {
 
                 Ok(lp)
             },
-            (DataFrameScan {df, schema, output_schema, filter, }, Some(state)) if filter.is_none() => {
+            (DataFrameScan {df, schema, output_schema, }, Some(state))  => {
                 let df = df.slice(state.offset, state.len as usize);
                 let lp = DataFrameScan {
                     df: Arc::new(df),
                     schema,
                     output_schema,
-                    filter
                 };
                 Ok(lp)
             }

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -92,11 +92,10 @@ impl Hash for HashableEqLP<'_> {
                 df,
                 schema: _,
                 output_schema,
-                filter: selection,
+                ..
             } => {
                 (Arc::as_ptr(df) as usize).hash(state);
                 output_schema.hash(state);
-                hash_option_expr(selection, self.expr_arena, state);
             },
             IR::SimpleProjection { columns, input: _ } => {
                 columns.hash(state);
@@ -275,19 +274,13 @@ impl HashableEqLP<'_> {
                     df: dfl,
                     schema: _,
                     output_schema: s_l,
-                    filter: sl,
                 },
                 IR::DataFrameScan {
                     df: dfr,
                     schema: _,
                     output_schema: s_r,
-                    filter: sr,
                 },
-            ) => {
-                Arc::as_ptr(dfl) == Arc::as_ptr(dfr)
-                    && s_l == s_r
-                    && opt_expr_ir_eq(sl, sr, self.expr_arena)
-            },
+            ) => Arc::as_ptr(dfl) == Arc::as_ptr(dfr) && s_l == s_r,
             (
                 IR::SimpleProjection {
                     input: _,

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -373,7 +373,6 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             df,
             schema: _,
             output_schema,
-            filter: selection,
         } => DataFrameScan {
             df: PyDataFrame::new((**df).clone()),
             projection: output_schema.as_ref().map_or_else(
@@ -385,7 +384,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                         .into_py_any(py)
                 },
             )?,
-            selection: selection.as_ref().map(|e| e.into()),
+            selection: None,
         }
         .into_py_any(py),
         IR::SimpleProjection { input, columns: _ } => {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -176,11 +176,10 @@ pub fn lower_ir(
         IR::DataFrameScan {
             df,
             output_schema: projection,
-            filter,
             schema,
             ..
         } => {
-            let mut schema = schema.clone(); // This is initially the schema of df, but can change with the projection.
+            let schema = schema.clone(); // This is initially the schema of df, but can change with the projection.
             let mut node_kind = PhysNodeKind::InMemorySource { df: df.clone() };
 
             // Do we need to apply a projection?
@@ -196,13 +195,7 @@ pub fn lower_ir(
                         input: phys_input,
                         columns: projection_schema.iter_names_cloned().collect::<Vec<_>>(),
                     };
-                    schema = projection_schema.clone();
                 }
-            }
-
-            if let Some(predicate) = filter.clone() {
-                let phys_input = phys_sm.insert(PhysNode::new(schema, node_kind));
-                return build_filter_node(phys_input, predicate, expr_arena, phys_sm, expr_cache);
             }
 
             node_kind

--- a/py-polars/tests/unit/lazyframe/test_explain.py
+++ b/py-polars/tests/unit/lazyframe/test_explain.py
@@ -5,19 +5,6 @@ import pytest
 import polars as pl
 
 
-def test_lf_explain() -> None:
-    lf = pl.LazyFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    plan = lf.select("a").select(pl.col("a").sum() + pl.len())
-
-    result = plan.explain()
-
-    expected = """\
- SELECT [[(col("a").sum()) + (len().cast(Int64))]] FROM
-  DF ["a", "b"]; PROJECT 1/2 COLUMNS; SELECTION: None\
-"""
-    assert result == expected
-
-
 def test_lf_explain_format_tree() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
     plan = lf.select("a").select(pl.col("a").sum() + pl.len())

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import date
 
 import pytest
@@ -44,7 +45,13 @@ def test_unique_predicate_pd() -> None:
             plan = q.explain()
             assert r'FILTER col("z")' in plan
             # We can push filters if they only depend on the subset columns of unique()
-            assert r'SELECTION: [(col("x")) == (String(abc))]' in plan
+            assert (
+                re.search(
+                    r"FILTER \[\(col\(\"x\"\)\) == \(String\(abc\)\)\] FROM\n\s*DF",
+                    plan,
+                )
+                is not None
+            )
             assert_frame_equal(q.collect(predicate_pushdown=False), q.collect())
 
 


### PR DESCRIPTION
Simplifies IR, saves a lowering step in streaming and ensures that the in-memory engine can parallelize if it wants to.

First solution for #20475