### PR TITLE
fix: Fix `clip` for `Decimal` returning wrong values

### DIFF
--- a/crates/polars-ops/src/series/ops/clip.rs
+++ b/crates/polars-ops/src/series/ops/clip.rs
@@ -18,22 +18,21 @@ pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
         max.to_physical_repr(),
     );
 
-    match s.dtype() {
-        dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
-                let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
-                let out = clip_helper_both_bounds(ca, min, max).into_series();
-                if original_type.is_logical() {
-                    out.cast(original_type)
-                } else {
-                    Ok(out)
-                }
-            })
-        },
-        dt => polars_bail!(opq = clippy, dt),
-    }
+    with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+        let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
+        let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
+        let out = clip_helper_both_bounds(ca, min, max).into_series();
+        match original_type {
+            #[cfg(feature = "dtype-decimal")]
+            DataType::Decimal(precision, scale) => {
+                let phys = out.i128()?.as_ref().clone();
+                Ok(phys.into_decimal_unchecked(*precision, scale.unwrap()).into_series())
+            },
+            dt if dt.is_logical() => out.cast(original_type),
+            _ => Ok(out)
+        }
+    })
 }
 
 /// Set values above the given maximum to the maximum value.
@@ -48,21 +47,20 @@ pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
 
     let (s, max) = (s.to_physical_repr(), max.to_physical_repr());
 
-    match s.dtype() {
-        dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
-                let out = clip_helper_single_bound(ca, max, num_traits::clamp_max).into_series();
-                if original_type.is_logical() {
-                    out.cast(original_type)
-                } else {
-                    Ok(out)
-                }
-            })
-        },
-        dt => polars_bail!(opq = clippy_max, dt),
-    }
+    with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+        let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
+        let out = clip_helper_single_bound(ca, max, num_traits::clamp_max).into_series();
+        match original_type {
+            #[cfg(feature = "dtype-decimal")]
+            DataType::Decimal(precision, scale) => {
+                let phys = out.i128()?.as_ref().clone();
+                Ok(phys.into_decimal_unchecked(*precision, scale.unwrap()).into_series())
+            },
+            dt if dt.is_logical() => out.cast(original_type),
+            _ => Ok(out)
+        }
+    })
 }
 
 /// Set values below the given minimum to the minimum value.
@@ -77,21 +75,20 @@ pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
 
     let (s, min) = (s.to_physical_repr(), min.to_physical_repr());
 
-    match s.dtype() {
-        dt if dt.is_primitive_numeric() => {
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
-                let out = clip_helper_single_bound(ca, min, num_traits::clamp_min).into_series();
-                if original_type.is_logical() {
-                    out.cast(original_type)
-                } else {
-                    Ok(out)
-                }
-            })
-        },
-        dt => polars_bail!(opq = clippy_min, dt),
-    }
+    with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+        let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+        let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
+        let out = clip_helper_single_bound(ca, min, num_traits::clamp_min).into_series();
+        match original_type {
+            #[cfg(feature = "dtype-decimal")]
+            DataType::Decimal(precision, scale) => {
+                let phys = out.i128()?.as_ref().clone();
+                Ok(phys.into_decimal_unchecked(*precision, scale.unwrap()).into_series())
+            },
+            dt if dt.is_logical() => out.cast(original_type),
+            _ => Ok(out)
+        }
+    })
 }
 
 fn clip_helper_both_bounds<T>(

--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 
 import pytest
 
 import polars as pl
 from polars.exceptions import InvalidOperationError
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 @pytest.fixture
@@ -138,3 +139,19 @@ def test_clip_bound_invalid_for_original_dtype() -> None:
         InvalidOperationError, match="conversion from `i32` to `u32` failed"
     ):
         s.clip(-1, 5)
+
+
+def test_clip_decimal() -> None:
+    ser = pl.Series("a", ["1.1", "2.2", "3.3"], pl.Decimal(21, 1))
+
+    result = ser.clip(lower_bound=Decimal("1.5"), upper_bound=Decimal("2.5"))
+    expected = pl.Series("a", ["1.5", "2.2", "2.5"], pl.Decimal(21, 1))
+    assert_series_equal(result, expected)
+
+    result = ser.clip(lower_bound=Decimal("1.5"))
+    expected = pl.Series("a", ["1.5", "2.2", "3.3"], pl.Decimal(21, 1))
+    assert_series_equal(result, expected)
+
+    result = ser.clip(upper_bound=Decimal("2.5"))
+    expected = pl.Series("a", ["1.1", "2.2", "2.5"], pl.Decimal(21, 1))
+    assert_series_equal(result, expected)


### PR DESCRIPTION
```python
import polars as pl
from decimal import Decimal as D

df = pl.Series("a", ["1.1", "2.2", "3.3"], pl.Decimal(21, 1)).to_frame()

df.select(
    pl.col("a").clip(lower_bound=D("1.5"), upper_bound=D("2.5"))
)
```

BEFORE:
```
shape: (3, 1)
┌───────────────┐
│ a             │
│ ---           │
│ decimal[21,1] │
╞═══════════════╡
│ 15.0          │
│ 22.0          │
│ 25.0          │
└───────────────┘
```

AFTER: 
```
shape: (3, 1)
┌───────────────┐
│ a             │
│ ---           │
│ decimal[21,1] │
╞═══════════════╡
│ 1.5           │
│ 2.2           │
│ 2.5           │
└───────────────┘
```