### PR TITLE
feat: Expose method to fill_infinity

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -504,6 +504,12 @@ impl LazyFrame {
             col(PlSmallStr::from_static("*")).shift_and_fill(n.into(), fill_value.into()),
         ])
     }
+    /// Fill INF and NEG_INF values in the DataFrame with an expression.
+    pub fn fill_infinity<E: Into<Expr>>(self, fill_value: E) -> LazyFrame {
+        let opt_state = self.get_opt_state();
+        let lp = self.get_plan_builder().fill_infinity(fill_value.into()).build();
+        Self::from_logical_plan(lp, opt_state)
+    }
 
     /// Fill None values in the DataFrame with an expression.
     pub fn fill_null<E: Into<Expr>>(self, fill_value: E) -> LazyFrame {

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -507,7 +507,10 @@ impl LazyFrame {
     /// Fill INF and NEG_INF values in the DataFrame with an expression.
     pub fn fill_infinity<E: Into<Expr>>(self, fill_value: E) -> LazyFrame {
         let opt_state = self.get_opt_state();
-        let lp = self.get_plan_builder().fill_infinity(fill_value.into()).build();
+        let lp = self
+            .get_plan_builder()
+            .fill_infinity(fill_value.into())
+            .build();
         Self::from_logical_plan(lp, opt_state)
     }
 

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1566,7 +1566,15 @@ fn test_round_after_agg() -> PolarsResult<()> {
 #[cfg(feature = "dtype-date")]
 fn test_fill_infinity() -> PolarsResult<()> {
     let s0 = Column::new("date".into(), &[1, 2, 3, 4]).cast(&DataType::Date)?;
-    let s1 = Column::new("float".into(), &[Some(1.0), Some(f32::INFINITY), Some(3.0), Some(f32::NEG_INFINITY)]);
+    let s1 = Column::new(
+        "float".into(),
+        &[
+            Some(1.0),
+            Some(f32::INFINITY),
+            Some(3.0),
+            Some(f32::NEG_INFINITY),
+        ],
+    );
 
     let df = DataFrame::new(vec![s0, s1])?;
     let out = df.lazy().fill_infinity(Null {}.lit()).collect()?;

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1564,6 +1564,20 @@ fn test_round_after_agg() -> PolarsResult<()> {
 
 #[test]
 #[cfg(feature = "dtype-date")]
+fn test_fill_infinity() -> PolarsResult<()> {
+    let s0 = Column::new("date".into(), &[1, 2, 3, 4]).cast(&DataType::Date)?;
+    let s1 = Column::new("float".into(), &[Some(1.0), Some(f32::INFINITY), Some(3.0), Some(f32::NEG_INFINITY)]);
+
+    let df = DataFrame::new(vec![s0, s1])?;
+    let out = df.lazy().fill_infinity(Null {}.lit()).collect()?;
+    let out = out.column("float")?;
+    assert_eq!(Vec::from(out.f32()?), &[Some(1.0), None, Some(3.0), None]);
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "dtype-date")]
 fn test_fill_nan() -> PolarsResult<()> {
     let s0 = Column::new("date".into(), &[1, 2, 3]).cast(&DataType::Date)?;
     let s1 = Column::new("float".into(), &[Some(1.0), Some(f32::NAN), Some(3.0)]);

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -267,6 +267,10 @@ impl DslBuilder {
         }
     }
 
+    pub fn fill_infinity(self, fill_value: Expr) -> Self {
+        self.map_private(DslFunction::FillInfinity(fill_value))
+    }
+
     pub fn fill_nan(self, fill_value: Expr) -> Self {
         self.map_private(DslFunction::FillNan(fill_value))
     }

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1099,6 +1099,16 @@ impl Expr {
         }
     }
 
+    /// Replace the floating point `INFINITY` and `NEG_INFINITY` values by a value.
+    pub fn fill_infinity<E: Into<Expr>>(self, fill_value: E) -> Self {
+        // we take the not branch so that self is truthy value of `when -> then -> otherwise`
+        // and that ensure we keep the name of `self`
+
+        when(self.clone().is_finite().or(self.clone().is_null()))
+            .then(self)
+            .otherwise(fill_value.into())
+    }
+
     /// Replace the floating point `NaN` values by a value.
     pub fn fill_nan<E: Into<Expr>>(self, fill_value: E) -> Self {
         // we take the not branch so that self is truthy value of `when -> then -> otherwise`

--- a/crates/polars-plan/src/plans/functions/dsl.rs
+++ b/crates/polars-plan/src/plans/functions/dsl.rs
@@ -45,6 +45,7 @@ pub enum DslFunction {
     Unnest(Vec<Selector>),
     Stats(StatsFunction),
     /// FillValue
+    FillInfinity(Expr),
     FillNan(Expr),
     Drop(DropFunction),
     // Function that is already converted to IR.
@@ -146,6 +147,7 @@ impl DslFunction {
             #[cfg(feature = "python")]
             DslFunction::OpaquePython(inner) => FunctionIR::OpaquePython(inner),
             DslFunction::Stats(_)
+            | DslFunction::FillInfinity(_)
             | DslFunction::FillNan(_)
             | DslFunction::Drop(_)
             | DslFunction::Explode { .. } => {

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -394,6 +394,10 @@ impl PyExpr {
         Ok(self.inner.clone().fill_null_with_strategy(strategy).into())
     }
 
+    fn fill_infinity(&self, expr: Self) -> Self {
+        self.inner.clone().fill_infinity(expr.inner).into()
+    }
+
     fn fill_nan(&self, expr: Self) -> Self {
         self.inner.clone().fill_nan(expr.inner).into()
     }

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -1223,6 +1223,11 @@ impl PyLazyFrame {
         out.into()
     }
 
+    fn fill_infinity(&self, fill_value: PyExpr) -> Self {
+        let ldf = self.ldf.clone();
+        ldf.fill_infinity(fill_value.inner).into()
+    }
+
     fn fill_nan(&self, fill_value: PyExpr) -> Self {
         let ldf = self.ldf.clone();
         ldf.fill_nan(fill_value.inner).into()

--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -17,6 +17,7 @@ Manipulation/selection
     DataFrame.drop_nulls
     DataFrame.explode
     DataFrame.extend
+    DataFrame.fill_infinity
     DataFrame.fill_nan
     DataFrame.fill_null
     DataFrame.filter

--- a/py-polars/docs/source/reference/expressions/modify_select.rst
+++ b/py-polars/docs/source/reference/expressions/modify_select.rst
@@ -20,6 +20,7 @@ Manipulation/selection
     Expr.drop_nulls
     Expr.explode
     Expr.extend_constant
+    Expr.fill_infinity
     Expr.fill_nan
     Expr.fill_null
     Expr.filter

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -15,6 +15,7 @@ Manipulation/selection
     LazyFrame.drop_nans
     LazyFrame.drop_nulls
     LazyFrame.explode
+    LazyFrame.fill_infinity
     LazyFrame.fill_nan
     LazyFrame.fill_null
     LazyFrame.filter

--- a/py-polars/docs/source/reference/series/modify_select.rst
+++ b/py-polars/docs/source/reference/series/modify_select.rst
@@ -22,6 +22,7 @@ Manipulation/selection
     Series.explode
     Series.extend
     Series.extend_constant
+    Series.fill_infinity
     Series.fill_nan
     Series.fill_null
     Series.filter

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8556,7 +8556,7 @@ class DataFrame:
 
         See Also
         --------
-        fill_nan
+        fill_infinity, fill_nan
 
         Examples
         --------
@@ -8623,6 +8623,47 @@ class DataFrame:
             .collect(_eager=True)
         )
 
+    def fill_infinity(self, value: Expr | int | float | None) -> DataFrame:
+        """
+        Fill floating point INF and NEG_INF by an Expression evaluation.
+
+        Parameters
+        ----------
+        value
+            Value with which to replace INF values.
+
+        Returns
+        -------
+        DataFrame
+            DataFrame with INF values replaced by the given value.
+
+        See Also
+        --------
+        fill_nan, fill_null
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1.5, 2, float("inf"), 4],
+        ...         "b": [0.5, 4, float("-inf"), 13],
+        ...     }
+        ... )
+        >>> df.fill_infinity(99)
+        shape: (4, 2)
+        ┌──────┬──────┐
+        │ a    ┆ b    │
+        │ ---  ┆ ---  │
+        │ f64  ┆ f64  │
+        ╞══════╪══════╡
+        │ 1.5  ┆ 0.5  │
+        │ 2.0  ┆ 4.0  │
+        │ 99.0 ┆ 99.0 │
+        │ 4.0  ┆ 13.0 │
+        └──────┴──────┘
+        """
+        return self.lazy().fill_infinity(value).collect(_eager=True)
+
     def fill_nan(self, value: Expr | int | float | None) -> DataFrame:
         """
         Fill floating point NaN values by an Expression evaluation.
@@ -8644,7 +8685,7 @@ class DataFrame:
 
         See Also
         --------
-        fill_null
+        fill_infinity, fill_null
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2847,7 +2847,6 @@ class Expr:
         fill_value = parse_into_expression(value, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.fill_infinity(fill_value))
 
-
     def fill_nan(self, value: int | float | Expr | None) -> Expr:
         """
         Fill floating point NaN value with a fill value.

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2727,7 +2727,7 @@ class Expr:
 
         See Also
         --------
-        fill_nan
+        fill_infinity, fill_nan
 
         Examples
         --------
@@ -2811,6 +2811,43 @@ class Expr:
                 self._pyexpr.fill_null_with_strategy(strategy, limit)
             )
 
+    def fill_infinity(self, value: int | float | Expr | None) -> Expr:
+        """
+        Fill floating point INF and NEG_INF with a fill value.
+
+        Parameters
+        ----------
+        value
+            Value used to fill INF values.
+
+        See Also
+        --------
+        fill_nan, fill_null
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1.0, None, float("inf")],
+        ...         "b": [4.0, float("-inf"), 6],
+        ...     }
+        ... )
+        >>> df.with_columns(pl.col("b").fill_nan(0))
+        shape: (3, 2)
+        ┌──────┬─────┐
+        │ a    ┆ b   │
+        │ ---  ┆ --- │
+        │ f64  ┆ f64 │
+        ╞══════╪═════╡
+        │ 1.0  ┆ 4.0 │
+        │ null ┆ 0.0 │
+        │ inf  ┆ 6.0 │
+        └──────┴─────┘
+        """
+        fill_value = parse_into_expression(value, str_as_lit=True)
+        return self._from_pyexpr(self._pyexpr.fill_infinity(fill_value))
+
+
     def fill_nan(self, value: int | float | Expr | None) -> Expr:
         """
         Fill floating point NaN value with a fill value.
@@ -2827,7 +2864,7 @@ class Expr:
 
         See Also
         --------
-        fill_null
+        fill_infinity, fill_null
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2832,7 +2832,7 @@ class Expr:
         ...         "b": [4.0, float("-inf"), 6],
         ...     }
         ... )
-        >>> df.with_columns(pl.col("b").fill_nan(0))
+        >>> df.with_columns(pl.col("b").fill_infinity(0))
         shape: (3, 2)
         ┌──────┬─────┐
         │ a    ┆ b   │

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -6340,7 +6340,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         See Also
         --------
-        fill_nan
+        fill_infinity, fill_nan
 
         Examples
         --------
@@ -6450,6 +6450,44 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self.select(F.all().fill_null(value, strategy, limit))
 
+    def fill_infinity(self, value: int | float | Expr | None) -> LazyFrame:
+        """
+        Fill floating point INF and NEG_INF values.
+
+        Parameters
+        ----------
+        value
+            Value to fill the INF values with.
+
+        See Also
+        --------
+        fill_nan, fill_null
+
+        Examples
+        --------
+        >>> lf = pl.LazyFrame(
+        ...     {
+        ...         "a": [1.5, 2, float("inf"), 4],
+        ...         "b": [0.5, 4, float("-inf"), 13],
+        ...     }
+        ... )
+        >>> lf.fill_infinity(99).collect()
+        shape: (4, 2)
+        ┌──────┬──────┐
+        │ a    ┆ b    │
+        │ ---  ┆ ---  │
+        │ f64  ┆ f64  │
+        ╞══════╪══════╡
+        │ 1.5  ┆ 0.5  │
+        │ 2.0  ┆ 4.0  │
+        │ 99.0 ┆ 99.0 │
+        │ 4.0  ┆ 13.0 │
+        └──────┴──────┘
+        """
+        if not isinstance(value, pl.Expr):
+            value = F.lit(value)
+        return self._from_pyldf(self._ldf.fill_infinity(value._pyexpr))
+
     def fill_nan(self, value: int | float | Expr | None) -> LazyFrame:
         """
         Fill floating point NaN values.
@@ -6466,7 +6504,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         See Also
         --------
-        fill_null
+        fill_infinity, fill_null
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4893,6 +4893,33 @@ class Series:
         """
         return self._from_pyseries(self._s.clone())
 
+    def fill_infinity(self, value: int | float | Expr | None) -> Series:
+        """
+        Fill floating point INF and NEG_INF value with a fill value.
+
+        Parameters
+        ----------
+        value
+            Value used to fill INF values.
+
+        See Also
+        --------
+        fill_infinity, fill_null
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [1.0, 2.0, 3.0, float("inf")])
+        >>> s.fill_infinity(0)
+        shape: (4,)
+        Series: 'a' [f64]
+        [
+                1.0
+                2.0
+                3.0
+                0.0
+        ]
+        """
+
     def fill_nan(self, value: int | float | Expr | None) -> Series:
         """
         Fill floating point NaN value with a fill value.
@@ -4909,7 +4936,7 @@ class Series:
 
         See Also
         --------
-        fill_null
+        fill_infinity, fill_null
 
         Examples
         --------
@@ -4946,7 +4973,7 @@ class Series:
 
         See Also
         --------
-        fill_nan
+        fill_infinity, fill_nan
 
         Examples
         --------

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1977,6 +1977,24 @@ def test_fill_null() -> None:
     assert s.dtype == pl.Categorical
     assert s.to_list() == ["a", "a"]
 
+def test_fill_infinity() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3.0, float("inf")]})
+    assert_frame_equal(
+        df.fill_infinity(4),
+        pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0]}),
+    )
+    assert_frame_equal(
+        df.fill_infinity(None),
+        pl.DataFrame({"a": [1, 2], "b": [3.0, None]}),
+    )
+    assert df["b"].fill_infinity(5.0).to_list() == [3.0, 5.0]
+    df = pl.DataFrame(
+        {
+            "a": [1.0, np.nan, 3.0],
+            "b": [datetime(1, 2, 2), datetime(2, 2, 2), datetime(3, 2, 2)],
+        }
+    )
+    assert df.fill_infinity(2.0).dtypes == [pl.Float64, pl.Datetime]
 
 def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3.0, float("nan")]})

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1977,6 +1977,7 @@ def test_fill_null() -> None:
     assert s.dtype == pl.Categorical
     assert s.to_list() == ["a", "a"]
 
