### PR TITLE
perf: Make an owned version of append

### DIFF
--- a/crates/polars-core/src/chunked_array/drop.rs
+++ b/crates/polars-core/src/chunked_array/drop.rs
@@ -1,18 +1,24 @@
 use crate::chunked_array::object::extension::drop::drop_list;
 use crate::prelude::*;
 
+#[inline(never)]
+#[cold]
+fn drop_slow<T: PolarsDataType>(ca: &mut ChunkedArray<T>) {
+    // SAFETY:
+    // guarded by the type system
+    // the transmute only convinces the type system that we are a list
+    #[allow(clippy::transmute_undefined_repr)]
+    unsafe {
+        drop_list(std::mem::transmute::<&mut ChunkedArray<T>, &ListChunked>(
+            ca,
+        ))
+    }
+}
+
 impl<T: PolarsDataType> Drop for ChunkedArray<T> {
     fn drop(&mut self) {
         if matches!(self.dtype(), DataType::List(_)) {
-            // SAFETY:
-            // guarded by the type system
-            // the transmute only convinces the type system that we are a list
-            #[allow(clippy::transmute_undefined_repr)]
-            unsafe {
-                drop_list(std::mem::transmute::<&mut ChunkedArray<T>, &ListChunked>(
-                    self,
-                ))
-            }
+            drop_slow(self);
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -26,7 +26,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct CategoricalChunked {
     physical: Logical<CategoricalType, UInt32Type>,
     /// 1st bit: original local categorical

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/append.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/append.rs
@@ -41,4 +41,9 @@ impl CategoricalChunked {
         std::mem::swap(self, &mut new_self);
         Ok(())
     }
+
+    pub fn append_owned(&mut self, other: Self) -> PolarsResult<()> {
+        // @TODO: Move the implementation to append_owned and make append dispatch here.
+        self.append(&other)
+    }
 }

--- a/crates/polars-core/src/chunked_array/logical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/mod.rs
@@ -40,6 +40,12 @@ pub struct Logical<Logical: PolarsDataType, Physical: PolarsDataType>(
     pub Option<DataType>,
 );
 
+impl<K: PolarsDataType, T: PolarsDataType> Default for Logical<K, T> {
+    fn default() -> Self {
+        Self(Default::default(), Default::default(), Default::default())
+    }
+}
+
 impl<K: PolarsDataType, T: PolarsDataType> Clone for Logical<K, T> {
     fn clone(&self) -> Self {
         let mut new = Logical::<K, _>::new_logical(self.0.clone());

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -873,12 +873,12 @@ impl DataType {
         }
     }
 
-    // Answers if this type matches the given type of a schema.
-    //
-    // Allows (nested) Null types in this type to match any type in the schema,
-    // but not vice versa. In such a case Ok(true) is returned, because a cast
-    // is necessary. If no cast is necessary Ok(false) is returned, and an
-    // error is returned if the types are incompatible.
+    /// Answers if this type matches the given type of a schema.
+    ///
+    /// Allows (nested) Null types in this type to match any type in the schema,
+    /// but not vice versa. In such a case Ok(true) is returned, because a cast
+    /// is necessary. If no cast is necessary Ok(false) is returned, and an
+    /// error is returned if the types are incompatible.
     pub fn matches_schema_type(&self, schema_type: &DataType) -> PolarsResult<bool> {
         match (self, schema_type) {
             (DataType::List(l), DataType::List(r)) => l.matches_schema_type(r),

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -905,6 +905,11 @@ impl Column {
             .append(other.as_materialized_series())?;
         Ok(self)
     }
+    pub fn append_owned(&mut self, other: Column) -> PolarsResult<&mut Self> {
+        self.into_materialized_series()
+            .append_owned(other.take_materialized_series())?;
+        Ok(self)
+    }
 
     pub fn arg_sort(&self, options: SortOptions) -> IdxCa {
         if self.is_empty() {

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1182,6 +1182,22 @@ impl DataFrame {
         self.height += other.height;
     }
 
+    /// Concatenate a [`DataFrame`] to this [`DataFrame`]
+    ///
+    /// If many `vstack` operations are done, it is recommended to call [`DataFrame::align_chunks_par`].
+    ///
+    /// # Panics
+    /// Panics if the schema's don't match.
+    pub fn vstack_mut_owned_unchecked(&mut self, other: DataFrame) {
+        self.columns
+            .iter_mut()
+            .zip(other.columns)
+            .for_each(|(left, right)| {
+                left.append_owned(right).expect("should not fail");
+            });
+        self.height += other.height;
+    }
+
     /// Extend the memory backed by this [`DataFrame`] with the values from `other`.
     ///
     /// Different from [`vstack`](Self::vstack) which adds the chunks from `other` to the chunks of this [`DataFrame`]

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -129,6 +129,10 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
         let other = other.array()?;
         self.0.append(other)
     }
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(other.take_inner())
+    }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -214,5 +218,9 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -131,6 +131,10 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         self.0.append(other.as_ref().as_ref())?;
         Ok(())
     }
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(other.take_inner())
+    }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -250,5 +254,9 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -97,6 +97,10 @@ impl SeriesTrait for SeriesWrap<BinaryOffsetChunked> {
         self.0.append(other.as_ref().as_ref())?;
         Ok(())
     }
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(other.take_inner())
+    }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -192,5 +196,9 @@ impl SeriesTrait for SeriesWrap<BinaryOffsetChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -149,6 +149,10 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.append(other.as_ref().as_ref())?;
         Ok(())
     }
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(other.take_inner())
+    }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -357,5 +361,9 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -164,6 +164,15 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         polars_ensure!(self.0.dtype() == other.dtype(), append);
         self.0.append(other.categorical().unwrap())
     }
