### PR TITLE
feat: Add SQL support for the `DELETE` statement

### DIFF
--- a/py-polars/docs/source/reference/sql/table_operations.rst
+++ b/py-polars/docs/source/reference/sql/table_operations.rst
@@ -9,6 +9,8 @@ Table Operations
      - Description
    * - :ref:`CREATE TABLE <create_table>`
      - Create a new table and its columns from a SQL query executed against an existing table.
+   * - :ref:`DELETE FROM <delete_from_table>`
+     - Remove specific rows of data from a table using an (optional) constraint.
    * - :ref:`DROP TABLES <drop_tables>`
      - Deletes the specified table, unregistering it.
    * - :ref:`EXPLAIN <explain>`
@@ -33,6 +35,19 @@ Create a new table and its columns from a SQL query executed against an existing
 
     CREATE TABLE new_table AS
     SELECT * FROM existing_table WHERE value > 42
+
+.. _delete_from_table:
+
+DELETE
+--------
+Remove specific rows from a table using an (optional) constraint.
+Omitting the constraint deletes all rows, equivalent to TRUNCATE.
+
+**Example:**
+
+.. code-block:: sql
+
+    DELETE FROM some_table WHERE value < 0
 
 .. _drop_tables:
 

--- a/py-polars/docs/source/reference/sql/table_operations.rst
+++ b/py-polars/docs/source/reference/sql/table_operations.rst
@@ -39,7 +39,7 @@ Create a new table and its columns from a SQL query executed against an existing
 .. _delete_from_table:
 
 DELETE
---------
+------
 Remove specific rows from a table using an (optional) constraint.
 Omitting the constraint deletes all rows, equivalent to TRUNCATE.
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4574,10 +4574,10 @@ class DataFrame:
 
         FFI buffers are included in this estimation.
 
-        Note
-        ----
-        For objects, the estimated size only reports the pointer size, which is
-        a huge underestimation.
+        Notes
+        -----
+        For data with Object dtype, the estimated size only reports the pointer
+        size, which is a huge underestimation.
 
         Parameters
         ----------
@@ -10741,6 +10741,7 @@ class DataFrame:
         include_key: bool = ...,
         unique: Literal[False] = ...,
     ) -> dict[Any, list[Any]]: ...
+
     @overload
     def rows_by_key(
         self,
@@ -10750,6 +10751,7 @@ class DataFrame:
         include_key: bool = ...,
         unique: Literal[True],
     ) -> dict[Any, Any]: ...
+
     @overload
     def rows_by_key(
         self,
@@ -10759,6 +10761,7 @@ class DataFrame:
         include_key: bool = ...,
         unique: Literal[False] = ...,
     ) -> dict[Any, list[dict[str, Any]]]: ...
+
     @overload
     def rows_by_key(
         self,
@@ -10768,6 +10771,7 @@ class DataFrame:
         include_key: bool = ...,
         unique: Literal[True],
     ) -> dict[Any, dict[str, Any]]: ...
+
     def rows_by_key(
         self,
         key: ColumnNameOrSelector | Sequence[ColumnNameOrSelector],

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1565,6 +1565,11 @@ class Series:
 
         FFI buffers are included in this estimation.
 
+        Notes
+        -----
+        For data with Object dtype, the estimated size only reports the pointer
+        size, which is a huge underestimation.
+
         Parameters
         ----------
         unit : {'b', 'kb', 'mb', 'gb', 'tb'}


### PR DESCRIPTION
Adds SQL support for the `DELETE FROM <table> [WHERE <constraint>]` statement.
(Validated edge-cases -such as constraints involving null values- against SQLite).

## Example

```python
import polars as pl

df = pl.DataFrame({
    "id": [100, 200, 300],
    "dt": [date(2020, 10, 10), date(1999, 1, 2), date(2001, 7, 5)],
    "v1": [3.5, -4.0, None],
    "v2": [10.0, 2.5, -1.5],
})
```
```python
df.sql("DELETE FROM self WHERE v1 < 0")
# ┌─────┬────────────┬──────┬──────┐
# │ id  ┆ dt         ┆ v1   ┆ v2   │
# │ --- ┆ ---        ┆ ---  ┆ ---  │
# │ i64 ┆ date       ┆ f64  ┆ f64  │
# ╞═════╪════════════╪══════╪══════╡
# │ 100 ┆ 2020-10-10 ┆ 3.5  ┆ 10.0 │
# │ 300 ┆ 2001-07-05 ┆ null ┆ -1.5 │
# └─────┴────────────┴──────┴──────┘
```
```python
df.sql("DELETE FROM self WHERE EXTRACT(year FROM dt) >= 2000")
# ┌─────┬────────────┬──────┬─────┐
# │ id  ┆ dt         ┆ v1   ┆ v2  │
# │ --- ┆ ---        ┆ ---  ┆ --- │
# │ i64 ┆ date       ┆ f64  ┆ f64 │
# ╞═════╪════════════╪══════╪═════╡
# │ 200 ┆ 1999-01-02 ┆ -4.0 ┆ 2.5 │
# └─────┴────────────┴──────┴─────┘
```