### PR TITLE
fix: Allow duration multiplied w/ primitive to propagate in IR schema

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -595,6 +595,14 @@ fn get_arithmetic_field(
                         polars_bail!(InvalidOperation: "{} not allowed on {} and {}", op, left_field.dtype, right_type)
                     },
                 },
+                (Duration(_), r) if r.is_primitive_numeric() => match op {
+                    Operator::Multiply => {
+                        return Ok(left_field);
+                    },
+                    _ => {
+                        polars_bail!(InvalidOperation: "{} not allowed on {} and {}", op, left_field.dtype, right_type)
+                    },
+                },
                 #[cfg(feature = "dtype-decimal")]
                 (Decimal(_, Some(scale_left)), Decimal(_, Some(scale_right))) => {
                     let scale = match op {


### PR DESCRIPTION
Closes #21389.

Right now, duration * primitive does not propagate the dtype and results in a schema error if the resulting expression is used afterwards, despite it being a valid operation.

```python
from datetime import datetime, timedelta
import polars as pl
from polars import col

df = pl.DataFrame({
    "ts": [datetime(2025, 1, 1)],
    "dur": [timedelta(days=1)],
})

df.select(col("dur") * 2)              # OK
df.select(2 * col("dur"))              # OK
df.select(col("ts") + col("dur"))      # OK
df.select(col("ts") + 2 * col("dur"))  # OK
df.select(col("ts") + col("dur") * 2)  # ERROR!!!
# polars.exceptions.InvalidOperationError: + not allowed on datetime[μs] and unknown
```
After fix:
```pycon
>>> df.select(col("ts") + col("dur") * 2)
shape: (1, 1)
┌─────────────────────┐
│ ts                  │
│ ---                 │
│ datetime[μs]        │
╞═════════════════════╡
│ 2025-01-03 00:00:00 │
└─────────────────────┘
```