### PR TITLE
fix: Infinite recursion when broadcasting into struct zip_outer_validity

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -828,6 +828,18 @@ where
         }
 
         if !is_missing && (a.null_count() > 0 || b.null_count() > 0) {
+            let mut a = a;
+            let mut b = b;
+
+            if broadcasts {
+                if a.len() == 1 {
+                    a = std::borrow::Cow::Owned(a.new_from_index(0, b.len()));
+                }
+                if b.len() == 1 {
+                    b = std::borrow::Cow::Owned(b.new_from_index(0, a.len()));
+                }
+            }
+
             let mut a = a.into_owned();
             a.zip_outer_validity(&b);
             unsafe {

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -400,6 +400,10 @@ impl StructChunked {
 
     /// Combine the validities of two structs.
     pub fn zip_outer_validity(&mut self, other: &StructChunked) {
+        // This might go wrong for broadcasting behavior. If this is not checked, it leads to a
+        // segfault because we infinitely recurse.
+        assert_eq!(self.len(), other.len());
+
         if other.null_count() == 0 {
             return;
         }

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1237,3 +1237,12 @@ def test_cast_to_struct_needs_field_14083() -> None:
         InvalidOperationError, match="must specify one field in the struct"
     ):
         pl.Series([1], dtype=pl.Int32).cast(pl.Struct({"a": pl.UInt8, "b": pl.UInt8}))
+
+
+@pytest.mark.filterwarnings("ignore:Comparisons with None always result in null.")
+def test_zip_outer_validity_infinite_recursion_21267() -> None:
+    s = pl.Series('x', [None, None], pl.Struct({ "f": pl.Null }))
+    assert_series_equal(
+        s.to_frame().select(pl.col.x.__eq__(None)).to_series(),
+        pl.Series('x', [None, None], pl.Boolean),
+    )

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1241,8 +1241,8 @@ def test_cast_to_struct_needs_field_14083() -> None:
 
 @pytest.mark.filterwarnings("ignore:Comparisons with None always result in null.")
 def test_zip_outer_validity_infinite_recursion_21267() -> None:
-    s = pl.Series('x', [None, None], pl.Struct({ "f": pl.Null }))
+    s = pl.Series("x", [None, None], pl.Struct({"f": pl.Null}))
     assert_series_equal(
         s.to_frame().select(pl.col.x.__eq__(None)).to_series(),
-        pl.Series('x', [None, None], pl.Boolean),
+        pl.Series("x", [None, None], pl.Boolean),
     )


### PR DESCRIPTION
Fixes #21267.