### PR TITLE
fix: Do not print sensitive information to output on `POLARS_VERBOSE`

### DIFF
--- a/crates/polars-core/src/config.rs
+++ b/crates/polars-core/src/config.rs
@@ -34,11 +34,20 @@ pub fn verbose() -> bool {
 }
 
 /// Configuration for logging information that may contain sensitive information.
-pub fn verbose_sensitive() -> bool {
-    std::env::var("POLARS_VERBOSE_SENSITIVE")
-        .as_deref()
-        .unwrap_or("")
-        == "1"
+pub fn verbose_print_sensitive<F: Fn() -> String>(create_log_message: F) {
+    fn do_log(create_log_message: &dyn Fn() -> String) {
+        if std::env::var("POLARS_VERBOSE_SENSITIVE")
+            .as_deref()
+            .unwrap_or("")
+            == "1"
+        {
+            // Force the message to be a single line.
+            let msg = create_log_message().replace('\n', "");
+            eprintln!("[SENSITIVE]: {}", msg)
+        }
+    }
+
+    do_log(&create_log_message)
 }
 
 pub fn get_file_prefetch_size() -> usize {

--- a/crates/polars-core/src/config.rs
+++ b/crates/polars-core/src/config.rs
@@ -33,7 +33,7 @@ pub fn verbose() -> bool {
     std::env::var("POLARS_VERBOSE").as_deref().unwrap_or("") == "1"
 }
 
-/// Configuration for logging information that may contain sensitive information.
+/// Prints a log message if sensitive verbose logging has been enabled.
 pub fn verbose_print_sensitive<F: Fn() -> String>(create_log_message: F) {
     fn do_log(create_log_message: &dyn Fn() -> String) {
         if std::env::var("POLARS_VERBOSE_SENSITIVE")

--- a/crates/polars-core/src/config.rs
+++ b/crates/polars-core/src/config.rs
@@ -33,6 +33,14 @@ pub fn verbose() -> bool {
     std::env::var("POLARS_VERBOSE").as_deref().unwrap_or("") == "1"
 }
 
+/// Configuration for logging information that may contain sensitive information.
+pub fn verbose_sensitive() -> bool {
+    std::env::var("POLARS_VERBOSE_SENSITIVE")
+        .as_deref()
+        .unwrap_or("")
+        == "1"
+}
+
 pub fn get_file_prefetch_size() -> usize {
     std::env::var("POLARS_PREFETCH_SIZE")
         .map(|s| s.parse::<usize>().expect("integer"))

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -31,24 +31,6 @@ fn err_missing_feature(feature: &str, scheme: &str) -> PolarsResult<Arc<dyn Obje
 
 /// Get the key of a url for object store registration.
 fn url_and_creds_to_key(url: &Url, options: Option<&CloudOptions>) -> Vec<u8> {
-    #[derive(Clone, Debug, PartialEq, Hash, Eq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-    struct C {
-        max_retries: usize,
-        #[cfg(feature = "file_cache")]
-        file_cache_ttl: u64,
-        config: Option<CloudConfig>,
-        #[cfg(feature = "cloud")]
-        credential_provider: usize,
-    }
-
-    #[derive(Clone, Debug, PartialEq, Hash, Eq)]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-    struct S {
-        url_base: PlSmallStr,
-        cloud_options: Option<C>,
-    }
-
     // We include credentials as they can expire, so users will send new credentials for the same url.
     let cloud_options = options.map(
         |CloudOptions {
@@ -60,7 +42,7 @@ fn url_and_creds_to_key(url: &Url, options: Option<&CloudOptions>) -> Vec<u8> {
              #[cfg(feature = "cloud")]
              credential_provider,
          }| {
-            C {
+            CloudOptions2 {
                 max_retries: *max_retries,
                 #[cfg(feature = "file_cache")]
                 file_cache_ttl: *file_cache_ttl,
@@ -71,7 +53,7 @@ fn url_and_creds_to_key(url: &Url, options: Option<&CloudOptions>) -> Vec<u8> {
         },
     );
 
-    let cache_key = S {
+    let cache_key = CacheKey {
         url_base: format_pl_smallstr!(
             "{}",
             &url[url::Position::BeforeScheme..url::Position::AfterPort]
@@ -79,11 +61,31 @@ fn url_and_creds_to_key(url: &Url, options: Option<&CloudOptions>) -> Vec<u8> {
         cloud_options,
     };
 
-    if config::verbose() {
+    if config::verbose_sensitive() {
         eprintln!("object store cache key: {} {:?}", url, &cache_key);
     }
 
-    pl_serialize::serialize_to_bytes(&cache_key).unwrap()
+    return pl_serialize::serialize_to_bytes(&cache_key).unwrap();
+
+    #[derive(Clone, Debug, PartialEq, Hash, Eq)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+    struct CacheKey {
+        url_base: PlSmallStr,
+        cloud_options: Option<CloudOptions2>,
+    }
+
+    /// Variant of CloudOptions for serializing to a cache key. The credential
+    /// provider is replaced by the function address.
+    #[derive(Clone, Debug, PartialEq, Hash, Eq)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+    struct CloudOptions2 {
+        max_retries: usize,
+        #[cfg(feature = "file_cache")]
+        file_cache_ttl: u64,
+        config: Option<CloudConfig>,
+        #[cfg(feature = "cloud")]
+        credential_provider: usize,
+    }
 }
 
 /// Construct an object_store `Path` from a string without any encoding/decoding.

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;
 use once_cell::sync::Lazy;
-use polars_core::config;
+use polars_core::config::{self, verbose_print_sensitive};
 use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};
 use polars_utils::aliases::PlHashMap;
 use polars_utils::pl_str::PlSmallStr;
@@ -61,9 +61,7 @@ fn url_and_creds_to_key(url: &Url, options: Option<&CloudOptions>) -> Vec<u8> {
         cloud_options,
     };
 
-    if config::verbose_sensitive() {
-        eprintln!("object store cache key: {} {:?}", url, &cache_key);
-    }
+    verbose_print_sensitive(|| format!("object store cache key: {} {:?}", url, &cache_key));
 
     return pl_serialize::serialize_to_bytes(&cache_key).unwrap();
 


### PR DESCRIPTION
We often request logs with `POLARS_VERBOSE` turned on - to prevent accidental key exposure we should not log any sensitive information. This PR instead introduces `POLARS_VERBOSE_SENSITIVE` for allowing logging of sensitive information.
