### PR TITLE
refactor(rust): Simplify decimal formatting and remove itoap dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,12 +2155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "itoap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9028f49264629065d057f340a86acb84867925865f73bbf8d47b4d149a7e88b8"
-
-[[package]]
 name = "jemalloc-sys"
 version = "0.5.4+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,7 +2959,6 @@ dependencies = [
  "hex",
  "indexmap",
  "itoa",
- "itoap",
  "lz4",
  "num-traits",
  "parking_lot",
@@ -3014,7 +3007,6 @@ dependencies = [
  "either",
  "fast-float2",
  "itoa",
- "itoap",
  "num-traits",
  "polars-arrow",
  "polars-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ hashbrown_old_nightly_hack = { package = "hashbrown", version = "0.14.5", featur
 hex = "0.4.3"
 indexmap = { version = "2", features = ["std", "serde"] }
 itoa = "1.0.6"
-itoap = { version = "1", features = ["simd"] }
 libc = "0.2"
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.9" }

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -35,7 +35,6 @@ ethnum = { workspace = true }
 atoi_simd = { workspace = true, optional = true }
 fast-float2 = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }
-itoap = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
 
 regex = { workspace = true, optional = true }
@@ -144,7 +143,7 @@ timezones = [
   "chrono-tz",
 ]
 dtype-array = []
-dtype-decimal = ["atoi", "itoap"]
+dtype-decimal = ["atoi", "itoa"]
 bigidx = ["polars-utils/bigidx"]
 nightly = []
 performant = []

--- a/crates/polars-arrow/src/compute/decimal.rs
+++ b/crates/polars-arrow/src/compute/decimal.rs
@@ -134,7 +134,7 @@ impl DecimalFmtBuffer {
             len: 0,
         }
     }
-    
+
     pub fn format(&mut self, x: i128, scale: usize, trim_zeros: bool) -> &str {
         let factor = POW10[scale];
         let mut itoa_buf = itoa::Buffer::new();
@@ -145,7 +145,7 @@ impl DecimalFmtBuffer {
             self.data[0] = b'-';
             self.len += 1;
         }
-        
+
         let div_fmt = itoa_buf.format(div);
         self.data[self.len..self.len + div_fmt.len()].copy_from_slice(div_fmt.as_bytes());
         self.len += div_fmt.len();
@@ -153,7 +153,7 @@ impl DecimalFmtBuffer {
         if scale == 0 {
             return unsafe { std::str::from_utf8_unchecked(&self.data[..self.len]) };
         }
-        
+
         self.data[self.len] = b'.';
         self.len += 1;
 
@@ -215,7 +215,6 @@ const POW10: [u128; 39] = [
     10000000000000000000000000000000000000,
     100000000000000000000000000000000000000,
 ];
-
 
 #[cfg(test)]
 mod test {

--- a/crates/polars-compute/Cargo.toml
+++ b/crates/polars-compute/Cargo.toml
@@ -16,7 +16,6 @@ chrono = { workspace = true, optional = true }
 either = { workspace = true }
 fast-float2 = { workspace = true, optional = true }
 itoa = { workspace = true, optional = true }
-itoap = { workspace = true, optional = true }
 num-traits = { workspace = true }
 polars-error = { workspace = true }
 polars-utils = { workspace = true }
@@ -37,7 +36,6 @@ cast = [
   "dep:chrono",
   "dep:fast-float2",
   "dep:itoa",
-  "dep:itoap",
   "dep:ryu",
 ]
 gather = []

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -1293,11 +1293,9 @@ impl Series {
 #[inline]
 #[cfg(feature = "dtype-decimal")]
 fn fmt_decimal(f: &mut Formatter<'_>, v: i128, scale: usize) -> fmt::Result {
-    use arrow::compute::decimal::format_decimal;
-
+    let mut fmt_buf = arrow::compute::decimal::DecimalFmtBuffer::new();
     let trim_zeros = get_trim_decimal_zeros();
-    let repr = format_decimal(v, scale, trim_zeros);
-    f.write_str(fmt_float_string(repr.as_str()).as_str())
+    f.write_str(fmt_float_string(fmt_buf.format(v, scale, trim_zeros)).as_str())
 }
 
 #[cfg(all(

--- a/crates/polars-io/src/csv/write/write_impl/serializer.rs
+++ b/crates/polars-io/src/csv/write/write_impl/serializer.rs
@@ -242,9 +242,9 @@ fn bool_serializer<const QUOTE_NON_NULL: bool>(array: &BooleanArray) -> impl Ser
 fn decimal_serializer(array: &PrimitiveArray<i128>, scale: usize) -> impl Serializer {
     let trim_zeros = arrow::compute::decimal::get_trim_decimal_zeros();
 
+    let mut fmt_buf = arrow::compute::decimal::DecimalFmtBuffer::new();
     let f = move |&item, buf: &mut Vec<u8>, _options: &SerializeOptions| {
-        let value = arrow::compute::decimal::format_decimal(item, scale, trim_zeros);
-        buf.extend_from_slice(value.as_str().as_bytes());
+        buf.extend_from_slice(fmt_buf.format(item, scale, trim_zeros).as_bytes());
     };
 
     make_serializer::<_, _, false>(f, array.iter(), |array| {

--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use arrow::array::*;
 use arrow::bitmap::utils::ZipValidity;
 #[cfg(feature = "dtype-decimal")]
-use arrow::compute::decimal::{format_decimal, get_trim_decimal_zeros};
+use arrow::compute::decimal::get_trim_decimal_zeros;
 use arrow::datatypes::{ArrowDataType, IntegerType, TimeUnit};
 use arrow::io::iterator::BufStreamingIterator;
 use arrow::offset::Offset;
@@ -122,9 +122,10 @@ fn decimal_serializer<'a>(
     take: usize,
 ) -> Box<dyn StreamingIterator<Item = [u8]> + 'a + Send + Sync> {
     let trim_zeros = get_trim_decimal_zeros();
+    let mut fmt_buf = arrow::compute::decimal::DecimalFmtBuffer::new();
     let f = move |x: Option<&i128>, buf: &mut Vec<u8>| {
         if let Some(x) = x {
-            utf8::write_str(buf, format_decimal(*x, scale, trim_zeros).as_str()).unwrap()
+            utf8::write_str(buf, fmt_buf.format(*x, scale, trim_zeros)).unwrap()
         } else {
             buf.extend(b"null")
         }


### PR DESCRIPTION
Possibly a bit slower but I doubt it's much different or it forming a bottleneck. Can always optimize it more later.