### PR TITLE
refactor(rust): Reduce size of ArrowDataType by boxing heavy variants

### DIFF
--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -172,7 +172,8 @@ impl UnionArray {
     /// Creates a new null [`UnionArray`].
     pub fn new_null(dtype: ArrowDataType, length: usize) -> Self {
         if let ArrowDataType::Union(u) = &dtype {
-            let fields = u.fields
+            let fields = u
+                .fields
                 .iter()
                 .map(|x| new_null_array(x.dtype().clone(), length))
                 .collect();
@@ -195,7 +196,8 @@ impl UnionArray {
     /// Creates a new empty [`UnionArray`].
     pub fn new_empty(dtype: ArrowDataType) -> Self {
         if let ArrowDataType::Union(u) = dtype.to_logical_type() {
-            let fields = u.fields
+            let fields = u
+                .fields
                 .iter()
                 .map(|x| new_empty_array(x.dtype().clone()))
                 .collect();
@@ -351,9 +353,7 @@ impl Array for UnionArray {
 impl UnionArray {
     fn try_get_all(dtype: &ArrowDataType) -> PolarsResult<UnionComponents> {
         match dtype.to_logical_type() {
-            ArrowDataType::Union(u) => {
-                Ok((&u.fields, u.ids.as_ref().map(|x| x.as_ref()), u.mode))
-            },
+            ArrowDataType::Union(u) => Ok((&u.fields, u.ids.as_ref().map(|x| x.as_ref()), u.mode)),
             _ => polars_bail!(ComputeError:
                 "The UnionArray requires a logical type of DataType::Union",
             ),

--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -171,13 +171,13 @@ impl UnionArray {
 
     /// Creates a new null [`UnionArray`].
     pub fn new_null(dtype: ArrowDataType, length: usize) -> Self {
-        if let ArrowDataType::Union(f, _, mode) = &dtype {
-            let fields = f
+        if let ArrowDataType::Union(u) = &dtype {
+            let fields = u.fields
                 .iter()
                 .map(|x| new_null_array(x.dtype().clone(), length))
                 .collect();
 
-            let offsets = if mode.is_sparse() {
+            let offsets = if u.mode.is_sparse() {
                 None
             } else {
                 Some((0..length as i32).collect::<Vec<_>>().into())
@@ -194,13 +194,13 @@ impl UnionArray {
 
     /// Creates a new empty [`UnionArray`].
     pub fn new_empty(dtype: ArrowDataType) -> Self {
-        if let ArrowDataType::Union(f, _, mode) = dtype.to_logical_type() {
-            let fields = f
+        if let ArrowDataType::Union(u) = dtype.to_logical_type() {
+            let fields = u.fields
                 .iter()
                 .map(|x| new_empty_array(x.dtype().clone()))
                 .collect();
 
-            let offsets = if mode.is_sparse() {
+            let offsets = if u.mode.is_sparse() {
                 None
             } else {
                 Some(Buffer::default())
@@ -351,8 +351,8 @@ impl Array for UnionArray {
 impl UnionArray {
     fn try_get_all(dtype: &ArrowDataType) -> PolarsResult<UnionComponents> {
         match dtype.to_logical_type() {
-            ArrowDataType::Union(fields, ids, mode) => {
-                Ok((fields, ids.as_ref().map(|x| x.as_ref()), *mode))
+            ArrowDataType::Union(u) => {
+                Ok((&u.fields, u.ids.as_ref().map(|x| x.as_ref()), u.mode))
             },
             _ => polars_bail!(ComputeError:
                 "The UnionArray requires a logical type of DataType::Union",

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -160,10 +160,7 @@ pub enum ArrowDataType {
     /// Decimal backed by 256 bits
     Decimal256(usize, usize),
     /// Extension type.
-    /// - name
-    /// - physical type
-    /// - metadata
-    Extension(PlSmallStr, Box<ArrowDataType>, Option<PlSmallStr>),
+    Extension(Box<ExtensionType>),
     /// A binary type that inlines small values
     /// and can intern bytes.
     BinaryView,
@@ -175,7 +172,22 @@ pub enum ArrowDataType {
     /// A nested datatype that can represent slots of differing types.
     /// Third argument represents mode
     #[cfg_attr(feature = "serde", serde(skip))]
-    Union(Vec<Field>, Option<Vec<i32>>, UnionMode),
+    Union(Box<UnionType>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ExtensionType {
+    pub name: PlSmallStr,
+    pub inner: ArrowDataType,
+    pub metadata: Option<PlSmallStr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UnionType {
+    pub fields: Vec<Field>,
+    pub ids: Option<Vec<i32>>,
+    pub mode: UnionMode
 }
 
 /// Mode of [`ArrowDataType::Union`]
@@ -277,10 +289,10 @@ impl ArrowDataType {
             FixedSizeList(_, _) => PhysicalType::FixedSizeList,
             LargeList(_) => PhysicalType::LargeList,
             Struct(_) => PhysicalType::Struct,
-            Union(_, _, _) => PhysicalType::Union,
+            Union(_) => PhysicalType::Union,
             Map(_, _) => PhysicalType::Map,
             Dictionary(key, _, _) => PhysicalType::Dictionary(*key),
-            Extension(_, key, _) => key.to_physical_type(),
+            Extension(ext) => ext.inner.to_physical_type(),
             Unknown => unimplemented!(),
         }
     }
@@ -322,9 +334,9 @@ impl ArrowDataType {
                     .collect(),
             ),
             Dictionary(keys, _, _) => (*keys).into(),
-            Union(_, _, _) => unimplemented!(),
+            Union(_) => unimplemented!(),
             Map(_, _) => unimplemented!(),
-            Extension(_, inner, _) => inner.underlying_physical_type(),
+            Extension(ext) => ext.inner.underlying_physical_type(),
             _ => self.clone(),
         }
     }
@@ -335,7 +347,7 @@ impl ArrowDataType {
     pub fn to_logical_type(&self) -> &ArrowDataType {
         use ArrowDataType::*;
         match self {
-            Extension(_, key, _) => key.to_logical_type(),
+            Extension(ext) => ext.inner.to_logical_type(),
             _ => self,
         }
     }
@@ -358,10 +370,10 @@ impl ArrowDataType {
                 | D::LargeList(_)
                 | D::FixedSizeList(_, _)
                 | D::Struct(_)
-                | D::Union(_, _, _)
+                | D::Union(_)
                 | D::Map(_, _)
                 | D::Dictionary(_, _, _)
-                | D::Extension(_, _, _)
+                | D::Extension(_)
         )
     }
 
@@ -439,11 +451,14 @@ impl ArrowDataType {
             | D::FixedSizeList(field, _)
             | D::Map(field, _)
             | D::LargeList(field) => field.dtype().contains_dictionary(),
-            D::Struct(fields) | D::Union(fields, _, _) => {
+            D::Struct(fields) => {
                 fields.iter().any(|f| f.dtype().contains_dictionary())
             },
+            D::Union(union) => {
+                union.fields.iter().any(|f| f.dtype().contains_dictionary())
+            },
             D::Dictionary(_, _, _) => true,
-            D::Extension(_, dtype, _) => dtype.contains_dictionary(),
+            D::Extension(ext) => ext.inner.contains_dictionary(),
         }
     }
 }

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -187,7 +187,7 @@ pub struct ExtensionType {
 pub struct UnionType {
     pub fields: Vec<Field>,
     pub ids: Option<Vec<i32>>,
-    pub mode: UnionMode
+    pub mode: UnionMode,
 }
 
 /// Mode of [`ArrowDataType::Union`]
@@ -451,12 +451,8 @@ impl ArrowDataType {
             | D::FixedSizeList(field, _)
             | D::Map(field, _)
             | D::LargeList(field) => field.dtype().contains_dictionary(),
-            D::Struct(fields) => {
-                fields.iter().any(|f| f.dtype().contains_dictionary())
-            },
-            D::Union(union) => {
-                union.fields.iter().any(|f| f.dtype().contains_dictionary())
-            },
+            D::Struct(fields) => fields.iter().any(|f| f.dtype().contains_dictionary()),
+            D::Union(union) => union.fields.iter().any(|f| f.dtype().contains_dictionary()),
             D::Dictionary(_, _, _) => true,
             D::Extension(ext) => ext.inner.contains_dictionary(),
         }

--- a/crates/polars-arrow/src/ffi/schema.rs
+++ b/crates/polars-arrow/src/ffi/schema.rs
@@ -7,7 +7,7 @@ use polars_utils::pl_str::PlSmallStr;
 
 use super::ArrowSchema;
 use crate::datatypes::{
-    ArrowDataType, Extension, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode,
+    ArrowDataType, Extension, ExtensionType, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode, UnionType
 };
 
 #[allow(dead_code)]
@@ -50,11 +50,15 @@ fn schema_children(dtype: &ArrowDataType, flags: &mut i64) -> Box<[*mut ArrowSch
             *flags += (*is_sorted as i64) * 4;
             Box::new([Box::into_raw(Box::new(ArrowSchema::new(field.as_ref())))])
         },
-        ArrowDataType::Struct(fields) | ArrowDataType::Union(fields, _, _) => fields
+        ArrowDataType::Struct(fields) => fields
             .iter()
             .map(|field| Box::into_raw(Box::new(ArrowSchema::new(field))))
             .collect::<Box<[_]>>(),
-        ArrowDataType::Extension(_, inner, _) => schema_children(inner, flags),
+        ArrowDataType::Union(u) => u.fields
+            .iter()
+            .map(|field| Box::into_raw(Box::new(ArrowSchema::new(field))))
+            .collect::<Box<[_]>>(),
+        ArrowDataType::Extension(ext) => schema_children(&ext.inner, flags),
         _ => Box::new([]),
     }
 }
@@ -86,13 +90,13 @@ impl ArrowSchema {
             .map(|inner| (**inner).clone())
             .unwrap_or_default();
 
-        let metadata = if let ArrowDataType::Extension(name, _, extension_metadata) = field.dtype()
+        let metadata = if let ArrowDataType::Extension(ext) = field.dtype()
         {
             // append extension information.
             let mut metadata = metadata.clone();
 
             // metadata
-            if let Some(extension_metadata) = extension_metadata {
+            if let Some(extension_metadata) = &ext.metadata {
                 metadata.insert(
                     PlSmallStr::from_static("ARROW:extension:metadata"),
                     extension_metadata.clone(),
@@ -101,7 +105,7 @@ impl ArrowSchema {
 
             metadata.insert(
                 PlSmallStr::from_static("ARROW:extension:name"),
-                name.clone(),
+                ext.name.clone(),
             );
 
             Some(metadata_to_bytes(&metadata))
@@ -218,7 +222,7 @@ pub(crate) unsafe fn to_field(schema: &ArrowSchema) -> PolarsResult<Field> {
     let (metadata, extension) = unsafe { metadata_from_bytes(schema.metadata) };
 
     let dtype = if let Some((name, extension_metadata)) = extension {
-        ArrowDataType::Extension(name, Box::new(dtype), extension_metadata)
+        ArrowDataType::Extension(Box::new(ExtensionType { name, inner: dtype, metadata: extension_metadata }))
     } else {
         dtype
     };
@@ -404,7 +408,7 @@ unsafe fn to_dtype(schema: &ArrowSchema) -> PolarsResult<ArrowDataType> {
                     let fields = (0..schema.n_children as usize)
                         .map(|x| to_field(schema.child(x)))
                         .collect::<PolarsResult<Vec<_>>>()?;
-                    ArrowDataType::Union(fields, Some(type_ids), mode)
+                    ArrowDataType::Union(Box::new(UnionType { fields, ids: Some(type_ids), mode }))
                 },
                 _ => {
                     polars_bail!(ComputeError:
@@ -481,14 +485,14 @@ fn to_format(dtype: &ArrowDataType) -> String {
         ArrowDataType::Struct(_) => "+s".to_string(),
         ArrowDataType::FixedSizeBinary(size) => format!("w:{size}"),
         ArrowDataType::FixedSizeList(_, size) => format!("+w:{size}"),
-        ArrowDataType::Union(f, ids, mode) => {
-            let sparsness = if mode.is_sparse() { 's' } else { 'd' };
+        ArrowDataType::Union(u) => {
+            let sparsness = if u.mode.is_sparse() { 's' } else { 'd' };
             let mut r = format!("+u{sparsness}:");
-            let ids = if let Some(ids) = ids {
+            let ids = if let Some(ids) = &u.ids {
                 ids.iter()
                     .fold(String::new(), |a, b| a + b.to_string().as_str() + ",")
             } else {
-                (0..f.len()).fold(String::new(), |a, b| a + b.to_string().as_str() + ",")
+                (0..u.fields.len()).fold(String::new(), |a, b| a + b.to_string().as_str() + ",")
             };
             let ids = &ids[..ids.len() - 1]; // take away last ","
             r.push_str(ids);
@@ -496,7 +500,7 @@ fn to_format(dtype: &ArrowDataType) -> String {
         },
         ArrowDataType::Map(_, _) => "+m".to_string(),
         ArrowDataType::Dictionary(index, _, _) => to_format(&(*index).into()),
-        ArrowDataType::Extension(_, inner, _) => to_format(inner.as_ref()),
+        ArrowDataType::Extension(ext) => to_format(&ext.inner),
         ArrowDataType::Unknown => unimplemented!(),
     }
 }
@@ -508,8 +512,8 @@ pub(super) fn get_child(dtype: &ArrowDataType, index: usize) -> PolarsResult<Arr
         (0, ArrowDataType::LargeList(field)) => Ok(field.dtype().clone()),
         (0, ArrowDataType::Map(field, _)) => Ok(field.dtype().clone()),
         (index, ArrowDataType::Struct(fields)) => Ok(fields[index].dtype().clone()),
-        (index, ArrowDataType::Union(fields, _, _)) => Ok(fields[index].dtype().clone()),
-        (index, ArrowDataType::Extension(_, subtype, _)) => get_child(subtype, index),
+        (index, ArrowDataType::Union(u)) => Ok(u.fields[index].dtype().clone()),
+        (index, ArrowDataType::Extension(ext)) => get_child(&ext.inner, index),
         (child, dtype) => polars_bail!(ComputeError:
             "Requested child {child} to type {dtype:?} that has no such child",
         ),
@@ -643,6 +647,8 @@ mod tests {
                 true,
             ),
             ArrowDataType::Union(
+                Box::new(UnionType {
+                    fields:
                 vec![
                     Field::new(PlSmallStr::from_static("a"), ArrowDataType::Int64, true),
                     Field::new(
@@ -655,11 +661,13 @@ mod tests {
                         true,
                     ),
                 ],
-                Some(vec![1, 2]),
-                UnionMode::Dense,
+                ids: Some(vec![1, 2]),
+                mode: UnionMode::Dense,
+                })
             ),
             ArrowDataType::Union(
-                vec![
+                Box::new(UnionType {
+                fields: vec![
                     Field::new(PlSmallStr::from_static("a"), ArrowDataType::Int64, true),
                     Field::new(
                         PlSmallStr::from_static("b"),
@@ -671,8 +679,9 @@ mod tests {
                         true,
                     ),
                 ],
-                Some(vec![0, 1]),
-                UnionMode::Sparse,
+                ids: Some(vec![0, 1]),
+                mode: UnionMode::Sparse,
+                })
             ),
         ];
         for time_unit in [

--- a/crates/polars-arrow/src/ffi/schema.rs
+++ b/crates/polars-arrow/src/ffi/schema.rs
@@ -7,7 +7,8 @@ use polars_utils::pl_str::PlSmallStr;
 
 use super::ArrowSchema;
 use crate::datatypes::{
-    ArrowDataType, Extension, ExtensionType, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode, UnionType
+    ArrowDataType, Extension, ExtensionType, Field, IntegerType, IntervalUnit, Metadata, TimeUnit,
+    UnionMode, UnionType,
 };
 
 #[allow(dead_code)]
@@ -54,7 +55,8 @@ fn schema_children(dtype: &ArrowDataType, flags: &mut i64) -> Box<[*mut ArrowSch
             .iter()
             .map(|field| Box::into_raw(Box::new(ArrowSchema::new(field))))
             .collect::<Box<[_]>>(),
-        ArrowDataType::Union(u) => u.fields
+        ArrowDataType::Union(u) => u
+            .fields
             .iter()
             .map(|field| Box::into_raw(Box::new(ArrowSchema::new(field))))
             .collect::<Box<[_]>>(),
@@ -90,8 +92,7 @@ impl ArrowSchema {
             .map(|inner| (**inner).clone())
             .unwrap_or_default();
 
-        let metadata = if let ArrowDataType::Extension(ext) = field.dtype()
-        {
+        let metadata = if let ArrowDataType::Extension(ext) = field.dtype() {
             // append extension information.
             let mut metadata = metadata.clone();
 
@@ -222,7 +223,11 @@ pub(crate) unsafe fn to_field(schema: &ArrowSchema) -> PolarsResult<Field> {
     let (metadata, extension) = unsafe { metadata_from_bytes(schema.metadata) };
 
     let dtype = if let Some((name, extension_metadata)) = extension {
-        ArrowDataType::Extension(Box::new(ExtensionType { name, inner: dtype, metadata: extension_metadata }))
+        ArrowDataType::Extension(Box::new(ExtensionType {
+            name,
+            inner: dtype,
+            metadata: extension_metadata,
+        }))
     } else {
         dtype
     };
@@ -408,7 +413,11 @@ unsafe fn to_dtype(schema: &ArrowSchema) -> PolarsResult<ArrowDataType> {
                     let fields = (0..schema.n_children as usize)
                         .map(|x| to_field(schema.child(x)))
                         .collect::<PolarsResult<Vec<_>>>()?;
-                    ArrowDataType::Union(Box::new(UnionType { fields, ids: Some(type_ids), mode }))
+                    ArrowDataType::Union(Box::new(UnionType {
+                        fields,
+                        ids: Some(type_ids),
+                        mode,
+                    }))
                 },
                 _ => {
                     polars_bail!(ComputeError:
@@ -646,10 +655,8 @@ mod tests {
                 )),
                 true,
             ),
-            ArrowDataType::Union(
-                Box::new(UnionType {
-                    fields:
-                vec![
+            ArrowDataType::Union(Box::new(UnionType {
+                fields: vec![
                     Field::new(PlSmallStr::from_static("a"), ArrowDataType::Int64, true),
                     Field::new(
                         PlSmallStr::from_static("b"),
@@ -663,10 +670,8 @@ mod tests {
                 ],
                 ids: Some(vec![1, 2]),
                 mode: UnionMode::Dense,
-                })
-            ),
-            ArrowDataType::Union(
-                Box::new(UnionType {
+            })),
+            ArrowDataType::Union(Box::new(UnionType {
                 fields: vec![
                     Field::new(PlSmallStr::from_static("a"), ArrowDataType::Int64, true),
                     Field::new(
@@ -681,8 +686,7 @@ mod tests {
                 ],
                 ids: Some(vec![0, 1]),
                 mode: UnionMode::Sparse,
-                })
-            ),
+            })),
         ];
         for time_unit in [
             TimeUnit::Second,

--- a/crates/polars-arrow/src/io/avro/read/schema.rs
+++ b/crates/polars-arrow/src/io/avro/read/schema.rs
@@ -116,7 +116,7 @@ fn schema_to_field(
                     .iter()
                     .map(|s| schema_to_field(s, None, Metadata::default()))
                     .collect::<PolarsResult<Vec<Field>>>()?;
-                ArrowDataType::Union(fields, None, UnionMode::Dense)
+                ArrowDataType::Union(Box::new(UnionType { fields, ids: None, mode: UnionMode::Dense }))
             }
         },
         AvroSchema::Record(Record { fields, .. }) => {

--- a/crates/polars-arrow/src/io/avro/read/schema.rs
+++ b/crates/polars-arrow/src/io/avro/read/schema.rs
@@ -116,7 +116,11 @@ fn schema_to_field(
                     .iter()
                     .map(|s| schema_to_field(s, None, Metadata::default()))
                     .collect::<PolarsResult<Vec<Field>>>()?;
-                ArrowDataType::Union(Box::new(UnionType { fields, ids: None, mode: UnionMode::Dense }))
+                ArrowDataType::Union(Box::new(UnionType {
+                    fields,
+                    ids: None,
+                    mode: UnionMode::Dense,
+                }))
             }
         },
         AvroSchema::Record(Record { fields, .. }) => {

--- a/crates/polars-arrow/src/io/ipc/read/array/union.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/union.rs
@@ -8,8 +8,7 @@ use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, Version};
 use crate::array::UnionArray;
-use crate::datatypes::ArrowDataType;
-use crate::datatypes::UnionMode::Dense;
+use crate::datatypes::{ArrowDataType, UnionMode};
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]
@@ -48,8 +47,8 @@ pub fn read_union<R: Read + Seek>(
         scratch,
     )?;
 
-    let offsets = if let ArrowDataType::Union(_, _, mode) = dtype {
-        if !mode.is_sparse() {
+    let offsets = if let ArrowDataType::Union(u) = &dtype {
+        if !u.mode.is_sparse() {
             Some(read_buffer(
                 buffers,
                 length,
@@ -108,7 +107,8 @@ pub fn skip_union(
     let _ = buffers
         .pop_front()
         .ok_or_else(|| polars_err!(oos = "IPC: missing validity buffer."))?;
-    if let ArrowDataType::Union(_, _, Dense) = dtype {
+    if let ArrowDataType::Union(u) = dtype {
+        assert!(u.mode == UnionMode::Dense);
         let _ = buffers
             .pop_front()
             .ok_or_else(|| polars_err!(oos = "IPC: missing offsets buffer."))?;

--- a/crates/polars-arrow/src/io/ipc/read/common.rs
+++ b/crates/polars-arrow/src/io/ipc/read/common.rs
@@ -216,8 +216,16 @@ fn find_first_dict_field_d<'a>(
         List(field) | LargeList(field) | FixedSizeList(field, ..) | Map(field, ..) => {
             find_first_dict_field(id, field.as_ref(), &ipc_field.fields[0])
         },
-        Union(fields, ..) | Struct(fields) => {
+        Struct(fields) => {
             for (field, ipc_field) in fields.iter().zip(ipc_field.fields.iter()) {
+                if let Some(f) = find_first_dict_field(id, field, ipc_field) {
+                    return Some(f);
+                }
+            }
+            None
+        },
+        Union(u) => {
+            for (field, ipc_field) in u.fields.iter().zip(ipc_field.fields.iter()) {
                 if let Some(f) = find_first_dict_field(id, field, ipc_field) {
                     return Some(f);
                 }

--- a/crates/polars-arrow/src/io/ipc/read/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/read/schema.rs
@@ -8,8 +8,7 @@ use polars_utils::pl_str::PlSmallStr;
 use super::super::{IpcField, IpcSchema};
 use super::{OutOfSpecKind, StreamMetadata};
 use crate::datatypes::{
-    get_extension, ArrowDataType, ArrowSchema, Extension, Field, IntegerType, IntervalUnit,
-    Metadata, TimeUnit, UnionMode,
+    get_extension, ArrowDataType, ArrowSchema, Extension, ExtensionType, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode, UnionType
 };
 
 fn try_unzip_vec<A, B, I: Iterator<Item = PolarsResult<(A, B)>>>(
@@ -132,7 +131,7 @@ fn deserialize_union(union_: UnionRef, field: FieldRef) -> PolarsResult<(ArrowDa
         fields: ipc_fields,
         dictionary_id: None,
     };
-    Ok((ArrowDataType::Union(fields, ids, mode), ipc_field))
+    Ok((ArrowDataType::Union(Box::new(UnionType { fields, ids, mode })), ipc_field))
 }
 
 fn deserialize_map(map: MapRef, field: FieldRef) -> PolarsResult<(ArrowDataType, IpcField)> {
@@ -258,7 +257,7 @@ fn get_dtype(
         let (name, metadata) = extension;
         let (dtype, fields) = get_dtype(field, None, false)?;
         return Ok((
-            ArrowDataType::Extension(name, Box::new(dtype), metadata),
+            ArrowDataType::Extension(Box::new(ExtensionType { name, inner: dtype, metadata })),
             fields,
         ));
     }

--- a/crates/polars-arrow/src/io/ipc/read/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/read/schema.rs
@@ -8,7 +8,8 @@ use polars_utils::pl_str::PlSmallStr;
 use super::super::{IpcField, IpcSchema};
 use super::{OutOfSpecKind, StreamMetadata};
 use crate::datatypes::{
-    get_extension, ArrowDataType, ArrowSchema, Extension, ExtensionType, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode, UnionType
+    get_extension, ArrowDataType, ArrowSchema, Extension, ExtensionType, Field, IntegerType,
+    IntervalUnit, Metadata, TimeUnit, UnionMode, UnionType,
 };
 
 fn try_unzip_vec<A, B, I: Iterator<Item = PolarsResult<(A, B)>>>(
@@ -131,7 +132,10 @@ fn deserialize_union(union_: UnionRef, field: FieldRef) -> PolarsResult<(ArrowDa
         fields: ipc_fields,
         dictionary_id: None,
     };
-    Ok((ArrowDataType::Union(Box::new(UnionType { fields, ids, mode })), ipc_field))
+    Ok((
+        ArrowDataType::Union(Box::new(UnionType { fields, ids, mode })),
+        ipc_field,
+    ))
 }
 
 fn deserialize_map(map: MapRef, field: FieldRef) -> PolarsResult<(ArrowDataType, IpcField)> {
@@ -257,7 +261,11 @@ fn get_dtype(
         let (name, metadata) = extension;
         let (dtype, fields) = get_dtype(field, None, false)?;
         return Ok((
-            ArrowDataType::Extension(Box::new(ExtensionType { name, inner: dtype, metadata })),
+            ArrowDataType::Extension(Box::new(ExtensionType {
+                name,
+                inner: dtype,
+                metadata,
+            })),
             fields,
         ));
     }

--- a/crates/polars-arrow/src/io/ipc/write/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write/mod.rs
@@ -38,7 +38,8 @@ fn default_ipc_field(dtype: &ArrowDataType, current_id: &mut i64) -> IpcField {
         },
         // multiple children => recurse
         Union(u) => IpcField {
-            fields: u.fields
+            fields: u
+                .fields
                 .iter()
                 .map(|f| default_ipc_field(f.dtype(), current_id))
                 .collect(),

--- a/crates/polars-arrow/src/io/ipc/write/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write/mod.rs
@@ -29,8 +29,16 @@ fn default_ipc_field(dtype: &ArrowDataType, current_id: &mut i64) -> IpcField {
             dictionary_id: None,
         },
         // multiple children => recurse
-        Union(fields, ..) | Struct(fields) => IpcField {
+        Struct(fields) => IpcField {
             fields: fields
+                .iter()
+                .map(|f| default_ipc_field(f.dtype(), current_id))
+                .collect(),
+            dictionary_id: None,
+        },
+        // multiple children => recurse
+        Union(u) => IpcField {
+            fields: u.fields
                 .iter()
                 .map(|f| default_ipc_field(f.dtype(), current_id))
                 .collect(),

--- a/crates/polars-arrow/src/io/ipc/write/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/write/schema.rs
@@ -89,10 +89,10 @@ fn write_extension(
 pub(crate) fn serialize_field(field: &Field, ipc_field: &IpcField) -> arrow_format::ipc::Field {
     // custom metadata.
     let mut kv_vec = vec![];
-    if let ArrowDataType::Extension(name, _, metadata) = field.dtype() {
+    if let ArrowDataType::Extension(ext) = field.dtype() {
         write_extension(
-            name.as_str(),
-            metadata.as_ref().map(|x| x.as_str()),
+            &ext.name,
+            ext.metadata.as_ref().map(|x| x.as_str()),
             &mut kv_vec,
         );
     }
@@ -102,10 +102,10 @@ pub(crate) fn serialize_field(field: &Field, ipc_field: &IpcField) -> arrow_form
 
     let dictionary = if let ArrowDataType::Dictionary(index_type, inner, is_ordered) = field.dtype()
     {
-        if let ArrowDataType::Extension(name, _, metadata) = inner.as_ref() {
+        if let ArrowDataType::Extension(ext) = inner.as_ref() {
             write_extension(
-                name.as_str(),
-                metadata.as_ref().map(|x| x.as_str()),
+                ext.name.as_str(),
+                ext.metadata.as_ref().map(|x| x.as_str()),
                 &mut kv_vec,
             );
         }
@@ -250,19 +250,19 @@ fn serialize_type(dtype: &ArrowDataType) -> arrow_format::ipc::Type {
         FixedSizeList(_, size) => ipc::Type::FixedSizeList(Box::new(ipc::FixedSizeList {
             list_size: *size as i32,
         })),
-        Union(_, type_ids, mode) => ipc::Type::Union(Box::new(ipc::Union {
-            mode: match mode {
+        Union(u) => ipc::Type::Union(Box::new(ipc::Union {
+            mode: match u.mode {
                 UnionMode::Dense => ipc::UnionMode::Dense,
                 UnionMode::Sparse => ipc::UnionMode::Sparse,
             },
-            type_ids: type_ids.clone(),
+            type_ids: u.ids.clone(),
         })),
         Map(_, keys_sorted) => ipc::Type::Map(Box::new(ipc::Map {
             keys_sorted: *keys_sorted,
         })),
         Struct(_) => ipc::Type::Struct(Box::new(ipc::Struct {})),
         Dictionary(_, v, _) => serialize_type(v),
-        Extension(_, v, _) => serialize_type(v),
+        Extension(ext) => serialize_type(&ext.inner),
         Utf8View => ipc::Type::Utf8View(Box::new(ipc::Utf8View {})),
         BinaryView => ipc::Type::BinaryView(Box::new(ipc::BinaryView {})),
         Unknown => unimplemented!(),
@@ -308,13 +308,18 @@ fn serialize_children(
         FixedSizeList(inner, _) | LargeList(inner) | List(inner) | Map(inner, _) => {
             vec![serialize_field(inner, &ipc_field.fields[0])]
         },
-        Union(fields, _, _) | Struct(fields) => fields
+        Struct(fields) => fields
+            .iter()
+            .zip(ipc_field.fields.iter())
+            .map(|(field, ipc)| serialize_field(field, ipc))
+            .collect(),
+        Union(u) => u.fields
             .iter()
             .zip(ipc_field.fields.iter())
             .map(|(field, ipc)| serialize_field(field, ipc))
             .collect(),
         Dictionary(_, inner, _) => serialize_children(inner, ipc_field),
-        Extension(_, inner, _) => serialize_children(inner, ipc_field),
+        Extension(ext) => serialize_children(&ext.inner, ipc_field),
         Unknown => unimplemented!(),
     }
 }

--- a/crates/polars-arrow/src/io/ipc/write/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/write/schema.rs
@@ -313,7 +313,8 @@ fn serialize_children(
             .zip(ipc_field.fields.iter())
             .map(|(field, ipc)| serialize_field(field, ipc))
             .collect(),
-        Union(u) => u.fields
+        Union(u) => u
+            .fields
             .iter()
             .zip(ipc_field.fields.iter())
             .map(|(field, ipc)| serialize_field(field, ipc))

--- a/crates/polars-core/src/chunked_array/object/extension/drop.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/drop.rs
@@ -21,7 +21,7 @@ pub(crate) unsafe fn drop_list(ca: &ListChunked) {
             if let ArrowDataType::LargeList(fld) = lst_arr.dtype() {
                 let dtype = fld.dtype();
 
-                assert!(matches!(dtype, ArrowDataType::Extension(_, _, _)));
+                assert!(matches!(dtype, ArrowDataType::Extension(_)));
 
                 // recreate the polars extension so that the content is dropped
                 let arr = lst_arr.as_any().downcast_ref::<LargeListArray>().unwrap();

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -126,7 +126,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
     let physical_type = ArrowDataType::FixedSizeBinary(t_size);
     let extension_type = ArrowDataType::Extension(Box::new(ExtensionType {
         name: PlSmallStr::from_static(EXTENSION_NAME),
-        inner: physical_type.into(),
+        inner: physical_type,
         metadata: Some(metadata),
     }));
     // first freeze, otherwise we compute null

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use arrow::array::FixedSizeBinaryArray;
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
+use arrow::datatypes::ExtensionType;
 use polars_extension::PolarsExtension;
 use polars_utils::format_pl_smallstr;
 
@@ -124,9 +125,11 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
 
     let physical_type = ArrowDataType::FixedSizeBinary(t_size);
     let extension_type = ArrowDataType::Extension(
-        PlSmallStr::from_static(EXTENSION_NAME),
-        physical_type.into(),
-        Some(metadata),
+        Box::new(ExtensionType {
+            name: PlSmallStr::from_static(EXTENSION_NAME),
+            inner: physical_type.into(),
+            metadata: Some(metadata),
+        })
     );
     // first freeze, otherwise we compute null
     let validity = if null_count > 0 {

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -124,13 +124,11 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
     let metadata = format_pl_smallstr!("{};{}", *PROCESS_ID, et_ptr as usize);
 
     let physical_type = ArrowDataType::FixedSizeBinary(t_size);
-    let extension_type = ArrowDataType::Extension(
-        Box::new(ExtensionType {
-            name: PlSmallStr::from_static(EXTENSION_NAME),
-            inner: physical_type.into(),
-            metadata: Some(metadata),
-        })
-    );
+    let extension_type = ArrowDataType::Extension(Box::new(ExtensionType {
+        name: PlSmallStr::from_static(EXTENSION_NAME),
+        inner: physical_type.into(),
+        metadata: Some(metadata),
+    }));
     // first freeze, otherwise we compute null
     let validity = if null_count > 0 {
         Some(validity.into())

--- a/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
@@ -41,8 +41,9 @@ impl PolarsExtension {
     /// Load the sentinel from the heap.
     /// be very careful, this dereferences a raw pointer on the heap,
     unsafe fn get_sentinel(&self) -> Box<ExtensionSentinel> {
-        if let ArrowDataType::Extension(_, _, Some(metadata)) = self.array.as_ref().unwrap().dtype()
+        if let ArrowDataType::Extension(ext) = self.array.as_ref().unwrap().dtype()
         {
+            let metadata = ext.metadata.as_ref().expect("should have metadata in extension type");
             let mut iter = metadata.split(';');
 
             let pid = iter.next().unwrap().parse::<u128>().unwrap();
@@ -53,7 +54,7 @@ impl PolarsExtension {
                 panic!("pid did not mach process id")
             }
         } else {
-            panic!("should have metadata in extension type")
+            panic!("should be extension type")
         }
     }
 

--- a/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
@@ -41,9 +41,11 @@ impl PolarsExtension {
     /// Load the sentinel from the heap.
     /// be very careful, this dereferences a raw pointer on the heap,
     unsafe fn get_sentinel(&self) -> Box<ExtensionSentinel> {
-        if let ArrowDataType::Extension(ext) = self.array.as_ref().unwrap().dtype()
-        {
-            let metadata = ext.metadata.as_ref().expect("should have metadata in extension type");
+        if let ArrowDataType::Extension(ext) = self.array.as_ref().unwrap().dtype() {
+            let metadata = ext
+                .metadata
+                .as_ref()
+                .expect("should have metadata in extension type");
             let mut iter = metadata.split(';');
 
             let pid = iter.next().unwrap().parse::<u128>().unwrap();

--- a/crates/polars-core/src/datatypes/field.rs
+++ b/crates/polars-core/src/datatypes/field.rs
@@ -208,7 +208,7 @@ impl DataType {
             ArrowDataType::Struct(_) => {
                 panic!("activate the 'dtype-struct' feature to handle struct data types")
             }
-            ArrowDataType::Extension(name, _, _) if name.as_str() == EXTENSION_NAME => {
+            ArrowDataType::Extension(ext) if ext.name.as_str() == EXTENSION_NAME => {
                 #[cfg(feature = "object")]
                 {
                     DataType::Object("object", None)

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -439,7 +439,9 @@ impl Series {
                 Ok(values)
             },
             #[cfg(feature = "object")]
-            ArrowDataType::Extension(ext) if ext.name == EXTENSION_NAME && ext.metadata.is_some() => {
+            ArrowDataType::Extension(ext)
+                if ext.name == EXTENSION_NAME && ext.metadata.is_some() =>
+            {
                 assert_eq!(chunks.len(), 1);
                 let arr = chunks[0]
                     .as_any()

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -439,7 +439,7 @@ impl Series {
                 Ok(values)
             },
             #[cfg(feature = "object")]
-            ArrowDataType::Extension(s, _, Some(_)) if s == EXTENSION_NAME => {
+            ArrowDataType::Extension(ext) if ext.name == EXTENSION_NAME && ext.metadata.is_some() => {
                 assert_eq!(chunks.len(), 1);
                 let arr = chunks[0]
                     .as_any()

--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -49,7 +49,7 @@ fn assert_dtypes(dtype: &ArrowDataType) {
 
         // Recursive checks
         D::Dictionary(_, dtype, _) => assert_dtypes(dtype),
-        D::Extension(_, dtype, _) => assert_dtypes(dtype),
+        D::Extension(ext) => assert_dtypes(&ext.inner),
         D::LargeList(inner) => assert_dtypes(&inner.dtype),
         D::FixedSizeList(inner, _) => assert_dtypes(&inner.dtype),
         D::Struct(fields) => fields.iter().for_each(|f| assert_dtypes(f.dtype())),

--- a/crates/polars-parquet/src/arrow/read/schema/metadata.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/metadata.rs
@@ -59,9 +59,12 @@ fn convert_dtype(mut dtype: ArrowDataType) -> ArrowDataType {
         Float16 => dtype = Float32,
         Binary | LargeBinary => dtype = BinaryView,
         Utf8 | LargeUtf8 => dtype = Utf8View,
-        Dictionary(_, ref mut dtype, _) | Extension(_, ref mut dtype, _) => {
+        Dictionary(_, ref mut dtype, _) => {
             let dtype = dtype.as_mut();
             *dtype = convert_dtype(std::mem::take(dtype));
+        },
+        Extension(ref mut ext) => {
+            ext.inner = convert_dtype(std::mem::take(&mut ext.inner));
         },
         Map(mut field, _ordered) => {
             // Polars doesn't support Map.

--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -41,7 +41,10 @@ fn convert_dtype(dtype: ArrowDataType) -> ArrowDataType {
         },
         D::Extension(ext) => {
             let dtype = convert_dtype(ext.inner);
-            D::Extension(Box::new(ExtensionType { inner: dtype, ..*ext }))
+            D::Extension(Box::new(ExtensionType {
+                inner: dtype,
+                ..*ext
+            }))
         },
         dt => dt,
     }

--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -1,4 +1,4 @@
-use arrow::datatypes::{ArrowDataType, ArrowSchema, Field, TimeUnit};
+use arrow::datatypes::{ArrowDataType, ArrowSchema, ExtensionType, Field, TimeUnit};
 use arrow::io::ipc::write::{default_ipc_fields, schema_to_bytes};
 use base64::engine::general_purpose;
 use base64::Engine as _;
@@ -39,9 +39,9 @@ fn convert_dtype(dtype: ArrowDataType) -> ArrowDataType {
             let dtype = convert_dtype(*dtype);
             D::Dictionary(it, Box::new(dtype), sorted)
         },
-        D::Extension(name, dtype, metadata) => {
-            let dtype = convert_dtype(*dtype);
-            D::Extension(name, Box::new(dtype), metadata)
+        D::Extension(ext) => {
+            let dtype = convert_dtype(ext.inner);
+            D::Extension(Box::new(ExtensionType { inner: dtype, ..*ext }))
         },
         dt => dt,
     }

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -136,10 +136,10 @@ fn dtype_and_data_to_encoded_item_len(
             item_len
         },
 
-        D::Union(_, _, _) => todo!(),
+        D::Union(_) => todo!(),
         D::Map(_, _) => todo!(),
         D::Decimal256(_, _) => todo!(),
-        D::Extension(_, _, _) => todo!(),
+        D::Extension(_) => todo!(),
         D::Unknown => todo!(),
 
         _ => unreachable!(),

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -458,9 +458,9 @@ fn get_encoder(
             )
         },
 
-        D::Union(_, _, _) => unreachable!(),
+        D::Union(_) => unreachable!(),
         D::Map(_, _) => unreachable!(),
-        D::Extension(_, _, _) => unreachable!(),
+        D::Extension(_) => unreachable!(),
         D::Unknown => unreachable!(),
 
         // All non-physical types
@@ -633,9 +633,9 @@ unsafe fn encode_flat_array(
         D::Decimal(_, _) => todo!(),
         D::Decimal256(_, _) => todo!(),
 
-        D::Union(_, _, _) => todo!(),
+        D::Union(_) => todo!(),
         D::Map(_, _) => todo!(),
-        D::Extension(_, _, _) => todo!(),
+        D::Extension(_) => todo!(),
         D::Unknown => todo!(),
 
         // All are non-physical types.

--- a/crates/polars/tests/it/arrow/array/fixed_size_binary/mod.rs
+++ b/crates/polars/tests/it/arrow/array/fixed_size_binary/mod.rs
@@ -1,7 +1,7 @@
 use arrow::array::FixedSizeBinaryArray;
 use arrow::bitmap::Bitmap;
 use arrow::buffer::Buffer;
-use arrow::datatypes::ArrowDataType;
+use arrow::datatypes::{ArrowDataType, ExtensionType};
 
 mod mutable;
 
@@ -94,10 +94,10 @@ fn to() {
     let values = Buffer::from(b"abba".to_vec());
     let a = FixedSizeBinaryArray::new(ArrowDataType::FixedSizeBinary(2), values, None);
 
-    let extension = ArrowDataType::Extension(
-        "a".into(),
-        Box::new(ArrowDataType::FixedSizeBinary(2)),
-        None,
-    );
+    let extension = ArrowDataType::Extension(Box::new(ExtensionType {
+        name: "a".into(),
+        inner: ArrowDataType::FixedSizeBinary(2),
+        metadata: None,
+    }));
     let _ = a.to(extension);
 }

--- a/crates/polars/tests/it/arrow/array/growable/list.rs
+++ b/crates/polars/tests/it/arrow/array/growable/list.rs
@@ -1,6 +1,6 @@
 use arrow::array::growable::{Growable, GrowableList};
 use arrow::array::{Array, ListArray, MutableListArray, MutablePrimitiveArray, TryExtend};
-use arrow::datatypes::ArrowDataType;
+use arrow::datatypes::{ArrowDataType, ExtensionType};
 
 fn create_list_array(data: Vec<Option<Vec<Option<i32>>>>) -> ListArray<i32> {
     let mut array = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new();
@@ -18,7 +18,11 @@ fn extension() {
 
     let array = create_list_array(data);
 
-    let dtype = ArrowDataType::Extension("ext".into(), Box::new(array.dtype().clone()), None);
+    let dtype = ArrowDataType::Extension(Box::new(ExtensionType {
+        name: "ext".into(),
+        inner: array.dtype().clone(),
+        metadata: None,
+    }));
     let array_ext = ListArray::new(
         dtype,
         array.offsets().clone(),

--- a/crates/polars/tests/it/arrow/array/growable/mod.rs
+++ b/crates/polars/tests/it/arrow/array/growable/mod.rs
@@ -11,7 +11,7 @@ mod utf8;
 
 use arrow::array::growable::make_growable;
 use arrow::array::*;
-use arrow::datatypes::{ArrowDataType, Field};
+use arrow::datatypes::{ArrowDataType, ExtensionType, Field};
 
 #[test]
 fn test_make_growable() {
@@ -44,20 +44,20 @@ fn test_make_growable_extension() {
     .unwrap();
     make_growable(&[&array], false, 2);
 
-    let dtype = ArrowDataType::Extension("ext".into(), Box::new(ArrowDataType::Int32), None);
+    let dtype = ArrowDataType::Extension(Box::new(ExtensionType {
+        name: "ext".into(),
+        inner: ArrowDataType::Int32,
+        metadata: None,
+    }));
     let array = Int32Array::from_slice([1, 2]).to(dtype.clone());
     let array_grown = make_growable(&[&array], false, 2).as_box();
     assert_eq!(array_grown.dtype(), &dtype);
 
-    let dtype = ArrowDataType::Extension(
-        "ext".into(),
-        Box::new(ArrowDataType::Struct(vec![Field::new(
-            "a".into(),
-            ArrowDataType::Int32,
-            false,
-        )])),
-        None,
-    );
+    let dtype = ArrowDataType::Extension(Box::new(ExtensionType {
+        name: "ext".into(),
+        inner: ArrowDataType::Struct(vec![Field::new("a".into(), ArrowDataType::Int32, false)]),
+        metadata: None,
+    }));
     let array = StructArray::new(
         dtype.clone(),
         2,

--- a/crates/polars/tests/it/arrow/array/union.rs
+++ b/crates/polars/tests/it/arrow/array/union.rs
@@ -4,6 +4,10 @@ use arrow::datatypes::*;
 use arrow::scalar::{new_scalar, PrimitiveScalar, Scalar, UnionScalar, Utf8Scalar};
 use polars_error::PolarsResult;
 
+pub fn union_type(fields: Vec<Field>, ids: Option<Vec<i32>>, mode: UnionMode) -> ArrowDataType {
+    ArrowDataType::Union(Box::new(UnionType { fields, ids, mode }))
+}
+
 fn next_unwrap<T, I>(iter: &mut I) -> T
 where
     I: Iterator<Item = Box<dyn Scalar>>,
@@ -23,7 +27,7 @@ fn sparse_debug() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -43,7 +47,7 @@ fn dense_debug() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Dense);
+    let dtype = union_type(fields, None, UnionMode::Dense);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -64,7 +68,7 @@ fn slice() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::LargeUtf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -92,7 +96,7 @@ fn iter_sparse() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -125,7 +129,7 @@ fn iter_dense() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Dense);
+    let dtype = union_type(fields, None, UnionMode::Dense);
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
@@ -159,7 +163,7 @@ fn iter_sparse_slice() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
         Int32Array::from(&[Some(1), Some(3), Some(2)]).boxed(),
@@ -185,7 +189,7 @@ fn iter_dense_slice() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Dense);
+    let dtype = union_type(fields, None, UnionMode::Dense);
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
@@ -212,7 +216,7 @@ fn scalar() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Dense);
+    let dtype = union_type(fields, None, UnionMode::Dense);
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
@@ -269,7 +273,7 @@ fn dense_without_offsets_is_error() {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Dense);
+    let dtype = union_type(fields, None, UnionMode::Dense);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
@@ -285,7 +289,7 @@ fn fields_must_match() {
         Field::new("a".into(), ArrowDataType::Int64, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
@@ -301,7 +305,7 @@ fn sparse_with_offsets_is_error() {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
@@ -319,7 +323,7 @@ fn offsets_must_be_in_bounds() {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
@@ -338,7 +342,7 @@ fn sparse_with_wrong_offsets1_is_error() {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
@@ -357,7 +361,7 @@ fn types_must_be_in_bounds() -> PolarsResult<()> {
         Field::new("a".into(), ArrowDataType::Int32, true),
         Field::new("b".into(), ArrowDataType::Utf8, true),
     ];
-    let dtype = ArrowDataType::Union(fields, None, UnionMode::Sparse);
+    let dtype = union_type(fields, None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -60,7 +60,7 @@ hypothesis
 # -------
 
 pytest==8.3.2
-pytest-codspeed==3.1.0
+pytest-codspeed==3.0.0
 pytest-cov==6.0.0
 pytest-xdist==3.6.1
 


### PR DESCRIPTION
This reduces the size of `ArrowDataType` from 64 to 32 bytes.