### PR TITLE
refactor: Prepare skeleton for partitioning sinks

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -843,7 +843,7 @@ impl LazyFrame {
         )
     }
 
-    /// Stream a query result into a parquet file in a partioned manner. This is useful if the
+    /// Stream a query result into a parquet file in a partitioned manner. This is useful if the
     /// final result doesn't fit into memory. This methods will return an error if the query cannot
     /// be completely done in a streaming fashion.
     #[cfg(feature = "parquet")]
@@ -865,7 +865,7 @@ impl LazyFrame {
         )
     }
 
-    /// Stream a query result into an ipc/arrow file in a partioned manner. This is useful if the
+    /// Stream a query result into an ipc/arrow file in a partitioned manner. This is useful if the
     /// final result doesn't fit into memory. This methods will return an error if the query cannot
     /// be completely done in a streaming fashion.
     #[cfg(feature = "ipc")]
@@ -887,7 +887,7 @@ impl LazyFrame {
         )
     }
 
-    /// Stream a query result into an csv file in a partioned manner. This is useful if the final
+    /// Stream a query result into an csv file in a partitioned manner. This is useful if the final
     /// result doesn't fit into memory. This methods will return an error if the query cannot be
     /// completely done in a streaming fashion.
     #[cfg(feature = "csv")]
@@ -909,7 +909,7 @@ impl LazyFrame {
         )
     }
 
-    /// Stream a query result into a JSON file in a partioned manner. This is useful if the final
+    /// Stream a query result into a JSON file in a partitioned manner. This is useful if the final
     /// result doesn't fit into memory. This methods will return an error if the query cannot be
     /// completely done in a streaming fashion.
     #[cfg(feature = "json")]

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -843,6 +843,94 @@ impl LazyFrame {
         )
     }
 
