### PR TITLE
depr(python): Rename `fmt` param to `f_string` in `inspect()`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6068,9 +6068,16 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.reinterpret(signed))
 
-    def inspect(self, fmt: str = "{}") -> Expr:
+    @deprecate_renamed_parameter("fmt", "f_string", version="1.20.0")
+    def inspect(self, f_string: str = "{}") -> Expr:
         """
         Print the value that this expression evaluates to and pass on the value.
+
+        Parameters
+        ----------
+        f_string
+            A string with a single placeholder, for example: "hello_{}" or "{}_world".
+
 
         Examples
         --------
@@ -6096,7 +6103,7 @@ class Expr:
         """
 
         def inspect(s: Series) -> Series:  # pragma: no cover
-            print(fmt.format(s))
+            print(f_string.format(s))
             return s
 
         return self.map_batches(inspect, return_dtype=None, agg_list=True)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6068,7 +6068,7 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.reinterpret(signed))
 
-    @deprecate_renamed_parameter("fmt", "f_string", version="1.21.0")
+    @deprecate_renamed_parameter("fmt", "f_string", version="1.22.0")
     def inspect(self, f_string: str = "{}") -> Expr:
         """
         Print the value that this expression evaluates to and pass on the value.

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6068,7 +6068,7 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.reinterpret(signed))
 
-    @deprecate_renamed_parameter("fmt", "f_string", version="1.20.0")
+    @deprecate_renamed_parameter("fmt", "f_string", version="1.21.0")
     def inspect(self, f_string: str = "{}") -> Expr:
         """
         Print the value that this expression evaluates to and pass on the value.

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -804,10 +804,10 @@ def format(f_string: str, *args: Expr | str) -> Expr:
     Parameters
     ----------
     f_string
-        A string that with placeholders.
-        For example: "hello_{}" or "{}_world
+        A string with placeholders, for example: "hello_{}" or "{}_world".
+
     args
-        Expression(s) that fill the placeholders
+        Expression(s) that fill the placeholders.
 
     Examples
     --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1223,12 +1223,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             figsize=figsize,
         )
 
-    def inspect(self, fmt: str = "{}") -> LazyFrame:
+    @deprecate_renamed_parameter("fmt", "f_string", version="1.20.0")
+    def inspect(self, f_string: str = "{}") -> LazyFrame:
         """
         Inspect a node in the computation graph.
 
         Print the value that this node in the computation graph evaluates to and pass on
         the value.
+
+        Parameters
+        ----------
+        f_string
+            A string with a single placeholder, for example: "hello_{}" or "{}_world".
 
         Examples
         --------
@@ -1242,7 +1248,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
 
         def inspect(s: DataFrame) -> DataFrame:
-            print(fmt.format(s))
+            print(f_string.format(s))
             return s
 
         return self.map_batches(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1223,7 +1223,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             figsize=figsize,
         )
 
-    @deprecate_renamed_parameter("fmt", "f_string", version="1.20.0")
+    @deprecate_renamed_parameter("fmt", "f_string", version="1.21.0")
     def inspect(self, f_string: str = "{}") -> LazyFrame:
         """
         Inspect a node in the computation graph.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1223,7 +1223,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             figsize=figsize,
         )
 
-    @deprecate_renamed_parameter("fmt", "f_string", version="1.21.0")
+    @deprecate_renamed_parameter("fmt", "f_string", version="1.22.0")
     def inspect(self, f_string: str = "{}") -> LazyFrame:
         """
         Inspect a node in the computation graph.


### PR DESCRIPTION
Fixes #19442

It was suggested in the issue to rename the `fmt` param and `f_string` already exists in `pl.format()`. This also adds documentation for this parameter.