### PR TITLE
feat(python): Account for SurrealDB Python API updates (handle both `SurrealDB` and `AsyncSurrealDB` classes) in `read_database`

### DIFF
--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -209,18 +209,19 @@ def read_database(
     ...     connection=async_engine,
     ... )  # doctest: +SKIP
 
-    Load data from an asynchronous SurrealDB client connection object; note that
-    both the WS (`Surreal`) and HTTP (`SurrealHTTP`) clients are supported:
+    Load data from an `AsyncSurrealDB` client connection object; note that both the "ws"
+    and "http" protocols are supported, as is the synchronous `SurrealDB` client. The
+    async loop can be run with standard `asyncio` or with `uvloop`:
 
-    >>> import asyncio
+    >>> import asyncio  # (or uvloop)
     >>> async def surreal_query_to_frame(query: str, url: str):
-    ...     async with Surreal(url) as client:
+    ...     async with AsyncSurrealDB(url) as client:
     ...         await client.use(namespace="test", database="test")
     ...         return pl.read_database(query=query, connection=client)
     >>> df = asyncio.run(
     ...     surreal_query_to_frame(
-    ...         query="SELECT * FROM test_data",
-    ...         url="ws://localhost:8000/rpc",
+    ...         query="SELECT * FROM test",
+    ...         url="http://localhost:8000",
     ...     )
     ... )  # doctest: +SKIP
 
@@ -236,7 +237,7 @@ def read_database(
             connection = ODBCCursorProxy(connection)
         elif "://" in connection:
             # otherwise looks like a mistaken call to read_database_uri
-            msg = "use of string URI is invalid here; call `read_database_uri` instead"
+            msg = "string URI is invalid here; call `read_database_uri` instead"
             raise ValueError(msg)
         else:
             msg = "unable to identify string connection as valid ODBC (no driver)"

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from math import ceil
+from types import ModuleType
 from typing import TYPE_CHECKING, Any, overload
 
 import pytest
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 import polars as pl
 from polars._utils.various import parse_version
 from polars.testing import assert_frame_equal
+from tests.unit.conftest import mock_module_import
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -67,6 +69,12 @@ class MockSurrealConnection:
         self, query: str, variables: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
         return [{"result": self._mock_data, "status": "OK", "time": "32.083µs"}]
+
+
+class MockedSurrealModule(ModuleType):
+    """Mock SurrealDB module; enables internal `isinstance` check for AsyncSurrealDB."""
+
+    AsyncSurrealDB = MockSurrealConnection
 
 
 @pytest.mark.skipif(
@@ -159,18 +167,19 @@ async def _surreal_query_as_frame(
 
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 4])
 def test_surrealdb_fetchall(batch_size: int | None) -> None:
-    df_expected = pl.DataFrame(SURREAL_MOCK_DATA)
-    res = asyncio.run(
-        _surreal_query_as_frame(
-            url="ws://localhost:8000/rpc",
-            query="SELECT * FROM item",
-            batch_size=batch_size,
+    with mock_module_import("surrealdb", MockedSurrealModule("surrealdb")):
+        df_expected = pl.DataFrame(SURREAL_MOCK_DATA)
+        res = asyncio.run(
+            _surreal_query_as_frame(
+                url="ws://localhost:8000/rpc",
+                query="SELECT * FROM item",
+                batch_size=batch_size,
+            )
         )
-    )
-    if batch_size:
-        frames = list(res)  # type: ignore[call-overload]
-        n_mock_rows = len(SURREAL_MOCK_DATA)
-        assert len(frames) == ceil(n_mock_rows / batch_size)
-        assert_frame_equal(df_expected[:batch_size], frames[0])
-    else:
-        assert_frame_equal(df_expected, res)  # type: ignore[arg-type]
+        if batch_size:
+            frames = list(res)  # type: ignore[call-overload]
+            n_mock_rows = len(SURREAL_MOCK_DATA)
+            assert len(frames) == ceil(n_mock_rows / batch_size)
+            assert_frame_equal(df_expected[:batch_size], frames[0])
+        else:
+            assert_frame_equal(df_expected, res)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/io/database/test_async.py
+++ b/py-polars/tests/unit/io/database/test_async.py
@@ -64,7 +64,7 @@ class MockSurrealConnection:
         pass
 
     async def query(
-        self, sql: str, vars: dict[str, Any] | None = None
+        self, query: str, variables: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
         return [{"result": self._mock_data, "status": "OK", "time": "32.083µs"}]
 


### PR DESCRIPTION
The [SurrealDB Python API](https://github.com/surrealdb/surrealdb.py) has been updated (at the end of last year) in conjunction with their latest major release, splitting out `SurrealDB` and `AsyncSurrealDB` classes.

This PR updates our `SurrealDBCursorProxy` shim so that it can handle both the sync and async variants of the client object.

Tested (thoroughly!) locally with the sync and async clients (executing the async loop under both `asyncio` and `uvloop`).

## Example

Synchronous (`SurrealDB`):
```python
def surreal_query_to_frame(url: str, query: str):
    with SurrealDB(url) as client:
        client.use(namespace="test", database="test")
        client.sign_in(username="elvis", password="pr3sley")
        return pl.read_database(query=query, connection=client)

surreal_query_to_frame(
    url="http://127.0.0.1:8000",
    query="SELECT * FROM person",
)
# shape: (3, 4)
# ┌─────────────────────────────┬───────────┬─────────────┬──────┐
# │ id                          ┆ pass      ┆ tags        ┆ user │
# │ ---                         ┆ ---       ┆ ---         ┆ ---  │
# │ object                      ┆ str       ┆ list[str]   ┆ str  │
# ╞═════════════════════════════╪═══════════╪═════════════╪══════╡
# │ person:1ck3rnl84dmpvzgoy8bc ┆ more_safe ┆ ["awesome"] ┆ you  │
# │ person:2r90lxkxoezisazaiudl ┆ very_safe ┆ ["polars"]  ┆ me   │
# │ person:hecx1ieleqg3d646x6ia ┆ p4ssw0rd  ┆ ["data"]    ┆ him  │
# └─────────────────────────────┴───────────┴─────────────┴──────┘
```
Aynchronous (`AsyncSurrealDB`):
```python
async def surreal_query_to_frame_async(url: str, query: str):
    async with AsyncSurrealDB(url) as client:
        await client.use(namespace="test", database="test")
        await client.sign_in(username="elvis", password="pr3sley")
        return pl.read_database(query=query, connection=client)

import uvloop  # or asyncio

uvloop.run(
  surreal_query_to_frame_async(
    url="http://127.0.0.1:8000",
    query="SELECT * FROM person",
))
# shape: (3, 4)
# ┌─────────────────────────────┬───────────┬─────────────┬──────┐
# │ id                          ┆ pass      ┆ tags        ┆ user │
# │ ---                         ┆ ---       ┆ ---         ┆ ---  │
# │ object                      ┆ str       ┆ list[str]   ┆ str  │
# ╞═════════════════════════════╪═══════════╪═════════════╪══════╡
# │ person:1ck3rnl84dmpvzgoy8bc ┆ more_safe ┆ ["awesome"] ┆ you  │
# │ person:2r90lxkxoezisazaiudl ┆ very_safe ┆ ["polars"]  ┆ me   │
# │ person:hecx1ieleqg3d646x6ia ┆ p4ssw0rd  ┆ ["data"]    ┆ him  │
# └─────────────────────────────┴───────────┴─────────────┴──────┘

```