### PR TITLE
feat: Implement df.unique() on new-streaming engine

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -210,6 +210,17 @@ impl PartialEq for DataType {
 impl Eq for DataType {}
 
 impl DataType {
+    pub fn new_idxsize() -> Self {
+        #[cfg(feature = "bigidx")]
+        {
+            Self::UInt64
+        }
+        #[cfg(not(feature = "bigidx"))]
+        {
+            Self::UInt32
+        }
+    }
+
     /// Standardize timezones to consistent values.
     pub(crate) fn canonical_timezone(tz: &Option<PlSmallStr>) -> Option<TimeZone> {
         match tz.as_deref() {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -1,26 +1,29 @@
 use std::sync::Arc;
 
-use polars_core::frame::DataFrame;
-use polars_core::prelude::{InitHashMaps, PlHashMap, PlIndexMap};
+use parking_lot::Mutex;
+use polars_core::frame::{DataFrame, UniqueKeepStrategy};
+use polars_core::prelude::{DataType, InitHashMaps, PlHashMap, PlHashSet, PlIndexMap};
 use polars_core::schema::Schema;
 use polars_error::PolarsResult;
+use polars_expr::state::ExecutionState;
 use polars_io::RowIndex;
 use polars_mem_engine::create_physical_plan;
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
-use polars_plan::plans::{AExpr, FileScan, FunctionIR, IR};
-use polars_plan::prelude::{FileType, SinkType};
+use polars_plan::plans::{AExpr, FileScan, FunctionIR, IRAggExpr, LiteralValue, IR};
+use polars_plan::prelude::{FileType, GroupbyOptions, SinkType};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::itertools::Itertools;
 use slotmap::SlotMap;
 
 use super::{PhysNode, PhysNodeKey, PhysNodeKind, PhysStream};
 use crate::physical_plan::lower_expr::{
-    build_select_stream, is_elementwise_rec_cached, lower_exprs, ExprCache,
+    build_select_stream, is_elementwise_rec_cached, lower_exprs, unique_column_name, ExprCache,
 };
 use crate::physical_plan::lower_group_by::build_group_by_stream;
+use crate::utils::late_materialized_df::LateMaterializedDataFrame;
 
 /// Creates a new PhysStream which outputs a slice of the input stream.
-fn build_slice_stream(
+pub fn build_slice_stream(
     input: PhysStream,
     offset: i64,
     length: usize,
@@ -514,7 +517,7 @@ pub fn lower_ir(
             let options = options.clone();
 
             let phys_input = lower_ir!(input)?;
-            let mut stream = build_group_by_stream(
+            return build_group_by_stream(
                 phys_input,
                 &keys,
                 &aggs,
@@ -525,11 +528,7 @@ pub fn lower_ir(
                 expr_arena,
                 phys_sm,
                 expr_cache,
-            )?;
-            if let Some((offset, len)) = options.slice {
-                stream = build_slice_stream(stream, offset, len, phys_sm);
-            }
-            return Ok(stream);
+            );
         },
         IR::Join {
             input_left,
@@ -595,7 +594,145 @@ pub fn lower_ir(
                 }
             }
         },
-        IR::Distinct { .. } => todo!(),
+
+        IR::Distinct { input, options } => {
+            let options = options.clone();
+            let phys_input = lower_ir!(*input)?;
+
+            // We don't have a dedicated distinct operator (yet), lower to group
+            // by with an aggregate for each column.
+            let input_schema = &phys_sm[phys_input.node].output_schema;
+            if input_schema.is_empty() {
+                // Can't group (or have duplicates) if dataframe has zero-width.
+                return Ok(phys_input);
+            }
+
+            if options.maintain_order && options.keep_strategy == UniqueKeepStrategy::Last {
+                // Unfortunately the order-preserving groupby always orders by the first occurrence
+                // of the group so we can't lower this and have to fallback.
+                let input_schema = phys_sm[phys_input.node].output_schema.clone();
+                let lmdf = Arc::new(LateMaterializedDataFrame::default());
+                let mut lp_arena = Arena::default();
+                let input_lp_node = lp_arena.add(lmdf.clone().as_ir_node(input_schema.clone()));
+                let distinct_lp_node = lp_arena.add(IR::Distinct {
+                    input: input_lp_node,
+                    options,
+                });
+                let executor = Mutex::new(create_physical_plan(
+                    distinct_lp_node,
+                    &mut lp_arena,
+                    expr_arena,
+                )?);
+
+                let distinct_node = PhysNode {
+                    output_schema,
+                    kind: PhysNodeKind::InMemoryMap {
+                        input: phys_input,
+                        map: Arc::new(move |df| {
+                            lmdf.set_materialized_dataframe(df);
+                            let mut state = ExecutionState::new();
+                            executor.lock().execute(&mut state)
+                        }),
+                    },
+                };
+
+                return Ok(PhysStream::first(phys_sm.insert(distinct_node)));
+            }
+
+            // Create the key and aggregate expressions.
+            let all_col_names = input_schema.iter_names().cloned().collect_vec();
+            let key_names = if let Some(subset) = options.subset {
+                subset.to_vec()
+            } else {
+                all_col_names.clone()
+            };
+            let key_name_set: PlHashSet<_> = key_names.iter().cloned().collect();
+
+            let mut group_by_output_schema = Schema::with_capacity(all_col_names.len() + 1);
+            let keys = key_names
+                .iter()
+                .map(|name| {
+                    group_by_output_schema
+                        .insert(name.clone(), input_schema.get(name).unwrap().clone());
+                    let col_expr = expr_arena.add(AExpr::Column(name.clone()));
+                    ExprIR::new(col_expr, OutputName::ColumnLhs(name.clone()))
+                })
+                .collect_vec();
+
+            let mut aggs = all_col_names
+                .iter()
+                .filter(|name| !key_name_set.contains(*name))
+                .map(|name| {
+                    group_by_output_schema
+                        .insert(name.clone(), input_schema.get(name).unwrap().clone());
+                    let col_expr = expr_arena.add(AExpr::Column(name.clone()));
+                    use UniqueKeepStrategy::*;
+                    let agg_expr = match options.keep_strategy {
+                        First | None | Any => {
+                            expr_arena.add(AExpr::Agg(IRAggExpr::First(col_expr)))
+                        },
+                        Last => expr_arena.add(AExpr::Agg(IRAggExpr::Last(col_expr))),
+                    };
+                    ExprIR::new(agg_expr, OutputName::ColumnLhs(name.clone()))
+                })
+                .collect_vec();
+
+            if options.keep_strategy == UniqueKeepStrategy::None {
+                // Track the length so we can filter out non-unique keys later.
+                let name = unique_column_name();
+                group_by_output_schema.insert(name.clone(), DataType::new_idxsize());
+                aggs.push(ExprIR::new(
+                    expr_arena.add(AExpr::Len),
+                    OutputName::Alias(name),
+                ));
+            }
+
+            let mut stream = build_group_by_stream(
+                phys_input,
+                &keys,
+                &aggs,
+                Arc::new(group_by_output_schema),
+                options.maintain_order,
+                Arc::new(GroupbyOptions::default()),
+                None,
+                expr_arena,
+                phys_sm,
+                expr_cache,
+            )?;
+
+            if options.keep_strategy == UniqueKeepStrategy::None {
+                // Filter to keep only those groups with length 1.
+                let unique_name = aggs.last().unwrap().output_name();
+                let left = expr_arena.add(AExpr::Column(unique_name.clone()));
+                let right = expr_arena.add(AExpr::Literal(LiteralValue::new_idxsize(1)));
+                let predicate_aexpr = expr_arena.add(AExpr::BinaryExpr {
+                    left,
+                    op: polars_plan::dsl::Operator::Eq,
+                    right,
+                });
+                let predicate =
+                    ExprIR::new(predicate_aexpr, OutputName::ColumnLhs(unique_name.clone()));
+                stream = build_filter_stream(stream, predicate, expr_arena, phys_sm, expr_cache)?;
+            }
+
+            // Restore column order and drop the temporary length column if any.
+            let exprs = all_col_names
+                .iter()
+                .map(|name| {
+                    let col_expr = expr_arena.add(AExpr::Column(name.clone()));
+                    ExprIR::new(col_expr, OutputName::ColumnLhs(name.clone()))
+                })
+                .collect_vec();
+            stream = build_select_stream(stream, &exprs, expr_arena, phys_sm, expr_cache)?;
+
+            // We didn't pass the slice earlier to build_group_by_stream because
+            // we might have the intermediate keep = "none" filter.
+            if let Some((offset, length)) = options.slice {
+                stream = build_slice_stream(stream, offset, length, phys_sm);
+            }
+
+            return Ok(stream);
+        },
         IR::ExtContext { .. } => todo!(),
         IR::Invalid => unreachable!(),
     };

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1015,9 +1015,12 @@ def test_join_lit_panic_11410() -> None:
     dates = df.select("date").unique(maintain_order=True)
     symbols = df.select("symbol").unique(maintain_order=True)
 
-    assert symbols.join(dates, left_on=pl.lit(1), right_on=pl.lit(1)).collect().to_dict(
-        as_series=False
-    ) == {"symbol": [4, 4, 4, 5, 5, 5, 6, 6, 6], "date": [1, 2, 3, 1, 2, 3, 1, 2, 3]}
+    assert symbols.join(
+        dates, left_on=pl.lit(1), right_on=pl.lit(1), maintain_order="left_right"
+    ).collect().to_dict(as_series=False) == {
+        "symbol": [4, 4, 4, 5, 5, 5, 6, 6, 6],
+        "date": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+    }
 
 
 def test_join_empty_literal_17027() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming_unique.py
+++ b/py-polars/tests/unit/streaming/test_streaming_unique.py
@@ -39,6 +39,7 @@ def test_streaming_out_of_core_unique(
     # assert "OOC group_by started" in err
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_streaming_unique(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     df = pl.DataFrame({"a": [1, 2, 2, 2], "b": [3, 4, 4, 4], "c": [5, 6, 7, 7]})


### PR DESCRIPTION
This isn't the most efficient implementation possible, but it already avoids a complete fallback to the eager engine in a lot of cases. At some point we should make a proper streaming distinct node though.