### PR TITLE
fix: Fix panic `InvalidHeaderValue` scanning from S3 on Windows

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -307,7 +307,7 @@ impl CloudOptions {
             &mut builder,
             &[(
                 Path::new("~/.aws/config"),
-                &[("region\\s*=\\s*(.*)\n", AmazonS3ConfigKey::Region)],
+                &[("region\\s*=\\s*([^\r\n]*)", AmazonS3ConfigKey::Region)],
             )],
         );
 
@@ -317,12 +317,16 @@ impl CloudOptions {
                 Path::new("~/.aws/credentials"),
                 &[
                     (
-                        "aws_access_key_id\\s*=\\s*(.*)\n",
+                        "aws_access_key_id\\s*=\\s*([^\\r\\n]*)",
                         AmazonS3ConfigKey::AccessKeyId,
                     ),
                     (
-                        "aws_secret_access_key\\s*=\\s*(.*)\n",
+                        "aws_secret_access_key\\s*=\\s*([^\\r\\n]*)",
                         AmazonS3ConfigKey::SecretAccessKey,
+                    ),
+                    (
+                        "aws_session_token\\s*=\\s*([^\\r\\n]*)",
+                        AmazonS3ConfigKey::Token,
                     ),
                 ],
             )],


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/20650

Issue is due to not handling the carriage return `\r` of the CRLF `\r\n` line terminator used in the configuration file.

This updates Rust-side code, however it is less-used after the Python-side CredentialProviderAWS was introduced.
