### PR TITLE
refactor: Traced await

### DIFF
--- a/crates/polars-stream/src/lib.rs
+++ b/crates/polars-stream/src/lib.rs
@@ -11,6 +11,7 @@ mod morsel;
 mod nodes;
 mod physical_plan;
 mod pipe;
+pub mod prelude;
 mod utils;
 
 // TODO: experiment with these, and make them configurable through environment variables.

--- a/crates/polars-stream/src/nodes/filter.rs
+++ b/crates/polars-stream/src/nodes/filter.rs
@@ -2,6 +2,7 @@ use polars_error::polars_err;
 
 use super::compute_node_prelude::*;
 use crate::expression::StreamExpr;
+use crate::prelude::TracedAwait;
 
 pub struct FilterNode {
     predicate: StreamExpr,
@@ -39,10 +40,10 @@ impl ComputeNode for FilterNode {
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                while let Ok(morsel) = recv.recv().await {
+                while let Ok(morsel) = recv.recv().traced_await().await {
 
                     let morsel = morsel.async_try_map(|df| async move {
-                        let mask = slf.predicate.evaluate(&df, state).await?;
+                        let mask = slf.predicate.evaluate(&df, state).traced_await().await?;
                         let mask = mask.bool().map_err(|_| {
                             polars_err!(
                                 ComputeError: "filter predicate must be of type `Boolean`, got `{}`", mask.dtype()
@@ -51,13 +52,13 @@ impl ComputeNode for FilterNode {
 
                         // We already parallelize, call the sequential filter.
                         df._filter_seq(mask)
-                    }).await?;
+                    }).traced_await().await?;
 
                     if morsel.df().is_empty() {
                         continue;
                     }
 
-                    if send.send(morsel).await.is_err() {
+                    if send.send(morsel).traced_await().await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -15,6 +15,7 @@ use super::compute_node_prelude::*;
 use crate::async_primitives::connector::Receiver;
 use crate::expression::StreamExpr;
 use crate::nodes::in_memory_source::InMemorySourceNode;
+use crate::prelude::TracedAwait;
 use crate::GROUP_BY_MIN_ROWS_PER_PARTITION;
 
 struct LocalGroupBySinkState {
@@ -68,13 +69,13 @@ impl GroupBySinkState {
             let random_state = &self.random_state;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 let mut group_idxs = Vec::new();
-                while let Ok(morsel) = recv.recv().await {
+                while let Ok(morsel) = recv.recv().traced_await().await {
                     // Compute group indices from key.
                     let seq = morsel.seq().to_u64();
                     let df = morsel.into_df();
                     let mut key_columns = Vec::new();
                     for selector in key_selectors {
-                        let s = selector.evaluate(&df, state).await?;
+                        let s = selector.evaluate(&df, state).traced_await().await?;
                         key_columns.push(s.into_column());
                     }
                     let keys = DataFrame::new_with_broadcast_len(key_columns, df.height())?;
@@ -92,6 +93,7 @@ impl GroupBySinkState {
                             reduction.update_groups(
                                 selector
                                     .evaluate(&df, state)
+                                    .traced_await()
                                     .await?
                                     .as_materialized_series(),
                                 &group_idxs,

--- a/crates/polars-stream/src/nodes/in_memory_map.rs
+++ b/crates/polars-stream/src/nodes/in_memory_map.rs
@@ -6,6 +6,7 @@ use polars_plan::plans::DataFrameUdf;
 use super::compute_node_prelude::*;
 use super::in_memory_sink::InMemorySinkNode;
 use super::in_memory_source::InMemorySourceNode;
+use crate::prelude::TracedAwait;
 
 pub enum InMemoryMapNode {
     Sink {

--- a/crates/polars-stream/src/nodes/in_memory_map.rs
+++ b/crates/polars-stream/src/nodes/in_memory_map.rs
@@ -6,7 +6,6 @@ use polars_plan::plans::DataFrameUdf;
 use super::compute_node_prelude::*;
 use super::in_memory_sink::InMemorySinkNode;
 use super::in_memory_source::InMemorySourceNode;
-use crate::prelude::TracedAwait;
 
 pub enum InMemoryMapNode {
     Sink {

--- a/crates/polars-stream/src/nodes/in_memory_sink.rs
+++ b/crates/polars-stream/src/nodes/in_memory_sink.rs
@@ -5,7 +5,6 @@ use polars_core::schema::Schema;
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
 
 use super::compute_node_prelude::*;
-use crate::prelude::TracedAwait;
 use crate::utils::in_memory_linearize::linearize;
 
 pub struct InMemorySinkNode {
@@ -58,7 +57,7 @@ impl ComputeNode for InMemorySinkNode {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 let mut morsels = Vec::new();
-                while let Ok(mut morsel) = recv.recv().traced_await().await {
+                while let Ok(mut morsel) = recv.recv().await {
                     morsel.take_consume_token();
                     morsels.push(morsel);
                 }

--- a/crates/polars-stream/src/nodes/in_memory_sink.rs
+++ b/crates/polars-stream/src/nodes/in_memory_sink.rs
@@ -5,6 +5,7 @@ use polars_core::schema::Schema;
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
 
 use super::compute_node_prelude::*;
+use crate::prelude::TracedAwait;
 use crate::utils::in_memory_linearize::linearize;
 
 pub struct InMemorySinkNode {
@@ -57,7 +58,7 @@ impl ComputeNode for InMemorySinkNode {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 let mut morsels = Vec::new();
-                while let Ok(mut morsel) = recv.recv().await {
+                while let Ok(mut morsel) = recv.recv().traced_await().await {
                     morsel.take_consume_token();
                     morsels.push(morsel);
                 }

--- a/crates/polars-stream/src/nodes/in_memory_source.rs
+++ b/crates/polars-stream/src/nodes/in_memory_source.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use super::compute_node_prelude::*;
 use crate::async_primitives::wait_group::WaitGroup;
 use crate::morsel::{get_ideal_morsel_size, MorselSeq, SourceToken};
-use crate::prelude::TracedAwait;
 
 pub struct InMemorySourceNode {
     source: Option<Arc<DataFrame>>,
@@ -93,11 +92,11 @@ impl ComputeNode for InMemorySourceNode {
                     let morsel_seq = MorselSeq::new(seq).offset_by(slf.seq_offset);
                     let mut morsel = Morsel::new(df, morsel_seq, source_token.clone());
                     morsel.set_consume_token(wait_group.token());
-                    if send.send(morsel).traced_await().await.is_err() {
+                    if send.send(morsel).await.is_err() {
                         break;
                     }
 
-                    wait_group.wait().traced_await().await;
+                    wait_group.wait().await;
                     if source_token.stop_requested() {
                         break;
                     }

--- a/crates/polars-stream/src/nodes/input_independent_select.rs
+++ b/crates/polars-stream/src/nodes/input_independent_select.rs
@@ -3,7 +3,6 @@ use polars_core::prelude::IntoColumn;
 use super::compute_node_prelude::*;
 use crate::expression::StreamExpr;
 use crate::morsel::SourceToken;
-use crate::prelude::TracedAwait;
 
 pub struct InputIndependentSelectNode {
     selectors: Vec<StreamExpr>,
@@ -49,7 +48,7 @@ impl ComputeNode for InputIndependentSelectNode {
             let empty_df = DataFrame::empty();
             let mut selected = Vec::new();
             for selector in self.selectors.iter() {
-                let s = selector.evaluate(&empty_df, state).traced_await().await?;
+                let s = selector.evaluate(&empty_df, state).await?;
                 selected.push(s.into_column());
             }
 
@@ -57,7 +56,7 @@ impl ComputeNode for InputIndependentSelectNode {
             let seq = MorselSeq::default();
             let source_token = SourceToken::new();
             let morsel = Morsel::new(ret, seq, source_token);
-            sender.send(morsel).traced_await().await.ok();
+            sender.send(morsel).await.ok();
             self.done = true;
             Ok(())
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/csv.rs
@@ -17,6 +17,7 @@ use crate::async_executor::spawn;
 use crate::async_primitives::linearizer::Linearizer;
 use crate::nodes::io_sinks::{tokio_sync_on_close, DEFAULT_SINK_LINEARIZER_BUFFER_SIZE};
 use crate::nodes::{JoinHandle, MorselSeq, TaskPriority};
+use crate::prelude::TracedAwait;
 
 type Linearized = Priority<Reverse<MorselSeq>, Vec<u8>>;
 pub struct CsvSinkNode {
@@ -104,7 +105,7 @@ impl SinkNode for CsvSinkNode {
                 let mut allocation_size = DEFAULT_ALLOCATION_SIZE;
                 let options = options.clone();
 
-                while let Ok(morsel) = rx.recv().await {
+                while let Ok(morsel) = rx.recv().traced_await().await {
                     let (df, seq, _, consume_token) = morsel.into_inner();
 
                     let mut buffer = Vec::with_capacity(allocation_size);
@@ -132,7 +133,12 @@ impl SinkNode for CsvSinkNode {
                     drop(consume_token); // Keep the consume_token until here to increase the
                                          // backpressure.
 
-                    if lin_tx.insert(Priority(Reverse(seq), buffer)).await.is_err() {
+                    if lin_tx
+                        .insert(Priority(Reverse(seq), buffer))
+                        .traced_await()
+                        .await
+                        .is_err()
+                    {
                         return Ok(());
                     }
                 }
@@ -170,20 +176,23 @@ impl SinkNode for CsvSinkNode {
 
             let mut file = file.try_into_async_writeable()?;
 
-            while let Some(Priority(_, buffer)) = lin_rx.get().await {
-                file.write_all(&buffer).await?;
+            while let Some(Priority(_, buffer)) = lin_rx.get().traced_await().await {
+                file.write_all(&buffer).traced_await().await?;
             }
 
             if let AsyncWriteable::Local(file) = &mut file {
-                tokio_sync_on_close(sink_options.sync_on_close, file).await?;
+                tokio_sync_on_close(sink_options.sync_on_close, file)
+                    .traced_await()
+                    .await?;
             }
 
-            file.close().await?;
+            file.close().traced_await().await?;
 
             PolarsResult::Ok(())
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
+                .traced_await()
                 .await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -28,6 +28,7 @@ use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
 use crate::nodes::io_sinks::sync_on_close;
 use crate::nodes::{JoinHandle, PhaseOutcome, TaskPriority};
+use crate::prelude::TracedAwait;
 
 pub struct IpcSinkNode {
     path: PathBuf,
@@ -116,7 +117,7 @@ impl SinkNode for IpcSinkNode {
                 .map(|(mut dist_rx, mut lin_tx)| {
                     let write_options = self.write_options;
                     spawn(TaskPriority::High, async move {
-                        while let Ok((seq, col_idx, column)) = dist_rx.recv().await {
+                        while let Ok((seq, col_idx, column)) = dist_rx.recv().traced_await().await {
                             let mut variadic_buffer_counts = Vec::new();
                             let mut buffers = Vec::new();
                             let mut arrow_data = Vec::new();
@@ -156,7 +157,7 @@ impl SinkNode for IpcSinkNode {
                                     offset,
                                 ),
                             );
-                            if lin_tx.insert(msg).await.is_err() {
+                            if lin_tx.insert(msg).traced_await().await.is_err() {
                                 return Ok(());
                             }
                         }
@@ -204,7 +205,7 @@ impl SinkNode for IpcSinkNode {
             while let Some(Priority(
                 Reverse(seq),
                 (i, array, variadic_buffer_counts, buffers, arrow_data, nodes, offset),
-            )) = lin_rx.get().await
+            )) = lin_rx.get().traced_await().await
             {
                 if current.num_columns_seen == 0 {
                     current.seq = seq;
@@ -281,6 +282,7 @@ impl SinkNode for IpcSinkNode {
                             std::mem::take(&mut current.encoded_dictionaries),
                             encoded_data,
                         ))
+                        .traced_await()
                         .await
                         .is_err()
                     {
@@ -312,7 +314,7 @@ impl SinkNode for IpcSinkNode {
                 .with_parallel(false)
                 .batched(&input_schema)?;
 
-            while let Ok((dicts, record_batch)) = io_rx.recv().await {
+            while let Ok((dicts, record_batch)) = io_rx.recv().traced_await().await {
                 // @TODO: At the moment this is a sync write, this is not ideal because we can only
                 // have so many blocking threads in the tokio threadpool.
                 writer.write_encoded(dicts.as_slice(), &record_batch)?;
@@ -331,6 +333,7 @@ impl SinkNode for IpcSinkNode {
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
+                .traced_await()
                 .await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -28,7 +28,6 @@ use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
 use crate::nodes::io_sinks::sync_on_close;
 use crate::nodes::{JoinHandle, TaskPriority};
-use crate::prelude::TracedAwait;
 
 pub struct IpcSinkNode {
     path: PathBuf,
@@ -135,7 +134,7 @@ impl SinkNode for IpcSinkNode {
                 .map(|(mut dist_rx, mut lin_tx)| {
                     let write_options = self.write_options;
                     spawn(TaskPriority::High, async move {
-                        while let Ok((seq, col_idx, column)) = dist_rx.recv().traced_await().await {
+                        while let Ok((seq, col_idx, column)) = dist_rx.recv().await {
                             let mut variadic_buffer_counts = Vec::new();
                             let mut buffers = Vec::new();
                             let mut arrow_data = Vec::new();
@@ -175,7 +174,7 @@ impl SinkNode for IpcSinkNode {
                                     offset,
                                 ),
                             );
-                            if lin_tx.insert(msg).traced_await().await.is_err() {
+                            if lin_tx.insert(msg).await.is_err() {
                                 return Ok(());
                             }
                         }
@@ -223,7 +222,7 @@ impl SinkNode for IpcSinkNode {
             while let Some(Priority(
                 Reverse(seq),
                 (i, array, variadic_buffer_counts, buffers, arrow_data, nodes, offset),
-            )) = lin_rx.get().traced_await().await
+            )) = lin_rx.get().await
             {
                 if current.num_columns_seen == 0 {
                     current.seq = seq;
@@ -300,7 +299,6 @@ impl SinkNode for IpcSinkNode {
                             std::mem::take(&mut current.encoded_dictionaries),
                             encoded_data,
                         ))
-                        .traced_await()
                         .await
                         .is_err()
                     {
@@ -332,7 +330,7 @@ impl SinkNode for IpcSinkNode {
                 .with_parallel(false)
                 .batched(&input_schema)?;
 
-            while let Ok((dicts, record_batch)) = io_rx.recv().traced_await().await {
+            while let Ok((dicts, record_batch)) = io_rx.recv().await {
                 // @TODO: At the moment this is a sync write, this is not ideal because we can only
                 // have so many blocking threads in the tokio threadpool.
                 writer.write_encoded(dicts.as_slice(), &record_batch)?;
@@ -351,7 +349,6 @@ impl SinkNode for IpcSinkNode {
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
-                .traced_await()
                 .await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/json.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/json.rs
@@ -14,6 +14,7 @@ use crate::async_executor::spawn;
 use crate::async_primitives::linearizer::Linearizer;
 use crate::nodes::io_sinks::{tokio_sync_on_close, DEFAULT_SINK_LINEARIZER_BUFFER_SIZE};
 use crate::nodes::{JoinHandle, MorselSeq, TaskPriority};
+use crate::prelude::TracedAwait;
 
 type Linearized = Priority<Reverse<MorselSeq>, Vec<u8>>;
 pub struct NDJsonSinkNode {
@@ -91,7 +92,7 @@ impl SinkNode for NDJsonSinkNode {
                 // allocations, we adjust to that over time.
                 let mut allocation_size = DEFAULT_ALLOCATION_SIZE;
 
-                while let Ok(morsel) = rx.recv().await {
+                while let Ok(morsel) = rx.recv().traced_await().await {
                     let (df, seq, _, consume_token) = morsel.into_inner();
 
                     let mut buffer = Vec::with_capacity(allocation_size);
@@ -105,7 +106,12 @@ impl SinkNode for NDJsonSinkNode {
                     drop(consume_token); // Keep the consume_token until here to increase the
                                          // backpressure.
 
-                    if lin_tx.insert(Priority(Reverse(seq), buffer)).await.is_err() {
+                    if lin_tx
+                        .insert(Priority(Reverse(seq), buffer))
+                        .traced_await()
+                        .await
+                        .is_err()
+                    {
                         return Ok(());
                     }
                 }
@@ -127,22 +133,26 @@ impl SinkNode for NDJsonSinkNode {
                 path.to_str().unwrap(),
                 cloud_options.as_ref(),
             )
+            .traced_await()
             .await?;
 
-            while let Some(Priority(_, buffer)) = lin_rx.get().await {
-                file.write_all(&buffer).await?;
+            while let Some(Priority(_, buffer)) = lin_rx.get().traced_await().await {
+                file.write_all(&buffer).traced_await().await?;
             }
 
             if let AsyncWriteable::Local(file) = &mut file {
-                tokio_sync_on_close(sink_options.sync_on_close, file).await?;
+                tokio_sync_on_close(sink_options.sync_on_close, file)
+                    .traced_await()
+                    .await?;
             }
 
-            file.close().await?;
+            file.close().traced_await().await?;
 
             PolarsResult::Ok(())
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
+                .traced_await()
                 .await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/json.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/json.rs
@@ -14,6 +14,7 @@ use crate::async_executor::spawn;
 use crate::async_primitives::connector::Receiver;
 use crate::nodes::io_sinks::{parallelize_receive_task, tokio_sync_on_close};
 use crate::nodes::{JoinHandle, PhaseOutcome, TaskPriority};
+use crate::prelude::TracedAwait;
 
 pub struct NDJsonSinkNode {
     path: PathBuf,
@@ -72,8 +73,8 @@ impl SinkNode for NDJsonSinkNode {
                 // allocations, we adjust to that over time.
                 let mut allocation_size = DEFAULT_ALLOCATION_SIZE;
 
-                while let Ok((mut rx, mut lin_tx)) = pass_rx.recv().await {
-                    while let Ok(morsel) = rx.recv().await {
+                while let Ok((mut rx, mut lin_tx)) = pass_rx.recv().traced_await().await {
+                    while let Ok(morsel) = rx.recv().traced_await().await {
                         let (df, seq, _, consume_token) = morsel.into_inner();
 
                         let mut buffer = Vec::with_capacity(allocation_size);
@@ -82,7 +83,12 @@ impl SinkNode for NDJsonSinkNode {
                         writer.write_batch(&df)?;
 
                         allocation_size = allocation_size.max(buffer.len());
-                        if lin_tx.insert(Priority(Reverse(seq), buffer)).await.is_err() {
+                        if lin_tx
+                            .insert(Priority(Reverse(seq), buffer))
+                            .traced_await()
+                            .await
+                            .is_err()
+                        {
                             return Ok(());
                         }
                         drop(consume_token); // Keep the consume_token until here to increase the
@@ -107,24 +113,28 @@ impl SinkNode for NDJsonSinkNode {
                 path.to_str().unwrap(),
                 cloud_options.as_ref(),
             )
+            .traced_await()
             .await?;
 
-            while let Ok(mut lin_rx) = io_rx.recv().await {
-                while let Some(Priority(_, buffer)) = lin_rx.get().await {
-                    file.write_all(&buffer).await?;
+            while let Ok(mut lin_rx) = io_rx.recv().traced_await().await {
+                while let Some(Priority(_, buffer)) = lin_rx.get().traced_await().await {
+                    file.write_all(&buffer).traced_await().await?;
                 }
             }
 
             if let AsyncWriteable::Local(file) = &mut file {
-                tokio_sync_on_close(sink_options.sync_on_close, file).await?;
+                tokio_sync_on_close(sink_options.sync_on_close, file)
+                    .traced_await()
+                    .await?;
             }
 
-            file.close().await?;
+            file.close().traced_await().await?;
 
             PolarsResult::Ok(())
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
+                .traced_await()
                 .await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/mod.rs
@@ -19,7 +19,6 @@ use crate::async_primitives::connector::{connector, Receiver, Sender};
 use crate::async_primitives::distributor_channel;
 use crate::async_primitives::wait_group::WaitGroup;
 use crate::nodes::TaskPriority;
-use crate::prelude::TracedAwait;
 
 #[cfg(feature = "csv")]
 pub mod csv;
@@ -76,22 +75,17 @@ impl SinkRecvPort {
         let wg = WaitGroup::default();
 
         join_handles.push(spawn(TaskPriority::High, async move {
-            while let Ok((outcome, port_rxs)) = self.recv.recv().traced_await().await {
+            while let Ok((outcome, port_rxs)) = self.recv.recv().await {
                 let port_rxs = port_rxs.parallel();
                 for (pass_tx, port_rx) in pass_txs.iter_mut().zip(port_rxs) {
                     let (token, outcome) = PhaseOutcome::new_shared_wait(wg.token());
-                    if pass_tx
-                        .send((outcome, port_rx))
-                        .traced_await()
-                        .await
-                        .is_err()
-                    {
+                    if pass_tx.send((outcome, port_rx)).await.is_err() {
                         return Ok(());
                     }
                     outcomes.push(token);
                 }
 
-                wg.wait().traced_await().await;
+                wg.wait().await;
                 for outcome_token in &outcomes {
                     if outcome_token.did_finish() {
                         return Ok(());
@@ -105,9 +99,9 @@ impl SinkRecvPort {
         }));
         join_handles.extend(pass_rxs.into_iter().zip(txs).map(|(mut pass_rx, mut tx)| {
             spawn(TaskPriority::High, async move {
-                while let Ok((outcome, mut rx)) = pass_rx.recv().traced_await().await {
-                    while let Ok(morsel) = rx.recv().traced_await().await {
-                        if tx.send(morsel).traced_await().await.is_err() {
+                while let Ok((outcome, mut rx)) = pass_rx.recv().await {
+                    while let Ok(morsel) = rx.recv().await {
+                        if tx.send(morsel).await.is_err() {
                             return Ok(());
                         }
                     }
@@ -127,10 +121,10 @@ impl SinkRecvPort {
     ) -> Receiver<Morsel> {
         let (mut tx, rx) = connector();
         join_handles.push(spawn(TaskPriority::High, async move {
-            while let Ok((outcome, port_rx)) = self.recv.recv().traced_await().await {
+            while let Ok((outcome, port_rx)) = self.recv.recv().await {
                 let mut port_rx = port_rx.serial();
-                while let Ok(morsel) = port_rx.recv().traced_await().await {
-                    if tx.send(morsel).traced_await().await.is_err() {
+                while let Ok(morsel) = port_rx.recv().await {
+                    if tx.send(morsel).await.is_err() {
                         return Ok(());
                     }
                 }
@@ -154,7 +148,7 @@ fn buffer_and_distribute_columns_task(
         let mut seq = 0usize;
         let mut buffer = DataFrame::empty_with_schema(schema.as_ref());
 
-        while let Ok(morsel) = rx.recv().traced_await().await {
+        while let Ok(morsel) = rx.recv().await {
             let (df, _, _, consume_token) = morsel.into_inner();
             // @NOTE: This also performs schema validation.
             buffer.vstack_mut(&df)?;
@@ -164,7 +158,7 @@ fn buffer_and_distribute_columns_task(
                 (df, buffer) = buffer.split_at(buffer.height().min(chunk_size) as i64);
 
                 for (i, column) in df.take_columns().into_iter().enumerate() {
-                    if dist_tx.send((seq, i, column)).traced_await().await.is_err() {
+                    if dist_tx.send((seq, i, column)).await.is_err() {
                         return Ok(());
                     }
                 }
@@ -179,7 +173,7 @@ fn buffer_and_distribute_columns_task(
         // Flush the remaining rows.
         assert!(buffer.height() <= chunk_size);
         for (i, column) in buffer.take_columns().into_iter().enumerate() {
-            if dist_tx.send((seq, i, column)).traced_await().await.is_err() {
+            if dist_tx.send((seq, i, column)).await.is_err() {
                 return Ok(());
             }
         }
@@ -259,7 +253,7 @@ impl ComputeNode for SinkComputeNode {
                 drop(started.input_send);
                 polars_io::pl_async::get_runtime().block_on(async move {
                     // Either the task finished or some error occurred.
-                    while let Some(ret) = started.join_handles.next().traced_await().await {
+                    while let Some(ret) = started.join_handles.next().await {
                         ret?;
                     }
                     PolarsResult::Ok(())
@@ -315,15 +309,9 @@ impl ComputeNode for SinkComputeNode {
         };
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             let (token, outcome) = PhaseOutcome::new_shared_wait(wait_group.token());
-            if started
-                .input_send
-                .send((outcome, sink_input))
-                .traced_await()
-                .await
-                .is_ok()
-            {
+            if started.input_send.send((outcome, sink_input)).await.is_ok() {
                 // Wait for the phase to finish.
-                wait_group.wait().traced_await().await;
+                wait_group.wait().await;
                 if !token.did_finish() {
                     return Ok(());
                 }
@@ -334,7 +322,7 @@ impl ComputeNode for SinkComputeNode {
             }
 
             // Either the task finished or some error occurred.
-            while let Some(ret) = started.join_handles.next().traced_await().await {
+            while let Some(ret) = started.join_handles.next().await {
                 ret?;
             }
 
@@ -357,7 +345,7 @@ pub async fn tokio_sync_on_close(
 ) -> io::Result<()> {
     match sync_on_close {
         SyncOnCloseType::None => Ok(()),
-        SyncOnCloseType::Data => file.sync_data().traced_await().await,
-        SyncOnCloseType::All => file.sync_all().traced_await().await,
+        SyncOnCloseType::Data => file.sync_data().await,
+        SyncOnCloseType::All => file.sync_all().await,
     }
 }

--- a/crates/polars-stream/src/nodes/io_sinks/parquet.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/parquet.rs
@@ -31,6 +31,7 @@ use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
 use crate::nodes::io_sinks::sync_on_close;
 use crate::nodes::{JoinHandle, PhaseOutcome, TaskPriority};
+use crate::prelude::TracedAwait;
 
 pub struct ParquetSinkNode {
     path: PathBuf,
@@ -134,7 +135,9 @@ impl SinkNode for ParquetSinkNode {
                     let encodings = self.encodings.clone();
 
                     spawn(TaskPriority::High, async move {
-                        while let Ok((rg_idx, col_idx, column)) = dist_rx.recv().await {
+                        while let Ok((rg_idx, col_idx, column)) =
+                            dist_rx.recv().traced_await().await
+                        {
                             let type_ = &parquet_schema.fields()[col_idx];
                             let encodings = &encodings[col_idx];
 
@@ -172,6 +175,7 @@ impl SinkNode for ParquetSinkNode {
 
                             if lin_tx
                                 .insert(Priority(Reverse(rg_idx), (col_idx, compressed_pages)))
+                                .traced_await()
                                 .await
                                 .is_err()
                             {
@@ -203,7 +207,9 @@ impl SinkNode for ParquetSinkNode {
             };
 
             // Linearize from all the Encoder tasks.
-            while let Some(Priority(Reverse(seq), (i, compressed_pages))) = lin_rx.get().await {
+            while let Some(Priority(Reverse(seq), (i, compressed_pages))) =
+                lin_rx.get().traced_await().await
+            {
                 if current.num_columns_seen == 0 {
                     current.seq = seq;
                 }
@@ -222,7 +228,7 @@ impl SinkNode for ParquetSinkNode {
                         current_row_group.extend(column.take().unwrap());
                     }
 
-                    if io_tx.send(current_row_group).await.is_err() {
+                    if io_tx.send(current_row_group).traced_await().await.is_err() {
                         return Ok(());
                     }
                     current.num_columns_seen = 0;
@@ -265,7 +271,7 @@ impl SinkNode for ParquetSinkNode {
             let mut writer = BatchedWriter::new(file_writer, encodings, write_options, false);
 
             let num_parquet_columns = writer.parquet_schema().leaves().len();
-            while let Ok(current_row_group) = io_rx.recv().await {
+            while let Ok(current_row_group) = io_rx.recv().traced_await().await {
                 // @TODO: At the moment this is a sync write, this is not ideal because we can only
                 // have so many blocking threads in the tokio threadpool.
                 assert_eq!(current_row_group.len(), num_parquet_columns);
@@ -285,6 +291,7 @@ impl SinkNode for ParquetSinkNode {
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
+                .traced_await()
                 .await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/parquet.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/parquet.rs
@@ -31,7 +31,6 @@ use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
 use crate::nodes::io_sinks::sync_on_close;
 use crate::nodes::{JoinHandle, TaskPriority};
-use crate::prelude::TracedAwait;
 
 pub struct ParquetSinkNode {
     path: PathBuf,
@@ -153,9 +152,7 @@ impl SinkNode for ParquetSinkNode {
                     let encodings = self.encodings.clone();
 
                     spawn(TaskPriority::High, async move {
-                        while let Ok((rg_idx, col_idx, column)) =
-                            dist_rx.recv().traced_await().await
-                        {
+                        while let Ok((rg_idx, col_idx, column)) = dist_rx.recv().await {
                             let type_ = &parquet_schema.fields()[col_idx];
                             let encodings = &encodings[col_idx];
 
@@ -193,7 +190,6 @@ impl SinkNode for ParquetSinkNode {
 
                             if lin_tx
                                 .insert(Priority(Reverse(rg_idx), (col_idx, compressed_pages)))
-                                .traced_await()
                                 .await
                                 .is_err()
                             {
@@ -225,9 +221,7 @@ impl SinkNode for ParquetSinkNode {
             };
 
             // Linearize from all the Encoder tasks.
-            while let Some(Priority(Reverse(seq), (i, compressed_pages))) =
-                lin_rx.get().traced_await().await
-            {
+            while let Some(Priority(Reverse(seq), (i, compressed_pages))) = lin_rx.get().await {
                 if current.num_columns_seen == 0 {
                     current.seq = seq;
                 }
@@ -246,7 +240,7 @@ impl SinkNode for ParquetSinkNode {
                         current_row_group.extend(column.take().unwrap());
                     }
 
-                    if io_tx.send(current_row_group).traced_await().await.is_err() {
+                    if io_tx.send(current_row_group).await.is_err() {
                         return Ok(());
                     }
                     current.num_columns_seen = 0;
@@ -289,7 +283,7 @@ impl SinkNode for ParquetSinkNode {
             let mut writer = BatchedWriter::new(file_writer, encodings, write_options, false);
 
             let num_parquet_columns = writer.parquet_schema().leaves().len();
-            while let Ok(current_row_group) = io_rx.recv().traced_await().await {
+            while let Ok(current_row_group) = io_rx.recv().await {
                 // @TODO: At the moment this is a sync write, this is not ideal because we can only
                 // have so many blocking threads in the tokio threadpool.
                 assert_eq!(current_row_group.len(), num_parquet_columns);
@@ -309,7 +303,6 @@ impl SinkNode for ParquetSinkNode {
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
-                .traced_await()
                 .await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -20,7 +20,6 @@ use crate::nodes::io_sinks::{
     SinkInputPort, SinkNode, SinkRecvPort, DEFAULT_SINK_DISTRIBUTOR_BUFFER_SIZE,
 };
 use crate::nodes::{JoinHandle, Morsel, TaskPriority};
-use crate::prelude::TracedAwait;
 
 pub struct MaxSizePartitionSinkNode {
     input_schema: SchemaRef,
@@ -139,7 +138,7 @@ impl SinkNode for MaxSizePartitionSinkNode {
             let mut part = 0;
             let mut current_sink_opt = None;
 
-            'morsel_loop: while let Ok(mut morsel) = recv_port.recv().traced_await().await {
+            'morsel_loop: while let Ok(mut morsel) = recv_port.recv().await {
                 while morsel.df().height() > 0 {
                     if retire_error.load(Ordering::Relaxed) {
                         return Ok(());
@@ -172,7 +171,7 @@ impl SinkNode for MaxSizePartitionSinkNode {
                                     .collect::<(Vec<_>, Vec<_>)>();
 
                                 for (i, channels) in dist_rxs.into_iter().zip(txs).enumerate() {
-                                    if dist_txs[i].send(channels).traced_await().await.is_err() {
+                                    if dist_txs[i].send(channels).await.is_err() {
                                         return Ok(());
                                     }
                                 }
@@ -210,8 +209,8 @@ impl SinkNode for MaxSizePartitionSinkNode {
                         // too much. The sinks are very specific about how they handle consume
                         // tokens and we want to keep that behavior.
                         let result = match &mut current_sink.sender {
-                            SinkSender::Connector(s) => s.send(morsel).traced_await().await.ok(),
-                            SinkSender::Distributor(s) => s.send(morsel).traced_await().await.ok(),
+                            SinkSender::Connector(s) => s.send(morsel).await.ok(),
+                            SinkSender::Distributor(s) => s.send(morsel).await.ok(),
                         };
 
                         if result.is_none() {
@@ -228,12 +227,8 @@ impl SinkNode for MaxSizePartitionSinkNode {
                     let final_sink_morsel = Morsel::new(final_sink_df, seq, source_token.clone());
 
                     let result = match &mut current_sink.sender {
-                        SinkSender::Connector(s) => {
-                            s.send(final_sink_morsel).traced_await().await.ok()
-                        },
-                        SinkSender::Distributor(s) => {
-                            s.send(final_sink_morsel).traced_await().await.ok()
-                        },
+                        SinkSender::Connector(s) => s.send(final_sink_morsel).await.ok(),
+                        SinkSender::Distributor(s) => s.send(final_sink_morsel).await.ok(),
                     };
 
                     if result.is_none() {
@@ -242,7 +237,7 @@ impl SinkNode for MaxSizePartitionSinkNode {
 
                     let join_handles = std::mem::take(&mut current_sink.join_handles);
                     drop(current_sink_opt.take());
-                    if retire_tx.send(join_handles).traced_await().await.is_err() {
+                    if retire_tx.send(join_handles).await.is_err() {
                         return Ok(());
                     };
 
@@ -256,7 +251,7 @@ impl SinkNode for MaxSizePartitionSinkNode {
 
             if let Some(mut current_sink) = current_sink_opt.take() {
                 drop(current_sink.sender);
-                while let Some(res) = current_sink.join_handles.next().traced_await().await {
+                while let Some(res) = current_sink.join_handles.next().await {
                     res?;
                 }
             }
@@ -270,9 +265,9 @@ impl SinkNode for MaxSizePartitionSinkNode {
         // a distributor.
         join_handles.extend(dist_rxs.into_iter().map(|mut dist_rx| {
             spawn(TaskPriority::High, async move {
-                while let Ok((mut rx, mut tx)) = dist_rx.recv().traced_await().await {
-                    while let Ok(m) = rx.recv().traced_await().await {
-                        if tx.send(m).traced_await().await.is_err() {
+                while let Ok((mut rx, mut tx)) = dist_rx.recv().await {
+                    while let Ok(m) = rx.recv().await {
+                        if tx.send(m).await.is_err() {
                             break;
                         }
                     }
@@ -290,8 +285,8 @@ impl SinkNode for MaxSizePartitionSinkNode {
         join_handles.extend(retire_rxs.into_iter().map(|mut retire_rx| {
             let has_error_occurred = has_error_occurred.clone();
             spawn(TaskPriority::High, async move {
-                while let Ok(mut join_handles) = retire_rx.recv().traced_await().await {
-                    while let Some(ret) = join_handles.next().traced_await().await {
+                while let Ok(mut join_handles) = retire_rx.recv().await {
+                    while let Some(ret) = join_handles.next().await {
                         ret.inspect_err(|_| {
                             has_error_occurred.store(true, Ordering::Relaxed);
                         })?;

--- a/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
@@ -9,6 +9,7 @@ use polars_plan::dsl::{FileType, PartitionVariant, SinkOptions};
 use polars_utils::pl_str::PlSmallStr;
 
 use super::SinkNode;
+use crate::prelude::TracedAwait;
 
 pub mod max_size;
 

--- a/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
@@ -9,7 +9,6 @@ use polars_plan::dsl::{FileType, PartitionVariant, SinkOptions};
 use polars_utils::pl_str::PlSmallStr;
 
 use super::SinkNode;
-use crate::prelude::TracedAwait;
 
 pub mod max_size;
 

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -34,7 +34,6 @@ use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::io_sources::MorselOutput;
 use crate::nodes::{MorselSeq, TaskPriority};
-use crate::prelude::TracedAwait;
 use crate::DEFAULT_DISTRIBUTOR_BUFFER_SIZE;
 
 struct LineBatch {
@@ -114,14 +113,14 @@ impl SourceNode for CsvSourceNode {
                 let wait_group = WaitGroup::default();
 
                 spawn(TaskPriority::Low, async move {
-                    while let Ok(mut morsel_output) = recv_from.recv().traced_await().await {
+                    while let Ok(mut morsel_output) = recv_from.recv().await {
                         while let Ok(LineBatch {
                             bytes,
                             n_lines,
                             slice: (offset, len),
                             row_offset,
                             morsel_seq,
-                        }) = line_batch_rx.recv().traced_await().await
+                        }) = line_batch_rx.recv().await
                         {
                             let df = chunk_reader.read_chunk(
                                 &bytes,
@@ -133,17 +132,11 @@ impl SourceNode for CsvSourceNode {
                             let mut morsel = Morsel::new(df, morsel_seq, source_token.clone());
                             morsel.set_consume_token(wait_group.token());
 
-                            if morsel_output
-                                .port
-                                .send(morsel)
-                                .traced_await()
-                                .await
-                                .is_err()
-                            {
+                            if morsel_output.port.send(morsel).await.is_err() {
                                 break;
                             }
 
-                            wait_group.wait().traced_await().await;
+                            wait_group.wait().await;
 
                             if source_token.stop_requested() {
                                 morsel_output.outcome.stop();
@@ -159,19 +152,19 @@ impl SourceNode for CsvSourceNode {
 
         join_handles.push(spawn(TaskPriority::Low, async move {
             // Every phase we are given a new send port.
-            while let Ok(phase_output) = output_recv.recv().traced_await().await {
+            while let Ok(phase_output) = output_recv.recv().await {
                 let morsel_senders = phase_output.port.parallel();
                 let mut morsel_outcomes = Vec::with_capacity(morsel_senders.len());
 
                 for (send_to, port) in send_to.iter_mut().zip(morsel_senders) {
                     let (outcome, wait_group, morsel_output) = MorselOutput::from_port(port);
-                    _ = send_to.send(morsel_output).traced_await().await;
+                    _ = send_to.send(morsel_output).await;
                     morsel_outcomes.push((outcome, wait_group));
                 }
 
                 let mut is_finished = true;
                 for (outcome, wait_group) in morsel_outcomes.into_iter() {
-                    wait_group.wait().traced_await().await;
+                    wait_group.wait().await;
                     is_finished &= outcome.did_finish();
                 }
 
@@ -187,7 +180,7 @@ impl SourceNode for CsvSourceNode {
             // Safety
             // * We dropped the receivers on the line above
             // * This function is only called once.
-            line_batch_source_task_handle.traced_await().await
+            line_batch_source_task_handle.await
         }))
     }
 }
@@ -369,7 +362,7 @@ impl CsvSourceNode {
                         row_offset: current_row_offset,
                         morsel_seq,
                     };
-                    if line_batch_sender.send(batch).traced_await().await.is_err() {
+                    if line_batch_sender.send(batch).await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/nodes/io_sources/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sources/csv.rs
@@ -34,6 +34,7 @@ use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::io_sources::MorselOutput;
 use crate::nodes::{MorselSeq, TaskPriority};
+use crate::prelude::TracedAwait;
 use crate::DEFAULT_DISTRIBUTOR_BUFFER_SIZE;
 
 struct LineBatch {
@@ -113,14 +114,14 @@ impl SourceNode for CsvSourceNode {
                 let wait_group = WaitGroup::default();
 
                 spawn(TaskPriority::Low, async move {
-                    while let Ok(mut morsel_output) = recv_from.recv().await {
+                    while let Ok(mut morsel_output) = recv_from.recv().traced_await().await {
                         while let Ok(LineBatch {
                             bytes,
                             n_lines,
                             slice: (offset, len),
                             row_offset,
                             morsel_seq,
-                        }) = line_batch_rx.recv().await
+                        }) = line_batch_rx.recv().traced_await().await
                         {
                             let df = chunk_reader.read_chunk(
                                 &bytes,
@@ -132,11 +133,17 @@ impl SourceNode for CsvSourceNode {
                             let mut morsel = Morsel::new(df, morsel_seq, source_token.clone());
                             morsel.set_consume_token(wait_group.token());
 
-                            if morsel_output.port.send(morsel).await.is_err() {
+                            if morsel_output
+                                .port
+                                .send(morsel)
+                                .traced_await()
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
 
-                            wait_group.wait().await;
+                            wait_group.wait().traced_await().await;
 
                             if source_token.stop_requested() {
                                 morsel_output.outcome.stop();
@@ -152,19 +159,19 @@ impl SourceNode for CsvSourceNode {
 
         join_handles.push(spawn(TaskPriority::Low, async move {
             // Every phase we are given a new send port.
-            while let Ok(phase_output) = output_recv.recv().await {
+            while let Ok(phase_output) = output_recv.recv().traced_await().await {
                 let morsel_senders = phase_output.port.parallel();
                 let mut morsel_outcomes = Vec::with_capacity(morsel_senders.len());
 
                 for (send_to, port) in send_to.iter_mut().zip(morsel_senders) {
                     let (outcome, wait_group, morsel_output) = MorselOutput::from_port(port);
-                    _ = send_to.send(morsel_output).await;
+                    _ = send_to.send(morsel_output).traced_await().await;
                     morsel_outcomes.push((outcome, wait_group));
                 }
 
                 let mut is_finished = true;
                 for (outcome, wait_group) in morsel_outcomes.into_iter() {
-                    wait_group.wait().await;
+                    wait_group.wait().traced_await().await;
                     is_finished &= outcome.did_finish();
                 }
 
@@ -180,7 +187,7 @@ impl SourceNode for CsvSourceNode {
             // Safety
             // * We dropped the receivers on the line above
             // * This function is only called once.
-            line_batch_source_task_handle.await
+            line_batch_source_task_handle.traced_await().await
         }))
     }
 }
@@ -362,7 +369,7 @@ impl CsvSourceNode {
                         row_offset: current_row_offset,
                         morsel_seq,
                     };
-                    if line_batch_sender.send(batch).await.is_err() {
+                    if line_batch_sender.send(batch).traced_await().await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/nodes/io_sources/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc.rs
@@ -37,6 +37,7 @@ use crate::async_primitives::linearizer::Linearizer;
 use crate::async_primitives::wait_group::WaitGroup;
 use crate::morsel::{get_ideal_morsel_size, SourceToken};
 use crate::nodes::{JoinHandle, Morsel, MorselSeq, TaskPriority};
+use crate::prelude::TracedAwait;
 use crate::{DEFAULT_DISTRIBUTOR_BUFFER_SIZE, DEFAULT_LINEARIZER_BUFFER_SIZE};
 
 const ROW_COUNT_OVERFLOW_ERR: PolarsError = PolarsError::ComputeError(ErrString::new_static(
@@ -239,20 +240,20 @@ impl SourceNode for IpcSourceNode {
         // available output pipelines.
         join_handles.push(spawn(TaskPriority::High, async move {
             // Every phase we are given a new send port.
-            'phase_loop: while let Ok(phase_output) = output_recv.recv().await {
+            'phase_loop: while let Ok(phase_output) = output_recv.recv().traced_await().await {
                 let mut sender = phase_output.port.serial();
                 let source_token = SourceToken::new();
                 let wait_group = WaitGroup::default();
 
-                while let Some(Priority(Reverse(seq), df)) = decoded_rx.get().await {
+                while let Some(Priority(Reverse(seq), df)) = decoded_rx.get().traced_await().await {
                     let mut morsel = Morsel::new(df, seq, source_token.clone());
                     morsel.set_consume_token(wait_group.token());
 
-                    if sender.send(morsel).await.is_err() {
+                    if sender.send(morsel).traced_await().await.is_err() {
                         return Ok(());
                     }
 
-                    wait_group.wait().await;
+                    wait_group.wait().traced_await().await;
                     if source_token.stop_requested() {
                         phase_output.outcome.stop();
                         continue 'phase_loop;
@@ -288,7 +289,7 @@ impl SourceNode for IpcSourceNode {
                         .map(|(n, f)| (n.clone(), DataType::from_arrow_field(f)))
                         .collect::<Schema>();
 
-                    while let Ok(m) = rx.recv().await {
+                    while let Ok(m) = rx.recv().traced_await().await {
                         let BatchMessage {
                             row_idx_offset,
                             slice,
@@ -341,7 +342,7 @@ impl SourceNode for IpcSourceNode {
                         for i in 0..df.height().div_ceil(max_morsel_size) {
                             let morsel_df = df.slice((i * max_morsel_size) as i64, max_morsel_size);
                             let seq = MorselSeq::new(morsel_seq_base + i as u64);
-                            if send.insert(Priority(Reverse(seq), morsel_df)).await.is_err() {
+                            if send.insert(Priority(Reverse(seq), morsel_df)).traced_await().await.is_err() {
                                 break;
                             }
                         }
@@ -469,7 +470,7 @@ impl SourceNode for IpcSourceNode {
                             break 'read;
                         }
 
-                        if batch_tx.send(message).await.is_err() {
+                        if batch_tx.send(message).traced_await().await.is_err() {
                             // This should only happen if the receiver of the decoder
                             // has broken off, meaning no further input will be needed.
                             break 'read;
@@ -494,7 +495,7 @@ impl SourceNode for IpcSourceNode {
 
             drop(batch_tx); // Inform decoder tasks to stop.
             for decoder_task in decoder_tasks {
-                decoder_task.await?;
+                decoder_task.traced_await().await?;
             }
 
             PolarsResult::Ok(())

--- a/crates/polars-stream/src/nodes/io_sources/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/mod.rs
@@ -14,6 +14,7 @@ use super::{ComputeNode, JoinHandle, Morsel, PortState, RecvPort, SendPort, Task
 use crate::async_executor::AbortOnDropHandle;
 use crate::async_primitives::connector::{connector, Receiver, Sender};
 use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
+use crate::prelude::TracedAwait;
 
 #[cfg(feature = "csv")]
 pub mod csv;
@@ -127,9 +128,15 @@ impl<T: SourceNode> ComputeNode for SourceComputeNode<T> {
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             let (outcome, wait_group, source_output) = SourceOutput::from_port(source_output);
 
-            if started.output_send.send(source_output).await.is_ok() {
+            if started
+                .output_send
+                .send(source_output)
+                .traced_await()
+                .await
+                .is_ok()
+            {
                 // Wait for the phase to finish.
-                wait_group.wait().await;
+                wait_group.wait().traced_await().await;
                 if !outcome.did_finish() {
                     return Ok(());
                 }
@@ -140,7 +147,7 @@ impl<T: SourceNode> ComputeNode for SourceComputeNode<T> {
             };
 
             // Either the task finished or some error occurred.
-            while let Some(ret) = started.join_handles.next().await {
+            while let Some(ret) = started.join_handles.next().traced_await().await {
                 ret?;
             }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan.rs
@@ -29,6 +29,7 @@ use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
 use crate::morsel::SourceToken;
 use crate::nodes::io_sources::{PhaseOutcomeToken, SourceOutputPort};
 use crate::nodes::{JoinHandle, Morsel, MorselSeq, TaskPriority};
+use crate::prelude::TracedAwait;
 
 fn source_name(scan_source: ScanSourceRef<'_>, index: usize) -> PlSmallStr {
     match scan_source {
@@ -536,9 +537,9 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                             cloud_options.as_ref().as_ref(),
                             None,
                         )
-                        .await?;
+                        .traced_await().await?;
 
-                        let num_rows = source.unrestricted_row_count().await?;
+                        let num_rows = source.unrestricted_row_count().traced_await().await?;
                         let num_rows = num_rows as usize;
                         source_length_sum += offset.min(num_rows);
 
@@ -619,7 +620,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
 
                             // Flush all remaining workers waiting for their slice.
                             for mut rx in slice_rx {
-                                let Ok((_, slice_range, wait_token)) = rx.recv().await else {
+                                let Ok((_, slice_range, wait_token)) = rx.recv().traced_await().await else {
                                     continue;
                                 };
 
@@ -634,7 +635,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                         }
 
                         let handler = i % max_concurrent_scans;
-                        let Ok((num_rows, slice_range, wait_token)) = slice_rx[handler].recv().await
+                        let Ok((num_rows, slice_range, wait_token)) = slice_rx[handler].recv().traced_await().await
                         else {
                             break;
                         };
@@ -737,10 +738,10 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                 cloud_options.as_ref().as_ref(),
                                 row_index_name.clone(),
                             )
-                            .await?;
+                            .traced_await().await?;
 
                             if is_selected {
-                                let row_count = source.unrestricted_row_count().await?;
+                                let row_count = source.unrestricted_row_count().traced_await().await?;
                                 let unrestricted_row_count_rx = {
                                     let (tx, rx) = tokio::sync::oneshot::channel();
                                     tx.send(row_count).unwrap();
@@ -754,14 +755,14 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                 };
                                 // Wait for the orchestrator task to actually be interested in the output
                                 // of this file.
-                                if si_send.send(phase).await.is_err() {
+                                if si_send.send(phase).traced_await().await.is_err() {
                                     break;
                                 };
                                 i += max_concurrent_scans;
                                 continue;
                             }
 
-                            let source_schema = source.physical_schema().await?;
+                            let source_schema = source.physical_schema().traced_await().await?;
                             let (source_projection, missing_columns) = resolve_source_projection(
                                 file_schema.as_ref(),
                                 source_schema.as_ref(),
@@ -773,15 +774,15 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                             )?;
 
                             if let Some(slice_tx) = &mut slice_tx {
-                                let row_count = source.unrestricted_row_count().await?;
+                                let row_count = source.unrestricted_row_count().traced_await().await?;
                                 if slice_tx
                                     .send((row_count, slice_range.clone(), slice_wg.token()))
-                                    .await
+                                    .traced_await().await
                                     .is_err()
                                 {
                                     break;
                                 };
-                                slice_wg.wait().await;
+                                slice_wg.wait().traced_await().await;
 
                                 let (start, length) = slice_range.as_ref();
                                 let start = start.load(Ordering::Relaxed);
@@ -810,7 +811,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
 
                                     // Wait for the orchestrator task to actually be interested in the output
                                     // of this file.
-                                    if si_send.send(phase).await.is_err() {
+                                    if si_send.send(phase).traced_await().await.is_err() {
                                         break;
                                     };
                                     i += max_concurrent_scans;
@@ -919,19 +920,19 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
 
                                 // Wait for the orchestrator task to actually be interested in the output
                                 // of this file.
-                                if si_send.send(phase).await.is_err() {
+                                if si_send.send(phase).traced_await().await.is_err() {
                                     break;
                                 };
 
                                 let (outcome, wait_group, tx) = SourceOutput::from_port(tx);
 
                                 // Start draining the source into the created channels.
-                                if output_send.send(tx).await.is_err() {
+                                if output_send.send(tx).traced_await().await.is_err() {
                                     break;
                                 };
 
                                 // Wait for the phase to end.
-                                wait_group.wait().await;
+                                wait_group.wait().traced_await().await;
                                 if outcome.did_finish() {
                                     break;
                                 }
@@ -944,7 +945,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
 
                             // One of the tasks might throw an error. In which case, we need to cancel all
                             // handles and find the error.
-                            while let Some(ret) = join_handles.next().await {
+                            while let Some(ret) = join_handles.next().traced_await().await {
                                 ret?;
                             }
 
@@ -985,12 +986,12 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                 let include_file_paths = include_file_paths.clone();
                 let hive_parts = hive_parts.clone();
                 spawn(TaskPriority::High, async move {
-                    'phase_loop: while let Ok(mut send) = pass_phase_recv.recv().await {
+                    'phase_loop: while let Ok(mut send) = pass_phase_recv.recv().traced_await().await {
                         let source_token = SourceToken::new();
                         let wait_group = WaitGroup::default();
 
-                        while let Ok(mut phase_source_pass) = pass_source_recv.recv().await {
-                            while let Ok(rg) = phase_source_pass.recv.recv().await {
+                        while let Ok(mut phase_source_pass) = pass_source_recv.recv().traced_await().await {
+                            while let Ok(rg) = phase_source_pass.recv.recv().traced_await().await {
                                 let original_seq = rg.seq();
                                 let original_source_token = rg.source_token().clone();
 
@@ -1017,12 +1018,12 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                 let mut morsel = Morsel::new(df, seq, source_token.clone());
                                 morsel.set_consume_token(wait_group.token());
 
-                                if send.send(morsel).await.is_err() {
+                                if send.send(morsel).traced_await().await.is_err() {
                                     return Ok(());
                                 }
 
                                 phase_source_pass.max_morsel_seq.store(seq.to_u64(), Ordering::Relaxed);
-                                wait_group.wait().await;
+                                wait_group.wait().traced_await().await;
                                 if source_token.stop_requested() {
                                     original_source_token.stop();
                                     phase_source_pass.outcome.stop();
@@ -1045,11 +1046,11 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                 let mut unrestricted_row_count_rx = None;
 
                 // Every phase we are given a new send channel.
-                'phase_loop: while let Ok(phase_output) = send_port_recv.recv().await {
+                'phase_loop: while let Ok(phase_output) = send_port_recv.recv().traced_await().await {
                     let send = phase_output.port.parallel();
                     for (pass_phase_send, send) in pass_phase_send.iter_mut().zip(send)
                     {
-                        if pass_phase_send.send(send).await.is_err() {
+                        if pass_phase_send.send(send).traced_await().await.is_err() {
                             return Ok(());
                         };
                     }
@@ -1070,7 +1071,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
 
                         let source_name = source_name(sources.at(current_scan), current_scan);
                         let si_recv = &mut si_recv[current_scan % max_concurrent_scans];
-                        let Ok(phase) = si_recv.recv().await else {
+                        let Ok(phase) = si_recv.recv().traced_await().await else {
                             return Ok(());
                         };
 
@@ -1107,17 +1108,17 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                         max_morsel_seq: max_morsel_seq.clone(),
                                         outcome: outcome.clone(),
                                         wait_token: wg.token(),
-                                    }).await.is_err() {
+                                    }).traced_await().await.is_err() {
                                         return Ok(());
                                     }
 
-                                    if tx.send(Morsel::new(df, MorselSeq::new(0), SourceToken::new())).await.is_err() {
+                                    if tx.send(Morsel::new(df, MorselSeq::new(0), SourceToken::new())).traced_await().await.is_err() {
                                         break 'phase_loop;
                                     }
                                     drop(tx); // Drop the channel so that the passer task waits for
                                               // a new source.
 
-                                    wg.wait().await;
+                                    wg.wait().traced_await().await;
                                     seq = seq.max(unsafe { MorselSeq::from_u64(max_morsel_seq.load(Ordering::Relaxed)) });
                                     let did_finish = outcome.did_finish();
                                     seq = seq.successor();
@@ -1137,8 +1138,8 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                         let mut offset = seq.to_u64() as usize;
                                         let (mut txs, rxs) = (0..num_pipelines).map(|_| connector()).collect::<(Vec<_>, Vec<_>)>();
                                         distributor = Some(AbortOnDropHandle::new(spawn(TaskPriority::High, async move {
-                                            while let Ok(m) = rx.recv().await {
-                                                if txs[offset % num_pipelines].send(m).await.is_err() {
+                                            while let Ok(m) = rx.recv().traced_await().await {
+                                                if txs[offset % num_pipelines].send(m).traced_await().await.is_err() {
                                                     return Ok(());
                                                 }
                                                 offset += 1;
@@ -1167,18 +1168,18 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                                         max_morsel_seq: max_morsel_seq.clone(),
                                         outcome: outcome.clone(),
                                         wait_token: wg.token(),
-                                    }).await.is_err() {
+                                    }).traced_await().await.is_err() {
                                         return Ok(());
                                     }
-                                    futures.push((max_morsel_seq, outcome, async move { wg.wait().await }));
+                                    futures.push((max_morsel_seq, outcome, async move { wg.wait().traced_await().await }));
                                 }
 
                                 if let Some(distributor) = distributor.take() {
-                                    distributor.await?;
+                                    distributor.traced_await().await?;
                                 }
                                 let mut did_finish = true;
                                 for (max_morsel_seq, outcome, f) in futures {
-                                    f.await;
+                                    f.traced_await().await;
                                     seq = seq.max(unsafe { MorselSeq::from_u64(max_morsel_seq.load(Ordering::Relaxed)) });
                                     did_finish &= outcome.did_finish();
                                 }
@@ -1196,7 +1197,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                             let source_num_rows = unrestricted_row_count_rx
                                 .take()
                                 .unwrap()
-                                .await
+                                .traced_await().await
                                 .unwrap();
                             ri.offset += source_num_rows;
                         }
@@ -1212,7 +1213,7 @@ impl<T: MultiScanable> SourceNode for MultiScanNode<T> {
                 .drain(..)
                 .map(AbortOnDropHandle::new)
                 .collect();
-            while let Some(ret) = join_handles.next().await {
+            while let Some(ret) = join_handles.next().traced_await().await {
                 ret?;
             }
 

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
@@ -7,7 +7,6 @@ use polars_plan::dsl::NDJsonReadOptions;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::nodes::compute_node_prelude::*;
-use crate::prelude::TracedAwait;
 
 /// NDJSON chunk reader.
 #[derive(Default)]

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
@@ -7,6 +7,7 @@ use polars_plan::dsl::NDJsonReadOptions;
 use polars_utils::pl_str::PlSmallStr;
 
 use crate::nodes::compute_node_prelude::*;
+use crate::prelude::TracedAwait;
 
 /// NDJSON chunk reader.
 #[derive(Default)]

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_distributor.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_distributor.rs
@@ -6,6 +6,7 @@ use polars_utils::mmap::MemSlice;
 
 use super::line_batch_processor::LineBatch;
 use crate::async_primitives::distributor_channel;
+use crate::prelude::TracedAwait;
 
 pub(super) struct LineBatchDistributor {
     pub(super) global_bytes: MemSlice,
@@ -109,6 +110,7 @@ impl LineBatchDistributor {
                             bytes: full_chunk,
                             chunk_idx,
                         })
+                        .traced_await()
                         .await
                         .is_err()
                 {

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_distributor.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_distributor.rs
@@ -6,7 +6,6 @@ use polars_utils::mmap::MemSlice;
 
 use super::line_batch_processor::LineBatch;
 use crate::async_primitives::distributor_channel;
-use crate::prelude::TracedAwait;
 
 pub(super) struct LineBatchDistributor {
     pub(super) global_bytes: MemSlice,
@@ -110,7 +109,6 @@ impl LineBatchDistributor {
                             bytes: full_chunk,
                             chunk_idx,
                         })
-                        .traced_await()
                         .await
                         .is_err()
                 {

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_processor.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_processor.rs
@@ -15,6 +15,7 @@ use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::io_sources::MorselOutput;
 use crate::nodes::MorselSeq;
+use crate::prelude::TracedAwait;
 
 /// Parses chunks into DataFrames (or counts rows depending on state).
 pub(super) struct LineBatchProcessor {
@@ -59,7 +60,7 @@ impl LineBatchProcessor {
             );
         }
 
-        if output_port.init().await.is_err() {
+        if output_port.init().traced_await().await.is_err() {
             if verbose {
                 eprintln!(
                     "[NDJSON LineBatchProcessor {}]: phase receiver ended at init, returning",
@@ -72,14 +73,19 @@ impl LineBatchProcessor {
 
         let mut n_rows_processed: usize = 0;
 
-        while let Ok(LineBatch { bytes, chunk_idx }) = line_batch_rx.recv().await {
+        while let Ok(LineBatch { bytes, chunk_idx }) = line_batch_rx.recv().traced_await().await {
             let df = chunk_reader.read_chunk(bytes)?;
 
             n_rows_processed = n_rows_processed.saturating_add(df.height());
 
             let morsel_seq = MorselSeq::new(chunk_idx as u64);
 
-            if output_port.send(morsel_seq, df).await.is_err() {
+            if output_port
+                .send(morsel_seq, df)
+                .traced_await()
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -95,7 +101,7 @@ impl LineBatchProcessor {
             while let Ok(LineBatch {
                 bytes,
                 chunk_idx: _,
-            }) = line_batch_rx.recv().await
+            }) = line_batch_rx.recv().traced_await().await
             {
                 n_rows_processed = n_rows_processed.saturating_add(ndjson::count_rows(bytes));
             }
@@ -152,7 +158,7 @@ impl LineBatchProcessorOutputPort {
         } = self
         {
             assert!(phase_tx.is_none());
-            *phase_tx = Some(phase_tx_receiver.recv().await?);
+            *phase_tx = Some(phase_tx_receiver.recv().traced_await().await?);
         }
 
         Ok(())
@@ -172,28 +178,38 @@ impl LineBatchProcessorOutputPort {
                     let mut morsel = Morsel::new(df, morsel_seq, source_token.clone());
                     morsel.set_consume_token(wait_group.token());
 
-                    if phase_tx.as_mut().unwrap().port.send(morsel).await.is_err() {
+                    if phase_tx
+                        .as_mut()
+                        .unwrap()
+                        .port
+                        .send(morsel)
+                        .traced_await()
+                        .await
+                        .is_err()
+                    {
                         return Err(());
                     };
 
-                    wait_group.wait().await;
+                    wait_group.wait().traced_await().await;
 
                     if source_token.stop_requested() {
                         let v = phase_tx.take().unwrap();
                         v.outcome.stop();
                         drop(v);
-                        *phase_tx = Some(phase_tx_receiver.recv().await?);
+                        *phase_tx = Some(phase_tx_receiver.recv().traced_await().await?);
                     }
 
                     Ok(())
                 },
                 Linearize { tx } => tx
                     .insert(Priority(Reverse(morsel_seq), df))
+                    .traced_await()
                     .await
                     .map_err(|_| ()),
                 Closed { .. } => unreachable!(),
             }
         }
+        .traced_await()
         .await;
 
         if result.is_err() {

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
@@ -34,7 +34,6 @@ use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::io_sources::MorselOutput;
 use crate::nodes::{MorselSeq, TaskPriority};
-use crate::prelude::TracedAwait;
 mod chunk_reader;
 mod line_batch_distributor;
 mod line_batch_processor;
@@ -354,14 +353,14 @@ impl SourceNode for NDJsonSourceNode {
         ));
 
         join_handles.push(spawn(TaskPriority::Low, async move {
-            let mut row_count = line_batch_distributor_task_handle.traced_await().await?;
+            let mut row_count = line_batch_distributor_task_handle.await?;
 
             if verbose {
                 eprintln!("[NDJSON source]: line batch distributor handle returned");
             }
 
             for handle in line_batch_processor_handles {
-                let n_rows_processed = handle.traced_await().await?;
+                let n_rows_processed = handle.await?;
                 if needs_total_row_count {
                     row_count = row_count.checked_add(n_rows_processed).unwrap();
                 }
@@ -401,7 +400,7 @@ impl SourceNode for NDJsonSourceNode {
             }
 
             if let Some(handle) = opt_post_process_handle {
-                handle.traced_await().await?;
+                handle.await?;
             }
 
             if verbose {
@@ -413,21 +412,21 @@ impl SourceNode for NDJsonSourceNode {
 
         join_handles.push(spawn(TaskPriority::Low, async move {
             // Every phase we are given a new send port.
-            while let Ok(phase_output) = output_recv.recv().traced_await().await {
+            while let Ok(phase_output) = output_recv.recv().await {
                 let morsel_senders = phase_output.port.parallel();
 
                 let mut morsel_outcomes = Vec::with_capacity(morsel_senders.len());
 
                 for (phase_tx_senders, port) in phase_tx_senders.iter_mut().zip(morsel_senders) {
                     let (outcome, wait_group, morsel_output) = MorselOutput::from_port(port);
-                    _ = phase_tx_senders.send(morsel_output).traced_await().await;
+                    _ = phase_tx_senders.send(morsel_output).await;
                     morsel_outcomes.push((outcome, wait_group));
                 }
 
                 let mut is_finished = true;
 
                 for (outcome, wait_group) in morsel_outcomes.into_iter() {
-                    wait_group.wait().traced_await().await;
+                    wait_group.wait().await;
                     is_finished &= outcome.did_finish();
                 }
 

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/negative_slice_pass.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/negative_slice_pass.rs
@@ -16,7 +16,6 @@ use crate::async_primitives::linearizer::Linearizer;
 use crate::async_primitives::wait_group::WaitGroup;
 use crate::morsel::{get_ideal_morsel_size, Morsel, MorselSeq, SourceToken};
 use crate::nodes::io_sources::MorselOutput;
-use crate::prelude::TracedAwait;
 
 /// Outputs a stream of morsels in reverse order from which they were received.
 /// Attaches (properly offsetted) row index if necessary.
@@ -51,9 +50,7 @@ impl MorselStreamReverser {
 
         let mut n_rows_received: usize = 0;
 
-        while let Some(Priority(Reverse(morsel_seq), df)) =
-            morsel_receiver.get().traced_await().await
-        {
+        while let Some(Priority(Reverse(morsel_seq), df)) = morsel_receiver.get().await {
             if acc_morsels.len() == acc_morsels.capacity() {
                 let morsel_seq = acc_morsels.last().unwrap().0;
                 let combined = combine_acc_morsels_reverse(&mut acc_morsels);
@@ -104,7 +101,7 @@ impl MorselStreamReverser {
                 eprintln!("MorselStreamReverser: wait for total row count");
             }
 
-            let Ok(total_count) = total_row_count_rx.traced_await().await else {
+            let Ok(total_count) = total_row_count_rx.await else {
                 // Errored, or empty file.
                 if verbose {
                     eprintln!("MorselStreamReverser: did not receive total row count, returning");
@@ -182,8 +179,7 @@ impl MorselStreamReverser {
                 AbortOnDropHandle::new(async_executor::spawn(
                     async_executor::TaskPriority::Low,
                     async move {
-                        let Ok(mut morsel_output) = phase_tx_receiver.recv().traced_await().await
-                        else {
+                        let Ok(mut morsel_output) = phase_tx_receiver.recv().await else {
                             return Ok(());
                         };
 
@@ -227,24 +223,17 @@ impl MorselStreamReverser {
 
                             morsel.set_consume_token(wait_group.token());
 
-                            if morsel_output
-                                .port
-                                .send(morsel)
-                                .traced_await()
-                                .await
-                                .is_err()
-                            {
+                            if morsel_output.port.send(morsel).await.is_err() {
                                 break 'outer;
                             }
 
-                            wait_group.wait().traced_await().await;
+                            wait_group.wait().await;
 
                             if source_token.stop_requested() {
                                 morsel_output.outcome.stop();
                                 drop(morsel_output);
 
-                                let Ok(next_output) = phase_tx_receiver.recv().traced_await().await
-                                else {
+                                let Ok(next_output) = phase_tx_receiver.recv().await else {
                                     break;
                                 };
 
@@ -259,7 +248,7 @@ impl MorselStreamReverser {
             .collect::<Vec<_>>();
 
         for handle in sender_join_handles {
-            handle.traced_await().await?;
+            handle.await?;
         }
 
         Ok(())

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/row_index_limit_pass.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/row_index_limit_pass.rs
@@ -13,6 +13,7 @@ use crate::async_primitives::wait_group::WaitGroup;
 use crate::async_primitives::{connector, distributor_channel};
 use crate::morsel::{Morsel, MorselSeq, SourceToken};
 use crate::nodes::io_sources::MorselOutput;
+use crate::prelude::TracedAwait;
 
 pub struct ApplyRowIndexOrLimit {
     pub morsel_receiver: Linearizer<Priority<Reverse<MorselSeq>, DataFrame>>,
@@ -48,7 +49,9 @@ impl ApplyRowIndexOrLimit {
 
         let mut n_rows_received: usize = 0;
 
-        while let Some(Priority(Reverse(morsel_seq), mut df)) = morsel_receiver.get().await {
+        while let Some(Priority(Reverse(morsel_seq), mut df)) =
+            morsel_receiver.get().traced_await().await
+        {
             if let Some(limit) = &limit {
                 let remaining = *limit - n_rows_received;
                 if remaining < df.height() {
@@ -74,7 +77,12 @@ impl ApplyRowIndexOrLimit {
 
             n_rows_received = n_rows_received.saturating_add(df.height());
 
-            if morsel_distributor.send((morsel_seq, df)).await.is_err() {
+            if morsel_distributor
+                .send((morsel_seq, df))
+                .traced_await()
+                .await
+                .is_err()
+            {
                 break;
             }
 
@@ -92,7 +100,7 @@ impl ApplyRowIndexOrLimit {
         }
 
         for handle in phase_sender_handles {
-            handle.await?;
+            handle.traced_await().await?;
         }
 
         if verbose {
@@ -123,14 +131,14 @@ fn init_morsel_distributor(
         .map(|(mut phase_tx_receiver, mut morsel_rx)| {
             let source_token = source_token.clone();
             AbortOnDropHandle::new(spawn(TaskPriority::Low, async move {
-                let Ok(mut morsel_output) = phase_tx_receiver.recv().await else {
+                let Ok(mut morsel_output) = phase_tx_receiver.recv().traced_await().await else {
                     return Ok(());
                 };
 
                 let wait_group = WaitGroup::default();
 
                 'outer: loop {
-                    let Ok((morsel_seq, df)) = morsel_rx.recv().await else {
+                    let Ok((morsel_seq, df)) = morsel_rx.recv().traced_await().await else {
                         return Ok(());
                     };
 
@@ -139,17 +147,23 @@ fn init_morsel_distributor(
 
                     let source_token = morsel.source_token().clone();
 
-                    if morsel_output.port.send(morsel).await.is_err() {
+                    if morsel_output
+                        .port
+                        .send(morsel)
+                        .traced_await()
+                        .await
+                        .is_err()
+                    {
                         break 'outer;
                     }
 
-                    wait_group.wait().await;
+                    wait_group.wait().traced_await().await;
 
                     if source_token.stop_requested() {
                         morsel_output.outcome.stop();
                         drop(morsel_output);
 
-                        let Ok(next_output) = phase_tx_receiver.recv().await else {
+                        let Ok(next_output) = phase_tx_receiver.recv().traced_await().await else {
                             break 'outer;
                         };
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -19,6 +19,7 @@ use super::{AsyncTaskData, ParquetSourceNode};
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::morsel::get_ideal_morsel_size;
 use crate::nodes::{MorselSeq, TaskPriority};
+use crate::prelude::TracedAwait;
 use crate::utils::task_handles_ext::{self, AbortOnDropHandle};
 use crate::{async_executor, DEFAULT_DISTRIBUTOR_BUFFER_SIZE};
 
@@ -111,6 +112,7 @@ async fn calculate_row_group_pred_pushdown_skip_mask(
         statistics_df.rechunk_mut();
         sbp.evaluate_with_stat_df(&statistics_df)
     })
+    .traced_await()
     .await?;
 
     if verbose {
@@ -181,6 +183,7 @@ impl ParquetSourceNode {
                     .get(0)
                     .unwrap()
                     .to_dyn_byte_source(&byte_source_builder, cloud_options.as_ref())
+                    .traced_await()
                     .await?,
             );
 
@@ -239,6 +242,7 @@ impl ParquetSourceNode {
                 &reader_schema,
                 verbose,
             )
+            .traced_await()
             .await?;
 
             let mut row_group_data_fetcher = RowGroupDataFetcher {
@@ -253,8 +257,8 @@ impl ParquetSourceNode {
                 row_offset,
             };
 
-            while let Some(prefetch) = row_group_data_fetcher.next().await {
-                if prefetch_send.send(prefetch?).await.is_err() {
+            while let Some(prefetch) = row_group_data_fetcher.next().traced_await().await {
+                if prefetch_send.send(prefetch?).traced_await().await.is_err() {
                     break;
                 }
             }
@@ -264,13 +268,16 @@ impl ParquetSourceNode {
         // Decode loop (spawns decodes on the computational executor).
         let (decode_send, mut decode_recv) = tokio::sync::mpsc::channel(self.config.num_pipelines);
         let decode_task = AbortOnDropHandle(io_runtime.spawn(async move {
-            while let Some(prefetch) = prefetch_recv.recv().await {
-                let row_group_data = prefetch.await.unwrap()?;
+            while let Some(prefetch) = prefetch_recv.recv().traced_await().await {
+                let row_group_data = prefetch.traced_await().await.unwrap()?;
                 let row_group_decoder = row_group_decoder.clone();
                 let decode_fut = async_executor::spawn(TaskPriority::High, async move {
-                    row_group_decoder.row_group_data_to_df(row_group_data).await
+                    row_group_decoder
+                        .row_group_data_to_df(row_group_data)
+                        .traced_await()
+                        .await
                 });
-                if decode_send.send(decode_fut).await.is_err() {
+                if decode_send.send(decode_fut).traced_await().await.is_err() {
                     break;
                 }
             }
@@ -286,10 +293,10 @@ impl ParquetSourceNode {
             // Decode first non-empty morsel.
             let mut next = None;
             loop {
-                let Some(decode_fut) = decode_recv.recv().await else {
+                let Some(decode_fut) = decode_recv.recv().traced_await().await else {
                     break;
                 };
-                let df = decode_fut.await?;
+                let df = decode_fut.traced_await().await?;
                 if df.height() == 0 {
                     continue;
                 }
@@ -301,10 +308,10 @@ impl ParquetSourceNode {
                 // Try to decode the next non-empty morsel first, so we know
                 // whether the df is the last morsel.
                 loop {
-                    let Some(decode_fut) = decode_recv.recv().await else {
+                    let Some(decode_fut) = decode_recv.recv().traced_await().await else {
                         break;
                     };
-                    let next_df = decode_fut.await?;
+                    let next_df = decode_fut.traced_await().await?;
                     if next_df.height() == 0 {
                         continue;
                     }
@@ -318,7 +325,12 @@ impl ParquetSourceNode {
                     next.is_none(),
                     last_morsel_min_split,
                 ) {
-                    if raw_morsel_sender.send((df, morsel_seq)).await.is_err() {
+                    if raw_morsel_sender
+                        .send((df, morsel_seq))
+                        .traced_await()
+                        .await
+                        .is_err()
+                    {
                         return Ok(());
                     }
                     morsel_seq = morsel_seq.successor();
@@ -328,9 +340,9 @@ impl ParquetSourceNode {
         });
 
         let join_task = io_runtime.spawn(async move {
-            prefetch_task.await.unwrap()?;
-            decode_task.await.unwrap()?;
-            distribute_task.await?;
+            prefetch_task.traced_await().await.unwrap()?;
+            decode_task.traced_await().await.unwrap()?;
+            distribute_task.traced_await().await?;
             Ok(())
         });
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/metadata_utils.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/metadata_utils.rs
@@ -2,8 +2,6 @@ use polars_error::PolarsResult;
 use polars_io::utils::byte_source::{ByteSource, DynByteSource};
 use polars_utils::mmap::MemSlice;
 
-use crate::prelude::TracedAwait;
-
 /// Read the metadata bytes of a parquet file, does not decode the bytes. If during metadata fetch
 /// the bytes of the entire file are loaded, it is returned in the second return value.
 pub(super) async fn read_parquet_metadata_bytes(
@@ -15,7 +13,7 @@ pub(super) async fn read_parquet_metadata_bytes(
 
     const FOOTER_HEADER_SIZE: usize = polars_parquet::parquet::FOOTER_SIZE as usize;
 
-    let file_size = byte_source.get_size().traced_await().await?;
+    let file_size = byte_source.get_size().await?;
 
     if file_size < FOOTER_HEADER_SIZE {
         return Err(ParquetError::OutOfSpec(format!(
@@ -34,7 +32,6 @@ pub(super) async fn read_parquet_metadata_bytes(
 
     let bytes = byte_source
         .get_range((file_size - estimated_metadata_size)..file_size)
-        .traced_await()
         .await?;
 
     let footer_header_bytes = bytes.slice((bytes.len() - FOOTER_HEADER_SIZE)..bytes.len());
@@ -84,10 +81,7 @@ pub(super) async fn read_parquet_metadata_bytes(
         let mut out = Vec::with_capacity(footer_size);
         let offset = file_size - footer_size;
         let len = footer_size - bytes.len();
-        let delta_bytes = byte_source
-            .get_range(offset..(offset + len))
-            .traced_await()
-            .await?;
+        let delta_bytes = byte_source.get_range(offset..(offset + len)).await?;
 
         debug_assert!(out.capacity() >= delta_bytes.len() + bytes.len());
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/metadata_utils.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/metadata_utils.rs
@@ -2,6 +2,8 @@ use polars_error::PolarsResult;
 use polars_io::utils::byte_source::{ByteSource, DynByteSource};
 use polars_utils::mmap::MemSlice;
 
+use crate::prelude::TracedAwait;
+
 /// Read the metadata bytes of a parquet file, does not decode the bytes. If during metadata fetch
 /// the bytes of the entire file are loaded, it is returned in the second return value.
 pub(super) async fn read_parquet_metadata_bytes(
@@ -13,7 +15,7 @@ pub(super) async fn read_parquet_metadata_bytes(
 
     const FOOTER_HEADER_SIZE: usize = polars_parquet::parquet::FOOTER_SIZE as usize;
 
-    let file_size = byte_source.get_size().await?;
+    let file_size = byte_source.get_size().traced_await().await?;
 
     if file_size < FOOTER_HEADER_SIZE {
         return Err(ParquetError::OutOfSpec(format!(
@@ -32,6 +34,7 @@ pub(super) async fn read_parquet_metadata_bytes(
 
     let bytes = byte_source
         .get_range((file_size - estimated_metadata_size)..file_size)
+        .traced_await()
         .await?;
 
     let footer_header_bytes = bytes.slice((bytes.len() - FOOTER_HEADER_SIZE)..bytes.len());
@@ -81,7 +84,10 @@ pub(super) async fn read_parquet_metadata_bytes(
         let mut out = Vec::with_capacity(footer_size);
         let offset = file_size - footer_size;
         let len = footer_size - bytes.len();
-        let delta_bytes = byte_source.get_range(offset..(offset + len)).await?;
+        let delta_bytes = byte_source
+            .get_range(offset..(offset + len))
+            .traced_await()
+            .await?;
 
         debug_assert!(out.capacity() >= delta_bytes.len() + bytes.len());
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -28,6 +28,7 @@ use crate::async_primitives::wait_group::WaitGroup;
 use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::TaskPriority;
+use crate::prelude::TracedAwait;
 use crate::utils::task_handles_ext;
 
 mod init;
@@ -184,18 +185,18 @@ impl SourceNode for ParquetSourceNode {
             }
 
             // Every phase we are given a new send port.
-            while let Ok(phase_output) = output_recv.recv().await {
+            while let Ok(phase_output) = output_recv.recv().traced_await().await {
                 let morsel_senders = phase_output.port.parallel();
                 let mut morsel_outcomes = Vec::with_capacity(morsel_senders.len());
                 for (send_to, port) in send_to.iter_mut().zip(morsel_senders) {
                     let (outcome, wait_group, morsel_output) = MorselOutput::from_port(port);
-                    _ = send_to.send(morsel_output).await;
+                    _ = send_to.send(morsel_output).traced_await().await;
                     morsel_outcomes.push((outcome, wait_group));
                 }
 
                 let mut is_finished = true;
                 for (outcome, wait_group) in morsel_outcomes.into_iter() {
-                    wait_group.wait().await;
+                    wait_group.wait().traced_await().await;
                     is_finished &= outcome.did_finish();
                 }
 
@@ -210,25 +211,33 @@ impl SourceNode for ParquetSourceNode {
             // Safety
             // * We dropped the receivers on the line above
             // * This function is only called once.
-            _ = morsel_stream_task_handle.await.unwrap();
+            _ = morsel_stream_task_handle.traced_await().await.unwrap();
             Ok(())
         }));
 
         join_handles.extend(recv_from.into_iter().zip(raw_morsel_receivers).map(
             |(mut recv_from, mut raw_morsel_rx)| {
                 spawn(TaskPriority::Low, async move {
-                    'port_recv: while let Ok(mut morsel_output) = recv_from.recv().await {
+                    'port_recv: while let Ok(mut morsel_output) =
+                        recv_from.recv().traced_await().await
+                    {
                         let source_token = SourceToken::new();
                         let wait_group = WaitGroup::default();
 
-                        while let Ok((df, seq)) = raw_morsel_rx.recv().await {
+                        while let Ok((df, seq)) = raw_morsel_rx.recv().traced_await().await {
                             let mut morsel = Morsel::new(df, seq, source_token.clone());
                             morsel.set_consume_token(wait_group.token());
-                            if morsel_output.port.send(morsel).await.is_err() {
+                            if morsel_output
+                                .port
+                                .send(morsel)
+                                .traced_await()
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
 
-                            wait_group.wait().await;
+                            wait_group.wait().traced_await().await;
                             if source_token.stop_requested() {
                                 morsel_output.outcome.stop();
                                 continue 'port_recv;
@@ -281,10 +290,14 @@ impl MultiScanable for ParquetSourceNode {
                         },
                         cloud_options.as_ref(),
                     )
+                    .traced_await()
                     .await?;
 
-                metadata_utils::read_parquet_metadata_bytes(&byte_source, verbose).await
+                metadata_utils::read_parquet_metadata_bytes(&byte_source, verbose)
+                    .traced_await()
+                    .await
             })
+            .traced_await()
             .await
             .unwrap()?;
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
@@ -12,6 +12,7 @@ use polars_parquet::read::RowGroupMetadata;
 use polars_utils::mmap::MemSlice;
 use polars_utils::pl_str::PlSmallStr;
 
+use crate::prelude::TracedAwait;
 use crate::utils::task_handles_ext;
 
 /// Represents byte-data that can be transformed into a DataFrame after some computation.
@@ -123,7 +124,10 @@ impl RowGroupDataFetcher {
 
                         let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+                        let bytes_map = current_byte_source
+                            .get_ranges(&mut ranges)
+                            .traced_await()
+                            .await?;
 
                         assert_eq!(bytes_map.len(), n_ranges);
 
@@ -141,7 +145,10 @@ impl RowGroupDataFetcher {
 
                         let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+                        let bytes_map = current_byte_source
+                            .get_ranges(&mut ranges)
+                            .traced_await()
+                            .await?;
 
                         assert_eq!(bytes_map.len(), n_ranges);
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
@@ -12,7 +12,6 @@ use polars_parquet::read::RowGroupMetadata;
 use polars_utils::mmap::MemSlice;
 use polars_utils::pl_str::PlSmallStr;
 
-use crate::prelude::TracedAwait;
 use crate::utils::task_handles_ext;
 
 /// Represents byte-data that can be transformed into a DataFrame after some computation.
@@ -124,10 +123,7 @@ impl RowGroupDataFetcher {
 
                         let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source
-                            .get_ranges(&mut ranges)
-                            .traced_await()
-                            .await?;
+                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
 
                         assert_eq!(bytes_map.len(), n_ranges);
 
@@ -145,10 +141,7 @@ impl RowGroupDataFetcher {
 
                         let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source
-                            .get_ranges(&mut ranges)
-                            .traced_await()
-                            .await?;
+                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
 
                         assert_eq!(bytes_map.len(), n_ranges);
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_decode.rs
@@ -20,6 +20,7 @@ use polars_utils::IdxSize;
 use super::row_group_data_fetch::RowGroupData;
 use crate::async_executor;
 use crate::nodes::TaskPriority;
+use crate::prelude::TracedAwait;
 
 /// Turns row group data into DataFrames.
 pub(super) struct RowGroupDecoder {
@@ -40,9 +41,13 @@ impl RowGroupDecoder {
         row_group_data: RowGroupData,
     ) -> PolarsResult<DataFrame> {
         if self.use_prefiltered.is_some() {
-            self.row_group_data_to_df_prefiltered(row_group_data).await
+            self.row_group_data_to_df_prefiltered(row_group_data)
+                .traced_await()
+                .await
         } else {
-            self.row_group_data_to_df_impl(row_group_data).await
+            self.row_group_data_to_df_impl(row_group_data)
+                .traced_await()
+                .await
         }
     }
 
@@ -73,6 +78,7 @@ impl RowGroupDecoder {
             &row_group_data,
             Some(polars_parquet::read::Filter::Range(slice_range.clone())),
         )
+        .traced_await()
         .await?;
 
         let projection_height = slice_range.len();
@@ -86,7 +92,9 @@ impl RowGroupDecoder {
             let mask = mask.bool().unwrap();
 
             let filtered =
-                unsafe { filter_cols(df.take_columns(), mask, self.min_values_per_thread) }.await?;
+                unsafe { filter_cols(df.take_columns(), mask, self.min_values_per_thread) }
+                    .traced_await()
+                    .await?;
 
             let height = if let Some(fst) = filtered.first() {
                 fst.len()
@@ -234,7 +242,7 @@ impl RowGroupDecoder {
         }
 
         for handle in task_handles {
-            out_vec.extend(handle.await?.into_iter().map(|(c, _)| c));
+            out_vec.extend(handle.traced_await().await?.into_iter().map(|(c, _)| c));
         }
 
         Ok(())
@@ -356,7 +364,7 @@ async unsafe fn filter_cols(
     }
 
     for handle in task_handles {
-        out_vec.extend(handle.await?)
+        out_vec.extend(handle.traced_await().await?)
     }
 
     Ok(out_vec)
@@ -529,6 +537,7 @@ impl RowGroupDecoder {
 
             let filtered =
                 unsafe { filter_cols(live_df.take_columns(), mask, self.min_values_per_thread) }
+                    .traced_await()
                     .await?;
 
             let filtered_height = if let Some(fst) = filtered.first() {

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -26,6 +26,7 @@ use crate::expression::StreamExpr;
 use crate::morsel::{get_ideal_morsel_size, SourceToken};
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::in_memory_source::InMemorySourceNode;
+use crate::prelude::TracedAwait;
 
 static SAMPLE_LIMIT: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("POLARS_JOIN_SAMPLE_LIMIT")
@@ -127,7 +128,7 @@ async fn select_keys(
         // We use key columns entirely by position, and allow duplicate names,
         // so just assign arbitrary unique names.
         let unique_name = format_pl_smallstr!("__POLARS_KEYCOL_{i}");
-        let s = selector.evaluate(df, state).await?;
+        let s = selector.evaluate(df, state).traced_await().await?;
         key_columns.push(s.into_column().with_name(unique_name));
     }
     let keys = DataFrame::new_with_broadcast_len(key_columns, df.height())?;
@@ -223,10 +224,10 @@ impl BufferedStream {
                     };
                     morsel.replace_source_token(source_token.clone());
                     morsel.set_consume_token(wait_group.token());
-                    if new_send.send(morsel).await.is_err() {
+                    if new_send.send(morsel).traced_await().await.is_err() {
                         return Ok(());
                     }
-                    wait_group.wait().await;
+                    wait_group.wait().traced_await().await;
                     // TODO: Unfortunately we can't actually stop here without
                     // re-buffering morsels from the stream that comes after.
                     // if source_token.stop_requested() {
@@ -235,12 +236,12 @@ impl BufferedStream {
                 }
 
                 if let Some(mut recv) = orig_recv {
-                    while let Ok(mut morsel) = recv.recv().await {
+                    while let Ok(mut morsel) = recv.recv().traced_await().await {
                         if source_token.stop_requested() {
                             morsel.source_token().stop();
                         }
                         morsel.set_seq(morsel.seq().offset_by(self.post_buffer_offset));
-                        if new_send.send(morsel).await.is_err() {
+                        if new_send.send(morsel).traced_await().await.is_err() {
                             break;
                         }
                     }
@@ -288,7 +289,7 @@ impl SampleState {
         this_final_len: Arc<AtomicUsize>,
         other_final_len: Arc<AtomicUsize>,
     ) -> PolarsResult<()> {
-        while let Ok(mut morsel) = recv.recv().await {
+        while let Ok(mut morsel) = recv.recv().traced_await().await {
             *len += morsel.df().height();
             if *len >= *SAMPLE_LIMIT
                 || *len
@@ -445,7 +446,7 @@ impl SampleState {
 
                 polars_io::pl_async::get_runtime().block_on(async move {
                     for handle in join_handles {
-                        handle.await?;
+                        handle.traced_await().await?;
                     }
                     PolarsResult::Ok(())
                 })
@@ -491,10 +492,12 @@ impl BuildState {
             key_selectors = &params.right_key_selectors;
         };
 
-        while let Ok(morsel) = recv.recv().await {
+        while let Ok(morsel) = recv.recv().traced_await().await {
             // Compute hashed keys and payload. We must rechunk the payload for
             // later chunked gathers.
-            let hash_keys = select_keys(morsel.df(), key_selectors, params, state).await?;
+            let hash_keys = select_keys(morsel.df(), key_selectors, params, state)
+                .traced_await()
+                .await?;
             let mut payload = select_payload(morsel.df().clone(), payload_selector);
             payload.rechunk_mut();
             payload._deshare_views_mut();
@@ -661,10 +664,12 @@ impl ProbeState {
             key_selectors = &params.left_key_selectors;
         };
 
-        while let Ok(morsel) = recv.recv().await {
+        while let Ok(morsel) = recv.recv().traced_await().await {
             // Compute hashed keys and payload.
             let (df, seq, src_token, wait_token) = morsel.into_inner();
-            let hash_keys = select_keys(&df, key_selectors, params, state).await?;
+            let hash_keys = select_keys(&df, key_selectors, params, state)
+                .traced_await()
+                .await?;
             let mut payload = select_payload(df, payload_selector);
             let mut payload_rechunked = false; // We don't eagerly rechunk because there might be no matches.
 
@@ -743,7 +748,7 @@ impl ProbeState {
 
                         // TODO: break in smaller morsels.
                         let out_morsel = Morsel::new(out_df, seq, src_token.clone());
-                        if send.send(out_morsel).await.is_err() {
+                        if send.send(out_morsel).traced_await().await.is_err() {
                             break;
                         }
                     }
@@ -801,7 +806,7 @@ impl ProbeState {
                                 let df =
                                     accumulate_dataframes_vertical_unchecked(out_frames.drain(..));
                                 let out_morsel = Morsel::new(df, seq, src_token.clone());
-                                if send.send(out_morsel).await.is_err() {
+                                if send.send(out_morsel).traced_await().await.is_err() {
                                     break;
                                 }
                             }
@@ -811,7 +816,7 @@ impl ProbeState {
                     if out_len > 0 {
                         let df = accumulate_dataframes_vertical_unchecked(out_frames.drain(..));
                         let out_morsel = Morsel::new(df, seq, src_token.clone());
-                        if send.send(out_morsel).await.is_err() {
+                        if send.send(out_morsel).traced_await().await.is_err() {
                             break;
                         }
                     }
@@ -956,11 +961,11 @@ impl EmitUnmatchedState {
                 let mut morsel = Morsel::new(out_df, self.morsel_seq, source_token.clone());
                 self.morsel_seq = self.morsel_seq.successor();
                 morsel.set_consume_token(wait_group.token());
-                if send.send(morsel).await.is_err() {
+                if send.send(morsel).traced_await().await.is_err() {
                     return Ok(());
                 }
 
-                wait_group.wait().await;
+                wait_group.wait().traced_await().await;
                 if source_token.stop_requested() {
                     return Ok(());
                 }
@@ -1373,7 +1378,7 @@ impl ComputeNode for EquiJoinNode {
                 let max_seq_sent = &mut probe_state.max_seq_sent;
                 join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                     for probe_task in probe_tasks {
-                        *max_seq_sent = (*max_seq_sent).max(probe_task.await?);
+                        *max_seq_sent = (*max_seq_sent).max(probe_task.traced_await().await?);
                     }
                     Ok(())
                 }));

--- a/crates/polars-stream/src/nodes/joins/in_memory.rs
+++ b/crates/polars-stream/src/nodes/joins/in_memory.rs
@@ -5,6 +5,7 @@ use polars_core::schema::Schema;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::in_memory_sink::InMemorySinkNode;
 use crate::nodes::in_memory_source::InMemorySourceNode;
+use crate::prelude::TracedAwait;
 
 enum InMemoryJoinState {
     Sink {

--- a/crates/polars-stream/src/nodes/joins/in_memory.rs
+++ b/crates/polars-stream/src/nodes/joins/in_memory.rs
@@ -5,7 +5,6 @@ use polars_core::schema::Schema;
 use crate::nodes::compute_node_prelude::*;
 use crate::nodes::in_memory_sink::InMemorySinkNode;
 use crate::nodes::in_memory_source::InMemorySourceNode;
-use crate::prelude::TracedAwait;
 
 enum InMemoryJoinState {
     Sink {

--- a/crates/polars-stream/src/nodes/joins/mod.rs
+++ b/crates/polars-stream/src/nodes/joins/mod.rs
@@ -1,3 +1,2 @@
-use crate::prelude::TracedAwait;
 pub mod equi_join;
 pub mod in_memory;

--- a/crates/polars-stream/src/nodes/joins/mod.rs
+++ b/crates/polars-stream/src/nodes/joins/mod.rs
@@ -1,2 +1,3 @@
+use crate::prelude::TracedAwait;
 pub mod equi_join;
 pub mod in_memory;

--- a/crates/polars-stream/src/nodes/map.rs
+++ b/crates/polars-stream/src/nodes/map.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use polars_plan::plans::DataFrameUdf;
 
 use super::compute_node_prelude::*;
-use crate::prelude::TracedAwait;
 
 /// A simple mapping node. Assumes the given udf is elementwise.
 pub struct MapNode {
@@ -42,9 +41,9 @@ impl ComputeNode for MapNode {
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                while let Ok(morsel) = recv.recv().traced_await().await {
+                while let Ok(morsel) = recv.recv().await {
                     let morsel = morsel.try_map(|df| slf.map.call_udf(df))?;
-                    if send.send(morsel).traced_await().await.is_err() {
+                    if send.send(morsel).await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/nodes/merge_sorted.rs
+++ b/crates/polars-stream/src/nodes/merge_sorted.rs
@@ -10,6 +10,7 @@ use crate::async_primitives::connector::Receiver;
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::morsel::{get_ideal_morsel_size, SourceToken};
 use crate::nodes::compute_node_prelude::*;
+use crate::prelude::TracedAwait;
 use crate::DEFAULT_DISTRIBUTOR_BUFFER_SIZE;
 
 pub struct MergeSortedNode {
@@ -254,13 +255,13 @@ impl ComputeNode for MergeSortedNode {
                         let morsel_offset = *seq;
                         scope.spawn_task(TaskPriority::High, async move {
                             let mut max_seq = morsel_offset;
-                            while let Ok(mut morsel) = recv.recv().await {
+                            while let Ok(mut morsel) = recv.recv().traced_await().await {
                                 // Ensure the morsel sequence id stream is monotone non-decreasing.
                                 let seq = morsel.seq().offset_by(morsel_offset);
                                 max_seq = max_seq.max(seq);
 
                                 morsel.set_seq(seq);
-                                if send.send(morsel).await.is_err() {
+                                if send.send(morsel).traced_await().await.is_err() {
                                     break;
                                 }
                             }
@@ -272,7 +273,7 @@ impl ComputeNode for MergeSortedNode {
                 join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                     // Update our global maximum.
                     for handle in inner_handles {
-                        *seq = (*seq).max(handle.await);
+                        *seq = (*seq).max(handle.traced_await().await);
                     }
                     Ok(())
                 }));
@@ -289,7 +290,7 @@ impl ComputeNode for MergeSortedNode {
                 ) {
                     // If a stop was requested, we need to buffer the remaining
                     // morsels and trigger a phase transition.
-                    let Ok(morsel) = port.recv().await else {
+                    let Ok(morsel) = port.recv().traced_await().await else {
                         return;
                     };
 
@@ -298,7 +299,7 @@ impl ComputeNode for MergeSortedNode {
 
                     // Buffer all the morsels that were already produced.
                     unmerged.push_back(morsel.into_df());
-                    while let Ok(morsel) = port.recv().await {
+                    while let Ok(morsel) = port.recv().traced_await().await {
                         unmerged.push_back(morsel.into_df());
                     }
                 }
@@ -332,6 +333,7 @@ impl ComputeNode for MergeSortedNode {
 
                             if distributor
                                 .send((left_mergeable, right_mergeable))
+                                .traced_await()
                                 .await
                                 .is_err()
                             {
@@ -343,10 +345,10 @@ impl ComputeNode for MergeSortedNode {
                             // Request that a port stops producing morsels and buffers all the
                             // remaining morsels.
                             if let Some(p) = &mut left {
-                                buffer_unmerged(p, left_unmerged).await;
+                                buffer_unmerged(p, left_unmerged).traced_await().await;
                             }
                             if let Some(p) = &mut right {
-                                buffer_unmerged(p, right_unmerged).await;
+                                buffer_unmerged(p, right_unmerged).traced_await().await;
                             }
                             break;
                         }
@@ -366,12 +368,12 @@ impl ComputeNode for MergeSortedNode {
                         };
 
                         // Try to get a new morsel from the empty side.
-                        let Ok(m) = empty_port.recv().await else {
+                        let Ok(m) = empty_port.recv().traced_await().await else {
                             if let Some(p) = &mut left {
-                                buffer_unmerged(p, left_unmerged).await;
+                                buffer_unmerged(p, left_unmerged).traced_await().await;
                             }
                             if let Some(p) = &mut right {
-                                buffer_unmerged(p, right_unmerged).await;
+                                buffer_unmerged(p, right_unmerged).traced_await().await;
                             }
                             break;
                         };
@@ -393,6 +395,7 @@ impl ComputeNode for MergeSortedNode {
 
                         if distributor
                             .send((left_mergeable, right_mergeable))
+                            .traced_await()
                             .await
                             .is_err()
                         {
@@ -414,14 +417,19 @@ impl ComputeNode for MergeSortedNode {
                         for df in std::mem::take(pass_unmerged) {
                             let m = Morsel::new(df, *seq, source_token.clone());
                             *seq = seq.successor();
-                            if distributor.send((m, DataFrame::empty())).await.is_err() {
+                            if distributor
+                                .send((m, DataFrame::empty()))
+                                .traced_await()
+                                .await
+                                .is_err()
+                            {
                                 return Ok(());
                             }
                         }
 
                         // Start passing on the port that is port that is still open.
                         if let Some(pass_port) = pass_port {
-                            let Ok(mut m) = pass_port.recv().await else {
+                            let Ok(mut m) = pass_port.recv().traced_await().await else {
                                 return Ok(());
                             };
                             if source_token.stop_requested() {
@@ -429,14 +437,24 @@ impl ComputeNode for MergeSortedNode {
                             }
                             m.set_seq(*seq);
                             *seq = seq.successor();
-                            if distributor.send((m, DataFrame::empty())).await.is_err() {
+                            if distributor
+                                .send((m, DataFrame::empty()))
+                                .traced_await()
+                                .await
+                                .is_err()
+                            {
                                 return Ok(());
                             }
 
-                            while let Ok(mut m) = pass_port.recv().await {
+                            while let Ok(mut m) = pass_port.recv().traced_await().await {
                                 m.set_seq(*seq);
                                 *seq = seq.successor();
-                                if distributor.send((m, DataFrame::empty())).await.is_err() {
+                                if distributor
+                                    .send((m, DataFrame::empty()))
+                                    .traced_await()
+                                    .await
+                                    .is_err()
+                                {
                                     return Ok(());
                                 }
                             }
@@ -451,12 +469,12 @@ impl ComputeNode for MergeSortedNode {
                 join_handles.extend(dist_recv.into_iter().zip(send).map(|(mut recv, mut send)| {
                     let ideal_morsel_size = get_ideal_morsel_size();
                     scope.spawn_task(TaskPriority::High, async move {
-                        while let Ok((left, right)) = recv.recv().await {
+                        while let Ok((left, right)) = recv.recv().traced_await().await {
                             // When we are flushing the buffer, we will just send one morsel from
                             // the input. We don't want to mess with the source token or wait group
                             // and just pass it on.
                             if right.is_empty() {
-                                if send.send(left).await.is_err() {
+                                if send.send(left).traced_await().await.is_err() {
                                     return Ok(());
                                 }
                                 continue;
@@ -478,16 +496,16 @@ impl ComputeNode for MergeSortedNode {
                                 // MorselSeq have to be monotonely non-decreasing so we can
                                 // pass the same sequence token twice.
                                 let morsel = Morsel::new(m1, seq, source_token.clone());
-                                if send.send(morsel).await.is_err() {
+                                if send.send(morsel).traced_await().await.is_err() {
                                     break;
                                 }
                                 let morsel = Morsel::new(m2, seq, source_token.clone());
-                                if send.send(morsel).await.is_err() {
+                                if send.send(morsel).traced_await().await.is_err() {
                                     break;
                                 }
                             } else {
                                 let morsel = Morsel::new(merged, seq, source_token.clone());
-                                if send.send(morsel).await.is_err() {
+                                if send.send(morsel).traced_await().await.is_err() {
                                     break;
                                 }
                             }

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -1,4 +1,3 @@
-use crate::prelude::TracedAwait;
 pub mod filter;
 pub mod group_by;
 pub mod in_memory_map;

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -1,3 +1,4 @@
+use crate::prelude::TracedAwait;
 pub mod filter;
 pub mod group_by;
 pub mod in_memory_map;

--- a/crates/polars-stream/src/nodes/multiplexer.rs
+++ b/crates/polars-stream/src/nodes/multiplexer.rs
@@ -4,7 +4,6 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 
 use super::compute_node_prelude::*;
 use crate::morsel::SourceToken;
-use crate::prelude::TracedAwait;
 
 // TODO: replace this with an out-of-core buffering solution.
 enum BufferedStream {
@@ -134,7 +133,7 @@ impl ComputeNode for MultiplexerNode {
             let buffered_source_token = buffered_source_token.clone();
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 loop {
-                    let Ok(morsel) = receiver.recv().traced_await().await else {
+                    let Ok(morsel) = receiver.recv().await else {
                         break;
                     };
 
@@ -186,7 +185,7 @@ impl ComputeNode for MultiplexerNode {
                     // First we try to flush all the old buffered data.
                     while let Some(mut morsel) = buf.pop_back() {
                         morsel.replace_source_token(buffered_source_token.clone());
-                        if sender.send(morsel).traced_await().await.is_err()
+                        if sender.send(morsel).await.is_err()
                             || buffered_source_token.stop_requested()
                         {
                             break;
@@ -194,8 +193,8 @@ impl ComputeNode for MultiplexerNode {
                     }
 
                     // Then send along data from the multiplexer.
-                    while let Some(morsel) = rx.recv().traced_await().await {
-                        if sender.send(morsel).traced_await().await.is_err() {
+                    while let Some(morsel) = rx.recv().await {
+                        if sender.send(morsel).await.is_err() {
                             break;
                         }
                     }

--- a/crates/polars-stream/src/nodes/negative_slice.rs
+++ b/crates/polars-stream/src/nodes/negative_slice.rs
@@ -5,7 +5,6 @@ use polars_core::utils::accumulate_dataframes_vertical_unchecked;
 
 use super::compute_node_prelude::*;
 use crate::nodes::in_memory_source::InMemorySourceNode;
-use crate::prelude::TracedAwait;
 
 /// A node that will pass-through up to length rows, starting at start_offset.
 /// Since start_offset must be non-negative this can be done in a streaming
@@ -124,7 +123,7 @@ impl ComputeNode for NegativeSliceNode {
                 assert!(send_ports[0].is_none());
                 let max_buffer_needed = self.slice_offset.unsigned_abs() as usize;
                 join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                    while let Ok(morsel) = recv.recv().traced_await().await {
+                    while let Ok(morsel) = recv.recv().await {
                         buffer.total_len += morsel.df().height();
                         buffer.frames.push_back(morsel.into_df());
 

--- a/crates/polars-stream/src/nodes/negative_slice.rs
+++ b/crates/polars-stream/src/nodes/negative_slice.rs
@@ -5,6 +5,7 @@ use polars_core::utils::accumulate_dataframes_vertical_unchecked;
 
 use super::compute_node_prelude::*;
 use crate::nodes::in_memory_source::InMemorySourceNode;
+use crate::prelude::TracedAwait;
 
 /// A node that will pass-through up to length rows, starting at start_offset.
 /// Since start_offset must be non-negative this can be done in a streaming
@@ -123,7 +124,7 @@ impl ComputeNode for NegativeSliceNode {
                 assert!(send_ports[0].is_none());
                 let max_buffer_needed = self.slice_offset.unsigned_abs() as usize;
                 join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                    while let Ok(morsel) = recv.recv().await {
+                    while let Ok(morsel) = recv.recv().traced_await().await {
                         buffer.total_len += morsel.df().height();
                         buffer.frames.push_back(morsel.into_df());
 

--- a/crates/polars-stream/src/nodes/ordered_union.rs
+++ b/crates/polars-stream/src/nodes/ordered_union.rs
@@ -1,4 +1,5 @@
 use super::compute_node_prelude::*;
+use crate::prelude::TracedAwait;
 
 /// A node that first passes through all data from the first input, then the
 /// second input, etc.
@@ -67,13 +68,13 @@ impl ComputeNode for OrderedUnionNode {
             let morsel_offset = self.morsel_offset;
             inner_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 let mut max_seq = MorselSeq::new(0);
-                while let Ok(mut morsel) = recv.recv().await {
+                while let Ok(mut morsel) = recv.recv().traced_await().await {
                     // Ensure the morsel sequence id stream is monotonic.
                     let seq = morsel.seq().offset_by(morsel_offset);
                     max_seq = max_seq.max(seq);
 
                     morsel.set_seq(seq);
-                    if send.send(morsel).await.is_err() {
+                    if send.send(morsel).traced_await().await.is_err() {
                         break;
                     }
                 }
@@ -84,7 +85,8 @@ impl ComputeNode for OrderedUnionNode {
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             // Update our global maximum.
             for handle in inner_handles {
-                self.max_morsel_seq_sent = self.max_morsel_seq_sent.max(handle.await);
+                self.max_morsel_seq_sent =
+                    self.max_morsel_seq_sent.max(handle.traced_await().await);
             }
             Ok(())
         }));

--- a/crates/polars-stream/src/nodes/ordered_union.rs
+++ b/crates/polars-stream/src/nodes/ordered_union.rs
@@ -1,5 +1,4 @@
 use super::compute_node_prelude::*;
-use crate::prelude::TracedAwait;
 
 /// A node that first passes through all data from the first input, then the
 /// second input, etc.
@@ -68,13 +67,13 @@ impl ComputeNode for OrderedUnionNode {
             let morsel_offset = self.morsel_offset;
             inner_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 let mut max_seq = MorselSeq::new(0);
-                while let Ok(mut morsel) = recv.recv().traced_await().await {
+                while let Ok(mut morsel) = recv.recv().await {
                     // Ensure the morsel sequence id stream is monotonic.
                     let seq = morsel.seq().offset_by(morsel_offset);
                     max_seq = max_seq.max(seq);
 
                     morsel.set_seq(seq);
-                    if send.send(morsel).traced_await().await.is_err() {
+                    if send.send(morsel).await.is_err() {
                         break;
                     }
                 }
@@ -85,8 +84,7 @@ impl ComputeNode for OrderedUnionNode {
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             // Update our global maximum.
             for handle in inner_handles {
-                self.max_morsel_seq_sent =
-                    self.max_morsel_seq_sent.max(handle.traced_await().await);
+                self.max_morsel_seq_sent = self.max_morsel_seq_sent.max(handle.await);
             }
             Ok(())
         }));

--- a/crates/polars-stream/src/nodes/reduce.rs
+++ b/crates/polars-stream/src/nodes/reduce.rs
@@ -9,7 +9,6 @@ use polars_utils::itertools::Itertools;
 use super::compute_node_prelude::*;
 use crate::expression::StreamExpr;
 use crate::morsel::SourceToken;
-use crate::prelude::TracedAwait;
 
 enum ReduceState {
     Sink {
@@ -62,10 +61,9 @@ impl ReduceNode {
                     .collect();
 
                 scope.spawn_task(TaskPriority::High, async move {
-                    while let Ok(morsel) = recv.recv().traced_await().await {
+                    while let Ok(morsel) = recv.recv().await {
                         for (reducer, selector) in local_reducers.iter_mut().zip(selectors) {
-                            let input =
-                                selector.evaluate(morsel.df(), state).traced_await().await?;
+                            let input = selector.evaluate(morsel.df(), state).await?;
                             reducer.update_group(
                                 input.as_materialized_series(),
                                 0,
@@ -81,7 +79,7 @@ impl ReduceNode {
 
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             for task in parallel_tasks {
-                let local_reducers = task.traced_await().await?;
+                let local_reducers = task.await?;
                 for (r1, r2) in reductions.iter_mut().zip(local_reducers) {
                     r1.resize(1);
                     unsafe {
@@ -103,7 +101,7 @@ impl ReduceNode {
         let mut send = send.serial();
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             let morsel = Morsel::new(df.take().unwrap(), MorselSeq::new(0), SourceToken::new());
-            let _ = send.send(morsel).traced_await().await;
+            let _ = send.send(morsel).await;
             Ok(())
         }));
     }

--- a/crates/polars-stream/src/nodes/select.rs
+++ b/crates/polars-stream/src/nodes/select.rs
@@ -5,7 +5,6 @@ use polars_core::schema::Schema;
 
 use super::compute_node_prelude::*;
 use crate::expression::StreamExpr;
-use crate::prelude::TracedAwait;
 
 pub struct SelectNode {
     selectors: Vec<StreamExpr>,
@@ -49,11 +48,11 @@ impl ComputeNode for SelectNode {
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                while let Ok(morsel) = recv.recv().traced_await().await {
+                while let Ok(morsel) = recv.recv().await {
                     let (df, seq, source_token, consume_token) = morsel.into_inner();
                     let mut selected = Vec::new();
                     for selector in slf.selectors.iter() {
-                        let s = selector.evaluate(&df, state).traced_await().await?;
+                        let s = selector.evaluate(&df, state).await?;
                         selected.push(s.into_column());
                     }
 
@@ -70,7 +69,7 @@ impl ComputeNode for SelectNode {
                         morsel.set_consume_token(token);
                     }
 
-                    if send.send(morsel).traced_await().await.is_err() {
+                    if send.send(morsel).await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/nodes/simple_projection.rs
+++ b/crates/polars-stream/src/nodes/simple_projection.rs
@@ -4,6 +4,7 @@ use polars_core::schema::Schema;
 use polars_utils::pl_str::PlSmallStr;
 
 use super::compute_node_prelude::*;
+use crate::prelude::TracedAwait;
 
 pub struct SimpleProjectionNode {
     columns: Vec<PlSmallStr>,
@@ -45,7 +46,7 @@ impl ComputeNode for SimpleProjectionNode {
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                while let Ok(morsel) = recv.recv().await {
+                while let Ok(morsel) = recv.recv().traced_await().await {
                     let morsel = morsel.try_map(|df| {
                         // TODO: can this be unchecked?
                         let check_duplicates = true;
@@ -56,7 +57,7 @@ impl ComputeNode for SimpleProjectionNode {
                         )
                     })?;
 
-                    if send.send(morsel).await.is_err() {
+                    if send.send(morsel).traced_await().await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/nodes/streaming_slice.rs
+++ b/crates/polars-stream/src/nodes/streaming_slice.rs
@@ -1,5 +1,4 @@
 use super::compute_node_prelude::*;
-use crate::prelude::TracedAwait;
 
 /// A node that will pass-through up to length rows, starting at start_offset.
 /// Since start_offset must be non-negative this can be done in a streaming
@@ -55,7 +54,7 @@ impl ComputeNode for StreamingSliceNode {
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
             let stop_offset = self.start_offset + self.length;
 
-            while let Ok(morsel) = recv.recv().traced_await().await {
+            while let Ok(morsel) = recv.recv().await {
                 let morsel = morsel.map(|df| {
                     let height = df.height();
 
@@ -83,7 +82,7 @@ impl ComputeNode for StreamingSliceNode {
                     morsel.source_token().stop();
                 }
 
-                if !morsel.df().is_empty() && send.send(morsel).traced_await().await.is_err() {
+                if !morsel.df().is_empty() && send.send(morsel).await.is_err() {
                     break;
                 }
 

--- a/crates/polars-stream/src/nodes/with_row_index.rs
+++ b/crates/polars-stream/src/nodes/with_row_index.rs
@@ -5,6 +5,7 @@ use polars_utils::pl_str::PlSmallStr;
 use super::compute_node_prelude::*;
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::wait_group::WaitGroup;
+use crate::prelude::TracedAwait;
 use crate::DEFAULT_DISTRIBUTOR_BUFFER_SIZE;
 
 pub struct WithRowIndexNode {
@@ -51,13 +52,18 @@ impl ComputeNode for WithRowIndexNode {
 
         // To figure out the correct offsets we need to be serial.
         join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-            while let Ok(morsel) = receiver.recv().await {
+            while let Ok(morsel) = receiver.recv().traced_await().await {
                 let offset = self.offset;
                 self.offset = self
                     .offset
                     .checked_add(morsel.df().len().try_into().unwrap())
                     .unwrap();
-                if distributor.send((morsel, offset)).await.is_err() {
+                if distributor
+                    .send((morsel, offset))
+                    .traced_await()
+                    .await
+                    .is_err()
+                {
                     break;
                 }
             }
@@ -70,14 +76,14 @@ impl ComputeNode for WithRowIndexNode {
             let name = name.clone();
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 let wait_group = WaitGroup::default();
-                while let Ok((morsel, offset)) = recv.recv().await {
+                while let Ok((morsel, offset)) = recv.recv().traced_await().await {
                     let mut morsel =
                         morsel.try_map(|df| df.with_row_index(name.clone(), Some(offset)))?;
                     morsel.set_consume_token(wait_group.token());
-                    if send.send(morsel).await.is_err() {
+                    if send.send(morsel).traced_await().await.is_err() {
                         break;
                     }
-                    wait_group.wait().await;
+                    wait_group.wait().traced_await().await;
                 }
 
                 Ok(())

--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -9,6 +9,7 @@ use polars_utils::itertools::Itertools;
 
 use super::compute_node_prelude::*;
 use crate::morsel::SourceToken;
+use crate::prelude::TracedAwait;
 use crate::DEFAULT_ZIP_HEAD_BUFFER_SIZE;
 
 /// The head of an input stream.
@@ -221,8 +222,8 @@ impl ComputeNode for ZipNode {
                 let mut serial_recv = recv_port.take()?.serial();
                 let (buf_send, buf_recv) = tokio::sync::mpsc::channel(DEFAULT_ZIP_HEAD_BUFFER_SIZE);
                 join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                    while let Ok(morsel) = serial_recv.recv().await {
-                        if buf_send.send(morsel).await.is_err() {
+                    while let Ok(morsel) = serial_recv.recv().traced_await().await {
+                        if buf_send.send(morsel).traced_await().await.is_err() {
                             break;
                         }
                     }
@@ -246,7 +247,7 @@ impl ComputeNode for ZipNode {
                 for (recv_idx, opt_recv) in receivers.iter_mut().enumerate() {
                     if let Some(recv) = opt_recv {
                         while !self.input_heads[recv_idx].ready_to_send() {
-                            if let Some(morsel) = recv.recv().await {
+                            if let Some(morsel) = recv.recv().traced_await().await {
                                 self.input_heads[recv_idx].add_morsel(morsel);
                             } else {
                                 break;
@@ -280,7 +281,7 @@ impl ComputeNode for ZipNode {
 
                 let morsel = Morsel::new(out_df, self.out_seq, source_token.clone());
                 self.out_seq = self.out_seq.successor();
-                if sender.send(morsel).await.is_err() {
+                if sender.send(morsel).traced_await().await.is_err() {
                     // Our receiver is no longer interested in any data, no
                     // need store the rest of the incoming stream, can directly
                     // return.
@@ -302,7 +303,7 @@ impl ComputeNode for ZipNode {
 
             for (recv_idx, opt_recv) in receivers.iter_mut().enumerate() {
                 if let Some(recv) = opt_recv {
-                    while let Some(mut morsel) = recv.recv().await {
+                    while let Some(mut morsel) = recv.recv().traced_await().await {
                         morsel.source_token().stop();
                         drop(morsel.take_consume_token());
                         self.input_heads[recv_idx].add_morsel(morsel);
@@ -325,7 +326,7 @@ impl ComputeNode for ZipNode {
 
                 let morsel = Morsel::new(out_df, self.out_seq, source_token.clone());
                 self.out_seq = self.out_seq.successor();
-                let _ = sender.send(morsel).await;
+                let _ = sender.send(morsel).traced_await().await;
             }
 
             Ok(())

--- a/crates/polars-stream/src/prelude.rs
+++ b/crates/polars-stream/src/prelude.rs
@@ -1,0 +1,47 @@
+use std::future::Future;
+use std::sync::atomic::AtomicUsize;
+use std::sync::LazyLock;
+
+pub trait TracedAwait: Sized + Future {
+    #[track_caller]
+    fn traced_await(self) -> impl Future<Output = Self::Output> {
+        static ID: AtomicUsize = AtomicUsize::new(0);
+        static ENABLE: LazyLock<bool> =
+            LazyLock::new(|| std::env::var("POLARS_TRACED_AWAIT").as_deref() == Ok("1"));
+
+        let enable = *ENABLE;
+        let caller_location = std::panic::Location::caller();
+
+        let local_id = if enable {
+            ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        } else {
+            0
+        };
+
+        async move {
+            if enable {
+                eprintln!(
+                    "begin_await {} {}:{}",
+                    local_id,
+                    caller_location.file(),
+                    caller_location.line()
+                );
+            }
+
+            let out = self.await;
+
+            if enable {
+                eprintln!(
+                    "finish_await {} {}:{}",
+                    local_id,
+                    caller_location.file(),
+                    caller_location.line()
+                );
+            }
+
+            out
+        }
+    }
+}
+
+impl<F: Sized + Future> TracedAwait for F {}


### PR DESCRIPTION
This is a branch with added tracing to await points in the new-streaming compute nodes, intended for finding which await points are blocking execution in the event of a deadlock.

Compile and run with `POLARS_TRACED_AWAIT=1` set in the environment, which should print lines to stderr similar to the following:

<img width="508" alt="image" src="https://github.com/user-attachments/assets/661886e0-d6ad-4fbb-a1eb-8db080ba8e24" />

The output should be saved to a file, the following script can then be used to extract the locations at which async tasks are currently blocked:

```python
import polars as pl
from pathlib import Path

trace_file = ".env/trace"

df = (
    pl.Series("raw", [Path(trace_file).read_text()])
    .str.strip_chars_end("\n")
    .str.split("\n")
    .list.explode()
    .to_frame()
    .filter(
        pl.first().str.starts_with("begin_await")
        | pl.first().str.starts_with("finish_await")
    )
)

v = (
    df.with_columns(
        pl.col("raw")
        .str.splitn(" ", 3)
        .struct.rename_fields(["event", "id", "location"])
        .struct.unnest()
    )
    .filter(pl.len().over("id") < 2)
    .unique("location")
    .sort("location")
)


with pl.Config(
    tbl_formatting="ASCII_MARKDOWN",
    fmt_str_lengths=999,
    tbl_width_chars=999,
    tbl_hide_column_data_types=True,
    tbl_rows=999,
):
    print(v.select("location"))

```
