### PR TITLE
ci: Update code coverage workflow to use macos-latest runners

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -38,7 +38,7 @@ jobs:
     # https://github.com/pola-rs/polars/issues/14255
     # Pinned on macos-13 because latest does not work:
     # https://github.com/pola-rs/polars/issues/15917
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -87,7 +87,7 @@ jobs:
   coverage-python:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -36,8 +36,6 @@ jobs:
   coverage-rust:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
-    # Pinned on macos-13 because latest does not work:
-    # https://github.com/pola-rs/polars/issues/15917
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -592,7 +592,8 @@ def test_join_on_strings() -> None:
     q = df.join_where(df, pl.col("a").ge(pl.col("a_right")))
 
     assert "NESTED LOOP JOIN" in q.explain()
-    assert q.collect().to_dict(as_series=False) == {
+    # Note: Output is flaky without sort when POLARS_MAX_THREADS=1
+    assert q.collect().sort(pl.all()).to_dict(as_series=False) == {
         "a": ["a", "b", "b", "c", "c", "c"],
         "b": ["b", "b", "b", "b", "b", "b"],
         "a_right": ["a", "a", "b", "a", "b", "c"],


### PR DESCRIPTION
Code coverage is currently failing as it runs on x86 macOS, which installs an old version of torch (2.2.2, March 2024) that is incompatible with the latest version of numpy (>v2). Note that torch wheels for x86 macOS have stopped being built since 2.2.2 due to deprecation.

We had previously pinned the macOS runner to use macos-13 due to difficulties on macos-latest at the time, this PR removes that pin and uses macos-latest instead.

* Closes https://github.com/pola-rs/polars/issues/15917

<details>
<summary>Debug notes</summary>

* Code coverage observed to be broken since at least 2025-01-29 07:35 UTC time, with no apparent changes to any dependency files
* Comparing the log differences, the `numpy` version being installed in the runner was suddenly changed from `1.26.3` to `2.1.2`. After some more digging I found that `numpy` was being downloaded from `download.pytorch.org` rather than PyPI:
  * https://download.pytorch.org/whl/numpy-1.26.3-cp312-cp312-macosx_10_9_x86_64.whl (before)
  * https://download.pytorch.org/whl/numpy-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl (current)
* Performing a HEAD request on https://download.pytorch.org/whl/numpy-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl.metadata, we see a Last-Modified of `Tue, 28 Jan 2025 20:15:33 GMT`, so I suspect that the cause of suddenly downloading a newer numpy version is due to a newly built wheel being uploaded to `download.pytorch.org`

Todo:
* I don't know why version 2.2.2 (released March 2024) of torch is being downloaded rather than the latest (2.6.0). As it is too old, it is not compatible with numpy v2+, causing the CI failure
  * *edit, our MacOS runner is on x86, and that is the latest wheel available for x86

</details>
