### PR TITLE
chore: Work around typos ignore bug

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,7 +5,7 @@ extend-exclude = [
   "*.gz",
   "dists.dss",
   "**/images/*",
-  "py-polars/polars/_utils/nest_asyncio.py",
+  "**/py-polars/polars/_utils/nest_asyncio.py",
 ]
 ignore-hidden = false
 


### PR DESCRIPTION
Workaround for https://github.com/crate-ci/typos/issues/593, `typos` doesn't work properly with exclude paths if run from a subdirectory (like `make precommit` from `py-polars` does right now).