### PR TITLE
fix: Handle all unsupported SQL operations

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -349,7 +349,7 @@ impl SQLContext {
             op => {
                 let op = match op {
                     SetExpr::SetOperation { op, .. } => op,
-                    _ => unreachable!(),
+                    _ => {},
                 };
                 polars_bail!(SQLInterface: "'{}' operation is currently unsupported", op)
             },


### PR DESCRIPTION
instead of triggering a panic with unreachable, let `polars_bail!` handle it.

For example, when attempting to do INSERT, UPDATE, DELETE operations...