### PR TITLE
ci: Fix Python deps installation in remote-benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-remote.yml
+++ b/.github/workflows/benchmark-remote.yml
@@ -47,7 +47,7 @@ jobs:
           # doesn't have an up-to-date typing-extensions, see
           # https://github.com/astral-sh/uv/issues/6028#issuecomment-2287232150
           uv pip install -U typing-extensions
-          uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose
+          uv pip install --compile-bytecode -r requirements-dev.txt -r requirements-ci.txt --verbose --index-strategy=unsafe-best-match
 
       - name: Install Polars-Benchmark dependencies
         working-directory: polars-benchmark


### PR DESCRIPTION
I missed a spot in https://github.com/pola-rs/polars/pull/20549