### PR TITLE
perf: Use downcast_ref instead of dtype equality in `<dyn SeriesTrait as AsRef<ChunkedArray<T>>`

### DIFF
--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -207,12 +207,11 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }
+
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
 
-    /// Get a hold to self as `Any` trait reference.
-    /// Only implemented for ObjectType
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
     }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -247,4 +247,8 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -189,4 +189,8 @@ impl SeriesTrait for SeriesWrap<BinaryOffsetChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -354,4 +354,8 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -293,8 +293,13 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     fn max_reduce(&self) -> PolarsResult<Scalar> {
         Ok(ChunkAggSeries::max_reduce(&self.0))
     }
+
     fn as_any(&self) -> &dyn Any {
         &self.0
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
     }
 }
 

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -351,6 +351,10 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<DateChunked> {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -360,7 +360,12 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }
+
     fn as_any(&self) -> &dyn Any {
         &self.0
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
     }
 }

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -419,4 +419,8 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -520,4 +520,8 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -362,8 +362,13 @@ macro_rules! impl_dyn_series {
             fn checked_div(&self, rhs: &Series) -> PolarsResult<Series> {
                 self.0.checked_div(rhs)
             }
+
             fn as_any(&self) -> &dyn Any {
                 &self.0
+            }
+
+            fn as_any_mut(&mut self) -> &mut dyn Any {
+                &mut self.0
             }
         }
     };

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -254,12 +254,11 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }
+
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
 
-    /// Get a hold to self as `Any` trait reference.
-    /// Only implemented for ObjectType
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
     }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -439,6 +439,10 @@ macro_rules! impl_dyn_series {
             fn as_any(&self) -> &dyn Any {
                 &self.0
             }
+
+            fn as_any_mut(&mut self) -> &mut dyn Any {
+                &mut self.0
+            }
         }
     };
 }

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -316,7 +316,12 @@ impl SeriesTrait for NullChunked {
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(self.clone())
     }