+
 def test_fill_infinity() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3.0, float("inf")]})
     assert_frame_equal(
@@ -1995,6 +1996,7 @@ def test_fill_infinity() -> None:
         }
     )
     assert df.fill_infinity(2.0).dtypes == [pl.Float64, pl.Datetime]
+
 
 def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3.0, float("nan")]})

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -672,6 +672,7 @@ def test_interpolate() -> None:
     assert df.interpolate()["a"].to_list() == [1, 2, 3]
     assert df.lazy().interpolate().collect()["a"].to_list() == [1, 2, 3]
 
+
 def test_fill_infinity() -> None:
     df = pl.DataFrame({"a": [1.0, np.inf, 3.0]})
     assert_series_equal(df.fill_infinity(2.0)["a"], pl.Series("a", [1.0, 2.0, 3.0]))
@@ -688,6 +689,7 @@ def test_fill_infinity() -> None:
     assert pl.Series([None, 1, None, None, None, -8, None, None, 10]).interpolate(
         method="nearest"
     ).to_list() == [None, 1, 1, -8, -8, -8, -8, 10, 10]
+
 
 def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1.0, np.nan, 3.0]})

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -672,6 +672,22 @@ def test_interpolate() -> None:
     assert df.interpolate()["a"].to_list() == [1, 2, 3]
     assert df.lazy().interpolate().collect()["a"].to_list() == [1, 2, 3]
 
+def test_fill_infinity() -> None:
+    df = pl.DataFrame({"a": [1.0, np.inf, 3.0]})
+    assert_series_equal(df.fill_infinity(2.0)["a"], pl.Series("a", [1.0, 2.0, 3.0]))
+    assert_series_equal(
+        df.lazy().fill_infinity(2.0).collect()["a"], pl.Series("a", [1.0, 2.0, 3.0])
+    )
+    assert_series_equal(
+        df.lazy().fill_infinity(None).collect()["a"], pl.Series("a", [1.0, None, 3.0])
+    )
+    assert_series_equal(
+        df.select(pl.col("a").fill_infinity(2))["a"], pl.Series("a", [1.0, 2.0, 3.0])
+    )
+    # nearest
+    assert pl.Series([None, 1, None, None, None, -8, None, None, 10]).interpolate(
+        method="nearest"
+    ).to_list() == [None, 1, 1, -8, -8, -8, -8, 10, 10]
 
 def test_fill_nan() -> None:
     df = pl.DataFrame({"a": [1.0, np.nan, 3.0]})

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -851,6 +851,11 @@ def test_str_series_min_max_10674() -> None:
     assert str_series.sort(descending=False).min() == "a"
     assert str_series.sort(descending=True).max() == "e"
 
+def test_fill_infinity() -> None:
+    inf, neg_inf= float("inf"), float("-inf")
+    a = pl.Series("a", [1.0, inf, 2.0, neg_inf, 3.0])
+    assert_series_equal(a.fill_infinity(None), pl.Series("a", [1.0, None, 2.0, None, 3.0]))
+    assert_series_equal(a.fill_infinity(0), pl.Series("a", [1.0, 0.0, 2.0, 0.0, 3.0]))
 
 def test_fill_nan() -> None:
     nan = float("nan")

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -851,11 +851,15 @@ def test_str_series_min_max_10674() -> None:
     assert str_series.sort(descending=False).min() == "a"
     assert str_series.sort(descending=True).max() == "e"
 
