### PR TITLE
fix: Fix DuplicateError when selecting columns after `join_where` or cross join + filter

### DIFF
--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -197,10 +197,6 @@ impl ExprIR {
         self.output_name = OutputName::Alias(name)
     }
 
-    pub(crate) fn set_columnlhs(&mut self, name: PlSmallStr) {
-        self.output_name = OutputName::ColumnLhs(name)
-    }
-
     pub fn output_name_inner(&self) -> &OutputName {
         &self.output_name
     }

--- a/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
@@ -77,7 +77,11 @@ fn remove_suffix(
     for expr in exprs {
         if let OutputName::ColumnLhs(colname) = expr.output_name_inner() {
             if colname.ends_with(suffix) && !schema.contains(colname.as_str()) {
-                expr.set_columnlhs(PlSmallStr::from(&colname[..colname.len() - suffix.len()]));
+                let name = PlSmallStr::from(&colname[..colname.len() - suffix.len()]);
+                *expr = ExprIR::new(
+                    expr_arena.add(AExpr::Column(name.clone())),
+                    OutputName::ColumnLhs(name),
+                );
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/20831
* https://github.com/pola-rs/polars/issues/20831

We have had this issue for queries in the form `.join(.., how='cross').filter(..).select(..)` for quite a while (since version 1.8.2).
