### PR TITLE
fix: Validate length of `schema_overrides` in `read_csv`

### DIFF
--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -206,6 +206,11 @@ impl<'a> CoreReader<'a> {
             },
         };
         if let Some(dtypes) = dtype_overwrite {
+            if dtypes.len() > schema.len() {
+                polars_bail!(InvalidOperation:
+                    "The number of schema overrides must be less than or equal to the number of fields".to_string(),
+                )
+            }
             let s = Arc::make_mut(&mut schema);
             for (index, dt) in dtypes.iter().enumerate() {
                 s.set_dtype_at_index(index, dt.clone()).unwrap();

--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -206,11 +206,10 @@ impl<'a> CoreReader<'a> {
             },
         };
         if let Some(dtypes) = dtype_overwrite {
-            if dtypes.len() > schema.len() {
-                polars_bail!(InvalidOperation:
-                    "The number of schema overrides must be less than or equal to the number of fields".to_string(),
-                )
-            }
+            polars_ensure!(
+                dtypes.len() <= schema.len(),
+                InvalidOperation: "The number of schema overrides must be less than or equal to the number of fields"
+            );
             let s = Arc::make_mut(&mut schema);
             for (index, dt) in dtypes.iter().enumerate() {
                 s.set_dtype_at_index(index, dt.clone()).unwrap();

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1399,7 +1399,8 @@ def _scan_csv_impl(
     dtype_list: list[tuple[str, PolarsDataType]] | None = None
     if schema_overrides is not None:
         if not isinstance(schema_overrides, dict):
-            raise TypeError("expected 'schema_overrides' dict, found 'list'")
+            msg = "expected 'schema_overrides' dict, found 'list'"
+            raise TypeError(msg)
         dtype_list = []
         for k, v in schema_overrides.items():
             dtype_list.append((k, parse_into_dtype(v)))

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1275,6 +1275,12 @@ def scan_csv(
     │ 4   ┆ read │
     └─────┴──────┘
     """
+    if schema_overrides is not None and not isinstance(
+        schema_overrides, (dict, Sequence)
+    ):
+        msg = "`schema_overrides` should be of type list or dict"
+        raise TypeError(msg)
+
     if not new_columns and isinstance(schema_overrides, Sequence):
         msg = f"expected 'schema_overrides' dict, found {type(schema_overrides).__name__!r}"
         raise TypeError(msg)
@@ -1392,6 +1398,8 @@ def _scan_csv_impl(
 ) -> LazyFrame:
     dtype_list: list[tuple[str, PolarsDataType]] | None = None
     if schema_overrides is not None:
+        if not isinstance(schema_overrides, dict):
+            raise TypeError("expected 'schema_overrides' dict, found 'list'")
         dtype_list = []
         for k, v in schema_overrides.items():
             dtype_list.append((k, parse_into_dtype(v)))

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2079,7 +2079,7 @@ def test_read_csv_invalid_schema_overrides_length() -> None:
     else:
         err = InvalidOperationError
         match = "The number of schema overrides must be less than or equal to the number of fields"
-    
+
     with pytest.raises(err, match=match):
         pl.read_csv(f, schema_overrides=[pl.Int64, pl.String, pl.Boolean])
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -375,7 +375,7 @@ def test_datetime_parsing_default_formats() -> None:
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
-def test_partial_dtype_overwrite() -> None:
+def test_partial_schema_overrides() -> None:
     csv = textwrap.dedent(
         """\
         a,b,c
@@ -389,7 +389,7 @@ def test_partial_dtype_overwrite() -> None:
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
-def test_dtype_overwrite_with_column_name_selection() -> None:
+def test_schema_overrides_with_column_name_selection() -> None:
     csv = textwrap.dedent(
         """\
         a,b,c,d
@@ -403,7 +403,7 @@ def test_dtype_overwrite_with_column_name_selection() -> None:
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
-def test_dtype_overwrite_with_column_idx_selection() -> None:
+def test_schema_overrides_with_column_idx_selection() -> None:
     csv = textwrap.dedent(
         """\
         a,b,c,d
@@ -503,7 +503,7 @@ def test_read_csv_encoding(tmp_path: Path) -> None:
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
-def test_column_rename_and_dtype_overwrite() -> None:
+def test_column_rename_and_schema_overrides() -> None:
     csv = textwrap.dedent(
         """\
         a,b,c
@@ -1242,7 +1242,7 @@ def test_skip_new_line_embedded_lines() -> None:
         }
 
 
-def test_csv_dtype_overwrite_bool() -> None:
+def test_csv_schema_overrides_bool() -> None:
     csv = "a, b\n" + ",false\n" + ",false\n" + ",false"
     df = pl.read_csv(
         csv.encode(),
@@ -2041,7 +2041,7 @@ def test_partial_read_compressed_file(
     assert df.shape == (30, 3)
 
 
-def test_read_csv_invalid_dtypes() -> None:
+def test_read_csv_invalid_schema_overrides() -> None:
     csv = textwrap.dedent(
         """\
         a,b
@@ -2055,6 +2055,13 @@ def test_read_csv_invalid_dtypes() -> None:
         TypeError, match="`schema_overrides` should be of type list or dict"
     ):
         pl.read_csv(f, schema_overrides={pl.Int64, pl.String})  # type: ignore[arg-type]
+
+    f = io.StringIO(csv)
+    with pytest.raises(
+        InvalidOperationError,
+        match="The number of schema overrides must be less than or equal to the number of fields",
+    ):
+        pl.read_csv(f, schema_overrides=[pl.Int64, pl.String, pl.Boolean])
 
 
 @pytest.mark.parametrize("columns", [["b"], "b"])
@@ -2357,7 +2364,7 @@ time
 
 
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
-def test_csv_read_time_dtype_overwrite() -> None:
+def test_csv_read_time_schema_overrides() -> None:
     df = pl.Series("time", [0]).cast(pl.Time()).to_frame()
 
     assert_frame_equal(


### PR DESCRIPTION
fixes #14989

Also renames existing tests from (deprecated) `dtype_overwrite` to `schema_overrides`. 