### PR TITLE
feat(python): Allow custom JSONEncoder for the `json_normalize` function, minor speedup

### DIFF
--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -6,6 +6,7 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    Callable,
     Literal,
     Protocol,
     TypedDict,
@@ -314,3 +315,5 @@ FileSource: TypeAlias = Union[
     list[IO[bytes]],
     list[bytes],
 ]
+
+JSONEncoder = Union[Callable[[Any], bytes], Callable[[Any], str]]

--- a/py-polars/polars/convert/normalize.py
+++ b/py-polars/polars/convert/normalize.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections import abc
+from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from polars._utils.unstable import unstable
@@ -11,8 +11,7 @@ from polars.dataframe import DataFrame
 from polars.datatypes.constants import N_INFER_DEFAULT
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
+    from polars._typing import JSONEncoder
     from polars.schema import Schema
 
 
@@ -20,17 +19,26 @@ def _simple_json_normalize(
     data: dict[Any, Any] | Sequence[dict[Any, Any] | Any],
     separator: str,
     max_level: int,
+    encoder: JSONEncoder,
 ) -> dict[Any, Any] | list[dict[Any, Any]] | Any:
     if max_level > 0:
+        # expect dict or list (both are valid JSON objects)
         normalized_json_object = {}
-        # expect a dictionary, as most jsons are. However, lists are perfectly valid
         if isinstance(data, dict):
             normalized_json_object = _normalize_json_ordered(
-                data=data, separator=separator, max_level=max_level
+                data=data,
+                separator=separator,
+                max_level=max_level,
+                encoder=encoder,
             )
         elif isinstance(data, list):
             normalized_json_list = [
-                _simple_json_normalize(row, separator=separator, max_level=max_level)
+                _simple_json_normalize(
+                    row,
+                    separator=separator,
+                    max_level=max_level,
+                    encoder=encoder,
+                )
                 for row in data
             ]
             return normalized_json_list
