### PR TITLE
feat: Allow `join_nulls` in asof join

### DIFF
--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -309,6 +309,7 @@ pub trait DataFrameJoinOps: IntoDf {
                         should_coalesce,
                         options.allow_eq,
                         options.check_sortedness,
+                        args.join_nulls,
                     ),
                     (None, None) => left_df._join_asof(
                         other,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -969,7 +969,7 @@ impl PyLazyFrame {
     }
 
     #[cfg(feature = "asof_join")]
-    #[pyo3(signature = (other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str, coalesce, allow_eq, check_sortedness))]
+    #[pyo3(signature = (other, left_on, right_on, left_by, right_by, allow_parallel, force_parallel, suffix, strategy, tolerance, tolerance_str, join_nulls, coalesce, allow_eq, check_sortedness))]
     fn join_asof(
         &self,
         other: Self,
@@ -983,6 +983,7 @@ impl PyLazyFrame {
         strategy: Wrap<AsofStrategy>,
         tolerance: Option<Wrap<AnyValue<'_>>>,
         tolerance_str: Option<String>,
+        join_nulls: bool,
         coalesce: bool,
         allow_eq: bool,
         check_sortedness: bool,
@@ -1004,6 +1005,7 @@ impl PyLazyFrame {
             .allow_parallel(allow_parallel)
             .force_parallel(force_parallel)
             .coalesce(coalesce)
+            .join_nulls(join_nulls)
             .how(JoinType::AsOf(AsOfOptions {
                 strategy: strategy.0,
                 left_by: left_by.map(strings_to_pl_smallstr),

--- a/docs/source/src/rust/user-guide/transformations/joins.rs
+++ b/docs/source/src/rust/user-guide/transformations/joins.rs
@@ -254,6 +254,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None,
         true,
         true,
+        false,
     )?;
     println!("{}", result);
     // --8<-- [end:asof]
@@ -269,6 +270,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(AnyValue::Duration(60000, TimeUnit::Milliseconds)),
         true,
         true,
+        false,
     )?;
     println!("{}", result);
     // --8<-- [end:asof-tolerance]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6982,6 +6982,7 @@ class DataFrame:
         tolerance: str | int | float | timedelta | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
+        join_nulls: bool = False,
         coalesce: bool = True,
         allow_exact_matches: bool = True,
         check_sortedness: bool = True,
@@ -7062,6 +7063,9 @@ class DataFrame:
         force_parallel
             Force the physical plan to evaluate the computation of both DataFrames up to
             the join in parallel.
+        join_nulls
+            Join on null values in the "by" part.
+            By default null values will never produce matches.
         coalesce
             Coalescing behavior (merging of `on` / `left_on` / `right_on` columns):
 
@@ -7312,6 +7316,7 @@ class DataFrame:
                 tolerance=tolerance,
                 allow_parallel=allow_parallel,
                 force_parallel=force_parallel,
+                join_nulls=join_nulls,
                 coalesce=coalesce,
                 allow_exact_matches=allow_exact_matches,
                 check_sortedness=check_sortedness,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4275,6 +4275,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         tolerance: str | int | float | timedelta | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
+        join_nulls: bool = False,
         coalesce: bool = True,
         allow_exact_matches: bool = True,
         check_sortedness: bool = True,
@@ -4355,6 +4356,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         force_parallel
             Force the physical plan to evaluate the computation of both DataFrames up to
             the join in parallel.
+        join_nulls
+            Join on null values in the "by" part.
+            By default null values will never produce matches.
         coalesce
             Coalescing behavior (merging of `on` / `left_on` / `right_on` columns):
 
@@ -4628,6 +4632,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 strategy,
                 tolerance_num,
                 tolerance_str,
+                join_nulls,
                 coalesce=coalesce,
                 allow_eq=allow_exact_matches,
                 check_sortedness=check_sortedness,


### PR DESCRIPTION
Fixes #17886: This PR introduces a `join_nulls` option to the `by` part of `join_asof`. 