### PR TITLE
fix(rust): Remove empty format precision specifier

### DIFF
--- a/crates/polars-io/src/csv/write/write_impl/serializer.rs
+++ b/crates/polars-io/src/csv/write/write_impl/serializer.rs
@@ -146,7 +146,7 @@ fn float_serializer_no_precision_scientific<I: NativeType + LowerExp>(
 ) -> impl Serializer {
     let f = move |&item, buf: &mut Vec<u8>, _options: &SerializeOptions| {
         // Float writing into a buffer of `Vec<u8>` cannot fail.
-        let _ = write!(buf, "{item:.e}");
+        let _ = write!(buf, "{item:e}");
     };
 
     make_serializer::<_, _, false>(f, array.iter(), |array| {


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.