### PR TITLE
fix: Don't hit parquet::pre-filtered in case of pre-slice

### DIFF
--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -231,7 +231,10 @@ pub(crate) fn insert_streaming_nodes(
             },
             Scan {
                 scan_type,
-                file_options: FileScanOptions { slice, .. },
+                file_options:
+                    FileScanOptions {
+                        pre_slice: slice, ..
+                    },
                 ..
             } if scan_type.streamable() && slice.map(|slice| slice.0 >= 0).unwrap_or(true) => {
                 if state.streamable {

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -123,7 +123,7 @@ impl LazyJsonLineReader {
 impl LazyFileListReader for LazyJsonLineReader {
     fn finish(self) -> PolarsResult<LazyFrame> {
         let file_options = FileScanOptions {
-            slice: self.n_rows.map(|x| (0, x)),
+            pre_slice: self.n_rows.map(|x| (0, x)),
             with_columns: None,
             cache: false,
             row_index: self.row_index,

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -399,7 +399,7 @@ fn test_scan_parquet_limit_9001() {
             let sliced = options.slice.unwrap();
             sliced.1 == 3
         },
-        IR::Scan { file_options, .. } => file_options.slice == Some((0, 3)),
+        IR::Scan { file_options, .. } => file_options.pre_slice == Some((0, 3)),
         _ => true,
     });
 }

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -85,7 +85,7 @@ fn slice_at_scan(q: LazyFrame) -> bool {
     (&lp_arena).iter(lp).any(|(_, lp)| {
         use IR::*;
         match lp {
-            Scan { file_options, .. } => file_options.slice.is_some(),
+            Scan { file_options, .. } => file_options.pre_slice.is_some(),
             _ => false,
         }
     })

--- a/crates/polars-mem-engine/src/executors/multi_file_scan.rs
+++ b/crates/polars-mem-engine/src/executors/multi_file_scan.rs
@@ -291,7 +291,7 @@ impl MultiScanExec {
 
         let allow_missing_columns = self.file_options.allow_missing_columns;
         self.file_options.allow_missing_columns = false;
-        let slice = self.file_options.slice.take();
+        let slice = self.file_options.pre_slice.take();
 
         let mut first_slice_file = None;
         let mut slice = match slice {

--- a/crates/polars-mem-engine/src/executors/scan/csv.rs
+++ b/crates/polars-mem-engine/src/executors/scan/csv.rs
@@ -27,7 +27,7 @@ impl CsvExec {
             // Interpret selecting no columns as selecting all columns.
             .filter(|columns| !columns.is_empty());
 
-        let n_rows = _set_n_rows_for_scan(self.file_options.slice.map(|x| {
+        let n_rows = _set_n_rows_for_scan(self.file_options.pre_slice.map(|x| {
             assert_eq!(x.0, 0);
             x.1
         }));
@@ -224,7 +224,7 @@ impl ScanExec for CsvExec {
         row_index: Option<polars_io::RowIndex>,
     ) -> PolarsResult<DataFrame> {
         self.file_options.with_columns = with_columns;
-        self.file_options.slice = slice.map(|(o, l)| (o as i64, l));
+        self.file_options.pre_slice = slice.map(|(o, l)| (o as i64, l));
         self.predicate = predicate;
         self.file_options.row_index = row_index;
 

--- a/crates/polars-mem-engine/src/executors/scan/ipc.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ipc.rs
@@ -63,7 +63,7 @@ impl IpcExec {
         if config::verbose() {
             eprintln!("executing ipc read sync with row_index = {:?}, n_rows = {:?}, predicate = {:?} for paths {:?}",
                 self.file_options.row_index.as_ref(),
-                self.file_options.slice.map(|x| {
+                self.file_options.pre_slice.map(|x| {
                     assert_eq!(x.0, 0);
                     x.1
                 }).as_ref(),
@@ -113,7 +113,7 @@ impl IpcExec {
                 .finish()
         };
 
-        let mut dfs = if let Some(mut n_rows) = self.file_options.slice.map(|x| {
+        let mut dfs = if let Some(mut n_rows) = self.file_options.pre_slice.map(|x| {
             assert_eq!(x.0, 0);
             x.1
         }) {
@@ -209,7 +209,7 @@ impl ScanExec for IpcExec {
         row_index: Option<polars_io::RowIndex>,
     ) -> PolarsResult<DataFrame> {
         self.file_options.with_columns = with_columns;
-        self.file_options.slice = slice.map(|(s, l)| (s as i64, l));
+        self.file_options.pre_slice = slice.map(|(s, l)| (s as i64, l));
         self.predicate = predicate;
         self.file_options.row_index = row_index;
 

--- a/crates/polars-mem-engine/src/executors/scan/mod.rs
+++ b/crates/polars-mem-engine/src/executors/scan/mod.rs
@@ -67,7 +67,7 @@ pub(crate) struct AnonymousScanExec {
 impl Executor for AnonymousScanExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
         let mut args = AnonymousScanArgs {
-            n_rows: self.file_options.slice.map(|x| {
+            n_rows: self.file_options.pre_slice.map(|x| {
                 assert_eq!(x.0, 0);
                 x.1
             }),

--- a/crates/polars-mem-engine/src/executors/scan/ndjson.rs
+++ b/crates/polars-mem-engine/src/executors/scan/ndjson.rs
@@ -49,7 +49,7 @@ impl JsonExec {
             eprintln!("ASYNC READING FORCED");
         }
 
-        let mut n_rows = self.file_options.slice.map(|x| {
+        let mut n_rows = self.file_options.pre_slice.map(|x| {
             assert_eq!(x.0, 0);
             x.1
         });
@@ -144,7 +144,7 @@ impl ScanExec for JsonExec {
         row_index: Option<polars_io::RowIndex>,
     ) -> PolarsResult<DataFrame> {
         self.file_options.with_columns = with_columns;
-        self.file_options.slice = slice.map(|(s, l)| (s as i64, l));
+        self.file_options.pre_slice = slice.map(|(s, l)| (s as i64, l));
         self.predicate = predicate;
         self.file_options.row_index = row_index;
 

--- a/crates/polars-mem-engine/src/executors/scan/parquet.rs
+++ b/crates/polars-mem-engine/src/executors/scan/parquet.rs
@@ -90,7 +90,7 @@ impl ParquetExec {
         let mut base_row_index = self.file_options.row_index.take();
 
         // (offset, end)
-        let (slice_offset, slice_end) = if let Some(slice) = self.file_options.slice {
+        let (slice_offset, slice_end) = if let Some(slice) = self.file_options.pre_slice {
             if slice.0 >= 0 {
                 (slice.0 as usize, slice.1.saturating_add(slice.0 as usize))
             } else {
@@ -305,7 +305,7 @@ impl ParquetExec {
         let mut first_file_idx = 0;
 
         // (offset, end)
-        let (slice_offset, slice_end) = if let Some(slice) = self.file_options.slice {
+        let (slice_offset, slice_end) = if let Some(slice) = self.file_options.pre_slice {
             if slice.0 >= 0 {
                 (slice.0 as usize, slice.1.saturating_add(slice.0 as usize))
             } else {
@@ -584,7 +584,7 @@ impl ScanExec for ParquetExec {
         row_index: Option<RowIndex>,
     ) -> PolarsResult<DataFrame> {
         self.file_options.with_columns = with_columns;
-        self.file_options.slice = slice.map(|(o, l)| (o as i64, l));
+        self.file_options.pre_slice = slice.map(|(o, l)| (o as i64, l));
         self.predicate = predicate;
         self.skip_batch_predicate = skip_batch_predicate;
         self.file_options.row_index = row_index;

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -203,7 +203,7 @@ fn create_physical_plan_impl(
             predicate,
             mut file_options,
         } => {
-            file_options.slice = if let Some((offset, len)) = file_options.slice {
+            file_options.pre_slice = if let Some((offset, len)) = file_options.pre_slice {
                 Some((offset, _set_n_rows_for_scan(Some(len)).unwrap()))
             } else {
                 _set_n_rows_for_scan(None).map(|x| (0, x))

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -43,7 +43,7 @@ impl CsvSource {
             .ok_or_else(|| polars_err!(nyi = "Streaming scanning of in-memory buffers"))?;
         let file_options = self.file_options.clone();
 
-        let n_rows = file_options.slice.map(|x| {
+        let n_rows = file_options.pre_slice.map(|x| {
             assert_eq!(x.0, 0);
             x.1
         });
@@ -82,7 +82,7 @@ impl CsvSource {
         };
         let n_rows = _set_n_rows_for_scan(
             file_options
-                .slice
+                .pre_slice
                 .map(|x| {
                     assert_eq!(x.0, 0);
                     x.1

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -110,7 +110,7 @@ impl ParquetSource {
         let Some(index) = self.iter.next() else {
             return Ok(());
         };
-        if let Some(slice) = self.file_options.slice {
+        if let Some(slice) = self.file_options.pre_slice {
             if self.processed_rows.load(Ordering::Relaxed) >= slice.0 as usize + slice.1 {
                 return Ok(());
             }
@@ -156,7 +156,7 @@ impl ParquetSource {
                 .processed_rows
                 .fetch_add(n_rows_this_file, Ordering::Relaxed);
 
-            let slice = file_options.slice.map(|slice| {
+            let slice = file_options.pre_slice.map(|slice| {
                 assert!(slice.0 >= 0);
                 let slice_start = slice.0 as usize;
                 let slice_end = slice_start + slice.1;
@@ -225,7 +225,7 @@ impl ParquetSource {
                 .processed_rows
                 .fetch_add(n_rows_this_file, Ordering::Relaxed);
 
-            let slice = file_options.slice.map(|slice| {
+            let slice = file_options.pre_slice.map(|slice| {
                 assert!(slice.0 >= 0);
                 let slice_start = slice.0 as usize;
                 let slice_end = slice_start + slice.1;
@@ -324,8 +324,8 @@ impl ParquetSource {
                         .collect::<Vec<_>>();
                     let init_iter = range.into_iter().map(|index| self.init_reader_async(index));
 
-                    let needs_exact_processed_rows_count =
-                        self.file_options.slice.is_some() || self.file_options.row_index.is_some();
+                    let needs_exact_processed_rows_count = self.file_options.pre_slice.is_some()
+                        || self.file_options.row_index.is_some();
 
                     let batched_readers = if needs_exact_processed_rows_count {
                         // We run serially to ensure we have a correct processed_rows count.

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -41,7 +41,7 @@ impl DslBuilder {
 
         let file_info = FileInfo::new(schema.clone(), None, (n_rows, n_rows.unwrap_or(usize::MAX)));
         let file_options = FileScanOptions {
-            slice: n_rows.map(|x| (0, x)),
+            pre_slice: n_rows.map(|x| (0, x)),
             with_columns: None,
             cache: false,
             row_index: None,
@@ -94,7 +94,7 @@ impl DslBuilder {
         let options = FileScanOptions {
             with_columns: None,
             cache,
-            slice: n_rows.map(|x| (0, x)),
+            pre_slice: n_rows.map(|x| (0, x)),
             rechunk,
             row_index,
             file_counter: Default::default(),
@@ -141,7 +141,7 @@ impl DslBuilder {
             file_options: FileScanOptions {
                 with_columns: None,
                 cache,
-                slice: n_rows.map(|x| (0, x)),
+                pre_slice: n_rows.map(|x| (0, x)),
                 rechunk,
                 row_index,
                 file_counter: Default::default(),
@@ -176,7 +176,7 @@ impl DslBuilder {
         let options = FileScanOptions {
             with_columns: None,
             cache,
-            slice: read_options_clone.n_rows.map(|x| (0, x)),
+            pre_slice: read_options_clone.n_rows.map(|x| (0, x)),
             rechunk: read_options_clone.rechunk,
             row_index: read_options_clone.row_index,
             file_counter: Default::default(),

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -192,6 +192,7 @@ pub type FileCount = u32;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Generic options for all file types.
 pub struct FileScanOptions {
+    // Slice applied before predicates
     pub pre_slice: Option<(i64, usize)>,
     pub with_columns: Option<Arc<[PlSmallStr]>>,
     pub cache: bool,

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -192,7 +192,7 @@ pub type FileCount = u32;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Generic options for all file types.
 pub struct FileScanOptions {
-    pub slice: Option<(i64, usize)>,
+    pub pre_slice: Option<(i64, usize)>,
     pub with_columns: Option<Arc<[PlSmallStr]>>,
     pub cache: bool,
     pub row_index: Option<RowIndex>,

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -257,7 +257,7 @@ impl<'a> IRDisplay<'a> {
                     n_columns,
                     file_info.schema.len(),
                     &predicate,
-                    file_options.slice,
+                    file_options.pre_slice,
                     file_options.row_index.as_ref(),
                 )
             },

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -461,7 +461,7 @@ impl PredicatePushDown<'_> {
 
                 let mut do_optimization = match &scan_type {
                     #[cfg(feature = "csv")]
-                    FileScan::Csv { .. } => options.slice.is_none(),
+                    FileScan::Csv { .. } => options.pre_slice.is_none(),
                     FileScan::Anonymous { function, .. } => function.allows_predicate_pushdown(),
                     #[cfg(feature = "json")]
                     FileScan::NDJson { .. } => true,

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -206,7 +206,7 @@ impl SlicePushDown {
                 predicate,
                 scan_type: FileScan::Csv { options, cloud_options },
             }, Some(state)) if predicate.is_none() && self.new_streaming =>  {
-                file_options.slice = Some((state.offset, state.len as usize));
+                file_options.pre_slice = Some((state.offset, state.len as usize));
 
                 let lp = Scan {
                     sources,
@@ -230,7 +230,7 @@ impl SlicePushDown {
                 predicate,
                 scan_type: FileScan::Csv { options, cloud_options },
             }, Some(state)) if predicate.is_none() && state.offset >= 0 =>  {
-                file_options.slice = Some((0, state.offset as usize + state.len as usize));
+                file_options.pre_slice = Some((0, state.offset as usize + state.len as usize));
 
                 let lp = Scan {
                     sources,
@@ -254,7 +254,7 @@ impl SlicePushDown {
                 predicate,
                 scan_type: FileScan::NDJson { options, cloud_options },
             }, Some(state)) if predicate.is_none() && self.new_streaming =>  {
-                file_options.slice = Some((state.offset, state.len as usize));
+                file_options.pre_slice = Some((state.offset, state.len as usize));
 
                 let lp = Scan {
                     sources,
@@ -278,7 +278,7 @@ impl SlicePushDown {
                 predicate,
                 scan_type: scan_type @ FileScan::Parquet { .. },
             }, Some(state)) if predicate.is_none() =>  {
-                file_options.slice = Some((state.offset, state.len as usize));
+                file_options.pre_slice = Some((state.offset, state.len as usize));
 
                 let lp = Scan {
                     sources,
@@ -303,7 +303,7 @@ impl SlicePushDown {
                 predicate,
                 scan_type: scan_type @ FileScan::Ipc { .. },
             }, Some(state)) if self.new_streaming && predicate.is_none() =>  {
-                file_options.slice = Some((state.offset, state.len as usize));
+                file_options.pre_slice = Some((state.offset, state.len as usize));
 
                 let lp = Scan {
                     sources,
@@ -328,7 +328,7 @@ impl SlicePushDown {
                 predicate,
                 scan_type
             }, Some(state)) if state.offset == 0 && predicate.is_none() => {
-                options.slice = Some((0, state.len as usize));
+                options.pre_slice = Some((0, state.len as usize));
 
                 let lp = Scan {
                     sources,

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -50,7 +50,7 @@ pub struct PyFileOptions {
 impl PyFileOptions {
     #[getter]
     fn n_rows(&self) -> Option<(i64, usize)> {
-        self.inner.slice
+        self.inner.pre_slice
     }
     #[getter]
     fn with_columns(&self) -> Option<Vec<&str>> {

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -211,7 +211,7 @@ impl CsvSourceNode {
         let skip_rows_after_header = options.skip_rows_after_header;
         let comment_prefix = parse_options.comment_prefix.clone();
         let has_header = options.has_header;
-        let global_slice = self.file_options.slice;
+        let global_slice = self.file_options.pre_slice;
 
         if verbose {
             eprintln!(
@@ -589,11 +589,11 @@ impl MultiScanable for CsvSourceNode {
         });
     }
     fn with_row_restriction(&mut self, row_restriction: Option<RowRestriction>) {
-        self.file_options.slice = None;
+        self.file_options.pre_slice = None;
         match row_restriction {
             None => {},
             Some(RowRestriction::Slice(rng)) => {
-                self.file_options.slice = Some((rng.start as i64, rng.end - rng.start))
+                self.file_options.pre_slice = Some((rng.start as i64, rng.end - rng.start))
             },
             Some(RowRestriction::Predicate(_)) => unreachable!(),
         }

--- a/crates/polars-stream/src/nodes/io_sources/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc.rs
@@ -75,7 +75,7 @@ impl IpcSourceNode {
         let IpcScanOptions = options;
 
         let FileScanOptions {
-            slice,
+            pre_slice: slice,
             with_columns,
             cache: _, // @TODO
             row_index,

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -205,6 +205,7 @@ impl ParquetSourceNode {
         let min_values_per_thread = self.config.min_values_per_thread;
 
         let mut use_prefiltered = self.predicate.is_some()
+            && self.file_options.pre_slice.is_none()
             && matches!(
                 self.options.parallel,
                 ParallelStrategy::Auto | ParallelStrategy::Prefiltered

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -40,7 +40,7 @@ impl ParquetSourceNode {
 
         let (mut raw_morsel_sender, raw_morsel_receivers) =
             distributor_channel(self.config.num_pipelines, DEFAULT_DISTRIBUTOR_BUFFER_SIZE);
-        if let Some((_, 0)) = self.file_options.slice {
+        if let Some((_, 0)) = self.file_options.pre_slice {
             return (
                 raw_morsel_receivers,
                 task_handles_ext::AbortOnDropHandle(io_runtime.spawn(std::future::ready(Ok(())))),

--- a/crates/polars-stream/src/nodes/io_sources/parquet/metadata_fetch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/metadata_fetch.rs
@@ -165,14 +165,14 @@ impl ParquetSourceNode {
 
         let metadata_task_handle = if self
             .file_options
-            .slice
+            .pre_slice
             .map(|(offset, _)| offset >= 0)
             .unwrap_or(true)
         {
             normalized_slice_oneshot_tx
                 .send(
                     self.file_options
-                        .slice
+                        .pre_slice
                         .map(|(offset, len)| (offset as usize, len)),
                 )
                 .unwrap();
@@ -180,7 +180,7 @@ impl ParquetSourceNode {
             // Safety: `offset + len` does not overflow.
             let slice_range = self
                 .file_options
-                .slice
+                .pre_slice
                 .map(|(offset, len)| offset as usize..offset as usize + len);
 
             let mut metadata_stream = futures::stream::iter(0..self.scan_sources.len())
@@ -281,7 +281,7 @@ impl ParquetSourceNode {
             })
         } else {
             // Walk the files in reverse to translate the slice into a positive offset.
-            let slice = self.file_options.slice.unwrap();
+            let slice = self.file_options.pre_slice.unwrap();
             let slice_start_as_n_from_end = -slice.0 as usize;
 
             let mut metadata_stream = futures::stream::iter((0..self.scan_sources.len()).rev())

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -333,12 +333,12 @@ impl MultiScanable for ParquetSourceNode {
     }
     fn with_row_restriction(&mut self, row_restriction: Option<RowRestriction>) {
         self.predicate = None;
-        self.file_options.slice = None;
+        self.file_options.pre_slice = None;
 
         if let Some(row_restriction) = row_restriction {
             match row_restriction {
                 RowRestriction::Slice(slice) => {
-                    self.file_options.slice = Some((slice.start as i64, slice.len()));
+                    self.file_options.pre_slice = Some((slice.start as i64, slice.len()));
                 },
                 // @TODO: Cache
                 RowRestriction::Predicate(scan_predicate) => {

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -201,7 +201,7 @@ fn visualize_plan_rec(
                 write!(f, r#"\nrow index: name: "{}", offset: {}"#, name, offset).unwrap();
             }
 
-            if let Some((offset, len)) = file_options.slice {
+            if let Some((offset, len)) = file_options.pre_slice {
                 write!(f, "\nslice: offset: {}, len: {}", offset, len).unwrap();
             }
 

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -440,7 +440,7 @@ pub fn lower_ir(
                                         // return an accurate line count :'(.
                                         (
                                             file_options.row_index.take(),
-                                            file_options.slice.take(),
+                                            file_options.pre_slice.take(),
                                             predicate.take(),
                                         )
                                     }
@@ -524,7 +524,7 @@ pub fn lower_ir(
                 });
 
                 let mut row_restriction = None;
-                if let Some((offset, len)) = file_options.slice.take() {
+                if let Some((offset, len)) = file_options.pre_slice.take() {
                     if offset < 0 {
                         let offset = (-offset) as usize;
                         row_restriction = Some(MultiscanRowRestriction::NegativeSlice(offset, len));

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -484,7 +484,7 @@ fn to_graph_rec<'a>(
                 unreachable!()
             };
 
-            file_options.slice = if let Some((offset, len)) = file_options.slice {
+            file_options.pre_slice = if let Some((offset, len)) = file_options.pre_slice {
                 Some((offset, _set_n_rows_for_scan(Some(len)).unwrap()))
             } else {
                 _set_n_rows_for_scan(None).map(|x| (0, x))
@@ -575,7 +575,7 @@ fn to_graph_rec<'a>(
                         if options.parse_options.comment_prefix.is_some() {
                             // Should have been re-written to separate streaming nodes
                             assert!(file_options.row_index.is_none());
-                            assert!(file_options.slice.is_none());
+                            assert!(file_options.pre_slice.is_none());
                         }
 
                         ctx.graph.add_node(


### PR DESCRIPTION
Made also clear that the slice is a `pre_slice`. Meaning pre-predicate.

fixes #21558