### PR TITLE
Add .with_options() method to CsvReader for easier configuration

### DIFF
--- a/crates/polars-io/src/csv/read/reader.rs
+++ b/crates/polars-io/src/csv/read/reader.rs
@@ -187,6 +187,14 @@ where
     }
 }
 
+impl<R: MmapBytesReader> CsvReader<R> {
+    /// Sets custom CSV read options.
+    pub fn with_options(mut self, options: CsvReadOptions) -> Self {
+        self.options = options;
+        self
+    }
+}
+
 /// Splits datatypes that cannot be natively read into a `fields_to_cast` for
 /// post-read casting.
 ///


### PR DESCRIPTION
This PR implements a new .with_options() method for CsvReader to allow custom CSV read options.

Although the existing into_reader_with_file_handle function from CsvReadOptions is useful for applying custom options, this PR introduces a helper function directly on CsvReader. This new function aims simplifying adding custom csv options—similar to how CsvWriter provides its own helper methods.

Fixes #16749.

Please feel free to let me know if you have any suggestions about this PR.