### PR TITLE
feat: Make user facing binary formats mostly self describing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,6 +2786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,6 +3544,7 @@ dependencies = [
  "rand",
  "raw-cpuid",
  "rayon",
+ "rmp-serde",
  "serde",
  "serde_json",
  "stacker",
@@ -4064,6 +4071,28 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ recursive = "0.1"
 regex = "1.9"
 regex-syntax = "0.8.5"
 reqwest = { version = "0.12", default-features = false }
+rmp-serde = "1.3"
 ryu = "1.0.13"
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_json = "1"

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -63,7 +63,7 @@ fn url_and_creds_to_key(url: &Url, options: Option<&CloudOptions>) -> Vec<u8> {
 
     verbose_print_sensitive(|| format!("object store cache key: {} {:?}", url, &cache_key));
 
-    return pl_serialize::serialize_to_bytes(&cache_key).unwrap();
+    return pl_serialize::serialize_to_bytes::<_, false>(&cache_key).unwrap();
 
     #[derive(Clone, Debug, PartialEq, Hash, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize))]

--- a/crates/polars-plan/src/client/mod.rs
+++ b/crates/polars-plan/src/client/mod.rs
@@ -12,7 +12,8 @@ pub fn prepare_cloud_plan(dsl: DslPlan) -> PolarsResult<Vec<u8>> {
 
     // Serialize the plan.
     let mut writer = Vec::new();
-    pl_serialize::SerializeOptions::default().serialize_into_writer(&mut writer, &dsl)?;
+    pl_serialize::SerializeOptions::default()
+        .serialize_into_writer::<_, _, true>(&mut writer, &dsl)?;
 
     Ok(writer)
 }

--- a/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
@@ -73,7 +73,7 @@ impl PythonUdfExpression {
         // Load UDF metadata
         let mut reader = Cursor::new(buf);
         let (output_type, is_elementwise, returns_scalar): (Option<DataType>, bool, bool) =
-            pl_serialize::deserialize_from_reader(&mut reader)?;
+            pl_serialize::deserialize_from_reader::<_, _, true>(&mut reader)?;
 
         let remainder = &buf[reader.position() as usize..];
 
@@ -163,7 +163,7 @@ impl ColumnsUdf for PythonUdfExpression {
             buf.extend_from_slice(&*PYTHON3_VERSION);
 
             // Write UDF metadata
-            pl_serialize::serialize_into_writer(
+            pl_serialize::serialize_into_writer::<_, _, true>(
                 &mut *buf,
                 &(
                     self.output_type.clone(),
@@ -199,7 +199,8 @@ impl PythonGetOutput {
         let buf = &buf[PYTHON_SERDE_MAGIC_BYTE_MARK.len()..];
 
         let mut reader = Cursor::new(buf);
-        let return_dtype: Option<DataType> = pl_serialize::deserialize_from_reader(&mut reader)?;
+        let return_dtype: Option<DataType> =
+            pl_serialize::deserialize_from_reader::<_, _, true>(&mut reader)?;
 
         Ok(Arc::new(Self::new(return_dtype)) as Arc<dyn FunctionOutputField>)
     }
@@ -226,7 +227,7 @@ impl FunctionOutputField for PythonGetOutput {
         use polars_utils::pl_serialize;
 
         buf.extend_from_slice(PYTHON_SERDE_MAGIC_BYTE_MARK);
-        pl_serialize::serialize_into_writer(&mut *buf, &self.return_dtype)
+        pl_serialize::serialize_into_writer::<_, _, true>(&mut *buf, &self.return_dtype)
     }
 }
 

--- a/crates/polars-plan/src/plans/python/predicate.rs
+++ b/crates/polars-plan/src/plans/python/predicate.rs
@@ -62,7 +62,7 @@ pub fn serialize(expr: &Expr) -> PolarsResult<Option<Vec<u8>>> {
         return Ok(None);
     }
     let mut buf = vec![];
-    pl_serialize::serialize_into_writer(&mut buf, expr)?;
+    pl_serialize::serialize_into_writer::<_, _, true>(&mut buf, expr)?;
 
     Ok(Some(buf))
 }

--- a/crates/polars-python/src/cloud.rs
+++ b/crates/polars-python/src/cloud.rs
@@ -29,7 +29,8 @@ pub fn prepare_cloud_plan(lf: PyLazyFrame, py: Python<'_>) -> PyResult<Bound<'_,
 pub fn _execute_ir_plan_with_gpu(ir_plan_ser: Vec<u8>, py: Python) -> PyResult<PyDataFrame> {
     // Deserialize into IRPlan.
     let mut ir_plan: IRPlan =
-        pl_serialize::deserialize_from_reader(ir_plan_ser.as_slice()).map_err(PyPolarsErr::from)?;
+        pl_serialize::deserialize_from_reader::<_, _, false>(ir_plan_ser.as_slice())
+            .map_err(PyPolarsErr::from)?;
 
     // Edit for use with GPU engine.
     gpu_post_opt(

--- a/crates/polars-python/src/expr/serde.rs
+++ b/crates/polars-python/src/expr/serde.rs
@@ -13,11 +13,13 @@ use crate::PyExpr;
 
 #[pymethods]
 impl PyExpr {
+    // Pickle we set FC is false, as that is used for caching (compact is faster) and is not intended to be used
+    // accross different versions.
     fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
         // Used in pickle/pickling
         let mut writer: Vec<u8> = vec![];
         pl_serialize::SerializeOptions::default()
-            .serialize_into_writer(&mut writer, &self.inner)
+            .serialize_into_writer::<_, _, false>(&mut writer, &self.inner)
             .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
 
         Ok(PyBytes::new(py, &writer))
@@ -27,7 +29,7 @@ impl PyExpr {
         // Used in pickle/pickling
         let bytes = state.extract::<PyBackedBytes>()?;
         self.inner = pl_serialize::SerializeOptions::default()
-            .deserialize_from_reader(&*bytes)
+            .deserialize_from_reader::<_, _, false>(&*bytes)
             .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
         Ok(())
     }
@@ -37,7 +39,7 @@ impl PyExpr {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         pl_serialize::SerializeOptions::default()
-            .serialize_into_writer(writer, &self.inner)
+            .serialize_into_writer::<_, _, true>(writer, &self.inner)
             .map_err(|err| ComputeError::new_err(err.to_string()))
     }
 
@@ -56,7 +58,7 @@ impl PyExpr {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
         let expr: Expr = pl_serialize::SerializeOptions::default()
-            .deserialize_from_reader(reader)
+            .deserialize_from_reader::<_, _, true>(reader)
             .map_err(|err| ComputeError::new_err(err.to_string()))?;
         Ok(expr.into())
     }

--- a/crates/polars-python/src/expr/serde.rs
+++ b/crates/polars-python/src/expr/serde.rs
@@ -14,7 +14,7 @@ use crate::PyExpr;
 #[pymethods]
 impl PyExpr {
     // Pickle we set FC is false, as that is used for caching (compact is faster) and is not intended to be used
-    // accross different versions.
+    // across different versions.
     fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
         // Used in pickle/pickling
         let mut writer: Vec<u8> = vec![];

--- a/crates/polars-python/src/lazyframe/serde.rs
+++ b/crates/polars-python/src/lazyframe/serde.rs
@@ -18,7 +18,7 @@ impl PyLazyFrame {
         let writer = BufWriter::new(file);
         py.enter_polars(|| {
             pl_serialize::SerializeOptions::default()
-                .serialize_into_writer(writer, &self.ldf.logical_plan)
+                .serialize_into_writer::<_, _, true>(writer, &self.ldf.logical_plan)
         })
     }
 
@@ -39,7 +39,7 @@ impl PyLazyFrame {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
         let lp: DslPlan = py.enter_polars(|| {
-            pl_serialize::SerializeOptions::default().deserialize_from_reader(reader)
+            pl_serialize::SerializeOptions::default().deserialize_from_reader::<_, _, true>(reader)
         })?;
         Ok(LazyFrame::from(lp).into())
     }

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -9,8 +9,6 @@ repository = { workspace = true }
 description = "Private utils for the Polars DataFrame library"
 
 [dependencies]
-polars-error = { workspace = true }
-
 ahash = { workspace = true }
 bincode = { workspace = true, optional = true }
 bytemuck = { workspace = true }
@@ -23,10 +21,12 @@ libc = { workspace = true }
 memmap = { workspace = true, optional = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
+polars-error = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 rand = { workspace = true }
 raw-cpuid = { workspace = true }
 rayon = { workspace = true }
+rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 stacker = { workspace = true }
@@ -43,5 +43,5 @@ mmap = ["memmap"]
 bigidx = []
 nightly = []
 ir_serde = ["serde"]
-serde = ["dep:serde", "serde/derive", "dep:bincode", "dep:flate2", "dep:serde_json"]
+serde = ["dep:serde", "serde/derive", "dep:rmp-serde", "dep:bincode", "dep:flate2", "dep:serde_json"]
 python = ["pyo3"]

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -1,19 +1,33 @@
+//! Centralized Polars serialization entry.
+//!
+//! Currently provides two serialization scheme's.
+//! - Self-describing (and thus more forward compatible) activated with `FC: true`
+//! - Compact activated with `FC: false`
 use polars_error::{to_compute_err, PolarsResult};
 
-fn serialize_impl<W, T>(writer: W, value: &T) -> PolarsResult<()>
+fn serialize_impl<W, T, const FC: bool>(writer: W, value: &T) -> PolarsResult<()>
 where
     W: std::io::Write,
     T: serde::ser::Serialize,
 {
-    bincode::serialize_into(writer, value).map_err(to_compute_err)
+    if FC {
+        let mut s = rmp_serde::Serializer::new(writer).with_struct_map();
+        value.serialize(&mut s).map_err(to_compute_err)
+    } else {
+        bincode::serialize_into(writer, value).map_err(to_compute_err)
+    }
 }
 
-pub fn deserialize_impl<T, R>(reader: R) -> PolarsResult<T>
+pub fn deserialize_impl<T, R, const FC: bool>(reader: R) -> PolarsResult<T>
 where
     T: serde::de::DeserializeOwned,
     R: std::io::Read,
 {
-    bincode::deserialize_from(reader).map_err(to_compute_err)
+    if FC {
+        rmp_serde::from_read(reader).map_err(to_compute_err)
+    } else {
+        bincode::deserialize_from(reader).map_err(to_compute_err)
+    }
 }
 
 /// Mainly used to enable compression when serializing the final outer value.
@@ -29,38 +43,42 @@ impl SerializeOptions {
         self
     }
 
-    pub fn serialize_into_writer<W, T>(&self, writer: W, value: &T) -> PolarsResult<()>
+    pub fn serialize_into_writer<W, T, const FC: bool>(
+        &self,
+        writer: W,
+        value: &T,
+    ) -> PolarsResult<()>
     where
         W: std::io::Write,
         T: serde::ser::Serialize,
     {
         if self.compression {
             let writer = flate2::write::ZlibEncoder::new(writer, flate2::Compression::fast());
-            serialize_impl(writer, value)
+            serialize_impl::<_, _, FC>(writer, value)
         } else {
-            serialize_impl(writer, value)
+            serialize_impl::<_, _, FC>(writer, value)
         }
     }
 
-    pub fn deserialize_from_reader<T, R>(&self, reader: R) -> PolarsResult<T>
+    pub fn deserialize_from_reader<T, R, const FC: bool>(&self, reader: R) -> PolarsResult<T>
     where
         T: serde::de::DeserializeOwned,
         R: std::io::Read,
     {
         if self.compression {
-            deserialize_impl(flate2::read::ZlibDecoder::new(reader))
+            deserialize_impl::<_, _, FC>(flate2::read::ZlibDecoder::new(reader))
         } else {
-            deserialize_impl(reader)
+            deserialize_impl::<_, _, FC>(reader)
         }
     }
 
-    pub fn serialize_to_bytes<T>(&self, value: &T) -> PolarsResult<Vec<u8>>
+    pub fn serialize_to_bytes<T, const FC: bool>(&self, value: &T) -> PolarsResult<Vec<u8>>
     where
         T: serde::ser::Serialize,
     {
         let mut v = vec![];
 
-        self.serialize_into_writer(&mut v, value)?;
+        self.serialize_into_writer::<_, _, FC>(&mut v, value)?;
 
         Ok(v)
     }
@@ -73,29 +91,29 @@ impl Default for SerializeOptions {
     }
 }
 
-pub fn serialize_into_writer<W, T>(writer: W, value: &T) -> PolarsResult<()>
+pub fn serialize_into_writer<W, T, const FC: bool>(writer: W, value: &T) -> PolarsResult<()>
 where
     W: std::io::Write,
     T: serde::ser::Serialize,
 {
-    serialize_impl(writer, value)
+    serialize_impl::<_, _, FC>(writer, value)
 }
 
-pub fn deserialize_from_reader<T, R>(reader: R) -> PolarsResult<T>
+pub fn deserialize_from_reader<T, R, const FC: bool>(reader: R) -> PolarsResult<T>
 where
     T: serde::de::DeserializeOwned,
     R: std::io::Read,
 {
-    deserialize_impl(reader)
+    deserialize_impl::<_, _, FC>(reader)
 }
 
-pub fn serialize_to_bytes<T>(value: &T) -> PolarsResult<Vec<u8>>
+pub fn serialize_to_bytes<T, const FC: bool>(value: &T) -> PolarsResult<Vec<u8>>
 where
     T: serde::ser::Serialize,
 {
     let mut v = vec![];
 
-    serialize_into_writer(&mut v, value)?;
+    serialize_into_writer::<_, _, FC>(&mut v, value)?;
 
     Ok(v)
 }
@@ -177,17 +195,17 @@ mod tests {
         }
 
         let v = Enum::A;
-        let b = super::serialize_to_bytes(&v).unwrap();
-        let r: Enum = super::deserialize_from_reader(b.as_slice()).unwrap();
+        let b = super::serialize_to_bytes::<_, false>(&v).unwrap();
+        let r: Enum = super::deserialize_from_reader::<_, _, false>(b.as_slice()).unwrap();
 
         assert_eq!(r, v);
 
         let v = Enum::A;
         let b = super::SerializeOptions::default()
-            .serialize_to_bytes(&v)
+            .serialize_to_bytes::<_, false>(&v)
             .unwrap();
         let r: Enum = super::SerializeOptions::default()
-            .deserialize_from_reader(b.as_slice())
+            .deserialize_from_reader::<_, _, false>(b.as_slice())
             .unwrap();
 
         assert_eq!(r, v);


### PR DESCRIPTION
Though we don't guarantee anything, this makes it much more likely that binary serialized data can be read across versions. 

The data is serialized into IPC for both compact as self-describing, so that is a compact serialization in both cases. As we call `serialize_bytes` on the `Series` impl. I believe we should go in the most optimal (1 byte per u8) encoding.

The caller must decide if it wants the `FC: true` (forward compatible) encoding via msgpack or `FC: false` encoding via bincode.