### PR TITLE
feat(python): Raise `DuplicateError` if given a pyarrow Table object with duplicate column names

### DIFF
--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -733,7 +733,7 @@ def test_init_arrow_dupes() -> None:
     )
     with pytest.raises(
         DuplicateError,
-        match="column 'col' appears 2 times; names must be unique",
+        match="column 'col' appears more than once; names must be unique",
     ):
         pl.DataFrame(tbl)
 

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -18,7 +18,7 @@ import polars as pl
 from polars._utils.construction.utils import try_get_type_hints
 from polars.datatypes import numpy_char_code_to_dtype
 from polars.dependencies import dataclasses, pydantic
-from polars.exceptions import ShapeError
+from polars.exceptions import DuplicateError, ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -721,6 +721,21 @@ def test_init_arrow() -> None:
     # Bad columns argument
     with pytest.raises(ValueError):
         pl.DataFrame(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}), schema=["c", "d", "e"])
+
+
+def test_init_arrow_dupes() -> None:
+    tbl = pa.Table.from_arrays(
+        arrays=[
+            pa.array([1, 2, 3], type=pa.int32()),
+            pa.array([4, 5, 6], type=pa.int32()),
+        ],
+        schema=pa.schema([("col", pa.int32()), ("col", pa.int32())]),
+    )
+    with pytest.raises(
+        DuplicateError,
+        match="column 'col' appears 2 times; names must be unique",
+    ):
+        pl.DataFrame(tbl)
 
 
 def test_init_from_frame() -> None:


### PR DESCRIPTION
Closes #20616.

We already catch this case in `read_database` (see: https://github.com/pola-rs/polars/pull/18548), but `read_database_uri` has exposed a more generic gremlin in frame construction  from `pyarrow.Table` objects (eg: `connectorx` loads query results to `pyarrow.Table`, which gets passed to `pl.from_arrow`).

We weren't explicitly checking the incoming `pyarrow.Table` for duplicate columns, which leads to a somewhat non-obvious `ShapeError`; with this PR we now raise a more helpful `DuplicateError` that explicitly refers to the column name that appears more than once.

## Example

```python
import pyarrow as pa
import polars as pl

tbl = pa.Table.from_arrays(
    arrays=[
        pa.array([1, 2, 3], type=pa.int32()),
        pa.array([4, 5, 6], type=pa.int32()),
    ],
    schema=pa.schema([
        ("dupe_col", pa.int32()), 
        ("dupe_col", pa.int32()),
    ]),
)
```
🔴 **Before**
```python
pl.from_arrow(tbl)
# ShapeError: 2 column names provided for a DataFrame of width 1
```
🟢 **After**
```python
pl.from_arrow(tbl)
# DuplicateError: column 'dupe_col' appears 2 times; names must be unique
```