### PR TITLE
feat: Implement sorted flags for struct series

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -649,7 +649,15 @@ impl ChunkSort<StructType> for StructChunked {
     fn sort_with(&self, mut options: SortOptions) -> ChunkedArray<StructType> {
         options.multithreaded &= POOL.current_num_threads() > 1;
         let idx = self.arg_sort(options);
-        unsafe { self.take_unchecked(&idx) }
+        let mut out = unsafe { self.take_unchecked(&idx) };
+
+        let s = if options.descending {
+            IsSorted::Descending
+        } else {
+            IsSorted::Ascending
+        };
+        out.set_sorted_flag(s);
+        out
     }
 
     fn sort(&self, descending: bool) -> ChunkedArray<StructType> {

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -19,7 +19,6 @@ use compare_inner::NonNull;
 use rayon::prelude::*;
 pub use slice::*;
 
-use crate::chunked_array::ops::row_encode::_get_rows_encoded_ca;
 use crate::prelude::compare_inner::TotalOrdInner;
 use crate::prelude::sort::arg_sort_multiple::*;
 use crate::prelude::*;
@@ -642,20 +641,6 @@ impl ChunkSort<BinaryOffsetType> for BinaryOffsetChunked {
         }
 
         arg_sort_multiple_impl(vals, by, options)
-    }
-}
-
-#[cfg(feature = "dtype-struct")]
-impl StructChunked {
-    pub(crate) fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        let bin = _get_rows_encoded_ca(
-            self.name().clone(),
-            &[self.clone().into_column()],
-            &[options.descending],
-            &[options.nulls_last],
-        )
-        .unwrap();
-        bin.arg_sort(Default::default())
     }
 }
 

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -27,10 +27,12 @@ impl PrivateSeries for SeriesWrap<StructChunked> {
     }
 
     fn _get_flags(&self) -> StatisticsFlags {
-        StatisticsFlags::empty()
+        self.0.get_flags()
     }
 
-    fn _set_flags(&mut self, _flags: StatisticsFlags) {}
+    fn _set_flags(&mut self, flags: StatisticsFlags) {
+        self.0.set_flags(flags);
+    }
 
     // TODO! remove this. Very slow. Asof join should use row-encoding.
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -430,7 +430,7 @@ def test_is_sorted_arithmetic_overflow_14106() -> None:
 
 
 def test_is_sorted_struct() -> None:
-    s = pl.Series("a", [{"x": 3 }, {"x": 1 }, {"x": 2 }]).sort()
+    s = pl.Series("a", [{"x": 3}, {"x": 1}, {"x": 2}]).sort()
     assert s.flags["SORTED_ASC"]
     assert not s.flags["SORTED_DESC"]
 

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -427,3 +427,13 @@ def test_is_sorted_chunked_select() -> None:
 def test_is_sorted_arithmetic_overflow_14106() -> None:
     s = pl.Series([0, 200], dtype=pl.UInt8).sort()
     assert not (s + 200).is_sorted()
+
+
+def test_is_sorted_struct() -> None:
+    s = pl.Series("a", [{"x": 3 }, {"x": 1 }, {"x": 2 }]).sort()
+    assert s.flags["SORTED_ASC"]
+    assert not s.flags["SORTED_DESC"]
+
+    s = s.sort(descending=True)
+    assert s.flags["SORTED_DESC"]
+    assert not s.flags["SORTED_ASC"]


### PR DESCRIPTION
This PR implements sorted flags for struct series.

```python
import polars as pl
s = pl.Series("a", [{"x": 3 }, {"x": 1 }, {"x": 2 }]).sort()
assert s.flags["SORTED_ASC"]
```

It removes a duplicate `StructChunked::arg_sort` function, it exists in `ChunkSort<StructType> for StructChunked` with the same name and implementation.

Closes #13484