### PR TITLE
fix: Only verify Parquet ConvertedType if no LogicalType is given

### DIFF
--- a/crates/polars-parquet/src/parquet/schema/types/parquet_type.rs
+++ b/crates/polars-parquet/src/parquet/schema/types/parquet_type.rs
@@ -160,8 +160,14 @@ impl ParquetType {
         logical_type: Option<PrimitiveLogicalType>,
         id: Option<i32>,
     ) -> ParquetResult<Self> {
-        spec::check_converted_invariants(&physical_type, &converted_type)?;
-        spec::check_logical_invariants(&physical_type, &logical_type)?;
+        // LogicalType has replaced the ConvertedType and there are certain LogicalType's that do
+        // not have a good counterpart in ConvertedType (e.g. Timestamp::Nanos). Therefore, we only
+        // check the ConvertedType if no LogicalType is given. This would signify a lot older
+        // Parquet file which could not have these new unsupported ConvertedTypes.
+        match logical_type {
+            None => spec::check_converted_invariants(&physical_type, &converted_type)?,
+            Some(logical_type) => spec::check_logical_invariants(&physical_type, logical_type)?,
+        }
 
         let field_info = FieldInfo {
             name,

--- a/crates/polars-parquet/src/parquet/schema/types/spec.rs
+++ b/crates/polars-parquet/src/parquet/schema/types/spec.rs
@@ -127,13 +127,8 @@ pub fn check_converted_invariants(
 
 pub fn check_logical_invariants(
     physical_type: &PhysicalType,
-    logical_type: &Option<PrimitiveLogicalType>,
+    logical_type: PrimitiveLogicalType,
 ) -> ParquetResult<()> {
-    if logical_type.is_none() {
-        return Ok(());
-    };
-    let logical_type = logical_type.unwrap();
-
     // Check that logical type and physical type are compatible
     use PrimitiveLogicalType::*;
     match (logical_type, physical_type) {


### PR DESCRIPTION
Since Parquet's `LogicalType` replaced the `ConvertedType`, there is no equivalent to certain `LogicalType`s in the ConvertedType (e.g. `Timestamp::Nanos`). Therefore, we should only verify whether the `ConvertedType` is valid if no `LogicalType` was given.

Fixes #20628.