+    /// Stream a query result into a parquet file in a partioned manner. This is useful if the
+    /// final result doesn't fit into memory. This methods will return an error if the query cannot
+    /// be completely done in a streaming fashion.
+    #[cfg(feature = "parquet")]
+    pub fn sink_parquet_partitioned(
+        self,
+        path_f_string: impl AsRef<Path>,
+        variant: PartitionVariant,
+        options: ParquetWriteOptions,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
+    ) -> PolarsResult<()> {
+        self.sink(
+            SinkType::Partition {
+                path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+                variant,
+                file_type: FileType::Parquet(options),
+                cloud_options,
+            },
+            "collect().write_parquet()",
+        )
+    }
+
+    /// Stream a query result into an ipc/arrow file in a partioned manner. This is useful if the
+    /// final result doesn't fit into memory. This methods will return an error if the query cannot
+    /// be completely done in a streaming fashion.
+    #[cfg(feature = "ipc")]
+    pub fn sink_ipc_partitioned(
+        self,
+        path_f_string: impl AsRef<Path>,
+        variant: PartitionVariant,
+        options: IpcWriterOptions,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
+    ) -> PolarsResult<()> {
+        self.sink(
+            SinkType::Partition {
+                path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+                variant,
+                file_type: FileType::Ipc(options),
+                cloud_options,
+            },
+            "collect().write_ipc()",
+        )
+    }
+
+    /// Stream a query result into an csv file in a partioned manner. This is useful if the final
+    /// result doesn't fit into memory. This methods will return an error if the query cannot be
+    /// completely done in a streaming fashion.
+    #[cfg(feature = "csv")]
+    pub fn sink_csv_partitioned(
+        self,
+        path_f_string: impl AsRef<Path>,
+        variant: PartitionVariant,
+        options: CsvWriterOptions,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
+    ) -> PolarsResult<()> {
+        self.sink(
+            SinkType::Partition {
+                path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+                variant,
+                file_type: FileType::Csv(options),
+                cloud_options,
+            },
+            "collect().write_csv()",
+        )
+    }
+
+    /// Stream a query result into a JSON file in a partioned manner. This is useful if the final
+    /// result doesn't fit into memory. This methods will return an error if the query cannot be
+    /// completely done in a streaming fashion.
+    #[cfg(feature = "json")]
+    pub fn sink_json_partitioned(
+        self,
+        path_f_string: impl AsRef<Path>,
+        variant: PartitionVariant,
+        options: JsonWriterOptions,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
+    ) -> PolarsResult<()> {
+        self.sink(
+            SinkType::Partition {
+                path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+                variant,
+                file_type: FileType::Json(options),
+                cloud_options,
+            },
+            "collect().write_ndjson()` or `collect().write_json()",
+        )
+    }
+
     #[cfg(feature = "new_streaming")]
     pub fn try_new_streaming_if_requested(
         &mut self,
@@ -916,6 +1004,10 @@ impl LazyFrame {
             {
                 return Ok(());
             }
+        }
+
+        if matches!(payload, SinkType::Partition { .. }) {
+            polars_bail!(InvalidOperation: "partition sinks are not supported on the old streaming engine");
         }
 
         self.logical_plan = DslPlan::Sink {

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -130,7 +130,7 @@ fn create_physical_plan_impl(
             SinkType::Memory => {
                 polars_bail!(InvalidOperation: "memory sink not supported in the standard engine")
             },
-            SinkType::File { file_type, .. } => {
+            SinkType::File { file_type, .. } | SinkType::Partition { file_type, .. } => {
                 polars_bail!(InvalidOperation:
                     "sink_{file_type:?} not yet supported in standard engine. Use 'collect().write_{file_type:?}()'"
                 )

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -222,6 +222,9 @@ where
                         _ => unreachable!(),
                     }
                 },
+                SinkType::Partition { .. } => {
+                    polars_bail!(InvalidOperation: "partitioning sink not supported in old streaming engine")
+                },
             }
         },
         Join {

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -299,6 +299,18 @@ pub enum SinkType {
         file_type: FileType,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
     },
+    Partition {
+        path_f_string: Arc<PathBuf>,
+        file_type: FileType,
+        variant: PartitionVariant,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
+    },
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PartitionVariant {
+    MaxSize(IdxSize),
 }
 
 impl SinkType {

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -13,7 +13,7 @@ use super::*;
 // (Major, Minor)
 // Add a field -> increment minor
 // Remove or modify a field -> increment major and reset minor
-pub static DSL_VERSION: (u16, u16) = (0, 0);
+pub static DSL_VERSION: (u16, u16) = (0, 1);
 static DSL_MAGIC_BYTES: &[u8] = b"DSL_VERSION";
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -311,6 +311,7 @@ impl<'a> IRDotDisplay<'a> {
                     f.write_str(match payload {
                         SinkType::Memory => "SINK (MEMORY)",
                         SinkType::File { .. } => "SINK (FILE)",
+                        SinkType::Partition { .. } => "SINK (PARTITION)",
                     })
                 })?;
             },

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -392,6 +392,7 @@ impl<'a> IRDisplay<'a> {
                 let name = match payload {
                     SinkType::Memory => "SINK (memory)",
                     SinkType::File { .. } => "SINK (file)",
+                    SinkType::Partition { .. } => "SINK (partition)",
                 };
                 write!(f, "{:indent$}{name}", "")?;
                 self.with_root(*input)._format(f, sub_indent)

--- a/crates/polars-plan/src/plans/ir/schema.rs
+++ b/crates/polars-plan/src/plans/ir/schema.rs
@@ -38,6 +38,7 @@ impl IR {
             Sink { payload, .. } => match payload {
                 SinkType::Memory => "sink (memory)",
                 SinkType::File { .. } => "sink (file)",
+                SinkType::Partition { .. } => "sink (partition)",
             },
             SimpleProjection { .. } => "simple_projection",
             #[cfg(feature = "merge_sorted")]

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -355,6 +355,7 @@ impl<'a> TreeFmtNode<'a> {
                             match payload {
                                 SinkType::Memory => "SINK (memory)",
                                 SinkType::File { .. } => "SINK (file)",
+                                SinkType::Partition { .. } => "SINK (partition)",
                             },
                         ),
                         vec![self.lp_node(None, *input)],

--- a/crates/polars-python/src/functions/mod.rs
+++ b/crates/polars-python/src/functions/mod.rs
@@ -5,6 +5,8 @@ mod io;
 mod lazy;
 mod meta;
 mod misc;
+#[cfg(feature = "pymethods")]
+mod partitioning;
 mod random;
 mod range;
 mod string_cache;
@@ -19,6 +21,8 @@ pub use io::*;
 pub use lazy::*;
 pub use meta::*;
 pub use misc::*;
+#[cfg(feature = "pymethods")]
+pub use partitioning::*;
 pub use random::*;
 pub use range::*;
 pub use string_cache::*;

--- a/crates/polars-python/src/functions/partitioning.rs
+++ b/crates/polars-python/src/functions/partitioning.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use polars::prelude::PartitionVariant;
+use polars_utils::IdxSize;
+use pyo3::{pyclass, pymethods};
+
+#[pyclass]
+#[derive(Clone)]
+pub struct PyPartitioning {
+    pub path: Arc<PathBuf>,
+    pub variant: PartitionVariant,
+}
+
+#[pymethods]
+impl PyPartitioning {
+    #[staticmethod]
+    pub fn new_max_size(path: PathBuf, max_size: IdxSize) -> PyPartitioning {
+        PyPartitioning {
+            path: Arc::new(path),
+            variant: PartitionVariant::MaxSize(max_size),
+        }
+    }
+}

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -119,6 +119,20 @@ fn visualize_plan_rec(
             #[allow(unreachable_patterns)]
             _ => todo!(),
         },
+        PhysNodeKind::PartitionSink {
+            input, file_type, ..
+        } => match file_type {
+            #[cfg(feature = "parquet")]
+            FileType::Parquet(_) => ("parquet-partition-sink".to_string(), from_ref(input)),
+            #[cfg(feature = "ipc")]
+            FileType::Ipc(_) => ("ipc-partition-sink".to_string(), from_ref(input)),
+            #[cfg(feature = "csv")]
+            FileType::Csv(_) => ("csv-partition-sink".to_string(), from_ref(input)),
+            #[cfg(feature = "json")]
+            FileType::Json(_) => ("json-partition-sink".to_string(), from_ref(input)),
+            #[allow(unreachable_patterns)]
+            _ => todo!(),
+        },
         PhysNodeKind::InMemoryMap { input, map: _ } => {
             ("in-memory-map".to_string(), from_ref(input))
         },

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -272,6 +272,24 @@ pub fn lower_ir(
                     },
                 }
             },
+            SinkType::Partition {
+                path_f_string,
+                variant,
+                file_type,
+                cloud_options: _,
+            } => {
+                let path_f_string = path_f_string.clone();
+                let variant = variant.clone();
+                let file_type = file_type.clone();
+
+                let phys_input = lower_ir!(*input)?;
+                PhysNodeKind::PartitionSink {
+                    path_f_string,
+                    variant,
+                    file_type,
+                    input: phys_input,
+                }
+            },
         },
 
         #[cfg(feature = "merge_sorted")]

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -8,7 +8,7 @@ use polars_core::utils::arrow::bitmap::Bitmap;
 use polars_error::PolarsResult;
 use polars_io::RowIndex;
 use polars_ops::frame::JoinArgs;