+    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        let other = other
+            ._get_inner_mut()
+            .as_any_mut()
+            .downcast_mut::<CategoricalChunked>()
+            .unwrap();
+        self.0.append_owned(std::mem::take(other))
+    }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -300,6 +309,10 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }
 

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -191,13 +191,20 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
 
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), append);
-        let other = other.to_physical_repr();
-        // 3 refs
-        // ref Cow
-        // ref SeriesTrait
-        // ref ChunkedArray
-        self.0.append(other.as_ref().as_ref().as_ref())?;
-        Ok(())
+        let mut other = other.to_physical_repr().into_owned();
+        self.0
+            .append_owned(std::mem::take(other._get_inner_mut().as_mut()))
+    }
+    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(std::mem::take(
+            &mut other
+                ._get_inner_mut()
+                .as_any_mut()
+                .downcast_mut::<DateChunked>()
+                .unwrap()
+                .0,
+        ))
     }
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -354,6 +361,10 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }
 

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -197,9 +197,20 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
 
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), append);
-        let other = other.to_physical_repr();
-        self.0.append(other.as_ref().as_ref().as_ref())?;
-        Ok(())
+        let mut other = other.to_physical_repr().into_owned();
+        self.0
+            .append_owned(std::mem::take(other._get_inner_mut().as_mut()))
+    }
+    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(std::mem::take(
+            &mut other
+                ._get_inner_mut()
+                .as_any_mut()
+                .downcast_mut::<DatetimeChunked>()
+                .unwrap()
+                .0,
+        ))
     }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
@@ -367,5 +378,9 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -225,13 +225,20 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
 
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), append);
-        // 3 refs
-        // ref Cow
-        // ref SeriesTrait
-        // ref ChunkedArray
-        let other = other.to_physical_repr();
-        self.0.append(other.as_ref().as_ref().as_ref())?;
-        Ok(())
+        let mut other = other.to_physical_repr().into_owned();
+        self.0
+            .append_owned(std::mem::take(other._get_inner_mut().as_mut()))
+    }
+    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(std::mem::take(
+            &mut other
+                ._get_inner_mut()
+                .as_any_mut()
+                .downcast_mut::<DecimalChunked>()
+                .unwrap()
+                .0,
+        ))
     }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
@@ -422,5 +429,9 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -183,6 +183,10 @@ macro_rules! impl_dyn_series {
                 self.0.append(other.as_ref().as_ref())?;
                 Ok(())
             }
+            fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+                polars_ensure!(self.0.dtype() == other.dtype(), append);
+                self.0.append_owned(other.take_inner())
+            }
 
             fn extend(&mut self, other: &Series) -> PolarsResult<()> {
                 polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -369,6 +373,10 @@ macro_rules! impl_dyn_series {
 
             fn as_any_mut(&mut self) -> &mut dyn Any {
                 &mut self.0
+            }
+
+            fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+                self as _
             }
         }
     };

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -127,6 +127,10 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         polars_ensure!(self.0.dtype() == other.dtype(), append);
         self.0.append(other.as_ref().as_ref())
     }
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(other.take_inner())
+    }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -261,5 +265,9 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -253,6 +253,10 @@ macro_rules! impl_dyn_series {
                 self.0.append(other.as_ref().as_ref())?;
                 Ok(())
             }
+            fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+                polars_ensure!(self.0.dtype() == other.dtype(), append);
+                self.0.append_owned(other.take_inner())
+            }
 
             fn extend(&mut self, other: &Series) -> PolarsResult<()> {
                 polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -442,6 +446,10 @@ macro_rules! impl_dyn_series {
 
             fn as_any_mut(&mut self) -> &mut dyn Any {
                 &mut self.0
+            }
+
+            fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+                self as _
             }
         }
     };

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -303,8 +303,16 @@ impl SeriesTrait for NullChunked {
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(other.dtype() == &DataType::Null, ComputeError: "expected null dtype");
         // we don't create a new null array to keep probability of aligned chunks higher
-        self.chunks.extend(other.chunks().iter().cloned());
         self.length += other.len() as IdxSize;
+        self.chunks.extend(other.chunks().iter().cloned());
+        Ok(())
+    }
+    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+        polars_ensure!(other.dtype() == &DataType::Null, ComputeError: "expected null dtype");
+        // we don't create a new null array to keep probability of aligned chunks higher
+        let other: &mut NullChunked = other._get_inner_mut().as_any_mut().downcast_mut().unwrap();
+        self.length += other.len() as IdxSize;
+        self.chunks.extend(std::mem::take(&mut other.chunks));
         Ok(())
     }
 
