### PR TITLE
perf: Add sampling to new-streaming equi join to decide between build/probe side

### DIFF
--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -116,7 +116,7 @@ impl HashKeys {
             }
         }
     }
-    
+
     /// Generates indices for a chunked gather such that the ith key gathers
     /// the next gathers_per_key[i] elements from the partition[i]th chunk.
     pub fn gen_partitioned_gather_idxs(
@@ -239,7 +239,6 @@ impl RowEncodedKeys {
         }
     }
 
-
     pub fn sketch_cardinality(&self, sketch: &mut CardinalitySketch) {
         if let Some(validity) = self.keys.validity() {
             for (h, is_v) in self.hashes.values_iter().zip(validity) {
@@ -306,7 +305,7 @@ impl SingleKeys {
             keys: self.keys.take_slice_unchecked(idxs),
         }
     }
-    
+
     pub fn sketch_cardinality(&self, _sketch: &mut CardinalitySketch) {
         todo!()
     }

--- a/crates/polars-io/src/parquet/read/predicates.rs
+++ b/crates/polars-io/src/parquet/read/predicates.rs
@@ -1,4 +1,4 @@
-use polars_core::prelude::*;
+use polars_core::{config, prelude::*};
 use polars_parquet::read::statistics::{deserialize, Statistics};
 use polars_parquet::read::RowGroupMetadata;
 
@@ -111,15 +111,15 @@ pub fn read_this_row_group(
             }
         }
 
-        // if config::verbose() {
-        //     if should_read {
-        //         eprintln!(
-        //             "parquet row group must be read, statistics not sufficient for predicate."
-        //         );
-        //     } else {
-        //         eprintln!("parquet row group can be skipped, the statistics were sufficient to apply the predicate.");
-        //     }
-        // }
+        if config::verbose() {
+            if should_read {
+                eprintln!(
+                    "parquet row group must be read, statistics not sufficient for predicate."
+                );
+            } else {
+                eprintln!("parquet row group can be skipped, the statistics were sufficient to apply the predicate.");
+            }
+        }
     }
 
     Ok(should_read)

--- a/crates/polars-io/src/parquet/read/predicates.rs
+++ b/crates/polars-io/src/parquet/read/predicates.rs
@@ -1,4 +1,5 @@
-use polars_core::{config, prelude::*};
+use polars_core::config;
+use polars_core::prelude::*;
 use polars_parquet::read::statistics::{deserialize, Statistics};
 use polars_parquet::read::RowGroupMetadata;
 

--- a/crates/polars-io/src/parquet/read/predicates.rs
+++ b/crates/polars-io/src/parquet/read/predicates.rs
@@ -1,4 +1,3 @@
-use polars_core::config;
 use polars_core::prelude::*;
 use polars_parquet::read::statistics::{deserialize, Statistics};
 use polars_parquet::read::RowGroupMetadata;
@@ -112,15 +111,15 @@ pub fn read_this_row_group(
             }
         }
 
