### PR TITLE
fix: Add `Int128` path for `join_asof`

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -297,6 +297,10 @@ pub trait AsofJoin: IntoDf {
                 let ca = left_key.i32().unwrap();
                 join_asof_numeric(ca, &right_key, strategy, tolerance, allow_eq)
             },
+            DataType::Int128 => {
+                let ca = left_key.i128().unwrap();
+                join_asof_numeric(ca, &right_key, strategy, tolerance, allow_eq)
+            },
             DataType::UInt64 => {
                 let ca = left_key.u64().unwrap();
                 join_asof_numeric(ca, &right_key, strategy, tolerance, allow_eq)

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -297,6 +297,7 @@ pub trait AsofJoin: IntoDf {
                 let ca = left_key.i32().unwrap();
                 join_asof_numeric(ca, &right_key, strategy, tolerance, allow_eq)
             },
+            #[cfg(feature = "dtype-i128")]
             DataType::Int128 => {
                 let ca = left_key.i128().unwrap();
                 join_asof_numeric(ca, &right_key, strategy, tolerance, allow_eq)


### PR DESCRIPTION
Closes #21276.

The supertype of i64 and u64 is i128, so both sides are upcast to i128. However, there was no i128 match arm and so the take idx defaulted to the `i32` path in that case. The result is that values larger than `i32::MAX` failed to downcast and resulted in null.