### PR TITLE
fix: Method `dt.ordinal_day` was returning UTC results as opposed to those on the local timestamp

### DIFF
--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -129,7 +129,20 @@ pub trait DatetimeMethods: AsDatetime {
             TimeUnit::Microseconds => datetime_to_ordinal_us,
             TimeUnit::Milliseconds => datetime_to_ordinal_ms,
         };
-        ca.apply_kernel_cast::<Int16Type>(&f)
+        match ca.dtype() {
+            #[cfg(feature = "timezones")]
+            DataType::Datetime(_, Some(_)) => {
+                let ca_local = polars_ops::chunked_array::replace_time_zone(
+                    ca,
+                    None,
+                    &StringChunked::new("".into(), ["raise"]),
+                    NonExistent::Raise,
+                )
+                .expect("Removing time zone is infallible");
+                ca_local.apply_kernel_cast::<Int16Type>(&f)
+            },
+            _ => ca.apply_kernel_cast::<Int16Type>(&f),
+        }
     }
 
     fn parse_from_str_slice(

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -53,12 +53,21 @@ def test_dt_to_string(series_of_int_dates: pl.Series) -> None:
         ("ordinal_day", pl.Series(values=[139, 278, 51], dtype=pl.Int16)),
     ],
 )
+@pytest.mark.parametrize("time_zone", ["Asia/Kathmandu", None])
 def test_dt_extract_datetime_component(
     unit_attr: str,
     expected: pl.Series,
     series_of_int_dates: pl.Series,
+    time_zone: str | None,
 ) -> None:
     assert_series_equal(getattr(series_of_int_dates.dt, unit_attr)(), expected)
+    assert_series_equal(
+        getattr(
+            series_of_int_dates.cast(pl.Datetime).dt.replace_time_zone(time_zone).dt,
+            unit_attr,
+        )(),
+        expected,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #21406 