### PR TITLE
feat: Use unique temporary directory path per user and restrict permissions

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -61,12 +61,14 @@ pub static POLARS_TEMP_DIR_BASE_PATH: Lazy<Box<Path>> = Lazy::new(|| {
             // the default temporary directory location is underneath the user profile, so we
             // shouldn't need to do anything.
             let tmp_dir = std::env::temp_dir();
-            let user_profile =
-                PathBuf::from(std::env::var("USERPROFILE").expect("failed to load USERPROFILE"));
+            let users_dir = Path::new("/Users");
 
             // Have this debug assert so it gets run by CI.
-            if cfg!(debug_assertions) && !tmp_dir.starts_with(&user_profile) {
-                panic!("{:?}, {:?}", tmp_dir, user_profile);
+            if cfg!(debug_assertions) && !tmp_dir.starts_with(&users_dir) {
+                panic!(
+                    "temporary directory {:?} not a subdirectory of: {:?}",
+                    tmp_dir, users_dir
+                );
             }
 
             tmp_dir.join("polars/")

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -64,7 +64,7 @@ pub static POLARS_TEMP_DIR_BASE_PATH: Lazy<Box<Path>> = Lazy::new(|| {
             let users_dir = Path::new("/Users");
 
             // Have this debug assert so it gets run by CI.
-            if cfg!(debug_assertions) && !tmp_dir.starts_with(&users_dir) {
+            if cfg!(debug_assertions) && !tmp_dir.starts_with(users_dir) {
                 panic!(
                     "temporary directory {:?} not a subdirectory of: {:?}",
                     tmp_dir, users_dir

--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -60,20 +60,9 @@ pub static POLARS_TEMP_DIR_BASE_PATH: Lazy<Box<Path>> = Lazy::new(|| {
             // Setting permissions on Windows is not as easy compared to Unix, but fortunately
             // the default temporary directory location is underneath the user profile, so we
             // shouldn't need to do anything.
-            let tmp_dir = std::env::temp_dir();
-            let users_dir = Path::new("/Users");
-
-            // Have this debug assert so it gets run by CI.
-            if cfg!(debug_assertions) && !tmp_dir.starts_with(users_dir) {
-                panic!(
-                    "temporary directory {:?} not a subdirectory of: {:?}",
-                    tmp_dir, users_dir
-                );
-            }
-
-            tmp_dir.join("polars/")
+            std::env::temp_dir().join("polars/")
         } else {
-            std::env::temp_dir().join("polars")
+            std::env::temp_dir().join("polars/")
         }
         .into_boxed_path();
 


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/21120

On unix systems this will use a unique temporary directory per user (generally `/tmp/polars-$USER`, and ensure that it is accessible only by the current user (i.e. `chmod 700`).

On Windows systems the temporary directory was already under the users data directory (e.g. `C:\Users\user\AppData\Local\Temp\polars`), so I haven't made any changes there
