### PR TITLE
fix: Panic in `to_physical` for series of arrays and lists

### DIFF
--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -44,9 +44,16 @@ impl ListChunked {
             return Cow::Borrowed(self);
         };
 
-        assert_eq!(self.chunks().len(), physical_repr.chunks().len());
+        let ca = if physical_repr.chunks().len() == 1 && self.chunks().len() > 1 {
+            // Physical repr got rechunked, rechunk self as well.
+            self.rechunk()
+        } else {
+            Cow::Borrowed(self)
+        };
 
-        let chunks: Vec<_> = self
+        assert_eq!(ca.chunks().len(), physical_repr.chunks().len());
+
+        let chunks: Vec<_> = ca
             .downcast_iter()
             .zip(physical_repr.into_chunks())
             .map(|(chunk, values)| {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1672,45 +1672,22 @@ def test_to_physical() -> None:
     assert_series_equal(s.to_physical(), expected)
 
 
-def test_to_physical_array_rechunked() -> None:
-    # A series with multiple chunks, dtype is array of structs with a null field
-    # (causes rechunking) and a field with a different physical and logical
-    # repr (causes the full body of `ArrayChunked::to_physical_repr` to run).
-    s = pl.Series(
-        "a",
-        [None],  # content doesn't matter
-        pl.Array(pl.Struct({"f0": pl.Time, "f1": pl.Null}), shape=(1,)),
-    )
+def test_to_physical_rechunked_21285() -> None:
+    # A series with multiple chunks, dtype is array or list of structs with a
+    # null field (causes rechunking) and a field with a different physical and
+    # logical repr (causes the full body of `to_physical_repr` to run).
+    dtype = pl.Array(pl.Struct({"f0": pl.Time, "f1": pl.Null}), shape=(1,))
+    s = pl.Series("a", [None], dtype) # content doesn't matter
     s = s.append(s)
-    expected = pl.Series(
-        "a",
-        [
-            None,
-            None,
-        ],
-        pl.Array(pl.Struct({"f0": Int64, "f1": pl.Null}), shape=(1,)),
-    )
+    expected_dtype = pl.Array(pl.Struct({"f0": Int64, "f1": pl.Null}), shape=(1,))
+    expected = pl.Series("a", [None, None], expected_dtype)
     assert_series_equal(s.to_physical(), expected)
 
-
-def test_to_physical_list_rechunked() -> None:
-    # A series with multiple chunks, dtype is list of structs with a null field
-    # (causes rechunking) and a field with a different physical and logical
-    # repr (causes the full body of `ListChunked::to_physical_repr` to run).
-    s = pl.Series(
-        "a",
-        [None],  # content doesn't matter
-        pl.List(pl.Struct({"f0": pl.Time, "f1": pl.Null})),
-    )
+    dtype = pl.List(pl.Struct({"f0": pl.Time, "f1": pl.Null}))
+    s = pl.Series("a", [None], dtype) # content doesn't matter
     s = s.append(s)
-    expected = pl.Series(
-        "a",
-        [
-            None,
-            None,
-        ],
-        pl.List(pl.Struct({"f0": Int64, "f1": pl.Null})),
-    )
+    expected_dtype = pl.List(pl.Struct({"f0": Int64, "f1": pl.Null}))
+    expected = pl.Series("a", [None, None], expected_dtype)
     assert_series_equal(s.to_physical(), expected)
 
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1693,6 +1693,27 @@ def test_to_physical_array_rechunked() -> None:
     assert_series_equal(s.to_physical(), expected)
 
 
+def test_to_physical_list_rechunked() -> None:
+    # A series with multiple chunks, dtype is list of structs with a null field
+    # (causes rechunking) and a field with a different physical and logical
+    # repr (causes the full body of `ListChunked::to_physical_repr` to run).
+    s = pl.Series(
+        "a",
+        [None],  # content doesn't matter
+        pl.List(pl.Struct({"f0": pl.Time, "f1": pl.Null})),
+    )
+    s = s.append(s)
+    expected = pl.Series(
+        "a",
+        [
+            None,
+            None,
+        ],
+        pl.List(pl.Struct({"f0": Int64, "f1": pl.Null})),
+    )
+    assert_series_equal(s.to_physical(), expected)
+
+
 def test_is_between_datetime() -> None:
     s = pl.Series("a", [datetime(2020, 1, 1, 10, 0, 0), datetime(2020, 1, 1, 20, 0, 0)])
     start = datetime(2020, 1, 1, 12, 0, 0)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1672,6 +1672,27 @@ def test_to_physical() -> None:
     assert_series_equal(s.to_physical(), expected)
 
 
+def test_to_physical_array_rechunked() -> None:
+    # A series with multiple chunks, dtype is array of structs with a null field
+    # (causes rechunking) and a field with a different physical and logical
+    # repr (causes the full body of `ArrayChunked::to_physical_repr` to run).
+    s = pl.Series(
+        "a",
+        [None],  # content doesn't matter
+        pl.Array(pl.Struct({"f0": pl.Time, "f1": pl.Null}), shape=(1,)),
+    )
+    s = s.append(s)
+    expected = pl.Series(
+        "a",
+        [
+            None,
+            None,
+        ],
+        pl.Array(pl.Struct({"f0": Int64, "f1": pl.Null}), shape=(1,)),
+    )
+    assert_series_equal(s.to_physical(), expected)
+
+
 def test_is_between_datetime() -> None:
     s = pl.Series("a", [datetime(2020, 1, 1, 10, 0, 0), datetime(2020, 1, 1, 20, 0, 0)])
     start = datetime(2020, 1, 1, 12, 0, 0)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1676,18 +1676,18 @@ def test_to_physical_rechunked_21285() -> None:
     # A series with multiple chunks, dtype is array or list of structs with a
     # null field (causes rechunking) and a field with a different physical and
     # logical repr (causes the full body of `to_physical_repr` to run).
-    dtype = pl.Array(pl.Struct({"f0": pl.Time, "f1": pl.Null}), shape=(1,))
-    s = pl.Series("a", [None], dtype)  # content doesn't matter
+    arr_dtype = pl.Array(pl.Struct({"f0": pl.Time, "f1": pl.Null}), shape=(1,))
+    s = pl.Series("a", [None], arr_dtype)  # content doesn't matter
     s = s.append(s)
-    expected_dtype = pl.Array(pl.Struct({"f0": Int64, "f1": pl.Null}), shape=(1,))
-    expected = pl.Series("a", [None, None], expected_dtype)
+    expected_arr_dtype = pl.Array(pl.Struct({"f0": Int64, "f1": pl.Null}), shape=(1,))
+    expected = pl.Series("a", [None, None], expected_arr_dtype)
     assert_series_equal(s.to_physical(), expected)
 
-    dtype = pl.List(pl.Struct({"f0": pl.Time, "f1": pl.Null}))
-    s = pl.Series("a", [None], dtype)  # content doesn't matter
+    list_dtype = pl.List(pl.Struct({"f0": pl.Time, "f1": pl.Null}))
+    s = pl.Series("a", [None], list_dtype)  # content doesn't matter
     s = s.append(s)
-    expected_dtype = pl.List(pl.Struct({"f0": Int64, "f1": pl.Null}))
-    expected = pl.Series("a", [None, None], expected_dtype)
+    expected_list_dtype = pl.List(pl.Struct({"f0": Int64, "f1": pl.Null}))
+    expected = pl.Series("a", [None, None], expected_list_dtype)
     assert_series_equal(s.to_physical(), expected)
 
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1677,14 +1677,14 @@ def test_to_physical_rechunked_21285() -> None:
     # null field (causes rechunking) and a field with a different physical and
     # logical repr (causes the full body of `to_physical_repr` to run).
     dtype = pl.Array(pl.Struct({"f0": pl.Time, "f1": pl.Null}), shape=(1,))
-    s = pl.Series("a", [None], dtype) # content doesn't matter
+    s = pl.Series("a", [None], dtype)  # content doesn't matter
     s = s.append(s)
     expected_dtype = pl.Array(pl.Struct({"f0": Int64, "f1": pl.Null}), shape=(1,))
     expected = pl.Series("a", [None, None], expected_dtype)
     assert_series_equal(s.to_physical(), expected)
 
     dtype = pl.List(pl.Struct({"f0": pl.Time, "f1": pl.Null}))
-    s = pl.Series("a", [None], dtype) # content doesn't matter
+    s = pl.Series("a", [None], dtype)  # content doesn't matter
     s = s.append(s)
     expected_dtype = pl.List(pl.Struct({"f0": Int64, "f1": pl.Null}))
     expected = pl.Series("a", [None, None], expected_dtype)


### PR DESCRIPTION
This PR adds rechunking in `ArrayChunked::to_physical_repr` and `ListChunked::to_physical_repr` when needed.

Fixes #21285 

The test depends on the `Null` field causing rechunking and should be removed or updated if that behavior changes.