### PR TITLE
fix(python): Throw exception if dataframe is too large to be compatible with Excel

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3514,7 +3514,7 @@ class DataFrame:
             table_finish[0] > excel_max_valid_rows
             or table_finish[1] > excel_max_valid_cols
         ):
-            msg = "Dataframe too large to be compatible with Excel. Exceeds Excel limit of 1048575 rows and/or 16384 columns of data."
+            msg = f"writing {df.height}x{df.width} frame at {position!r} does not fit worksheet dimensions of {excel_max_valid_rows} rows and {excel_max_valid_cols} columns"
             raise InvalidOperationError(msg)
 
         # write table structure and formats into the target sheet

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3507,23 +3507,25 @@ class DataFrame:
             table_start[1] + len(df.columns) - 1,
         )
 
-        # verify that the number of rows and columns, after accounting for an offset and a header row, is within the maximum for Excel
+        # verify the number of rows and columns,
+        # after accounting for an offset and a header row
+        # is within the maximum for Excel
         excel_max_valid_rows = 1048575
         excel_max_valid_cols = 16384
-        
+
         initial_row_offset = 0
         initial_col_offset = 0
-        
+
         # it is just a numerical offset given in the form of a tuple
         if isinstance(position, tuple):
             initial_row_offset, initial_col_offset = position
-        
+
         total_rows = self.height + initial_row_offset
         if include_header:
             total_rows += 1
-            
+
         total_cols = self.width + initial_col_offset
-        
+
         if total_rows > excel_max_valid_rows or total_cols > excel_max_valid_cols:
             msg = "Dataframe too large to be compatible with Excel. Exceeded Excel limit of 1048575 rows and/or 16384 columns of data."
             raise InvalidOperationError(msg)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -97,8 +97,8 @@ from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import (
-    InvalidOperationError,
     ColumnNotFoundError,
+    InvalidOperationError,
     ModuleUpgradeRequiredError,
     NoRowsReturnedError,
     TooManyRowsReturnedError,
@@ -3506,9 +3506,9 @@ class DataFrame:
             + int(bool(column_totals)),
             table_start[1] + len(df.columns) - 1,
         )
-        
+
         excel_max_valid_rows = 1048575
-        if len(self.rows) > excel_max_valid_rows:
+        if self.height > excel_max_valid_rows:
             msg = "Dataframe too large to be compatible with Excel. Exceeded Excel limit of 1048575 rows of data."
             raise InvalidOperationError(msg)
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3507,27 +3507,14 @@ class DataFrame:
             table_start[1] + len(df.columns) - 1,
         )
 
-        # verify the number of rows and columns,
-        # after accounting for an offset and a header row
-        # is within the maximum for Excel
         excel_max_valid_rows = 1048575
         excel_max_valid_cols = 16384
 
-        initial_row_offset = 0
-        initial_col_offset = 0
-
-        # it is just a numerical offset given in the form of a tuple
-        if isinstance(position, tuple):
-            initial_row_offset, initial_col_offset = position
-
-        total_rows = self.height + initial_row_offset
-        if include_header:
-            total_rows += 1
-
-        total_cols = self.width + initial_col_offset
-
-        if total_rows > excel_max_valid_rows or total_cols > excel_max_valid_cols:
-            msg = "Dataframe too large to be compatible with Excel. Exceeded Excel limit of 1048575 rows and/or 16384 columns of data."
+        if (
+            table_finish[0] > excel_max_valid_rows
+            or table_finish[1] > excel_max_valid_cols
+        ):
+            msg = "Dataframe too large to be compatible with Excel. Exceeds Excel limit of 1048575 rows and/or 16384 columns of data."
             raise InvalidOperationError(msg)
 
         # write table structure and formats into the target sheet

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -97,6 +97,7 @@ from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import (
+    InvalidOperationError,
     ColumnNotFoundError,
     ModuleUpgradeRequiredError,
     NoRowsReturnedError,
@@ -3505,6 +3506,11 @@ class DataFrame:
             + int(bool(column_totals)),
             table_start[1] + len(df.columns) - 1,
         )
