### PR TITLE
feat: Add a dedicated `remove` method for `DataFrame` and `LazyFrame`

### DIFF
--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -875,6 +875,11 @@ impl PyLazyFrame {
         ldf.filter(predicate.inner).into()
     }
 
+    fn remove(&mut self, predicate: PyExpr) -> Self {
+        let ldf = self.ldf.clone();
+        ldf.remove(predicate.inner).into()
+    }
+
     fn select(&mut self, exprs: Vec<PyExpr>) -> Self {
         let ldf = self.ldf.clone();
         let exprs = exprs.to_exprs();

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -996,11 +996,11 @@ impl SQLContext {
                 filter_expression = all_horizontal([filter_expression])?;
             }
             lf = self.process_subqueries(lf, vec![&mut filter_expression]);
-            if invert_filter {
-                // negate the filter (being careful about null values)
-                filter_expression = filter_expression.neq_missing(lit(true))
-            }
-            lf = lf.filter(filter_expression);
+            lf = if invert_filter {
+                lf.remove(filter_expression)
+            } else {
+                lf.filter(filter_expression)
+            };
         }
         Ok(lf)
     }

--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -44,6 +44,7 @@ Manipulation/selection
     DataFrame.pipe
     DataFrame.pivot
     DataFrame.rechunk
+    DataFrame.remove
     DataFrame.rename
     DataFrame.replace_column
     DataFrame.reverse

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -32,6 +32,7 @@ Manipulation/selection
     LazyFrame.limit
     LazyFrame.melt
     LazyFrame.merge_sorted
+    LazyFrame.remove
     LazyFrame.rename
     LazyFrame.reverse
     LazyFrame.rolling

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4892,30 +4892,29 @@ class DataFrame:
         **constraints: Any,
     ) -> DataFrame:
         """
-        Filter the rows in the DataFrame based on one or more predicate expressions.
+        Filter rows, retaining those that match the given predicate expression(s).
 
         The original order of the remaining rows is preserved.
 
-        Rows where the filter does not evaluate to True are discarded, including nulls.
+        Only rows where the predicate resolves as True are retained; when the
+        predicate result is False (or null), the row is discarded.
 
         Parameters
         ----------
         predicates
-            Expression(s) that evaluates to a boolean Series.
+            Expression(s) that evaluate to a boolean Series.
         constraints
             Column filters; use `name = value` to filter columns by the supplied value.
             Each constraint will behave the same as `pl.col(name).eq(value)`, and
-            will be implicitly joined with the other filter conditions using `&`.
+            be implicitly joined with the other filter conditions using `&`.
 
         Notes
         -----
-        If you are transitioning from pandas and performing filter operations based on
-        the comparison of two or more columns, please note that in Polars,
-        any comparison involving null values will always result in null.
-        As a result, these rows will be filtered out.
-        Ensure to handle null values appropriately to avoid unintended filtering
-        (See examples below).
-
+        If you are transitioning from Pandas, and performing filter operations based on
+        the comparison of two or more columns, please note that in Polars any comparison
+        involving `null` values will result in a `null` result, *not* boolean True or
+        False. As a result, these rows will not be retained. Ensure that null values
+        are handled appropriately to avoid unexpected behaviour (see examples below).
 
         Examples
         --------
@@ -4927,7 +4926,7 @@ class DataFrame:
         ...     }
         ... )
 
-        Filter on one condition:
+        Filter rows matching a condition:
 
         >>> df.filter(pl.col("foo") > 1)
         shape: (3, 3)
@@ -4943,7 +4942,9 @@ class DataFrame:
 
         Filter on multiple conditions, combined with and/or operators:
 
-        >>> df.filter((pl.col("foo") < 3) & (pl.col("ham") == "a"))
+        >>> df.filter(
+        ...     (pl.col("foo") < 3) & (pl.col("ham") == "a"),
+        ... )
         shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -4953,7 +4954,9 @@ class DataFrame:
         │ 1   ┆ 6   ┆ a   │
         └─────┴─────┴─────┘
 
-        >>> df.filter((pl.col("foo") == 1) | (pl.col("ham") == "c"))
+        >>> df.filter(
+        ...     (pl.col("foo") == 1) | (pl.col("ham") == "c"),
+        ... )
         shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -4992,9 +4995,11 @@ class DataFrame:
         │ 2   ┆ 7   ┆ b   │
         └─────┴─────┴─────┘
 
-        Filter by comparing two columns against each other
+        Filter by comparing two columns against each other:
 
-        >>> df.filter(pl.col("foo") == pl.col("bar"))
+        >>> df.filter(
+        ...     pl.col("foo") == pl.col("bar"),
+        ... )
         shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -5004,7 +5009,9 @@ class DataFrame:
         │ 0   ┆ 0   ┆ f   │
         └─────┴─────┴─────┘
 
-        >>> df.filter(pl.col("foo") != pl.col("bar"))
+        >>> df.filter(
+        ...     pl.col("foo") != pl.col("bar"),
+        ... )
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -5019,7 +5026,9 @@ class DataFrame:
         Notice how the row with `None` values is filtered out. In order to keep the
         same behavior as pandas, use:
 
-        >>> df.filter(pl.col("foo").ne_missing(pl.col("bar")))
+        >>> df.filter(
+        ...     pl.col("foo").ne_missing(pl.col("bar")),
+        ... )
         shape: (5, 3)
         ┌──────┬──────┬─────┐
         │ foo  ┆ bar  ┆ ham │
@@ -5032,9 +5041,143 @@ class DataFrame:
         │ 4    ┆ null ┆ d   │
         │ null ┆ 9    ┆ e   │
         └──────┴──────┴─────┘
-
         """
         return self.lazy().filter(*predicates, **constraints).collect(_eager=True)
