### PR TITLE
feat: Add 'nulls_equal' parameter to `is_in`

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -438,7 +438,7 @@ impl PhysicalExpr for ApplyExpr {
         match function {
             FunctionExpr::Boolean(BooleanFunction::IsNull) => Some(self),
             #[cfg(feature = "is_in")]
-            FunctionExpr::Boolean(BooleanFunction::IsIn) => Some(self),
+            FunctionExpr::Boolean(BooleanFunction::IsIn { .. }) => Some(self),
             #[cfg(feature = "is_between")]
             FunctionExpr::Boolean(BooleanFunction::IsBetween { closed: _ }) => Some(self),
             FunctionExpr::Boolean(BooleanFunction::IsNotNull) => Some(self),
@@ -573,7 +573,7 @@ impl ApplyExpr {
                 }
             },
             #[cfg(feature = "is_in")]
-            FunctionExpr::Boolean(BooleanFunction::IsIn) => {
+            FunctionExpr::Boolean(BooleanFunction::IsIn { .. }) => {
                 let should_read = || -> Option<bool> {
                     let root = expr_to_leaf_column_name(&input[0]).ok()?;
 

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -136,7 +136,7 @@ fn test_parquet_statistics() -> PolarsResult<()> {
 
     // issue: 13427
     let out = scan_foods_parquet(par)
-        .filter(col("calories").is_in(lit(Series::new("".into(), [0, 500]))))
+        .filter(col("calories").is_in(lit(Series::new("".into(), [0, 500])), false))
         .collect()?;
     assert_eq!(out.shape(), (0, 4));
 

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -136,7 +136,7 @@ fn test_parquet_statistics() -> PolarsResult<()> {
 
     // issue: 13427
     let out = scan_foods_parquet(par)
-        .filter(col("calories").is_in(lit(Series::new("".into(), [0, 500])), true))
+        .filter(col("calories").is_in(lit(Series::new("".into(), [0, 500])), false))
         .collect()?;
     assert_eq!(out.shape(), (0, 4));
 

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -136,7 +136,7 @@ fn test_parquet_statistics() -> PolarsResult<()> {
 
     // issue: 13427
     let out = scan_foods_parquet(par)
-        .filter(col("calories").is_in(lit(Series::new("".into(), [0, 500])), false))
+        .filter(col("calories").is_in(lit(Series::new("".into(), [0, 500])), true))
         .collect()?;
     assert_eq!(out.shape(), (0, 4));
 

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -48,7 +48,7 @@ fn test_issue_2472() -> PolarsResult<()> {
         .extract(lit(r"(\d+-){4}(\w+)-"), 2)
         .cast(DataType::Int32)
         .alias("age");
-    let predicate = col("age").is_in(lit(Series::new("".into(), [2i32])));
+    let predicate = col("age").is_in(lit(Series::new("".into(), [2i32])), false);
 
     let out = base
         .clone()

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -48,7 +48,7 @@ fn test_issue_2472() -> PolarsResult<()> {
         .extract(lit(r"(\d+-){4}(\w+)-"), 2)
         .cast(DataType::Int32)
         .alias("age");
-    let predicate = col("age").is_in(lit(Series::new("".into(), [2i32])), true);
+    let predicate = col("age").is_in(lit(Series::new("".into(), [2i32])), false);
 
     let out = base
         .clone()

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -48,7 +48,7 @@ fn test_issue_2472() -> PolarsResult<()> {
         .extract(lit(r"(\d+-){4}(\w+)-"), 2)
         .cast(DataType::Int32)
         .alias("age");
-    let predicate = col("age").is_in(lit(Series::new("".into(), [2i32])), false);
+    let predicate = col("age").is_in(lit(Series::new("".into(), [2i32])), true);
 
     let out = base
         .clone()

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -355,7 +355,7 @@ fn test_lazy_query_8() -> PolarsResult<()> {
     let mut selection = vec![];
 
     for &c in &["A", "B", "C", "D", "E"] {
-        let e = when(col(c).is_in(col("E")))
+        let e = when(col(c).is_in(col("E"), false))
             .then(col("A"))
             .otherwise(Null {}.lit())
             .alias(c);
@@ -1761,7 +1761,7 @@ fn test_is_in() -> PolarsResult<()> {
         .clone()
         .lazy()
         .group_by_stable([col("fruits")])
-        .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))))])
+        .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))), false)])
         .collect()?;
     let out = out.column("cars").unwrap();
     let out = out.explode()?;
@@ -1775,7 +1775,7 @@ fn test_is_in() -> PolarsResult<()> {
     let out = df
         .lazy()
         .group_by_stable([col("fruits")])
-        .agg([col("cars").is_in(lit(Series::new("a".into(), ["beetle", "vw"])))])
+        .agg([col("cars").is_in(lit(Series::new("a".into(), ["beetle", "vw"])), false)])
         .collect()?;
 
     let out = out.column("cars").unwrap();

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -355,7 +355,7 @@ fn test_lazy_query_8() -> PolarsResult<()> {
     let mut selection = vec![];
 
     for &c in &["A", "B", "C", "D", "E"] {
-        let e = when(col(c).is_in(col("E"), false))
+        let e = when(col(c).is_in(col("E"), true))
             .then(col("A"))
             .otherwise(Null {}.lit())
             .alias(c);
@@ -1761,7 +1761,7 @@ fn test_is_in() -> PolarsResult<()> {
         .clone()
         .lazy()
         .group_by_stable([col("fruits")])
-        .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))), false)])
+        .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))), true)])
         .collect()?;
     let out = out.column("cars").unwrap();
     let out = out.explode()?;
