### PR TITLE
fix: Properly update groups after `gather` in aggregation context

### DIFF
--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -167,6 +167,7 @@ impl GatherExpr {
             };
 
             ac.with_values(taken, true, Some(&self.expr))?;
+            ac.with_update_groups(UpdateGroups::WithSeriesLen);
             Ok(ac)
         } else {
             self.gather_aggregated_expensive(ac, idx)
@@ -185,7 +186,7 @@ impl GatherExpr {
             .try_apply_amortized(|s| s.as_ref().take(idx))?;
 
         ac.with_values(out.into_column(), true, Some(&self.expr))?;
-        ac.with_update_groups(UpdateGroups::WithGroupsLen);
+        ac.with_update_groups(UpdateGroups::WithSeriesLen);
         Ok(ac)
     }
 
@@ -233,7 +234,7 @@ impl GatherExpr {
                     };
 
                     ac.with_values(taken, true, Some(&self.expr))?;
-                    ac.with_update_groups(UpdateGroups::WithGroupsLen);
+                    ac.with_update_groups(UpdateGroups::WithSeriesLen);
                     Ok(ac)
                 },
             }
@@ -268,6 +269,7 @@ impl GatherExpr {
         }
         let out = builder.finish().into_column();
         ac.with_agg_state(AggState::AggregatedList(out));
+        ac.with_update_groups(UpdateGroups::WithSeriesLen);
         Ok(ac)
     }
 }


### PR DESCRIPTION
I traced #21178 down to `gather` in aggregation context not updating the groups properly.

This PR makes sure the groups are updated, otherwise this causes wrong results or OOB access in the following operation. I checked that each changed line fixes the matching test.

I added Python tests to cover each of the changed lines, but they are a bit fragile, since there is no guarantee they will keep triggering this Rust code in the future. Is there a better way I can write the tests, maybe as Rust unit tests?

Closes #21178