### PR TITLE
refactor(rust): Add ArrayBuilders

### DIFF
--- a/crates/polars-arrow/src/array/binview/builder.rs
+++ b/crates/polars-arrow/src/array/binview/builder.rs
@@ -5,7 +5,6 @@ use hashbrown::hash_map::Entry;
 use polars_utils::aliases::{InitHashMaps, PlHashMap};
 use polars_utils::IdxSize;
 
-use super::BinaryViewArray;
 use crate::array::binview::{DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE};
 use crate::array::builder::{ArrayBuilder, ShareStrategy, StaticArrayBuilder};
 use crate::array::{Array, BinaryViewArrayGeneric, View, ViewType};
@@ -249,7 +248,12 @@ impl<V: ViewType + ?Sized> StaticArrayBuilder for BinaryViewArrayGenericBuilder<
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
-    unsafe fn gather_extend(&mut self, other: &Self::Array, idxs: &[IdxSize], share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        other: &Self::Array,
+        idxs: &[IdxSize],
+        share: ShareStrategy,
+    ) {
         self.views.reserve(idxs.len());
 
         unsafe {

--- a/crates/polars-arrow/src/array/binview/builder.rs
+++ b/crates/polars-arrow/src/array/binview/builder.rs
@@ -1,0 +1,269 @@
+use std::marker::PhantomData;
+use std::sync::{Arc, LazyLock};
+
+use hashbrown::hash_map::Entry;
+use polars_utils::aliases::{InitHashMaps, PlHashMap};
+use polars_utils::IdxSize;
+
+use super::BinaryViewArray;
+use crate::array::binview::{DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE};
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
+use crate::array::{Array, BinaryViewArrayGeneric, View, ViewType};
+use crate::bitmap::{BitmapBuilder, OptBitmapBuilder};
+use crate::buffer::Buffer;
+use crate::datatypes::ArrowDataType;
+
+static PLACEHOLDER_BUFFER: LazyLock<Buffer<u8>> = LazyLock::new(|| Buffer::from_static(&[]));
+
+pub struct BinaryViewArrayGenericBuilder<V: ViewType + ?Sized> {
+    dtype: ArrowDataType,
+    views: Vec<View>,
+    active_buffer: Vec<u8>,
+    active_buffer_idx: u32,
+    buffer_set: Vec<Buffer<u8>>,
+    stolen_buffers: PlHashMap<*const u8, u32>,
+
+    // With these we can amortize buffer set translation costs if repeatedly
+    // stealing from the same set of buffers.
+    last_buffer_set_stolen_from: Option<Arc<[Buffer<u8>]>>,
+    buffer_set_translation_idxs: Vec<(u32, u32)>, // (idx, generation)
+    buffer_set_translation_generation: u32,
+
+    validity: OptBitmapBuilder,
+    /// Total bytes length if we would concatenate them all.
+    total_bytes_len: usize,
+    /// Total bytes in the buffer set (excluding remaining capacity).
+    total_buffer_len: usize,
+    view_type: PhantomData<V>,
+}
+
+impl<V: ViewType + ?Sized> BinaryViewArrayGenericBuilder<V> {
+    pub fn new(dtype: ArrowDataType) -> Self {
+        Self {
+            dtype,
+            views: Vec::new(),
+            active_buffer: Vec::new(),
+            active_buffer_idx: 0,
+            buffer_set: Vec::new(),
+            stolen_buffers: PlHashMap::new(),
+            last_buffer_set_stolen_from: None,
+            buffer_set_translation_idxs: Vec::new(),
+            buffer_set_translation_generation: 0,
+            validity: OptBitmapBuilder::default(),
+            total_bytes_len: 0,
+            total_buffer_len: 0,
+            view_type: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn reserve_active_buffer(&mut self, additional: usize) {
+        let len = self.active_buffer.len();
+        let cap = self.active_buffer.capacity();
+        if additional > cap - len || len + additional >= (u32::MAX - 1) as usize {
+            self.reserve_active_buffer_slow(additional);
+        }
+    }
+
+    #[cold]
+    fn reserve_active_buffer_slow(&mut self, additional: usize) {
+        assert!(
+            additional <= (u32::MAX - 1) as usize,
+            "strings longer than 2^32 - 2 are not supported"
+        );
+
+        // Allocate a new buffer and flush the old buffer.
+        let new_capacity = (self.active_buffer.capacity() * 2)
+            .clamp(DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE)
+            .max(additional);
+
+        let old_buffer =
+            core::mem::replace(&mut self.active_buffer, Vec::with_capacity(new_capacity));
+        if !old_buffer.is_empty() {
+            //  Replace dummy with real buffer.
+            self.buffer_set[self.active_buffer_idx as usize] = Buffer::from(old_buffer);
+        }
+        self.active_buffer_idx = self.buffer_set.len().try_into().unwrap();
+        self.buffer_set.push(PLACEHOLDER_BUFFER.clone()) // Push placeholder so active_buffer_idx stays valid.
+    }
+
+    fn push_value_ignore_validity(&mut self, bytes: &V) {
+        let bytes = bytes.to_bytes();
+        self.total_bytes_len += bytes.len();
+        unsafe {
+            let view = if bytes.len() > View::MAX_INLINE_SIZE as usize {
+                self.reserve_active_buffer(bytes.len());
+
+                let buffer_idx = u32::try_from(self.buffer_set.len()).unwrap();
+                let offset = self.active_buffer.len() as u32; // Ensured no overflow by reserve_active_buffer.
+                self.active_buffer.extend_from_slice(bytes);
+                self.total_buffer_len += bytes.len();
+                View::new_noninline_unchecked(bytes, buffer_idx, offset)
+            } else {
+                View::new_inline_unchecked(bytes)
+            };
+            self.views.push(view);
+        }
+    }
+    
+    fn switch_active_stealing_bufferset_to(&mut self, buffer_set: &Arc<[Buffer<u8>]>) {
+        // Fat pointer equality, checks both start and length.
+        if self.last_buffer_set_stolen_from.as_ref().is_some_and(|stolen_bs| std::ptr::eq(
+            Arc::as_ptr(stolen_bs),
+            Arc::as_ptr(buffer_set)
+        )) {
+            return; // Already active.
+        }
+        
+        // Switch to new generation (invalidating all old translation indices),
+        // and resizing the buffer with invalid indices if necessary.
+        let old_gen = self.buffer_set_translation_generation;
+        self.buffer_set_translation_generation = old_gen.wrapping_add(1);
+        if self.buffer_set_translation_idxs.len() < buffer_set.len() {
+            self.buffer_set_translation_idxs.resize(buffer_set.len(), (0, old_gen));
+        }
+    }
+    
+    unsafe fn extend_views_dedup_ignore_validity(&mut self, views: impl IntoIterator<Item=View>, other_bufferset: &Arc<[Buffer<u8>]>) {
+        // TODO: if there are way more buffers than length translate per-view
+        // rather than all at once.
+        self.switch_active_stealing_bufferset_to(other_bufferset);
+
+        for mut view in views {
+            if view.length > View::MAX_INLINE_SIZE {
+                // Translate from old array-local buffer idx to global stolen buffer idx.
+                let (mut new_buffer_idx, gen) =
+                    *self.buffer_set_translation_idxs.get_unchecked(view.buffer_idx as usize);
+                if gen != self.buffer_set_translation_generation {
+                    // This buffer index wasn't seen before for this array, do a dedup lookup.
+                    // Since we map by starting pointer and different subslices may have different lengths, we expand
+                    // the buffer to the maximum it could be.
+                    let buffer = other_bufferset.get_unchecked(view.buffer_idx as usize).clone().expand_end_to_storage();
+                    let buf_id = buffer.as_slice().as_ptr();
+                    let idx = match self.stolen_buffers.entry(buf_id) {
+                        Entry::Occupied(o) => *o.get(),
+                        Entry::Vacant(v) => {
+                            let idx = self.buffer_set.len() as u32;
+                            self.total_buffer_len += buffer.len();
+                            self.buffer_set.push(buffer);
+                            v.insert(idx);
+                            idx
+                        },
+                    };
+
+                    // Cache result for future lookups.
+                    *self.buffer_set_translation_idxs.get_unchecked_mut(view.buffer_idx as usize) = (idx, self.buffer_set_translation_generation);
+                    new_buffer_idx = idx;
+                }
+                view.buffer_idx = new_buffer_idx;
+            }
+
+            self.total_bytes_len += view.length as usize;
+            self.views.push(view);
+        }
+    }
+}
+
+impl<V: ViewType + ?Sized> ArrayBuilder for BinaryViewArrayGenericBuilder<V> {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.views.reserve(additional);
+        self.validity.reserve(additional);
+    }
+
+    fn freeze(mut self) -> Box<dyn Array> {
+        // Flush active buffer and/or remove extra placeholder buffer.
+        if !self.active_buffer.is_empty() {
+            self.buffer_set[self.active_buffer_idx as usize] = Buffer::from(self.active_buffer);
+        } else if self.buffer_set.last().is_some_and(|b| b.is_empty()) {
+            self.buffer_set.pop();
+        }
+
+        unsafe {
+            Box::new(BinaryViewArray::new_unchecked(
+                self.dtype,
+                Buffer::from(self.views),
+                Arc::from(self.buffer_set),
+                self.validity.into_opt_validity(),
+                self.total_bytes_len,
+                self.total_buffer_len,
+            ))
+        }
+    }
+
+    fn subslice_extend(
+        &mut self,
+        other: &dyn Array,
+        start: usize,
+        length: usize,
+        share: ShareStrategy,
+    ) {
+        let other: &BinaryViewArrayGeneric<V> = other.as_any().downcast_ref().unwrap();
+        self.views.reserve(length);
+
+        unsafe {
+            match share {
+                ShareStrategy::Never => {
+                    if let Some(v) = other.validity() {
+                        for i in start..start + length {
+                            if v.get_bit_unchecked(i) {
+                                self.push_value_ignore_validity(other.value_unchecked(i));
+                            } else {
+                                self.views.push(View::default())
+                            }
+                        }
+                    } else {
+                        for i in start..start + length {
+                            self.push_value_ignore_validity(other.value_unchecked(i));
+                        }
+                    }
+                },
+                ShareStrategy::Always => {
+                    let other_views = &other.views()[start..start + length];
+                    self.extend_views_dedup_ignore_validity(other_views.iter().copied(), other.data_buffers());
+                },
+            }
+        }
+
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
+    }
+
+    unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], share: ShareStrategy) {
+        let other: &BinaryViewArrayGeneric<V> = other.as_any().downcast_ref().unwrap();
+        self.views.reserve(idxs.len());
+
+        unsafe {
+            match share {
+                ShareStrategy::Never => {
+                    if let Some(v) = other.validity() {
+                        for idx in idxs {
+                            if v.get_bit_unchecked(*idx as usize) {
+                                self.push_value_ignore_validity(
+                                    other.value_unchecked(*idx as usize),
+                                );
+                            } else {
+                                self.views.push(View::default())
+                            }
+                        }
+                    } else {
+                        for idx in idxs {
+                            self.push_value_ignore_validity(other.value_unchecked(*idx as usize));
+                        }
+                    }
+                },
+                ShareStrategy::Always => {
+                    let other_view_slice = other.views().as_slice();
+                    let other_views = idxs.iter().map(|idx| *other_view_slice.get_unchecked(*idx as usize));
+                    self.extend_views_dedup_ignore_validity(other_views, other.data_buffers());
+                },
+            }
+        }
+
+        self.validity
+            .gather_extend_from_opt_validity(other.validity(), idxs);
+    }
+}

--- a/crates/polars-arrow/src/array/binview/builder.rs
+++ b/crates/polars-arrow/src/array/binview/builder.rs
@@ -6,7 +6,7 @@ use polars_utils::aliases::{InitHashMaps, PlHashMap};
 use polars_utils::IdxSize;
 
 use crate::array::binview::{DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE};
-use crate::array::builder::{ArrayBuilder, ShareStrategy, StaticArrayBuilder};
+use crate::array::builder::{ShareStrategy, StaticArrayBuilder};
 use crate::array::{Array, BinaryViewArrayGeneric, View, ViewType};
 use crate::bitmap::OptBitmapBuilder;
 use crate::buffer::Buffer;

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -381,14 +381,14 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         if self
             .validity
             .as_ref()
-            .is_none_or(|v| !v.get_bit_unchecked(i))
+            .is_none_or(|v| v.get_bit_unchecked(i))
         {
-            None
-        } else {
             let v = self.views.get_unchecked(i);
             Some(T::from_bytes_unchecked(
                 v.get_slice_unchecked(&self.buffers),
             ))
+        } else {
+            None
         }
     }
 

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -1,4 +1,3 @@
-
 //! See thread: https://lists.apache.org/thread/w88tpz76ox8h3rxkjl4so6rg3f1rv7wt
 
 mod builder;
