### PR TITLE
feat(python): Experimental credential provider support for Delta read/scan/write

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4285,6 +4285,7 @@ class DataFrame:
         mode: Literal["error", "append", "overwrite", "ignore"] = ...,
         overwrite_schema: bool | None = ...,
         storage_options: dict[str, str] | None = ...,
+        credential_provider: CredentialProviderFunction | Literal["auto"] | None = ...,
         delta_write_options: dict[str, Any] | None = ...,
     ) -> None: ...
 
@@ -4296,6 +4297,7 @@ class DataFrame:
         mode: Literal["merge"],
         overwrite_schema: bool | None = ...,
         storage_options: dict[str, str] | None = ...,
+        credential_provider: CredentialProviderFunction | Literal["auto"] | None = ...,
         delta_merge_options: dict[str, Any],
     ) -> deltalake.table.TableMerger: ...
 
@@ -4306,6 +4308,9 @@ class DataFrame:
         mode: Literal["error", "append", "overwrite", "ignore", "merge"] = "error",
         overwrite_schema: bool | None = None,
         storage_options: dict[str, str] | None = None,
+        credential_provider: CredentialProviderFunction
+        | Literal["auto"]
+        | None = "auto",
         delta_write_options: dict[str, Any] | None = None,
         delta_merge_options: dict[str, Any] | None = None,
     ) -> deltalake.table.TableMerger | None:
@@ -4338,6 +4343,14 @@ class DataFrame:
             - See a list of supported storage options for S3 `here <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html#variants>`__.
             - See a list of supported storage options for GCS `here <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html#variants>`__.
             - See a list of supported storage options for Azure `here <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html#variants>`__.
+        credential_provider
+            Provide a function that can be called to provide cloud storage
+            credentials. The function is expected to return a dictionary of
+            credential keys along with an optional credential expiry time.
+
+            .. warning::
+                This functionality is considered **unstable**. It may be changed
+                at any point without it being considered a breaking change.
         delta_write_options
             Additional keyword arguments while writing a Delta lake Table.
             See a list of supported write options `here <https://delta-io.github.io/delta-rs/api/delta_writer/#deltalake.write_deltalake>`__.
@@ -4462,6 +4475,8 @@ class DataFrame:
 
         _check_if_delta_available()
 
+        credential_provider_creds = {}
+
         from deltalake import DeltaTable, write_deltalake
         from deltalake import __version__ as delta_version
         from packaging.version import Version
@@ -4475,6 +4490,34 @@ class DataFrame:
             data = self.to_arrow(compat_level=CompatLevel.newest())
         else:
             data = self.to_arrow()
+
+        from polars.io.cloud.credential_provider import (
+            _get_credentials_from_provider_expiry_aware,
+            _maybe_init_credential_provider,
+        )
+
+        if not isinstance(target, DeltaTable):
+            credential_provider = _maybe_init_credential_provider(
+                credential_provider, target, storage_options, "write_delta"
+            )
+        elif credential_provider is not None and credential_provider != "auto":
+            msg = "cannot use credential_provider when passing a DeltaTable object"
+            raise ValueError(msg)
+        else:
+            credential_provider = None
+
+        if credential_provider is not None:
+            credential_provider_creds = _get_credentials_from_provider_expiry_aware(
+                credential_provider
+            )
+
+        # We aren't calling into polars-native write functions so we just update
+        # the storage_options here.
+        storage_options = (
+            {**(storage_options or {}), **credential_provider_creds}
+            if storage_options is not None or credential_provider is not None
+            else None
+        )
 
         if mode == "merge":
             if delta_merge_options is None:

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -1,23 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import IO
+from typing import Any
 
 from polars._utils.various import is_path_or_str_sequence
 
 
 def _first_scan_path(
-    source: str
-    | Path
-    | IO[str]
-    | IO[bytes]
-    | bytes
-    | list[str]
-    | list[Path]
-    | list[IO[str]]
-    | list[IO[bytes]]
-    | list[bytes]
-    | None,
+    source: Any,
 ) -> str | Path | None:
     if isinstance(source, (str, Path)):
         return source


### PR DESCRIPTION
Adds automatic Python-side credential provider initialization to the Delta I/O functions (`read_delta`, `scan_delta`, `write_delta`), similar to those previously added to other I/O functions. This includes `DefaultAzureCredential` (ref https://github.com/pola-rs/polars/issues/20808):

* https://github.com/pola-rs/polars/issues/20808

Before calling into the Delta Python library, we directly call the credential provider on the Python-side and inject them into `storage_options`, as the Delta Python library does not accept a callable credential provider. This works as our built-in credential providers (`AWS`, `Azure`, `GCP`) all return `object_store`-compatible key-value pairs - i.e. it's valid to do something like this:

```python
creds, _expiry = pl.CredentialProviderAzure()()

pl.read_delta(
    "abfss://...",
    storage_options=creds,
)
```
