### PR TITLE
chore: Use tikv-jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,26 +2146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,12 +3627,12 @@ name = "py-polars"
 version = "1.23.0"
 dependencies = [
  "either",
- "jemallocator",
  "libc",
  "mimalloc",
  "polars",
  "polars-python",
  "pyo3",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -4787,6 +4767,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.94",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -325,13 +325,13 @@
 //! ### Custom allocator
 //! An OLAP query engine does a lot of heap allocations. It is recommended to use a custom
 //! allocator, (we have found this to have up to ~25% runtime influence).
-//! [JeMalloc](https://crates.io/crates/jemallocator) and
+//! [JeMalloc](https://crates.io/crates/tikv-jemallocator) and
 //! [Mimalloc](https://crates.io/crates/mimalloc) for instance, show a significant
 //! performance gain in runtime as well as memory usage.
 //!
 //! #### Jemalloc Usage
 //! ```ignore
-//! use jemallocator::Jemalloc;
+//! use tikv_jemallocator::Jemalloc;
 //!
 //! #[global_allocator]
 //! static GLOBAL: Jemalloc = Jemalloc;
@@ -340,7 +340,7 @@
 //! #### Cargo.toml
 //! ```toml
 //! [dependencies]
-//! jemallocator = { version = "*" }
+//! tikv-jemallocator = { version = "*" }
 //! ```
 //!
 //! #### Mimalloc Usage

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -19,10 +19,10 @@ mimalloc = { version = "0.1", default-features = false }
 
 # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).
 [target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
-jemallocator = { version = "0.5", features = ["disable_initial_exec_tls", "background_threads"] }
+tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls", "background_threads"] }
 
 [target.'cfg(all(target_family = "unix", target_os = "macos", not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
-jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
+tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls"] }
 either = { workspace = true }
 
 [features]

--- a/py-polars/src/allocator.rs
+++ b/py-polars/src/allocator.rs
@@ -5,7 +5,7 @@
     target_family = "unix",
     not(target_os = "emscripten"),
 ))]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
 #[cfg(all(


### PR DESCRIPTION
The [jemallocator](https://crates.io/crates/jemallocator) crate mentions to use `tikv-jemallocator` instead which is otherwise identical.