### PR TITLE
test: Add various tests for open issues

### DIFF
--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -161,6 +161,14 @@ def test_series_init_np_2d_zero_zero_shape() -> None:
     )
 
 
+def test_series_init_np_2d_empty() -> None:
+    arr = np.array([]).reshape(0, 2)
+    assert_series_equal(
+        pl.Series("a", arr),
+        pl.Series("a", [], pl.Array(pl.Float64, 2)),
+    )
+
+
 def test_list_null_constructor_schema() -> None:
     expected = pl.List(pl.Null)
     assert pl.Series([[]]).dtype == expected

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -625,6 +625,33 @@ def test_decimal_horizontal_20482() -> None:
     }
 
 
+def test_decimal_horizontal_different_scales_16296() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [D("1.111")],
+            "b": [D("2.22")],
+            "c": [D("3.3")],
+        },
+        schema={
+            "a": pl.Decimal(18, 3),
+            "b": pl.Decimal(18, 2),
+            "c": pl.Decimal(18, 1),
+        },
+    )
+
+    assert (
+        df.select(
+            min=pl.min_horizontal(pl.col("a", "b", "c")),
+            max=pl.max_horizontal(pl.col("a", "b", "c")),
+            sum=pl.sum_horizontal(pl.col("a", "b", "c")),
+        )
+    ).to_dict(as_series=False) == {
+        "min": [D("1.111")],
+        "max": [D("3.300")],
+        "sum": [D("6.631")],
+    }
+
+
 def test_shift_over_12957() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -525,3 +525,16 @@ def test_read_json_struct_schema() -> None:
         ),
         pl.DataFrame({"a": [1, 2]}),
     )
+
+
+def test_read_ndjson_inner_list_types_18244() -> None:
+    assert pl.read_ndjson(
+        io.StringIO("""{"a":null,"b":null,"c":null}"""),
+        schema={
+            "a": pl.List(pl.String),
+            "b": pl.List(pl.Int32),
+            "c": pl.List(pl.Float64),
+        },
+    ).schema == (
+        {"a": pl.List(pl.String), "b": pl.List(pl.Int32), "c": pl.List(pl.Float64)}
+    )

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -538,3 +538,10 @@ def test_read_ndjson_inner_list_types_18244() -> None:
     ).schema == (
         {"a": pl.List(pl.String), "b": pl.List(pl.Int32), "c": pl.List(pl.Float64)}
     )
+
+
+def test_read_json_utf_8_sig_encoding() -> None:
+    data = [{"a": [1, 2], "b": [1, 2]}]
+    result = pl.read_json(json.dumps(data).encode("utf-8-sig"))
+    expected = pl.DataFrame(data)
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/aggregation/test_aggregations.py
+++ b/py-polars/tests/unit/operations/aggregation/test_aggregations.py
@@ -760,3 +760,12 @@ def test_agg_scalar_empty_groups_20115() -> None:
         ),
         pl.select(key=pl.lit(123, pl.Int64), value=pl.lit(None, pl.Int64)),
     )
+
+
+def test_agg_expr_returns_list_type_15574() -> None:
+    assert (
+        pl.LazyFrame({"a": [1, None], "b": [1, 2]})
+        .group_by("b")
+        .agg(pl.col("a").drop_nulls())
+        .collect_schema()
+    ) == {"b": pl.Int64, "a": pl.List(pl.Int64)}

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -384,3 +384,14 @@ def test_map_elements_list_return_dtype() -> None:
     )
     expected = pl.Series([[2], [3, 4]], dtype=return_dtype)
     assert_series_equal(result, expected)
+
+
+def test_map_elements_null_with_nested_type() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    result = df.with_columns(
+        pl.col("a").map_elements(
+            lambda x: None, #return_dtype=pl.List(pl.Int32)
+        )
+    )
+    expected = pl.DataFrame({"a": [None]}, schema={"a": pl.List(pl.Int32)})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -384,14 +384,3 @@ def test_map_elements_list_return_dtype() -> None:
     )
     expected = pl.Series([[2], [3, 4]], dtype=return_dtype)
     assert_series_equal(result, expected)
