### PR TITLE
fix: Fix empty output of `to_arrow()` on unit height filtered DataFrame

### DIFF
--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -857,3 +857,8 @@ def test_from_arrow_string_cache_20271() -> None:
         assert_series_equal(
             df.to_series().to_physical(), pl.Series("b", [3, 4]), check_dtypes=False
         )
+
+
+def test_to_arrow_empty_chunks_20627() -> None:
+    df = pl.concat(2 * [pl.Series([1])]).filter(pl.Series([False, True])).to_frame()
+    assert df.to_arrow().shape == (1, 1)

--- a/py-polars/tests/unit/test_scalar.py
+++ b/py-polars/tests/unit/test_scalar.py
@@ -79,3 +79,8 @@ def test_scalar_identification_function_expr_in_binary() -> None:
         pl.select(x).with_columns(o=pl.col("x").null_count() > 0),
         pl.select(x, o=False),
     )
+
+
+def test_scalar_rechunk_20627() -> None:
+    df = pl.concat(2 * [pl.Series([1])]).filter(pl.Series([False, True])).to_frame()
+    assert df.rechunk().to_series().n_chunks() == 1


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/20627

Fix `Column::n_chunks()/rechunk()` to account for the chunks in the cached materialized Series for the scalar case.
