### PR TITLE
fix: Ensure that SQL `LIKE` and `ILIKE` operators support multi-line matches

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1355,7 +1355,7 @@ impl SQLContext {
                 .replace('%', ".*")
                 .replace('_', ".");
 
-            modifiers.ilike = Some(regex::Regex::new(format!("^(?i){}$", rx).as_str()).unwrap());
+            modifiers.ilike = Some(regex::Regex::new(format!("^(?is){}$", rx).as_str()).unwrap());
         }
 
         // SELECT * RENAME

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -357,7 +357,11 @@ impl SQLExprVisitor<'_> {
                 .replace('%', ".*")
                 .replace('_', ".");
 
-            rx = format!("^{}{}$", if case_insensitive { "(?i)" } else { "" }, rx);
+            rx = format!(
+                "^{}{}$",
+                if case_insensitive { "(?is)" } else { "(?s)" },
+                rx
+            );
 
             let expr = self.visit_expr(expr)?;
             let matches = expr.str().contains(lit(rx), true);


### PR DESCRIPTION
Closes #20606.

The "%" pattern in SQL `LIKE` and `ILIKE` ops is expected to match across linebreaks [^1].

## Example

```python
import polars as pl

s1 = "Hello World"
s2 = "Hello\nWorld"
s3 = "hello\nWORLD"

df = pl.DataFrame({
  "idx": [10, 20, 30],
  "txt": [s1, s2, s3],
})
```
🔴 **Before**

_(linebreaks interrupt the match)_
```python
df.sql("SELECT * FROM self WHERE txt ILIKE 'Hello%'")
# shape: (1, 2)
# ┌─────┬─────────────┐
# │ idx ┆ txt         │
# │ --- ┆ ---         │
# │ i64 ┆ str         │
# ╞═════╪═════════════╡
# │ 10  ┆ Hello World │
# └─────┴─────────────┘
```
🟢 **After**

_(linebreaks do **not** interrupt the match)_
```python
df.sql("SELECT * FROM self WHERE txt ILIKE 'Hello%'")
# shape: (3, 2)
# ┌─────┬─────────────┐
# │ idx ┆ txt         │
# │ --- ┆ ---         │
# │ i64 ┆ str         │
# ╞═════╪═════════════╡
# │ 10  ┆ Hello World │
# │ 20  ┆ Hello       │
# │     ┆ World       │
# │ 30  ┆ hello       │
# │     ┆ WORLD       │
# └─────┴─────────────┘
```

**Aside:** I think we should look at rendering "\n" in the table output here (and "\t", etc) instead of actually rendering newlines/tabs (etc) as-is. Might take a look at that later 👀 

[^1]: _"a percent sign (%) matches **any** sequence of zero or more characters."_ ([link](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE))