### PR TITLE
fix: Do not panic in `strptime()` if `format` ends with '%'

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -207,31 +207,34 @@ pub(super) fn fmt_len(fmt: &[u8]) -> Option<u16> {
 
     while let Some(&val) = iter.next() {
         match val {
-            b'%' => match iter.next().expect("invalid pattern") {
-                b'Y' => cnt += 4,
-                b'y' => cnt += 2,
-                b'd' => cnt += 2,
-                b'm' => cnt += 2,
-                b'b' => cnt += 3,
-                b'H' => cnt += 2,
-                b'M' => cnt += 2,
-                b'S' => cnt += 2,
-                b'9' => {
-                    cnt += 9;
-                    debug_assert_eq!(iter.next(), Some(&b'f'));
-                    return Some(cnt);
+            b'%' => match iter.next() {
+                Some(&next_val) => match next_val {
+                    b'Y' => cnt += 4,
+                    b'y' => cnt += 2,
+                    b'd' => cnt += 2,
+                    b'm' => cnt += 2,
+                    b'b' => cnt += 3,
+                    b'H' => cnt += 2,
+                    b'M' => cnt += 2,
+                    b'S' => cnt += 2,
+                    b'9' => {
+                        cnt += 9;
+                        debug_assert_eq!(iter.next(), Some(&b'f'));
+                        return Some(cnt);
+                    },
+                    b'6' => {
+                        cnt += 6;
+                        debug_assert_eq!(iter.next(), Some(&b'f'));
+                        return Some(cnt);
+                    },
+                    b'3' => {
+                        cnt += 3;
+                        debug_assert_eq!(iter.next(), Some(&b'f'));
+                        return Some(cnt);
+                    },
+                    _ => return None,
                 },
-                b'6' => {
-                    cnt += 6;
-                    debug_assert_eq!(iter.next(), Some(&b'f'));
-                    return Some(cnt);
-                },
-                b'3' => {
-                    cnt += 3;
-                    debug_assert_eq!(iter.next(), Some(&b'f'));
-                    return Some(cnt);
-                },
-                _ => return None,
+                None => return None,
             },
             _ => {
                 cnt += 1;

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -755,3 +755,8 @@ def test_out_of_ns_range_no_tu_specified_13592() -> None:
         dtype=pl.Datetime("us"),
     )
     assert_series_equal(result, expected)
+
+
+def test_wrong_format_percent() -> None:
+    with pytest.raises(InvalidOperationError):
+        pl.Series(["2019-01-01"]).str.strptime(pl.Date, format="d%")


### PR DESCRIPTION
```python
import polars as pl
df=pl.DataFrame({"a": ["2020-01-01"]})
df.select(pl.col("a").str.strptime(pl.Date, format="d%"))
```

**Before:**
```
pyo3_runtime.PanicException: invalid pattern
```

**After:**
```
polars.exceptions.InvalidOperationError: conversion from `str` to `date` failed in column 'a' for 1 out of 1 values: ["2020-01-01"]

You might want to try:
- setting `strict=False` to set values that cannot be converted to `null`
- using `str.strptime`, `str.to_date`, or `str.to_datetime` and providing a format string
```