### PR TITLE
fix: Fix incorrect predicate pushdown for predicates referring to right-join key columns

### DIFF
--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -15,7 +15,6 @@ pub type ChunkJoinOptIds = Vec<NullableIdxSize>;
 #[cfg(not(feature = "chunked_ids"))]
 pub type ChunkJoinIds = Vec<IdxSize>;
 
-use once_cell::sync::Lazy;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
@@ -138,8 +137,8 @@ impl JoinArgs {
     }
 
     pub fn suffix(&self) -> &PlSmallStr {
-        static DEFAULT: Lazy<PlSmallStr> = Lazy::new(|| PlSmallStr::from_static("_right"));
-        self.suffix.as_ref().unwrap_or(&*DEFAULT)
+        const DEFAULT: &PlSmallStr = &PlSmallStr::from_static("_right");
+        self.suffix.as_ref().unwrap_or(DEFAULT)
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
+++ b/crates/polars-plan/src/plans/optimizer/collapse_joins.rs
@@ -10,84 +10,11 @@ use polars_core::schema::*;
 use polars_ops::frame::{IEJoinOptions, InequalityOperator};
 use polars_ops::frame::{JoinCoalesce, JoinType, MaintainOrderJoin};
 use polars_utils::arena::{Arena, Node};
-use polars_utils::pl_str::PlSmallStr;
 
 use super::{aexpr_to_leaf_names_iter, AExpr, ExprOrigin, JoinOptions, IR};
 use crate::dsl::{JoinTypeOptionsIR, Operator};
-use crate::plans::visitor::{AexprNode, RewriteRecursion, RewritingVisitor, TreeWalker};
-use crate::plans::{ExprIR, MintermIter, OutputName};
-
-fn remove_suffix<'a>(
-    exprs: &mut Vec<ExprIR>,
-    expr_arena: &mut Arena<AExpr>,
-    schema: &'a SchemaRef,
-    suffix: &'a str,
-) {
-    let mut remover = RemoveSuffix {
-        schema: schema.as_ref(),
-        suffix,
-    };
-
-    for expr in exprs {
-        // Using AexprNode::rewrite() ensures we do not mutate any nodes in-place. The nodes may be
-        // used in other locations and mutating them will cause really confusing bugs, such as
-        // https://github.com/pola-rs/polars/issues/20831.
-        match AexprNode::new(expr.node()).rewrite(&mut remover, expr_arena) {
-            Ok(v) => {
-                expr.set_node(v.node());
-
-                if let OutputName::ColumnLhs(colname) = expr.output_name_inner() {
-                    if colname.ends_with(suffix) && !schema.contains(colname.as_str()) {
-                        let name = PlSmallStr::from(&colname[..colname.len() - suffix.len()]);
-                        expr.set_columnlhs(name);
-                    }
-                }
-            },
-            e @ Err(_) => panic!("should not have failed: {:?}", e),
-        }
-    }
-}
-
-struct RemoveSuffix<'a> {
-    schema: &'a Schema,
-    suffix: &'a str,
-}
-
-impl RewritingVisitor for RemoveSuffix<'_> {
-    type Node = AexprNode;
-    type Arena = Arena<AExpr>;
-
-    fn pre_visit(
-        &mut self,
-        node: &Self::Node,
-        arena: &mut Self::Arena,
-    ) -> polars_core::prelude::PolarsResult<crate::prelude::visitor::RewriteRecursion> {
-        let AExpr::Column(colname) = arena.get(node.node()) else {
-            return Ok(RewriteRecursion::NoMutateAndContinue);
-        };
-
-        if !colname.ends_with(self.suffix) || self.schema.contains(colname.as_str()) {
-            return Ok(RewriteRecursion::NoMutateAndContinue);
-        }
-
-        Ok(RewriteRecursion::MutateAndContinue)
-    }
-
-    fn mutate(
-        &mut self,
-        node: Self::Node,
-        arena: &mut Self::Arena,
-    ) -> polars_core::prelude::PolarsResult<Self::Node> {
-        let AExpr::Column(colname) = arena.get(node.node()) else {
-            unreachable!();
-        };
-
-        // Safety: Checked in pre_visit()
-        Ok(AexprNode::new(arena.add(AExpr::Column(PlSmallStr::from(
-            &colname[..colname.len() - self.suffix.len()],
-        )))))
-    }
-}
+use crate::plans::optimizer::join_utils::remove_suffix;
+use crate::plans::{ExprIR, MintermIter};
 
 fn and_expr(left: Node, right: Node, expr_arena: &mut Arena<AExpr>) -> Node {
     expr_arena.add(AExpr::BinaryExpr {
@@ -195,14 +122,16 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &mut Arena<AEx
                             left_schema,
                             right_schema,
                             suffix.as_str(),
-                        );
+                        )
+                        .unwrap();
                         let right_origin = ExprOrigin::get_expr_origin(
                             right,
                             expr_arena,
                             left_schema,
                             right_schema,
                             suffix.as_str(),
-                        );
+                        )
+                        .unwrap();
 
                         use ExprOrigin as EO;
 