+
     fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 }

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -237,6 +237,10 @@ where
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }
 
 #[cfg(test)]

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -261,4 +261,8 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -257,6 +257,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         &self.0
     }
 
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
+
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
         Ok(self.0.sort_with(options).into_series())
     }

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -324,6 +324,10 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
     fn as_any(&self) -> &dyn Any {
         &self.0
     }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<TimeChunked> {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1030,7 +1030,7 @@ where
     T: 'static + PolarsDataType<IsLogical = FalseT>,
 {
     fn as_mut(&mut self) -> &mut ChunkedArray<T> {
-        if !self.as_any_mut().is::<T>() {
+        if !self.as_any_mut().is::<ChunkedArray<T>>() {
             panic!(
                 "implementation error, cannot get ref {:?} from {:?}",
                 T::get_dtype(),

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1006,55 +1006,41 @@ impl Default for Series {
     }
 }
 
-fn equal_outer_type<T: 'static + PolarsDataType>(dtype: &DataType) -> bool {
-    match (T::get_dtype(), dtype) {
-        (DataType::List(_), DataType::List(_)) => true,
-        #[cfg(feature = "dtype-array")]
-        (DataType::Array(_, _), DataType::Array(_, _)) => true,
-        #[cfg(feature = "dtype-struct")]
-        (DataType::Struct(_), DataType::Struct(_)) => true,
-        (a, b) => &a == b,
-    }
-}
-
 impl<T> AsRef<ChunkedArray<T>> for dyn SeriesTrait + '_
 where
-    T: 'static + PolarsDataType,
+    T: 'static + PolarsDataType<IsLogical = FalseT>,
 {
     fn as_ref(&self) -> &ChunkedArray<T> {
-        let dtype = self.dtype();
+        // @NOTE: SeriesTrait `as_any` returns a std::any::Any for the underlying ChunkedArray /
+        // Logical (so not the SeriesWrap).
+        let Some(ca) = self.as_any().downcast_ref::<ChunkedArray<T>>() else {
+            panic!(
+                "implementation error, cannot get ref {:?} from {:?}",
+                T::get_dtype(),
+                self.dtype()
+            );
+        };
 
-        #[cfg(feature = "dtype-decimal")]
-        if dtype.is_decimal() {
-            let logical = self.as_any().downcast_ref::<DecimalChunked>().unwrap();
-            let ca = logical.physical();
-            return ca.as_any().downcast_ref::<ChunkedArray<T>>().unwrap();
-        }
-        let eq = equal_outer_type::<T>(dtype);
-        assert!(
-            eq,
-            "implementation error, cannot get ref {:?} from {:?}",
-            T::get_dtype(),
-            self.dtype()
-        );
-        // SAFETY: we just checked the type.
-        unsafe { &*(self as *const dyn SeriesTrait as *const ChunkedArray<T>) }
+        ca
     }
 }
 
 impl<T> AsMut<ChunkedArray<T>> for dyn SeriesTrait + '_
 where
-    T: 'static + PolarsDataType,
+    T: 'static + PolarsDataType<IsLogical = FalseT>,
 {
     fn as_mut(&mut self) -> &mut ChunkedArray<T> {
-        let eq = equal_outer_type::<T>(self.dtype());
-        assert!(
-            eq,
-            "implementation error, cannot get ref {:?} from {:?}",
-            T::get_dtype(),
-            self.dtype()
-        );
-        unsafe { &mut *(self as *mut dyn SeriesTrait as *mut ChunkedArray<T>) }
+        if !self.as_any_mut().is::<T>() {
+            panic!(
+                "implementation error, cannot get ref {:?} from {:?}",
+                T::get_dtype(),
+                self.dtype()
+            );
+        }
+
+        // @NOTE: SeriesTrait `as_any` returns a std::any::Any for the underlying ChunkedArray /
+        // Logical (so not the SeriesWrap).
+        self.as_any_mut().downcast_mut::<ChunkedArray<T>>().unwrap()
     }
 }
 

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -563,12 +563,11 @@ pub trait SeriesTrait:
         invalid_operation_panic!(get_object_chunked_unchecked, self)
     }
 
-    /// Get a hold of the [`ChunkedArray`], [`Logical`] or
-    /// [`NullChunked`][super::implementations::null::NullChunked] as an `Any` trait reference.
+    /// Get a hold of the [`ChunkedArray`], [`Logical`] or `NullChunked` as an `Any` trait
+    /// reference.
     fn as_any(&self) -> &dyn Any;
 
-    /// Get a hold of the [`ChunkedArray`], [`Logical`] or
-    /// [`NullChunked`][super::implementations::null::NullChunked] as an `Any` trait mutable
+    /// Get a hold of the [`ChunkedArray`], [`Logical`] or `NullChunked` as an `Any` trait mutable
     /// reference.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -563,14 +563,13 @@ pub trait SeriesTrait:
         invalid_operation_panic!(get_object_chunked_unchecked, self)
     }
 
-    /// Get a hold to self as `Any` trait reference.
+    /// Get a hold of the [`ChunkedArray`], [`Logical`] or [`NullChunked`] as an `Any` trait
+    /// reference.
     fn as_any(&self) -> &dyn Any;
 
-    /// Get a hold to self as `Any` trait reference.
-    /// Only implemented for ObjectType
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        invalid_operation_panic!(as_any_mut, self)
-    }
+    /// Get a hold of the [`ChunkedArray`], [`Logical`] or [`NullChunked`] as an `Any` trait
+    /// mutable reference.
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 
     #[cfg(feature = "checked_arithmetic")]
     fn checked_div(&self, _rhs: &Series) -> PolarsResult<Series> {
@@ -592,7 +591,7 @@ pub trait SeriesTrait:
 impl (dyn SeriesTrait + '_) {
     pub fn unpack<N>(&self) -> PolarsResult<&ChunkedArray<N>>
     where
-        N: 'static + PolarsDataType,
+        N: 'static + PolarsDataType<IsLogical = FalseT>,
     {
         polars_ensure!(&N::get_dtype() == self.dtype(), unpack);
         Ok(self.as_ref())

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -563,12 +563,13 @@ pub trait SeriesTrait:
         invalid_operation_panic!(get_object_chunked_unchecked, self)
     }
 
-    /// Get a hold of the [`ChunkedArray`], [`Logical`] or [`NullChunked`] as an `Any` trait
-    /// reference.
+    /// Get a hold of the [`ChunkedArray`], [`Logical`] or
+    /// [`NullChunked`][super::implementations::null::NullChunked] as an `Any` trait reference.
     fn as_any(&self) -> &dyn Any;
 
-    /// Get a hold of the [`ChunkedArray`], [`Logical`] or [`NullChunked`] as an `Any` trait
-    /// mutable reference.
+    /// Get a hold of the [`ChunkedArray`], [`Logical`] or
+    /// [`NullChunked`][super::implementations::null::NullChunked] as an `Any` trait mutable
+    /// reference.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
     #[cfg(feature = "checked_arithmetic")]

--- a/crates/polars-expr/src/reduce/mod.rs
+++ b/crates/polars-expr/src/reduce/mod.rs
@@ -94,7 +94,7 @@ pub trait GroupedReduction: Any + Send + Sync {
 // Helper traits used in the VecGroupedReduction and VecMaskGroupedReduction to
 // reduce code duplication.
 pub trait Reducer: Send + Sync + Clone + 'static {
-    type Dtype: PolarsDataType;
+    type Dtype: PolarsDataType<IsLogical = FalseT>;
     type Value: Clone + Send + Sync + 'static;
     fn init(&self) -> Self::Value;
     #[inline(always)]


### PR DESCRIPTION
This sped up concat by ~2x for me.