### PR TITLE
perf: Change default memory prefetch to MADV_WILLNEED

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/parquet/mem_prefetch_funcs.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mem_prefetch_funcs.rs
@@ -6,13 +6,13 @@ pub(super) fn no_prefetch(_: &[u8]) {}
 pub(super) fn get_memory_prefetch_func(verbose: bool) -> fn(&[u8]) -> () {
     let memory_prefetch_func = match std::env::var("POLARS_MEMORY_PREFETCH").ok().as_deref() {
         None => {
-            // Sequential advice was observed to provide speedups on Linux.
-            // ref https://github.com/pola-rs/polars/pull/18152#discussion_r1721701965
-            #[cfg(target_os = "linux")]
+            // madvise_willneed performed the best on both MacOS on Apple Silicon and Ubuntu on x86-64,
+            // using PDS-H query 3 SF=10 after clearing file cache as a benchmark.
+            #[cfg(target_family = "unix")]
             {
-                madvise_sequential
+                madvise_willneed
             }
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(target_family = "unix"))]
             {
                 no_prefetch
             }

--- a/crates/polars-utils/src/mem.rs
+++ b/crates/polars-utils/src/mem.rs
@@ -82,6 +82,9 @@ pub fn force_populate_read(slice: &[u8]) {
 
 #[cfg(target_family = "unix")]
 fn madvise(slice: &[u8], advice: libc::c_int) {
+    if slice.len() == 0 {
+        return;
+    }
     let ptr = slice.as_ptr();
 
     let align = ptr as usize % *PAGE_SIZE;


### PR DESCRIPTION
I found the following performance numbers on a c7a.4xlarge running Ubuntu 240.4 LTS for PDS-H query 3 after clearing file cache:

```
no_prefetch: 7.68605
madvise_sequential: 5.49557
madvise_populate_read: 7.70463
madvise_willneed: 3.98322
```

On Apple M2 Ventura 13.5 the following:

```
no_prefetch: 1.49381
madvise_sequential:  2.43979
madvise_willneed: 1.36631
```