### PR TITLE
fix: Fix ColumnNotFound error selecting `len()` after semi/anti join

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/semi_anti_join.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/semi_anti_join.rs
@@ -19,7 +19,7 @@ pub(super) fn process_semi_anti_join(
     let mut names_left = PlHashSet::with_capacity(n);
     let mut names_right = PlHashSet::with_capacity(n);
 
-    if ctx.acc_projections.is_empty() {
+    if !ctx.has_pushed_down() {
         // Only project the join columns.
         for e in &right_on {
             add_expr_to_accumulated(e.node(), &mut pushdown_right, &mut names_right, expr_arena);

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1800,3 +1800,12 @@ def test_join_where_eager_perf_21145() -> None:
     if runtime_ratio > threshold:
         msg = f"runtime_ratio ({runtime_ratio}) > {threshold}x ({runtime_eager = }, {runtime_lazy = })"
         raise ValueError(msg)
+
+
+def test_select_len_after_semi_anti_join_21343() -> None:
+    lhs = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    rhs = pl.LazyFrame({"a": [1, 2, 3]})
+
+    q = lhs.join(rhs, on="a", how="anti").select(pl.len())
+
+    assert q.collect().item() == 0


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/21343

Note that there are a few other occurrences of `acc_projections.is_empty()` - I'm not sure whether those can be problematic:

<img width="452" alt="image" src="https://github.com/user-attachments/assets/a30c75a5-a7fc-4efa-ad3b-f290c77e596e" />
