### PR TITLE
docs: Update "group_by_rolling" (deprecated) to "rolling" in user guide

### DIFF
--- a/docs/source/user-guide/concepts/expressions-and-contexts.md
+++ b/docs/source/user-guide/concepts/expressions-and-contexts.md
@@ -149,7 +149,7 @@ aggregating expressions. In turn, we can specify as many aggregating expressions
 --8<-- "python/user-guide/concepts/expressions.py:group_by-3"
 ```
 
-See also `group_by_dynamic` and `group_by_rolling` for other grouping contexts.
+See also `group_by_dynamic` and `rolling` for other grouping contexts.
 
 ## Expression expansion
 


### PR DESCRIPTION
Deprecated since version 0.19.9: This method has been renamed to DataFrame.rolling().