### PR TITLE
feat: Add hint to error message for extra struct field in JSON

### DIFF
--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -223,7 +223,7 @@ fn deserialize_struct<'a, A: Borrow<BorrowedValue<'a>>>(
         if !allow_extra_fields_in_struct {
             polars_bail!(
                ComputeError:
-               "extra key in struct data: {}, consider increasing infer_schema_length, or \
+               "extra field in struct data: {}, consider increasing infer_schema_length, or \
                manually specifying the full schema to ignore extra fields",
                v
             )

--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -221,7 +221,12 @@ fn deserialize_struct<'a, A: Borrow<BorrowedValue<'a>>>(
 
     if let Some(v) = extra_field {
         if !allow_extra_fields_in_struct {
-            polars_bail!(ComputeError: "extra key in struct data: {}", v)
+            polars_bail!(
+               ComputeError:
+               "extra key in struct data: {}, consider increasing infer_schema_length, or \
+               manually specifying the full schema to ignore extra fields",
+               v
+            )
         }
     }
 

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -69,7 +69,7 @@ def test_write_json_decimal() -> None:
 def test_json_infer_schema_length_11148() -> None:
     response = [{"col1": 1}] * 2 + [{"col1": 1, "col2": 2}] * 1
     with pytest.raises(
-        pl.exceptions.ComputeError, match="extra key in struct data: col2"
+        pl.exceptions.ComputeError, match="extra field in struct data: col2"
     ):
         pl.read_json(json.dumps(response).encode(), infer_schema_length=2)
 
@@ -471,7 +471,7 @@ def test_read_json_raise_on_data_type_mismatch() -> None:
 
 
 def test_read_json_struct_schema() -> None:
-    with pytest.raises(ComputeError, match="extra key in struct data: b"):
+    with pytest.raises(ComputeError, match="extra field in struct data: b"):
         pl.read_json(
             b"""\
 [

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1813,7 +1813,7 @@ def test_json_decode_raise_on_data_type_mismatch_13061() -> None:
 
 
 def test_json_decode_struct_schema() -> None:
-    with pytest.raises(ComputeError, match="extra key in struct data: b"):
+    with pytest.raises(ComputeError, match="extra field in struct data: b"):
         pl.Series([r'{"a": 1}', r'{"a": 2, "b": 2}']).str.json_decode(
             infer_schema_length=1
         )


### PR DESCRIPTION
Adds a hint in the error message on how to resolve the error - a few users have run into it and it currently isn't immediately clear what could be done to resolve it.
