### PR TITLE
fix(python): Selectors should raise on `+` between themselves

### DIFF
--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -390,17 +390,19 @@ class CredentialProviderGCP(CredentialProvider):
 
 def _maybe_init_credential_provider(
     credential_provider: CredentialProviderFunction | Literal["auto"] | None,
-    source: str
-    | Path
-    | IO[str]
-    | IO[bytes]
-    | bytes
-    | list[str]
-    | list[Path]
-    | list[IO[str]]
-    | list[IO[bytes]]
-    | list[bytes]
-    | None,
+    source: (
+        str
+        | Path
+        | IO[str]
+        | IO[bytes]
+        | bytes
+        | list[str]
+        | list[Path]
+        | list[IO[str]]
+        | list[IO[bytes]]
+        | list[bytes]
+        | None
+    ),
     storage_options: dict[str, Any] | None,
     caller_name: str,
 ) -> CredentialProviderFunction | CredentialProvider | None:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -358,23 +358,20 @@ class _selector_proxy_(Expr):
                 return f"cs.{selector_name}({str_params})"
 
     @overload
-    def __sub__(self, other: SelectorType) -> SelectorType: ...
+    def __add__(self, other: SelectorType) -> SelectorType: ...
 
     @overload
-    def __sub__(self, other: Any) -> SelectorType | Expr: ...
+    def __add__(self, other: Any) -> Expr: ...
 
-    def __sub__(self, other: Any) -> Expr:
+    def __add__(self, other: Any) -> SelectorType | Expr:
         if is_selector(other):
-            return _selector_proxy_(
-                self.meta._as_selector().meta._selector_sub(other),
-                parameters={"self": self, "other": other},
-                name="sub",
-            )
+            msg = "unsupported operand type(s) for op: ('Selector' + 'Selector')"
+            raise TypeError(msg)
         else:
-            return self.as_expr().__sub__(other)
+            return self.as_expr().__add__(other)
 
-    def __rsub__(self, other: Any) -> NoReturn:
-        msg = "unsupported operand type(s) for op: ('Expr' - 'Selector')"
+    def __radd__(self, other: Any) -> Expr:
+        msg = "unsupported operand type(s) for op: ('Expr' + 'Selector')"
         raise TypeError(msg)
 
     @overload
@@ -424,6 +421,26 @@ class _selector_proxy_(Expr):
         if is_column(other):
             other = by_name(other.meta.output_name())
         return self.as_expr().__ror__(other)
+
+    @overload
+    def __sub__(self, other: SelectorType) -> SelectorType: ...
+
+    @overload
+    def __sub__(self, other: Any) -> SelectorType | Expr: ...
+
+    def __sub__(self, other: Any) -> Expr:
+        if is_selector(other):
+            return _selector_proxy_(
+                self.meta._as_selector().meta._selector_sub(other),
+                parameters={"self": self, "other": other},
+                name="sub",
+            )
+        else:
+            return self.as_expr().__sub__(other)
+
+    def __rsub__(self, other: Any) -> NoReturn:
+        msg = "unsupported operand type(s) for op: ('Expr' - 'Selector')"
+        raise TypeError(msg)
 
     @overload
     def __xor__(self, other: SelectorType) -> SelectorType: ...

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -710,6 +710,12 @@ def test_selector_sets(df: pl.DataFrame) -> None:
     with pytest.raises(TypeError, match=r"unsupported .* \('Expr' - 'Selector'\)"):
         df.select(pl.col("colx") - cs.matches("[yz]$"))
 
+    with pytest.raises(TypeError, match=r"unsupported .* \('Expr' \+ 'Selector'\)"):
+        df.select(pl.col("colx") + cs.numeric())
+
+    with pytest.raises(TypeError, match=r"unsupported .* \('Selector' \+ 'Selector'\)"):
+        df.select(cs.string() + cs.numeric())
+
     # complement
     assert df.select(~cs.by_dtype([pl.Duration, pl.Time])).schema == {
         "abc": pl.UInt16,


### PR DESCRIPTION
Closes #20821.

### Selectors as sets

Selectors act as sets and support the standard set ops:
https://docs.pola.rs/api/python/stable/reference/selectors.html#set-operations

Operation | Expression
-- | --
UNION | A \| B
INTERSECTION | A & B
DIFFERENCE | A - B
SYMMETRIC DIFFERENCE | A ^ B
COMPLEMENT | ~A

### Standard set behaviour

_However_... sets do **not** support the `+` operator between themselves. 

```python
{1,2,3} + {2,3,4}
# TypeError: unsupported operand type(s) for +: 'set' and 'set'
```

We are inadvertently passing-through `+` between selectors to Expr, leading to very peculiar (and unintended) results or errors in cases where the caller meant to use `|` or `&` instead. This PR fixes that (while retaining support for broadcasting).

## Example

```python
import polars as pl
import polars.selectors as cs

data = {
    "col1": [1, 2, 3],
    "col2": [4.1, 5.2, 6.3],
    "col3": ["x", "y", "z"],
}
df = pl.DataFrame(data)
```
Use of `+` between selectors now raises...
```python
df.select(cs.numeric() + cs.string())
# TypeError: unsupported operand type(s) for op: ('Selector' + 'Selector')
```
...but continues to broadcast:
```python
df.select(cs.numeric() + 100)
# shape: (3, 2)
# ┌──────┬───────┐
# │ col1 ┆ col2  │
# │ ---  ┆ ---   │
# │ i64  ┆ f64   │
# ╞══════╪═══════╡
# │ 101  ┆ 104.1 │
# │ 102  ┆ 105.2 │
# │ 103  ┆ 106.3 │
# └──────┴───────┘
```