### PR TITLE
perf: Remove cast to boolean after comparison in optimizer

### DIFF
--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -117,7 +117,7 @@ pub(super) fn run_conversion(
 ) -> PolarsResult<Node> {
     let lp_node = ctxt.lp_arena.add(lp);
     ctxt.conversion_optimizer
-        .coerce_types(ctxt.expr_arena, ctxt.lp_arena, lp_node)
+        .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, lp_node)
         .map_err(|e| e.context(format!("'{name}' failed").into()))?;
 
     Ok(lp_node)

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -448,7 +448,7 @@ fn resolve_join_where(
         let predicate = to_expr_ir_ignore_alias(e, ctxt.expr_arena)?;
 
         ctxt.conversion_optimizer
-            .fill_scratch(&[predicate.node()], ctxt.expr_arena);
+            .push_scratch(predicate.node(), ctxt.expr_arena);
 
         let ir = IR::Filter {
             input: last_node,
@@ -456,10 +456,11 @@ fn resolve_join_where(
         };
 
         last_node = ctxt.lp_arena.add(ir);
-
-        ctxt.conversion_optimizer
-            .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, last_node)
-            .map_err(|e| e.context("'join_where' failed".into()))?;
     }
+
+    ctxt.conversion_optimizer
+        .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, last_node)
+        .map_err(|e| e.context("'join_where' failed".into()))?;
+
     Ok((last_node, join_node))
 }

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -129,12 +129,12 @@ pub fn resolve_join(
     ctxt.conversion_optimizer
         .fill_scratch(&left_on, ctxt.expr_arena);
     ctxt.conversion_optimizer
-        .coerce_types(ctxt.expr_arena, ctxt.lp_arena, input_left)
+        .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, input_left)
         .map_err(|e| e.context("'join' failed".into()))?;
     ctxt.conversion_optimizer
         .fill_scratch(&right_on, ctxt.expr_arena);
     ctxt.conversion_optimizer
-        .coerce_types(ctxt.expr_arena, ctxt.lp_arena, input_right)
+        .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, input_right)
         .map_err(|e| e.context("'join' failed".into()))?;
 
     // Re-evaluate because of mutable borrows earlier.
@@ -458,7 +458,7 @@ fn resolve_join_where(
         last_node = ctxt.lp_arena.add(ir);
 
         ctxt.conversion_optimizer
-            .coerce_types(ctxt.expr_arena, ctxt.lp_arena, last_node)
+            .optimize_exprs(ctxt.expr_arena, ctxt.lp_arena, last_node)
             .map_err(|e| e.context("'join_where' failed".into()))?;
     }
     Ok((last_node, join_node))

--- a/crates/polars-plan/src/plans/conversion/stack_opt.rs
+++ b/crates/polars-plan/src/plans/conversion/stack_opt.rs
@@ -61,17 +61,19 @@ impl ConversionOptimizer {
         }
     }
 
