### PR TITLE
fix: Fix `unique(maintain_order=True)` raising `InvalidOperationError` for null array

### DIFF
--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -223,6 +223,12 @@ impl SeriesTrait for NullChunked {
         Ok(n)
     }
 
+    #[cfg(feature = "algorithm_group_by")]
+    fn arg_unique(&self) -> PolarsResult<IdxCa> {
+        let idxs: Vec<IdxSize> = (0..self.n_unique().unwrap() as IdxSize).collect();
+        Ok(IdxCa::new(self.name().clone(), idxs))
+    }
+
     fn new_from_index(&self, _index: usize, length: usize) -> Series {
         NullChunked::new(self.name.clone(), length).into_series()
     }

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -117,15 +117,16 @@ def test_sorted_unique_dates() -> None:
     ).to_dict(as_series=False) == {"dt": [date(2015, 6, 23), date(2015, 6, 24)]}
 
 
-def test_unique_null() -> None:
+@pytest.mark.parametrize("maintain_order", [True, False])
+def test_unique_null(maintain_order: bool) -> None:
     s0 = pl.Series([])
-    assert_series_equal(s0.unique(), s0)
+    assert_series_equal(s0.unique(maintain_order=maintain_order), s0)
 
     s1 = pl.Series([None])
-    assert_series_equal(s1.unique(), s1)
+    assert_series_equal(s1.unique(maintain_order=maintain_order), s1)
 
     s2 = pl.Series([None, None])
-    assert_series_equal(s2.unique(), s1)
+    assert_series_equal(s2.unique(maintain_order=maintain_order), s1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fixes #20249