### PR TITLE
fix: Incorrect loop length in new-streaming group by

### DIFF
--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -178,7 +178,7 @@ impl GroupBySinkState {
 
                         // Combine everything.
                         let mut group_idxs = Vec::new();
-                        for l in 0..num_partitions {
+                        for l in 0..locals.len() {
                             combined.grouper.gather_combine(
                                 &*locals[l].grouper,
                                 &l_partitions[l].0[p],

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -279,3 +279,9 @@ def test_unique_nan_12950() -> None:
     df = pl.DataFrame({"x": float("nan")})
     result = df.unique()
     assert_frame_equal(result, df)
+
+
+def test_unique_lengths_21654() -> None:
+    for n in range(0, 1000, 37):
+        df = pl.DataFrame({"x": pl.int_range(n, eager=True)})
+        assert df.unique().height == n


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/21654.

We didn't hit this case in the CI because we run with `POLARS_MAX_THREADS=4` which makes it impossible to hit this case. I added a test case nevertheless.

It was hard to hit in general, you needed a combination of small morsel sizes and small input size. In most cases the number of partitions was equal to the number of local groupers. 