### PR TITLE
fix: Remove `assert` that panics on `group_by` followed by `head(n)`, where `n` is larger then the frame height

### DIFF
--- a/crates/polars-core/src/frame/group_by/position.rs
+++ b/crates/polars-core/src/frame/group_by/position.rs
@@ -620,7 +620,12 @@ impl Default for GroupPositions {
 impl GroupPositions {
     pub fn slice(&self, offset: i64, len: usize) -> Self {
         let offset = self.offset + offset;
-        slice_groups(self.original.clone(), offset, len)
+        slice_groups(
+            self.original.clone(),
+            offset,
+            // invariant that len should be in bounds, so truncate if not
+            if len > self.len { self.len } else { len },
+        )
     }
 
     pub fn sort(&mut self) {

--- a/crates/polars-core/src/frame/group_by/position.rs
+++ b/crates/polars-core/src/frame/group_by/position.rs
@@ -620,7 +620,6 @@ impl Default for GroupPositions {
 impl GroupPositions {
     pub fn slice(&self, offset: i64, len: usize) -> Self {
         let offset = self.offset + offset;
-        assert!(len <= self.len);
         slice_groups(self.original.clone(), offset, len)
     }
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -168,7 +168,7 @@ ArrayLike = Union[
 @expr_dispatch
 class Series:
     """
-    A Series represents a single column in a polars DataFrame.
+    A Series represents a single column in a Polars DataFrame.
 
     Parameters
     ----------

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -172,6 +172,30 @@ def test_group_by_agg_equals_zero_3535() -> None:
     }
 
 
+def test_group_by_followed_by_limit() -> None:
+    lf = pl.LazyFrame(
+        {
+            "key": ["xx", "yy", "zz", "xx", "zz", "zz"],
+            "val1": [15, 25, 10, 20, 20, 20],
+            "val2": [-33, 20, 44, -2, 16, 71],
+        }
+    )
+    grp = lf.group_by("key", maintain_order=True).agg(pl.col("val1", "val2").sum())
+    assert sorted(grp.collect().rows()) == [
+        ("xx", 35, -35),
+        ("yy", 25, 20),
+        ("zz", 50, 131),
+    ]
+    assert sorted(grp.head(2).collect().rows()) == [
+        ("xx", 35, -35),
+        ("yy", 25, 20),
+    ]
+    assert sorted(grp.head(10).collect().rows()) == [
+        ("xx", 35, -35),
+        ("yy", 25, 20),
+        ("zz", 50, 131),
+    ]
+
 def test_dtype_concat_3735() -> None:
     for dt in NUMERIC_DTYPES:
         d1 = pl.DataFrame([pl.Series("val", [1, 2], dtype=dt)])

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -196,6 +196,7 @@ def test_group_by_followed_by_limit() -> None:
         ("zz", 50, 131),
     ]
 
+
 def test_dtype_concat_3735() -> None:
     for dt in NUMERIC_DTYPES:
         d1 = pl.DataFrame([pl.Series("val", [1, 2], dtype=dt)])


### PR DESCRIPTION
Closes #20818.

Following the code further down, I think the panicking `assert` is invalid, and can be removed... @ritchie46, could you double-check, in case I missed some other paths that _do_ rely on this?🤞😅 It's not an error to ask for a slice larger than the number of available rows - in this case it should just get clipped to how many rows there actually are.

## Example

The `1.20.0` release panics on the following:
```python
import polars as pl

lf = pl.LazyFrame({
    "key": ["xx", "yy", "zz", "xx", "zz", "zz"],
    "val": [15, 25, 10, 20, 20, 20],
})
grp = lf.group_by("key").agg(pl.col("val").sum())
grp.head(5).collect()  # aggregate result is 3 rows; head(5) panics
```
