### PR TITLE
fix: Fix duplicate column names after join if suffix already present

### DIFF
--- a/crates/polars-ops/src/frame/join/general.rs
+++ b/crates/polars-ops/src/frame/join/general.rs
@@ -38,16 +38,12 @@ pub fn _finish_join(
 
     for name in rename_strs {
         let new_name = _join_suffix_name(name.as_str(), suffix.as_str());
-
-        df_right.rename(&name, new_name.clone()).map_err(|_| {
-            polars_err!(Duplicate: "column with name '{}' already exists\n\n\
-            You may want to try:\n\
-            - renaming the column prior to joining\n\
-            - using the `suffix` parameter to specify a suffix different to the default one ('_right')", new_name)
-        })?;
+        // Safety: IR resolving should guarantee this passes
+        df_right.rename(&name, new_name.clone()).unwrap();
     }
 
     drop(left_names);
+    // Safety: IR resolving should guarantee this passes
     unsafe { df_left.hstack_mut_unchecked(df_right.get_columns()) };
     Ok(df_left)
 }

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -298,7 +298,7 @@ pub(crate) fn det_join_schema(
                         suffixed.replace(format_pl_smallstr!("{}{}", name, options.args.suffix()));
                         (suffixed.clone().unwrap(), dtype.clone())
                     } else {
-                        suffixed.take();
+                        suffixed = None;
                         (name.clone(), dtype.clone())
                     }
                 }))

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -404,7 +404,9 @@ pub(crate) fn det_join_schema(
 fn join_suffix_duplicate_help_msg(column_name: &str) -> PolarsError {
     polars_err!(
         Duplicate:
-        "column with name '{}' already exists
+        "\
+column with name '{}' already exists
+
 You may want to try:
 - renaming the column prior to joining
 - using the `suffix` parameter to specify a suffix different to the default one ('_right')",

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -291,14 +291,15 @@ pub(crate) fn det_join_schema(
                 }))?
                 // Columns from right
                 .hstack(schema_right.iter().map(|(name, dtype)| {
+                    suffixed = None;
+
                     let in_left_schema = schema_left.contains(name.as_str());
                     let is_coalesced = join_on_left.contains(name.as_str());
 
                     if in_left_schema && !is_coalesced {
-                        suffixed.replace(format_pl_smallstr!("{}{}", name, options.args.suffix()));
+                        suffixed = Some(format_pl_smallstr!("{}{}", name, options.args.suffix()));
                         (suffixed.clone().unwrap(), dtype.clone())
                     } else {
-                        suffixed = None;
                         (name.clone(), dtype.clone())
                     }
                 }))
@@ -381,7 +382,7 @@ pub(crate) fn det_join_schema(
                 let mut suffixed = None;
 
                 let (name, dtype) = if schema_left.contains(name) {
-                    suffixed.replace(format_pl_smallstr!("{}{}", name, options.args.suffix()));
+                    suffixed = Some(format_pl_smallstr!("{}{}", name, options.args.suffix()));
                     (suffixed.clone().unwrap(), dtype.clone())
                 } else {
                     (name.clone(), dtype.clone())

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -214,20 +214,51 @@ impl<D> Schema<D> {
         Some(std::mem::replace(old_dtype, dtype))
     }
 
-    /// Insert a new column in the [`Schema`].
+    /// Insert a column into the [`Schema`].
     ///
-    /// If an equivalent name already exists in the schema: the name remains and
-    /// retains in its place in the order, its corresponding value is updated
-    /// with [`D`] and the older dtype is returned inside `Some(_)`.
-    ///
-    /// If no equivalent key existed in the map: the new name-dtype pair is
-    /// inserted, last in order, and `None` is returned.
+    /// If the schema already has this column, this instead updates it with the new value and
+    /// returns the old one. Otherwise, the column is inserted at the end.
     ///
     /// To enforce the index of the resulting field, use [`insert_at_index`][Self::insert_at_index].
-    ///
-    /// Computes in **O(1)** time (amortized average).
     pub fn with_column(&mut self, name: PlSmallStr, dtype: D) -> Option<D> {
         self.fields.insert(name, dtype)
+    }
+
+    /// Raises DuplicateError if this column already exists in the schema.
+    pub fn try_insert(&mut self, name: PlSmallStr, value: D) -> PolarsResult<()> {
+        if self.fields.contains_key(&name) {
+            polars_bail!(Duplicate: "column '{}' is duplicate", name)
+        }
+
+        self.fields.insert(name, value);
+
+        Ok(())
+    }
+
+    /// Performs [`Schema::try_insert`] for every column.
+    ///
+    /// Raises DuplicateError if a column already exists in the schema.
+    pub fn hstack_mut(
+        &mut self,
+        columns: impl IntoIterator<Item = impl Into<(PlSmallStr, D)>>,
+    ) -> PolarsResult<()> {
+        for v in columns {
+            let (k, v) = v.into();
+            self.try_insert(k, v)?;
+        }
+
+        Ok(())
+    }
+
+    /// Performs [`Schema::try_insert`] for every column.
+    ///
+    /// Raises DuplicateError if a column already exists in the schema.
+    pub fn hstack(
+        mut self,
+        columns: impl IntoIterator<Item = impl Into<(PlSmallStr, D)>>,
+    ) -> PolarsResult<Self> {
+        self.hstack_mut(columns)?;
+        Ok(self)
     }
 
     /// Merge `other` into `self`.

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -614,6 +614,7 @@ impl SQLContext {
             for join in &tbl_expr.joins {
                 let (r_name, mut rf) = self.get_table(&join.relation)?;
                 if r_name.is_empty() {
+                    // Require non-empty to avoid duplicate column errors from nested self-joins.
                     polars_bail!(
                         SQLInterface:
                         "cannot join on unnamed relation; please provide an alias"

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1793,6 +1793,10 @@ def test_join_where_eager_perf_21145() -> None:
     runtime_lazy = time_func(lambda: left.lazy().join_where(right.lazy(), p).collect())
     runtime_ratio = runtime_eager / runtime_lazy
 
-    if runtime_ratio > 1.3:
-        msg = f"runtime_ratio ({runtime_ratio}) > 1.3x ({runtime_eager = }, {runtime_lazy = })"
+    # Pick as high as reasonably possible for CI stability
+    # * Was observed to be >=5 seconds on the bugged version, so 3 is a safe bet.
+    threshold = 3
+
+    if runtime_ratio > threshold:
+        msg = f"runtime_ratio ({runtime_ratio}) > {threshold}x ({runtime_eager = }, {runtime_lazy = })"
         raise ValueError(msg)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -862,30 +862,35 @@ def test_join_results_in_duplicate_names() -> None:
     def f(x: Any) -> Any:
         return x.join(x, on=["a", "b"], how="left")
 
-    with pytest.raises(DuplicateError, match="'c_right' is duplicate"):
+    match_str = "(?s)column with name 'c_right' already exists.*You may want to try"
+
+    with pytest.raises(DuplicateError, match=match_str):
         f(df.lazy()).collect_schema()
 
-    with pytest.raises(DuplicateError, match="'c_right' is duplicate"):
+    with pytest.raises(DuplicateError, match=match_str):
         f(df.lazy()).collect()
 
-    with pytest.raises(DuplicateError, match="'c_right' is duplicate"):
+    with pytest.raises(DuplicateError, match=match_str):
         f(df).collect()
 
 
-def test_join_duplicate_suffixed_columns_21048() -> None:
+def test_join_duplicate_suffixed_columns_from_join_key_column_21048() -> None:
     df = pl.DataFrame({"a": 1, "b": 1, "b_right": 1})
 
     def f(x: Any) -> Any:
         return x.join(x, on="a")
 
+    # Ensure it also contains the hint
+    match_str = "(?s)column with name 'b_right' already exists.*You may want to try"
+
     # Ensure it fails immediately when resolving schema.
-    with pytest.raises(DuplicateError, match="'b_right' is duplicate"):
+    with pytest.raises(DuplicateError, match=match_str):
         f(df.lazy()).collect_schema()
 
-    with pytest.raises(DuplicateError, match="'b_right' is duplicate"):
+    with pytest.raises(DuplicateError, match=match_str):
         f(df.lazy()).collect()
 
-    with pytest.raises(DuplicateError, match="'b_right' is duplicate"):
+    with pytest.raises(DuplicateError, match=match_str):
         f(df)
 
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -862,8 +862,10 @@ def test_join_results_in_duplicate_names() -> None:
     def f(x: Any) -> Any:
         return x.join(x, on=["a", "b"], how="left")
 
+    # Ensure it also contains the hint
     match_str = "(?s)column with name 'c_right' already exists.*You may want to try"
 
+    # Ensure it fails immediately when resolving schema.
     with pytest.raises(DuplicateError, match=match_str):
         f(df.lazy()).collect_schema()
 

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -682,7 +682,7 @@ def test_nested_join(join_clause: str) -> None:
         ]
 
 
-def test_sql_forbid_join_unnamed_relation() -> None:
+def test_sql_forbid_nested_join_unnamed_relation() -> None:
     df = pl.DataFrame({"a": 1})
 
     with (
@@ -691,7 +691,7 @@ def test_sql_forbid_join_unnamed_relation() -> None:
     ):
         ctx.execute(
             """\
-SELECT a
+SELECT *
 FROM left
 JOIN (right JOIN right ON right.a = right.a)
 ON left.a = right.a

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -603,10 +603,10 @@ def test_natural_joins_02(cols_constraint: str, expect_data: list[tuple[int]]) -
 @pytest.mark.parametrize(
     "join_clause",
     [
-        """
-        df2 JOIN df3 ON
-        df2.CharacterID = df3.CharacterID
-        """,
+        # """
+        # df2 JOIN df3 ON
+        # df2.CharacterID = df3.CharacterID
+        # """,
         """
         df2 INNER JOIN (
           df3 JOIN df4 ON df3.CharacterID = df4.CharacterID

--- a/py-polars/tests/unit/sql/test_joins.py
+++ b/py-polars/tests/unit/sql/test_joins.py
@@ -603,10 +603,10 @@ def test_natural_joins_02(cols_constraint: str, expect_data: list[tuple[int]]) -
 @pytest.mark.parametrize(
     "join_clause",
     [
-        # """
-        # df2 JOIN df3 ON
-        # df2.CharacterID = df3.CharacterID
-        # """,
+        """
+        df2 JOIN df3 ON
+        df2.CharacterID = df3.CharacterID
+        """,
         """
         df2 INNER JOIN (
           df3 JOIN df4 ON df3.CharacterID = df4.CharacterID


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/21048

Updates to use (newly added) `Schema::try_insert()` instead of `Schema::with_column` during IR resolution to catch duplicate errors.

Note, there are a lot more places in the codebase that should probably be using `try_insert()` instead of `with_column`.
