### PR TITLE
fix: Initialize AWS object store config from environment

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -287,14 +287,7 @@ impl CloudOptions {
     pub async fn build_aws(&self, url: &str) -> PolarsResult<impl object_store::ObjectStore> {
         use super::credential_provider::IntoCredentialProvider;
 
-        let mut builder = {
-            if self.credential_provider.is_none() {
-                AmazonS3Builder::from_env()
-            } else {
-                AmazonS3Builder::new()
-            }
-        }
-        .with_url(url);
+        let mut builder = AmazonS3Builder::from_env().with_url(url);
         if let Some(options) = &self.config {
             let CloudConfig::Aws(options) = options else {
                 panic!("impl error: cloud type mismatch")


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/issues/20096

Partially reverts https://github.com/pola-rs/polars/commit/d75d8d9717307c9c5129bc3f2e740fd81de1e520 - that PR was originally to address an issue for GCP but it also changed the code for AWS.

This should fix the issue - I couldn't reproduce the panic but I suspect that it is due to the code that is attempting to get the bucket name due to the region being unset in the config
