### PR TITLE
docs(python): Correct typos and grammar in Python docstrings

### DIFF
--- a/py-polars/polars/dataframe/plotting.py
+++ b/py-polars/polars/dataframe/plotting.py
@@ -53,7 +53,7 @@ class DataFramePlot:
 
         `df.plot.bar(**kwargs)` is shorthand for
         `alt.Chart(df).mark_bar().encode(**kwargs).interactive()`,
-        and is provided for convenience - for full customisatibility, use a plotting
+        and is provided for convenience - for full customisability, use a plotting
         library directly.
 
         .. versionchanged:: 1.6.0

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -172,7 +172,7 @@ class ExprDateTimeNameSpace:
 
         Notes
         -----
-        The `every` argument is created with the
+        The `every` argument is created with
         the following string language:
 
         - 1ns   (1 nanosecond)
@@ -306,7 +306,7 @@ class ExprDateTimeNameSpace:
 
         Notes
         -----
-        The `every` argument is created with the
+        The `every` argument is created with
         the following small string formatting language:
 
         - 1ns   (1 nanosecond)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1290,7 +1290,7 @@ class Expr:
         --------
         >>> df = pl.DataFrame({"a": [1, 1, 2]})
 
-        Create a Series with 3 nulls, append column a then rechunk
+        Create a Series with 3 nulls, append column `a`, then rechunk.
 
         >>> df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk())
         shape: (6, 1)

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -311,7 +311,7 @@ def _alignment_join(
     descending: bool | Sequence[bool] = False,
 ) -> LazyFrame:
     """Create a single master frame with all rows aligned on the common key values."""
-    # note: can stackoverflow if the join becomes too large, so we
+    # note: can stack overflow if the join becomes too large, so we
     # collect eagerly when hitting a large enough number of frames
     post_align_collect = len(idx_frames) >= 250
 

--- a/py-polars/polars/functions/escape_regex.py
+++ b/py-polars/polars/functions/escape_regex.py
@@ -14,7 +14,7 @@ def escape_regex(s: str) -> str:
     Parameters
     ----------
     s
-        The string that all of its meta characters will be escaped.
+        The string whose meta characters will be escaped.
 
     """
     if isinstance(s, pl.Expr):

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -789,7 +789,7 @@ def corr(
     propagate_nans: bool = False,
 ) -> Expr:
     """
-    Compute the Pearson's or Spearman rank correlation correlation between two columns.
+    Compute the Pearson's or Spearman rank correlation between two columns.
 
     Parameters
     ----------

--- a/py-polars/polars/interchange/dataframe.py
+++ b/py-polars/polars/interchange/dataframe.py
@@ -21,7 +21,7 @@ class PolarsDataFrame(InterchangeDataFrame):
 
     Parameters
     ----------
-    column
+    df
         The Polars DataFrame backing the dataframe object.
     allow_copy
         Allow data to be copied during operations on this column. If set to `False`,

--- a/py-polars/polars/ml/torch.py
+++ b/py-polars/polars/ml/torch.py
@@ -74,7 +74,7 @@ class PolarsDataset(TensorDataset):  # type: ignore[misc]
     ... )
 
     Create a Dataset from a Polars DataFrame, standardising the dtype and
-    distinguishing the label/feature columns.
+    separating the label/feature columns.
 
     >>> ds = df.to_torch("dataset", label="lbl", dtype=pl.Float32)
     >>> ds  # doctest: +IGNORE_RESULT

--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -36,13 +36,13 @@ def assert_frame_equal(
     right
         The second DataFrame or LazyFrame to compare.
     check_row_order
-        Require row order to match.
+        Requires row order to match.
     check_column_order
-        Require column order to match.
+        Requires column order to match.
     check_dtypes
-        Require data types to match.
+        Requires data types to match.
     check_exact
-        Require float values to match exactly. If set to `False`, values are considered
+        Requires float values to match exactly. If set to `False`, values are considered
         equal when within tolerance of each other (see `rtol` and `atol`).
         Only affects columns with a Float data type.
     rtol
@@ -218,13 +218,13 @@ def assert_frame_not_equal(
     right
         The second DataFrame or LazyFrame to compare.
     check_row_order
-        Require row order to match.
+        Requires row order to match.
     check_column_order
-        Require column order to match.
+        Requires column order to match.
     check_dtypes
-        Require data types to match.
+        Requires data types to match.
     check_exact
-        Require float values to match exactly. If set to `False`, values are considered
+        Requires float values to match exactly. If set to `False`, values are considered
         equal when within tolerance of each other (see `rtol` and `atol`).
         Only affects columns with a Float data type.
     rtol

--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -59,13 +59,13 @@ def assert_series_equal(
     right
         The second Series to compare.
     check_dtypes
-        Require data types to match.
+        Requires data types to match.
     check_names
-        Require names to match.
+        Requires names to match.
     check_order
-        Require elements to appear in the same order.
+        Requires elements to appear in the same order.
     check_exact
-        Require float values to match exactly. If set to `False`, values are considered
+        Requires float values to match exactly. If set to `False`, values are considered
         equal when within tolerance of each other (see `rtol` and `atol`).
         Only affects columns with a Float data type.
     rtol
@@ -386,13 +386,13 @@ def assert_series_not_equal(
     right
         The second Series to compare.
     check_dtypes
-        Require data types to match.
+        Requires data types to match.
     check_names
-        Require names to match.
+        Requires names to match.
     check_order
-        Require elements to appear in the same order.
+        Requires elements to appear in the same order.
     check_exact
-        Require float values to match exactly. If set to `False`, values are considered
+        Requires float values to match exactly. If set to `False`, values are considered
         equal when within tolerance of each other (see `rtol` and `atol`).
         Only affects columns with a Float data type.
     rtol


### PR DESCRIPTION
Does not resolve a specific issue. Just some light maintenance to fix typos and adjust grammar in some doc strings. No functional changes to the code base. 

For `py-polars/polars/interchange/dataframe.py`, the parameter was named `column` but it refers to a Polars DataFrame in the description, so it was changed to `df`.

