### PR TITLE
perf: Allow elementwise functions in recursive lowering

### DIFF
--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -1271,7 +1271,7 @@ impl Series {
             _ if max_items >= self.len() => {
                 // this will always leave a trailing ", " after the last item
                 // but for long lists, this is faster than checking against the length each time
-                for item in self.iter() {
+                for item in self.rechunk().iter() {
                     write!(result, "{item}, ").unwrap();
                 }
                 // remove trailing ", " and replace with closing brace

--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -81,7 +81,7 @@ pub fn hor_str_concat(
         .unwrap_or(1);
     polars_ensure!(
         cas.iter().all(|ca| ca.len() == 1 || ca.len() == len),
-        ComputeError: "all series in `hor_str_concat` should have equal or unit length"
+        ShapeMismatch: "all series in `hor_str_concat` should have equal or unit length"
     );
 
     let mut builder = StringChunkedBuilder::new(cas[0].name().clone(), len);

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -1036,7 +1036,7 @@ fn _ensure_lengths(s: &[Column]) -> bool {
 fn _check_same_length(s: &[Column], fn_name: &str) -> Result<(), PolarsError> {
     polars_ensure!(
         _ensure_lengths(s),
-        ComputeError: "all series in `str.{}()` should have equal or unit length",
+        ShapeMismatch: "all series in `str.{}()` should have equal or unit length",
         fn_name
     );
     Ok(())

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -301,7 +301,7 @@ impl ListNameSpace {
     /// Check if the list array contain an element
     pub fn contains<E: Into<Expr>>(self, other: E) -> Expr {
         let other = other.into();
-        
+
         if has_leaf_literal(&other) {
             self.0.map_many_private(
                 FunctionExpr::ListExpr(ListFunction::Contains),

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -302,22 +302,14 @@ impl ListNameSpace {
     pub fn contains<E: Into<Expr>>(self, other: E) -> Expr {
         let other = other.into();
 
-        if has_leaf_literal(&other) {
-            self.0.map_many_private(
-                FunctionExpr::ListExpr(ListFunction::Contains),
-                &[other],
-                false,
-                None,
-            )
-        } else {
-            self.0.apply_many_private(
-                FunctionExpr::ListExpr(ListFunction::Contains),
-                &[other],
-                false,
-                false,
-            )
-        }
+        self.0.map_many_private(
+            FunctionExpr::ListExpr(ListFunction::Contains),
+            &[other],
+            false,
+            None,
+        )
     }
+
     #[cfg(feature = "list_count")]
     /// Count how often the value produced by ``element`` occurs.
     pub fn count_matches<E: Into<Expr>>(self, element: E) -> Expr {

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -168,11 +168,11 @@ impl ListNameSpace {
     ///   This behavior is more expensive than defaulting to returning an `Error`.
     #[cfg(feature = "list_gather")]
     pub fn gather(self, index: Expr, null_on_oob: bool) -> Expr {
-        self.0.map_many_private(
+        self.0.apply_many_private(
             FunctionExpr::ListExpr(ListFunction::Gather(null_on_oob)),
             &[index],
             false,
-            None,
+            false,
         )
     }
 
@@ -301,13 +301,22 @@ impl ListNameSpace {
     /// Check if the list array contain an element
     pub fn contains<E: Into<Expr>>(self, other: E) -> Expr {
         let other = other.into();
-
-        self.0.map_many_private(
-            FunctionExpr::ListExpr(ListFunction::Contains),
-            &[other],
-            false,
-            None,
-        )
+        
+        if has_leaf_literal(&other) {
+            self.0.map_many_private(
+                FunctionExpr::ListExpr(ListFunction::Contains),
+                &[other],
+                false,
+                None,
+            )
+        } else {
+            self.0.apply_many_private(
+                FunctionExpr::ListExpr(ListFunction::Contains),
+                &[other],
+                false,
+                false,
+            )
+        }
     }
     #[cfg(feature = "list_count")]
     /// Count how often the value produced by ``element`` occurs.

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1581,17 +1581,7 @@ impl Expr {
     pub fn replace<E: Into<Expr>>(self, old: E, new: E) -> Expr {
         let old = old.into();
         let new = new.into();
-
-        // If we search and replace by literals, we can run on batches.
-        let literal_searchers = matches!(&old, Expr::Literal(_)) & matches!(&new, Expr::Literal(_));
-
-        let args = [old, new];
-
-        if literal_searchers {
-            self.map_many_private(FunctionExpr::Replace, &args, false, None)
-        } else {
-            self.apply_many_private(FunctionExpr::Replace, &args, false, false)
-        }
+        self.apply_many_private(FunctionExpr::Replace, &[old, new], false, false)
     }
 
     #[cfg(feature = "replace")]
@@ -1606,29 +1596,16 @@ impl Expr {
         let old = old.into();
         let new = new.into();
 
-        // If we replace by literals, we can run on batches.
-        let literal_searchers = matches!(&old, Expr::Literal(_)) & matches!(&new, Expr::Literal(_));
-
         let mut args = vec![old, new];
         if let Some(default) = default {
             args.push(default.into())
         }
-
-        if literal_searchers {
-            self.map_many_private(
-                FunctionExpr::ReplaceStrict { return_dtype },
-                &args,
-                false,
-                None,
-            )
-        } else {
-            self.apply_many_private(
-                FunctionExpr::ReplaceStrict { return_dtype },
-                &args,
-                false,
-                false,
-            )
-        }
+        self.apply_many_private(
+            FunctionExpr::ReplaceStrict { return_dtype },
+            &args,
+            false,
+            false,
+        )
     }
 
     #[cfg(feature = "cutqcut")]

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1198,7 +1198,10 @@ impl Expr {
     #[cfg(feature = "is_in")]
     pub fn is_in<E: Into<Expr>>(self, other: E, nulls_equal: bool) -> Self {
         let other = other.into();
-        let has_literal = all_leafs_literal(&other);
+        
+        // TODO: I believe this should be all_leafs_literal but this crashes
+        // the IN SQL subquery with unknown column errors.
+        let has_literal = has_leaf_literal(&other);
 
         // lit(true).is_in() returns a scalar.
         let returns_scalar = all_return_scalar(&self);

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1203,6 +1203,7 @@ impl Expr {
 
         let arguments = &[other];
         // we don't have to apply on groups, so this is faster
+        // TODO: this optimization should be done during conversion to IR.
         if other_constant {
             self.map_many_private(
                 BooleanFunction::IsIn { nulls_equal }.into(),
@@ -1580,6 +1581,7 @@ impl Expr {
         let old = old.into();
         let new = new.into();
         // If we search and replace by constants, we can run on batches.
+        // TODO: this optimization should be done during conversion to IR.
         let literal_args = is_column_independent(&old) && is_column_independent(&new);
         let args = [old, new];
         if literal_args {
@@ -1602,6 +1604,7 @@ impl Expr {
         let new = new.into();
 
         // If we replace by constants, we can run on batches.
+        // TODO: this optimization should be done during conversion to IR.
         let literal_args = is_column_independent(&old) && is_column_independent(&new);
 
         let mut args = vec![old, new];

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1198,7 +1198,7 @@ impl Expr {
     #[cfg(feature = "is_in")]
     pub fn is_in<E: Into<Expr>>(self, other: E, nulls_equal: bool) -> Self {
         let other = other.into();
-        
+
         // TODO: I believe this should be all_leaves_literal but this crashes
         // the IN SQL subquery with unknown column errors.
         let has_literal = has_leaf_literal(&other);

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1199,7 +1199,7 @@ impl Expr {
     pub fn is_in<E: Into<Expr>>(self, other: E, nulls_equal: bool) -> Self {
         let other = other.into();
         
-        // TODO: I believe this should be all_leafs_literal but this crashes
+        // TODO: I believe this should be all_leaves_literal but this crashes
         // the IN SQL subquery with unknown column errors.
         let has_literal = has_leaf_literal(&other);
 

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1198,17 +1198,12 @@ impl Expr {
     #[cfg(feature = "is_in")]
     pub fn is_in<E: Into<Expr>>(self, other: E, nulls_equal: bool) -> Self {
         let other = other.into();
-
-        // TODO: I believe this should be all_leaves_literal but this crashes
-        // the IN SQL subquery with unknown column errors.
-        let has_literal = has_leaf_literal(&other);
-
-        // lit(true).is_in() returns a scalar.
+        let other_constant = is_column_independent(&other);
         let returns_scalar = all_return_scalar(&self);
 
         let arguments = &[other];
         // we don't have to apply on groups, so this is faster
-        if has_literal {
+        if other_constant {
             self.map_many_private(
                 BooleanFunction::IsIn { nulls_equal }.into(),
                 arguments,
@@ -1584,8 +1579,8 @@ impl Expr {
     pub fn replace<E: Into<Expr>>(self, old: E, new: E) -> Expr {
         let old = old.into();
         let new = new.into();
-        // If we search and replace by literals, we can run on batches.
-        let literal_args = all_leaves_literal(&old) && all_leaves_literal(&new);
+        // If we search and replace by constants, we can run on batches.
+        let literal_args = is_column_independent(&old) && is_column_independent(&new);
         let args = [old, new];
         if literal_args {
             self.map_many_private(FunctionExpr::Replace, &args, false, None)
@@ -1606,8 +1601,8 @@ impl Expr {
         let old = old.into();
         let new = new.into();
 
-        // If we replace by literals, we can run on batches.
-        let literal_args = all_leaves_literal(&old) && all_leaves_literal(&new);
+        // If we replace by constants, we can run on batches.
+        let literal_args = is_column_independent(&old) && is_column_independent(&new);
 
         let mut args = vec![old, new];
         if let Some(default) = default {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1585,7 +1585,7 @@ impl Expr {
         let old = old.into();
         let new = new.into();
         // If we search and replace by literals, we can run on batches.
-        let literal_args = all_leafs_literal(&old) && all_leafs_literal(&new);
+        let literal_args = all_leaves_literal(&old) && all_leaves_literal(&new);
         let args = [old, new];
         if literal_args {
             self.map_many_private(FunctionExpr::Replace, &args, false, None)
@@ -1607,7 +1607,7 @@ impl Expr {
         let new = new.into();
 
         // If we replace by literals, we can run on batches.
-        let literal_args = all_leafs_literal(&old) && all_leafs_literal(&new);
+        let literal_args = all_leaves_literal(&old) && all_leaves_literal(&new);
 
         let mut args = vec![old, new];
         if let Some(default) = default {

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -114,14 +114,14 @@ impl StringNameSpace {
         ascii_case_insensitive: bool,
         overlapping: bool,
     ) -> Expr {
-        self.0.map_many_private(
+        self.0.apply_many_private(
             FunctionExpr::StringExpr(StringFunction::FindMany {
                 ascii_case_insensitive,
                 overlapping,
             }),
             &[patterns],
             false,
-            None,
+            false,
         )
     }
 

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -297,8 +297,8 @@ impl StringNameSpace {
     /// Convert a String column into a Date/Datetime/Time column.
     #[cfg(feature = "temporal")]
     pub fn strptime(self, dtype: DataType, options: StrptimeOptions, ambiguous: Expr) -> Expr {
-        // Only elementwise if the format is explicitly set.
-        if options.format.is_some() {
+        // Only elementwise if the format is explicitly set, or we're constant.
+        if options.format.is_some() || is_column_independent(&self.0) {
             self.0.map_many_private(
                 StringFunction::Strptime(dtype, options).into(),
                 &[ambiguous],

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -41,13 +41,13 @@ impl StringNameSpace {
     ///   ASCII letters (a-z and A-Z) only.
     #[cfg(feature = "find_many")]
     pub fn contains_any(self, patterns: Expr, ascii_case_insensitive: bool) -> Expr {
-        self.0.map_many_private(
+        self.0.apply_many_private(
             FunctionExpr::StringExpr(StringFunction::ContainsAny {
                 ascii_case_insensitive,
             }),
             &[patterns],
             false,
-            None,
+            false,
         )
     }
 
@@ -65,13 +65,13 @@ impl StringNameSpace {
         replace_with: Expr,
         ascii_case_insensitive: bool,
     ) -> Expr {
-        self.0.map_many_private(
+        self.0.apply_many_private(
             FunctionExpr::StringExpr(StringFunction::ReplaceMany {
                 ascii_case_insensitive,
             }),
             &[patterns, replace_with],
             false,
-            None,
+            false,
         )
     }
 
@@ -89,14 +89,14 @@ impl StringNameSpace {
         ascii_case_insensitive: bool,
         overlapping: bool,
     ) -> Expr {
-        self.0.map_many_private(
+        self.0.apply_many_private(
             FunctionExpr::StringExpr(StringFunction::ExtractMany {
                 ascii_case_insensitive,
                 overlapping,
             }),
             &[patterns],
             false,
-            None,
+            false,
         )
     }
 
@@ -297,12 +297,22 @@ impl StringNameSpace {
     /// Convert a String column into a Date/Datetime/Time column.
     #[cfg(feature = "temporal")]
     pub fn strptime(self, dtype: DataType, options: StrptimeOptions, ambiguous: Expr) -> Expr {
-        self.0.map_many_private(
-            StringFunction::Strptime(dtype, options).into(),
-            &[ambiguous],
-            false,
-            None,
-        )
+        // Only elementwise if the format is explicitly set.
+        if options.format.is_some() {
+            self.0.map_many_private(
+                StringFunction::Strptime(dtype, options).into(),
+                &[ambiguous],
+                false,
+                None,
+            )
+        } else {
+            self.0.apply_many_private(
+                StringFunction::Strptime(dtype, options).into(),
+                &[ambiguous],
+                false,
+                false,
+            )
+        }
     }
 
     /// Convert a String column into a Date column.

--- a/crates/polars-plan/src/plans/aexpr/properties.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties.rs
@@ -19,18 +19,6 @@ impl AExpr {
         match self {
             AnonymousFunction { options, .. } => options.is_elementwise(),
 
-            // Non-strict strptime must be done in-memory to ensure the format
-            // is consistent across the entire dataframe.
-            #[cfg(all(feature = "strings", feature = "temporal"))]
-            Function {
-                options,
-                function: FunctionExpr::StringExpr(StringFunction::Strptime(_, opts)),
-                ..
-            } => {
-                assert!(options.is_elementwise());
-                opts.strict
-            },
-
             Function { options, .. } => options.is_elementwise(),
 
             Literal(v) => v.is_scalar(),

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -149,8 +149,8 @@ impl FunctionOptions {
     }
 
     pub fn is_elementwise(&self) -> bool {
-        self.collect_groups == ApplyOptions::ElementWise
-        && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
+        matches!(self.collect_groups, ApplyOptions::ElementWise | ApplyOptions::ApplyList)
+            && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
             && !self.flags.contains(FunctionFlags::RETURNS_SCALAR)
     }
 

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -149,8 +149,10 @@ impl FunctionOptions {
     }
 
     pub fn is_elementwise(&self) -> bool {
-        matches!(self.collect_groups, ApplyOptions::ElementWise | ApplyOptions::ApplyList)
-            && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
+        matches!(
+            self.collect_groups,
+            ApplyOptions::ElementWise | ApplyOptions::ApplyList
+        ) && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
             && !self.flags.contains(FunctionFlags::RETURNS_SCALAR)
     }
 

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -149,10 +149,8 @@ impl FunctionOptions {
     }
 
     pub fn is_elementwise(&self) -> bool {
-        matches!(
-            self.collect_groups,
-            ApplyOptions::ElementWise | ApplyOptions::ApplyList
-        ) && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
+        self.collect_groups == ApplyOptions::ElementWise
+        && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
             && !self.flags.contains(FunctionFlags::RETURNS_SCALAR)
     }
 

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -76,6 +76,14 @@ where
     current_expr.into_iter().any(matches)
 }
 
+/// Check if at least one leaf expressions is a literal.
+pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
+    match e {
+        Expr::Literal(_) => true,
+        _ => expr_to_leaf_column_exprs_iter(e).any(|e| matches!(e, Expr::Literal(_))),
+    }
+}
+
 /// Check if all leaf expressions are literals.
 pub(crate) fn all_leafs_literal(e: &Expr) -> bool {
     match e {

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -85,7 +85,7 @@ pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
 }
 
 /// Check if all leaf expressions are literals.
-pub(crate) fn all_leafs_literal(e: &Expr) -> bool {
+pub(crate) fn all_leaves_literal(e: &Expr) -> bool {
     match e {
         Expr::Literal(_) => true,
         _ => expr_to_leaf_column_exprs_iter(e).all(|e| matches!(e, Expr::Literal(_))),

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -76,20 +76,21 @@ where
     current_expr.into_iter().any(matches)
 }
 
-/// Check if at least one leaf expressions is a literal.
-pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
-    match e {
-        Expr::Literal(_) => true,
-        _ => expr_to_leaf_column_exprs_iter(e).any(|e| matches!(e, Expr::Literal(_))),
-    }
-}
-
-/// Check if all leaf expressions are literals.
-pub(crate) fn all_leaves_literal(e: &Expr) -> bool {
-    match e {
-        Expr::Literal(_) => true,
-        _ => expr_to_leaf_column_exprs_iter(e).all(|e| matches!(e, Expr::Literal(_))),
-    }
+/// Check if expression is independent from any column.
+pub(crate) fn is_column_independent(expr: &Expr) -> bool {
+    expr.into_iter().all(|e| match e {
+        Expr::Nth(_)
+        | Expr::Column(_)
+        | Expr::Columns(_)
+        | Expr::DtypeColumn(_)
+        | Expr::IndexColumn(_)
+        | Expr::Wildcard
+        | Expr::Len
+        | Expr::SubPlan(..)
+        | Expr::Field(_)
+        | Expr::Selector(_) => false,
+        _ => true,
+    })
 }
 /// Check if leaf expression returns a scalar
 #[cfg(feature = "is_in")]

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -78,20 +78,20 @@ where
 
 /// Check if expression is independent from any column.
 pub(crate) fn is_column_independent(expr: &Expr) -> bool {
-    !expr.into_iter().any(|e| {
-        matches!(
-            e,
-            Expr::Nth(_)
-                | Expr::Column(_)
-                | Expr::Columns(_)
-                | Expr::DtypeColumn(_)
-                | Expr::IndexColumn(_)
-                | Expr::Wildcard
-                | Expr::Len
-                | Expr::SubPlan(..)
-                | Expr::Field(_)
-                | Expr::Selector(_)
-        )
+    !expr.into_iter().any(|e| match e {
+        Expr::Nth(_)
+        | Expr::Column(_)
+        | Expr::Columns(_)
+        | Expr::DtypeColumn(_)
+        | Expr::IndexColumn(_)
+        | Expr::Wildcard
+        | Expr::Len
+        | Expr::SubPlan(..)
+        | Expr::Selector(_) => true,
+
+        #[cfg(feature = "dtype-struct")]
+        Expr::Field(_) => true,
+        _ => false,
     })
 }
 

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -76,12 +76,11 @@ where
     current_expr.into_iter().any(matches)
 }
 
-/// Check if leaf expression is a literal
-#[cfg(feature = "is_in")]
-pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
+/// Check if all leaf expressions are literals.
+pub(crate) fn all_leafs_literal(e: &Expr) -> bool {
     match e {
         Expr::Literal(_) => true,
-        _ => expr_to_leaf_column_exprs_iter(e).any(|e| matches!(e, Expr::Literal(_))),
+        _ => expr_to_leaf_column_exprs_iter(e).all(|e| matches!(e, Expr::Literal(_))),
     }
 }
 /// Check if leaf expression returns a scalar

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -78,18 +78,20 @@ where
 
 /// Check if expression is independent from any column.
 pub(crate) fn is_column_independent(expr: &Expr) -> bool {
-    expr.into_iter().all(|e| match e {
-        Expr::Nth(_)
-        | Expr::Column(_)
-        | Expr::Columns(_)
-        | Expr::DtypeColumn(_)
-        | Expr::IndexColumn(_)
-        | Expr::Wildcard
-        | Expr::Len
-        | Expr::SubPlan(..)
-        | Expr::Field(_)
-        | Expr::Selector(_) => false,
-        _ => true,
+    !expr.into_iter().any(|e| {
+        matches!(
+            e,
+            Expr::Nth(_)
+                | Expr::Column(_)
+                | Expr::Columns(_)
+                | Expr::DtypeColumn(_)
+                | Expr::IndexColumn(_)
+                | Expr::Wildcard
+                | Expr::Len
+                | Expr::SubPlan(..)
+                | Expr::Field(_)
+                | Expr::Selector(_)
+        )
     })
 }
 

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -92,6 +92,7 @@ pub(crate) fn is_column_independent(expr: &Expr) -> bool {
         _ => true,
     })
 }
+
 /// Check if leaf expression returns a scalar
 #[cfg(feature = "is_in")]
 pub(crate) fn all_return_scalar(e: &Expr) -> bool {

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -530,7 +530,7 @@ fn lower_exprs_with_ctx(
                 input: ref inner_exprs,
                 options,
                 ..
-            } if options.is_elementwise() => {
+            } if options.is_elementwise() && options.collect_groups != ApplyOptions::ApplyList => {
                 let inner_nodes = inner_exprs.iter().map(|expr| expr.node()).collect_vec();
                 let (trans_input, trans_exprs) = lower_exprs_with_ctx(input, &inner_nodes, ctx)?;
 
@@ -538,7 +538,9 @@ fn lower_exprs_with_ctx(
                 let new_input = trans_exprs
                     .into_iter()
                     .zip(inner_exprs)
-                    .map(|(trans, orig)| ExprIR::new(trans, OutputName::Alias(orig.output_name().clone())))
+                    .map(|(trans, orig)| {
+                        ExprIR::new(trans, OutputName::Alias(orig.output_name().clone()))
+                    })
                     .collect_vec();
                 let mut new_node = node.clone();
                 match &mut new_node {

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -84,7 +84,7 @@ pub(crate) fn is_elementwise_rec_cached(
 
                 loop {
                     let ae = arena.get(expr_key);
-                    
+
                     if is_fake_elementwise_function(ae) {
                         return false;
                     }

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -19,7 +19,7 @@ use slotmap::SlotMap;
 use super::lower_expr::lower_exprs;
 use super::{ExprCache, PhysNode, PhysNodeKey, PhysNodeKind, PhysStream};
 use crate::physical_plan::lower_expr::{
-    build_select_stream, compute_output_schema, is_fake_elementwise_function, is_input_independent
+    build_select_stream, compute_output_schema, is_fake_elementwise_function, is_input_independent,
 };
 use crate::physical_plan::lower_ir::build_slice_stream;
 use crate::utils::late_materialized_df::LateMaterializedDataFrame;

--- a/py-polars/tests/unit/operations/namespaces/string/test_pad.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_pad.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ShapeError
 from polars.testing import assert_frame_equal
 
 
@@ -93,7 +93,7 @@ def test_str_zfill_expr() -> None:
 
 def test_str_zfill_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.zfill(pl.Series([1, 2])))
 
 

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -11,6 +11,7 @@ from polars.exceptions import (
     ComputeError,
     InvalidOperationError,
     SchemaError,
+    ShapeError,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -56,7 +57,7 @@ def test_str_slice_expr() -> None:
 
 def test_str_slice_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.slice(pl.Series([1, 2])))
 
 
@@ -123,7 +124,7 @@ def test_str_head_expr() -> None:
 
 def test_str_head_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.head(pl.Series([1, 2])))
 
 
@@ -190,7 +191,7 @@ def test_str_tail_expr() -> None:
 
 def test_str_tail_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.tail(pl.Series([1, 2])))
 
 
@@ -232,7 +233,7 @@ def test_str_contains() -> None:
 
 def test_str_contains_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.contains(pl.Series(["a", "b"])))  # type: ignore [arg-type]
 
 
@@ -362,9 +363,10 @@ def test_str_find_escaped_chars() -> None:
     )
 
 
+@pytest.mark.may_fail_auto_streaming
 def test_str_find_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.find(pl.Series(["a", "b"])))  # type: ignore [arg-type]
 
 
@@ -547,7 +549,7 @@ def test_str_strip_chars() -> None:
 
 def test_str_strip_chars_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.strip_chars(pl.Series(["a", "b"])))
 
 
@@ -565,7 +567,7 @@ def test_str_strip_chars_start() -> None:
 
 def test_str_strip_chars_start_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.strip_chars_start(pl.Series(["a", "b"])))
 
 
@@ -583,7 +585,7 @@ def test_str_strip_chars_end() -> None:
 
 def test_str_strip_chars_end_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.strip_chars_end(pl.Series(["a", "b"])))
 
 
@@ -629,7 +631,7 @@ def test_str_strip_prefix_suffix_expr() -> None:
 
 def test_str_strip_prefix_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.strip_prefix(pl.Series(["a", "b"])))
 
 
@@ -644,7 +646,7 @@ def test_str_strip_suffix() -> None:
 
 def test_str_strip_suffix_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises(ShapeError):
         df.select(pl.col("num").str.strip_suffix(pl.Series(["a", "b"])))
 
 
@@ -792,7 +794,7 @@ def test_json_path_match() -> None:
 
 def test_str_json_path_match_wrong_length() -> None:
     df = pl.DataFrame({"num": ["-10", "-1", "0"]})
-    with pytest.raises(ComputeError, match="should have equal or unit length"):
+    with pytest.raises((ShapeError, ComputeError)):
         df.select(pl.col("num").str.json_path_match(pl.Series(["a", "b"])))
 
 

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -1196,6 +1196,23 @@ def test_replace_many(
     )
 
 
+def test_replace_many_groupby() -> None:
+    df = pl.DataFrame(
+        {
+            "x": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+            "g": [0, 0, 0, 1, 1, 1, 2, 2, 2],
+        }
+    )
+    out = df.group_by("g").agg(pl.col.x.str.replace_many(pl.col.x.head(2), ""))
+    expected = pl.DataFrame(
+        {
+            "g": [0, 1, 2],
+            "x": [["", "", "c"], ["", "", "f"], ["", "", "i"]],
+        }
+    )
+    assert_frame_equal(out, expected, check_row_order=False)
+
+
 @pytest.mark.parametrize(
     ("mapping", "case_insensitive", "expected"),
     [

--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -244,3 +244,9 @@ def test_group_by_errors() -> None:
         match=r"HAVING clause not valid outside of GROUP BY",
     ):
         df.sql("SELECT a, COUNT(a) AS n FROM self HAVING n > 1")
+
+
+def test_group_by_output_struct() -> None:
+    df = pl.DataFrame({"g": [1], "x": [2], "y": [3]})
+    out = df.group_by("g").agg(pl.struct(pl.col.x.min(), pl.col.y.sum()))
+    assert out.rows() == [(1, {"x": 2, "y": 3})]

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -122,15 +122,12 @@ def test_streaming_apply(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
 
     q = pl.DataFrame({"a": [1, 2]}).lazy()
-
     with pytest.warns(PolarsInefficientMapWarning, match="with this one instead"):
         (
             q.select(
                 pl.col("a").map_elements(lambda x: x * 2, return_dtype=pl.Int64)
             ).collect(engine="old-streaming")  # type: ignore[call-overload]
         )
-        (_, err) = capfd.readouterr()
-        assert "df -> projection -> ordered_sink" in err
 
 
 def test_streaming_ternary() -> None:


### PR DESCRIPTION
In the new streaming engine we already allowed elementwise functions in completely elementwise expressions, but this also allows us to lower elementwise functions applied to non-elementwise subexpressions without having to defer entirely to an in-memory map. For example `pl.col.x.sum().abs()` is now completely lowered to native new-streaming operations.