### PR TITLE
feat: Add mermaid output to `show_graph`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,6 +3248,7 @@ dependencies = [
  "polars-utils",
  "pyo3",
  "rayon",
+ "regex",
  "serde_json",
  "tokio",
  "version_check",

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -226,6 +226,7 @@ dynamic_group_by = [
 ewma = ["polars-plan/ewma"]
 ewma_by = ["polars-plan/ewma_by"]
 dot_diagram = ["polars-plan/dot_diagram"]
+mermaid_diagram = ["polars-plan/mermaid_diagram"]
 diagonal_concat = []
 unique_counts = ["polars-plan/unique_counts"]
 log = ["polars-plan/log"]
@@ -382,6 +383,7 @@ features = [
   "list_to_struct",
   "log",
   "merge_sorted",
+  "mermaid_diagram",
   "meta",
   "mode",
   "moment",

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -29,7 +29,7 @@ memchr = { workspace = true }
 once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 rayon = { workspace = true }
-regex = { workspace = true}
+regex = { workspace = true }
 tokio = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -29,6 +29,7 @@ memchr = { workspace = true }
 once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 rayon = { workspace = true }
+regex = { workspace = true}
 tokio = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/polars-lazy/src/lib.rs
+++ b/crates/polars-lazy/src/lib.rs
@@ -200,12 +200,15 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 extern crate core;
 
-#[cfg(feature = "dot_diagram")]
+#[cfg(any(feature = "dot_diagram", feature = "mermaid_diagram"))]
 mod dot;
 pub mod dsl;
 pub mod frame;
 pub mod physical_plan;
 pub mod prelude;
+
+#[cfg(feature = "mermaid_diagram")]
+mod mermaid;
 
 mod scan;
 #[cfg(test)]

--- a/crates/polars-lazy/src/mermaid.rs
+++ b/crates/polars-lazy/src/mermaid.rs
@@ -1,40 +1,48 @@
-use polars_core::{export::regex, prelude::*};
+use polars_core::prelude::*;
+use regex::Regex;
 
 use crate::prelude::*;
 
 impl LazyFrame {
     pub fn to_mermaid(&self, optimized: bool) -> PolarsResult<String> {
-        // Mermaid strings are very similar to dot strings, so 
+        // Mermaid strings are very similar to dot strings, so
         // we can reuse the dot implementation.
         let dot = self.to_dot(optimized)?;
-        
-        let edge_regex = regex::Regex::new(r"(?P<node1>\w+) -- (?P<node2>\w+)").unwrap();
-        let node_regex = regex::Regex::new(r#"(?P<node>\w+)(\s+)?\[label="(?P<label>.*)"]"#).unwrap();
+
+        let edge_regex = Regex::new(r"(?P<node1>\w+) -- (?P<node2>\w+)").unwrap();
+        let node_regex = Regex::new(r#"(?P<node>\w+)(\s+)?\[label="(?P<label>.*)"]"#).unwrap();
 
         let nodes = node_regex.captures_iter(&dot);
         let edges = edge_regex.captures_iter(&dot);
-        
-        let node_lines = nodes.map(|node| {
-            format!(
-                "\t{}[\"{}\"]", 
-                node.name("node").unwrap().as_str(), 
-                node.name("label").unwrap().as_str()
-                .replace(r"\n", "\n") // replace escaped newlines
-                .replace(r#"\""#, "#quot;") // replace escaped quotes
-            )
-        }).collect::<Vec<_>>().join("\n");
 
-        let edge_lines = edges.map(|edge| {
-            format!(
-                "\t{} --- {}", 
-                edge.name("node1").unwrap().as_str(), 
-                edge.name("node2").unwrap().as_str()
-            )
-        }).collect::<Vec<_>>().join("\n");
+        let node_lines = nodes
+            .map(|node| {
+                format!(
+                    "\t{}[\"{}\"]",
+                    node.name("node").unwrap().as_str(),
+                    node.name("label")
+                        .unwrap()
+                        .as_str()
+                        .replace(r"\n", "\n") // replace escaped newlines
+                        .replace(r#"\""#, "#quot;") // replace escaped quotes
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let edge_lines = edges
+            .map(|edge| {
+                format!(
+                    "\t{} --- {}",
+                    edge.name("node1").unwrap().as_str(),
+                    edge.name("node2").unwrap().as_str()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
 
         let mermaid = format!("graph TD\n{node_lines}\n{edge_lines}");
-        
-        Ok(mermaid)
 
+        Ok(mermaid)
     }
 }

--- a/crates/polars-lazy/src/mermaid.rs
+++ b/crates/polars-lazy/src/mermaid.rs
@@ -1,0 +1,40 @@
+use polars_core::{export::regex, prelude::*};
+
+use crate::prelude::*;
+
+impl LazyFrame {
+    pub fn to_mermaid(&self, optimized: bool) -> PolarsResult<String> {
+        // Mermaid strings are very similar to dot strings, so 
+        // we can reuse the dot implementation.
+        let dot = self.to_dot(optimized)?;
+        
+        let edge_regex = regex::Regex::new(r"(?P<node1>\w+) -- (?P<node2>\w+)").unwrap();
+        let node_regex = regex::Regex::new(r#"(?P<node>\w+)(\s+)?\[label="(?P<label>.*)"]"#).unwrap();
+
+        let nodes = node_regex.captures_iter(&dot);
+        let edges = edge_regex.captures_iter(&dot);
+        
+        let node_lines = nodes.map(|node| {
+            format!(
+                "\t{}[\"{}\"]", 
+                node.name("node").unwrap().as_str(), 
+                node.name("label").unwrap().as_str()
+                .replace(r"\n", "\n") // replace escaped newlines
+                .replace(r#"\""#, "#quot;") // replace escaped quotes
+            )
+        }).collect::<Vec<_>>().join("\n");
+
+        let edge_lines = edges.map(|edge| {
+            format!(
+                "\t{} --- {}", 
+                edge.name("node1").unwrap().as_str(), 
+                edge.name("node2").unwrap().as_str()
+            )
+        }).collect::<Vec<_>>().join("\n");
+
+        let mermaid = format!("graph TD\n{node_lines}\n{edge_lines}");
+        
+        Ok(mermaid)
+
+    }
+}

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -148,6 +148,7 @@ dynamic_group_by = ["polars-core/dynamic_group_by"]
 ewma = ["polars-ops/ewma"]
 ewma_by = ["polars-ops/ewma_by"]
 dot_diagram = []
+mermaid_diagram = []
 unique_counts = ["polars-ops/unique_counts"]
 log = ["polars-ops/log"]
 chunked_ids = []
@@ -291,6 +292,7 @@ features = [
   "concat_str",
   "coalesce",
   "dot_diagram",
+  "mermaid_diagram",
   "trigonometry",
   "streaming",
   "true_div",

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -84,6 +84,7 @@ features = [
   "array_arithmetic",
   "array_to_struct",
   "log",
+  "mermaid_diagram",
   "mode",
   "moment",
   "ndarray",

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -481,6 +481,11 @@ impl PyLazyFrame {
         Ok(result)
     }
 
+    fn to_mermaid(&self, optimized: bool) -> PyResult<String> {
+        let result = self.ldf.to_mermaid(optimized).map_err(PyPolarsErr::from)?;
+        Ok(result)
+    }
+
     fn optimization_toggle(
         &self,
         type_coercion: bool,

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -192,6 +192,7 @@ array_arithmetic = ["polars-core/array_arithmetic", "dtype-array"]
 array_to_struct = ["polars-ops/array_to_struct", "polars-lazy?/array_to_struct"]
 log = ["polars-ops/log", "polars-lazy?/log"]
 merge_sorted = ["polars-lazy?/merge_sorted"]
+mermaid_diagram = ["polars-lazy?/mermaid_diagram"]
 meta = ["polars-lazy?/meta"]
 mode = ["polars-ops/mode", "polars-lazy?/mode"]
 moment = ["polars-ops/moment", "polars-lazy?/moment"]
@@ -415,6 +416,7 @@ docs-selection = [
   "diagonal_concat",
   "abs",
   "dot_diagram",
+  "mermaid_diagram",
   "string_encoding",
   "product",
   "to_dummies",

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -177,6 +177,7 @@
 //! * `lazy` - Lazy API
 //!     - `regex` - Use regexes in [column selection]
 //!     - `dot_diagram` - Create dot diagrams from lazy logical plans.
+//!     - `mermaid` - Create mermaid diagrams from lazy logical plans.
 //! * `sql` - Pass SQL queries to Polars.
 //! * `streaming` - Process datasets larger than RAM.
 //! * `random` - Generate arrays with randomly sampled values

--- a/docs/source/user-guide/installation.md
+++ b/docs/source/user-guide/installation.md
@@ -181,6 +181,7 @@ The opt-in features are:
 - `lazy` - Lazy API:
     - `regex` - Use regexes in column selection.
     - `dot_diagram` - Create dot diagrams from lazy logical plans.
+    - `mermaid_diagram` - Create mermaid diagrams from lazy logical plans.
 - `sql` - Pass SQL queries to Polars.
 - `streaming` - Be able to process datasets that are larger than RAM.
 - `random` - Generate arrays with randomly sampled values

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -188,6 +188,7 @@ TorchExportType: TypeAlias = Literal["tensor", "dataset", "dict"]
 TransferEncoding: TypeAlias = Literal["hex", "base64"]
 WindowMappingStrategy: TypeAlias = Literal["group_to_rows", "join", "explode"]
 ExplainFormat: TypeAlias = Literal["plain", "tree"]
+ShowGraphFormat: TypeAlias = Literal["dot", "mermaid"]
 
 # type signature for allowed frame init
 FrameInitTypes: TypeAlias = Union[

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -61,6 +61,8 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
     T = TypeVar("T")
 
+    from IPython.display import Markdown
+
 # note: reversed views don't match as instances of MappingView
 if sys.version_info >= (3, 11):
     _views: list[Reversible[Any]] = [{}.keys(), {}.values(), {}.items()]
@@ -702,3 +704,13 @@ def display_dot_graph(
         plt.imshow(img)
         plt.show()
         return None
+
+
+def display_mermaid_graph(mermaid: str) -> Markdown:
+    if not _in_notebook():
+        msg = "This function is only available in Jupyter notebooks."
+        raise OSError(msg)
+
+    from IPython.display import Markdown
+
+    return Markdown(f"```mermaid\n{mermaid}\n```")

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -746,4 +746,4 @@ def display_mermaid_graph(
 
     from IPython.display import Markdown, display
 
-    display(Markdown(f"```mermaid\n{mermaid}\n```"))
+    return display(Markdown(f"```mermaid\n{mermaid}\n```"))

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -705,8 +705,15 @@ def display_dot_graph(
 
 
 def display_mermaid_graph(
-    *, mermaid: str, show: bool = True, output_path: str | Path | None = None
-) -> None:
+    *,
+    mermaid: str,
+    show: bool = True,
+    output_path: str | Path | None = None,
+    raw_output: bool = False,
+) -> str | None:
+    if raw_output:
+        return mermaid
+
     # Make font monospace
     mermaid += r'%%{init: {"fontFamily": "monospace"}}%%' + "\n"
 


### PR DESCRIPTION
This pull request would close #12075 and supersedes #20607. Thanks again to @ritchie46, @eitsupi, and @alexander-beedie for their feedback. 

This PR adds support for mermaid string generation to polars. In #12075 it was suggested that mermaid output be added to `explain`, but I believe that it makes more sense to have mermaid output come from the `show_graph` method instead of `explain` because `explain` appears to be for generating printable representations of the query plan wheras `show_graph` is for generating strings that can be fed to a visualization engine (currently just graphviz).

In addition to being able to output mermaid strings this PR will output a mermaid diagram if the user is in a notebook and graphviz is not installed when calling `show_graph`. I think at some point it may be a better user experience to always export mermaid instead of the SVG in notebooks, but for now I did not want to change the behavior. I also considered adding functionality that would change the behavior of `_repr_html_` to show a mermaid diagram if graphviz is not installed, but if without a way to check if the user can render mermaid this could be a worse user experience than the current behavior which calls `explain`.

Compared with #20607 this PR generates the mermaid string in rust instead of in python. 

Here is a sample output:

![image](https://github.com/user-attachments/assets/ffb88a57-4451-450f-85e9-38adc97536e5)

Note that the mermaid renderer in Jupyter Lab and VS Code (with extension) is theme aware, so the graph changes color with the user theme. 
