### PR TITLE
feat(python): Support passing `token` in `storage_options` for GCP cloud

### DIFF
--- a/py-polars/polars/io/cloud/credential_provider/_builder.py
+++ b/py-polars/polars/io/cloud/credential_provider/_builder.py
@@ -368,6 +368,13 @@ def _init_credential_provider_builder(
                     # https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html
                     if k in {"token", "bearer_token"}:
                         token = v
+                    elif k in {
+                        "google_bucket",
+                        "google_bucket_name",
+                        "bucket",
+                        "bucket_name",
+                    }:
+                        continue
                     elif k in OBJECT_STORE_CLIENT_OPTIONS:
                         continue
                     else:


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/13138
* Fixes https://github.com/pola-rs/polars/issues/21417

```python
scan_parquet(..., storage_options = { 'token': '...' })
```