### PR TITLE
test: Add various tests

### DIFF
--- a/py-polars/tests/unit/dataframe/test_serde.py
+++ b/py-polars/tests/unit/dataframe/test_serde.py
@@ -202,3 +202,10 @@ def test_df_serialize_invalid_type() -> None:
         ComputeError, match="serializing data of type Object is not supported"
     ):
         df.serialize()
+
+
+def test_df_serde_list_of_null_17230() -> None:
+    df = pl.Series([[]], dtype=pl.List(pl.Null)).to_frame()
+    ser = df.serialize(format="json")
+    result = pl.DataFrame.deserialize(io.StringIO(ser), format="json")
+    assert_frame_equal(result, df)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2501,3 +2501,10 @@ def test_trailing_separator_8240() -> None:
 
     result = pl.scan_csv(io.StringIO(csv), separator="|", has_header=False).collect()
     assert_frame_equal(result, expected)
+
+
+def test_header_only_column_selection_17173() -> None:
+    csv = "A,B"
+    result = pl.read_csv(io.StringIO(csv), columns=["B"])
+    expected = pl.Series("B", [], pl.String()).to_frame()
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -61,3 +61,10 @@ def test_fill_null_lit_() -> None:
         df.fill_null(pl.lit(0)).select(pl.all().null_count()).transpose().sum().item()
         == 0
     )
+
+
+def test_fill_null_decimal_with_int_14331() -> None:
+    s = pl.Series("a", ["1.1", None], dtype=pl.Decimal(precision=None, scale=5))
+    result = s.fill_null(0)
+    expected = pl.Series("a", ["1.1", "0.0"], dtype=pl.Decimal(precision=None, scale=5))
+    assert_series_equal(result, expected)

--- a/py-polars/tests/unit/series/test_item.py
+++ b/py-polars/tests/unit/series/test_item.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
 import polars as pl
@@ -36,3 +38,9 @@ def test_series_item_with_index(index: int, expected: int, s: pl.Series) -> None
 def test_df_item_out_of_bounds(index: int, s: pl.Series) -> None:
     with pytest.raises(IndexError, match="out of bounds"):
         s.item(index)
+
+
+def test_series_item_out_of_range_date() -> None:
+    s = pl.Series([datetime.date(9999, 12, 31)]).dt.offset_by("1d")
+    with pytest.raises(ValueError, match="out of range"):
+        s.item()


### PR DESCRIPTION
New tests added for the following already fixed issues:

closes #8632
closes #14331
closes #17173
closes #17230
closes #18026

The following issues appears to be fixed and already tested (noted below). This PR does not add any new tests for these issues.

closes #10047 - `test_list.py::test_sort`
closes #17745 - `test_explode.py::test_explode_struct_nulls`
closes #17820 - `test_array.py::test_array_arithmetic_values`
closes #18516 - `test_ipc.py::test_ipc_variadic_buffers_categorical_binview_18636`
closes #18671 - `test_csv.py::test_write_csv_passing_params_18825`
closes #17221 - `test_join.py::test_join_numeric_type_upcast_15338`