### PR TITLE
refactor(rust): Use a oneshot channel for `unrestricted_row_count`, fix panic in new-streaming negative slice

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use polars_core::config;
@@ -21,7 +20,6 @@ use polars_io::RowIndex;
 use polars_plan::dsl::ScanSource;
 use polars_plan::plans::{isolated_csv_file_info, FileInfo};
 use polars_plan::prelude::FileScanOptions;
-use polars_utils::index::AtomicIdxSize;
 use polars_utils::mmap::MemSlice;
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::IdxSize;
@@ -96,7 +94,7 @@ impl SourceNode for CsvSourceNode {
         mut output_recv: Receiver<SourceOutput>,
         _state: &ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
-        unrestricted_row_count: Option<Arc<AtomicIdxSize>>,
+        unrestricted_row_count: Option<tokio::sync::oneshot::Sender<IdxSize>>,
     ) {
         let (mut send_to, recv_from) = (0..num_pipelines)
             .map(|_| connector::<MorselOutput>())
@@ -190,7 +188,7 @@ impl CsvSourceNode {
     fn init_line_batch_source(
         &mut self,
         num_pipelines: usize,
-        unrestricted_row_count: Option<Arc<AtomicIdxSize>>,
+        unrestricted_row_count: Option<tokio::sync::oneshot::Sender<IdxSize>>,
     ) -> AsyncTaskData {
         let verbose = self.verbose;
 
@@ -370,11 +368,11 @@ impl CsvSourceNode {
                     }
                 }
 
-                if let Some(unrestricted_row_count) = unrestricted_row_count.as_ref() {
+                if let Some(unrestricted_row_count) = unrestricted_row_count {
                     let num_rows = *current_row_offset_ref;
                     let num_rows = IdxSize::try_from(num_rows)
                         .map_err(|_| polars_err!(bigidx, ctx = "csv file", size = num_rows))?;
-                    unrestricted_row_count.store(num_rows, Ordering::Relaxed);
+                    _ = unrestricted_row_count.send(num_rows);
                 }
 
                 Ok(())

--- a/crates/polars-stream/src/nodes/io_sources/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/mod.rs
@@ -8,7 +8,7 @@ use polars_core::config;
 use polars_error::PolarsResult;
 use polars_expr::state::ExecutionState;
 use polars_io::predicates::ScanIOPredicate;
-use polars_utils::index::AtomicIdxSize;
+use polars_utils::IdxSize;
 
 use super::{ComputeNode, JoinHandle, Morsel, PortState, RecvPort, SendPort, TaskPriority};
 use crate::async_executor::AbortOnDropHandle;
@@ -174,6 +174,7 @@ impl PhaseOutcomeToken {
     pub fn was_stopped(&self) -> bool {
         self.stop.load(Ordering::Relaxed)
     }
+
     /// Returns whether the phase was finished completely.
     pub fn did_finish(&self) -> bool {
         !self.was_stopped()
@@ -280,6 +281,6 @@ pub trait SourceNode: Sized + Send + Sync {
         output_recv: Receiver<SourceOutput>,
         state: &ExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
-        unrestricted_row_count: Option<Arc<AtomicIdxSize>>,
+        unrestricted_row_count: Option<tokio::sync::oneshot::Sender<IdxSize>>,
     );
 }

--- a/crates/polars-stream/src/nodes/negative_slice.rs
+++ b/crates/polars-stream/src/nodes/negative_slice.rs
@@ -72,8 +72,9 @@ impl ComputeNode for NegativeSliceNode {
                     signed_start_offset -= len as i64;
                 }
 
-                while buffer.total_len as i64 - buffer.frames.back().unwrap().height() as i64
-                    > signed_stop_offset
+                while !buffer.frames.is_empty()
+                    && buffer.total_len as i64 - buffer.frames.back().unwrap().height() as i64
+                        > signed_stop_offset
                 {
                     buffer.total_len -= buffer.frames.pop_back().unwrap().height();
                 }

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -310,3 +310,9 @@ def test_slice_pushdown_panic_20216() -> None:
 
     assert_frame_equal(q.slice(0, 1).collect(), pl.DataFrame({"A": ["1"]}))
     assert_frame_equal(q.collect(), pl.DataFrame({"A": ["1"]}))
+
+
+def test_slice_empty_morsel_input() -> None:
+    q = pl.LazyFrame({"a": []})
+    assert_frame_equal(q.slice(999, 3).slice(999, 3).collect(), q.collect().clear())
+    assert_frame_equal(q.slice(-999, 3).slice(-999, 3).collect(), q.collect().clear())


### PR DESCRIPTION
Instead of an atomic integer, this ensures we explicitly block until the source has sent the final row count.

Also fixes a panic in new-streaming negative slice on empty morsel inputs.
