### PR TITLE
feat: Update `sqlparser-rs`, enabling "LEFT" keyword to be optional for anti/semi joins in SQL queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4584,9 +4584,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
+checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
 dependencies = [
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ serde_json = "1"
 simd-json = { version = "0.14", features = ["known-key"] }
 simdutf8 = "0.1.4"
 slotmap = "1"
-sqlparser = "0.52"
+sqlparser = "0.53"
 stacker = "0.1"
 streaming-iterator = "0.1.9"
 strength_reduce = "0.2"

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -566,6 +566,8 @@ impl SQLContext {
                     | JoinOperator::LeftOuter(constraint)
                     | JoinOperator::RightOuter(constraint)
                     | JoinOperator::Inner(constraint)
+                    | JoinOperator::Anti(constraint)
+                    | JoinOperator::Semi(constraint)
                     | JoinOperator::LeftAnti(constraint)
                     | JoinOperator::LeftSemi(constraint)
                     | JoinOperator::RightAnti(constraint)
@@ -592,9 +594,9 @@ impl SQLContext {
                                 JoinOperator::RightOuter(_) => JoinType::Right,
                                 JoinOperator::Inner(_) => JoinType::Inner,
                                 #[cfg(feature = "semi_anti_join")]
-                                JoinOperator::LeftAnti(_) | JoinOperator::RightAnti(_) => JoinType::Anti,
+                                JoinOperator::Anti(_) | JoinOperator::LeftAnti(_) | JoinOperator::RightAnti(_) => JoinType::Anti,
                                 #[cfg(feature = "semi_anti_join")]
-                                JoinOperator::LeftSemi(_) | JoinOperator::RightSemi(_) => JoinType::Semi,
+                                JoinOperator::Semi(_) | JoinOperator::LeftSemi(_) | JoinOperator::RightSemi(_) => JoinType::Semi,
                                 join_type => polars_bail!(SQLInterface: "join type '{:?}' not currently supported", join_type),
                             },
                         )?
@@ -1028,10 +1030,10 @@ impl SQLContext {
                         .columns
                         .iter()
                         .map(|c| {
-                            if c.value.is_empty() {
+                            if c.name.value.is_empty() {
                                 None
                             } else {
-                                Some(PlSmallStr::from_str(c.value.as_str()))
+                                Some(PlSmallStr::from_str(c.name.value.as_str()))
                             }
                         })
                         .collect();
@@ -1399,7 +1401,8 @@ impl SQLContext {
                 )
             } else {
                 let existing_columns: Vec<_> = schema.iter_names().collect();
-                let new_columns: Vec<_> = alias.columns.iter().map(|c| c.value.clone()).collect();
+                let new_columns: Vec<_> =
+                    alias.columns.iter().map(|c| c.name.value.clone()).collect();
                 Ok(lf.rename(existing_columns, new_columns, true))
             }
         }

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -246,7 +246,7 @@ impl SQLExprVisitor<'_> {
             },
             SQLExpr::UnaryOp { op, expr } => self.visit_unary_op(op, expr),
             SQLExpr::Value(value) => self.visit_literal(value),
-            SQLExpr::Wildcard => Ok(Expr::Wildcard),
+            SQLExpr::Wildcard(_) => Ok(Expr::Wildcard),
             e @ SQLExpr::Case { .. } => self.visit_case_when_then(e),
             other => {
                 polars_bail!(SQLInterface: "expression {:?} is not currently supported", other)

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -24,11 +24,19 @@ def foods_ipc_path() -> Path:
             pl.DataFrame({"a": [2], "b": [0], "c": ["y"]}),
         ),
         (
+            "SELECT * FROM tbl_a SEMI JOIN tbl_b USING (a,c)",
+            pl.DataFrame({"a": [2], "b": [0], "c": ["y"]}),
+        ),
+        (
             "SELECT * FROM tbl_a LEFT SEMI JOIN tbl_b USING (a)",
             pl.DataFrame({"a": [1, 2, 3], "b": [4, 0, 6], "c": ["w", "y", "z"]}),
         ),
         (
             "SELECT * FROM tbl_a LEFT ANTI JOIN tbl_b USING (a)",
+            pl.DataFrame(schema={"a": pl.Int64, "b": pl.Int64, "c": pl.String}),
+        ),
+        (
+            "SELECT * FROM tbl_a ANTI JOIN tbl_b USING (a)",
             pl.DataFrame(schema={"a": pl.Int64, "b": pl.Int64, "c": pl.String}),
         ),
         (


### PR DESCRIPTION
Closes #20546, upgrading `sqlparser-rs` to  version`0.53` and taking advantage of some anti/semi join-parsing updates.

The following SQL queries are now both valid for use with Polars, and are equivalent (the "LEFT" keyword can be implicit, as per other dialects such as DuckDB):

```sql
SELECT * FROM tbl_a LEFT SEMI JOIN tbl_b USING (a,b,c)
SELECT * FROM tbl_a SEMI JOIN tbl_b USING (a,b,c)
```