### PR TITLE
feat(python): Add frame-level `all_horizontal` / `any_horizontal`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9893,6 +9893,72 @@ class DataFrame:
             mean=F.mean_horizontal(F.all(), ignore_nulls=ignore_nulls)
         ).to_series()
 
+    def all_horizontal(self) -> Series:
+        """
+        Take the bitwise AND horizontally across columns.
+
+        Notes
+        -----
+        `Kleene logic`_ is used to deal with nulls: if the column contains any null
+        values and no `True` values, the output is null.
+
+        .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [False, False, True, True, False, None],
+        ...         "bar": [False, True, True, None, None, None],
+        ...     }
+        ... )
+        >>> df.all_horizontal()
+        shape: (6,)
+        Series: 'all' [bool]
+        [
+                false
+                false
+                true
+                null
+                false
+                null
+        ]
+        """
+        return self.select(all=F.all_horizontal(F.all())).to_series()
+
+    def any_horizontal(self) -> Series:
+        """
+        Take the bitwise OR horizontally across columns.
+
+        Notes
+        -----
+        `Kleene logic`_ is used to deal with nulls: if the column contains any null
+        values and no `True` values, the output is null.
+
+        .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [False, False, True, True, False, None],
+        ...         "bar": [False, True, True, None, None, None],
+        ...     }
+        ... )
+        >>> df.any_horizontal()
+        shape: (6,)
+        Series: 'any' [bool]
+        [
+                false
+                true
+                true
+                true
+                null
+                null
+        ]
+        """
+        return self.select(any=F.any_horizontal(F.all())).to_series()
+
     def std(self, ddof: int = 1) -> DataFrame:
         """
         Aggregate the columns of this DataFrame to their standard deviation value.

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -809,6 +809,28 @@ def test_df_stats(df: pl.DataFrame) -> None:
     df.quantile(0.4, "nearest")
 
 
+def test_df_horizontal() -> None:
+    # check horizontal numeric aggregations
+    df = pl.DataFrame({"a": [3, 2, 1], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
+
+    assert_series_equal(df.sum_horizontal(), pl.Series("sum", [5.0, 6.0, 7.0]))
+    assert_series_equal(df.mean_horizontal(), pl.Series("mean", [5 / 3, 6 / 3, 7 / 3]))
+    assert_series_equal(df.min_horizontal(), pl.Series("min", [1.0, 2.0, 1.0]))
+    assert_series_equal(df.max_horizontal(), pl.Series("max", [3.0, 2.0, 3.0]))
+
+    # check horizontal boolean aggregations
+    df = pl.DataFrame(
+        {
+            "a": [True, False, None],
+            "b": [True, True, False],
+            "c": [True, True, False],
+        }
+    )
+
+    assert_series_equal(df.all_horizontal(), pl.Series("all", [True, False, False]))
+    assert_series_equal(df.any_horizontal(), pl.Series("any", [True, True, None]))
+
+
 def test_df_fold() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
 
@@ -823,13 +845,6 @@ def test_df_fold() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     out = df.fold(lambda s1, s2: s1 + s2)
     assert_series_equal(out, pl.Series("a", ["foo11.0", "bar22.0", "233.0"]))
-
-    df = pl.DataFrame({"a": [3, 2, 1], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
-    # just check dispatch. values are tested on rust side.
-    assert len(df.sum_horizontal()) == 3
-    assert len(df.mean_horizontal()) == 3
-    assert len(df.min_horizontal()) == 3
-    assert len(df.max_horizontal()) == 3
 
     df_width_one = df[["a"]]
     assert_series_equal(df_width_one.fold(lambda s1, s2: s1), df["a"])


### PR DESCRIPTION
Addresses #20718 .

I didn't add any tests as the implementation simply relies on `polars.all_horizontal` / `polars.any_horizontal`, which are already covered by existing tests (similar to the testing of `polars.DataFrame.min_horizontal`, `polars.DataFrame.mean_horizontal`, `polars.DataFrame.max_horizontal`).  

The issue is not yet marked as _accepted_, but I thought it'd be simple enough to implement without too much risk of unnecessary work. Feel free to close if the API shouldn't be adapted as proposed.