### PR TITLE
fix(python): Propagate `tenant_id` to `CredentialProviderAzure` if given

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -407,6 +407,7 @@ impl CloudOptions {
     pub fn build_azure(&self, url: &str) -> PolarsResult<impl object_store::ObjectStore> {
         use super::credential_provider::IntoCredentialProvider;
 
+        let verbose = polars_core::config::verbose();
         let mut storage_account: Option<polars_utils::pl_str::PlSmallStr> = None;
 
         // The credential provider `self.credentials` is prioritized if it is set. We also need
@@ -430,19 +431,30 @@ impl CloudOptions {
             .with_url(url)
             .with_retry(get_retry_config(self.max_retries));
 
-        // Prefer the one embedded in the path
-        storage_account = extract_adls_uri_storage_account(url)
-            .map(|x| x.into())
-            .or(storage_account);
-
         let builder = if let Some(v) = self.credential_provider.clone() {
+            if verbose {
+                eprintln!(
+                    "[CloudOptions::build_azure]: Using credential provider {:?}",
+                    &v
+                );
+            }
             builder.with_credentials(v.into_azure_provider())
-        } else if let Some(v) = storage_account
+        } else if let Some(v) = extract_adls_uri_storage_account(url) // Prefer the one embedded in the path
+            .map(|x| x.into())
+            .or(storage_account)
             .as_deref()
             .and_then(get_azure_storage_account_key)
         {
+            if verbose {
+                eprintln!("[CloudOptions::build_azure]: Retrieved account key from Azure CLI")
+            }
             builder.with_access_key(v)
         } else {
+            if verbose {
+                eprintln!(
+                    "[CloudOptions::build_azure]: Could not retrieve account key from Azure CLI"
+                )
+            }
             builder
         };
 

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -157,6 +157,7 @@ class CredentialProviderAzure(CredentialProvider):
         *,
         scopes: list[str] | None = None,
         storage_account: str | None = None,
+        tenant_id: str | None = None,
         _verbose: bool = False,
     ) -> None:
         """
@@ -173,6 +174,8 @@ class CredentialProviderAzure(CredentialProvider):
             for this account using the Azure CLI. If this is successful, the
             account keys will be used instead of
             `DefaultAzureCredential.get_token()`
+        tenant_id
+            Azure tenant ID.
         """
         msg = "`CredentialProviderAzure` functionality is considered unstable"
         issue_unstable_warning(msg)
@@ -180,6 +183,7 @@ class CredentialProviderAzure(CredentialProvider):
         self._check_module_availability()
 
         self.account_name = storage_account
+        self.tenant_id = tenant_id
         # Done like this to bypass mypy, we don't have stubs for azure.identity
         self.credential = importlib.import_module("azure.identity").__dict__[
             "DefaultAzureCredential"
@@ -192,6 +196,7 @@ class CredentialProviderAzure(CredentialProvider):
                 (
                     "CredentialProviderAzure "
                     f"{self.account_name = } "
+                    f"{self.tenant_id = } "
                     f"{self.scopes = } "
                 ),
                 file=sys.stderr,
@@ -209,19 +214,19 @@ class CredentialProviderAzure(CredentialProvider):
 
                 if self._verbose:
                     print(
-                        "[CredentialProviderAzure]: retrieved account keys from Azure CLI",
+                        "[CredentialProviderAzure]: Retrieved account key from Azure CLI",
                         file=sys.stderr,
                     )
             except Exception as e:
                 if self._verbose:
                     print(
-                        f"[CredentialProviderAzure]: failed to retrieve account keys from Azure CLI: {e}",
+                        f"[CredentialProviderAzure]: Could not retrieve account key from Azure CLI: {e}",
                         file=sys.stderr,
                     )
             else:
                 return creds, None  # type: ignore[return-value]
 
-        token = self.credential.get_token(*self.scopes)
+        token = self.credential.get_token(*self.scopes, tenant_id=self.tenant_id)
 
         return {
             "bearer_token": token.token,
@@ -248,22 +253,8 @@ class CredentialProviderAzure(CredentialProvider):
         except IndexError:
             return None
 
-    @staticmethod
-    def _get_azure_storage_account_key_az_cli(account_name: str) -> str:
-        az_cmd = [
-            "az",
-            "storage",
-            "account",
-            "keys",
-            "list",
-            "--output",
-            "json",
-            "--account-name",
-            account_name,
-        ]
-
-        cmd = az_cmd if sys.platform != "win32" else ["cmd", "/C", *az_cmd]
-
+    @classmethod
+    def _get_azure_storage_account_key_az_cli(cls, account_name: str) -> str:
         # [
         #     {
         #         "creationTime": "1970-01-01T00:00:00.000000+00:00",
@@ -279,7 +270,31 @@ class CredentialProviderAzure(CredentialProvider):
         #     }
         # ]
 
-        return json.loads(subprocess.check_output(cmd))[0]["value"]
+        return json.loads(
+            cls._azcli(
+                "storage",
+                "account",
+                "keys",
+                "list",
+                "--output",
+                "json",
+                "--account-name",
+                account_name,
+            )
+        )[0]["value"]
+
+    @classmethod
+    def _azcli_version(cls) -> str | None:
+        try:
+            return json.loads(cls._azcli("version"))["azure-cli"]
+        except Exception:
+            return None
+
+    @staticmethod
+    def _azcli(*args: str) -> bytes:
+        return subprocess.check_output(
+            ["az", *args] if sys.platform != "win32" else ["cmd", "/C", "az", *args]
+        )
 
 
 class CredentialProviderGCP(CredentialProvider):
@@ -392,9 +407,6 @@ def _maybe_init_credential_provider(
     if credential_provider != "auto":
         return credential_provider
 
-    if storage_options is not None:
-        return None
-
     verbose = os.getenv("POLARS_VERBOSE") == "1"
 
     if (path := _first_scan_path(source)) is None:
@@ -406,20 +418,53 @@ def _maybe_init_credential_provider(
     provider = None
 
     try:
-        provider = (
-            CredentialProviderAWS()
-            if _is_aws_cloud(scheme)
-            else CredentialProviderAzure(
-                storage_account=(
-                    CredentialProviderAzure._extract_adls_uri_storage_account(str(path))
-                ),
+        # For Azure we dispatch to `azure.identity` as much as possible
+        if _is_azure_cloud(scheme):
+            tenant_id = None
+            storage_account = None
+
+            if storage_options is not None:
+                for k, v in storage_options.items():
+                    if k in {
+                        "azure_storage_tenant_id",
+                        "azure_storage_authority_id",
+                        "azure_tenant_id",
+                        "azure_authority_id",
+                        "tenant_id",
+                        "authority_id",
+                    }:
+                        tenant_id = v
+                    elif k in {"azure_storage_account_name", "account_name"}:
+                        storage_account = v
+                    elif k in {"azure_use_azure_cli", "use_azure_cli"}:
+                        continue
+                    else:
+                        # We assume some sort of access key was given, so we
+                        # just dispatch to the rust side.
+                        return None
+
+            storage_account = (
+                # Prefer the one embedded in the path
+                CredentialProviderAzure._extract_adls_uri_storage_account(str(path))
+                or storage_account
+            )
+
+            provider = CredentialProviderAzure(
+                storage_account=storage_account,
+                tenant_id=tenant_id,
                 _verbose=verbose,
             )
-            if _is_azure_cloud(scheme)
-            else CredentialProviderGCP()
-            if _is_gcp_cloud(scheme)
-            else None
-        )
+        elif storage_options is not None:
+            return None
+        else:
+            provider = (
+                CredentialProviderAWS()
+                if _is_aws_cloud(scheme)
+                else CredentialProviderGCP()
+                if _is_gcp_cloud(scheme)
+                else None
+            )
+
     except ImportError as e:
         if verbose:
             msg = f"Unable to auto-select credential provider: {e}"

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -458,7 +458,7 @@ def _maybe_init_credential_provider(
             return None
         else:
             provider = (
-                CredentialProviderAWS()
+                CredentialProviderAWS()  # type: ignore[assignment]
                 if _is_aws_cloud(scheme)
                 else CredentialProviderGCP()
                 if _is_gcp_cloud(scheme)

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -425,6 +425,7 @@ def _maybe_init_credential_provider(
 
             if storage_options is not None:
                 for k, v in storage_options.items():
+                    # https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html
                     if k in {
                         "azure_storage_tenant_id",
                         "azure_storage_authority_id",

--- a/py-polars/polars/meta/versions.py
+++ b/py-polars/polars/meta/versions.py
@@ -48,7 +48,7 @@ def show_versions() -> None:
 
     deps = _get_dependency_list()
     core_properties = ("Polars", "Index type", "Platform", "Python", "LTS CPU")
-    keylen = max(len(x) for x in [*core_properties, *deps]) + 1
+    keylen = max(len(x) for x in [*core_properties, "Azure CLI", *deps]) + 1
 
     print("--------Version info---------")
     print(f"{'Polars:':{keylen}s} {get_polars_version()}")
@@ -58,6 +58,12 @@ def show_versions() -> None:
     print(f"{'LTS CPU:':{keylen}s} {get_lts_cpu()}")
 
     print("\n----Optional dependencies----")
+
+    from polars.io.cloud.credential_provider import CredentialProviderAzure
+
+    print(f"{'Azure CLI':{keylen}s} ", end="", flush=True)
+    print(CredentialProviderAzure._azcli_version() or "<not installed>")
+
     for name in deps:
         print(f"{name:{keylen}s} ", end="", flush=True)
         print(_get_dependency_version(name))


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/issues/20545

This is a bit of guesswork as I don't have a local repro of it - we now pass `tenant_id` to `DefaultAzureCredential.get_token()` if we see it in `storage_options`.

Other drive-bys to help with future debugging:
* The Azure CLI version is now printed under `pl.show_versions()` - this affects the auth flow as one of the things we do is attempting to fetch the storage account key from the Azure CLI
* Add more debug prints when `POLARS_VERBOSE` is enabled
