### PR TITLE
 feat: Add `pl.defer`, a function that defers DataFrame construction. 

### DIFF
--- a/crates/polars-lazy/src/frame/python.rs
+++ b/crates/polars-lazy/src/frame/python.rs
@@ -12,6 +12,8 @@ impl LazyFrame {
         schema: Either<PyObject, SchemaRef>,
         scan_fn: PyObject,
         pyarrow: bool,
+        // Validate that the source gives the proper schema
+        check_schema: bool,
     ) -> Self {
         DslPlan::PythonScan {
             options: PythonOptionsDsl {
@@ -23,6 +25,7 @@ impl LazyFrame {
                 } else {
                     PythonScanSource::IOPlugin
                 },
+                check_schema,
             },
         }
         .into()

--- a/crates/polars-lazy/src/frame/python.rs
+++ b/crates/polars-lazy/src/frame/python.rs
@@ -13,7 +13,7 @@ impl LazyFrame {
         scan_fn: PyObject,
         pyarrow: bool,
         // Validate that the source gives the proper schema
-        check_schema: bool,
+        validate_schema: bool,
     ) -> Self {
         DslPlan::PythonScan {
             options: PythonOptionsDsl {
@@ -25,7 +25,7 @@ impl LazyFrame {
                 } else {
                     PythonScanSource::IOPlugin
                 },
-                check_schema,
+                validate_schema,
             },
         }
         .into()

--- a/crates/polars-mem-engine/src/executors/scan/python_scan.rs
+++ b/crates/polars-mem-engine/src/executors/scan/python_scan.rs
@@ -14,6 +14,38 @@ pub(crate) struct PythonScanExec {
     pub(crate) predicate_serialized: Option<Vec<u8>>,
 }
 
+impl PythonScanExec {
+    fn check_schema(&self, df: &DataFrame) -> PolarsResult<()> {
+        if self.options.check_schema {
+            let output_schema = self
+                .options
+                .output_schema
+                .as_ref()
+                .unwrap_or_else(|| &self.options.schema);
+            polars_ensure!(df.schema() == output_schema, SchemaMismatch: "user provided schema: {:?} doesn't match the DataFrame schema: {:?}", output_schema, df.schema());
+        }
+        Ok(())
+    }
+
+    fn finish_df(
+        &self,
+        py: Python,
+        df: Bound<'_, PyAny>,
+        state: &mut ExecutionState,
+    ) -> PolarsResult<DataFrame> {
+        let df = python_df_to_rust(py, df)?;
+
+        self.check_schema(&df)?;
+
+        if let Some(pred) = &self.predicate {
+            let mask = pred.evaluate(&df, state)?;
+            df.filter(mask.bool()?)
+        } else {
+            Ok(df)
+        }
+    }
+}
+
 impl Executor for PythonScanExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
         state.should_stop()?;
@@ -51,97 +83,97 @@ impl Executor for PythonScanExec {
                 },
             };
 
-            let generator_init = if matches!(self.options.python_source, PythonScanSource::Cuda) {
-                let args = (
-                    python_scan_function,
-                    with_columns.map(|x| x.into_iter().map(|x| x.to_string()).collect::<Vec<_>>()),
-                    predicate,
-                    n_rows,
-                    // If this boolean is true, callback should return
-                    // a dataframe and list of timings [(start, end,
-                    // name)]
-                    state.has_node_timer(),
-                );
-                let result = callable.call1(args).map_err(to_compute_err)?;
-                if state.has_node_timer() {
-                    let df = result.get_item(0).map_err(to_compute_err);
-                    let timing_info: Vec<(u64, u64, String)> = result
-                        .get_item(1)
-                        .map_err(to_compute_err)?
-                        .extract()
-                        .map_err(to_compute_err)?;
-                    state.record_raw_timings(&timing_info);
-                    df
-                } else {
-                    Ok(result)
-                }
-            } else if matches!(self.options.python_source, PythonScanSource::Pyarrow) {
-                let args = (
-                    python_scan_function,
-                    with_columns.map(|x| x.into_iter().map(|x| x.to_string()).collect::<Vec<_>>()),
-                    predicate,
-                    n_rows,
-                );
-                callable.call1(args).map_err(to_compute_err)
-            } else {
-                // If there are filters, take smaller chunks to ensure we can keep memory
-                // pressure low.
-                let batch_size = if self.predicate.is_some() {
-                    Some(100_000usize)
-                } else {
-                    None
-                };
-                let args = (
-                    python_scan_function,
-                    with_columns.map(|x| x.into_iter().map(|x| x.to_string()).collect::<Vec<_>>()),
-                    predicate,
-                    n_rows,
-                    batch_size,
-                );
-                callable.call1(args).map_err(to_compute_err)
-            }?;
+            match self.options.python_source {
+                PythonScanSource::Cuda => {
+                    let args = (
+                        python_scan_function,
+                        with_columns
+                            .map(|x| x.into_iter().map(|x| x.to_string()).collect::<Vec<_>>()),
+                        predicate,
+                        n_rows,
+                        // If this boolean is true, callback should return
+                        // a dataframe and list of timings [(start, end,
+                        // name)]
+                        state.has_node_timer(),
+                    );
+                    let result = callable.call1(args).map_err(to_compute_err)?;
+                    let df = if state.has_node_timer() {
+                        let df = result.get_item(0).map_err(to_compute_err);
+                        let timing_info: Vec<(u64, u64, String)> = result
+                            .get_item(1)
+                            .map_err(to_compute_err)?
+                            .extract()
+                            .map_err(to_compute_err)?;
+                        state.record_raw_timings(&timing_info);
+                        df?
+                    } else {
+                        result
+                    };
+                    self.finish_df(py, df, state)
+                },
+                PythonScanSource::Pyarrow => {
+                    let args = (
+                        python_scan_function,
+                        with_columns
+                            .map(|x| x.into_iter().map(|x| x.to_string()).collect::<Vec<_>>()),
+                        predicate,
+                        n_rows,
+                    );
+                    let df = callable.call1(args).map_err(to_compute_err)?;
+                    self.finish_df(py, df, state)
+                },
+                PythonScanSource::IOPlugin => {
+                    // If there are filters, take smaller chunks to ensure we can keep memory
+                    // pressure low.
+                    let batch_size = if self.predicate.is_some() {
+                        Some(100_000usize)
+                    } else {
+                        None
+                    };
+                    let args = (
+                        python_scan_function,
+                        with_columns
+                            .map(|x| x.into_iter().map(|x| x.to_string()).collect::<Vec<_>>()),
+                        predicate,
+                        n_rows,
+                        batch_size,
+                    );
 
-            // This isn't a generator, but a `DataFrame`.
-            // This is the pyarrow and the CuDF path.
-            if generator_init.getattr(intern!(py, "_df")).is_ok() {
-                let df = python_df_to_rust(py, generator_init)?;
-                return if let Some(pred) = &self.predicate {
-                    let mask = pred.evaluate(&df, state)?;
-                    df.filter(mask.bool()?)
-                } else {
-                    Ok(df)
-                };
-            }
+                    let generator_init = callable.call1(args).map_err(to_compute_err)?;
+                    let generator = generator_init.get_item(0).map_err(
+                        |_| polars_err!(ComputeError: "expected tuple got {}", generator_init),
+                    )?;
+                    let can_parse_predicate = generator_init.get_item(1).map_err(
+                        |_| polars_err!(ComputeError: "expected tuple got {}", generator),
+                    )?;
+                    let can_parse_predicate = can_parse_predicate.extract::<bool>().map_err(
+                        |_| polars_err!(ComputeError: "expected bool got {}", can_parse_predicate),
+                    )? && could_serialize_predicate;
 
-            // This is the IO plugin path.
-            let generator = generator_init
-                .get_item(0)
-                .map_err(|_| polars_err!(ComputeError: "expected tuple got {}", generator_init))?;
-            let can_parse_predicate = generator_init
-                .get_item(1)
-                .map_err(|_| polars_err!(ComputeError: "expected tuple got {}", generator))?;
-            let can_parse_predicate = can_parse_predicate.extract::<bool>().map_err(
-                |_| polars_err!(ComputeError: "expected bool got {}", can_parse_predicate),
-            )? && could_serialize_predicate;
-
-            let mut chunks = vec![];
-            loop {
-                match generator.call_method0(intern!(py, "__next__")) {
-                    Ok(out) => {
-                        let mut df = python_df_to_rust(py, out)?;
-                        if let (Some(pred), false) = (&self.predicate, can_parse_predicate) {
-                            let mask = pred.evaluate(&df, state)?;
-                            df = df.filter(mask.bool()?)?;
+                    let mut chunks = vec![];
+                    loop {
+                        match generator.call_method0(intern!(py, "__next__")) {
+                            Ok(out) => {
+                                let mut df = python_df_to_rust(py, out)?;
+                                if let (Some(pred), false) = (&self.predicate, can_parse_predicate)
+                                {
+                                    let mask = pred.evaluate(&df, state)?;
+                                    df = df.filter(mask.bool()?)?;
+                                }
+                                chunks.push(df)
+                            },
+                            Err(err) if err.matches(py, PyStopIteration::type_object(py))? => break,
+                            Err(err) => {
+                                polars_bail!(ComputeError: "caught exception during execution of a Python source, exception: {}", err)
+                            },
                         }
-                        chunks.push(df)
-                    },
-                    Err(err) if err.matches(py, PyStopIteration::type_object(py))? => break,
-                    Err(err) => {
-                        polars_bail!(ComputeError: "caught exception during execution of a Python source, exception: {}", err)
-                    },
-                }
+                    }
+                    let df = accumulate_dataframes_vertical(chunks)?;
+
+                    self.check_schema(&df)?;
+                    Ok(df)
+                },
             }
-            accumulate_dataframes_vertical(chunks)
         })
     }
 }

