### PR TITLE
build(python): Officially support Python 3.13

### DIFF
--- a/.github/workflows/benchmark-remote.yml
+++ b/.github/workflows/benchmark-remote.yml
@@ -26,12 +26,12 @@ jobs:
 
       - name: Clone Polars-benchmark
         run: |
-          git clone --depth=1 https://github.com/pola-rs/polars-benchmark.git 
+          git clone --depth=1 https://github.com/pola-rs/polars-benchmark.git
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Create virtual environment
         run: |
@@ -46,7 +46,7 @@ jobs:
           # Install typing-extensions separately whilst the `--extra-index-url` in `requirements-ci.txt`
           # doesn't have an up-to-date typing-extensions, see
           # https://github.com/astral-sh/uv/issues/6028#issuecomment-2287232150
-          uv pip install -U typing-extensions 
+          uv pip install -U typing-extensions
           uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose
 
       - name: Install Polars-Benchmark dependencies
@@ -68,7 +68,7 @@ jobs:
         working-directory: polars-benchmark
         run: |
           "$HOME/py-polars-cache/run-benchmarks.sh" | tee ../py-polars/benchmark-results
-      
+
       - name: Cache the Polars build
         if: ${{ github.ref == 'refs/heads/main' }}
         working-directory: py-polars

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Set up Graphviz
         uses: ts-graphviz/setup-graphviz@v2
@@ -52,7 +52,7 @@ jobs:
           # Install typing-extensions separately whilst the `--extra-index-url` in `requirements-ci.txt`
           # doesn't have an up-to-date typing-extensions, see
           # https://github.com/astral-sh/uv/issues/6028#issuecomment-2287232150
-          uv pip install -U typing-extensions 
+          uv pip install -U typing-extensions
           uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose
 
       - name: Set up Rust

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
           # doesn't have an up-to-date typing-extensions, see
           # https://github.com/astral-sh/uv/issues/6028#issuecomment-2287232150
           uv pip install -U typing-extensions
-          uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose
+          uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose --index-strategy=unsafe-best-match
 
       - name: Set up Rust
         run: rustup show

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Create virtual environment
         run: |

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Install Python dependencies
         working-directory: py-polars
-        run: uv pip install -r requirements-dev.txt -r requirements-lint.txt
+        # TODO: Fix typing issues for newer NumPy versions
+        # https://github.com/pola-rs/polars/issues/20561
+        run: uv pip install -r requirements-dev.txt -r requirements-lint.txt 'numpy<2.1'
 
       # Allow untyped calls for older Python versions
       - name: Run mypy

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -70,7 +70,7 @@ jobs:
           # doesn't have an up-to-date typing-extensions, see
           # https://github.com/astral-sh/uv/issues/6028#issuecomment-2287232150
           uv pip install -U typing-extensions
-          uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose
+          uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose --index-strategy=unsafe-best-match
 
       - name: Set up Rust
         run: rustup show

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -39,10 +39,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.12', '3.13']
         include:
           - os: windows-latest
-            python-version: '3.12'
+            python-version: '3.13'
 
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
         run: maturin develop
 
       - name: Run doctests
-        if: github.ref_name != 'main' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        if: github.ref_name != 'main' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
         run: |
           python tests/docs/run_doctest.py
           pytest tests/docs/test_user_guide.py -m docs
@@ -107,7 +107,7 @@ jobs:
         run: pytest -m "not release and not benchmark and not docs" tests/unit/io/
 
       - name: Check import without optional dependencies
-        if: github.ref_name != 'main' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        if: github.ref_name != 'main' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
         run: |
           declare -a deps=("pandas"
           "pyarrow"

--- a/docs/source/development/contributing/index.md
+++ b/docs/source/development/contributing/index.md
@@ -99,7 +99,7 @@ rustup toolchain install nightly --component miri
 ```
 
 Next, install Python, for example using [pyenv](https://github.com/pyenv/pyenv#installation). We
-recommend using the latest Python version (`3.12`). Make sure you deactivate any active virtual
+recommend using the latest Python version (`3.13`). Make sure you deactivate any active virtual
 environments (command: `deactivate`) or conda environments (command: `conda deactivate`), as the
 steps below will create a new [virtual environment](https://docs.python.org/3/tutorial/venv.html)
 for Polars. You will need Python even if you intend to work on the Rust code only, as we rely on the

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Rust",
   "Topic :: Scientific/Engineering",
 ]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -259,6 +259,8 @@ filterwarnings = [
   # Ignore invalid warnings when running earlier versions of SQLAlchemy (we
   # know they are invalid because our standard tests run the latest version)
   "ignore:Deprecated API features detected.*:DeprecationWarning",
+  # numpy import can generate this warning in Python 3.13 on certain runners
+  "ignore:.*numpy\\.longdouble.*:UserWarning",
 ]
 xfail_strict = true
 

--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -3,6 +3,6 @@
 # (installable via `make requirements-all`)
 # -------------------------------------------------------
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch
+torch; python_version < '3.13' or platform_system != 'Windows'  # torch provides no wheel for Python 3.13 on Windows
 jax[cpu]
 pyiceberg>=0.5.0

--- a/py-polars/tests/unit/ml/test_to_torch.py
+++ b/py-polars/tests/unit/ml/test_to_torch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Any
 
 import pytest
@@ -12,7 +13,13 @@ from polars.dependencies import _lazy_import
 # ensures the tests aren't run locally; this avoids premature local import)
 torch, _ = _lazy_import("torch")
 
-pytestmark = pytest.mark.ci_only
+pytestmark = [
+    pytest.mark.ci_only,
+    pytest.mark.skipif(
+        sys.platform == "win32" and sys.version_info >= (3, 13),
+        reason="Torch does not ship wheels for Python 3.13 on Windows",
+    ),
+]
 
 
 @pytest.fixture


### PR DESCRIPTION
Polars was already installable under Python 3.13 and already worked. This PR officially marks Python 3.13 as supported and updates our CI to also run tests under Python 3.13.

There's an issue with running MyPy with the latest NumPy version that came up because of this PR. I made a separate issue for this: https://github.com/pola-rs/polars/issues/20561