### PR TITLE
docs: Miscellaneous minor updates/fixes

### DIFF
--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -49,7 +49,7 @@ use polars_error::{polars_bail, PolarsResult};
 ///
 /// # Safety
 /// The following invariants hold:
-/// * Two consecutives `offsets` casted (`as`) to `usize` are valid slices of `values`.
+/// * Two consecutive `offsets` cast (`as`) to `usize` are valid slices of `values`.
 /// * `len` is equal to `validity.len()`, when defined.
 #[derive(Clone)]
 pub struct BinaryArray<O: Offset> {

--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -40,7 +40,7 @@ pub unsafe trait DictionaryKey: NativeType + TryInto<usize> + TryFrom<usize> + H
     /// Represents this key as a `usize`.
     ///
     /// # Safety
-    /// The caller _must_ have checked that the value can be casted to `usize`.
+    /// The caller _must_ have checked that the value can be cast to `usize`.
     #[inline]
     unsafe fn as_usize(self) -> usize {
         match self.try_into() {

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -11,7 +11,7 @@
 //! * [`ListArray`] and [`MutableListArray`], an array of arrays (e.g. `[[1, 2], None, [], [None]]`)
 //! * [`StructArray`] and [`MutableStructArray`], an array of arrays identified by a string (e.g. `{"a": [1, 2], "b": [true, false]}`)
 //!
-//! All immutable arrays implement the trait object [`Array`] and that can be downcasted
+//! All immutable arrays implement the trait object [`Array`] and that can be downcast
 //! to a concrete struct based on [`PhysicalType`](crate::datatypes::PhysicalType) available from [`Array::dtype`].
 //! All immutable arrays are backed by [`Buffer`](crate::buffer::Buffer) and thus cloning and slicing them is `O(1)`.
 //!
@@ -58,7 +58,7 @@ pub trait Splitable: Sized {
 }
 
 /// A trait representing an immutable Arrow array. Arrow arrays are trait objects
-/// that are infallibly downcasted to concrete types according to the [`Array::dtype`].
+/// that are infallibly downcast to concrete types according to the [`Array::dtype`].
 pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     /// Converts itself to a reference of [`Any`], which enables downcasting to concrete types.
     fn as_any(&self) -> &dyn Any;

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -58,8 +58,8 @@ impl<T: AsRef<str>> AsRef<[u8]> for StrAsBytes<T> {
 ///
 /// # Safety
 /// The following invariants hold:
-/// * Two consecutives `offsets` casted (`as`) to `usize` are valid slices of `values`.
-/// * A slice of `values` taken from two consecutives `offsets` is valid `utf8`.
+/// * Two consecutive `offsets` cast (`as`) to `usize` are valid slices of `values`.
+/// * A slice of `values` taken from two consecutive `offsets` is valid `utf8`.
 /// * `len` is equal to `validity.len()`, when defined.
 #[derive(Clone)]
 pub struct Utf8Array<O: Offset> {

--- a/crates/polars-compute/src/cast/decimal_to.rs
+++ b/crates/polars-compute/src/cast/decimal_to.rs
@@ -29,7 +29,7 @@ fn decimal_to_decimal_impl<F: Fn(i128) -> Option<i128>>(
         .to(ArrowDataType::Decimal(to_precision, to_scale))
 }
 
-/// Returns a [`PrimitiveArray<i128>`] with the casted values. Values are `None` on overflow
+/// Returns a [`PrimitiveArray<i128>`] with the cast values. Values are `None` on overflow
 pub fn decimal_to_decimal(
     from: &PrimitiveArray<i128>,
     to_precision: usize,
@@ -79,7 +79,7 @@ pub(super) fn decimal_to_decimal_dyn(
     Ok(Box::new(decimal_to_decimal(from, to_precision, to_scale)))
 }
 
-/// Returns a [`PrimitiveArray<i128>`] with the casted values. Values are `None` on overflow
+/// Returns a [`PrimitiveArray<i128>`] with the cast values. Values are `None` on overflow
 pub fn decimal_to_float<T>(from: &PrimitiveArray<i128>) -> PrimitiveArray<T>
 where
     T: NativeType + Float,
@@ -110,7 +110,7 @@ where
     Ok(Box::new(decimal_to_float::<T>(from)))
 }
 
-/// Returns a [`PrimitiveArray<i128>`] with the casted values. Values are `None` on overflow
+/// Returns a [`PrimitiveArray<i128>`] with the cast values. Values are `None` on overflow
 pub fn decimal_to_integer<T>(from: &PrimitiveArray<i128>) -> PrimitiveArray<T>
 where
     T: NativeType + NumCast,

--- a/crates/polars-compute/src/cast/primitive_to.rs
+++ b/crates/polars-compute/src/cast/primitive_to.rs
@@ -172,7 +172,7 @@ where
     PrimitiveArray::<O>::from_trusted_len_iter(iter).to(to_type.clone())
 }
 
-/// Returns a [`PrimitiveArray<i128>`] with the casted values. Values are `None` on overflow
+/// Returns a [`PrimitiveArray<i128>`] with the cast values. Values are `None` on overflow
 pub fn integer_to_decimal<T: NativeType + AsPrimitive<i128>>(
     from: &PrimitiveArray<T>,
     to_precision: usize,
@@ -213,7 +213,7 @@ where
     Ok(Box::new(integer_to_decimal::<T>(from, precision, scale)))
 }
 
-/// Returns a [`PrimitiveArray<i128>`] with the casted values. Values are `None` on overflow
+/// Returns a [`PrimitiveArray<i128>`] with the cast values. Values are `None` on overflow
 pub fn float_to_decimal<T>(
     from: &PrimitiveArray<T>,
     to_precision: usize,

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -477,7 +477,7 @@ impl ChunkCast for ListChunked {
                     _ => {
                         // ensure the inner logical type bubbles up
                         let (arr, child_type) = cast_list(self, child_type, options)?;
-                        // SAFETY: we just casted so the dtype matches.
+                        // SAFETY: we just cast so the dtype matches.
                         // we must take this path to correct for physical types.
                         unsafe {
                             Ok(Series::from_chunks_and_dtype_unchecked(
@@ -499,7 +499,7 @@ impl ChunkCast for ListChunked {
 
                 // cast to the physical type to avoid logical chunks.
                 let chunks = cast_chunks(self.chunks(), &physical_type, options)?;
-                // SAFETY: we just casted so the dtype matches.
+                // SAFETY: we just cast so the dtype matches.
                 // we must take this path to correct for physical types.
                 unsafe {
                     Ok(Series::from_chunks_and_dtype_unchecked(
@@ -550,7 +550,7 @@ impl ChunkCast for ArrayChunked {
                     _ => {
                         // ensure the inner logical type bubbles up
                         let (arr, child_type) = cast_fixed_size_list(self, child_type, options)?;
-                        // SAFETY: we just casted so the dtype matches.
+                        // SAFETY: we just cast so the dtype matches.
                         // we must take this path to correct for physical types.
                         unsafe {
                             Ok(Series::from_chunks_and_dtype_unchecked(
@@ -566,7 +566,7 @@ impl ChunkCast for ArrayChunked {
                 let physical_type = dtype.to_physical();
                 // cast to the physical type to avoid logical chunks.
                 let chunks = cast_chunks(self.chunks(), &physical_type, options)?;
-                // SAFETY: we just casted so the dtype matches.
+                // SAFETY: we just cast so the dtype matches.
                 // we must take this path to correct for physical types.
                 unsafe {
                     Ok(Series::from_chunks_and_dtype_unchecked(

--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -76,7 +76,7 @@ impl ListChunked {
 
 impl DataFrame {
     /// Create a 2D [`ndarray::Array`] from this [`DataFrame`]. This requires all columns in the
-    /// [`DataFrame`] to be non-null and numeric. They will be casted to the same data type
+    /// [`DataFrame`] to be non-null and numeric. They will be cast to the same data type
     /// (if they aren't already).
     ///
     /// For floating point data we implicitly convert `None` to `NaN` without failure.

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -161,7 +161,7 @@ impl<T: PolarsNumericType> ChunkedArray<T> {
         S: PolarsNumericType,
     {
         // if we cast, we create a new arrow buffer
-        // then we clone the arrays and drop the casted arrays
+        // then we clone the arrays and drop the cast arrays
         // this will ensure we have a single ref count
         // and we can mutate in place
         let chunks = {

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -35,10 +35,10 @@ fn assert_dtypes(dtype: &ArrowDataType) {
     use ArrowDataType as D;
 
     match dtype {
-        // These should all be casted to the BinaryView / Utf8View variants
+        // These should all be cast to the BinaryView / Utf8View variants
         D::Utf8 | D::Binary | D::LargeUtf8 | D::LargeBinary => unreachable!(),
 
-        // These should be casted to Float32
+        // These should be cast to Float32
         D::Float16 => unreachable!(),
 
         // This should have been converted to a LargeList

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -822,7 +822,7 @@ impl LazyFrame {
         )
     }
 
-    /// Stream a query result into a json file. This is useful if the final result doesn't fit
+    /// Stream a query result into a JSON file. This is useful if the final result doesn't fit
     /// into memory. This methods will return an error if the query cannot be completely done in a
     /// streaming fashion.
     #[cfg(feature = "json")]

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -236,7 +236,7 @@ pub fn resolve_join(
 
     // # Cast lossless
     //
-    // If we do a full join and keys are coalesced, the casted keys must be added up front.
+    // If we do a full join and keys are coalesced, the cast keys must be added up front.
     let key_cols_coalesced =
         options.args.should_coalesce() && matches!(&options.args.how, JoinType::Full);
     let mut as_with_columns_l = vec![];

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -409,7 +409,7 @@ fn try_inline_literal_cast(
                 Some(av) => av.into(),
             }
         },
-        // We generate casted literal datetimes, so ensure we cast upon conversion
+        // We generate cast literal datetimes, so ensure we cast upon conversion
         // to create simpler expr trees.
         #[cfg(feature = "dtype-datetime")]
         LiteralValue::DateTime(ts, tu, None) if dtype.is_date() => {

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -626,7 +626,7 @@ unsafe fn encode_flat_array(
             encode_strs(buffer, array.iter(), opt, offsets);
         },
 
-        // Lexical ordered Categorical are casted to PrimitiveArray above.
+        // Lexical ordered Categorical are cast to PrimitiveArray above.
         D::Dictionary(_, _, _) => todo!(),
 
         D::FixedSizeBinary(_) => todo!(),

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -446,7 +446,7 @@ NoDefault = Literal[_NoDefault.no_default]
 
 def find_stacklevel() -> int:
     """
-    Find the first place in the stack that is not inside polars.
+    Find the first place in the stack that is not inside Polars.
 
     Taken from:
     https://github.com/pandas-dev/pandas/blob/ab89c53f48df67709a533b6a95ce3d911871a0a8/pandas/util/_exceptions.py#L30-L51

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10356,7 +10356,7 @@ class DataFrame:
         Apply a horizontal reduction on a DataFrame.
 
         This can be used to effectively determine aggregations on a row level, and can
-        be applied to any DataType that can be supercasted (casted to a similar parent
+        be applied to any DataType that can be supercast (cast to a similar parent
         type).
 
         An example of the supercast rules when applying an arithmetic operation on two

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -142,7 +142,7 @@ class DataType(metaclass=DataTypeClass):
         Parameters
         ----------
         other
-            the other polars dtype to compare with.
+            the other Polars dtype to compare with.
 
         Examples
         --------

--- a/py-polars/polars/expr/binary.py
+++ b/py-polars/polars/expr/binary.py
@@ -301,7 +301,7 @@ class ExprBinaryNameSpace:
         self, *, dtype: PolarsDataType, endianness: Endianness = "little"
     ) -> Expr:
         r"""
-        Interpret a buffer as a numerical polars type.
+        Interpret a buffer as a numerical Polars type.
 
         Parameters
         ----------
@@ -321,19 +321,19 @@ class ExprBinaryNameSpace:
         --------
         >>> df = pl.DataFrame({"data": [b"\x05\x00\x00\x00", b"\x10\x00\x01\x00"]})
         >>> df.with_columns(  # doctest: +IGNORE_RESULT
-        ...     casted=pl.col("data").bin.reinterpret(
+        ...     bin2int=pl.col("data").bin.reinterpret(
         ...         dtype=pl.Int32, endianness="little"
         ...     ),
         ... )
-        shape: (2, 3)
-        ┌─────────────────────┬────────┐
-        │ data                ┆ caster │
-        │ ---                 ┆ ---    │
-        │ binary              ┆ i32    │
-        ╞═════════════════════╪════════╡
-        │ b"\x05\x00\x00\x00" ┆ 5      │
-        │ b"\x10\x00\x01\x00" ┆ 65552  │
-        └─────────────────────┴────────┘
+        shape: (2, 2)
+        ┌─────────────────────┬─────────┐
+        │ data                ┆ bin2int │
+        │ ---                 ┆ ---     │
+        │ binary              ┆ i32     │
+        ╞═════════════════════╪═════════╡
+        │ b"\x05\x00\x00\x00" ┆ 5       │
+        │ b"\x10\x00\x01\x00" ┆ 65552   │
+        └─────────────────────┴─────────┘
         """
         dtype = parse_into_dtype(dtype)
 

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1232,8 +1232,8 @@ class ExprStringNameSpace:
 
         See Also
         --------
-        json_path_match : Extract the first match of json string with provided JSONPath
-            expression.
+        json_path_match : Extract the first match from a JSON string using the provided
+            JSONPath.
 
         Examples
         --------
@@ -1259,19 +1259,18 @@ class ExprStringNameSpace:
 
     def json_path_match(self, json_path: IntoExprColumn) -> Expr:
         """
-        Extract the first match of JSON string with the provided JSONPath expression.
+        Extract the first match from a JSON string using the provided JSONPath.
 
-        Throws errors if invalid JSON strings are encountered.
-        All return values will be cast to :class:`String` regardless of the original
-        value.
+        Throws errors if invalid JSON strings are encountered. All return values
+        are cast to :class:`String`, regardless of the original value.
 
-        Documentation on JSONPath standard can be found
+        Documentation on the JSONPath standard can be found
         `here <https://goessner.net/articles/JsonPath/>`_.
 
         Parameters
         ----------
         json_path
-            A valid JSON path query string.
+            A valid JSONPath query string.
 
         Returns
         -------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -682,7 +682,7 @@ class StringNameSpace:
         Extract the first match of json string with provided JSONPath expression.
 
         Throw errors if encounter invalid json strings.
-        All return value will be casted to String regardless of the original value.
+        All return value will be cast to String regardless of the original value.
 
         Documentation on JSONPath standard can be found
         `here <https://goessner.net/articles/JsonPath/>`_.

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -679,10 +679,10 @@ class StringNameSpace:
 
     def json_path_match(self, json_path: IntoExprColumn) -> Series:
         """
-        Extract the first match of json string with provided JSONPath expression.
+        Extract the first match of JSON string with provided JSONPath expression.
 
-        Throw errors if encounter invalid json strings.
-        All return value will be cast to String regardless of the original value.
+        Throw errors if encounter invalid JSON strings.
+        All return values will be cast to String regardless of the original value.
 
         Documentation on JSONPath standard can be found
         `here <https://goessner.net/articles/JsonPath/>`_.

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -134,7 +134,9 @@ def test_from_dataframe_pyarrow_boolean() -> None:
     result = pl.from_dataframe(df_pa)
     assert_frame_equal(result, df)
 
-    with pytest.raises(RuntimeError, match="Boolean column will be casted to uint8"):
+    # note: pyarrow uses the incorrect form "casted" instead of "cast" in this error.
+    # (in case they fix it in the future, the regex match handles both forms)
+    with pytest.raises(RuntimeError, match="Boolean column will be cast(ed)? to uint8"):
         pl.from_dataframe(df_pa, allow_copy=False)
 
 

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -688,8 +688,8 @@ def test_json_decode_primitive_to_list_11053() -> None:
     )
 
     output = df.select(
-        pl.col("json").str.json_decode(schema).alias("casted_json")
-    ).unnest("casted_json")
+        pl.col("json").str.json_decode(schema).alias("decoded_json")
+    ).unnest("decoded_json")
     expected = pl.DataFrame({"col1": [["123"], ["xyz"]], "col2": [["123"], None]})
     assert_frame_equal(output, expected)
 


### PR DESCRIPTION
Fixed a few minor gremlins in Python/Rust docstrings:

* Updated "casted" → "cast" (it's irregular, so the past tense still conjugates as "cast" :)
* Updated "consecutives" → "consecutive" in a few places.
* Some "polars" → "Polars" adjustments for consistency.
* Fixed the output of the "reinterpret" example.
