### PR TITLE
feat(python): Allow column expressions in DataFrame `unnest`

### DIFF
--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -651,13 +651,6 @@ impl PyDataFrame {
         })
     }
 
-    pub fn unnest(&self, py: Python, columns: Vec<String>) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| self.df.unnest(columns))
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
-    }
-
     pub fn clear(&self, py: Python) -> Self {
         py.allow_threads(|| self.df.clear()).into()
     }

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -11261,8 +11261,7 @@ class DataFrame:
         │ bar    ┆ 2   ┆ b   ┆ null ┆ [3]       ┆ womp  │
         └────────┴─────┴─────┴──────┴───────────┴───────┘
         """
-        columns = _expand_selectors(self, columns, *more_columns)
-        return self._from_pydf(self._df.unnest(columns))
+        return self.lazy().unnest(columns, *more_columns).collect(_eager=True)
 
     def corr(self, **kwargs: Any) -> DataFrame:
         """


### PR DESCRIPTION
Closes  #20128.

We can redirect to `LazyFrame` to handle this consistently, dropping the passthrough method on `PyDataFrame`.