### PR TITLE
docs(python): Update social icons in API reference docs

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -145,9 +145,9 @@ html_theme_options = {
             "icon": "fa-brands fa-discord",
         },
         {
-            "name": "Twitter",
-            "url": "https://twitter.com/DataPolars",
-            "icon": "fa-brands fa-twitter",
+            "name": "X/Twitter",
+            "url": "https://x.com/datapolars",
+            "icon": "fa-brands fa-x-twitter",
         },
     ],
     "logo": {

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -149,6 +149,11 @@ html_theme_options = {
             "url": "https://x.com/datapolars",
             "icon": "fa-brands fa-x-twitter",
         },
+        {
+            "name": "Bluesky",
+            "url": "https://bsky.app/profile/pola.rs",
+            "icon": "fa-brands fa-bluesky",
+        },
     ],
     "logo": {
         "image_light": f"{static_assets_root}/logos/polars-logo-dark-medium.png",


### PR DESCRIPTION
Twitter was rebranded to X in 2023, so I thought it would be time to replace the Twitter logo in our API reference docs.