### PR TITLE
build: Speed up CI by running a few more tests in parallel

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           POLARS_FORCE_ASYNC: 1
         run: >
-          pytest tests/unit/io/
+          pytest -n auto tests/unit/io/
           -n auto --dist loadgroup
           -m "not release and not benchmark and not docs"
           --cov --cov-report xml:async.xml --cov-fail-under=0

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           POLARS_FORCE_ASYNC: 1
         run: >
-          pytest -n auto tests/unit/io/
+          pytest tests/unit/io/
           -n auto --dist loadgroup
           -m "not release and not benchmark and not docs"
           --cov --cov-report xml:async.xml --cov-fail-under=0

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -104,7 +104,7 @@ jobs:
         if: github.ref_name != 'main' && matrix.os != 'windows-latest'
         env:
           POLARS_FORCE_ASYNC: 1
-        run: pytest -m "not release and not benchmark and not docs" tests/unit/io/
+        run: pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/
 
       - name: Check import without optional dependencies
         if: github.ref_name != 'main' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
This seems to shave off around 50 seconds from the `test-python` jobs.