### PR TITLE
fix: Fix `map_elements` ignoring `skip_nulls=True` for struct dtype

### DIFF
--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -49,20 +49,28 @@ def test_map_elements_arithmetic_consistency() -> None:
 
 def test_map_elements_struct() -> None:
     df = pl.DataFrame(
-        {"A": ["a", "a"], "B": [2, 3], "C": [True, False], "D": [12.0, None]}
+        {
+            "A": ["a", "a", None],
+            "B": [2, 3, None],
+            "C": [True, False, None],
+            "D": [12.0, None, None],
+            "E": [None, [1], [2, 3]],
+        }
     )
     out = df.with_columns(pl.struct(df.columns).alias("struct")).select(
         pl.col("struct").map_elements(lambda x: x["A"]).alias("A_field"),
         pl.col("struct").map_elements(lambda x: x["B"]).alias("B_field"),
         pl.col("struct").map_elements(lambda x: x["C"]).alias("C_field"),
         pl.col("struct").map_elements(lambda x: x["D"]).alias("D_field"),
+        pl.col("struct").map_elements(lambda x: x["E"]).alias("E_field"),
     )
     expected = pl.DataFrame(
         {
-            "A_field": ["a", "a"],
-            "B_field": [2, 3],
-            "C_field": [True, False],
-            "D_field": [12.0, None],
+            "A_field": ["a", "a", None],
+            "B_field": [2, 3, None],
+            "C_field": [True, False, None],
+            "D_field": [12.0, None, None],
+            "E_field": [None, [1], [2, 3]],
         }
     )
 

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -182,14 +182,14 @@ def test_empty_list_in_map_elements() -> None:
 
 @pytest.mark.parametrize("value", [1, True, "abc", [1, 2], {"a": 1}])
 @pytest.mark.parametrize("return_value", [1, True, "abc", [1, 2], {"a": 1}])
-@pytest.mark.parametrize("skip_nulls", [True, False])
-def test_map_elements_skip_nulls(
-    value: Any, return_value: Any, skip_nulls: bool
-) -> None:
+def test_map_elements_skip_nulls(value: Any, return_value: Any) -> None:
     s = pl.Series([value, None])
-    result = s.map_elements(lambda x: return_value, skip_nulls=skip_nulls).to_list()
-    expected = [return_value, None] if skip_nulls else [return_value, return_value]
-    assert result == expected
+
+    result = s.map_elements(lambda x: return_value, skip_nulls=True).to_list()
+    assert result == [return_value, None]
+
+    result = s.map_elements(lambda x: return_value, skip_nulls=False).to_list()
+    assert result == [return_value, return_value]
 
 
 def test_map_elements_object_dtypes() -> None:


### PR DESCRIPTION
closes #10102 


```python
import polars as pl

df = pl.DataFrame(
    {
        "a": [{"b": 1}, None],
    }
)

df.select(
    pl.col("a").map_elements(lambda x: x["b"], skip_nulls=True)
)
```

main:
```
polars.exceptions.ComputeError: TypeError: 'NoneType' object is not subscriptable
```

This PR:
```
shape: (2, 1)
┌──────┐
│ a    │
│ ---  │
│ i64  │
╞══════╡
│ 1    │
│ null │
└──────┘
```