@@ -1775,7 +1775,7 @@ fn test_is_in() -> PolarsResult<()> {
     let out = df
         .lazy()
         .group_by_stable([col("fruits")])
-        .agg([col("cars").is_in(lit(Series::new("a".into(), ["beetle", "vw"])), false)])
+        .agg([col("cars").is_in(lit(Series::new("a".into(), ["beetle", "vw"])), true)])
         .collect()?;
 
     let out = out.column("cars").unwrap();

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -355,7 +355,7 @@ fn test_lazy_query_8() -> PolarsResult<()> {
     let mut selection = vec![];
 
     for &c in &["A", "B", "C", "D", "E"] {
-        let e = when(col(c).is_in(col("E"), true))
+        let e = when(col(c).is_in(col("E"), false))
             .then(col("A"))
             .otherwise(Null {}.lit())
             .alias(c);
@@ -1761,7 +1761,7 @@ fn test_is_in() -> PolarsResult<()> {
         .clone()
         .lazy()
         .group_by_stable([col("fruits")])
-        .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))), true)])
+        .agg([col("cars").is_in(col("cars").filter(col("cars").eq(lit("beetle"))), false)])
         .collect()?;
     let out = out.column("cars").unwrap();
     let out = out.explode()?;
@@ -1775,7 +1775,7 @@ fn test_is_in() -> PolarsResult<()> {
     let out = df
         .lazy()
         .group_by_stable([col("fruits")])
-        .agg([col("cars").is_in(lit(Series::new("a".into(), ["beetle", "vw"])), true)])
+        .agg([col("cars").is_in(lit(Series::new("a".into(), ["beetle", "vw"])), false)])
         .collect()?;
 
     let out = out.column("cars").unwrap();

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -150,7 +150,7 @@ fn get_replacement_mask(s: &Series, old: &Series) -> PolarsResult<BooleanChunked
         // Fast path for when users are using `replace(None, ...)` instead of `fill_null`.
         Ok(s.is_null())
     } else {
-        is_in(s, old)
+        is_in(s, old, false)
     }
 }
 

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -150,7 +150,7 @@ fn get_replacement_mask(s: &Series, old: &Series) -> PolarsResult<BooleanChunked
         // Fast path for when users are using `replace(None, ...)` instead of `fill_null`.
         Ok(s.is_null())
     } else {
-        is_in(s, old, false)
+        is_in(s, old, true)
     }
 }
 

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -150,7 +150,7 @@ fn get_replacement_mask(s: &Series, old: &Series) -> PolarsResult<BooleanChunked
         // Fast path for when users are using `replace(None, ...)` instead of `fill_null`.
         Ok(s.is_null())
     } else {
-        is_in(s, old, true)
+        is_in(s, old, false)
     }
 }
 

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -240,6 +240,7 @@ pub(super) fn contains(s: &[Column]) -> PolarsResult<Column> {
     Ok(is_in(
         item.as_materialized_series(),
         array.as_materialized_series(),
+        false,
     )?
     .with_name(array.name().clone())
     .into_column())

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -240,7 +240,7 @@ pub(super) fn contains(s: &[Column]) -> PolarsResult<Column> {
     Ok(is_in(
         item.as_materialized_series(),
         array.as_materialized_series(),
-        false,
+        true,
     )?
     .with_name(array.name().clone())
     .into_column())

--- a/crates/polars-plan/src/dsl/function_expr/binary.rs
+++ b/crates/polars-plan/src/dsl/function_expr/binary.rs
@@ -27,7 +27,7 @@ impl BinaryFunction {
     pub(super) fn get_field(&self, mapper: FieldsMapper) -> PolarsResult<Field> {
         use BinaryFunction::*;
         match self {
-            Contains { .. } => mapper.with_dtype(DataType::Boolean),
+            Contains => mapper.with_dtype(DataType::Boolean),
             EndsWith | StartsWith => mapper.with_dtype(DataType::Boolean),
             #[cfg(feature = "binary_encoding")]
             HexDecode(_) | Base64Decode(_) => mapper.with_same_dtype(),
@@ -44,7 +44,7 @@ impl Display for BinaryFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use BinaryFunction::*;
         let s = match self {
-            Contains { .. } => "contains",
+            Contains => "contains",
             StartsWith => "starts_with",
             EndsWith => "ends_with",
             #[cfg(feature = "binary_encoding")]

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -36,7 +36,9 @@ pub enum BooleanFunction {
         closed: ClosedInterval,
     },
     #[cfg(feature = "is_in")]
-    IsIn,
+    IsIn {
+        missing: bool,
+    },
     AllHorizontal,
     AnyHorizontal,
     // Also bitwise negate
@@ -84,7 +86,7 @@ impl Display for BooleanFunction {
             #[cfg(feature = "is_between")]
             IsBetween { .. } => "is_between",
             #[cfg(feature = "is_in")]
-            IsIn => "is_in",
+            IsIn { .. } => "is_in",
             AnyHorizontal => "any_horizontal",
             AllHorizontal => "all_horizontal",
             Not => "not",
@@ -116,7 +118,7 @@ impl From<BooleanFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "is_between")]
             IsBetween { closed } => map_as_slice!(is_between, closed),
             #[cfg(feature = "is_in")]
-            IsIn => wrap!(is_in),
+            IsIn { missing } => wrap!(is_in, missing),
             Not => map!(not),
             AllHorizontal => map_as_slice!(all_horizontal),
             AnyHorizontal => map_as_slice!(any_horizontal),
@@ -207,12 +209,13 @@ fn is_between(s: &[Column], closed: ClosedInterval) -> PolarsResult<Column> {
 }
 
 #[cfg(feature = "is_in")]
-fn is_in(s: &mut [Column]) -> PolarsResult<Option<Column>> {
+fn is_in(s: &mut [Column], missing: bool) -> PolarsResult<Option<Column>> {
     let left = &s[0];
     let other = &s[1];
     polars_ops::prelude::is_in(
         left.as_materialized_series(),
         other.as_materialized_series(),
+        missing,
     )
     .map(|ca| Some(ca.into_column()))
 }

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -37,7 +37,7 @@ pub enum BooleanFunction {
     },
     #[cfg(feature = "is_in")]
     IsIn {
-        missing: bool,
+        propagate_nulls: bool,
     },
     AllHorizontal,
     AnyHorizontal,
@@ -118,7 +118,7 @@ impl From<BooleanFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "is_between")]
             IsBetween { closed } => map_as_slice!(is_between, closed),
             #[cfg(feature = "is_in")]
-            IsIn { missing } => wrap!(is_in, missing),
+            IsIn { propagate_nulls } => wrap!(is_in, propagate_nulls),
             Not => map!(not),
             AllHorizontal => map_as_slice!(all_horizontal),
             AnyHorizontal => map_as_slice!(any_horizontal),
@@ -209,13 +209,13 @@ fn is_between(s: &[Column], closed: ClosedInterval) -> PolarsResult<Column> {
 }
 
 #[cfg(feature = "is_in")]
-fn is_in(s: &mut [Column], missing: bool) -> PolarsResult<Option<Column>> {
+fn is_in(s: &mut [Column], propagate_nulls: bool) -> PolarsResult<Option<Column>> {
     let left = &s[0];
     let other = &s[1];
     polars_ops::prelude::is_in(
         left.as_materialized_series(),
         other.as_materialized_series(),
-        missing,
+        propagate_nulls,
     )
     .map(|ca| Some(ca.into_column()))
 }

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -37,7 +37,7 @@ pub enum BooleanFunction {
     },
     #[cfg(feature = "is_in")]
     IsIn {
-        propagate_nulls: bool,
+        nulls_equal: bool,
     },
     AllHorizontal,
     AnyHorizontal,
@@ -118,7 +118,7 @@ impl From<BooleanFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "is_between")]
             IsBetween { closed } => map_as_slice!(is_between, closed),
             #[cfg(feature = "is_in")]
-            IsIn { propagate_nulls } => wrap!(is_in, propagate_nulls),
+            IsIn { nulls_equal } => wrap!(is_in, nulls_equal),
             Not => map!(not),
             AllHorizontal => map_as_slice!(all_horizontal),
             AnyHorizontal => map_as_slice!(any_horizontal),
@@ -209,13 +209,13 @@ fn is_between(s: &[Column], closed: ClosedInterval) -> PolarsResult<Column> {
 }
 
 #[cfg(feature = "is_in")]
-fn is_in(s: &mut [Column], propagate_nulls: bool) -> PolarsResult<Option<Column>> {
+fn is_in(s: &mut [Column], nulls_equal: bool) -> PolarsResult<Option<Column>> {
     let left = &s[0];
     let other = &s[1];
     polars_ops::prelude::is_in(
         left.as_materialized_series(),
         other.as_materialized_series(),
-        propagate_nulls,
+        nulls_equal,
     )
     .map(|ca| Some(ca.into_column()))
 }

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -254,12 +254,15 @@ pub(super) fn contains(args: &mut [Column]) -> PolarsResult<Option<Column>> {
     polars_ensure!(matches!(list.dtype(), DataType::List(_)),
         SchemaMismatch: "invalid series dtype: expected `List`, got `{}`", list.dtype(),
     );
-    polars_ops::prelude::is_in(item.as_materialized_series(), list.as_materialized_series()).map(
-        |mut ca| {
-            ca.rename(list.name().clone());
-            Some(ca.into_column())
-        },
+    polars_ops::prelude::is_in(
+        item.as_materialized_series(),
+        list.as_materialized_series(),
+        false,
     )
+    .map(|mut ca| {
+        ca.rename(list.name().clone());
+        Some(ca.into_column())
+    })
 }
 
 #[cfg(feature = "list_drop_nulls")]

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -257,7 +257,7 @@ pub(super) fn contains(args: &mut [Column]) -> PolarsResult<Option<Column>> {
     polars_ops::prelude::is_in(
         item.as_materialized_series(),
         list.as_materialized_series(),
-        false,
+        true,
     )
     .map(|mut ca| {
         ca.rename(list.name().clone());

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1196,7 +1196,7 @@ impl Expr {
     /// Check if the values of the left expression are in the lists of the right expr.
     #[allow(clippy::wrong_self_convention)]
     #[cfg(feature = "is_in")]
-    pub fn is_in<E: Into<Expr>>(self, other: E) -> Self {
+    pub fn is_in<E: Into<Expr>>(self, other: E, missing: bool) -> Self {
         let other = other.into();
         let has_literal = has_leaf_literal(&other);
 
@@ -1207,14 +1207,14 @@ impl Expr {
         // we don't have to apply on groups, so this is faster
         if has_literal {
             self.map_many_private(
-                BooleanFunction::IsIn.into(),
+                BooleanFunction::IsIn { missing }.into(),
                 arguments,
                 returns_scalar,
                 Some(Default::default()),
             )
         } else {
             self.apply_many_private(
-                BooleanFunction::IsIn.into(),
+                BooleanFunction::IsIn { missing }.into(),
                 arguments,
                 returns_scalar,
                 true,

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1196,7 +1196,7 @@ impl Expr {
     /// Check if the values of the left expression are in the lists of the right expr.
     #[allow(clippy::wrong_self_convention)]
     #[cfg(feature = "is_in")]
-    pub fn is_in<E: Into<Expr>>(self, other: E, missing: bool) -> Self {
+    pub fn is_in<E: Into<Expr>>(self, other: E, propagate_nulls: bool) -> Self {
         let other = other.into();
         let has_literal = has_leaf_literal(&other);
 
@@ -1207,14 +1207,14 @@ impl Expr {
         // we don't have to apply on groups, so this is faster
         if has_literal {
             self.map_many_private(
-                BooleanFunction::IsIn { missing }.into(),
+                BooleanFunction::IsIn { propagate_nulls }.into(),
                 arguments,
                 returns_scalar,
                 Some(Default::default()),
             )
         } else {
             self.apply_many_private(
-                BooleanFunction::IsIn { missing }.into(),
+                BooleanFunction::IsIn { propagate_nulls }.into(),
                 arguments,
                 returns_scalar,
                 true,

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1196,7 +1196,7 @@ impl Expr {
     /// Check if the values of the left expression are in the lists of the right expr.
     #[allow(clippy::wrong_self_convention)]
     #[cfg(feature = "is_in")]
-    pub fn is_in<E: Into<Expr>>(self, other: E, propagate_nulls: bool) -> Self {
+    pub fn is_in<E: Into<Expr>>(self, other: E, nulls_equal: bool) -> Self {
         let other = other.into();
         let has_literal = has_leaf_literal(&other);
 
@@ -1207,14 +1207,14 @@ impl Expr {
         // we don't have to apply on groups, so this is faster
         if has_literal {
             self.map_many_private(
-                BooleanFunction::IsIn { propagate_nulls }.into(),
+                BooleanFunction::IsIn { nulls_equal }.into(),
                 arguments,
                 returns_scalar,
                 Some(Default::default()),
             )
         } else {
             self.apply_many_private(
-                BooleanFunction::IsIn { propagate_nulls }.into(),
+                BooleanFunction::IsIn { nulls_equal }.into(),
                 arguments,
                 returns_scalar,
                 true,

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -398,7 +398,7 @@ fn aexpr_to_skip_batch_predicate_rec(
         } => match function {
             FunctionExpr::Boolean(f) => match f {
                 #[cfg(feature = "is_in")]
-                BooleanFunction::IsIn => {
+                BooleanFunction::IsIn { .. } => {
                     let lv_node = input[1].node();
                     match (
                         into_column(input[0].node(), expr_arena, schema, 0),

--- a/crates/polars-plan/src/plans/aexpr/properties.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties.rs
@@ -64,7 +64,7 @@ pub fn is_elementwise(stack: &mut UnitVec<Node>, ae: &AExpr, expr_arena: &Arena<
         // for inspection. (e.g. `is_in(<literal>)`).
         #[cfg(feature = "is_in")]
         Function {
-            function: FunctionExpr::Boolean(BooleanFunction::IsIn),
+            function: FunctionExpr::Boolean(BooleanFunction::IsIn { .. }),
             input,
             ..
         } => (|| {

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -159,7 +159,7 @@ impl OptimizationRule for TypeCoercionRule {
             } => return process_binary(expr_arena, lp_arena, lp_node, node_left, op, node_right),
             #[cfg(feature = "is_in")]
             AExpr::Function {
-                function: FunctionExpr::Boolean(BooleanFunction::IsIn),
+                function: FunctionExpr::Boolean(BooleanFunction::IsIn { missing }),
                 ref input,
                 options,
             } => {
@@ -173,7 +173,7 @@ impl OptimizationRule for TypeCoercionRule {
                 input[1].set_node(other_input);
 
                 Some(AExpr::Function {
-                    function: FunctionExpr::Boolean(BooleanFunction::IsIn),
+                    function: FunctionExpr::Boolean(BooleanFunction::IsIn { missing }),
                     input,
                     options,
                 })

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -159,7 +159,7 @@ impl OptimizationRule for TypeCoercionRule {
             } => return process_binary(expr_arena, lp_arena, lp_node, node_left, op, node_right),
             #[cfg(feature = "is_in")]
             AExpr::Function {
-                function: FunctionExpr::Boolean(BooleanFunction::IsIn { missing }),
+                function: FunctionExpr::Boolean(BooleanFunction::IsIn { propagate_nulls }),
                 ref input,
                 options,
             } => {
@@ -173,7 +173,7 @@ impl OptimizationRule for TypeCoercionRule {
                 input[1].set_node(other_input);
 
                 Some(AExpr::Function {
-                    function: FunctionExpr::Boolean(BooleanFunction::IsIn { missing }),
+                    function: FunctionExpr::Boolean(BooleanFunction::IsIn { propagate_nulls }),
                     input,
                     options,
                 })

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -159,7 +159,7 @@ impl OptimizationRule for TypeCoercionRule {
             } => return process_binary(expr_arena, lp_arena, lp_node, node_left, op, node_right),
             #[cfg(feature = "is_in")]
             AExpr::Function {
-                function: FunctionExpr::Boolean(BooleanFunction::IsIn { propagate_nulls }),
+                function: FunctionExpr::Boolean(BooleanFunction::IsIn { nulls_equal }),
                 ref input,
                 options,
             } => {
@@ -173,7 +173,7 @@ impl OptimizationRule for TypeCoercionRule {
                 input[1].set_node(other_input);
 
                 Some(AExpr::Function {
-                    function: FunctionExpr::Boolean(BooleanFunction::IsIn { propagate_nulls }),
+                    function: FunctionExpr::Boolean(BooleanFunction::IsIn { nulls_equal }),
                     input,
                     options,
                 })

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/join.rs
@@ -25,7 +25,7 @@ fn should_block_join_specific(
         } => join_produces_null(how),
         #[cfg(feature = "is_in")]
         Function {
-            function: FunctionExpr::Boolean(BooleanFunction::IsIn),
+            function: FunctionExpr::Boolean(BooleanFunction::IsIn { .. }),
             ..
         } => join_produces_null(how),
         // joins can produce duplicates

--- a/crates/polars-plan/src/plans/python/pyarrow.rs
+++ b/crates/polars-plan/src/plans/python/pyarrow.rs
@@ -116,7 +116,7 @@ pub fn predicate_to_pa(
         },
         #[cfg(feature = "is_in")]
         AExpr::Function {
-            function: FunctionExpr::Boolean(BooleanFunction::IsIn),
+            function: FunctionExpr::Boolean(BooleanFunction::IsIn { .. }),
             input,
             ..
         } => {

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -652,8 +652,8 @@ impl PyExpr {
     }
 
     #[cfg(feature = "is_in")]
-    fn is_in(&self, expr: Self) -> Self {
-        self.inner.clone().is_in(expr.inner).into()
+    fn is_in(&self, expr: Self, missing: bool) -> Self {
+        self.inner.clone().is_in(expr.inner, missing).into()
     }
 
     #[cfg(feature = "repeat_by")]

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -652,8 +652,8 @@ impl PyExpr {
     }
 
     #[cfg(feature = "is_in")]
-    fn is_in(&self, expr: Self, missing: bool) -> Self {
-        self.inner.clone().is_in(expr.inner, missing).into()
+    fn is_in(&self, expr: Self, propagate_nulls: bool) -> Self {
+        self.inner.clone().is_in(expr.inner, propagate_nulls).into()
     }
 
     #[cfg(feature = "repeat_by")]

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -652,8 +652,8 @@ impl PyExpr {
     }
 
     #[cfg(feature = "is_in")]
-    fn is_in(&self, expr: Self, propagate_nulls: bool) -> Self {
-        self.inner.clone().is_in(expr.inner, propagate_nulls).into()
+    fn is_in(&self, expr: Self, nulls_equal: bool) -> Self {
+        self.inner.clone().is_in(expr.inner, nulls_equal).into()
     }
 
     #[cfg(feature = "repeat_by")]

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1086,7 +1086,9 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                         (PyBooleanFunction::IsBetween, Into::<&str>::into(closed)).into_py_any(py)
                     },
                     #[cfg(feature = "is_in")]
-                    BooleanFunction::IsIn => (PyBooleanFunction::IsIn,).into_py_any(py),
+                    BooleanFunction::IsIn { missing } => {
+                        (PyBooleanFunction::IsIn, missing).into_py_any(py)
+                    },
                     BooleanFunction::AllHorizontal => {
                         (PyBooleanFunction::AllHorizontal,).into_py_any(py)
                     },

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1086,8 +1086,8 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                         (PyBooleanFunction::IsBetween, Into::<&str>::into(closed)).into_py_any(py)
                     },
                     #[cfg(feature = "is_in")]
-                    BooleanFunction::IsIn { propagate_nulls } => {
-                        (PyBooleanFunction::IsIn, propagate_nulls).into_py_any(py)
+                    BooleanFunction::IsIn { nulls_equal } => {
+                        (PyBooleanFunction::IsIn, nulls_equal).into_py_any(py)
                     },
                     BooleanFunction::AllHorizontal => {
                         (PyBooleanFunction::AllHorizontal,).into_py_any(py)

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1086,8 +1086,8 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                         (PyBooleanFunction::IsBetween, Into::<&str>::into(closed)).into_py_any(py)
                     },
                     #[cfg(feature = "is_in")]
-                    BooleanFunction::IsIn { missing } => {
-                        (PyBooleanFunction::IsIn, missing).into_py_any(py)
+                    BooleanFunction::IsIn { propagate_nulls } => {
+                        (PyBooleanFunction::IsIn, propagate_nulls).into_py_any(py)
                     },
                     BooleanFunction::AllHorizontal => {
                         (PyBooleanFunction::AllHorizontal,).into_py_any(py)

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -124,7 +124,7 @@ impl SQLExprVisitor<'_> {
             } => {
                 let expr = self.visit_expr(expr)?;
                 let elems = self.visit_array_expr(list, false, Some(&expr))?;
-                let is_in = expr.is_in(elems);
+                let is_in = expr.is_in(elems, false);
                 Ok(if *negated { is_in.not() } else { is_in })
             },
             SQLExpr::InSubquery {
@@ -692,8 +692,8 @@ impl SQLExprVisitor<'_> {
             SQLBinaryOperator::Lt => Ok(left.lt(right.max())),
             SQLBinaryOperator::GtEq => Ok(left.gt_eq(right.min())),
             SQLBinaryOperator::LtEq => Ok(left.lt_eq(right.max())),
-            SQLBinaryOperator::Eq => Ok(left.is_in(right)),
-            SQLBinaryOperator::NotEq => Ok(left.is_in(right).not()),
+            SQLBinaryOperator::Eq => Ok(left.is_in(right, false)),
+            SQLBinaryOperator::NotEq => Ok(left.is_in(right, false).not()),
             _ => polars_bail!(SQLInterface: "invalid comparison operator"),
         }
     }
@@ -917,9 +917,9 @@ impl SQLExprVisitor<'_> {
         let subquery_result = self.visit_subquery(subquery, SubqueryRestriction::SingleColumn)?;
         let expr = self.visit_expr(expr)?;
         Ok(if negated {
-            expr.is_in(subquery_result).not()
+            expr.is_in(subquery_result, false).not()
         } else {
-            expr.is_in(subquery_result)
+            expr.is_in(subquery_result, false)
         })
     }
 

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -124,7 +124,7 @@ impl SQLExprVisitor<'_> {
             } => {
                 let expr = self.visit_expr(expr)?;
                 let elems = self.visit_array_expr(list, false, Some(&expr))?;
-                let is_in = expr.is_in(elems, false);
+                let is_in = expr.is_in(elems, true);
                 Ok(if *negated { is_in.not() } else { is_in })
             },
             SQLExpr::InSubquery {
@@ -692,8 +692,8 @@ impl SQLExprVisitor<'_> {
             SQLBinaryOperator::Lt => Ok(left.lt(right.max())),
             SQLBinaryOperator::GtEq => Ok(left.gt_eq(right.min())),
             SQLBinaryOperator::LtEq => Ok(left.lt_eq(right.max())),
-            SQLBinaryOperator::Eq => Ok(left.is_in(right, false)),
-            SQLBinaryOperator::NotEq => Ok(left.is_in(right, false).not()),
+            SQLBinaryOperator::Eq => Ok(left.is_in(right, true)),
+            SQLBinaryOperator::NotEq => Ok(left.is_in(right, true).not()),
             _ => polars_bail!(SQLInterface: "invalid comparison operator"),
         }
     }
@@ -917,9 +917,9 @@ impl SQLExprVisitor<'_> {
         let subquery_result = self.visit_subquery(subquery, SubqueryRestriction::SingleColumn)?;
         let expr = self.visit_expr(expr)?;
         Ok(if negated {
-            expr.is_in(subquery_result, false).not()
+            expr.is_in(subquery_result, true).not()
         } else {
-            expr.is_in(subquery_result, false)
+            expr.is_in(subquery_result, true)
         })
     }
 

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -124,7 +124,7 @@ impl SQLExprVisitor<'_> {
             } => {
                 let expr = self.visit_expr(expr)?;
                 let elems = self.visit_array_expr(list, false, Some(&expr))?;
-                let is_in = expr.is_in(elems, true);
+                let is_in = expr.is_in(elems, false);
                 Ok(if *negated { is_in.not() } else { is_in })
             },
             SQLExpr::InSubquery {
@@ -692,8 +692,8 @@ impl SQLExprVisitor<'_> {
             SQLBinaryOperator::Lt => Ok(left.lt(right.max())),
             SQLBinaryOperator::GtEq => Ok(left.gt_eq(right.min())),
             SQLBinaryOperator::LtEq => Ok(left.lt_eq(right.max())),
-            SQLBinaryOperator::Eq => Ok(left.is_in(right, true)),
-            SQLBinaryOperator::NotEq => Ok(left.is_in(right, true).not()),
+            SQLBinaryOperator::Eq => Ok(left.is_in(right, false)),
+            SQLBinaryOperator::NotEq => Ok(left.is_in(right, false).not()),
             _ => polars_bail!(SQLInterface: "invalid comparison operator"),
         }
     }
@@ -917,9 +917,9 @@ impl SQLExprVisitor<'_> {
         let subquery_result = self.visit_subquery(subquery, SubqueryRestriction::SingleColumn)?;
         let expr = self.visit_expr(expr)?;
         Ok(if negated {
-            expr.is_in(subquery_result, true).not()
+            expr.is_in(subquery_result, false).not()
         } else {
-            expr.is_in(subquery_result, true)
+            expr.is_in(subquery_result, false)
         })
     }
 

--- a/crates/polars/tests/it/lazy/expressions/is_in.rs
+++ b/crates/polars/tests/it/lazy/expressions/is_in.rs
@@ -10,7 +10,7 @@ fn test_is_in() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .select([col("y").is_in(lit(s)).alias("isin")])
+        .select([col("y").is_in(lit(s), false).alias("isin")])
         .collect()?;
     assert_eq!(
         Vec::from(out.column("isin")?.bool()?),

--- a/crates/polars/tests/it/lazy/expressions/is_in.rs
+++ b/crates/polars/tests/it/lazy/expressions/is_in.rs
@@ -10,7 +10,7 @@ fn test_is_in() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .select([col("y").is_in(lit(s), false).alias("isin")])
+        .select([col("y").is_in(lit(s), true).alias("isin")])
         .collect()?;
     assert_eq!(
         Vec::from(out.column("isin")?.bool()?),

--- a/crates/polars/tests/it/lazy/expressions/is_in.rs
+++ b/crates/polars/tests/it/lazy/expressions/is_in.rs
@@ -10,7 +10,7 @@ fn test_is_in() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .select([col("y").is_in(lit(s), true).alias("isin")])
+        .select([col("y").is_in(lit(s), false).alias("isin")])
         .collect()?;
     assert_eq!(
         Vec::from(out.column("isin")?.bool()?),

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -140,7 +140,7 @@ fn test_is_in_categorical_3420() -> PolarsResult<()> {
     let out = df
         .lazy()
         .with_column(col("a").strict_cast(DataType::Categorical(None, Default::default())))
-        .filter(col("a").is_in(lit(s).alias("x")))
+        .filter(col("a").is_in(lit(s).alias("x"), false))
         .collect()?;
 
     let mut expected = df![

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -140,7 +140,7 @@ fn test_is_in_categorical_3420() -> PolarsResult<()> {
     let out = df
         .lazy()
         .with_column(col("a").strict_cast(DataType::Categorical(None, Default::default())))
-        .filter(col("a").is_in(lit(s).alias("x"), false))
+        .filter(col("a").is_in(lit(s).alias("x"), true))
         .collect()?;
 
     let mut expected = df![

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -140,7 +140,7 @@ fn test_is_in_categorical_3420() -> PolarsResult<()> {
     let out = df
         .lazy()
         .with_column(col("a").strict_cast(DataType::Categorical(None, Default::default())))
-        .filter(col("a").is_in(lit(s).alias("x"), true))
+        .filter(col("a").is_in(lit(s).alias("x"), false))
         .collect()?;
 
     let mut expected = df![

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5782,7 +5782,12 @@ class Expr:
         """
         return self.__xor__(other)
 
-    def is_in(self, other: Expr | Collection[Any] | Series) -> Expr:
+    def is_in(
+        self,
+        other: Expr | Collection[Any] | Series,
+        *,
+        missing: bool = False,
+    ) -> Expr:
         """
         Check if elements of this expression are present in the other Series.
 
@@ -5790,6 +5795,8 @@ class Expr:
         ----------
         other
             Series or sequence of primitive type.
+        missing : bool, default False
+            Treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -5819,7 +5826,7 @@ class Expr:
             other = F.lit(pl.Series(other))._pyexpr
         else:
             other = parse_into_expression(other)
-        return self._from_pyexpr(self._pyexpr.is_in(other))
+        return self._from_pyexpr(self._pyexpr.is_in(other, missing))
 
     def repeat_by(self, by: pl.Series | Expr | str | int) -> Expr:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5786,7 +5786,7 @@ class Expr:
         self,
         other: Expr | Collection[Any] | Series,
         *,
-        propagate_nulls: bool = True,
+        nulls_equal: bool = False,
     ) -> Expr:
         """
         Check if elements of this expression are present in the other Series.
@@ -5795,8 +5795,8 @@ class Expr:
         ----------
         other
             Series or sequence of primitive type.
-        propagate_nulls : bool, default True
-            if False, treat null as a distinct value. Null values will not propagate.
+        nulls_equal : bool, default False
+            If True, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -5826,7 +5826,7 @@ class Expr:
             other = F.lit(pl.Series(other))._pyexpr
         else:
             other = parse_into_expression(other)
-        return self._from_pyexpr(self._pyexpr.is_in(other, propagate_nulls))
+        return self._from_pyexpr(self._pyexpr.is_in(other, nulls_equal))
 
     def repeat_by(self, by: pl.Series | Expr | str | int) -> Expr:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5786,7 +5786,7 @@ class Expr:
         self,
         other: Expr | Collection[Any] | Series,
         *,
-        missing: bool = False,
+        propagate_nulls: bool = True,
     ) -> Expr:
         """
         Check if elements of this expression are present in the other Series.
@@ -5795,8 +5795,8 @@ class Expr:
         ----------
         other
             Series or sequence of primitive type.
-        missing : bool, default False
-            Treat null as a distinct value. Null values will not propagate.
+        propagate_nulls : bool, default True
+            if False, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -5826,7 +5826,7 @@ class Expr:
             other = F.lit(pl.Series(other))._pyexpr
         else:
             other = parse_into_expression(other)
-        return self._from_pyexpr(self._pyexpr.is_in(other, missing))
+        return self._from_pyexpr(self._pyexpr.is_in(other, propagate_nulls))
 
     def repeat_by(self, by: pl.Series | Expr | str | int) -> Expr:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3787,15 +3787,15 @@ class Series:
         self,
         other: Series | Collection[Any],
         *,
-        missing: bool = False,
+        propagate_nulls: bool = True,
     ) -> Series:
         """
         Check if elements of this Series are in the other Series.
 
         Parameters
         ----------
-        missing : bool, default False
-            Treat null as a distinct value. Null values will not propagate.
+        propagate_nulls : bool, default True
+            if False, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -3814,8 +3814,8 @@ class Series:
                 false
                 null
         ]
-        >>> # when missing=True, None is treated as a distinct value
-        >>> s2.is_in(s, missing=True)
+        >>> # when propagate_nulls=False, None is treated as a distinct value
+        >>> s2.is_in(s, propagate_nulls=False)
         shape: (3,)
         Series: 'b' [bool]
         [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3787,15 +3787,15 @@ class Series:
         self,
         other: Series | Collection[Any],
         *,
-        propagate_nulls: bool = True,
+        nulls_equal: bool = False,
     ) -> Series:
         """
         Check if elements of this Series are in the other Series.
 
         Parameters
         ----------
-        propagate_nulls : bool, default True
-            if False, treat null as a distinct value. Null values will not propagate.
+        nulls_equal : bool, default False
+            If True, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -3814,8 +3814,8 @@ class Series:
                 false
                 null
         ]
-        >>> # when propagate_nulls=False, None is treated as a distinct value
-        >>> s2.is_in(s, propagate_nulls=False)
+        >>> # when nulls_equal=True, None is treated as a distinct value
+        >>> s2.is_in(s, nulls_equal=True)
         shape: (3,)
         Series: 'b' [bool]
         [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3783,9 +3783,19 @@ class Series:
         ]
         """
 
-    def is_in(self, other: Series | Collection[Any]) -> Series:
+    def is_in(
+        self,
+        other: Series | Collection[Any],
+        *,
+        missing: bool = False,
+    ) -> Series:
         """
         Check if elements of this Series are in the other Series.
+
+        Parameters
+        ----------
+        missing : bool, default False
+            Treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -3795,12 +3805,22 @@ class Series:
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
-        >>> s2 = pl.Series("b", [2, 4])
+        >>> s2 = pl.Series("b", [2, 4, None])
         >>> s2.is_in(s)
-        shape: (2,)
+        shape: (3,)
         Series: 'b' [bool]
         [
                 true
+                false
+                null
+        ]
+        >>> # when missing=True, None is treated as a distinct value
+        >>> s2.is_in(s, missing=True)
+        shape: (3,)
+        Series: 'b' [bool]
+        [
+                true
+                false
                 false
         ]
 


### PR DESCRIPTION
Closes #12591.

**Edit**: after some discussion, the argument has been renamed from `missing` to ~`propagate_nulls`~ `nulls_equal` and it defaults to True.

---

#18728 had much more discussion but was closed as a duplicate. This solves the problem of `filter(~col("a").is_in(exclusion_list))` silently passing all nulls through the filter, which has been a pretty big source of error for me, at least.

This now gives `is_in` the ability to use `eq_missing`/`ne_missing` logic in order to treat null as a distinct value:

```python
import polars as pl

# default behavior
pl.Series([1, 2, None]).is_in([1, 3])
shape: (3,)
Series: '' [bool]
[
        true
        false
        null
]

# new behavior
pl.Series([1, 2, None]).is_in([1, 3], nulls_equal=True)
shape: (3,)
Series: '' [bool]
[
        true
        false
        false
]

# Nones are also treated as equals
pl.Series([1, 2, None]).is_in([1, None], nulls_equal=True)
shape: (3,)
Series: '' [bool]
[
        true
        false
        true   # <--- this is True because None = None here
]
```

~~I am not a huge fan of the name `missing` for this parameter--I don't find it intuitive at all, but it's used elsewhere in e.g. `eq_missing` and `ne_missing`. Regardless, this is a much-desired feature that has really nefariously tripped me up by propagating nulls when I didn't intend to.~~