-
-
-def test_map_elements_null_with_nested_type() -> None:
-    df = pl.DataFrame({"a": [1, 2]})
-    result = df.with_columns(
-        pl.col("a").map_elements(
-            lambda x: None,  # return_dtype=pl.List(pl.Int32)
-        )
-    )
-    expected = pl.DataFrame({"a": [None]}, schema={"a": pl.List(pl.Int32)})
-    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -390,7 +390,7 @@ def test_map_elements_null_with_nested_type() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     result = df.with_columns(
         pl.col("a").map_elements(
-            lambda x: None, #return_dtype=pl.List(pl.Int32)
+            lambda x: None,  # return_dtype=pl.List(pl.Int32)
         )
     )
     expected = pl.DataFrame({"a": [None]}, schema={"a": pl.List(pl.Int32)})

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1274,3 +1274,19 @@ def test_rolling_empty_21032() -> None:
         index_column="a", period=timedelta(days=2), offset=timedelta(days=3)
     ).agg(pl.col("b").sum())
     assert_frame_equal(result, df)
+
+
+def test_rolling_offset_agg_15122() -> None:
+    df = pl.DataFrame({"a": [1, 1, 1, 2, 2, 2], "b": [1, 2, 3, 1, 2, 3]})
+
+    result = df.rolling(index_column="b", period="1i", offset="0i", group_by="a").agg(
+        window=pl.col("b")
+    )
+    expected = df.with_columns(window=pl.Series([[2], [3], [], [2], [3], []]))
+    assert_frame_equal(result, expected)
+
+    result = df.rolling(index_column="b", period="1i", offset="1i", group_by="a").agg(
+        window=pl.col("b")
+    )
+    expected = df.with_columns(window=pl.Series([[3], [], [], [3], [], []]))
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_fill_null.py
+++ b/py-polars/tests/unit/operations/test_fill_null.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 import polars as pl
-from polars.testing import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_fill_null_minimal_upcast_4056() -> None:
@@ -84,3 +84,10 @@ def test_fill_null_date_with_int_11362() -> None:
     s = pl.Series([None], dtype=pl.Date)
     with pytest.raises(pl.exceptions.InvalidOperationError, match=match):
         s.fill_null(1)
+
+
+def test_fill_null_int_dtype_15546() -> None:
+    df = pl.Series("a", [1, 2, None], dtype=pl.Int8).to_frame().lazy()
+    result = df.fill_null(0).collect()
+    expected = pl.Series("a", [1, 2, 0], dtype=pl.Int8).to_frame()
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal
 
 
@@ -1280,7 +1281,9 @@ def test_join_asof_no_exact_matches() -> None:
     }
 
 
-def test_join_asof_not_sorted_warning() -> None:
+def test_join_asof_not_sorted() -> None:
     df = pl.DataFrame({"a": [1, 1, 1, 2, 2, 2], "b": [2, 1, 3, 1, 2, 3]})
-    with pytest.warns(UserWarning, match="asof join is not sorted"):
+    with pytest.warns(UserWarning, match="is not sorted"):
         df.join_asof(df, on="b", by="a")
+    with pytest.raises(InvalidOperationError, match="is not sorted"):
+        df.join_asof(df, on="b")

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -391,7 +391,7 @@ def test_elementwise_identification_in_ternary_15767(tmp_path: Path) -> None:
 
 def test_streaming_temporal_17669() -> None:
     df = (
-        pl.LazyFrame({"a": [1, 2, 3]}, schema={"a": pl.Datetime})
+        pl.LazyFrame({"a": [1, 2, 3]}, schema={"a": pl.Datetime("us")})
         .with_columns(
             b=pl.col("a").dt.date(),
             c=pl.col("a").dt.time(),
@@ -399,7 +399,7 @@ def test_streaming_temporal_17669() -> None:
         .collect(streaming=True)
     )
     assert df.schema == {
-        "a": pl.Datetime,
+        "a": pl.Datetime("us"),
         "b": pl.Date,
         "c": pl.Time,
     }

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -387,3 +387,19 @@ def test_elementwise_identification_in_ternary_15767(tmp_path: Path) -> None:
         )
         .sink_parquet(tmp_path / "1")
     )
+
+
+def test_streaming_temporal_17669() -> None:
+    df = (
+        pl.LazyFrame({"a": [1, 2, 3]}, schema={"a": pl.Datetime})
+        .with_columns(
+            b=pl.col("a").dt.date(),
+            c=pl.col("a").dt.time(),
+        )
+        .collect(streaming=True)
+    )
+    assert df.schema == {
+        "a": pl.Datetime,
+        "b": pl.Date,
+        "c": pl.Time,
+    }


### PR DESCRIPTION
tests added for open issues that appear to be fixed but untested:

closes #15122
closes #15145
closes #15546
closes #15574
closes #16296
closes #17669
closes #18244
closes #18369


open issues that appear to be fixed and already tested (noting tests in order to close):

closes #19528 - `test_concat.py::test_concat_invalid_schema_err_20355`
closes #15347 - `test_join_asof.py::test_join_asof_not_sorted`
