### PR TITLE
fix: Incorrect `Decimal` value for `fill_null(strategy="one")`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -93,6 +93,7 @@ impl Series {
                 fill_backward_gather(self)
             },
             FillNullStrategy::Backward(Some(limit)) => fill_backward_gather_limit(self, limit),
+            #[cfg(feature = "dtype-decimal")]
             FillNullStrategy::One if self.dtype().is_decimal() => {
                 let ca = self.decimal().unwrap();
                 let precision = ca.precision();

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -638,3 +638,16 @@ def test_shift_over_12957() -> None:
     )
     assert result["x"].to_list() == [None, D("1.1"), None, D("2.2")]
     assert result["y"].to_list() == [None, 1, None, 2]
+
+
+def test_fill_null() -> None:
+    s = pl.Series("a", [D("1.2"), None, D("1.4")])
+
+    assert s.fill_null(D("0.0")).to_list() == [D("1.2"), D("0.0"), D("1.4")]
+    assert s.fill_null(strategy="zero").to_list() == [D("1.2"), D("0.0"), D("1.4")]
+    assert s.fill_null(strategy="max").to_list() == [D("1.2"), D("1.4"), D("1.4")]
+    assert s.fill_null(strategy="min").to_list() == [D("1.2"), D("1.2"), D("1.4")]
+    assert s.fill_null(strategy="one").to_list() == [D("1.2"), D("1.0"), D("1.4")]
+    assert s.fill_null(strategy="forward").to_list() == [D("1.2"), D("1.2"), D("1.4")]
+    assert s.fill_null(strategy="backward").to_list() == [D("1.2"), D("1.4"), D("1.4")]
+    assert s.fill_null(strategy="mean").to_list() == [D("1.2"), D("1.3"), D("1.4")]


### PR DESCRIPTION
Fixes the following:

```python
from decimal import Decimal
import polars as pl

ser = pl.Series([Decimal("1.23"), None])
ser.fill_null(strategy="one")
```

BEFORE:
```
shape: (2,)
Series: '' [decimal[*,2]]
[
        1.23
        0.01
]
```

AFTER:
```
shape: (2,)
Series: '' [decimal[*,2]]
[
        1.23
        1.00
]
```