### PR TITLE
refactor: Rename `ContainsMany` to `ContainsAny`

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -122,7 +122,7 @@ pub enum StringFunction {
     #[cfg(feature = "string_pad")]
     ZFill,
     #[cfg(feature = "find_many")]
-    ContainsMany {
+    ContainsAny {
         ascii_case_insensitive: bool,
     },
     #[cfg(feature = "find_many")]
@@ -205,7 +205,7 @@ impl StringFunction {
                     .collect(),
             )),
             #[cfg(feature = "find_many")]
-            ContainsMany { .. } => mapper.with_dtype(DataType::Boolean),
+            ContainsAny { .. } => mapper.with_dtype(DataType::Boolean),
             #[cfg(feature = "find_many")]
             ReplaceMany { .. } => mapper.with_same_dtype(),
             #[cfg(feature = "find_many")]
@@ -299,7 +299,7 @@ impl Display for StringFunction {
             #[cfg(feature = "string_pad")]
             ZFill => "zfill",
             #[cfg(feature = "find_many")]
-            ContainsMany { .. } => "contains_many",
+            ContainsAny { .. } => "contains_any",
             #[cfg(feature = "find_many")]
             ReplaceMany { .. } => "replace_many",
             #[cfg(feature = "find_many")]
@@ -407,10 +407,10 @@ impl From<StringFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "extract_jsonpath")]
             JsonPathMatch => map_as_slice!(strings::json_path_match),
             #[cfg(feature = "find_many")]
-            ContainsMany {
+            ContainsAny {
                 ascii_case_insensitive,
             } => {
-                map_as_slice!(contains_many, ascii_case_insensitive)
+                map_as_slice!(contains_any, ascii_case_insensitive)
             },
             #[cfg(feature = "find_many")]
             ReplaceMany {
@@ -439,7 +439,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
 }
 
 #[cfg(feature = "find_many")]
-fn contains_many(s: &[Column], ascii_case_insensitive: bool) -> PolarsResult<Column> {
+fn contains_any(s: &[Column], ascii_case_insensitive: bool) -> PolarsResult<Column> {
     let ca = s[0].str()?;
     let patterns = s[1].str()?;
     polars_ops::chunked_array::strings::contains_any(ca, patterns, ascii_case_insensitive)

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -42,7 +42,7 @@ impl StringNameSpace {
     #[cfg(feature = "find_many")]
     pub fn contains_any(self, patterns: Expr, ascii_case_insensitive: bool) -> Expr {
         self.0.map_many_private(
-            FunctionExpr::StringExpr(StringFunction::ContainsMany {
+            FunctionExpr::StringExpr(StringFunction::ContainsAny {
                 ascii_case_insensitive,
             }),
             &[patterns],

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -65,7 +65,7 @@ fn can_pushdown_slice_past_projections(
         //
         // TODO: Simply checking that a column node is present does not handle e.g.:
         // `select(c = Literal([1, 2, 3]).is_in(col(a)))`, for functions like `is_in`,
-        // `str.contains`, `str.contains_many` etc. - observe a column node is present
+        // `str.contains`, `str.contains_any` etc. - observe a column node is present
         // but the output height is not dependent on it.
         let mut has_column = false;
         let mut literals_all_scalar = true;

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -170,7 +170,7 @@ pub enum PyStringFunction {
     Titlecase,
     Uppercase,
     ZFill,
-    ContainsMany,
+    ContainsAny,
     ReplaceMany,
     EscapeRegex,
     Normalize,
@@ -933,9 +933,9 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                     StringFunction::Uppercase => (PyStringFunction::Uppercase,).into_py_any(py),
                     StringFunction::ZFill => (PyStringFunction::ZFill,).into_py_any(py),
                     #[cfg(feature = "find_many")]
-                    StringFunction::ContainsMany {
+                    StringFunction::ContainsAny {
                         ascii_case_insensitive,
-                    } => (PyStringFunction::ContainsMany, ascii_case_insensitive).into_py_any(py),
+                    } => (PyStringFunction::ContainsAny, ascii_case_insensitive).into_py_any(py),
                     #[cfg(feature = "find_many")]
                     StringFunction::ReplaceMany {
                         ascii_case_insensitive,


### PR DESCRIPTION
The external function is called `contains_any()` but internal structs were called `ContainsMany` (probably because `replace_many()` was implemented at the same time).