@@ -282,12 +211,16 @@ pub fn optimize(root: Node, lp_arena: &mut Arena<IR>, expr_arena: &mut Arena<AEx
                 let mut can_simplify_join = false;
 
                 if !eq_left_on.is_empty() {
-                    remove_suffix(&mut eq_right_on, expr_arena, right_schema, suffix.as_str());
+                    for expr in eq_right_on.iter_mut() {
+                        remove_suffix(expr, expr_arena, right_schema, suffix.as_str());
+                    }
                     can_simplify_join = true;
                 } else {
                     #[cfg(feature = "iejoin")]
                     if !ie_op.is_empty() {
-                        remove_suffix(&mut ie_right_on, expr_arena, right_schema, suffix.as_str());
+                        for expr in ie_right_on.iter_mut() {
+                            remove_suffix(expr, expr_arena, right_schema, suffix.as_str());
+                        }
                         can_simplify_join = true;
                     }
                     can_simplify_join |= options.args.how.is_cross();

--- a/crates/polars-plan/src/plans/optimizer/join_utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_utils.rs
@@ -52,7 +52,9 @@ impl ExprOrigin {
         Ok(if left_schema.contains(column_name) {
             ExprOrigin::Left
         } else if right_schema.contains(column_name)
-            || right_schema.contains(column_name.strip_suffix(suffix).unwrap_or(column_name))
+            || column_name
+                .strip_suffix(suffix)
+                .map_or(false, |x| right_schema.contains(x))
         {
             ExprOrigin::Right
         } else {

--- a/crates/polars-plan/src/plans/optimizer/join_utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_utils.rs
@@ -54,7 +54,7 @@ impl ExprOrigin {
         } else if right_schema.contains(column_name)
             || column_name
                 .strip_suffix(suffix)
-                .map_or(false, |x| right_schema.contains(x))
+                .is_some_and(|x| right_schema.contains(x))
         {
             ExprOrigin::Right
         } else {

--- a/crates/polars-plan/src/plans/optimizer/join_utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_utils.rs
@@ -1,14 +1,18 @@
+use polars_core::error::{polars_bail, PolarsResult};
 use polars_core::schema::*;
 use polars_utils::arena::{Arena, Node};
+use polars_utils::pl_str::PlSmallStr;
 
 use super::{aexpr_to_leaf_names_iter, AExpr};
+use crate::plans::visitor::{AexprNode, RewriteRecursion, RewritingVisitor, TreeWalker};
+use crate::plans::{ExprIR, OutputName};
 
 /// Join origin of an expression
 #[derive(Debug, Clone, PartialEq, Copy)]
 #[repr(u8)]
 pub(crate) enum ExprOrigin {
-    // Note: There is a merge() function implemented on this enum that relies
-    // on this exact u8 repr layout.
+    // Note: BitOr is implemented on this struct that relies on this exact u8
+    // repr layout (i.e. treated as a bitfield).
     //
     /// Utilizes no columns
     None = 0b00,
@@ -21,52 +25,117 @@ pub(crate) enum ExprOrigin {
 }
 
 impl ExprOrigin {
+    /// Errors with ColumnNotFound if a column cannot be found on either side.
     pub(crate) fn get_expr_origin(
         root: Node,
         expr_arena: &Arena<AExpr>,
-        left_schema: &SchemaRef,
-        right_schema: &SchemaRef,
+        left_schema: &Schema,
+        right_schema: &Schema,
         suffix: &str,
-    ) -> ExprOrigin {
-        let mut expr_origin = ExprOrigin::None;
-
-        for name in aexpr_to_leaf_names_iter(root, expr_arena) {
-            let in_left = left_schema.contains(name.as_str());
-            let in_right = right_schema.contains(name.as_str());
-            let has_suffix = name.as_str().ends_with(suffix);
-            let in_right = in_right
-                | (has_suffix
-                    && right_schema.contains(&name.as_str()[..name.len() - suffix.len()]));
-
-            let name_origin = match (in_left, in_right, has_suffix) {
-                (true, false, _) | (true, true, false) => ExprOrigin::Left,
-                (false, true, _) | (true, true, true) => ExprOrigin::Right,
-                (false, false, _) => {
-                    unreachable!("Invalid filter column should have been filtered before")
-                },
-            };
-
-            use ExprOrigin as O;
-            expr_origin = match (expr_origin, name_origin) {
-                (O::None, other) | (other, O::None) => other,
-                (O::Left, O::Left) => O::Left,
-                (O::Right, O::Right) => O::Right,
-                _ => O::Both,
-            };
-        }
-
-        expr_origin
+    ) -> PolarsResult<ExprOrigin> {
+        aexpr_to_leaf_names_iter(root, expr_arena).try_fold(
+            ExprOrigin::None,
+            |acc_origin, column_name| {
+                Ok(acc_origin
+                    | Self::get_column_origin(&column_name, left_schema, right_schema, suffix)?)
+            },
+        )
     }
 
-    /// Logical OR with another [`ExprOrigin`]
-    fn merge(&mut self, other: Self) {
-        *self = unsafe { std::mem::transmute::<u8, ExprOrigin>(*self as u8 | other as u8) }
+    /// Errors with ColumnNotFound if a column cannot be found on either side.
+    pub(crate) fn get_column_origin(
+        column_name: &str,
+        left_schema: &Schema,
+        right_schema: &Schema,
+        suffix: &str,
+    ) -> PolarsResult<ExprOrigin> {
+        Ok(if left_schema.contains(column_name) {
+            ExprOrigin::Left
+        } else if right_schema.contains(column_name.strip_suffix(suffix).unwrap_or(column_name)) {
+            ExprOrigin::Right
+        } else {
+            polars_bail!(ColumnNotFound: "{}", column_name)
+        })
+    }
+}
+
+impl std::ops::BitOr for ExprOrigin {
+    type Output = ExprOrigin;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        unsafe { std::mem::transmute::<u8, ExprOrigin>(self as u8 | rhs as u8) }
     }
 }
 
 impl std::ops::BitOrAssign for ExprOrigin {
     fn bitor_assign(&mut self, rhs: Self) {
-        self.merge(rhs)
+        *self = *self | rhs;
+    }
+}
+
+pub(super) fn remove_suffix<'a>(
+    expr: &mut ExprIR,
+    expr_arena: &mut Arena<AExpr>,
+    schema_rhs: &'a Schema,
+    suffix: &'a str,
+) {
+    let schema = schema_rhs;
+    // Using AexprNode::rewrite() ensures we do not mutate any nodes in-place. The nodes may be
+    // used in other locations and mutating them will cause really confusing bugs, such as
+    // https://github.com/pola-rs/polars/issues/20831.
+    let node = AexprNode::new(expr.node())
+        .rewrite(&mut RemoveSuffix { schema, suffix }, expr_arena)
+        .unwrap()
+        .node();
+
+    expr.set_node(node);
+
+    if let OutputName::ColumnLhs(colname) = expr.output_name_inner() {
+        if colname.ends_with(suffix) && !schema.contains(colname.as_str()) {
+            let name = PlSmallStr::from(&colname[..colname.len() - suffix.len()]);
+            expr.set_columnlhs(name);
+        }
+    }
+
+    struct RemoveSuffix<'a> {
+        schema: &'a Schema,
+        suffix: &'a str,
+    }
+
+    impl RewritingVisitor for RemoveSuffix<'_> {
+        type Node = AexprNode;
+        type Arena = Arena<AExpr>;
+
+        fn pre_visit(
+            &mut self,
+            node: &Self::Node,
+            arena: &mut Self::Arena,
+        ) -> polars_core::prelude::PolarsResult<crate::prelude::visitor::RewriteRecursion> {
+            let AExpr::Column(colname) = arena.get(node.node()) else {
+                return Ok(RewriteRecursion::NoMutateAndContinue);
+            };
+
+            if !colname.ends_with(self.suffix) || self.schema.contains(colname.as_str()) {
+                return Ok(RewriteRecursion::NoMutateAndContinue);
+            }
+
+            Ok(RewriteRecursion::MutateAndContinue)
+        }
+
+        fn mutate(
+            &mut self,
+            node: Self::Node,
+            arena: &mut Self::Arena,
+        ) -> polars_core::prelude::PolarsResult<Self::Node> {
+            let AExpr::Column(colname) = arena.get(node.node()) else {
+                unreachable!();
+            };
+
+            // Safety: Checked in pre_visit()
+            Ok(AexprNode::new(arena.add(AExpr::Column(PlSmallStr::from(
+                &colname[..colname.len() - self.suffix.len()],
+            )))))
+        }
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/join_utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/join_utils.rs
@@ -51,7 +51,9 @@ impl ExprOrigin {
     ) -> PolarsResult<ExprOrigin> {
         Ok(if left_schema.contains(column_name) {
             ExprOrigin::Left
-        } else if right_schema.contains(column_name.strip_suffix(suffix).unwrap_or(column_name)) {
+        } else if right_schema.contains(column_name)
+            || right_schema.contains(column_name.strip_suffix(suffix).unwrap_or(column_name))
+        {
             ExprOrigin::Right
         } else {
             polars_bail!(ColumnNotFound: "{}", column_name)

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -136,9 +136,9 @@ pub(super) fn process_join(
             &schema_right,
             options.args.suffix(),
         )
-        .unwrap_or_else(|_| {
+        .unwrap_or_else(|e| {
             if cfg!(debug_assertions) {
-                panic!()
+                panic!("{:?}", e)
             } else {
                 ExprOrigin::None
             }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::plans::optimizer::join_utils::split_suffix;
+use crate::plans::optimizer::join_utils::remove_suffix;
 
 // Information concerning individual sides of a join.
 #[derive(PartialEq, Eq)]
@@ -97,28 +97,6 @@ fn all_pred_cols_in_left_on(
         .all(|pred_column_name| left_on.iter().any(|e| e.output_name() == &pred_column_name))
 }
 
-// Checks if a predicate refers to columns in both tables
-fn predicate_applies_to_both_tables(
-    predicate: Node,
-    expr_arena: &Arena<AExpr>,
-    schema_left: &Schema,
-    schema_right: &Schema,
-    suffix: &str,
-) -> bool {
-    let mut left_used = false;
-    let mut right_used = false;
-    for name in aexpr_to_leaf_names_iter(predicate, expr_arena) {
-        if schema_left.contains(name.as_ref()) {
-            left_used |= true;
-        } else {
-            right_used |= schema_right.contains(name.as_ref())
-                || name.ends_with(suffix)
-                    && schema_right.contains(split_suffix(name.as_ref(), suffix))
-        }
-    }
-    left_used && right_used
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_join(
     opt: &mut PredicatePushDown,
@@ -151,23 +129,32 @@ pub(super) fn process_join(
     let mut local_predicates = Vec::with_capacity(acc_predicates.len());
 
     for (_, predicate) in acc_predicates {
+        let column_origins = ExprOrigin::get_expr_origin(
+            predicate.node(),
+            expr_arena,
+            &schema_left,
+            &schema_right,
+            options.args.suffix(),
+        )
+        .unwrap_or_else(|_| {
+            if cfg!(debug_assertions) {
+                panic!()
+            } else {
+                ExprOrigin::None
+            }
+        });
+
         // Cross joins produce a cartesian product, so if a predicate combines columns from both tables, we should not push down.
         // Inequality joins logically produce a cartesian product, so the same logic applies.
         if (options.args.how.is_cross() || options.args.how.is_ie())
-            && predicate_applies_to_both_tables(
-                predicate.node(),
-                expr_arena,
-                &schema_left,
-                &schema_right,
-                options.args.suffix(),
-            )
+            && column_origins == ExprOrigin::Both
         {
             local_predicates.push(predicate);
             continue;
         }
 
         // check if predicate can pass the joins node
-        let block_pushdown_left = has_aexpr(predicate.node(), expr_arena, |ae| {
+        let allow_pushdown_left = !has_aexpr(predicate.node(), expr_arena, |ae| {
             should_block_join_specific(
                 ae,
                 &options.args.how,
@@ -178,7 +165,8 @@ pub(super) fn process_join(
             )
             .0
         });
-        let block_pushdown_right = has_aexpr(predicate.node(), expr_arena, |ae| {
+
+        let allow_pushdown_right = !has_aexpr(predicate.node(), expr_arena, |ae| {
             should_block_join_specific(
                 ae,
                 &options.args.how,
@@ -194,9 +182,10 @@ pub(super) fn process_join(
         let mut filter_left = false;
         let mut filter_right = false;
 
-        if !block_pushdown_left && check_input_node(predicate.node(), &schema_left, expr_arena) {
-            insert_and_combine_predicate(&mut pushdown_left, &predicate, expr_arena);
+        if allow_pushdown_left && column_origins == ExprOrigin::Left {
             filter_left = true;
+
+            insert_and_combine_predicate(&mut pushdown_left, &predicate, expr_arena);
             // If we push down to the left and all predicate columns are also
             // join columns, we also push down right for inner, left or semi join
             if all_pred_cols_in_left_on(&predicate, expr_arena, &left_on) {
@@ -215,12 +204,17 @@ pub(super) fn process_join(
         // the right hand side should be renamed with the suffix.
         // in that case we should not push down as the user wants to filter on `x`
         // not on `x_rhs`.
-        } else if !block_pushdown_right
-            && check_input_node(predicate.node(), &schema_right, expr_arena)
-        {
-            filter_right = true
-        }
-        if filter_right {
+        } else if allow_pushdown_right && column_origins == ExprOrigin::Right {
+            filter_right = true;
+
+            let mut predicate = predicate.clone();
+            remove_suffix(
+                &mut predicate,
+                expr_arena,
+                &schema_right,
+                options.args.suffix(),
+            );
+
             insert_and_combine_predicate(&mut pushdown_right, &predicate, expr_arena);
         }
 


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/21142

Non-suffixed columns were incorrectly identified as belonging to the RHS table due to using `check_input_node(predicate.node(), &schema_right, expr_arena)` (which incorrectly matches to the non-suffixed column on the RHS before join). We now use `ExprOrigin` to correctly identify this.

This PR also improves predicate pushdown for predicates referring only to RHS columns in right-joins:

**Before**
```python
FILTER col("values_right").is_null() FROM
  RIGHT JOIN:
  LEFT PLAN ON: [col("key")]
    DF ["key", "values"]; PROJECT */2 COLUMNS
  RIGHT PLAN ON: [col("key")]
    DF ["key", "values"]; PROJECT */2 COLUMNS
  END RIGHT JOIN
```

**After**
```python
RIGHT JOIN:
LEFT PLAN ON: [col("key")]
  DF ["key", "values"]; PROJECT */2 COLUMNS
RIGHT PLAN ON: [col("key")]
  FILTER col("values").is_null() FROM
    DF ["key", "values"]; PROJECT */2 COLUMNS
END RIGHT JOIN
```
