### PR TITLE
fix: Fix `from_numpy` returning Null dtype for empty 1D numpy array

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1289,7 +1289,7 @@ def numpy_to_pydf(
             )._s
             for series_name, record_name in zip(column_names, record_names)
         ]
-    elif shape == (0,):
+    elif shape == (0,) and n_columns == 0:
         data_series = []
 
     elif len(shape) == 1:

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
@@ -10,7 +10,9 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars._typing import PolarsTemporalType
+    import numpy.typing as npt
+
+    from polars._typing import PolarsDataType, PolarsTemporalType
 
 
 def test_from_numpy() -> None:
@@ -156,7 +158,7 @@ def test_from_numpy_supported_units(
         (np.int32, pl.Int32),
     ],
 )
-def test_from_numpy_empty(np_dtype: np.dtype, dtype: pl.DataType) -> None:
+def test_from_numpy_empty(np_dtype: npt.DTypeLike, dtype: PolarsDataType) -> None:
     data = np.array([], dtype=np_dtype)
     result = pl.from_numpy(data, schema=["a"])
     expected = pl.Series("a", [], dtype=dtype).to_frame()

--- a/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_from_numpy_df.py
@@ -147,3 +147,17 @@ def test_from_numpy_supported_units(
         pl.Series("column_0", expected_values).str.strptime(expected_dtype).to_frame()
     )
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("np_dtype", "dtype"),
+    [
+        (np.float64, pl.Float64),
+        (np.int32, pl.Int32),
+    ],
+)
+def test_from_numpy_empty(np_dtype: np.dtype, dtype: pl.DataType) -> None:
+    data = np.array([], dtype=np_dtype)
+    result = pl.from_numpy(data, schema=["a"])
+    expected = pl.Series("a", [], dtype=dtype).to_frame()
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
fixes #18310