### PR TITLE
fix: Invalidate sortedness flag when sorting from pl.Categorical to pl.Categorical("lexical")

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -415,8 +415,13 @@ impl LogicalType for CategoricalChunked {
                         return Ok(self.to_local().set_ordering(*ordering, true).into_series());
                     }
                 }
-                // Otherwise we do nothing
-                Ok(self.clone().set_ordering(*ordering, true).into_series())
+                // If casting to lexical categorical, set sorted flag as not set
+
+                let mut ca = self.clone().set_ordering(*ordering, true);
+                if ca.uses_lexical_ordering() {
+                    ca.physical.set_sorted_flag(IsSorted::Not);
+                }
+                Ok(ca.into_series())
             },
             dt if dt.is_primitive_numeric() => {
                 // Apply the cast to the categories and then index into the casted series.

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -868,6 +868,16 @@ def test_cat_append_lexical_sorted_flag() -> None:
 
 
 @pytest.mark.usefixtures("test_global_and_local")
+def test_cast_physical_lexical_sorted_flag_20864() -> None:
+    df = pl.DataFrame({"s": ["b", "a"], "v": [1, 2]})
+    sorted_physically = df.cast({"s": pl.Categorical("physical")}).sort("s")
+    sorted_lexically = sorted_physically.cast({"s": pl.Categorical("lexical")}).sort(
+        "s"
+    )
+    assert sorted_lexically["s"].to_list() == ["a", "b"]
+
+
+@pytest.mark.usefixtures("test_global_and_local")
 def test_get_cat_categories_multiple_chunks() -> None:
     df = pl.DataFrame(
         [


### PR DESCRIPTION
Fixes #20864 .

As we never set sorted flags for pl.Categorical("lexical"), when casting to it we need to explicitly set it to not sorted.
