### PR TITLE
fix: Allow init from BigQuery Arrow data containing ExtensionType cols with irrelevant metadata

### DIFF
--- a/crates/polars-python/src/interop/arrow/to_rust.rs
+++ b/crates/polars-python/src/interop/arrow/to_rust.rs
@@ -17,7 +17,49 @@ pub fn field_to_rust_arrow(obj: Bound<'_, PyAny>) -> PyResult<ArrowField> {
     // make the conversion through PyArrow's private API
     obj.call_method1("_export_to_c", (schema_ptr as Py_uintptr_t,))?;
     let field = unsafe { ffi::import_field_from_c(schema.as_ref()).map_err(PyPolarsErr::from)? };
-    Ok(field.clone())
+    Ok(normalize_arrow_fields(&field))
+}
+
+fn normalize_arrow_fields(field: &ArrowField) -> ArrowField {
+    // normalize fields with extension dtypes that are otherwise standard dtypes associated
+    // with (for us) irrelevant metadata; recreate the field using the inner (standard) dtype
+    match field {
+        ArrowField {
+            dtype: ArrowDataType::Struct(ref fields),
+            ..
+        } => {
+            let mut normalized = false;
+            let normalized_fields: Vec<_> = fields
+                .iter()
+                .map(|f| {
+                    // note: google bigquery column data is returned as a standard arrow dtype, but the
+                    // sql type it was loaded from is associated as metadata (resulting in an extension dtype)
+                    if let ArrowDataType::Extension(ext_type) = &f.dtype {
+                        if ext_type.name.starts_with("google:sqlType:") {
+                            normalized = true;
+                            return ArrowField::new(
+                                f.name.clone(),
+                                ext_type.inner.clone(),
+                                f.is_nullable,
+                            );
+                        }
+                    }
+                    f.clone()
+                })
+                .collect();
+
+            if normalized {
+                ArrowField::new(
+                    field.name.clone(),
+                    ArrowDataType::Struct(normalized_fields),
+                    field.is_nullable,
+                )
+            } else {
+                field.clone()
+            }
+        },
+        _ => field.clone(),
+    }
 }
 
 pub fn field_to_rust(obj: Bound<'_, PyAny>) -> PyResult<Field> {

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -127,13 +127,13 @@ def expand_selector(
     Parameters
     ----------
     target
-        A polars DataFrame, LazyFrame or schema.
+        A Polars DataFrame, LazyFrame or Schema.
     selector
         An arbitrary polars selector (or compound selector).
     strict
-        Setting False will additionally allow for a broader range of column selection
-        expressions (such as bare columns or use of `.exclude()`) to be expanded, not
-        just the dedicated selectors.
+        Setting False additionally allows for a broader range of column selection
+        expressions (such as bare columns or use of `.exclude()`) to be expanded,
+        not just the dedicated selectors.
 
     Examples
     --------
@@ -158,7 +158,7 @@ def expand_selector(
     >>> cs.expand_selector(df.lazy(), ~(cs.first() | cs.last()))
     ('coly',)
 
-    Expand selector with respect to a standalone schema:
+    Expand selector with respect to a standalone `Schema` dict:
 
     >>> schema = {
     ...     "id": pl.Int64,


### PR DESCRIPTION
Closes #20700 (and its duplicate: #20849).

This is a conservative fix, targeting (for now) _only_ Arrow `Field` dtypes with recognised BigQuery metadata. I currently have access to a BigQuery instance to test on, so can confirm that the fix works well (and I was able to replicate/mock the issue with some new unit tests that don't require BigQuery access to run).

#20248 ensured that we do not drop the `Field`-associated metadata... https://github.com/pola-rs/polars/blob/5ce00116a9cc44803fc123957219e73d78610760/py-polars/polars/_utils/construction/dataframe.py#L1167-L1168 
...on DataFrame init, but also caused a regression where we now raise errors on init from common BigQuery Arrow data.

It's not entirely clear to me what sort of metadata we do want/expect to support, so this PR introduces a `normalize_arrow_fields` function that can be extended/tweaked later, if needed; for now it _only_ strips the irrelevant metadata from `Field` objects that can be positively identified as having come from BigQuery, normalising the `Field` to use the inner dtype (which we can handle fine) instead of presenting as an `ExtensionType` (which we don't).

These BigQuery `Field` objects just associate a trivial metadata payload (describing the underlying SQL datatype that they were loaded from), but are otherwise vanilla Arrow dtypes. They have the following structure...

```
Field {
    name: "some_bigquery_datetime_col",
    dtype: Extension(
        ExtensionType {
            name: "google:sqlType:datetime",
            inner: Timestamp(
                Microsecond,
                None,
            ),
            metadata: None,
        },
    ),
    is_nullable: true,
    metadata: None,
}
```
...but we just want this:
```
Field {
    name: "some_bigquery_datetime_col",
    dtype: Timestamp(
        Microsecond,
        None,
    ),
    is_nullable: true,
    metadata: None,
}
```

Loading these field types from BigQuery currently results in the following error: 
```
ComputeError: cannot create series from Extension(ExtensionType {
  name: "google:sqlType:datetime",
  inner: Timestamp(Microsecond, None), 
  metadata: None
})
```
With the PR, everything loads smoothly as we unpack the inner dtype and use that.

---

@coastalwhite: You likely have a better idea than me as to whether we want a broader stripping of metadata or not? For now I've just targeted this fix at the only (currently) known related issue, to avoid any unintended side effects. 

Could perhaps setup a more generic pattern-match for type names we know we can unpack like this? Or, alternatively, keep metadata connected to names we understand and strip everything else? 🤔