### PR TITLE
feat: Add `AssertionError` variant to `PolarsError` in `polars-error`

### DIFF
--- a/crates/polars-python/src/error.rs
+++ b/crates/polars-python/src/error.rs
@@ -12,7 +12,7 @@ use pyo3::prelude::*;
 use pyo3::PyTypeInfo;
 
 use crate::exceptions::{
-    CategoricalRemappingWarning, ColumnNotFoundError, ComputeError, DuplicateError,
+    AssertionError, CategoricalRemappingWarning, ColumnNotFoundError, ComputeError, DuplicateError,
     InvalidOperationError, MapWithoutReturnDtypeWarning, NoDataError, OutOfBoundsError,
     SQLInterfaceError, SQLSyntaxError, SchemaError, SchemaFieldNotFoundError, ShapeError,
     StringCacheMismatchError, StructFieldNotFoundError,
@@ -68,6 +68,7 @@ impl From<PyPolarsErr> for PyErr {
         use PyPolarsErr::*;
         match err {
             Polars(err) => match err {
+                PolarsError::AssertionError(err) => AssertionError::new_err(err.to_string()),
                 PolarsError::ColumnNotFound(name) => ColumnNotFoundError::new_err(name.to_string()),
                 PolarsError::ComputeError(err) => ComputeError::new_err(err.to_string()),
                 PolarsError::Duplicate(err) => DuplicateError::new_err(err.to_string()),

--- a/crates/polars-python/src/exceptions.rs
+++ b/crates/polars-python/src/exceptions.rs
@@ -5,6 +5,7 @@ use pyo3::exceptions::{PyException, PyWarning};
 
 // Errors
 create_exception!(polars.exceptions, PolarsError, PyException);
+create_exception!(polars.exceptions, AssertionError, PolarsError);
 create_exception!(polars.exceptions, ColumnNotFoundError, PolarsError);
 create_exception!(polars.exceptions, ComputeError, PolarsError);
 create_exception!(polars.exceptions, DuplicateError, PolarsError);


### PR DESCRIPTION
This PR adds support for assertion errors to Polars error handling system. The assertion errors will ultimately be used in Rust when working on migrating `assert_series_equal` and `assert_frame_equal` to Rust to facilitate testing. This is the first part (of roughly 3) working on this issue: https://github.com/pola-rs/polars/issues/21388

`crates/polars-error/src/lib.rs`: 
* Added `AssertionError` variant to `PolarsError` enum
* Added `AssertionError` to implementation of `Display`
* Added `AssertionError` to `wrap_msg()`
* Added a macro for `AssertionError` under `macro rules! polars_err`

`crates/polars-python/src/error.rs`
* Imported `AssertionError` exception
* Added `AssertionError` `match` arm

`crates/polars-python/src/exceptions.rs`
* Added `AssertionError` to `create_exception!()`