-        if config::verbose() {
-            if should_read {
-                eprintln!(
-                    "parquet row group must be read, statistics not sufficient for predicate."
-                );
-            } else {
-                eprintln!("parquet row group can be skipped, the statistics were sufficient to apply the predicate.");
-            }
-        }
+        // if config::verbose() {
+        //     if should_read {
+        //         eprintln!(
+        //             "parquet row group must be read, statistics not sufficient for predicate."
+        //         );
+        //     } else {
+        //         eprintln!("parquet row group can be skipped, the statistics were sufficient to apply the predicate.");
+        //     }
+        // }
     }
 
     Ok(should_read)

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -839,7 +839,7 @@ impl EquiJoinNode {
 
 // Not ideal - doesn't support stop requests before all cached items are flushed.
 fn insert_cached_into_parallel_stream<'s, 'env>(
-    cached: &'s Vec<Morsel>,
+    cached: &'s [Morsel],
     cached_idx: &'s AtomicUsize,
     num_pipelines: usize,
     recv_port: Option<RecvPort<'_>>,
@@ -956,7 +956,7 @@ impl ComputeNode for EquiJoinNode {
                 };
 
                 // Simulate the sample build morsels flowing into the build side.
-                if sampled_build_morsels.len() > 0 {
+                if !sampled_build_morsels.is_empty() {
                     let state = ExecutionState::new();
                     let sampled_build_morsel_idx = AtomicUsize::new(0);
                     crate::async_executor::task_scope(|scope| {

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -66,7 +66,7 @@ def test_categorical_full_outer_join() -> None:
         ]
     )
 
-    df = dfa.join(dfb, on="key", how="full")
+    df = dfa.join(dfb, on="key", how="full", maintain_order="right_left")
     # the cast is important to test the rev map
     assert df["key"].cast(pl.String).to_list() == ["bar", None, "foo"]
     assert df["key_right"].cast(pl.String).to_list() == ["bar", "baz", None]

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -826,7 +826,7 @@ def test_full_outer_join_coalesce_different_names_13450() -> None:
     )
 
     out = df1.join(df2, left_on="L1", right_on="L3", how="full", coalesce=True)
-    assert_frame_equal(out, expected)
+    assert_frame_equal(out, expected, check_row_order=False)
 
 
 # https://github.com/pola-rs/polars/issues/10663

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -108,13 +108,15 @@ def test_struct_unique_df() -> None:
 
 
 def test_sorted_unique_dates() -> None:
-    assert (
+    out = (
         pl.DataFrame(
             [pl.Series("dt", [date(2015, 6, 24), date(2015, 6, 23)], dtype=pl.Date)]
         )
         .sort("dt")
         .unique(maintain_order=False)
-    ).to_dict(as_series=False) == {"dt": [date(2015, 6, 23), date(2015, 6, 24)]}
+    )
+    expected = pl.DataFrame({"dt": [date(2015, 6, 23), date(2015, 6, 24)]})
+    assert_frame_equal(out, expected, check_row_order=False)
 
 
 @pytest.mark.parametrize("maintain_order", [True, False])

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -165,8 +165,9 @@ def test_join_null_matches(streaming: bool) -> None:
         {"idx_a": [0, 1, 2], "a": [None, 1, 2], "idx_b": [None, 2, 1]}
     )
     assert_frame_equal(
-        df_a.join(df_b, on="a", how="left").collect(streaming=streaming), expected,
-        check_row_order=False
+        df_a.join(df_b, on="a", how="left").collect(streaming=streaming),
+        expected,
+        check_row_order=False,
     )
     # Full outer
     expected = pl.DataFrame(
@@ -203,7 +204,7 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
     assert_frame_equal(
         df_a.join(df_b, on=["a", "idx"], how="inner").collect(streaming=streaming),
         expected,
-        check_row_order=False
+        check_row_order=False,
     )
     expected = pl.DataFrame(
         {"a": [None, 1, 2], "idx": [0, 1, 2], "c": [None, 50, None]}
@@ -211,7 +212,7 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
     assert_frame_equal(
         df_a.join(df_b, on=["a", "idx"], how="left").collect(streaming=streaming),
         expected,
-        check_row_order=False
+        check_row_order=False,
     )
 
     expected = pl.DataFrame(

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -165,7 +165,8 @@ def test_join_null_matches(streaming: bool) -> None:
         {"idx_a": [0, 1, 2], "a": [None, 1, 2], "idx_b": [None, 2, 1]}
     )
     assert_frame_equal(
-        df_a.join(df_b, on="a", how="left").collect(streaming=streaming), expected
+        df_a.join(df_b, on="a", how="left").collect(streaming=streaming), expected,
+        check_row_order=False
     )
     # Full outer
     expected = pl.DataFrame(
@@ -202,6 +203,7 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
     assert_frame_equal(
         df_a.join(df_b, on=["a", "idx"], how="inner").collect(streaming=streaming),
         expected,
+        check_row_order=False
     )
     expected = pl.DataFrame(
         {"a": [None, 1, 2], "idx": [0, 1, 2], "c": [None, 50, None]}
@@ -209,6 +211,7 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
     assert_frame_equal(
         df_a.join(df_b, on=["a", "idx"], how="left").collect(streaming=streaming),
         expected,
+        check_row_order=False
     )
 
     expected = pl.DataFrame(

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -389,6 +389,7 @@ def test_schema_full_outer_join_projection_pd_13287() -> None:
         how="full",
         left_on="a",
         right_on="c",
+        maintain_order="right_left",
     ).with_columns(
         pl.col("a").fill_null(pl.col("c")),
     ).select("a").collect().to_dict(as_series=False) == {"a": [2, 3, 1, 1]}


### PR DESCRIPTION
The new streaming engine's join will now buffer at least `POLARS_JOIN_SAMPLE_LIMIT` rows (default 10 million) from both sides of the join before deciding which side will become a build or probe side.