### PR TITLE
refactor: Add as_phys_any to PrivateSeries for downcasting

### DIFF
--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -220,6 +220,10 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        &self.0
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -256,6 +256,10 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        &self.0
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -198,6 +198,10 @@ impl SeriesTrait for SeriesWrap<BinaryOffsetChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        &self.0
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -363,6 +363,10 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        &self.0
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -312,6 +312,10 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self.0.physical()
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -363,6 +363,10 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self.0.physical()
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -383,6 +383,10 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self.0.physical()
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -448,6 +448,10 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self.0.physical()
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -539,6 +539,10 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self.0.physical()
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -377,6 +377,10 @@ macro_rules! impl_dyn_series {
                 &mut self.0
             }
 
+            fn as_phys_any(&self) -> &dyn Any {
+                &self.0
+            }
+
             fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
                 self as _
             }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -264,6 +264,10 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        &self.0
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -451,6 +451,10 @@ macro_rules! impl_dyn_series {
                 &mut self.0
             }
 
+            fn as_phys_any(&self) -> &dyn Any {
+                &self.0
+            }
+
             fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
                 self as _
             }

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -339,6 +339,10 @@ impl SeriesTrait for NullChunked {
         self
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -243,6 +243,10 @@ where
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -268,6 +268,10 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        &self.0
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -266,6 +266,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        &self.0
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -336,6 +336,10 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
         &mut self.0
     }
 
+    fn as_phys_any(&self) -> &dyn Any {
+        self.0.physical()
+    }
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self as _
     }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -572,6 +572,10 @@ pub trait SeriesTrait:
     /// reference.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
+    /// Get a hold of the [`ChunkedArray`] or `NullChunked` as an `Any` trait reference. This
+    /// pierces through `Logical` types to get the underlying physical array.
+    fn as_phys_any(&self) -> &dyn Any;
+
     fn as_arc_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 
     #[cfg(feature = "checked_arithmetic")]


### PR DESCRIPTION
This lets us directly downcast from `Series` to the underlying physical `ChunkedArray` without needing to create a new `Series` with `to_physical_repr`.