### PR TITLE
perf: Specialize first/last agg for simple types in new-streaming engine

### DIFF
--- a/crates/polars-expr/src/reduce/mean.rs
+++ b/crates/polars-expr/src/reduce/mean.rs
@@ -101,12 +101,12 @@ where
     }
 
     #[inline(always)]
-    fn reduce_one(&self, a: &mut Self::Value, b: Option<T::Native>) {
+    fn reduce_one(&self, a: &mut Self::Value, b: Option<T::Native>, _seq_id: u64) {
         a.0 += b.unwrap_or(T::Native::zero()).as_();
         a.1 += b.is_some() as usize;
     }
 
-    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) {
+    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>, _seq_id: u64) {
         v.0 += ChunkAgg::_sum_as_f64(ca);
         v.1 += ca.len() - ca.null_count();
     }
@@ -141,12 +141,12 @@ impl Reducer for BoolMeanReducer {
     }
 
     #[inline(always)]
-    fn reduce_one(&self, a: &mut Self::Value, b: Option<bool>) {
+    fn reduce_one(&self, a: &mut Self::Value, b: Option<bool>, _seq_id: u64) {
         a.0 += b.unwrap_or(false) as usize;
         a.1 += b.is_some() as usize;
     }
 
-    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) {
+    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>, _seq_id: u64) {
         v.0 += ca.sum().unwrap_or(0) as usize;
         v.1 += ca.len() - ca.null_count();
     }

--- a/crates/polars-expr/src/reduce/min_max.rs
+++ b/crates/polars-expr/src/reduce/min_max.rs
@@ -190,10 +190,10 @@ impl Reducer for BinaryMinReducer {
     }
 
     fn combine(&self, a: &mut Self::Value, b: &Self::Value) {
-        self.reduce_one(a, b.as_deref())
+        self.reduce_one(a, b.as_deref(), 0)
     }
 
-    fn reduce_one(&self, a: &mut Self::Value, b: Option<&[u8]>) {
+    fn reduce_one(&self, a: &mut Self::Value, b: Option<&[u8]>, _seq_id: u64) {
         match (a, b) {
             (_, None) => {},
             (l @ None, Some(r)) => *l = Some(r.to_owned()),
@@ -206,8 +206,8 @@ impl Reducer for BinaryMinReducer {
         }
     }
 
-    fn reduce_ca(&self, v: &mut Self::Value, ca: &BinaryChunked) {
-        self.reduce_one(v, ca.min_binary())
+    fn reduce_ca(&self, v: &mut Self::Value, ca: &BinaryChunked, _seq_id: u64) {
+        self.reduce_one(v, ca.min_binary(), 0)
     }
 
     fn finish(
@@ -238,11 +238,11 @@ impl Reducer for BinaryMaxReducer {
 
     #[inline(always)]
     fn combine(&self, a: &mut Self::Value, b: &Self::Value) {
-        self.reduce_one(a, b.as_deref())
+        self.reduce_one(a, b.as_deref(), 0)
     }
 
     #[inline(always)]
-    fn reduce_one(&self, a: &mut Self::Value, b: Option<&[u8]>) {
+    fn reduce_one(&self, a: &mut Self::Value, b: Option<&[u8]>, _seq_id: u64) {
         match (a, b) {
             (_, None) => {},
             (l @ None, Some(r)) => *l = Some(r.to_owned()),
@@ -256,8 +256,8 @@ impl Reducer for BinaryMaxReducer {
     }
 
     #[inline(always)]
-    fn reduce_ca(&self, v: &mut Self::Value, ca: &BinaryChunked) {
-        self.reduce_one(v, ca.max_binary())
+    fn reduce_ca(&self, v: &mut Self::Value, ca: &BinaryChunked, _seq_id: u64) {
+        self.reduce_one(v, ca.max_binary(), 0)
     }
 
     #[inline(always)]

--- a/crates/polars-expr/src/reduce/var_std.rs
+++ b/crates/polars-expr/src/reduce/var_std.rs
@@ -75,13 +75,13 @@ impl<T: PolarsNumericType> Reducer for VarStdReducer<T> {
     }
 
     #[inline(always)]
-    fn reduce_one(&self, a: &mut Self::Value, b: Option<T::Native>) {
+    fn reduce_one(&self, a: &mut Self::Value, b: Option<T::Native>, _seq_id: u64) {
         if let Some(x) = b {
             a.add_one(x.as_());
         }
     }
 
-    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) {
+    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>, _seq_id: u64) {
         for arr in ca.downcast_iter() {
             v.combine(&polars_compute::var_cov::var(arr))
         }
@@ -129,12 +129,12 @@ impl Reducer for BoolVarStdReducer {
     }
 
     #[inline(always)]
-    fn reduce_one(&self, a: &mut Self::Value, b: Option<bool>) {
+    fn reduce_one(&self, a: &mut Self::Value, b: Option<bool>, _seq_id: u64) {
         a.0 += b.unwrap_or(false) as usize;
         a.1 += b.is_some() as usize;
     }
 
-    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>) {
+    fn reduce_ca(&self, v: &mut Self::Value, ca: &ChunkedArray<Self::Dtype>, _seq_id: u64) {
         v.0 += ca.sum().unwrap_or(0) as usize;
         v.1 += ca.len() - ca.null_count();
     }


### PR DESCRIPTION
Ensures we don't use the generic `AnyValue` path for numeric/temporal types, string types and bools.