### PR TITLE
fix: Add outer validity to AnyValueBufferTrusted for structs

### DIFF
--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -473,22 +473,22 @@ def test_pivot_struct() -> None:
         "id": ["a", "b", "c"],
         "1": [
             {"num1": 1, "num2": 4},
-            {"num1": None, "num2": None},
+            None,
             {"num1": 6, "num2": 6},
         ],
         "2": [
             {"num1": 3, "num2": 5},
-            {"num1": None, "num2": None},
-            {"num1": None, "num2": None},
+            None,
+            None,
         ],
         "3": [
-            {"num1": None, "num2": None},
+            None,
             {"num1": 5, "num2": 3},
             {"num1": 3, "num2": 6},
         ],
         "4": [
-            {"num1": None, "num2": None},
-            {"num1": None, "num2": None},
+            None,
+            None,
             {"num1": 4, "num2": 4},
         ],
     }


### PR DESCRIPTION
This technically changes behavior for `df.pivot` (possibly other things), but the old behavior was honestly bugged (despite us having a test for it).

Old behavior:

```python
>>> df
┌─────┬──────┬──────┬──────┬───────────┐
│ id  ┆ week ┆ num1 ┆ num2 ┆ nums      │
│ --- ┆ ---  ┆ ---  ┆ ---  ┆ ---       │
│ str ┆ str  ┆ i64  ┆ i64  ┆ struct[2] │
╞═════╪══════╪══════╪══════╪═══════════╡
│ a   ┆ 1    ┆ 1    ┆ 4    ┆ {1,4}     │
│ a   ┆ 2    ┆ 3    ┆ 5    ┆ {3,5}     │
│ b   ┆ 3    ┆ 5    ┆ 3    ┆ {5,3}     │
│ c   ┆ 4    ┆ 4    ┆ 4    ┆ {4,4}     │
│ c   ┆ 3    ┆ 3    ┆ 6    ┆ {3,6}     │
│ c   ┆ 1    ┆ 6    ┆ 6    ┆ {6,6}     │
└─────┴──────┴──────┴──────┴───────────┘
>>> df.pivot(values="nums", index="id", on="week", aggregate_function="first")
┌─────┬─────────────┬─────────────┬─────────────┬─────────────┐
│ id  ┆ 1           ┆ 2           ┆ 3           ┆ 4           │
│ --- ┆ ---         ┆ ---         ┆ ---         ┆ ---         │
│ str ┆ struct[2]   ┆ struct[2]   ┆ struct[2]   ┆ struct[2]   │
╞═════╪═════════════╪═════════════╪═════════════╪═════════════╡
│ a   ┆ {1,4}       ┆ {3,5}       ┆ {null,null} ┆ {null,null} │
│ b   ┆ {null,null} ┆ {null,null} ┆ {5,3}       ┆ {null,null} │
│ c   ┆ {6,6}       ┆ {null,null} ┆ {3,6}       ┆ {4,4}       │
└─────┴─────────────┴─────────────┴─────────────┴─────────────┘
```

New behavior:

```python
┌─────┬───────────┬───────────┬───────────┬───────────┐
│ id  ┆ 1         ┆ 2         ┆ 3         ┆ 4         │
│ --- ┆ ---       ┆ ---       ┆ ---       ┆ ---       │
│ str ┆ struct[2] ┆ struct[2] ┆ struct[2] ┆ struct[2] │
╞═════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ a   ┆ {1,4}     ┆ {3,5}     ┆ null      ┆ null      │
│ b   ┆ null      ┆ null      ┆ {5,3}     ┆ null      │
│ c   ┆ {6,6}     ┆ null      ┆ {3,6}     ┆ {4,4}     │
└─────┴───────────┴───────────┴───────────┴───────────┘
```