### PR TITLE
feat: Partitioning sink for the new streaming engine

### DIFF
--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -207,6 +207,7 @@ pub(super) fn construct(
         Sink {
             input,
             payload: SinkType::Memory,
+            num_partition_exprs: 0,
         } => *input,
         // Other sinks were not inserted during conversion,
         // so they are returned as-is

--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -76,6 +76,7 @@ fn insert_file_sink(mut root: Node, lp_arena: &mut Arena<IR>) -> Node {
         root = lp_arena.add(IR::Sink {
             input: root,
             payload: SinkType::Memory,
+            num_partition_exprs: 0,
         })
     }
     root

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -174,7 +174,8 @@ where
 {
     use IR::*;
     let out = match lp_arena.get(node) {
-        Sink { input, payload } => {
+        Sink { input, payload, num_partition_exprs } => {
+            assert_eq!(*num_partition_exprs, 0);
             let input_schema = lp_arena.get(*input).schema(lp_arena);
             match payload {
                 SinkType::Memory => {

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -13,7 +13,7 @@ use super::*;
 // (Major, Minor)
 // Add a field -> increment minor
 // Remove or modify a field -> increment major and reset minor
-pub static DSL_VERSION: (u16, u16) = (0, 0);
+pub static DSL_VERSION: (u16, u16) = (0, 1);
 static DSL_MAGIC_BYTES: &[u8] = b"DSL_VERSION";
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -120,6 +120,10 @@ pub enum DslPlan {
     Sink {
         input: Arc<DslPlan>,
         payload: SinkType,
+
+        /// Number of expressions this sink is partitioned over. If this is 0, it is not
+        /// partitioned.
+        num_partition_exprs: usize,
     },
     #[cfg(feature = "merge_sorted")]
     MergeSorted {
@@ -161,7 +165,7 @@ impl Clone for DslPlan {
             Self::Union { inputs, args} => Self::Union { inputs: inputs.clone(), args: args.clone() },
             Self::HConcat { inputs, options } => Self::HConcat { inputs: inputs.clone(), options: options.clone() },
             Self::ExtContext { input, contexts, } => Self::ExtContext { input: input.clone(), contexts: contexts.clone() },
-            Self::Sink { input, payload } => Self::Sink { input: input.clone(), payload: payload.clone() },
+            Self::Sink { input, payload, num_partition_exprs } => Self::Sink { input: input.clone(), payload: payload.clone(), num_partition_exprs: *num_partition_exprs },
             #[cfg(feature = "merge_sorted")]
             Self::MergeSorted { input_left, input_right, key } => Self::MergeSorted { input_left: input_left.clone(), input_right: input_right.clone(), key: key.clone() },
             Self::IR {node, dsl, version} => Self::IR {node: *node, dsl: dsl.clone(), version: *version},

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -915,10 +915,10 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 schema: Arc::new(schema),
             }
         },
-        DslPlan::Sink { input, payload } => {
+        DslPlan::Sink { input, payload, num_partition_exprs } => {
             let input =
                 to_alp_impl(owned(input), ctxt).map_err(|e| e.context(failed_here!(sink)))?;
-            IR::Sink { input, payload }
+            IR::Sink { input, payload, num_partition_exprs }
         },
         #[cfg(feature = "merge_sorted")]
         DslPlan::MergeSorted {

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -270,9 +270,9 @@ impl IR {
                     .collect();
                 DslPlan::ExtContext { input, contexts }
             },
-            IR::Sink { input, payload } => {
+            IR::Sink { input, payload, num_partition_exprs } => {
                 let input = Arc::new(convert_to_lp(input, lp_arena));
-                DslPlan::Sink { input, payload }
+                DslPlan::Sink { input, payload, num_partition_exprs }
             },
             #[cfg(feature = "merge_sorted")]
             IR::MergeSorted {

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -136,9 +136,10 @@ impl IR {
                 contexts: inputs,
                 schema: schema.clone(),
             },
-            Sink { payload, .. } => Sink {
+            Sink { payload, num_partition_exprs, .. } => Sink {
                 input: inputs.pop().unwrap(),
                 payload: payload.clone(),
+                num_partition_exprs: *num_partition_exprs,
             },
             SimpleProjection { columns, .. } => SimpleProjection {
                 input: inputs.pop().unwrap(),

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -147,6 +147,10 @@ pub enum IR {
     Sink {
         input: Node,
         payload: SinkType,
+
+        /// Number of expressions this sink is partitioned over. If this is 0, it is not
+        /// partitioned.
+        num_partition_exprs: usize,
     },
     #[cfg(feature = "merge_sorted")]
     MergeSorted {

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -349,14 +349,27 @@ impl<'a> TreeFmtNode<'a> {
                     ExtContext { input, .. } => {
                         ND(wh(h, "EXTERNAL_CONTEXT"), vec![self.lp_node(None, *input)])
                     },
-                    Sink { input, payload } => ND(
-                        wh(
-                            h,
-                            match payload {
-                                SinkType::Memory => "SINK (memory)",
-                                SinkType::File { .. } => "SINK (file)",
-                            },
-                        ),
+                    Sink {
+                        input,
+                        payload,
+                        num_partition_exprs,
+                    } => ND(
+                        {
+                            let ty = match payload {
+                                SinkType::Memory => "memory",
+                                SinkType::File { .. } => "file",
+                            };
+                            if *num_partition_exprs == 0 {
+                                wh(h, &format!("SINK ({ty})"))
+                            } else {
+                                wh(
+                                    h,
+                                    &format!(
+                                        "SINK ({ty}, partioned by {num_partition_exprs} exprs)"
+                                    ),
+                                )
+                            }
+                        },
                         vec![self.lp_node(None, *input)],
                     ),
                     SimpleProjection { input, columns } => {

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -178,8 +178,9 @@ impl Hash for HashableEqLP<'_> {
                     traverse_and_hash_aexpr(*node, self.expr_arena, state);
                 }
             },
-            IR::Sink { input: _, payload } => {
+            IR::Sink { input: _, payload, num_partition_exprs } => {
                 payload.hash(state);
+                num_partition_exprs.hash(state);
             },
             IR::Cache {
                 input: _,

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -644,6 +644,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
         IR::Sink {
             input: _,
             payload: _,
+            num_partition_exprs: _,
         } => Err(PyNotImplementedError::new_err(
             "Not expecting to see a Sink node",
         )),

--- a/crates/polars-schema/src/schema.rs
+++ b/crates/polars-schema/src/schema.rs
@@ -235,6 +235,11 @@ impl<D> Schema<D> {
         Ok(())
     }
 
+    /// Remove the last element from the schema.
+    pub fn pop(&mut self) -> Option<(PlSmallStr, D)> {
+        self.fields.pop()
+    }
+
     /// Performs [`Schema::try_insert`] for every column.
     ///
     /// Raises DuplicateError if a column already exists in the schema.

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -253,14 +253,12 @@ impl PartionableSinkNode for IpcSinkNode {
         path: &Path,
         input_schema: &SchemaRef,
         options: &Self::SinkOptions,
-    ) -> impl Future<Output = PolarsResult<Self>> + Send + Sync {
-        async move {
-            Ok(Self::new(
-                input_schema.clone(),
-                path.to_path_buf(),
-                options.clone(),
-            ))
-        }
+    ) -> PolarsResult<Self> {
+        Ok(Self::new(
+            input_schema.clone(),
+            path.to_path_buf(),
+            options.clone(),
+        ))
     }
 
     fn key_to_path(

--- a/crates/polars-stream/src/nodes/io_sinks/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/mod.rs
@@ -19,6 +19,7 @@ pub mod ipc;
 pub mod json;
 #[cfg(feature = "parquet")]
 pub mod parquet;
+pub mod partition;
 
 pub enum SinkInputPort {
     Serial(Receiver<Morsel>),

--- a/crates/polars-stream/src/nodes/io_sinks/parquet.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/parquet.rs
@@ -117,20 +117,13 @@ impl SinkNode for ParquetSinkNode {
 
             while let Ok(input) = recv_ports_recv.recv().await {
                 let mut receiver = input.port.serial();
-                loop {
-                    match receiver.recv().await {
-                        Err(_) => stop_requested = true,
-                        Ok(morsel) => {
-                            let df = morsel.into_df();
+                while let Ok(morsel) = receiver.recv().await {
+                    let df = morsel.into_df();
 
-                            // @NOTE: This also performs schema validation.
-                            buffer.vstack_mut(&df)?;
-                        },
-                    }
+                    // @NOTE: This also performs schema validation.
+                    buffer.vstack_mut(&df)?;
 
-                    while (stop_requested && buffer.height() > 0)
-                        || buffer.height() >= row_group_size
-                    {
+                    while buffer.height() >= row_group_size {
                         let row_group;
 
                         (row_group, buffer) =
@@ -146,13 +139,26 @@ impl SinkNode for ParquetSinkNode {
 
                         row_group_index += 1;
                     }
-
-                    if stop_requested {
-                        break;
-                    }
                 }
 
                 input.outcome.stop();
+            }
+
+            while buffer.height() > 0 {
+                let row_group;
+
+                (row_group, buffer) =
+                    buffer.split_at(row_group_size.min(buffer.height()) as i64);
+
+                for (column_idx, column) in row_group.take_columns().into_iter().enumerate()
+                {
+                    distribute
+                        .send((row_group_index, column_idx, column))
+                        .await
+                        .unwrap();
+                }
+
+                row_group_index += 1;
             }
 
             PolarsResult::Ok(())
@@ -289,8 +295,8 @@ impl PartionableSinkNode for ParquetSinkNode {
         path: &Path,
         input_schema: &SchemaRef,
         options: &Self::SinkOptions,
-    ) -> impl Future<Output = PolarsResult<Self>> + Send + Sync {
-        async move { Self::new(input_schema.clone(), path, options) }
+    ) -> PolarsResult<Self> {
+        Self::new(input_schema.clone(), path, options)
     }
 
     fn key_to_path(

--- a/crates/polars-stream/src/nodes/io_sinks/partition.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition.rs
@@ -1,9 +1,13 @@
 use std::cmp::Reverse;
+use std::collections::VecDeque;
 use std::future::Future;
+use std::ops::DerefMut;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
 use futures::stream::{FuturesUnordered, StreamExt};
+use polars_core::config::{self, verbose};
 use polars_core::frame::DataFrame;
 use polars_core::prelude::{AnyValue, GroupsType, PlHashMap, PlIndexMap, PlIndexSet};
 use polars_core::schema::SchemaRef;
@@ -13,10 +17,11 @@ use polars_expr::state::ExecutionState;
 use polars_utils::format_pl_smallstr;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::priority::Priority;
+use tokio::sync::{Barrier, Mutex};
 
 use super::SinkNode;
 use crate::async_executor::{spawn, AbortOnDropHandle};
-use crate::async_primitives::connector::{connector, Sender};
+use crate::async_primitives::connector::{connector, SendError, Sender};
 use crate::async_primitives::linearizer::Linearizer;
 use crate::async_primitives::wait_group::WaitGroup;
 use crate::morsel::SourceToken;
@@ -32,7 +37,7 @@ pub trait PartionableSinkNode: Sized + SinkNode + Send + Sync + 'static {
         path: &Path,
         input_schema: &SchemaRef,
         options: &Self::SinkOptions,
-    ) -> impl Future<Output = PolarsResult<Self>> + Send + Sync;
+    ) -> PolarsResult<Self>;
     fn key_to_path(
         keys: &[AnyValue<'static>],
         options: &Self::SinkOptions,
@@ -40,14 +45,75 @@ pub trait PartionableSinkNode: Sized + SinkNode + Send + Sync + 'static {
 }
 
 struct OpenSinkNode {
-    tx: Sender<Morsel>,
     node: Box<dyn SinkNode + Send + Sync>,
     join_handles: FuturesUnordered<AbortOnDropHandle<PolarsResult<()>>>,
     seq: MorselSeq,
 
-    oneshot_tx: Sender<SinkInput>,
-    wg: WaitGroup,
-    outcome: PhaseOutcomeToken,
+    phase_tx: Sender<SinkInput>,
+    phase: Option<(WaitGroup, PhaseOutcomeToken, Vec<JoinHandle<PolarsResult<()>>>)>,
+}
+
+impl OpenSinkNode {
+    async fn start_phase(&mut self, gp_txs: &mut [Option<Vec<Sender<Morsel>>>], num_pipelines: usize) -> Result<(), SinkInput> {
+        assert!(self.phase.is_none());
+
+        let mut join_handles = Vec::new();
+        let (mut txs, mut rxs) = (0..num_pipelines)
+            .map(|_| connector())
+            .collect::<(Vec<_>, Vec<_>)>();
+
+    let sink_input = if self.node.is_sink_input_parallel() {
+        SinkInputPort::Parallel(rxs)
+    } else {
+        let (mut linearizer, inserters) =
+            Linearizer::new(num_pipelines, DEFAULT_LINEARIZER_BUFFER_SIZE);
+        let (mut sink_tx, sink_rx) = connector();
+        join_handles.extend(
+            rxs.into_iter()
+                .zip(inserters)
+                .map(|(mut rx, mut inserter)| {
+                    spawn(TaskPriority::High, async move {
+                        while let Ok(m) = rx.recv().await {
+                            if inserter
+                                .insert(Priority(Reverse(m.seq()), m))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Ok(())
+                    })
+                }),
+        );
+
+        // Place a linearizer between the RXS and the actual sink receive port.
+        join_handles.push(spawn(TaskPriority::High, async move {
+            while let Some(Priority(_, m)) = linearizer.get().await {
+                // Specifically filter out empty dataframes here.
+                if m.df().height() == 0 {
+                    continue;
+                }
+
+                if sink_tx.send(m).await.is_err() {
+                    break;
+                }
+            }
+            Ok(())
+        }));
+        SinkInputPort::Serial(sink_rx)
+    };
+    for (gp_tx, tx) in gp_txs.iter_mut().zip(txs) {
+        if let Some(gp_tx) = gp_tx {
+            gp_tx.push(tx);
+        }
+    }
+
+    let (outcome, wg, sink_input) = SinkInput::from_port(sink_input);
+    self.phase_tx.send(sink_input).await?;
+    self.phase = Some((wg, outcome, join_handles));
+    Ok(())
+    }
 }
 
 pub struct PartitionSink<T: PartionableSinkNode> {
@@ -60,7 +126,7 @@ pub struct PartitionSink<T: PartionableSinkNode> {
 
     include_key: bool,
     stable: bool,
-    
+
     /// How many partition sinks may be open / active at any given time.
     ///
     /// This is needed because platforms put limits on the amount of open files you can have at any
@@ -99,7 +165,7 @@ impl<T: PartionableSinkNode> PartitionSink<T> {
 
     pub fn with_max_open_partitions(mut self, max_open_partitions: usize) -> Self {
         self.max_open_partitions = max_open_partitions;
-        max_open_partitions
+        self
     }
 }
 
@@ -116,45 +182,21 @@ fn max_open_partitions() -> usize {
     })
 }
 
-async fn open_sink<T: PartionableSinkNode>(
+fn open_sink<T: PartionableSinkNode>(
     keys: &[AnyValue<'static>],
     output_schema: &SchemaRef,
     options: &T::SinkOptions,
+    gp_txs: &mut [Option<Vec<Sender<Morsel>>>],
     num_pipelines: usize,
-) -> PolarsResult<(SinkInput, OpenSinkNode)> {
+) -> PolarsResult<OpenSinkNode> {
     let path = T::key_to_path(&keys, &options)?;
-    let (tx, mut rx) = connector();
-    let mut sink_node = T::new(&path, &output_schema, &options).await?;
+    let mut sink_node = T::new(&path, &output_schema, &options)?;
     let mut join_handles = Vec::new();
 
-    let sink_input = if sink_node.is_sink_input_parallel() {
-        let (mut txs, mut rxs) = (0..num_pipelines)
-            .map(|_| connector())
-            .collect::<(Vec<_>, Vec<_>)>();
-
-        // Place a small distributor between the RX and the actual sink receive port. This allows
-        // the sink to actually use parallelism properly.
-        join_handles.push(spawn(TaskPriority::High, async move {
-            let mut rr = 0;
-            while let Ok(m) = rx.recv().await {
-                if txs[rr].send(m).await.is_err() {
-                    break;
-                }
-                rr += 1;
-                rr %= num_pipelines;
-            }
-
-            Ok(())
-        }));
-        SinkInputPort::Parallel(rxs)
-    } else {
-        SinkInputPort::Serial(rx)
-    };
-    let (outcome, wg, sink_input) = SinkInput::from_port(sink_input);
-    let (mut oneshot_tx, oneshot_rx) = connector();
+    let (mut phase_tx, phase_rx) = connector();
     let port = SinkRecvPort {
         num_pipelines,
-        recv: oneshot_rx,
+        recv: phase_rx,
     };
 
     let state = ExecutionState::new();
@@ -164,19 +206,16 @@ async fn open_sink<T: PartionableSinkNode>(
         .map(AbortOnDropHandle::new)
         .collect();
 
-    Ok((
-        sink_input,
+    Ok(
         OpenSinkNode {
-            tx,
             node: Box::new(sink_node),
             join_handles,
 
             seq: MorselSeq::default(),
-            oneshot_tx,
-            wg,
-            outcome,
+            phase_tx,
+            phase: None,
         },
-    ))
+    )
 }
 
 impl<T: PartionableSinkNode> SinkNode for PartitionSink<T> {
@@ -198,25 +237,68 @@ impl<T: PartionableSinkNode> SinkNode for PartitionSink<T> {
         let (handle, rx_receivers) = recv_ports_recv.parallel();
         join_handles.push(handle);
 
-        let (mut linearizer, txs) = Linearizer::<Priority<Reverse<MorselSeq>, Vec<DataFrame>>>::new(
-            num_pipelines,
-            DEFAULT_LINEARIZER_BUFFER_SIZE,
-        );
+        struct GlobalPartitions {
+            known_partitions: Arc<PlIndexSet<Vec<AnyValue<'static>>>>,
+            open_sinks: Vec<OpenSinkNode>,
+            txs: Vec<Option<Vec<Sender<Morsel>>>>,
+        }
+
+        let global_partitions: Arc<Mutex<GlobalPartitions>> =
+            Arc::new(Mutex::new(GlobalPartitions {
+                known_partitions: Arc::new(Default::default()),
+                open_sinks: Vec::default(),
+                txs: (0..num_pipelines).map(|_| Some(Vec::new())).collect(),
+            }));
+        let barrier = Arc::new(Barrier::new(num_pipelines));
 
         // Evaluate and Partition Tasks
         join_handles.extend(
             rx_receivers
                 .into_iter()
-                .zip(txs)
-                .map(|(mut rx_receiver, mut tx)| {
+                .enumerate()
+                .map(|(i, mut rx_receiver)| {
                     let num_partition_exprs = self.num_partition_exprs;
                     let stable = self.stable;
                     let include_key = self.include_key;
+                    let max_open_partitions = self.max_open_partitions;
+                    let output_schema = self.output_schema.clone();
+                    let options = self.options.clone();
+                    let global_partitions = global_partitions.clone();
+                    let verbose = config::verbose();
+                    let barrier = barrier.clone();
 
                     spawn(TaskPriority::High, async move {
+                        let mut known_partitions =
+                            Arc::new(PlIndexSet::<Vec<AnyValue<'static>>>::default());
+                        let mut unknown_idxs = Vec::new();
+                        let mut unknown_keys = Vec::new();
+                        let mut unknown_morsels = Vec::new();
+                        let mut sink_txs = Vec::<Sender<Morsel>>::new();
+                        let mut buffering = Vec::<Option<Morsel>>::new();
+                        let mut keys = Vec::new();
+
                         while let Ok((_token, outcome, mut rx)) = rx_receiver.recv().await {
+                            { // Critical section that holds the Mutex lock.
+                                let mut global_partitions = global_partitions.lock().await;
+                                let GlobalPartitions { known_partitions, ref mut open_sinks, ref mut txs } = global_partitions.deref_mut();
+                                if !open_sinks.is_empty() && open_sinks[0].phase.is_none() {
+                                    let num_open_sinks = open_sinks.len();
+                                    for txs in txs.iter_mut() {
+                                        *txs = Some(Vec::with_capacity(num_open_sinks));
+                                    }
+                                    for open_sink in open_sinks.iter_mut() {
+                                        if open_sink.start_phase(txs, num_pipelines).await.is_err() {
+                                            dbg!("TODO: wait for joinhandles");
+                                            return Ok(());
+                                        };
+                                    }
+                                }
+                                sink_txs.extend(txs[i].as_mut().unwrap().drain(..));
+                                drop(global_partitions);
+                            }
+
                             while let Ok(m) = rx.recv().await {
-                                let (df, seq, _, _) = m.into_inner();
+                                let (df, seq, source_token, _) = m.into_inner();
                                 if df.height() == 0 {
                                     continue;
                                 }
@@ -227,139 +309,199 @@ impl<T: PartionableSinkNode> SinkNode for PartitionSink<T> {
                                     .map(|c| c.name().clone())
                                     .collect::<Vec<_>>();
 
-                                let partitions =
+                                let mut partitions =
                                     df._partition_by_impl(&partition_cols, stable, true, false)?;
-                                if tx.insert(Priority(Reverse(seq), partitions)).await.is_err() {
-                                    return Ok(());
+
+                                for mut df in partitions.drain(..) {
+                                    assert_ne!(df.height(), 0);
+                                    keys.clear();
+                                    df.clear_schema();
+                                    let columns = unsafe { df.get_columns_mut() };
+
+                                    for key_column in
+                                        columns.drain(columns.len() - num_partition_exprs..)
+                                    {
+                                        let key_value = unsafe { key_column.get_unchecked(0) };
+                                        keys.push(key_value.into_static());
+                                    }
+
+                                    let morsel = Morsel::new(df, seq, source_token.clone());
+                                    let Some(idx) = known_partitions.get_index_of(&keys) else {
+                                        unknown_morsels.push(morsel);
+                                        unknown_keys.push(std::mem::replace(
+                                            &mut keys,
+                                            Vec::with_capacity(num_partition_exprs),
+                                        ));
+                                        continue;
+                                    };
+
+                                    debug_assert!(buffering[idx].is_none());
+                                    buffering[idx] = Some(morsel);
                                 }
+
+                                if !unknown_keys.is_empty() {
+                                    unknown_idxs.clear();
+
+                                    let mut mut_known_partitions = None;
+
+                                    { // Critical section that holds the Mutex lock.
+                                        let mut global_partitions = global_partitions.lock().await;
+                                        for keys in unknown_keys.drain(..) {
+                                            let idx = match global_partitions
+                                                .known_partitions
+                                                .get_index_of(&keys)
+                                            {
+                                                None => {
+                                                    if global_partitions.known_partitions.len()
+                                                        < max_open_partitions
+                                                    {
+                                                        let mut open_sink =
+                                                            open_sink::<T>(
+                                                                &keys,
+                                                                &output_schema,
+                                                                &options,
+                                                                &mut global_partitions.txs,
+                                                                num_pipelines,
+                                                            )?;
+                                                        if open_sink.start_phase(&mut global_partitions.txs, num_pipelines).await.is_err() {
+                                                            dbg!("TODO: wait for join handles");
+                                                            return Ok(());
+                                                        }
+                                                        global_partitions
+                                                            .open_sinks
+                                                            .push(open_sink);
+                                                    }
+                                                    mut_known_partitions
+                                                        .get_or_insert_with(|| {
+                                                            global_partitions
+                                                                .known_partitions
+                                                                .as_ref()
+                                                                .clone()
+                                                        })
+                                                        .insert_full(keys)
+                                                        .0
+                                                },
+                                                Some(idx) => idx,
+                                            };
+                                            unknown_idxs.push(idx);
+                                        }
+
+                                        if let Some(mut_known_partitions) = mut_known_partitions {
+                                            if verbose && global_partitions.known_partitions.len() <= max_open_partitions && mut_known_partitions.len() > max_open_partitions {
+                                                eprintln!("[PartitionSink]: Reached the maximum open partitions, resorting to buffering remaining partitions");
+                                            }
+
+                                            global_partitions.known_partitions =
+                                                Arc::new(mut_known_partitions);
+                                        }
+                                        known_partitions =
+                                            global_partitions.known_partitions.clone();
+
+                                        let offset = sink_txs.len();
+                                        sink_txs.extend(
+                                            global_partitions.txs[i].as_mut().unwrap().drain(..)
+                                        );
+                                        drop(global_partitions);
+                                    }
+
+                                    buffering.resize_with(known_partitions.len(), || None);
+                                    for ((idx, morsel), buf) in
+                                        unknown_idxs.drain(..).zip(unknown_morsels.drain(..))
+                                            .zip(buffering.iter_mut())
+
+                                    {
+                                        debug_assert!(buf.is_none());
+                                        *buf = Some(morsel);
+                                    }
+                                }
+
+                                let mut sends = FuturesUnordered::from_iter(
+                                    sink_txs.iter_mut().zip(buffering.iter_mut()).map(|(sink_tx, buf)| {
+                                        let m = buf.take().unwrap_or_else(|| 
+                                            Morsel::new(DataFrame::empty(), seq, source_token.clone()));
+                                        sink_tx.send(m)
+                                    })
+                                );
+                                while let Some(send) = sends.next().await {
+                                    if send.is_err() {
+                                        panic!("failed to send");
+                                    }
+                                }
+                            }
+
+                            debug_assert!(buffering.iter().all(|b| b.is_none()));
+
+                            sink_txs.clear();
+                            { // Critical section that holds the Mutex lock.
+                                let mut global_partitions = global_partitions.lock().await;
+                                let _txs = global_partitions.txs[i].take();
+                                drop(global_partitions);
+                                drop(_txs);
+                            }
+
+                            if i == 0 {
+                                let mut global_partitions = global_partitions.lock().await;
+                                for mut open_sink_node in global_partitions.open_sinks.iter_mut() {
+                                    let (wg, outcome, join_handles) = open_sink_node.phase.take().unwrap();
+
+                                    // @NOTE: The combination of the following two are essentially
+                                    // a barrier for this open sink.
+                                    for handle in join_handles {
+                                        handle.await?;
+                                    }
+                                    wg.wait().await;
+
+                                    if outcome.did_finish() {
+                                        // Some error occurred.
+                                        while let Some(ret) = open_sink_node.join_handles.next().await {
+                                            ret?;
+                                        }
+                                    }
+                                }
+                                let num_open_sinks = global_partitions.open_sinks.len();
+                                drop(global_partitions);
                             }
 
                             outcome.stop();
                         }
 
+                        barrier.wait().await;
+
+                        if i == 0 {
+                            if verbose {
+                                eprintln!("[PartitionSink]: Finished receiving morsels. Closing and flushing partitions.");
+                            }
+
+                            {
+                                let mut global_partitions = global_partitions.lock().await;
+                                for mut open_sink_node in global_partitions.open_sinks.drain(..) {
+                                    drop(open_sink_node.phase_tx);
+                                    // Either the task finished or some error occurred.
+                                    while let Some(ret) = open_sink_node.join_handles.next().await {
+                                        ret?;
+                                    }
+                                }
+                                drop(global_partitions);
+                            }
+                        }
+
+                        assert!(buffering.len() <= max_open_partitions && buffering.iter().all(|b| b.is_none())); // @TODO
+
+                       // for ms in buffering {
+                       //     let Ok(mut tx) = buffering_flush_rx.recv().await else {
+                       //         return Ok(());
+                       //     };
+                       //
+                       //     for m in ms {
+                       //         if tx.send(m).await.is_err() {
+                       //             return Ok(());
+                       //         }
+                       //     }
+                       // }
+
                         Ok(())
                     })
                 }),
         );
-
-        let max_open_partitions = self.max_open_partitions;
-        let options = self.options.clone();
-        let num_partition_exprs = self.num_partition_exprs;
-        let output_schema = self.output_schema.clone();
-        join_handles.push(spawn(TaskPriority::High, async move {
-            let mut known_partitions = PlIndexSet::<Vec<AnyValue<'static>>>::default();
-            let mut open_sinks = Vec::<OpenSinkNode>::with_capacity(max_open_partitions);
-            let mut buffering_partitions = Vec::<DataFrame>::new();
-
-            let mut keys = Vec::with_capacity(num_partition_exprs);
-            let source_token = SourceToken::new();
-
-            while let Some(Priority(_, partitions)) = linearizer.get().await {
-                for mut df in partitions {
-                    assert_ne!(df.height(), 0);
-                    keys.clear();
-                    df.clear_schema();
-                    let columns = unsafe { df.get_columns_mut() };
-
-                    for key_column in columns.drain(columns.len() - num_partition_exprs..) {
-                        let key_value = unsafe { key_column.get_unchecked(0) };
-                        keys.push(key_value.into_static());
-                    }
-
-                    let idx = match known_partitions.get_index_of(&keys) {
-                        None => {
-                            let key = std::mem::replace(
-                                &mut keys,
-                                Vec::with_capacity(num_partition_exprs),
-                            );
-                            let (idx, _) = known_partitions.insert_full(key);
-                            if idx < max_open_partitions {
-                                let (sink_input, mut open_sink) =
-                                    open_sink::<T>(&keys, &output_schema, &options, num_pipelines)
-                                        .await?;
-                                if open_sink.oneshot_tx.send(sink_input).await.is_err() {
-                                    open_sinks.push(open_sink);
-                                    break;
-                                };
-                                open_sinks.push(open_sink);
-                            } else {
-                                // If there are too many files open, we need to start buffering the
-                                // remaining partitions.
-                                buffering_partitions
-                                    .push(DataFrame::empty_with_schema(&output_schema));
-                            };
-                            idx
-                        },
-                        Some(idx) => idx,
-                    };
-
-                    if idx < max_open_partitions {
-                        let open_sink_node = &mut open_sinks[idx];
-                        let seq = open_sink_node.seq;
-                        open_sink_node.seq = seq.successor();
-
-                        if open_sink_node
-                            .tx
-                            .send(Morsel::new(df, seq, source_token.clone()))
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                        assert!(!source_token.stop_requested());
-                    } else {
-                        let buffer_df = &mut buffering_partitions[idx - max_open_partitions];
-                        buffer_df.vstack_mut_owned_unchecked(df);
-                    }
-                }
-            }
-
-            if known_partitions.is_empty() {
-                return Ok(());
-            }
-
-            let mut num_open_sinks = known_partitions.len().min(max_open_partitions);
-            for mut open_sink_node in open_sinks.drain(..) {
-                drop(open_sink_node.oneshot_tx);
-                drop(open_sink_node.tx);
-                open_sink_node.wg.wait().await;
-
-                // Either the task finished or some error occurred.
-                while let Some(ret) = open_sink_node.join_handles.next().await {
-                    ret?;
-                }
-            }
-
-            // @Improvement: This should be better parallelized.
-            for (idx, mut df) in buffering_partitions.into_iter().enumerate() {
-                let keys = known_partitions
-                    .get_index(idx + max_open_partitions)
-                    .unwrap();
-                let (sink_input, mut open_sink_node) =
-                    open_sink::<T>(keys, &output_schema, &options, num_pipelines).await?;
-                if open_sink_node.oneshot_tx.send(sink_input).await.is_ok() {
-                    if open_sink_node
-                        .tx
-                        .send(Morsel::new(df, MorselSeq::default(), source_token.clone()))
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
-                    assert!(!source_token.stop_requested());
-                };
-
-                drop(open_sink_node.oneshot_tx);
-                drop(open_sink_node.tx);
-                open_sink_node.wg.wait().await;
-
-                // Either the task finished or some error occurred.
-                while let Some(ret) = open_sink_node.join_handles.next().await {
-                    ret?;
-                }
-            }
-
-            Ok(())
-        }));
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/partition.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition.rs
@@ -1,0 +1,286 @@
+use std::cmp::Reverse;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use polars_core::frame::DataFrame;
+use polars_core::prelude::{AnyValue, PlHashMap};
+use polars_core::schema::{Schema, SchemaRef};
+use polars_error::PolarsResult;
+use polars_expr::prelude::PhysicalExpr;
+use polars_expr::state::ExecutionState;
+use polars_utils::format_pl_smallstr;
+use polars_utils::pl_str::PlSmallStr;
+use polars_utils::priority::Priority;
+
+use super::SinkNode;
+use crate::async_executor::{spawn, AbortOnDropHandle};
+use crate::async_primitives::connector::{connector, Sender};
+use crate::async_primitives::linearizer::Linearizer;
+use crate::async_primitives::wait_group::WaitGroup;
+use crate::morsel::SourceToken;
+use crate::nodes::io_sinks::{SinkInput, SinkInputPort, SinkRecvPort};
+use crate::nodes::io_sources::PhaseOutcomeToken;
+use crate::nodes::{JoinHandle, Morsel, MorselSeq, TaskPriority};
+use crate::DEFAULT_LINEARIZER_BUFFER_SIZE;
+
+pub trait PartionableSinkNode: Sized + SinkNode + Send + Sync + 'static {
+    type SinkOptions: Clone + Send + Sync + 'static;
+
+    fn new(
+        path: &Path,
+        input_schema: &SchemaRef,
+        options: &Self::SinkOptions,
+    ) -> impl Future<Output = PolarsResult<Self>> + Send + Sync;
+    fn key_to_path(
+        keys: &[AnyValue<'static>],
+        options: &Self::SinkOptions,
+    ) -> PolarsResult<PathBuf>;
+}
+
+struct OpenSinkNode {
+    tx: Sender<Morsel>,
+    node: Box<dyn SinkNode + Send + Sync>,
+    join_handles: FuturesUnordered<AbortOnDropHandle<PolarsResult<()>>>,
+
+    oneshot_tx: Sender<SinkInput>,
+    wg: WaitGroup,
+    outcome: PhaseOutcomeToken,
+}
+
+struct OpenPartition {
+    sink_node: Result<OpenSinkNode, DataFrame>,
+    seq: MorselSeq,
+}
+
+pub struct PartitionSink<T: PartionableSinkNode> {
+    options: T::SinkOptions,
+
+    num_partition_exprs: usize,
+
+    input_schema: SchemaRef,
+    output_schema: SchemaRef,
+}
+
+impl<T: PartionableSinkNode> PartitionSink<T> {
+    pub fn new(
+        options: T::SinkOptions,
+        num_partition_exprs: usize,
+        input_schema: SchemaRef,
+    ) -> Self {
+        assert!(input_schema.len() > num_partition_exprs);
+
+        let mut output_schema = input_schema.as_ref().clone();
+        for _ in 0..num_partition_exprs {
+            output_schema.pop();
+        }
+        let output_schema = Arc::new(output_schema);
+
+        Self {
+            options,
+
+            num_partition_exprs,
+
+            input_schema,
+            output_schema,
+        }
+    }
+}
+
+fn part_key_colname(i: usize) -> PlSmallStr {
+    format_pl_smallstr!("__PL_PARTBY_{i}")
+}
+
+const DEFAULT_MAX_OPEN_PARTITION_SINKS: usize = 16;
+fn max_open_partitions() -> usize {
+    std::env::var("POLARS_MAX_OPEN_PARTITION_SINKS").map_or(DEFAULT_MAX_OPEN_PARTITION_SINKS, |v| {
+        v.parse::<usize>()
+            .expect("unable to parse POLARS_MAX_OPEN_PARTITION_SINKS")
+            .max(1)
+    })
+}
+
+impl<T: PartionableSinkNode> SinkNode for PartitionSink<T> {
+    fn name(&self) -> &str {
+        "partition_sink"
+    }
+
+    fn is_sink_input_parallel(&self) -> bool {
+        true
+    }
+
+    fn spawn_sink(
+        &mut self,
+        num_pipelines: usize,
+        recv_ports_recv: super::SinkRecvPort,
+        state: &ExecutionState,
+        join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
+    ) {
+        let (handle, rx_receivers) = recv_ports_recv.parallel();
+        join_handles.push(handle);
+
+        let (mut linearizer, txs) = Linearizer::<Priority<Reverse<MorselSeq>, Vec<DataFrame>>>::new(
+            num_pipelines,
+            DEFAULT_LINEARIZER_BUFFER_SIZE,
+        );
+
+        // Evaluate and Partition Tasks
+        join_handles.extend(
+            rx_receivers
+                .into_iter()
+                .zip(txs)
+                .map(|(mut rx_receiver, mut tx)| {
+                    let num_partition_exprs = self.num_partition_exprs;
+                    let state = state.clone();
+                    spawn(TaskPriority::High, async move {
+                        while let Ok((_token, outcome, mut rx)) = rx_receiver.recv().await {
+                            while let Ok(m) = rx.recv().await {
+                                let (mut df, seq, _, _) = m.into_inner();
+                                if df.height() == 0 {
+                                    continue;
+                                }
+
+                                let partition_cols = df.get_columns()
+                                    [df.width() - num_partition_exprs..]
+                                    .iter()
+                                    .map(|c| c.name().clone());
+
+                                // @Incomplete: Stability
+                                let partitions = df.partition_by(partition_cols, true)?;
+                                if tx.insert(Priority(Reverse(seq), partitions)).await.is_err() {
+                                    return Ok(());
+                                }
+                            }
+
+                            outcome.stop();
+                        }
+
+                        Ok(())
+                    })
+                }),
+        );
+
+        let max_open_partitions = max_open_partitions();
+        let options = self.options.clone();
+        let num_partition_exprs = self.num_partition_exprs;
+        let output_schema = self.output_schema.clone();
+        join_handles.push(spawn(TaskPriority::High, async move {
+            let mut open_partitions = PlHashMap::<Vec<AnyValue<'static>>, OpenPartition>::default();
+
+            let mut keys = Vec::with_capacity(num_partition_exprs);
+            let source_token = SourceToken::new();
+
+            while let Some(Priority(_, partitions)) = linearizer.get().await {
+                for mut df in partitions {
+                    assert_ne!(df.height(), 0);
+                    keys.clear();
+                    df.clear_schema();
+                    let columns = unsafe { df.get_columns_mut() };
+
+                    for key_column in columns.drain(columns.len() - num_partition_exprs..) {
+                        let key_value = unsafe { key_column.get_unchecked(0) };
+                        keys.push(key_value.into_static());
+                    }
+
+                    let open_partition = match open_partitions.get_mut(&keys) {
+                        Some(open_partition) => open_partition,
+                        None => {
+                            let sink_node = if open_partitions.len() <= max_open_partitions {
+                                let path = T::key_to_path(&keys, &options)?;
+                                let (tx, rx) = connector();
+                                let mut sink_node = T::new(&path, &output_schema, &options).await?;
+                                let sink_input = if sink_node.is_sink_input_parallel() {
+                                    SinkInputPort::Parallel(vec![rx])
+                                } else {
+                                    SinkInputPort::Serial(rx)
+                                };
+                                let (outcome, wg, sink_input) = SinkInput::from_port(sink_input);
+                                let (mut oneshot_tx, oneshot_rx) = connector();
+                                let port = SinkRecvPort {
+                                    num_pipelines: 1,
+                                    recv: oneshot_rx,
+                                };
+
+                                let mut join_handles = Vec::new();
+                                let state = ExecutionState::new();
+                                sink_node.spawn_sink(1, port, &state, &mut join_handles);
+                                let join_handles = join_handles
+                                    .into_iter()
+                                    .map(AbortOnDropHandle::new)
+                                    .collect();
+
+                                if oneshot_tx.send(sink_input).await.is_err() {
+                                    return Ok(());
+                                }
+
+                                Ok(OpenSinkNode {
+                                    tx,
+                                    node: Box::new(sink_node),
+                                    join_handles,
+
+                                    oneshot_tx,
+                                    wg,
+                                    outcome,
+                                })
+                            } else {
+                                Err(DataFrame::empty_with_schema(&output_schema))
+                            };
+
+                            let mut open_partition = OpenPartition {
+                                sink_node,
+                                seq: MorselSeq::default(),
+                            };
+                            let key = std::mem::replace(
+                                &mut keys,
+                                Vec::with_capacity(num_partition_exprs),
+                            );
+                            let (_, open_partition) = unsafe {
+                                open_partitions.insert_unique_unchecked(key, open_partition)
+                            };
+
+                            open_partition
+                        },
+                    };
+
+                    match open_partition.sink_node.as_mut() {
+                        Ok(open_sink_node) => {
+                            let seq = open_partition.seq;
+                            open_partition.seq = open_partition.seq.successor();
+                            if open_sink_node
+                                .tx
+                                .send(Morsel::new(df, seq, source_token.clone()))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                            assert!(!source_token.stop_requested());
+                        },
+                        Err(buffer_df) => buffer_df.vstack_mut_owned_unchecked(df),
+                    }
+                }
+            }
+
+            if open_partitions.len() > max_open_partitions {
+                todo!()
+            }
+            for (_, open_partition) in open_partitions.into_iter() {
+                match open_partition.sink_node {
+                    Ok(mut sink_node) => {
+                        drop(sink_node.oneshot_tx);
+                        sink_node.wg.wait().await;
+
+                        // Either the task finished or some error occurred.
+                        while let Some(ret) = sink_node.join_handles.next().await {
+                            ret?;
+                        }
+                    },
+                    _ => todo!(),
+                }
+            }
+
+            Ok(())
+        }));
+    }
+}

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -220,7 +220,7 @@ pub fn lower_ir(
             node_kind
         },
 
-        IR::Sink { input, payload } => match payload {
+        IR::Sink { input, payload, num_partition_exprs } => match payload {
             SinkType::Memory => {
                 let phys_input = lower_ir!(*input)?;
                 PhysNodeKind::InMemorySink { input: phys_input }
@@ -232,6 +232,7 @@ pub fn lower_ir(
             } => {
                 let path = path.clone();
                 let file_type = file_type.clone();
+                let num_partition_exprs = *num_partition_exprs;
 
                 match file_type {
                     #[cfg(feature = "ipc")]
@@ -241,6 +242,7 @@ pub fn lower_ir(
                             path,
                             file_type,
                             input: phys_input,
+                            num_partition_exprs,
                         }
                     },
                     #[cfg(feature = "parquet")]
@@ -250,6 +252,7 @@ pub fn lower_ir(
                             path,
                             file_type,
                             input: phys_input,
+                            num_partition_exprs,
                         }
                     },
                     #[cfg(feature = "csv")]
@@ -259,6 +262,7 @@ pub fn lower_ir(
                             path,
                             file_type,
                             input: phys_input,
+                            num_partition_exprs,
                         }
                     },
                     #[cfg(feature = "json")]
@@ -268,6 +272,7 @@ pub fn lower_ir(
                             path,
                             file_type,
                             input: phys_input,
+                            num_partition_exprs,
                         }
                     },
                 }

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -131,6 +131,7 @@ pub enum PhysNodeKind {
         path: Arc<PathBuf>,
         file_type: FileType,
         input: PhysStream,
+        num_partition_exprs: usize,
     },
 
     /// Generic fallback for (as-of-yet) unsupported streaming mappings.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2308,6 +2308,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         | Literal["auto"]
         | None = "auto",
         retries: int = 2,
+        partition_by: None | list[Expr] = None,
     ) -> None:
         """
         Evaluate the query in streaming mode and write to a Parquet file.
@@ -2464,6 +2465,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             cloud_options=storage_options,
             credential_provider=credential_provider_builder,
             retries=retries,
+            partition_by=None if partition_by is None else [e._pyexpr for e in partition_by],
         )
 
     @unstable()


### PR DESCRIPTION
TODO:
- Many IR representation better
- Deal with bottleneck on the partitioning thread (current plan is to make the partitioning tasks send the data to another task that figures out which sink to send it to)
- implement better keys to path strategies
- implement for csv and parquet (easy pleazy)