### PR TITLE
fix(python): Add height check to frame-level row indexing when key is int

### DIFF
--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -291,6 +291,9 @@ def _select_rows(
 ) -> DataFrame | Series:
     """Select one or more rows from the DataFrame."""
     if isinstance(key, int):
+        if key >= len(df):
+            msg = f"index {key} is out of bounds for DataFrame of height {len(df)}"
+            raise IndexError(msg)
         return df.slice(key, 1)
 
     if isinstance(key, slice):

--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -291,7 +291,8 @@ def _select_rows(
 ) -> DataFrame | Series:
     """Select one or more rows from the DataFrame."""
     if isinstance(key, int):
-        if key >= len(df):
+        num_rows = len(df)
+        if (key >= num_rows) or (key < -num_rows):
             msg = f"index {key} is out of bounds for DataFrame of height {len(df)}"
             raise IndexError(msg)
         return df.slice(key, 1)

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2995,3 +2995,21 @@ def test_get_column_after_drop_20119() -> None:
     df.drop_in_place("a")
     c = df.get_column("c")
     assert_series_equal(c, pl.Series("c", ["C"]))
+
+
+def test_select_oob_row_20775() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    with pytest.raises(
+        IndexError,
+        match="index 99 is out of bounds for DataFrame of height 3",
+    ):
+        df[99]
+
+
+def test_select_oob_element_20775() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    with pytest.raises(
+        IndexError,
+        match="index 99 is out of bounds for sequence of length 3",
+    ):
+        df[99, "a"]

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3006,10 +3006,11 @@ def test_select_oob_row_20775() -> None:
         df[99]
 
 
-def test_select_oob_element_20775() -> None:
+@pytest.mark.parametrize("idx", [3, 99, -4, -99])
+def test_select_oob_element_20775_too_large(idx: int) -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     with pytest.raises(
         IndexError,
-        match="index 99 is out of bounds for sequence of length 3",
+        match=f"index {idx} is out of bounds for sequence of length 3",
     ):
-        df[99, "a"]
+        df[idx, "a"]


### PR DESCRIPTION
Closes #20775.

The issue is that `df.slice(idx, 1)` was being called for a single integer index key, and slices return the empty set instead of raising when `idx` is out of bounds. This PR adds a small height check.