### PR TITLE
fix(rust): `slice_pushdown` optimization leading to incorrectly sliced row index on parquet file

### DIFF
--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -689,8 +689,8 @@ fn rg_to_dfs_par_over_rg(
         .sum();
     let slice_end = slice.0 + slice.1;
 
-    // we need to distinguish between the number of rows scanned and the number of rows actually read
-    // these values can differ when the slice_pushdown optimization and/or the async Parquet reader are being used
+    // we distinguish between the number of rows scanned and the number of rows actually
+    // read as these values can differ when the slice pushdown optimization is used
     let mut rows_scanned: IdxSize = (0..row_group_start)
         .map(|i| file_metadata.row_groups[i].num_rows() as IdxSize)
         .sum();

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -692,10 +692,11 @@ fn rg_to_dfs_par_over_rg(
     for i in row_group_start..row_group_end {
         let row_count_start = *previous_row_count;
         let rg_md = &file_metadata.row_groups[i];
+        let n_rows_this_file = rg_md.num_rows();
         let rg_slice =
-            split_slice_at_file(&mut n_rows_processed, rg_md.num_rows(), slice.0, slice_end);
+            split_slice_at_file(&mut n_rows_processed, n_rows_this_file, slice.0, slice_end);
         *previous_row_count = previous_row_count
-            .checked_add(rg_slice.1 as IdxSize)
+            .checked_add(n_rows_this_file as IdxSize)
             .ok_or(ROW_COUNT_OVERFLOW_ERR)?;
 
         if rg_slice.1 == 0 {


### PR DESCRIPTION
Fixes #20485 

The `row_count_start` values in the `rg_to_dfs_par_over_rg()` function were not properly reflecting the number of rows that had already been processed when the `slice_pushdown` optimization was being used.
