### PR TITLE
fix: Fix `Expr.over` applying scale incorrectly for Decimal types

### DIFF
--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -699,7 +699,7 @@ fn set_by_groups(
             }};
         }
         downcast_as_macro_arg_physical!(&s, dispatch)
-            .map(|s| s.cast(dtype).unwrap())
+            .map(|s| unsafe { s.from_physical_unchecked(dtype) }.unwrap())
             .map(Column::from)
     } else {
         None

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -712,3 +712,9 @@ def test_cast_float_to_decimal_12775() -> None:
     # default scale = 0
     assert s.cast(pl.Decimal).to_list() == [D("1")]
     assert s.cast(pl.Decimal(scale=1)).to_list() == [D("1.5")]
+
+
+def test_decimal_min_over_21096() -> None:
+    df = pl.Series("x", [1, 2], pl.Decimal(scale=2)).to_frame()
+    result = df.select(pl.col("x").min().over("x"))
+    assert result["x"].to_list() == [D("1.00"), D("2.00")]


### PR DESCRIPTION
fixes #21096


```python
import polars as pl

df = pl.Series("x", [1, 2], pl.Decimal(scale=2)).to_frame()
df.select(pl.col("x").min().over("x"))
```

Before:

```
shape: (2, 1)
┌──────────────┐
│ x            │
│ ---          │
│ decimal[*,2] │
╞══════════════╡
│ 100.00       │
│ 200.00       │
└──────────────┘
```

After:

```
shape: (2, 1)
┌──────────────┐
│ x            │
│ ---          │
│ decimal[*,2] │
╞══════════════╡
│ 1.00         │
│ 2.00         │
└──────────────┘
```