### PR TITLE
Publicly document MutableBinaryViewArray invariants

### DIFF
--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -20,11 +20,11 @@ use crate::trusted_len::TrustedLen;
 const DEFAULT_BLOCK_SIZE: usize = 8 * 1024;
 const MAX_EXP_BLOCK_SIZE: usize = 16 * 1024 * 1024;
 
-// Invariants:
-//
-// - Each view must point to a valid slice of a buffer
-// - `total_buffer_len` must be equal to `completed_buffers.iter().map(Vec::len).sum()`
-// - `total_bytes_len` must be equal to `views.iter().map(View::len).sum()`
+/// # Safety invariants
+///
+/// - Each view must point to a valid slice of a buffer
+/// - `total_buffer_len` must be equal to `completed_buffers.iter().map(Vec::len).sum()`
+/// - `total_bytes_len` must be equal to `views.iter().map(View::len).sum()`
 pub struct MutableBinaryViewArray<T: ViewType + ?Sized> {
     pub(crate) views: Vec<View>,
     pub(crate) completed_buffers: Vec<Buffer<u8>>,


### PR DESCRIPTION
These invariants are referenced from the safety documentation of several publicly-exposed methods. This information should therefore be public so that callers can ensure correct usage.