### PR TITLE
feat(python): Auto-initialize Python credential providers in more cases

### DIFF
--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -29,25 +29,27 @@ CredentialProviderFunction: TypeAlias = Union[
 ]
 
 # https://docs.rs/object_store/latest/object_store/enum.ClientConfigKey.html
-OBJECT_STORE_CLIENT_OPTIONS: frozenset[str] = {
-    "allow_http",
-    "allow_invalid_certificates",
-    "connect_timeout",
-    "default_content_type",
-    "http1_only",
-    "http2_only",
-    "http2_keep_alive_interval",
-    "http2_keep_alive_timeout",
-    "http2_keep_alive_while_idle",
-    "http2_max_frame_size",
-    "pool_idle_timeout",
-    "pool_max_idle_per_host",
-    "proxy_url",
-    "proxy_ca_certificate",
-    "proxy_excludes",
-    "timeout",
-    "user_agent",
-}
+OBJECT_STORE_CLIENT_OPTIONS: frozenset[str] = frozenset(
+    [
+        "allow_http",
+        "allow_invalid_certificates",
+        "connect_timeout",
+        "default_content_type",
+        "http1_only",
+        "http2_only",
+        "http2_keep_alive_interval",
+        "http2_keep_alive_timeout",
+        "http2_keep_alive_while_idle",
+        "http2_max_frame_size",
+        "pool_idle_timeout",
+        "pool_max_idle_per_host",
+        "proxy_url",
+        "proxy_ca_certificate",
+        "proxy_excludes",
+        "timeout",
+        "user_agent",
+    ]
+)
 
 
 class AWSAssumeRoleKWArgs(TypedDict):
@@ -454,7 +456,9 @@ def _maybe_init_credential_provider(
     if (scheme := _get_path_scheme(path)) is None:
         return None
 
-    provider = None
+    provider: (
+        CredentialProviderAWS | CredentialProviderAzure | CredentialProviderGCP | None
+    ) = None
 
     try:
         # For Azure we dispatch to `azure.identity` as much as possible

--- a/py-polars/polars/io/cloud/credential_provider.py
+++ b/py-polars/polars/io/cloud/credential_provider.py
@@ -468,6 +468,8 @@ def _maybe_init_credential_provider(
 
             if storage_options is not None:
                 for k, v in storage_options.items():
+                    k = k.lower()
+
                     # https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html
                     if k in {
                         "azure_storage_tenant_id",
@@ -506,6 +508,8 @@ def _maybe_init_credential_provider(
 
             if storage_options is not None:
                 for k, v in storage_options.items():
+                    k = k.lower()
+
                     # https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html
                     if k in {"aws_region", "region"}:
                         region = v
@@ -520,7 +524,7 @@ def _maybe_init_credential_provider(
 
             provider = CredentialProviderAWS(region_name=region or default_region)
         elif storage_options is not None and any(
-            key not in OBJECT_STORE_CLIENT_OPTIONS for key in storage_options
+            key.lower() not in OBJECT_STORE_CLIENT_OPTIONS for key in storage_options
         ):
             return None
         elif _is_gcp_cloud(scheme):

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -28,6 +28,8 @@ def test_scan_credential_provider(
 
     with pytest.raises(AssertionError, match=err_magic):
         io_func("s3://bucket/path", credential_provider="auto")
+
+    with pytest.raises(AssertionError, match=err_magic):
         io_func(
             "s3://bucket/path",
             credential_provider="auto",

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -28,6 +28,11 @@ def test_scan_credential_provider(
 
     with pytest.raises(AssertionError, match=err_magic):
         io_func("s3://bucket/path", credential_provider="auto")
+        io_func(
+            "s3://bucket/path",
+            credential_provider="auto",
+            storage_options={"aws_region": "eu-west-1"},
+        )
 
     # We can't test these with the `read_` functions as they end up executing
     # the query

--- a/py-polars/tests/unit/io/cloud/test_credential_provider.py
+++ b/py-polars/tests/unit/io/cloud/test_credential_provider.py
@@ -37,7 +37,11 @@ def test_scan_credential_provider(
         io_func("s3://bucket/path", credential_provider=None)
         # Passing `storage_options` should disable the automatic instantiation of
         # `CredentialProviderAWS`
-        io_func("s3://bucket/path", credential_provider="auto", storage_options={})
+        io_func(
+            "s3://bucket/path",
+            credential_provider="auto",
+            storage_options={"aws_access_key_id": "polars"},
+        )
 
     err_magic = "err_magic_7"
 


### PR DESCRIPTION
* For AWS, this enables auto-initialization of `CredentialProviderAWS` if `storage_options` contains only an `aws_region` config key.
* In general, for all supported cloud types:
  *  Allows credential providers to be auto-initialized if `storage_options` contains client config keys[^1]
* Adjusts checking of keys on the Python-side to be case-insensitive

[^1]: https://docs.rs/object_store/latest/object_store/enum.ClientConfigKey.html
