### PR TITLE
fix: Incorrect scale used in `log` and `exp` for Decimal type

### DIFF
--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -18,7 +18,12 @@ fn exp<T: PolarsNumericType>(ca: &ChunkedArray<T>) -> Float64Chunked {
 pub trait LogSeries: SeriesSealed {
     /// Compute the logarithm to a given base
     fn log(&self, base: f64) -> Series {
-        let s = self.as_series().to_physical_repr();
+        let s = self.as_series();
+        if s.dtype().is_decimal() {
+            return s.cast(&DataType::Float64).unwrap().log(base);
+        }
+
+        let s = s.to_physical_repr();
         let s = s.as_ref();
 
         use DataType::*;
@@ -41,7 +46,12 @@ pub trait LogSeries: SeriesSealed {
 
     /// Compute the natural logarithm of all elements plus one in the input array
     fn log1p(&self) -> Series {
-        let s = self.as_series().to_physical_repr();
+        let s = self.as_series();
+        if s.dtype().is_decimal() {
+            return s.cast(&DataType::Float64).unwrap().log1p();
+        }
+
+        let s = s.to_physical_repr();
         let s = s.as_ref();
 
         use DataType::*;
@@ -60,7 +70,12 @@ pub trait LogSeries: SeriesSealed {
 
     /// Calculate the exponential of all elements in the input array.
     fn exp(&self) -> Series {
-        let s = self.as_series().to_physical_repr();
+        let s = self.as_series();
+        if s.dtype().is_decimal() {
+            return s.cast(&DataType::Float64).unwrap().exp();
+        }
+
+        let s = s.to_physical_repr();
         let s = s.as_ref();
 
         use DataType::*;

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1627,18 +1627,26 @@ def test_nested_list_types_preserved(dtype: pl.DataType) -> None:
         assert srs_nested.dtype == dtype
 
 
-def test_log_exp() -> None:
-    a = pl.Series("a", [1, 100, 1000])
-    b = pl.Series("a", [0.0, 2.0, 3.0])
-    assert_series_equal(a.log10(), b)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.Float64,
+        pl.Int32,
+        pl.Decimal(21, 3),
+    ],
+)
+def test_log_exp(dtype: pl.DataType) -> None:
+    a = pl.Series("a", [1, 100, 1000], dtype=dtype)
+    b = pl.Series("a", [0, 2, 3], dtype=dtype)
+    assert_series_equal(a.log10(), b.cast(pl.Float64))
 
-    expected = pl.Series("a", np.log(a.to_numpy()))
+    expected = pl.Series("a", np.log(a.cast(pl.Float64).to_numpy()))
     assert_series_equal(a.log(), expected)
 
-    expected = pl.Series("a", np.exp(b.to_numpy()))
+    expected = pl.Series("a", np.exp(b.cast(pl.Float64).to_numpy()))
     assert_series_equal(b.exp(), expected)
 
-    expected = pl.Series("a", np.log1p(a.to_numpy()))
+    expected = pl.Series("a", np.log1p(a.cast(pl.Float64).to_numpy()))
     assert_series_equal(a.log1p(), expected)
 
 


### PR DESCRIPTION
```python
from decimal import Decimal as D
import polars as pl

df = pl.Series("a", [D("1.0")]).to_frame()

df.with_columns(
    pl.col("a").log().alias("a_log"),
    pl.col("a").exp().alias("a_exp"),
)
```

BEFORE:
```
┌──────────────┬──────────┬──────────────┐
│ a            ┆ a_log    ┆ a_exp        │
│ ---          ┆ ---      ┆ ---          │
│ decimal[*,1] ┆ f64      ┆ f64          │
╞══════════════╪══════════╪══════════════╡
│ 1.0          ┆ 2.302585 ┆ 22026.465795 │
└──────────────┴──────────┴──────────────┘
```

AFTER: 
```
┌──────────────┬───────┬──────────┐
│ a            ┆ a_log ┆ a_exp    │
│ ---          ┆ ---   ┆ ---      │
│ decimal[*,1] ┆ f64   ┆ f64      │
╞══════════════╪═══════╪══════════╡
│ 1.0          ┆ 0.0   ┆ 2.718282 │
└──────────────┴───────┴──────────┘
```