### PR TITLE
refactor(rust): Reduce bloat in static_array_collect by using BitmapBuilders

### DIFF
--- a/crates/polars-arrow/src/legacy/trusted_len/push_unchecked.rs
+++ b/crates/polars-arrow/src/legacy/trusted_len/push_unchecked.rs
@@ -60,7 +60,7 @@ pub trait TrustedLenPush<T> {
 }
 
 impl<T> TrustedLenPush<T> for Vec<T> {
-    #[inline]
+    #[inline(always)]
     unsafe fn push_unchecked(&mut self, value: T) {
         debug_assert!(self.capacity() > self.len());
         let end = self.as_mut_ptr().add(self.len());


### PR DESCRIPTION
In some cases this might be a bit slower but I don't think the heavy unrolling and macro inlining of the previous implementation was justified to use in such a general and often used method.