### PR TITLE
docs(python): Improve `Expr.name.map` docstring example

### DIFF
--- a/py-polars/polars/expr/name.py
+++ b/py-polars/polars/expr/name.py
@@ -102,7 +102,7 @@ class ExprNameNameSpace:
         ...     }
         ... )
         >>> df.with_columns(
-        ...     pl.all().reverse().name.map(lambda c: c.rstrip("_reverse").lower())
+        ...     pl.all().reverse().name.map(lambda c: c.removesuffix("_reverse").lower())
         ... )
         shape: (3, 4)
         ┌───────────┬───────────┬─────┬─────┐

--- a/py-polars/polars/expr/name.py
+++ b/py-polars/polars/expr/name.py
@@ -102,7 +102,9 @@ class ExprNameNameSpace:
         ...     }
         ... )
         >>> df.with_columns(
-        ...     pl.all().reverse().name.map(lambda c: c.removesuffix("_reverse").lower())
+        ...     pl.all()
+        ...     .reverse()
+        ...     .name.map(lambda c: c.removesuffix("_reverse").lower())
         ... )
         shape: (3, 4)
         ┌───────────┬───────────┬─────┬─────┐


### PR DESCRIPTION
Closes #21305.

(`removesuffix` was made available in py3.9, which has been our minimum supported version for a while now; updated the example to use it, as per the linked issue).