### PR TITLE
fix: Right join on multiple columns not coalescing left_on columns

### DIFF
--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -348,10 +348,17 @@ pub trait DataFrameJoinOps: IntoDf {
         let rhs_keys = prepare_keys_multiple(&selected_right, args.nulls_equal)?.into_series();
 
         let drop_names = if should_coalesce {
-            selected_right
-                .iter()
-                .map(|s| s.name().clone())
-                .collect::<Vec<_>>()
+            if args.how == JoinType::Right {
+                selected_left
+                    .iter()
+                    .map(|s| s.name().clone())
+                    .collect::<Vec<_>>()
+            } else {
+                selected_right
+                    .iter()
+                    .map(|s| s.name().clone())
+                    .collect::<Vec<_>>()
+            }
         } else {
             vec![]
         };

--- a/py-polars/tests/unit/operations/test_join_right.py
+++ b/py-polars/tests/unit/operations/test_join_right.py
@@ -1,4 +1,5 @@
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_right_join_schemas() -> None:
@@ -95,3 +96,12 @@ def test_join_right_different_key() -> None:
         "apple": ["x", "y", "z"],
         "ham2": ["a", "b", "d"],
     }
+
+
+def test_join_right_different_multikey() -> None:
+    left = pl.LazyFrame({"a": [1, 2], "b": [1, 2]})
+    right = pl.LazyFrame({"c": [1, 2], "d": [1, 2]})
+    result = left.join(right, left_on=["a", "b"], right_on=["c", "d"], how="right")
+    expected = pl.DataFrame({"c": [1, 2], "d": [1, 2]})
+    assert_frame_equal(result.collect(), expected)
+    assert result.collect_schema() == expected.schema


### PR DESCRIPTION
fixes #20670
fixes #20671

Right join on multiple columns where `left_on` and `right_on` names do not match was failing to coalesce the `left_on` columns. The lazy schema was already producing the correct behavior.

```python
import polars as pl

left = pl.LazyFrame({"a": [1, 2], "b": [1, 2]})
right = pl.LazyFrame({"c": [1, 2], "d": [1, 2]})

print(
    left.join(right, left_on=["a", "b"], right_on=["c", "d"], how="left").collect()
)

# shape: (2, 2)
# ┌─────┬─────┐
# │ a   ┆ b   │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 1   ┆ 1   │
# │ 2   ┆ 2   │
# └─────┴─────┘

print(
    left.join(right, left_on=["a", "b"], right_on=["c", "d"], how="right").collect()
)

# BEFORE:

# shape: (2, 4)
# ┌─────┬─────┬─────┬─────┐
# │ a   ┆ b   ┆ c   ┆ d   │
# │ --- ┆ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╪═════╡
# │ 1   ┆ 1   ┆ 1   ┆ 1   │
# │ 2   ┆ 2   ┆ 2   ┆ 2   │
# └─────┴─────┴─────┴─────┘

# AFTER:

# shape: (2, 2)
# ┌─────┬─────┐
# │ c   ┆ d   │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 1   ┆ 1   │
# │ 2   ┆ 2   │
# └─────┴─────┘
```


