### PR TITLE
feat: Improved support for KeyboardInterrupts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,6 +3080,7 @@ dependencies = [
  "object_store",
  "polars-arrow-format",
  "regex",
+ "signal-hook",
  "simdutf8",
  "thiserror 2.0.9",
 ]
@@ -4422,6 +4423,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ reqwest = { version = "0.12", default-features = false }
 ryu = "1.0.13"
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_json = "1"
-signal-hook = "0.3"
 simd-json = { version = "0.14", features = ["known-key"] }
 simdutf8 = "0.1.4"
 slotmap = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ reqwest = { version = "0.12", default-features = false }
 ryu = "1.0.13"
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_json = "1"
+signal-hook = "0.3"
 simd-json = { version = "0.14", features = ["known-key"] }
 simdutf8 = "0.1.4"
 slotmap = "1"

--- a/crates/polars-core/src/chunked_array/object/registry.rs
+++ b/crates/polars-core/src/chunked_array/object/registry.rs
@@ -123,12 +123,6 @@ pub fn register_object_builder(
     })
 }
 
-pub fn is_object_builder_registered() -> bool {
-    let reg = GLOBAL_OBJECT_REGISTRY.deref();
-    let reg = reg.read().unwrap();
-    reg.is_some()
-}
-
 #[cold]
 pub fn get_object_physical_type() -> ArrowDataType {
     let reg = GLOBAL_OBJECT_REGISTRY.read().unwrap();

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -1,5 +1,5 @@
 use arrow::legacy::kernels::sort_partition::{create_clean_partitions, partition_to_groups};
-use polars_error::check_signals;
+use polars_error::signals::try_raise_keyboard_interrupt;
 use polars_utils::total_ord::{ToTotalOrd, TotalHash};
 
 use super::*;
@@ -235,7 +235,7 @@ where
                 num_groups_proxy(ca, multithreaded, sorted)
             },
         };
-        check_signals()?;
+        try_raise_keyboard_interrupt();
         Ok(out)
     }
 }
@@ -287,7 +287,7 @@ impl IntoGroupsType for BinaryChunked {
         } else {
             group_by(bh[0].iter(), sorted)
         };
-        check_signals()?;
+        try_raise_keyboard_interrupt();
         Ok(out)
     }
 }

--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -40,6 +40,7 @@ pub use crate::datatypes::{ArrayCollectIterExt, *};
 pub use crate::error::{
     polars_bail, polars_ensure, polars_err, polars_warn, PolarsError, PolarsResult,
 };
+pub use crate::error::signals::try_raise_keyboard_interrupt;
 pub use crate::frame::column::{Column, IntoColumn};
 pub use crate::frame::explode::UnpivotArgsIR;
 #[cfg(feature = "algorithm_group_by")]

--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -37,10 +37,10 @@ pub use crate::chunked_array::StructChunked;
 #[cfg(feature = "dtype-categorical")]
 pub use crate::datatypes::string_cache::StringCacheHolder;
 pub use crate::datatypes::{ArrayCollectIterExt, *};
+pub use crate::error::signals::try_raise_keyboard_interrupt;
 pub use crate::error::{
     polars_bail, polars_ensure, polars_err, polars_warn, PolarsError, PolarsResult,
 };
-pub use crate::error::signals::try_raise_keyboard_interrupt;
 pub use crate::frame::column::{Column, IntoColumn};
 pub use crate::frame::explode::UnpivotArgsIR;
 #[cfg(feature = "algorithm_group_by")]

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -13,9 +13,11 @@ arrow-format = { workspace = true, optional = true }
 avro-schema = { workspace = true, optional = true }
 object_store = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
-signal-hook = { workspace = true }
 simdutf8 = { workspace = true }
 thiserror = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+signal-hook = "0.3"
 
 [features]
 python = []

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -13,9 +13,9 @@ arrow-format = { workspace = true, optional = true }
 avro-schema = { workspace = true, optional = true }
 object_store = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
+signal-hook = { workspace = true }
 simdutf8 = { workspace = true }
 thiserror = { workspace = true }
-signal-hook = { workspace = true }
 
 [features]
 python = []

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -15,6 +15,7 @@ object_store = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 simdutf8 = { workspace = true }
 thiserror = { workspace = true }
+signal-hook = { workspace = true }
 
 [features]
 python = []

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -9,9 +9,8 @@ use std::fmt::{self, Display, Formatter, Write};
 use std::ops::Deref;
 use std::sync::{Arc, LazyLock};
 use std::{env, io};
-mod signals;
+pub mod signals;
 
-pub use signals::{check_signals, set_signals_function};
 pub use warning::*;
 
 enum ErrorStrategy {

--- a/crates/polars-error/src/signals.rs
+++ b/crates/polars-error/src/signals.rs
@@ -1,23 +1,75 @@
-use crate::PolarsResult;
+use std::panic::{catch_unwind, UnwindSafe};
+use std::sync::atomic::{AtomicU64, Ordering};
 
-type SignalsFunction = fn() -> PolarsResult<()>;
-static mut SIGNALS_FUNCTION: Option<SignalsFunction> = None;
+/// Python hooks SIGINT to instead generate a KeyboardInterrupt exception.
+/// So we do the same to try and abort long-running computations and return to
+/// Python so that the Python exception can be generated.
 
-/// Set the function that will be called check_signals.
-/// This can be set on startup to enable stopping a query when user input like `ctrl-c` is called.
-///
-/// # Safety
-/// The caller must ensure there is no other thread accessing this function
-/// or calling `check_signals`.
-pub unsafe fn set_signals_function(function: SignalsFunction) {
-    SIGNALS_FUNCTION = Some(function)
+pub struct KeyboardInterrupt;
+
+// Bottom bit: interrupt flag.
+// Top 63 bits: number of alive interrupt catchers.
+static INTERRUPT_STATE: AtomicU64 = AtomicU64::new(0);
+
+pub fn register_polars_keyboard_interrupt_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |p| {
+        // Suppress panic output on KeyboardInterrupt.
+        if p.payload().downcast_ref::<KeyboardInterrupt>().is_none() {
+            default_hook(p);
+        }
+    }));
+
+    unsafe {
+        // SAFETY: we only do an atomic store in the signal handler, which is allowed.
+        signal_hook::low_level::register(signal_hook::consts::signal::SIGINT, move || {
+            INTERRUPT_STATE.fetch_or(1, Ordering::Relaxed);
+        })
+        .unwrap();
+    }
 }
 
-fn default() -> PolarsResult<()> {
-    Ok(())
+/// Checks if the keyboard interrupt flag is set, and if yes panics with a
+/// KeyboardInterrupt. This function is very cheap.
+#[inline(always)]
+pub fn try_raise_keyboard_interrupt() {
+    if INTERRUPT_STATE.load(Ordering::Relaxed) & 1 > 0 {
+        try_raise_keyboard_interrupt_slow()
+    }
 }
 
-pub fn check_signals() -> PolarsResult<()> {
-    let f = unsafe { SIGNALS_FUNCTION.unwrap_or(default) };
-    f()
+#[inline(never)]
+#[cold]
+fn try_raise_keyboard_interrupt_slow() {
+    std::panic::panic_any(KeyboardInterrupt);
+}
+
+/// Runs the passed function, catching any KeyboardInterrupts if they occur
+/// while running the function.
+pub fn catch_keyboard_interrupt<R, F: FnOnce() -> R + UnwindSafe>(
+    try_fn: F,
+) -> Result<R, KeyboardInterrupt> {
+    // Clear any stale interrupts from immediately cancelling the computation,
+    // but only if there aren't any other interrupt catchers.
+    INTERRUPT_STATE
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |state| {
+            let num_catchers = state >> 1;
+            let interrupt = state & 1;
+            if num_catchers > 0 && interrupt != 0 {
+                // Interrupt still in progress.
+                None
+            } else {
+                // Clear stale interrupt flag and increment number of catchers.
+                Some((state & !1) + 2)
+            }
+        })
+        .map_err(|_| KeyboardInterrupt)?;
+
+    catch_unwind(try_fn).map_err(|p| {
+        INTERRUPT_STATE.fetch_sub(2, Ordering::Relaxed);
+        match p.downcast::<KeyboardInterrupt>() {
+            Ok(_) => KeyboardInterrupt,
+            Err(p) => std::panic::resume_unwind(p),
+        }
+    })
 }

--- a/crates/polars-error/src/signals.rs
+++ b/crates/polars-error/src/signals.rs
@@ -63,11 +63,9 @@ pub fn catch_keyboard_interrupt<R, F: FnOnce() -> R + UnwindSafe>(
     try_register_catcher()?;
     let ret = catch_unwind(try_fn);
     unregister_catcher();
-    ret.map_err(|p| {
-        match p.downcast::<KeyboardInterrupt>() {
-            Ok(_) => KeyboardInterrupt,
-            Err(p) => std::panic::resume_unwind(p),
-        }
+    ret.map_err(|p| match p.downcast::<KeyboardInterrupt>() {
+        Ok(_) => KeyboardInterrupt,
+        Err(p) => std::panic::resume_unwind(p),
     })
 }
 

--- a/crates/polars-error/src/signals.rs
+++ b/crates/polars-error/src/signals.rs
@@ -34,7 +34,8 @@ pub fn register_polars_keyboard_interrupt_hook() {
                     }
                 })
                 .ok();
-        }).unwrap();
+        })
+        .unwrap();
     }
 }
 

--- a/crates/polars-error/src/signals.rs
+++ b/crates/polars-error/src/signals.rs
@@ -84,7 +84,7 @@ fn unregister_catcher() {
         .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |state| {
             let num_catchers = state >> 1;
             if num_catchers > 1 {
-                Some(num_catchers - 2)
+                Some(state - 2)
             } else {
                 // Last catcher, clear interrupt flag.
                 Some(0)

--- a/crates/polars-error/src/signals.rs
+++ b/crates/polars-error/src/signals.rs
@@ -19,6 +19,8 @@ pub fn register_polars_keyboard_interrupt_hook() {
         }
     }));
 