+        
+        excel_max_valid_rows = 1048575
+        if len(self.rows) > excel_max_valid_rows:
+            msg = "Dataframe too large to be compatible with Excel. Exceeded Excel limit of 1048575 rows of data."
+            raise InvalidOperationError(msg)
 
         # write table structure and formats into the target sheet
         if not is_empty or include_header:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3507,9 +3507,25 @@ class DataFrame:
             table_start[1] + len(df.columns) - 1,
         )
 
+        # verify that the number of rows and columns, after accounting for an offset and a header row, is within the maximum for Excel
         excel_max_valid_rows = 1048575
-        if self.height > excel_max_valid_rows:
-            msg = "Dataframe too large to be compatible with Excel. Exceeded Excel limit of 1048575 rows of data."
+        excel_max_valid_cols = 16384
+        
+        initial_row_offset = 0
+        initial_col_offset = 0
+        
+        # it is just a numerical offset given in the form of a tuple
+        if isinstance(position, tuple):
+            initial_row_offset, initial_col_offset = position
+        
+        total_rows = self.height + initial_row_offset
+        if include_header:
+            total_rows += 1
+            
+        total_cols = self.width + initial_col_offset
+        
+        if total_rows > excel_max_valid_rows or total_cols > excel_max_valid_cols:
+            msg = "Dataframe too large to be compatible with Excel. Exceeded Excel limit of 1048575 rows and/or 16384 columns of data."
             raise InvalidOperationError(msg)
 
         # write table structure and formats into the target sheet

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -1187,8 +1187,9 @@ def test_excel_write_worksheet_object() -> None:
             df.write_excel(None, worksheet=ws)
 
 
-def test_excel_write_beyond_max_rows_cols() -> None:
-    path = "/tmp/test.xlsx"
+def test_excel_write_beyond_max_rows_cols(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    path = tmp_path / "test_max_dimensions.xlsx"
     sheet = "mysheet"
 
     df = pl.DataFrame({"col1": range(10), "col2": range(10, 20)})

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -12,7 +12,10 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.exceptions import NoDataError, ParameterCollisionError, InvalidOperationError
+from polars.exceptions import (
+    NoDataError,
+    ParameterCollisionError,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 from tests.unit.conftest import FLOAT_DTYPES, NUMERIC_DTYPES
 
@@ -1183,41 +1186,15 @@ def test_excel_write_worksheet_object() -> None:
         with Workbook(BytesIO()) as wb:
             df.write_excel(None, worksheet=ws)
 
+
 def test_excel_write_beyond_max_rows_cols() -> None:
+    path = "/tmp/test.xlsx"
+    sheet = "mysheet"
 
-    with pytest.raises(InvalidOperationError):
-        path = "/tmp/test.xlsx"
-        sheet = "mysheet"
-        (
-            pl
-            .LazyFrame({
-            "x": "a"
-            })
-            .select(pl.repeat(pl.col("x"), 1048576))
-            .collect()
-            .write_excel(
-                workbook=path,
-                worksheet=sheet,
-            )
-        )
+    df = pl.DataFrame({"col1": range(10), "col2": range(10, 20)})
 
-        pl.read_excel(source=path, sheet_name=sheet)
-        
-
-    with pytest.raises(InvalidOperationError):
-        path = "/tmp/test.xlsx"
-        sheet = "mysheet"
-        (
-            pl
-            .DataFrame({
-            "col1": range(10),
-            "col2": range(10, 20)
-            })
-            .write_excel(workbook=path, worksheet=sheet,position="A1048570")
-        )
-
-        pl.read_excel(source=path, sheet_name=sheet)
-
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        df.write_excel(workbook=path, worksheet=sheet, position="A1048570")
 
 
 def test_excel_freeze_panes() -> None:


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/20870

I have what I believe is a working solution and it is passing all the pre-existing tests. However, I don't know how to test whether my change is creating the expected behavior or not (when the dataframe is too large to be compatible with Excel, an exception should be thrown). 

This is my very first commit to an open-source project, so I apologize in advance for any mistakes I might have made and I look forward to hearing any and all feedback. 