### PR TITLE
chore(rust): Add force_populate_read for debugging pagefault performance problems

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/parquet/mem_prefetch_funcs.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mem_prefetch_funcs.rs
@@ -1,5 +1,5 @@
 pub(super) use polars_utils::mem::{
-    madvise_populate_read, madvise_sequential, madvise_willneed, prefetch_l2, force_populate_read
+    force_populate_read, madvise_populate_read, madvise_sequential, madvise_willneed, prefetch_l2,
 };
 pub(super) fn no_prefetch(_: &[u8]) {}
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mem_prefetch_funcs.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mem_prefetch_funcs.rs
@@ -1,5 +1,5 @@
 pub(super) use polars_utils::mem::{
-    madvise_populate_read, madvise_sequential, madvise_willneed, prefetch_l2,
+    madvise_populate_read, madvise_sequential, madvise_willneed, prefetch_l2, force_populate_read
 };
 pub(super) fn no_prefetch(_: &[u8]) {}
 
@@ -51,6 +51,7 @@ pub(super) fn get_memory_prefetch_func(verbose: bool) -> fn(&[u8]) -> () {
                 );
             }
         },
+        Some("force_populate_read") => force_populate_read,
         Some(v) => panic!("invalid value for POLARS_MEMORY_PREFETCH: {}", v),
     };
 
@@ -61,6 +62,7 @@ pub(super) fn get_memory_prefetch_func(verbose: bool) -> fn(&[u8]) -> () {
             v if v == madvise_sequential as usize => "madvise_sequential",
             v if v == madvise_willneed as usize => "madvise_willneed",
             v if v == madvise_populate_read as usize => "madvise_populate_read",
+            v if v == force_populate_read as usize => "force_populate_read",
             _ => unreachable!(),
         };
 

--- a/crates/polars-utils/src/mem.rs
+++ b/crates/polars-utils/src/mem.rs
@@ -71,6 +71,15 @@ pub fn madvise_populate_read(#[allow(unused)] slice: &[u8]) {
     madvise(slice, libc::MADV_POPULATE_READ);
 }
 
+/// Forcibly reads at least one byte each page.
+pub fn force_populate_read(slice: &[u8]) {
+    for i in (0..slice.len()).step_by(*PAGE_SIZE) {
+        std::hint::black_box(slice[i]);
+    }
+
+    std::hint::black_box(slice.last().copied());
+}
+
 #[cfg(target_family = "unix")]
 fn madvise(slice: &[u8], advice: libc::c_int) {
     let ptr = slice.as_ptr();


### PR DESCRIPTION
This ensures that in the new-streaming engine we forcibly pre-fault in e.g. the parquet reader to get clearer performance profiles.