+
 def test_fill_infinity() -> None:
-    inf, neg_inf= float("inf"), float("-inf")
+    inf, neg_inf = float("inf"), float("-inf")
     a = pl.Series("a", [1.0, inf, 2.0, neg_inf, 3.0])
-    assert_series_equal(a.fill_infinity(None), pl.Series("a", [1.0, None, 2.0, None, 3.0]))
+    assert_series_equal(
+        a.fill_infinity(None), pl.Series("a", [1.0, None, 2.0, None, 3.0])
+    )
     assert_series_equal(a.fill_infinity(0), pl.Series("a", [1.0, 0.0, 2.0, 0.0, 3.0]))
+
 
 def test_fill_nan() -> None:
     nan = float("nan")


### PR DESCRIPTION
This PR should provide a faster path to replacing INFINITY and NEG_INFINITY for floats (similar to `fill_nan` and `fill_null`).

Some very basic benchmarks on my M3 Pro:

```python
In [2]: a = pl.Series([float("inf")] * 1_000_000)

In [3]: %timeit a.replace(float("inf"), None)
114 ms ± 790 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [4]: %timeit a.fill_infinity(None)
13.8 ms ± 60.7 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

```python
In [5]: a = pl.DataFrame({f"c{i}": pl.Series([float("inf")] * 1_000_000) for i in range(100)})

In [6]: %timeit a.with_columns(pl.all().replace(float("inf"), None))
1.9 s ± 33.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [7]: %timeit a.fill_infinity(None)
229 ms ± 11.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Two main questions might be worth discussing on this PR:
1. Should I rename from `fill_infinity` to `fill_infinite` to align with other `_infinite` methods?
2. Should I handle INFINITY and NEG_INFINITY differently (two methods, or two fill values, or align the sign)?