### PR TITLE
test: Add tests for open issues

### DIFF
--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1846,16 +1846,16 @@ def test_init_from_subclassed_types() -> None:
 
 
 def test_series_init_with_python_type_7737() -> None:
-    assert pl.Series([], dtype=int).dtype == pl.Int64
-    assert pl.Series([], dtype=float).dtype == pl.Float64
-    assert pl.Series([], dtype=bool).dtype == pl.Boolean
-    assert pl.Series([], dtype=str).dtype == pl.Utf8
+    assert pl.Series([], dtype=int).dtype == pl.Int64  # type: ignore[arg-type]
+    assert pl.Series([], dtype=float).dtype == pl.Float64  # type: ignore[arg-type]
+    assert pl.Series([], dtype=bool).dtype == pl.Boolean  # type: ignore[arg-type]
+    assert pl.Series([], dtype=str).dtype == pl.Utf8  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
-        pl.Series(["a"], dtype=int)
+        pl.Series(["a"], dtype=int)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
-        pl.Series([True], dtype=pl.String)
+        pl.Series([True], dtype=str)  # type: ignore[arg-type]
 
 
 def test_init_from_list_shape_6968() -> None:

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -202,3 +202,9 @@ def test_series_duration_units() -> None:
         ),
         pl.DataFrame({"x": [td(microseconds=i) for i in range(4)]}),
     )
+
+
+def test_comparison_with_string_raises_9461() -> None:
+    df = pl.DataFrame({"duration": [timedelta(hours=2)]})
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        df.filter(pl.col("duration") > "1h")

--- a/py-polars/tests/unit/interop/test_to_init_repr.py
+++ b/py-polars/tests/unit/interop/test_to_init_repr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import zoneinfo  # noqa: F401
 from datetime import date, datetime, time, timedelta, timezone
 
 import polars as pl
@@ -24,6 +25,11 @@ def test_to_init_repr() -> None:
                         datetime(2023, 10, 12, 20, 3, 8, 11),
                         None,
                     ],
+                    "i": [
+                        datetime(2022, 7, 5, 10, 30, 45, 4560),
+                        datetime(2023, 10, 12, 20, 3, 8, 11),
+                        None,
+                    ],
                     "null": [None, None, None],
                     "enum": ["a", "b", "c"],
                     "duration": [timedelta(days=1), timedelta(days=2), None],
@@ -34,6 +40,7 @@ def test_to_init_repr() -> None:
             .with_columns(
                 pl.col("c").cast(pl.Categorical),
                 pl.col("h").cast(pl.Datetime("ns")),
+                pl.col("i").dt.replace_time_zone("Australia/Melbourne"),
                 pl.col("enum").cast(pl.Enum(["a", "b", "c"])),
             )
             .collect()

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -427,3 +427,17 @@ def test_memmap_ipc_chunked_structs(
     f = tmp_path / "f.ipc"
     c.write_ipc(f)
     assert_frame_equal(c, pl.read_ipc(f))
+
+
+def test_categorical_lexical_sort_2732() -> None:
+    df = pl.DataFrame(
+        {
+            "a": ["foo", "bar", "baz"],
+            "b": [1, 3, 2],
+        },
+        schema_overrides={"a": pl.Categorical("lexical")},
+    )
+    f = io.BytesIO()
+    df.write_ipc(f)
+    f.seek(0)
+    assert_frame_equal(df, pl.read_ipc(f))

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -681,3 +681,12 @@ def test_cast_int_to_string_unsets_sorted_flag_19424() -> None:
     s = pl.Series([1, 2]).set_sorted()
     assert s.flags["SORTED_ASC"]
     assert not s.cast(pl.String).flags["SORTED_ASC"]
+
+
+def test_cast_integer_to_decimal() -> None:
+    s = pl.Series([1, 2, 3])
+    result = s.cast(pl.Decimal(10, 2))
+    expected = pl.Series(
+        "", [Decimal("1.00"), Decimal("2.00"), Decimal("3.00")], pl.Decimal(10, 2)
+    )
+    assert_series_equal(result, expected)

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -271,3 +271,9 @@ def test_unique_enum_19338() -> None:
             {"enum": ["A"]}, schema={"enum": pl.Enum(["A", "B", "C"])}
         )
         assert_frame_equal(result, expected)
+
+
+def test_unique_nan_12950() -> None:
+    df = pl.DataFrame({"x": float("nan")})
+    result = df.unique()
+    assert_frame_equal(result, df)


### PR DESCRIPTION
Tests added for the following open issues that appear to already be fixed:

closes #2732
closes #6968
closes #7737
closes #9461
closes #12950
closes #13759
closes #15014
closes #17006

These open issues also appear to be fixed and already have tests. Just noting the existing tests in order to close these issues:

closes #9383 - `test_rolling_fixed.py::test_rolling_var_stability_12905`
closes #11194 - `test_decimal.py::test_df_constructor_convert_decimal_to_float_9873`
