### PR TITLE
docs: Update source URL for `legislators-historical.csv`

### DIFF
--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -27,7 +27,10 @@ pub struct LazyCsvReader {
 #[cfg(feature = "csv")]
 impl LazyCsvReader {
     /// Re-export to shorten code.
-    fn map_parse_options<F: Fn(CsvParseOptions) -> CsvParseOptions>(mut self, map_func: F) -> Self {
+    pub fn map_parse_options<F: Fn(CsvParseOptions) -> CsvParseOptions>(
+        mut self,
+        map_func: F,
+    ) -> Self {
         self.read_options = self.read_options.map_parse_options(map_func);
         self
     }

--- a/docs/source/src/python/user-guide/expressions/aggregation.py
+++ b/docs/source/src/python/user-guide/expressions/aggregation.py
@@ -1,7 +1,7 @@
 # --8<-- [start:dataframe]
 import polars as pl
 
-url = "https://theunitedstates.io/congress-legislators/legislators-historical.csv"
+url = "hf://datasets/nameexhaustion/polars-docs/legislators-historical.csv"
 
 schema_overrides = {
     "first_name": pl.Categorical,

--- a/docs/source/src/python/user-guide/expressions/aggregation.py
+++ b/docs/source/src/python/user-guide/expressions/aggregation.py
@@ -11,8 +11,10 @@ schema_overrides = {
     "party": pl.Categorical,
 }
 
-dataset = pl.read_csv(url, schema_overrides=schema_overrides).with_columns(
-    pl.col("birthday").str.to_date(strict=False)
+dataset = (
+    pl.read_csv(url, schema_overrides=schema_overrides)
+    .with_columns(pl.col("first", "middle", "last").name.suffix("_name"))
+    .with_columns(pl.col("birthday").str.to_date(strict=False))
 )
 # --8<-- [end:dataframe]
 

--- a/docs/source/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/source/src/rust/user-guide/expressions/aggregation.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     use polars::prelude::*;
     use reqwest::blocking::Client;
 
-    let url = "https://theunitedstates.io/congress-legislators/legislators-historical.csv";
+    let url = "hf://datasets/nameexhaustion/polars-docs/legislators-historical.csv";
 
     let mut schema = Schema::default();
     schema.with_column(

--- a/docs/source/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/source/src/rust/user-guide/expressions/aggregation.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     schema.with_column("birthday".into(), DataType::Date);
 
-    let data: Vec<u8> = Client::new().get(url).send()?.text()?.bytes().collect();
+    let data = Client::new().get(url).send()?.bytes()?;
 
     let dataset = CsvReadOptions::default()
         .with_has_header(true)

--- a/docs/source/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/source/src/rust/user-guide/expressions/aggregation.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     use polars::prelude::*;
     use reqwest::blocking::Client;
 
-    let url = "hf://datasets/nameexhaustion/polars-docs/legislators-historical.csv";
+    let url = "https://huggingface.co/datasets/nameexhaustion/polars-docs/resolve/main/legislators-historical.csv";
 
     let mut schema = Schema::default();
     schema.with_column(
@@ -37,7 +37,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_schema_overwrite(Some(Arc::new(schema)))
         .map_parse_options(|parse_options| parse_options.with_try_parse_dates(true))
         .into_reader_with_file_handle(Cursor::new(data))
-        .finish()?;
+        .finish()?
+        .lazy()
+        .with_columns([
+            col("first").name().suffix("_name"),
+            col("middle").name().suffix("_name"),
+            col("last").name().suffix("_name"),
+        ])
+        .collect()?;
 
     println!("{}", &dataset);
     // --8<-- [end:dataframe]


### PR DESCRIPTION
The original URL at https://theunitedstates.io/congress-legislators/legislators-historical.csv currently returns a 404 and is causing CI to fail.