@@ -379,11 +378,17 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     /// Assumes that the `i < self.len`.
     #[inline]
     pub unsafe fn get_unchecked(&self, i: usize) -> Option<&T> {
-        if self.validity.as_ref().is_none_or(|v| !v.get_bit_unchecked(i)) {
+        if self
+            .validity
+            .as_ref()
+            .is_none_or(|v| !v.get_bit_unchecked(i))
+        {
             None
         } else {
             let v = self.views.get_unchecked(i);
-            Some(T::from_bytes_unchecked(v.get_slice_unchecked(&self.buffers)))
+            Some(T::from_bytes_unchecked(
+                v.get_slice_unchecked(&self.buffers),
+            ))
         }
     }
 

--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -9,7 +9,9 @@ use polars_utils::aliases::{InitHashMaps, PlHashMap};
 
 use crate::array::binview::iterator::MutableBinaryViewValueIter;
 use crate::array::binview::view::validate_utf8_only;
-use crate::array::binview::{BinaryViewArrayGeneric, ViewType, DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE};
+use crate::array::binview::{
+    BinaryViewArrayGeneric, ViewType, DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE,
+};
 use crate::array::{Array, MutableArray, TryExtend, TryPush, View};
 use crate::bitmap::MutableBitmap;
 use crate::buffer::Buffer;

--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -9,16 +9,13 @@ use polars_utils::aliases::{InitHashMaps, PlHashMap};
 
 use crate::array::binview::iterator::MutableBinaryViewValueIter;
 use crate::array::binview::view::validate_utf8_only;
-use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
+use crate::array::binview::{BinaryViewArrayGeneric, ViewType, DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE};
 use crate::array::{Array, MutableArray, TryExtend, TryPush, View};
 use crate::bitmap::MutableBitmap;
 use crate::buffer::Buffer;
 use crate::datatypes::ArrowDataType;
 use crate::legacy::trusted_len::TrustedLenPush;
 use crate::trusted_len::TrustedLen;
-
-const DEFAULT_BLOCK_SIZE: usize = 8 * 1024;
-const MAX_EXP_BLOCK_SIZE: usize = 16 * 1024 * 1024;
 
 // Invariants:
 //

--- a/crates/polars-arrow/src/array/boolean/builder.rs
+++ b/crates/polars-arrow/src/array/boolean/builder.rs
@@ -1,0 +1,59 @@
+use polars_utils::IdxSize;
+
+use super::BooleanArray;
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
+use crate::array::Array;
+use crate::bitmap::{BitmapBuilder, OptBitmapBuilder};
+use crate::datatypes::ArrowDataType;
+
+pub struct BooleanArrayBuilder {
+    dtype: ArrowDataType,
+    values: BitmapBuilder,
+    validity: OptBitmapBuilder,
+}
+
+impl BooleanArrayBuilder {
+    pub fn new(dtype: ArrowDataType) -> Self {
+        Self {
+            dtype,
+            values: BitmapBuilder::new(),
+            validity: OptBitmapBuilder::default(),
+        }
+    }
+}
+
+impl ArrayBuilder for BooleanArrayBuilder {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.values.reserve(additional);
+        self.validity.reserve(additional);
+    }
+
+    fn freeze(self) -> Box<dyn Array> {
+        let values = self.values.freeze();
+        let validity = self.validity.into_opt_validity();
+        Box::new(BooleanArray::try_new(self.dtype, values, validity).unwrap())
+    }
+
+    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, _share: ShareStrategy) {
+        let other: &BooleanArray = other.as_any().downcast_ref().unwrap();
+        self.values
+            .subslice_extend_from_bitmap(other.values(), start, length);
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
+    }
+
+    unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], _share: ShareStrategy) {
+        let other: &BooleanArray = other.as_any().downcast_ref().unwrap();
+        self.values.reserve(idxs.len());
+        for idx in idxs {
+            self.values
+                .push_unchecked(other.value_unchecked(*idx as usize));
+        }
+        self.validity
+            .gather_extend_from_opt_validity(other.validity(), idxs);
+    }
+}

