### PR TITLE
refactor(rust): Remove unnecessary unsafe around warning function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,6 +3078,7 @@ version = "0.46.0"
 dependencies = [
  "avro-schema",
  "object_store",
+ "parking_lot",
  "polars-arrow-format",
  "regex",
  "signal-hook",

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -12,6 +12,7 @@ description = "Error definitions for the Polars DataFrame library"
 arrow-format = { workspace = true, optional = true }
 avro-schema = { workspace = true, optional = true }
 object_store = { workspace = true, optional = true }
+parking_lot = { workspace = true }
 regex = { workspace = true, optional = true }
 simdutf8 = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
I doubt we'll be using warning functions at top speed.