### PR TITLE
refactor: Move Parquet deserialization to `BitmapBuilder`

### DIFF
--- a/crates/polars-arrow/src/bitmap/builder.rs
+++ b/crates/polars-arrow/src/bitmap/builder.rs
@@ -1,5 +1,6 @@
 use polars_utils::slice::load_padded_le_u64;
 
+use super::bitmask::BitMask;
 use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::storage::SharedStorage;
 use crate::trusted_len::TrustedLen;
@@ -234,6 +235,11 @@ impl BitmapBuilder {
         // TODO: we can perhaps use the bitmaps bitcount here instead of
         // recomputing it if it has a known bitcount.
         let (slice, offset, length) = bitmap.as_slice();
+        self.extend_from_slice(slice, offset, length);
+    }
+
+    pub fn extend_from_bitmask(&mut self, bitmap: BitMask<'_>) {
+        let (slice, offset, length) = bitmap.inner();
         self.extend_from_slice(slice, offset, length);
     }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/categorical.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/categorical.rs
@@ -1,5 +1,5 @@
 use arrow::array::{DictionaryArray, MutableBinaryViewArray, PrimitiveArray};
-use arrow::bitmap::{Bitmap, MutableBitmap};
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::datatypes::ArrowDataType;
 use arrow::types::{AlignedBytes, NativeType};
 
