### PR TITLE
fix: Fix `merge_sorted` producing incorrect results or panicking for some logical types

### DIFF
--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -1,7 +1,8 @@
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.exceptions import ComputeError
+from polars.testing import assert_frame_equal, assert_series_equal
 
 left = pl.DataFrame({"a": [42, 13, 37], "b": [3, 8, 9]})
 right = pl.DataFrame({"a": [5, 10, 1996], "b": [1, 5, 7]})
@@ -43,3 +44,27 @@ def test_merge_sorted_proj_pd() -> None:
         lf.select("a").collect(),
         lf.collect().select("a"),
     )
+
+
+@pytest.mark.parametrize("precision", [2, 3])
+def test_merge_sorted_decimal_20990(precision: int) -> None:
+    dtype = pl.Decimal(precision=precision, scale=1)
+    s = pl.Series("a", ["1.0", "0.1"], dtype)
+    df = pl.DataFrame([s.sort()])
+    result = df.lazy().merge_sorted(df.lazy(), "a").collect().get_column("a")
+    expected = pl.Series("a", ["0.1", "0.1", "1.0", "1.0"], dtype)
+    assert_series_equal(result, expected)
+
+
+def test_merge_sorted_categorical() -> None:
+    left = pl.Series("a", ["a", "b"], pl.Categorical()).sort().to_frame()
+    right = pl.Series("a", ["a", "b", "b"], pl.Categorical()).sort().to_frame()
+    result = left.merge_sorted(right, "a").get_column("a")
+    expected = pl.Series("a", ["a", "a", "b", "b", "b"], pl.Categorical())
+    assert_series_equal(result, expected)
+
+    right = pl.Series("a", ["b", "a"], pl.Categorical()).sort().to_frame()
+    with pytest.raises(
+        ComputeError, match="can only merge-sort categoricals with the same categories"
+    ):
+        left.merge_sorted(right, "a")


### PR DESCRIPTION
Fixes the cases for `Categorical` and `Decimal`.

fixes #20987
fixes #20989
fixes #20990
