### PR TITLE
fix: Improve SQL interface behaviour when `INTERVAL` is not a fixed duration

### DIFF
--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -445,6 +445,11 @@ impl Literal for ChronoDuration {
 #[cfg(feature = "dtype-duration")]
 impl Literal for Duration {
     fn lit(self) -> Expr {
+        assert!(
+            self.months() == 0,
+            "Cannot create literal duration that is not of fixed length; found {}",
+            self
+        );
         let ns = self.duration_ns();
         Expr::Literal(LiteralValue::Duration(
             if self.negative() { -ns } else { ns },

--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -11,7 +11,7 @@ description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 [dependencies]
 polars-core = { workspace = true, features = ["rows"] }
 polars-error = { workspace = true }
-polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "dtype-decimal", "dtype-struct", "is_in", "list_eval", "log", "meta", "regex", "round_series", "sign", "string_normalize", "string_reverse", "strings", "timezones", "trigonometry"] }
+polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "dtype-decimal", "dtype-struct", "is_in", "list_eval", "log", "meta", "offset_by", "regex", "round_series", "sign", "string_normalize", "string_reverse", "strings", "timezones", "trigonometry"] }
 polars-ops = { workspace = true }
 polars-plan = { workspace = true }
 polars-time = { workspace = true }

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -1056,7 +1056,7 @@ pub(crate) fn interval_to_duration(interval: &Interval, fixed: bool) -> PolarsRe
     }
     let s = match &*interval.value {
         SQLExpr::UnaryOp { .. } => {
-            polars_bail!(SQLSyntax: "unary ops are not valid on interval strings; found '{}'", interval.value)
+            polars_bail!(SQLSyntax: "unary ops are not valid on interval strings; found {}", interval.value)
         },
         SQLExpr::Value(SQLValue::SingleQuotedString(s)) => Some(s),
         _ => None,
@@ -1070,7 +1070,7 @@ pub(crate) fn interval_to_duration(interval: &Interval, fixed: bool) -> PolarsRe
             // interval parts can only be used with respect to a reference point
             let duration = Duration::parse_interval(s);
             if fixed && duration.months() != 0 {
-                polars_bail!(SQLSyntax: "fixed-duration interval cannot contain years, quarters, or months; found '{}'", s)
+                polars_bail!(SQLSyntax: "fixed-duration interval cannot contain years, quarters, or months; found {}", s)
             };
             Ok(duration)
         },

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -19,10 +19,9 @@ use rand::{thread_rng, Rng};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::{
-    BinaryOperator as SQLBinaryOperator, BinaryOperator, CastFormat, CastKind,
-    DataType as SQLDataType, DateTimeField, Expr as SQLExpr, Function as SQLFunction, Ident,
-    Interval, Query as Subquery, SelectItem, Subscript, TimezoneInfo, TrimWhereField,
-    UnaryOperator, Value as SQLValue,
+    BinaryOperator as SQLBinaryOperator, CastFormat, CastKind, DataType as SQLDataType,
+    DateTimeField, Expr as SQLExpr, Function as SQLFunction, Ident, Interval, Query as Subquery,
+    SelectItem, Subscript, TimezoneInfo, TrimWhereField, UnaryOperator, Value as SQLValue,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::{Parser, ParserOptions};
@@ -133,7 +132,7 @@ impl SQLExprVisitor<'_> {
                 subquery,
                 negated,
             } => self.visit_in_subquery(expr, subquery, *negated),
-            SQLExpr::Interval(interval) => self.visit_interval(interval),
+            SQLExpr::Interval(interval) => Ok(lit(interval_to_duration(interval, true)?)),
             SQLExpr::IsDistinctFrom(e1, e2) => {
                 Ok(self.visit_expr(e1)?.neq_missing(self.visit_expr(e2)?))
             },
@@ -301,30 +300,6 @@ impl SQLExprVisitor<'_> {
         Ok(resolve_compound_identifier(self.ctx, idents, self.active_schema)?[0].clone())
     }
 
