### PR TITLE
refactor(rust): Map Polars `AssertionError` to pyo3's `AssertionError` and improve macro flexibility

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -411,12 +411,12 @@ on startup."#.trim_start())
             $dtype,
         )
     };
-    (assert_eq = $lhs:expr, $rhs:expr) => {
+    (assertion_error = $objects:expr, $detail:expr, $lhs:expr, $rhs:expr) => {
         $crate::polars_err!(
-            AssertionError: "equality assertion failed: {} != {}",
-            $lhs, $rhs
+            AssertionError: "{} are different ({})\n[left]: {}\n[right]: {}",
+            $objects, $detail, $lhs, $rhs
         )
-    }
+    };
 }
 
 #[macro_export]

--- a/crates/polars-python/src/error.rs
+++ b/crates/polars-python/src/error.rs
@@ -12,7 +12,7 @@ use pyo3::prelude::*;
 use pyo3::PyTypeInfo;
 
 use crate::exceptions::{
-    AssertionError, CategoricalRemappingWarning, ColumnNotFoundError, ComputeError, DuplicateError,
+    CategoricalRemappingWarning, ColumnNotFoundError, ComputeError, DuplicateError,
     InvalidOperationError, MapWithoutReturnDtypeWarning, NoDataError, OutOfBoundsError,
     SQLInterfaceError, SQLSyntaxError, SchemaError, SchemaFieldNotFoundError, ShapeError,
     StringCacheMismatchError, StructFieldNotFoundError,
@@ -68,7 +68,9 @@ impl From<PyPolarsErr> for PyErr {
         use PyPolarsErr::*;
         match err {
             Polars(err) => match err {
-                PolarsError::AssertionError(err) => AssertionError::new_err(err.to_string()),
+                PolarsError::AssertionError(err) => {
+                    pyo3::exceptions::PyAssertionError::new_err(err.to_string())
+                },
                 PolarsError::ColumnNotFound(name) => ColumnNotFoundError::new_err(name.to_string()),
                 PolarsError::ComputeError(err) => ComputeError::new_err(err.to_string()),
                 PolarsError::Duplicate(err) => DuplicateError::new_err(err.to_string()),

--- a/crates/polars-python/src/exceptions.rs
+++ b/crates/polars-python/src/exceptions.rs
@@ -5,7 +5,6 @@ use pyo3::exceptions::{PyException, PyWarning};
 
 // Errors
 create_exception!(polars.exceptions, PolarsError, PyException);
-create_exception!(polars.exceptions, AssertionError, PolarsError);
 create_exception!(polars.exceptions, ColumnNotFoundError, PolarsError);
 create_exception!(polars.exceptions, ComputeError, PolarsError);
 create_exception!(polars.exceptions, DuplicateError, PolarsError);


### PR DESCRIPTION
This PR is regarding comments from @coastalwhite on this PR: https://github.com/pola-rs/polars/pull/21460# and from Discord regarding using pyo3's built in `AssertionError` and using the macro for more general assertions. 

Previous PR relates to issue: https://github.com/pola-rs/polars/issues/21388#.

- In `polars-error/lib.rs`, the macro has been updated to be more generalize and also match the already existing Python assertion error.
- In `error.rs`, `PolarsError::AssertionError` has been mapped to `PyAssertionError` rather than making a new exception.
- In `exceptions.rs`, the `create_exception_macro!()` has been removed for `AssertionError` since it will be relying on pyo3's existing implementation. 