### PR TITLE
fix: Checking overflow in Sliced function

### DIFF
--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -444,8 +444,11 @@ macro_rules! impl_sliced {
         #[inline]
         #[must_use]
         pub fn sliced(self, offset: usize, length: usize) -> Self {
+            let total = offset
+                .checked_add(length)
+                .expect("offset + length overflowed");
             assert!(
-                offset + length <= self.len(),
+                total <= self.len(),
                 "the offset of the new Buffer cannot exceed the existing length"
             );
             unsafe { Self::sliced_unchecked(self, offset, length) }


### PR DESCRIPTION
Fixes #20239
This issue happens in release mode when integer overflow is wrapped.

We can use checked_add function of usize to check for overflow in release mode without letting it wrap.
Using expect, lets the code panic fulfilling the assertion.