### PR TITLE
perf: Remove unnecessary black_boxes in Kahan summation

### DIFF
--- a/crates/polars-compute/src/rolling/no_nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/sum.rs
@@ -21,8 +21,7 @@ fn sum_kahan<
                 let y = val - err;
                 let new_sum = sum + y;
 
-                // Algebraically, err should always be zero, so compiler should not optimize.
-                err = std::hint::black_box((new_sum - sum) - y);
+                err = (new_sum - sum) - y;
                 sum = new_sum;
             } else {
                 sum += val
@@ -52,7 +51,7 @@ impl<T: NativeType + IsFloat + AddAssign + SubAssign + Sub<Output = T> + Add<Out
             let new_sum = self.sum + y;
 
             // Algebraically, err should always be zero, so compiler should not optimize.
-            self.err = std::hint::black_box((new_sum - self.sum) - y);
+            self.err = (new_sum - self.sum) - y;
             self.sum = new_sum;
         } else {
             self.sum += val;

--- a/crates/polars-compute/src/rolling/no_nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/sum.rs
@@ -20,7 +20,6 @@ fn sum_kahan<
             if val.is_finite() {
                 let y = val - err;
                 let new_sum = sum + y;
-
                 err = (new_sum - sum) - y;
                 sum = new_sum;
             } else {
@@ -49,8 +48,6 @@ impl<T: NativeType + IsFloat + AddAssign + SubAssign + Sub<Output = T> + Add<Out
         if T::is_float() && val.is_finite() {
             let y = val - self.err;
             let new_sum = self.sum + y;
-
-            // Algebraically, err should always be zero, so compiler should not optimize.
             self.err = (new_sum - self.sum) - y;
             self.sum = new_sum;
         } else {

--- a/crates/polars-compute/src/rolling/nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/nulls/sum.rs
@@ -20,8 +20,6 @@ impl<T: NativeType + IsFloat + AddAssign + SubAssign + Sub<Output = T> + Add<Out
             self.sum = self.sum.map(|sum| {
                 let y = val - self.err;
                 let new_sum = sum + y;
-
-                // Algebraically, err should always be zero, so compiler should not optimize.
                 self.err = (new_sum - sum) - y;
                 new_sum
             });

--- a/crates/polars-compute/src/rolling/nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/nulls/sum.rs
@@ -22,7 +22,7 @@ impl<T: NativeType + IsFloat + AddAssign + SubAssign + Sub<Output = T> + Add<Out
                 let new_sum = sum + y;
 
                 // Algebraically, err should always be zero, so compiler should not optimize.
-                self.err = std::hint::black_box((new_sum - sum) - y);
+                self.err = (new_sum - sum) - y;
                 new_sum
             });
         } else {


### PR DESCRIPTION
@ritchie46 Just happened to spot these, the Rust compiler can't optimize Kahan summation out even without the black box, that would be semantics-changing optimizations. And `std::hint::black_box` isn't free, it actually forcibly writes the value to the stack and reads it back.