### PR TITLE
fix(python): Ensure `lit` handles datetimes with tzinfo that represents a fixed offset from UTC

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -107,6 +107,7 @@ module = [
   "arrow_odbc",
   "backports",
   "connectorx",
+  "dateutil.*",
   "deltalake.*",
   "fsspec.*",
   "gevent",

--- a/py-polars/tests/unit/expr/test_literal.py
+++ b/py-polars/tests/unit/expr/test_literal.py
@@ -1,4 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+from dateutil.tz import tzoffset
+
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_literal_scalar_list_18686() -> None:
@@ -28,3 +38,87 @@ def test_literal_integer_20807() -> None:
         assert pl.select(pl.lit(-value)).item() == -value
         assert pl.select(pl.lit(value, dtype=pl.Int128)).item() == value
         assert pl.select(pl.lit(-value, dtype=pl.Int128)).item() == -value
+
+
+@pytest.mark.parametrize(
+    ("tz", "lit_dtype"),
+    [
+        (ZoneInfo("Asia/Kabul"), None),
+        (ZoneInfo("Asia/Kabul"), pl.Datetime("us", "Asia/Kabul")),
+        (ZoneInfo("Europe/Paris"), pl.Datetime("us", "Europe/Paris")),
+        (timezone.utc, pl.Datetime("us", "UTC")),
+    ],
+)
+def test_literal_datetime_timezone(tz: Any, lit_dtype: pl.DataType | None) -> None:
+    expected_dtype = pl.Datetime("us", time_zone=str(tz))
+    value = datetime(2020, 1, 1, tzinfo=tz)
+
+    df1 = pl.DataFrame({"dt": [value]})
+    df2 = pl.select(dt=pl.lit(value, dtype=lit_dtype))
+
+    assert_frame_equal(df1, df2)
+    assert df1.schema["dt"] == expected_dtype
+    assert df1.item() == value
+
+
+@pytest.mark.parametrize(
+    ("tz", "lit_dtype", "expected_item"),
+    [
+        (
+            # fixed offset from UTC
+            tzoffset(None, 16200),
+            None,
+            datetime(2019, 12, 31, 19, 30, tzinfo=timezone.utc),
+        ),
+        (
+            # fixed offset from UTC
+            tzoffset("Kabul", 16200),
+            None,
+            datetime(2019, 12, 31, 19, 30, tzinfo=ZoneInfo("UTC")),
+        ),
+        (
+            # fixed offset from UTC with matching timezone
+            tzoffset(None, 16200),
+            pl.Datetime("us", "Asia/Kabul"),
+            datetime(2020, 1, 1, tzinfo=ZoneInfo("Asia/Kabul")),
+        ),
+        (
+            # fixed offset from UTC with matching timezone
+            tzoffset("Kabul", 16200),
+            pl.Datetime("us", "Asia/Kabul"),
+            datetime(2020, 1, 1, tzinfo=ZoneInfo("Asia/Kabul")),
+        ),
+    ],
+)
+def test_literal_datetime_timezone_utc_offset(
+    tz: Any, lit_dtype: pl.DataType | None, expected_item: datetime
+) -> None:
+    overrides = {"schema_overrides": {"dt": lit_dtype}} if lit_dtype else {}
+    value = datetime(2020, 1, 1, tzinfo=tz)
+
+    # validate both frame and lit constructors
+    df1 = pl.DataFrame({"dt": [value]}, **overrides)  # type: ignore[arg-type]
+    df2 = pl.select(dt=pl.lit(value, dtype=lit_dtype))
+
+    assert_frame_equal(df1, df2)
+
+    expected_tz = "UTC" if lit_dtype is None else getattr(lit_dtype, "time_zone", None)
+    expected_dtype = pl.Datetime("us", time_zone=expected_tz)
+
+    for df in (df1, df2):
+        assert df.schema["dt"] == expected_dtype
+        assert df.item() == expected_item
+
+
+def test_literal_datetime_timezone_utc_error() -> None:
+    value = datetime(2020, 1, 1, tzinfo=tzoffset("Somewhere", offset=3600))
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"time zone of dtype \('Pacific/Galapagos'\) differs from"
+            r" time zone of value \(tzoffset\('Somewhere', 3600\)\)"
+        ),
+    ):
+        # the offset does not correspond to the offset of the declared timezone
+        pl.select(dt=pl.lit(value, dtype=pl.Datetime(time_zone="Pacific/Galapagos")))


### PR DESCRIPTION
Closes #20544.

* The Rust-side `AnyValue` path accounts for fixed offsets from UTC, but `lit` construction on the Python side didn't. Now works for both. 

* Plenty of new test coverage added.

## Example

```python
from dateutil.tz import tzoffset
from datetime import datetime
import polars as pl

dt = datetime(2020, 1, 1, tzinfo=tzoffset(None, 20700))
pl.select(pl.lit(dt))
# shape: (1, 1)
# ┌─────────────────────────┐
# │ literal                 │
# │ ---                     │
# │ datetime[μs, UTC]       │
# ╞═════════════════════════╡
# │ 2019-12-31 18:15:00 UTC │
# └─────────────────────────┘
```
**Previously**:
```
ComputeError: unable to parse time zone: 'tzoffset(None, 20700)'. 
  Please check the Time Zone Database for a list of available time zones
```