### PR TITLE
fix: Fix error filtering after `with_columns()` on unit height LazyFrame

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/properties.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties.rs
@@ -33,7 +33,7 @@ impl AExpr {
 
             Function { options, .. } => options.is_elementwise(),
 
-            Literal(v) => v.projects_as_scalar(),
+            Literal(v) => v.is_scalar(),
 
             Alias(_, _) | BinaryExpr { .. } | Column(_) | Ternary { .. } | Cast { .. } => true,
 

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -105,16 +105,6 @@ impl LiteralValue {
         !matches!(self, LiteralValue::Series(_) | LiteralValue::Range { .. })
     }
 
-    /// Less-strict `is_scalar` check - generally used for internal functionality such as our
-    /// optimizers.
-    pub(crate) fn projects_as_scalar(&self) -> bool {
-        match self {
-            LiteralValue::Series(s) => s.len() == 1,
-            LiteralValue::Range { low, high, .. } => high.saturating_sub(*low) == 1,
-            _ => true,
-        }
-    }
-
     pub fn to_any_value(&self) -> Option<AnyValue> {
         use LiteralValue::*;
         let av = match self {

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -78,7 +78,7 @@ fn can_pushdown_slice_past_projections(
 
             match ae {
                 AExpr::Column(_) => has_column = true,
-                AExpr::Literal(v) => literals_all_scalar &= v.projects_as_scalar(),
+                AExpr::Literal(v) => literals_all_scalar &= v.is_scalar(),
                 _ => {},
             }
 

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -87,7 +87,7 @@ pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
 #[cfg(feature = "is_in")]
 pub(crate) fn all_return_scalar(e: &Expr) -> bool {
     match e {
-        Expr::Literal(lv) => lv.projects_as_scalar(),
+        Expr::Literal(lv) => lv.is_scalar(),
         Expr::Function { options: opt, .. } => opt.flags.contains(FunctionFlags::RETURNS_SCALAR),
         Expr::Agg(_) => true,
         Expr::Column(_) | Expr::Wildcard => false,

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -628,3 +628,13 @@ def test_predicate_pushdown_join_19772(
 
     assert_frame_equal(q.collect(no_optimization=True), expect)
     assert_frame_equal(q.collect(), expect)
+
+
+def test_predicate_pushdown_scalar_20489() -> None:
+    df = pl.DataFrame({"a": [1]})
+    mask = pl.Series([False])
+
+    assert_frame_equal(
+        df.lazy().with_columns(b=pl.Series([2])).filter(mask).collect(),
+        pl.DataFrame(schema={"a": pl.Int64, "b": pl.Int64}),
+    )


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/20489

Replaces all uses of `projects_as_scalar()` with `is_scalar()` to be consistent with the strictness check used by `with_columns()`
