### PR TITLE
test: Add tests for already resolved issues

### DIFF
--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -659,3 +659,22 @@ def test_unique() -> None:
     assert ser.unique().to_list() == [D("1.1"), D("2.2")]
     assert ser.n_unique() == 2
     assert ser.arg_unique().to_list() == [0, 2]
+
+
+def test_groupby_agg_single_element_11232() -> None:
+    data = {"g": [-1], "decimal": [-1]}
+    schema = {"g": pl.Int64, "decimal": pl.Decimal(38, 0)}
+    result = (
+        pl.LazyFrame(data, schema=schema)
+        .group_by("g", maintain_order=True)
+        .agg(pl.col("decimal").min())
+        .collect()
+    )
+    expected = pl.DataFrame(data, schema=schema)
+    assert_frame_equal(result, expected)
+
+
+def test_decimal_from_large_ints_9084() -> None:
+    numbers = [2963091539321097135000000000, 25658709114149718824803874]
+    s = pl.Series(numbers, dtype=pl.Decimal)
+    assert s.to_list() == [D(n) for n in numbers]

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -663,7 +663,7 @@ def test_unique() -> None:
 
 def test_groupby_agg_single_element_11232() -> None:
     data = {"g": [-1], "decimal": [-1]}
-    schema = {"g": pl.Int64, "decimal": pl.Decimal(38, 0)}
+    schema = {"g": pl.Int64(), "decimal": pl.Decimal(38, 0)}
     result = (
         pl.LazyFrame(data, schema=schema)
         .group_by("g", maintain_order=True)

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -736,3 +736,21 @@ def test_struct_when_then_broadcasting_combinations_19122(
             pl.when(pl.col.a.struct.field("x") != 0).then(rv).otherwise(None).alias("a")
         ),
     )
+
+
+def test_when_then_to_decimal_18375() -> None:
+    df = pl.DataFrame({"a": ["1.23", "4.56"]})
+
+    result = df.with_columns(
+        b=pl.when(False).then(None).otherwise(pl.col("a").str.to_decimal()),
+        c=pl.when(True).then(pl.col("a").str.to_decimal()),
+    )
+    expected = pl.DataFrame(
+        {
+            "a": ["1.23", "4.56"],
+            "b": ["1.23", "4.56"],
+            "c": ["1.23", "4.56"],
+        },
+        schema={"a": pl.String, "b": pl.Decimal, "c": pl.Decimal},
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -680,6 +680,12 @@ def test_list_to_struct() -> None:
     ).collect_schema() == {"n": pl.Unknown}
 
 
+def test_list_to_struct_all_null_12119() -> None:
+    s = pl.Series([None], dtype=pl.List(pl.Int64))
+    result = s.list.to_struct(fields=["a", "b", "c"]).to_list()
+    assert result == [{"a": None, "b": None, "c": None}]
+
+
 def test_select_from_list_to_struct_11143() -> None:
     ldf = pl.LazyFrame({"some_col": [[1.0, 2.0], [1.5, 3.0]]})
     ldf = ldf.select(

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -1,3 +1,7 @@
+import datetime
+
+import pytest
+
 import polars as pl
 from polars.testing import assert_series_equal
 
@@ -68,3 +72,15 @@ def test_fill_null_decimal_with_int_14331() -> None:
     result = s.fill_null(0)
     expected = pl.Series("a", ["1.1", "0.0"], dtype=pl.Decimal(precision=None, scale=5))
     assert_series_equal(result, expected)
+
+
+def test_fill_null_date_with_int_11362() -> None:
+    match = "got invalid or ambiguous dtypes"
+
+    s = pl.Series([datetime.date(2000, 1, 1)])
+    with pytest.raises(pl.exceptions.InvalidOperationError, match=match):
+        s.fill_null(0)
+
+    s = pl.Series([None], dtype=pl.Date)
+    with pytest.raises(pl.exceptions.InvalidOperationError, match=match):
+        s.fill_null(1)

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1278,3 +1278,9 @@ def test_join_asof_no_exact_matches() -> None:
         "bid": [None, 51.97, None, None, None],
         "ask": [None, 51.98, None, None, None],
     }
+
+
+def test_join_asof_not_sorted_warning() -> None:
+    df = pl.DataFrame({"a": [1, 1, 1, 2, 2, 2], "b": [2, 1, 3, 1, 2, 3]})
+    with pytest.warns(UserWarning, match="asof join is not sorted"):
+        df.join_asof(df, on="b", by="a")

--- a/py-polars/tests/unit/series/test_equals.py
+++ b/py-polars/tests/unit/series/test_equals.py
@@ -297,3 +297,9 @@ def test_eq_missing_lists_arrays_19153(
         ),
         pl.Series([False, True, False]),
     )
+
+
+def test_equals_nested_null_categorical_14875() -> None:
+    dtype = pl.List(pl.Struct({"cat": pl.Categorical}))
+    s = pl.Series([[{"cat": None}]], dtype=dtype)
+    assert s.equals(s)


### PR DESCRIPTION

Closes a few categories of open issues:

1. Fixed or implemented but does not appear to be tested (tests added in this PR):

closes #9084
closes #11232
closes #11362
closes #12199
closes #14875
closes #18014
closes #18375
closes #18587


2. Fixed or implemented and already tested (just noting existing tests that appear to cover the reported issue):

closes #11078 - `test_decimal.py::test_decimal_aggregations`
closes #11079 - `test_decimal.py::test_decimal_sort`
closes #11081 - `test_lit.py::test_lit_decimal`
closes #14773 - `test_csv.py::test_csv_quote_styles`
closes #19794 - `test_csv.py::test_csv_quoted_newlines_skip_rows_19535`


3. Feature requests that have since been implemented:

closes #7675
closes #12203


4. Usage questions which have been answered and are unlikely to be further actionable. Feel free to remove these if there is a desire to keep them open.

closes #12592
closes #18267
closes #18410
closes #19372
closes #19450
