### PR TITLE
perf: Add primitive single-key hashtable to new-streaming join

### DIFF
--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -42,6 +42,7 @@ use polars_utils::abs_diff::AbsDiff;
 use polars_utils::float::IsFloat;
 use polars_utils::min_max::MinMax;
 use polars_utils::nulls::IsNull;
+use polars_utils::total_ord::TotalHash;
 pub use schema::SchemaExtPl;
 #[cfg(feature = "serde")]
 use serde::de::{EnumAccess, Error, Unexpected, VariantAccess, Visitor};
@@ -325,6 +326,7 @@ pub type ObjectChunked<T> = ChunkedArray<ObjectType<T>>;
 pub trait NumericNative:
     TotalOrd
     + PartialOrd
+    + TotalHash
     + NativeType
     + Num
     + NumCast

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -27,15 +27,7 @@ pub fn hash_keys_variant_for_dtype(dt: &DataType) -> HashKeysVariant {
             HashKeysVariant::RowEncoded
         },
 
-        DataType::BinaryOffset
-        | DataType::Array(_, _)
-        | DataType::List(_)
-        | DataType::Object(_)
-        | DataType::Categorical(_, _)
-        | DataType::Struct(_)
-        | DataType::Unknown(_) => HashKeysVariant::RowEncoded,
-
-        _ => unreachable!(),
+        _ => HashKeysVariant::RowEncoded,
     }
 }
 