@@ -323,6 +331,10 @@ impl SeriesTrait for NullChunked {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }
 

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -125,7 +125,7 @@ where
     }
     fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
         polars_ensure!(self.dtype() == other.dtype(), append);
-        ObjectChunked::append_owned(&mut self.0, std::mem::take(other._get_inner_mut().as_mut()))
+        ObjectChunked::append_owned(&mut self.0, other.take_inner())
     }
 
     fn extend(&mut self, _other: &Series) -> PolarsResult<()> {

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -120,11 +120,12 @@ where
     }
 
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
-        if self.dtype() != other.dtype() {
-            polars_bail!(append);
-        }
-        ObjectChunked::append(&mut self.0, other.as_ref().as_ref())?;
-        Ok(())
+        polars_ensure!(self.dtype() == other.dtype(), append);
+        ObjectChunked::append(&mut self.0, other.as_ref().as_ref())
+    }
+    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.dtype() == other.dtype(), append);
+        ObjectChunked::append_owned(&mut self.0, std::mem::take(other._get_inner_mut().as_mut()))
     }
 
     fn extend(&mut self, _other: &Series) -> PolarsResult<()> {
@@ -240,6 +241,10 @@ where
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }
 

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -123,7 +123,7 @@ where
         polars_ensure!(self.dtype() == other.dtype(), append);
         ObjectChunked::append(&mut self.0, other.as_ref().as_ref())
     }
-    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
         polars_ensure!(self.dtype() == other.dtype(), append);
         ObjectChunked::append_owned(&mut self.0, other.take_inner())
     }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -125,13 +125,15 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
     }
 
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
-        polars_ensure!(
-            self.0.dtype() == other.dtype(),
-            SchemaMismatch: "cannot extend Series: data types don't match",
-        );
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
         // todo! add object
         self.0.append(other.as_ref().as_ref())?;
         Ok(())
+    }
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        // todo! add object
+        self.0.append_owned(other.take_inner())
     }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
@@ -264,5 +266,9 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -114,6 +114,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         polars_ensure!(self.0.dtype() == other.dtype(), append);
         self.0.append(other.as_ref().as_ref())
     }
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(other.take_inner())
+    }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), extend);
@@ -259,6 +263,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -173,13 +173,20 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
 
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
         polars_ensure!(self.0.dtype() == other.dtype(), append);
-        let other = other.to_physical_repr();
-        // 3 refs
-        // ref Cow
-        // ref SeriesTrait
-        // ref ChunkedArray
-        self.0.append(other.as_ref().as_ref().as_ref())?;
-        Ok(())
+        let mut other = other.to_physical_repr().into_owned();
+        self.0
+            .append_owned(std::mem::take(other._get_inner_mut().as_mut()))
+    }
+    fn append_owned(&mut self, mut other: Series) -> PolarsResult<()> {
+        polars_ensure!(self.0.dtype() == other.dtype(), append);
+        self.0.append_owned(std::mem::take(
+            &mut other
+                ._get_inner_mut()
+                .as_any_mut()
+                .downcast_mut::<TimeChunked>()
+                .unwrap()
+                .0,
+        ))
     }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
@@ -327,6 +334,10 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         &mut self.0
+    }
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self as _
     }
 }
 

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -255,8 +255,8 @@ pub trait SeriesTrait:
     /// end of the array
     fn split_at(&self, _offset: i64) -> (Series, Series);
 
-    #[doc(hidden)]
-    fn append(&mut self, _other: &Series) -> PolarsResult<()>;
+    fn append(&mut self, other: &Series) -> PolarsResult<()>;
+    fn append_owned(&mut self, other: Series) -> PolarsResult<()>;
 
     #[doc(hidden)]
     fn extend(&mut self, _other: &Series) -> PolarsResult<()>;
@@ -570,6 +570,8 @@ pub trait SeriesTrait:
     /// Get a hold of the [`ChunkedArray`], [`Logical`] or `NullChunked` as an `Any` trait mutable
     /// reference.
     fn as_any_mut(&mut self) -> &mut dyn Any;
+
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 
     #[cfg(feature = "checked_arithmetic")]
     fn checked_div(&self, _rhs: &Series) -> PolarsResult<Series> {


### PR DESCRIPTION
This reduces runtime for me on a vconcat by roughly 33%.

In the end, I chose to do a non-parallel version. As this performance is primarily important for the streaming engine where we don't have the same kind of parallelism.