### PR TITLE
fix: Raise error instead of panicking with struct inside `.over()`

### DIFF
--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -576,8 +576,7 @@ impl PhysicalExpr for WindowExpr {
                                             right.as_materialized_series(),
                                             JoinValidation::ManyToMany,
                                             true,
-                                        )
-                                        .unwrap()
+                                        )?
                                         .1,
                                 ))
                             } else {

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -536,3 +537,10 @@ def test_order_by_sorted_keys_18943() -> None:
 
     out = df.set_sorted("g").select(pl.col("x").cum_sum().over("g", order_by="t"))
     assert_frame_equal(out, expect)
+
+
+def test_over_on_struct_20688() -> None:
+    df = pl.DataFrame({"x": 1, "y": "two"})
+
+    with pytest.raises(ComputeError, match="not yet implemented"):
+        df.select(pl.col("y").first().over(pl.struct("x")))

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -542,5 +542,5 @@ def test_order_by_sorted_keys_18943() -> None:
 def test_over_on_struct_20688() -> None:
     df = pl.DataFrame({"x": 1, "y": "two"})
 
-    with pytest.raises(ComputeError, match="not yet implemented"):
+    with pytest.raises(ComputeError, match="not yet implemented: Hash Left Join"):
         df.select(pl.col("y").first().over(pl.struct("x")))


### PR DESCRIPTION
Fixes #20688

I don't know how to implement this (or even if you'd want that), but at least it doesn't panic anymore.