### PR TITLE
perf: Add `.list.struct_field` to obtain fields in lists of structs

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -59,7 +59,7 @@ pub enum ListFunction {
     #[cfg(feature = "list_to_struct")]
     ToStruct(ListToStructArgs),
     #[cfg(feature = "dtype-struct")]
-    StructField(String),
+    StructField(PlSmallStr),
 }
 
 impl ListFunction {
@@ -214,7 +214,7 @@ impl Display for ListFunction {
             #[cfg(feature = "list_to_struct")]
             ToStruct(_) => "to_struct",
             #[cfg(feature = "dtype-struct")]
-            StructField(_) => "struct_field",
+            StructField(name) => return write!(f, "list.struct_field({:?})", name),
         };
         write!(f, "list.{name}")
     }
@@ -711,6 +711,6 @@ pub(super) fn n_unique(s: &Column) -> PolarsResult<Column> {
 pub(super) fn struct_field(s: &Column, name: &str) -> PolarsResult<Column> {
     Ok(s.list()?
         .apply_to_inner(&|s| s.struct_()?.field_by_name(name))?
-        .with_name(name.into())
-        .into_column())
+        .into_column()
+        .with_name(name.into()))
 }

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -380,6 +380,10 @@ impl FunctionExpr {
     pub(crate) fn output_name(&self) -> Option<OutputName> {
         match self {
             #[cfg(feature = "dtype-struct")]
+            FunctionExpr::ListExpr(ListFunction::StructField(name)) => {
+                Some(OutputName::Field(name.clone()))
+            },
+            #[cfg(feature = "dtype-struct")]
             FunctionExpr::StructExpr(StructFunction::FieldByName(name)) => {
                 Some(OutputName::Field(name.clone()))
             },

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -366,4 +366,17 @@ impl ListNameSpace {
         let other = other.into();
         self.set_operation(other, SetOperation::SymmetricDifference)
     }
+
+    /// Map a list of structs to a list of an individual struct field.
+    #[cfg(feature = "dtype-struct")]
+    pub fn struct_field(self, name: &str) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ListExpr(ListFunction::StructField(
+                name.into(),
+            )))
+            .with_function_options(|mut options| {
+                options.flags |= FunctionFlags::ALLOW_RENAME;
+                options
+            })
+    }
 }

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -136,6 +136,10 @@ impl ExprIR {
                 } => {
                     match function {
                         #[cfg(feature = "dtype-struct")]
+                        FunctionExpr::ListExpr(ListFunction::StructField(name)) => {
+                            out.output_name = OutputName::Field(name.clone());
+                        },
+                        #[cfg(feature = "dtype-struct")]
                         FunctionExpr::StructExpr(StructFunction::FieldByName(name)) => {
                             out.output_name = OutputName::Field(name.clone());
                         },

--- a/crates/polars-python/src/expr/list.rs
+++ b/crates/polars-python/src/expr/list.rs
@@ -276,4 +276,8 @@ impl PyExpr {
         }
         .into()
     }
+
+    fn list_struct_field(&self, name: &str) -> Self {
+        self.inner.clone().list().struct_field(name).into()
+    }
 }

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1372,3 +1372,45 @@ class ExprListNameSpace:
         """  # noqa: W505.
         other = parse_into_expression(other, str_as_lit=False)
         return wrap_expr(self._pyexpr.list_set_operation(other, "symmetric_difference"))
+
+    def struct_field(self, name: str) -> Expr:
+        """
+        Extract a single struct field from a series of type `List(Struct(...))`.
+
+        Parameters
+        ----------
+        name
+            The name of the struct field to extract.
+
+        Notes
+        -----
+        This method is functionally equivalent to using
+        `.list.eval(pl.element().struct.field("..."))`. However, it is zero-copy and,
+        thus, considerably faster.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [
+        ...             [{"x": 1, "y": 2}],
+        ...             [{"x": 3, "y": 4}, {"x": 5, "y": 6}, None],
+        ...             [],
+        ...             None,
+        ...         ],
+        ...     }
+        ... )
+        >>> df.with_columns(pl.col("a").list.struct_field("x"))
+        shape: (4, 2)
+        ┌──────────────────────┬──────────────┐
+        │ a                    ┆ x            │
+        │ ---                  ┆ ---          │
+        │ list[struct[2]]      ┆ list[i64]    │
+        ╞══════════════════════╪══════════════╡
+        │ [{1,2}]              ┆ [1]          │
+        │ [{3,4}, {5,6}, null] ┆ [3, 5, null] │
+        │ []                   ┆ []           │
+        │ null                 ┆ null         │
+        └──────────────────────┴──────────────┘
+        """
+        return wrap_expr(self._pyexpr.list_struct_field(name))

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1056,16 +1056,25 @@ def test_list_struct_field_schema(
             {
                 "a": [[{"x": 1, "y": 2}]],
                 "b": [[{"x": 3, "y": 4}]],
+                "c": [[{"x": 5, "y": 6}]],
             }
         )
         .cast(
             {
                 "a": pl.List(pl.Struct({"x": dtype_x_series_a, "y": pl.UInt8})),
                 "b": pl.List(pl.Struct({"x": dtype_x_series_b, "y": pl.UInt8})),
+                "c": pl.List(pl.Struct({"x": pl.UInt8, "y": pl.UInt8})),
             }
         )
-        .select(pl.col("a", "b").list.struct_field("x").name.keep())
+        .select(
+            pl.col("a", "b").list.struct_field("x").name.keep(),
+            pl.col("c").list.struct_field("y"),
+        )
     )
-    expected = {"a": pl.List(dtype_x_series_a), "b": pl.List(dtype_x_series_b)}
+    expected = {
+        "a": pl.List(dtype_x_series_a),
+        "b": pl.List(dtype_x_series_b),
+        "y": pl.List(pl.UInt8),
+    }
     assert lf.collect_schema() == expected
     assert lf.collect().schema == expected

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1040,9 +1040,9 @@ def test_list_struct_field() -> None:
             ],
         }
     )
-    actual = df.select(pl.col("a").list.struct_field("x"))
+    out = df.select(pl.col("a").list.struct_field("x"))
     expected = pl.DataFrame({"x": [[1], [3, 5, None], [], None]})
-    assert_frame_equal(actual, expected)
+    assert_frame_equal(out, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Motivation

When using lists of structs, a common operation is to reduce the list to only a single field of the struct. Unfortunately, the only way to currently do this in polars is to use the `eval` method:

```python
df.list.eval(pl.element().struct.field("..."))
```

This is suboptimal since it actually copies the data for that field even though the Arrow memory layout would not require this.

This PR adds a new function in the list expression namespace, namely `struct_field`. It allows to reduce a list of structs to a single field without performing an expensive copy:

```python
df.list.struct_field("...")
```

On a data frame with 1,000,000 rows, `struct_field` is ~40x faster than using `eval`. On a data frame with 10,000,000 rows, it is even up to 100x faster.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210034268005368