@@ -56,13 +56,13 @@ impl CategoricalDecoder {
 impl utils::Decoder for CategoricalDecoder {
     type Translation<'a> = HybridRleDecoder<'a>;
     type Dict = <BinViewDecoder as utils::Decoder>::Dict;
-    type DecodedState = (Vec<u32>, MutableBitmap);
+    type DecodedState = (Vec<u32>, BitmapBuilder);
     type Output = DictionaryArray<u32>;
 
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState {
         (
             Vec::<u32>::with_capacity(capacity),
-            MutableBitmap::with_capacity(capacity),
+            BitmapBuilder::with_capacity(capacity),
         )
     }
 
@@ -131,7 +131,7 @@ impl utils::Decoder for CategoricalDecoder {
         &mut self,
         state: utils::State<'_, Self>,
         decoded: &mut Self::DecodedState,
-        pred_true_mask: &mut MutableBitmap,
+        pred_true_mask: &mut BitmapBuilder,
         filter: Option<super::Filter>,
     ) -> ParquetResult<()> {
         super::dictionary_encoded::decode_dict_dispatch(

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/mod.rs
@@ -1,5 +1,5 @@
 use arrow::bitmap::bitmask::BitMask;
-use arrow::bitmap::{Bitmap, MutableBitmap};
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::types::{AlignedBytes, Bytes4Alignment4, NativeType};
 use polars_compute::filter::filter_boolean_kernel;
 
@@ -64,9 +64,9 @@ pub fn decode_dict<T: NativeType>(
     is_optional: bool,
     page_validity: Option<&Bitmap>,
     filter: Option<Filter>,
-    validity: &mut MutableBitmap,
+    validity: &mut BitmapBuilder,
     target: &mut Vec<T>,
-    pred_true_mask: &mut MutableBitmap,
+    pred_true_mask: &mut BitmapBuilder,
 ) -> ParquetResult<()> {
     decode_dict_dispatch(
         values,
@@ -90,9 +90,9 @@ pub fn decode_dict_dispatch<B: AlignedBytes, D: IndexMapping<Output = B>>(
     is_optional: bool,
     page_validity: Option<&Bitmap>,
     filter: Option<Filter>,
-    validity: &mut MutableBitmap,
+    validity: &mut BitmapBuilder,
     target: &mut Vec<B>,
-    pred_true_mask: &mut MutableBitmap,
+    pred_true_mask: &mut BitmapBuilder,
 ) -> ParquetResult<()> {
     if is_optional {
         append_validity(page_validity, filter.as_ref(), validity, values.len());
@@ -128,7 +128,7 @@ pub fn decode_dict_dispatch<B: AlignedBytes, D: IndexMapping<Output = B>>(
 pub(crate) fn append_validity(
     page_validity: Option<&Bitmap>,
     filter: Option<&Filter>,
-    validity: &mut MutableBitmap,
+    validity: &mut BitmapBuilder,
     values_len: usize,
 ) {
     match (page_validity, filter) {

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/predicate.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/predicate.rs
@@ -1,5 +1,4 @@
-use arrow::bitmap::bitmask::BitMask;
-use arrow::bitmap::{Bitmap, MutableBitmap};
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::types::AlignedBytes;
 
 use super::{oob_dict_idx, verify_dict_indices, verify_dict_indices_slice, IndexMapping};
@@ -14,7 +13,7 @@ pub fn decode<B: AlignedBytes, D: IndexMapping<Output = B>>(
     dict_mask: &Bitmap,
     predicate: &PredicateFilter,
     target: &mut Vec<B>,
-    pred_true_mask: &mut MutableBitmap,
+    pred_true_mask: &mut BitmapBuilder,
 ) -> ParquetResult<()> {
     let num_filtered_dict_values = dict_mask.set_bits();
 
@@ -25,17 +24,12 @@ pub fn decode<B: AlignedBytes, D: IndexMapping<Output = B>>(
         pred_true_mask.extend_constant(values.len(), false);
     } else if num_filtered_dict_values == 1 {
         let needle = dict_mask.leading_zeros();
-        let start_mask_length = pred_true_mask.len();
+        let start_num_values = pred_true_mask.set_bits();
 
         decode_single_no_values(values, needle as u32, pred_true_mask)?;
 
         if predicate.include_values {
-            let num_values = BitMask::new(
-                pred_true_mask.as_slice(),
-                start_mask_length,
-                pred_true_mask.len() - start_mask_length,
-            )
-            .set_bits();
+            let num_values = pred_true_mask.set_bits() - start_num_values;
             target.resize(target.len() + num_values, dict.get(needle as u32).unwrap());
         }
     } else if predicate.include_values {
@@ -53,7 +47,7 @@ pub fn decode<B: AlignedBytes, D: IndexMapping<Output = B>>(
 pub fn decode_single_no_values(
     mut values: HybridRleDecoder<'_>,
     needle: u32,
-    pred_true_mask: &mut MutableBitmap,
+    pred_true_mask: &mut BitmapBuilder,
 ) -> ParquetResult<()> {
     pred_true_mask.reserve(values.len());
 
@@ -71,21 +65,25 @@ pub fn decode_single_no_values(
                     let n = chunked.next_into(&mut unpacked).unwrap();
                     debug_assert_eq!(n, 32);
 
-                    unsafe {
-                        pred_true_mask.extend_from_trusted_len_iter_unchecked(
-                            unpacked.iter().map(|&v| v == needle),
-                        )
-                    };
+                    let mut is_equal_mask = 0u64;
+                    for (i, &v) in unpacked.iter().enumerate() {
+                        is_equal_mask |= u64::from(v == needle) << i;
+                    }
+
+                    // SAFETY: We reserved enough in the beginning of the function.
+                    unsafe { pred_true_mask.push_word_with_len_unchecked(is_equal_mask, 32) };
                 }
 
                 if let Some(n) = chunked.next_into(&mut unpacked) {
                     debug_assert_eq!(n, size % 32);
 
-                    unsafe {
-                        pred_true_mask.extend_from_trusted_len_iter_unchecked(
-                            unpacked.get_unchecked(..n).iter().map(|&v| v == needle),
-                        )
-                    };
+                    let mut is_equal_mask = 0u64;
+                    for (i, &v) in unpacked.iter().enumerate() {
+                        is_equal_mask |= u64::from(v == needle) << i;
+                    }
+
+                    // SAFETY: We reserved enough in the beginning of the function.
+                    unsafe { pred_true_mask.push_word_with_len_unchecked(is_equal_mask, n) };
                 }
             },
         }
@@ -98,7 +96,7 @@ pub fn decode_single_no_values(
 pub fn decode_multiple_no_values(
     mut values: HybridRleDecoder<'_>,
     dict_mask: &Bitmap,
-    pred_true_mask: &mut MutableBitmap,
+    pred_true_mask: &mut BitmapBuilder,
 ) -> ParquetResult<()> {
     pred_true_mask.reserve(values.len());
 
@@ -110,31 +108,39 @@ pub fn decode_multiple_no_values(
                 pred_true_mask.extend_constant(size, is_pred_true);
             },
             HybridRleChunk::Bitpacked(mut decoder) => {
+                let size = decoder.len();
                 let mut chunked = decoder.chunked();
 
-                let mut n = 0;
-                while let Some(num) = chunked.next_into(&mut unpacked) {
-                    n = num;
-                    if n < 32 {
-                        break;
-                    }
+                for _ in 0..size / 32 {
+                    let n = chunked.next_into(&mut unpacked).unwrap();
+                    debug_assert_eq!(n, 32);
 
                     verify_dict_indices(&unpacked, dict_mask.len())?;
-                    pred_true_mask.extend(
-                        unpacked
-                            .iter()
-                            // SAFETY: We just verified the dictionary indices
-                            .map(|&v| unsafe { dict_mask.get_bit_unchecked(v as usize) }),
-                    );
+                    let mut is_pred_true_mask = 0u64;
+                    for (i, &v) in unpacked.iter().enumerate() {
+                        // SAFETY: We just verified the dictionary indices
+                        let is_pred_true = unsafe { dict_mask.get_bit_unchecked(v as usize) };
+                        is_pred_true_mask |= u64::from(is_pred_true) << i;
+                    }
+
+                    // SAFETY: We reserved enough in the beginning of the function.
+                    unsafe { pred_true_mask.push_word_with_len_unchecked(is_pred_true_mask, 32) };
                 }
 
-                verify_dict_indices_slice(&unpacked[..n], dict_mask.len())?;
-                pred_true_mask.extend(
-                    unpacked[..n]
-                        .iter()
+                if let Some(n) = chunked.next_into(&mut unpacked) {
+                    debug_assert_eq!(n, size % 32);
+
+                    verify_dict_indices_slice(&unpacked[..n], dict_mask.len())?;
+                    let mut is_pred_true_mask = 0u64;
+                    for (i, &v) in unpacked[..n].iter().enumerate() {
                         // SAFETY: We just verified the dictionary indices
-                        .map(|&v| unsafe { dict_mask.get_bit_unchecked(v as usize) }),
-                );
+                        let is_pred_true = unsafe { dict_mask.get_bit_unchecked(v as usize) };
+                        is_pred_true_mask |= u64::from(is_pred_true) << i;
+                    }
+
+                    // SAFETY: We reserved enough in the beginning of the function.
+                    unsafe { pred_true_mask.push_word_with_len_unchecked(is_pred_true_mask, n) };
+                }
             },
         }
     }
@@ -148,7 +154,7 @@ pub fn decode_multiple_values<B: AlignedBytes, D: IndexMapping<Output = B>>(
     dict: D,
     dict_mask: &Bitmap,
     target: &mut Vec<B>,
-    pred_true_mask: &mut MutableBitmap,
+    pred_true_mask: &mut BitmapBuilder,
 ) -> ParquetResult<()> {
     pred_true_mask.reserve(values.len());
     target.reserve(values.len());
@@ -177,26 +183,25 @@ pub fn decode_multiple_values<B: AlignedBytes, D: IndexMapping<Output = B>>(
                     debug_assert_eq!(n, 32);
 
                     verify_dict_indices(&unpacked, dict_mask.len())?;
-                    let mut count = 0;
-                    pred_true_mask.extend(
-                        unpacked
-                            .iter()
-                            // SAFETY: We just verified the dictionary indices
-                            .map(|&v| {
-                                let select = unsafe { dict_mask.get_bit_unchecked(v as usize) };
-                                count += usize::from(select);
-                                select
-                            }),
-                    );
+                    let mut is_pred_true_mask = 0u64;
+                    for (i, &v) in unpacked.iter().enumerate() {
+                        // SAFETY: We just verified the dictionary indices
+                        let is_pred_true = unsafe { dict_mask.get_bit_unchecked(v as usize) };
+                        is_pred_true_mask |= u64::from(is_pred_true) << i;
+                    }
+                    // SAFETY: We reserved enough in the beginning of the function.
+                    unsafe { pred_true_mask.push_word_with_len_unchecked(is_pred_true_mask, 32) };
 
-                    if count == 32 {
+                    let num_pred_true_values = is_pred_true_mask.count_ones() as usize;
+
+                    if num_pred_true_values == 32 {
                         target.extend(
                             unpacked
                                 .iter()
                                 // SAFETY: We just verified the dictionary indices
                                 .map(|&v| unsafe { dict.get_unchecked(v) }),
                         );
-                    } else if count > 0 {
+                    } else if num_pred_true_values > 0 {
                         let mut write_ptr = unsafe { target.as_mut_ptr().add(target.len()) };
                         for v in unpacked {
                             unsafe {
@@ -206,7 +211,7 @@ pub fn decode_multiple_values<B: AlignedBytes, D: IndexMapping<Output = B>>(
                             }
                         }
 
-                        let new_len = target.len() + count;
+                        let new_len = target.len() + num_pred_true_values;
                         unsafe { target.set_len(new_len) };
                     }
                 }
@@ -215,26 +220,25 @@ pub fn decode_multiple_values<B: AlignedBytes, D: IndexMapping<Output = B>>(
                     debug_assert_eq!(n, size % 32);
 
                     verify_dict_indices_slice(&unpacked[..n], dict_mask.len())?;
-                    let mut count = 0;
-                    pred_true_mask.extend(
-                        unpacked[..n]
-                            .iter()
-                            // SAFETY: We just verified the dictionary indices
-                            .map(|&v| {
-                                let select = unsafe { dict_mask.get_bit_unchecked(v as usize) };
-                                count += usize::from(select);
-                                select
-                            }),
-                    );
+                    let mut is_pred_true_mask = 0u64;
+                    for (i, &v) in unpacked[..n].iter().enumerate() {
+                        // SAFETY: We just verified the dictionary indices
+                        let is_pred_true = unsafe { dict_mask.get_bit_unchecked(v as usize) };
+                        is_pred_true_mask |= u64::from(is_pred_true) << i;
+                    }
+                    // SAFETY: We reserved enough in the beginning of the function.
+                    unsafe { pred_true_mask.push_word_with_len_unchecked(is_pred_true_mask, n) };
 
-                    if count == n {
+                    let num_pred_true_values = is_pred_true_mask.count_ones() as usize;
+
+                    if num_pred_true_values == n {
                         target.extend(
                             unpacked[..n]
                                 .iter()
                                 // SAFETY: We just verified the dictionary indices
                                 .map(|&v| unsafe { dict.get_unchecked(v) }),
                         );
-                    } else if count > 0 {
+                    } else if num_pred_true_values > 0 {
                         let mut write_ptr = unsafe { target.as_mut_ptr().add(target.len()) };
                         for &v in &unpacked[..n] {
                             unsafe {
@@ -244,7 +248,7 @@ pub fn decode_multiple_values<B: AlignedBytes, D: IndexMapping<Output = B>>(
                             }
                         }
 
-                        let new_len = target.len() + count;
+                        let new_len = target.len() + num_pred_true_values;
                         unsafe { target.set_len(new_len) };
                     }
                 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/null.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null.rs
@@ -3,7 +3,7 @@
 //! `DecodedState`.
 
 use arrow::array::NullArray;
-use arrow::bitmap::{Bitmap, MutableBitmap};
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::datatypes::ArrowDataType;
 
 use super::utils::filter::Filter;
@@ -98,7 +98,7 @@ impl utils::Decoder for NullDecoder {
         &mut self,
         state: utils::State<'_, Self>,
         decoded: &mut Self::DecodedState,
-        _pred_true_mask: &mut MutableBitmap,
+        _pred_true_mask: &mut BitmapBuilder,
         filter: Option<Filter>,
     ) -> ParquetResult<()> {
         if matches!(filter, Some(Filter::Predicate(_))) {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/float.rs
@@ -1,5 +1,5 @@
 use arrow::array::PrimitiveArray;
-use arrow::bitmap::{Bitmap, MutableBitmap};
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl<T: NativeType> utils::Decoded for (Vec<T>, MutableBitmap) {
+impl<T: NativeType> utils::Decoded for (Vec<T>, BitmapBuilder) {
     fn len(&self) -> usize {
         self.0.len()
     }
@@ -124,13 +124,13 @@ where
 {
     type Translation<'a> = StateTranslation<'a>;
     type Dict = PrimitiveArray<T>;
-    type DecodedState = (Vec<T>, MutableBitmap);
+    type DecodedState = (Vec<T>, BitmapBuilder);
     type Output = PrimitiveArray<T>;
 
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState {
         (
             Vec::<T>::with_capacity(capacity),
-            MutableBitmap::with_capacity(capacity),
+            BitmapBuilder::with_capacity(capacity),
         )
     }
 
@@ -143,10 +143,10 @@ where
             false,
             None,
             None,
-            &mut MutableBitmap::new(),
+            &mut BitmapBuilder::new(),
             &mut self.0.intermediate,
             &mut target,
-            &mut MutableBitmap::new(),
+            &mut BitmapBuilder::new(),
             self.0.decoder,
         )?;
         Ok(PrimitiveArray::new(
@@ -198,7 +198,7 @@ where
         &mut self,
         mut state: utils::State<'_, Self>,
         decoded: &mut Self::DecodedState,
-        pred_true_mask: &mut MutableBitmap,
+        pred_true_mask: &mut BitmapBuilder,
         filter: Option<Filter>,
     ) -> ParquetResult<()> {
         match state.translation {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -1,5 +1,5 @@
 use arrow::array::PrimitiveArray;
-use arrow::bitmap::{Bitmap, MutableBitmap};
+use arrow::bitmap::{Bitmap, BitmapBuilder};
 use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 
@@ -156,13 +156,13 @@ where
 {
     type Translation<'a> = StateTranslation<'a>;
     type Dict = PrimitiveArray<T>;
-    type DecodedState = (Vec<T>, MutableBitmap);
+    type DecodedState = (Vec<T>, BitmapBuilder);
     type Output = PrimitiveArray<T>;
 
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState {
         (
             Vec::<T>::with_capacity(capacity),
-            MutableBitmap::with_capacity(capacity),
+            BitmapBuilder::with_capacity(capacity),
         )
     }
 
@@ -175,10 +175,10 @@ where
             false,
             None,
             None,
-            &mut MutableBitmap::new(),
+            &mut BitmapBuilder::new(),
             &mut self.0.intermediate,
             &mut target,
-            &mut MutableBitmap::new(),
+            &mut BitmapBuilder::new(),
             self.0.decoder,
         )?;
         Ok(PrimitiveArray::new(
@@ -240,7 +240,7 @@ where
         &mut self,
         mut state: utils::State<'_, Self>,
         decoded: &mut Self::DecodedState,
-        pred_true_mask: &mut MutableBitmap,
+        pred_true_mask: &mut BitmapBuilder,
         filter: Option<Filter>,
     ) -> ParquetResult<()> {
         match state.translation {


### PR DESCRIPTION
follow up for #20714.