### PR TITLE
chore(python): Avoid while loop in `Array.__repr__`

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -904,9 +904,9 @@ class Array(NestedType):
 
     def __repr__(self) -> str:
         # Get leaf type
-        dtype = self.inner
-        while isinstance(dtype, Array):
-            dtype = dtype.inner
+        dtype = self
+        for _ in self.shape:
+            dtype = dtype.inner  # type: ignore[assignment]
 
         class_name = self.__class__.__name__
         return f"{class_name}({dtype!r}, shape={self.shape})"


### PR DESCRIPTION
# Description

Avoids infinite loop in unexpected scenario by limiting the depth to the known depth of `self.shape`.

Suggested by @MarcoGorelli 