-use polars_plan::dsl::{FileScan, JoinTypeOptionsIR, ScanSource, ScanSources};
+use polars_plan::dsl::{FileScan, JoinTypeOptionsIR, PartitionVariant, ScanSource, ScanSources};
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, FileInfo, IR};
 use polars_plan::prelude::expr_ir::ExprIR;
@@ -129,6 +129,15 @@ pub enum PhysNodeKind {
 
     FileSink {
         path: Arc<PathBuf>,
+        file_type: FileType,
+        input: PhysStream,
+    },
+
+    PartitionSink {
+        #[expect(unused)]
+        path_f_string: Arc<PathBuf>,
+        #[expect(unused)]
+        variant: PartitionVariant,
         file_type: FileType,
         input: PhysStream,
     },
@@ -271,6 +280,7 @@ fn visit_node_inputs_mut(
             | PhysNodeKind::SimpleProjection { input, .. }
             | PhysNodeKind::InMemorySink { input }
             | PhysNodeKind::FileSink { input, .. }
+            | PhysNodeKind::PartitionSink { input, .. }
             | PhysNodeKind::InMemoryMap { input, .. }
             | PhysNodeKind::Map { input, .. }
             | PhysNodeKind::Sort { input, .. }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -275,6 +275,15 @@ fn to_graph_rec<'a>(
             }
         },
 
