### PR TITLE
feat(python): Improve `df.corr`, add "spearman" method and row labels, align with `pl.corr`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -789,7 +789,7 @@ def corr(
     propagate_nans: bool = False,
 ) -> Expr:
     """
-    Compute the Pearson's or Spearman rank correlation correlation between two columns.
+    Compute the Pearson's or Spearman rank correlation between two columns.
 
     Parameters
     ----------


### PR DESCRIPTION
fix #20957 
fix #16864 
fix #14457 
fix #16832 

# 👍 
- remove numpy dependency -> use `pl.corr` instead
- align parameters with `pl.corr`
- add "spearman" method
- add parameter to optionally show column with row names

# 👎 
- Muuuuch slower: 10-1000x depending on number of columns 
  - `pl.corr` is already about 10x slower than numpy
  - no parallelization
  - calculation could be more efficient
 - However, IMO correlation analysis is mostly an exploration tool and for that and many normal use cases it is fast enough.
 - If a user wants more speed they can still use numpy instead but must to that explicitly 