### PR TITLE
feat(python): Add `write_table()` function to Unity catalog client

### DIFF
--- a/py-polars/polars/catalog/unity/client.py
+++ b/py-polars/polars/catalog/unity/client.py
@@ -75,7 +75,7 @@ class Catalog:
             * "databricks-sdk": Use the Databricks SDK to retrieve and use the
             bearer token from the environment.
         require_https
-            Require the `workspace_url` to be HTTPS.
+            Require the `workspace_url` to use HTTPS.
         """
         issue_unstable_warning("`Catalog` functionality is considered unstable.")
 

--- a/py-polars/polars/catalog/unity/client.py
+++ b/py-polars/polars/catalog/unity/client.py
@@ -19,8 +19,11 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from datetime import datetime
 
+    import deltalake
+
     from polars._typing import SchemaDict
     from polars.catalog.unity.models import DataSourceFormat, TableType
+    from polars.dataframe.frame import DataFrame
     from polars.io.cloud import (
         CredentialProviderFunction,
         CredentialProviderFunctionReturn,
@@ -52,6 +55,7 @@ class Catalog:
         workspace_url: str,
         *,
         bearer_token: str | None = "auto",
+        require_https: bool = True,
     ) -> None:
         """
         Initialize a catalog client.
@@ -70,8 +74,17 @@ class Catalog:
             * "auto": Automatically retrieve bearer tokens from the environment.
             * "databricks-sdk": Use the Databricks SDK to retrieve and use the
             bearer token from the environment.
+        require_https
+            Require the `workspace_url` to be HTTPS.
         """
         issue_unstable_warning("`Catalog` functionality is considered unstable.")
+
+        if require_https and not workspace_url.startswith("https://"):
+            msg = (
+                f"a non-HTTPS workspace_url was given ({workspace_url}). To "
+                "allow non-HTTPS URLs, pass require_https=False."
+            )
+            raise ValueError(msg)
 
         if bearer_token == "databricks-sdk" or (
             bearer_token == "auto"
@@ -274,6 +287,111 @@ class Catalog:
                 retries=retries,
             )
         )
+
+    def write_table(
+        self,
+        df: DataFrame,
+        catalog_name: str,
+        namespace: str,
+        table_name: str,
+        *,
+        delta_mode: Literal[
+            "error", "append", "overwrite", "ignore", "merge"
+        ] = "error",
+        delta_write_options: dict[str, Any] | None = None,
+        delta_merge_options: dict[str, Any] | None = None,
+        storage_options: dict[str, str] | None = None,
+        credential_provider: CredentialProviderFunction
+        | Literal["auto"]
+        | None = "auto",
+    ) -> None | deltalake.table.TableMerger:
+        """
+        Write a DataFrame to a catalog table.
+
+        .. warning::
+            This functionality is considered **unstable**. It may be changed
+            at any point without it being considered a breaking change.
+
+        Parameters
+        ----------
+        df
+            DataFrame to write.
+        catalog_name
+            Name of the catalog.
+        namespace
+            Name of the namespace (unity schema).
+        table_name
+            Name of the table.
+        delta_mode : {'error', 'append', 'overwrite', 'ignore', 'merge'}
+            (For delta tables) How to handle existing data.
+
+            - If 'error', throw an error if the table already exists (default).
+            - If 'append', will add new data.
+            - If 'overwrite', will replace table with new data.
+            - If 'ignore', will not write anything if table already exists.
+            - If 'merge', return a `TableMerger` object to merge data from the DataFrame
+              with the existing data.
+        delta_write_options
+            (For delta tables) Additional keyword arguments while writing a
+            Delta lake Table.
+            See a list of supported write options `here <https://delta-io.github.io/delta-rs/api/delta_writer/#deltalake.write_deltalake>`__.
+        delta_merge_options
+            (For delta tables) Keyword arguments which are required to `MERGE` a
+            Delta lake Table.
+            See a list of supported merge options `here <https://delta-io.github.io/delta-rs/api/delta_table/#deltalake.DeltaTable.merge>`__.
+        storage_options
+            Options that indicate how to connect to a cloud provider.
+
+            The cloud providers currently supported are AWS, GCP, and Azure.
+            See supported keys here:
+
+            * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
+            * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
+            * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
+            * Hugging Face (`hf://`): Accepts an API key under the `token` parameter: \
+            `{'token': '...'}`, or by setting the `HF_TOKEN` environment variable.
+
+            If `storage_options` is not provided, Polars will try to infer the
+            information from environment variables.
+        credential_provider
+            Provide a function that can be called to provide cloud storage
+            credentials. The function is expected to return a dictionary of
+            credential keys along with an optional credential expiry time.
+
+            .. warning::
+                This functionality is considered **unstable**. It may be changed
+                at any point without it being considered a breaking change.
+        """
+        table_info = self.get_table_info(catalog_name, namespace, table_name)
+        storage_location, data_source_format = _extract_location_and_data_format(
+            table_info, "scan table"
+        )
+
+        credential_provider, storage_options = self._init_credentials(
+            credential_provider,
+            storage_options,
+            table_info,
+            write=True,
+            caller_name="Catalog.write_table",
+        )
+
+        if data_source_format in ["DELTA", "DELTASHARING"]:
+            return df.write_delta(  # type: ignore[misc]
+                storage_location,
+                storage_options=storage_options,
+                credential_provider=credential_provider,
+                mode=delta_mode,
+                delta_write_options=delta_write_options,
+                delta_merge_options=delta_merge_options,
+            )  # type: ignore[call-overload]
+
+        else:
+            msg = (
+                "write_table: table format of "
+                f"{catalog_name}.{namespace}.{table_name} "
+                f"({data_source_format}) is unsupported."
+            )
+            raise NotImplementedError(msg)
 
     def create_catalog(
         self,
@@ -514,7 +632,7 @@ class Catalog:
                 table_id = table_info.table_id
                 msg = (
                     f"error auto-initializing CatalogCredentialProvider: {e!r} "
-                    f"{table_name = } ({table_id = })"
+                    f"{table_name = } ({table_id = }) ({write = })"
                 )
                 print(msg, file=sys.stderr)
         else:

--- a/py-polars/tests/unit/io/cloud/test_catalog.py
+++ b/py-polars/tests/unit/io/cloud/test_catalog.py
@@ -1,0 +1,11 @@
+import pytest
+
+import polars as pl
+
+
+def test_catalog_require_https() -> None:
+    with pytest.raises(ValueError):
+        pl.Catalog("http://")
+
+    pl.Catalog("https://")
+    pl.Catalog("http://", require_https=False)


### PR DESCRIPTION
Adds a Python-side function to write tables. The version in this PR will currently only support writing to delta tables (`data_source_format` is `DELTA` or `DELTASHARING`).

Drive-by forbids using unsecured `http://` URLs as the `workspace_url` by default unless `require_https=False` is passed
