### PR TITLE
feat(python): Add mermaid output to `show_graph`

### DIFF
--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -187,6 +187,7 @@ TorchExportType: TypeAlias = Literal["tensor", "dataset", "dict"]
 TransferEncoding: TypeAlias = Literal["hex", "base64"]
 WindowMappingStrategy: TypeAlias = Literal["group_to_rows", "join", "explode"]
 ExplainFormat: TypeAlias = Literal["plain", "tree"]
+ShowGraphFormat: TypeAlias = Literal["dot", "mermaid"]
 
 # type signature for allowed frame init
 FrameInitTypes: TypeAlias = Union[

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -668,11 +668,13 @@ def dot_to_mermaid(dot: str) -> str:
         ]
     )
 
-    return (
-        mermaid_str
-        .replace(r"\n", "\n") # replace escaped newlines
-        .replace(r'\"', "#quot;") # replace escaped quotes
-    )
+    # replace escaped newlines
+    mermaid_str = mermaid_str.replace(r"\n", "\n")
+
+    # replace escaped quotes
+    mermaid_str = mermaid_str.replace(r"\"", "#quot;")
+
+    return mermaid_str
 
 
 # Don't rename or move. This is used by polars cloud

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -707,9 +707,6 @@ def display_dot_graph(
     except (ImportError, FileNotFoundError):
         graphviz_installed = False
 
-    # temp force graphviz to be uninstalled for testing purposes
-    graphviz_installed = False
-
     exporting_file = output_path is not None
     showing_outside_of_notebook = show and not _in_notebook()
 

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -660,19 +660,18 @@ def dot_to_mermaid(dot: str) -> str:
     nodes = re.finditer(node_regex, dot)
     edges = re.finditer(edge_regex, dot)
 
-    return "\n".join(
+    mermaid_str = "\n".join(
         [
             "graph TD",
-            *[
-                f'\t{n["node"]}["{
-                    n["label"]
-                    .replace(r"\n", "\n") # replace escaped newlines
-                    .replace(r'\"', "#quot;") # replace escaped quotes
-                }"]'
-                for n in nodes
-            ],
+            *[f'\t{n["node"]}["{n["label"]}"]' for n in nodes],
             *[f'\t{e["node1"]} --- {e["node2"]}' for e in edges],
         ]
+    )
+
+    return (
+        mermaid_str
+        .replace(r"\n", "\n") # replace escaped newlines
+        .replace(r'\"', "#quot;") # replace escaped quotes
     )
 
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
         SchemaDefinition,
         SchemaDict,
         SerializationFormat,
+        ShowGraphFormat,
         StartBy,
         UniqueKeepStrategy,
     )
@@ -1131,6 +1132,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         show: bool = True,
         output_path: str | Path | None = None,
         raw_output: bool = False,
+        raw_output_format: ShowGraphFormat = "dot",
         figsize: tuple[float, float] = (16.0, 12.0),
         type_coercion: bool = True,
         _type_check: bool = True,
@@ -1148,8 +1150,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Show a plot of the query plan.
 
-        Note that Graphviz must be installed to render the visualization (if not
-        already present, you can download it here: `<https://graphviz.org/download>`_).
+        Note that Graphviz must be installed to export the visualization
+        or show it outside of a notebook
+        (if not already present, you can download it here: `<https://graphviz.org/download>`_).
 
         Parameters
         ----------
@@ -1161,6 +1164,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Write the figure to disk.
         raw_output
             Return dot syntax. This cannot be combined with `show` and/or `output_path`.
+        raw_output_format
+            The format of the raw output.
         figsize
             Passed to matplotlib if `show == True`.
         type_coercion
@@ -1221,6 +1226,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             show=show,
             output_path=output_path,
             raw_output=raw_output,
+            raw_output_format=raw_output_format,
             figsize=figsize,
         )
 


### PR DESCRIPTION
This is a fix for #12075 adding mermaid output to polars. I have decided that it makes more sense to have mermaid output come from the `show_graph` method instead of `explain` because `explain` appears to be for generating printable representations of the query plan wheras `show_graph` is for generating strings that can be fed to a visualization engine (currently just graphviz)

In addition to being able to output mermaid strings this PR will output a mermaid diagram if the user is in a notebook and graphviz is not installed. I think at some point it may be a better user experience to always export mermaid instead of the SVG in notebooks, but for now I did not want to change the behavior.