### PR TITLE
fix(rust): Fix height validation in `hstack_mut` was bypassed when adding to empty frame

### DIFF
--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -18,7 +18,11 @@ impl DataFrame {
         self.columns.extend_from_slice(columns);
 
         if cfg!(debug_assertions) {
-            DataFrame::validate_columns_slice(&self.columns).unwrap();
+            if let err @ Err(_) = DataFrame::validate_columns_slice(&self.columns) {
+                // Reset DataFrame state to before extend.
+                self.columns.truncate(self.columns.len() - columns.len());
+                err.unwrap();
+            }
         }
 
         if let Some(c) = self.columns.first() {
@@ -43,7 +47,11 @@ impl DataFrame {
         self.clear_schema();
         self.columns.extend_from_slice(columns);
 
-        DataFrame::validate_columns_slice(&self.columns)?;
+        if let err @ Err(_) = DataFrame::validate_columns_slice(&self.columns) {
+            // Reset DataFrame state to before extend.
+            self.columns.truncate(self.columns.len() - columns.len());
+            err?;
+        }
 
         if let Some(c) = self.columns.first() {
             unsafe { self.set_height(c.len()) };

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -108,15 +108,11 @@ pub fn concat_df_horizontal(dfs: &[DataFrame], check_duplicates: bool) -> Polars
         acc_cols.extend(df.get_columns().iter().cloned());
     }
 
-    let df = if check_duplicates {
-        DataFrame::new(acc_cols).map_err(|e| e.context("unable to hstack".into()))?
-    } else {
-        if cfg!(debug_assertions) && acc_cols.len() > 1 {
-            assert!(acc_cols.iter().all(|c| c.len() == acc_cols[0].len()));
-        }
+    if check_duplicates {
+        DataFrame::validate_columns_slice(&acc_cols)?;
+    }
 
-        unsafe { DataFrame::new_no_checks_height_from_first(acc_cols) }
-    };
+    let df = unsafe { DataFrame::new_no_checks_height_from_first(acc_cols) };
 
     Ok(df)
 }

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -18,7 +18,7 @@ impl DataFrame {
         self.columns.extend_from_slice(columns);
 
         if cfg!(debug_assertions) {
-            Self::validate_columns_slice(&self.columns).unwrap();
+            DataFrame::validate_columns_slice(&self.columns).unwrap();
         }
 
         if let Some(c) = self.columns.first() {
@@ -43,7 +43,7 @@ impl DataFrame {
         self.clear_schema();
         self.columns.extend_from_slice(columns);
 
-        Self::validate_columns_slice(&self.columns)?;
+        DataFrame::validate_columns_slice(&self.columns)?;
 
         if let Some(c) = self.columns.first() {
             unsafe { self.set_height(c.len()) };

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -74,10 +74,14 @@ pub fn concat_df_horizontal(dfs: &[DataFrame], check_duplicates: bool) -> Polars
 
     // if not all equal length, extend the DataFrame with nulls
     let dfs = if !all_equal_height {
+        out_width = 0;
+
         owned_df = dfs
             .iter()
             .cloned()
             .map(|mut df| {
+                out_width += df.width();
+
                 if df.height() != output_height {
                     let diff = output_height - df.height();
 

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -1,28 +1,8 @@
-use polars_error::{polars_ensure, polars_err, PolarsResult};
-use polars_utils::aliases::PlHashSet;
+use polars_error::{polars_err, PolarsResult};
 
 use super::Column;
 use crate::datatypes::AnyValue;
 use crate::frame::DataFrame;
-use crate::prelude::PlSmallStr;
-
-fn check_hstack(
-    col: &Column,
-    names: &mut PlHashSet<PlSmallStr>,
-    height: usize,
-    is_empty: bool,
-) -> PolarsResult<()> {
-    polars_ensure!(
-        col.len() == height || is_empty,
-        ShapeMismatch: "unable to hstack Series of length {} and DataFrame of height {}",
-        col.len(), height,
-    );
-    polars_ensure!(
-        names.insert(col.name().clone()),
-        Duplicate: "unable to hstack, column with name {:?} already exists", col.name().as_str(),
-    );
-    Ok(())
-}
 
 impl DataFrame {
     /// Add columns horizontally.
@@ -31,6 +11,8 @@ impl DataFrame {
     /// The caller must ensure:
     /// - the length of all [`Column`] is equal to the height of this [`DataFrame`]
     /// - the columns names are unique
+    ///
+    /// Note that on a debug build this will panic on duplicates / height mismatch
     pub unsafe fn hstack_mut_unchecked(&mut self, columns: &[Column]) -> &mut Self {
         // If we don't have any columns yet, copy the height from the given columns.
         if let Some(fst) = columns.first() {
@@ -41,13 +23,13 @@ impl DataFrame {
             }
         }
 
-        if cfg!(debug_assertions) {
-            // It is an impl error if this fails.
-            self._validate_hstack(columns).unwrap();
-        }
-
         self.clear_schema();
         self.columns.extend_from_slice(columns);
+
+        if cfg!(debug_assertions) {
+            Self::validate_columns_slice(&self.columns).unwrap();
+        }
+
         self
     }
 
@@ -63,28 +45,15 @@ impl DataFrame {
     /// }
     /// ```
     pub fn hstack_mut(&mut self, columns: &[Column]) -> PolarsResult<&mut Self> {
-        self._validate_hstack(columns)?;
-        Ok(unsafe { self.hstack_mut_unchecked(columns) })
-    }
+        // Validate first - on a debug build `hstack_mut_unchecked` will panic on invalid columns.
+        Self::validate_columns_iter(self.get_columns().iter().chain(columns))?;
 
-    fn _validate_hstack(&self, columns: &[Column]) -> PolarsResult<()> {
-        let mut names = self
-            .columns
-            .iter()
-            .map(|c| c.name().clone())
-            .collect::<PlHashSet<_>>();
+        unsafe { self.hstack_mut_unchecked(columns) };
 
-        let height = self.height();
-        let is_empty = self.is_empty();
-        // first loop check validity. We don't do this in a single pass otherwise
-        // this DataFrame is already modified when an error occurs.
-        for col in columns {
-            check_hstack(col, &mut names, height, is_empty)?;
-        }
-
-        Ok(())
+        Ok(self)
     }
 }
+
 /// Concat [`DataFrame`]s horizontally.
 /// Concat horizontally and extend with null values if lengths don't match
 pub fn concat_df_horizontal(dfs: &[DataFrame], check_duplicates: bool) -> PolarsResult<DataFrame> {
@@ -96,8 +65,15 @@ pub fn concat_df_horizontal(dfs: &[DataFrame], check_duplicates: bool) -> Polars
 
     let owned_df;
 
+    let mut out_width = 0;
+
+    let all_equal_height = dfs.iter().all(|df| {
+        out_width += df.width();
+        df.height() == output_height
+    });
+
     // if not all equal length, extend the DataFrame with nulls
-    let dfs = if !dfs.iter().all(|df| df.height() == output_height) {
+    let dfs = if !all_equal_height {
         owned_df = dfs
             .iter()
             .cloned()
@@ -123,30 +99,38 @@ pub fn concat_df_horizontal(dfs: &[DataFrame], check_duplicates: bool) -> Polars
         dfs
     };
 
-    let mut first_df = dfs[0].clone();
-    let height = first_df.height();
-    let is_empty = first_df.is_empty();
+    let mut acc_df = DataFrame::empty();
+    unsafe { acc_df.get_columns_mut() }.reserve(out_width);
 
-    let mut names = if check_duplicates {
-        first_df
-            .columns
-            .iter()
-            .map(|s| s.name().clone())
-            .collect::<PlHashSet<_>>()
-    } else {
-        Default::default()
-    };
-
-    for df in &dfs[1..] {
-        let cols = df.get_columns();
-
-        if check_duplicates {
-            for col in cols {
-                check_hstack(col, &mut names, height, is_empty)?;
-            }
-        }
-
-        unsafe { first_df.hstack_mut_unchecked(cols) };
+    for df in dfs {
+        unsafe { acc_df.get_columns_mut() }.extend(df.get_columns().iter().cloned());
     }
-    Ok(first_df)
+
+    if check_duplicates {
+        DataFrame::validate_columns_slice(acc_df.get_columns())
+            .map_err(|e| e.context("unable to hstack".into()))?;
+    }
+
+    Ok(acc_df)
+}
+
+#[cfg(test)]
+mod tests {
+    use polars_error::PolarsError;
+
+    #[test]
+    fn test_hstack_mut_empty_frame_height_validation() {
+        use crate::frame::DataFrame;
+        use crate::prelude::{Column, DataType};
+        let mut df = DataFrame::empty();
+        let result = df.hstack_mut(&[
+            Column::full_null("a".into(), 1, &DataType::Null),
+            Column::full_null("b".into(), 3, &DataType::Null),
+        ]);
+
+        assert!(
+            matches!(result, Err(PolarsError::ShapeMismatch(_))),
+            "expected shape mismatch error"
+        );
+    }
 }

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -29,7 +29,7 @@ impl DataFrame {
     }
 
     /// Add multiple [`Column`] to a [`DataFrame`].
-    /// The added `Series` are required to have the same length.
+    /// Errors if the resulting DataFrame columns have duplicate names or unequal heights.
     ///
     /// # Example
     ///

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -35,6 +35,9 @@ impl DataFrame {
     /// Add multiple [`Column`] to a [`DataFrame`].
     /// Errors if the resulting DataFrame columns have duplicate names or unequal heights.
     ///
+    /// Note: If `self` is empty, `self.height` will always be overridden by the height of the first
+    /// column in `columns`.
+    ///
     /// # Example
     ///
     /// ```rust

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -143,5 +143,8 @@ mod tests {
             matches!(result, Err(PolarsError::ShapeMismatch(_))),
             "expected shape mismatch error"
         );
+
+        // Ensure the DataFrame is not mutated in the error case.
+        assert_eq!(df.width(), 0);
     }
 }

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -112,11 +112,10 @@ pub fn concat_df_horizontal(dfs: &[DataFrame], check_duplicates: bool) -> Polars
     let df = if check_duplicates {
         DataFrame::new(acc_cols).map_err(|e| e.context("unable to hstack".into()))?
     } else {
-        if cfg!(debug_assertions) {
-            if acc_cols.len() > 2 {
-                assert!(acc_cols.iter().all(|c| c.len() == acc_cols[0].len()));
-            }
+        if cfg!(debug_assertions) && acc_cols.len() > 1 {
+            assert!(acc_cols.iter().all(|c| c.len() == acc_cols[0].len()));
         }
+
         unsafe { DataFrame::new_no_checks_height_from_first(acc_cols) }
     };
 

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -12,6 +12,9 @@ impl DataFrame {
     /// - the length of all [`Column`] is equal to the height of this [`DataFrame`]
     /// - the columns names are unique
     ///
+    /// Note: If `self` is empty, `self.height` will always be overridden by the height of the first
+    /// column in `columns`.
+    ///
     /// Note that on a debug build this will panic on duplicates / height mismatch.
     pub unsafe fn hstack_mut_unchecked(&mut self, columns: &[Column]) -> &mut Self {
         self.clear_schema();

--- a/crates/polars-core/src/frame/horizontal.rs
+++ b/crates/polars-core/src/frame/horizontal.rs
@@ -12,7 +12,7 @@ impl DataFrame {
     /// - the length of all [`Column`] is equal to the height of this [`DataFrame`]
     /// - the columns names are unique
     ///
-    /// Note that on a debug build this will panic on duplicates / height mismatch
+    /// Note that on a debug build this will panic on duplicates / height mismatch.
     pub unsafe fn hstack_mut_unchecked(&mut self, columns: &[Column]) -> &mut Self {
         // If we don't have any columns yet, copy the height from the given columns.
         if let Some(fst) = columns.first() {

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -515,11 +515,7 @@ impl DataFrame {
     /// having an equal length and a unique name, if not this may panic down the line.
     pub unsafe fn new_no_checks(height: usize, columns: Vec<Column>) -> DataFrame {
         if cfg!(debug_assertions) {
-            ensure_names_unique(&columns, |s| s.name().as_str()).unwrap();
-
-            for col in &columns {
-                assert_eq!(col.len(), height);
-            }
+            DataFrame::validate_columns_slice(&columns).unwrap();
         }
 
         unsafe { Self::_new_no_checks_impl(height, columns) }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -273,7 +273,7 @@ impl DataFrame {
     /// ```
     pub fn new(columns: Vec<Column>) -> PolarsResult<Self> {
         DataFrame::validate_columns_slice(&columns)
-            .map_err(|e| e.context("could not create a new DataFrame"))?;
+            .map_err(|e| e.context("could not create a new DataFrame".into()))?;
         Ok(unsafe { Self::new_no_checks_height_from_first(columns) })
     }
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -273,7 +273,7 @@ impl DataFrame {
     /// ```
     pub fn new(columns: Vec<Column>) -> PolarsResult<Self> {
         DataFrame::validate_columns_slice(&columns)
-            .map_err(|e| e.context("could not create a new DataFrame".into()))?;
+            .map_err(|e| e.wrap_msg(|e| format!("could not create a new DataFrame: {}", e)))?;
         Ok(unsafe { Self::new_no_checks_height_from_first(columns) })
     }
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -261,6 +261,8 @@ impl DataFrame {
 
     /// Create a DataFrame from a Vector of Series.
     ///
+    /// Errors if a column names are not unique, or if heights are not all equal.
+    ///
     /// # Example
     ///
     /// ```

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -533,30 +533,6 @@ impl DataFrame {
         }
     }
 
-    /// Create a new `DataFrame` but does not check the length of the `Series`,
-    /// only check for duplicates.
-    ///
-    /// It is advised to use [DataFrame::new] in favor of this method.
-    ///
-    /// # Safety
-    ///
-    /// It is the callers responsibility to uphold the contract of all `Series`
-    /// having an equal length, if not this may panic down the line.
-    pub unsafe fn new_no_length_checks(columns: Vec<Column>) -> PolarsResult<DataFrame> {
-        ensure_names_unique(&columns, |s| s.name().as_str())?;
-
-        Ok(if cfg!(debug_assertions) {
-            Self::new(columns).unwrap()
-        } else {
-            let height = Self::infer_height(&columns);
-            DataFrame {
-                height,
-                columns,
-                cached_schema: OnceLock::new(),
-            }
-        })
-    }
-
     /// Shrink the capacity of this DataFrame to fit its length.
     pub fn shrink_to_fit(&mut self) {
         // Don't parallelize this. Memory overhead

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -272,7 +272,8 @@ impl DataFrame {
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn new(columns: Vec<Column>) -> PolarsResult<Self> {
-        DataFrame::validate_columns_slice(&columns)?;
+        DataFrame::validate_columns_slice(&columns)
+            .map_err(|e| e.context("could not create a new DataFrame"))?;
         Ok(unsafe { Self::new_no_checks_height_from_first(columns) })
     }
 

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -12,6 +12,9 @@ impl DataFrame {
         Self::validate_columns_iter(columns.iter())
     }
 
+    /// Ensure all equal height and names are unique.
+    ///
+    /// An Ok() result indicates `columns` is a valid state for a DataFrame.
     pub fn validate_columns_iter<'a, I: IntoIterator<Item = &'a Column>>(
         columns_iter: I,
     ) -> PolarsResult<()> {

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -9,7 +9,9 @@ impl DataFrame {
     ///
     /// An Ok() result indicates `columns` is a valid state for a DataFrame.
     pub fn validate_columns_slice(columns: &[Column]) -> PolarsResult<()> {
-        if columns.len() <= 4 {
+        if columns.len() <= 1 {
+            Ok(())
+        } else if columns.len() <= 4 {
             // Too small to be worth spawning a hashmap for, this is at most 6 comparisons.
             for i in 0..columns.len() - 1 {
                 let name = columns[i].name();

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -34,7 +34,7 @@ impl DataFrame {
 
             Ok(())
         } else {
-            Self::validate_columns_iter(columns.iter())
+            DataFrame::validate_columns_iter(columns.iter())
         }
     }
 

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -18,6 +18,8 @@ impl DataFrame {
     pub fn validate_columns_iter<'a, I: IntoIterator<Item = &'a Column>>(
         columns_iter: I,
     ) -> PolarsResult<()> {
+        return _validate_columns_iter_impl(&mut columns_iter.into_iter());
+
         fn _validate_columns_iter_impl(
             columns_iter: &mut dyn Iterator<Item = &Column>,
         ) -> PolarsResult<()> {
@@ -56,7 +58,5 @@ impl DataFrame {
 
             Ok(())
         }
-
-        _validate_columns_iter_impl(&mut columns_iter.into_iter())
     }
 }

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -1,0 +1,59 @@
+use polars_error::{polars_bail, PolarsResult};
+use polars_utils::aliases::{InitHashMaps, PlHashSet};
+
+use super::column::Column;
+use super::DataFrame;
+
+impl DataFrame {
+    /// Ensure all equal height and names are unique.
+    ///
+    /// An Ok() result indicates `columns` is a valid state for a DataFrame.
+    pub fn validate_columns_slice(columns: &[Column]) -> PolarsResult<()> {
+        Self::validate_columns_iter(columns.iter())
+    }
+
+    pub fn validate_columns_iter<'a, I: IntoIterator<Item = &'a Column>>(
+        columns_iter: I,
+    ) -> PolarsResult<()> {
+        fn _validate_columns_iter_impl(
+            columns_iter: &mut dyn Iterator<Item = &Column>,
+        ) -> PolarsResult<()> {
+            let Some(first) = columns_iter.next() else {
+                return Ok(());
+            };
+
+            let first_len = first.len();
+            let first_name = first.name();
+
+            let mut names = PlHashSet::with_capacity({
+                let (_, exact) = columns_iter.size_hint();
+                exact.unwrap_or(16)
+            });
+
+            names.insert(first_name);
+
+            for col in columns_iter {
+                let col_name = col.name();
+                let col_len = col.len();
+
+                if col_len != first_len {
+                    polars_bail!(
+                        ShapeMismatch:
+                        "height of '{}' ({}) does not match height of '{}' ({})",
+                        col_name, col_len, first_name, first_len
+                    )
+                }
+
+                if names.contains(col_name) {
+                    polars_bail!(Duplicate: "column '{}' is duplicate", col_name)
+                }
+
+                names.insert(col_name);
+            }
+
+            Ok(())
+        }
+
+        _validate_columns_iter_impl(&mut columns_iter.into_iter())
+    }
+}

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -44,7 +44,7 @@ impl DataFrame {
                 if col_len != first_len {
                     polars_bail!(
                         ShapeMismatch:
-                        "height of '{}' ({}) does not match height of '{}' ({})",
+                        "height of column '{}' ({}) does not match height of column '{}' ({})",
                         col_name, col_len, first_name, first_len
                     )
                 }

--- a/crates/polars-core/src/frame/validation.rs
+++ b/crates/polars-core/src/frame/validation.rs
@@ -34,14 +34,11 @@ impl DataFrame {
 
             Ok(())
         } else {
-            DataFrame::validate_columns_iter(columns.iter())
+            DataFrame::_validate_columns_iter(columns.iter())
         }
     }
 
-    /// Ensure all equal height and names are unique.
-    ///
-    /// An Ok() result indicates `columns` is a valid state for a DataFrame.
-    pub fn validate_columns_iter<'a, I: IntoIterator<Item = &'a Column>>(
+    fn _validate_columns_iter<'a, I: IntoIterator<Item = &'a Column>>(
         columns_iter: I,
     ) -> PolarsResult<()> {
         return _validate_columns_iter_impl(&mut columns_iter.into_iter());

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -379,6 +379,5 @@ fn pivot_impl_single_column(
     });
     out?;
 
-    // SAFETY: length has already been checked.
-    unsafe { DataFrame::new_no_length_checks(final_cols) }
+    DataFrame::new(final_cols)
 }

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -46,8 +46,7 @@ impl ToDummies for Series {
             })
             .collect::<Vec<_>>();
 
-        // SAFETY: `dummies_helper` functions preserve `self.len()` length
-        unsafe { DataFrame::new_no_length_checks(sort_columns(columns)) }
+        DataFrame::new(sort_columns(columns))
     }
 }
 

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -458,14 +458,14 @@ where
 }
 
 pub fn ensure_matching_schema_names<D>(lhs: &Schema<D>, rhs: &Schema<D>) -> PolarsResult<()> {
-    let lhs = lhs.iter_names().collect::<Vec<_>>();
-    let rhs = rhs.iter_names().collect::<Vec<_>>();
+    let lhs_names = lhs.iter_names();
+    let rhs_names = rhs.iter_names();
 
-    if lhs != rhs {
+    if !(lhs_names.len() == rhs_names.len() && lhs_names.zip(rhs_names).all(|(l, r)| l == r)) {
         polars_bail!(
             SchemaMismatch:
             "lhs: {:?} rhs: {:?}",
-            lhs, rhs
+            lhs.iter_names().collect::<Vec<_>>(), rhs.iter_names().collect::<Vec<_>>()
         )
     }
 

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -457,18 +457,16 @@ where
     }
 }
 
-pub fn debug_ensure_matching_schema_names<D>(lhs: &Schema<D>, rhs: &Schema<D>) -> PolarsResult<()> {
-    if cfg!(debug_assertions) {
-        let lhs = lhs.iter_names().collect::<Vec<_>>();
-        let rhs = rhs.iter_names().collect::<Vec<_>>();
+pub fn ensure_matching_schema_names<D>(lhs: &Schema<D>, rhs: &Schema<D>) -> PolarsResult<()> {
+    let lhs = lhs.iter_names().collect::<Vec<_>>();
+    let rhs = rhs.iter_names().collect::<Vec<_>>();
 
-        if lhs != rhs {
-            polars_bail!(
-                SchemaMismatch:
-                "lhs: {:?} rhs: {:?}",
-                lhs, rhs
-            )
-        }
+    if lhs != rhs {
+        polars_bail!(
+            SchemaMismatch:
+            "lhs: {:?} rhs: {:?}",
+            lhs, rhs
+        )
     }
 
     Ok(())

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3009,7 +3009,7 @@ def test_get_column_index() -> None:
 def test_dataframe_creation_with_different_series_lengths_19795() -> None:
     with pytest.raises(
         ShapeError,
-        match='could not create a new DataFrame: series "a" has length 2 while series "b" has length 1',
+        match=r"could not create a new DataFrame: height of column 'b' \(1\) does not match height of column 'a' \(2\)",
     ):
         pl.DataFrame({"a": [1, 2], "b": [1]})
 


### PR DESCRIPTION
If `self` was empty, we failed to check that the columns within the slice being added all had equal heights.

E.g. this currently passes and creates a DataFrame with invalid state:

```rust
let mut df = DataFrame::empty();
let result = df.hstack_mut(&[
    Column::full_null("a".into(), 1, &DataType::Null),
    Column::full_null("b".into(), 3, &DataType::Null),
]);
```

This PR adds a `DataFrame::validate_columns_slice` function, and we now take an approach where we perform the append first, and then call the validation function on the resulting slice.

There is a chance this PR may start to uncover implementation bugs elsewhere.
