### PR TITLE
feat(python): Additional support for loading `numpy.float16` values (as Float32)

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -206,6 +206,7 @@ class _DataTypeMappings:
             # (np.dtype().kind, np.dtype().itemsize)
             ("M", 8): Datetime,
             ("b", 1): Boolean,
+            ("f", 2): Float32,
             ("f", 4): Float32,
             ("f", 8): Float64,
             ("i", 1): Int8,


### PR DESCRIPTION
Adds an entry to the numpy kind/size conversion mapping covering `np.float16`. 
(We don't have a native `Float16`, so it loads as `Float32`).

## Example

```python
import numpy as np
import polars as pl

df = pl.DataFrame({
  "n": [np.float16(123)],
})
```
**Before:**
```python
# ValueError:
#   cannot parse numpy data type dtype('float16') into Polars data type
```
**After:**
```python
# shape: (1, 1)
# ┌───────┐
# │ n     │
# │ ---   │
# │ f32   │
# ╞═══════╡
# │ 123.0 │
# └───────┘
```