### PR TITLE
fix: Fix serialization of empty DF in LazyFrame

### DIFF
--- a/crates/polars-core/src/serde/df.rs
+++ b/crates/polars-core/src/serde/df.rs
@@ -88,6 +88,9 @@ impl DataFrame {
             })
             .collect::<PolarsResult<Vec<DataFrame>>>()?;
 
+        if dfs.is_empty() {
+            return Ok(DataFrame::empty());
+        }
         let mut df = accumulate_dataframes_vertical_unchecked(dfs);
 
         // Set custom metadata (fallible)

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -217,3 +217,11 @@ def test_serde_udf() -> None:
     result = pl.LazyFrame.deserialize(io.BytesIO(lf.serialize()))
 
     assert_frame_equal(lf, result)
+
+
+def test_serde_empty_df_lazy_frame() -> None:
+    lf = pl.LazyFrame()
+    f = io.BytesIO()
+    f.write(lf.serialize())
+    f.seek(0)
+    assert pl.LazyFrame.deserialize(f).collect().shape == (0, 0)


### PR DESCRIPTION
This wasn't released yet, so it never was broken. Now it is tested.