### PR TITLE
perf: Use Cow as output for rechunk and add rechunk_mut

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -601,7 +601,7 @@ fn cast_list(
     // We still rechunk because we must bubble up a single data-type
     // TODO!: consider a version that works on chunks and merges the data-types and arrays.
     let ca = ca.rechunk();
-    let arr = ca.downcast_iter().next().unwrap();
+    let arr = ca.downcast_as_array();
     // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked(
@@ -630,7 +630,7 @@ fn cast_list(
 unsafe fn cast_list_unchecked(ca: &ListChunked, child_type: &DataType) -> PolarsResult<Series> {
     // TODO! add chunked, but this must correct for list offsets.
     let ca = ca.rechunk();
-    let arr = ca.downcast_iter().next().unwrap();
+    let arr = ca.downcast_as_array();
     // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked(
@@ -666,7 +666,7 @@ fn cast_fixed_size_list(
     options: CastOptions,
 ) -> PolarsResult<(ArrayRef, DataType)> {
     let ca = ca.rechunk();
-    let arr = ca.downcast_iter().next().unwrap();
+    let arr = ca.downcast_as_array();
     // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked(

--- a/crates/polars-core/src/chunked_array/iterator/par/list.rs
+++ b/crates/polars-core/src/chunked_array/iterator/par/list.rs
@@ -30,7 +30,7 @@ impl ListChunked {
     // Get an indexed parallel iterator over the [`Series`] in this [`ListChunked`].
     // Also might be faster as it doesn't use `flat_map`.
     pub fn par_iter_indexed(&mut self) -> impl IndexedParallelIterator<Item = Option<Series>> + '_ {
-        *self = self.rechunk();
+        self.rechunk_mut();
         let arr = self.downcast_iter().next().unwrap();
 
         let dtype = self.inner_dtype();

--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -135,7 +135,7 @@ impl ListChunked {
     ) -> PolarsResult<ListChunked> {
         // generated Series will have wrong length otherwise.
         let ca = self.rechunk();
-        let arr = ca.downcast_iter().next().unwrap();
+        let arr = ca.downcast_as_array();
 
         // SAFETY:
         // Inner dtype is passed correctly

--- a/crates/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -27,7 +27,7 @@ impl CategoricalChunked {
             ArrowDataType::LargeUtf8
         };
         let keys = self.physical().rechunk();
-        let keys = keys.downcast_iter().next().unwrap();
+        let keys = keys.downcast_as_array();
         let map = &**self.get_rev_map();
         let dtype = ArrowDataType::Dictionary(IntegerType::UInt32, Box::new(values_dtype), false);
         match map {
@@ -40,7 +40,7 @@ impl CategoricalChunked {
             },
             RevMapping::Global(reverse_map, values, _uuid) => {
                 let iter = keys
-                    .into_iter()
+                    .iter()
                     .map(|opt_k| opt_k.map(|k| *reverse_map.get(k).unwrap()));
                 let keys = PrimitiveArray::from_trusted_len_iter(iter);
 
@@ -60,7 +60,7 @@ impl CategoricalChunked {
             ArrowDataType::LargeUtf8
         };
         let keys = self.physical().rechunk();
-        let keys = keys.downcast_iter().next().unwrap();
+        let keys = keys.downcast_as_array();
         let map = &**self.get_rev_map();
         let dtype = ArrowDataType::Dictionary(IntegerType::Int64, Box::new(values_dtype), false);
         match map {
@@ -85,7 +85,7 @@ impl CategoricalChunked {
             },
             RevMapping::Global(reverse_map, values, _uuid) => {
                 let iter = keys
-                    .into_iter()
+                    .iter()
                     .map(|opt_k| opt_k.map(|k| *reverse_map.get(k).unwrap() as i64));
                 let keys = PrimitiveArray::from_trusted_len_iter(iter);
 

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cell::Cell;
 
 use arrow::bitmap::{Bitmap, BitmapBuilder};
@@ -158,7 +159,9 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             .sum::<usize>();
     }
 
-    pub fn rechunk(&self) -> Self {
+    /// Rechunks this ChunkedArray, returning a new Cow::Owned ChunkedArray if it was
+    /// rechunked or simply a Cow::Borrowed of itself if it was already a single chunk.
+    pub fn rechunk(&self) -> Cow<'_, Self> {
         match self.dtype() {
             #[cfg(feature = "object")]
             DataType::Object(_, _) => {
@@ -166,19 +169,33 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             },
             _ => {
                 if self.chunks.len() == 1 {
-                    self.clone()
+                    Cow::Borrowed(self)
                 } else {
                     let chunks = vec![concatenate_unchecked(&self.chunks).unwrap()];
 
                     let mut ca = unsafe { self.copy_with_chunks(chunks) };
                     use StatisticsFlags as F;
                     ca.retain_flags_from(self, F::IS_SORTED_ANY | F::CAN_FAST_EXPLODE_LIST);
-                    ca
+                    Cow::Owned(ca)
                 }
             },
         }
     }
-
+    
+    /// Rechunks this ChunkedArray in-place.
+    pub fn rechunk_mut(&mut self) {
+        if self.chunks.len() > 1 {
+            let rechunked = concatenate_unchecked(&self.chunks).unwrap();
+            if self.chunks.capacity() <= 8 {
+                // Reuse chunk allocation if not excessive.
+                self.chunks.clear();
+                self.chunks.push(rechunked);
+            } else {
+                self.chunks = vec![rechunked];
+            }
+        }
+    }
+    
     pub fn rechunk_validity(&self) -> Option<Bitmap> {
         if self.chunks.len() == 1 {
             return self.chunks[0].validity().cloned();

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -181,7 +181,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             },
         }
     }
-    
+
     /// Rechunks this ChunkedArray in-place.
     pub fn rechunk_mut(&mut self) {
         if self.chunks.len() > 1 {
@@ -195,7 +195,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             }
         }
     }
-    
+
     pub fn rechunk_validity(&self) -> Option<Bitmap> {
         if self.chunks.len() == 1 {
             return self.chunks[0].validity().cloned();

--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -108,9 +108,9 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
     #[inline]
-    pub fn downcast_into_array(self) -> T::Array {
+    pub fn downcast_as_array(&self) -> &T::Array {
         assert_eq!(self.chunks.len(), 1);
-        self.downcast_get(0).unwrap().clone()
+        self.downcast_get(0).unwrap()
     }
 
     #[inline]

--- a/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
@@ -51,7 +51,6 @@ impl ChunkExplode for ListChunked {
         let ca = self.rechunk();
         let listarr: &LargeListArray = ca.downcast_iter().next().unwrap();
         let offsets = listarr.offsets().clone();
-
         Ok(offsets)
     }
 

--- a/crates/polars-core/src/chunked_array/ops/extend.rs
+++ b/crates/polars-core/src/chunked_array/ops/extend.rs
@@ -41,7 +41,7 @@ where
         // all to a single chunk
         if self.chunks.len() > 1 {
             self.append(other)?;
-            *self = self.rechunk();
+            self.rechunk_mut();
             return Ok(());
         }
         // Depending on the state of the underlying arrow array we
@@ -119,7 +119,7 @@ impl BooleanChunked {
         // make sure that we are a single chunk already
         if self.chunks.len() > 1 {
             self.append(other)?;
-            *self = self.rechunk();
+            self.rechunk_mut();
             return Ok(());
         }
         let arr = self.downcast_iter().next().unwrap();

--- a/crates/polars-core/src/chunked_array/ops/gather.rs
+++ b/crates/polars-core/src/chunked_array/ops/gather.rs
@@ -327,8 +327,8 @@ impl IdxCa {
 impl ChunkTakeUnchecked<IdxCa> for ArrayChunked {
     unsafe fn take_unchecked(&self, indices: &IdxCa) -> Self {
         let chunks = vec![take_unchecked(
-            &self.rechunk().downcast_into_array(),
-            &indices.rechunk().downcast_into_array(),
+            self.rechunk().downcast_as_array(),
+            indices.rechunk().downcast_as_array(),
         )];
         self.copy_with_chunks(chunks)
     }
@@ -345,8 +345,8 @@ impl<I: AsRef<[IdxSize]> + ?Sized> ChunkTakeUnchecked<I> for ArrayChunked {
 impl ChunkTakeUnchecked<IdxCa> for ListChunked {
     unsafe fn take_unchecked(&self, indices: &IdxCa) -> Self {
         let chunks = vec![take_unchecked(
-            &self.rechunk().downcast_into_array(),
-            &indices.rechunk().downcast_into_array(),
+            self.rechunk().downcast_as_array(),
+            indices.rechunk().downcast_as_array(),
         )];
         self.copy_with_chunks(chunks)
     }

--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -88,7 +88,7 @@ impl ChunkReverse for ArrayChunked {
             todo!("reverse for FixedSizeList with non-numeric dtypes not yet supported")
         }
         let ca = self.rechunk();
-        let arr = ca.downcast_iter().next().unwrap();
+        let arr = ca.downcast_as_array();
         let values = arr.values().as_ref();
 
         let mut builder =

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -95,7 +95,7 @@ mod inner_mod {
             options.window_size = std::cmp::min(self.len(), options.window_size);
 
             let len = self.len();
-            let arr = ca.downcast_iter().next().unwrap();
+            let arr = ca.downcast_as_array();
             let mut ca = ChunkedArray::<T>::from_slice(PlSmallStr::EMPTY, &[T::Native::zero()]);
             let ptr = ca.chunks[0].as_mut() as *mut dyn Array as *mut PrimitiveArray<T::Native>;
             let mut series_container = ca.into_series();
@@ -215,7 +215,7 @@ mod inner_mod {
                 return Ok(Self::full_null(self.name().clone(), self.len()));
             }
             let ca = self.rechunk();
-            let arr = ca.downcast_iter().next().unwrap();
+            let arr = ca.downcast_as_array();
 
             // We create a temporary dummy ChunkedArray. This will be a
             // container where we swap the window contents every iteration doing

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -408,7 +408,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
         // We will sort by the views and reconstruct with sorted views. We leave the buffers as is.
         // We must rechunk to ensure that all views point into the proper buffers.
         let ca = self.rechunk();
-        let arr = ca.downcast_into_array();
+        let arr = ca.downcast_as_array().clone();
 
         let (views, buffers, validity, total_bytes_len, total_buffer_len) = arr.into_inner();
         let mut views = views.make_mut();
@@ -590,7 +590,7 @@ impl ChunkSort<BinaryOffsetType> for BinaryOffsetChunked {
     fn arg_sort(&self, mut options: SortOptions) -> IdxCa {
         options.multithreaded &= POOL.current_num_threads() > 1;
         let ca = self.rechunk();
-        let arr = ca.downcast_into_array();
+        let arr = ca.downcast_as_array();
         let mut idx = (0..(arr.len() as IdxSize)).collect::<Vec<_>>();
 
         let argsort = |args| {

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -411,7 +411,7 @@ impl StructChunked {
                 .zip(other.chunks())
                 .any(|(a, b)| a.len() != b.len())
         {
-            *self = self.rechunk();
+            self.rechunk_mut();
             let other = other.rechunk();
             return self.zip_outer_validity(&other);
         }

--- a/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
@@ -287,7 +287,7 @@ impl AggList for StructChunked {
             let out = ca.into_series().take_unchecked(&gather);
             out.struct_().unwrap().clone()
         } else {
-            ca.rechunk()
+            ca.rechunk().into_owned()
         };
 
         let arr = gathered.chunks()[0].clone();

--- a/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
@@ -1,6 +1,7 @@
+use std::borrow::Cow;
+
 use super::*;
 use crate::chunked_array::cast::CastOptions;
-use std::borrow::Cow;
 
 pub fn _agg_helper_idx_bool<F>(groups: &GroupsIdx, f: F) -> Series
 where

--- a/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/boolean.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::chunked_array::cast::CastOptions;
+use std::borrow::Cow;
 
 pub fn _agg_helper_idx_bool<F>(groups: &GroupsIdx, f: F) -> Series
 where
@@ -24,10 +25,11 @@ unsafe fn bitwise_agg(
     f: fn(&BooleanChunked) -> Option<bool>,
 ) -> Series {
     // Prevent a rechunk for every individual group.
+
     let s = if groups.len() > 1 {
         ca.rechunk()
     } else {
-        ca.clone()
+        Cow::Borrowed(ca)
     };
 
     match groups {

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -3,6 +3,7 @@ mod boolean;
 mod dispatch;
 mod string;
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 
 pub use agg_list::*;
@@ -456,10 +457,11 @@ where
         ChunkTakeUnchecked<[IdxSize]> + ChunkBitwiseReduce<Physical = T::Native> + IntoSeries,
 {
     // Prevent a rechunk for every individual group.
+
     let s = if groups.len() > 1 {
         ca.rechunk()
     } else {
-        ca.clone()
+        Cow::Borrowed(ca)
     };
 
     match groups {

--- a/crates/polars-core/src/frame/group_by/aggregations/string.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/string.rs
@@ -33,7 +33,7 @@ impl BinaryChunked {
         match groups {
             GroupsType::Idx(groups) => {
                 let ca_self = self.rechunk();
-                let arr = ca_self.downcast_iter().next().unwrap();
+                let arr = ca_self.downcast_as_array();
                 let no_nulls = arr.null_count() == 0;
                 _agg_helper_idx_bin(groups, |(first, idx)| {
                     debug_assert!(idx.len() <= ca_self.len());
@@ -95,7 +95,7 @@ impl BinaryChunked {
         match groups {
             GroupsType::Idx(groups) => {
                 let ca_self = self.rechunk();
-                let arr = ca_self.downcast_iter().next().unwrap();
+                let arr = ca_self.downcast_as_array();
                 let no_nulls = arr.null_count() == 0;
                 _agg_helper_idx_bin(groups, |(first, idx)| {
                     debug_assert!(idx.len() <= self.len());

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3109,7 +3109,7 @@ impl DataFrame {
         for ca in iter {
             acc_ca.append(&ca)?;
         }
-        Ok(acc_ca.rechunk())
+        Ok(acc_ca.rechunk().into_owned())
     }
 
     /// Get the supertype of the columns in this DataFrame

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -164,7 +164,7 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_series()
+        self.0.rechunk().into_owned().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -167,7 +167,7 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_series()
+        self.0.rechunk().into_owned().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -139,7 +139,7 @@ impl SeriesTrait for SeriesWrap<BinaryOffsetChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_series()
+        self.0.rechunk().into_owned().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -193,7 +193,7 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_series()
+        self.0.rechunk().into_owned().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -223,7 +223,7 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.with_state(true, |ca| ca.rechunk()).into_series()
+        self.with_state(true, |ca| ca.rechunk().into_owned()).into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -223,7 +223,8 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.with_state(true, |ca| ca.rechunk().into_owned()).into_series()
+        self.with_state(true, |ca| ca.rechunk().into_owned())
+            .into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -242,7 +242,7 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_date().into_series()
+        self.0.rechunk().into_owned().into_date().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -260,6 +260,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     fn rechunk(&self) -> Series {
         self.0
             .rechunk()
+            .into_owned()
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
     }

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -295,7 +295,7 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        let ca = self.0.rechunk();
+        let ca = self.0.rechunk().into_owned();
         ca.into_decimal_unchecked(self.0.precision(), self.0.scale())
             .into_series()
     }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -383,6 +383,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
     fn rechunk(&self) -> Series {
         self.0
             .rechunk()
+            .into_owned()
             .into_duration(self.0.time_unit())
             .into_series()
     }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -239,7 +239,7 @@ macro_rules! impl_dyn_series {
             }
 
             fn rechunk(&self) -> Series {
-                self.0.rechunk().into_series()
+                self.0.rechunk().into_owned().into_series()
             }
 
             fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -162,7 +162,7 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_series()
+        self.0.rechunk().into_owned().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -309,7 +309,7 @@ macro_rules! impl_dyn_series {
             }
 
             fn rechunk(&self) -> Series {
-                self.0.rechunk().into_series()
+                self.0.rechunk().into_owned().into_series()
             }
 
             fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -170,7 +170,7 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_series()
+        self.0.rechunk().into_owned().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -149,8 +149,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        let ca = self.0.rechunk();
-        ca.into_series()
+        self.0.rechunk().into_owned().into_series()
     }
 
     fn new_from_index(&self, _index: usize, _length: usize) -> Series {

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -225,7 +225,7 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
     }
 
     fn rechunk(&self) -> Series {
-        self.0.rechunk().into_time().into_series()
+        self.0.rechunk().into_owned().into_time().into_series()
     }
 
     fn new_from_index(&self, index: usize, length: usize) -> Series {

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -957,9 +957,9 @@ where
         {
             (left, right)
         },
-        (_, 1) => (left.rechunk(), right),
-        (1, _) => (left, right.rechunk()),
-        (_, _) => (left.rechunk(), right.rechunk()),
+        (_, 1) => (left.rechunk().into_owned(), right),
+        (1, _) => (left, right.rechunk().into_owned()),
+        (_, _) => (left.rechunk().into_owned(), right.rechunk().into_owned()),
     }
 }
 

--- a/crates/polars-expr/src/expressions/filter.rs
+++ b/crates/polars-expr/src/expressions/filter.rs
@@ -97,7 +97,7 @@ impl PhysicalExpr for FilterExpr {
             // Filter the indexes that are true.
             else {
                 let predicate = predicate.rechunk();
-                let predicate = predicate.downcast_iter().next().unwrap();
+                let predicate = predicate.downcast_as_array();
                 POOL.install(|| {
                     match groups.as_ref().as_ref() {
                         GroupsType::Idx(groups) => {

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -122,7 +122,7 @@ fn run_on_group_by_engine(
     expr: &Expr,
 ) -> PolarsResult<Option<Column>> {
     let lst = lst.rechunk();
-    let arr = lst.downcast_iter().next().unwrap();
+    let arr = lst.downcast_as_array();
     let groups = offsets_to_groups(arr.offsets()).unwrap();
 
     // List elements in a series.

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -141,9 +141,10 @@ where
     let mut breaks_iter = breaks.iter().skip(1); // Skip the first lower bound
     let (min_break, max_break) = (breaks[0], breaks[breaks.len() - 1]);
     let mut upper_bound = *breaks_iter.next().unwrap();
-    let sorted = ca.sort(false).rechunk();
+    let mut sorted = ca.sort(false);
+    sorted.rechunk_mut();
     let mut current_count: IdxSize = 0;
-    let chunk = sorted.downcast_iter().next().unwrap();
+    let chunk = sorted.downcast_as_array();
     let mut count: Vec<IdxSize> = Vec::with_capacity(num_bins);
 
     'item: for item in chunk.non_null_values_iter() {

--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -419,8 +419,8 @@ pub fn list_set_operation(
     let mut a = a.clone();
     let mut b = b.clone();
     if a.len() != b.len() {
-        a = a.rechunk();
-        b = b.rechunk();
+        a.rechunk_mut();
+        b.rechunk_mut();
     }
 
     // We will OOB in the kernel otherwise.

--- a/crates/polars-ops/src/chunked_array/scatter.rs
+++ b/crates/polars-ops/src/chunked_array/scatter.rs
@@ -101,7 +101,8 @@ where
         V: IntoIterator<Item = Option<T::Native>>,
     {
         check_bounds(idx, self.len() as IdxSize)?;
-        let mut ca = std::mem::take(self).rechunk();
+        let mut ca = std::mem::take(self);
+        ca.rechunk_mut();
 
         // SAFETY:
         // we will not modify the length

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -71,7 +71,8 @@ where
     }
 
     // Get rid of all the nulls and transform into Vec<T::Native>.
-    let nnca = ca.drop_nulls().rechunk();
+    let mut nnca = ca.drop_nulls();
+    nnca.rechunk_mut();
     let chunk = nnca.downcast_into_iter().next().unwrap();
     let (_, buffer, _) = chunk.into_inner();
     let mut vec = buffer.make_mut();
@@ -105,7 +106,8 @@ fn top_k_binary_impl(
     }
 
     // Get rid of all the nulls and transform into mutable views.
-    let nnca = ca.drop_nulls().rechunk();
+    let mut nnca = ca.drop_nulls();
+    nnca.rechunk_mut();
     let chunk = nnca.downcast_into_iter().next().unwrap();
     let buffers = chunk.data_buffers().clone();
     let mut views = chunk.into_views();

--- a/crates/polars-ops/src/frame/join/asof/default.rs
+++ b/crates/polars-ops/src/frame/join/asof/default.rs
@@ -120,8 +120,8 @@ pub(crate) fn join_asof_numeric<T: PolarsNumericType>(
 
     let ca = input_ca.rechunk();
     let other = other.rechunk();
-    let left = ca.downcast_iter().next().unwrap();
-    let right = other.downcast_iter().next().unwrap();
+    let left = ca.downcast_as_array();
+    let right = other.downcast_as_array();
 
     let out = if let Some(t) = tolerance {
         let native_tolerance = t.try_extract::<T::Native>()?;

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -89,8 +89,8 @@ where
     F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
     let (left_asof, right_asof) = POOL.join(|| left_asof.rechunk(), || right_asof.rechunk());
-    let left_val_arr = left_asof.downcast_iter().next().unwrap();
-    let right_val_arr = right_asof.downcast_iter().next().unwrap();
+    let left_val_arr = left_asof.downcast_as_array();
+    let right_val_arr = right_asof.downcast_as_array();
 
     let n_threads = POOL.current_num_threads();
     // `strict` is false so that we always flatten. Even if there are more chunks than threads.
@@ -173,8 +173,8 @@ where
     F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
     let (left_asof, right_asof) = POOL.join(|| left_asof.rechunk(), || right_asof.rechunk());
-    let left_val_arr = left_asof.downcast_iter().next().unwrap();
-    let right_val_arr = right_asof.downcast_iter().next().unwrap();
+    let left_val_arr = left_asof.downcast_as_array();
+    let right_val_arr = right_asof.downcast_as_array();
 
     let (prep_by_left, prep_by_right, _, _) = prepare_binary::<B>(by_left, by_right, false);
     let offsets = compute_len_offsets(prep_by_left.iter().map(|s| s.len()));

--- a/crates/polars-ops/src/frame/join/iejoin/mod.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/mod.rs
@@ -444,9 +444,9 @@ fn iejoin_tuples(
         .slice(
             y_ordered_by_x.null_count() as i64,
             y_ordered_by_x.len() - y_ordered_by_x.null_count(),
-        )
-        .rechunk();
-    let l2_order = l2_order.downcast_get(0).unwrap().values().as_slice();
+        );
+    let l2_order = l2_order.rechunk();
+    let l2_order = l2_order.downcast_as_array().values().as_slice();
 
     let (left_row_idx, right_row_idx) = with_match_physical_numeric_polars_type!(x.dtype(), |$T| {
          ie_join_impl_t::<$T>(
@@ -528,13 +528,13 @@ fn piecewise_merge_join_tuples(
                 .with_order_descending(descending);
 
             // Get order and slice to ignore any null values, which cannot be match results
-            let order = series
+            let mut order = series
                 .arg_sort(sort_options)
                 .slice(
                     series.null_count() as i64,
                     series.len() - series.null_count(),
-                )
-                .rechunk();
+                );
+            order.rechunk_mut();
             let ordered = unsafe { series.take_unchecked(&order) };
             (ordered, Some(order))
         }

--- a/crates/polars-ops/src/frame/join/iejoin/mod.rs
+++ b/crates/polars-ops/src/frame/join/iejoin/mod.rs
@@ -439,12 +439,10 @@ fn iejoin_tuples(
         .with_order_descending(l2_descending);
     // Get the indexes into l1, ordered by y values.
     // l2_order is the same as "p" from Khayyat et al.
-    let l2_order = y_ordered_by_x
-        .arg_sort(l2_sort_options)
-        .slice(
-            y_ordered_by_x.null_count() as i64,
-            y_ordered_by_x.len() - y_ordered_by_x.null_count(),
-        );
+    let l2_order = y_ordered_by_x.arg_sort(l2_sort_options).slice(
+        y_ordered_by_x.null_count() as i64,
+        y_ordered_by_x.len() - y_ordered_by_x.null_count(),
+    );
     let l2_order = l2_order.rechunk();
     let l2_order = l2_order.downcast_as_array().values().as_slice();
 
@@ -528,12 +526,10 @@ fn piecewise_merge_join_tuples(
                 .with_order_descending(descending);
 
             // Get order and slice to ignore any null values, which cannot be match results
-            let mut order = series
-                .arg_sort(sort_options)
-                .slice(
-                    series.null_count() as i64,
-                    series.len() - series.null_count(),
-                );
+            let mut order = series.arg_sort(sort_options).slice(
+                series.null_count() as i64,
+                series.len() - series.null_count(),
+            );
             order.rechunk_mut();
             let ordered = unsafe { series.take_unchecked(&order) };
             (ordered, Some(order))

--- a/crates/polars-ops/src/series/ops/concat_arr.rs
+++ b/crates/polars-ops/src/series/ops/concat_arr.rs
@@ -65,7 +65,7 @@ pub fn concat_arr(args: &[Column], dtype: &DataType) -> PolarsResult<Column> {
                         validities.push(v)
                     }
 
-                    (arr.rechunk().downcast_into_array().values().clone(), *width)
+                    (arr.downcast_as_array().values().clone(), *width)
                 },
                 dtype => {
                     debug_assert_eq!(dtype, inner_dtype);

--- a/crates/polars-ops/src/series/ops/is_first_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_first_distinct.rs
@@ -42,7 +42,7 @@ fn is_first_distinct_boolean(ca: &BooleanChunked) -> BooleanChunked {
         out.set(0, true);
     } else {
         let ca = ca.rechunk();
-        let arr = ca.downcast_iter().next().unwrap();
+        let arr = ca.downcast_as_array();
         if ca.null_count() == 0 {
             let (true_index, false_index) =
                 find_first_true_false_no_null(arr.values().chunks::<u64>());

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -113,8 +113,8 @@ fn is_last_distinct_boolean(ca: &BooleanChunked) -> BooleanChunked {
 fn is_last_distinct_bin(ca: &BinaryChunked) -> BooleanChunked {
     let mut unique = PlHashSet::new();
     let ca = ca.rechunk();
-    let mut new_ca: BooleanChunked = ca
-        .downcast_as_array()
+    let arr = ca.downcast_as_array();
+    let mut new_ca: BooleanChunked = arr
         .iter()
         .rev()
         .map(|opt_v| unique.insert(opt_v))
@@ -132,8 +132,8 @@ where
 {
     let mut unique = PlHashSet::new();
     let ca = ca.rechunk();
-    let mut new_ca: BooleanChunked = ca
-        .downcast_as_array()
+    let arr = ca.downcast_as_array();
+    let mut new_ca: BooleanChunked = arr
         .iter()
         .rev()
         .map(|opt_v| unique.insert(opt_v.to_total_ord()))

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -111,18 +111,15 @@ fn is_last_distinct_boolean(ca: &BooleanChunked) -> BooleanChunked {
 }
 
 fn is_last_distinct_bin(ca: &BinaryChunked) -> BooleanChunked {
+    let tmp = ca.rechunk();
+    let arr = tmp.downcast_as_array();
     let mut unique = PlHashSet::new();
-    let ca = ca.rechunk();
-    let arr = ca.downcast_as_array();
-    let mut new_ca: BooleanChunked = arr
-        .iter()
+    arr.iter()
         .rev()
         .map(|opt_v| unique.insert(opt_v))
         .collect_reversed::<NoNull<BooleanChunked>>()
-        .into_inner();
-    drop(unique);
-    new_ca.rename(ca.name().clone());
-    new_ca
+        .into_inner()
+        .with_name(ca.name().clone())
 }
 
 fn is_last_distinct_numeric<T>(ca: &ChunkedArray<T>) -> BooleanChunked
@@ -131,18 +128,15 @@ where
     T::Native: TotalHash + TotalEq + ToTotalOrd,
     <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
+    let tmp = ca.rechunk();
+    let arr = tmp.downcast_as_array();
     let mut unique = PlHashSet::new();
-    let ca = ca.rechunk();
-    let arr = ca.downcast_as_array();
-    let mut new_ca: BooleanChunked = arr
-        .iter()
+    arr.iter()
         .rev()
         .map(|opt_v| unique.insert(opt_v.to_total_ord()))
         .collect_reversed::<NoNull<BooleanChunked>>()
-        .into_inner();
-    drop(unique);
-    new_ca.rename(ca.name().clone());
-    new_ca
+        .into_inner()
+        .with_name(ca.name().clone())
 }
 
 #[cfg(feature = "dtype-struct")]

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -67,8 +67,8 @@ fn is_last_distinct_boolean(ca: &BooleanChunked) -> BooleanChunked {
         let mut first_null_found = false;
         let mut all_found = false;
         let ca = ca.rechunk();
-        let arr = ca.downcast_iter().next().unwrap();
-        arr.into_iter()
+        ca.downcast_as_array()
+            .iter()
             .enumerate()
             .rev()
             .find_map(|(idx, val)| match val {
@@ -111,11 +111,11 @@ fn is_last_distinct_boolean(ca: &BooleanChunked) -> BooleanChunked {
 }
 
 fn is_last_distinct_bin(ca: &BinaryChunked) -> BooleanChunked {
-    let ca = ca.rechunk();
-    let arr = ca.downcast_iter().next().unwrap();
     let mut unique = PlHashSet::new();
-    let mut new_ca: BooleanChunked = arr
-        .into_iter()
+    let ca = ca.rechunk();
+    let mut new_ca: BooleanChunked = ca
+        .downcast_as_array()
+        .iter()
         .rev()
         .map(|opt_v| unique.insert(opt_v))
         .collect_reversed::<NoNull<BooleanChunked>>()
@@ -130,11 +130,11 @@ where
     T::Native: TotalHash + TotalEq + ToTotalOrd,
     <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
-    let ca = ca.rechunk();
-    let arr = ca.downcast_iter().next().unwrap();
     let mut unique = PlHashSet::new();
-    let mut new_ca: BooleanChunked = arr
-        .into_iter()
+    let ca = ca.rechunk();
+    let mut new_ca: BooleanChunked = ca
+        .downcast_as_array()
+        .iter()
         .rev()
         .map(|opt_v| unique.insert(opt_v.to_total_ord()))
         .collect_reversed::<NoNull<BooleanChunked>>()

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -120,6 +120,7 @@ fn is_last_distinct_bin(ca: &BinaryChunked) -> BooleanChunked {
         .map(|opt_v| unique.insert(opt_v))
         .collect_reversed::<NoNull<BooleanChunked>>()
         .into_inner();
+    drop(unique);
     new_ca.rename(ca.name().clone());
     new_ca
 }
@@ -139,6 +140,7 @@ where
         .map(|opt_v| unique.insert(opt_v.to_total_ord()))
         .collect_reversed::<NoNull<BooleanChunked>>()
         .into_inner();
+    drop(unique);
     new_ca.rename(ca.name().clone());
     new_ca
 }

--- a/crates/polars-ops/src/series/ops/rank.rs
+++ b/crates/polars-ops/src/series/ops/rank.rs
@@ -123,9 +123,9 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
         let not_consecutive_same = sorted_values
             .slice(1, sorted_values.len() - 1)
             .not_equal(&sorted_values.slice(0, sorted_values.len() - 1))
-            .unwrap()
-            .rechunk();
-        let neq = not_consecutive_same.downcast_iter().next().unwrap();
+            .unwrap();
+        let neq = not_consecutive_same.rechunk();
+        let neq = neq.downcast_as_array();
 
         let mut rank = 1;
         match method {

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -440,8 +440,8 @@ pub(super) fn get(s: &mut [Column], null_on_oob: bool) -> PolarsResult<Option<Co
             }
         },
         len if len == ca.len() => {
-            let ca = ca.rechunk();
-            let arr = ca.downcast_iter().next().unwrap();
+            let tmp = ca.rechunk();
+            let arr = tmp.downcast_as_array();
             let offsets = arr.offsets().as_slice();
             let take_by = if ca.null_count() == 0 {
                 index

--- a/crates/polars-plan/src/dsl/function_expr/rolling.rs
+++ b/crates/polars-plan/src/dsl/function_expr/rolling.rs
@@ -184,7 +184,7 @@ pub(super) fn rolling_corr_cov(
     let count_x_y = if (x.null_count() + y.null_count()) > 0 {
         // mask out nulls on both sides before compute mean/var
         let valids = x.is_not_null().bitand(y.is_not_null());
-        let valids_arr = valids.clone().downcast_into_array();
+        let valids_arr = valids.downcast_as_array();
         let valids_bitmap = valids_arr.values();
 
         unsafe {

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -560,7 +560,7 @@ impl PyDataFrame {
         invalid_indices: Vec<usize>,
     ) -> PyResult<PySeries> {
         py.enter_polars_series(|| {
-            let ca = self.df.clone().into_struct(name.into());
+            let mut ca = self.df.clone().into_struct(name.into());
 
             if !invalid_indices.is_empty() {
                 let mut validity = MutableBitmap::with_capacity(ca.len());
@@ -568,7 +568,7 @@ impl PyDataFrame {
                 for i in invalid_indices {
                     validity.set(i, false);
                 }
-                let ca = ca.rechunk();
+                ca.rechunk_mut();
                 Ok(ca.with_outer_validity(Some(validity.freeze())))
             } else {
                 Ok(ca)

--- a/crates/polars-python/src/series/buffers.rs
+++ b/crates/polars-python/src/series/buffers.rs
@@ -346,15 +346,12 @@ where
 {
     let ca: &ChunkedArray<T> = s.as_ref().as_ref();
     let ca = ca.rechunk();
-    let arr = ca.downcast_iter().next().unwrap();
-    arr.values().clone()
+    ca.downcast_as_array().values().clone()
 }
 fn series_to_bitmap(s: Series) -> PyResult<Bitmap> {
     let ca_result = s.bool();
     let ca = ca_result.map_err(PyPolarsErr::from)?.rechunk();
-    let arr = ca.downcast_iter().next().unwrap();
-    let bitmap = arr.values().clone();
-    Ok(bitmap)
+    Ok(ca.downcast_as_array().values().clone())
 }
 fn series_to_offsets(s: Series) -> OffsetsBuffer<i64> {
     let buffer = series_to_buffer::<Int64Type>(s);

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -36,7 +36,7 @@ fn scatter(mut s: Series, idx: &Series, values: &Series) -> Result<Series, (Seri
         Err(err) => return Err((s, err)),
     };
     let idx = idx.rechunk();
-    let idx = idx.downcast_iter().next().unwrap();
+    let idx = idx.downcast_as_array();
 
     if idx.null_count() > 0 {
         return Err((

--- a/crates/polars-stream/src/nodes/merge_sorted.rs
+++ b/crates/polars-stream/src/nodes/merge_sorted.rs
@@ -144,13 +144,13 @@ fn find_mergeable(
         } else if left_key_last.lt(&right_key_last)?.all() {
             // @TODO: This is essentially search sorted, but that does not
             // support categoricals at moment.
-            let gt_mask = right_key.gt(&left_key_last)?.downcast_into_array();
-            right_cutoff = gt_mask.values().leading_zeros();
+            let gt_mask = right_key.gt(&left_key_last)?;
+            right_cutoff = gt_mask.downcast_as_array().values().leading_zeros();
         } else if left_key_last.gt(&right_key_last)?.all() {
             // @TODO: This is essentially search sorted, but that does not
             // support categoricals at moment.
-            let gt_mask = left_key.gt(&right_key_last)?.downcast_into_array();
-            left_cutoff = gt_mask.values().leading_zeros();
+            let gt_mask = left_key.gt(&right_key_last)?;
+            left_cutoff = gt_mask.downcast_as_array().values().leading_zeros();
         }
 
         let left_mergeable: DataFrame;


### PR DESCRIPTION
I went through the references to `rechunk()` and I didn't find any cases where I'd think that the `Cow` branch would introduce performance issues.

I also refactored some to use the new `rechunk_mut`, and refactored some `downcast_iter().next().unwrap()`s to `downcast_as_array`.