### PR TITLE
perf: Reduce sharing in stringview arrays in new-streaming equijoin

### DIFF
--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -450,9 +450,9 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     }
 
     pub fn deshare(&self) -> Self {
-        if Arc::strong_count(&self.buffers) == 1 && self.buffers.iter().all(|b| {
-            b.storage_refcount() == 1
-        }) {
+        if Arc::strong_count(&self.buffers) == 1
+            && self.buffers.iter().all(|b| b.storage_refcount() == 1)
+        {
             return self.clone();
         }
         self.clone().gc()

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -449,6 +449,15 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         mutable.freeze().with_validity(self.validity)
     }
 
+    pub fn deshare(&self) -> Self {
+        if Arc::strong_count(&self.buffers) == 1 && self.buffers.iter().all(|b| {
+            b.storage_refcount() == 1
+        }) {
+            return self.clone();
+        }
+        self.clone().gc()
+    }
+
     pub fn is_sliced(&self) -> bool {
         self.views.as_ptr() != self.views.storage_ptr()
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -600,7 +600,7 @@ impl DataFrame {
             *col = col.rechunk();
         }
     }
-    
+
     pub fn _deshare_views_mut(&mut self) {
         // SAFETY: We never adjust the length or names of the columns.
         unsafe {

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -674,7 +674,7 @@ fn materialize_column(join_opt_ids: &ChunkJoinOptIds, out_column: &Column) -> Co
             Either::Left(ids) => unsafe {
                 IdxCa::with_nullable_idx(ids, |idx| out_column.take_unchecked(idx))
             },
-            Either::Right(ids) => unsafe { out_column.take_opt_chunked_unchecked(ids) },
+            Either::Right(ids) => unsafe { out_column.take_opt_chunked_unchecked(ids, false) },
         }
     }
 }

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -31,7 +31,9 @@ pub trait TakeChunked {
 
     /// # Safety
     /// This function doesn't do any bound checks.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>],
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(
+        &self,
+        by: &[ChunkId<B>],
         avoid_sharing: bool,
     ) -> Self;
 }
@@ -59,7 +61,11 @@ impl TakeChunked for DataFrame {
     ///
     /// # Safety
     /// Does not do any bound checks.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, idx: &[ChunkId<B>], avoid_sharing: bool) -> DataFrame {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(
+        &self,
+        idx: &[ChunkId<B>],
+        avoid_sharing: bool,
+    ) -> DataFrame {
         let cols = self
             .to_df()
             ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx, avoid_sharing));