--- a/crates/polars-arrow/src/array/boolean/builder.rs
+++ b/crates/polars-arrow/src/array/boolean/builder.rs
@@ -52,7 +52,12 @@ impl StaticArrayBuilder for BooleanArrayBuilder {
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
-    unsafe fn gather_extend(&mut self, other: &BooleanArray, idxs: &[IdxSize], _share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        other: &BooleanArray,
+        idxs: &[IdxSize],
+        _share: ShareStrategy,
+    ) {
         self.values.reserve(idxs.len());
         for idx in idxs {
             self.values

--- a/crates/polars-arrow/src/array/boolean/builder.rs
+++ b/crates/polars-arrow/src/array/boolean/builder.rs
@@ -38,7 +38,13 @@ impl ArrayBuilder for BooleanArrayBuilder {
         Box::new(BooleanArray::try_new(self.dtype, values, validity).unwrap())
     }
 
-    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, _share: ShareStrategy) {
+    fn subslice_extend(
+        &mut self,
+        other: &dyn Array,
+        start: usize,
+        length: usize,
+        _share: ShareStrategy,
+    ) {
         let other: &BooleanArray = other.as_any().downcast_ref().unwrap();
         self.values
             .subslice_extend_from_bitmap(other.values(), start, length);

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -1,4 +1,5 @@
 use either::Either;
+use polars_error::{polars_bail, PolarsResult};
 
 use super::{Array, Splitable};
 use crate::array::iterator::NonNullValuesIter;
@@ -12,9 +13,9 @@ pub(super) mod fmt;
 mod from;
 mod iterator;
 mod mutable;
-
 pub use mutable::*;
-use polars_error::{polars_bail, PolarsResult};
+mod builder;
+pub use builder::*;
 
 /// A [`BooleanArray`] is Arrow's semantically equivalent of an immutable `Vec<Option<bool>>`.
 /// It implements [`Array`].

--- a/crates/polars-arrow/src/array/builder.rs
+++ b/crates/polars-arrow/src/array/builder.rs
@@ -7,7 +7,7 @@ use crate::array::fixed_size_list::FixedSizeListArrayBuilder;
 use crate::array::list::ListArrayBuilder;
 use crate::array::null::NullArrayBuilder;
 use crate::array::struct_::StructArrayBuilder;
-use crate::array::{Array, PrimitiveArrayBuilder, StaticArray};
+use crate::array::{Array, PrimitiveArrayBuilder};
 use crate::datatypes::{ArrowDataType, PhysicalType};
 use crate::with_match_primitive_type_full;
 

--- a/crates/polars-arrow/src/array/builder.rs
+++ b/crates/polars-arrow/src/array/builder.rs
@@ -7,7 +7,7 @@ use crate::array::fixed_size_list::FixedSizeListArrayBuilder;
 use crate::array::list::ListArrayBuilder;
 use crate::array::null::NullArrayBuilder;
 use crate::array::struct_::StructArrayBuilder;
-use crate::array::{Array, MutableArray, PrimitiveArrayBuilder, StaticArray};
+use crate::array::{Array, PrimitiveArrayBuilder};
 use crate::datatypes::{ArrowDataType, PhysicalType};
 use crate::with_match_primitive_type_full;
 

--- a/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
@@ -1,8 +1,7 @@
 use polars_utils::IdxSize;
 
 use super::FixedSizeBinaryArray;
-use crate::array::builder::{ArrayBuilder, ShareStrategy, StaticArrayBuilder};
-use crate::array::Array;
+use crate::array::builder::{ShareStrategy, StaticArrayBuilder};
 use crate::bitmap::OptBitmapBuilder;
 use crate::buffer::Buffer;
 use crate::datatypes::ArrowDataType;

--- a/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
@@ -57,7 +57,12 @@ impl StaticArrayBuilder for FixedSizeBinaryArrayBuilder {
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
-    unsafe fn gather_extend(&mut self, other: &FixedSizeBinaryArray, idxs: &[IdxSize], _share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        other: &FixedSizeBinaryArray,
+        idxs: &[IdxSize],
+        _share: ShareStrategy,
+    ) {
         let other_slice = other.values().as_slice();
         let size = FixedSizeBinaryArray::get_size(&self.dtype);
         self.values.reserve(idxs.len() * size);

--- a/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
@@ -1,0 +1,61 @@
+use polars_utils::IdxSize;
+
+use super::FixedSizeBinaryArray;
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
+use crate::array::Array;
+use crate::bitmap::OptBitmapBuilder;
+use crate::buffer::Buffer;
+use crate::datatypes::ArrowDataType;
+
+pub struct FixedSizeBinaryArrayBuilder {
+    dtype: ArrowDataType,
+    values: Vec<u8>,
+    validity: OptBitmapBuilder,
+}
+
+impl FixedSizeBinaryArrayBuilder {
+    pub fn new(dtype: ArrowDataType) -> Self {
+        Self { dtype, values: Vec::new(), validity: OptBitmapBuilder::default() }
+    }
+}
+
+impl ArrayBuilder for FixedSizeBinaryArrayBuilder {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        let bytes = additional * FixedSizeBinaryArray::get_size(&self.dtype);
+        self.values.reserve(bytes);
+        self.validity.reserve(additional);
+    }
+
+    fn freeze(self) -> Box<dyn Array> {
+        let values = Buffer::from(self.values);
+        let validity = self.validity.into_opt_validity();
+        Box::new(FixedSizeBinaryArray::new(self.dtype, values, validity))
+    }
+
+    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, _share: ShareStrategy) {
+        let other: &FixedSizeBinaryArray = other.as_any().downcast_ref().unwrap();
+        let other_slice = other.values().as_slice();
+        let size = FixedSizeBinaryArray::get_size(&self.dtype);
+        self.values.extend_from_slice(&other_slice[start * size..(start + length) * size]);
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
+    }
+
+    unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], _share: ShareStrategy) {
+        let other: &FixedSizeBinaryArray = other.as_any().downcast_ref().unwrap();
+        let other_slice = other.values().as_slice();
+        let size = FixedSizeBinaryArray::get_size(&self.dtype);
+        self.values.reserve(idxs.len() * size);
+        for idx in idxs {
+            let idx = *idx as usize;
+            let subslice = other_slice.get_unchecked(idx * size..(idx + 1) * size);
+            self.values.extend_from_slice(subslice);
+        }
+        self.validity
+            .gather_extend_from_opt_validity(other.validity(), idxs);
+    }
+}

--- a/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
@@ -15,7 +15,11 @@ pub struct FixedSizeBinaryArrayBuilder {
 
 impl FixedSizeBinaryArrayBuilder {
     pub fn new(dtype: ArrowDataType) -> Self {
-        Self { dtype, values: Vec::new(), validity: OptBitmapBuilder::default() }
+        Self {
+            dtype,
+            values: Vec::new(),
+            validity: OptBitmapBuilder::default(),
+        }
     }
 }
 
@@ -36,11 +40,18 @@ impl ArrayBuilder for FixedSizeBinaryArrayBuilder {
         Box::new(FixedSizeBinaryArray::new(self.dtype, values, validity))
     }
 
-    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, _share: ShareStrategy) {
+    fn subslice_extend(
+        &mut self,
+        other: &dyn Array,
+        start: usize,
+        length: usize,
+        _share: ShareStrategy,
+    ) {
         let other: &FixedSizeBinaryArray = other.as_any().downcast_ref().unwrap();
         let other_slice = other.values().as_slice();
         let size = FixedSizeBinaryArray::get_size(&self.dtype);
-        self.values.extend_from_slice(&other_slice[start * size..(start + length) * size]);
+        self.values
+            .extend_from_slice(&other_slice[start * size..(start + length) * size]);
         self.validity
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -6,6 +6,8 @@ use crate::datatypes::ArrowDataType;
 mod ffi;
 pub(super) mod fmt;
 mod iterator;
+mod builder;
+pub use builder::*;
 mod mutable;
 pub use mutable::*;
 use polars_error::{polars_bail, polars_ensure, PolarsResult};

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -3,10 +3,10 @@ use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
 use crate::datatypes::ArrowDataType;
 
+mod builder;
 mod ffi;
 pub(super) mod fmt;
 mod iterator;
-mod builder;
 pub use builder::*;
 mod mutable;
 pub use mutable::*;

--- a/crates/polars-arrow/src/array/fixed_size_list/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/builder.rs
@@ -2,7 +2,6 @@ use polars_utils::IdxSize;
 
 use super::FixedSizeListArray;
 use crate::array::builder::{ArrayBuilder, ShareStrategy, StaticArrayBuilder};
-use crate::array::Array;
 use crate::bitmap::OptBitmapBuilder;
 use crate::datatypes::ArrowDataType;
 

--- a/crates/polars-arrow/src/array/fixed_size_list/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/builder.rs
@@ -1,0 +1,72 @@
+use polars_utils::IdxSize;
+
+use super::FixedSizeListArray;
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
+use crate::array::Array;
+use crate::bitmap::{BitmapBuilder, OptBitmapBuilder};
+use crate::datatypes::ArrowDataType;
+
+pub struct FixedSizeListArrayBuilder<B: ArrayBuilder> {
+    dtype: ArrowDataType,
+    size: usize,
+    length: usize,
+    inner_builder: B,
+    validity: OptBitmapBuilder,
+}
+impl<B: ArrayBuilder> FixedSizeListArrayBuilder<B> {
+    pub fn new(dtype: ArrowDataType, inner_builder: B) -> Self {
+        Self {
+            size: FixedSizeListArray::get_child_and_size(&dtype).1,
+            dtype,
+            length: 0,
+            inner_builder,
+            validity: OptBitmapBuilder::default(),
+        }
+    }
+}
+
+impl<B: ArrayBuilder> ArrayBuilder for FixedSizeListArrayBuilder<B> {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.inner_builder.reserve(additional);
+        self.validity.reserve(additional);
+    }
+
+    fn freeze(self) -> Box<dyn Array> {
+        let values = self.inner_builder.freeze();
+        let validity = self.validity.into_opt_validity();
+        Box::new(FixedSizeListArray::new(self.dtype, self.length, values, validity))
+    }
+
+    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, share: ShareStrategy) {
+        let other: &FixedSizeListArray = other.as_any().downcast_ref().unwrap();
+        self.inner_builder.subslice_extend(&**other.values(), start * self.size, length * self.size, share);
+        self.validity.subslice_extend_from_opt_validity(other.validity(), start, length);
+        self.length += length;
+    }
+
+    unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], share: ShareStrategy) {
+        let other: &FixedSizeListArray = other.as_any().downcast_ref().unwrap();
+        let other_values = &**other.values();
+        self.inner_builder.reserve(idxs.len() * self.size);
+        
+        // Group consecutive indices into larger copies.
+        let mut group_start = 0;
+        while group_start < idxs.len() {
+            let start_idx = idxs[group_start] as usize;
+            let mut group_len = 1;
+            while group_start + group_len < idxs.len() && idxs[group_start + group_len] as usize == start_idx + group_len {
+                group_len += 1;
+            }
+            self.inner_builder
+                .subslice_extend(other_values, start_idx * self.size, group_len * self.size, share);
+            group_start += group_len;
+        }
+
+        self.validity.gather_extend_from_opt_validity(other.validity(), idxs);
+        self.length += idxs.len();
+    }
+}

