### PR TITLE
feat: Make automatic use of Azure storage account keys opt-in

### DIFF
--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -201,7 +201,6 @@ class CredentialProviderAzure(CredentialProvider):
 
     def __call__(self) -> CredentialProviderFunctionReturn:
         """Fetch the credentials."""
-
         POLARS_AUTO_USE_AZURE_STORAGE_ACCOUNT_KEY = os.getenv(
             "POLARS_AUTO_USE_AZURE_STORAGE_ACCOUNT_KEY"
         )


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/issues/20634

* Fixes a behavior where storage account keys retrieved from Azure CLI would in some cases override user-specified configurations
* Disables retrieving and using storage account keys from Azure CLI by default, this is now only done if `POLARS_AUTO_USE_AZURE_STORAGE_ACCOUNT_KEY=1` is in the environment (note that `azure.identity` must also be installed as well, so that `CredentialProviderAzure` gets instantiated)
