### PR TITLE
feat: Implement `merge_sorted` for struct

### DIFF
--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -159,6 +159,13 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> Vec<bool> {
             let rhs = rhs_s.binary().unwrap();
             get_merge_indicator(lhs.into_iter(), rhs.into_iter())
         },
+        #[cfg(feature = "dtype-struct")]
+        DataType::Struct(_) => {
+            let options = SortOptions::default();
+            let lhs = lhs_s.struct_().unwrap().get_row_encoded(options).unwrap();
+            let rhs = rhs_s.struct_().unwrap().get_row_encoded(options).unwrap();
+            get_merge_indicator(lhs.into_iter(), rhs.into_iter())
+        },
         _ => {
             with_match_physical_numeric_polars_type!(lhs_s.dtype(), |$T| {
                     let lhs: &ChunkedArray<$T> = lhs_s.as_ref().as_ref().as_ref();

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -90,7 +90,10 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> PolarsR
                 .fields_as_series()
                 .iter()
                 .zip(rhs.fields_as_series())
-                .map(|(lhs, rhs)| merge_series(lhs, &rhs, merge_indicator))
+                .map(|(lhs, rhs)| {
+                    merge_series(lhs, &rhs, merge_indicator)
+                        .map(|merged| merged.with_name(lhs.name().clone()))
+                })
                 .collect::<PolarsResult<Vec<_>>>()?;
             StructChunked::from_series(PlSmallStr::EMPTY, new_fields[0].len(), new_fields.iter())
                 .unwrap()

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -173,10 +173,31 @@ def test_merge_sorted_parametric_string(lhs: pl.Series, rhs: pl.Series) -> None:
 
 
 @given(
+    lhs=series(
+        name="a",
+        allowed_dtypes=[pl.Struct({"x": pl.Int32, "y": pl.Int8})],
+        allow_null=False,
+    ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
+    rhs=series(
+        name="a",
+        allowed_dtypes=[pl.Struct({"x": pl.Int32, "y": pl.Int8})],
+        allow_null=False,
+    ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
+)
+def test_merge_sorted_parametric_struct(lhs: pl.Series, rhs: pl.Series) -> None:
+    l_df = pl.DataFrame([lhs.sort()])
+    r_df = pl.DataFrame([rhs.sort()])
+
+    merge_sorted = l_df.lazy().merge_sorted(r_df.lazy(), "a").collect().get_column("a")
+    append_sorted = lhs.append(rhs).sort()
+
+    assert_series_equal(merge_sorted, append_sorted)
+
+
+@given(
     s=series(
         name="a",
         excluded_dtypes=[
-            pl.Struct,  # Bug. See https://github.com/pola-rs/polars/issues/20986
             pl.Categorical(
                 ordering="lexical"
             ),  # Bug. See https://github.com/pola-rs/polars/issues/21025

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -175,12 +175,16 @@ def test_merge_sorted_parametric_string(lhs: pl.Series, rhs: pl.Series) -> None:
 @given(
     lhs=series(
         name="a",
-        allowed_dtypes=[pl.Struct({"x": pl.Int32, "y": pl.Int8})],
+        allowed_dtypes=[
+            pl.Struct({"x": pl.Int32, "y": pl.Struct({"x": pl.Int8, "y": pl.Int8})})
+        ],
         allow_null=False,
     ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
     rhs=series(
         name="a",
-        allowed_dtypes=[pl.Struct({"x": pl.Int32, "y": pl.Int8})],
+        allowed_dtypes=[
+            pl.Struct({"x": pl.Int32, "y": pl.Struct({"x": pl.Int8, "y": pl.Int8})})
+        ],
         allow_null=False,
     ),  # Nulls see: https://github.com/pola-rs/polars/issues/20991
 )


### PR DESCRIPTION
This PR implements `merge_sort` by struct-typed columns and fixes a bug where the field column names would be empty after merging.

Closes https://github.com/pola-rs/polars/issues/20986
Closes https://github.com/pola-rs/polars/issues/13485

```python
import polars as pl

df1 = pl.DataFrame({
    "a": [{"x": 1, "y": 1}, {"x": 1, "y": 3}, {"x": 2, "y": 2}],
})
df2 = pl.DataFrame({
    "a": [{"x": 1, "y": 2}, {"x": 2, "y": 1}, {"x": 2, "y": 3}],
})

print(df1.merge_sorted(df2, "a"))

# shape: (6, 1)
# ┌───────────┐
# │ a         │
# │ ---       │
# │ struct[2] │
# ╞═══════════╡
# │ {1,1}     │
# │ {1,2}     │
# │ {1,3}     │
# │ {2,1}     │
# │ {2,2}     │
# │ {2,3}     │
# └───────────┘
```