### PR TITLE
feat(python): Support writing to file objects from `write_excel`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3106,8 +3106,8 @@ class DataFrame:
         Parameters
         ----------
         workbook : {str, Workbook}
-            String name or path of the workbook to create, BytesIO object to write
-            into, or an open `xlsxwriter.Workbook` object that has not been closed.
+            String name or path of the workbook to create, BytesIO object, file opened
+            in binary-mode, or an `xlsxwriter.Workbook` object that has not been closed.
             If None, writes to a `dataframe.xlsx` workbook in the working directory.
         worksheet : {str, Worksheet}
             Name of target worksheet or an `xlsxwriter.Worksheet` object (in which

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from io import BytesIO
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
@@ -594,13 +595,20 @@ def _xl_setup_workbook(
         if isinstance(workbook, BytesIO):
             wb, ws, can_close = Workbook(workbook, workbook_options), None, True
         else:
-            file = Path("dataframe.xlsx" if workbook is None else workbook)
-            wb = Workbook(
-                (file if file.suffix else file.with_suffix(".xlsx"))
-                .expanduser()
-                .resolve(strict=False),
-                workbook_options,
-            )
+            if workbook is None:
+                file = Path("dataframe.xlsx")
+            elif isinstance(workbook, str):
+                file = Path(workbook)
+            else:
+                file = workbook
+
+            if isinstance(file, PathLike):
+                file = (
+                    (file if file.suffix else file.with_suffix(".xlsx"))
+                    .expanduser()
+                    .resolve(strict=False)
+                )
+            wb = Workbook(file, workbook_options)
             ws, can_close = None, True
 
     if ws is None:

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -4,6 +4,7 @@ import warnings
 from collections import OrderedDict
 from datetime import date, datetime
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 import pytest
@@ -16,7 +17,6 @@ from tests.unit.conftest import FLOAT_DTYPES, NUMERIC_DTYPES
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
     from polars._typing import ExcelSpreadsheetEngine, SchemaDict, SelectorType
 
@@ -848,6 +848,37 @@ def test_excel_write_compound_types(engine: ExcelSpreadsheetEngine) -> None:
         ("[3, 4]", "{'y': 'b', 'z': 8}", "in-mem"),
         ("[5, 6]", "{'y': 'c', 'z': 7}", "in-mem"),
     ]
+
+
+@pytest.mark.parametrize("engine", ["xlsx2csv", "openpyxl", "calamine"])
+def test_excel_write_to_file_object(
+    engine: ExcelSpreadsheetEngine, tmp_path: Path
+) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    df = pl.DataFrame({"x": ["aaa", "bbb", "ccc"], "y": [123, 456, 789]})
+
+    # write to bytesio
+    xls = BytesIO()
+    df.write_excel(xls, worksheet="data")
+    assert_frame_equal(df, pl.read_excel(xls, engine=engine))
+
+    # write to file path
+    path = Path(tmp_path).joinpath("test_write_path.xlsx")
+    df.write_excel(path, worksheet="data")
+    assert_frame_equal(df, pl.read_excel(xls, engine=engine))
+
+    # write to file path (as string)
+    path = Path(tmp_path).joinpath("test_write_path_str.xlsx")
+    df.write_excel(str(path), worksheet="data")
+    assert_frame_equal(df, pl.read_excel(xls, engine=engine))
+
+    # write to file object
+    path = Path(tmp_path).joinpath("test_write_file_object.xlsx")
+    with path.open("wb") as tgt:
+        df.write_excel(tgt, worksheet="data")
+    with path.open("rb") as src:
+        assert_frame_equal(df, pl.read_excel(src, engine=engine))
 
 
 @pytest.mark.parametrize("engine", ["xlsx2csv", "openpyxl", "calamine"])


### PR DESCRIPTION
Closes #18849.

Allows `write_excel` to export to file _objects_ as well as file _paths_ (and BytesIO).

## Example

```python
from pathlib import Path
import polars as pl

df1 = pl.DataFrame({"colx": ["aaa", "bbb", "ccc"]})

# write to an open (binary-mode) file object
with Path("dataframe.xlsx").open(mode="wb") as p:
    df1.write_excel(p)

df2 = pl.read_excel(Path("dataframe.xlsx"))
df1.equals(df2)
# True
```