### PR TITLE
fix: Incorrect flag check on is_elementwise

### DIFF
--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -252,9 +252,8 @@ impl FunctionOptions {
         matches!(
             self.collect_groups,
             ApplyOptions::ElementWise | ApplyOptions::ApplyList
-        ) && !self
-            .flags
-            .contains(FunctionFlags::CHANGES_LENGTH | FunctionFlags::RETURNS_SCALAR)
+        ) && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
+            && !self.flags.contains(FunctionFlags::RETURNS_SCALAR)
     }
 }
 


### PR DESCRIPTION
`BitFlags::contains` only returns true if *all* bits on the right-hand side are true.