### PR TITLE
docs: Explicitly call out that the GPU open beta runs on a single GPU

### DIFF
--- a/docs/source/user-guide/lazy/gpu.md
+++ b/docs/source/user-guide/lazy/gpu.md
@@ -2,7 +2,7 @@
 
 Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API in Python using
 [RAPIDS cuDF](https://docs.rapids.ai/api/cudf/stable/) on NVIDIA GPUs. This functionality is
-available in Open Beta and is undergoing rapid development and currently is a single GPU
+available in Open Beta, is undergoing rapid development, and is currently a single GPU
 implementation.
 
 If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based

--- a/docs/source/user-guide/lazy/gpu.md
+++ b/docs/source/user-guide/lazy/gpu.md
@@ -2,7 +2,8 @@
 
 Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API in Python using
 [RAPIDS cuDF](https://docs.rapids.ai/api/cudf/stable/) on NVIDIA GPUs. This functionality is
-available in Open Beta and is undergoing rapid development and currently is a single GPU implementation.
+available in Open Beta and is undergoing rapid development and currently is a single GPU
+implementation.
 
 If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based
 execution by running `.collect(engine="gpu")` instead of `.collect()`.

--- a/docs/source/user-guide/lazy/gpu.md
+++ b/docs/source/user-guide/lazy/gpu.md
@@ -2,7 +2,8 @@
 
 Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API in Python using
 [RAPIDS cuDF](https://docs.rapids.ai/api/cudf/stable/) on NVIDIA GPUs. This functionality is
-available in Open Beta and is undergoing rapid development.
+available in Open Beta and is undergoing rapid development. This functionality is available in 
+Open Beta and is undergoing rapid development and currently is a single GPU implementation.
 
 If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based
 execution by running `.collect(engine="gpu")` instead of `.collect()`.

--- a/docs/source/user-guide/lazy/gpu.md
+++ b/docs/source/user-guide/lazy/gpu.md
@@ -2,8 +2,7 @@
 
 Polars provides an in-memory, GPU-accelerated execution engine for the Lazy API in Python using
 [RAPIDS cuDF](https://docs.rapids.ai/api/cudf/stable/) on NVIDIA GPUs. This functionality is
-available in Open Beta and is undergoing rapid development. This functionality is available in 
-Open Beta and is undergoing rapid development and currently is a single GPU implementation.
+available in Open Beta and is undergoing rapid development and currently is a single GPU implementation.
 
 If you install Polars with the [GPU feature flag](../installation.md), you can trigger GPU-based
 execution by running `.collect(engine="gpu")` instead of `.collect()`.


### PR DESCRIPTION
due to questions that arose, I wanted to clarify up front that the GPU Open beta works on a single GPU.