### PR TITLE
feat: Ergonomic casts from `Categorical` to `Enum`

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -302,7 +302,7 @@ impl ChunkCast for StringChunked {
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(rev_map, ordering) => {
                 let Some(rev_map) = rev_map else {
-                    polars_bail!(ComputeError: "can not cast / initialize Enum without categories present")
+                    polars_bail!(ComputeError: "cannot cast or initialize Enum without categories present")
                 };
                 CategoricalChunked::from_string_to_enum(self, rev_map.get_categories(), *ordering)
                     .map(|ca| {

--- a/crates/polars-core/src/chunked_array/logical/categorical/revmap.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/revmap.rs
@@ -61,7 +61,7 @@ impl RevMapping {
         }
     }
 
-    fn build_hash(categories: &Utf8ViewArray) -> u128 {
+    pub fn build_hash(categories: &Utf8ViewArray) -> u128 {
         // TODO! we must also validate the cases of duplicates!
         let mut hb = PlRandomState::with_seed(0).build_hasher();
         categories.values_iter().for_each(|val| {

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -832,6 +832,20 @@ def test_cast_from_cat_to_numeric() -> None:
     assert s.cast(pl.UInt8).sum() == 6
 
 
+def test_cast_from_cat_to_enum() -> None:
+    countries = ["Japan", "Australia", "Netherlands", "Wakanda"]
+    sorted_countries = sorted(countries)
+
+    cat_series = pl.Series("countries", countries).cast(pl.Categorical)
+
+    se1 = cat_series.cast(pl.Enum(sorted(cat_series.cat.get_categories())))
+    se2 = cat_series.cast(pl.Enum)  # more ergonomic version of the above
+
+    assert_series_equal(se1, se2)
+    for se in (se1, se2):
+        assert se.dtype == pl.Enum(sorted_countries)
+
+
 @pytest.mark.usefixtures("test_global_and_local")
 def test_cat_preserve_lexical_ordering_on_clear() -> None:
     s = pl.Series("a", ["a", "b"], dtype=pl.Categorical(ordering="lexical"))


### PR DESCRIPTION
ref: https://github.com/pola-rs/polars/issues/19868#issuecomment-2514780994.

Allow for stable ergonomic casts from `Categorical` to `Enum`.

If _no_ categories are defined, we read the `Categorical` rev_map and normalise to a lexically sorted `Enum` (which ensures that if the same categories appear in a different order they will return the _same_ `Enum`).

## Example

```python
import polars as pl

df = pl.DataFrame({
  "id": [0, 1, 2, 3],
  "foo": pl.Series(["aaa", "bbb", "aaa", "bbb"], dtype=pl.Categorical),
  "bar": pl.Series(["zzz", "xxx", "xxx", "yyy"], dtype=pl.Categorical),
  "baz": pl.Series(["xxx", "yyy", "zzz", "xxx"], dtype=pl.Categorical),
})
```
**Before:**
_(note that we have to sort the categories to ensure a stable Enum)_
```python
df.cast({
  "foo": pl.Enum(sorted(df["foo"].cat.get_categories())),
  "bar": pl.Enum(sorted(df["bar"].cat.get_categories())),
  "baz": pl.Enum(sorted(df["baz"].cat.get_categories())),
})
```
**After:**
_(no boilerplate, and the resulting enums will be stable/sorted)_
```python
df.cast({pl.Categorical: pl.Enum})
```