### PR TITLE
refactor(python): Avoid unnecessary `packaging` dependency

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4486,14 +4486,13 @@ class DataFrame:
 
         from deltalake import DeltaTable, write_deltalake
         from deltalake import __version__ as delta_version
-        from packaging.version import Version
 
         _check_for_unsupported_types(self.dtypes)
 
         if isinstance(target, (str, Path)):
             target = _resolve_delta_lake_uri(str(target), strict=False)
 
-        if Version(delta_version) >= Version("0.23.0"):
+        if parse_version(delta_version) >= (0, 23, 0):
             data = self.to_arrow(compat_level=CompatLevel.newest())
         else:
             data = self.to_arrow()


### PR DESCRIPTION
Closes #21221.

Unnecessary import of the `packaging` module (inside `write_delta()`).
We can use our own `parse_version()` here to drop the dependency 👌 