### PR TITLE
feat: Adjust scale when rounding `Decimal`

### DIFF
--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -60,9 +60,9 @@ pub trait RoundSeries: SeriesSealed {
                         0
                     };
                     let round_offset = if v < 0 { -round_offset } else { round_offset };
-                    v - rem + round_offset
+                    (v - rem + round_offset) / multiplier
                 })
-                .into_decimal_unchecked(precision, scale as usize);
+                .into_decimal_unchecked(precision, decimals as usize);
 
             return Ok(ca.into_series());
         }

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -559,7 +559,11 @@ def test_decimal_round() -> None:
 
     for decimals in range(10):
         got_s = i_s.round(decimals)
-        expected_s = pl.Series("a", [round(v, decimals) for v in values], dtype)
+        expected_s = pl.Series(
+            "a",
+            [round(v, decimals) for v in values],
+            dtype=pl.Decimal(dtype.precision, min(dtype.scale, decimals)),
+        )
 
         assert_series_equal(got_s, expected_s)
 


### PR DESCRIPTION
fix #21159

Rounding a `Decimal[*, 4]` like `1.2345` to 2 decimal places should result in 
- `1.23` (this seems the "standard") and not
- `1.2300` (currently)