### PR TITLE
feat(python): Support passing `aws_profile` in `storage_options`

### DIFF
--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2387,6 +2387,7 @@ def test_selection_regex_and_multicol() -> None:
 
 
 @pytest.mark.parametrize("subset", ["a", cs.starts_with("x", "a")])
+@pytest.mark.may_fail_auto_streaming  # Flaky in CI, see https://github.com/pola-rs/polars/issues/20943
 def test_unique_on_sorted(subset: Any) -> None:
     df = pl.DataFrame(data={"a": [1, 1, 3], "b": [1, 2, 3]})
 


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/18757
* https://github.com/pola-rs/polars/issues/18757

Adds handling for `aws_profile` being passed in `storage_options`. This is not natively supported by object_store, but we can check this on the Python side and forward it to `CredentialProviderAWS`. This requires `boto3` to be installed, so we also issue a warning if this is not the case.

Note that on the latest release (1.21.0) the environment variable `AWS_PROFILE` is already being implicitly picked up by boto3.