--- a/crates/polars-arrow/src/array/fixed_size_list/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/builder.rs
@@ -40,12 +40,7 @@ impl<B: ArrayBuilder> StaticArrayBuilder for FixedSizeListArrayBuilder<B> {
     fn freeze(self) -> FixedSizeListArray {
         let values = self.inner_builder.freeze();
         let validity = self.validity.into_opt_validity();
-        FixedSizeListArray::new(
-            self.dtype,
-            self.length,
-            values,
-            validity,
-        )
+        FixedSizeListArray::new(self.dtype, self.length, values, validity)
     }
 
     fn subslice_extend(
@@ -66,7 +61,12 @@ impl<B: ArrayBuilder> StaticArrayBuilder for FixedSizeListArrayBuilder<B> {
         self.length += length;
     }
 
-    unsafe fn gather_extend(&mut self, other: &FixedSizeListArray, idxs: &[IdxSize], share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        other: &FixedSizeListArray,
+        idxs: &[IdxSize],
+        share: ShareStrategy,
+    ) {
         let other_values = &**other.values();
         self.inner_builder.reserve(idxs.len() * self.size);
 

--- a/crates/polars-arrow/src/array/fixed_size_list/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/builder.rs
@@ -3,7 +3,7 @@ use polars_utils::IdxSize;
 use super::FixedSizeListArray;
 use crate::array::builder::{ArrayBuilder, ShareStrategy};
 use crate::array::Array;
-use crate::bitmap::{BitmapBuilder, OptBitmapBuilder};
+use crate::bitmap::OptBitmapBuilder;
 use crate::datatypes::ArrowDataType;
 
 pub struct FixedSizeListArrayBuilder<B: ArrayBuilder> {
@@ -38,13 +38,30 @@ impl<B: ArrayBuilder> ArrayBuilder for FixedSizeListArrayBuilder<B> {
     fn freeze(self) -> Box<dyn Array> {
         let values = self.inner_builder.freeze();
         let validity = self.validity.into_opt_validity();
-        Box::new(FixedSizeListArray::new(self.dtype, self.length, values, validity))
+        Box::new(FixedSizeListArray::new(
+            self.dtype,
+            self.length,
+            values,
+            validity,
+        ))
     }
 
-    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, share: ShareStrategy) {
+    fn subslice_extend(
+        &mut self,
+        other: &dyn Array,
+        start: usize,
+        length: usize,
+        share: ShareStrategy,
+    ) {
         let other: &FixedSizeListArray = other.as_any().downcast_ref().unwrap();
-        self.inner_builder.subslice_extend(&**other.values(), start * self.size, length * self.size, share);
-        self.validity.subslice_extend_from_opt_validity(other.validity(), start, length);
+        self.inner_builder.subslice_extend(
+            &**other.values(),
+            start * self.size,
+            length * self.size,
+            share,
+        );
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
         self.length += length;
     }
 
@@ -52,21 +69,28 @@ impl<B: ArrayBuilder> ArrayBuilder for FixedSizeListArrayBuilder<B> {
         let other: &FixedSizeListArray = other.as_any().downcast_ref().unwrap();
         let other_values = &**other.values();
         self.inner_builder.reserve(idxs.len() * self.size);
-        
+
         // Group consecutive indices into larger copies.
         let mut group_start = 0;
         while group_start < idxs.len() {
             let start_idx = idxs[group_start] as usize;
             let mut group_len = 1;
-            while group_start + group_len < idxs.len() && idxs[group_start + group_len] as usize == start_idx + group_len {
+            while group_start + group_len < idxs.len()
+                && idxs[group_start + group_len] as usize == start_idx + group_len
+            {
                 group_len += 1;
             }
-            self.inner_builder
-                .subslice_extend(other_values, start_idx * self.size, group_len * self.size, share);
+            self.inner_builder.subslice_extend(
+                other_values,
+                start_idx * self.size,
+                group_len * self.size,
+                share,
+            );
             group_start += group_len;
         }
 
-        self.validity.gather_extend_from_opt_validity(other.validity(), idxs);
+        self.validity
+            .gather_extend_from_opt_validity(other.validity(), idxs);
         self.length += idxs.len();
     }
 }

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -6,6 +6,8 @@ mod ffi;
 pub(super) mod fmt;
 mod iterator;
 
+mod builder;
+pub use builder::*;
 mod mutable;
 pub use mutable::*;
 use polars_error::{polars_bail, polars_ensure, PolarsResult};

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -1,0 +1,88 @@
+use polars_utils::IdxSize;
+
+use super::ListArray;
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
+use crate::array::Array;
+use crate::bitmap::{BitmapBuilder, OptBitmapBuilder};
+use crate::datatypes::ArrowDataType;
+use crate::offset::{Offsets, OffsetsBuffer};
+use crate::types::Offset;
+
+pub struct ListArrayBuilder<O: Offset, B: ArrayBuilder> {
+    dtype: ArrowDataType,
+    offsets: Offsets<O>,
+    inner_builder: B,
+    validity: OptBitmapBuilder,
+}
+
+impl<O: Offset, B: ArrayBuilder> ListArrayBuilder<O, B> {
+    pub fn new(dtype: ArrowDataType, inner_builder: B) -> Self {
+        Self {
+            dtype,
+            inner_builder,
+            offsets: Offsets::new(),
+            validity: OptBitmapBuilder::default(),
+        }
+    }
+}
+
+impl<O: Offset, B: ArrayBuilder> ArrayBuilder for ListArrayBuilder<O, B> {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.offsets.reserve(additional);
+        self.validity.reserve(additional);
+        // No inner reserve, we have no idea how large it needs to be.
+    }
+
+    fn freeze(self) -> Box<dyn Array> {
+        let offsets = OffsetsBuffer::from(self.offsets);
+        let values = self.inner_builder.freeze();
+        let validity = self.validity.into_opt_validity();
+        Box::new(ListArray::new(self.dtype, offsets, values, validity))
+    }
+
+    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, share: ShareStrategy) {
+        let other: &ListArray<O> = other.as_any().downcast_ref().unwrap();
+        let start_offset = other.offsets()[start].to_usize();
+        let stop_offset = other.offsets()[start + length].to_usize();
+        self.offsets.try_extend_from_slice(other.offsets(), start, length).unwrap();
+        self.inner_builder.subslice_extend(&**other.values(), start_offset, stop_offset - start_offset, share);
+        self.validity.subslice_extend_from_opt_validity(other.validity(), start, length);
+    }
+
+    unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], share: ShareStrategy) {
+        let other: &ListArray<O> = other.as_any().downcast_ref().unwrap();
+        let other_values = &**other.values();
+        let other_offsets = other.offsets();
+        
+        // Pre-compute proper length for reserve.
+        let total_len: usize = idxs.iter().map(|i| {
+            let start = other_offsets.get_unchecked(*i as usize).to_usize();
+            let stop = other_offsets.get_unchecked(*i as usize + 1).to_usize();
+            stop - start
+        }).sum();
+        self.inner_builder.reserve(total_len);
+        
+        // Group consecutive indices into larger copies.
+        let mut group_start = 0;
+        while group_start < idxs.len() {
+            let start_idx = idxs[group_start] as usize;
+            let mut group_len = 1;
+            while group_start + group_len < idxs.len() && idxs[group_start + group_len] as usize == start_idx + group_len {
+                group_len += 1;
+            }
+            
+            let start_offset = other_offsets.get_unchecked(start_idx).to_usize();
+            let stop_offset = other_offsets.get_unchecked(start_idx + group_len).to_usize();
+            self.offsets.try_extend_from_slice(other_offsets, group_start, group_len).unwrap();
+            self.inner_builder
+                .subslice_extend(other_values, start_offset, stop_offset - start_offset, share);
+            group_start += group_len;
+        }
+
+        self.validity.gather_extend_from_opt_validity(other.validity(), idxs);
+    }
+}

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -68,7 +68,12 @@ impl<O: Offset, B: ArrayBuilder> StaticArrayBuilder for ListArrayBuilder<O, B> {
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
-    unsafe fn gather_extend(&mut self, other: &ListArray<O>, idxs: &[IdxSize], share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        other: &ListArray<O>,
+        idxs: &[IdxSize],
+        share: ShareStrategy,
+    ) {
         let other_values = &**other.values();
         let other_offsets = other.offsets();
 

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -3,7 +3,7 @@ use polars_utils::IdxSize;
 use super::ListArray;
 use crate::array::builder::{ArrayBuilder, ShareStrategy};
 use crate::array::Array;
-use crate::bitmap::{BitmapBuilder, OptBitmapBuilder};
+use crate::bitmap::OptBitmapBuilder;
 use crate::datatypes::ArrowDataType;
 use crate::offset::{Offsets, OffsetsBuffer};
 use crate::types::Offset;
@@ -44,45 +44,73 @@ impl<O: Offset, B: ArrayBuilder> ArrayBuilder for ListArrayBuilder<O, B> {
         Box::new(ListArray::new(self.dtype, offsets, values, validity))
     }
 
-    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, share: ShareStrategy) {
+    fn subslice_extend(
+        &mut self,
+        other: &dyn Array,
+        start: usize,
+        length: usize,
+        share: ShareStrategy,
+    ) {
         let other: &ListArray<O> = other.as_any().downcast_ref().unwrap();
         let start_offset = other.offsets()[start].to_usize();
         let stop_offset = other.offsets()[start + length].to_usize();
-        self.offsets.try_extend_from_slice(other.offsets(), start, length).unwrap();
-        self.inner_builder.subslice_extend(&**other.values(), start_offset, stop_offset - start_offset, share);
-        self.validity.subslice_extend_from_opt_validity(other.validity(), start, length);
+        self.offsets
+            .try_extend_from_slice(other.offsets(), start, length)
+            .unwrap();
+        self.inner_builder.subslice_extend(
+            &**other.values(),
+            start_offset,
+            stop_offset - start_offset,
+            share,
+        );
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
     unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], share: ShareStrategy) {
         let other: &ListArray<O> = other.as_any().downcast_ref().unwrap();
         let other_values = &**other.values();
         let other_offsets = other.offsets();
-        
+
         // Pre-compute proper length for reserve.
-        let total_len: usize = idxs.iter().map(|i| {
-            let start = other_offsets.get_unchecked(*i as usize).to_usize();
-            let stop = other_offsets.get_unchecked(*i as usize + 1).to_usize();
-            stop - start
-        }).sum();
+        let total_len: usize = idxs
+            .iter()
+            .map(|i| {
+                let start = other_offsets.get_unchecked(*i as usize).to_usize();
+                let stop = other_offsets.get_unchecked(*i as usize + 1).to_usize();
+                stop - start
+            })
+            .sum();
         self.inner_builder.reserve(total_len);
-        
+
         // Group consecutive indices into larger copies.
         let mut group_start = 0;
         while group_start < idxs.len() {
             let start_idx = idxs[group_start] as usize;
             let mut group_len = 1;
-            while group_start + group_len < idxs.len() && idxs[group_start + group_len] as usize == start_idx + group_len {
+            while group_start + group_len < idxs.len()
+                && idxs[group_start + group_len] as usize == start_idx + group_len
+            {
                 group_len += 1;
             }
-            
+
             let start_offset = other_offsets.get_unchecked(start_idx).to_usize();
-            let stop_offset = other_offsets.get_unchecked(start_idx + group_len).to_usize();
-            self.offsets.try_extend_from_slice(other_offsets, group_start, group_len).unwrap();
-            self.inner_builder
-                .subslice_extend(other_values, start_offset, stop_offset - start_offset, share);
+            let stop_offset = other_offsets
+                .get_unchecked(start_idx + group_len)
+                .to_usize();
+            self.offsets
+                .try_extend_from_slice(other_offsets, group_start, group_len)
+                .unwrap();
+            self.inner_builder.subslice_extend(
+                other_values,
+                start_offset,
+                stop_offset - start_offset,
+                share,
+            );
             group_start += group_len;
         }
 
-        self.validity.gather_extend_from_opt_validity(other.validity(), idxs);
+        self.validity
+            .gather_extend_from_opt_validity(other.validity(), idxs);
     }
 }

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -2,7 +2,6 @@ use polars_utils::IdxSize;
 
 use super::ListArray;
 use crate::array::builder::{ArrayBuilder, ShareStrategy, StaticArrayBuilder};
-use crate::array::Array;
 use crate::bitmap::OptBitmapBuilder;
 use crate::datatypes::ArrowDataType;
 use crate::offset::{Offsets, OffsetsBuffer};

--- a/crates/polars-arrow/src/array/list/mod.rs
+++ b/crates/polars-arrow/src/array/list/mod.rs
@@ -4,6 +4,8 @@ use crate::bitmap::Bitmap;
 use crate::datatypes::{ArrowDataType, Field};
 use crate::offset::{Offset, Offsets, OffsetsBuffer};
 
+mod builder;
+pub use builder::*;
 mod ffi;
 pub(super) mod fmt;
 mod iterator;

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -653,6 +653,7 @@ impl<'a> AsRef<(dyn Array + 'a)> for dyn Array {
 
 mod binary;
 mod boolean;
+pub mod builder;
 mod dictionary;
 mod fixed_size_binary;
 mod fixed_size_list;

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -216,7 +216,6 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for NullArray {
     }
 }
 
-
 pub struct NullArrayBuilder {
     dtype: ArrowDataType,
     length: usize,
@@ -233,17 +232,28 @@ impl ArrayBuilder for NullArrayBuilder {
         &self.dtype
     }
 
-    fn reserve(&mut self, _additional: usize) { }
+    fn reserve(&mut self, _additional: usize) {}
 
     fn freeze(self) -> Box<dyn Array> {
         NullArray::new(self.dtype, self.length).to_boxed()
     }
 
-    fn subslice_extend(&mut self, _other: &dyn Array, _start: usize, length: usize, _share: ShareStrategy) {
+    fn subslice_extend(
+        &mut self,
+        _other: &dyn Array,
+        _start: usize,
+        length: usize,
+        _share: ShareStrategy,
+    ) {
         self.length += length;
     }
 
-    unsafe fn gather_extend(&mut self, _other: &dyn Array, idxs: &[IdxSize], _share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        _other: &dyn Array,
+        idxs: &[IdxSize],
+        _share: ShareStrategy,
+    ) {
         self.length += idxs.len();
     }
 }

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -1,8 +1,10 @@
 use std::any::Any;
 
 use polars_error::{polars_bail, PolarsResult};
+use polars_utils::IdxSize;
 
 use super::Splitable;
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
 use crate::array::{Array, FromFfi, MutableArray, ToFfi};
 use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::datatypes::{ArrowDataType, PhysicalType};
@@ -211,5 +213,37 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for NullArray {
     unsafe fn try_from_ffi(array: A) -> PolarsResult<Self> {
         let dtype = array.dtype().clone();
         Self::try_new(dtype, array.array().len())
+    }
+}
+
+
+pub struct NullArrayBuilder {
+    dtype: ArrowDataType,
+    length: usize,
+}
+
+impl NullArrayBuilder {
+    pub fn new(dtype: ArrowDataType) -> Self {
+        Self { dtype, length: 0 }
+    }
+}
+
+impl ArrayBuilder for NullArrayBuilder {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, _additional: usize) { }
+
+    fn freeze(self) -> Box<dyn Array> {
+        NullArray::new(self.dtype, self.length).to_boxed()
+    }
+
+    fn subslice_extend(&mut self, _other: &dyn Array, _start: usize, length: usize, _share: ShareStrategy) {
+        self.length += length;
+    }
+
+    unsafe fn gather_extend(&mut self, _other: &dyn Array, idxs: &[IdxSize], _share: ShareStrategy) {
+        self.length += idxs.len();
     }
 }

--- a/crates/polars-arrow/src/array/primitive/builder.rs
+++ b/crates/polars-arrow/src/array/primitive/builder.rs
@@ -57,7 +57,12 @@ impl<T: NativeType> StaticArrayBuilder for PrimitiveArrayBuilder<T> {
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
-    unsafe fn gather_extend(&mut self, other: &PrimitiveArray<T>, idxs: &[IdxSize], _share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        other: &PrimitiveArray<T>,
+        idxs: &[IdxSize],
+        _share: ShareStrategy,
+    ) {
         let other: &PrimitiveArray<T> = other.as_any().downcast_ref().unwrap();
         self.values.reserve(idxs.len());
         for idx in idxs {

--- a/crates/polars-arrow/src/array/primitive/builder.rs
+++ b/crates/polars-arrow/src/array/primitive/builder.rs
@@ -1,0 +1,57 @@
+use polars_utils::vec::PushUnchecked;
+use polars_utils::IdxSize;
+
+use super::PrimitiveArray;
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
+use crate::array::Array;
+use crate::bitmap::OptBitmapBuilder;
+use crate::buffer::Buffer;
+use crate::datatypes::ArrowDataType;
+use crate::types::NativeType;
+
+pub struct PrimitiveArrayBuilder<T> {
+    dtype: ArrowDataType,
+    values: Vec<T>,
+    validity: OptBitmapBuilder,
+}
+
+impl<T: NativeType> PrimitiveArrayBuilder<T> {
+    pub fn new(dtype: ArrowDataType) -> Self {
+        Self { dtype, values: Vec::new(), validity: OptBitmapBuilder::default() }
+    }
+}
+
+impl<T: NativeType> ArrayBuilder for PrimitiveArrayBuilder<T> {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.values.reserve(additional);
+        self.validity.reserve(additional);
+    }
+
+    fn freeze(self) -> Box<dyn Array> {
+        let values = Buffer::from(self.values);
+        let validity = self.validity.into_opt_validity();
+        Box::new(PrimitiveArray::new(self.dtype, values, validity))
+    }
+
+    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, _share: ShareStrategy) {
+        let other: &PrimitiveArray<T> = other.as_any().downcast_ref().unwrap();
+        self.values.extend_from_slice(&other.values()[start..start+length]);
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
+    }
+
+    unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], _share: ShareStrategy) {
+        let other: &PrimitiveArray<T> = other.as_any().downcast_ref().unwrap();
+        self.values.reserve(idxs.len());
+        for idx in idxs {
+            self.values
+                .push_unchecked(other.value_unchecked(*idx as usize));
+        }
+        self.validity
+            .gather_extend_from_opt_validity(other.validity(), idxs);
+    }
+}

