### PR TITLE
fix: Fix `join_asof` panicking for invalid `tolerance` input

### DIFF
--- a/crates/polars-mem-engine/src/executors/join.rs
+++ b/crates/polars-mem-engine/src/executors/join.rs
@@ -107,7 +107,7 @@ impl Executor for JoinExec {
                 if let JoinType::AsOf(options) = &mut self.args.how {
                     use polars_core::utils::arrow::temporal_conversions::MILLISECONDS_IN_DAY;
                     if let Some(tol) = &options.tolerance_str {
-                        let duration = polars_time::Duration::parse(tol);
+                        let duration = polars_time::Duration::try_parse(tol)?;
                         polars_ensure!(
                             duration.months() == 0,
                             ComputeError: "cannot use month offset in timedelta of an asof join; \

--- a/crates/polars-ops/src/frame/join/asof/default.rs
+++ b/crates/polars-ops/src/frame/join/asof/default.rs
@@ -99,7 +99,7 @@ pub(crate) fn join_asof_numeric<T: PolarsNumericType>(
     let right = other.downcast_iter().next().unwrap();
 
     let out = if let Some(t) = tolerance {
-        let native_tolerance = t.extract::<T::Native>().unwrap();
+        let native_tolerance = t.try_extract::<T::Native>()?;
         let abs_tolerance = native_tolerance.abs_diff(T::Native::zero());
         let filter = |l: T::Native, r: T::Native| l.abs_diff(r) <= abs_tolerance;
         match strategy {

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -263,6 +263,15 @@ def test_join_asof_tolerance() -> None:
         "quote": [100, None, 300, None],
     }
 
+    for invalid_tolerance, match in [
+        ("foo", "expected leading integer"),
+        ([None], "could not extract number"),
+    ]:
+        with pytest.raises(pl.exceptions.PolarsError, match=match):
+            df_trades.join_asof(
+                df_quotes, on="time", by="stock", tolerance=invalid_tolerance
+            )
+
 
 def test_join_asof_tolerance_forward() -> None:
     df_quotes = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -269,7 +269,10 @@ def test_join_asof_tolerance() -> None:
     ]:
         with pytest.raises(pl.exceptions.PolarsError, match=match):
             df_trades.join_asof(
-                df_quotes, on="time", by="stock", tolerance=invalid_tolerance
+                df_quotes,
+                on="time",
+                by="stock",
+                tolerance=invalid_tolerance,  # type: ignore[arg-type]
             )
 
 


### PR DESCRIPTION
closes #20321