### PR TITLE
feat(rust): Expose `include_file_paths` to python visitor

### DIFF
--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -85,6 +85,10 @@ impl PyFileOptions {
     fn hive_options(&self, _py: Python<'_>) -> PyResult<PyObject> {
         Err(PyNotImplementedError::new_err("hive options"))
     }
+    #[getter]
+    fn include_file_paths(&self, _py: Python<'_>) -> Option<&str> {
+        self.inner.include_file_paths.as_deref()
+    }
 }
 
 #[pyclass]


### PR DESCRIPTION
Needed to implement in the polars GPU executor. xref https://github.com/rapidsai/cudf/issues/18012