### PR TITLE
fix(python): Add correct deprecation warning for .str.concat

### DIFF
--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -241,7 +241,7 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         Err(polars_err!(
             op = "`sum`",
             DataType::String,
-            hint = "you may mean to call `str.concat` or `list.join`"
+            hint = "you may mean to call `str.join` or `list.join`"
         ))
     }
     fn max_reduce(&self) -> PolarsResult<Scalar> {

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -9,7 +9,6 @@ from polars import functions as F
 from polars._utils.deprecation import (
     deprecate_function,
     deprecate_nonkeyword_arguments,
-    issue_deprecation_warning,
 )
 from polars._utils.parse import parse_into_expression
 from polars._utils.unstable import unstable
@@ -2851,12 +2850,12 @@ class ExprStringNameSpace:
         └──────┘
         """
         return wrap_expr(self._pyexpr.str_join(delimiter, ignore_nulls=ignore_nulls))
-    
-    @deprecate_function( 
-         "Use `str.join` instead. Note that the default `delimiter` for `str.join`" 
+
+    @deprecate_function(
+         "Use `str.join` instead. Note that the default `delimiter` for `str.join`"
          " is an empty string instead of a hyphen.", 
-         version="1.0.0", 
-    ) 
+         version="1.0.0",
+    )
     def concat(
         self, delimiter: str | None = None, *, ignore_nulls: bool = True
     ) -> Expr:

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2852,9 +2852,9 @@ class ExprStringNameSpace:
         return wrap_expr(self._pyexpr.str_join(delimiter, ignore_nulls=ignore_nulls))
 
     @deprecate_function(
-         "Use `str.join` instead. Note that the default `delimiter` for `str.join`"
-         " is an empty string instead of a hyphen.",
-         version="1.0.0",
+        "Use `str.join` instead. Note that the default `delimiter` for `str.join`"
+        " is an empty string instead of a hyphen.",
+        version="1.0.0",
     )
     def concat(
         self, delimiter: str | None = None, *, ignore_nulls: bool = True

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2851,7 +2851,12 @@ class ExprStringNameSpace:
         └──────┘
         """
         return wrap_expr(self._pyexpr.str_join(delimiter, ignore_nulls=ignore_nulls))
-
+    
+    @deprecate_function( 
+         "Use `str.join` instead. Note that the default `delimiter` for `str.join`" 
+         " is an empty string instead of a hyphen.", 
+         version="1.0.0", 
+    ) 
     def concat(
         self, delimiter: str | None = None, *, ignore_nulls: bool = True
     ) -> Expr:
@@ -2901,11 +2906,6 @@ class ExprStringNameSpace:
         └──────┘
         """
         if delimiter is None:
-            issue_deprecation_warning(
-                "The default `delimiter` for `str.concat` will change from '-' to an empty string."
-                " Pass a delimiter to silence this warning.",
-                version="0.20.5",
-            )
             delimiter = "-"
         return self.join(delimiter, ignore_nulls=ignore_nulls)
 

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2853,7 +2853,7 @@ class ExprStringNameSpace:
 
     @deprecate_function(
          "Use `str.join` instead. Note that the default `delimiter` for `str.join`"
-         " is an empty string instead of a hyphen.", 
+         " is an empty string instead of a hyphen.",
          version="1.0.0",
     )
     def concat(

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -654,6 +654,6 @@ def test_function_expr_scalar_identification_18755() -> None:
 
 def test_concat_deprecation() -> None:
     with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
-        pl.DataFrame({"foo": ["bar"]}).select(pl.all().str.concat())
-    with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
         pl.Series(["foo"]).str.concat()
+    with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
+        pl.DataFrame({"foo": ["bar"]}).select(pl.all().str.concat())

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -655,3 +655,5 @@ def test_function_expr_scalar_identification_18755() -> None:
 def test_concat_deprecation() -> None:
     with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
         pl.DataFrame({"foo": ["bar"]}).select(pl.all().str.concat())
+    with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
+        pl.Series(["foo"]).str.concat()

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -650,3 +650,8 @@ def test_function_expr_scalar_identification_18755() -> None:
         pl.DataFrame({"a": [1, 2]}).with_columns(pl.lit(5).shrink_dtype().alias("b")),
         pl.DataFrame({"a": [1, 2], "b": pl.Series([5, 5], dtype=pl.Int8)}),
     )
+
+
+def test_concat_deprecation() -> None:
+    with pytest.deprecated_call():
+        result = pl.DataFrame({"foo": ["bar"]}).select(pl.all().str.concat())

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -653,5 +653,5 @@ def test_function_expr_scalar_identification_18755() -> None:
 
 
 def test_concat_deprecation() -> None:
-    with pytest.deprecated_call():
-        result = pl.DataFrame({"foo": ["bar"]}).select(pl.all().str.concat())
+    with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
+        pl.DataFrame({"foo": ["bar"]}).select(pl.all().str.concat())


### PR DESCRIPTION
closes #19144