### PR TITLE
fix(rust): Remove mutual exclusivity from `elementwise` and `returns_scalar`

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -46,13 +46,6 @@ impl ApplyExpr {
         output_field: Field,
         returns_scalar: bool,
     ) -> Self {
-        #[cfg(debug_assertions)]
-        if matches!(options.collect_groups, ApplyOptions::ElementWise)
-            && options.flags.contains(FunctionFlags::RETURNS_SCALAR)
-        {
-            panic!("expr {:?} is not implemented correctly. 'returns_scalar' and 'elementwise' are mutually exclusive", expr)
-        }
-
         Self {
             inputs,
             function,

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -242,10 +242,11 @@ impl DateLikeNameSpace {
 
     /// Round the Datetime/Date range into buckets.
     pub fn round(self, every: Expr) -> Expr {
+        let returns_scalar = all_return_scalar(&self.0);
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::Round),
             &[every],
-            false,
+            returns_scalar,
             None,
         )
     }
@@ -254,10 +255,11 @@ impl DateLikeNameSpace {
     /// This will take leap years/ months into account.
     #[cfg(feature = "offset_by")]
     pub fn offset_by(self, by: Expr) -> Expr {
+        let returns_scalar = all_return_scalar(&self.0);
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::OffsetBy),
             &[by],
-            false,
+            returns_scalar,
             None,
         )
     }
@@ -269,20 +271,22 @@ impl DateLikeNameSpace {
         ambiguous: Expr,
         non_existent: NonExistent,
     ) -> Expr {
+        let returns_scalar = all_return_scalar(&self.0);
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::ReplaceTimeZone(time_zone, non_existent)),
             &[ambiguous],
-            false,
+            returns_scalar,
             None,
         )
     }
 
     /// Combine an existing Date/Datetime with a Time, creating a new Datetime value.
     pub fn combine(self, time: Expr, tu: TimeUnit) -> Expr {
+        let returns_scalar = all_return_scalar(&self.0) && all_return_scalar(&time);
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::Combine(tu)),
             &[time],
-            false,
+            returns_scalar,
             None,
         )
     }


### PR DESCRIPTION
** Edit 2**: This isn't needed.

--

**Edit**: pending results of #21292.

---

In the `ApplyExpr` implementation, there is a check to ensure that `returns_scalar` and `elementwise` are mutually exclusive, seen [here](https://github.com/pola-rs/polars/blob/main/crates/polars-expr/src/expressions/apply.rs#L49-L54):

```rust
#[cfg(debug_assertions)]
if matches!(options.collect_groups, ApplyOptions::ElementWise)
    && options.flags.contains(FunctionFlags::RETURNS_SCALAR)
{
  panic!("expr {:?} is not implemented correctly. 'returns_scalar' and 'elementwise' are mutually exclusive", expr)
}
```

I don't think that this is necessarily true (but I may be missing something). For any function that doesn't change the length, if the input is a scalar, then the output is a scalar.

This is currently preventing some expressions from being able to report that they return scalars, even if they have scalar inputs. One example is the `round` function in the `DateLikeNamespace`:

```rust
/// Round the Datetime/Date range into buckets.
pub fn round(self, every: Expr) -> Expr {
    self.0.map_many_private(
        FunctionExpr::TemporalExpr(TemporalFunction::Round),
        &[every],
        false  // this is "returns_scalar"
        None,
    )
}
```
Since `round` doesn't change the length of the input, this could be replaced with:

```rust
/// Round the Datetime/Date range into buckets.
pub fn round(self, every: Expr) -> Expr {
    let returns_scalar = all_return_scalar(&self.0);
    self.0.map_many_private(
        FunctionExpr::TemporalExpr(TemporalFunction::Round),
        &[every],
        returns_scalar,
        None,
    )
}
```
where the return value is scalar if the input is scalar. This would allow expressions like `round(pl.col('a").max())` to propagate scalar-ness. But implementing this currently panics due to the `elementwise` check above.

Am I missing something?