### PR TITLE
fix: Incorrect output type for `map_groups` returning all-NULL column

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -300,6 +300,12 @@ impl ApplyExpr {
 
 fn all_unit_length(ca: &ListChunked) -> bool {
     assert_eq!(ca.chunks().len(), 1);
+
+    // Handles the Null dtype - in that case the offsets can be (e.g. [0,0,0 ...])
+    if ca.null_count() == ca.len() {
+        return true;
+    }
+
     let list_arr = ca.downcast_iter().next().unwrap();
     let offset = list_arr.offsets().as_slice();
     (offset[offset.len() - 1] as usize) == list_arr.len()

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -155,7 +155,7 @@ def test_map_groups_numpy_output_3057() -> None:
 
 
 def test_map_groups_return_all_null_15260() -> None:
-    def foo(x: pl.Series) -> None:
+    def foo(x: pl.Series) -> pl.Series:
         return pl.Series([x[0][0]], dtype=x[0].dtype)
 
     assert_frame_equal(

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -152,3 +152,16 @@ def test_map_groups_numpy_output_3057() -> None:
 
     expected = pl.DataFrame({"id": [0, 1], "result": [2.266666, 7.333333]})
     assert_frame_equal(result, expected)
+
+
+def test_map_groups_return_all_null_15260() -> None:
+    def foo(x: pl.Series) -> None:
+        return pl.Series([x[0][0]], dtype=x[0].dtype)
+
+    assert_frame_equal(
+        pl.DataFrame({"key": [0, 0, 1], "a": [None, None, None]})
+        .group_by("key")
+        .agg(pl.map_groups(exprs=["a"], function=foo))
+        .sort("a"),
+        pl.DataFrame({"key": [0, 1], "a": [None, None]}),
+    )

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -161,7 +161,7 @@ def test_map_groups_return_all_null_15260() -> None:
     assert_frame_equal(
         pl.DataFrame({"key": [0, 0, 1], "a": [None, None, None]})
         .group_by("key")
-        .agg(pl.map_groups(exprs=["a"], function=foo))
+        .agg(pl.map_groups(exprs=["a"], function=foo))  # type: ignore[arg-type]
         .sort("a"),
         pl.DataFrame({"key": [0, 1], "a": [None, None]}),
     )


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/15260
Fixes https://github.com/pola-rs/polars/issues/15260