-    pub(super) fn coerce_types(
+    /// Optimizes the expressions in the scratch space. This should be called after filling the
+    /// scratch space with the expressions that you want to optimize.
+    pub(super) fn optimize_exprs(
         &mut self,
         expr_arena: &mut Arena<AExpr>,
         ir_arena: &mut Arena<IR>,
-        current_node: Node,
+        current_ir_node: Node,
     ) -> PolarsResult<()> {
         // Different from the stack-opt in the optimizer phase, this does a single pass until fixed point per expression.
 
         if let Some(rule) = &mut self.check {
-            while let Some(x) = rule.optimize_plan(ir_arena, expr_arena, current_node)? {
-                ir_arena.replace(current_node, x);
+            while let Some(x) = rule.optimize_plan(ir_arena, expr_arena, current_ir_node)? {
+                ir_arena.replace(current_ir_node, x);
             }
         }
 
@@ -85,14 +87,14 @@ impl ConversionOptimizer {
 
             if let Some(rule) = &mut self.simplify {
                 while let Some(x) =
-                    rule.optimize_expr(expr_arena, current_expr_node, ir_arena, current_node)?
+                    rule.optimize_expr(expr_arena, current_expr_node, ir_arena, current_ir_node)?
                 {
                     expr_arena.replace(current_expr_node, x);
                 }
             }
             if let Some(rule) = &mut self.coerce {
                 while let Some(x) =
-                    rule.optimize_expr(expr_arena, current_expr_node, ir_arena, current_node)?
+                    rule.optimize_expr(expr_arena, current_expr_node, ir_arena, current_ir_node)?
                 {
                     expr_arena.replace(current_expr_node, x);
                 }

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -400,11 +400,11 @@ fn inline_or_prune_cast(
 fn try_inline_literal_cast(
     lv: &LiteralValue,
     dtype: &DataType,
-    cast_options: CastOptions,
+    options: CastOptions,
 ) -> PolarsResult<Option<LiteralValue>> {
     let lv = match lv {
         LiteralValue::Series(s) => {
-            let s = s.cast_with_options(dtype, cast_options)?;
+            let s = s.cast_with_options(dtype, options)?;
             LiteralValue::Series(SpecialEq::new(s))
         },
         LiteralValue::StrCat(s) => {

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -103,14 +103,7 @@ impl OptimizationRule for TypeCoercionRule {
             } => {
                 let input = expr_arena.get(expr);
 
-                inline_or_prune_cast(
-                    input,
-                    dtype,
-                    options.strict(),
-                    lp_node,
-                    lp_arena,
-                    expr_arena,
-                )?
+                inline_or_prune_cast(input, dtype, options, lp_node, lp_arena, expr_arena)?
             },
             AExpr::Ternary {
                 truthy: truthy_node,
@@ -323,7 +316,13 @@ impl OptimizationRule for TypeCoercionRule {
                             DataType::Categorical(_, _) if dtype.is_string() => {
                                 // pass
                             },
-                            _ => cast_expr_ir(e, &dtype, &super_type, expr_arena, false)?,
+                            _ => cast_expr_ir(
+                                e,
+                                &dtype,
+                                &super_type,
+                                expr_arena,
+                                CastOptions::NonStrict,
+                            )?,
                         }
                     }
                 }
@@ -355,7 +354,7 @@ impl OptimizationRule for TypeCoercionRule {
 fn inline_or_prune_cast(
     aexpr: &AExpr,
     dtype: &DataType,
-    strict: bool,
+    options: CastOptions,
     lp_node: Node,
     lp_arena: &Arena<IR>,
     expr_arena: &Arena<AExpr>,
@@ -363,41 +362,52 @@ fn inline_or_prune_cast(
     if !dtype.is_known() {
         return Ok(None);
     }
-    let lv = match aexpr {
+
+    let out = match aexpr {
         // PRUNE
-        AExpr::BinaryExpr {
-            op: Operator::LogicalOr | Operator::LogicalAnd,
-            ..
-        } => {
-            if let Some(schema) = lp_arena.get(lp_node).input_schema(lp_arena) {
-                let field = aexpr.to_field(&schema, Context::Default, expr_arena)?;
-                if field.dtype == *dtype {
-                    return Ok(Some(aexpr.clone()));
-                }
+        AExpr::BinaryExpr { op, .. } => {
+            use Operator::*;
+
+            match op {
+                LogicalOr | LogicalAnd => {
+                    if let Some(schema) = lp_arena.get(lp_node).input_schema(lp_arena) {
+                        let field = aexpr.to_field(&schema, Context::Default, expr_arena)?;
+                        if field.dtype == *dtype {
+                            return Ok(Some(aexpr.clone()));
+                        }
+                    }
+
+                    None
+                },
+                Eq | EqValidity | NotEq | NotEqValidity | Lt | LtEq | Gt | GtEq => {
+                    if dtype.is_bool() {
+                        Some(aexpr.clone())
+                    } else {
+                        None
+                    }
+                },
+                _ => None,
             }
-            return Ok(None);
         },
         // INLINE
-        AExpr::Literal(lv) => match try_inline_literal_cast(lv, dtype, strict)? {
-            None => return Ok(None),
-            Some(lv) => lv,
-        },
-        _ => return Ok(None),
+        AExpr::Literal(lv) => try_inline_literal_cast(lv, dtype, options)?.map(AExpr::Literal),
+        _ => None,
     };
-    Ok(Some(AExpr::Literal(lv)))
+
+    Ok(out)
 }
 
 fn try_inline_literal_cast(
     lv: &LiteralValue,
     dtype: &DataType,
-    strict: bool,
+    cast_options: CastOptions,
 ) -> PolarsResult<Option<LiteralValue>> {
     let lv = match lv {
         LiteralValue::Series(s) => {
-            let s = if strict {
+            let s = if cast_options.strict() {
                 s.strict_cast(dtype)
             } else {
-                s.cast(dtype)
+                s.cast_with_options(dtype, cast_options)
             }?;
             LiteralValue::Series(SpecialEq::new(s))
         },
@@ -477,7 +487,7 @@ fn cast_expr_ir(
     from_dtype: &DataType,
     to_dtype: &DataType,
     expr_arena: &mut Arena<AExpr>,
-    strict: bool,
+    options: CastOptions,
 ) -> PolarsResult<()> {
     if from_dtype == to_dtype {
         return Ok(());
@@ -486,7 +496,7 @@ fn cast_expr_ir(
     check_cast(from_dtype, to_dtype)?;
 
     if let AExpr::Literal(lv) = expr_arena.get(e.node()) {
-        if let Some(literal) = try_inline_literal_cast(lv, to_dtype, strict)? {
+        if let Some(literal) = try_inline_literal_cast(lv, to_dtype, options)? {
             e.set_node(expr_arena.add(AExpr::Literal(literal)));
             e.set_dtype(to_dtype.clone());
             return Ok(());

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -404,11 +404,7 @@ fn try_inline_literal_cast(
 ) -> PolarsResult<Option<LiteralValue>> {
     let lv = match lv {
         LiteralValue::Series(s) => {
-            let s = if cast_options.strict() {
-                s.strict_cast(dtype)
-            } else {
-                s.cast_with_options(dtype, cast_options)
-            }?;
+            let s = s.cast_with_options(dtype, cast_options)?;
             LiteralValue::Series(SpecialEq::new(s))
         },
         LiteralValue::StrCat(s) => {

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -701,7 +701,7 @@ def test_cast_python_dtypes() -> None:
 
 
 def test_overflowing_cast_literals_21023() -> None:
-    for optimized in [True, False]:
+    for no_optimization in [True, False]:
         assert_frame_equal(
             (
                 pl.LazyFrame()
@@ -710,7 +710,7 @@ def test_overflowing_cast_literals_21023() -> None:
                         pl.Int8, wrap_numerical=True
                     )
                 )
-                .collect(optimized=optimized)
+                .collect(no_optimization=no_optimization)
             ),
             pl.Series([-128], dtype=pl.Int8).to_frame(),
         )

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -698,3 +698,19 @@ def test_cast_python_dtypes() -> None:
     assert s.cast(float).dtype == pl.Float64
     assert s.cast(bool).dtype == pl.Boolean
     assert s.cast(str).dtype == pl.String
+
+
+def test_overflowing_cast_literals_21023() -> None:
+    for optimized in [True, False]:
+        assert_frame_equal(
+            (
+                pl.LazyFrame()
+                .select(
+                    pl.lit(pl.Series([128], dtype=pl.Int64)).cast(
+                        pl.Int8, wrap_numerical=True
+                    )
+                )
+                .collect(optimized=optimized)
+            ),
+            pl.Series([-128], dtype=pl.Int8).to_frame(),
+        )

--- a/py-polars/tests/unit/test_cwc.py
+++ b/py-polars/tests/unit/test_cwc.py
@@ -146,8 +146,7 @@ def test_cwc_with_internal_aliases() -> None:
     explain = df.explain()
 
     assert (
-        """[[(col("a")) == (2)].cast(Boolean).alias("c"), [(col("b")) * (3)].alias("d")]"""
-        in explain
+        """[[(col("a")) == (2)].alias("c"), [(col("b")) * (3)].alias("d")]""" in explain
     )
 
 


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/21009
  * The expression gets recognized by `collapse_joins` without issue after we remove the extra cast
* Fixes https://github.com/pola-rs/polars/issues/21023
  * Updates some old code to propagate `options: CastOptions` instead of `strict: bool`

Drive-by renames `fn coerce_types()` to `fn optimize_exprs()` under `ConversionOptimizer`, as it also does other optimizations aside from type coercion.
