### PR TITLE
docs: Fix comment in cross-join for using polars-u64-idx

### DIFF
--- a/crates/polars-ops/src/frame/join/cross_join.rs
+++ b/crates/polars-ops/src/frame/join/cross_join.rs
@@ -94,7 +94,7 @@ fn cross_join_dfs(
     let Some(total_rows) = n_rows_left.checked_mul(n_rows_right) else {
         polars_bail!(
             ComputeError: "cross joins would produce more rows than fits into 2^32; \
-            consider compiling with polars-big-idx feature, or set 'streaming'"
+            consider compiling with polars-u64-idx feature, or set 'streaming'"
         );
     };
     if n_rows_left == 0 || n_rows_right == 0 {


### PR DESCRIPTION
From looking at https://docs.pola.rs/user-guide/installation/ it's `polars-u64-idx` *not* `polars-big-idx`.

`polars-big-idx` does not seem to exist on pypi which references `polars-u64-idx`: https://pypi.org/project/polars/

I've not submitted an issue matching this.