### PR TITLE
fix: UTF-8 validation of nested string slice in Parquet

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/mod.rs
@@ -248,6 +248,8 @@ pub fn decode_plain_generic(
     target.finish_in_progress();
     unsafe { target.views_mut() }.reserve(num_rows);
 
+    let start_target_length = target.len();
+
     let buffer_idx = target.completed_buffers().len() as u32;
     let mut buffer = Vec::with_capacity(values.len() + 1);
     let mut none_starting_with_continuation_byte = true; // Whether the transition from between strings is valid
@@ -346,7 +348,7 @@ pub fn decode_plain_generic(
 
             // @NOTE: This is only valid because we initialize our inline View's to be zeroes on
             // non-included bytes.
-            for view in &target.views()[target.len() - num_seen..] {
+            for view in &target.views()[start_target_length..] {
                 all_inlined_are_ascii &= (view.length > View::MAX_INLINE_SIZE)
                     | (view.as_u128() & 0x0000_0000_8080_8080_8080_8080_8080_8080 == 0);
             }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -2849,3 +2849,23 @@ def test_equality_filter(
             raise
 
     pl.read_parquet(f)
+
+
+def test_nested_string_slice_utf8_21202() -> None:
+    s = pl.Series(
+        "a",
+        [
+            ["A" * 128],
+            ["A"],
+        ],
+        pl.List(pl.String()),
+    )
+
+    f = io.BytesIO()
+    s.to_frame().write_parquet(f)
+
+    f.seek(0)
+    assert_series_equal(
+        pl.scan_parquet(f).slice(1, 1).collect().to_series(),
+        s.slice(1, 1),
+    )


### PR DESCRIPTION
Fixes #21202.