### PR TITLE
fix: Disallow cast to empty Enum

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -391,6 +391,7 @@ impl Series {
                 true
             },
             dt if dt.is_primitive() && dt == self.dtype() => true,
+            #[cfg(feature = "dtype-categorical")]
             D::Enum(None, _) => {
                 polars_bail!(InvalidOperation: "cannot cast to Enum without categories present");
             },

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -393,7 +393,7 @@ impl Series {
             dt if dt.is_primitive() && dt == self.dtype() => true,
             #[cfg(feature = "dtype-categorical")]
             D::Enum(None, _) => {
-                polars_bail!(InvalidOperation: "cannot cast to Enum without categories present");
+                polars_bail!(InvalidOperation: "cannot cast / initialize Enum without categories present");
             },
             _ => false,
         };

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -391,6 +391,9 @@ impl Series {
                 true
             },
             dt if dt.is_primitive() && dt == self.dtype() => true,
+            D::Enum(None, _) => {
+                polars_bail!(InvalidOperation: "cannot cast to Enum without categories present");
+            },
             _ => false,
         };
 

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -338,7 +338,7 @@ def test_extend_to_an_enum() -> None:
 
 def test_series_init_uninstantiated_enum() -> None:
     with pytest.raises(
-        ComputeError,
+        InvalidOperationError,
         match="cannot cast / initialize Enum without categories present",
     ):
         pl.Series(["a", "b", "a"], dtype=pl.Enum)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -339,7 +339,7 @@ def test_extend_to_an_enum() -> None:
 def test_series_init_uninstantiated_enum() -> None:
     with pytest.raises(
         ComputeError,
-        match="can not cast / initialize Enum without categories present",
+        match="cannot cast / initialize Enum without categories present",
     ):
         pl.Series(["a", "b", "a"], dtype=pl.Enum)
 

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -714,3 +714,10 @@ def test_overflowing_cast_literals_21023() -> None:
             ),
             pl.Series([-128], dtype=pl.Int8).to_frame(),
         )
+
+
+def test_invalid_empty_cast_to_empty_enum() -> None:
+    with pytest.raises(
+        InvalidOperationError, match="cannot cast to Enum without categories present"
+    ):
+        pl.Series([], dtype=pl.Enum)

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -718,6 +718,7 @@ def test_overflowing_cast_literals_21023() -> None:
 
 def test_invalid_empty_cast_to_empty_enum() -> None:
     with pytest.raises(
-        InvalidOperationError, match="cannot cast / initialize Enum without categories present"
+        InvalidOperationError,
+        match="cannot cast / initialize Enum without categories present",
     ):
         pl.Series([], dtype=pl.Enum)

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -718,6 +718,6 @@ def test_overflowing_cast_literals_21023() -> None:
 
 def test_invalid_empty_cast_to_empty_enum() -> None:
     with pytest.raises(
-        InvalidOperationError, match="cannot cast to Enum without categories present"
+        InvalidOperationError, match="cannot cast / initialize Enum without categories present"
     ):
         pl.Series([], dtype=pl.Enum)


### PR DESCRIPTION
Fixes #14665.

Old behavior allowed any cast of all-null arrays to any dtype, but empty Enums should not be allowed:

```python
import polars as pl

pl.Series([]).cast(pl.Enum)  # works, but should not

# new behavior:
# polars.exceptions.InvalidOperationError: cannot cast to Enum without categories present
```