### PR TITLE
docs(python): Fix doc for SQL Functions navigation

### DIFF
--- a/py-polars/docs/source/reference/sql/functions/bitwise.rst
+++ b/py-polars/docs/source/reference/sql/functions/bitwise.rst
@@ -1,4 +1,4 @@
-Temporal
+Bitwise
 ========
 
 .. list-table::


### PR DESCRIPTION
The `bitwise.rst` file had "Temporal" as title.

![image](https://github.com/user-attachments/assets/a813dadc-04f4-4861-876e-2fa6d40c5c2e)
