### PR TITLE
feat(python): Add `is_object` method to Polars `DataType` class

### DIFF
--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -19,7 +19,7 @@ from polars._utils.construction.series import arrow_to_pyseries, pandas_to_pyser
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import _cast_repr_strings_with_schema
 from polars._utils.wrap import wrap_df, wrap_s
-from polars.datatypes import N_INFER_DEFAULT, Categorical, List, Object, String, Struct
+from polars.datatypes import N_INFER_DEFAULT, Categorical, String
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
@@ -740,7 +740,7 @@ def _from_dataframe_repr(m: re.Match[str]) -> DataFrame:
         data.extend((pl.Series(empty_data, dtype=String)) for _ in range(n_extend_cols))
 
     for dtype in set(schema.values()):
-        if dtype in (List, Struct, Object):
+        if dtype is not None and (dtype.is_nested() or dtype.is_object()):
             msg = (
                 f"`from_repr` does not support data type {dtype.base_type().__name__!r}"
             )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2429,8 +2429,7 @@ class DataFrame:
                 else:
                     raise ModuleNotFoundError(msg)
 
-        # Object columns must be handled separately as Arrow does not convert them
-        # correctly
+        # handle Object columns separately (Arrow does not convert them correctly)
         if Object in self.dtypes:
             return self._to_pandas_with_object_columns(
                 use_pyarrow_extension_array=use_pyarrow_extension_array, **kwargs
@@ -2450,7 +2449,7 @@ class DataFrame:
         object_columns = []
         not_object_columns = []
         for i, dtype in enumerate(self.dtypes):
-            if dtype == Object:
+            if dtype.is_object():
                 object_columns.append(i)
             else:
                 not_object_columns.append(i)

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -69,6 +69,10 @@ class DataTypeClass(type):
         ...
 
     @classmethod
+    def is_object(cls) -> bool:  # noqa: D102
+        ...
+
+    @classmethod
     def is_signed_integer(cls) -> bool:  # noqa: D102
         ...
 
@@ -167,6 +171,11 @@ class DataType(metaclass=DataTypeClass):
     def is_integer(cls) -> bool:
         """Check whether the data type is an integer type."""
         return issubclass(cls, IntegerType)
+
+    @classmethod
+    def is_object(cls) -> bool:
+        """Check whether the data type is an object type."""
+        return issubclass(cls, ObjectType)
 
     @classmethod
     def is_signed_integer(cls) -> bool:
@@ -301,6 +310,10 @@ class TemporalType(DataType):
 
 class NestedType(DataType):
     """Base class for nested data types."""
+
+
+class ObjectType(DataType):
+    """Base class for object data types."""
 
 
 class Int8(SignedIntegerType):
@@ -728,7 +741,7 @@ class Enum(DataType):
     __or__ = union
 
 
-class Object(DataType):
+class Object(ObjectType):
     """Data type for wrapping arbitrary Python objects."""
 
 

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -12,7 +12,6 @@ from polars.datatypes import (
     Datetime,
     Float64,
     Int64,
-    Object,
     Time,
 )
 from polars.datatypes.group import FLOAT_DTYPES, INTEGER_DTYPES
@@ -356,7 +355,7 @@ def _xl_setup_table_columns(
     cast_cols = [
         F.col(col).map_batches(_map_str).alias(col)
         for col, tp in df.schema.items()
-        if (tp.is_nested() or tp == Object)
+        if tp.is_nested() or tp.is_object()
     ]
     if cast_cols:
         df = df.with_columns(cast_cols)

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1616,7 +1616,7 @@ def test_df_init_dict_raise_on_expression_input() -> None:
 
     # Passing a list of expressions is allowed
     df = pl.DataFrame({"a": [pl.int_range(0, 3)]})
-    assert df.get_column("a").dtype == pl.Object
+    assert df.get_column("a").dtype.is_object()
 
 
 def test_df_schema_sequences() -> None:

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -51,7 +51,7 @@ def test_df_object() -> None:
             return f"{self.__class__.__name__}({self._value})"
 
     df = pl.DataFrame({"a": [Foo(1), Foo(2)]})
-    assert df["a"].dtype == pl.Object
+    assert df["a"].dtype.is_object()
     assert df.rows() == [(Foo(1),), (Foo(2),)]
 
 

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -44,7 +44,7 @@ def test_series_mixed_dtypes_object() -> None:
         pl.Series(values)
 
     s = pl.Series(values, strict=False)
-    assert s.dtype == pl.Object
+    assert s.dtype.is_object()
     assert s.to_list() == values
     assert s[1] == b"foo"
 

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -260,4 +260,4 @@ def test_object_polars_dtypes_20572() -> None:
             "e": pl.String(),
         }
     )
-    assert all(dt == pl.Object() for dt in df.schema.dtypes())
+    assert all(dt.is_object() for dt in df.schema.dtypes())

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -103,7 +103,7 @@ def test_object_to_pandas(column_type_names: list[Literal["Object", "Int32"]]) -
     """
     column_types = [getattr(pl, name) for name in column_type_names]
     data = {
-        f"col_{i}": [object()] if dtype == pl.Object else [-i]
+        f"col_{i}": [object()] if dtype.is_object() else [-i]
         for i, dtype in enumerate(column_types)
     }
     df = pl.DataFrame(

--- a/py-polars/tests/unit/series/test_scatter.py
+++ b/py-polars/tests/unit/series/test_scatter.py
@@ -77,7 +77,7 @@ def test_object_dtype_16905() -> None:
     with pytest.raises(InvalidOperationError):
         s[0] = 5
     # The error doesn't trash the series, as it used to:
-    assert s.dtype == pl.Object
+    assert s.dtype.is_object()
     assert s.name == "s"
     assert s.to_list() == [obj, 27]
 


### PR DESCRIPTION
Minor nicety - adds missing `is_object()` method to DataType (we have all manner of other dtype helpers like `is_nested()`, `is_temporal()`, etc, but this one was absent).