### PR TITLE
feat(python,rust): Support engine callback for `LazyFrame.profile`

### DIFF
--- a/crates/polars-lazy/src/frame/exitable.rs
+++ b/crates/polars-lazy/src/frame/exitable.rs
@@ -8,7 +8,7 @@ use super::*;
 
 impl LazyFrame {
     pub fn collect_concurrently(self) -> PolarsResult<InProcessQuery> {
-        let (mut state, mut physical_plan, _) = self.prepare_collect(false)?;
+        let (mut state, mut physical_plan, _) = self.prepare_collect(false, None)?;
 
         let (tx, rx) = channel();
         let token = state.cancel_token();

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1675,6 +1675,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         streaming: bool = False,
         engine: EngineType = "cpu",
         _check_order: bool = True,
+        **_kwargs: Any,
     ) -> tuple[DataFrame, DataFrame]:
         """
         Profile a LazyFrame.
@@ -1771,6 +1772,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
          │ sort(a)                 ┆ 475   ┆ 1964 │
          └─────────────────────────┴───────┴──────┘)
         """
+        for k in _kwargs:
+            if k not in (  # except "private" kwargs
+                "post_opt_callback",
+            ):
+                error_msg = f"profile() got an unexpected keyword argument '{k}'"
+                raise TypeError(error_msg)
         if no_optimization:
             predicate_pushdown = False
             projection_pushdown = False
@@ -1803,6 +1810,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             new_streaming=False,
             _eager=False,
         )
+        if _kwargs.get("post_opt_callback") is not None:
+            # Only for testing
+            callback = _kwargs.get("post_opt_callback")
         df, timings = ldf.profile(callback)
         (df, timings) = wrap_df(df), wrap_df(timings)
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -146,6 +146,46 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
+def _gpu_engine_callback(
+    engine: EngineType,
+    *,
+    streaming: bool,
+    background: bool,
+    new_streaming: bool,
+    _eager: bool,
+) -> Callable[[Any, int | None], None] | None:
+    is_gpu = (is_config_obj := isinstance(engine, GPUEngine)) or engine == "gpu"
+    if not (is_config_obj or engine in ("cpu", "gpu")):
+        msg = f"Invalid engine argument {engine=}"
+        raise ValueError(msg)
+    if (streaming or background or new_streaming) and is_gpu:
+        issue_warning(
+            "GPU engine does not support streaming or background collection, "
+            "disabling GPU engine.",
+            category=UserWarning,
+        )
+        is_gpu = False
+    if _eager:
+        # Don't run on GPU in _eager mode (but don't warn)
+        is_gpu = False
+
+    if not is_gpu:
+        return None
+    cudf_polars = import_optional(
+        "cudf_polars",
+        err_prefix="GPU engine requested, but required package",
+        install_message=(
+            "Please install using the command "
+            "`pip install cudf-polars-cu12` "
+            "(or `pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11` "
+            "if your system has a CUDA 11 driver)."
+        ),
+    )
+    if not is_config_obj:
+        engine = GPUEngine()
+    return partial(cudf_polars.execute_with_cudf, config=engine)
+
+
 class LazyFrame:
     """
     Representation of a Lazy computation graph/query against a DataFrame.
@@ -1633,6 +1673,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         truncate_nodes: int = 0,
         figsize: tuple[int, int] = (18, 8),
         streaming: bool = False,
+        engine: EngineType = "cpu",
         _check_order: bool = True,
     ) -> tuple[DataFrame, DataFrame]:
         """
@@ -1675,6 +1716,27 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             matplotlib figsize of the profiling plot
         streaming
             Run parts of the query in a streaming fashion (this is in an alpha state)
+        engine
+            Select the engine used to process the query, optional.
+            If set to `"cpu"` (default), the query is run using the
+            polars CPU engine. If set to `"gpu"`, the GPU engine is
+            used. Fine-grained control over the GPU engine, for
+            example which device to use on a system with multiple
+            devices, is possible by providing a :class:`~.GPUEngine` object
+            with configuration options.
+
+            .. note::
+               GPU mode is considered **unstable**. Not all queries will run
+               successfully on the GPU, however, they should fall back transparently
+               to the default engine if execution is not supported.
+
+               Running with `POLARS_VERBOSE=1` will provide information if a query
+               falls back (and why).
+
+            .. note::
+               The GPU engine does not support streaming, if streaming
+               is enabled then GPU execution is switched off.
+
 
         Examples
         --------