+        PartitionSink {
+            path_f_string: _,
+            variant: _,
+            file_type: _,
+            input: _,
+        } => {
+            todo!()
+        },
+
         InMemoryMap { input, map } => {
             let input_schema = ctx.phys_sm[input.node].output_schema.clone();
             let input_key = to_graph_rec(input.node, ctx)?;

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -1,5 +1,5 @@
 import contextlib
-from typing import Literal, TypeAlias, Union
+from typing import TypeAlias, Union
 
 from polars._utils.unstable import issue_unstable_warning
 
@@ -9,7 +9,10 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 class MaxSizePartitioning:
     """
-    File Partitioning scheme that generates files up to a maximum size and then switches to the next file.
+    Partitioning scheme to write files with a maximum size.
+
+    This partitioning scheme generates files that have a given maximum size. If
+    the size reaches the maximum size, it is closes and a new file is opened.
 
     The `path` can be given a `{part}` to specify the output files.
 

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -1,0 +1,29 @@
+import contextlib
+from typing import Literal, TypeAlias, Union
+
+from polars._utils.unstable import issue_unstable_warning
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyPartitioning
+
+
+class MaxSizePartitioning:
+    """
+    File Partitioning scheme that generates files up to a maximum size and then switches to the next file.
+
+    The `path` can be given a `{part}` to specify the output files.
+
+    .. warning::
+        This functionality is currently considered **unstable**. It may be
+        changed at any point without it being considered a breaking change.
+    """
+
+    _p: PyPartitioning
+
+    def __init__(self, path: str, max_size: int) -> None:
+        msg = "Partitioning strategies are considered unstable."
+        issue_unstable_warning(msg)
+        self._p = PyPartitioning.new_max_size(path, max_size)
+
+
+IOPartitioning: TypeAlias = Union[MaxSizePartitioning]

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -1,5 +1,4 @@
 import contextlib
-from typing import TypeAlias, Union
 
 from polars._utils.unstable import issue_unstable_warning
 
@@ -27,6 +26,3 @@ class MaxSizePartitioning:
         msg = "Partitioning strategies are considered unstable."
         issue_unstable_warning(msg)
         self._p = PyPartitioning.new_max_size(path, max_size)
-
-
-IOPartitioning: TypeAlias = Union[MaxSizePartitioning]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2457,7 +2457,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             storage_options = None
 
         target: str | Path | PyPartitioning
-        if not isinstance(path, (str | Path)):
+        if not isinstance(path, (str, Path)):
             target = path._p
         else:
             target = normalize_filepath(path)
@@ -2590,7 +2590,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             storage_options = None
 
         target: str | Path | PyPartitioning
-        if not isinstance(path, (str | Path)):
+        if not isinstance(path, (str, Path)):
             target = path._p
         else:
             target = path
@@ -2786,7 +2786,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             storage_options = None
 
         target: str | Path | PyPartitioning
-        if not isinstance(path, (str | Path)):
+        if not isinstance(path, (str, Path)):
             target = path._p
         else:
             target = normalize_filepath(path)
@@ -2923,7 +2923,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             storage_options = None
 
         target: str | Path | PyPartitioning
-        if not isinstance(path, (str | Path)):
+        if not isinstance(path, (str, Path)):
             target = path._p
         else:
             target = path

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -100,6 +100,9 @@ if TYPE_CHECKING:
     from io import IOBase
     from typing import Literal
 
+    with contextlib.suppress(ImportError):  # Module not available when building docs
+        from polars.polars import PyPartitioning
+
     from polars import DataFrame, DataType, Expr
     from polars._typing import (
         AsofJoinStrategy,
@@ -2453,11 +2456,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        target: str | Path | PyPartitioning
         if not isinstance(path, (str | Path)):
-            path = path._p
+            target = path._p
+        else:
+            target = normalize_filepath(path)
 
         return lf.sink_parquet(
-            target=normalize_filepath(path),
+            target=target,
             compression=compression,
             compression_level=compression_level,
             statistics=statistics,
@@ -2583,11 +2589,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        target: str | Path | PyPartitioning
         if not isinstance(path, (str | Path)):
-            path = path._p
+            target = path._p
+        else:
+            target = path
 
         return lf.sink_ipc(
-            target=path,
+            target=target,
             compression=compression,
             maintain_order=maintain_order,
             cloud_options=storage_options,
@@ -2776,11 +2785,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        target: str | Path | PyPartitioning
         if not isinstance(path, (str | Path)):
-            path = path._p
+            target = path._p
+        else:
+            target = normalize_filepath(path)
 
         return lf.sink_csv(
-            target=normalize_filepath(path),
+            target=target,
             include_bom=include_bom,
             include_header=include_header,
             separator=ord(separator),
@@ -2910,11 +2922,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        target: str | Path | PyPartitioning
         if not isinstance(path, (str | Path)):
-            path = path._p
+            target = path._p
+        else:
+            target = path
 
         return lf.sink_json(
-            target=path,
+            target=target,
             maintain_order=maintain_order,
             cloud_options=storage_options,
             credential_provider=credential_provider_builder,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2453,8 +2453,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        if not isinstance(path, (str | Path)):
+            path = path._p
+
         return lf.sink_parquet(
-            path=normalize_filepath(path),
+            target=normalize_filepath(path),
             compression=compression,
             compression_level=compression_level,
             statistics=statistics,
@@ -2580,8 +2583,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        if not isinstance(path, (str | Path)):
+            path = path._p
+
         return lf.sink_ipc(
-            path=path,
+            target=path,
             compression=compression,
             maintain_order=maintain_order,
             cloud_options=storage_options,
@@ -2770,8 +2776,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        if not isinstance(path, (str | Path)):
+            path = path._p
+
         return lf.sink_csv(
-            path=normalize_filepath(path),
+            target=normalize_filepath(path),
             include_bom=include_bom,
             include_header=include_header,
             separator=ord(separator),
@@ -2901,8 +2910,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             # Handle empty dict input
             storage_options = None
 
+        if not isinstance(path, (str | Path)):
+            path = path._p
+
         return lf.sink_json(
-            path=path,
+            target=path,
             maintain_order=maintain_order,
             cloud_options=storage_options,
             credential_provider=credential_provider_builder,

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -14,7 +14,7 @@ use polars_python::catalog::unity::PyCatalogClient;
 use polars_python::cloud;
 use polars_python::dataframe::PyDataFrame;
 use polars_python::expr::PyExpr;
-use polars_python::functions::PyStringCacheHolder;
+use polars_python::functions::{PyPartitioning, PyStringCacheHolder};
 #[cfg(not(target_arch = "wasm32"))]
 use polars_python::lazyframe::PyInProcessQuery;
 use polars_python::lazyframe::PyLazyFrame;
@@ -94,6 +94,7 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyInProcessQuery>().unwrap();
     m.add_class::<PyLazyGroupBy>().unwrap();
     m.add_class::<PyExpr>().unwrap();
+    m.add_class::<PyPartitioning>().unwrap();
     m.add_class::<PyStringCacheHolder>().unwrap();
     #[cfg(feature = "csv")]
     m.add_class::<PyBatchedCsv>().unwrap();

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -139,7 +139,7 @@ def test_sink_csv_with_options() -> None:
     df = pl.LazyFrame({"dummy": ["abc"]})
     with patch.object(df, "_ldf") as ldf:
         df.sink_csv(
-            "path",
+            "target",
             include_bom=True,
             include_header=False,
             separator=";",
@@ -160,7 +160,7 @@ def test_sink_csv_with_options() -> None:
         )
 
         ldf.optimization_toggle().sink_csv.assert_called_with(
-            path="path",
+            target="target",
             include_bom=True,
             include_header=False,
             separator=ord(";"),


### PR DESCRIPTION
This adds a generic `SinkType::Partition` that can (now still invisibly) be called from Python.

```python
import polars as pl
from polars.io.partition import MaxSizePartitioning
import os

os.environ['POLARS_FORCE_NEW_STREAMING'] = '1'

lf = pl.LazyFrame(
    {
        "a": list(range(8)),
        "b": [5, 10, 1996, 13, 37, 42, 00, 1],
    }
)
lf.sink_ipc(MaxSizePartitioning("{part}.ipc", max_size=1))
```