@@ -46,24 +38,35 @@ macro_rules! downcast_single_key_ca {
         #[allow(unused_imports)]
         use polars_core::datatypes::DataType::*;
         match $self.dtype() {
+            #[cfg(feature = "dtype-i8")]
             DataType::Int8 => { let $ca = $self.i8().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-i16")]
             DataType::Int16 => { let $ca = $self.i16().unwrap(); $($body)* },
             DataType::Int32 => { let $ca = $self.i32().unwrap(); $($body)* },
             DataType::Int64 => { let $ca = $self.i64().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-u8")]
             DataType::UInt8 => { let $ca = $self.u8().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-u16")]
             DataType::UInt16 => { let $ca = $self.u16().unwrap(); $($body)* },
             DataType::UInt32 => { let $ca = $self.u32().unwrap(); $($body)* },
             DataType::UInt64 => { let $ca = $self.u64().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-i128")]
             DataType::Int128 => { let $ca = $self.i128().unwrap(); $($body)* },
             DataType::Float32 => { let $ca = $self.f32().unwrap(); $($body)* },
             DataType::Float64 => { let $ca = $self.f64().unwrap(); $($body)* },
 
+            #[cfg(feature = "dtype-date")]
             DataType::Date => { let $ca = $self.date().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-time")]
             DataType::Time => { let $ca = $self.time().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-datetime")]
             DataType::Datetime(..) => { let $ca = $self.datetime().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-duration")]
             DataType::Duration(..) => { let $ca = $self.duration().unwrap(); $($body)* },
 
+            #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(..) => { let $ca = $self.decimal().unwrap(); $($body)* },
+            #[cfg(feature = "dtype-categorical")]
             DataType::Enum(..) => { let $ca = $self.categorical().unwrap().physical(); $($body)* },
 
             _ => unreachable!(),

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -446,10 +446,8 @@ fn sketch_cardinality<T>(
 {
     if ca.has_nulls() {
         for arr in ca.downcast_iter() {
-            for opt_k in arr.iter() {
-                if let Some(k) = opt_k {
-                    sketch.insert(random_state.tot_hash_one(k));
-                }
+            for k in arr.iter().flatten() {
+                sketch.insert(random_state.tot_hash_one(k));
             }
         }
     } else {

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -54,6 +54,7 @@ macro_rules! downcast_single_key_ca {
             DataType::UInt16 => { let $ca = $self.u16().unwrap(); $($body)* },
             DataType::UInt32 => { let $ca = $self.u32().unwrap(); $($body)* },
             DataType::UInt64 => { let $ca = $self.u64().unwrap(); $($body)* },
+            DataType::Int128 => { let $ca = $self.i128().unwrap(); $($body)* },
             DataType::Float32 => { let $ca = $self.f32().unwrap(); $($body)* },
             DataType::Float64 => { let $ca = $self.f64().unwrap(); $($body)* },
 

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -20,7 +20,11 @@ pub enum HashKeysVariant {
 pub fn hash_keys_variant_for_dtype(dt: &DataType) -> HashKeysVariant {
     match dt {
         dt if dt.is_primitive_numeric() | dt.is_temporal() => HashKeysVariant::Single,
-        DataType::Decimal(_, _) | DataType::Enum(_, _) => HashKeysVariant::Single,
+
+        #[cfg(feature = "dtype-decimal")]
+        DataType::Decimal(_, _) => HashKeysVariant::Single,
+        #[cfg(feature = "dtype-categorical")]
+        DataType::Enum(_, _) => HashKeysVariant::Single,
 
         // TODO: more efficient encoding for these.
         DataType::String | DataType::Binary | DataType::Boolean | DataType::Null => {

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -120,6 +120,7 @@ impl HashKeys {
             Self::Single(SingleKeys {
                 random_state,
                 keys: df[0].as_materialized_series().clone(),
+                null_is_valid,
             })
         }
     }
@@ -296,6 +297,7 @@ impl RowEncodedKeys {
 pub struct SingleKeys {
     pub random_state: PlRandomState,
     pub keys: Series,
+    pub null_is_valid: bool,
 }
 
 impl SingleKeys {
@@ -312,7 +314,7 @@ impl SingleKeys {
                 &self.random_state,
                 partitioner,
                 partitions,
-                partition_nulls,
+                partition_nulls | self.null_is_valid,
             );
         });
     }
@@ -331,7 +333,7 @@ impl SingleKeys {
                 partitioner,
                 partition_idxs,
                 sketches,
-                partition_nulls,
+                partition_nulls | self.null_is_valid,
             );
         });
     }

--- a/crates/polars-expr/src/idx_table/mod.rs
+++ b/crates/polars-expr/src/idx_table/mod.rs
@@ -91,20 +91,12 @@ pub fn new_idx_table(key_schema: Arc<Schema>) -> Box<dyn IdxTable> {
             DataType::Duration(_) => Box::new(SKIT::<Int64Type>::new()),
             DataType::Time => Box::new(SKIT::<Int64Type>::new()),
 
+            #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(_, _) => Box::new(SKIT::<Int128Type>::new()),
+            #[cfg(feature = "dtype-categorical")]
             DataType::Enum(_, _) => Box::new(SKIT::<UInt32Type>::new()),
 
-            DataType::String
-            | DataType::Binary
-            | DataType::Boolean
-            | DataType::Null
-            | DataType::BinaryOffset
-            | DataType::Array(_, _)
-            | DataType::List(_)
-            | DataType::Object(_)
-            | DataType::Categorical(_, _)
-            | DataType::Struct(_)
-            | DataType::Unknown(_) => Box::new(row_encoded::RowEncodedIdxTable::new()),
+            _ => Box::new(row_encoded::RowEncodedIdxTable::new()),
         }
     }
 }

--- a/crates/polars-expr/src/idx_table/mod.rs
+++ b/crates/polars-expr/src/idx_table/mod.rs
@@ -74,21 +74,30 @@ pub fn new_idx_table(key_schema: Arc<Schema>) -> Box<dyn IdxTable> {
     } else {
         use single_key::SingleKeyIdxTable as SKIT;
         match key_schema.get_at_index(0).unwrap().1 {
+            #[cfg(feature = "dtype-u8")]
             DataType::UInt8 => Box::new(SKIT::<UInt8Type>::new()),
+            #[cfg(feature = "dtype-u16")]
             DataType::UInt16 => Box::new(SKIT::<UInt16Type>::new()),
             DataType::UInt32 => Box::new(SKIT::<UInt32Type>::new()),
             DataType::UInt64 => Box::new(SKIT::<UInt64Type>::new()),
+            #[cfg(feature = "dtype-i8")]
             DataType::Int8 => Box::new(SKIT::<Int8Type>::new()),
+            #[cfg(feature = "dtype-i16")]
             DataType::Int16 => Box::new(SKIT::<Int16Type>::new()),
             DataType::Int32 => Box::new(SKIT::<Int32Type>::new()),
             DataType::Int64 => Box::new(SKIT::<Int64Type>::new()),
+            #[cfg(feature = "dtype-i128")]
             DataType::Int128 => Box::new(SKIT::<Int128Type>::new()),
             DataType::Float32 => Box::new(SKIT::<Float32Type>::new()),
             DataType::Float64 => Box::new(SKIT::<Float64Type>::new()),
 
+            #[cfg(feature = "dtype-date")]
             DataType::Date => Box::new(SKIT::<Int32Type>::new()),
+            #[cfg(feature = "dtype-datetime")]
             DataType::Datetime(_, _) => Box::new(SKIT::<Int64Type>::new()),
+            #[cfg(feature = "dtype-duration")]
             DataType::Duration(_) => Box::new(SKIT::<Int64Type>::new()),
+            #[cfg(feature = "dtype-time")]
             DataType::Time => Box::new(SKIT::<Int64Type>::new()),
 
             #[cfg(feature = "dtype-decimal")]

--- a/crates/polars-expr/src/idx_table/single_key.rs
+++ b/crates/polars-expr/src/idx_table/single_key.rs
@@ -38,7 +38,7 @@ where
     K: TotalHash + TotalEq + Send + Sync + 'static,
 {
     #[inline(always)]
-    fn probe_one<'a, const MARK_MATCHES: bool>(
+    fn probe_one<const MARK_MATCHES: bool>(
         &self,
         key_idx: IdxSize,
         key: &K,
@@ -68,7 +68,6 @@ where
     }
 
     fn probe_impl<
-        'a,
         const MARK_MATCHES: bool,
         const EMIT_UNMATCHED: bool,
         const NULL_IS_VALID: bool,
@@ -88,10 +87,8 @@ where
                     table_match.push(*idx);
                     probe_match.push(key_idx);
                 }
-                if MARK_MATCHES {
-                    if !self.nulls_emitted.load(Ordering::Relaxed) {
-                        self.nulls_emitted.store(true, Ordering::Relaxed);
-                    }
+                if MARK_MATCHES && !self.nulls_emitted.load(Ordering::Relaxed) {
+                    self.nulls_emitted.store(true, Ordering::Relaxed);
                 }
                 !self.null_keys.is_empty()
             } else {
@@ -111,7 +108,8 @@ where
         keys_processed
     }
 
-    fn probe_dispatch<'a>(
+    #[allow(clippy::too_many_arguments)]
+    fn probe_dispatch(
         &self,
         keys: impl Iterator<Item = (IdxSize, Option<K>)>,
         table_match: &mut Vec<IdxSize>,

--- a/crates/polars-expr/src/idx_table/single_key.rs
+++ b/crates/polars-expr/src/idx_table/single_key.rs
@@ -52,7 +52,7 @@ where
                 probe_match.push(key_idx);
             }
 
-            // Mark if necessary. This action is idempotent so doesn't need 
+            // Mark if necessary. This action is idempotent so doesn't need
             // atomic fetch_or to do it atomically.
             if MARK_MATCHES {
                 let first_idx = unsafe { idxs.get_unchecked(0) };
@@ -67,7 +67,12 @@ where
         }
     }
 
-    fn probe_impl<'a, const MARK_MATCHES: bool, const EMIT_UNMATCHED: bool, const NULL_IS_VALID: bool>(
+    fn probe_impl<
+        'a,
+        const MARK_MATCHES: bool,
+        const EMIT_UNMATCHED: bool,
+        const NULL_IS_VALID: bool,
+    >(
         &self,
         keys: impl Iterator<Item = (IdxSize, Option<K>)>,
         table_match: &mut Vec<IdxSize>,
@@ -120,15 +125,27 @@ where
             (false, false, false) => {
                 self.probe_impl::<false, false, false>(keys, table_match, probe_match, limit)
             },
-            (false, false, true) => self.probe_impl::<false, false, true>(keys, table_match, probe_match, limit),
-            (false, true, false) => self.probe_impl::<false, true, false>(keys, table_match, probe_match, limit),
-            (false, true, true) => self.probe_impl::<false, true, true>(keys, table_match, probe_match, limit),
+            (false, false, true) => {
+                self.probe_impl::<false, false, true>(keys, table_match, probe_match, limit)
+            },
+            (false, true, false) => {
+                self.probe_impl::<false, true, false>(keys, table_match, probe_match, limit)
+            },
+            (false, true, true) => {
+                self.probe_impl::<false, true, true>(keys, table_match, probe_match, limit)
+            },
             (true, false, false) => {
                 self.probe_impl::<true, false, false>(keys, table_match, probe_match, limit)
             },
-            (true, false, true) => self.probe_impl::<true, false, true>(keys, table_match, probe_match, limit),
-            (true, true, false) => self.probe_impl::<true, true, false>(keys, table_match, probe_match, limit),
-            (true, true, true) => self.probe_impl::<true, true, true>(keys, table_match, probe_match, limit),
+            (true, false, true) => {
+                self.probe_impl::<true, false, true>(keys, table_match, probe_match, limit)
+            },
+            (true, true, false) => {
+                self.probe_impl::<true, true, false>(keys, table_match, probe_match, limit)
+            },
+            (true, true, true) => {
+                self.probe_impl::<true, true, true>(keys, table_match, probe_match, limit)
+            },
         }
     }
 }

--- a/crates/polars-expr/src/idx_table/single_key.rs
+++ b/crates/polars-expr/src/idx_table/single_key.rs
@@ -154,7 +154,8 @@ where
         );
 
         let keys: &ChunkedArray<T> = hash_keys.keys.as_phys_any().downcast_ref().unwrap();
-        for (i, key) in keys.iter().enumerate_idx() {
+        for (i, subset_idx) in subset.iter().enumerate_idx() {
+            let key = unsafe { keys.get_unchecked(*subset_idx as usize) };
             let idx = self.idx_offset + i;
             if let Some(key) = key {
                 match self.idx_map.entry(key) {

--- a/crates/polars-expr/src/idx_table/single_key.rs
+++ b/crates/polars-expr/src/idx_table/single_key.rs
@@ -1,0 +1,271 @@
+#![allow(clippy::unnecessary_cast)] // Clippy doesn't recognize that IdxSize and u64 can be different.
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use polars_utils::idx_map::total_idx_map::{Entry, TotalIndexMap};
+use polars_utils::idx_vec::UnitVec;
+use polars_utils::itertools::Itertools;
+use polars_utils::total_ord::{TotalEq, TotalHash};
+use polars_utils::unitvec;
+
+use super::*;
+use crate::hash_keys::HashKeys;
+
+pub struct SingleKeyIdxTable<T: PolarsDataType> {
+    // These AtomicU64s actually are IdxSizes, but we use the top bit of the
+    // first index in each to mark keys during probing.
+    idx_map: TotalIndexMap<T::Physical<'static>, UnitVec<AtomicU64>>,
+    idx_offset: IdxSize,
+    null_keys: Vec<IdxSize>,
+}
+
+impl<T: PolarsDataType> SingleKeyIdxTable<T> {
+    pub fn new() -> Self {
+        Self {
+            idx_map: TotalIndexMap::default(),
+            idx_offset: 0,
+            null_keys: Vec::new(),
+        }
+    }
+}
+
+impl<T, K> SingleKeyIdxTable<T>
+where
+    for<'a> T: PolarsDataType<Physical<'a> = K>,
+    K: TotalHash + TotalEq + Send + Sync + 'static,
+{
+    #[inline(always)]
+    fn probe_one<'a, const MARK_MATCHES: bool>(
+        &self,
+        key_idx: IdxSize,
+        key: &K,
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+    ) -> bool {
+        if let Some(idxs) = self.idx_map.get(key) {
+            for idx in &idxs[..] {
+                // Create matches, making sure to clear top bit.
+                table_match.push((idx.load(Ordering::Relaxed) & !(1 << 63)) as IdxSize);
+                probe_match.push(key_idx);
+            }
+
+            // Mark if necessary. This action is idempotent so doesn't
+            // need any synchronization on the load, nor does it need a
+            // fetch_or to do it atomically.
+            if MARK_MATCHES {
+                let first_idx = unsafe { idxs.get_unchecked(0) };
+                let first_idx_val = first_idx.load(Ordering::Relaxed);
+                if first_idx_val >> 63 == 0 {
+                    first_idx.store(first_idx_val | (1 << 63), Ordering::Release);
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    fn probe_impl<'a, const MARK_MATCHES: bool, const EMIT_UNMATCHED: bool>(
+        &self,
+        keys: impl Iterator<Item = (IdxSize, Option<K>)>,
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+        limit: IdxSize,
+    ) -> IdxSize {
+        let mut keys_processed = 0;
+        for (key_idx, key) in keys {
+            let found_match = if let Some(key) = key {
+                self.probe_one::<MARK_MATCHES>(key_idx, &key, table_match, probe_match)
+            } else {
+                false
+            };
+
+            if EMIT_UNMATCHED && !found_match {
+                table_match.push(IdxSize::MAX);
+                probe_match.push(key_idx);
+            }
+
+            keys_processed += 1;
+            if table_match.len() >= limit as usize {
+                break;
+            }
+        }
+        keys_processed
+    }
+
+    fn probe_dispatch<'a>(
+        &self,
+        keys: impl Iterator<Item = (IdxSize, Option<K>)>,
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+        mark_matches: bool,
+        emit_unmatched: bool,
+        limit: IdxSize,
+    ) -> IdxSize {
+        match (mark_matches, emit_unmatched) {
+            (false, false) => {
+                self.probe_impl::<false, false>(keys, table_match, probe_match, limit)
+            },
+            (false, true) => self.probe_impl::<false, true>(keys, table_match, probe_match, limit),
+            (true, false) => self.probe_impl::<true, false>(keys, table_match, probe_match, limit),
+            (true, true) => self.probe_impl::<true, true>(keys, table_match, probe_match, limit),
+        }
+    }
+}
+
+impl<T, K> IdxTable for SingleKeyIdxTable<T>
+where
+    for<'a> T: PolarsDataType<Physical<'a> = K>,
+    K: TotalHash + TotalEq + Send + Sync + 'static,
+{
+    fn new_empty(&self) -> Box<dyn IdxTable> {
+        Box::new(Self::new())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.idx_map.reserve(additional);
+    }
+
+    fn num_keys(&self) -> IdxSize {
+        self.idx_map.len()
+    }
+
+    fn insert_keys(&mut self, _hash_keys: &HashKeys, _track_unmatchable: bool) {
+        // Isn't needed anymore, but also don't want to remove the code from the other implementations.
+        unimplemented!()
+    }
+
+    unsafe fn insert_keys_subset(
+        &mut self,
+        hash_keys: &HashKeys,
+        subset: &[IdxSize],
+        track_unmatchable: bool,
+    ) {
+        let HashKeys::Single(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+        let new_idx_offset = (self.idx_offset as usize)
+            .checked_add(subset.len())
+            .unwrap();
+        assert!(
+            new_idx_offset < IdxSize::MAX as usize,
+            "overly large index in SingleKeyIdxTable"
+        );
+
+        let keys: &ChunkedArray<T> = hash_keys.keys.as_phys_any().downcast_ref().unwrap();
+        for (i, key) in keys.iter().enumerate_idx() {
+            let idx = self.idx_offset + i;
+            if let Some(key) = key {
+                match self.idx_map.entry(key) {
+                    Entry::Occupied(o) => {
+                        o.into_mut().push(AtomicU64::new(idx as u64));
+                    },
+                    Entry::Vacant(v) => {
+                        v.insert(unitvec![AtomicU64::new(idx as u64)]);
+                    },
+                }
+            } else if track_unmatchable {
+                self.null_keys.push(idx);
+            }
+        }
+
+        self.idx_offset = new_idx_offset as IdxSize;
+    }
+
+    fn probe(
+        &self,
+        _hash_keys: &HashKeys,
+        _table_match: &mut Vec<IdxSize>,
+        _probe_match: &mut Vec<IdxSize>,
+        _mark_matches: bool,
+        _emit_unmatched: bool,
+        _limit: IdxSize,
+    ) -> IdxSize {
+        // Isn't needed anymore, but also don't want to remove the code from the other implementations.
+        unimplemented!()
+    }
+
+    unsafe fn probe_subset(
+        &self,
+        hash_keys: &HashKeys,
+        subset: &[IdxSize],
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+        mark_matches: bool,
+        emit_unmatched: bool,
+        limit: IdxSize,
+    ) -> IdxSize {
+        let HashKeys::Single(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+
+        let keys: &ChunkedArray<T> = hash_keys.keys.as_phys_any().downcast_ref().unwrap();
+        if keys.has_nulls() {
+            let iter = subset.iter().map(|i| (*i, keys.get_unchecked(*i as usize)));
+            self.probe_dispatch(
+                iter,
+                table_match,
+                probe_match,
+                mark_matches,
+                emit_unmatched,
+                limit,
+            )
+        } else {
+            let iter = subset
+                .iter()
+                .map(|i| (*i, Some(keys.value_unchecked(*i as usize))));
+            self.probe_dispatch(
+                iter,
+                table_match,
+                probe_match,
+                mark_matches,
+                emit_unmatched,
+                limit,
+            )
+        }
+    }
+
+    fn unmarked_keys(
+        &self,
+        out: &mut Vec<IdxSize>,
+        mut offset: IdxSize,
+        limit: IdxSize,
+    ) -> IdxSize {
+        out.clear();
+
+        let mut keys_processed = 0;
+        if (offset as usize) < self.null_keys.len() {
+            out.extend(
+                self.null_keys[offset as usize..]
+                    .iter()
+                    .copied()
+                    .take(limit as usize),
+            );
+            keys_processed += out.len() as IdxSize;
+            offset += out.len() as IdxSize;
+            if out.len() >= limit as usize {
+                return keys_processed;
+            }
+        }
+
+        offset -= self.null_keys.len() as IdxSize;
+        while let Some((_, idxs)) = self.idx_map.get_index(offset) {
+            let first_idx = unsafe { idxs.get_unchecked(0) };
+            let first_idx_val = first_idx.load(Ordering::Acquire);
+            if first_idx_val >> 63 == 0 {
+                for idx in &idxs[..] {
+                    out.push((idx.load(Ordering::Relaxed) & !(1 << 63)) as IdxSize);
+                }
+            }
+
+            keys_processed += 1;
+            offset += 1;
+            if out.len() >= limit as usize {
+                break;
+            }
+        }
+
+        keys_processed
+    }
+}

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -196,6 +196,14 @@ impl ExprIR {
     pub(crate) fn set_alias(&mut self, name: PlSmallStr) {
         self.output_name = OutputName::Alias(name)
     }
+    
+    pub fn with_alias(&self, name: PlSmallStr) -> Self {
+        Self {
+            output_name: OutputName::Alias(name),
+            node: self.node,
+            output_dtype: self.output_dtype.clone(),
+        }
+    }
 
     pub(crate) fn set_columnlhs(&mut self, name: PlSmallStr) {
         debug_assert!(matches!(

--- a/crates/polars-plan/src/plans/expr_ir.rs
+++ b/crates/polars-plan/src/plans/expr_ir.rs
@@ -196,7 +196,7 @@ impl ExprIR {
     pub(crate) fn set_alias(&mut self, name: PlSmallStr) {
         self.output_name = OutputName::Alias(name)
     }
-    
+
     pub fn with_alias(&self, name: PlSmallStr) -> Self {
         Self {
             output_name: OutputName::Alias(name),

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -1323,11 +1323,9 @@ impl ComputeNode for EquiJoinNode {
 
         // If we are sampling and both sides are done/filled, transition to building.
         if let EquiJoinState::Sample(sample_state) = &mut self.state {
-            if let Some(build_state) = sample_state.try_transition_to_build(
-                recv,
-                self.num_pipelines,
-                &mut self.params,
-            )? {
+            if let Some(build_state) =
+                sample_state.try_transition_to_build(recv, self.num_pipelines, &mut self.params)?
+            {
                 self.state = EquiJoinState::Build(build_state);
             }
         }

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -138,7 +138,7 @@ async fn select_keys(
         &keys,
         params.random_state.clone(),
         params.args.nulls_equal,
-        true,
+        false,
     ))
 }
 

--- a/crates/polars-stream/src/nodes/joins/equi_join.rs
+++ b/crates/polars-stream/src/nodes/joins/equi_join.rs
@@ -126,12 +126,8 @@ async fn select_keys(
     state: &ExecutionState,
 ) -> PolarsResult<HashKeys> {
     let mut key_columns = Vec::new();
-    for (i, selector) in key_selectors.iter().enumerate() {
-        // We use key columns entirely by position, and allow duplicate names,
-        // so just assign arbitrary unique names.
-        let unique_name = format_pl_smallstr!("__POLARS_KEYCOL_{i}");
-        let s = selector.evaluate(df, state).await?;
-        key_columns.push(s.into_column().with_name(unique_name));
+    for selector in key_selectors {
+        key_columns.push(selector.evaluate(df, state).await?.into_column());
     }
     let keys = DataFrame::new_with_broadcast_len(key_columns, df.height())?;
     Ok(HashKeys::from_df(
@@ -347,7 +343,6 @@ impl SampleState {
         recv: &[PortState],
         num_pipelines: usize,
         params: &mut EquiJoinParams,
-        table: &mut Option<Box<dyn IdxTable>>,
     ) -> PolarsResult<Option<BuildState>> {
         let left_saturated = self.left_len >= *SAMPLE_LIMIT;
         let right_saturated = self.right_len >= *SAMPLE_LIMIT;
@@ -416,12 +411,6 @@ impl SampleState {
 
         // Transition to building state.
         params.left_is_build = Some(left_is_build);
-        *table = Some(if left_is_build {
-            new_idx_table(params.left_key_schema.clone())
-        } else {
-            new_idx_table(params.right_key_schema.clone())
-        });
-
         let mut sampled_build_morsels =
             BufferedStream::new(core::mem::take(&mut self.left), MorselSeq::default());
         let mut sampled_probe_morsels =
@@ -1195,6 +1184,7 @@ struct EquiJoinParams {
     preserve_order_probe: bool,
     left_key_schema: Arc<Schema>,
     left_key_selectors: Vec<StreamExpr>,
+    #[allow(dead_code)]
     right_key_schema: Arc<Schema>,
     right_key_selectors: Vec<StreamExpr>,
     left_payload_select: Vec<Option<PlSmallStr>>,
@@ -1229,7 +1219,7 @@ pub struct EquiJoinNode {
     state: EquiJoinState,
     params: EquiJoinParams,
     num_pipelines: usize,
-    table: Option<Box<dyn IdxTable>>,
+    table: Box<dyn IdxTable>,
 }
 
 impl EquiJoinNode {
@@ -1239,6 +1229,7 @@ impl EquiJoinNode {
         right_input_schema: Arc<Schema>,
         left_key_schema: Arc<Schema>,
         right_key_schema: Arc<Schema>,
+        unique_key_schema: Arc<Schema>,
         left_key_selectors: Vec<StreamExpr>,
         right_key_selectors: Vec<StreamExpr>,
         args: JoinArgs,
@@ -1255,14 +1246,6 @@ impl EquiJoinNode {
             MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight => Some(false),
             MaintainOrderJoin::Right | MaintainOrderJoin::RightLeft => Some(true),
         };
-
-        let table = left_is_build.map(|lib| {
-            if lib {
-                new_idx_table(left_key_schema.clone())
-            } else {
-                new_idx_table(right_key_schema.clone())
-            }
-        });
 
         let preserve_order_probe = args.maintain_order != MaintainOrderJoin::None;
         let preserve_order_build = matches!(
@@ -1316,7 +1299,7 @@ impl EquiJoinNode {
                 args,
                 random_state: PlRandomState::new(),
             },
-            table,
+            table: new_idx_table(unique_key_schema),
         })
     }
 }
@@ -1344,7 +1327,6 @@ impl ComputeNode for EquiJoinNode {
                 recv,
                 self.num_pipelines,
                 &mut self.params,
-                &mut self.table,
             )? {
                 self.state = EquiJoinState::Build(build_state);
             }
@@ -1361,9 +1343,9 @@ impl ComputeNode for EquiJoinNode {
         if let EquiJoinState::Build(build_state) = &mut self.state {
             if recv[build_idx] == PortState::Done {
                 let probe_state = if self.params.preserve_order_build {
-                    build_state.finalize_ordered(&self.params, self.table.as_deref().unwrap())
+                    build_state.finalize_ordered(&self.params, &*self.table)
                 } else {
-                    build_state.finalize_unordered(&self.params, self.table.as_deref().unwrap())
+                    build_state.finalize_unordered(&self.params, &*self.table)
                 };
                 self.state = EquiJoinState::Probe(probe_state);
             }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -801,9 +801,9 @@ fn to_graph_rec<'a>(
             let right_input_schema = ctx.phys_sm[input_right.node].output_schema.clone();
 
             let left_key_schema =
-                compute_output_schema(&left_input_schema, &left_on, ctx.expr_arena)?;
+                compute_output_schema(&left_input_schema, left_on, ctx.expr_arena)?;
             let right_key_schema =
-                compute_output_schema(&right_input_schema, &right_on, ctx.expr_arena)?;
+                compute_output_schema(&right_input_schema, right_on, ctx.expr_arena)?;
 
             // We use key columns entirely by position, and allow duplicate names in key selectors,
             // so just assign arbitrary unique names for the selectors.

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -807,12 +807,16 @@ fn to_graph_rec<'a>(
 
             // We use key columns entirely by position, and allow duplicate names in key selectors,
             // so just assign arbitrary unique names for the selectors.
-            let unique_left_on = left_on.iter().enumerate().map(|(i, expr)| {
-                expr.with_alias(format_pl_smallstr!("__POLARS_KEYCOL_{i}"))
-            }).collect_vec();
-            let unique_right_on = right_on.iter().enumerate().map(|(i, expr)| {
-                expr.with_alias(format_pl_smallstr!("__POLARS_KEYCOL_{i}"))
-            }).collect_vec();
+            let unique_left_on = left_on
+                .iter()
+                .enumerate()
+                .map(|(i, expr)| expr.with_alias(format_pl_smallstr!("__POLARS_KEYCOL_{i}")))
+                .collect_vec();
+            let unique_right_on = right_on
+                .iter()
+                .enumerate()
+                .map(|(i, expr)| expr.with_alias(format_pl_smallstr!("__POLARS_KEYCOL_{i}")))
+                .collect_vec();
 
             let left_key_selectors = unique_left_on
                 .iter()

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -16,6 +16,7 @@ use polars_plan::plans::expr_ir::ExprIR;
 use polars_plan::plans::{AExpr, ArenaExprIter, Context, IR};
 use polars_plan::prelude::{FileType, FunctionFlags};
 use polars_utils::arena::{Arena, Node};
+use polars_utils::format_pl_smallstr;
 use polars_utils::itertools::Itertools;
 use recursive::recursive;
 use slotmap::{SecondaryMap, SlotMap};
@@ -800,18 +801,30 @@ fn to_graph_rec<'a>(
             let right_input_schema = ctx.phys_sm[input_right.node].output_schema.clone();
 
             let left_key_schema =
-                compute_output_schema(&left_input_schema, left_on, ctx.expr_arena)?;
+                compute_output_schema(&left_input_schema, &left_on, ctx.expr_arena)?;
             let right_key_schema =
-                compute_output_schema(&right_input_schema, right_on, ctx.expr_arena)?;
+                compute_output_schema(&right_input_schema, &right_on, ctx.expr_arena)?;
 
-            let left_key_selectors = left_on
+            // We use key columns entirely by position, and allow duplicate names in key selectors,
+            // so just assign arbitrary unique names for the selectors.
+            let unique_left_on = left_on.iter().enumerate().map(|(i, expr)| {
+                expr.with_alias(format_pl_smallstr!("__POLARS_KEYCOL_{i}"))
+            }).collect_vec();
+            let unique_right_on = right_on.iter().enumerate().map(|(i, expr)| {
+                expr.with_alias(format_pl_smallstr!("__POLARS_KEYCOL_{i}"))
+            }).collect_vec();
+
+            let left_key_selectors = unique_left_on
                 .iter()
                 .map(|e| create_stream_expr(e, ctx, &left_input_schema))
                 .try_collect_vec()?;
-            let right_key_selectors = right_on
+            let right_key_selectors = unique_right_on
                 .iter()
                 .map(|e| create_stream_expr(e, ctx, &right_input_schema))
                 .try_collect_vec()?;
+
+            let unique_key_schema =
+                compute_output_schema(&right_input_schema, &unique_left_on, ctx.expr_arena)?;
 
             ctx.graph.add_node(
                 nodes::joins::equi_join::EquiJoinNode::new(
@@ -819,6 +832,7 @@ fn to_graph_rec<'a>(
                     right_input_schema,
                     left_key_schema,
                     right_key_schema,
+                    unique_key_schema,
                     left_key_selectors,
                     right_key_selectors,
                     args,

--- a/crates/polars-utils/src/idx_map/mod.rs
+++ b/crates/polars-utils/src/idx_map/mod.rs
@@ -1,2 +1,5 @@
 pub mod bytes_idx_map;
 pub use bytes_idx_map::BytesIndexMap;
+
+pub mod total_idx_map;
+pub use total_idx_map::TotalIndexMap;

--- a/crates/polars-utils/src/idx_map/total_idx_map.rs
+++ b/crates/polars-utils/src/idx_map/total_idx_map.rs
@@ -1,0 +1,147 @@
+use hashbrown::hash_table::{
+    Entry as TEntry, HashTable, OccupiedEntry as TOccupiedEntry, VacantEntry as TVacantEntry,
+};
+
+use crate::IdxSize;
+use crate::aliases::PlRandomState;
+use crate::total_ord::{BuildHasherTotalExt, TotalEq, TotalHash};
+
+/// An IndexMap where the keys are hashed and compared with TotalOrd/TotalEq.
+pub struct TotalIndexMap<K, V> {
+    table: HashTable<IdxSize>,
+    tuples: Vec<(K, V)>,
+    random_state: PlRandomState,
+}
+
+impl<K, V> Default for TotalIndexMap<K, V> {
+    fn default() -> Self {
+        Self {
+            table: HashTable::new(),
+            tuples: Vec::new(),
+            random_state: PlRandomState::default(),
+        }
+    }
+}
+
+impl<K: TotalHash + TotalEq, V> TotalIndexMap<K, V> {
+    pub fn reserve(&mut self, additional: usize) {
+        self.table.reserve(additional, |i| unsafe {
+            let tuple = self.tuples.get_unchecked(*i as usize);
+            self.random_state.tot_hash_one(&tuple.0)
+        });
+        self.tuples.reserve(additional);
+    }
+
+    pub fn len(&self) -> IdxSize {
+        self.table.len() as IdxSize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        let hash = self.random_state.tot_hash_one(&key);
+        let idx = self.table.find(hash, |i| unsafe {
+            let t = self.tuples.get_unchecked(*i as usize);
+            hash == self.random_state.tot_hash_one(&t.0) && key.tot_eq(&t.0)
+        })?;
+        unsafe { Some(&self.tuples.get_unchecked(*idx as usize).1) }
+    }
+
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
+        let hash = self.random_state.tot_hash_one(&key);
+        let entry = self.table.entry(
+            hash,
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                hash == self.random_state.tot_hash_one(&t.0) && key.tot_eq(&t.0)
+            },
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                self.random_state.tot_hash_one(&t.0)
+            },
+        );
+
+        match entry {
+            TEntry::Occupied(o) => Entry::Occupied(OccupiedEntry {
+                entry: o,
+                tuples: &mut self.tuples,
+            }),
+            TEntry::Vacant(v) => Entry::Vacant(VacantEntry {
+                key,
+                entry: v,
+                tuples: &mut self.tuples,
+            }),
+        }
+    }
+
+    /// Gets the key and value at the given index by insertion order.
+    #[inline(always)]
+    pub fn get_index(&self, idx: IdxSize) -> Option<(&K, &V)> {
+        let t = self.tuples.get(idx as usize)?;
+        Some((&t.0, &t.1))
+    }
+
+    /// Gets the key and value at the given index by insertion order.
+    ///
+    /// # Safety
+    /// The index must be less than len().
+    #[inline(always)]
+    pub unsafe fn get_index_unchecked(&self, idx: IdxSize) -> (&K, &V) {
+        let t = unsafe { self.tuples.get_unchecked(idx as usize) };
+        (&t.0, &t.1)
+    }
+
+    /// Iterates over the keys in insertion order.
+    pub fn iter_keys(&self) -> impl Iterator<Item = &K> {
+        self.tuples.iter().map(|t| &t.0)
+    }
+
+    /// Iterates over the values in insertion order.
+    pub fn iter_values(&self) -> impl Iterator<Item = &V> {
+        self.tuples.iter().map(|t| &t.1)
+    }
+}
+
+pub enum Entry<'a, K, V> {
+    Occupied(OccupiedEntry<'a, K, V>),
+    Vacant(VacantEntry<'a, K, V>),
+}
+
+pub struct OccupiedEntry<'a, K, V> {
+    entry: TOccupiedEntry<'a, IdxSize>,
+    tuples: &'a mut Vec<(K, V)>,
+}
+
+impl<'a, K, V> OccupiedEntry<'a, K, V> {
+    pub fn index(&self) -> IdxSize {
+        *self.entry.get()
+    }
+
+    pub fn into_mut(self) -> &'a mut V {
+        let idx = self.index();
+        unsafe { &mut self.tuples.get_unchecked_mut(idx as usize).1 }
+    }
+}
+
+pub struct VacantEntry<'a, K, V> {
+    key: K,
+    entry: TVacantEntry<'a, IdxSize>,
+    tuples: &'a mut Vec<(K, V)>,
+}
+
+impl<'a, K, V> VacantEntry<'a, K, V> {
+    pub fn index(&self) -> IdxSize {
+        self.tuples.len() as IdxSize
+    }
+
+    pub fn insert(self, value: V) -> &'a mut V {
+        unsafe {
+            let tuple_idx: IdxSize = self.tuples.len().try_into().unwrap();
+            self.tuples.push((self.key, value));
+            self.entry.insert(tuple_idx);
+            &mut self.tuples.last_mut().unwrap_unchecked().1
+        }
+    }
+}

--- a/crates/polars-utils/src/idx_map/total_idx_map.rs
+++ b/crates/polars-utils/src/idx_map/total_idx_map.rs
@@ -41,7 +41,7 @@ impl<K: TotalHash + TotalEq, V> TotalIndexMap<K, V> {
     }
 
     pub fn get(&self, key: &K) -> Option<&V> {
-        let hash = self.random_state.tot_hash_one(&key);
+        let hash = self.random_state.tot_hash_one(key);
         let idx = self.table.find(hash, |i| unsafe {
             let t = self.tuples.get_unchecked(*i as usize);
             hash == self.random_state.tot_hash_one(&t.0) && key.tot_eq(&t.0)

--- a/crates/polars-utils/src/total_ord.rs
+++ b/crates/polars-utils/src/total_ord.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 
 use bytemuck::TransparentWrapper;
 
@@ -86,6 +86,21 @@ pub trait TotalHash {
         }
     }
 }
+
+pub trait BuildHasherTotalExt: BuildHasher {
+    fn tot_hash_one<T>(&self, x: T) -> u64
+    where
+        T: TotalHash,
+        Self: Sized,
+        <Self as BuildHasher>::Hasher: Hasher,
+    {
+        let mut hasher = self.build_hasher();
+        x.tot_hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl<T: BuildHasher> BuildHasherTotalExt for T {}
 
 #[repr(transparent)]
 pub struct TotalOrdWrap<T>(pub T);

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1861,12 +1861,13 @@ def test_join_null_equal(order: Literal["none", "left_right", "right_left"]) -> 
     lhs = pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3]})
     with_null = pl.DataFrame({"x": [1, None], "z": [1, 2]})
     without_null = pl.DataFrame({"x": [1, 3], "z": [1, 3]})
+    check_row_order = order != "none"
 
     # Inner join.
     assert_frame_equal(
         lhs.join(with_null, on="x", nulls_equal=True, maintain_order=order),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
-        check_row_order=order is not None,
+        check_row_order=check_row_order,
     )
     assert_frame_equal(
         lhs.join(without_null, on="x", nulls_equal=True),
@@ -1877,14 +1878,14 @@ def test_join_null_equal(order: Literal["none", "left_right", "right_left"]) -> 
     assert_frame_equal(
         lhs.join(with_null, on="x", how="left", nulls_equal=True, maintain_order=order),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
-        check_row_order=order is not None,
+        check_row_order=check_row_order,
     )
     assert_frame_equal(
         lhs.join(
             without_null, on="x", how="left", nulls_equal=True, maintain_order=order
         ),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, None, None]}),
-        check_row_order=order is not None,
+        check_row_order=check_row_order,
     )
 
     # Full join.
@@ -1898,7 +1899,7 @@ def test_join_null_equal(order: Literal["none", "left_right", "right_left"]) -> 
             maintain_order=order,
         ),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
-        check_row_order=order is not None,
+        check_row_order=check_row_order,
     )
     if order == "left_right":
         expected = pl.DataFrame(
@@ -1923,6 +1924,6 @@ def test_join_null_equal(order: Literal["none", "left_right", "right_left"]) -> 
             without_null, on="x", how="full", nulls_equal=True, maintain_order=order
         ),
         expected,
-        check_row_order=order is not None,
+        check_row_order=check_row_order,
         check_column_order=False,
     )

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -675,9 +675,8 @@ def test_full_outer_join_list_() -> None:
         },
         schema=join_schema,  # type: ignore[arg-type]
     )
-    assert_frame_equal(
-        df1.join(df2, on="id", how="full"), expected, check_row_order=False
-    )
+    out = df1.join(df2, on="id", how="full", maintain_order="right_left")
+    assert_frame_equal(out, expected)
 
 
 @pytest.mark.slow

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1856,8 +1856,8 @@ def test_multi_leftjoin_empty_right_21701() -> None:
     assert_frame_equal(joined_df.collect(), parent_df.collect(), check_row_order=False)
 
 
-@pytest.mark.parametrize("order", [None, "left_right", "right_left"])
-def test_join_null_equal(order: str | None) -> None:
+@pytest.mark.parametrize("order", ["none", "left_right", "right_left"])
+def test_join_null_equal(order: Literal["none", "left_right", "right_left"]) -> None:
     lhs = pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3]})
     with_null = pl.DataFrame({"x": [1, None], "z": [1, 2]})
     without_null = pl.DataFrame({"x": [1, 3], "z": [1, 3]})
@@ -1866,38 +1866,63 @@ def test_join_null_equal(order: str | None) -> None:
     assert_frame_equal(
         lhs.join(with_null, on="x", nulls_equal=True, maintain_order=order),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
-        check_row_order=order is not None
+        check_row_order=order is not None,
     )
     assert_frame_equal(
         lhs.join(without_null, on="x", nulls_equal=True),
-        pl.DataFrame({"x": [1], "y": [1], "z": [1]})
+        pl.DataFrame({"x": [1], "y": [1], "z": [1]}),
     )
 
     # Left join.
     assert_frame_equal(
         lhs.join(with_null, on="x", how="left", nulls_equal=True, maintain_order=order),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
-        check_row_order=order is not None
+        check_row_order=order is not None,
     )
     assert_frame_equal(
-        lhs.join(without_null, on="x", how="left", nulls_equal=True, maintain_order=order),
+        lhs.join(
+            without_null, on="x", how="left", nulls_equal=True, maintain_order=order
+        ),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, None, None]}),
-        check_row_order=order is not None
+        check_row_order=order is not None,
     )
 
     # Full join.
     assert_frame_equal(
-        lhs.join(with_null, on="x", how="full", nulls_equal=True, coalesce=True, maintain_order=order),
+        lhs.join(
+            with_null,
+            on="x",
+            how="full",
+            nulls_equal=True,
+            coalesce=True,
+            maintain_order=order,
+        ),
         pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
-        check_row_order=order is not None
+        check_row_order=order is not None,
     )
     if order == "left_right":
-        expected = pl.DataFrame({"x": [1, None, None, None], "x_right": [1, None, None, 3], "y": [1, 2, 3, None], "z": [1, None, None, 3]})
+        expected = pl.DataFrame(
+            {
+                "x": [1, None, None, None],
+                "x_right": [1, None, None, 3],
+                "y": [1, 2, 3, None],
+                "z": [1, None, None, 3],
+            }
+        )
     else:
-        expected = pl.DataFrame({"x": [1, None, None, None], "x_right": [1, 3, None, None], "y": [1, None, 2, 3], "z": [1, 3, None, None]})
+        expected = pl.DataFrame(
+            {
+                "x": [1, None, None, None],
+                "x_right": [1, 3, None, None],
+                "y": [1, None, 2, 3],
+                "z": [1, 3, None, None],
+            }
+        )
     assert_frame_equal(
-        lhs.join(without_null, on="x", how="full", nulls_equal=True, maintain_order=order),
+        lhs.join(
+            without_null, on="x", how="full", nulls_equal=True, maintain_order=order
+        ),
         expected,
         check_row_order=order is not None,
-        check_column_order=False
+        check_column_order=False,
     )

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1854,3 +1854,50 @@ def test_multi_leftjoin_empty_right_21701() -> None:
     )
     joined_df = joined_df.select("id", "parent_field1")
     assert_frame_equal(joined_df.collect(), parent_df.collect(), check_row_order=False)
+
+
+@pytest.mark.parametrize("order", [None, "left_right", "right_left"])
+def test_join_null_equal(order: str | None) -> None:
+    lhs = pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3]})
+    with_null = pl.DataFrame({"x": [1, None], "z": [1, 2]})
+    without_null = pl.DataFrame({"x": [1, 3], "z": [1, 3]})
+
+    # Inner join.
+    assert_frame_equal(
+        lhs.join(with_null, on="x", nulls_equal=True, maintain_order=order),
+        pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
+        check_row_order=order is not None
+    )
+    assert_frame_equal(
+        lhs.join(without_null, on="x", nulls_equal=True),
+        pl.DataFrame({"x": [1], "y": [1], "z": [1]})
+    )
+
+    # Left join.
+    assert_frame_equal(
+        lhs.join(with_null, on="x", how="left", nulls_equal=True, maintain_order=order),
+        pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
+        check_row_order=order is not None
+    )
+    assert_frame_equal(
+        lhs.join(without_null, on="x", how="left", nulls_equal=True, maintain_order=order),
+        pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, None, None]}),
+        check_row_order=order is not None
+    )
+
+    # Full join.
+    assert_frame_equal(
+        lhs.join(with_null, on="x", how="full", nulls_equal=True, coalesce=True, maintain_order=order),
+        pl.DataFrame({"x": [1, None, None], "y": [1, 2, 3], "z": [1, 2, 2]}),
+        check_row_order=order is not None
+    )
+    if order == "left_right":
+        expected = pl.DataFrame({"x": [1, None, None, None], "x_right": [1, None, None, 3], "y": [1, 2, 3, None], "z": [1, None, None, 3]})
+    else:
+        expected = pl.DataFrame({"x": [1, None, None, None], "x_right": [1, 3, None, None], "y": [1, None, 2, 3], "z": [1, 3, None, None]})
+    assert_frame_equal(
+        lhs.join(without_null, on="x", how="full", nulls_equal=True, maintain_order=order),
+        expected,
+        check_row_order=order is not None,
+        check_column_order=False
+    )

--- a/py-polars/tests/unit/operations/test_join_right.py
+++ b/py-polars/tests/unit/operations/test_join_right.py
@@ -24,12 +24,18 @@ def test_right_join_schemas() -> None:
     ]
 
     # coalesces the join key, so the key of the right table remains
-    assert b.join(a, on="a", how="right", coalesce=True).to_dict(as_series=False) == {
-        "b": [1, None, 3],
-        "c": [1, None, 3],
-        "a": [1, 2, 3],
-        "b_right": [1, 2, 3],
-    }
+    assert_frame_equal(
+        b.join(a, on="a", how="right", coalesce=True),
+        pl.DataFrame(
+            {
+                "b": [1, None, 3],
+                "c": [1, None, 3],
+                "a": [1, 2, 3],
+                "b_right": [1, 2, 3],
+            }
+        ),
+        check_row_order=False,
+    )
     assert b.join(a, on="a", how="right", coalesce=False).columns == [
         "a",
         "b",


### PR DESCRIPTION
Before this PR everything always went through the row-encoding in the new-streaming join, even for small single keys. This adds a single-key hashtable for the primitive types (or those logical types backed by primitive types). Not yet included is single-key string support, that still goes through the row encoding.