### PR TITLE
refactor: Simplify hive predicate handling in `NEW_MULTIFILE`

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -428,43 +428,6 @@ impl PhysicalExpr for ApplyExpr {
             i.collect_live_columns(lv);
         }
     }
-    fn replace_elementwise_const_columns(
-        &self,
-        const_columns: &PlHashMap<PlSmallStr, AnyValue<'static>>,
-    ) -> Option<Arc<dyn PhysicalExpr>> {
-        if self.collect_groups == ApplyOptions::ElementWise {
-            let mut new_inputs = Vec::new();
-            for i in 0..self.inputs.len() {
-                match self.inputs[i].replace_elementwise_const_columns(const_columns) {
-                    None => continue,
-                    Some(new) => {
-                        new_inputs.reserve(self.inputs.len());
-                        new_inputs.extend(self.inputs[..i].iter().cloned());
-                        new_inputs.push(new);
-                        break;
-                    },
-                }
-            }
-
-            // Only copy inputs if it is actually needed
-            if new_inputs.is_empty() {
-                return None;
-            }
-
-            new_inputs.extend(self.inputs[new_inputs.len()..].iter().map(|i| {
-                match i.replace_elementwise_const_columns(const_columns) {
-                    None => i.clone(),
-                    Some(new) => new,
-                }
-            }));
-
-            let mut slf = self.clone();
-            slf.inputs = new_inputs;
-            return Some(Arc::new(slf));
-        }
-
-        None
-    }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.expr.to_field(input_schema, Context::Default)

--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -272,26 +272,6 @@ impl PhysicalExpr for BinaryExpr {
         self.left.collect_live_columns(lv);
         self.right.collect_live_columns(lv);
     }
-    fn replace_elementwise_const_columns(
-        &self,
-        const_columns: &PlHashMap<PlSmallStr, AnyValue<'static>>,
-    ) -> Option<Arc<dyn PhysicalExpr>> {
-        let rcc_left = self.left.replace_elementwise_const_columns(const_columns);
-        let rcc_right = self.right.replace_elementwise_const_columns(const_columns);
-
-        if rcc_left.is_some() || rcc_right.is_some() {
-            let mut slf = self.clone();
-            if let Some(left) = rcc_left {
-                slf.left = left;
-            }
-            if let Some(right) = rcc_right {
-                slf.right = right;
-            }
-            return Some(Arc::new(slf));
-        }
-
-        None
-    }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.expr.to_field(input_schema, Context::Default)

--- a/crates/polars-expr/src/expressions/column.rs
+++ b/crates/polars-expr/src/expressions/column.rs
@@ -182,18 +182,6 @@ impl PhysicalExpr for ColumnExpr {
     fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>) {
         lv.insert(self.name.clone());
     }
-    fn replace_elementwise_const_columns(
-        &self,
-        const_columns: &PlHashMap<PlSmallStr, AnyValue<'static>>,
-    ) -> Option<Arc<dyn PhysicalExpr>> {
-        if let Some(av) = const_columns.get(&self.name) {
-            let lv = LiteralValue::from(av.clone());
-            let le = LiteralExpr::new(lv, self.expr.clone());
-            return Some(Arc::new(le));
-        }
-
-        None
-    }
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         input_schema.get_field(&self.name).ok_or_else(|| {

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -606,18 +606,6 @@ pub trait PhysicalExpr: Send + Sync {
     /// This can contain duplicates.
     fn collect_live_columns(&self, lv: &mut PlIndexSet<PlSmallStr>);
 
-    /// Replace columns that are known to be a constant value with their const value.
-    ///
-    /// This should not replace values that are calculated non-elementwise e.g. col.max(),
-    /// col.std(), etc.
-    fn replace_elementwise_const_columns(
-        &self,
-        const_columns: &PlHashMap<PlSmallStr, AnyValue<'static>>,
-    ) -> Option<Arc<dyn PhysicalExpr>> {
-        _ = const_columns;
-        None
-    }
-
     /// Can take &dyn Statistics and determine of a file should be
     /// read -> `true`
     /// or not -> `false`


### PR DESCRIPTION
Don't do a manipulation of the `PhysicalExpr` instead just supply the columns when `evaulate` happens.