+    // WASM doesn't support signals, so we just skip installing the hook there.
+    #[cfg(not(target_family = "wasm"))]
     unsafe {
         // SAFETY: we only do an atomic op in the signal handler, which is allowed.
         signal_hook::low_level::register(signal_hook::consts::signal::SIGINT, move || {

--- a/crates/polars-error/src/signals.rs
+++ b/crates/polars-error/src/signals.rs
@@ -61,8 +61,9 @@ pub fn catch_keyboard_interrupt<R, F: FnOnce() -> R + UnwindSafe>(
     // Try to register this catcher (or immediately return if there is an
     // uncaught interrupt).
     try_register_catcher()?;
-    catch_unwind(try_fn).map_err(|p| {
-        unregister_catcher();
+    let ret = catch_unwind(try_fn);
+    unregister_catcher();
+    ret.map_err(|p| {
         match p.downcast::<KeyboardInterrupt>() {
             Ok(_) => KeyboardInterrupt,
             Err(p) => std::panic::resume_unwind(p),

--- a/crates/polars-error/src/signals.rs
+++ b/crates/polars-error/src/signals.rs
@@ -4,7 +4,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Python hooks SIGINT to instead generate a KeyboardInterrupt exception.
 /// So we do the same to try and abort long-running computations and return to
 /// Python so that the Python exception can be generated.
-
 pub struct KeyboardInterrupt;
 
 // Bottom bit: interrupt flag.

--- a/crates/polars-expr/src/state/execution_state.rs
+++ b/crates/polars-expr/src/state/execution_state.rs
@@ -5,7 +5,6 @@ use std::sync::{Mutex, RwLock};
 use bitflags::bitflags;
 use once_cell::sync::OnceCell;
 use polars_core::config::verbose;
-use polars_core::error::check_signals;
 use polars_core::prelude::*;
 use polars_ops::prelude::ChunkJoinOptIds;
 
@@ -150,7 +149,7 @@ impl ExecutionState {
 
     // This is wrong when the U64 overflows which will never happen.
     pub fn should_stop(&self) -> PolarsResult<()> {
-        check_signals()?;
+        try_raise_keyboard_interrupt();
         polars_ensure!(!self.stop.load(Ordering::Relaxed), ComputeError: "query interrupted");
         Ok(())
     }

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -6,7 +6,6 @@ use std::cmp::Ordering;
 use default::*;
 pub use groups::AsofJoinBy;
 use polars_core::prelude::*;
-use polars_error::check_signals;
 use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -334,7 +333,7 @@ pub trait AsofJoin: IntoDf {
                 join_asof_numeric(ca, &right_key, strategy, tolerance, allow_eq)
             },
         }?;
-        check_signals()?;
+        try_raise_keyboard_interrupt();
 
         // Drop right join column.
         let other = if coalesce && left_key.name() == right_key.name() {

--- a/crates/polars-ops/src/frame/join/cross_join.rs
+++ b/crates/polars-ops/src/frame/join/cross_join.rs
@@ -133,7 +133,7 @@ fn cross_join_dfs(
         }
     };
     let (l_df, r_df) = if parallel {
-        check_signals()?;
+        try_raise_keyboard_interrupt();
         POOL.install(|| rayon::join(create_left_df, create_right_df))
     } else {
         (create_left_df(), create_right_df())

--- a/crates/polars-ops/src/frame/join/dispatch_left_right.rs
+++ b/crates/polars-ops/src/frame/join/dispatch_left_right.rs
@@ -87,7 +87,7 @@ pub fn materialize_left_join_from_series(
     } else {
         right.drop(s_right.name()).unwrap()
     };
-    check_signals()?;
+    try_raise_keyboard_interrupt();
 
     #[cfg(feature = "chunked_ids")]
     match (left_idx, right_idx) {

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -155,7 +155,7 @@ pub trait JoinDispatch: IntoDf {
         let (mut join_idx_l, mut join_idx_r) =
             s_left.hash_join_outer(s_right, args.validation, args.join_nulls)?;
 
-        check_signals()?;
+        try_raise_keyboard_interrupt();
         if let Some((offset, len)) = args.slice {
             let (offset, len) = slice_offsets(offset, len, join_idx_l.len());
             join_idx_l.slice(offset, len);

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
@@ -69,7 +69,7 @@ where
     } else {
         build_tables(build, join_nulls)
     };
-    check_signals()?;
+    try_raise_keyboard_interrupt();
 
     let n_tables = hash_tbls.len();
     let offsets = probe_to_offsets(&probe);

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
@@ -136,7 +136,7 @@ where
     } else {
         build_tables(build, join_nulls)
     };
-    check_signals()?;
+    try_raise_keyboard_interrupt();
     let n_tables = hash_tbls.len();
 
     // we determine the offset so that we later know which index to store in the join tuples

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
@@ -231,7 +231,7 @@ where
     let (probe_hashes, _) = create_hash_and_keys_threaded_vectorized(probe, Some(random_state));
 
     let n_tables = hash_tbls.len();
-    check_signals()?;
+    try_raise_keyboard_interrupt();
 
     // probe the hash table.
     // Note: indexes from b that are not matched will be None, Some(idx_b)

--- a/crates/polars-ops/src/frame/join/iejoin/mod.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/mod.rs
@@ -12,7 +12,7 @@ use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_core::utils::{_set_partition_size, split};
 use polars_core::{with_match_physical_numeric_polars_type, POOL};
-use polars_error::{check_signals, polars_err, PolarsResult};
+use polars_error::{polars_err, PolarsResult};
 use polars_utils::binary_search::ExponentialSearch;
 use polars_utils::itertools::Itertools;
 use polars_utils::total_ord::{TotalEq, TotalOrd};
@@ -362,7 +362,7 @@ unsafe fn materialize_join(
     right_row_idx: &IdxCa,
     suffix: Option<PlSmallStr>,
 ) -> PolarsResult<DataFrame> {
-    check_signals()?;
+    try_raise_keyboard_interrupt();
     let (join_left, join_right) = {
         POOL.join(
             || left.take_unchecked(left_row_idx),

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -45,7 +45,6 @@ use polars_core::utils::slice_offsets;
 #[allow(unused_imports)]
 use polars_core::utils::slice_slice;
 use polars_core::POOL;
-use polars_error::check_signals;
 use polars_utils::hashing::BytesHash;
 use rayon::prelude::*;
 
@@ -565,7 +564,7 @@ trait DataFrameJoinOpsPrivate: IntoDf {
                 args.maintain_order,
                 MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight
             );
-        check_signals()?;
+        try_raise_keyboard_interrupt();
         let (df_left, df_right) =
             if args.maintain_order != MaintainOrderJoin::None && !already_left_sorted {
                 let mut df =

--- a/crates/polars-python/src/batched_csv.rs
+++ b/crates/polars-python/src/batched_csv.rs
@@ -10,8 +10,8 @@ use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
 
 use crate::error::PyPolarsErr;
-use crate::{PyDataFrame, Wrap};
 use crate::utils::EnterPolarsExt;
+use crate::{PyDataFrame, Wrap};
 
 #[pyclass]
 #[repr(transparent)]
@@ -137,12 +137,7 @@ impl PyBatchedCsv {
 
     fn next_batches(&self, py: Python, n: usize) -> PyResult<Option<Vec<PyDataFrame>>> {
         let reader = &self.reader;
-        let batches = py.enter_polars(move || {
-            reader
-                .lock()
-                .unwrap()
-                .next_batches(n)
-        })?;
+        let batches = py.enter_polars(move || reader.lock().unwrap().next_batches(n))?;
 
         // SAFETY: same memory layout
         let batches = unsafe {

--- a/crates/polars-python/src/batched_csv.rs
+++ b/crates/polars-python/src/batched_csv.rs
@@ -11,6 +11,7 @@ use pyo3::pybacked::PyBackedStr;
 
 use crate::error::PyPolarsErr;
 use crate::{PyDataFrame, Wrap};
+use crate::utils::EnterPolarsExt;
 
 #[pyclass]
 #[repr(transparent)]
@@ -136,12 +137,11 @@ impl PyBatchedCsv {
 
     fn next_batches(&self, py: Python, n: usize) -> PyResult<Option<Vec<PyDataFrame>>> {
         let reader = &self.reader;
-        let batches = py.allow_threads(move || {
+        let batches = py.enter_polars(move || {
             reader
                 .lock()
-                .map_err(|e| PyPolarsErr::Other(e.to_string()))?
+                .unwrap()
                 .next_batches(n)
-                .map_err(PyPolarsErr::from)
         })?;
 
         // SAFETY: same memory layout

--- a/crates/polars-python/src/catalog/mod.rs
+++ b/crates/polars-python/src/catalog/mod.rs
@@ -46,10 +46,9 @@ impl PyCatalogClient {
     }
 
     pub fn list_catalogs(&self, py: Python) -> PyResult<PyObject> {
-        let v = py
-            .enter_polars(|| {
-                pl_async::get_runtime().block_on_potential_spawn(self.client().list_catalogs())
-            })?;
+        let v = py.enter_polars(|| {
+            pl_async::get_runtime().block_on_potential_spawn(self.client().list_catalogs())
+        })?;
 
         PyList::new(
             py,
@@ -69,11 +68,10 @@ impl PyCatalogClient {
 
     #[pyo3(signature = (catalog_name))]
     pub fn list_schemas(&self, py: Python, catalog_name: &str) -> PyResult<PyObject> {
-        let v = py
-            .enter_polars(|| {
-                pl_async::get_runtime()
-                    .block_on_potential_spawn(self.client().list_schemas(catalog_name))
-            })?;
+        let v = py.enter_polars(|| {
+            pl_async::get_runtime()
+                .block_on_potential_spawn(self.client().list_schemas(catalog_name))
+        })?;
 
         PyList::new(
             py,
@@ -98,11 +96,10 @@ impl PyCatalogClient {
         catalog_name: &str,
         schema_name: &str,
     ) -> PyResult<PyObject> {
-        let v = py
-            .enter_polars(|| {
-                pl_async::get_runtime()
-                    .block_on_potential_spawn(self.client().list_tables(catalog_name, schema_name))
-            })?;
+        let v = py.enter_polars(|| {
+            pl_async::get_runtime()
+                .block_on_potential_spawn(self.client().list_tables(catalog_name, schema_name))
+        })?;
 
         PyList::new(
             py,
@@ -120,14 +117,13 @@ impl PyCatalogClient {
         schema_name: &str,
         table_name: &str,
     ) -> PyResult<PyObject> {
-        let table_entry = py
-            .enter_polars(|| {
-                pl_async::get_runtime().block_on_potential_spawn(self.client().get_table_info(
-                    catalog_name,
-                    schema_name,
-                    table_name,
-                ))
-            })?;
+        let table_entry = py.enter_polars(|| {
+            pl_async::get_runtime().block_on_potential_spawn(self.client().get_table_info(
+                catalog_name,
+                schema_name,
+                table_name,
+            ))
+        })?;
 
         Ok(table_entry_to_pydict(py, table_entry).into())
     }
@@ -143,14 +139,13 @@ impl PyCatalogClient {
         credential_provider: Option<PyObject>,
         retries: usize,
     ) -> PyResult<PyLazyFrame> {
-        let table_info = py
-            .enter_polars(|| {
-                pl_async::get_runtime().block_on_potential_spawn(self.client().get_table_info(
-                    catalog_name,
-                    schema_name,
-                    table_name,
-                ))
-            })?;
+        let table_info = py.enter_polars(|| {
+            pl_async::get_runtime().block_on_potential_spawn(self.client().get_table_info(
+                catalog_name,
+                schema_name,
+                table_name,
+            ))
+        })?;
 
         let Some(storage_location) = table_info.storage_location.as_deref() else {
             return Err(PyValueError::new_err(

--- a/crates/polars-python/src/cloud.rs
+++ b/crates/polars-python/src/cloud.rs
@@ -11,6 +11,7 @@ use pyo3::types::{IntoPyDict, PyBytes};
 use crate::error::PyPolarsErr;
 use crate::lazyframe::visit::NodeTraverser;
 use crate::{PyDataFrame, PyLazyFrame};
+use crate::utils::EnterPolarsExt;
 
 #[pyfunction]
 pub fn prepare_cloud_plan(lf: PyLazyFrame, py: Python<'_>) -> PyResult<Bound<'_, PyBytes>> {
@@ -46,9 +47,7 @@ pub fn _execute_ir_plan_with_gpu(ir_plan_ser: Vec<u8>, py: Python) -> PyResult<P
 
     // Execute the plan.
     let mut state = ExecutionState::new();
-    let df = py.allow_threads(|| physical_plan.execute(&mut state).map_err(PyPolarsErr::from))?;
-
-    Ok(df.into())
+    py.enter_polars_df(|| physical_plan.execute(&mut state))
 }
 
 /// Prepare the IR for execution by the Polars GPU engine.

--- a/crates/polars-python/src/cloud.rs
+++ b/crates/polars-python/src/cloud.rs
@@ -10,8 +10,8 @@ use pyo3::types::{IntoPyDict, PyBytes};
 
 use crate::error::PyPolarsErr;
 use crate::lazyframe::visit::NodeTraverser;
-use crate::{PyDataFrame, PyLazyFrame};
 use crate::utils::EnterPolarsExt;
+use crate::{PyDataFrame, PyLazyFrame};
 
 #[pyfunction]
 pub fn prepare_cloud_plan(lf: PyLazyFrame, py: Python<'_>) -> PyResult<Bound<'_, PyBytes>> {

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -7,8 +7,8 @@ use super::PyDataFrame;
 use crate::conversion::any_value::py_object_to_any_value;
 use crate::conversion::{vec_extract_wrapped, Wrap};
 use crate::error::PyPolarsErr;
-use crate::utils::EnterPolarsExt;
 use crate::interop;
+use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PyDataFrame {

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -7,6 +7,7 @@ use super::PyDataFrame;
 use crate::conversion::any_value::py_object_to_any_value;
 use crate::conversion::{vec_extract_wrapped, Wrap};
 use crate::error::PyPolarsErr;
+use crate::utils::EnterPolarsExt;
 use crate::interop;
 
 #[pymethods]
@@ -21,7 +22,7 @@ impl PyDataFrame {
     ) -> PyResult<Self> {
         let data = vec_extract_wrapped(data);
         let schema = schema.map(|wrap| wrap.0);
-        py.allow_threads(move || finish_from_rows(data, schema, None, infer_schema_length))
+        py.enter_polars(move || finish_from_rows(data, schema, None, infer_schema_length))
     }
 
     #[staticmethod]
@@ -46,7 +47,7 @@ impl PyDataFrame {
             ))
         });
 
-        py.allow_threads(move || {
+        py.enter_polars(move || {
             finish_from_rows(rows, schema, schema_overrides, infer_schema_length)
         })
     }

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -9,6 +9,7 @@ use pyo3::IntoPyObjectExt;
 use super::PyDataFrame;
 use crate::conversion::{ObjectValue, Wrap};
 use crate::error::PyPolarsErr;
+use crate::utils::EnterPolarsExt;
 use crate::interop;
 use crate::interop::arrow::to_py::dataframe_to_stream;
 use crate::prelude::PyCompatLevel;
@@ -74,7 +75,7 @@ impl PyDataFrame {
 
     #[allow(clippy::wrong_self_convention)]
     pub fn to_arrow(&mut self, py: Python, compat_level: PyCompatLevel) -> PyResult<Vec<PyObject>> {
-        py.allow_threads(|| self.df.align_chunks_par());
+        py.enter_polars_ok(|| self.df.align_chunks_par())?;
         let pyarrow = py.import("pyarrow")?;
 
         let rbs = self
@@ -92,7 +93,7 @@ impl PyDataFrame {
     /// code should make sure these are not included.
     #[allow(clippy::wrong_self_convention)]
     pub fn to_pandas(&mut self, py: Python) -> PyResult<Vec<PyObject>> {
-        py.allow_threads(|| self.df.as_single_chunk_par());
+        py.enter_polars_ok(|| self.df.as_single_chunk_par())?;
         Python::with_gil(|py| {
             let pyarrow = py.import("pyarrow")?;
             let cat_columns = self
@@ -163,7 +164,7 @@ impl PyDataFrame {
         py: Python<'py>,
         requested_schema: Option<PyObject>,
     ) -> PyResult<Bound<'py, PyCapsule>> {
-        py.allow_threads(|| self.df.align_chunks_par());
+        py.enter_polars_ok(|| self.df.align_chunks_par())?;
         dataframe_to_stream(&self.df, py)
     }
 }

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -9,10 +9,10 @@ use pyo3::IntoPyObjectExt;
 use super::PyDataFrame;
 use crate::conversion::{ObjectValue, Wrap};
 use crate::error::PyPolarsErr;
-use crate::utils::EnterPolarsExt;
 use crate::interop;
 use crate::interop::arrow::to_py::dataframe_to_stream;
 use crate::prelude::PyCompatLevel;
+use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PyDataFrame {

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -22,6 +22,7 @@ use crate::map::dataframe::{
 use crate::prelude::strings_to_pl_smallstr;
 use crate::py_modules::polars;
 use crate::series::{PySeries, ToPySeries, ToSeries};
+use crate::utils::EnterPolarsExt;
 use crate::{PyExpr, PyLazyFrame};
 
 #[pymethods]
@@ -48,73 +49,43 @@ impl PyDataFrame {
     }
 
     pub fn add(&self, py: Python, s: &PySeries) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df + &s.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df + &s.series)
     }
 
     pub fn sub(&self, py: Python, s: &PySeries) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df - &s.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
-    }
-
-    pub fn div(&self, py: Python, s: &PySeries) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df / &s.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df - &s.series)
     }
 
     pub fn mul(&self, py: Python, s: &PySeries) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df * &s.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df * &s.series)
+    }
+
+    pub fn div(&self, py: Python, s: &PySeries) -> PyResult<Self> {
+        py.enter_polars_df(|| &self.df / &s.series)
     }
 
     pub fn rem(&self, py: Python, s: &PySeries) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df % &s.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df % &s.series)
     }
 
     pub fn add_df(&self, py: Python, s: &Self) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df + &s.df)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df + &s.df)
     }
 
     pub fn sub_df(&self, py: Python, s: &Self) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df - &s.df)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
-    }
-
-    pub fn div_df(&self, py: Python, s: &Self) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df / &s.df)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df - &s.df)
     }
 
     pub fn mul_df(&self, py: Python, s: &Self) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df * &s.df)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df * &s.df)
+    }
+
+    pub fn div_df(&self, py: Python, s: &Self) -> PyResult<Self> {
+        py.enter_polars_df(|| &self.df / &s.df)
     }
 
     pub fn rem_df(&self, py: Python, s: &Self) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| &self.df % &s.df)
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| &self.df % &s.df)
     }
 
     #[pyo3(signature = (n, with_replacement, shuffle, seed=None))]
@@ -126,10 +97,7 @@ impl PyDataFrame {
         shuffle: bool,
         seed: Option<u64>,
     ) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| self.df.sample_n(&n.series, with_replacement, shuffle, seed))
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| self.df.sample_n(&n.series, with_replacement, shuffle, seed))
     }
 
     #[pyo3(signature = (frac, with_replacement, shuffle, seed=None))]
@@ -141,19 +109,18 @@ impl PyDataFrame {
         shuffle: bool,
         seed: Option<u64>,
     ) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| {
-                self.df
-                    .sample_frac(&frac.series, with_replacement, shuffle, seed)
-            })
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| {
+            self.df
+                .sample_frac(&frac.series, with_replacement, shuffle, seed)
+        })
     }
 
-    pub fn rechunk(&self, py: Python) -> Self {
-        let mut df = self.df.clone();
-        py.allow_threads(|| df.as_single_chunk_par());
-        df.into()
+    pub fn rechunk(&self, py: Python) -> PyResult<Self> {
+        py.enter_polars_df(|| {
+            let mut df = self.df.clone();
+            df.as_single_chunk_par();
+            Ok(df)
+        })
     }
 
     /// Format `DataFrame` as String
@@ -212,37 +179,28 @@ impl PyDataFrame {
         let columns = columns.to_series();
         // @scalar-opt
         let columns = columns.into_iter().map(Into::into).collect::<Vec<_>>();
-        let df = py
-            .allow_threads(|| self.df.hstack(&columns))
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| self.df.hstack(&columns))
     }
 
     pub fn hstack_mut(&mut self, py: Python, columns: Vec<PySeries>) -> PyResult<()> {
         let columns = columns.to_series();
         // @scalar-opt
         let columns = columns.into_iter().map(Into::into).collect::<Vec<_>>();
-        py.allow_threads(|| self.df.hstack_mut(&columns))
-            .map_err(PyPolarsErr::from)?;
+        py.enter_polars(|| self.df.hstack_mut(&columns))?;
         Ok(())
     }
 
     pub fn vstack(&self, py: Python, other: &PyDataFrame) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| self.df.vstack(&other.df))
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| self.df.vstack(&other.df))
     }
 
     pub fn vstack_mut(&mut self, py: Python, other: &PyDataFrame) -> PyResult<()> {
-        py.allow_threads(|| self.df.vstack_mut(&other.df))
-            .map_err(PyPolarsErr::from)?;
+        py.enter_polars(|| self.df.vstack_mut(&other.df))?;
         Ok(())
     }
 
     pub fn extend(&mut self, py: Python, other: &PyDataFrame) -> PyResult<()> {
-        py.allow_threads(|| self.df.extend(&other.df))
-            .map_err(PyPolarsErr::from)?;
+        py.enter_polars(|| self.df.extend(&other.df))?;
         Ok(())
     }
 
@@ -287,23 +245,18 @@ impl PyDataFrame {
     }
 
     pub fn select(&self, py: Python, columns: Vec<PyBackedStr>) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| self.df.select(columns.iter().map(|x| &**x)))
-            .map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
+        py.enter_polars_df(|| self.df.select(columns.iter().map(|x| &**x)))
     }
 
     pub fn gather(&self, py: Python, indices: Wrap<Vec<IdxSize>>) -> PyResult<Self> {
         let indices = indices.0;
         let indices = IdxCa::from_vec("".into(), indices);
-        let df = Python::allow_threads(py, || self.df.take(&indices).map_err(PyPolarsErr::from))?;
-        Ok(PyDataFrame::new(df))
+        py.enter_polars_df(|| self.df.take(&indices))
     }
 
     pub fn gather_with_series(&self, py: Python, indices: &PySeries) -> PyResult<Self> {
         let indices = indices.series.idx().map_err(PyPolarsErr::from)?;
-        let df = Python::allow_threads(py, || self.df.take(indices).map_err(PyPolarsErr::from))?;
-        Ok(PyDataFrame::new(df))
+        py.enter_polars_df(|| self.df.take(indices))
     }
 
     pub fn replace(&mut self, column: &str, new_col: PySeries) -> PyResult<()> {
@@ -328,43 +281,35 @@ impl PyDataFrame {
     }
 
     #[pyo3(signature = (offset, length=None))]
-    pub fn slice(&self, py: Python, offset: i64, length: Option<usize>) -> Self {
-        let df = py.allow_threads(|| {
-            self.df
-                .slice(offset, length.unwrap_or_else(|| self.df.height()))
-        });
-        df.into()
+    pub fn slice(&self, py: Python, offset: i64, length: Option<usize>) -> PyResult<Self> {
+        py.enter_polars_df(|| {
+            Ok(self
+                .df
+                .slice(offset, length.unwrap_or_else(|| self.df.height())))
+        })
     }
 
-    pub fn head(&self, py: Python, n: usize) -> Self {
-        let df = py.allow_threads(|| self.df.head(Some(n)));
-        PyDataFrame::new(df)
+    pub fn head(&self, py: Python, n: usize) -> PyResult<Self> {
+        py.enter_polars_df(|| Ok(self.df.head(Some(n))))
     }
 
-    pub fn tail(&self, py: Python, n: usize) -> Self {
-        let df = py.allow_threads(|| self.df.tail(Some(n)));
-        PyDataFrame::new(df)
+    pub fn tail(&self, py: Python, n: usize) -> PyResult<Self> {
+        py.enter_polars_df(|| Ok(self.df.tail(Some(n))))
     }
 
     pub fn is_unique(&self, py: Python) -> PyResult<PySeries> {
-        let mask = py
-            .allow_threads(|| self.df.is_unique())
-            .map_err(PyPolarsErr::from)?;
-        Ok(mask.into_series().into())
+        py.enter_polars_series(|| Ok(self.df.is_unique()?.into_series()))
     }
 
     pub fn is_duplicated(&self, py: Python) -> PyResult<PySeries> {
-        let mask = py
-            .allow_threads(|| self.df.is_duplicated())
-            .map_err(PyPolarsErr::from)?;
-        Ok(mask.into_series().into())
+        py.enter_polars_series(|| Ok(self.df.is_duplicated()?.into_series()))
     }
 
-    pub fn equals(&self, py: Python, other: &PyDataFrame, null_equal: bool) -> bool {
+    pub fn equals(&self, py: Python, other: &PyDataFrame, null_equal: bool) -> PyResult<bool> {
         if null_equal {
-            py.allow_threads(|| self.df.equals_missing(&other.df))
+            py.enter_polars_ok(|| self.df.equals_missing(&other.df))
         } else {
-            py.allow_threads(|| self.df.equals(&other.df))
+            py.enter_polars_ok(|| self.df.equals(&other.df))
         }
     }
 
@@ -375,10 +320,7 @@ impl PyDataFrame {
         name: &str,
         offset: Option<IdxSize>,
     ) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| self.df.with_row_index(name.into(), offset))
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| self.df.with_row_index(name.into(), offset))
     }
 
     pub fn _to_metadata(&self) -> Self {
@@ -452,10 +394,7 @@ impl PyDataFrame {
             variable_name: variable_name.map(|s| s.into()),
         };
 
-        let df = py
-            .allow_threads(|| self.df.unpivot2(args))
-            .map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
+        py.enter_polars_df(|| self.df.unpivot2(args))
     }
 
     #[cfg(feature = "pivot")]
@@ -473,20 +412,17 @@ impl PyDataFrame {
     ) -> PyResult<Self> {
         let fun = if maintain_order { pivot_stable } else { pivot };
         let agg_expr = aggregate_expr.map(|expr| expr.inner);
-        let df = py
-            .allow_threads(|| {
-                fun(
-                    &self.df,
-                    on,
-                    index,
-                    values,
-                    sort_columns,
-                    agg_expr,
-                    separator,
-                )
-            })
-            .map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
+        py.enter_polars_df(|| {
+            fun(
+                &self.df,
+                on,
+                index,
+                values,
+                sort_columns,
+                agg_expr,
+                separator,
+            )
+        })
     }
 
     pub fn partition_by(
@@ -496,15 +432,13 @@ impl PyDataFrame {
         maintain_order: bool,
         include_key: bool,
     ) -> PyResult<Vec<Self>> {
-        let out = py
-            .allow_threads(|| {
-                if maintain_order {
-                    self.df.partition_by_stable(by, include_key)
-                } else {
-                    self.df.partition_by(by, include_key)
-                }
-            })
-            .map_err(PyPolarsErr::from)?;
+        let out = py.enter_polars(|| {
+            if maintain_order {
+                self.df.partition_by_stable(by, include_key)
+            } else {
+                self.df.partition_by(by, include_key)
+            }
+        })?;
 
         // SAFETY: PyDataFrame is a repr(transparent) DataFrame.
         Ok(unsafe { std::mem::transmute::<Vec<DataFrame>, Vec<PyDataFrame>>(out) })
@@ -522,22 +456,18 @@ impl PyDataFrame {
         separator: Option<&str>,
         drop_first: bool,
     ) -> PyResult<Self> {
-        let df = py
-            .allow_threads(|| match columns {
-                Some(cols) => self.df.columns_to_dummies(
-                    cols.iter().map(|x| x as &str).collect(),
-                    separator,
-                    drop_first,
-                ),
-                None => self.df.to_dummies(separator, drop_first),
-            })
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| match columns {
+            Some(cols) => self.df.columns_to_dummies(
+                cols.iter().map(|x| x as &str).collect(),
+                separator,
+                drop_first,
+            ),
+            None => self.df.to_dummies(separator, drop_first),
+        })
     }
 
-    pub fn null_count(&self, py: Python) -> Self {
-        let df = py.allow_threads(|| self.df.null_count());
-        df.into()
+    pub fn null_count(&self, py: Python) -> PyResult<Self> {
+        py.enter_polars_df(|| Ok(self.df.null_count()))
     }
 
     #[pyo3(signature = (lambda, output_type, inference_size))]
@@ -572,8 +502,8 @@ impl PyDataFrame {
         })
     }
 
-    pub fn shrink_to_fit(&mut self, py: Python) {
-        py.allow_threads(|| self.df.shrink_to_fit());
+    pub fn shrink_to_fit(&mut self, py: Python) -> PyResult<()> {
+        py.enter_polars_ok(|| self.df.shrink_to_fit())
     }
 
     pub fn hash_rows(
@@ -585,10 +515,7 @@ impl PyDataFrame {
         k3: u64,
     ) -> PyResult<PySeries> {
         let hb = PlRandomState::with_seeds(k0, k1, k2, k3);
-        let hash = py
-            .allow_threads(|| self.df.hash_rows(Some(hb)))
-            .map_err(PyPolarsErr::from)?;
-        Ok(hash.into_series().into())
+        py.enter_polars_series(|| Ok(self.df.hash_rows(Some(hb))?.into_series()))
     }
 
     #[pyo3(signature = (keep_names_as, column_names))]
@@ -605,10 +532,7 @@ impl PyDataFrame {
         } else {
             None
         };
-        Ok(py
-            .allow_threads(|| self.df.transpose(keep_names_as, new_col_names))
-            .map_err(PyPolarsErr::from)?
-            .into())
+        py.enter_polars_df(|| self.df.transpose(keep_names_as, new_col_names))
     }
 
     pub fn upsample(
@@ -620,19 +544,22 @@ impl PyDataFrame {
         stable: bool,
     ) -> PyResult<Self> {
         let every = Duration::try_parse(every).map_err(PyPolarsErr::from)?;
-        let out = py.allow_threads(|| {
+        py.enter_polars_df(|| {
             if stable {
                 self.df.upsample_stable(by, index_column, every)
             } else {
                 self.df.upsample(by, index_column, every)
             }
-        });
-        let out = out.map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        })
     }
 
-    pub fn to_struct(&self, py: Python, name: &str, invalid_indices: Vec<usize>) -> PySeries {
-        py.allow_threads(|| {
+    pub fn to_struct(
+        &self,
+        py: Python,
+        name: &str,
+        invalid_indices: Vec<usize>,
+    ) -> PyResult<PySeries> {
+        py.enter_polars_series(|| {
             let ca = self.df.clone().into_struct(name.into());
 
             if !invalid_indices.is_empty() {
@@ -642,17 +569,17 @@ impl PyDataFrame {
                     validity.set(i, false);
                 }
                 let ca = ca.rechunk();
-                ca.with_outer_validity(Some(validity.freeze()))
-                    .into_series()
-                    .into()
+                Ok(ca
+                    .with_outer_validity(Some(validity.freeze()))
+                    .into_series())
             } else {
-                ca.into_series().into()
+                Ok(ca.into_series())
             }
         })
     }
 
-    pub fn clear(&self, py: Python) -> Self {
-        py.allow_threads(|| self.df.clear()).into()
+    pub fn clear(&self, py: Python) -> PyResult<Self> {
+        py.enter_polars_df(|| Ok(self.df.clear()))
     }
 
     #[allow(clippy::wrong_self_convention)]
@@ -675,7 +602,7 @@ impl PyDataFrame {
         py: Python<'py>,
         opts: Vec<(bool, bool, bool)>,
     ) -> PyResult<PySeries> {
-        py.allow_threads(|| {
+        py.enter_polars_series(|| {
             let name = PlSmallStr::from_static("row_enc");
             let is_unordered = opts.first().is_some_and(|(_, _, v)| *v);
 
@@ -691,10 +618,9 @@ impl PyDataFrame {
                     descending.as_slice(),
                     nulls_last.as_slice(),
                 )
-            }
-            .map_err(PyPolarsErr::from)?;
+            }?;
 
-            Ok(ca.into_series().into())
+            Ok(ca.into_series())
         })
     }
 }

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -298,11 +298,11 @@ impl PyDataFrame {
     }
 
     pub fn is_unique(&self, py: Python) -> PyResult<PySeries> {
-        py.enter_polars_series(|| Ok(self.df.is_unique()?.into_series()))
+        py.enter_polars_series(|| self.df.is_unique())
     }
 
     pub fn is_duplicated(&self, py: Python) -> PyResult<PySeries> {
-        py.enter_polars_series(|| Ok(self.df.is_duplicated()?.into_series()))
+        py.enter_polars_series(|| self.df.is_duplicated())
     }
 
     pub fn equals(&self, py: Python, other: &PyDataFrame, null_equal: bool) -> PyResult<bool> {
@@ -515,7 +515,7 @@ impl PyDataFrame {
         k3: u64,
     ) -> PyResult<PySeries> {
         let hb = PlRandomState::with_seeds(k0, k1, k2, k3);
-        py.enter_polars_series(|| Ok(self.df.hash_rows(Some(hb))?.into_series()))
+        py.enter_polars_series(|| self.df.hash_rows(Some(hb)))
     }
 
     #[pyo3(signature = (keep_names_as, column_names))]
@@ -569,11 +569,9 @@ impl PyDataFrame {
                     validity.set(i, false);
                 }
                 let ca = ca.rechunk();
-                Ok(ca
-                    .with_outer_validity(Some(validity.freeze()))
-                    .into_series())
+                Ok(ca.with_outer_validity(Some(validity.freeze())))
             } else {
-                Ok(ca.into_series())
+                Ok(ca)
             }
         })
     }
@@ -620,7 +618,7 @@ impl PyDataFrame {
                 )
             }?;
 
-            Ok(ca.into_series())
+            Ok(ca)
         })
     }
 }

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -26,6 +26,8 @@ use crate::file::{
 #[cfg(feature = "cloud")]
 use crate::prelude::parse_cloud_options;
 use crate::prelude::PyCompatLevel;
+use crate::utils::EnterPolarsExt;
+
 
 #[pymethods]
 impl PyDataFrame {
@@ -97,7 +99,7 @@ impl PyDataFrame {
         });
 
         let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
-        let df = py.allow_threads(move || {
+        py.enter_polars_df(move || {
             CsvReadOptions::default()
                 .with_path(path)
                 .with_infer_schema_length(infer_schema_length)
@@ -133,9 +135,7 @@ impl PyDataFrame {
                 )
                 .into_reader_with_file_handle(mmap_bytes_r)
                 .finish()
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(df.into())
+        })
     }
 
     #[staticmethod]
@@ -160,10 +160,10 @@ impl PyDataFrame {
             offset,
         });
 
-        let result = match get_either_file(py_f, false)? {
+        match get_either_file(py_f, false)? {
             Py(f) => {
                 let buf = std::io::Cursor::new(f.to_memslice());
-                py.allow_threads(move || {
+                py.enter_polars_df(move || {
                     ParquetReader::new(buf)
                         .with_projection(projection)
                         .with_columns(columns)
@@ -176,7 +176,7 @@ impl PyDataFrame {
                         .finish()
                 })
             },
-            Rust(f) => py.allow_threads(move || {
+            Rust(f) => py.enter_polars_df(move || {
                 ParquetReader::new(f)
                     .with_projection(projection)
                     .with_columns(columns)
@@ -187,9 +187,7 @@ impl PyDataFrame {
                     .set_rechunk(rechunk)
                     .finish()
             }),
-        };
-        let df = result.map_err(PyPolarsErr::from)?;
-        Ok(PyDataFrame::new(df))
+        }
     }
 
     #[staticmethod]
@@ -205,7 +203,7 @@ impl PyDataFrame {
         assert!(infer_schema_length != Some(0));
         let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
 
-        py.allow_threads(move || {
+        py.enter_polars_df(move || {
             let mut builder = JsonReader::new(mmap_bytes_r)
                 .with_json_format(JsonFormat::Json)
                 .infer_schema_len(infer_schema_length.and_then(NonZeroUsize::new));
@@ -218,8 +216,7 @@ impl PyDataFrame {
                 builder = builder.with_schema_overwrite(&schema.0);
             }
 
-            let out = builder.finish().map_err(PyPolarsErr::from)?;
-            Ok(out.into())
+            builder.finish()
         })
     }
 
@@ -247,10 +244,7 @@ impl PyDataFrame {
             builder = builder.with_schema_overwrite(&schema.0);
         }
 
-        let out = py
-            .allow_threads(move || builder.finish())
-            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
-        Ok(out.into())
+        py.enter_polars_df(move || builder.finish())
     }
 
     #[staticmethod]
@@ -272,7 +266,7 @@ impl PyDataFrame {
         let (mmap_bytes_r, mmap_path) = get_mmap_bytes_reader_and_path(&py_f)?;
 
         let mmap_path = if memory_map { mmap_path } else { None };
-        let df = py.allow_threads(move || {
+        py.enter_polars_df(move || {
             IpcReader::new(mmap_bytes_r)
                 .with_projection(projection)
                 .with_columns(columns)
@@ -280,9 +274,7 @@ impl PyDataFrame {
                 .with_row_index(row_index)
                 .memory_mapped(mmap_path)
                 .finish()
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(PyDataFrame::new(df))
+        })
     }
 
     #[staticmethod]
@@ -302,7 +294,7 @@ impl PyDataFrame {
             offset,
         });
         let mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
-        let df = py.allow_threads(move || {
+        py.enter_polars_df(move || {
             IpcStreamReader::new(mmap_bytes_r)
                 .with_projection(projection)
                 .with_columns(columns)
@@ -310,9 +302,7 @@ impl PyDataFrame {
                 .with_row_index(row_index)
                 .set_rechunk(rechunk)
                 .finish()
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(PyDataFrame::new(df))
+        })
     }
 
     #[staticmethod]
@@ -328,15 +318,13 @@ impl PyDataFrame {
         use polars::io::avro::AvroReader;
 
         let file = get_file_like(py_f, false)?;
-        let df = py.allow_threads(move || {
+        py.enter_polars_df(move || {
             AvroReader::new(file)
                 .with_projection(projection)
                 .with_columns(columns)
                 .with_n_rows(n_rows)
                 .finish()
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(PyDataFrame::new(df))
+        })
     }
 
     #[cfg(feature = "csv")]
@@ -387,7 +375,7 @@ impl PyDataFrame {
 
         let f = crate::file::try_get_writeable(py_f, cloud_options.as_ref())?;
 
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             CsvWriter::new(f)
                 .include_bom(include_bom)
                 .include_header(include_header)
@@ -403,9 +391,7 @@ impl PyDataFrame {
                 .with_null_value(null)
                 .with_quote_style(quote_style.map(|wrap| wrap.0).unwrap_or_default())
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        })
     }
 
     #[cfg(feature = "parquet")]
@@ -452,7 +438,7 @@ impl PyDataFrame {
         if let Some(partition_by) = partition_by {
             let path = py_f.extract::<String>(py)?;
 
-            py.allow_threads(|| {
+            return py.enter_polars(|| {
                 let write_options = ParquetWriteOptions {
                     compression,
                     statistics: statistics.0,
@@ -468,24 +454,20 @@ impl PyDataFrame {
                     cloud_options.as_ref(),
                     partition_chunk_size_bytes,
                 )
-                .map_err(PyPolarsErr::from)
-            })?;
-
-            return Ok(());
+            });
         };
 
         let f = crate::file::try_get_writeable(py_f, cloud_options.as_ref())?;
 
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             ParquetWriter::new(BufWriter::new(f))
                 .with_compression(compression)
                 .with_statistics(statistics.0)
                 .with_row_group_size(row_group_size)
                 .with_data_page_size(data_page_size)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+                .map(|_| ())
+        })
     }
 
     #[cfg(feature = "json")]
@@ -548,14 +530,12 @@ impl PyDataFrame {
 
         let f = crate::file::try_get_writeable(py_f, cloud_options.as_ref())?;
 
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             IpcWriter::new(f)
                 .with_compression(compression.0)
                 .with_compat_level(compat_level.0)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        })
     }
 
     #[cfg(feature = "ipc_streaming")]
@@ -567,14 +547,12 @@ impl PyDataFrame {
         compat_level: PyCompatLevel,
     ) -> PyResult<()> {
         let mut buf = get_file_like(py_f, true)?;
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             IpcStreamWriter::new(&mut buf)
                 .with_compression(compression.0)
                 .with_compat_level(compat_level.0)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        })
     }
 
     #[cfg(feature = "avro")]
@@ -588,13 +566,11 @@ impl PyDataFrame {
     ) -> PyResult<()> {
         use polars::io::avro::AvroWriter;
         let mut buf = get_file_like(py_f, true)?;
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             AvroWriter::new(&mut buf)
                 .with_compression(compression.0)
                 .with_name(name)
                 .finish(&mut self.df)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        })
     }
 }

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -28,7 +28,6 @@ use crate::prelude::parse_cloud_options;
 use crate::prelude::PyCompatLevel;
 use crate::utils::EnterPolarsExt;
 
-
 #[pymethods]
 impl PyDataFrame {
     #[staticmethod]

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -26,9 +26,7 @@ impl PyDataFrame {
         let file = get_file_like(py_f, false)?;
         let mut file = BufReader::new(file);
 
-        py.enter_polars_df(|| {
-            DataFrame::deserialize_from_reader(&mut file)
-        })
+        py.enter_polars_df(|| DataFrame::deserialize_from_reader(&mut file))
     }
 
     /// Serialize into a JSON string.

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -6,9 +6,9 @@ use polars_io::mmap::ReaderBytes;
 use pyo3::prelude::*;
 
 use super::PyDataFrame;
-use crate::error::PyPolarsErr;
 use crate::exceptions::ComputeError;
 use crate::file::{get_file_like, get_mmap_bytes_reader};
+use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PyDataFrame {
@@ -17,11 +17,7 @@ impl PyDataFrame {
         let file = get_file_like(py_f, true)?;
         let mut writer = BufWriter::new(file);
 
-        py.allow_threads(|| {
-            self.df
-                .serialize_into_writer(&mut writer)
-                .map_err(|e| PyPolarsErr::from(e).into())
-        })
+        py.enter_polars(|| self.df.serialize_into_writer(&mut writer))
     }
 
     /// Deserialize a file-like object containing binary data into a DataFrame.
@@ -30,10 +26,8 @@ impl PyDataFrame {
         let file = get_file_like(py_f, false)?;
         let mut file = BufReader::new(file);
 
-        py.allow_threads(|| {
+        py.enter_polars_df(|| {
             DataFrame::deserialize_from_reader(&mut file)
-                .map_err(|e| PyPolarsErr::from(e).into())
-                .map(|x| x.into())
         })
     }
 
@@ -42,7 +36,7 @@ impl PyDataFrame {
     pub fn serialize_json(&mut self, py: Python, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             serde_json::to_writer(writer, &self.df)
                 .map_err(|err| ComputeError::new_err(err.to_string()))
         })
@@ -54,12 +48,12 @@ impl PyDataFrame {
     pub fn deserialize_json(py: Python, py_f: Bound<PyAny>) -> PyResult<Self> {
         let mut mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
 
-        py.allow_threads(move || {
+        py.enter_polars(move || {
             let mmap_read: ReaderBytes = (&mut mmap_bytes_r).into();
             let bytes = mmap_read.deref();
             let df = serde_json::from_slice::<DataFrame>(bytes)
                 .map_err(|err| ComputeError::new_err(err.to_string()))?;
-            Ok(df.into())
+            PyResult::Ok(df.into())
         })
     }
 }

--- a/crates/polars-python/src/error.rs
+++ b/crates/polars-python/src/error.rs
@@ -23,6 +23,8 @@ use crate::Wrap;
 pub enum PyPolarsErr {
     #[error(transparent)]
     Polars(#[from] PolarsError),
+    #[error(transparent)]
+    Python(#[from] PyErr),
     #[error("{0}")]
     Other(String),
 }
@@ -35,7 +37,6 @@ impl std::convert::From<std::io::Error> for PyPolarsErr {
 
 impl std::convert::From<PyPolarsErr> for PyErr {
     fn from(err: PyPolarsErr) -> PyErr {
-        let default = || PyRuntimeError::new_err(format!("{:?}", &err));
 
         use PyPolarsErr::*;
         match err {
@@ -79,7 +80,8 @@ impl std::convert::From<PyPolarsErr> for PyErr {
                     PyErr::from(tmp)
                 },
             },
-            _ => default(),
+            Python(err) => err,
+            err => PyRuntimeError::new_err(format!("{:?}", &err)),
         }
     }
 }
@@ -89,6 +91,7 @@ impl Debug for PyPolarsErr {
         use PyPolarsErr::*;
         match self {
             Polars(err) => write!(f, "{err:?}"),
+            Python(err) => write!(f, "{err:?}"),
             Other(err) => write!(f, "BindingsError: {err:?}"),
         }
     }

--- a/crates/polars-python/src/error.rs
+++ b/crates/polars-python/src/error.rs
@@ -37,7 +37,6 @@ impl std::convert::From<std::io::Error> for PyPolarsErr {
 
 impl std::convert::From<PyPolarsErr> for PyErr {
     fn from(err: PyPolarsErr) -> PyErr {
-
         use PyPolarsErr::*;
         match err {
             Polars(err) => match err {

--- a/crates/polars-python/src/functions/eager.rs
+++ b/crates/polars-python/src/functions/eager.rs
@@ -4,8 +4,8 @@ use pyo3::prelude::*;
 
 use crate::conversion::{get_df, get_series};
 use crate::error::PyPolarsErr;
-use crate::{PyDataFrame, PySeries};
 use crate::utils::EnterPolarsExt;
+use crate::{PyDataFrame, PySeries};
 
 #[pyfunction]
 pub fn concat_df(dfs: &Bound<'_, PyAny>, py: Python) -> PyResult<PyDataFrame> {
@@ -27,22 +27,21 @@ pub fn concat_df(dfs: &Bound<'_, PyAny>, py: Python) -> PyResult<PyDataFrame> {
 
     let identity = || Ok(identity_df.clone());
 
-    py
-        .enter_polars_df(|| {
-            polars_core::POOL.install(|| {
-                rdfs.into_par_iter()
-                    .fold(identity, |acc: PolarsResult<DataFrame>, df| {
-                        let mut acc = acc?;
-                        acc.vstack_mut(&df?)?;
-                        Ok(acc)
-                    })
-                    .reduce(identity, |acc, df| {
-                        let mut acc = acc?;
-                        acc.vstack_mut(&df?)?;
-                        Ok(acc)
-                    })
-            })
+    py.enter_polars_df(|| {
+        polars_core::POOL.install(|| {
+            rdfs.into_par_iter()
+                .fold(identity, |acc: PolarsResult<DataFrame>, df| {
+                    let mut acc = acc?;
+                    acc.vstack_mut(&df?)?;
+                    Ok(acc)
+                })
+                .reduce(identity, |acc, df| {
+                    let mut acc = acc?;
+                    acc.vstack_mut(&df?)?;
+                    Ok(acc)
+                })
         })
+    })
 }
 
 #[pyfunction]

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 use crate::error::PyPolarsErr;
 use crate::prelude::*;
 use crate::{PyExpr, PySeries};
+use crate::utils::EnterPolarsExt;
 
 #[pyfunction]
 pub fn int_range(start: PyExpr, end: PyExpr, step: i64, dtype: Wrap<DataType>) -> PyExpr {
@@ -32,15 +33,12 @@ pub fn eager_int_range(
         .into());
     }
 
-    let ret = with_match_physical_integer_polars_type!(dtype, |$T| {
+    with_match_physical_integer_polars_type!(dtype, |$T| {
         let start_v: <$T as PolarsNumericType>::Native = lower.extract()?;
         let end_v: <$T as PolarsNumericType>::Native = upper.extract()?;
         let step: i64 = step.extract()?;
-        py.allow_threads(|| new_int_range::<$T>(start_v, end_v, step, PlSmallStr::from_static("literal")))
-    });
-
-    let s = ret.map_err(PyPolarsErr::from)?;
-    Ok(s.into())
+        py.enter_polars_series(|| new_int_range::<$T>(start_v, end_v, step, PlSmallStr::from_static("literal")))
+    })
 }
 
 #[pyfunction]

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -5,8 +5,8 @@ use pyo3::prelude::*;
 
 use crate::error::PyPolarsErr;
 use crate::prelude::*;
-use crate::{PyExpr, PySeries};
 use crate::utils::EnterPolarsExt;
+use crate::{PyExpr, PySeries};
 
 #[pyfunction]
 pub fn int_range(start: PyExpr, end: PyExpr, step: i64, dtype: Wrap<DataType>) -> PyExpr {

--- a/crates/polars-python/src/interop/arrow/to_rust.rs
+++ b/crates/polars-python/src/interop/arrow/to_rust.rs
@@ -8,6 +8,7 @@ use pyo3::types::PyList;
 use rayon::prelude::*;
 
 use crate::error::PyPolarsErr;
+use crate::utils::EnterPolarsExt;
 
 pub fn field_to_rust_arrow(obj: Bound<'_, PyAny>) -> PyResult<ArrowField> {
     let mut schema = Box::new(ffi::ArrowSchema::empty());
@@ -90,7 +91,7 @@ pub fn to_rust_df(py: Python, rb: &[Bound<PyAny>], schema: Bound<PyAny>) -> PyRe
             // for instance string -> large-utf8
             // dict encoded to categorical
             let columns = if run_parallel {
-                py.allow_threads(|| {
+                py.enter_polars(|| {
                     POOL.install(|| {
                         columns
                             .into_par_iter()

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -18,6 +18,7 @@ use crate::expr::ToExprs;
 use crate::interop::arrow::to_rust::pyarrow_schema_to_rust;
 use crate::lazyframe::visit::NodeTraverser;
 use crate::prelude::*;
+use crate::utils::EnterPolarsExt;
 use crate::{PyDataFrame, PyExpr, PyLazyGroupBy};
 
 fn pyobject_to_first_path_and_scan_sources(
@@ -603,20 +604,13 @@ impl PyLazyFrame {
     }
 
     fn profile(&self, py: Python) -> PyResult<(PyDataFrame, PyDataFrame)> {
-        // if we don't allow threads and we have udfs trying to acquire the gil from different
-        // threads we deadlock.
-        let (df, time_df) = py.allow_threads(|| {
-            let ldf = self.ldf.clone();
-            ldf.profile().map_err(PyPolarsErr::from)
-        })?;
+        let (df, time_df) = py.enter_polars(|| self.ldf.clone().profile())?;
         Ok((df.into(), time_df.into()))
     }
 
     #[pyo3(signature = (lambda_post_opt=None))]
     fn collect(&self, py: Python, lambda_post_opt: Option<PyObject>) -> PyResult<PyDataFrame> {
-        // if we don't allow threads and we have udfs trying to acquire the gil from different
-        // threads we deadlock.
-        let df = py.allow_threads(|| {
+        py.enter_polars_df(|| {
             let ldf = self.ldf.clone();
             if let Some(lambda) = lambda_post_opt {
                 ldf._collect_post_opt(|root, lp_arena, expr_arena| {
@@ -648,9 +642,7 @@ impl PyLazyFrame {
             } else {
                 ldf.collect()
             }
-            .map_err(PyPolarsErr::from)
-        })?;
-        Ok(df.into())
+        })
     }
 
     #[pyo3(signature = (lambda,))]
@@ -718,14 +710,7 @@ impl PyLazyFrame {
             )
         };
 
-        // if we don't allow threads and we have udfs trying to acquire the gil from different
-        // threads we deadlock.
-        py.allow_threads(|| {
-            let ldf = self.ldf.clone();
-            ldf.sink_parquet(&path, options, cloud_options)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        py.enter_polars(|| self.ldf.clone().sink_parquet(&path, options, cloud_options))
     }
 
     #[cfg(all(feature = "streaming", feature = "ipc"))]
@@ -761,14 +746,9 @@ impl PyLazyFrame {
         #[cfg(not(feature = "cloud"))]
         let cloud_options = None;
 
-        // if we don't allow threads and we have udfs trying to acquire the gil from different
-        // threads we deadlock.
-        py.allow_threads(|| {
-            let ldf = self.ldf.clone();
-            ldf.sink_ipc(path, options, cloud_options)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        py.enter_polars(|| {
+            self.ldf.clone().sink_ipc(path, options, cloud_options)
+        })
     }
 
     #[cfg(all(feature = "streaming", feature = "csv"))]
@@ -839,14 +819,10 @@ impl PyLazyFrame {
         #[cfg(not(feature = "cloud"))]
         let cloud_options = None;
 
-        // if we don't allow threads and we have udfs trying to acquire the gil from different
-        // threads we deadlock.
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             let ldf = self.ldf.clone();
             ldf.sink_csv(path, options, cloud_options)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -875,20 +851,15 @@ impl PyLazyFrame {
             )
         };
 
-        // if we don't allow threads and we have udfs trying to acquire the gil from different
-        // threads we deadlock.
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             let ldf = self.ldf.clone();
             ldf.sink_json(path, options, cloud_options)
-                .map_err(PyPolarsErr::from)
-        })?;
-        Ok(())
+        })
     }
 
     fn fetch(&self, py: Python, n_rows: usize) -> PyResult<PyDataFrame> {
         let ldf = self.ldf.clone();
-        let df = py.allow_threads(|| ldf.fetch(n_rows).map_err(PyPolarsErr::from))?;
-        Ok(df.into())
+        py.enter_polars_df(|| ldf.fetch(n_rows))
     }
 
     fn filter(&mut self, predicate: PyExpr) -> Self {
@@ -1316,9 +1287,7 @@ impl PyLazyFrame {
     }
 
     fn collect_schema<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
-        let schema = py
-            .allow_threads(|| self.ldf.collect_schema())
-            .map_err(PyPolarsErr::from)?;
+        let schema = py.enter_polars(|| self.ldf.collect_schema())?;
 
         let schema_dict = PyDict::new(py);
         schema.iter_fields().for_each(|fld| {

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -746,9 +746,7 @@ impl PyLazyFrame {
         #[cfg(not(feature = "cloud"))]
         let cloud_options = None;
 
-        py.enter_polars(|| {
-            self.ldf.clone().sink_ipc(path, options, cloud_options)
-        })
+        py.enter_polars(|| self.ldf.clone().sink_ipc(path, options, cloud_options))
     }
 
     #[cfg(all(feature = "streaming", feature = "csv"))]

--- a/crates/polars-python/src/lazyframe/serde.rs
+++ b/crates/polars-python/src/lazyframe/serde.rs
@@ -7,6 +7,8 @@ use super::PyLazyFrame;
 use crate::exceptions::ComputeError;
 use crate::file::get_file_like;
 use crate::prelude::*;
+use crate::utils::EnterPolarsExt;
+
 
 #[pymethods]
 #[allow(clippy::should_implement_trait)]
@@ -15,10 +17,9 @@ impl PyLazyFrame {
     fn serialize_binary(&self, py: Python, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             pl_serialize::SerializeOptions::default()
                 .serialize_into_writer(writer, &self.ldf.logical_plan)
-                .map_err(|err| ComputeError::new_err(err.to_string()))
         })
     }
 
@@ -27,7 +28,7 @@ impl PyLazyFrame {
     fn serialize_json(&self, py: Python, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
-        py.allow_threads(|| {
+        py.enter_polars(|| {
             serde_json::to_writer(writer, &self.ldf.logical_plan)
                 .map_err(|err| ComputeError::new_err(err.to_string()))
         })
@@ -38,10 +39,9 @@ impl PyLazyFrame {
     fn deserialize_binary(py: Python, py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
-        let lp: DslPlan = py.allow_threads(|| {
+        let lp: DslPlan = py.enter_polars(|| {
             pl_serialize::SerializeOptions::default()
                 .deserialize_from_reader(reader)
-                .map_err(|err| ComputeError::new_err(err.to_string()))
         })?;
         Ok(LazyFrame::from(lp).into())
     }
@@ -65,7 +65,7 @@ impl PyLazyFrame {
         // in this scope.
         let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
 
-        let lp = py.allow_threads(|| {
+        let lp = py.enter_polars(|| {
             serde_json::from_str::<DslPlan>(json)
                 .map_err(|err| ComputeError::new_err(err.to_string()))
         })?;

--- a/crates/polars-python/src/lazyframe/serde.rs
+++ b/crates/polars-python/src/lazyframe/serde.rs
@@ -9,7 +9,6 @@ use crate::file::get_file_like;
 use crate::prelude::*;
 use crate::utils::EnterPolarsExt;
 
-
 #[pymethods]
 #[allow(clippy::should_implement_trait)]
 impl PyLazyFrame {
@@ -40,8 +39,7 @@ impl PyLazyFrame {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
         let lp: DslPlan = py.enter_polars(|| {
-            pl_serialize::SerializeOptions::default()
-                .deserialize_from_reader(reader)
+            pl_serialize::SerializeOptions::default().deserialize_from_reader(reader)
         })?;
         Ok(LazyFrame::from(lp).into())
     }

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -5,10 +5,12 @@ use polars_core::chunked_array::object::builder::ObjectChunkedBuilder;
 use polars_core::chunked_array::object::registry::AnonymousObjectBuilder;
 use polars_core::chunked_array::object::{registry, set_polars_allow_extension};
 use polars_core::error::PolarsError::ComputeError;
-use polars_error::{set_signals_function, PolarsWarning};
+use polars_error::PolarsWarning;
+use polars_error::signals::register_polars_keyboard_interrupt_hook;
 use pyo3::prelude::*;
 use pyo3::{intern, IntoPyObjectExt};
 
+use std::sync::OnceLock;
 use crate::dataframe::PyDataFrame;
 use crate::map::lazy::{call_lambda_with_series, ToSeries};
 use crate::prelude::ObjectValue;
@@ -68,11 +70,15 @@ fn warning_function(msg: &str, warning: PolarsWarning) {
     });
 }
 
+static POLARS_REGISTRY_INIT_LOCK: OnceLock<()> = OnceLock::new();
+
 /// # Safety
 /// Caller must ensure that no other threads read the objects set by this registration.
-pub unsafe fn register_startup_deps(check_python_signals: bool) {
-    set_polars_allow_extension(true);
-    if !registry::is_object_builder_registered() {
+pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool) {
+    // TODO: should we throw an error if we try to initialize while already initialized?
+    POLARS_REGISTRY_INIT_LOCK.get_or_init(|| {
+        set_polars_allow_extension(true);
+
         // Stack frames can get really large in debug mode.
         #[cfg(debug_assertions)]
         {
@@ -80,7 +86,7 @@ pub unsafe fn register_startup_deps(check_python_signals: bool) {
             recursive::set_stack_allocation_size(1024 * 1024 * 16);
         }
 
-        // register object type builder
+        // Register object type builder.
         let object_builder = Box::new(|name: PlSmallStr, capacity: usize| {
             Box::new(ObjectChunkedBuilder::<ObjectValue>::new(name, capacity))
                 as Box<dyn AnonymousObjectBuilder>
@@ -96,29 +102,22 @@ pub unsafe fn register_startup_deps(check_python_signals: bool) {
         let object_size = size_of::<ObjectValue>();
         let physical_dtype = ArrowDataType::FixedSizeBinary(object_size);
         registry::register_object_builder(object_builder, object_converter, physical_dtype);
-        // register SERIES UDF
+        // Register SERIES UDF.
         python_udf::CALL_COLUMNS_UDF_PYTHON = Some(python_function_caller_series);
-        // register DATAFRAME UDF
+        // Register DATAFRAME UDF.
         python_udf::CALL_DF_UDF_PYTHON = Some(python_function_caller_df);
-        // register warning function for `polars_warn!`
+        // Register warning function for `polars_warn!`.
         polars_error::set_warning_function(warning_function);
 
-        if check_python_signals {
-            fn signals_function() -> PolarsResult<()> {
-                Python::with_gil(|py| {
-                    py.check_signals()
-                        .map_err(|err| polars_err!(ComputeError: "{err}"))
-                })
-            }
-
-            set_signals_function(signals_function);
+        if catch_keyboard_interrupt {
+            register_polars_keyboard_interrupt_hook();
         }
 
         Python::with_gil(|py| {
-            // init AnyValue LUT
+            // Init AnyValue LUT.
             crate::conversion::any_value::LUT
                 .set(py, Default::default())
                 .unwrap();
         });
-    }
+    });
 }

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -1,16 +1,16 @@
 use std::any::Any;
+use std::sync::OnceLock;
 
 use polars::prelude::*;
 use polars_core::chunked_array::object::builder::ObjectChunkedBuilder;
 use polars_core::chunked_array::object::registry::AnonymousObjectBuilder;
 use polars_core::chunked_array::object::{registry, set_polars_allow_extension};
 use polars_core::error::PolarsError::ComputeError;
-use polars_error::PolarsWarning;
 use polars_error::signals::register_polars_keyboard_interrupt_hook;
+use polars_error::PolarsWarning;
 use pyo3::prelude::*;
 use pyo3::{intern, IntoPyObjectExt};
 
-use std::sync::OnceLock;
 use crate::dataframe::PyDataFrame;
 use crate::map::lazy::{call_lambda_with_series, ToSeries};
 use crate::prelude::ObjectValue;

--- a/crates/polars-python/src/series/aggregation.rs
+++ b/crates/polars-python/src/series/aggregation.rs
@@ -5,13 +5,14 @@ use DataType::*;
 use super::PySeries;
 use crate::conversion::Wrap;
 use crate::error::PyPolarsErr;
+use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PySeries {
     fn any(&self, py: Python, ignore_nulls: bool) -> PyResult<Option<bool>> {
-        py.allow_threads(|| {
-            let s = self.series.bool().map_err(PyPolarsErr::from)?;
-            Ok(if ignore_nulls {
+        py.enter_polars(|| {
+            let s = self.series.bool()?;
+            PolarsResult::Ok(if ignore_nulls {
                 Some(s.any())
             } else {
                 s.any_kleene()
@@ -20,9 +21,9 @@ impl PySeries {
     }
 
     fn all(&self, py: Python, ignore_nulls: bool) -> PyResult<Option<bool>> {
-        py.allow_threads(|| {
-            let s = self.series.bool().map_err(PyPolarsErr::from)?;
-            Ok(if ignore_nulls {
+        py.enter_polars(|| {
+            let s = self.series.bool()?;
+            PolarsResult::Ok(if ignore_nulls {
                 Some(s.all())
             } else {
                 s.all_kleene()
@@ -30,12 +31,12 @@ impl PySeries {
         })
     }
 
-    fn arg_max(&self, py: Python) -> Option<usize> {
-        py.allow_threads(|| self.series.arg_max())
+    fn arg_max(&self, py: Python) -> PyResult<Option<usize>> {
+        py.enter_polars_ok(|| self.series.arg_max())
     }
 
-    fn arg_min(&self, py: Python) -> Option<usize> {
-        py.allow_threads(|| self.series.arg_min())
+    fn arg_min(&self, py: Python) -> PyResult<Option<usize>> {
+        py.enter_polars_ok(|| self.series.arg_min())
     }
 
     fn max<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {

--- a/crates/polars-python/src/series/aggregation.rs
+++ b/crates/polars-python/src/series/aggregation.rs
@@ -7,6 +7,10 @@ use crate::conversion::Wrap;
 use crate::error::PyPolarsErr;
 use crate::utils::EnterPolarsExt;
 
+fn scalar_to_py<'py>(scalar: PyResult<Scalar>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    Ok(Wrap(scalar?.as_any_value()).into_pyobject(py)?)
+}
+
 #[pymethods]
 impl PySeries {
     fn any(&self, py: Python, ignore_nulls: bool) -> PyResult<Option<bool>> {
@@ -39,70 +43,44 @@ impl PySeries {
         py.enter_polars_ok(|| self.series.arg_min())
     }
 
+    fn min<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        scalar_to_py(py.enter_polars(|| self.series.min_reduce()), py)
+    }
+
     fn max<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.max_reduce().map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.max_reduce()), py)
     }
 
     fn mean<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         match self.series.dtype() {
-            Boolean => Wrap(
-                py.allow_threads(|| self.series.cast(&DataType::UInt8).unwrap().mean_reduce())
-                    .as_any_value(),
-            )
-            .into_pyobject(py),
+            Boolean => scalar_to_py(
+                py.enter_polars_ok(|| self.series.cast(&DataType::UInt8).unwrap().mean_reduce()),
+                py,
+            ),
             // For non-numeric output types we require mean_reduce.
-            dt if dt.is_temporal() => Wrap(
-                py.allow_threads(|| self.series.mean_reduce())
-                    .as_any_value(),
-            )
-            .into_pyobject(py),
-            _ => py
-                .allow_threads(|| self.series.mean())
-                .into_pyobject(py)
-                .map_err(Into::into),
+            dt if dt.is_temporal() => {
+                scalar_to_py(py.enter_polars_ok(|| self.series.mean_reduce()), py)
+            },
+            _ => Ok(self.series.mean().into_pyobject(py)?),
         }
     }
 
     fn median<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         match self.series.dtype() {
-            Boolean => Wrap(
-                py.allow_threads(|| self.series.cast(&DataType::UInt8).unwrap().median_reduce())
-                    .map_err(PyPolarsErr::from)?
-                    .as_any_value(),
-            )
-            .into_pyobject(py),
+            Boolean => scalar_to_py(
+                py.enter_polars(|| self.series.cast(&DataType::UInt8).unwrap().median_reduce()),
+                py,
+            ),
             // For non-numeric output types we require median_reduce.
-            dt if dt.is_temporal() => Wrap(
-                py.allow_threads(|| self.series.median_reduce())
-                    .map_err(PyPolarsErr::from)?
-                    .as_any_value(),
-            )
-            .into_pyobject(py),
-            _ => py
-                .allow_threads(|| self.series.median())
-                .into_pyobject(py)
-                .map_err(Into::into),
+            dt if dt.is_temporal() => {
+                scalar_to_py(py.enter_polars(|| self.series.median_reduce()), py)
+            },
+            _ => Ok(self.series.median().into_pyobject(py)?),
         }
     }
 
-    fn min<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.min_reduce().map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
-    }
-
     fn product<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.product().map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.product()), py)
     }
 
     fn quantile<'py>(
@@ -111,73 +89,49 @@ impl PySeries {
         quantile: f64,
         interpolation: Wrap<QuantileMethod>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let bind = py.allow_threads(|| self.series.quantile_reduce(quantile, interpolation.0));
-        let sc = bind.map_err(PyPolarsErr::from)?;
-
-        Wrap(sc.as_any_value()).into_pyobject(py)
+        scalar_to_py(
+            py.enter_polars(|| self.series.quantile_reduce(quantile, interpolation.0)),
+            py,
+        )
     }
 
     fn std<'py>(&self, py: Python<'py>, ddof: u8) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.std_reduce(ddof).map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.std_reduce(ddof)), py)
     }
 
     fn var<'py>(&self, py: Python<'py>, ddof: u8) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.var_reduce(ddof).map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.var_reduce(ddof)), py)
     }
 
     fn sum<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.sum_reduce().map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.sum_reduce()), py)
     }
 
     fn first<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(py.allow_threads(|| self.series.first()).as_any_value()).into_pyobject(py)
+        scalar_to_py(py.enter_polars_ok(|| self.series.first()), py)
     }
 
     fn last<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(py.allow_threads(|| self.series.last()).as_any_value()).into_pyobject(py)
+        scalar_to_py(py.enter_polars_ok(|| self.series.last()), py)
     }
 
     #[cfg(feature = "approx_unique")]
-    fn approx_n_unique(&self, py: Python) -> Result<IdxSize, PyPolarsErr> {
-        py.allow_threads(|| self.series.approx_n_unique().map_err(PyPolarsErr::from))
+    fn approx_n_unique(&self, py: Python) -> PyResult<IdxSize> {
+        py.enter_polars(|| self.series.approx_n_unique())
     }
 
     #[cfg(feature = "bitwise")]
     fn bitwise_and<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.and_reduce().map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.and_reduce()), py)
     }
 
     #[cfg(feature = "bitwise")]
     fn bitwise_or<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.or_reduce().map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.or_reduce()), py)
     }
 
     #[cfg(feature = "bitwise")]
     fn bitwise_xor<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        Wrap(
-            py.allow_threads(|| self.series.xor_reduce().map_err(PyPolarsErr::from))?
-                .as_any_value(),
-        )
-        .into_pyobject(py)
+        scalar_to_py(py.enter_polars(|| self.series.xor_reduce()), py)
     }
 }

--- a/crates/polars-python/src/series/aggregation.rs
+++ b/crates/polars-python/src/series/aggregation.rs
@@ -4,7 +4,6 @@ use DataType::*;
 
 use super::PySeries;
 use crate::conversion::Wrap;
-use crate::error::PyPolarsErr;
 use crate::utils::EnterPolarsExt;
 
 fn scalar_to_py<'py>(scalar: PyResult<Scalar>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {

--- a/crates/polars-python/src/series/aggregation.rs
+++ b/crates/polars-python/src/series/aggregation.rs
@@ -7,7 +7,7 @@ use crate::conversion::Wrap;
 use crate::utils::EnterPolarsExt;
 
 fn scalar_to_py<'py>(scalar: PyResult<Scalar>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-    Ok(Wrap(scalar?.as_any_value()).into_pyobject(py)?)
+    Wrap(scalar?.as_any_value()).into_pyobject(py)
 }
 
 #[pymethods]

--- a/crates/polars-python/src/series/aggregation.rs
+++ b/crates/polars-python/src/series/aggregation.rs
@@ -6,7 +6,7 @@ use super::PySeries;
 use crate::conversion::Wrap;
 use crate::utils::EnterPolarsExt;
 
-fn scalar_to_py<'py>(scalar: PyResult<Scalar>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+fn scalar_to_py(scalar: PyResult<Scalar>, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
     Wrap(scalar?.as_any_value()).into_pyobject(py)
 }
 

--- a/crates/polars-python/src/series/buffers.rs
+++ b/crates/polars-python/src/series/buffers.rs
@@ -27,6 +27,7 @@ use super::{PySeries, ToSeries};
 use crate::conversion::Wrap;
 use crate::error::PyPolarsErr;
 use crate::raise_err;
+use crate::utils::EnterPolarsExt;
 
 struct BufferInfo {
     pointer: usize,
@@ -90,7 +91,7 @@ impl PySeries {
     /// Return the underlying values, validity, and offsets buffers as Series.
     fn _get_buffers(&self, py: Python) -> PyResult<(Self, Option<Self>, Option<Self>)> {
         let s = &self.series;
-        py.allow_threads(|| match s.dtype().to_physical() {
+        py.enter_polars(|| match s.dtype().to_physical() {
             dt if dt.is_primitive_numeric() => get_buffers_from_primitive(s),
             DataType::Boolean => get_buffers_from_primitive(s),
             DataType::String => get_buffers_from_string(s),
@@ -326,7 +327,7 @@ impl PySeries {
                     )),
                 };
                 let values = series_to_buffer::<UInt8Type>(values);
-                py.allow_threads(|| from_buffers_string_impl(values, validity, offsets))?
+                py.enter_polars(|| from_buffers_string_impl(values, validity, offsets))?
             },
             dt => {
                 let msg = format!("`_from_buffers` not implemented for `dtype` {dt}");

--- a/crates/polars-python/src/series/comparison.rs
+++ b/crates/polars-python/src/series/comparison.rs
@@ -2,8 +2,8 @@ use pyo3::prelude::*;
 
 use crate::error::PyPolarsErr;
 use crate::prelude::*;
-use crate::PySeries;
 use crate::utils::EnterPolarsExt;
+use crate::PySeries;
 
 #[pymethods]
 impl PySeries {

--- a/crates/polars-python/src/series/comparison.rs
+++ b/crates/polars-python/src/series/comparison.rs
@@ -3,49 +3,32 @@ use pyo3::prelude::*;
 use crate::error::PyPolarsErr;
 use crate::prelude::*;
 use crate::PySeries;
+use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PySeries {
     fn eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        let s = py
-            .allow_threads(|| self.series.equal(&rhs.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into_series().into())
+        py.enter_polars_series(|| Ok(self.series.equal(&rhs.series)?.into_series()))
     }
 
     fn neq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        let s = py
-            .allow_threads(|| self.series.not_equal(&rhs.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into_series().into())
+        py.enter_polars_series(|| Ok(self.series.not_equal(&rhs.series)?.into_series()))
     }
 
     fn gt(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        let s = py
-            .allow_threads(|| self.series.gt(&rhs.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into_series().into())
+        py.enter_polars_series(|| Ok(self.series.gt(&rhs.series)?.into_series()))
     }
 
     fn gt_eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        let s = py
-            .allow_threads(|| self.series.gt_eq(&rhs.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into_series().into())
+        py.enter_polars_series(|| Ok(self.series.gt_eq(&rhs.series)?.into_series()))
     }
 
     fn lt(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        let s = py
-            .allow_threads(|| self.series.lt(&rhs.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into_series().into())
+        py.enter_polars_series(|| Ok(self.series.lt(&rhs.series)?.into_series()))
     }
 
     fn lt_eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        let s = py
-            .allow_threads(|| self.series.lt_eq(&rhs.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into_series().into())
+        py.enter_polars_series(|| Ok(self.series.lt_eq(&rhs.series)?.into_series()))
     }
 }
 

--- a/crates/polars-python/src/series/comparison.rs
+++ b/crates/polars-python/src/series/comparison.rs
@@ -8,193 +8,118 @@ use crate::utils::EnterPolarsExt;
 #[pymethods]
 impl PySeries {
     fn eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        py.enter_polars_series(|| Ok(self.series.equal(&rhs.series)?.into_series()))
+        py.enter_polars_series(|| self.series.equal(&rhs.series))
     }
 
     fn neq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        py.enter_polars_series(|| Ok(self.series.not_equal(&rhs.series)?.into_series()))
+        py.enter_polars_series(|| self.series.not_equal(&rhs.series))
     }
 
     fn gt(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        py.enter_polars_series(|| Ok(self.series.gt(&rhs.series)?.into_series()))
+        py.enter_polars_series(|| self.series.gt(&rhs.series))
     }
 
     fn gt_eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        py.enter_polars_series(|| Ok(self.series.gt_eq(&rhs.series)?.into_series()))
+        py.enter_polars_series(|| self.series.gt_eq(&rhs.series))
     }
 
     fn lt(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        py.enter_polars_series(|| Ok(self.series.lt(&rhs.series)?.into_series()))
+        py.enter_polars_series(|| self.series.lt(&rhs.series))
     }
 
     fn lt_eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
-        py.enter_polars_series(|| Ok(self.series.lt_eq(&rhs.series)?.into_series()))
+        py.enter_polars_series(|| self.series.lt_eq(&rhs.series))
     }
 }
 
-macro_rules! impl_eq_num {
-    ($name:ident, $type:ty) => {
+macro_rules! impl_op {
+    ($op:ident, $name:ident, $type:ty) => {
         #[pymethods]
         impl PySeries {
             fn $name(&self, py: Python, rhs: $type) -> PyResult<Self> {
-                let s = py
-                    .allow_threads(|| self.series.equal(rhs))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(s.into_series().into())
+                py.enter_polars_series(|| self.series.$op(rhs))
             }
         }
     };
 }
 
-impl_eq_num!(eq_u8, u8);
-impl_eq_num!(eq_u16, u16);
-impl_eq_num!(eq_u32, u32);
-impl_eq_num!(eq_u64, u64);
-impl_eq_num!(eq_i8, i8);
-impl_eq_num!(eq_i16, i16);
-impl_eq_num!(eq_i32, i32);
-impl_eq_num!(eq_i64, i64);
-impl_eq_num!(eq_i128, i128);
-impl_eq_num!(eq_f32, f32);
-impl_eq_num!(eq_f64, f64);
-impl_eq_num!(eq_str, &str);
+impl_op!(equal, eq_u8, u8);
+impl_op!(equal, eq_u16, u16);
+impl_op!(equal, eq_u32, u32);
+impl_op!(equal, eq_u64, u64);
+impl_op!(equal, eq_i8, i8);
+impl_op!(equal, eq_i16, i16);
+impl_op!(equal, eq_i32, i32);
+impl_op!(equal, eq_i64, i64);
+impl_op!(equal, eq_i128, i128);
+impl_op!(equal, eq_f32, f32);
+impl_op!(equal, eq_f64, f64);
+impl_op!(equal, eq_str, &str);
 
-macro_rules! impl_neq_num {
-    ($name:ident, $type:ty) => {
-        #[allow(clippy::nonstandard_macro_braces)]
-        #[pymethods]
-        impl PySeries {
-            fn $name(&self, py: Python, rhs: $type) -> PyResult<Self> {
-                let s = py
-                    .allow_threads(|| self.series.not_equal(rhs))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(s.into_series().into())
-            }
-        }
-    };
-}
+impl_op!(not_equal, neq_u8, u8);
+impl_op!(not_equal, neq_u16, u16);
+impl_op!(not_equal, neq_u32, u32);
+impl_op!(not_equal, neq_u64, u64);
+impl_op!(not_equal, neq_i8, i8);
+impl_op!(not_equal, neq_i16, i16);
+impl_op!(not_equal, neq_i32, i32);
+impl_op!(not_equal, neq_i64, i64);
+impl_op!(not_equal, neq_i128, i128);
+impl_op!(not_equal, neq_f32, f32);
+impl_op!(not_equal, neq_f64, f64);
+impl_op!(not_equal, neq_str, &str);
 
-impl_neq_num!(neq_u8, u8);
-impl_neq_num!(neq_u16, u16);
-impl_neq_num!(neq_u32, u32);
-impl_neq_num!(neq_u64, u64);
-impl_neq_num!(neq_i8, i8);
-impl_neq_num!(neq_i16, i16);
-impl_neq_num!(neq_i32, i32);
-impl_neq_num!(neq_i64, i64);
-impl_neq_num!(neq_i128, i128);
-impl_neq_num!(neq_f32, f32);
-impl_neq_num!(neq_f64, f64);
-impl_neq_num!(neq_str, &str);
+impl_op!(gt, gt_u8, u8);
+impl_op!(gt, gt_u16, u16);
+impl_op!(gt, gt_u32, u32);
+impl_op!(gt, gt_u64, u64);
+impl_op!(gt, gt_i8, i8);
+impl_op!(gt, gt_i16, i16);
+impl_op!(gt, gt_i32, i32);
+impl_op!(gt, gt_i64, i64);
+impl_op!(gt, gt_i128, i128);
+impl_op!(gt, gt_f32, f32);
+impl_op!(gt, gt_f64, f64);
+impl_op!(gt, gt_str, &str);
 
-macro_rules! impl_gt_num {
-    ($name:ident, $type:ty) => {
-        #[pymethods]
-        impl PySeries {
-            fn $name(&self, py: Python, rhs: $type) -> PyResult<Self> {
-                let s = py
-                    .allow_threads(|| self.series.gt(rhs))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(s.into_series().into())
-            }
-        }
-    };
-}
+impl_op!(gt_eq, gt_eq_u8, u8);
+impl_op!(gt_eq, gt_eq_u16, u16);
+impl_op!(gt_eq, gt_eq_u32, u32);
+impl_op!(gt_eq, gt_eq_u64, u64);
+impl_op!(gt_eq, gt_eq_i8, i8);
+impl_op!(gt_eq, gt_eq_i16, i16);
+impl_op!(gt_eq, gt_eq_i32, i32);
+impl_op!(gt_eq, gt_eq_i64, i64);
+impl_op!(gt_eq, gt_eq_i128, i128);
+impl_op!(gt_eq, gt_eq_f32, f32);
+impl_op!(gt_eq, gt_eq_f64, f64);
+impl_op!(gt_eq, gt_eq_str, &str);
 
-impl_gt_num!(gt_u8, u8);
-impl_gt_num!(gt_u16, u16);
-impl_gt_num!(gt_u32, u32);
-impl_gt_num!(gt_u64, u64);
-impl_gt_num!(gt_i8, i8);
-impl_gt_num!(gt_i16, i16);
-impl_gt_num!(gt_i32, i32);
-impl_gt_num!(gt_i64, i64);
-impl_gt_num!(gt_i128, i128);
-impl_gt_num!(gt_f32, f32);
-impl_gt_num!(gt_f64, f64);
-impl_gt_num!(gt_str, &str);
+impl_op!(lt, lt_u8, u8);
+impl_op!(lt, lt_u16, u16);
+impl_op!(lt, lt_u32, u32);
+impl_op!(lt, lt_u64, u64);
+impl_op!(lt, lt_i8, i8);
+impl_op!(lt, lt_i16, i16);
+impl_op!(lt, lt_i32, i32);
+impl_op!(lt, lt_i64, i64);
+impl_op!(lt, lt_i128, i128);
+impl_op!(lt, lt_f32, f32);
+impl_op!(lt, lt_f64, f64);
+impl_op!(lt, lt_str, &str);
 
-macro_rules! impl_gt_eq_num {
-    ($name:ident, $type:ty) => {
-        #[pymethods]
-        impl PySeries {
-            fn $name(&self, py: Python, rhs: $type) -> PyResult<Self> {
-                let s = py
-                    .allow_threads(|| self.series.gt_eq(rhs))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(s.into_series().into())
-            }
-        }
-    };
-}
-
-impl_gt_eq_num!(gt_eq_u8, u8);
-impl_gt_eq_num!(gt_eq_u16, u16);
-impl_gt_eq_num!(gt_eq_u32, u32);
-impl_gt_eq_num!(gt_eq_u64, u64);
-impl_gt_eq_num!(gt_eq_i8, i8);
-impl_gt_eq_num!(gt_eq_i16, i16);
-impl_gt_eq_num!(gt_eq_i32, i32);
-impl_gt_eq_num!(gt_eq_i64, i64);
-impl_gt_eq_num!(gt_eq_i128, i128);
-impl_gt_eq_num!(gt_eq_f32, f32);
-impl_gt_eq_num!(gt_eq_f64, f64);
-impl_gt_eq_num!(gt_eq_str, &str);
-
-macro_rules! impl_lt_num {
-    ($name:ident, $type:ty) => {
-        #[allow(clippy::nonstandard_macro_braces)]
-        #[pymethods]
-        impl PySeries {
-            fn $name(&self, py: Python, rhs: $type) -> PyResult<Self> {
-                let s = py
-                    .allow_threads(|| self.series.lt(rhs))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(s.into_series().into())
-            }
-        }
-    };
-}
-
-impl_lt_num!(lt_u8, u8);
-impl_lt_num!(lt_u16, u16);
-impl_lt_num!(lt_u32, u32);
-impl_lt_num!(lt_u64, u64);
-impl_lt_num!(lt_i8, i8);
-impl_lt_num!(lt_i16, i16);
-impl_lt_num!(lt_i32, i32);
-impl_lt_num!(lt_i64, i64);
-impl_lt_num!(lt_i128, i128);
-impl_lt_num!(lt_f32, f32);
-impl_lt_num!(lt_f64, f64);
-impl_lt_num!(lt_str, &str);
-
-macro_rules! impl_lt_eq_num {
-    ($name:ident, $type:ty) => {
-        #[pymethods]
-        impl PySeries {
-            fn $name(&self, py: Python, rhs: $type) -> PyResult<Self> {
-                let s = py
-                    .allow_threads(|| self.series.lt_eq(rhs))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(s.into_series().into())
-            }
-        }
-    };
-}
-
-impl_lt_eq_num!(lt_eq_u8, u8);
-impl_lt_eq_num!(lt_eq_u16, u16);
-impl_lt_eq_num!(lt_eq_u32, u32);
-impl_lt_eq_num!(lt_eq_u64, u64);
-impl_lt_eq_num!(lt_eq_i8, i8);
-impl_lt_eq_num!(lt_eq_i16, i16);
-impl_lt_eq_num!(lt_eq_i32, i32);
-impl_lt_eq_num!(lt_eq_i64, i64);
-impl_lt_eq_num!(lt_eq_i128, i128);
-impl_lt_eq_num!(lt_eq_f32, f32);
-impl_lt_eq_num!(lt_eq_f64, f64);
-impl_lt_eq_num!(lt_eq_str, &str);
+impl_op!(lt_eq, lt_eq_u8, u8);
+impl_op!(lt_eq, lt_eq_u16, u16);
+impl_op!(lt_eq, lt_eq_u32, u32);
+impl_op!(lt_eq, lt_eq_u64, u64);
+impl_op!(lt_eq, lt_eq_i8, i8);
+impl_op!(lt_eq, lt_eq_i16, i16);
+impl_op!(lt_eq, lt_eq_i32, i32);
+impl_op!(lt_eq, lt_eq_i64, i64);
+impl_op!(lt_eq, lt_eq_i128, i128);
+impl_op!(lt_eq, lt_eq_f32, f32);
+impl_op!(lt_eq, lt_eq_f64, f64);
+impl_op!(lt_eq, lt_eq_str, &str);
 
 struct PyDecimal(i128, usize);
 
@@ -241,10 +166,7 @@ macro_rules! impl_decimal {
                     PlSmallStr::from_static("decimal"),
                     &[AnyValue::Decimal(rhs.0, rhs.1)],
                 );
-                let s = py
-                    .allow_threads(|| self.series.$method(&rhs))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(s.into_series().into())
+                py.enter_polars_series(|| self.series.$method(&rhs))
             }
         }
     };

--- a/crates/polars-python/src/series/construction.rs
+++ b/crates/polars-python/src/series/construction.rs
@@ -51,19 +51,30 @@ fn mmap_numpy_array<T: Element + NativeType>(name: &str, array: &Bound<PyArray1<
 #[pymethods]
 impl PySeries {
     #[staticmethod]
-    fn new_bool(py: Python, name: &str, array: &Bound<PyArray1<bool>>, _strict: bool) -> PyResult<Self> {
+    fn new_bool(
+        py: Python,
+        name: &str,
+        array: &Bound<PyArray1<bool>>,
+        _strict: bool,
+    ) -> PyResult<Self> {
         let array = array.readonly();
         let vals = array.as_slice().unwrap();
         py.enter_polars_series(|| Ok(Series::new(name.into(), vals)))
     }
 
     #[staticmethod]
-    fn new_f32(py: Python, name: &str, array: &Bound<PyArray1<f32>>, nan_is_null: bool) -> PyResult<Self> {
+    fn new_f32(
+        py: Python,
+        name: &str,
+        array: &Bound<PyArray1<f32>>,
+        nan_is_null: bool,
+    ) -> PyResult<Self> {
         if nan_is_null {
             let array = array.readonly();
             let vals = array.as_slice().unwrap();
             py.enter_polars_series(|| {
-                let ca: Float32Chunked = vals.iter()
+                let ca: Float32Chunked = vals
+                    .iter()
                     .map(|&val| if f32::is_nan(val) { None } else { Some(val) })
                     .collect_trusted();
                 Ok(ca.with_name(name.into()))
@@ -74,12 +85,18 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn new_f64(py: Python, name: &str, array: &Bound<PyArray1<f64>>, nan_is_null: bool) -> PyResult<Self> {
+    fn new_f64(
+        py: Python,
+        name: &str,
+        array: &Bound<PyArray1<f64>>,
+        nan_is_null: bool,
+    ) -> PyResult<Self> {
         if nan_is_null {
             let array = array.readonly();
             let vals = array.as_slice().unwrap();
             py.enter_polars_series(|| {
-                let ca: Float64Chunked = vals.iter()
+                let ca: Float64Chunked = vals
+                    .iter()
                     .map(|&val| if f64::is_nan(val) { None } else { Some(val) })
                     .collect_trusted();
                 Ok(ca.with_name(name.into()))

--- a/crates/polars-python/src/series/construction.rs
+++ b/crates/polars-python/src/series/construction.rs
@@ -14,6 +14,7 @@ use crate::conversion::{reinterpret_vec, Wrap};
 use crate::error::PyPolarsErr;
 use crate::interop::arrow::to_rust::array_to_rust;
 use crate::prelude::ObjectValue;
+use crate::utils::EnterPolarsExt;
 use crate::PySeries;
 
 // Init with numpy arrays.
@@ -50,41 +51,41 @@ fn mmap_numpy_array<T: Element + NativeType>(name: &str, array: &Bound<PyArray1<
 #[pymethods]
 impl PySeries {
     #[staticmethod]
-    fn new_bool(py: Python, name: &str, array: &Bound<PyArray1<bool>>, _strict: bool) -> Self {
+    fn new_bool(py: Python, name: &str, array: &Bound<PyArray1<bool>>, _strict: bool) -> PyResult<Self> {
         let array = array.readonly();
         let vals = array.as_slice().unwrap();
-        py.allow_threads(|| Series::new(name.into(), vals).into())
+        py.enter_polars_series(|| Ok(Series::new(name.into(), vals)))
     }
 
     #[staticmethod]
-    fn new_f32(py: Python, name: &str, array: &Bound<PyArray1<f32>>, nan_is_null: bool) -> Self {
+    fn new_f32(py: Python, name: &str, array: &Bound<PyArray1<f32>>, nan_is_null: bool) -> PyResult<Self> {
         if nan_is_null {
             let array = array.readonly();
             let vals = array.as_slice().unwrap();
-            let ca: Float32Chunked = py.allow_threads(|| {
-                vals.iter()
+            py.enter_polars_series(|| {
+                let ca: Float32Chunked = vals.iter()
                     .map(|&val| if f32::is_nan(val) { None } else { Some(val) })
-                    .collect_trusted()
-            });
-            ca.with_name(name.into()).into_series().into()
+                    .collect_trusted();
+                Ok(ca.with_name(name.into()))
+            })
         } else {
-            mmap_numpy_array(name, array)
+            Ok(mmap_numpy_array(name, array))
         }
     }
 
     #[staticmethod]
-    fn new_f64(py: Python, name: &str, array: &Bound<PyArray1<f64>>, nan_is_null: bool) -> Self {
+    fn new_f64(py: Python, name: &str, array: &Bound<PyArray1<f64>>, nan_is_null: bool) -> PyResult<Self> {
         if nan_is_null {
             let array = array.readonly();
             let vals = array.as_slice().unwrap();
-            let ca: Float64Chunked = py.allow_threads(|| {
-                vals.iter()
+            py.enter_polars_series(|| {
+                let ca: Float64Chunked = vals.iter()
                     .map(|&val| if f64::is_nan(val) { None } else { Some(val) })
-                    .collect_trusted()
-            });
-            ca.with_name(name.into()).into_series().into()
+                    .collect_trusted();
+                Ok(ca.with_name(name.into()))
+            })
         } else {
-            mmap_numpy_array(name, array)
+            Ok(mmap_numpy_array(name, array))
         }
     }
 }

--- a/crates/polars-python/src/series/export.rs
+++ b/crates/polars-python/src/series/export.rs
@@ -146,7 +146,7 @@ impl PySeries {
     /// Return the underlying Arrow array.
     #[allow(clippy::wrong_self_convention)]
     fn to_arrow(&mut self, py: Python, compat_level: PyCompatLevel) -> PyResult<PyObject> {
-        self.rechunk(py, true);
+        self.rechunk(py, true)?;
         let pyarrow = py.import("pyarrow")?;
 
         interop::arrow::to_py::to_py_array(

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -13,13 +13,12 @@ use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::prelude::*;
 use crate::py_modules::polars;
+use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PySeries {
     fn struct_unnest(&self, py: Python) -> PyResult<PyDataFrame> {
-        let ca = self.series.struct_().map_err(PyPolarsErr::from)?;
-        let df: DataFrame = py.allow_threads(|| ca.clone().unnest());
-        Ok(df.into())
+        py.enter_polars_df(|| Ok(self.series.struct_()?.clone().unnest()))
     }
 
     fn struct_fields(&self) -> PyResult<Vec<&str>> {
@@ -57,8 +56,7 @@ impl PySeries {
     }
 
     pub fn cat_to_local(&self, py: Python) -> PyResult<Self> {
-        let ca = self.series.categorical().map_err(PyPolarsErr::from)?;
-        Ok(py.allow_threads(|| ca.to_local().into_series().into()))
+        py.enter_polars_series(|| Ok(self.series.categorical()?.to_local()))
     }
 
     fn estimated_size(&self) -> usize {
@@ -82,10 +80,7 @@ impl PySeries {
             .map(ReshapeDimension::new)
             .collect::<Vec<_>>();
 
-        let out = py
-            .allow_threads(|| self.series.reshape_array(&dims))
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        py.enter_polars_series(|| self.series.reshape_array(&dims))
     }
 
     /// Returns the string format of a single element of the Series.
@@ -111,13 +106,13 @@ impl PySeries {
         }
     }
 
-    pub fn rechunk(&mut self, py: Python, in_place: bool) -> Option<Self> {
-        let series = py.allow_threads(|| self.series.rechunk());
+    pub fn rechunk(&mut self, py: Python, in_place: bool) -> PyResult<Option<Self>> {
+        let series = py.enter_polars_ok(|| self.series.rechunk())?;
         if in_place {
             self.series = series;
-            None
+            Ok(None)
         } else {
-            Some(series.into())
+            Ok(Some(series.into()))
         }
     }
 
@@ -158,23 +153,15 @@ impl PySeries {
     }
 
     fn bitand(&self, py: Python, other: &PySeries) -> PyResult<Self> {
-        let out = py
-            .allow_threads(|| &self.series & &other.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        py.enter_polars_series(|| &self.series & &other.series)
     }
 
     fn bitor(&self, py: Python, other: &PySeries) -> PyResult<Self> {
-        let out = py
-            .allow_threads(|| &self.series | &other.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        py.enter_polars_series(|| &self.series | &other.series)
     }
+
     fn bitxor(&self, py: Python, other: &PySeries) -> PyResult<Self> {
-        let out = py
-            .allow_threads(|| &self.series ^ &other.series)
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        py.enter_polars_series(|| &self.series ^ &other.series)
     }
 
     fn chunk_lengths(&self) -> Vec<usize> {
@@ -215,26 +202,24 @@ impl PySeries {
     }
 
     fn extend(&mut self, py: Python, other: &PySeries) -> PyResult<()> {
-        py.allow_threads(|| self.series.extend(&other.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(())
+        py.enter_polars(|| {
+            self.series.extend(&other.series)?;
+            PolarsResult::Ok(())
+        })
     }
 
     fn new_from_index(&self, py: Python, index: usize, length: usize) -> PyResult<Self> {
         if index >= self.series.len() {
             Err(PyValueError::new_err("index is out of bounds"))
         } else {
-            Ok(py.allow_threads(|| self.series.new_from_index(index, length).into()))
+            py.enter_polars_series(|| Ok(self.series.new_from_index(index, length)))
         }
     }
 
     fn filter(&self, py: Python, filter: &PySeries) -> PyResult<Self> {
         let filter_series = &filter.series;
         if let Ok(ca) = filter_series.bool() {
-            let series = py
-                .allow_threads(|| self.series.filter(ca))
-                .map_err(PyPolarsErr::from)?;
-            Ok(PySeries { series })
+            py.enter_polars_series(|| self.series.filter(ca))
         } else {
             Err(PyRuntimeError::new_err("Expected a boolean mask"))
         }
@@ -247,25 +232,18 @@ impl PySeries {
         nulls_last: bool,
         multithreaded: bool,
     ) -> PyResult<Self> {
-        Ok(py
-            .allow_threads(|| {
-                self.series.sort(
-                    SortOptions::default()
-                        .with_order_descending(descending)
-                        .with_nulls_last(nulls_last)
-                        .with_multithreaded(multithreaded),
-                )
-            })
-            .map_err(PyPolarsErr::from)?
-            .into())
+        py.enter_polars_series(|| {
+            self.series.sort(
+                SortOptions::default()
+                    .with_order_descending(descending)
+                    .with_nulls_last(nulls_last)
+                    .with_multithreaded(multithreaded),
+            )
+        })
     }
 
     fn gather_with_series(&self, py: Python, indices: &PySeries) -> PyResult<Self> {
-        py.allow_threads(|| {
-            let indices = indices.series.idx().map_err(PyPolarsErr::from)?;
-            let s = self.series.take(indices).map_err(PyPolarsErr::from)?;
-            Ok(s.into())
-        })
+        py.enter_polars_series(|| self.series.take(indices.series.idx()?))
     }
 
     fn null_count(&self) -> PyResult<usize> {
@@ -283,17 +261,17 @@ impl PySeries {
         check_dtypes: bool,
         check_names: bool,
         null_equal: bool,
-    ) -> bool {
+    ) -> PyResult<bool> {
         if check_dtypes && (self.series.dtype() != other.series.dtype()) {
-            return false;
+            return Ok(false);
         }
         if check_names && (self.series.name() != other.series.name()) {
-            return false;
+            return Ok(false);
         }
         if null_equal {
-            py.allow_threads(|| self.series.equals_missing(&other.series))
+            py.enter_polars_ok(|| self.series.equals_missing(&other.series))
         } else {
-            py.allow_threads(|| self.series.equals(&other.series))
+            py.enter_polars_ok(|| self.series.equals(&other.series))
         }
     }
 
@@ -309,10 +287,7 @@ impl PySeries {
     /// Rechunk and return a pointer to the start of the Series.
     /// Only implemented for numeric types
     fn as_single_ptr(&mut self, py: Python) -> PyResult<usize> {
-        let ptr = py
-            .allow_threads(|| self.series.as_single_ptr())
-            .map_err(PyPolarsErr::from)?;
-        Ok(ptr)
+        py.enter_polars(|| self.series.as_single_ptr())
     }
 
     fn clone(&self) -> Self {
@@ -321,10 +296,7 @@ impl PySeries {
 
     fn zip_with(&self, py: Python, mask: &PySeries, other: &PySeries) -> PyResult<Self> {
         let mask = mask.series.bool().map_err(PyPolarsErr::from)?;
-        let s = py
-            .allow_threads(|| self.series.zip_with(mask, &other.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into())
+        py.enter_polars_series(|| self.series.zip_with(mask, &other.series))
     }
 
     #[pyo3(signature = (separator, drop_first=false))]
@@ -334,10 +306,7 @@ impl PySeries {
         separator: Option<&str>,
         drop_first: bool,
     ) -> PyResult<PyDataFrame> {
-        let df = py
-            .allow_threads(|| self.series.to_dummies(separator, drop_first))
-            .map_err(PyPolarsErr::from)?;
-        Ok(df.into())
+        py.enter_polars_df(|| self.series.to_dummies(separator, drop_first))
     }
 
     fn get_list(&self, index: usize) -> Option<Self> {
@@ -346,21 +315,15 @@ impl PySeries {
     }
 
     fn n_unique(&self, py: Python) -> PyResult<usize> {
-        let n = py
-            .allow_threads(|| self.series.n_unique())
-            .map_err(PyPolarsErr::from)?;
-        Ok(n)
+        py.enter_polars(|| self.series.n_unique())
     }
 
     fn floor(&self, py: Python) -> PyResult<Self> {
-        let s = py
-            .allow_threads(|| self.series.floor())
-            .map_err(PyPolarsErr::from)?;
-        Ok(s.into())
+        py.enter_polars_series(|| self.series.floor())
     }
 
-    fn shrink_to_fit(&mut self, py: Python) {
-        py.allow_threads(|| self.series.shrink_to_fit());
+    fn shrink_to_fit(&mut self, py: Python) -> PyResult<()> {
+        py.enter_polars_ok(|| self.series.shrink_to_fit())
     }
 
     fn dot<'py>(&self, other: &PySeries, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
@@ -375,12 +338,10 @@ impl PySeries {
         }
 
         let result: AnyValue = if lhs_dtype.is_float() || rhs_dtype.is_float() {
-            py.allow_threads(|| (&self.series * &other.series)?.sum::<f64>())
-                .map_err(PyPolarsErr::from)?
+            py.enter_polars(|| (&self.series * &other.series)?.sum::<f64>())?
                 .into()
         } else {
-            py.allow_threads(|| (&self.series * &other.series)?.sum::<i64>())
-                .map_err(PyPolarsErr::from)?
+            py.enter_polars(|| (&self.series * &other.series)?.sum::<i64>())?
                 .into()
         };
 
@@ -391,7 +352,7 @@ impl PySeries {
         // Used in pickle/pickling
         Ok(PyBytes::new(
             py,
-            &py.allow_threads(|| self.series.serialize_to_bytes().map_err(PyPolarsErr::from))?,
+            &py.enter_polars(|| self.series.serialize_to_bytes())?,
         ))
     }
 
@@ -400,27 +361,21 @@ impl PySeries {
 
         use pyo3::pybacked::PyBackedBytes;
         match state.extract::<PyBackedBytes>(py) {
-            Ok(s) => py.allow_threads(|| {
-                let s = Series::deserialize_from_reader(&mut &*s).map_err(PyPolarsErr::from)?;
+            Ok(s) => py.enter_polars(|| {
+                let s = Series::deserialize_from_reader(&mut &*s)?;
                 self.series = s;
-                Ok(())
+                PolarsResult::Ok(())
             }),
             Err(e) => Err(e),
         }
     }
 
     fn skew(&self, py: Python, bias: bool) -> PyResult<Option<f64>> {
-        let out = py
-            .allow_threads(|| self.series.skew(bias))
-            .map_err(PyPolarsErr::from)?;
-        Ok(out)
+        py.enter_polars(|| self.series.skew(bias))
     }
 
     fn kurtosis(&self, py: Python, fisher: bool, bias: bool) -> PyResult<Option<f64>> {
-        let out = py
-            .allow_threads(|| self.series.kurtosis(fisher, bias))
-            .map_err(PyPolarsErr::from)?;
-        Ok(out)
+        py.enter_polars(|| self.series.kurtosis(fisher, bias))
     }
 
     fn cast(
@@ -437,11 +392,7 @@ impl PySeries {
         } else {
             CastOptions::NonStrict
         };
-
-        let dtype = dtype.0;
-        let out = py.allow_threads(|| self.series.cast_with_options(&dtype, options));
-        let out = out.map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        py.enter_polars_series(|| self.series.cast_with_options(&dtype.0, options))
     }
 
     fn get_chunks(&self) -> PyResult<Vec<PyObject>> {
@@ -462,21 +413,19 @@ impl PySeries {
             maintain_order: false,
             limit: None,
         };
-        Ok(py
-            .allow_threads(|| self.series.is_sorted(options))
-            .map_err(PyPolarsErr::from)?)
+        py.enter_polars(|| self.series.is_sorted(options))
     }
 
     fn clear(&self) -> Self {
         self.series.clear().into()
     }
 
-    fn head(&self, py: Python, n: usize) -> Self {
-        py.allow_threads(|| self.series.head(Some(n))).into()
+    fn head(&self, py: Python, n: usize) -> PyResult<Self> {
+        py.enter_polars_series(|| Ok(self.series.head(Some(n))))
     }
 
-    fn tail(&self, py: Python, n: usize) -> Self {
-        py.allow_threads(|| self.series.tail(Some(n))).into()
+    fn tail(&self, py: Python, n: usize) -> PyResult<Self> {
+        py.enter_polars_series(|| Ok(self.series.tail(Some(n))))
     }
 
     fn value_counts(
@@ -487,13 +436,10 @@ impl PySeries {
         name: String,
         normalize: bool,
     ) -> PyResult<PyDataFrame> {
-        let out = py
-            .allow_threads(|| {
-                self.series
-                    .value_counts(sort, parallel, name.into(), normalize)
-            })
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        py.enter_polars_df(|| {
+            self.series
+                .value_counts(sort, parallel, name.into(), normalize)
+        })
     }
 
     #[pyo3(signature = (offset, length=None))]
@@ -503,10 +449,8 @@ impl PySeries {
     }
 
     pub fn not_(&self, py: Python) -> PyResult<Self> {
-        let out = py
-            .allow_threads(|| polars_ops::series::negate_bitwise(&self.series))
-            .map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        py
+            .enter_polars_series(|| polars_ops::series::negate_bitwise(&self.series))
     }
 
     /// Internal utility function to allow direct access to the row encoding from python.
@@ -517,7 +461,7 @@ impl PySeries {
         dtypes: Vec<(String, Wrap<DataType>)>,
         opts: Vec<(bool, bool, bool)>,
     ) -> PyResult<PyDataFrame> {
-        py.allow_threads(|| {
+        py.enter_polars_df(|| {
             assert_eq!(dtypes.len(), opts.len());
 
             let opts = opts
@@ -546,7 +490,7 @@ impl PySeries {
 
             // Get the BinaryOffset array.
             let arr = self.series.rechunk();
-            let arr = arr.binary_offset().map_err(PyPolarsErr::from)?;
+            let arr = arr.binary_offset()?;
             assert_eq!(arr.chunks().len(), 1);
             let mut values = arr
                 .downcast_iter()
@@ -555,9 +499,9 @@ impl PySeries {
                 .values_iter()
                 .collect::<Vec<&[u8]>>();
 
-            let columns = PyResult::Ok(unsafe {
+            let columns = unsafe {
                 polars_row::decode::decode_rows(&mut values, &opts, &dicts, &arrow_dtypes)
-            })?;
+            };
 
             // Construct a DataFrame from the result.
             let columns = columns
@@ -572,9 +516,8 @@ impl PySeries {
                     .into_column()
                     .from_physical_unchecked(&dtype.0)
                 })
-                .collect::<PolarsResult<Vec<_>>>()
-                .map_err(PyPolarsErr::from)?;
-            Ok(DataFrame::new(columns).map_err(PyPolarsErr::from)?.into())
+                .collect::<PolarsResult<Vec<_>>>()?;
+            DataFrame::new(columns)
         })
     }
 }
@@ -601,10 +544,7 @@ macro_rules! impl_set_with_mask {
                 filter: &PySeries,
                 value: Option<$native>,
             ) -> PyResult<Self> {
-                let series = py
-                    .allow_threads(|| $name(&self.series, filter, value))
-                    .map_err(PyPolarsErr::from)?;
-                Ok(Self::new(series))
+                py.enter_polars_series(|| $name(&self.series, filter, value))
             }
         }
     };

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -449,8 +449,7 @@ impl PySeries {
     }
 
     pub fn not_(&self, py: Python) -> PyResult<Self> {
-        py
-            .enter_polars_series(|| polars_ops::series::negate_bitwise(&self.series))
+        py.enter_polars_series(|| polars_ops::series::negate_bitwise(&self.series))
     }
 
     /// Internal utility function to allow direct access to the row encoding from python.

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -1,6 +1,16 @@
-use pyo3::PyErr;
+use std::panic::AssertUnwindSafe;
 
+use polars::frame::DataFrame;
+use polars::series::Series;
+use polars_error::PolarsResult;
+use pyo3::exceptions::PyKeyboardInterrupt;
+use pyo3::marker::Ungil;
+use pyo3::{Python, PyErr, PyResult};
+use polars_error::signals::{KeyboardInterrupt, catch_keyboard_interrupt};
+
+use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
+use crate::series::PySeries;
 
 // was redefined because I could not get feature flags activated?
 #[macro_export]
@@ -33,4 +43,69 @@ macro_rules! apply_method_all_arrow_series2 {
 #[allow(unused)]
 pub(crate) fn to_py_err<E: Into<PyPolarsErr>>(e: E) -> PyErr {
     e.into().into()
+}
+
+pub trait EnterPolarsExt {
+    /// Whenever you have a block of code in the public Python API that
+    /// (potentially) takes a long time, wrap it in enter_polars. This will
+    /// ensure we release the GIL and catch KeyboardInterrupts.
+    /// 
+    /// This not only can increase performance and usability, it can avoid
+    /// deadlocks on the GIL for Python UDFs.
+    fn enter_polars<T, E, F>(self, f: F) -> PyResult<T>
+    where
+        F: Ungil + Send + FnOnce() -> Result<T, E>,
+        T: Ungil + Send,
+        E: Ungil + Send + Into<PyPolarsErr>;
+
+    /// Same as enter_polars, but wraps the result in PyResult::Ok, useful
+    /// shorthand for infallible functions.
+    #[inline(always)]
+    fn enter_polars_ok<T, F>(self, f: F) -> PyResult<T>
+    where
+        Self: Sized,
+        F: Ungil + Send + FnOnce() -> T,
+        T: Ungil + Send
+        {
+            self.enter_polars(move || PyResult::Ok(f()))
+        }
+
+    /// Same as enter_polars, but expects a PolarsResult<DataFrame> as return
+    /// which is converted to a PyDataFrame.
+    #[inline(always)]
+    fn enter_polars_df<F>(self, f: F) -> PyResult<PyDataFrame>
+    where
+        Self: Sized,
+        F: Ungil + Send + FnOnce() -> PolarsResult<DataFrame>,
+        {
+            self.enter_polars(f).map(PyDataFrame::new)
+        }
+
+    /// Same as enter_polars, but expects a PolarsResult<Series> as return which
+    /// is converted to a PySeries.
+    #[inline(always)]
+    fn enter_polars_series<F>(self, f: F) -> PyResult<PySeries>
+    where
+        Self: Sized,
+        F: Ungil + Send + FnOnce() -> PolarsResult<Series>,
+        {
+            self.enter_polars(f).map(PySeries::new)
+        }
+}
+
+impl<'a> EnterPolarsExt for Python<'a> {
+    fn enter_polars<T, E, F>(self, f: F) -> PyResult<T>
+    where
+        F: Ungil + Send + FnOnce() -> Result<T, E>,
+        T: Ungil + Send,
+        E: Ungil + Send + Into<PyPolarsErr>
+    {
+        self.allow_threads(|| {
+            match catch_keyboard_interrupt(AssertUnwindSafe(f))  {
+                Ok(Ok(ret)) => Ok(ret),
+                Ok(Err(err)) => Err(PyErr::from(err.into())),
+                Err(KeyboardInterrupt) => Err(PyKeyboardInterrupt::new_err("")),
+            }
+        })
+    }
 }

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -94,7 +94,7 @@ pub trait EnterPolarsExt {
     }
 }
 
-impl<'a> EnterPolarsExt for Python<'a> {
+impl EnterPolarsExt for Python<'_> {
     fn enter_polars<T, E, F>(self, f: F) -> PyResult<T>
     where
         F: Ungil + Send + FnOnce() -> Result<T, E>,

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -1,13 +1,12 @@
 use std::panic::AssertUnwindSafe;
 
 use polars::frame::DataFrame;
-use polars::prelude::Scalar;
-use polars::series::{IntoSeries, Series};
+use polars::series::IntoSeries;
 use polars_error::signals::{catch_keyboard_interrupt, KeyboardInterrupt};
 use polars_error::PolarsResult;
 use pyo3::exceptions::PyKeyboardInterrupt;
 use pyo3::marker::Ungil;
-use pyo3::{Bound, PyAny, PyErr, PyResult, Python};
+use pyo3::{PyErr, PyResult, Python};
 
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;

--- a/crates/polars-stream/src/async_executor/task.rs
+++ b/crates/polars-stream/src/async_executor/task.rs
@@ -9,6 +9,8 @@ use std::task::{Context, Poll, Wake, Waker};
 use atomic_waker::AtomicWaker;
 use parking_lot::Mutex;
 
+use polars_error::signals::try_raise_keyboard_interrupt;
+
 /// The state of the task. Can't be part of the TaskData enum as it needs to be
 /// atomically updateable, even when we hold the lock on the data.
 #[derive(Default)]
@@ -166,7 +168,10 @@ where
                 // SAFETY: we always store a Task in an Arc and never move it.
                 let fut = unsafe { Pin::new_unchecked(future) };
                 let mut ctx = Context::from_waker(waker);
-                catch_unwind(AssertUnwindSafe(|| fut.poll(&mut ctx)))
+                catch_unwind(AssertUnwindSafe(|| {
+                    try_raise_keyboard_interrupt();
+                    fut.poll(&mut ctx)
+                }))
             },
             TaskData::Cancelled => return true,
             _ => unreachable!("invalid TaskData when polling"),

--- a/crates/polars-stream/src/async_executor/task.rs
+++ b/crates/polars-stream/src/async_executor/task.rs
@@ -8,7 +8,6 @@ use std::task::{Context, Poll, Wake, Waker};
 
 use atomic_waker::AtomicWaker;
 use parking_lot::Mutex;
-
 use polars_error::signals::try_raise_keyboard_interrupt;
 
 /// The state of the task. Can't be part of the TaskData enum as it needs to be


### PR DESCRIPTION
We now install a signal handler that detects when ctrl+c is pressed, and if so causes `try_raise_keyboard_interrupt()` calls we should spread through the codebase to panic with `KeyboardInterrupt`. This panic should be caught right before returning to Python (by wrapping code that call Polars with `py.enter_polars`) and turned it into a proper `KeyboardInterrupt` exception.