### PR TITLE
feat: Cloud support for new-streaming scans and sinks

### DIFF
--- a/crates/polars-python/src/lazyframe/sink.rs
+++ b/crates/polars-python/src/lazyframe/sink.rs
@@ -33,6 +33,11 @@ impl PyPartitioning {
             variant: PartitionVariant::MaxSize(max_size),
         }
     }
+
+    #[getter]
+    fn path(&self) -> &str {
+        self.path.to_str().unwrap()
+    }
 }
 
 impl<'py> FromPyObject<'py> for SinkTarget {

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -135,6 +135,7 @@ impl SourceNode for CsvSourceNode {
                             if morsel_output.port.send(morsel).await.is_err() {
                                 break;
                             }
+
                             wait_group.wait().await;
 
                             if source_token.stop_requested() {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -229,11 +229,12 @@ pub fn lower_ir(
                 path,
                 sink_options,
                 file_type,
-                cloud_options: _,
+                cloud_options,
             } => {
                 let path = path.clone();
                 let sink_options = sink_options.clone();
                 let file_type = file_type.clone();
+                let cloud_options = cloud_options.clone();
 
                 match file_type {
                     #[cfg(feature = "ipc")]
@@ -244,6 +245,7 @@ pub fn lower_ir(
                             sink_options,
                             file_type,
                             input: phys_input,
+                            cloud_options,
                         }
                     },
                     #[cfg(feature = "parquet")]
@@ -254,6 +256,7 @@ pub fn lower_ir(
                             sink_options,
                             file_type,
                             input: phys_input,
+                            cloud_options,
                         }
                     },
                     #[cfg(feature = "csv")]
@@ -264,6 +267,7 @@ pub fn lower_ir(
                             sink_options,
                             file_type,
                             input: phys_input,
+                            cloud_options,
                         }
                     },
                     #[cfg(feature = "json")]
@@ -274,6 +278,7 @@ pub fn lower_ir(
                             sink_options,
                             file_type,
                             input: phys_input,
+                            cloud_options,
                         }
                     },
                 }
@@ -283,12 +288,13 @@ pub fn lower_ir(
                 sink_options,
                 variant,
                 file_type,
-                cloud_options: _,
+                cloud_options,
             } => {
                 let path_f_string = path_f_string.clone();
                 let sink_options = sink_options.clone();
                 let variant = variant.clone();
                 let file_type = file_type.clone();
+                let cloud_options = cloud_options.clone();
 
                 let phys_input = lower_ir!(*input)?;
                 PhysNodeKind::PartitionSink {
@@ -297,6 +303,7 @@ pub fn lower_ir(
                     variant,
                     file_type,
                     input: phys_input,
+                    cloud_options,
                 }
             },
         },

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -6,6 +6,7 @@ use polars_core::prelude::{IdxSize, InitHashMaps, PlHashMap, SortMultipleOptions
 use polars_core::schema::{Schema, SchemaRef};
 use polars_core::utils::arrow::bitmap::Bitmap;
 use polars_error::PolarsResult;
+use polars_io::cloud::CloudOptions;
 use polars_io::RowIndex;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::{
@@ -134,6 +135,7 @@ pub enum PhysNodeKind {
         sink_options: SinkOptions,
         file_type: FileType,
         input: PhysStream,
+        cloud_options: Option<CloudOptions>,
     },
 
     PartitionSink {
@@ -142,6 +144,7 @@ pub enum PhysNodeKind {
         variant: PartitionVariant,
         file_type: FileType,
         input: PhysStream,
+        cloud_options: Option<CloudOptions>,
     },
 
     /// Generic fallback for (as-of-yet) unsupported streaming mappings.

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -225,6 +225,7 @@ fn to_graph_rec<'a>(
             sink_options,
             file_type,
             input,
+            cloud_options,
         } => {
             let sink_options = sink_options.clone();
             let input_schema = ctx.phys_sm[input.node].output_schema.clone();
@@ -238,6 +239,7 @@ fn to_graph_rec<'a>(
                         path.to_path_buf(),
                         sink_options,
                         *ipc_writer_options,
+                        cloud_options.clone(),
                     )),
                     [(input_key, input.port)],
                 ),
@@ -246,6 +248,7 @@ fn to_graph_rec<'a>(
                     SinkComputeNode::from(nodes::io_sinks::json::NDJsonSinkNode::new(
                         path.to_path_buf(),
                         sink_options,
+                        cloud_options.clone(),
                     )),
                     [(input_key, input.port)],
                 ),
@@ -256,16 +259,18 @@ fn to_graph_rec<'a>(
                         path,
                         sink_options,
                         parquet_writer_options,
+                        cloud_options.clone(),
                     )?),
                     [(input_key, input.port)],
                 ),
                 #[cfg(feature = "csv")]
                 FileType::Csv(csv_writer_options) => ctx.graph.add_node(
                     SinkComputeNode::from(nodes::io_sinks::csv::CsvSinkNode::new(
-                        input_schema,
                         path.to_path_buf(),
+                        input_schema,
                         sink_options,
                         csv_writer_options.clone(),
+                        cloud_options.clone(),
                     )),
                     [(input_key, input.port)],
                 ),
@@ -287,6 +292,7 @@ fn to_graph_rec<'a>(
             variant,
             file_type,
             input,
+            cloud_options,
         } => {
             let input_schema = ctx.phys_sm[input.node].output_schema.clone();
             let input_key = to_graph_rec(input.node, ctx)?;
@@ -298,6 +304,7 @@ fn to_graph_rec<'a>(
                 file_type.clone(),
                 sink_options.clone(),
                 args_to_path,
+                cloud_options.clone(),
             );
 
             match variant {

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from polars._utils.various import is_path_or_str_sequence
+from polars.io.partition import PartitionMaxSize
 
 
 def _first_scan_path(
@@ -13,6 +14,8 @@ def _first_scan_path(
         return source
     elif is_path_or_str_sequence(source) and source:
         return source[0]
+    elif isinstance(source, PartitionMaxSize):
+        return source._path
 
     return None
 

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -37,3 +37,7 @@ class PartitionMaxSize:
     def __init__(self, path: Path | str, *, max_size: int) -> None:
         issue_unstable_warning("Partitioning strategies are considered unstable.")
         self._p = PyPartitioning.new_max_size(path, max_size)
+
+    @property
+    def _path(self) -> str:
+        return self._p.path


### PR DESCRIPTION
Enables cloud support for all scan and sink functions on new-streaming, including `PartitionMaxSize`.

Note that currently if any errors occur in writing they are silently ignored (there is a fix for this at  https://github.com/pola-rs/polars/pull/21589/files#diff-744a743b5337b77c8e26e0efabdfe8410bfd77e3d1e55ffa54eb0f29cc51e33bR1177)
