### PR TITLE
feat: Implement `merge_sorted` for binary

### DIFF
--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -152,15 +152,13 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> Vec<bool> {
             get_merge_indicator(lhs.into_iter(), rhs.into_iter())
         },
         DataType::String => {
-            let lhs = lhs_s.str().unwrap();
-            let rhs = rhs_s.str().unwrap();
-
+            let lhs = lhs.str().unwrap().as_binary();
+            let rhs = rhs.str().unwrap().as_binary();
             get_merge_indicator(lhs.into_iter(), rhs.into_iter())
         },
         DataType::Binary => {
             let lhs = lhs_s.binary().unwrap();
             let rhs = rhs_s.binary().unwrap();
-
             get_merge_indicator(lhs.into_iter(), rhs.into_iter())
         },
         _ => {

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -157,6 +157,12 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> Vec<bool> {
 
             get_merge_indicator(lhs.into_iter(), rhs.into_iter())
         },
+        DataType::Binary => {
+            let lhs = lhs_s.binary().unwrap();
+            let rhs = rhs_s.binary().unwrap();
+
+            get_merge_indicator(lhs.into_iter(), rhs.into_iter())
+        },
         _ => {
             with_match_physical_numeric_polars_type!(lhs_s.dtype(), |$T| {
                     let lhs: &ChunkedArray<$T> = lhs_s.as_ref().as_ref().as_ref();

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -155,6 +155,24 @@ def test_merge_sorted_parametric_binary(lhs: pl.Series, rhs: pl.Series) -> None:
 
 
 @given(
+    lhs=series(
+        name="a", allowed_dtypes=[pl.String], allow_null=False
+    ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
+    rhs=series(
+        name="a", allowed_dtypes=[pl.String], allow_null=False
+    ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
+)
+def test_merge_sorted_parametric_string(lhs: pl.Series, rhs: pl.Series) -> None:
+    l_df = pl.DataFrame([lhs.sort()])
+    r_df = pl.DataFrame([rhs.sort()])
+
+    merge_sorted = l_df.lazy().merge_sorted(r_df.lazy(), "a").collect().get_column("a")
+    append_sorted = lhs.append(rhs).sort()
+
+    assert_series_equal(merge_sorted, append_sorted)
+
+
+@given(
     s=series(
         name="a",
         excluded_dtypes=[

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -126,7 +126,25 @@ def test_merge_sorted_unbalanced(size: int, ra: list[int]) -> None:
         name="a", allowed_dtypes=[pl.Int32], allow_null=False
     ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
 )
-def test_merge_sorted_parametric(lhs: pl.Series, rhs: pl.Series) -> None:
+def test_merge_sorted_parametric_int(lhs: pl.Series, rhs: pl.Series) -> None:
+    l_df = pl.DataFrame([lhs.sort()])
+    r_df = pl.DataFrame([rhs.sort()])
+
+    merge_sorted = l_df.lazy().merge_sorted(r_df.lazy(), "a").collect().get_column("a")
+    append_sorted = lhs.append(rhs).sort()
+
+    assert_series_equal(merge_sorted, append_sorted)
+
+
+@given(
+    lhs=series(
+        name="a", allowed_dtypes=[pl.Binary], allow_null=False
+    ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
+    rhs=series(
+        name="a", allowed_dtypes=[pl.Binary], allow_null=False
+    ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
+)
+def test_merge_sorted_parametric_binary(lhs: pl.Series, rhs: pl.Series) -> None:
     l_df = pl.DataFrame([lhs.sort()])
     r_df = pl.DataFrame([rhs.sort()])
 
@@ -141,7 +159,6 @@ def test_merge_sorted_parametric(lhs: pl.Series, rhs: pl.Series) -> None:
         name="a",
         excluded_dtypes=[
             pl.Struct,  # Bug. See https://github.com/pola-rs/polars/issues/20986
-            pl.Binary,  # Bug. See https://github.com/pola-rs/polars/issues/20988
             pl.Categorical(
                 ordering="lexical"
             ),  # Bug. See https://github.com/pola-rs/polars/issues/21025


### PR DESCRIPTION
Quite trivial, closes #20988

```python
import polars as pl

df1 = pl.DataFrame({
    "a": pl.Series("a", [b"1", b"3", b"5"], pl.Binary()),
    "b": [1, 3, 5],
})
df2 = pl.DataFrame({
    "a": pl.Series("a", [b"2", b"4", b"6"], pl.Binary()),
    "b": [2, 4, 6],
})

print(df1.merge_sorted(df2, "a"))
# shape: (6, 2)
# ┌────────┬─────┐
# │ a      ┆ b   │
# │ ---    ┆ --- │
# │ binary ┆ i64 │
# ╞════════╪═════╡
# │ b"1"   ┆ 1   │
# │ b"2"   ┆ 2   │
# │ b"3"   ┆ 3   │
# │ b"4"   ┆ 4   │
# │ b"5"   ┆ 5   │
# │ b"6"   ┆ 6   │
# └────────┴─────┘
```