### PR TITLE
fix: Incorrect logic in `assert_series_equal` for infinities

### DIFF
--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -319,9 +319,11 @@ def _assert_series_values_within_tolerance(
 
     difference = (left_unequal - right_unequal).abs()
     tolerance = atol + rtol * right_unequal.abs()
-    exceeds_tolerance = difference > tolerance
+    within_tolerance = (difference <= tolerance) & right_unequal.is_finite() | (
+        left_unequal == right_unequal
+    )
 
-    if exceeds_tolerance.any():
+    if not within_tolerance.all():
         raise_assertion_error(
             "Series",
             "value mismatch",

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1016,7 +1016,7 @@ def test_diff() -> None:
 
 def test_pct_change() -> None:
     s = pl.Series("a", [1, 2, 4, 8, 16, 32, 64])
-    expected = pl.Series("a", [None, None, float("inf"), 3.0, 3.0, 3.0, 3.0])
+    expected = pl.Series("a", [None, None, 3.0, 3.0, 3.0, 3.0, 3.0])
     assert_series_equal(s.pct_change(2), expected)
     assert_series_equal(s.pct_change(pl.Series([2])), expected)
     # negative

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -837,3 +837,29 @@ def test_series_data_type_fail():
     assert "AssertionError: Series are different (nan value mismatch)" in stdout
     assert "AssertionError: Series are different (dtype mismatch)" in stdout
     assert "AssertionError: inputs are different (unexpected input types)" in stdout
+
+
+def test_assert_series_equal_inf() -> None:
+    s1 = pl.Series([1.0, float("inf")])
+    s2 = pl.Series([1.0, float("inf")])
+    assert_series_equal(s1, s2)
+
+    s1 = pl.Series([1.0, float("-inf")])
+    s2 = pl.Series([1.0, float("-inf")])
+    assert_series_equal(s1, s2)
+
+    s1 = pl.Series([1.0, float("inf")])
+    s2 = pl.Series([float("inf"), 1.0])
+    assert_series_not_equal(s1, s2)
+
+    s1 = pl.Series([1.0, float("inf")])
+    s2 = pl.Series([1.0, float("-inf")])
+    assert_series_not_equal(s1, s2)
+
+    s1 = pl.Series([1.0, float("inf")])
+    s2 = pl.Series([1.0, 2.0])
+    assert_series_not_equal(s1, s2)
+
+    s1 = pl.Series([1.0, float("inf")])
+    s2 = pl.Series([1.0, float("nan")])
+    assert_series_not_equal(s1, s2)


### PR DESCRIPTION
fixes #16859

main branch does NOT raise for the following example:

```python

import polars as pl
from polars.testing import assert_series_equal

s1 = pl.Series([1.0])
s2 = pl.Series([float("inf")])

assert_series_equal(s1, s2)
```

This PR:
```
AssertionError: Series are different (value mismatch)
[left]:  [1.0]
[right]: [inf]
```
