### PR TITLE
fix: Don't silently produce null values from invalid input to `pl.datetime` and `pl.date`

### DIFF
--- a/crates/polars-time/src/chunkedarray/date.rs
+++ b/crates/polars-time/src/chunkedarray/date.rs
@@ -84,21 +84,32 @@ pub trait DateMethods: AsDate {
         day: &Int8Chunked,
         name: PlSmallStr,
     ) -> PolarsResult<DateChunked> {
+        let mut error_values: Option<(i32, i8, i8)> = None;
         let mut ca: Int32Chunked = year
             .into_iter()
             .zip(month)
             .zip(day)
             .map(|((y, m), d)| {
                 if let (Some(y), Some(m), Some(d)) = (y, m, d) {
-                    let Some(ns) = NaiveDate::from_ymd_opt(y, m as u32, d as u32) else {
-                        panic!("Invalid date components ({}, {}, {}) supplied", y, m, d)
-                    };
-                    Some(ns.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+                    NaiveDate::from_ymd_opt(y, m as u32, d as u32).map_or_else(
+                        // If None is returned, then we have an invalid date.
+                        // We save the faulty values and move on.
+                        || {
+                            error_values = Some((y, m, d));
+                            None
+                        },
+                        // We have a valid date.
+                        |ns| Some(ns.num_days_from_ce() - EPOCH_DAYS_FROM_CE),
+                    )
                 } else {
                     None
                 }
             })
             .collect_trusted();
+        if let Some(values) = error_values {
+            // An invalid y/m/d was detected.
+            polars_bail!(ComputeError: format!("Invalid date components ({}, {}, {}) supplied", values.0, values.1, values.2))
+        };
         ca.rename(name);
         Ok(ca.into_date())
     }

--- a/crates/polars-time/src/chunkedarray/date.rs
+++ b/crates/polars-time/src/chunkedarray/date.rs
@@ -90,8 +90,10 @@ pub trait DateMethods: AsDate {
             .zip(day)
             .map(|((y, m), d)| {
                 if let (Some(y), Some(m), Some(d)) = (y, m, d) {
-                    NaiveDate::from_ymd_opt(y, m as u32, d as u32)
-                        .map(|t| t.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+                    let Some(ns) = NaiveDate::from_ymd_opt(y, m as u32, d as u32) else {
+                        panic!("Invalid date components ({}, {}, {}) supplied.", y, m, d)
+                    };
+                    Some(ns.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
                 } else {
                     None
                 }

--- a/crates/polars-time/src/chunkedarray/date.rs
+++ b/crates/polars-time/src/chunkedarray/date.rs
@@ -91,7 +91,7 @@ pub trait DateMethods: AsDate {
             .map(|((y, m), d)| {
                 if let (Some(y), Some(m), Some(d)) = (y, m, d) {
                     let Some(ns) = NaiveDate::from_ymd_opt(y, m as u32, d as u32) else {
-                        panic!("Invalid date components ({}, {}, {}) supplied.", y, m, d)
+                        panic!("Invalid date components ({}, {}, {}) supplied", y, m, d)
                     };
                     Some(ns.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
                 } else {

--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -198,17 +198,14 @@ pub trait DatetimeMethods: AsDatetime {
                                         error_time_values = Some((h, mnt, s, ns));
                                         None
                                     },
-                                    // We have a valid date.
+                                    // We have a valid time.
                                     |ndt| {
+                                        let t = ndt.and_utc();
                                         Some(match time_unit {
-                                            TimeUnit::Milliseconds => {
-                                                ndt.and_utc().timestamp_millis()
-                                            },
-                                            TimeUnit::Microseconds => {
-                                                ndt.and_utc().timestamp_micros()
-                                            },
+                                            TimeUnit::Milliseconds => t.timestamp_millis(),
+                                            TimeUnit::Microseconds => t.timestamp_micros(),
                                             TimeUnit::Nanoseconds => {
-                                                ndt.and_utc().timestamp_nanos_opt().unwrap()
+                                                t.timestamp_nanos_opt().unwrap()
                                             },
                                         })
                                     },

--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -180,16 +180,13 @@ pub trait DatetimeMethods: AsDatetime {
                     (y, m, d, h, mnt, s, ns)
                 {
                     let Some(t) = NaiveDate::from_ymd_opt(y, m as u32, d as u32) else {
-                        panic!(
-                            "Invalid datetime components ({}, {}, {}, {}, {}, {}, {}) supplied.",
-                            y, m, d, h, mnt, s, ns
-                        )
+                        panic!("Invalid date components ({}, {}, {}) supplied", y, m, d)
                     };
                     let Some(ndt) = t.and_hms_nano_opt(h as u32, mnt as u32, s as u32, ns as u32)
                     else {
                         panic!(
-                            "Invalid datetime components ({}, {}, {}, {}, {}, {}, {}) supplied.",
-                            y, m, d, h, mnt, s, ns
+                            "Invalid time components ({}, {}, {}, {}) supplied",
+                            h, mnt, s, ns
                         )
                     };
                     Some(match time_unit {

--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -179,21 +179,31 @@ pub trait DatetimeMethods: AsDatetime {
                 if let (Some(y), Some(m), Some(d), Some(h), Some(mnt), Some(s), Some(ns)) =
                     (y, m, d, h, mnt, s, ns)
                 {
-                    NaiveDate::from_ymd_opt(y, m as u32, d as u32)
-                        .and_then(|nd| {
-                            nd.and_hms_nano_opt(h as u32, mnt as u32, s as u32, ns as u32)
-                        })
-                        .map(|ndt| match time_unit {
-                            TimeUnit::Milliseconds => ndt.and_utc().timestamp_millis(),
-                            TimeUnit::Microseconds => ndt.and_utc().timestamp_micros(),
-                            TimeUnit::Nanoseconds => ndt.and_utc().timestamp_nanos_opt().unwrap(),
-                        })
+                    let Some(t) = NaiveDate::from_ymd_opt(y, m as u32, d as u32) else {
+                        panic!(
+                            "Invalid datetime components ({}, {}, {}, {}, {}, {}, {}) supplied.",
+                            y, m, d, h, mnt, s, ns
+                        )
+                    };
+                    let Some(ndt) = t.and_hms_nano_opt(h as u32, mnt as u32, s as u32, ns as u32)
+                    else {
+                        panic!(
+                            "Invalid datetime components ({}, {}, {}, {}, {}, {}, {}) supplied.",
+                            y, m, d, h, mnt, s, ns
+                        )
+                    };
+                    Some(match time_unit {
+                        TimeUnit::Milliseconds => ndt.and_utc().timestamp_millis(),
+                        TimeUnit::Microseconds => ndt.and_utc().timestamp_micros(),
+                        TimeUnit::Nanoseconds => ndt.and_utc().timestamp_nanos_opt().unwrap(),
+                    })
                 } else {
                     None
                 }
             })
             .collect_trusted();
 
+        println!("here");
         let mut ca = match time_zone {
             #[cfg(feature = "timezones")]
             Some(_) => {

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -72,7 +72,7 @@ def test_datetime_invalid_date_component(components: list[int]) -> None:
     ],
 )
 def test_datetime_invalid_time_component(components: list[int]) -> None:
-    y, m, d, h, mnt, s, us = components
+    h, mnt, s, us = components[3:]
     ns = us * 1_000
     msg = rf"Invalid time components \({h}, {mnt}, {s}, {ns}\) supplied"
     with pytest.raises(PanicException, match=msg):

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, PanicException
+from polars.exceptions import ComputeError
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
@@ -43,7 +43,7 @@ def test_date_datetime() -> None:
 def test_date_invalid_component(components: list[int]) -> None:
     y, m, d = components
     msg = rf"Invalid date components \({y}, {m}, {d}\) supplied"
-    with pytest.raises(PanicException, match=msg):
+    with pytest.raises(ComputeError, match=msg):
         pl.select(pl.date(*components))
 
 
@@ -58,7 +58,7 @@ def test_date_invalid_component(components: list[int]) -> None:
 def test_datetime_invalid_date_component(components: list[int]) -> None:
     y, m, d = components[0:3]
     msg = rf"Invalid date components \({y}, {m}, {d}\) supplied"
-    with pytest.raises(PanicException, match=msg):
+    with pytest.raises(ComputeError, match=msg):
         pl.select(pl.datetime(*components))
 
 
@@ -75,7 +75,7 @@ def test_datetime_invalid_time_component(components: list[int]) -> None:
     h, mnt, s, us = components[3:]
     ns = us * 1_000
     msg = rf"Invalid time components \({h}, {mnt}, {s}, {ns}\) supplied"
-    with pytest.raises(PanicException, match=msg):
+    with pytest.raises(ComputeError, match=msg):
         pl.select(pl.datetime(*components))
 
 

--- a/py-polars/tests/unit/functions/as_datatype/test_datetime.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_datetime.py
@@ -42,7 +42,7 @@ def test_date_datetime() -> None:
 )
 def test_date_invalid_component(components: list[int]) -> None:
     y, m, d = components
-    msg = rf"Invalid datetime components \({y}, {m}, {d}, 0, 0, 0, 0\) supplied."
+    msg = rf"Invalid date components \({y}, {m}, {d}\) supplied"
     with pytest.raises(PanicException, match=msg):
         pl.select(pl.date(*components))
 
@@ -53,16 +53,28 @@ def test_date_invalid_component(components: list[int]) -> None:
         [2025, 13, 1, 0, 0, 0, 0],
         [2025, 1, 32, 0, 0, 0, 0],
         [2025, 2, 29, 0, 0, 0, 0],
+    ],
+)
+def test_datetime_invalid_date_component(components: list[int]) -> None:
+    y, m, d = components[0:3]
+    msg = rf"Invalid date components \({y}, {m}, {d}\) supplied"
+    with pytest.raises(PanicException, match=msg):
+        pl.select(pl.datetime(*components))
+
+
+@pytest.mark.parametrize(
+    "components",
+    [
         [2025, 1, 1, 25, 0, 0, 0],
         [2025, 1, 1, 0, 60, 0, 0],
         [2025, 1, 1, 0, 0, 60, 0],
         [2025, 1, 1, 0, 0, 0, 2_000_000],
     ],
 )
-def test_datetime_invalid_component(components: list[int]) -> None:
+def test_datetime_invalid_time_component(components: list[int]) -> None:
     y, m, d, h, mnt, s, us = components
     ns = us * 1_000
-    msg = rf"Invalid datetime components \({y}, {m}, {d}, {h}, {mnt}, {s}, {ns}\) supplied."
+    msg = rf"Invalid time components \({h}, {mnt}, {s}, {ns}\) supplied"
     with pytest.raises(PanicException, match=msg):
         pl.select(pl.datetime(*components))
 

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -30,11 +30,6 @@ def test_date_range_invalid_time_unit() -> None:
         )
 
 
-def test_date_range_invalid_time() -> None:
-    with pytest.raises(ComputeError, match="end is an out-of-range time"):
-        pl.date_range(pl.date(2024, 1, 1), pl.date(2024, 2, 30), eager=True)
-
-
 def test_date_range_lazy_with_literals() -> None:
     df = pl.DataFrame({"misc": ["x"]}).with_columns(
         pl.date_ranges(

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_replace.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_replace.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, PanicException
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -304,11 +304,11 @@ def test_replace_date_invalid_components() -> None:
     df = pl.DataFrame({"a": [date(2025, 1, 1)]})
 
     with pytest.raises(
-        PanicException, match=r"Invalid date components \(2025, 13, 1\) supplied"
+        ComputeError, match=r"Invalid date components \(2025, 13, 1\) supplied"
     ):
         df.select(pl.col("a").dt.replace(month=13))
     with pytest.raises(
-        PanicException, match=r"Invalid date components \(2025, 1, 32\) supplied"
+        ComputeError, match=r"Invalid date components \(2025, 1, 32\) supplied"
     ):
         df.select(pl.col("a").dt.replace(day=32))
 
@@ -317,11 +317,11 @@ def test_replace_datetime_invalid_date_components() -> None:
     df = pl.DataFrame({"a": [datetime(2025, 1, 1)]})
 
     with pytest.raises(
-        PanicException, match=r"Invalid date components \(2025, 13, 1\) supplied"
+        ComputeError, match=r"Invalid date components \(2025, 13, 1\) supplied"
     ):
         df.select(pl.col("a").dt.replace(month=13))
     with pytest.raises(
-        PanicException, match=r"Invalid date components \(2025, 1, 32\) supplied"
+        ComputeError, match=r"Invalid date components \(2025, 1, 32\) supplied"
     ):
         df.select(pl.col("a").dt.replace(day=32))
 
@@ -331,25 +331,25 @@ def test_replace_datetime_invalid_time_components() -> None:
 
     # hour
     with pytest.raises(
-        PanicException, match=r"Invalid time components \(25, 0, 0, 0\) supplied"
+        ComputeError, match=r"Invalid time components \(25, 0, 0, 0\) supplied"
     ):
         df.select(pl.col("a").dt.replace(hour=25))
 
     # minute
     with pytest.raises(
-        PanicException, match=r"Invalid time components \(0, 61, 0, 0\) supplied"
+        ComputeError, match=r"Invalid time components \(0, 61, 0, 0\) supplied"
     ):
         df.select(pl.col("a").dt.replace(minute=61))
 
     # second
     with pytest.raises(
-        PanicException, match=r"Invalid time components \(0, 0, 61, 0\) supplied"
+        ComputeError, match=r"Invalid time components \(0, 0, 61, 0\) supplied"
     ):
         df.select(pl.col("a").dt.replace(second=61))
 
     # microsecond
     with pytest.raises(
-        PanicException,
+        ComputeError,
         match=r"Invalid time components \(0, 0, 0, 2000000000\) supplied",
     ):
         df.select(pl.col("a").dt.replace(microsecond=2_000_000))

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_replace.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_replace.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, PanicException
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -298,3 +298,58 @@ def test_replace_preserve_tu_and_tz(tu: TimeUnit, tzinfo: str) -> None:
     result = s.dt.replace(year=2000)
     assert result.dtype.time_unit == tu  # type: ignore[attr-defined]
     assert result.dtype.time_zone == tzinfo  # type: ignore[attr-defined]
+
+
+def test_replace_date_invalid_components() -> None:
+    df = pl.DataFrame({"a": [date(2025, 1, 1)]})
+
+    with pytest.raises(
+        PanicException, match=r"Invalid date components \(2025, 13, 1\) supplied"
+    ):
+        df.select(pl.col("a").dt.replace(month=13))
+    with pytest.raises(
+        PanicException, match=r"Invalid date components \(2025, 1, 32\) supplied"
+    ):
+        df.select(pl.col("a").dt.replace(day=32))
+
+
+def test_replace_datetime_invalid_date_components() -> None:
+    df = pl.DataFrame({"a": [datetime(2025, 1, 1)]})
+
+    with pytest.raises(
+        PanicException, match=r"Invalid date components \(2025, 13, 1\) supplied"
+    ):
+        df.select(pl.col("a").dt.replace(month=13))
+    with pytest.raises(
+        PanicException, match=r"Invalid date components \(2025, 1, 32\) supplied"
+    ):
+        df.select(pl.col("a").dt.replace(day=32))
+
+
+def test_replace_datetime_invalid_time_components() -> None:
+    df = pl.DataFrame({"a": [datetime(2025, 1, 1)]})
+
+    # hour
+    with pytest.raises(
+        PanicException, match=r"Invalid time components \(25, 0, 0, 0\) supplied"
+    ):
+        df.select(pl.col("a").dt.replace(hour=25))
+
+    # minute
+    with pytest.raises(
+        PanicException, match=r"Invalid time components \(0, 61, 0, 0\) supplied"
+    ):
+        df.select(pl.col("a").dt.replace(minute=61))
+
+    # second
+    with pytest.raises(
+        PanicException, match=r"Invalid time components \(0, 0, 61, 0\) supplied"
+    ):
+        df.select(pl.col("a").dt.replace(second=61))
+
+    # microsecond
+    with pytest.raises(
+        PanicException,
+        match=r"Invalid time components \(0, 0, 0, 2000000000\) supplied",
+    ):
+        df.select(pl.col("a").dt.replace(microsecond=2_000_000))


### PR DESCRIPTION
Fixes #20977.

I am not sure if this is a breaking change or not.

Example of new behavior:

```pycon
>>> import polars as pl
>>> pl.select(pl.date(2025, 13, 1))  # month 13 is invalid (pl.Date)
polars.exceptions.ComputeError: Invalid date components (2025, 13, 1) supplied

>>> pl.select(pl.datetime(2025, 13, 1))  # month 13 is invalid (pl.Datetime)
polars.exceptions.ComputeError: Invalid date components (2025, 13, 1) supplied


>>> pl.select(pl.datetime(2025, 1, 1, 25))  # hour 25 is invalid
polars.exceptions.ComputeError: Invalid time components (25, 0, 0, 0) supplied
```