### PR TITLE
fix: Incorrect result for top_k/bottom_k when input is sorted

### DIFF
--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -178,8 +178,7 @@ pub fn top_k(s: &[Column], descending: bool) -> PolarsResult<Column> {
     if is_sorted {
         let out_len = k.min(src.len());
         let ignored_len = src.len() - out_len;
-
-        let slice_at_start = (sorted_flag == IsSorted::Ascending) ^ descending;
+        let slice_at_start = (sorted_flag == IsSorted::Ascending) == descending;
         let nulls_at_start = src.get(0).unwrap() == AnyValue::Null;
         let offset = if nulls_at_start == slice_at_start {
             src.null_count().min(ignored_len)

--- a/py-polars/tests/unit/operations/test_top_k.py
+++ b/py-polars/tests/unit/operations/test_top_k.py
@@ -533,3 +533,14 @@ def test_top_k_list_dtype() -> None:
 
     s = pl.Series([[[1, 2], [3]], [[4], []], [[0]]], dtype=pl.List(pl.List(pl.Int64)))
     assert s.top_k(2).to_list() == [[[4], []], [[1, 2], [3]]]
+
+
+def test_top_k_sorted_21260() -> None:
+    s = pl.Series([1, 2, 3, 4, 5])
+    assert s.top_k(3).sort().to_list() == [3, 4, 5]
+    assert s.sort(descending=False).top_k(3).sort().to_list() == [3, 4, 5]
+    assert s.sort(descending=True).top_k(3).sort().to_list() == [3, 4, 5]
+
+    assert s.bottom_k(3).sort().to_list() == [1, 2, 3]
+    assert s.sort(descending=False).bottom_k(3).sort().to_list() == [1, 2, 3]
+    assert s.sort(descending=True).bottom_k(3).sort().to_list() == [1, 2, 3]


### PR DESCRIPTION
closes #21260

```python
import polars as pl

pl.Series([1, 2, 3, 4]).sort().top_k(3)

# BEFORE

# shape: (3,)
# Series: '' [i64]
# [
#         1
#         2
#         3
# ]

# AFTER

# shape: (3,)
# Series: '' [i64]
# [
#         2
#         3
#         4
# ]
```