@@ -39,8 +47,64 @@ def _simple_json_normalize(
         return data
 
 
+def _normalize_json(
+    data: Any,
+    key_string: str,
+    normalized_dict: dict[str, Any],
+    separator: str,
+    max_level: int,
+    encoder: JSONEncoder,
+) -> dict[str, Any]:
+    """
+    Main recursive function.
+
+    Designed for the most basic use case of `pl.json_normalize(data)`,
+    intended as a performance improvement.
+
+    Parameters
+    ----------
+    data : Any
+        Type dependent on types contained within nested Json
+    key_string : str
+        New key (with separator(s) in) for data
+    normalized_dict : dict
+        The new normalized/flattened Json dict
+    separator : str, default '.'
+        Nested records will generate names separated by sep,
+        e.g., for sep='.', { 'foo' : { 'bar' : 0 } } -> foo.bar
+    max_level
+        recursion depth
+    encoder
+        Custom JSON encoder; if not given, `json.dumps` is used.
+    """
+    if isinstance(data, dict):
+        if max_level > 0:
+            key_root = f"{key_string}{separator}" if key_string else ""
+            nested_max_level = max_level - 1
+
+            for key, value in data.items():
+                new_key = f"{key_root}{key}" if key_root else key
+                _normalize_json(
+                    data=value,
+                    key_string=new_key,
+                    normalized_dict=normalized_dict,
+                    separator=separator,
+                    max_level=nested_max_level,
+                    encoder=encoder,
+                )
+        else:
+            normalized_dict[key_string] = encoder(data)
+            return normalized_dict
+    else:
+        normalized_dict[key_string] = data
+    return normalized_dict
+
+
 def _normalize_json_ordered(
-    data: dict[str, Any], separator: str, max_level: int
+    data: dict[str, Any],
+    separator: str,
+    max_level: int,
+    encoder: JSONEncoder,
 ) -> dict[str, Any]:
     """
     Order the top level keys and then recursively go to depth.
@@ -48,27 +112,35 @@ def _normalize_json_ordered(
     Parameters
     ----------
     data
-        dict or list of dicts
+        Deserialized JSON objects (dict or list of dicts)
     separator
-        str, default '.'
-        Nested records will generate names separated by sep,
-        e.g., for sep='.', { 'foo' : { 'bar' : 0 } } -> foo.bar
+        Nested records will generate names separated by sep. e.g.,
+        for `separator=".", {"foo": {"bar": 0}}` -> foo.bar.
     max_level
-        max recursing level
+        Max number of levels(depth of dict) to normalize.
+    encoder
+        Custom JSON encoder; if not given, `json.dumps` is used.
 
     Returns
     -------
     dict or list of dicts, matching `normalized_json_object`
     """
-    top_dict_ = {k: v for k, v in data.items() if not isinstance(v, dict)}
-    nested_dict_ = normalize_json(
-        data={k: v for k, v in data.items() if isinstance(v, dict)},
+    top_, nested_data = {}, {}
+    for k, v in data.items():
+        if isinstance(v, dict):
+            nested_data[k] = v
+        else:
+            top_[k] = v
+
+    nested_ = _normalize_json(
+        data=nested_data,
         key_string="",
         normalized_dict={},
         separator=separator,
         max_level=max_level,
+        encoder=encoder,
     )
-    return {**top_dict_, **nested_dict_}
+    return {**top_, **nested_}
 
 
 @unstable()
@@ -80,6 +152,7 @@ def json_normalize(
     schema: Schema | None = None,
     strict: bool = True,
     infer_schema_length: int | None = N_INFER_DEFAULT,
+    encoder: JSONEncoder | None = None,
 ) -> DataFrame:
     """
     Normalize semi-structured deserialized JSON data into a flat table.
@@ -109,6 +182,8 @@ def json_normalize(
         Whether Polars should be strict when constructing the DataFrame.
     infer_schema_length
         Number of rows to take into consideration to determine the schema.
+    encoder
+        Custom JSON encoder function; if not given, `json.dumps` is used.
 
     Examples
     --------
@@ -116,13 +191,16 @@ def json_normalize(
     ...     {
     ...         "id": 1,
     ...         "name": "Cole Volk",
-    ...         "fitness": {"height": 130, "weight": 60},
+    ...         "fitness": {"height": 180, "weight": 85},
     ...     },
-    ...     {"name": "Mark Reg", "fitness": {"height": 130, "weight": 60}},
     ...     {
     ...         "id": 2,
     ...         "name": "Faye Raker",
-    ...         "fitness": {"height": 130, "weight": 60},
+    ...         "fitness": {"height": 155, "weight": 58},
+    ...     },
+    ...     {
+    ...         "name": "Mark Reg",
+    ...         "fitness": {"height": 170, "weight": 78},
     ...     },
     ... ]
     >>> pl.json_normalize(data, max_level=1)
@@ -132,88 +210,52 @@ def json_normalize(
     │ ---  ┆ ---        ┆ ---            ┆ ---            │
     │ i64  ┆ str        ┆ i64            ┆ i64            │
     ╞══════╪════════════╪════════════════╪════════════════╡
-    │ 1    ┆ Cole Volk  ┆ 130            ┆ 60             │
-    │ null ┆ Mark Reg   ┆ 130            ┆ 60             │
-    │ 2    ┆ Faye Raker ┆ 130            ┆ 60             │
+    │ 1    ┆ Cole Volk  ┆ 180            ┆ 85             │
+    │ 2    ┆ Faye Raker ┆ 155            ┆ 58             │
+    │ null ┆ Mark Reg   ┆ 170            ┆ 78             │
     └──────┴────────────┴────────────────┴────────────────┘
-    >>> pl.json_normalize(data, max_level=0)
+
+    Normalize to a specific depth, using a custom JSON encoder
+    (note that `orson.dumps` encodes to bytes, not str).
+
+    >>> import orjson
+    >>> pl.json_normalize(data, max_level=0, encoder=orjson.dumps)
     shape: (3, 3)
     ┌──────┬────────────┬───────────────────────────────┐
     │ id   ┆ name       ┆ fitness                       │
     │ ---  ┆ ---        ┆ ---                           │
-    │ i64  ┆ str        ┆ str                           │
+    │ i64  ┆ str        ┆ binary                        │
     ╞══════╪════════════╪═══════════════════════════════╡
-    │ 1    ┆ Cole Volk  ┆ {"height": 130, "weight": 60} │
-    │ null ┆ Mark Reg   ┆ {"height": 130, "weight": 60} │
-    │ 2    ┆ Faye Raker ┆ {"height": 130, "weight": 60} │
+    │ 1    ┆ Cole Volk  ┆ b"{"height":180,"weight":85}" │
+    │ 2    ┆ Faye Raker ┆ b"{"height":155,"weight":58}" │
+    │ null ┆ Mark Reg   ┆ b"{"height":170,"weight":78}" │
     └──────┴────────────┴───────────────────────────────┘
-
     """
     if max_level is None:
-        max_level = 1 << 32
+        max_level = 1 << 32  # eg: u32
     max_level += 1
-    if isinstance(data, list) and len(data) == 0:
+
+    if isinstance(data, Sequence) and len(data) == 0:
         return DataFrame()
-    elif isinstance(data, dict):
+    elif isinstance(data, Mapping):
         data = [data]
-    elif isinstance(data, abc.Iterable) and not isinstance(data, str):  # type: ignore[redundant-expr]
+    elif isinstance(data, Iterable) and not isinstance(data, str):  # type: ignore[redundant-expr]
         data = list(data)
     else:
-        msg = "expected list of objects"
+        msg = "expected list or dict of objects"
         raise ValueError(msg)
+
+    if encoder is None:
+        encoder = json.dumps
+
     return DataFrame(
-        _simple_json_normalize(data, separator=separator, max_level=max_level),
+        _simple_json_normalize(
+            data,
+            separator=separator,
+            max_level=max_level,
+            encoder=encoder,
+        ),
         schema=schema,
         strict=strict,
         infer_schema_length=infer_schema_length,
     )
-
-
-def normalize_json(
-    data: Any,
-    key_string: str,
-    normalized_dict: dict[str, Any],
-    separator: str,
-    max_level: int,
-) -> dict[str, Any]:
-    """
-    Main recursive function.
-
-    Designed for the most basic use case of pl.json_normalize(data)
-    intended as a performance improvement.
-
-    Parameters
-    ----------
-    data : Any
-        Type dependent on types contained within nested Json
-    key_string : str
-        New key (with separator(s) in) for data
-    normalized_dict : dict
-        The new normalized/flattened Json dict
-    separator : str, default '.'
-        Nested records will generate names separated by sep,
-        e.g., for sep='.', { 'foo' : { 'bar' : 0 } } -> foo.bar
-    max_level
-        recursion depth
-    """
-    if isinstance(data, dict):
-        if max_level > 0:
-            for key, value in data.items():
-                new_key = f"{key_string}{separator}{key}"
-
-                if not key_string:
-                    new_key = new_key.removeprefix(separator)
-
-                normalize_json(
-                    data=value,
-                    key_string=new_key,
-                    normalized_dict=normalized_dict,
-                    separator=separator,
-                    max_level=max_level - 1,
-                )
-        else:
-            normalized_dict[key_string] = json.dumps(data)
-            return normalized_dict
-    else:
-        normalized_dict[key_string] = data
-    return normalized_dict

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -53,6 +53,8 @@ gevent
 matplotlib
 # Testing
 hypothesis
+# Miscellaneous
+orjson
 
 # -------
 # TOOLING


### PR DESCRIPTION
Closes #20950.

* Allows a custom json encoder function to be passed to `json_normalize`, enabling the caller to target specific performance/behaviour.
* Minor speedup (~6-7% faster) from optimising Python loops 🚀 
* No change to default behaviour (uses `json.dumps`).
* Additional JSON test coverage.

## Example

```python
import polars as pl

data = [
    {
        "id": n,
        "name": {"first": "Some", "middle": None, "last": "Name"},
        "attrs": {"height": 185, "weight": 90},
        "lifts": {
            "max_deadlift": 190, 
            "max_squat": 140, 
            "max_bench": 100,
        },
    } for n in range(5)
]
```
#### Default
```python
pl.json_normalize(data, max_level=0)
# shape: (5, 4)
# ┌─────┬─────────────────────────────────┬───────────────────────────────┬─────────────────────────────────┐
# │ id  ┆ name                            ┆ attrs                         ┆ lifts                           │
# │ --- ┆ ---                             ┆ ---                           ┆ ---                             │
# │ i64 ┆ str                             ┆ str                           ┆ str                             │
# ╞═════╪═════════════════════════════════╪═══════════════════════════════╪═════════════════════════════════╡
# │ 0   ┆ {"first": "Some", "middle": nu… ┆ {"height": 185, "weight": 90} ┆ {"max_deadlift": 190, "max_squ… │
# │ 1   ┆ {"first": "Some", "middle": nu… ┆ {"height": 185, "weight": 90} ┆ {"max_deadlift": 190, "max_squ… │
# │ 2   ┆ {"first": "Some", "middle": nu… ┆ {"height": 185, "weight": 90} ┆ {"max_deadlift": 190, "max_squ… │
# │ 3   ┆ {"first": "Some", "middle": nu… ┆ {"height": 185, "weight": 90} ┆ {"max_deadlift": 190, "max_squ… │
# │ 4   ┆ {"first": "Some", "middle": nu… ┆ {"height": 185, "weight": 90} ┆ {"max_deadlift": 190, "max_squ… │
# └─────┴─────────────────────────────────┴───────────────────────────────┴─────────────────────────────────┘
```
#### Custom encoder
```python
import orjson
pl.json_normalize(data, max_level=0, encoder=orjson.dumps)
# shape: (5, 4)
# ┌─────┬─────────────────────────────────┬───────────────────────────────┬─────────────────────────────────┐
# │ id  ┆ name                            ┆ attrs                         ┆ lifts                           │
# │ --- ┆ ---                             ┆ ---                           ┆ ---                             │
# │ i64 ┆ binary                          ┆ binary                        ┆ binary                          │
# ╞═════╪═════════════════════════════════╪═══════════════════════════════╪═════════════════════════════════╡
# │ 0   ┆ b"{"first":"Some","middle":nul… ┆ b"{"height":185,"weight":90}" ┆ b"{"max_deadlift":190,"max_squ… │
# │ 1   ┆ b"{"first":"Some","middle":nul… ┆ b"{"height":185,"weight":90}" ┆ b"{"max_deadlift":190,"max_squ… │
# │ 2   ┆ b"{"first":"Some","middle":nul… ┆ b"{"height":185,"weight":90}" ┆ b"{"max_deadlift":190,"max_squ… │
# │ 3   ┆ b"{"first":"Some","middle":nul… ┆ b"{"height":185,"weight":90}" ┆ b"{"max_deadlift":190,"max_squ… │
# │ 4   ┆ b"{"first":"Some","middle":nul… ┆ b"{"height":185,"weight":90}" ┆ b"{"max_deadlift":190,"max_squ… │
# └─────┴─────────────────────────────────┴───────────────────────────────┴─────────────────────────────────┘
```