### PR TITLE
docs: Fix initial selector example

### DIFF
--- a/py-polars/docs/source/reference/selectors.rst
+++ b/py-polars/docs/source/reference/selectors.rst
@@ -28,7 +28,7 @@ Importing
               "z": ["a", "b", "a", "b", "b"],
           },
       )
-      df.group_by(by=cs.string()).agg(cs.numeric().sum())
+      df.group_by(cs.string()).agg(cs.numeric().sum())
 
 Set operations
 --------------


### PR DESCRIPTION
Closes #21320.

Since the example was created, `group_by` now takes "*by" (args), not "by=" 😅 