### PR TITLE
fix(rust): Fix minor histogram issues

### DIFF
--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -57,15 +57,15 @@ where
             // User-supplied bin count, or 10 by default. Compute edges from the data.
             let bin_count = bin_count.unwrap_or(DEFAULT_BIN_COUNT);
             let n = ca.len() - ca.null_count();
-            let (offset, width) = if n == 0 {
+            let (offset, width, upper_limit) = if n == 0 {
                 // No non-null items; supply unit interval.
-                (0.0, 1.0 / bin_count as f64)
+                (0.0, 1.0 / bin_count as f64, 1.0)
             } else if n == 1 {
                 // Unit interval around single point
                 let idx = ca.first_non_null().unwrap();
                 // SAFETY: idx is guaranteed to contain an element.
                 let center = unsafe { ca.get_unchecked(idx) }.unwrap().to_f64().unwrap();
-                (center - 0.5, 1.0 / bin_count as f64)
+                (center - 0.5, 1.0 / bin_count as f64, center + 0.5)
             } else {
                 // Determine outer bin edges from the data itself
                 let min_value = ca.min().unwrap().to_f64().unwrap();
@@ -73,14 +73,21 @@ where
 
                 // All data points are identical--use unit interval.
                 if min_value == max_value {
-                    (min_value - 0.5, 1.0 / bin_count as f64)
+                    (min_value - 0.5, 1.0 / bin_count as f64, max_value + 0.5)
                 } else {
                     pad_lower = true;
-                    (min_value, (max_value - min_value) / bin_count as f64)
+                    (
+                        min_value,
+                        (max_value - min_value) / bin_count as f64,
+                        max_value,
+                    )
                 }
             };
-            let out = (0..bin_count + 1)
+            // Manually set the final value to the maximum value to ensure the final value isn't
+            // missed due to floating-point precision.
+            let out = (0..bin_count)
                 .map(|x| (x as f64 * width) + offset)
+                .chain(std::iter::once(upper_limit))
                 .collect::<Vec<f64>>();
             (out, true)
         },
@@ -143,7 +150,7 @@ where
         let item = item.to_f64().unwrap();
 
         // Cycle through items until we hit the first bucket.
-        if item < min_break || (exclude_lower && item == min_break) {
+        if item.is_nan() || item < min_break || (exclude_lower && item == min_break) {
             continue;
         }
 

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -474,3 +474,53 @@ def test_hist_breakpoint_accuracy() -> None:
         }
     )
     assert_frame_equal(out, expected)
+
+
+def test_hist_ensure_max_value_20879() -> None:
+    s = pl.Series([-1 / 3, 0, 1, 2, 3, 7])
+    with pl.StringCache():
+        result = s.hist(bin_count=3)
+        expected = pl.DataFrame(
+            {
+                "breakpoint": pl.Series(
+                    [
+                        2.0 + 1 / 9,
+                        4.0 + 5 / 9,
+                        7.0,
+                    ],
+                    dtype=pl.Float64,
+                ),
+                "category": pl.Series(
+                    [
+                        "(-0.340667, 2.111111]",
+                        "(2.111111, 4.555556]",
+                        "(4.555556, 7.0]",
+                    ],
+                    dtype=pl.Categorical,
+                ),
+                "count": pl.Series([4, 1, 1], dtype=pl.get_index_type()),
+            }
+        )
+    assert_frame_equal(result, expected)
+
+
+def test_hist_ignore_nans_21082() -> None:
+    s = pl.Series([0.0, float("nan"), 0.5, float("nan"), 1.0])
+    with pl.StringCache():
+        result = s.hist(bins=[-0.001, 0.25, 0.5, 0.75, 1.0])
+        expected = pl.DataFrame(
+            {
+                "breakpoint": pl.Series([0.25, 0.5, 0.75, 1.0], dtype=pl.Float64),
+                "category": pl.Series(
+                    [
+                        "(-0.001, 0.25]",
+                        "(0.25, 0.5]",
+                        "(0.5, 0.75]",
+                        "(0.75, 1.0]",
+                    ],
+                    dtype=pl.Categorical,
+                ),
+                "count": pl.Series([1, 1, 0, 1], dtype=pl.get_index_type()),
+            }
+        )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Closes #21082 and closes #20879.

Minor fixes:

1) Ensure upper breakpoint is equal to upper value when bins are auto-computed (due to floating point issues, sometimes the max value would be e.g. 7.0 and the upper bin limit would be 6.999999...).
2) NaN values were not being skipped and sometimes fell into the default logical path which incremented a bucket.