### PR TITLE
feat: Enable new streaming memory sinks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ import times:
 If you have data that does not fit into memory, Polars' query engine is able to process your query
 (or parts of your query) in a streaming fashion. This drastically reduces memory requirements, so
 you might be able to process your 250GB dataset on your laptop. Collect with
-`collect(streaming=True)` to run the query streaming. (This might be a little slower, but it is
+`collect(engine='streaming')` to run the query streaming. (This might be a little slower, but it is
 still very fast!)
 
 ## Setup

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -1084,7 +1084,8 @@ pub fn create_enum_dtype(categories: Utf8ViewArray) -> DataType {
     DataType::Enum(Some(Arc::new(rev_map)), Default::default())
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompatLevel(pub(crate) u16);
 
 impl CompatLevel {

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -1084,7 +1084,7 @@ pub fn create_enum_dtype(categories: Utf8ViewArray) -> DataType {
     DataType::Enum(Some(Arc::new(rev_map)), Default::default())
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct CompatLevel(pub(crate) u16);
 
 impl CompatLevel {

--- a/crates/polars-io/src/ipc/write.rs
+++ b/crates/polars-io/src/ipc/write.rs
@@ -16,6 +16,8 @@ pub struct IpcWriterOptions {
     pub compression: Option<IpcCompression>,
     /// Compatibility level
     pub compat_level: CompatLevel,
+    /// Size of each written chunk.
+    pub chunk_size: IdxSize,
 }
 
 impl Default for IpcWriterOptions {
@@ -23,6 +25,7 @@ impl Default for IpcWriterOptions {
         Self {
             compression: None,
             compat_level: CompatLevel::newest(),
+            chunk_size: 1 << 18,
         }
     }
 }

--- a/crates/polars-io/src/ipc/write.rs
+++ b/crates/polars-io/src/ipc/write.rs
@@ -9,11 +9,22 @@ use serde::{Deserialize, Serialize};
 use crate::prelude::*;
 use crate::shared::schema_to_arrow_checked;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IpcWriterOptions {
     /// Data page compression
     pub compression: Option<IpcCompression>,
+    /// Compatibility level
+    pub compat_level: CompatLevel,
+}
+
+impl Default for IpcWriterOptions {
+    fn default() -> Self {
+        Self {
+            compression: None,
+            compat_level: CompatLevel::newest(),
+        }
+    }
 }
 
 impl IpcWriterOptions {

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -746,6 +746,7 @@ impl LazyFrame {
         match engine {
             #[cfg(feature = "new_streaming")]
             Engine::Streaming => self = self.with_new_streaming(true),
+            #[cfg(feature = "streaming")]
             Engine::OldStreaming => self = self.with_streaming(true),
             _ => {},
         }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -803,9 +803,6 @@ impl LazyFrame {
     /// ```
     pub fn collect(self) -> PolarsResult<DataFrame> {
         self.collect_with_engine(Engine::InMemory)
-
-        #[cfg(not(feature = "new_streaming"))]
-        self._collect_post_opt(|_, _, _, _| Ok(()))
     }
 
     // post_opt: A function that is called after optimization. This can be used to modify the IR jit.

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -215,6 +215,18 @@ pub enum Engine {
     Gpu,
 }
 
+impl Engine {
+    pub fn into_static_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::OldStreaming => "old-streaming",
+            Self::Streaming => "streaming",
+            Self::InMemory => "in-memory",
+            Self::Gpu => "gpu",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UnionOptions {

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -205,6 +205,15 @@ pub struct FileScanOptions {
     pub allow_missing_columns: bool,
 }
 
+#[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Engine {
+    OldStreaming,
+    Streaming,
+    InMemory,
+    Gpu,
+}
+
 #[derive(Clone, Debug, Copy, Default, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UnionOptions {

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -208,6 +208,7 @@ pub struct FileScanOptions {
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Engine {
+    Auto,
     OldStreaming,
     Streaming,
     InMemory,

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -2,6 +2,7 @@ use std::hash::Hash;
 #[cfg(feature = "json")]
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use polars_core::error::PolarsResult;
@@ -213,6 +214,24 @@ pub enum Engine {
     Streaming,
     InMemory,
     Gpu,
+}
+
+impl FromStr for Engine {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            // "cpu" for backwards compatibility
+            "auto" => Ok(Engine::Auto),
+            "cpu" | "in-memory" => Ok(Engine::InMemory),
+            "streaming" => Ok(Engine::Streaming),
+            "old-streaming" => Ok(Engine::OldStreaming),
+            "gpu" => Ok(Engine::Gpu),
+            v => Err(format!(
+                "`engine` must be one of {{'auto', 'in-memory', 'streaming', 'old-streaming', 'gpu'}}, got {v}",
+            )),
+        }
+    }
 }
 
 impl Engine {

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -691,7 +691,7 @@ impl PyLazyFrame {
     #[cfg(all(feature = "streaming", feature = "parquet"))]
     #[pyo3(signature = (
         target, compression, compression_level, statistics, row_group_size, data_page_size,
-        cloud_options, credential_provider, retries, sink_options
+        cloud_options, credential_provider, retries, sink_options, engine
     ))]
     fn sink_parquet(
         &self,
@@ -706,6 +706,7 @@ impl PyLazyFrame {
         credential_provider: Option<PyObject>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
+        engine: Wrap<Engine>,
     ) -> PyResult<()> {
         let compression = parse_parquet_compression(compression, compression_level)?;
 
@@ -738,6 +739,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    engine.0,
                 ),
                 SinkTarget::Partition(partition) => ldf.sink_parquet_partitioned(
                     partition.path.as_ref(),
@@ -745,13 +747,16 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    engine.0,
                 ),
             }
         })
     }
 
     #[cfg(all(feature = "streaming", feature = "ipc"))]
-    #[pyo3(signature = (target, compression, cloud_options, credential_provider, retries, sink_options))]
+    #[pyo3(signature = (
+        target, compression, cloud_options, credential_provider, retries, sink_options, engine
+    ))]
     fn sink_ipc(
         &self,
         py: Python,
@@ -761,6 +766,7 @@ impl PyLazyFrame {
         credential_provider: Option<PyObject>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
+        engine: Wrap<Engine>,
     ) -> PyResult<()> {
         let options = IpcWriterOptions {
             compression: compression.map(|c| c.0),
@@ -788,7 +794,7 @@ impl PyLazyFrame {
             let ldf = self.ldf.clone();
             match target {
                 SinkTarget::Path(path) => {
-                    ldf.sink_ipc(path, options, cloud_options, sink_options.0)
+                    ldf.sink_ipc(path, options, cloud_options, sink_options.0, engine.0)
                 },
                 SinkTarget::Partition(partition) => ldf.sink_ipc_partitioned(
                     partition.path.as_ref(),
@@ -796,6 +802,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    engine.0,
                 ),
             }
         })
@@ -805,7 +812,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (
         target, include_bom, include_header, separator, line_terminator, quote_char, batch_size,
         datetime_format, date_format, time_format, float_scientific, float_precision, null_value,
-        quote_style, cloud_options, credential_provider, retries, sink_options
+        quote_style, cloud_options, credential_provider, retries, sink_options, engine
     ))]
     fn sink_csv(
         &self,
@@ -828,6 +835,7 @@ impl PyLazyFrame {
         credential_provider: Option<PyObject>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
+        engine: Wrap<Engine>,
     ) -> PyResult<()> {
         let quote_style = quote_style.map_or(QuoteStyle::default(), |wrap| wrap.0);
         let null_value = null_value.unwrap_or(SerializeOptions::default().null);
@@ -874,7 +882,7 @@ impl PyLazyFrame {
             let ldf = self.ldf.clone();
             match target {
                 SinkTarget::Path(path) => {
-                    ldf.sink_csv(path, options, cloud_options, sink_options.0)
+                    ldf.sink_csv(path, options, cloud_options, sink_options.0, engine.0)
                 },
                 SinkTarget::Partition(partition) => ldf.sink_csv_partitioned(
                     partition.path.as_ref(),
@@ -882,6 +890,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    engine.0,
                 ),
             }
         })
@@ -889,7 +898,7 @@ impl PyLazyFrame {
 
     #[allow(clippy::too_many_arguments)]
     #[cfg(all(feature = "streaming", feature = "json"))]
-    #[pyo3(signature = (target, cloud_options, credential_provider, retries, sink_options))]
+    #[pyo3(signature = (target, cloud_options, credential_provider, retries, sink_options, engine))]
     fn sink_json(
         &self,
         py: Python,
@@ -898,6 +907,7 @@ impl PyLazyFrame {
         credential_provider: Option<PyObject>,
         retries: usize,
         sink_options: Wrap<SinkOptions>,
+        engine: Wrap<Engine>,
     ) -> PyResult<()> {
         let options = JsonWriterOptions {};
 
@@ -919,7 +929,7 @@ impl PyLazyFrame {
             let ldf = self.ldf.clone();
             match target {
                 SinkTarget::Path(path) => {
-                    ldf.sink_json(path, options, cloud_options, sink_options.0)
+                    ldf.sink_json(path, options, cloud_options, sink_options.0, engine.0)
                 },
                 SinkTarget::Partition(partition) => ldf.sink_json_partitioned(
                     partition.path.as_ref(),
@@ -927,6 +937,7 @@ impl PyLazyFrame {
                     options,
                     cloud_options,
                     sink_options.0,
+                    engine.0,
                 ),
             }
         })

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -651,7 +651,12 @@ impl PyLazyFrame {
     }
 
     #[pyo3(signature = (engine, lambda_post_opt=None))]
-    fn collect(&self, py: Python, engine: Wrap<Engine>, lambda_post_opt: Option<PyObject>) -> PyResult<PyDataFrame> {
+    fn collect(
+        &self,
+        py: Python,
+        engine: Wrap<Engine>,
+        lambda_post_opt: Option<PyObject>,
+    ) -> PyResult<PyDataFrame> {
         py.enter_polars_df(|| {
             let ldf = self.ldf.clone();
             if let Some(lambda) = lambda_post_opt {

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -773,6 +773,7 @@ impl PyLazyFrame {
         let options = IpcWriterOptions {
             compression: compression.map(|c| c.0),
             compat_level: compat_level.0,
+            ..Default::default()
         };
 
         #[cfg(feature = "cloud")]

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -755,13 +755,15 @@ impl PyLazyFrame {
 
     #[cfg(all(feature = "streaming", feature = "ipc"))]
     #[pyo3(signature = (
-        target, compression, cloud_options, credential_provider, retries, sink_options, engine
+        target, compression, compat_level, cloud_options, credential_provider, retries,
+        sink_options, engine
     ))]
     fn sink_ipc(
         &self,
         py: Python,
         target: SinkTarget,
         compression: Option<Wrap<IpcCompression>>,
+        compat_level: PyCompatLevel,
         cloud_options: Option<Vec<(String, String)>>,
         credential_provider: Option<PyObject>,
         retries: usize,
@@ -770,6 +772,7 @@ impl PyLazyFrame {
     ) -> PyResult<()> {
         let options = IpcWriterOptions {
             compression: compression.map(|c| c.0),
+            compat_level: compat_level.0,
         };
 
         #[cfg(feature = "cloud")]

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -659,7 +659,7 @@ impl PyLazyFrame {
                     post_opt_callback(&lambda, root, lp_arena, expr_arena, None)
                 })
             } else {
-                ldf.collect_with_engine(engine)
+                ldf.collect_with_engine(engine.0)
             }
         })
     }
@@ -670,7 +670,7 @@ impl PyLazyFrame {
 
         polars_core::POOL.spawn(move || {
             let result = ldf
-                .collect_with_engine(engine)
+                .collect_with_engine(engine.0)
                 .map(PyDataFrame::new)
                 .map_err(PyPolarsErr::from);
 

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -9,9 +9,14 @@ pub mod visitor;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use exitable::PyInProcessQuery;
-use polars::prelude::LazyFrame;
-use pyo3::pyclass;
+use polars::prelude::{Engine, LazyFrame};
+use pyo3::exceptions::PyValueError;
+use pyo3::pybacked::PyBackedStr;
+use pyo3::types::PyAnyMethods;
+use pyo3::{pyclass, Bound, FromPyObject, PyAny, PyResult};
 pub use sink::{PyPartitioning, SinkTarget};
+
+use crate::prelude::Wrap;
 
 #[pyclass]
 #[repr(transparent)]
@@ -23,5 +28,23 @@ pub struct PyLazyFrame {
 impl From<LazyFrame> for PyLazyFrame {
     fn from(ldf: LazyFrame) -> Self {
         PyLazyFrame { ldf }
+    }
+}
+
+impl<'py> FromPyObject<'py> for Wrap<Engine> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let parsed = match &*ob.extract::<PyBackedStr>()? {
+            // "cpu" for backwards compatibility
+            "cpu" | "in-memory" => Engine::InMemory,
+            "streaming" => Engine::Streaming,
+            "old-streaming" => Engine::OldStreaming,
+            "gpu" => Engine::Gpu,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "`engine` must be one of {{'in-memory', 'streaming', 'old-streaming', 'gpu'}}, got {v}",
+                )))
+            },
+        };
+        Ok(Wrap(parsed))
     }
 }

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -33,7 +33,10 @@ impl From<LazyFrame> for PyLazyFrame {
 
 impl<'py> FromPyObject<'py> for Wrap<Engine> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let parsed = ob.extract::<PyBackedStr>()?.parse().map_err(PyValueError::new_err)?;
+        let parsed = ob
+            .extract::<PyBackedStr>()?
+            .parse()
+            .map_err(PyValueError::new_err)?;
         Ok(Wrap(parsed))
     }
 }

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -35,13 +35,14 @@ impl<'py> FromPyObject<'py> for Wrap<Engine> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let parsed = match &*ob.extract::<PyBackedStr>()? {
             // "cpu" for backwards compatibility
+            "auto" => Engine::Auto,
             "cpu" | "in-memory" => Engine::InMemory,
             "streaming" => Engine::Streaming,
             "old-streaming" => Engine::OldStreaming,
             "gpu" => Engine::Gpu,
             v => {
                 return Err(PyValueError::new_err(format!(
-                    "`engine` must be one of {{'in-memory', 'streaming', 'old-streaming', 'gpu'}}, got {v}",
+                    "`engine` must be one of {{'auto', 'in-memory', 'streaming', 'old-streaming', 'gpu'}}, got {v}",
                 )))
             },
         };

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -33,19 +33,7 @@ impl From<LazyFrame> for PyLazyFrame {
 
 impl<'py> FromPyObject<'py> for Wrap<Engine> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let parsed = match &*ob.extract::<PyBackedStr>()? {
-            // "cpu" for backwards compatibility
-            "auto" => Engine::Auto,
-            "cpu" | "in-memory" => Engine::InMemory,
-            "streaming" => Engine::Streaming,
-            "old-streaming" => Engine::OldStreaming,
-            "gpu" => Engine::Gpu,
-            v => {
-                return Err(PyValueError::new_err(format!(
-                    "`engine` must be one of {{'auto', 'in-memory', 'streaming', 'old-streaming', 'gpu'}}, got {v}",
-                )))
-            },
-        };
+        let parsed = ob.extract::<PyBackedStr>()?.parse().map_err(PyValueError::new_err)?;
         Ok(Wrap(parsed))
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -107,9 +107,7 @@ impl SinkNode for IpcSinkNode {
             compression: self.write_options.compression.map(Into::into),
         };
 
-        let chunk_size = self
-            .write_options
-            .chunk_size;
+        let chunk_size = self.write_options.chunk_size;
 
         let ipc_fields = self
             .input_schema

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -2,7 +2,6 @@ use std::cmp::Reverse;
 use std::io::BufWriter;
 use std::path::PathBuf;
 
-use polars_core::prelude::CompatLevel;
 use polars_core::schema::{SchemaExt, SchemaRef};
 use polars_core::utils::arrow;
 use polars_core::utils::arrow::array::Array;
@@ -27,7 +26,6 @@ use crate::async_executor::spawn;
 use crate::async_primitives::connector::connector;
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
-use crate::morsel::get_ideal_morsel_size;
 use crate::nodes::io_sinks::sync_on_close;
 use crate::nodes::{JoinHandle, TaskPriority};
 
@@ -37,10 +35,6 @@ pub struct IpcSinkNode {
     input_schema: SchemaRef,
     write_options: IpcWriterOptions,
     sink_options: SinkOptions,
-
-    compat_level: CompatLevel,
-
-    chunk_size: usize,
     cloud_options: Option<CloudOptions>,
 }
 
@@ -58,10 +52,6 @@ impl IpcSinkNode {
             input_schema,
             write_options,
             sink_options,
-
-            compat_level: CompatLevel::newest(), // @TODO: make this accessible from outside
-
-            chunk_size: get_ideal_morsel_size(), // @TODO: change to something more appropriate
             cloud_options,
         }
     }
@@ -117,13 +107,14 @@ impl SinkNode for IpcSinkNode {
             compression: self.write_options.compression.map(Into::into),
         };
 
-        let compat_level = self.compat_level;
-        let chunk_size = self.chunk_size;
+        let chunk_size = self
+            .write_options
+            .chunk_size;
 
         let ipc_fields = self
             .input_schema
             .iter_fields()
-            .map(|f| f.to_arrow(compat_level))
+            .map(|f| f.to_arrow(self.write_options.compat_level))
             .collect::<Vec<_>>();
         let ipc_fields = default_ipc_fields(ipc_fields.iter());
 
@@ -131,7 +122,7 @@ impl SinkNode for IpcSinkNode {
         join_handles.push(buffer_and_distribute_columns_task(
             buffer_rx,
             dist_tx,
-            chunk_size,
+            chunk_size as usize,
             self.input_schema.clone(),
         ));
 
@@ -143,6 +134,7 @@ impl SinkNode for IpcSinkNode {
                 .into_iter()
                 .zip(lin_txs)
                 .map(|(mut dist_rx, mut lin_tx)| {
+                    let write_options = self.write_options;
                     spawn(TaskPriority::High, async move {
                         while let Ok((seq, col_idx, column)) = dist_rx.recv().await {
                             let mut variadic_buffer_counts = Vec::new();
@@ -158,7 +150,7 @@ impl SinkNode for IpcSinkNode {
                             //
                             // This also properly sets the inner types of the record batches, which is
                             // important for dictionary and nested type encoding.
-                            let array = column.rechunk_to_arrow(compat_level);
+                            let array = column.rechunk_to_arrow(write_options.compat_level);
 
                             // Encode array.
                             encode_array(

--- a/docs/source/src/python/user-guide/concepts/streaming.py
+++ b/docs/source/src/python/user-guide/concepts/streaming.py
@@ -10,11 +10,11 @@ q1 = (
     .group_by("species")
     .agg(pl.col("sepal_width").mean())
 )
-df = q1.collect(engine='streaming')
+df = q1.collect(engine="streaming")
 # --8<-- [end:streaming]
 
 # --8<-- [start:example]
-print(q1.explain(engine='streaming'))
+print(q1.explain(engine="streaming"))
 
 # --8<-- [end:example]
 
@@ -23,5 +23,5 @@ q2 = pl.scan_csv("docs/assets/data/iris.csv").with_columns(
     pl.col("sepal_length").mean().over("species")
 )
 
-print(q2.explain(engine='streaming'))
+print(q2.explain(engine="streaming"))
 # --8<-- [end:example2]

--- a/docs/source/src/python/user-guide/concepts/streaming.py
+++ b/docs/source/src/python/user-guide/concepts/streaming.py
@@ -10,11 +10,11 @@ q1 = (
     .group_by("species")
     .agg(pl.col("sepal_width").mean())
 )
-df = q1.collect(streaming=True)
+df = q1.collect(engine='streaming')
 # --8<-- [end:streaming]
 
 # --8<-- [start:example]
-print(q1.explain(streaming=True))
+print(q1.explain(engine='streaming'))
 
 # --8<-- [end:example]
 
@@ -23,5 +23,5 @@ q2 = pl.scan_csv("docs/assets/data/iris.csv").with_columns(
     pl.col("sepal_length").mean().over("species")
 )
 
-print(q2.explain(streaming=True))
+print(q2.explain(engine='streaming'))
 # --8<-- [end:example2]

--- a/docs/source/src/python/user-guide/lazy/execution.py
+++ b/docs/source/src/python/user-guide/lazy/execution.py
@@ -25,7 +25,7 @@ q5 = (
     pl.scan_csv(f"docs/assets/data/reddit.csv")
     .with_columns(pl.col("name").str.to_uppercase())
     .filter(pl.col("comment_karma") > 0)
-    .collect(streaming=True)
+    .collect(engine='streaming')
 )
 # --8<-- [end:stream]
 # --8<-- [start:partial]

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -305,7 +305,7 @@ MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, Boole
 
 # LazyFrame engine selection
 EngineType: TypeAlias = Union[
-    Literal["in-memory", "streaming", "old-streaming", "gpu"], "GPUEngine"
+    Literal["auto", "in-memory", "streaming", "old-streaming", "gpu"], "GPUEngine"
 ]
 
 FileSource: TypeAlias = Union[

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -304,7 +304,9 @@ SingleColSelector: TypeAlias = Union[SingleIndexSelector, SingleNameSelector]
 MultiColSelector: TypeAlias = Union[MultiIndexSelector, MultiNameSelector, BooleanMask]
 
 # LazyFrame engine selection
-EngineType: TypeAlias = Union[Literal["cpu", "gpu"], "GPUEngine"]
+EngineType: TypeAlias = Union[
+    Literal["in-memory", "streaming", "old-streaming", "gpu"], "GPUEngine"
+]
 
 FileSource: TypeAlias = Union[
     str,

--- a/py-polars/polars/_utils/cloud.py
+++ b/py-polars/polars/_utils/cloud.py
@@ -34,5 +34,5 @@ def prepare_cloud_plan(
     ComputeError
         If the given LazyFrame cannot be serialized.
     """
-    pylf = lf._set_sink_optimizations(**optimizations)
+    pylf = lf._set_sink_optimizations(engine="old-streaming", **optimizations)
     return plr.prepare_cloud_plan(pylf)

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -332,7 +332,7 @@ def _post_apply_columns(
             pydf = pydf.with_columns(column_casts)
         if column_subset:
             pydf = pydf.select([F.col(col)._pyexpr for col in column_subset])
-        pydf = pydf.collect()
+        pydf = pydf.collect(engine='in-memory')
 
     return pydf
 

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -332,7 +332,7 @@ def _post_apply_columns(
             pydf = pydf.with_columns(column_casts)
         if column_subset:
             pydf = pydf.select([F.col(col)._pyexpr for col in column_subset])
-        pydf = pydf.collect(engine='in-memory')
+        pydf = pydf.collect(engine="in-memory")
 
     return pydf
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -158,7 +158,7 @@ def _gpu_engine_callback(
     is_gpu = (is_config_obj := isinstance(engine, GPUEngine)) or engine == "gpu"
     if not (
         is_config_obj
-        or engine in ("cpu", "in-memory", "streaming", "old-streaming", "gpu")
+        or engine in ("auto", "cpu", "in-memory", "streaming", "old-streaming", "gpu")
     ):
         msg = f"Invalid engine argument {engine=}"
         raise ValueError(msg)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3248,7 +3248,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             comm_subexpr_elim=comm_subexpr_elim,
             cluster_with_columns=cluster_with_columns,
             collapse_joins=collapse_joins,
-            engine="old-streaming" if streaming else "in-memory",
+            streaming=streaming,
         )
 
     def _fetch(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -156,7 +156,10 @@ def _gpu_engine_callback(
     _eager: bool,
 ) -> Callable[[Any, int | None], None] | None:
     is_gpu = (is_config_obj := isinstance(engine, GPUEngine)) or engine == "gpu"
-    if not (is_config_obj or engine in ("cpu", "in-memory", "streaming", "old-streaming", "gpu")):
+    if not (
+        is_config_obj
+        or engine in ("cpu", "in-memory", "streaming", "old-streaming", "gpu")
+    ):
         msg = f"Invalid engine argument {engine=}"
         raise ValueError(msg)
     if (streaming or background or new_streaming) and is_gpu:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2133,7 +2133,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         # Only for testing purposes
         callback = _kwargs.get("post_opt_callback", callback)
-        return wrap_df(ldf.collect_with_engine(engine, callback))
+        return wrap_df(ldf.collect(engine, callback))
 
     @overload
     def collect_async(

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -507,9 +507,9 @@ def test_decimal_streaming() -> None:
         {"group": choice("abc"), "value": randrange(10**32) / scale} for _ in range(20)
     ]
     lf = pl.LazyFrame(data, schema_overrides={"value": pl.Decimal(scale=18)})
-    assert lf.group_by("group").agg(pl.sum("value")).collect(streaming=True).sort(
-        "group"
-    ).to_dict(as_series=False) == {
+    assert lf.group_by("group").agg(pl.sum("value")).collect(
+        engine="old-streaming"
+    ).sort("group").to_dict(as_series=False) == {
         "group": ["a", "b", "c"],
         "value": [
             D("244215083629512.120161049441284000"),

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -1126,7 +1126,12 @@ def test_zfs_row_encoding(size: int) -> None:
 
     df = pl.DataFrame([a, pl.Series("x", list(range(size)), pl.Int8)])
 
-    gb = df.lazy().group_by(["a", "x"]).agg(pl.all().min()).collect(streaming=True)
+    gb = (
+        df.lazy()
+        .group_by(["a", "x"])
+        .agg(pl.all().min())
+        .collect(engine="old-streaming")
+    )
 
     # We need to ignore the order because the group_by is non-deterministic
     assert_frame_equal(gb, df, check_row_order=False)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2397,7 +2397,7 @@ time
     assert_frame_equal(pl.scan_csv(path, try_parse_dates=True).collect(), df)
     assert_frame_equal(pl.scan_csv(path, schema={"time": pl.Time}).collect(), df)
     assert_frame_equal(
-        pl.scan_csv(path, schema={"time": pl.Time}).collect(streaming=True), df
+        pl.scan_csv(path, schema={"time": pl.Time}).collect(engine="old-streaming"), df
     )
 
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2205,7 +2205,9 @@ def test_skip_rows_after_header(tmp_path: Path, streaming: bool) -> None:
 
     skip = 2
     expect = df.slice(skip)
-    out = pl.scan_csv(path, skip_rows_after_header=skip).collect(streaming=streaming)
+    out = pl.scan_csv(path, skip_rows_after_header=skip).collect(
+        engine="old-streaming" if streaming else "in-memory"
+    )
 
     assert_frame_equal(out, expect)
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -56,7 +56,9 @@ def impl_test_hive_partitioned_predicate_pushdown(
             (pl.col("fats_g") == 0.5) & (pl.col("category") == "vegetables"),
         ]:
             assert_frame_equal(
-                q.filter(pred).sort(sort_by).collect(streaming=streaming),
+                q.filter(pred)
+                .sort(sort_by)
+                .collect(engine="old-streaming" if streaming else "in-memory"),
                 df.filter(pred).sort(sort_by),
             )
             err = capfd.readouterr().err
@@ -162,9 +164,14 @@ def test_hive_partitioned_slice_pushdown(
     expect_count = pl.select(pl.lit(1, dtype=pl.UInt32).alias(x) for x in schema)
 
     assert_frame_equal(
-        q.head(1).collect(streaming=streaming).select(pl.all().len()), expect_count
+        q.head(1)
+        .collect(engine="old-streaming" if streaming else "in-memory")
+        .select(pl.all().len()),
+        expect_count,
     )
-    assert q.head(0).collect(streaming=streaming).columns == [
+    assert q.head(0).collect(
+        engine="old-streaming" if streaming else "in-memory"
+    ).columns == [
         "calories",
         "sugars_g",
         "category",
@@ -193,7 +200,12 @@ def test_hive_partitioned_projection_pushdown(
     q = pl.scan_parquet(root / "**/*.parquet", hive_partitioning=True)
     columns = ["sugars_g", "category"]
     for streaming in [True, False]:
-        assert q.select(columns).collect(streaming=streaming).columns == columns
+        assert (
+            q.select(columns)
+            .collect(engine="old-streaming" if streaming else "in-memory")
+            .columns
+            == columns
+        )
 
     # test that hive partition columns are projected with the correct height when
     # the projection contains only hive partition columns (11796)

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -358,11 +358,13 @@ def test_file_list_schema_mismatch(
 
     lf = pl.scan_csv(paths)
     with pytest.raises(ComputeError):
-        lf.collect(streaming=streaming)
+        lf.collect(engine="old-streaming" if streaming else "in-memory")
 
     if len({df.width for df in dfs}) == 1:
         expect = pl.concat(df.select(x=pl.first().cast(pl.Int8)) for df in dfs)
-        out = pl.scan_csv(paths, schema={"x": pl.Int8}).collect(streaming=streaming)
+        out = pl.scan_csv(paths, schema={"x": pl.Int8}).collect(
+            engine="old-streaming" if streaming else "in-memory"
+        )
 
         assert_frame_equal(out, expect)
 
@@ -392,7 +394,9 @@ c
             f.write(data)
 
     expect = pl.Series("a", ["1", "2", "b", "c"]).to_frame()
-    out = pl.scan_csv(paths).collect(streaming=streaming)
+    out = pl.scan_csv(paths).collect(
+        engine="old-streaming" if streaming else "in-memory"
+    )
 
     assert_frame_equal(out, expect)
 
@@ -422,7 +426,9 @@ c
             f.write(data)
 
     expect = pl.Series("a", ["b", "c", "b", "c"]).to_frame()
-    out = pl.scan_csv(paths, comment_prefix="#").collect(streaming=streaming)
+    out = pl.scan_csv(paths, comment_prefix="#").collect(
+        engine="old-streaming" if streaming else "in-memory"
+    )
 
     assert_frame_equal(out, expect)
 

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -133,9 +133,9 @@ def test_multiscan_projection(
     ]:
         assert_frame_equal(
             scan(multiscan_path, **args)
-            .collect(new_streaming=True)  # type: ignore[call-overload]
+            .collect(engine="streaming")  # type: ignore[call-overload]
             .select(projection),
-            scan(multiscan_path, **args).select(projection).collect(new_streaming=True),  # type: ignore[call-overload]
+            scan(multiscan_path, **args).select(projection).collect(engine="streaming"),  # type: ignore[call-overload]
         )
 
     for remove in range(len(base_projection)):
@@ -149,11 +149,11 @@ def test_multiscan_projection(
             print(projection)
             assert_frame_equal(
                 scan(multiscan_path, **args)
-                .collect(new_streaming=True)  # type: ignore[call-overload]
+                .collect(engine="streaming")  # type: ignore[call-overload]
                 .select(projection),
                 scan(multiscan_path, **args)
                 .select(projection)
-                .collect(new_streaming=True),  # type: ignore[call-overload]
+                .collect(engine="streaming"),  # type: ignore[call-overload]
             )
 
 
@@ -188,7 +188,7 @@ def test_multiscan_hive_predicate(
     write(b, b_path)
     write(c, c_path)
 
-    full = scan(multiscan_path).collect(new_streaming=True)  # type: ignore[call-overload]
+    full = scan(multiscan_path).collect(engine="streaming")  # type: ignore[call-overload]
     full_ri = full.with_row_index("ri", 42)
 
     last_pred = None
@@ -209,7 +209,7 @@ def test_multiscan_hive_predicate(
             last_pred = pred
             assert_frame_equal(
                 full.filter(pred),
-                scan(multiscan_path).filter(pred).collect(new_streaming=True),  # type: ignore[call-overload]
+                scan(multiscan_path).filter(pred).collect(engine="streaming"),  # type: ignore[call-overload]
             )
 
             assert_frame_equal(
@@ -217,7 +217,7 @@ def test_multiscan_hive_predicate(
                 scan(multiscan_path)
                 .with_row_index("ri", 42)
                 .filter(pred)
-                .collect(new_streaming=True),  # type: ignore[call-overload]
+                .collect(engine="streaming"),  # type: ignore[call-overload]
             )
     except Exception as _:
         print(last_pred)
@@ -337,7 +337,7 @@ def test_schema_mismatch_type_mismatch(
         pl.exceptions.SchemaError,
         match="data type mismatch for column xyz_col: expected: i64, found: str",
     ):
-        q.collect(new_streaming=True)  # type: ignore[call-overload]
+        q.collect(engine="streaming")  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize(
@@ -377,7 +377,7 @@ def test_schema_mismatch_order_mismatch(
     q = scan(multiscan_path)
 
     with pytest.raises(pl.exceptions.SchemaError):
-        q.collect(new_streaming=True)  # type: ignore[call-overload]
+        q.collect(engine="streaming")  # type: ignore[call-overload]
 
 
 @pytest.mark.parametrize(
@@ -403,7 +403,7 @@ def test_multiscan_head(
         f.seek(0)
 
     assert_frame_equal(
-        scan([a, b]).head(5).collect(new_streaming=True),  # type: ignore[call-overload]
+        scan([a, b]).head(5).collect(engine="streaming"),  # type: ignore[call-overload]
         pl.Series("c1", range(5)).to_frame(),
     )
 
@@ -431,7 +431,7 @@ def test_multiscan_tail(
         f.seek(0)
 
     assert_frame_equal(
-        scan([a, b]).tail(5).collect(new_streaming=True),  # type: ignore[call-overload]
+        scan([a, b]).tail(5).collect(engine="streaming"),  # type: ignore[call-overload]
         pl.Series("c1", range(5, 10)).to_frame(),
     )
 
@@ -469,22 +469,22 @@ def test_multiscan_slice_middle(
     ] + expected_series
 
     assert_frame_equal(
-        scan(fs).slice(offset, 17).collect(new_streaming=True),  # type: ignore[call-overload]
+        scan(fs).slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
         pl.DataFrame(expected_series),
     )
     assert_frame_equal(
-        scan(fs, row_index_name="ri").slice(offset, 17).collect(new_streaming=True),  # type: ignore[call-overload]
+        scan(fs, row_index_name="ri").slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
         pl.DataFrame(ri_expected_series),
     )
 
     # Negative slices
     offset = -(13 * 7 - offset)
     assert_frame_equal(
-        scan(fs).slice(offset, 17).collect(new_streaming=True),  # type: ignore[call-overload]
+        scan(fs).slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
         pl.DataFrame(expected_series),
     )
     assert_frame_equal(
-        scan(fs, row_index_name="ri").slice(offset, 17).collect(new_streaming=True),  # type: ignore[call-overload]
+        scan(fs, row_index_name="ri").slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
         pl.DataFrame(ri_expected_series),
     )
 
@@ -517,7 +517,7 @@ def test_multiscan_slice_parametric(
 
     assert_frame_equal(
         scan(ref).slice(offset, length).collect(),
-        scan(fs).slice(offset, length).collect(new_streaming=True),  # type: ignore[call-overload]
+        scan(fs).slice(offset, length).collect(engine="streaming"),  # type: ignore[call-overload]
     )
 
     ref.seek(0)
@@ -530,7 +530,7 @@ def test_multiscan_slice_parametric(
         .collect(),
         scan(fs, row_index_name="ri", row_index_offset=42)
         .slice(offset, length)
-        .collect(new_streaming=True),  # type: ignore[call-overload]
+        .collect(engine="streaming"),  # type: ignore[call-overload]
     )
 
 

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -132,10 +132,8 @@ def test_multiscan_projection(
         base_projection[::-1],
     ]:
         assert_frame_equal(
-            scan(multiscan_path, **args)
-            .collect(engine="streaming")  # type: ignore[call-overload]
-            .select(projection),
-            scan(multiscan_path, **args).select(projection).collect(engine="streaming"),  # type: ignore[call-overload]
+            scan(multiscan_path, **args).collect(engine="streaming").select(projection),
+            scan(multiscan_path, **args).select(projection).collect(engine="streaming"),
         )
 
     for remove in range(len(base_projection)):
@@ -149,11 +147,11 @@ def test_multiscan_projection(
             print(projection)
             assert_frame_equal(
                 scan(multiscan_path, **args)
-                .collect(engine="streaming")  # type: ignore[call-overload]
+                .collect(engine="streaming")
                 .select(projection),
                 scan(multiscan_path, **args)
                 .select(projection)
-                .collect(engine="streaming"),  # type: ignore[call-overload]
+                .collect(engine="streaming"),
             )
 
 
@@ -188,7 +186,7 @@ def test_multiscan_hive_predicate(
     write(b, b_path)
     write(c, c_path)
 
-    full = scan(multiscan_path).collect(engine="streaming")  # type: ignore[call-overload]
+    full = scan(multiscan_path).collect(engine="streaming")
     full_ri = full.with_row_index("ri", 42)
 
     last_pred = None
@@ -209,7 +207,7 @@ def test_multiscan_hive_predicate(
             last_pred = pred
             assert_frame_equal(
                 full.filter(pred),
-                scan(multiscan_path).filter(pred).collect(engine="streaming"),  # type: ignore[call-overload]
+                scan(multiscan_path).filter(pred).collect(engine="streaming"),
             )
 
             assert_frame_equal(
@@ -217,7 +215,7 @@ def test_multiscan_hive_predicate(
                 scan(multiscan_path)
                 .with_row_index("ri", 42)
                 .filter(pred)
-                .collect(engine="streaming"),  # type: ignore[call-overload]
+                .collect(engine="streaming"),
             )
     except Exception as _:
         print(last_pred)
@@ -337,7 +335,7 @@ def test_schema_mismatch_type_mismatch(
         pl.exceptions.SchemaError,
         match="data type mismatch for column xyz_col: expected: i64, found: str",
     ):
-        q.collect(engine="streaming")  # type: ignore[call-overload]
+        q.collect(engine="streaming")
 
 
 @pytest.mark.parametrize(
@@ -377,7 +375,7 @@ def test_schema_mismatch_order_mismatch(
     q = scan(multiscan_path)
 
     with pytest.raises(pl.exceptions.SchemaError):
-        q.collect(engine="streaming")  # type: ignore[call-overload]
+        q.collect(engine="streaming")
 
 
 @pytest.mark.parametrize(
@@ -403,7 +401,7 @@ def test_multiscan_head(
         f.seek(0)
 
     assert_frame_equal(
-        scan([a, b]).head(5).collect(engine="streaming"),  # type: ignore[call-overload]
+        scan([a, b]).head(5).collect(engine="streaming"),
         pl.Series("c1", range(5)).to_frame(),
     )
 
@@ -431,7 +429,7 @@ def test_multiscan_tail(
         f.seek(0)
 
     assert_frame_equal(
-        scan([a, b]).tail(5).collect(engine="streaming"),  # type: ignore[call-overload]
+        scan([a, b]).tail(5).collect(engine="streaming"),
         pl.Series("c1", range(5, 10)).to_frame(),
     )
 
@@ -469,22 +467,22 @@ def test_multiscan_slice_middle(
     ] + expected_series
 
     assert_frame_equal(
-        scan(fs).slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
+        scan(fs).slice(offset, 17).collect(engine="streaming"),
         pl.DataFrame(expected_series),
     )
     assert_frame_equal(
-        scan(fs, row_index_name="ri").slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
+        scan(fs, row_index_name="ri").slice(offset, 17).collect(engine="streaming"),
         pl.DataFrame(ri_expected_series),
     )
 
     # Negative slices
     offset = -(13 * 7 - offset)
     assert_frame_equal(
-        scan(fs).slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
+        scan(fs).slice(offset, 17).collect(engine="streaming"),
         pl.DataFrame(expected_series),
     )
     assert_frame_equal(
-        scan(fs, row_index_name="ri").slice(offset, 17).collect(engine="streaming"),  # type: ignore[call-overload]
+        scan(fs, row_index_name="ri").slice(offset, 17).collect(engine="streaming"),
         pl.DataFrame(ri_expected_series),
     )
 
@@ -517,7 +515,7 @@ def test_multiscan_slice_parametric(
 
     assert_frame_equal(
         scan(ref).slice(offset, length).collect(),
-        scan(fs).slice(offset, length).collect(engine="streaming"),  # type: ignore[call-overload]
+        scan(fs).slice(offset, length).collect(engine="streaming"),
     )
 
     ref.seek(0)
@@ -530,7 +528,7 @@ def test_multiscan_slice_parametric(
         .collect(),
         scan(fs, row_index_name="ri", row_index_offset=42)
         .slice(offset, length)
-        .collect(engine="streaming"),  # type: ignore[call-overload]
+        .collect(engine="streaming"),
     )
 
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -2005,7 +2005,7 @@ def test_allow_missing_columns(
         match="enabling `allow_missing_columns`",
     ):
         pl.scan_parquet(paths, parallel=parallel).select(projection).collect(  # type: ignore[arg-type]
-            streaming=streaming
+            engine="old-streaming" if streaming else "in-memory"
         )
 
     assert_frame_equal(
@@ -2020,7 +2020,7 @@ def test_allow_missing_columns(
     assert_frame_equal(
         pl.scan_parquet(paths, parallel=parallel, allow_missing_columns=True)  # type: ignore[arg-type]
         .select(projection)
-        .collect(streaming=streaming),
+        .collect(engine="old-streaming" if streaming else "in-memory"),
         expected,
     )
 
@@ -3116,6 +3116,6 @@ def test_unspecialized_decoding_prefiltering() -> None:
     result = (
         pl.scan_parquet(f, parallel="prefiltered")
         .filter(expr)
-        .collect(new_streaming=True)  # type: ignore[call-overload]
+        .collect(engine="streaming")
     )
     assert_frame_equal(result, df.filter(expr))

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -36,14 +36,13 @@ def test_max_size_partition(
     io_type: IOType,
     length: int,
     max_size: int,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     lf = pl.Series("a", range(length), pl.Int64).to_frame().lazy()
 
-    monkeypatch.setenv("POLARS_FORCE_NEW_STREAMING", "1")
     (io_type["sink"])(
         lf,
         PartitionMaxSize(tmp_path / f"{{part}}.{io_type['ext']}", max_size=max_size),
+        engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on
         # one thread is immediately visible on another thread.
         #

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -847,7 +847,7 @@ def test_streaming_scan_csv_include_file_paths_18257(io_files_path: Path) -> Non
         include_file_paths="path",
     ).select("category", "path")
 
-    assert lf.collect(streaming=True).columns == ["category", "path"]
+    assert lf.collect(engine="old-streaming").columns == ["category", "path"]
 
 
 def test_streaming_scan_csv_with_row_index_19172(io_files_path: Path) -> None:
@@ -859,7 +859,7 @@ def test_streaming_scan_csv_with_row_index_19172(io_files_path: Path) -> None:
     )
 
     assert_frame_equal(
-        lf.collect(streaming=True),
+        lf.collect(engine="old-streaming"),
         pl.DataFrame(
             {"calories": "45", "index": 0},
             schema={"calories": pl.String, "index": pl.UInt32},

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -972,7 +972,7 @@ def test_scan_csv_bytesio_memory_usage(
     assert (
         pl.scan_csv(f)
         .filter(pl.col("mydata") == 999_999)
-        .collect(engine="streaming" if streaming else "in-memory")  # type: ignore[call-overload]
+        .collect(engine="streaming" if streaming else "in-memory")
         .item()
         == 999_999
     )

--- a/py-polars/tests/unit/lazyframe/test_engine_selection.py
+++ b/py-polars/tests/unit/lazyframe/test_engine_selection.py
@@ -27,15 +27,6 @@ def test_engine_selection_invalid_raises(df: pl.LazyFrame) -> None:
         df.collect(engine="unknown")  # type: ignore[call-overload]
 
 
-def test_engine_selection_streaming_warns(df: pl.LazyFrame, engine: EngineType) -> None:
-    expect = df.collect()
-    with pytest.warns(
-        UserWarning, match="GPU engine does not support streaming or background"
-    ):
-        got = df.collect(engine=engine, streaming=True)
-        assert_frame_equal(expect, got)
-
-
 def test_engine_selection_background_warns(
     df: pl.LazyFrame, engine: EngineType
 ) -> None:

--- a/py-polars/tests/unit/lazyframe/test_with_context.py
+++ b/py-polars/tests/unit/lazyframe/test_with_context.py
@@ -73,7 +73,7 @@ def test_streaming_11219() -> None:
         context = lf.with_context([lf_other, lf_other2])
 
     assert context.select(pl.col("b") + pl.col("c").first()).collect(
-        streaming=True
+        engine="old-streaming"
     ).to_dict(as_series=False) == {"b": ["afoo", "cfoo", None]}
 
 

--- a/py-polars/tests/unit/operations/test_concat.py
+++ b/py-polars/tests/unit/operations/test_concat.py
@@ -11,7 +11,7 @@ def test_concat_invalid_schema_err_20355() -> None:
     lf1 = pl.LazyFrame({"x": [1], "y": [None]})
     lf2 = pl.LazyFrame({"y": [1]})
     with pytest.raises(pl.exceptions.InvalidOperationError):
-        pl.concat([lf1, lf2]).collect(streaming=True)
+        pl.concat([lf1, lf2]).collect(engine="old-streaming")
 
 
 def test_concat_df() -> None:

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -256,7 +256,7 @@ def test_sorted_flag_after_streaming_join() -> None:
     assert (
         df1.lazy()
         .join(df2.lazy(), on="x", how="left")
-        .collect(streaming=True)["x"]
+        .collect(engine="old-streaming")["x"]
         .flags["SORTED_ASC"]
     )
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1078,14 +1078,14 @@ def test_join_empty_literal_17027() -> None:
     assert (
         df1.lazy()
         .join(df2.lazy(), on=pl.lit(0), how="inner")
-        .collect(streaming=True)
+        .collect(engine="old-streaming")
         .height
         == 0
     )
     assert (
         df1.lazy()
         .join(df2.lazy(), on=pl.lit(0), how="left")
-        .collect(streaming=True)
+        .collect(engine="old-streaming")
         .height
         == 1
     )

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -23,7 +23,7 @@ lf = left.lazy().merge_sorted(right.lazy(), "b")
 @pytest.mark.parametrize("streaming", [False, True])
 def test_merge_sorted(streaming: bool) -> None:
     assert_frame_equal(
-        lf.collect(new_streaming=streaming),  # type: ignore[call-overload]
+        lf.collect(engine="streaming" if streaming else "in-memory"),  # type: ignore[call-overload]
         expected,
     )
 
@@ -114,7 +114,7 @@ def test_merge_sorted_unbalanced(size: int, ra: list[int]) -> None:
     )
 
     lf = lhs.lazy().merge_sorted(rhs.lazy(), "a")
-    df = lf.collect(new_streaming=True)  # type: ignore[call-overload]
+    df = lf.collect(engine="streaming")  # type: ignore[call-overload]
 
     nulls_last = ra[0] is not None
 

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -23,7 +23,7 @@ lf = left.lazy().merge_sorted(right.lazy(), "b")
 @pytest.mark.parametrize("streaming", [False, True])
 def test_merge_sorted(streaming: bool) -> None:
     assert_frame_equal(
-        lf.collect(engine="streaming" if streaming else "in-memory"),  # type: ignore[call-overload]
+        lf.collect(engine="streaming" if streaming else "in-memory"),
         expected,
     )
 
@@ -114,7 +114,7 @@ def test_merge_sorted_unbalanced(size: int, ra: list[int]) -> None:
     )
 
     lf = lhs.lazy().merge_sorted(rhs.lazy(), "a")
-    df = lf.collect(engine="streaming")  # type: ignore[call-overload]
+    df = lf.collect(engine="streaming")
 
     nulls_last = ra[0] is not None
 

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -355,9 +355,9 @@ def test_streaming_with_hconcat(tmp_path: Path) -> None:
     # doesn't yet support streaming.
     for i, line in enumerate(plan_lines):
         if line.startswith("PLAN"):
-            assert plan_lines[i + 1].startswith(
-                "STREAMING"
-            ), f"{line} does not contain a streaming section"
+            assert plan_lines[i + 1].startswith("STREAMING"), (
+                f"{line} does not contain a streaming section"
+            )
 
     result = query.collect(engine="old-streaming")
 

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -28,7 +28,7 @@ def test_streaming_categoricals_5921() -> None:
             .group_by("X")
             .agg(pl.col("Y").min())
             .sort("Y", descending=True)
-            .collect(streaming=True)
+            .collect(engine='old-streaming')
         )
 
         out_eager = (
@@ -64,7 +64,7 @@ def test_streaming_streamable_functions(monkeypatch: Any, capfd: Any) -> None:
             schema={"a": pl.Int64, "b": pl.Int64},
             streamable=True,
         )
-    ).collect(streaming=True).to_dict(as_series=False) == {
+    ).collect(engine='old-streaming').to_dict(as_series=False) == {
         "a": [1, 2, 3],
         "b": [1, 2, 3],
     }
@@ -80,7 +80,7 @@ def test_cross_join_stack() -> None:
     t0 = time.time()
     # this should be instant if directly pushed into sink
     # if not the cross join will first fill the stack with all matches of a single chunk
-    assert a.join(a, how="cross").head().collect(streaming=True).shape == (5, 2)
+    assert a.join(a, how="cross").head().collect(engine='old-streaming').shape == (5, 2)
     t1 = time.time()
     assert (t1 - t0) < 0.5
 
@@ -99,7 +99,7 @@ def test_streaming_literal_expansion() -> None:
         z=pl.col("z"),
     )
 
-    assert q.collect(streaming=True).to_dict(as_series=False) == {
+    assert q.collect(engine='old-streaming').to_dict(as_series=False) == {
         "x": ["constant", "constant"],
         "y": ["a", "b"],
         "z": [1, 2],
@@ -127,7 +127,7 @@ def test_streaming_apply(monkeypatch: Any, capfd: Any) -> None:
         (
             q.select(
                 pl.col("a").map_elements(lambda x: x * 2, return_dtype=pl.Int64)
-            ).collect(streaming=True)
+            ).collect(engine='old-streaming')
         )
         (_, err) = capfd.readouterr()
         assert "df -> projection -> ordered_sink" in err
@@ -140,7 +140,7 @@ def test_streaming_ternary() -> None:
         q.with_columns(
             pl.when(pl.col("a") >= 2).then(pl.col("a")).otherwise(None).alias("b"),
         )
-        .explain(streaming=True)
+        .explain(engine='old-streaming')
         .startswith("STREAMING")
     )
 
@@ -157,7 +157,7 @@ def test_streaming_sortedness_propagation_9494() -> None:
         .sort("when")
         .group_by_dynamic("when", every="1mo")
         .agg(pl.col("what").sum())
-        .collect(streaming=True)
+        .collect(engine='old-streaming')
     ).to_dict(as_series=False) == {
         "when": [date(2023, 5, 1), date(2023, 6, 1)],
         "what": [3, 3],
@@ -192,7 +192,7 @@ def test_streaming_generic_left_and_inner_join_from_disk(tmp_path: Path) -> None
     for how in join_strategies:
         q = lf0.join(lf1, left_on="id", right_on="id_r", how=how)
         assert_frame_equal(
-            q.collect(streaming=True),
+            q.collect(engine='old-streaming'),
             q.collect(streaming=False),
             check_row_order=how == "left",
         )
@@ -229,7 +229,7 @@ def test_stream_empty_file(tmp_path: Path) -> None:
         schema=schema,
     )
     df.write_parquet(p)
-    assert pl.scan_parquet(p).collect(streaming=True).schema == schema
+    assert pl.scan_parquet(p).collect(engine='old-streaming').schema == schema
 
 
 def test_streaming_empty_df() -> None:
@@ -244,7 +244,7 @@ def test_streaming_empty_df() -> None:
         df.lazy()
         .join(df.lazy(), on="a", how="inner")
         .filter(False)
-        .collect(streaming=True)
+        .collect(engine='old-streaming')
     )
 
     assert result.to_dict(as_series=False) == {"a": [], "b": [], "b_right": []}
@@ -253,7 +253,7 @@ def test_streaming_empty_df() -> None:
 def test_streaming_duplicate_cols_5537() -> None:
     assert pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}).lazy().with_columns(
         (pl.col("a") * 2).alias("foo"), (pl.col("a") * 3)
-    ).collect(streaming=True).to_dict(as_series=False) == {
+    ).collect(engine='old-streaming').to_dict(as_series=False) == {
         "a": [3, 6, 9],
         "b": [1, 2, 3],
         "foo": [2, 4, 6],
@@ -268,7 +268,7 @@ def test_null_sum_streaming_10455() -> None:
         },
         schema={"x": pl.Int64, "y": pl.Float32},
     )
-    result = df.lazy().group_by("x").sum().collect(streaming=True)
+    result = df.lazy().group_by("x").sum().collect(engine='old-streaming')
     expected = {"x": [1], "y": [0.0]}
     assert result.to_dict(as_series=False) == expected
 
@@ -300,7 +300,7 @@ def test_streaming_csv_headers_but_no_data_13770(tmp_path: Path) -> None:
     df = (
         pl.scan_csv(tmp_path / "header_no_data.csv", schema=schema)
         .head()
-        .collect(streaming=True)
+        .collect(engine='old-streaming')
     )
     assert df.height == 0
     assert df.schema == schema
@@ -315,7 +315,7 @@ def test_custom_temp_dir(tmp_path: Path, monkeypatch: Any) -> None:
 
     s = pl.arange(0, 100_000, eager=True).rename("idx")
     df = s.shuffle().to_frame()
-    df.lazy().sort("idx").collect(streaming=True)
+    df.lazy().sort("idx").collect(engine='old-streaming')
 
     assert os.listdir(tmp_path), f"Temp directory '{tmp_path}' is empty"
 
@@ -346,7 +346,7 @@ def test_streaming_with_hconcat(tmp_path: Path) -> None:
         .sort(pl.col("id"))
     )
 
-    plan_lines = [line.strip() for line in query.explain(streaming=True).splitlines()]
+    plan_lines = [line.strip() for line in query.explain(engine='old-streaming').splitlines()]
 
     # Each input of the concatenation should be a streaming section,
     # as these might be streamable even though the horizontal concatenation itself
@@ -357,7 +357,7 @@ def test_streaming_with_hconcat(tmp_path: Path) -> None:
                 f"{line} does not contain a streaming section"
             )
 
-    result = query.collect(streaming=True)
+    result = query.collect(engine='old-streaming')
 
     expected = pl.DataFrame(
         {
@@ -396,7 +396,7 @@ def test_streaming_temporal_17669() -> None:
             b=pl.col("a").dt.date(),
             c=pl.col("a").dt.time(),
         )
-        .collect(streaming=True)
+        .collect(engine='old-streaming')
     )
     assert df.schema == {
         "a": pl.Datetime("us"),

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -28,7 +28,7 @@ def test_streaming_categoricals_5921() -> None:
             .group_by("X")
             .agg(pl.col("Y").min())
             .sort("Y", descending=True)
-            .collect(engine='old-streaming')
+            .collect(engine="old-streaming")
         )
 
         out_eager = (
@@ -49,7 +49,7 @@ def test_streaming_block_on_literals_6054() -> None:
     s = pl.Series("col_2", list(range(10)))
 
     assert df.lazy().with_columns(s).group_by("col_1").agg(pl.all().first()).collect(
-        streaming=True
+        engine="old-streaming"
     ).sort("col_1").to_dict(as_series=False) == {"col_1": [0, 1], "col_2": [0, 5]}
 
 
@@ -64,7 +64,7 @@ def test_streaming_streamable_functions(monkeypatch: Any, capfd: Any) -> None:
             schema={"a": pl.Int64, "b": pl.Int64},
             streamable=True,
         )
-    ).collect(engine='old-streaming').to_dict(as_series=False) == {
+    ).collect(engine="old-streaming").to_dict(as_series=False) == {
         "a": [1, 2, 3],
         "b": [1, 2, 3],
     }
@@ -80,7 +80,7 @@ def test_cross_join_stack() -> None:
     t0 = time.time()
     # this should be instant if directly pushed into sink
     # if not the cross join will first fill the stack with all matches of a single chunk
-    assert a.join(a, how="cross").head().collect(engine='old-streaming').shape == (5, 2)
+    assert a.join(a, how="cross").head().collect(engine="old-streaming").shape == (5, 2)
     t1 = time.time()
     assert (t1 - t0) < 0.5
 
@@ -99,13 +99,13 @@ def test_streaming_literal_expansion() -> None:
         z=pl.col("z"),
     )
 
-    assert q.collect(engine='old-streaming').to_dict(as_series=False) == {
+    assert q.collect(engine="old-streaming").to_dict(as_series=False) == {
         "x": ["constant", "constant"],
         "y": ["a", "b"],
         "z": [1, 2],
     }
     assert q.group_by(["x", "y"]).agg(pl.mean("z")).sort("y").collect(
-        streaming=True
+        engine="old-streaming"
     ).to_dict(as_series=False) == {
         "x": ["constant", "constant"],
         "y": ["a", "b"],
@@ -127,7 +127,7 @@ def test_streaming_apply(monkeypatch: Any, capfd: Any) -> None:
         (
             q.select(
                 pl.col("a").map_elements(lambda x: x * 2, return_dtype=pl.Int64)
-            ).collect(engine='old-streaming')
+            ).collect(engine="old-streaming")
         )
         (_, err) = capfd.readouterr()
         assert "df -> projection -> ordered_sink" in err
@@ -140,7 +140,7 @@ def test_streaming_ternary() -> None:
         q.with_columns(
             pl.when(pl.col("a") >= 2).then(pl.col("a")).otherwise(None).alias("b"),
         )
-        .explain(engine='old-streaming')
+        .explain(engine="old-streaming")
         .startswith("STREAMING")
     )
 
@@ -157,7 +157,7 @@ def test_streaming_sortedness_propagation_9494() -> None:
         .sort("when")
         .group_by_dynamic("when", every="1mo")
         .agg(pl.col("what").sum())
-        .collect(engine='old-streaming')
+        .collect(engine="old-streaming")
     ).to_dict(as_series=False) == {
         "when": [date(2023, 5, 1), date(2023, 6, 1)],
         "what": [3, 3],
@@ -192,8 +192,8 @@ def test_streaming_generic_left_and_inner_join_from_disk(tmp_path: Path) -> None
     for how in join_strategies:
         q = lf0.join(lf1, left_on="id", right_on="id_r", how=how)
         assert_frame_equal(
-            q.collect(engine='old-streaming'),
-            q.collect(streaming=False),
+            q.collect(engine="old-streaming"),
+            q.collect(engine="in-memory"),
             check_row_order=how == "left",
         )
 
@@ -229,7 +229,7 @@ def test_stream_empty_file(tmp_path: Path) -> None:
         schema=schema,
     )
     df.write_parquet(p)
-    assert pl.scan_parquet(p).collect(engine='old-streaming').schema == schema
+    assert pl.scan_parquet(p).collect(engine="old-streaming").schema == schema
 
 
 def test_streaming_empty_df() -> None:
@@ -244,7 +244,7 @@ def test_streaming_empty_df() -> None:
         df.lazy()
         .join(df.lazy(), on="a", how="inner")
         .filter(False)
-        .collect(engine='old-streaming')
+        .collect(engine="old-streaming")
     )
 
     assert result.to_dict(as_series=False) == {"a": [], "b": [], "b_right": []}
@@ -253,7 +253,7 @@ def test_streaming_empty_df() -> None:
 def test_streaming_duplicate_cols_5537() -> None:
     assert pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}).lazy().with_columns(
         (pl.col("a") * 2).alias("foo"), (pl.col("a") * 3)
-    ).collect(engine='old-streaming').to_dict(as_series=False) == {
+    ).collect(engine="old-streaming").to_dict(as_series=False) == {
         "a": [3, 6, 9],
         "b": [1, 2, 3],
         "foo": [2, 4, 6],
@@ -268,7 +268,7 @@ def test_null_sum_streaming_10455() -> None:
         },
         schema={"x": pl.Int64, "y": pl.Float32},
     )
-    result = df.lazy().group_by("x").sum().collect(engine='old-streaming')
+    result = df.lazy().group_by("x").sum().collect(engine="old-streaming")
     expected = {"x": [1], "y": [0.0]}
     assert result.to_dict(as_series=False) == expected
 
@@ -285,7 +285,7 @@ def test_boolean_agg_schema() -> None:
 
     for streaming in [True, False]:
         assert (
-            agg_df.collect(streaming=streaming).schema
+            agg_df.collect(engine="old-streaming" if streaming else "in-memory").schema
             == agg_df.collect_schema()
             == {"x": pl.Int64, "max_y": pl.Boolean}
         )
@@ -300,7 +300,7 @@ def test_streaming_csv_headers_but_no_data_13770(tmp_path: Path) -> None:
     df = (
         pl.scan_csv(tmp_path / "header_no_data.csv", schema=schema)
         .head()
-        .collect(engine='old-streaming')
+        .collect(engine="old-streaming")
     )
     assert df.height == 0
     assert df.schema == schema
@@ -315,7 +315,7 @@ def test_custom_temp_dir(tmp_path: Path, monkeypatch: Any) -> None:
 
     s = pl.arange(0, 100_000, eager=True).rename("idx")
     df = s.shuffle().to_frame()
-    df.lazy().sort("idx").collect(engine='old-streaming')
+    df.lazy().sort("idx").collect(engine="old-streaming")
 
     assert os.listdir(tmp_path), f"Temp directory '{tmp_path}' is empty"
 
@@ -346,18 +346,20 @@ def test_streaming_with_hconcat(tmp_path: Path) -> None:
         .sort(pl.col("id"))
     )
 
-    plan_lines = [line.strip() for line in query.explain(engine='old-streaming').splitlines()]
+    plan_lines = [
+        line.strip() for line in query.explain(engine="old-streaming").splitlines()
+    ]
 
     # Each input of the concatenation should be a streaming section,
     # as these might be streamable even though the horizontal concatenation itself
     # doesn't yet support streaming.
     for i, line in enumerate(plan_lines):
         if line.startswith("PLAN"):
-            assert plan_lines[i + 1].startswith("STREAMING"), (
-                f"{line} does not contain a streaming section"
-            )
+            assert plan_lines[i + 1].startswith(
+                "STREAMING"
+            ), f"{line} does not contain a streaming section"
 
-    result = query.collect(engine='old-streaming')
+    result = query.collect(engine="old-streaming")
 
     expected = pl.DataFrame(
         {
@@ -396,7 +398,7 @@ def test_streaming_temporal_17669() -> None:
             b=pl.col("a").dt.date(),
             c=pl.col("a").dt.time(),
         )
-        .collect(engine='old-streaming')
+        .collect(engine="old-streaming")
     )
     assert df.schema == {
         "a": pl.Datetime("us"),

--- a/py-polars/tests/unit/streaming/test_streaming_categoricals.py
+++ b/py-polars/tests/unit/streaming/test_streaming_categoricals.py
@@ -12,7 +12,7 @@ def test_streaming_nested_categorical() -> None:
         .group_by("numbers")
         .agg(pl.col("cat").first())
         .sort("numbers")
-    ).collect(streaming=True).to_dict(as_series=False) == {
+    ).collect(engine="old-streaming").to_dict(as_series=False) == {
         "numbers": [1, 2],
         "cat": [["str"], ["bar"]],
     }
@@ -30,4 +30,4 @@ def test_streaming_cat_14933() -> None:
     )
     result = df1.join(df2, on="a", how="left")
     expected = {"a": [0], "l": [None]}
-    assert result.collect(streaming=True).to_dict(as_series=False) == expected
+    assert result.collect(engine="old-streaming").to_dict(as_series=False) == expected

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -194,7 +194,7 @@ def test_streaming_group_by_sorted_fast_path() -> None:
                     ]
                 )
                 .sort("a")
-                .collect(streaming=streaming)
+                .collect(engine="old-streaming" if streaming else "in-memory")
             )
             results.append(out)
 
@@ -413,7 +413,7 @@ def test_group_by_min_max_string_type() -> None:
             table.lazy()
             .group_by("a")
             .agg([pl.min("b").alias("min"), pl.max("b").alias("max")])
-            .collect(streaming=streaming)
+            .collect(engine="old-streaming" if streaming else "in-memory")
             .sort("a")
             .to_dict(as_series=False)
             == expected
@@ -446,7 +446,7 @@ def test_group_by_multiple_keys_one_literal(streaming: bool) -> None:
         .group_by("a", pl.lit(1))
         .agg(pl.col("b").max())
         .sort(["a", "b"])
-        .collect(streaming=streaming)
+        .collect(engine="old-streaming" if streaming else "in-memory")
         .to_dict(as_series=False)
         == expected
     )

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -529,5 +529,5 @@ def test_streaming_group_by_all_null_21593() -> None:
         }
     )
 
-    out = df.lazy().group_by(pl.all()).min().collect(engine="streaming")  # type: ignore[call-overload]
+    out = df.lazy().group_by(pl.all()).min().collect(engine="streaming")
     assert_frame_equal(df, out, check_row_order=False)

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -32,7 +32,7 @@ def test_streaming_group_by_sorted_fast_path_nulls_10273() -> None:
         .lazy()
         .group_by("x")
         .agg(pl.len())
-        .collect(streaming=True)
+        .collect(engine="old-streaming")
         .sort("x")
     ).to_dict(as_series=False) == {
         "x": [None, 0, 1, 2, 3],
@@ -77,7 +77,7 @@ def test_streaming_group_by_types() -> None:
                 )
             )
             .select(pl.all().exclude(by))
-            .collect(streaming=True)
+            .collect(engine="old-streaming")
         )
         assert out.schema == {
             "str_first": pl.String,
@@ -129,7 +129,7 @@ def test_streaming_group_by_types() -> None:
                 ]
             )
             .select(pl.all().exclude("person_id"))
-            .collect(streaming=True)
+            .collect(engine="old-streaming")
         )
 
 
@@ -155,14 +155,14 @@ def test_streaming_non_streaming_gb() -> None:
     n = 100
     df = pl.DataFrame({"a": np.random.randint(0, 20, n)})
     q = df.lazy().group_by("a").agg(pl.len()).sort("a")
-    assert_frame_equal(q.collect(streaming=True), q.collect())
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect())
 
     q = df.lazy().with_columns(pl.col("a").cast(pl.String))
     q = q.group_by("a").agg(pl.len()).sort("a")
-    assert_frame_equal(q.collect(streaming=True), q.collect())
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect())
     q = df.lazy().with_columns(pl.col("a").alias("b"))
     q = q.group_by(["a", "b"]).agg(pl.len(), pl.col("a").sum().alias("sum_a")).sort("a")
-    assert_frame_equal(q.collect(streaming=True), q.collect())
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect())
 
 
 def test_streaming_group_by_sorted_fast_path() -> None:
@@ -222,7 +222,7 @@ def test_streaming_group_by_ooc_q1(
         lf.group_by("a")
         .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
         .sort("a")
-        .collect(streaming=True)
+        .collect(engine="old-streaming")
     )
 
     expected = pl.DataFrame(
@@ -250,7 +250,7 @@ def test_streaming_group_by_ooc_q2(
         lf.group_by("a")
         .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
         .sort("a")
-        .collect(streaming=True)
+        .collect(engine="old-streaming")
     )
 
     expected = pl.DataFrame(
@@ -278,7 +278,7 @@ def test_streaming_group_by_ooc_q3(
         lf.group_by("a", "b")
         .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
         .sort("a")
-        .collect(streaming=True)
+        .collect(engine="old-streaming")
     )
 
     expected = pl.DataFrame(
@@ -298,7 +298,7 @@ def test_streaming_group_by_struct_key() -> None:
     )
     df1 = df.lazy().with_columns(pl.struct(["A", "C"]).alias("tuples"))
     assert df1.group_by("tuples").agg(pl.len(), pl.col("B").first()).sort("B").collect(
-        streaming=True
+        engine="old-streaming"
     ).to_dict(as_series=False) == {
         "tuples": [{"A": 3, "C": 4}, {"A": 1, "C": 2}, {"A": 2, "C": 3}],
         "len": [1, 1, 2],
@@ -329,7 +329,7 @@ def test_streaming_group_by_all_numeric_types_stability_8570() -> None:
                 .with_columns(pl.col("z").cast(dtype))
                 .group_by(keys)
                 .agg(pl.col("z").sum().alias("z_sum"))
-                .collect(streaming=True)
+                .collect(engine="old-streaming")
             )
             assert dfd["z_sum"].sum() == dfc["z"].sum()
 
@@ -354,7 +354,7 @@ def test_streaming_group_by_categorical_aggregate() -> None:
             )
             .group_by(["a", "b"])
             .agg([pl.col("a").first().alias("sum")])
-            .collect(streaming=True)
+            .collect(engine="old-streaming")
         )
 
     assert out.sort("b").to_dict(as_series=False) == {
@@ -379,7 +379,7 @@ def test_streaming_group_by_list_9758() -> None:
         pl.LazyFrame(payload)
         .group_by("a")
         .first()
-        .collect(streaming=True)
+        .collect(engine="old-streaming")
         .to_dict(as_series=False)
         == payload
     )
@@ -400,7 +400,7 @@ def test_streaming_restart_non_streamable_group_by() -> None:
         )  # non-streamable UDF + nested_agg
     )
 
-    assert "STREAMING" in res.explain(streaming=True)
+    assert "STREAMING" in res.explain(engine="old-streaming")
 
 
 def test_group_by_min_max_string_type() -> None:
@@ -429,7 +429,7 @@ def test_streaming_group_by_literal(literal: Any) -> None:
             pl.col("a").count().alias("a_count"),
             pl.col("a").sum().alias("a_sum"),
         ]
-    ).collect(streaming=True).to_dict(as_series=False) == {
+    ).collect(engine="old-streaming").to_dict(as_series=False) == {
         "literal": [literal],
         "a_count": [20],
         "a_sum": [190],
@@ -454,9 +454,9 @@ def test_group_by_multiple_keys_one_literal(streaming: bool) -> None:
 
 def test_streaming_group_null_count() -> None:
     df = pl.DataFrame({"g": [1] * 6, "a": ["yes", None] * 3}).lazy()
-    assert df.group_by("g").agg(pl.col("a").count()).collect(streaming=True).to_dict(
-        as_series=False
-    ) == {"g": [1], "a": [3]}
+    assert df.group_by("g").agg(pl.col("a").count()).collect(
+        engine="old-streaming"
+    ).to_dict(as_series=False) == {"g": [1], "a": [3]}
 
 
 def test_streaming_group_by_binary_15116() -> None:
@@ -480,7 +480,7 @@ def test_streaming_group_by_binary_15116() -> None:
         .select([pl.col("str").cast(pl.Binary)])
         .group_by(["str"])
         .agg([pl.len().alias("count")])
-    ).sort("str").collect(streaming=True).to_dict(as_series=False) == {
+    ).sort("str").collect(engine="old-streaming").to_dict(as_series=False) == {
         "str": [b"A", b"BB", b"CCCC", b"DDDDDDDD", b"EEEEEEEEEEEEEEEE"],
         "count": [3, 2, 2, 2, 1],
     }
@@ -515,7 +515,7 @@ def test_streaming_group_by_boolean_mean_15610(
         .group_by("a")
         .agg(c=pl.mean("b"))
         .sort("a")
-        .collect(streaming=streaming)
+        .collect(engine="old-streaming" if streaming else "in-memory")
     )
 
     assert_frame_equal(out, expect)
@@ -529,5 +529,5 @@ def test_streaming_group_by_all_null_21593() -> None:
         }
     )
 
-    out = df.lazy().group_by(pl.all()).min().collect(new_streaming=True)  # type: ignore[call-overload]
+    out = df.lazy().group_by(pl.all()).min().collect(engine="streaming")  # type: ignore[call-overload]
     assert_frame_equal(df, out, check_row_order=False)

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -21,18 +21,22 @@ def test_streaming_parquet_glob_5900(df: pl.DataFrame, tmp_path: Path) -> None:
     df.write_parquet(file_path)
 
     path_glob = tmp_path / "small*.parquet"
-    result = pl.scan_parquet(path_glob).select(pl.all().first()).collect(streaming=True)
+    result = (
+        pl.scan_parquet(path_glob)
+        .select(pl.all().first())
+        .collect(engine="old-streaming")
+    )
     assert result.shape == (1, df.width)
 
 
 def test_scan_slice_streaming(io_files_path: Path) -> None:
     foods_file_path = io_files_path / "foods1.csv"
-    df = pl.scan_csv(foods_file_path).head(5).collect(streaming=True)
+    df = pl.scan_csv(foods_file_path).head(5).collect(engine="old-streaming")
     assert df.shape == (5, 4)
 
     # globbing
     foods_file_path = io_files_path / "foods*.csv"
-    df = pl.scan_csv(foods_file_path).head(5).collect(streaming=True)
+    df = pl.scan_csv(foods_file_path).head(5).collect(engine="old-streaming")
     assert df.shape == (5, 4)
 
 
@@ -161,13 +165,15 @@ def test_sink_csv_nested_data(tmp_path: Path) -> None:
 
 def test_scan_csv_only_header_10792(io_files_path: Path) -> None:
     foods_file_path = io_files_path / "only_header.csv"
-    df = pl.scan_csv(foods_file_path).collect(streaming=True)
+    df = pl.scan_csv(foods_file_path).collect(engine="old-streaming")
     assert df.to_dict(as_series=False) == {"Name": [], "Address": []}
 
 
 def test_scan_empty_csv_10818(io_files_path: Path) -> None:
     empty_file_path = io_files_path / "empty.csv"
-    df = pl.scan_csv(empty_file_path, raise_if_empty=False).collect(streaming=True)
+    df = pl.scan_csv(empty_file_path, raise_if_empty=False).collect(
+        engine="old-streaming"
+    )
     assert df.is_empty()
 
 
@@ -243,7 +249,7 @@ def test_streaming_empty_parquet_16523(tmp_path: Path) -> None:
     df.write_parquet(file_path)
     q = pl.scan_parquet(file_path)
     q2 = pl.LazyFrame({"a": [1]}, schema={"a": pl.Int32})
-    assert q.join(q2, on="a").collect(streaming=True).shape == (0, 1)
+    assert q.join(q2, on="a").collect(engine="old-streaming").shape == (0, 1)
 
 
 @pytest.mark.may_fail_auto_streaming
@@ -267,7 +273,7 @@ def test_nyi_scan_in_memory(method: str) -> None:
         pl.exceptions.ComputeError,
         match="not yet implemented: Streaming scanning of in-memory buffers",
     ):
-        (getattr(pl, f"scan_{method}"))(f).collect(streaming=True)
+        (getattr(pl, f"scan_{method}"))(f).collect(engine="old-streaming")
 
 
 def test_empty_sink_parquet_join_14863(tmp_path: Path) -> None:

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -46,7 +46,7 @@ def test_scan_csv_overwrite_small_dtypes(
 ) -> None:
     file_path = io_files_path / "foods1.csv"
     df = pl.scan_csv(file_path, schema_overrides={"sugars_g": dtype}).collect(
-        streaming=True
+        engine="old-streaming"
     )
     assert df.dtypes == [pl.String, pl.Int64, pl.Float64, dtype]
 
@@ -228,7 +228,11 @@ def test_parquet_eq_statistics(
         pl.col("idx") == 150,
         pl.col("idx") == 210,
     ]:
-        result = pl.scan_parquet(file_path).filter(pred).collect(streaming=streaming)
+        result = (
+            pl.scan_parquet(file_path)
+            .filter(pred)
+            .collect(engine="old-streaming" if streaming else "in-memory")
+        )
         assert_frame_equal(result, df.filter(pred))
 
     captured = capfd.readouterr().err

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -278,3 +278,14 @@ def test_empty_sink_parquet_join_14863(tmp_path: Path) -> None:
         pl.LazyFrame({"a": ["uno"]}).join(pl.scan_parquet(file_path), on="a").collect(),
         lf.collect(),
     )
+
+
+@pytest.mark.write_disk
+def test_scan_non_existent_file_21527() -> None:
+    with pytest.raises(
+        FileNotFoundError,
+        match="No such file or directory (os error 2): a-file-that-does-not-exist",
+    ):
+        pl.scan_parquet("a-file-that-does-not-exist").sink_ipc(
+            "x.ipc", engine="streaming"
+        )

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -284,7 +284,7 @@ def test_empty_sink_parquet_join_14863(tmp_path: Path) -> None:
 def test_scan_non_existent_file_21527() -> None:
     with pytest.raises(
         FileNotFoundError,
-        match="No such file or directory (os error 2): a-file-that-does-not-exist",
+        match=r"a-file-that-does-not-exist",
     ):
         pl.scan_parquet("a-file-that-does-not-exist").sink_ipc(
             "x.ipc", engine="streaming"

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -46,7 +46,7 @@ def test_streaming_full_outer_joins() -> None:
             .sort(["idx"])
         )
         a = q.collect(engine="old-streaming")
-        b = q.collect(streaming=False)
+        b = q.collect(engine="in-memory")
         assert_frame_equal(a, b, check_row_order=False)
 
 
@@ -148,16 +148,18 @@ def test_join_null_matches(streaming: bool) -> None:
     )
     # Semi
     assert df_a.join(df_b, on="a", how="semi", nulls_equal=True).collect(
-        streaming=streaming
+        engine="old-streaming" if streaming else "in-memory"
     )["idx_a"].to_list() == [0, 1, 2]
     assert df_a.join(df_b, on="a", how="semi", nulls_equal=False).collect(
-        streaming=streaming
+        engine="old-streaming" if streaming else "in-memory"
     )["idx_a"].to_list() == [1, 2]
 
     # Inner
     expected = pl.DataFrame({"idx_a": [2, 1], "a": [2, 1], "idx_b": [1, 2]})
     assert_frame_equal(
-        df_a.join(df_b, on="a", how="inner").collect(streaming=streaming),
+        df_a.join(df_b, on="a", how="inner").collect(
+            engine="old-streaming" if streaming else "in-memory"
+        ),
         expected,
         check_row_order=False,
     )
@@ -167,7 +169,9 @@ def test_join_null_matches(streaming: bool) -> None:
         {"idx_a": [0, 1, 2], "a": [None, 1, 2], "idx_b": [None, 2, 1]}
     )
     assert_frame_equal(
-        df_a.join(df_b, on="a", how="left").collect(streaming=streaming),
+        df_a.join(df_b, on="a", how="left").collect(
+            engine="old-streaming" if streaming else "in-memory"
+        ),
         expected,
         check_row_order=False,
     )
@@ -204,7 +208,9 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
 
     expected = pl.DataFrame({"a": [1], "idx": [1], "c": [50]})
     assert_frame_equal(
-        df_a.join(df_b, on=["a", "idx"], how="inner").collect(streaming=streaming),
+        df_a.join(df_b, on=["a", "idx"], how="inner").collect(
+            engine="old-streaming" if streaming else "in-memory"
+        ),
         expected,
         check_row_order=False,
     )
@@ -212,7 +218,9 @@ def test_join_null_matches_multiple_keys(streaming: bool) -> None:
         {"a": [None, 1, 2], "idx": [0, 1, 2], "c": [None, 50, None]}
     )
     assert_frame_equal(
-        df_a.join(df_b, on=["a", "idx"], how="left").collect(streaming=streaming),
+        df_a.join(df_b, on=["a", "idx"], how="left").collect(
+            engine="old-streaming" if streaming else "in-memory"
+        ),
         expected,
         check_row_order=False,
     )
@@ -244,7 +252,7 @@ def test_streaming_join_and_union() -> None:
     q = pl.concat([a, b, c])
 
     out = q.collect(engine="old-streaming")
-    assert_frame_equal(out, q.collect(streaming=False))
+    assert_frame_equal(out, q.collect(engine="in-memory"))
     assert out.to_series().to_list() == [1, 2, 1, 2, 4, 8, 1, 2]
 
 

--- a/py-polars/tests/unit/streaming/test_streaming_sort.py
+++ b/py-polars/tests/unit/streaming/test_streaming_sort.py
@@ -57,7 +57,7 @@ def test_streaming_sort_multiple_columns_logical_types() -> None:
         ],
     }
 
-    result = pl.LazyFrame(data).sort("foo", "baz").collect(streaming=True)
+    result = pl.LazyFrame(data).sort("foo", "baz").collect(engine="old-streaming")
 
     expected = pl.DataFrame(
         {
@@ -86,7 +86,7 @@ def test_ooc_sort(tmp_path: Path, monkeypatch: Any) -> None:
 
     for descending in [True, False]:
         out = (
-            df.lazy().sort("idx", descending=descending).collect(streaming=True)
+            df.lazy().sort("idx", descending=descending).collect(engine="old-streaming")
         ).to_series()
 
         assert_series_equal(out, s.sort(descending=descending))
@@ -110,7 +110,7 @@ def test_streaming_sort(
         .to_frame("s")
         .lazy()
         .sort("s")
-        .collect(streaming=True)["s"]
+        .collect(engine="old-streaming")["s"]
         .is_sorted()
     )
     (_, err) = capfd.readouterr()
@@ -152,7 +152,7 @@ def test_out_of_core_sort_9503(
     )
     lf = df.lazy()
 
-    result = lf.sort(df.columns).collect(streaming=True)
+    result = lf.sort(df.columns).collect(engine="old-streaming")
 
     assert result.shape == (1_000_000, 2)
     assert result["column_0"].flags["SORTED_ASC"]
@@ -194,7 +194,7 @@ def test_streaming_sort_multiple_columns(
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     df = str_ints_df
 
-    out = df.lazy().sort(["strs", "vals"]).collect(streaming=True)
+    out = df.lazy().sort(["strs", "vals"]).collect(engine="old-streaming")
     assert_frame_equal(out, out.sort(["strs", "vals"]))
     err = capfd.readouterr().err
     assert "OOC sort forced" in err
@@ -213,7 +213,7 @@ def test_streaming_sort_sorted_flag() -> None:
         }
     ).sort("timestamp")
 
-    assert q.collect(streaming=True)["timestamp"].flags["SORTED_ASC"]
+    assert q.collect(engine="old-streaming")["timestamp"].flags["SORTED_ASC"]
 
 
 @pytest.mark.parametrize(
@@ -229,7 +229,7 @@ def test_streaming_sort_varying_order_and_dtypes(
 ) -> None:
     q = pl.scan_parquet(io_files_path / "foods*.parquet")
     df = q.collect()
-    assert_df_sorted_by(df, q.sort(sort_by).collect(streaming=True), sort_by)
+    assert_df_sorted_by(df, q.sort(sort_by).collect(engine="old-streaming"), sort_by)
     assert_df_sorted_by(df, q.sort(sort_by).collect(streaming=False), sort_by)
 
 
@@ -244,7 +244,7 @@ def test_streaming_sort_fixed_reverse() -> None:
     q = df.lazy().sort(by=["a", "b"], descending=descending)
 
     assert_df_sorted_by(
-        df, q.collect(streaming=True), ["a", "b"], descending=descending
+        df, q.collect(engine="old-streaming"), ["a", "b"], descending=descending
     )
     assert_df_sorted_by(
         df, q.collect(streaming=False), ["a", "b"], descending=descending
@@ -258,9 +258,12 @@ def test_reverse_variable_sort_13573() -> None:
             "b": ["four", "five", "six"],
         }
     ).lazy()
-    assert df.sort("a", "b", descending=[True, False]).collect(streaming=True).to_dict(
-        as_series=False
-    ) == {"a": ["two", "three", "one"], "b": ["five", "six", "four"]}
+    assert df.sort("a", "b", descending=[True, False]).collect(
+        engine="old-streaming"
+    ).to_dict(as_series=False) == {
+        "a": ["two", "three", "one"],
+        "b": ["five", "six", "four"],
+    }
 
 
 def test_nulls_last_streaming_sort() -> None:
@@ -283,13 +286,13 @@ def test_sort_descending_nulls_last(descending: bool, nulls_last: bool) -> None:
     assert_frame_equal(
         df.lazy()
         .sort("x", descending=descending, nulls_last=nulls_last)
-        .collect(streaming=True),
+        .collect(engine="old-streaming"),
         pl.DataFrame({"x": ref_x, "y": ref_y}),
     )
 
     assert_frame_equal(
         df.lazy()
         .sort(["x", "y"], descending=descending, nulls_last=nulls_last)
-        .collect(streaming=True),
+        .collect(engine="old-streaming"),
         pl.DataFrame({"x": ref_x, "y": ref_y}),
     )

--- a/py-polars/tests/unit/streaming/test_streaming_sort.py
+++ b/py-polars/tests/unit/streaming/test_streaming_sort.py
@@ -230,7 +230,7 @@ def test_streaming_sort_varying_order_and_dtypes(
     q = pl.scan_parquet(io_files_path / "foods*.parquet")
     df = q.collect()
     assert_df_sorted_by(df, q.sort(sort_by).collect(engine="old-streaming"), sort_by)
-    assert_df_sorted_by(df, q.sort(sort_by).collect(streaming=False), sort_by)
+    assert_df_sorted_by(df, q.sort(sort_by).collect(engine="in-memory"), sort_by)
 
 
 def test_streaming_sort_fixed_reverse() -> None:
@@ -247,7 +247,7 @@ def test_streaming_sort_fixed_reverse() -> None:
         df, q.collect(engine="old-streaming"), ["a", "b"], descending=descending
     )
     assert_df_sorted_by(
-        df, q.collect(streaming=False), ["a", "b"], descending=descending
+        df, q.collect(engine="in-memory"), ["a", "b"], descending=descending
     )
 
 
@@ -268,7 +268,7 @@ def test_reverse_variable_sort_13573() -> None:
 
 def test_nulls_last_streaming_sort() -> None:
     assert pl.LazyFrame({"x": [1, None]}).sort("x", nulls_last=True).collect(
-        streaming=True
+        engine="old-streaming"
     ).to_dict(as_series=False) == {"x": [1, None]}
 
 

--- a/py-polars/tests/unit/streaming/test_streaming_unique.py
+++ b/py-polars/tests/unit/streaming/test_streaming_unique.py
@@ -29,9 +29,9 @@ def test_streaming_out_of_core_unique(
     q = q.join(q, how="cross").select(df.columns).head(10_000)
 
     # uses out-of-core unique
-    df1 = q.join(q.head(1000), how="cross").unique().collect(streaming=True)
+    df1 = q.join(q.head(1000), how="cross").unique().collect(engine="old-streaming")
     # this ensures the cross join gives equal result but uses the in-memory unique
-    df2 = q.join(q.head(1000), how="cross").collect(streaming=True).unique()
+    df2 = q.join(q.head(1000), how="cross").collect(engine="old-streaming").unique()
     assert df1.shape == df2.shape
 
     # TODO: Re-enable this check when this issue is fixed: https://github.com/pola-rs/polars/issues/10466
@@ -44,12 +44,12 @@ def test_streaming_unique(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     df = pl.DataFrame({"a": [1, 2, 2, 2], "b": [3, 4, 4, 4], "c": [5, 6, 7, 7]})
     q = df.lazy().unique(subset=["a", "c"], maintain_order=False).sort(["a", "b", "c"])
-    assert_frame_equal(q.collect(streaming=True), q.collect(streaming=False))
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(streaming=False))
 
     q = df.lazy().unique(subset=["b", "c"], maintain_order=False).sort(["a", "b", "c"])
-    assert_frame_equal(q.collect(streaming=True), q.collect(streaming=False))
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(streaming=False))
 
     q = df.lazy().unique(subset=None, maintain_order=False).sort(["a", "b", "c"])
-    assert_frame_equal(q.collect(streaming=True), q.collect(streaming=False))
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(streaming=False))
     (_, err) = capfd.readouterr()
     assert "df -> re-project-sink -> sort_multiple" in err

--- a/py-polars/tests/unit/streaming/test_streaming_unique.py
+++ b/py-polars/tests/unit/streaming/test_streaming_unique.py
@@ -44,12 +44,12 @@ def test_streaming_unique(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     df = pl.DataFrame({"a": [1, 2, 2, 2], "b": [3, 4, 4, 4], "c": [5, 6, 7, 7]})
     q = df.lazy().unique(subset=["a", "c"], maintain_order=False).sort(["a", "b", "c"])
-    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(streaming=False))
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(engine="in-memory"))
 
     q = df.lazy().unique(subset=["b", "c"], maintain_order=False).sort(["a", "b", "c"])
-    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(streaming=False))
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(engine="in-memory"))
 
     q = df.lazy().unique(subset=None, maintain_order=False).sort(["a", "b", "c"])
-    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(streaming=False))
+    assert_frame_equal(q.collect(engine="old-streaming"), q.collect(engine="in-memory"))
     (_, err) = capfd.readouterr()
     assert "df -> re-project-sink -> sort_multiple" in err


### PR DESCRIPTION
As part of #20947, this enables the new-streaming engine sinks by default. A large part of this PR is replacing the previous `streaming: bool` and `new_streaming: bool` flags with `engine` flag.

This deprecates the those old flags.

Fixes #21527.
Fixes #19506.