@@ -114,7 +120,11 @@ impl TakeChunked for Column {
         s.into_column()
     }
 
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>], avoid_sharing: bool) -> Self {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(
+        &self,
+        by: &[ChunkId<B>],
+        avoid_sharing: bool,
+    ) -> Self {
         // @scalar-opt
         let s = self.as_materialized_series();
         let s = unsafe { s.take_opt_chunked_unchecked(by, avoid_sharing) };
@@ -139,7 +149,8 @@ impl TakeChunked for Series {
             },
             Boolean => {
                 let ca = self.bool().unwrap();
-                ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
+                ca.take_chunked_unchecked(by, sorted, avoid_sharing)
+                    .into_series()
             },
             Binary => {
                 let ca = self.binary().unwrap();
@@ -151,12 +162,14 @@ impl TakeChunked for Series {
             },
             List(_) => {
                 let ca = self.list().unwrap();
-                ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
+                ca.take_chunked_unchecked(by, sorted, avoid_sharing)
+                    .into_series()
             },
             #[cfg(feature = "dtype-array")]
             Array(_, _) => {
                 let ca = self.array().unwrap();
-                ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
+                ca.take_chunked_unchecked(by, sorted, avoid_sharing)
+                    .into_series()
             },
             #[cfg(feature = "dtype-struct")]
             Struct(_) => {
@@ -209,7 +222,9 @@ impl TakeChunked for Series {
             #[cfg(feature = "dtype-categorical")]
             Categorical(revmap, ord) | Enum(revmap, ord) => {
                 let ca = self.categorical().unwrap();
-                let t = ca.physical().take_chunked_unchecked(by, sorted, avoid_sharing);
+                let t = ca
+                    .physical()
+                    .take_chunked_unchecked(by, sorted, avoid_sharing);
                 CategoricalChunked::from_cats_and_rev_map_unchecked(
                     t,
                     revmap.as_ref().unwrap().clone(),
@@ -224,7 +239,11 @@ impl TakeChunked for Series {
     }
 
     /// Take function that checks of null state in `ChunkIdx`.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>], avoid_sharing: bool) -> Self {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(
+        &self,
+        by: &[ChunkId<B>],
+        avoid_sharing: bool,
+    ) -> Self {
         use DataType::*;
         match self.dtype() {
             dt if dt.is_primitive_numeric() => {
@@ -235,7 +254,8 @@ impl TakeChunked for Series {
             },
             Boolean => {
                 let ca = self.bool().unwrap();
-                ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
+                ca.take_opt_chunked_unchecked(by, avoid_sharing)
+                    .into_series()
             },
             Binary => {
                 let ca = self.binary().unwrap();
@@ -247,12 +267,14 @@ impl TakeChunked for Series {
             },
             List(_) => {
                 let ca = self.list().unwrap();
-                ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
+                ca.take_opt_chunked_unchecked(by, avoid_sharing)
+                    .into_series()
             },
             #[cfg(feature = "dtype-array")]
             Array(_, _) => {
                 let ca = self.array().unwrap();
-                ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
+                ca.take_opt_chunked_unchecked(by, avoid_sharing)
+                    .into_series()
             },
             #[cfg(feature = "dtype-struct")]
             Struct(_) => {
@@ -366,7 +388,11 @@ where
     }
 
     // Take function that checks of null state in `ChunkIdx`.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>], _allow_sharing: bool) -> Self {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(
+        &self,
+        by: &[ChunkId<B>],
+        _allow_sharing: bool,
+    ) -> Self {
         let arrow_dtype = self.dtype().to_arrow(CompatLevel::newest());
 
         if !self.has_nulls() {
@@ -424,7 +450,11 @@ unsafe fn take_unchecked_object<const B: u64>(
 }
 
 #[cfg(feature = "object")]
-unsafe fn take_opt_unchecked_object<const B: u64>(s: &Series, by: &[ChunkId<B>], _allow_sharing: bool) -> Series {
+unsafe fn take_opt_unchecked_object<const B: u64>(
+    s: &Series,
+    by: &[ChunkId<B>],
+    _allow_sharing: bool,
+) -> Series {
     let DataType::Object(_, reg) = s.dtype() else {
         unreachable!()
     };

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -15,17 +15,25 @@ use crate::frame::IntoDf;
 
 /// Gather by [`ChunkId`]
 pub trait TakeChunked {
+    /// Gathers elements from a ChunkedArray, specifying for each element a
+    /// chunk index and index within that chunk through ChunkId. If
+    /// avoid_sharing is true the returned data should not share references
+    /// with the original array (like shared buffers in views).
+    ///
     /// # Safety
     /// This function doesn't do any bound checks.
     unsafe fn take_chunked_unchecked<const B: u64>(
         &self,
         by: &[ChunkId<B>],
         sorted: IsSorted,
+        avoid_sharing: bool,
     ) -> Self;
 
     /// # Safety
     /// This function doesn't do any bound checks.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>]) -> Self;
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>],
+        avoid_sharing: bool,
+    ) -> Self;
 }
 
 impl TakeChunked for DataFrame {
@@ -38,10 +46,11 @@ impl TakeChunked for DataFrame {
         &self,
         idx: &[ChunkId<B>],
         sorted: IsSorted,
+        avoid_sharing: bool,
     ) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns(&|s| s.take_chunked_unchecked(idx, sorted));
+            ._apply_columns(&|s| s.take_chunked_unchecked(idx, sorted, avoid_sharing));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -50,10 +59,10 @@ impl TakeChunked for DataFrame {
     ///
     /// # Safety
     /// Does not do any bound checks.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, idx: &[ChunkId<B>]) -> DataFrame {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, idx: &[ChunkId<B>], avoid_sharing: bool) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx));
+            ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx, avoid_sharing));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -69,7 +78,7 @@ pub trait TakeChunkedHorPar: IntoDf {
     ) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_par(&|s| s.take_chunked_unchecked(idx, sorted));
+            ._apply_columns_par(&|s| s.take_chunked_unchecked(idx, sorted, false));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -84,7 +93,7 @@ pub trait TakeChunkedHorPar: IntoDf {
     ) -> DataFrame {
         let cols = self
             .to_df()
-            ._apply_columns_par(&|s| s.take_opt_chunked_unchecked(idx));
+            ._apply_columns_par(&|s| s.take_opt_chunked_unchecked(idx, false));
 
         unsafe { DataFrame::new_no_checks_height_from_first(cols) }
     }
@@ -97,17 +106,18 @@ impl TakeChunked for Column {
         &self,
         by: &[ChunkId<B>],
         sorted: IsSorted,
+        avoid_sharing: bool,
     ) -> Self {
         // @scalar-opt
         let s = self.as_materialized_series();
-        let s = unsafe { s.take_chunked_unchecked(by, sorted) };
+        let s = unsafe { s.take_chunked_unchecked(by, sorted, avoid_sharing) };
         s.into_column()
     }
 
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>]) -> Self {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>], avoid_sharing: bool) -> Self {
         // @scalar-opt
         let s = self.as_materialized_series();
-        let s = unsafe { s.take_opt_chunked_unchecked(by) };
+        let s = unsafe { s.take_opt_chunked_unchecked(by, avoid_sharing) };
         s.into_column()
     }
 }
@@ -117,40 +127,41 @@ impl TakeChunked for Series {
         &self,
         by: &[ChunkId<B>],
         sorted: IsSorted,
+        avoid_sharing: bool,
     ) -> Self {
         use DataType::*;
         match self.dtype() {
             dt if dt.is_primitive_numeric() => {
                 with_match_physical_numeric_polars_type!(self.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
-                    ca.take_chunked_unchecked(by, sorted).into_series()
+                    ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
                 })
             },
             Boolean => {
                 let ca = self.bool().unwrap();
-                ca.take_chunked_unchecked(by, sorted).into_series()
+                ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
             },
             Binary => {
                 let ca = self.binary().unwrap();
-                take_unchecked_binview(ca, by, sorted).into_series()
+                take_unchecked_binview(ca, by, sorted, avoid_sharing).into_series()
             },
             String => {
                 let ca = self.str().unwrap();
-                take_unchecked_binview(ca, by, sorted).into_series()
+                take_unchecked_binview(ca, by, sorted, avoid_sharing).into_series()
             },
             List(_) => {
                 let ca = self.list().unwrap();
-                ca.take_chunked_unchecked(by, sorted).into_series()
+                ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
             },
             #[cfg(feature = "dtype-array")]
             Array(_, _) => {
                 let ca = self.array().unwrap();
-                ca.take_chunked_unchecked(by, sorted).into_series()
+                ca.take_chunked_unchecked(by, sorted, avoid_sharing).into_series()
             },
             #[cfg(feature = "dtype-struct")]
             Struct(_) => {
                 let ca = self.struct_().unwrap();
-                ca._apply_fields(|s| s.take_chunked_unchecked(by, sorted))
+                ca._apply_fields(|s| s.take_chunked_unchecked(by, sorted, avoid_sharing))
                     .expect("infallible")
                     .into_series()
             },
@@ -159,7 +170,7 @@ impl TakeChunked for Series {
             #[cfg(feature = "dtype-decimal")]
             Decimal(_, _) => {
                 let ca = self.decimal().unwrap();
-                let out = ca.0.take_chunked_unchecked(by, sorted);
+                let out = ca.0.take_chunked_unchecked(by, sorted, avoid_sharing);
                 out.into_decimal_unchecked(ca.precision(), ca.scale())
                     .into_series()
             },
@@ -167,7 +178,7 @@ impl TakeChunked for Series {
             Date => {
                 let ca = self.date().unwrap();
                 ca.physical()
-                    .take_chunked_unchecked(by, sorted)
+                    .take_chunked_unchecked(by, sorted, avoid_sharing)
                     .into_date()
                     .into_series()
             },
@@ -175,7 +186,7 @@ impl TakeChunked for Series {
             Datetime(u, z) => {
                 let ca = self.datetime().unwrap();
                 ca.physical()
-                    .take_chunked_unchecked(by, sorted)
+                    .take_chunked_unchecked(by, sorted, avoid_sharing)
                     .into_datetime(*u, z.clone())
                     .into_series()
             },
@@ -183,7 +194,7 @@ impl TakeChunked for Series {
             Duration(u) => {
                 let ca = self.duration().unwrap();
                 ca.physical()
-                    .take_chunked_unchecked(by, sorted)
+                    .take_chunked_unchecked(by, sorted, avoid_sharing)
                     .into_duration(*u)
                     .into_series()
             },
@@ -191,14 +202,14 @@ impl TakeChunked for Series {
             Time => {
                 let ca = self.time().unwrap();
                 ca.physical()
-                    .take_chunked_unchecked(by, sorted)
+                    .take_chunked_unchecked(by, sorted, avoid_sharing)
                     .into_time()
                     .into_series()
             },
             #[cfg(feature = "dtype-categorical")]
             Categorical(revmap, ord) | Enum(revmap, ord) => {
                 let ca = self.categorical().unwrap();
-                let t = ca.physical().take_chunked_unchecked(by, sorted);
+                let t = ca.physical().take_chunked_unchecked(by, sorted, avoid_sharing);
                 CategoricalChunked::from_cats_and_rev_map_unchecked(
                     t,
                     revmap.as_ref().unwrap().clone(),
@@ -213,49 +224,49 @@ impl TakeChunked for Series {
     }
 
     /// Take function that checks of null state in `ChunkIdx`.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>]) -> Self {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>], avoid_sharing: bool) -> Self {
         use DataType::*;
         match self.dtype() {
             dt if dt.is_primitive_numeric() => {
                 with_match_physical_numeric_polars_type!(self.dtype(), |$T| {
                  let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
-                 ca.take_opt_chunked_unchecked(by).into_series()
+                 ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
                 })
             },
             Boolean => {
                 let ca = self.bool().unwrap();
-                ca.take_opt_chunked_unchecked(by).into_series()
+                ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
             },
             Binary => {
                 let ca = self.binary().unwrap();
-                take_unchecked_binview_opt(ca, by).into_series()
+                take_unchecked_binview_opt(ca, by, avoid_sharing).into_series()
             },
             String => {
                 let ca = self.str().unwrap();
-                take_unchecked_binview_opt(ca, by).into_series()
+                take_unchecked_binview_opt(ca, by, avoid_sharing).into_series()
             },
             List(_) => {
                 let ca = self.list().unwrap();
-                ca.take_opt_chunked_unchecked(by).into_series()
+                ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
             },
             #[cfg(feature = "dtype-array")]
             Array(_, _) => {
                 let ca = self.array().unwrap();
-                ca.take_opt_chunked_unchecked(by).into_series()
+                ca.take_opt_chunked_unchecked(by, avoid_sharing).into_series()
             },
             #[cfg(feature = "dtype-struct")]
             Struct(_) => {
                 let ca = self.struct_().unwrap();
-                ca._apply_fields(|s| s.take_opt_chunked_unchecked(by))
+                ca._apply_fields(|s| s.take_opt_chunked_unchecked(by, avoid_sharing))
                     .expect("infallible")
                     .into_series()
             },
             #[cfg(feature = "object")]
-            Object(_, _) => take_opt_unchecked_object(self, by),
+            Object(_, _) => take_opt_unchecked_object(self, by, avoid_sharing),
             #[cfg(feature = "dtype-decimal")]
             Decimal(_, _) => {
                 let ca = self.decimal().unwrap();
-                let out = ca.0.take_opt_chunked_unchecked(by);
+                let out = ca.0.take_opt_chunked_unchecked(by, avoid_sharing);
                 out.into_decimal_unchecked(ca.precision(), ca.scale())
                     .into_series()
             },
@@ -263,7 +274,7 @@ impl TakeChunked for Series {
             Date => {
                 let ca = self.date().unwrap();
                 ca.physical()
-                    .take_opt_chunked_unchecked(by)
+                    .take_opt_chunked_unchecked(by, avoid_sharing)
                     .into_date()
                     .into_series()
             },
@@ -271,7 +282,7 @@ impl TakeChunked for Series {
             Datetime(u, z) => {
                 let ca = self.datetime().unwrap();
                 ca.physical()
-                    .take_opt_chunked_unchecked(by)
+                    .take_opt_chunked_unchecked(by, avoid_sharing)
                     .into_datetime(*u, z.clone())
                     .into_series()
             },
@@ -279,7 +290,7 @@ impl TakeChunked for Series {
             Duration(u) => {
                 let ca = self.duration().unwrap();
                 ca.physical()
-                    .take_opt_chunked_unchecked(by)
+                    .take_opt_chunked_unchecked(by, avoid_sharing)
                     .into_duration(*u)
                     .into_series()
             },
@@ -287,14 +298,14 @@ impl TakeChunked for Series {
             Time => {
                 let ca = self.time().unwrap();
                 ca.physical()
-                    .take_opt_chunked_unchecked(by)
+                    .take_opt_chunked_unchecked(by, avoid_sharing)
                     .into_time()
                     .into_series()
             },
             #[cfg(feature = "dtype-categorical")]
             Categorical(revmap, ord) | Enum(revmap, ord) => {
                 let ca = self.categorical().unwrap();
-                let ret = ca.physical().take_opt_chunked_unchecked(by);
+                let ret = ca.physical().take_opt_chunked_unchecked(by, avoid_sharing);
                 CategoricalChunked::from_cats_and_rev_map_unchecked(
                     ret,
                     revmap.as_ref().unwrap().clone(),
@@ -318,6 +329,7 @@ where
         &self,
         by: &[ChunkId<B>],
         sorted: IsSorted,
+        _allow_sharing: bool,
     ) -> Self {
         let arrow_dtype = self.dtype().to_arrow(CompatLevel::newest());
 
@@ -354,7 +366,7 @@ where
     }
 
     // Take function that checks of null state in `ChunkIdx`.
-    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>]) -> Self {
+    unsafe fn take_opt_chunked_unchecked<const B: u64>(&self, by: &[ChunkId<B>], _allow_sharing: bool) -> Self {
         let arrow_dtype = self.dtype().to_arrow(CompatLevel::newest());
 
         if !self.has_nulls() {
@@ -412,7 +424,7 @@ unsafe fn take_unchecked_object<const B: u64>(
 }
 
 #[cfg(feature = "object")]
-unsafe fn take_opt_unchecked_object<const B: u64>(s: &Series, by: &[ChunkId<B>]) -> Series {
+unsafe fn take_opt_unchecked_object<const B: u64>(s: &Series, by: &[ChunkId<B>], _allow_sharing: bool) -> Series {
     let DataType::Object(_, reg) = s.dtype() else {
         unreachable!()
     };
@@ -435,11 +447,17 @@ unsafe fn take_unchecked_binview<const B: u64, T, V>(
     ca: &ChunkedArray<T>,
     by: &[ChunkId<B>],
     sorted: IsSorted,
+    avoid_sharing: bool,
 ) -> ChunkedArray<T>
 where
     T: PolarsDataType<Array = BinaryViewArrayGeneric<V>>,
+    T::Array: Debug,
     V: ViewType + ?Sized,
 {
+    if avoid_sharing {
+        return ca.take_chunked_unchecked(by, sorted, avoid_sharing);
+    }
+
     let mut views = Vec::with_capacity(by.len());
     let (validity, arc_data_buffers);
 
@@ -633,11 +651,17 @@ where
 unsafe fn take_unchecked_binview_opt<const B: u64, T, V>(
     ca: &ChunkedArray<T>,
     by: &[ChunkId<B>],
+    avoid_sharing: bool,
 ) -> ChunkedArray<T>
 where
     T: PolarsDataType<Array = BinaryViewArrayGeneric<V>>,
+    T::Array: Debug,
     V: ViewType + ?Sized,
 {
+    if avoid_sharing {
+        return ca.take_opt_chunked_unchecked(by, avoid_sharing);
+    }
+
     let mut views = Vec::with_capacity(by.len());
     let mut validity = BitmapBuilder::with_capacity(by.len());
 
@@ -822,7 +846,7 @@ mod test {
                 ChunkId::store(2, 2),
             ];
 
-            let out = s_1.take_chunked_unchecked(&by, IsSorted::Not);
+            let out = s_1.take_chunked_unchecked(&by, IsSorted::Not, true);
             let idx = IdxCa::new("".into(), [0, 1, 3, 2, 4, 5, 6]);
             let expected = s_1.rechunk().take(&idx).unwrap();
             assert!(out.equals(&expected));
@@ -834,7 +858,7 @@ mod test {
                 ChunkId::store(1, 1),
                 ChunkId::store(1, 0),
             ];
-            let out = s_1.take_opt_chunked_unchecked(&by);
+            let out = s_1.take_opt_chunked_unchecked(&by, true);
 
             let idx = IdxCa::new("".into(), [None, Some(1), Some(3), Some(2)]);
             let expected = s_1.rechunk().take(&idx).unwrap();
@@ -856,7 +880,7 @@ mod test {
                 ChunkId::store(1, 0),
             ];
 
-            let out = s_1.take_chunked_unchecked(&by, IsSorted::Not);
+            let out = s_1.take_chunked_unchecked(&by, IsSorted::Not, true);
             let idx = IdxCa::new("".into(), [0, 1, 3, 2]);
             let expected = s_1.rechunk().take(&idx).unwrap();
             assert!(out.equals_missing(&expected));
@@ -868,7 +892,7 @@ mod test {
                 ChunkId::store(1, 1),
                 ChunkId::store(1, 0),
             ];
-            let out = s_1.take_opt_chunked_unchecked(&by);
+            let out = s_1.take_opt_chunked_unchecked(&by, true);
 
             let idx = IdxCa::new("".into(), [None, Some(1), Some(3), Some(2)]);
             let expected = s_1.rechunk().take(&idx).unwrap();

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
@@ -208,7 +208,7 @@ impl<K: ExtraPayload> GenericJoinProbe<K> {
                 .data
                 ._take_unchecked_slice_sorted(&self.join_tuples_b, false, IsSorted::Ascending)
         };
-        let right_df = unsafe { right_df.take_opt_chunked_unchecked(&self.join_tuples_a) };
+        let right_df = unsafe { right_df.take_opt_chunked_unchecked(&self.join_tuples_a, false) };
 
         let out = self.finish_join(left_df, right_df)?;
 
@@ -271,7 +271,7 @@ impl<K: ExtraPayload> GenericJoinProbe<K> {
 
         let left_df = unsafe {
             self.df_a
-                .take_chunked_unchecked(&self.join_tuples_a, IsSorted::Not)
+                .take_chunked_unchecked(&self.join_tuples_a, IsSorted::Not, false)
         };
         let right_df = unsafe {
             let mut df = Cow::Borrowed(&chunk.data);

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
@@ -224,7 +224,10 @@ impl<K: ExtraPayload> GenericFullOuterJoinProbe<K> {
         }
         self.hashes = hashes;
 
-        let left_df = unsafe { self.df_a.take_opt_chunked_unchecked(&self.join_tuples_a, false) };
+        let left_df = unsafe {
+            self.df_a
+                .take_opt_chunked_unchecked(&self.join_tuples_a, false)
+        };
         let right_df = unsafe {
             self.join_tuples_b.with_freeze(|idx| {
                 let idx = IdxCa::from(idx.clone());

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
@@ -224,7 +224,7 @@ impl<K: ExtraPayload> GenericFullOuterJoinProbe<K> {
         }
         self.hashes = hashes;
 
-        let left_df = unsafe { self.df_a.take_opt_chunked_unchecked(&self.join_tuples_a) };
+        let left_df = unsafe { self.df_a.take_opt_chunked_unchecked(&self.join_tuples_a, false) };
         let right_df = unsafe {
             self.join_tuples_b.with_freeze(|idx| {
                 let idx = IdxCa::from(idx.clone());
@@ -257,7 +257,7 @@ impl<K: ExtraPayload> GenericFullOuterJoinProbe<K> {
 
         let left_df = unsafe {
             self.df_a
-                .take_chunked_unchecked(&self.join_tuples_a, IsSorted::Not)
+                .take_chunked_unchecked(&self.join_tuples_a, IsSorted::Not, false)
         };
 
         let size = left_df.height();

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -189,10 +189,7 @@ impl BuildState {
                 for (p, idxs_in_p) in partitions.iter_mut().zip(&partition_idxs) {
                     let payload_for_partition = payload.take_slice_unchecked_impl(idxs_in_p, false);
                     p.hash_keys.push(hash_keys.gather(idxs_in_p));
-                    p.frames.push((
-                        morsel.seq(),
-                        payload_for_partition,
-                    ));
+                    p.frames.push((morsel.seq(), payload_for_partition));
                 }
             }
         }
@@ -519,7 +516,8 @@ impl ProbeState {
                 p.table.unmarked_keys(&mut unmarked_idxs, 0, IdxSize::MAX);
 
                 // Gather and create full-null counterpart.
-                let mut build_df = p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not, false);
+                let mut build_df =
+                    p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not, false);
                 let len = build_df.height();
                 let mut out_df = if params.left_is_build {
                     let probe_df = DataFrame::full_null(&params.right_payload_schema, len);
@@ -617,7 +615,8 @@ impl EmitUnmatchedState {
 
                 // Gather and create full-null counterpart.
                 let out_df = unsafe {
-                    let mut build_df = p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not, false);
+                    let mut build_df =
+                        p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not, false);
                     let len = build_df.height();
                     if params.left_is_build {
                         let probe_df = DataFrame::full_null(&params.right_payload_schema, len);

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -177,6 +177,7 @@ impl BuildState {
             let hash_keys = select_keys(morsel.df(), key_selectors, params, state).await?;
             let mut payload = select_payload(morsel.df().clone(), payload_selector);
             payload.rechunk_mut();
+            payload._deshare_views_mut();
 
             unsafe {
                 hash_keys.gen_partition_idxs(
@@ -186,10 +187,11 @@ impl BuildState {
                     track_unmatchable,
                 );
                 for (p, idxs_in_p) in partitions.iter_mut().zip(&partition_idxs) {
+                    let payload_for_partition = payload.take_slice_unchecked_impl(idxs_in_p, false);
                     p.hash_keys.push(hash_keys.gather(idxs_in_p));
                     p.frames.push((
                         morsel.seq(),
-                        payload.take_slice_unchecked_impl(idxs_in_p, false),
+                        payload_for_partition,
                     ));
                 }
             }
@@ -379,9 +381,9 @@ impl ProbeState {
 
                         // Gather output and add to buffer.
                         let mut build_df = if emit_unmatched {
-                            p.df.take_opt_chunked_unchecked(&table_match)
+                            p.df.take_opt_chunked_unchecked(&table_match, false)
                         } else {
-                            p.df.take_chunked_unchecked(&table_match, IsSorted::Not)
+                            p.df.take_chunked_unchecked(&table_match, IsSorted::Not, false)
                         };
 
                         if !payload_rechunked {
@@ -448,9 +450,9 @@ impl ProbeState {
 
                             // Gather output and send.
                             let mut build_df = if emit_unmatched {
-                                p.df.take_opt_chunked_unchecked(&table_match)
+                                p.df.take_opt_chunked_unchecked(&table_match, false)
                             } else {
-                                p.df.take_chunked_unchecked(&table_match, IsSorted::Not)
+                                p.df.take_chunked_unchecked(&table_match, IsSorted::Not, false)
                             };
                             if !payload_rechunked {
                                 // TODO: can avoid rechunk? We have to rechunk here or else we do it
@@ -517,7 +519,7 @@ impl ProbeState {
                 p.table.unmarked_keys(&mut unmarked_idxs, 0, IdxSize::MAX);
 
                 // Gather and create full-null counterpart.
-                let mut build_df = p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not);
+                let mut build_df = p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not, false);
                 let len = build_df.height();
                 let mut out_df = if params.left_is_build {
                     let probe_df = DataFrame::full_null(&params.right_payload_schema, len);
@@ -615,7 +617,7 @@ impl EmitUnmatchedState {
 
                 // Gather and create full-null counterpart.
                 let out_df = unsafe {
-                    let mut build_df = p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not);
+                    let mut build_df = p.df.take_chunked_unchecked(&unmarked_idxs, IsSorted::Not, false);
                     let len = build_df.height();
                     if params.left_is_build {
                         let probe_df = DataFrame::full_null(&params.right_payload_schema, len);


### PR DESCRIPTION
This is a regression on some queries in PDS-H but gets rid of really problematic contention in others, so makes behavior more predictable & scalable.

The PR also includes some unused code for avoiding sharing in a chunked gather. From experimenting that was slower but I left it in because it might come in handy in the future for more experimentation.