### PR TITLE
fix: IPC round-trip of list of empty view with non-empty bufferset

### DIFF
--- a/crates/polars-arrow/src/compute/concatenate.rs
+++ b/crates/polars-arrow/src/compute/concatenate.rs
@@ -318,7 +318,6 @@ fn concatenate_view<V: ViewType + ?Sized, A: AsRef<dyn Array>>(
         Arc::new([Buffer::from(new_buffer)]) as Arc<[_]>
     };
 
-    dbg!(buffers.len());
     unsafe {
         BinaryViewArrayGeneric::new_unchecked(
             dtype,

--- a/crates/polars-arrow/src/compute/concatenate.rs
+++ b/crates/polars-arrow/src/compute/concatenate.rs
@@ -204,6 +204,9 @@ fn concatenate_view<V: ViewType + ?Sized, A: AsRef<dyn Array>>(
 ) -> BinaryViewArrayGeneric<V> {
     let dtype = arrays[0].as_ref().dtype().clone();
     let (total_len, null_count) = len_null_count(arrays);
+    if total_len == 0 {
+        return BinaryViewArrayGeneric::new_empty(dtype);
+    }
     let validity = concatenate_validities_with_len_null_count(arrays, total_len, null_count);
 
     let first_arr: &BinaryViewArrayGeneric<V> = arrays[0].as_ref().as_any().downcast_ref().unwrap();
@@ -315,6 +318,7 @@ fn concatenate_view<V: ViewType + ?Sized, A: AsRef<dyn Array>>(
         Arc::new([Buffer::from(new_buffer)]) as Arc<[_]>
     };
 
+    dbg!(buffers.len());
     unsafe {
         BinaryViewArrayGeneric::new_unchecked(
             dtype,

--- a/crates/polars-arrow/src/io/ipc/write/common.rs
+++ b/crates/polars-arrow/src/io/ipc/write/common.rs
@@ -260,7 +260,7 @@ fn set_variadic_buffer_counts(counts: &mut Vec<i64>, array: &dyn Array) {
         },
         ArrowDataType::LargeList(_) => {
             // Subslicing can change the variadic buffer count, so we have to
-            // slice here as well.
+            // slice here as well to stay synchronized.
             let array = array.as_any().downcast_ref::<LargeListArray>().unwrap();
             let offsets = array.offsets().buffer();
             let first = *offsets.first().unwrap();

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, no_type_check
 
 import pandas as pd
 import pytest
@@ -457,6 +457,7 @@ def test_enum_scan_21564() -> None:
     )
 
 
+@no_type_check
 def test_roundtrip_empty_str_list_21163() -> None:
     schema = {
         "s": pl.Utf8,

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -455,3 +455,16 @@ def test_enum_scan_21564() -> None:
         pl.scan_ipc(f).collect().to_series(),
         s,
     )
+
+
+def test_roundtrip_empty_str_list_21163() -> None:
+    schema = {
+        "s": pl.Utf8,
+        "list": pl.List(pl.Utf8),
+    }
+    row1 = pl.DataFrame({"s": ["A"], "list": [[]]}).cast(schema)
+    row2 = pl.DataFrame({"s": ["B"], "list": [[]]}).cast(schema)
+    df = pl.concat([row1, row2])
+    bytes = df.serialize()
+    deserialized = pl.DataFrame.deserialize(io.BytesIO(bytes))
+    assert_frame_equal(df, deserialized)

--- a/py-polars/tests/unit/io/test_ipc.py
+++ b/py-polars/tests/unit/io/test_ipc.py
@@ -462,8 +462,8 @@ def test_roundtrip_empty_str_list_21163() -> None:
         "s": pl.Utf8,
         "list": pl.List(pl.Utf8),
     }
-    row1 = pl.DataFrame({"s": ["A"], "list": [[]]}).cast(schema)
-    row2 = pl.DataFrame({"s": ["B"], "list": [[]]}).cast(schema)
+    row1 = pl.DataFrame({"s": ["A"], "list": [[]]}, schema=schema)
+    row2 = pl.DataFrame({"s": ["B"], "list": [[]]}, schema=schema)
     df = pl.concat([row1, row2])
     bytes = df.serialize()
     deserialized = pl.DataFrame.deserialize(io.BytesIO(bytes))


### PR DESCRIPTION
Fixes #21163.

