### PR TITLE
feat: Add `cat.contains` and `cat.contains_any`

### DIFF
--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -36,4 +36,34 @@ impl CategoricalNameSpace {
                 suffix,
             )))
     }
+
+    /// Check if a string value contains a literal substring.
+    #[cfg(all(feature = "strings", feature = "regex"))]
+    pub fn contains(self, pat: &str, literal: bool, strict: bool) -> Expr {
+        self.0
+            .map_private(FunctionExpr::Categorical(CategoricalFunction::Contains {
+                pat: pat.into(),
+                literal,
+                strict: strict && !literal, // if literal, strict = false
+            }))
+    }
+
+    /// Uses aho-corasick to find many patterns.
+    ///
+    /// # Arguments
+    /// - `patterns`: an expression that evaluates to a String column
+    /// - `ascii_case_insensitive`: Enable ASCII-aware case insensitive matching.
+    ///   When this option is enabled, searching will be performed without respect to case for
+    ///   ASCII letters (a-z and A-Z) only.
+    #[cfg(feature = "find_many")]
+    pub fn contains_any(self, patterns: Expr, ascii_case_insensitive: bool) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::Categorical(CategoricalFunction::ContainsMany {
+                ascii_case_insensitive,
+            }),
+            &[patterns],
+            false,
+            None,
+        )
+    }
 }

