### PR TITLE
feat: Support writing `Time` type in json

### DIFF
--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -10,12 +10,12 @@ use arrow::offset::Offset;
 #[cfg(feature = "timezones")]
 use arrow::temporal_conversions::parse_offset_tz;
 use arrow::temporal_conversions::{
-    date32_to_date, duration_ms_to_duration, duration_ns_to_duration, duration_s_to_duration,
-    duration_us_to_duration, parse_offset, timestamp_ms_to_datetime, timestamp_ns_to_datetime,
-    timestamp_s_to_datetime, timestamp_to_datetime, timestamp_us_to_datetime,
+    date32_to_date, duration_ms_to_duration, duration_ns_to_duration, duration_us_to_duration,
+    parse_offset, time64ns_to_time, timestamp_ms_to_datetime, timestamp_ns_to_datetime,
+    timestamp_to_datetime, timestamp_us_to_datetime,
 };
 use arrow::types::NativeType;
-use chrono::{Duration, NaiveDate, NaiveDateTime};
+use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
 use streaming_iterator::StreamingIterator;
 
 use super::utf8;
@@ -337,6 +337,28 @@ where
     materialize_serializer(f, array.iter(), offset, take)
 }
 
+fn time_serializer<'a, T, F>(
+    array: &'a PrimitiveArray<T>,
+    convert: F,
+    offset: usize,
+    take: usize,
+) -> Box<dyn StreamingIterator<Item = [u8]> + 'a + Send + Sync>
+where
+    T: NativeType,
+    F: Fn(T) -> NaiveTime + 'static + Send + Sync,
+{
+    let f = move |x: Option<&T>, buf: &mut Vec<u8>| {
+        if let Some(x) = x {
+            let time = convert(*x);
+            write!(buf, "\"{time}\"").unwrap();
+        } else {
+            buf.extend_from_slice(b"null")
+        }
+    };
+
+    materialize_serializer(f, array.iter(), offset, take)
+}
+
 fn timestamp_serializer<'a, F>(
     array: &'a PrimitiveArray<i64>,
     convert: F,
@@ -484,7 +506,7 @@ pub(crate) fn new_serializer<'a>(
                 TimeUnit::Nanosecond => timestamp_ns_to_datetime,
                 TimeUnit::Microsecond => timestamp_us_to_datetime,
                 TimeUnit::Millisecond => timestamp_ms_to_datetime,
-                TimeUnit::Second => timestamp_s_to_datetime,
+                tu => panic!("Invalid time unit '{:?}' for Datetime.", tu),
             };
             timestamp_serializer(
                 array.as_any().downcast_ref().unwrap(),
@@ -505,9 +527,21 @@ pub(crate) fn new_serializer<'a>(
                 TimeUnit::Nanosecond => duration_ns_to_duration,
                 TimeUnit::Microsecond => duration_us_to_duration,
                 TimeUnit::Millisecond => duration_ms_to_duration,
-                TimeUnit::Second => duration_s_to_duration,
+                tu => panic!("Invalid time unit '{:?}' for Duration.", tu),
             };
             duration_serializer(
+                array.as_any().downcast_ref().unwrap(),
+                convert,
+                offset,
+                take,
+            )
+        },
+        ArrowDataType::Time64(tu) => {
+            let convert = match tu {
+                TimeUnit::Nanosecond => time64ns_to_time,
+                tu => panic!("Invalid time unit '{:?}' for Time.", tu),
+            };
+            time_serializer(
                 array.as_any().downcast_ref().unwrap(),
                 convert,
                 offset,

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -59,6 +59,24 @@ def test_write_json_duration() -> None:
     assert value == expected
 
 
+def test_write_json_time() -> None:
+    ns = 1_000_000_000
+    df = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [7291 * ns + 54321, 54321 * ns + 12345, 86399 * ns],
+                dtype=pl.Time,
+            ),
+        }
+    )
+
+    value = df.write_json()
+    expected = (
+        '[{"a":"02:01:31.000054321"},{"a":"15:05:21.000012345"},{"a":"23:59:59"}]'
+    )
+    assert value == expected
+
+
 def test_write_json_decimal() -> None:
     df = pl.DataFrame({"a": pl.Series([D("1.00"), D("2.00"), None])})
 


### PR DESCRIPTION
Closes #21452.

I also removed two small branches that aren't relevant to Polars:

1. `ArrowDataType::Timestamp(s)` - this is our `Datetime` dtype, which only uses `ms`, `us`, and `ns`, we have no `s` implementation.
2. `ArrowDataType::Duration(s)` - same as `Datetime` units described above.