### PR TITLE
fix(Rust): minor: Allow custom CsvReaderOptions

### DIFF
--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -50,6 +50,11 @@ where
         self
     }
 
+    pub fn _with_options(mut self, options: CsvReadOptions) -> Self {
+        self.options = options;
+        self
+    }
+
     // TODO: Investigate if we can remove this
     pub(crate) fn with_schema(mut self, schema: SchemaRef) -> Self {
         self.options.schema = Some(schema);


### PR DESCRIPTION
minor: Allow custom CsvReaderOptions

This commit adds the ability to pass custom CsvReaderOptions to the CsvReader, enabling greater flexibility and control over CSV parsing.