-    fn visit_interval(&self, interval: &Interval) -> PolarsResult<Expr> {
-        if interval.last_field.is_some()
-            || interval.leading_field.is_some()
-            || interval.leading_precision.is_some()
-            || interval.fractional_seconds_precision.is_some()
-        {
-            polars_bail!(SQLSyntax: "unsupported interval syntax ('{}')", interval)
-        }
-        let s = match &*interval.value {
-            SQLExpr::UnaryOp { .. } => {
-                polars_bail!(SQLSyntax: "unary ops are not valid on interval strings; found {}", interval.value)
-            },
-            SQLExpr::Value(SQLValue::SingleQuotedString(s)) => Some(s),
-            _ => None,
-        };
-        match s {
-            Some(s) if s.contains('-') => {
-                polars_bail!(SQLInterface: "minus signs are not yet supported in interval strings; found '{}'", s)
-            },
-            Some(s) => Ok(lit(Duration::parse_interval(s))),
-            None => polars_bail!(SQLSyntax: "invalid interval {:?}", interval),
-        }
-    }
-
     fn visit_like(
         &mut self,
         negated: bool,
@@ -345,9 +320,9 @@ impl SQLExprVisitor<'_> {
         if pat.is_empty() || (!case_insensitive && pat.chars().all(|c| !matches!(c, '%' | '_'))) {
             // empty string or other exact literal match (eg: no wildcard chars)
             let op = if negated {
-                BinaryOperator::NotEq
+                SQLBinaryOperator::NotEq
             } else {
-                BinaryOperator::Eq
+                SQLBinaryOperator::Eq
             };
             self.visit_binary_op(expr, &op, pattern)
         } else {
@@ -480,11 +455,45 @@ impl SQLExprVisitor<'_> {
     fn visit_binary_op(
         &mut self,
         left: &SQLExpr,
-        op: &BinaryOperator,
+        op: &SQLBinaryOperator,
         right: &SQLExpr,
     ) -> PolarsResult<Expr> {
-        let lhs = self.visit_expr(left)?;
-        let mut rhs = self.visit_expr(right)?;
+        // need special handling for interval offsets and comparisons
+        let (lhs, mut rhs) = match (left, op, right) {
+            (_, SQLBinaryOperator::Minus, SQLExpr::Interval(v)) => {
+                let duration = interval_to_duration(v, false)?;
+                return Ok(self
+                    .visit_expr(left)?
+                    .dt()
+                    .offset_by(lit(format!("-{}", duration))));
+            },
+            (_, SQLBinaryOperator::Plus, SQLExpr::Interval(v)) => {
+                let duration = interval_to_duration(v, false)?;
+                return Ok(self
+                    .visit_expr(left)?
+                    .dt()
+                    .offset_by(lit(format!("{}", duration))));
+            },
+            (SQLExpr::Interval(v1), _, SQLExpr::Interval(v2)) => {
+                // shortcut interval comparison evaluation (-> bool)
+                let d1 = interval_to_duration(v1, false)?;
+                let d2 = interval_to_duration(v2, false)?;
+                let res = match op {
+                    SQLBinaryOperator::Gt => Ok(lit(d1 > d2)),
+                    SQLBinaryOperator::Lt => Ok(lit(d1 < d2)),
+                    SQLBinaryOperator::GtEq => Ok(lit(d1 >= d2)),
+                    SQLBinaryOperator::LtEq => Ok(lit(d1 <= d2)),
+                    SQLBinaryOperator::NotEq => Ok(lit(d1 != d2)),
+                    SQLBinaryOperator::Eq | SQLBinaryOperator::Spaceship => Ok(lit(d1 == d2)),
+                    _ => polars_bail!(SQLInterface: "invalid interval comparison operator"),
+                };
+                if res.is_ok() {
+                    return res;
+                }
+                (self.visit_expr(left)?, self.visit_expr(right)?)
+            },
+            _ => (self.visit_expr(left)?, self.visit_expr(right)?),
+        };
         rhs = self.convert_temporal_strings(&lhs, &rhs);
 
         Ok(match op {
@@ -649,19 +658,19 @@ impl SQLExprVisitor<'_> {
     fn visit_all(
         &mut self,
         left: &SQLExpr,
-        compare_op: &BinaryOperator,
+        compare_op: &SQLBinaryOperator,
         right: &SQLExpr,
     ) -> PolarsResult<Expr> {
         let left = self.visit_expr(left)?;
         let right = self.visit_expr(right)?;
 
         match compare_op {
-            BinaryOperator::Gt => Ok(left.gt(right.max())),
-            BinaryOperator::Lt => Ok(left.lt(right.min())),
-            BinaryOperator::GtEq => Ok(left.gt_eq(right.max())),
-            BinaryOperator::LtEq => Ok(left.lt_eq(right.min())),
-            BinaryOperator::Eq => polars_bail!(SQLSyntax: "ALL cannot be used with ="),
-            BinaryOperator::NotEq => polars_bail!(SQLSyntax: "ALL cannot be used with !="),
+            SQLBinaryOperator::Gt => Ok(left.gt(right.max())),
+            SQLBinaryOperator::Lt => Ok(left.lt(right.min())),
+            SQLBinaryOperator::GtEq => Ok(left.gt_eq(right.max())),
+            SQLBinaryOperator::LtEq => Ok(left.lt_eq(right.min())),
+            SQLBinaryOperator::Eq => polars_bail!(SQLSyntax: "ALL cannot be used with ="),
+            SQLBinaryOperator::NotEq => polars_bail!(SQLSyntax: "ALL cannot be used with !="),
             _ => polars_bail!(SQLInterface: "invalid comparison operator"),
         }
     }
@@ -672,19 +681,19 @@ impl SQLExprVisitor<'_> {
     fn visit_any(
         &mut self,
         left: &SQLExpr,
-        compare_op: &BinaryOperator,
+        compare_op: &SQLBinaryOperator,
         right: &SQLExpr,
     ) -> PolarsResult<Expr> {
         let left = self.visit_expr(left)?;
         let right = self.visit_expr(right)?;
 
         match compare_op {
-            BinaryOperator::Gt => Ok(left.gt(right.min())),
-            BinaryOperator::Lt => Ok(left.lt(right.max())),
-            BinaryOperator::GtEq => Ok(left.gt_eq(right.min())),
-            BinaryOperator::LtEq => Ok(left.lt_eq(right.max())),
-            BinaryOperator::Eq => Ok(left.is_in(right)),
-            BinaryOperator::NotEq => Ok(left.is_in(right).not()),
+            SQLBinaryOperator::Gt => Ok(left.gt(right.min())),
+            SQLBinaryOperator::Lt => Ok(left.lt(right.max())),
+            SQLBinaryOperator::GtEq => Ok(left.gt_eq(right.min())),
+            SQLBinaryOperator::LtEq => Ok(left.lt_eq(right.max())),
+            SQLBinaryOperator::Eq => Ok(left.is_in(right)),
+            SQLBinaryOperator::NotEq => Ok(left.is_in(right).not()),
             _ => polars_bail!(SQLInterface: "invalid comparison operator"),
         }
     }
@@ -1035,6 +1044,38 @@ pub fn sql_expr<S: AsRef<str>>(s: S) -> PolarsResult<Expr> {
         SelectItem::UnnamedExpr(expr) => parse_sql_expr(expr, &mut ctx, None)?,
         _ => polars_bail!(SQLInterface: "unable to parse '{}' as Expr", s.as_ref()),
     })
+}
+
+pub(crate) fn interval_to_duration(interval: &Interval, fixed: bool) -> PolarsResult<Duration> {
+    if interval.last_field.is_some()
+        || interval.leading_field.is_some()
+        || interval.leading_precision.is_some()
+        || interval.fractional_seconds_precision.is_some()
+    {
+        polars_bail!(SQLSyntax: "unsupported interval syntax ('{}')", interval)
+    }
+    let s = match &*interval.value {
+        SQLExpr::UnaryOp { .. } => {
+            polars_bail!(SQLSyntax: "unary ops are not valid on interval strings; found '{}'", interval.value)
+        },
+        SQLExpr::Value(SQLValue::SingleQuotedString(s)) => Some(s),
+        _ => None,
+    };
+    match s {
+        Some(s) if s.contains('-') => {
+            polars_bail!(SQLInterface: "minus signs are not yet supported in interval strings; found '{}'", s)
+        },
+        Some(s) => {
+            // years, quarters, and months do not have a fixed duration; these
+            // interval parts can only be used with respect to a reference point
+            let duration = Duration::parse_interval(s);
+            if fixed && duration.months() != 0 {
+                polars_bail!(SQLSyntax: "fixed-duration interval cannot contain years, quarters, or months; found '{}'", s)
+            };
+            Ok(duration)
+        },
+        None => polars_bail!(SQLSyntax: "invalid interval {:?}", interval),
+    }
 }
 
 pub(crate) fn parse_sql_expr(

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -196,7 +196,7 @@ fn test_literal_exprs() {
             'foo' as string_lit,
             true as bool_lit,
             null as null_lit,
-            interval '1 quarter 2 weeks 1 day 50 seconds' as duration_lit
+            interval '2 weeks 1 day 50 seconds' as duration_lit
         FROM df"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let df_pl = df
@@ -208,7 +208,7 @@ fn test_literal_exprs() {
             lit("foo").alias("string_lit"),
             lit(true).alias("bool_lit"),
             lit(NULL).alias("null_lit"),
-            lit(Duration::parse("1q2w1d50s")).alias("duration_lit"),
+            lit(Duration::parse("2w1d50s")).alias("duration_lit"),
         ])
         .collect()
         .unwrap()

--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -79,7 +79,7 @@ impl Display for Duration {
             write!(f, "-")?
         }
         if self.months > 0 {
-            write!(f, "{}m", self.months)?
+            write!(f, "{}mo", self.months)?
         }
         if self.weeks > 0 {
             write!(f, "{}w", self.weeks)?
@@ -289,10 +289,10 @@ impl Duration {
         }
 
         Ok(Duration {
-            nsecs: nsecs.abs(),
-            days: days.abs(),
-            weeks: weeks.abs(),
             months: months.abs(),
+            weeks: weeks.abs(),
+            days: days.abs(),
+            nsecs: nsecs.abs(),
             negative,
             parsed_int,
         })
@@ -1116,5 +1116,22 @@ mod test {
         let duration = Duration::parse("1h5000ns");
         let expected = "3600000005us";
         assert_eq!(format!("{duration}"), expected);
+        let duration = Duration::parse("3mo");
+        let expected = "3mo";
+        assert_eq!(format!("{duration}"), expected);
+        let duration = Duration::parse_interval("4 weeks");
+        let expected = "4w";
+        assert_eq!(format!("{duration}"), expected);
+    }
+
+    #[test]
+    fn test_equality() {
+        let d1 = Duration::parse("1w");
+        let d2 = Duration::parse("7d");
+        assert_eq!(d1, d2);
+
+        let d3 = Duration::parse_interval("2 months");
+        let d4 = Duration::parse_interval("8 weeks");
+        assert_ne!(d3, d4);
     }
 }

--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -1123,15 +1123,4 @@ mod test {
         let expected = "4w";
         assert_eq!(format!("{duration}"), expected);
     }
-
-    #[test]
-    fn test_equality() {
-        let d1 = Duration::parse("1w");
-        let d2 = Duration::parse("7d");
-        assert_eq!(d1, d2);
-
-        let d3 = Duration::parse_interval("2 months");
-        let d4 = Duration::parse_interval("8 weeks");
-        assert_ne!(d3, d4);
-    }
 }


### PR DESCRIPTION
As brought up in the Discord, there was a bug with SQL interface `INTERVAL` literals that don't represent fixed durations (eg: "1 month", "1 year").

### Issue
Interval addition/subtraction from date or datetime values was not being done correctly for intervals that don't represent a fixed duration (eg: `SELECT datecol + '6 months'`; this fix ensures such queries are properly converted to `pl.col("datecol").dt.offset_by('6mo')`.

### Also
Standalone intervals can now _only_ be created where they represent a fixed duration (on the Python side such intervals are returned as `timedelta` literals, which also have to represent fixed durations).

**Valid:** `SELECT INTERVAL '1 week'` (allowed - represents an exact value)
**Invalid:** `SELECT INTERVAL '1 month'` (raises - does _not_ represent an exact value)

## Example

```python
import polars as pl

df = pl.DataFrame({
    "dtm": [
        datetime(1899, 12, 31, 8),
        datetime(1999, 6, 8, 10, 30),
        datetime(2010, 5, 7, 20, 20, 20),
    ],
    "dt": [
        date(1950, 4, 10),
        date(2048, 1, 20),
        date(2026, 8, 5),
    ],
})
```
```python
df.sql("""
  SELECT
    dtm,
    dtm + INTERVAL '2 months, 30 minutes' AS dtm_plus_2mo30m,
  FROM self
  ORDER BY dtm
""")
# shape: (3, 2)
# ┌─────────────────────┬─────────────────────┐
# │ dtm                 ┆ dtm_plus_2mo30m     │
# │ ---                 ┆ ---                 │
# │ datetime[μs]        ┆ datetime[μs]        │
# ╞═════════════════════╪═════════════════════╡
# │ 1899-12-31 08:00:00 ┆ 1900-02-28 08:30:00 │
# │ 1999-06-08 10:30:00 ┆ 1999-08-08 11:00:00 │
# │ 2010-05-07 20:20:20 ┆ 2010-07-07 20:50:20 │
# └─────────────────────┴─────────────────────┘
```
```python
df.sql("""
  SELECT
    dt,
    dt + INTERVAL '100 years' AS dt_plus_100y,
    dt - INTERVAL '1 quarter' AS dt_minus_1q
  FROM self
  ORDER BY dt
""")
# shape: (3, 3)
# ┌────────────┬──────────────┬─────────────┐
# │ dt         ┆ dt_plus_100y ┆ dt_minus_1q │
# │ ---        ┆ ---          ┆ ---         │
# │ date       ┆ date         ┆ date        │
# ╞════════════╪══════════════╪═════════════╡
# │ 1950-04-10 ┆ 2050-04-10   ┆ 1950-01-10  │
# │ 2026-08-05 ┆ 2126-08-05   ┆ 2026-05-05  │
# │ 2048-01-20 ┆ 2148-01-20   ┆ 2047-10-20  │
# └────────────┴──────────────┴─────────────┘
```