--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -58,7 +58,7 @@ impl CategoricalNameSpace {
     #[cfg(feature = "find_many")]
     pub fn contains_any(self, patterns: Expr, ascii_case_insensitive: bool) -> Expr {
         self.0.map_many_private(
-            FunctionExpr::Categorical(CategoricalFunction::ContainsMany {
+            FunctionExpr::Categorical(CategoricalFunction::ContainsAny {
                 ascii_case_insensitive,
             }),
             &[patterns],

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -22,7 +22,7 @@ pub enum CategoricalFunction {
         strict: bool,
     },
     #[cfg(all(feature = "strings", feature = "find_many"))]
-    ContainsMany {
+    ContainsAny {
         ascii_case_insensitive: bool,
     },
 }
@@ -43,7 +43,7 @@ impl CategoricalFunction {
             #[cfg(all(feature = "strings", feature = "regex"))]
             Contains { .. } => mapper.with_dtype(DataType::Boolean),
             #[cfg(all(feature = "strings", feature = "find_many"))]
-            ContainsMany { .. } => mapper.with_dtype(DataType::Boolean),
+            ContainsAny { .. } => mapper.with_dtype(DataType::Boolean),
         }
     }
 }
@@ -64,7 +64,7 @@ impl Display for CategoricalFunction {
             #[cfg(all(feature = "strings", feature = "regex"))]
             Contains { .. } => "contains",
             #[cfg(all(feature = "strings", feature = "find_many"))]
-            ContainsMany { .. } => "contains_many",
+            ContainsAny { .. } => "contains_many",
         };
         write!(f, "cat.{s}")
     }
@@ -90,7 +90,7 @@ impl From<CategoricalFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
                 strict,
             } => map!(contains, pat.as_str(), literal, strict),
             #[cfg(all(feature = "strings", feature = "find_many"))]
-            ContainsMany {
+            ContainsAny {
                 ascii_case_insensitive,
             } => {
                 map_as_slice!(contains_many, ascii_case_insensitive)

--- a/crates/polars-python/src/expr/categorical.rs
+++ b/crates/polars-python/src/expr/categorical.rs
@@ -23,4 +23,20 @@ impl PyExpr {
     fn cat_ends_with(&self, suffix: String) -> Self {
         self.inner.clone().cat().ends_with(suffix).into()
     }
+
+    #[pyo3(signature = (pat, literal, strict))]
+    #[cfg(feature = "regex")]
+    fn cat_contains(&self, pat: &str, literal: Option<bool>, strict: bool) -> Self {
+        let lit = literal.unwrap_or(false);
+        self.inner.clone().cat().contains(pat, lit, strict).into()
+    }
+
+    #[cfg(feature = "find_many")]
+    fn cat_contains_any(&self, patterns: PyExpr, ascii_case_insensitive: bool) -> Self {
+        self.inner
+            .clone()
+            .cat()
+            .contains_any(patterns.inner, ascii_case_insensitive)
+            .into()
+    }
 }

--- a/py-polars/docs/source/reference/expressions/categories.rst
+++ b/py-polars/docs/source/reference/expressions/categories.rst
@@ -9,6 +9,8 @@ The following methods are available under the `expr.cat` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Expr.cat.contains
+    Expr.cat.contains_any
     Expr.cat.ends_with
     Expr.cat.get_categories
     Expr.cat.len_bytes

--- a/py-polars/docs/source/reference/series/categories.rst
+++ b/py-polars/docs/source/reference/series/categories.rst
@@ -9,6 +9,8 @@ The following methods are available under the `Series.cat` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Series.cat.contains
+    Series.cat.contains_any
     Series.cat.ends_with
     Series.cat.get_categories
     Series.cat.is_local

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -322,9 +322,9 @@ class ExprCatNameSpace:
         self, patterns: IntoExpr, *, ascii_case_insensitive: bool = False
     ) -> Expr:
         """
-        Use the Aho-Corasick algorithm to find matches.
-
         Determines if any of the patterns are contained in the string representation.
+
+        Use the Aho-Corasick algorithm to find matches.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2453,9 +2453,9 @@ class ExprStringNameSpace:
         self, patterns: IntoExpr, *, ascii_case_insensitive: bool = False
     ) -> Expr:
         """
-        Use the Aho-Corasick algorithm to find matches.
-
         Determines if any of the patterns are contained in the string.
+
+        Use the Aho-Corasick algorithm to find matches.
 
         Parameters
         ----------

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -239,3 +239,116 @@ class CatNameSpace:
             null
         ]
         """
+
+    def contains(
+        self, pattern: str, *, literal: bool = False, strict: bool = True
+    ) -> Series:
+        """
+        Check if the string representation contains a substring that matches a pattern.
+
+        Parameters
+        ----------
+        pattern
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
+        literal
+            Treat `pattern` as a literal string, not as a regular expression.
+        strict
+            Raise an error if the underlying pattern is not a valid regex,
+            otherwise mask out with a null value.
+
+        Notes
+        -----
+        To modify regular expression behaviour (such as case-sensitivity) with
+        flags, use the inline `(?iLmsuxU)` syntax. For example:
+
+        Default (case-sensitive) match:
+
+        >>> s = pl.Series("s", ["AAA", "aAa", "aaa"], dtype=pl.Categorical)
+        >>> s.cat.contains("AA").to_list()
+        [True, False, False]
+
+        Case-insensitive match, using an inline flag:
+
+        >>> s = pl.Series("s", ["AAA", "aAa", "aaa"], dtype=pl.Categorical)
+        >>> s.cat.contains("(?i)AA").to_list()
+        [True, True, True]
+
+        See the regex crate's section on `grouping and flags
+        <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
+        additional information about the use of inline expression modifiers.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`Boolean`.
+
+        Examples
+        --------
+        >>> s = pl.Series(
+        ...     ["Crab", "cat and dog", "rab$bit", None],
+        ...     dtype=pl.Categorical,
+        ... )
+        >>> s.cat.contains("cat|bit")
+        shape: (4,)
+        Series: '' [bool]
+        [
+            false
+            true
+            true
+            null
+        ]
+        >>> s.cat.contains("rab$", literal=True)
+        shape: (4,)
+        Series: '' [bool]
+        [
+            false
+            false
+            true
+            null
+        ]
+        """
+
+    def contains_any(
+        self, patterns: Series | list[str], *, ascii_case_insensitive: bool = False
+    ) -> Series:
+        """
+        Use the Aho-Corasick algorithm to find matches.
+
+        Determines if any of the patterns are contained in the string representation.
+
+        Parameters
+        ----------
+        patterns
+            String patterns to search.
+        ascii_case_insensitive
+            Enable ASCII-aware case-insensitive matching.
+            When this option is enabled, searching will be performed without respect
+            to case for ASCII letters (a-z and A-Z) only.
+
+        Notes
+        -----
+        This method supports matching on string literals only, and does not support
+        regular expression matching.
+
+        Examples
+        --------
+        >>> _ = pl.Config.set_fmt_str_lengths(100)
+        >>> s = pl.Series(
+        ...     "lyrics",
+        ...     [
+        ...         "Everybody wants to rule the world",
+        ...         "Tell me what you want, what you really really want",
+        ...         "Can you feel the love tonight",
+        ...     ],
+        ...     dtype=pl.Categorical,
+        ... )
+        >>> s.cat.contains_any(["you", "me"])
+        shape: (3,)
+        Series: 'lyrics' [bool]
+        [
+            false
+            true
+            true
+        ]
+        """

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -313,9 +313,9 @@ class CatNameSpace:
         self, patterns: Series | list[str], *, ascii_case_insensitive: bool = False
     ) -> Series:
         """
-        Use the Aho-Corasick algorithm to find matches.
-
         Determines if any of the patterns are contained in the string representation.
+
+        Use the Aho-Corasick algorithm to find matches.
 
         Parameters
         ----------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1875,9 +1875,9 @@ class StringNameSpace:
         self, patterns: Series | list[str], *, ascii_case_insensitive: bool = False
     ) -> Series:
         """
-        Use the Aho-Corasick algorithm to find matches.
-
         Determines if any of the patterns are contained in the string.
+
+        Use the Aho-Corasick algorithm to find matches.
 
         Parameters
         ----------


### PR DESCRIPTION
Followup to #20257. Again, expression input patterns not allowed in `cat.contains`, only string inputs. For `contains_any`, expression inputs *are* allowed, because these are interpreted as a list of possible patterns.