### PR TITLE
refactor(rust): Add freeze_reset to the builders

### DIFF
--- a/crates/polars-arrow/src/array/boolean/builder.rs
+++ b/crates/polars-arrow/src/array/boolean/builder.rs
@@ -39,6 +39,12 @@ impl StaticArrayBuilder for BooleanArrayBuilder {
         BooleanArray::try_new(self.dtype, values, validity).unwrap()
     }
 
+    fn freeze_reset(&mut self) -> Self::Array {
+        let values = core::mem::take(&mut self.values).freeze();
+        let validity = core::mem::take(&mut self.validity).into_opt_validity();
+        BooleanArray::try_new(self.dtype.clone(), values, validity).unwrap()
+    }
+
     fn len(&self) -> usize {
         self.values.len()
     }

--- a/crates/polars-arrow/src/array/builder.rs
+++ b/crates/polars-arrow/src/array/builder.rs
@@ -28,6 +28,9 @@ pub trait StaticArrayBuilder {
     /// Consume this builder returning the built array.
     fn freeze(self) -> Self::Array;
 
+    /// Return the built array and reset to an empty state.
+    fn freeze_reset(&mut self) -> Self::Array;
+
     /// Returns the length of this builder (so far).
     fn len(&self) -> usize;
 
@@ -97,6 +100,11 @@ impl<T: StaticArrayBuilder> ArrayBuilder for T {
     }
 
     #[inline(always)]
+    fn freeze_reset(&mut self) -> Box<dyn Array> {
+        Box::new(StaticArrayBuilder::freeze_reset(self))
+    }
+
+    #[inline(always)]
     fn len(&self) -> usize {
         StaticArrayBuilder::len(self)
     }
@@ -151,6 +159,9 @@ pub trait ArrayBuilder: ArrayBuilderBoxedHelper {
 
     /// Consume this builder returning the built array.
     fn freeze(self) -> Box<dyn Array>;
+
+    /// Return the built array and reset to an empty state.
+    fn freeze_reset(&mut self) -> Box<dyn Array>;
 
     /// Returns the length of this builder (so far).
     fn len(&self) -> usize;
@@ -225,6 +236,11 @@ impl ArrayBuilder for Box<dyn ArrayBuilder> {
     #[inline(always)]
     fn freeze(self) -> Box<dyn Array> {
         self.freeze_boxed()
+    }
+
+    #[inline(always)]
+    fn freeze_reset(&mut self) -> Box<dyn Array> {
+        (**self).freeze_reset()
     }
 
     #[inline(always)]

--- a/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
@@ -48,6 +48,16 @@ impl StaticArrayBuilder for FixedSizeBinaryArrayBuilder {
         FixedSizeBinaryArray::new(self.dtype, values, validity)
     }
 
+    fn freeze_reset(&mut self) -> Self::Array {
+        // TODO: FixedSizeBinaryArray should track its own length to be correct
+        // for size-0 inner.
+        let values = Buffer::from(core::mem::take(&mut self.values));
+        let validity = core::mem::take(&mut self.validity).into_opt_validity();
+        let out = FixedSizeBinaryArray::new(self.dtype.clone(), values, validity);
+        self.length = 0;
+        out
+    }
+
     fn len(&self) -> usize {
         self.length
     }

--- a/crates/polars-arrow/src/array/fixed_size_list/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/builder.rs
@@ -42,6 +42,14 @@ impl<B: ArrayBuilder> StaticArrayBuilder for FixedSizeListArrayBuilder<B> {
         FixedSizeListArray::new(self.dtype, self.length, values, validity)
     }
 
+    fn freeze_reset(&mut self) -> Self::Array {
+        let values = self.inner_builder.freeze_reset();
+        let validity = core::mem::take(&mut self.validity).into_opt_validity();
+        let out = FixedSizeListArray::new(self.dtype.clone(), self.length, values, validity);
+        self.length = 0;
+        out
+    }
+
     fn len(&self) -> usize {
         self.length
     }

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -45,6 +45,13 @@ impl<O: Offset, B: ArrayBuilder> StaticArrayBuilder for ListArrayBuilder<O, B> {
         ListArray::new(self.dtype, offsets, values, validity)
     }
 
+    fn freeze_reset(&mut self) -> Self::Array {
+        let offsets = OffsetsBuffer::from(core::mem::take(&mut self.offsets));
+        let values = self.inner_builder.freeze_reset();
+        let validity = core::mem::take(&mut self.validity).into_opt_validity();
+        ListArray::new(self.dtype.clone(), offsets, values, validity)
+    }
+
     fn len(&self) -> usize {
         self.offsets.len()
     }

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -240,6 +240,12 @@ impl StaticArrayBuilder for NullArrayBuilder {
         NullArray::new(self.dtype, self.length)
     }
 
+    fn freeze_reset(&mut self) -> Self::Array {
+        let out = NullArray::new(self.dtype.clone(), self.length);
+        self.length = 0;
+        out
+    }
+
     fn len(&self) -> usize {
         self.length
     }

--- a/crates/polars-arrow/src/array/primitive/builder.rs
+++ b/crates/polars-arrow/src/array/primitive/builder.rs
@@ -42,6 +42,12 @@ impl<T: NativeType> StaticArrayBuilder for PrimitiveArrayBuilder<T> {
         PrimitiveArray::new(self.dtype, values, validity)
     }
 
+    fn freeze_reset(&mut self) -> Self::Array {
+        let values = Buffer::from(core::mem::take(&mut self.values));
+        let validity = core::mem::take(&mut self.validity).into_opt_validity();
+        PrimitiveArray::new(self.dtype.clone(), values, validity)
+    }
+
     fn len(&self) -> usize {
         self.values.len()
     }

--- a/crates/polars-arrow/src/array/struct_/builder.rs
+++ b/crates/polars-arrow/src/array/struct_/builder.rs
@@ -47,6 +47,18 @@ impl StaticArrayBuilder for StructArrayBuilder {
         StructArray::new(self.dtype, self.length, values, validity)
     }
 
+    fn freeze_reset(&mut self) -> Self::Array {
+        let values = self
+            .inner_builders
+            .iter_mut()
+            .map(|b| b.freeze_reset())
+            .collect();
+        let validity = core::mem::take(&mut self.validity).into_opt_validity();
+        let out = StructArray::new(self.dtype.clone(), self.length, values, validity);
+        self.length = 0;
+        out
+    }
+
     fn len(&self) -> usize {
         self.length
     }

--- a/crates/polars-core/src/frame/builder.rs
+++ b/crates/polars-core/src/frame/builder.rs
@@ -50,6 +50,25 @@ impl DataFrameBuilder {
         unsafe { DataFrame::new_no_checks(self.height, columns) }
     }
 
+    pub fn freeze_reset(&mut self) -> DataFrame {
+        let columns = self
+            .schema
+            .iter_names()
+            .zip(&mut self.builders)
+            .map(|(n, b)| {
+                let s = b.freeze_reset(n.clone());
+                assert!(s.len() == self.height);
+                Column::from(s)
+            })
+            .collect();
+
+        // SAFETY: we checked the lengths and the names are unique because they
+        // come from Schema.
+        let out = unsafe { DataFrame::new_no_checks(self.height, columns) };
+        self.height = 0;
+        out
+    }
+
     pub fn len(&self) -> usize {
         self.height
     }

--- a/crates/polars-core/src/series/builder.rs
+++ b/crates/polars-core/src/series/builder.rs
@@ -27,6 +27,16 @@ impl SeriesBuilder {
         }
     }
 
+    pub fn freeze_reset(&mut self, name: PlSmallStr) -> Series {
+        unsafe {
+            Series::from_chunks_and_dtype_unchecked(
+                name,
+                vec![self.builder.freeze_reset()],
+                &self.dtype,
+            )
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.builder.len()
     }


### PR DESCRIPTION
This should avoid some extra overhead from repeatedly making builders.