### PR TITLE
feat(python): Enable ingest of objects supporting the PyCapsule interface via `from_arrow`

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -952,6 +952,7 @@ def iterable_to_pydf(
     orient: Orientation | None = None,
     chunk_size: int | None = None,
     infer_schema_length: int | None = N_INFER_DEFAULT,
+    rechunk: bool = True,
 ) -> PyDataFrame:
     """Construct a PyDataFrame from an iterable/generator."""
     original_schema = schema
@@ -1028,7 +1029,7 @@ def iterable_to_pydf(
     if df is None:
         df = to_frame_chunk([], original_schema)
 
-    if n_chunks > 0:
+    if n_chunks > 0 and rechunk:
         df = df.rechunk()
 
     return df._df

--- a/py-polars/polars/_utils/pycapsule.py
+++ b/py-polars/polars/_utils/pycapsule.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+from polars._utils.construction.dataframe import dataframe_to_pydf
+from polars._utils.wrap import wrap_df, wrap_s
+
+with contextlib.suppress(ImportError):
+    from polars.polars import PySeries
+
+if TYPE_CHECKING:
+    from polars import DataFrame
+    from polars._typing import SchemaDefinition, SchemaDict
+
+
+def is_pycapsule(obj: Any) -> bool:
+    """Check if object supports the PyCapsule interface."""
+    return hasattr(obj, "__arrow_c_stream__") or hasattr(obj, "__arrow_c_array__")
+
+
+def pycapsule_to_frame(
+    obj: Any,
+    *,
+    schema: SchemaDefinition | None = None,
+    schema_overrides: SchemaDict | None = None,
+    rechunk: bool = False,
+) -> DataFrame:
+    """Convert PyCapsule object to DataFrame."""
+    if hasattr(obj, "__arrow_c_array__"):
+        # This uses the fact that PySeries.from_arrow_c_array will create a
+        # struct-typed Series. Then we unpack that to a DataFrame.
+        tmp_col_name = ""
+        s = wrap_s(PySeries.from_arrow_c_array(obj))
+        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
+
+    elif hasattr(obj, "__arrow_c_stream__"):
+        # This uses the fact that PySeries.from_arrow_c_stream will create a
+        # struct-typed Series. Then we unpack that to a DataFrame.
+        tmp_col_name = ""
+        s = wrap_s(PySeries.from_arrow_c_stream(obj))
+        df = s.to_frame(tmp_col_name).unnest(tmp_col_name)
+    else:
+        msg = f"object does not support PyCapsule interface; found {obj!r} "
+        raise TypeError(msg)
+
+    if rechunk:
+        df = df.rechunk()
+    if schema or schema_overrides:
+        df = wrap_df(
+            dataframe_to_pydf(df, schema=schema, schema_overrides=schema_overrides)
+        )
+    return df

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6,12 +6,7 @@ import contextlib
 import os
 import random
 from collections import defaultdict
-from collections.abc import (
-    Generator,
-    Iterable,
-    Sequence,
-    Sized,
-)
+from collections.abc import Generator, Iterable, Sequence, Sized
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
@@ -28,11 +23,7 @@ from typing import (
 
 import polars._reexport as pl
 from polars import functions as F
-from polars._typing import (
-    DbWriteMode,
-    JaxExportType,
-    TorchExportType,
-)
+from polars._typing import DbWriteMode, JaxExportType, TorchExportType
 from polars._utils.construction import (
     arrow_to_pydf,
     dataframe_to_pydf,
@@ -51,6 +42,7 @@ from polars._utils.deprecation import (
 )
 from polars._utils.getitem import get_df_item_by_key
 from polars._utils.parse import parse_into_expression
+from polars._utils.pycapsule import is_pycapsule, pycapsule_to_frame
 from polars._utils.serde import serialize_polars_object
 from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
@@ -108,17 +100,13 @@ from polars.schema import Schema
 from polars.selectors import _expand_selector_dicts, _expand_selectors
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars.polars import PyDataFrame, PySeries
+    from polars.polars import PyDataFrame
     from polars.polars import dtype_str_repr as _dtype_str_repr
     from polars.polars import write_clipboard_string as _write_clipboard_string
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import (
-        Collection,
-        Iterator,
-        Mapping,
-    )
+    from collections.abc import Collection, Iterator, Mapping
     from datetime import timedelta
     from io import IOBase
     from typing import Literal
@@ -427,20 +415,12 @@ class DataFrame:
                 data, schema=schema, schema_overrides=schema_overrides, strict=strict
             )
 
-        elif hasattr(data, "__arrow_c_array__"):
-            # This uses the fact that PySeries.from_arrow_c_array will create a
-            # struct-typed Series. Then we unpack that to a DataFrame.
-            tmp_col_name = ""
-            s = wrap_s(PySeries.from_arrow_c_array(data))
-            self._df = s.to_frame(tmp_col_name).unnest(tmp_col_name)._df
-
-        elif hasattr(data, "__arrow_c_stream__"):
-            # This uses the fact that PySeries.from_arrow_c_stream will create a
-            # struct-typed Series. Then we unpack that to a DataFrame.
-            tmp_col_name = ""
-            s = wrap_s(PySeries.from_arrow_c_stream(data))
-            self._df = s.to_frame(tmp_col_name).unnest(tmp_col_name)._df
-
+        elif is_pycapsule(data):
+            self._df = pycapsule_to_frame(
+                data,
+                schema=schema,
+                schema_overrides=schema_overrides,
+            )._df
         else:
             msg = (
                 f"DataFrame constructor called with unsupported type {type(data).__name__!r}"

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -68,7 +68,6 @@ def test_arrow_dict_to_polars() -> None:
         name="pa_dict",
         values=["AAA", "BBB", "CCC", "DDD", "BBB", "AAA", "CCC", "DDD", "DDD", "CCC"],
     )
-
     assert_series_equal(s, pl.Series("pa_dict", pa_dict))
 
 
@@ -812,13 +811,23 @@ def test_df_pycapsule_interface() -> None:
             "c": ["fooooooooooooooooooooo", "bar", "looooooooooooooooong string"],
         }
     )
-    out = pa.table(PyCapsuleStreamHolder(df))
+
+    capsule_df = PyCapsuleStreamHolder(df)
+    out = pa.table(capsule_df)
     assert df.shape == out.shape
     assert df.schema.names() == out.schema.names
 
-    df2 = pl.from_arrow(out)
-    assert isinstance(df2, pl.DataFrame)
-    assert df.equals(df2)
+    schema_overrides = {"a": pl.Int128}
+    expected_schema = pl.Schema([("a", pl.Int128), ("b", pl.String), ("c", pl.String)])
+
+    for arrow_obj in (
+        pl.from_arrow(capsule_df),  # capsule
+        out,  # table loaded from capsule
+    ):
+        df_res = pl.from_arrow(arrow_obj, schema_overrides=schema_overrides)
+        assert expected_schema == df_res.schema  # type: ignore[union-attr]
+        assert isinstance(df_res, pl.DataFrame)
+        assert df.equals(df_res)
 
 
 def test_misaligned_nested_arrow_19097() -> None:


### PR DESCRIPTION
Closes #20872.

Allows loading of objects that support `PyCapsule` via `pl.from_arrow` without having to import/load `pyarrow`. We already allow the DataFrame constructor to take such objects, so this resolves an inconsistency... Moved the common code out into a `_utils` module to make things clean.