### PR TITLE
feat: Allow Series::iter() to support more than one chunk

### DIFF
--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -1279,7 +1279,7 @@ impl Series {
                 result.push(']');
             },
             _ => {
-                let s = self.slice(0, max_items).rechunk();
+                let s = self.slice(0, max_items);
                 for (i, item) in s.iter().enumerate() {
                     if i == max_items.saturating_sub(1) {
                         write!(result, "{ellipsis} {}", self.get(self.len() - 1).unwrap()).unwrap();

--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -44,7 +44,7 @@ pub fn predicate_to_pa(
             } else {
                 let mut list_repr = String::with_capacity(s.len() * 5);
                 list_repr.push('[');
-                for av in s.rechunk().iter() {
+                for av in s.iter() {
                     if let AnyValue::Boolean(v) = av {
                         let s = if v { "True" } else { "False" };
                         write!(list_repr, "{},", s).unwrap();


### PR DESCRIPTION
1. I (probably, if I'm not doing ChunkedArray dispatch + conversion into AnyValue) need this in a PR I'm working on so I don't have to do a rechunk().
2. It enables removing some existing rechunk()s. I probably missed some others, but having trouble getting rust-analyzer to find callers.
3. Doesn't seem like a good limitation? Seeing as some current callers do a rechunk().