@@ -1734,7 +1796,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             _check_order=_check_order,
             new_streaming=False,
         )
-        df, timings = ldf.profile()
+        callback = _gpu_engine_callback(
+            engine,
+            streaming=streaming,
+            background=False,
+            new_streaming=False,
+            _eager=False,
+        )
+        df, timings = ldf.profile(callback)
         (df, timings) = wrap_df(df), wrap_df(timings)
 
         if show_plot:
@@ -2011,21 +2080,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if streaming:
             issue_unstable_warning("Streaming mode is considered unstable.")
 
-        is_gpu = (is_config_obj := isinstance(engine, GPUEngine)) or engine == "gpu"
-        if not (is_config_obj or engine in ("cpu", "gpu")):
-            msg = f"Invalid engine argument {engine=}"
-            raise ValueError(msg)
-        if (streaming or background or new_streaming) and is_gpu:
-            issue_warning(
-                "GPU engine does not support streaming or background collection, "
-                "disabling GPU engine.",
-                category=UserWarning,
-            )
-            is_gpu = False
-        if _eager:
-            # Don't run on GPU in _eager mode (but don't warn)
-            is_gpu = False
-
+        callback = _gpu_engine_callback(
+            engine,
+            streaming=streaming,
+            background=background,
+            new_streaming=new_streaming,
+            _eager=_eager,
+        )
         type_check = _type_check
         ldf = self._ldf.optimization_toggle(
             type_coercion=type_coercion,
@@ -2048,21 +2109,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             issue_unstable_warning("Background mode is considered unstable.")
             return InProcessQuery(ldf.collect_concurrently())
 
-        callback = None
-        if is_gpu:
-            cudf_polars = import_optional(
-                "cudf_polars",
-                err_prefix="GPU engine requested, but required package",
-                install_message=(
-                    "Please install using the command "
-                    "`pip install cudf-polars-cu12` "
-                    "(or `pip install --extra-index-url=https://pypi.nvidia.com cudf-polars-cu11` "
-                    "if your system has a CUDA 11 driver)."
-                ),
-            )
-            if not is_config_obj:
-                engine = GPUEngine()
-            callback = partial(cudf_polars.execute_with_cudf, config=engine)
         # Only for testing purposes
         callback = _kwargs.get("post_opt_callback", callback)
         return wrap_df(ldf.collect(callback))

--- a/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
+++ b/py-polars/tests/unit/lazyframe/cuda/test_node_visitor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -11,10 +12,29 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
+class Timer:
+    """Simple-minded timing of nodes."""
+
+    def __init__(self, start: int | None) -> None:
+        self.start = start
+        self.timings: list[tuple[int, int, str]] = []
+
+    def record(self, fn: Callable[[], pd.DataFrame], name: str) -> pd.DataFrame:
+        start = time.monotonic_ns()
+        result = fn()
+        end = time.monotonic_ns()
+        if self.start is not None:
+            self.timings.append((start - self.start, end - self.start, name))
+        return result
+
+
 def test_run_on_pandas() -> None:
     # Simple join example, missing multiple columns, slices, etc.
     def join(
-        inputs: list[Callable[[], pd.DataFrame]], obj: Any, _node_traverser: Any
+        inputs: list[Callable[[], pd.DataFrame]],
+        obj: Any,
+        _node_traverser: Any,
+        timer: Timer,
     ) -> Callable[[], pd.DataFrame]:
         assert len(obj.left_on) == 1
         assert len(obj.right_on) == 1
@@ -26,53 +46,68 @@ def test_run_on_pandas() -> None:
         def run(inputs: list[Callable[[], pd.DataFrame]]) -> pd.DataFrame:
             # materialize inputs
             dataframes = [call() for call in inputs]
-            return dataframes[0].merge(
-                dataframes[1], left_on=left_on, right_on=right_on
+            return timer.record(
+                lambda: dataframes[0].merge(
+                    dataframes[1], left_on=left_on, right_on=right_on
+                ),
+                "pandas-join",
             )
 
         return partial(run, inputs)
 
     # Simple scan example, missing predicates, columns pruning, slices, etc.
-    def df_scan(_inputs: None, obj: Any, _: Any) -> Callable[[], pd.DataFrame]:
+    def df_scan(
+        _inputs: None, obj: Any, _: Any, timer: Timer
+    ) -> Callable[[], pd.DataFrame]:
         assert obj.selection is None
-        return lambda: wrap_df(obj.df).to_pandas()
+        return lambda: timer.record(lambda: wrap_df(obj.df).to_pandas(), "pandas-scan")
 
     @lru_cache(1)
     def get_node_converters() -> dict[
-        type, Callable[[Any, Any, Any], Callable[[], pd.DataFrame]]
+        type, Callable[[Any, Any, Any, Timer], Callable[[], pd.DataFrame]]
     ]:
         return {
             _ir_nodes.Join: join,
             _ir_nodes.DataFrameScan: df_scan,
         }
 
-    def get_input(node_traverser: Any) -> Callable[[], pd.DataFrame]:
+    def get_input(node_traverser: Any, *, timer: Timer) -> Callable[[], pd.DataFrame]:
         current_node = node_traverser.get_node()
 
         inputs_callable = []
         for inp in node_traverser.get_inputs():
             node_traverser.set_node(inp)
-            inputs_callable.append(get_input(node_traverser))
+            inputs_callable.append(get_input(node_traverser, timer=timer))
 
         node_traverser.set_node(current_node)
         ir_node = node_traverser.view_current_node()
         return get_node_converters()[ir_node.__class__](
-            inputs_callable, ir_node, node_traverser
+            inputs_callable, ir_node, node_traverser, timer
         )
 
-    def run_on_pandas(node_traverser: Any) -> None:
+    def run_on_pandas(node_traverser: Any, query_start: int | None) -> None:
+        timer = Timer(
+            time.monotonic_ns() - query_start if query_start is not None else None
+        )
         current_node = node_traverser.get_node()
 
-        callback = get_input(node_traverser)
+        callback = get_input(node_traverser, timer=timer)
 
         def run_callback(
-            columns: list[str] | None, _: Any, n_rows: int | None
-        ) -> pl.DataFrame:
+            columns: list[str] | None,
+            _: Any,
+            n_rows: int | None,
+            should_time: bool,
+        ) -> pl.DataFrame | tuple[pl.DataFrame, list[tuple[int, int, str]]]:
             assert n_rows is None
             assert columns is None
 
             # produce a wrong result to ensure the callback has run.
-            return pl.from_pandas(callback() * 2)
+            result = pl.from_pandas(callback() * 2)
+            if should_time:
+                return result, timer.timings
+            else:
+                return result
 
         node_traverser.set_node(current_node)
         node_traverser.set_udf(run_callback)
@@ -87,3 +122,15 @@ def test_run_on_pandas() -> None:
         "foo": [2],
         "bar": [4],
     }
+
+    result, timings = q.profile(post_opt_callback=run_on_pandas)
+    assert result.to_dict(as_series=False) == {
+        "foo": [2],
+        "bar": [4],
+    }
+    assert timings["node"].to_list() == [
+        "optimization",
+        "pandas-scan",
+        "pandas-scan",
+        "pandas-join",
+    ]


### PR DESCRIPTION
So that we can support the GPU engine in profiled collection of a lazyframe, plumb through a mechanism for recording raw timings for nodes that were executed through the PythonScan node.

This necessitates some small changes to the internals of the NodeTimer, since `Instant`s are opaque. We instead directly store durations (as nanoseconds since the query start) and when calling into the IR post-optimization callback, provide a duration that is the number of nanoseconds since the query was started. On the Python side we can then keep track and record durations independently, offsetted by this optimisation duration.

As a side-effect, `profile` now correctly measures the optimisation time in the logical plan, rather than as previously just the time to produce the physical plan from the optimised logical plan.

- Closes #20039 