### PR TITLE
feat: Implement rolling_sum and rolling_sum_by for Boolean dtype

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -551,6 +551,7 @@ impl<'a> FieldsMapper<'a> {
     pub fn sum_dtype(&self) -> PolarsResult<Field> {
         use DataType::*;
         self.map_dtype(|dtype| match dtype {
+            Boolean => IDX_DTYPE,
             Int8 | UInt8 | Int16 | UInt16 => Int64,
             dt => dt.clone(),
         })

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -1315,3 +1315,17 @@ def test_rolling_offset_agg_15122() -> None:
     )
     expected = df.with_columns(window=pl.Series([[3], [], [], [3], [], []]))
     assert_frame_equal(result, expected)
+
+
+def test_rolling_sum_boolean() -> None:
+    lf = pl.LazyFrame({"a": [False, True, True]}).with_row_index()
+
+    q = lf.select(pl.col("a").rolling_sum(2, min_samples=1))
+    expected = pl.DataFrame({"a": [0, 1, 2]}).cast(pl.get_index_type())
+    assert_frame_equal(q.collect(), expected)
+    assert q.collect_schema() == expected.schema
+
+    q = lf.select(pl.col("a").rolling_sum_by("index", "2i"))
+    expected = pl.DataFrame({"a": [0, 1, 2]}).cast(pl.get_index_type())
+    assert_frame_equal(q.collect(), expected)
+    assert q.collect_schema() == expected.schema


### PR DESCRIPTION
fixes #19986

Allows `rolling_sum` and `rolling_sum_by` to operate on `Boolean` dtype which is consistent with `sum` and `cum_sum`.