--- a/crates/polars-mem-engine/src/executors/scan/python_scan.rs
+++ b/crates/polars-mem-engine/src/executors/scan/python_scan.rs
@@ -16,12 +16,12 @@ pub(crate) struct PythonScanExec {
 
 impl PythonScanExec {
     fn check_schema(&self, df: &DataFrame) -> PolarsResult<()> {
-        if self.options.check_schema {
+        if self.options.validate_schema {
             let output_schema = self
                 .options
                 .output_schema
                 .as_ref()
-                .unwrap_or_else(|| &self.options.schema);
+                .unwrap_or(&self.options.schema);
             polars_ensure!(df.schema() == output_schema, SchemaMismatch: "user provided schema: {:?} doesn't match the DataFrame schema: {:?}", output_schema, df.schema());
         }
         Ok(())

--- a/crates/polars-plan/src/dsl/python_dsl/source.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/source.rs
@@ -19,6 +19,7 @@ pub struct PythonOptionsDsl {
     /// Either the schema fn or schema is set.
     pub schema_fn: Option<SpecialEq<Arc<Either<PythonFunction, SchemaRef>>>>,
     pub python_source: PythonScanSource,
+    pub check_schema: bool,
 }
 
 impl PythonOptionsDsl {

--- a/crates/polars-plan/src/dsl/python_dsl/source.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/source.rs
@@ -19,7 +19,7 @@ pub struct PythonOptionsDsl {
     /// Either the schema fn or schema is set.
     pub schema_fn: Option<SpecialEq<Arc<Either<PythonFunction, SchemaRef>>>>,
     pub python_source: PythonScanSource,
-    pub check_schema: bool,
+    pub validate_schema: bool,
 }
 
 impl PythonOptionsDsl {

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -371,7 +371,11 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     scan_fn,
                     schema,
                     python_source: options.python_source,
-                    ..Default::default()
+                    check_schema: options.check_schema,
+                    output_schema: Default::default(),
+                    with_columns: Default::default(),
+                    n_rows: Default::default(),
+                    predicate: Default::default(),
                 },
             }
         },

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -371,7 +371,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     scan_fn,
                     schema,
                     python_source: options.python_source,
-                    check_schema: options.check_schema,
+                    validate_schema: options.validate_schema,
                     output_schema: Default::default(),
                     with_columns: Default::default(),
                     n_rows: Default::default(),

--- a/crates/polars-plan/src/plans/python/source.rs
+++ b/crates/polars-plan/src/plans/python/source.rs
@@ -27,7 +27,7 @@ pub struct PythonOptions {
     /// Optional predicate the reader must apply.
     pub predicate: PythonPredicate,
     /// Validate if the source gives the proper schema.
-    pub check_schema: bool,
+    pub validate_schema: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]

--- a/crates/polars-plan/src/plans/python/source.rs
+++ b/crates/polars-plan/src/plans/python/source.rs
@@ -26,6 +26,8 @@ pub struct PythonOptions {
     pub n_rows: Option<usize>,
     /// Optional predicate the reader must apply.
     pub predicate: PythonPredicate,
+    /// Validate if the source gives the proper schema.
+    pub check_schema: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -462,10 +462,17 @@ impl PyLazyFrame {
         schema: &Bound<'_, PyList>,
         scan_fn: PyObject,
         pyarrow: bool,
+        check_schema: bool,
     ) -> PyResult<Self> {
         let schema = Arc::new(pyarrow_schema_to_rust(schema)?);
 
-        Ok(LazyFrame::scan_from_python_function(Either::Right(schema), scan_fn, pyarrow).into())
+        Ok(LazyFrame::scan_from_python_function(
+            Either::Right(schema),
+            scan_fn,
+            pyarrow,
+            check_schema,
+        )
+        .into())
     }
 
     #[staticmethod]
@@ -473,21 +480,35 @@ impl PyLazyFrame {
         schema: Vec<(PyBackedStr, Wrap<DataType>)>,
         scan_fn: PyObject,
         pyarrow: bool,
+        check_schema: bool,
     ) -> PyResult<Self> {
         let schema = Arc::new(Schema::from_iter(
             schema
                 .into_iter()
                 .map(|(name, dt)| Field::new((&*name).into(), dt.0)),
         ));
-        Ok(LazyFrame::scan_from_python_function(Either::Right(schema), scan_fn, pyarrow).into())
+        Ok(LazyFrame::scan_from_python_function(
+            Either::Right(schema),
+            scan_fn,
+            pyarrow,
+            check_schema,
+        )
+        .into())
     }
 
     #[staticmethod]
     fn scan_from_python_function_schema_function(
         schema_fn: PyObject,
         scan_fn: PyObject,
+        check_schema: bool,
     ) -> PyResult<Self> {
-        Ok(LazyFrame::scan_from_python_function(Either::Left(schema_fn), scan_fn, false).into())
+        Ok(LazyFrame::scan_from_python_function(
+            Either::Left(schema_fn),
+            scan_fn,
+            false,
+            check_schema,
+        )
+        .into())
     }
 
     fn describe_plan(&self, py: Python) -> PyResult<String> {

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -462,7 +462,7 @@ impl PyLazyFrame {
         schema: &Bound<'_, PyList>,
         scan_fn: PyObject,
         pyarrow: bool,
-        check_schema: bool,
+        validate_schema: bool,
     ) -> PyResult<Self> {
         let schema = Arc::new(pyarrow_schema_to_rust(schema)?);
 
@@ -470,7 +470,7 @@ impl PyLazyFrame {
             Either::Right(schema),
             scan_fn,
             pyarrow,
-            check_schema,
+            validate_schema,
         )
         .into())
     }
@@ -480,7 +480,7 @@ impl PyLazyFrame {
         schema: Vec<(PyBackedStr, Wrap<DataType>)>,
         scan_fn: PyObject,
         pyarrow: bool,
-        check_schema: bool,
+        validate_schema: bool,
     ) -> PyResult<Self> {
         let schema = Arc::new(Schema::from_iter(
             schema
@@ -491,7 +491,7 @@ impl PyLazyFrame {
             Either::Right(schema),
             scan_fn,
             pyarrow,
-            check_schema,
+            validate_schema,
         )
         .into())
     }
@@ -500,13 +500,13 @@ impl PyLazyFrame {
     fn scan_from_python_function_schema_function(
         schema_fn: PyObject,
         scan_fn: PyObject,
-        check_schema: bool,
+        validate_schema: bool,
     ) -> PyResult<Self> {
         Ok(LazyFrame::scan_from_python_function(
             Either::Left(schema_fn),
             scan_fn,
             false,
-            check_schema,
+            validate_schema,
         )
         .into())
     }

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -166,6 +166,7 @@ impl NodeTraverser {
                 python_source: PythonScanSource::Cuda,
                 predicate: Default::default(),
                 n_rows: None,
+                check_schema: false,
             },
         };
         lp_arena.replace(self.root, ir);

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -166,7 +166,7 @@ impl NodeTraverser {
                 python_source: PythonScanSource::Cuda,
                 predicate: Default::default(),
                 n_rows: None,
-                check_schema: false,
+                validate_schema: false,
             },
         };
         lp_arena.replace(self.root, ir);

--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -25,6 +25,7 @@ Miscellaneous
 
     align_frames
     concat
+    defer
     escape_regex
 
 Parallelization

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -158,6 +158,7 @@ from polars.functions import (
 )
 from polars.interchange import CompatLevel
 from polars.io import (
+    defer,
     read_avro,
     read_clipboard,
     read_csv,
@@ -258,6 +259,7 @@ __all__ = [
     "Unknown",
     "Utf8",
     # polars.io
+    "defer",
     "read_avro",
     "read_clipboard",
     "read_csv",

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -12,8 +12,10 @@ from polars.io.ndjson import read_ndjson, scan_ndjson
 from polars.io.parquet import read_parquet, read_parquet_schema, scan_parquet
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 from polars.io.spreadsheet import read_excel, read_ods
+from polars.io.plugins import _defer as defer
 
 __all__ = [
+    "defer",
     "read_avro",
     "read_clipboard",
     "read_csv",

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -10,9 +10,9 @@ from polars.io.ipc import read_ipc, read_ipc_schema, read_ipc_stream, scan_ipc
 from polars.io.json import read_json
 from polars.io.ndjson import read_ndjson, scan_ndjson
 from polars.io.parquet import read_parquet, read_parquet_schema, scan_parquet
+from polars.io.plugins import _defer as defer
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 from polars.io.spreadsheet import read_excel, read_ods
-from polars.io.plugins import _defer as defer
 
 __all__ = [
     "defer",

--- a/py-polars/polars/io/plugins.py
+++ b/py-polars/polars/io/plugins.py
@@ -96,6 +96,7 @@ def register_io_source(
     )
 
 
+@unstable()
 def _defer(
     function: Callable[[], DataFrame],
     *,
@@ -105,7 +106,7 @@ def _defer(
     """
     Deferred execution.
 
-    Takes a function that produces a `DataFrame` but defers it execution until the
+    Takes a function that produces a `DataFrame` but defers execution until the
     `LazyFrame` is collected.
 
     Parameters

--- a/py-polars/polars/io/plugins.py
+++ b/py-polars/polars/io/plugins.py
@@ -23,7 +23,7 @@ def register_io_source(
     ],
     *,
     schema: Callable[[], SchemaDict] | SchemaDict,
-    validate_schema: bool = False
+    validate_schema: bool = False,
 ) -> LazyFrame:
     """
     Register your IO plugin and initialize a LazyFrame.
@@ -92,7 +92,7 @@ def register_io_source(
         ), parsed_predicate_success
 
     return pl.LazyFrame._scan_python_function(
-        schema=schema, scan_fn=wrap, pyarrow=False, check_schema=validate_schema
+        schema=schema, scan_fn=wrap, pyarrow=False, validate_schema=validate_schema
     )
 
 
@@ -100,11 +100,13 @@ def _defer(
     function: Callable[[], DataFrame],
     *,
     schema: SchemaDict | Callable[[], SchemaDict],
-    validate_schema: bool = True
+    validate_schema: bool = True,
 ) -> LazyFrame:
     """
-    Takes a function that produces a `DataFrame` but defers
-    it execution until the `LazyFrame` is collected.
+    Deferred execution.
+
+    Takes a function that produces a `DataFrame` but defers it execution until the
+    `LazyFrame` is collected.
 
     Parameters
     ----------
@@ -123,7 +125,9 @@ def _defer(
     Delay DataFrame execution until query is executed.
 
     >>> np.random.seed(0)
-    >>> lf = pl.defer(lambda: pl.DataFrame({"a": np.random.randn(3)}), schema = {"a": pl.Float64})
+    >>> lf = pl.defer(
+    ...     lambda: pl.DataFrame({"a": np.random.randn(3)}), schema={"a": pl.Float64}
+    ... )
     >>> lf.collect()
     shape: (3, 1)
     ┌──────────┐
@@ -139,15 +143,19 @@ def _defer(
      Run an eager source in Polars Cloud
 
     >>> (
-    ...     pl.defer(lambda: pl.read_database("select * from tbl"), schema = {"a": pl.Float64, "b": pl.Boolean})
+    ...     pl.defer(
+    ...         lambda: pl.read_database("select * from tbl"),
+    ...         schema={"a": pl.Float64, "b": pl.Boolean},
+    ...     )
     ...     .filter("b")
     ...     .sum("a")
     ...     .remote()
     ...     .collect()
-    ... ) # doctest: +SKIP
+    ... )  # doctest: +SKIP
 
 
     """
+
     def source(
         with_columns: list[str] | None,
         predicate: Expr | None,
@@ -163,4 +171,6 @@ def _defer(
             lf = lf.limit(n_rows)
         yield lf.collect()
 
-    return register_io_source(io_source=source, schema=schema, validate_schema=validate_schema)
+    return register_io_source(
+        io_source=source, schema=schema, validate_schema=validate_schema
+    )

--- a/py-polars/polars/io/plugins.py
+++ b/py-polars/polars/io/plugins.py
@@ -124,6 +124,7 @@ def _defer(
     --------
     Delay DataFrame execution until query is executed.
 
+    >>> import numpy as np
     >>> np.random.seed(0)
     >>> lf = pl.defer(
     ...     lambda: pl.DataFrame({"a": np.random.randn(3)}), schema={"a": pl.Float64}

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -394,19 +394,20 @@ class LazyFrame:
         scan_fn: Any,
         *,
         pyarrow: bool = False,
+        check_schema: bool = False
     ) -> LazyFrame:
         self = cls.__new__(cls)
         if isinstance(schema, Mapping):
             self._ldf = PyLazyFrame.scan_from_python_function_pl_schema(
-                list(schema.items()), scan_fn, pyarrow
+                list(schema.items()), scan_fn, pyarrow=pyarrow, check_schema=check_schema
             )
         elif _PYARROW_AVAILABLE and isinstance(schema, pa.Schema):
             self._ldf = PyLazyFrame.scan_from_python_function_arrow_schema(
-                list(schema), scan_fn, pyarrow
+                list(schema), scan_fn, pyarrow=pyarrow, check_schema=check_schema
             )
         else:
             self._ldf = PyLazyFrame.scan_from_python_function_schema_function(
-                schema, scan_fn
+                schema, scan_fn, check_schema=check_schema
             )
         return self
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -394,20 +394,23 @@ class LazyFrame:
         scan_fn: Any,
         *,
         pyarrow: bool = False,
-        check_schema: bool = False
+        validate_schema: bool = False,
     ) -> LazyFrame:
         self = cls.__new__(cls)
         if isinstance(schema, Mapping):
             self._ldf = PyLazyFrame.scan_from_python_function_pl_schema(
-                list(schema.items()), scan_fn, pyarrow=pyarrow, check_schema=check_schema
+                list(schema.items()),
+                scan_fn,
+                pyarrow=pyarrow,
+                validate_schema=validate_schema,
             )
         elif _PYARROW_AVAILABLE and isinstance(schema, pa.Schema):
             self._ldf = PyLazyFrame.scan_from_python_function_arrow_schema(
-                list(schema), scan_fn, pyarrow=pyarrow, check_schema=check_schema
+                list(schema), scan_fn, pyarrow=pyarrow, validate_schema=validate_schema
             )
         else:
             self._ldf = PyLazyFrame.scan_from_python_function_schema_function(
-                schema, scan_fn, check_schema=check_schema
+                schema, scan_fn, validate_schema=validate_schema
             )
         return self
 

--- a/py-polars/tests/unit/io/test_io_plugin.py
+++ b/py-polars/tests/unit/io/test_io_plugin.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
+import pytest
+
 import polars as pl
 from polars.io.plugins import register_io_source
 
@@ -36,3 +39,19 @@ def test_io_plugin_predicate_no_serialization_21130() -> None:
     assert lf.filter(
         pl.col("json_val").str.json_path_match("$.a").is_in(["1"])
     ).collect().to_dict(as_series=False) == {"json_val": ['{"a":"1"}']}
+
+
+def test_defer() -> None:
+    lf = pl.defer(
+        lambda: pl.DataFrame({"a": np.ones(3)}),
+        schema={"a": pl.Boolean},
+        validate_schema=False,
+    )
+    assert lf.collect().to_dict(as_series=False) == {"a": [1.0, 1.0, 1.0]}
+    lf = pl.defer(
+        lambda: pl.DataFrame({"a": np.ones(3)}),
+        schema={"a": pl.Boolean},
+        validate_schema=True,
+    )
+    with pytest.raises(pl.exceptions.SchemaError):
+        lf.collect()


### PR DESCRIPTION
This defers `DataFrame` execution until `collect` is called. This can enable more parallelism if the plan is executed bushy (the in memory engine is), and the DataFrame producer releases the gil (numpy does).

This also enables `DataFrame`s to be constructed remotely in Polars Cloud. Hereby enabling eager sources to be read remotely.