### PR TITLE
test: Add tests for resolved issues

### DIFF
--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -678,3 +678,10 @@ def test_decimal_from_large_ints_9084() -> None:
     numbers = [2963091539321097135000000000, 25658709114149718824803874]
     s = pl.Series(numbers, dtype=pl.Decimal)
     assert s.to_list() == [D(n) for n in numbers]
+
+
+def test_cast_float_to_decimal_12775() -> None:
+    s = pl.Series([1.5])
+    # default scale = 0
+    assert s.cast(pl.Decimal).to_list() == [D("1")]
+    assert s.cast(pl.Decimal(scale=1)).to_list() == [D("1.5")]

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -142,6 +142,15 @@ def test_object_concat() -> None:
     assert catted.to_dict(as_series=False) == {"a": [1, 2, 3, 1, 4, 3]}
 
 
+def test_object_concat_diagonal_14651() -> None:
+    df1 = pl.DataFrame({"a": ["abc"]}, schema={"a": pl.Object})
+    df2 = pl.DataFrame({"b": ["def"]}, schema={"b": pl.Object})
+    result = pl.concat([df1, df2], how="diagonal")
+    assert result.schema == pl.Schema({"a": pl.Object, "b": pl.Object})
+    assert result["a"].to_list() == ["abc", None]
+    assert result["b"].to_list() == [None, "def"]
+
+
 def test_object_row_construction() -> None:
     data = [
         [uuid4()],

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -117,3 +117,10 @@ def test_lazy_map_schema() -> None:
     assert df.lazy().map_batches(
         custom2, validate_output_schema=False
     ).collect().to_dict(as_series=False) == {"a": ["1", "2", "3"], "b": ["a", "b", "c"]}
+
+
+def test_map_batches_collect_schema_17327() -> None:
+    df = pl.LazyFrame({"a": [1, 1, 1], "b": [2, 3, 4]})
+    q = df.group_by("a").agg(pl.col("b").map_batches(lambda s: s))
+    expected = pl.Schema({"a": pl.Int64(), "b": pl.List(pl.Unknown)})
+    assert q.collect_schema() == expected

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -690,3 +690,11 @@ def test_cast_integer_to_decimal() -> None:
         "", [Decimal("1.00"), Decimal("2.00"), Decimal("3.00")], pl.Decimal(10, 2)
     )
     assert_series_equal(result, expected)
+
+
+def test_cast_python_dtypes() -> None:
+    s = pl.Series([0, 1])
+    assert s.cast(int).dtype == pl.Int64
+    assert s.cast(float).dtype == pl.Float64
+    assert s.cast(bool).dtype == pl.Boolean
+    assert s.cast(str).dtype == pl.String

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1194,3 +1194,10 @@ def test_group_by_lit_series(capfd: Any, monkeypatch: Any) -> None:
     df.lazy().group_by("y").agg(pl.col("x").dot(a)).collect()
     captured = capfd.readouterr().err
     assert "are not partitionable" in captured
+
+
+def test_group_by_list_column() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [[1, 2], [3], [1, 2]]})
+    result = df.group_by("b").agg(pl.sum("a")).sort("b")
+    expected = pl.DataFrame({"b": [[1, 2], [3]], "a": [4, 2]})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -880,3 +880,18 @@ def test_selector_list_of_lists_18499() -> None:
 
     with pytest.raises(InvalidOperationError, match="invalid selector expression"):
         lf.unique(subset=[["bar", "ham"]])  # type: ignore[list-item]
+
+
+def test_selector_python_dtypes() -> None:
+    df = pl.DataFrame(
+        {
+            "int": [1, 2, 3],
+            "float": [1.0, 2.0, 3.0],
+            "bool": [True, False, True],
+            "str": ["x", "y", "z"],
+        }
+    )
+    assert df.select(cs.by_dtype(int)).columns == ["int"]
+    assert df.select(cs.by_dtype(float)).columns == ["float"]
+    assert df.select(cs.by_dtype(bool)).columns == ["bool"]
+    assert df.select(cs.by_dtype(str)).columns == ["str"]


### PR DESCRIPTION
Tests added in this PR for open issues that are already fixed:

closes #4175
closes #12775
closes #13117
closes #14651
closes #17327

Other open issues that have already been resolved (just noting tests in order to close):

closes #7683 - `test_split_expr.py::test_split_expr`
closes #9718 - `test_array.py::test_arr_first_last`, `test_array.py::test_array_get`
closes #10137 - `test_join.py::test_join_numeric_type_upcast_15338`
closes #11853 - `test_lazy_parquet.py::test_parquet_schema_arg`
closes #11917 - `test_explain.py::test_lf_explain_format_tree`
closes #13846 - `test_concat_arr.py::test_concat_arr`
closes #14540 - `test_concat_arr.py::test_concat_arr`
closes #17514 - `test_is_in.py`
closes #18018 - `test_enum.py::test_init_from_enums`
closes #18419 - `test_window.py::test_window_order_by_8662`

