### PR TITLE
perf: Speed up from_pandas when converting frame with multi-index columns

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1102,9 +1102,9 @@ def pandas_to_pydf(
                 length=length,
             )
 
-    for col in data.columns:
-        arrow_dict[str(col)] = plc.pandas_series_to_arrow(
-            data[col], nan_to_null=nan_to_null, length=length
+    for col_idx, col_data in data.items():
+        arrow_dict[str(col_idx)] = plc.pandas_series_to_arrow(
+            col_data, nan_to_null=nan_to_null, length=length
         )
 
     arrow_table = pa.table(arrow_dict)


### PR DESCRIPTION
[Sorry for screenshots instead of code - I do not have much time right now. I can tweak this PR later if needed.]

Given a frame like this:

![CleanShot 2025-02-03 at 21 31 31@2x](https://github.com/user-attachments/assets/3a1bb348-5d24-40aa-b1d5-3d0f59cf2248)

Without the patch:

![CleanShot 2025-02-03 at 21 34 00@2x](https://github.com/user-attachments/assets/11585cad-5d3a-4d11-b11f-63d8144e9fde)


With the patch:

![CleanShot 2025-02-03 at 21 33 21@2x](https://github.com/user-attachments/assets/9ea9d378-2abd-4c70-8035-8eb5266f7580)
