### PR TITLE
chore: Add make fix for running cargo clippy --fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,9 @@ fmt:  ## Run autoformatting and linting
 	
 .PHONY: fix
 fix:
-	cargo fix --workspace --all-targets --all-features
-	# We allow dirty on this one, if the repo was dirty the previous command would've failed.
-	cargo clippy --workspace --all-targets --all-features --fix --allow-dirty
+	cargo clippy --workspace --all-targets --all-features --fix 
+	@# Good chance the fixing introduced formatting issues, best to just do a quick format.
+	cargo fmt --all
 	
 
 .PHONY: pre-commit

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,13 @@ fmt:  ## Run autoformatting and linting
 	cargo fmt --all
 	dprint fmt
 	$(VENV_BIN)/typos
+	
+.PHONY: fix
+fix:
+	cargo fix --workspace --all-targets --all-features
+	# We allow dirty on this one, if the repo was dirty the previous command would've failed.
+	cargo clippy --workspace --all-targets --all-features --fix --allow-dirty
+	
 
 .PHONY: pre-commit
 pre-commit: fmt clippy clippy-default  ## Run all code quality checks

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -3,6 +3,10 @@
 SHELL=bash
 BASE ?= main
 
+.PHONY: fix
+fix:
+	@$(MAKE) -s -C .. $@
+
 .PHONY: fmt
 fmt:  ## Run rustfmt and dprint
 	cargo fmt --all

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -41,6 +41,10 @@ build-debug-release: .venv  ## Same as build-release, but with full debug symbol
 .PHONY: build-dist-release
 build-dist-release: .venv  ## Compile and install Python Polars binary with super slow extra optimization turned on, for distribution
 	@$(MAKE) -s -C .. $@
+	
+.PHONY: fix
+fix:
+	@$(MAKE) -s -C .. $@
 
 .PHONY: lint
 lint: .venv  ## Run lint checks (only)


### PR DESCRIPTION
Working on Rust code? `make pre-commit` or the CI yells at you? Good chance `make fix` just solves it for you.