### PR TITLE
refactor: Only use chrono_tz timezones in hypothesis testing

### DIFF
--- a/crates/polars-python/src/datatypes.rs
+++ b/crates/polars-python/src/datatypes.rs
@@ -135,3 +135,12 @@ pub fn _get_dtype_min(dt: Wrap<DataType>) -> PyResult<PyExpr> {
     let v = dt.0.min().map_err(PyPolarsErr::from)?;
     Ok(dsl::lit(v).into())
 }
+
+#[pyfunction]
+pub fn _known_timezones() -> PyResult<Vec<String>> {
+    use polars_time::prelude::known_timezones;
+    Ok(known_timezones()
+        .iter()
+        .map(|tz| tz.to_string())
+        .collect::<Vec<_>>())
+}

--- a/crates/polars-time/src/lib.rs
+++ b/crates/polars-time/src/lib.rs
@@ -41,6 +41,8 @@ pub use round::*;
 #[cfg(feature = "dtype-date")]
 pub use truncate::*;
 pub use upsample::*;
+#[cfg(feature = "timezones")]
+pub use utils::known_timezones;
 pub use windows::duration::Duration;
 pub use windows::group_by::ClosedWindow;
 pub use windows::window::Window;

--- a/crates/polars-time/src/utils.rs
+++ b/crates/polars-time/src/utils.rs
@@ -9,6 +9,8 @@ use chrono::NaiveDateTime;
 #[cfg(feature = "timezones")]
 use chrono::TimeZone;
 #[cfg(feature = "timezones")]
+use chrono_tz::TZ_VARIANTS;
+#[cfg(feature = "timezones")]
 use polars_core::prelude::PolarsResult;
 
 /// Localize datetime according to given time zone.
@@ -45,4 +47,9 @@ pub(crate) fn localize_datetime_opt(
 pub(crate) fn unlocalize_datetime(ndt: NaiveDateTime, tz: &Tz) -> NaiveDateTime {
     // e.g. '2021-01-01 03:00CDT' -> '2021-01-01 03:00'
     tz.from_utc_datetime(&ndt).naive_local()
+}
+
+#[cfg(feature = "timezones")]
+pub fn known_timezones() -> [&'static str; TZ_VARIANTS.len()] {
+    core::array::from_fn(|i| TZ_VARIANTS[i].name())
 }

--- a/py-polars/polars/testing/parametric/strategies/dtype.py
+++ b/py-polars/polars/testing/parametric/strategies/dtype.py
@@ -329,8 +329,12 @@ def _time_units() -> SearchStrategy[TimeUnit]:
 
 def _time_zones() -> SearchStrategy[str]:
     """Create a strategy for generating valid time zones."""
+    # Not available when building docs, so just import here.
+    from polars.polars import _known_timezones
+
+    chrono_known_tz = set(_known_timezones())
     return st.timezone_keys(allow_prefix=False).filter(
-        lambda tz: tz not in {"Factory", "localtime"}
+        lambda tz: tz not in {"Factory", "localtime"} and tz in chrono_known_tz
     )
 
 

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -303,6 +303,8 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(datatypes::_get_dtype_min))
         .unwrap();
+    m.add_wrapped(wrap_pyfunction!(datatypes::_known_timezones))
+        .unwrap();
 
     // Exceptions - Errors
     m.add("PolarsError", py.get_type::<exceptions::PolarsError>())


### PR DESCRIPTION
Rather than reading the valid timezones (and aliases) from the local machine's zoneinfo, chrono_tz bakes the known timezones in at build time. This can result in hypothesis testing producing timezones in python that are unknown on the rust side.

To avoid this, filter out timezones that are unknown when sampling.