+
+    def remove(
+        self,
+        *predicates: (
+            IntoExprColumn
+            | Iterable[IntoExprColumn]
+            | bool
+            | list[bool]
+            | np.ndarray[Any, Any]
+        ),
+        **constraints: Any,
+    ) -> DataFrame:
+        """
+        Remove rows, dropping those that match the given predicate expression(s).
+
+        The original order of the remaining rows is preserved.
+
+        Rows where the filter predicate does not evaluate to True are retained
+        (this includes rows where the predicate evaluates as `null`).
+
+        Parameters
+        ----------
+        predicates
+            Expression that evaluates to a boolean Series.
+        constraints
+            Column filters; use `name = value` to filter columns using the supplied
+            value. Each constraint behaves the same as `pl.col(name).eq(value)`,
+            and is implicitly joined with the other filter conditions using `&`.
+
+        Notes
+        -----
+        If you are transitioning from Pandas, and performing filter operations based on
+        the comparison of two or more columns, please note that in Polars any comparison
+        involving `null` values will result in a `null` result, *not* boolean True or
+        False. As a result, these rows will not be removed. Ensure that null values
+        are handled appropriately to avoid unexpected behaviour (see examples below).
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [2, 3, None, 4, 0],
+        ...         "bar": [5, 6, None, None, 0],
+        ...         "ham": ["a", "b", None, "c", "d"],
+        ...     }
+        ... )
+
+        Remove rows matching a condition:
+
+        >>> df.remove(pl.col("bar") >= 5)
+        shape: (3, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        │ 0    ┆ 0    ┆ d    │
+        └──────┴──────┴──────┘
+
+        Discard rows based on multiple conditions, combined with and/or operators:
+
+        >>> df.remove(
+        ...     (pl.col("foo") >= 0) & (pl.col("bar") >= 0),
+        ... )
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        └──────┴──────┴──────┘
+
+        >>> df.remove(
+        ...     (pl.col("foo") >= 0) | (pl.col("bar") >= 0),
+        ... )
+        shape: (1, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        └──────┴──────┴──────┘
+
+        Provide multiple constraints using `*args` syntax:
+
+        >>> df.remove(
+        ...     pl.col("ham").is_not_null(),
+        ...     pl.col("bar") >= 0,
+        ... )
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        └──────┴──────┴──────┘
+
+        Provide constraints(s) using `**kwargs` syntax:
+
+        >>> df.remove(foo=0, bar=0)
+        shape: (4, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ 2    ┆ 5    ┆ a    │
+        │ 3    ┆ 6    ┆ b    │
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        └──────┴──────┴──────┘
+
+        Remove rows by comparing two columns against each other:
+
+        >>> df.remove(
+        ...     pl.col("foo").ne_missing(pl.col("bar")),
+        ... )
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 0    ┆ 0    ┆ d    │
+        └──────┴──────┴──────┘
+        """
+        return self.lazy().remove(*predicates, **constraints).collect(_eager=True)
 
     @overload
     def glimpse(
@@ -7293,7 +7436,6 @@ class DataFrame:
         │ Netherlands ┆ 2018-08-01 ┆ 17.32      ┆ 910  │
         │ Netherlands ┆ 2019-01-01 ┆ 17.4       ┆ 910  │
         └─────────────┴────────────┴────────────┴──────┘
-
         """
         if not isinstance(other, DataFrame):
             msg = f"expected `other` join table to be a DataFrame, got {type(other).__name__!r}"
@@ -7628,7 +7770,6 @@ class DataFrame:
         │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 676  ┆ 150  ┆ 15   ┆ 1           │
         │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 742  ┆ 170  ┆ 16   ┆ 4           │
         └─────┴─────┴─────┴───────┴──────┴──────┴──────┴─────────────┘
-
         """
         if not isinstance(other, DataFrame):
             msg = f"expected `other` join table to be a DataFrame, got {type(other).__name__!r}"

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4916,6 +4916,10 @@ class DataFrame:
         False. As a result, these rows will not be retained. Ensure that null values
         are handled appropriately to avoid unexpected behaviour (see examples below).
 
+        See Also
+        --------
+        remove
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -5079,6 +5083,10 @@ class DataFrame:
         involving `null` values will result in a `null` result, *not* boolean True or
         False. As a result, these rows will not be removed. Ensure that null values
         are handled appropriately to avoid unexpected behaviour (see examples below).
+
+        See Also
+        --------
+        filter
 
         Examples
         --------

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -348,7 +348,6 @@ class ExprArrayNameSpace:
         │ [3, 2, 1]     ┆ [3, 2, 1]     │
         │ [9, 1, 2]     ┆ [9, 2, 1]     │
         └───────────────┴───────────────┘
-
         """
         return wrap_expr(self._pyexpr.arr_sort(descending, nulls_last))
 
@@ -374,7 +373,6 @@ class ExprArrayNameSpace:
         │ [3, 2, 1]     ┆ [1, 2, 3]     │
         │ [9, 1, 2]     ┆ [2, 1, 9]     │
         └───────────────┴───────────────┘
-
         """
         return wrap_expr(self._pyexpr.arr_reverse())
 
@@ -406,7 +404,6 @@ class ExprArrayNameSpace:
         │ [1, 2]        ┆ 0       │
         │ [2, 1]        ┆ 1       │
         └───────────────┴─────────┘
-
         """
         return wrap_expr(self._pyexpr.arr_arg_min())
 
@@ -438,7 +435,6 @@ class ExprArrayNameSpace:
         │ [1, 2]        ┆ 1       │
         │ [2, 1]        ┆ 0       │
         └───────────────┴─────────┘
-
         """
         return wrap_expr(self._pyexpr.arr_arg_max())
 
@@ -476,7 +472,6 @@ class ExprArrayNameSpace:
         │ [4, 5, 6]     ┆ -2  ┆ 5   │
         │ [7, 8, 9]     ┆ 0   ┆ 7   │
         └───────────────┴─────┴─────┘
-
         """
         index = parse_into_expression(index)
         return wrap_expr(self._pyexpr.arr_get(index, null_on_oob))
@@ -502,7 +497,6 @@ class ExprArrayNameSpace:
         │ [4, 5, 6]     ┆ 4     │
         │ [7, 8, 9]     ┆ 7     │
         └───────────────┴───────┘
-
         """
         return self.get(0, null_on_oob=True)
 
@@ -527,7 +521,6 @@ class ExprArrayNameSpace:
         │ [4, 5, 6]     ┆ 6    │
         │ [7, 9, 8]     ┆ 8    │
         └───────────────┴──────┘
-
         """
         return self.get(-1, null_on_oob=True)
 
@@ -571,7 +564,6 @@ class ExprArrayNameSpace:
         │ ["a", "b"]    ┆ *         ┆ a*b  │
         │ ["x", "y"]    ┆ _         ┆ x_y  │
         └───────────────┴───────────┴──────┘
-
         """
         separator = parse_into_expression(separator, str_as_lit=True)
         return wrap_expr(self._pyexpr.arr_join(separator, ignore_nulls))
@@ -640,7 +632,6 @@ class ExprArrayNameSpace:
         │ ["x", "y"]    ┆ false    │
         │ ["a", "c"]    ┆ true     │
         └───────────────┴──────────┘
-
         """
         item = parse_into_expression(item, str_as_lit=True)
         return wrap_expr(self._pyexpr.arr_contains(item))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1494,7 +1494,6 @@ class Expr:
         │ 1   ┆ 1       ┆ 1               │
         │ 2   ┆ 1       ┆ 2               │
         └─────┴─────────┴─────────────────┘
-
         """
         return self._from_pyexpr(self._pyexpr.cum_min(reverse))
 
@@ -4216,7 +4215,7 @@ class Expr:
         constraints
             Column filters; use `name = value` to filter columns by the supplied value.
             Each constraint will behave the same as `pl.col(name).eq(value)`, and
-            will be implicitly joined with the other filter conditions using `&`.
+            be implicitly joined with the other filter conditions using `&`.
 
         Examples
         --------
@@ -4484,7 +4483,6 @@ class Expr:
         │ 0   ┆ 3   ┆ 0         │
         │ 3   ┆ 4   ┆ 12        │
         └─────┴─────┴───────────┘
-
         """
         if return_dtype is not None:
             return_dtype = parse_into_dtype(return_dtype)

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2724,7 +2724,6 @@ class ExprStringNameSpace:
         │ ["disco"]       │
         │ ["rhap", "ody"] │
         └─────────────────┘
-
         """
         patterns = parse_into_expression(
             patterns, str_as_lit=False, list_as_series=True
@@ -2803,7 +2802,6 @@ class ExprStringNameSpace:
         │ [0]       │
         │ [0, 5]    │
         └───────────┘
-
         """
         patterns = parse_into_expression(
             patterns, str_as_lit=False, list_as_series=True

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -143,7 +143,6 @@ class ExprStructNameSpace:
         │ ab  │
         │ cd  │
         └─────┘
-
         """
         if more_names:
             name = [*([name] if isinstance(name, str) else name), *more_names]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3335,6 +3335,91 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self._from_pyldf(self._ldf.clone())
 
+    def _filter(
+        self,
+        *,
+        predicates: tuple[
+            IntoExprColumn
+            | Iterable[IntoExprColumn]
+            | bool
+            | list[bool]
+            | np.ndarray[Any, Any],
+            ...,
+        ],
+        constraints: dict[str, Any],
+        invert: bool = False,
+    ) -> LazyFrame:
+        """Common code for filter/remove ops."""
+        all_predicates: list[pl.Expr] = []
+        boolean_masks = []
+
+        for p in predicates:
+            # quick exit/skip conditions
+            if (p is False and invert) or (p is True and not invert):
+                continue  # ignore; doesn't filter/remove anything
+            if (p is True and invert) or (p is False and not invert):
+                return self.clear()  # discard all rows
+
+            if _is_generator(p):
+                p = tuple(p)
+
+            # note: identify masks separately from predicates
+            if is_bool_sequence(p, include_series=True):
+                boolean_masks.append(pl.Series(p, dtype=Boolean))
+            elif (
+                (is_seq := is_sequence(p))
+                and any(not isinstance(x, pl.Expr) for x in p)
+            ) or (
+                not is_seq
+                and not isinstance(p, pl.Expr)
+                and not (isinstance(p, str) and p in self.collect_schema())
+            ):
+                err = (
+                    f"Series(…, dtype={p.dtype})"
+                    if isinstance(p, pl.Series)
+                    else repr(p)
+                )
+                msg = f"invalid predicate for `filter`: {err}"
+                raise TypeError(msg)
+            else:
+                all_predicates.extend(
+                    wrap_expr(x) for x in parse_into_list_of_expressions(p)
+                )
+
+        # unpack equality constraints from kwargs
+        all_predicates.extend(
+            F.col(name).eq(value) for name, value in constraints.items()
+        )
+        if not (all_predicates or boolean_masks):
+            msg = "at least one predicate or constraint must be provided"
+            raise TypeError(msg)
+
+        # if multiple predicates, combine as 'horizontal' expression
+        combined_predicate = (
+            (
+                F.all_horizontal(*all_predicates)
+                if len(all_predicates) > 1
+                else all_predicates[0]
+            )
+            if all_predicates
+            else None
+        )
+
+        # apply reduced boolean mask first, if applicable, then predicates
+        if boolean_masks:
+            mask_expr = F.lit(reduce(and_, boolean_masks))
+            combined_predicate = (
+                mask_expr
+                if combined_predicate is None
+                else mask_expr & combined_predicate
+            )
+
+        if combined_predicate is None:
+            return self._from_pyldf(self._ldf)
+
+        filter_method = self._ldf.remove if invert else self._ldf.filter
+        return self._from_pyldf(filter_method(combined_predicate._pyexpr))
+
     def filter(
         self,
         *predicates: (
@@ -3347,29 +3432,29 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         **constraints: Any,
     ) -> LazyFrame:
         """
-        Filter the rows in the LazyFrame based on a predicate expression.
+        Filter rows in the LazyFrame based on a predicate expression.
 
         The original order of the remaining rows is preserved.
 
-        Rows where the filter does not evaluate to True are discarded, including nulls.
+        Rows where the filter predicate does not evaluate to True are discarded
+        (this includes rows where the predicate evaluates as `null`).
 
         Parameters
         ----------
         predicates
             Expression that evaluates to a boolean Series.
         constraints
-            Column filters; use `name = value` to filter columns by the supplied value.
-            Each constraint will behave the same as `pl.col(name).eq(value)`, and
-            will be implicitly joined with the other filter conditions using `&`.
+            Column filters; use `name = value` to filter columns using the supplied
+            value. Each constraint behaves the same as `pl.col(name).eq(value)`,
+            and is implicitly joined with the other filter conditions using `&`.
 
         Notes
         -----
-        If you are transitioning from pandas and performing filter operations based on
-        the comparison of two or more columns, please note that in Polars,
-        any comparison involving null values will always result in null.
-        As a result, these rows will be filtered out.
-        Ensure to handle null values appropriately to avoid unintended filtering
-        (See examples below).
+        If you are transitioning from Pandas, and performing filter operations based on
+        the comparison of two or more columns, please note that in Polars any comparison
+        involving `null` values will result in a `null` result, *not* boolean True or
+        False. As a result, these rows will not be retained. Ensure that null values
+        are handled appropriately to avoid unexpected behaviour (see examples below).
 
         Examples
         --------
@@ -3436,7 +3521,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Filter on an OR condition:
 
-        >>> lf.filter((pl.col("foo") == 1) | (pl.col("ham") == "c")).collect()
+        >>> lf.filter(
+        ...     (pl.col("foo") == 1) | (pl.col("ham") == "c"),
+        ... ).collect()
         shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -3449,7 +3536,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Filter by comparing two columns against each other
 
-        >>> lf.filter(pl.col("foo") == pl.col("bar")).collect()
+        >>> lf.filter(
+        ...     pl.col("foo") == pl.col("bar"),
+        ... ).collect()
         shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -3459,7 +3548,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 0   ┆ 0   ┆ f   │
         └─────┴─────┴─────┘
 
-        >>> lf.filter(pl.col("foo") != pl.col("bar")).collect()
+        >>> lf.filter(
+        ...     pl.col("foo") != pl.col("bar"),
+        ... ).collect()
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -3471,10 +3562,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
-        Notice how the row with `None` values is filtered out.
-        In order to keep the same behavior as pandas, use:
+        Notice how the row with `None` values is filtered out; using `ne_missing`
+        ensures that null values compare equal, and we get similar behaviour to Pandas:
 
-        >>> lf.filter(pl.col("foo").ne_missing(pl.col("bar"))).collect()
+        >>> lf.filter(
+        ...     pl.col("foo").ne_missing(pl.col("bar")),
+        ... ).collect()
         shape: (5, 3)
         ┌──────┬──────┬─────┐
         │ foo  ┆ bar  ┆ ham │
@@ -3488,70 +3581,167 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ null ┆ 9    ┆ e   │
         └──────┴──────┴─────┘
         """
-        all_predicates: list[pl.Expr] = []
-        boolean_masks = []
-
-        # no-op; immediately matches all rows
-        if len(predicates) == 1 and predicates[0] is True and not constraints:
-            return self.clone()
-
-        # note: identify masks separately from predicates
-        for p in predicates:
-            if p is False:  # immediately disallows all rows
+        if not constraints:
+            # early-exit conditions (exclude/include all rows)
+            if not predicates or (len(predicates) == 1 and predicates[0] is True):
+                return self.clone()
+            if len(predicates) == 1 and predicates[0] is False:
                 return self.clear()
-            elif p is True:
-                continue  # no-op; matches all rows
-            if _is_generator(p):
-                p = tuple(p)
-            if is_bool_sequence(p, include_series=True):
-                boolean_masks.append(pl.Series(p, dtype=Boolean))
-            elif (
-                (is_seq := is_sequence(p))
-                and any(not isinstance(x, pl.Expr) for x in p)
-            ) or (
-                not is_seq
-                and not isinstance(p, pl.Expr)
-                and not (isinstance(p, str) and p in self.collect_schema())
-            ):
-                err = (
-                    f"Series(…, dtype={p.dtype})"
-                    if isinstance(p, pl.Series)
-                    else repr(p)
-                )
-                msg = f"invalid predicate for `filter`: {err}"
-                raise TypeError(msg)
-            else:
-                all_predicates.extend(
-                    wrap_expr(x) for x in parse_into_list_of_expressions(p)
-                )
 
-        # unpack equality constraints from kwargs
-        all_predicates.extend(
-            F.col(name).eq(value) for name, value in constraints.items()
-        )
-        if not (all_predicates or boolean_masks):
-            msg = "at least one predicate or constraint must be provided"
-            raise TypeError(msg)
-
-        # if multiple predicates, combine as 'horizontal' expression
-        combined_predicate = (
-            (
-                F.all_horizontal(*all_predicates)
-                if len(all_predicates) > 1
-                else all_predicates[0]
-            )._pyexpr
-            if all_predicates
-            else None
+        return self._filter(
+            predicates=predicates,
+            constraints=constraints,
+            invert=False,
         )
 
-        # apply reduced boolean mask first, if applicable, then predicates
-        ldf = (
-            self._ldf.filter(F.lit(reduce(and_, boolean_masks))._pyexpr)
-            if boolean_masks
-            else self._ldf
-        )
-        return self._from_pyldf(
-            ldf if combined_predicate is None else ldf.filter(combined_predicate)
+    def remove(
+        self,
+        *predicates: (
+            IntoExprColumn
+            | Iterable[IntoExprColumn]
+            | bool
+            | list[bool]
+            | np.ndarray[Any, Any]
+        ),
+        **constraints: Any,
+    ) -> LazyFrame:
+        """
+        Remove rows, dropping those that match the given predicate expression(s).
+
+        The original order of the remaining rows is preserved.
+
+        Rows where the filter predicate does not evaluate to True are retained
+        (this includes rows where the predicate evaluates as `null`).
+
+        Parameters
+        ----------
+        predicates
+            Expression that evaluates to a boolean Series.
+        constraints
+            Column filters; use `name = value` to filter columns using the supplied
+            value. Each constraint behaves the same as `pl.col(name).eq(value)`,
+            and is implicitly joined with the other filter conditions using `&`.
+
+        Notes
+        -----
+        If you are transitioning from Pandas, and performing filter operations based on
+        the comparison of two or more columns, please note that in Polars any comparison
+        involving `null` values will result in a `null` result, *not* boolean True or
+        False. As a result, these rows will not be removed. Ensure that null values
+        are handled appropriately to avoid unexpected behaviour (see examples below).
+
+        Examples
+        --------
+        >>> lf = pl.LazyFrame(
+        ...     {
+        ...         "foo": [2, 3, None, 4, 0],
+        ...         "bar": [5, 6, None, None, 0],
+        ...         "ham": ["a", "b", None, "c", "d"],
+        ...     }
+        ... )
+
+        Remove rows matching a condition:
+
+        >>> lf.remove(
+        ...     pl.col("bar") >= 5,
+        ... ).collect()
+        shape: (3, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        │ 0    ┆ 0    ┆ d    │
+        └──────┴──────┴──────┘
+
+        Discard rows based on multiple conditions, combined with and/or operators:
+
+        >>> lf.remove(
+        ...     (pl.col("foo") >= 0) & (pl.col("bar") >= 0),
+        ... ).collect()
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        └──────┴──────┴──────┘
+
+        >>> lf.remove(
+        ...     (pl.col("foo") >= 0) | (pl.col("bar") >= 0),
+        ... ).collect()
+        shape: (1, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        └──────┴──────┴──────┘
+
+        Provide multiple constraints using `*args` syntax:
+
+        >>> lf.remove(
+        ...     pl.col("ham").is_not_null(),
+        ...     pl.col("bar") >= 0,
+        ... ).collect()
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        └──────┴──────┴──────┘
+
+        Provide constraints(s) using `**kwargs` syntax:
+
+        >>> lf.remove(foo=0, bar=0).collect()
+        shape: (4, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ 2    ┆ 5    ┆ a    │
+        │ 3    ┆ 6    ┆ b    │
+        │ null ┆ null ┆ null │
+        │ 4    ┆ null ┆ c    │
+        └──────┴──────┴──────┘
+
+        Remove rows by comparing two columns against each other; in this case, we
+        remove rows where the two columns are not equal (using `ne_missing` to
+        ensure that null values compare equal):
+
+        >>> lf.remove(
+        ...     pl.col("foo").ne_missing(pl.col("bar")),
+        ... ).collect()
+        shape: (2, 3)
+        ┌──────┬──────┬──────┐
+        │ foo  ┆ bar  ┆ ham  │
+        │ ---  ┆ ---  ┆ ---  │
+        │ i64  ┆ i64  ┆ str  │
+        ╞══════╪══════╪══════╡
+        │ null ┆ null ┆ null │
+        │ 0    ┆ 0    ┆ d    │
+        └──────┴──────┴──────┘
+        """
+        if not constraints:
+            # early-exit conditions (exclude/include all rows)
+            if not predicates or (len(predicates) == 1 and predicates[0] is True):
+                return self.clear()
+            if len(predicates) == 1 and predicates[0] is False:
+                return self.clone()
+
+        return self._filter(
+            predicates=predicates,
+            constraints=constraints,
+            invert=True,
         )
 
     def select(
@@ -4587,7 +4777,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ Netherlands ┆ 2018-08-01 ┆ 17.32      ┆ 910  │
         │ Netherlands ┆ 2019-01-01 ┆ 17.4       ┆ 910  │
         └─────────────┴────────────┴────────────┴──────┘
-
         """
         if not isinstance(other, LazyFrame):
             msg = f"expected `other` join table to be a LazyFrame, not a {type(other).__name__!r}"
@@ -4983,7 +5172,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 676  ┆ 150  ┆ 15   ┆ 1           │
         │ 101 ┆ 140 ┆ 14  ┆ 8     ┆ 742  ┆ 170  ┆ 16   ┆ 4           │
         └─────┴─────┴─────┴───────┴──────┴──────┴──────┴─────────────┘
-
         """
         if not isinstance(other, LazyFrame):
             msg = f"expected `other` join table to be a LazyFrame, not a {type(other).__name__!r}"

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3456,6 +3456,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         False. As a result, these rows will not be retained. Ensure that null values
         are handled appropriately to avoid unexpected behaviour (see examples below).
 
+        See Also
+        --------
+        remove
+
         Examples
         --------
         >>> lf = pl.LazyFrame(
@@ -3629,6 +3633,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         involving `null` values will result in a `null` result, *not* boolean True or
         False. As a result, these rows will not be removed. Ensure that null values
         are handled appropriately to avoid unexpected behaviour (see examples below).
+
+        See Also
+        --------
+        filter
 
         Examples
         --------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -2121,7 +2121,6 @@ class StringNameSpace:
         │ [0]       │
         │ [0, 5]    │
         └───────────┘
-
         """
 
     def join(self, delimiter: str = "", *, ignore_nulls: bool = True) -> Series:


### PR DESCRIPTION
We currently have frame-level `filter`, but after adding "DELETE" [support](https://github.com/pola-rs/polars/pull/21190) to the SQL engine it felt like we should really offer a dedicated `remove` method too:

* Aside from improved semantics (eg: it's much clearer to say _"remove rows that match this"_ rather than using `filter` to say _"don't remove rows that don't match this"_) there is also a slight subtlety as `remove(predicate)` is **not** the same thing as `filter(~predicate)`. This is because of null value comparison.

  For `filter` and `remove` to share common/consistent semantics (we require the predicate to evaluate as `True` in order to be acted on) the correct conversion is actually `filter(predicate.ne_missing(true))` - this is not necessarily immediately obvious; handling it correctly in a clearly-named method is good UX.

* Common code was factored out, and no new query/graph nodes are required (`remove` guarantees that the correct predicate conversion is done, re-using `filter` internally).

* Plenty of new tests added, various docstrings tidied-up / clarified, and SQL "DELETE" support was repointed to the new `remove` method.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "lbl": ["xx", "zz", "yy", "xx"],
    "ccy": ["USD", "EUR", "USD", "JPY"],
    "year": [2021, 2022, 2023, 2023],
    "total": [3245, None, -6680, 25000],
})
```
Note where `total > 0` evaluate as True...
```python
df.with_columns(pl.col("total") > 0)
# shape: (4, 4)
# ┌─────┬─────┬──────┬───────┐
# │ lbl ┆ ccy ┆ year ┆ total │
# │ --- ┆ --- ┆ ---  ┆ ---   │
# │ str ┆ str ┆ i64  ┆ bool  │
# ╞═════╪═════╪══════╪═══════╡
# │ xx  ┆ USD ┆ 2021 ┆ true  │
# │ zz  ┆ EUR ┆ 2022 ┆ null  │
# │ yy  ┆ USD ┆ 2023 ┆ false │
# │ xx  ┆ JPY ┆ 2023 ┆ true  │
# └─────┴─────┴──────┴───────┘
```
...and those are the rows that `remove` correctly discards:
```python
df.remove(pl.col("total") > 0)
# shape: (2, 4)
# ┌─────┬─────┬──────┬───────┐
# │ lbl ┆ ccy ┆ year ┆ total │
# │ --- ┆ --- ┆ ---  ┆ ---   │
# │ str ┆ str ┆ i64  ┆ i64   │
# ╞═════╪═════╪══════╪═══════╡
# │ zz  ┆ EUR ┆ 2022 ┆ null  │
# │ yy  ┆ USD ┆ 2023 ┆ -6680 │
# └─────┴─────┴──────┴───────┘
```