### PR TITLE
refactor: Move storage of hive partitions to DataFrame

### DIFF
--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -247,7 +247,7 @@ fn create_physical_plan_impl(
                 return Ok(Box::new(executors::MultiScanExec::new(
                     sources,
                     file_info,
-                    hive_parts,
+                    hive_parts.map(|h| h.into_statistics()),
                     predicate,
                     file_options,
                     scan_type,
@@ -274,7 +274,7 @@ fn create_physical_plan_impl(
                     predicate,
                     options,
                     file_options,
-                    hive_parts,
+                    hive_parts: hive_parts.map(|h| h.into_statistics()),
                     cloud_options,
                     metadata,
                 })),
@@ -286,7 +286,7 @@ fn create_physical_plan_impl(
                 } => Ok(Box::new(executors::ParquetExec::new(
                     sources,
                     file_info,
-                    hive_parts,
+                    hive_parts.map(|h| h.into_statistics()),
                     predicate,
                     options,
                     cloud_options,

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -149,7 +149,7 @@ where
                         metadata,
                         file_options,
                         file_info,
-                        hive_parts,
+                        hive_parts.map(|h| h.into_statistics()),
                         verbose,
                         predicate,
                     )?;

--- a/crates/polars-plan/src/plans/hive.rs
+++ b/crates/polars-plan/src/plans/hive.rs
@@ -14,20 +14,38 @@ pub struct HivePartitions {
     stats: BatchStats,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub struct HivePartitionsDf(DataFrame);
+
 impl HivePartitions {
+    pub fn get_statistics(&self) -> &BatchStats {
+        &self.stats
+    }
+
+    pub fn materialize_partition_columns(&self) -> Vec<Series> {
+        self.stats
+            .column_stats()
+            .iter()
+            .map(|cs| cs.get_min_state().unwrap().clone())
+            .collect()
+    }
+}
+
+impl HivePartitionsDf {
     pub fn get_projection_schema_and_indices(
         &self,
         names: &PlHashSet<PlSmallStr>,
     ) -> (SchemaRef, Vec<usize>) {
-        let mut out_schema = Schema::with_capacity(self.stats.schema().len());
-        let mut out_indices = Vec::with_capacity(self.stats.column_stats().len());
+        let mut out_schema = Schema::with_capacity(self.schema().len());
+        let mut out_indices = Vec::with_capacity(self.0.get_columns().len());
 
-        for (i, cs) in self.stats.column_stats().iter().enumerate() {
-            let name = cs.field_name();
+        for (i, column) in self.0.get_columns().iter().enumerate() {
+            let name = column.name();
             if names.contains(name.as_str()) {
                 out_indices.push(i);
                 out_schema
-                    .insert_at_index(out_schema.len(), name.clone(), cs.dtype().clone())
+                    .insert_at_index(out_schema.len(), name.clone(), column.dtype().clone())
                     .unwrap();
             }
         }
@@ -35,25 +53,52 @@ impl HivePartitions {
         (out_schema.into(), out_indices)
     }
 
-    pub fn apply_projection(&mut self, new_schema: SchemaRef, column_indices: &[usize]) {
-        self.stats.with_schema(new_schema);
-        self.stats.take_indices(column_indices);
+    pub fn apply_projection(&mut self, column_indices: &[usize]) {
+        let schema = self.schema();
+        let projected_schema = schema.try_project_indices(column_indices).unwrap();
+        self.0 = self.0.select(projected_schema.iter_names_cloned()).unwrap();
     }
 
-    pub fn get_statistics(&self) -> &BatchStats {
-        &self.stats
+    pub fn take_indices(&self, row_indexes: &[IdxSize]) -> Self {
+        if !row_indexes.is_empty() {
+            let mut max_idx = 0;
+            for &i in row_indexes {
+                max_idx = max_idx.max(i);
+            }
+            assert!(max_idx < self.0.height() as IdxSize);
+        }
+        // SAFETY: Checked bounds before.
+        Self(unsafe { self.0.take_slice_unchecked(row_indexes) })
     }
 
-    pub(crate) fn schema(&self) -> &SchemaRef {
-        self.get_statistics().schema()
+    pub fn df(&self) -> &DataFrame {
+        &self.0
     }
 
-    pub fn materialize_partition_columns(&self) -> Vec<Series> {
-        self.get_statistics()
-            .column_stats()
-            .iter()
-            .map(|cs| cs.get_min_state().unwrap().clone())
-            .collect()
+    /// Compatibility function. Should be removed later.
+    pub fn into_statistics(&self) -> Arc<Vec<HivePartitions>> {
+        let partitions: Vec<_> = (0..self.0.height())
+            .map(|i| {
+                let column_stats = self
+                    .0
+                    .get_columns()
+                    .iter()
+                    .map(|c| {
+                        ColumnStats::from_column_literal(
+                            c.as_materialized_series().slice(i as i64, 1),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                let stats = BatchStats::new(self.schema().clone(), column_stats, None);
+                HivePartitions { stats }
+            })
+            .collect();
+        Arc::new(partitions)
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        self.0.schema()
     }
 }
 
@@ -67,7 +112,7 @@ pub fn hive_partitions_from_paths(
     schema: Option<SchemaRef>,
     reader_schema: &Schema,
     try_parse_dates: bool,
-) -> PolarsResult<Option<Arc<Vec<HivePartitions>>>> {
+) -> PolarsResult<Option<HivePartitionsDf>> {
     let Some(path) = paths.first() else {
         return Ok(None);
     };
@@ -199,36 +244,16 @@ pub fn hive_partitions_from_paths(
         }
     }
 
-    let mut hive_partitions = Vec::with_capacity(paths.len());
     let mut buffers = buffers
         .into_iter()
-        .map(|x| x.into_series())
+        .map(|x| Ok(x.into_series()?.into_column()))
         .collect::<PolarsResult<Vec<_>>>()?;
-
     buffers.sort_by_key(|s| reader_schema.index_of(s.name()).unwrap_or(usize::MAX));
 
-    #[allow(clippy::needless_range_loop)]
-    for i in 0..paths.len() {
-        let column_stats = buffers
-            .iter()
-            .map(|x| {
-                ColumnStats::from_column_literal(unsafe { x.take_slice_unchecked(&[i as IdxSize]) })
-            })
-            .collect::<Vec<_>>();
-
-        if column_stats.is_empty() {
-            polars_bail!(
-                ComputeError: "expected Hive partitioned path, got {}\n\n\
-                This error occurs if some paths are Hive partitioned and some paths are not.",
-                paths[i].to_str().unwrap(),
-            )
-        }
-
-        let stats = BatchStats::new(hive_schema.clone(), column_stats, None);
-        hive_partitions.push(HivePartitions { stats });
-    }
-
-    Ok(Some(Arc::from(hive_partitions)))
+    Ok(Some(HivePartitionsDf(DataFrame::new_with_height(
+        paths.len(),
+        buffers,
+    )?)))
 }
 
 /// Determine the path separator for identifying Hive partitions.

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -10,7 +10,6 @@ use std::fmt;
 
 pub use dot::{EscapeLabel, IRDotDisplay, PathsDisplay, ScanSourcesDisplay};
 pub use format::{ExprIRDisplay, IRDisplay};
-use hive::HivePartitions;
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::unitvec;
@@ -19,6 +18,7 @@ pub use scan_sources::{ScanSource, ScanSourceIter, ScanSourceRef, ScanSources};
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
 
+use self::hive::HivePartitionsDf;
 use crate::prelude::*;
 
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
@@ -57,7 +57,7 @@ pub enum IR {
     Scan {
         sources: ScanSources,
         file_info: FileInfo,
-        hive_parts: Option<Arc<Vec<HivePartitions>>>,
+        hive_parts: Option<HivePartitionsDf>,
         predicate: Option<ExprIR>,
         /// schema of the projected file
         output_schema: Option<SchemaRef>,

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -411,13 +411,15 @@ impl PredicatePushDown<'_> {
                             let mut new_paths = Vec::with_capacity(paths.len());
                             let mut new_hive_parts = Vec::with_capacity(paths.len());
 
+                            let hive_parts_stats = hive_parts.into_statistics();
+
                             for i in 0..paths.len() {
                                 let path = &paths[i];
-                                let hive_parts = &hive_parts[i];
+                                let hive_part = &hive_parts_stats[i];
 
-                                if stats_evaluator.should_read(hive_parts.get_statistics())? {
+                                if stats_evaluator.should_read(hive_part.get_statistics())? {
                                     new_paths.push(path.clone());
-                                    new_hive_parts.push(hive_parts.clone());
+                                    new_hive_parts.push(i as IdxSize);
                                 }
                             }
 
@@ -442,7 +444,7 @@ impl PredicatePushDown<'_> {
                                 });
                             } else {
                                 sources = ScanSources::Paths(new_paths.into());
-                                scan_hive_parts = Some(Arc::from(new_hive_parts));
+                                scan_hive_parts = Some(hive_parts.take_indices(&new_hive_parts));
                             }
                         }
                     }

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan.rs
@@ -17,7 +17,7 @@ use polars_error::{polars_bail, PolarsResult};
 use polars_expr::state::ExecutionState;
 use polars_io::cloud::CloudOptions;
 use polars_io::RowIndex;
-use polars_plan::plans::hive::HivePartitions;
+use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{ScanSource, ScanSourceRef, ScanSources};
 use polars_utils::index::AtomicIdxSize;
 use polars_utils::pl_str::PlSmallStr;
@@ -57,7 +57,7 @@ pub struct MultiScanNode<T: MultiScanable> {
     name: String,
     sources: ScanSources,
 
-    hive_parts: Option<Arc<Vec<HivePartitions>>>,
+    hive_parts: Option<HivePartitionsDf>,
     allow_missing_columns: bool,
     include_file_paths: Option<PlSmallStr>,
 
@@ -77,7 +77,7 @@ impl<T: MultiScanable> MultiScanNode<T> {
     pub fn new(
         sources: ScanSources,
 
-        hive_parts: Option<Arc<Vec<HivePartitions>>>,
+        hive_parts: Option<HivePartitionsDf>,
         allow_missing_columns: bool,
         include_file_paths: Option<PlSmallStr>,
 
@@ -114,7 +114,8 @@ impl<T: MultiScanable> MultiScanNode<T> {
 fn process_dataframe(
     mut df: DataFrame,
     source_name: &PlSmallStr,
-    hive_part: Option<&HivePartitions>,
+    current_scan: usize,
+    hive_parts: Option<&HivePartitionsDf>,
     missing_columns: Option<&Bitmap>,
     include_file_paths: Option<&PlSmallStr>,
 
@@ -135,33 +136,34 @@ fn process_dataframe(
         .into_column();
     }
 
-    if let Some(hive_part) = hive_part {
+    if let Some(hive_parts) = hive_parts {
         let height = df.height();
 
         if cfg!(debug_assertions) {
             let schema = df.schema();
             // We should have projected the hive column out when we read the file.
-            for column in hive_part.get_statistics().column_stats().iter() {
-                assert!(!schema.contains(column.field_name()));
+            for column in hive_parts.df().get_columns() {
+                assert!(!schema.contains(column.name()));
             }
         }
         let mut columns = df.take_columns();
 
-        columns.extend(hive_part.get_statistics().column_stats().iter().filter_map(
-            |column_stat| {
-                let value = column_stat.get_min_state().unwrap().clone();
-                let column_idx = file_schema
-                    .index_of(value.name())
-                    .expect("hive column not in schema");
+        columns.extend(hive_parts.df().get_columns().iter().filter_map(|column| {
+            let column_idx = file_schema
+                .index_of(column.name())
+                .expect("hive column not in schema");
 
-                // If the hive column is not included in the projection, skip it.
-                if projection.is_some_and(|p| !p.get_bit(column_idx)) {
-                    return None;
-                }
+            // If the hive column is not included in the projection, skip it.
+            if projection.is_some_and(|p| !p.get_bit(column_idx)) {
+                return None;
+            }
 
-                Some(ScalarColumn::from_single_value_series(value, height).into_column())
-            },
-        ));
+            // @TODO: Do without cloning the series several times here.
+            let value = column
+                .slice(current_scan as i64, 1)
+                .take_materialized_series();
+            Some(ScalarColumn::from_single_value_series(value, height).into_column())
+        }));
 
         df = DataFrame::new_with_height(height, columns)?;
     }
@@ -393,8 +395,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
         let hive_schema = self
             .hive_parts
             .as_ref()
-            .and_then(|p| Some(p.first()?.get_statistics().schema().clone()))
-            .unwrap_or_else(|| Arc::new(Schema::default()));
+            .map_or_else(|| Arc::new(Schema::default()), |p| p.schema().clone());
         let physical_columns: Bitmap = file_schema
             .iter_names()
             .map(|n| {
@@ -787,7 +788,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
 
                     while current_scan < sources.len() {
                         let source_name = source_name(sources.at(current_scan), current_scan);
-                        let hive_part = hive_parts.as_deref().map(|parts| &parts[current_scan]);
+                        let hive_part = hive_parts.as_ref();
                         let si_recv = &mut si_recv[current_scan % max_concurrent_scans];
                         let Ok(phase) = si_recv.recv().await else {
                             return Ok(());
@@ -800,6 +801,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                 let df = process_dataframe(
                                     df,
                                     &source_name,
+                                    current_scan,
                                     hive_part,
                                     phase.missing_columns.as_ref(),
                                     include_file_paths.as_ref(),
@@ -837,6 +839,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                         let df = process_dataframe(
                                             df,
                                             &source_name,
+                                            current_scan,
                                             hive_part,
                                             phase.missing_columns.as_ref(),
                                             include_file_paths.as_ref(),
@@ -889,6 +892,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                         let df = process_dataframe(
                                             df,
                                             &source_name,
+                                            current_scan,
                                             hive_part,
                                             phase.missing_columns.as_ref(),
                                             include_file_paths.as_ref(),

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -144,11 +144,19 @@ fn visualize_plan_rec(
             (label.to_string(), inputs.as_slice())
         },
         PhysNodeKind::Multiplexer { input } => ("multiplexer".to_string(), from_ref(input)),
-        PhysNodeKind::MultiScan { .. } => ("multi-scan-source".to_string(), &[][..]),
+        PhysNodeKind::MultiScan { hive_parts, .. } => {
+            let mut out = "multi-scan-source".to_string();
+            let mut f = EscapeLabel(&mut out);
+
+            if let Some(v) = hive_parts.as_ref().map(|h| h.df().width()) {
+                write!(f, "\nhive: {} columns", v).unwrap();
+            }
+
+            (out, &[][..])
+        },
         PhysNodeKind::FileScan {
             scan_source,
             file_info,
-            hive_parts,
             output_schema: _,
             scan_type,
             predicate,
@@ -198,13 +206,6 @@ fn visualize_plan_rec(
 
             if let Some(predicate) = predicate.as_ref() {
                 write!(f, "\nfilter: {}", predicate.display(expr_arena)).unwrap();
-            }
-
-            if let Some(v) = hive_parts
-                .as_deref()
-                .map(|x| x[0].get_statistics().column_stats().len())
-            {
-                write!(f, "\nhive: {} columns", v).unwrap();
             }
 
             (out, &[][..])

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -449,7 +449,6 @@ pub fn lower_ir(
                             let node_kind = PhysNodeKind::FileScan {
                                 scan_source,
                                 file_info,
-                                hive_parts,
                                 output_schema: scan_output_schema,
                                 scan_type,
                                 predicate,

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -9,7 +9,7 @@ use polars_error::PolarsResult;
 use polars_io::RowIndex;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::JoinTypeOptionsIR;
-use polars_plan::plans::hive::HivePartitions;
+use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, FileInfo, FileScan, ScanSource, ScanSources, IR};
 use polars_plan::prelude::expr_ir::ExprIR;
 
@@ -172,7 +172,7 @@ pub enum PhysNodeKind {
 
     MultiScan {
         scan_sources: ScanSources,
-        hive_parts: Option<Arc<Vec<HivePartitions>>>,
+        hive_parts: Option<HivePartitionsDf>,
         scan_type: FileScan,
         allow_missing_columns: bool,
         include_file_paths: Option<PlSmallStr>,
@@ -198,7 +198,6 @@ pub enum PhysNodeKind {
     FileScan {
         scan_source: ScanSource,
         file_info: FileInfo,
-        hive_parts: Option<Arc<Vec<HivePartitions>>>,
         predicate: Option<ExprIR>,
         output_schema: Option<SchemaRef>,
         scan_type: FileScan,

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -440,7 +440,6 @@ fn to_graph_rec<'a>(
             let FileScan {
                 scan_source,
                 file_info,
-                hive_parts: _,
                 output_schema,
                 scan_type,
                 predicate,


### PR DESCRIPTION
This makes it so that Hive Partitions are stored in a `DataFrame`. This is going to allow for much more efficient evaluation of the predicates.