--- a/crates/polars-arrow/src/array/primitive/builder.rs
+++ b/crates/polars-arrow/src/array/primitive/builder.rs
@@ -2,7 +2,7 @@ use polars_utils::vec::PushUnchecked;
 use polars_utils::IdxSize;
 
 use super::PrimitiveArray;
-use crate::array::builder::{ArrayBuilder, ShareStrategy, StaticArrayBuilder};
+use crate::array::builder::{ShareStrategy, StaticArrayBuilder};
 use crate::array::Array;
 use crate::bitmap::OptBitmapBuilder;
 use crate::buffer::Buffer;

--- a/crates/polars-arrow/src/array/primitive/builder.rs
+++ b/crates/polars-arrow/src/array/primitive/builder.rs
@@ -17,7 +17,11 @@ pub struct PrimitiveArrayBuilder<T> {
 
 impl<T: NativeType> PrimitiveArrayBuilder<T> {
     pub fn new(dtype: ArrowDataType) -> Self {
-        Self { dtype, values: Vec::new(), validity: OptBitmapBuilder::default() }
+        Self {
+            dtype,
+            values: Vec::new(),
+            validity: OptBitmapBuilder::default(),
+        }
     }
 }
 
@@ -37,9 +41,16 @@ impl<T: NativeType> ArrayBuilder for PrimitiveArrayBuilder<T> {
         Box::new(PrimitiveArray::new(self.dtype, values, validity))
     }
 
-    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, _share: ShareStrategy) {
+    fn subslice_extend(
+        &mut self,
+        other: &dyn Array,
+        start: usize,
+        length: usize,
+        _share: ShareStrategy,
+    ) {
         let other: &PrimitiveArray<T> = other.as_any().downcast_ref().unwrap();
-        self.values.extend_from_slice(&other.values()[start..start+length]);
+        self.values
+            .extend_from_slice(&other.values()[start..start + length]);
         self.validity
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -18,6 +18,8 @@ pub mod iterator;
 
 mod mutable;
 pub use mutable::*;
+mod builder;
+pub use builder::*;
 use polars_error::{polars_bail, PolarsResult};
 use polars_utils::index::{Bounded, Indexable, NullCount};
 use polars_utils::slice::SliceAble;

--- a/crates/polars-arrow/src/array/struct_/builder.rs
+++ b/crates/polars-arrow/src/array/struct_/builder.rs
@@ -1,0 +1,62 @@
+use polars_utils::IdxSize;
+
+use super::StructArray;
+use crate::array::builder::{ArrayBuilder, ShareStrategy};
+use crate::array::Array;
+use crate::bitmap::OptBitmapBuilder;
+use crate::datatypes::ArrowDataType;
+
+pub struct StructArrayBuilder {
+    dtype: ArrowDataType,
+    length: usize,
+    inner_builders: Vec<Box<dyn ArrayBuilder>>,
+    validity: OptBitmapBuilder,
+}
+
+impl StructArrayBuilder {
+    pub fn new(dtype: ArrowDataType, inner_builders: Vec<Box<dyn ArrayBuilder>>) -> Self {
+        Self {
+            dtype,
+            length: 0,
+            inner_builders,
+            validity: OptBitmapBuilder::default(),
+        }
+    }
+}
+
+impl ArrayBuilder for StructArrayBuilder {
+    fn dtype(&self) -> &ArrowDataType {
+        &self.dtype
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        for builder in &mut self.inner_builders {
+            builder.reserve(additional);
+        }
+        self.validity.reserve(additional);
+    }
+
+    fn freeze(self) -> Box<dyn Array> {
+        let values = self.inner_builders.into_iter().map(|b| b.freeze()).collect();
+        let validity = self.validity.into_opt_validity();
+        Box::new(StructArray::new(self.dtype, self.length, values, validity))
+    }
+
+    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, share: ShareStrategy) {
+        let other: &StructArray = other.as_any().downcast_ref().unwrap();
+        for (builder, other_values) in self.inner_builders.iter_mut().zip(other.values()) {
+            builder.subslice_extend(&**other_values, start, length, share);
+        }
+        self.validity.subslice_extend_from_opt_validity(other.validity(), start, length);
+        self.length += length;
+    }
+
+    unsafe fn gather_extend(&mut self, other: &dyn Array, idxs: &[IdxSize], share: ShareStrategy) {
+        let other: &StructArray = other.as_any().downcast_ref().unwrap();
+        for (builder, other_values) in self.inner_builders.iter_mut().zip(other.values()) {
+            builder.gather_extend(&**other_values, idxs, share);
+        }
+        self.validity.gather_extend_from_opt_validity(other.validity(), idxs);
+        self.length += idxs.len();
+    }
+}

--- a/crates/polars-arrow/src/array/struct_/builder.rs
+++ b/crates/polars-arrow/src/array/struct_/builder.rs
@@ -2,7 +2,6 @@ use polars_utils::IdxSize;
 
 use super::StructArray;
 use crate::array::builder::{ArrayBuilder, ShareStrategy, StaticArrayBuilder};
-use crate::array::Array;
 use crate::bitmap::OptBitmapBuilder;
 use crate::datatypes::ArrowDataType;
 

--- a/crates/polars-arrow/src/array/struct_/builder.rs
+++ b/crates/polars-arrow/src/array/struct_/builder.rs
@@ -63,7 +63,12 @@ impl StaticArrayBuilder for StructArrayBuilder {
         self.length += length;
     }
 
-    unsafe fn gather_extend(&mut self, other: &StructArray, idxs: &[IdxSize], share: ShareStrategy) {
+    unsafe fn gather_extend(
+        &mut self,
+        other: &StructArray,
+        idxs: &[IdxSize],
+        share: ShareStrategy,
+    ) {
         for (builder, other_values) in self.inner_builders.iter_mut().zip(other.values()) {
             builder.gather_extend(&**other_values, idxs, share);
         }

--- a/crates/polars-arrow/src/array/struct_/builder.rs
+++ b/crates/polars-arrow/src/array/struct_/builder.rs
@@ -37,17 +37,28 @@ impl ArrayBuilder for StructArrayBuilder {
     }
 
     fn freeze(self) -> Box<dyn Array> {
-        let values = self.inner_builders.into_iter().map(|b| b.freeze()).collect();
+        let values = self
+            .inner_builders
+            .into_iter()
+            .map(|b| b.freeze())
+            .collect();
         let validity = self.validity.into_opt_validity();
         Box::new(StructArray::new(self.dtype, self.length, values, validity))
     }
 
-    fn subslice_extend(&mut self, other: &dyn Array, start: usize, length: usize, share: ShareStrategy) {
+    fn subslice_extend(
+        &mut self,
+        other: &dyn Array,
+        start: usize,
+        length: usize,
+        share: ShareStrategy,
+    ) {
         let other: &StructArray = other.as_any().downcast_ref().unwrap();
         for (builder, other_values) in self.inner_builders.iter_mut().zip(other.values()) {
             builder.subslice_extend(&**other_values, start, length, share);
         }
-        self.validity.subslice_extend_from_opt_validity(other.validity(), start, length);
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
         self.length += length;
     }
 
@@ -56,7 +67,8 @@ impl ArrayBuilder for StructArrayBuilder {
         for (builder, other_values) in self.inner_builders.iter_mut().zip(other.values()) {
             builder.gather_extend(&**other_values, idxs, share);
         }
-        self.validity.gather_extend_from_opt_validity(other.validity(), idxs);
+        self.validity
+            .gather_extend_from_opt_validity(other.validity(), idxs);
         self.length += idxs.len();
     }
 }

--- a/crates/polars-arrow/src/array/struct_/mod.rs
+++ b/crates/polars-arrow/src/array/struct_/mod.rs
@@ -2,6 +2,8 @@ use super::{new_empty_array, new_null_array, Array, Splitable};
 use crate::bitmap::Bitmap;
 use crate::datatypes::{ArrowDataType, Field};
 
+mod builder;
+pub use builder::*;
 mod ffi;
 pub(super) mod fmt;
 mod iterator;

--- a/crates/polars-arrow/src/bitmap/builder.rs
+++ b/crates/polars-arrow/src/bitmap/builder.rs
@@ -1,4 +1,5 @@
 use polars_utils::slice::load_padded_le_u64;
+use polars_utils::IdxSize;
 
 use super::bitmask::BitMask;
 use crate::bitmap::{Bitmap, MutableBitmap};
@@ -142,7 +143,7 @@ impl BitmapBuilder {
             self.bit_len += length;
         }
     }
-
+    
     /// Pushes the first length bits from the given word, assuming the rest of
     /// the bits are zero.
     /// # Safety
@@ -243,6 +244,36 @@ impl BitmapBuilder {
         self.extend_from_slice(slice, offset, length);
     }
 
+    /// Extends this BitmapBuilder with a subslice of a bitmap.
+    pub fn subslice_extend_from_bitmap(&mut self, bitmap: &Bitmap, start: usize, length: usize) {
+        let (slice, bm_offset, bm_length) = bitmap.as_slice();
+        assert!(start + length <= bm_length);
+        self.extend_from_slice(slice, bm_offset + start, length);
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn gather_extend_from_slice(&mut self, slice: &[u8], offset: usize, length: usize, idxs: &[IdxSize]) {
+        assert!(8 * slice.len() >= offset + length);
+
+        self.reserve(idxs.len());
+        unsafe {
+            for idx in idxs {
+                debug_assert!((*idx as usize) < length);
+                let idx_in_slice = offset + *idx as usize;
+                let bit = (*slice.get_unchecked(idx_in_slice / 8) >> (idx_in_slice % 8)) & 1;
+                self.push_unchecked(bit != 0);
+            }
+        }
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn gather_extend_from_bitmap(&mut self, bitmap: &Bitmap, idxs: &[IdxSize]) {
+        let (slice, offset, length) = bitmap.as_slice();
+        self.gather_extend_from_slice(slice, offset, length, idxs);
+    }
+
     /// # Safety
     /// May only be called once at the end.
     unsafe fn finish(&mut self) {
@@ -325,5 +356,92 @@ impl BitmapBuilder {
         let mut builder = Self::new();
         builder.extend_trusted_len_iter(iterator);
         builder
+    }
+}
+
+
+/// A wrapper for BitmapBuilder that does not allocate until the first false is
+/// pushed. Less efficient if you know there are false values because it must
+/// check if it has allocated for each push.
+pub enum OptBitmapBuilder {
+    AllTrue {
+        bit_len: usize,
+        bit_cap: usize,
+    },
+    MayHaveFalse(BitmapBuilder),
+}
+
+impl Default for OptBitmapBuilder {
+    fn default() -> Self {
+        Self::AllTrue { bit_len: 0, bit_cap: 0 }
+    }
+}
+
+impl OptBitmapBuilder {
+    pub fn reserve(&mut self, additional: usize) {
+        match self {
+            Self::AllTrue { bit_len, bit_cap } => {
+                *bit_cap = usize::max(*bit_cap, *bit_len + additional);
+            }
+            Self::MayHaveFalse(inner) => inner.reserve(additional),
+        }
+    }
+    
+    pub fn extend_constant(&mut self, length: usize, value: bool) {
+        match self {
+            Self::AllTrue { bit_len, bit_cap } => {
+                if value {
+                    *bit_cap = usize::max(*bit_cap, *bit_len + length);
+                    *bit_len += length;
+                } else {
+                    self.get_builder().extend_constant(length, value);
+                }
+            }
+            Self::MayHaveFalse(inner) => inner.extend_constant(length, value),
+        }
+    }
+
+    pub fn into_opt_validity(mut self) -> Option<Bitmap> {
+        match self {
+            Self::AllTrue { .. } => None,
+            Self::MayHaveFalse(inner) => inner.into_opt_validity(),
+        }
+    }
+    
+    pub fn subslice_extend_from_opt_validity(&mut self, bitmap: Option<&Bitmap>, start: usize, length: usize) {
+        match bitmap {
+            Some(bm) => {
+                self.get_builder().subslice_extend_from_bitmap(bm, start, length);
+            }
+            None => {
+                self.extend_constant(length, true);
+            }
+        }
+    }
+    
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn gather_extend_from_opt_validity(&mut self, bitmap: Option<&Bitmap>, idxs: &[IdxSize]) {
+        match bitmap {
+            Some(bm) => {
+                self.get_builder().gather_extend_from_bitmap(bm, idxs);
+            }
+            None => {
+                self.extend_constant(idxs.len(), true);
+            }
+        }
+    }
+
+    fn get_builder(&mut self) -> &mut BitmapBuilder {
+        match self {
+            Self::AllTrue { bit_len, bit_cap } => {
+                let mut builder = BitmapBuilder::with_capacity(*bit_cap);
+                builder.extend_constant(*bit_len, true);
+                *self = Self::MayHaveFalse(builder);
+                let Self::MayHaveFalse(inner) = self else { unreachable!() };
+                inner
+            }
+            Self::MayHaveFalse(inner) => inner,
+        }
     }
 }

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -88,7 +88,7 @@ impl<T> Buffer<T> {
             length,
         }
     }
-    
+
     pub fn from_static(data: &'static [T]) -> Self {
         Self::from_storage(SharedStorage::from_static(data))
     }
@@ -111,7 +111,7 @@ impl<T> Buffer<T> {
     pub fn is_sliced(&self) -> bool {
         self.storage.len() != self.length
     }
-    
+
     /// Expands this slice to the maximum allowed by the underlying storage.
     /// Only expands towards the end, the offset isn't changed. That is, element
     /// i before and after this operation refer to the same element.

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -88,6 +88,10 @@ impl<T> Buffer<T> {
             length,
         }
     }
+    
+    pub fn from_static(data: &'static [T]) -> Self {
+        Self::from_storage(SharedStorage::from_static(data))
+    }
 
     /// Returns the number of bytes in the buffer
     #[inline]
@@ -106,6 +110,20 @@ impl<T> Buffer<T> {
     /// more data than the length of `Self`.
     pub fn is_sliced(&self) -> bool {
         self.storage.len() != self.length
+    }
+    
+    /// Expands this slice to the maximum allowed by the underlying storage.
+    /// Only expands towards the end, the offset isn't changed. That is, element
+    /// i before and after this operation refer to the same element.
+    pub fn expand_end_to_storage(self) -> Self {
+        unsafe {
+            let offset = self.ptr.offset_from(self.storage.as_ptr()) as usize;
+            Self {
+                ptr: self.ptr,
+                length: self.storage.len() - offset,
+                storage: self.storage,
+            }
+        }
     }
 
     /// Returns the byte slice stored in this buffer


### PR DESCRIPTION
This doesn't actually do anything (nor is it tested yet), but I have to slice it somewhere. These builders are intended for the join operator, letting us build arrays by gathering from other arrays, amortizing the allocation. I intend to expand them to more uses, and replace other parts of the code with them (such as the last remaining uses of the `Growable`).