### PR TITLE
feat(rust): Add `polars_testing` folder with relevant files and `add_series_equal!()` functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "polars-testing"
+version = "0.46.0"
+dependencies = [
+ "polars-core",
+ "polars-ops",
+]
+
+[[package]]
 name = "polars-time"
 version = "0.46.0"
 dependencies = [

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -54,6 +54,7 @@ test:  ## Run tests
 		-p polars-plan \
 		-p polars-row \
 		-p polars-sql \
+		-p polars-testing \
 		-p polars-time \
 		-p polars-utils \
 		-- \
@@ -70,6 +71,7 @@ nextest:  ## Run tests with nextest
 		-p polars-plan \
 		-p polars-row \
 		-p polars-sql \
+		-p polars-testing \
 		-p polars-time \
 		-p polars-utils \
 

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -85,6 +85,7 @@ test-doc:  ## Run doc examples
 	    -p polars-lazy \
 	    -p polars-io \
 	    -p polars-core \
+		-p polars-testing \
 		-p polars-sql
 
 .PHONY: bench-save

--- a/crates/polars-testing/Cargo.toml
+++ b/crates/polars-testing/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "polars-testing"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "Testing Suite for the Polars DataFrame library"
+
+[dependencies]
+polars-core = { workspace = true }
+polars-ops = { workspace = true }
+
+# There is probably something missing from this file that needs to be added,
+# like in the other `Cargo.toml` files in other sub-crates.
+# It's hard for me to pinpoint exactly what is needed, so I would need
+# some guidance here.

--- a/crates/polars-testing/Cargo.toml
+++ b/crates/polars-testing/Cargo.toml
@@ -6,13 +6,8 @@ edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-description = "Testing Suite for the Polars DataFrame library"
+description = "Testing suite for the Polars DataFrame library"
 
 [dependencies]
 polars-core = { workspace = true }
 polars-ops = { workspace = true }
-
-# There is probably something missing from this file that needs to be added,
-# like in the other `Cargo.toml` files in other sub-crates.
-# It's hard for me to pinpoint exactly what is needed, so I would need
-# some guidance here.

--- a/crates/polars-testing/LICENSE
+++ b/crates/polars-testing/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2025 Ritchie Vink
+Some portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/polars-testing/README.md
+++ b/crates/polars-testing/README.md
@@ -1,0 +1,22 @@
+# polars-testing
+
+`polars-testing` is a sub-crate of the [Polars](https://crates.io/crates/polars) library, offering
+comprehensive functionality for unit testing in Rust.
+
+## Usage
+
+To use `polars-testing`, add it as a dependency to your Rust project's `Cargo.toml` file:
+
+```toml
+[dependencies]
+polars-testing = "0.46.0"
+```
+
+You can then import the crate in your Rust code using:
+
+```rust
+use polars_testing::*;
+```
+
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main
+[Polars crate](https://crates.io/crates/polars) for intended usage.

--- a/crates/polars-testing/src/asserts/mod.rs
+++ b/crates/polars-testing/src/asserts/mod.rs
@@ -1,0 +1,4 @@
+pub mod series;
+mod utils;
+
+pub use utils::{SeriesEqualOptions, assert_series_equal};

--- a/crates/polars-testing/src/asserts/series.rs
+++ b/crates/polars-testing/src/asserts/series.rs
@@ -1,0 +1,651 @@
+// **Note:** Some tests and helper functions in this file create collections using `vec![]`
+// where a direct array might seem more concise. However, these are intentionally using
+// `vec![]` to ensure runtime flexibility, support iterator methods like `.iter()`,
+// and satisfy trait bounds requiring `Clone` and `ExactSizeIterator`.
+// The tests that use this start on line 446.
+#![allow(clippy::useless_vec)]
+
+#[macro_export]
+macro_rules! assert_series_equal {
+    // **Note:** Allows the user to use the macro with custom options.
+    (custom = $left:expr, $right:expr, $options:expr) => {
+        match $crate::asserts::assert_series_equal($left, $right, $options) {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e),
+        }
+    };
+    // **Note:** Allows the user to use the macro with default options enabled.
+    (default = $left:expr, $right:expr) => {
+        match $crate::asserts::assert_series_equal(
+            $left,
+            $right,
+            $crate::asserts::SeriesEqualOptions::default(),
+        ) {
+            Ok(_) => {},
+            Err(e) => panic!("{}", e),
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use polars_core::prelude::*;
+    use polars_core::{disable_string_cache, enable_string_cache};
+
+    // Testing default struct implementation
+    #[test]
+    fn test_series_equal_options() {
+        let options = crate::asserts::SeriesEqualOptions::default();
+
+        assert!(options.check_dtypes);
+        assert!(options.check_names);
+        assert!(options.check_order);
+        assert!(options.check_exact);
+        assert_eq!(options.rtol, 1e-5);
+        assert_eq!(options.atol, 1e-8);
+        assert!(!options.categorical_as_str);
+    }
+
+    // Testing with basic parameters
+    #[test]
+    #[should_panic(expected = "length mismatch")]
+    fn test_series_length_mismatch() {
+        let s1 = Series::new("".into(), &[1, 2]);
+        let s2 = Series::new("".into(), &[1, 2, 3]);
+
+        assert_series_equal!(default = &s1, &s2)
+    }
+
+    #[test]
+    #[should_panic(expected = "name mismatch")]
+    fn test_series_names_mismatch() {
+        let s1 = Series::new("s1".into(), &[1, 2, 3]);
+        let s2 = Series::new("s2".into(), &[1, 2, 3]);
+
+        assert_series_equal!(default = &s1, &s2)
+    }
+
+    #[test]
+    fn test_series_check_names_false() {
+        let s1 = Series::new("s1".into(), &[1, 2, 3]);
+        let s2 = Series::new("s2".into(), &[1, 2, 3]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_names(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    #[should_panic(expected = "data type mismatch")]
+    fn test_series_dtype_mismatch() {
+        let s1 = Series::new("".into(), &[1, 2, 3]);
+        let s2 = Series::new("".into(), &["1", "2", "3"]);
+
+        assert_series_equal!(default = &s1, &s2)
+    }
+
+    #[test]
+    fn test_series_check_dtypes_false() {
+        let s1 = Series::new("s1".into(), &[1, 2, 3]);
+        let s2 = Series::new("s1".into(), &[1.0, 2.0, 3.0]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_dtypes(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    // Testing basic equality
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_value_mismatch_int() {
+        let s1 = Series::new("".into(), &[1, 2, 3]);
+        let s2 = Series::new("".into(), &[2, 3, 4]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_values_match_int() {
+        let s1 = Series::new("".into(), &[1, 2, 3]);
+        let s2 = Series::new("".into(), &[1, 2, 3]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_value_mismatch_str() {
+        let s1 = Series::new("".into(), &["foo", "bar"]);
+        let s2 = Series::new("".into(), &["moo", "car"]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_values_match_str() {
+        let s1 = Series::new("".into(), &["foo", "bar"]);
+        let s2 = Series::new("".into(), &["foo", "bar"]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_values_mismatch_float() {
+        let s1 = Series::new("".into(), &[1.1, 2.2, 3.3]);
+        let s2 = Series::new("".into(), &[2.2, 3.3, 4.4]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_values_match_float() {
+        let s1 = Series::new("".into(), &[1.1, 2.2, 3.3]);
+        let s2 = Series::new("".into(), &[1.1, 2.2, 3.3]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    // Testing float value precision equality
+    #[test]
+    #[should_panic(expected = "values not within tolerance")]
+    fn test_series_float_exceeded_tol() {
+        let s1 = Series::new("".into(), &[1.0, 2.2, 3.3]);
+        let s2 = Series::new("".into(), &[1.00012, 2.200025, 3.300035]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    fn test_series_float_within_tol() {
+        let s1 = Series::new("".into(), &[1.0, 2.0, 3.0]);
+        let s2 = Series::new("".into(), &[1.000005, 2.000015, 3.000025]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    fn test_series_float_exact_tolerance_boundary() {
+        let s1 = Series::new("".into(), &[1.0, 2.0, 3.0]);
+        let s2 = Series::new("".into(), &[1.0, 2.0 + 1e-5, 3.0]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    fn test_series_float_custom_rtol() {
+        let s1 = Series::new("".into(), &[10.0, 100.0, 1000.0]);
+        let s2 = Series::new("".into(), &[10.05, 100.1, 1000.2]);
+
+        let options = crate::asserts::SeriesEqualOptions::default()
+            .with_check_exact(false)
+            .with_rtol(0.01);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    #[should_panic(expected = "values not within tolerance")]
+    fn test_series_float_custom_atol() {
+        let s1 = Series::new("".into(), &[0.001, 0.01, 0.1]);
+        let s2 = Series::new("".into(), &[0.001, 0.02, 0.1]);
+
+        let options = crate::asserts::SeriesEqualOptions::default()
+            .with_check_exact(false)
+            .with_atol(0.005);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    // Testing equality with special values
+    #[test]
+    fn test_series_empty_equal() {
+        let s1 = Series::default();
+        let s2 = Series::default();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_nan_equal() {
+        let s1 = Series::new("".into(), &[f64::NAN, f64::NAN, f64::NAN]);
+        let s2 = Series::new("".into(), &[f64::NAN, f64::NAN, f64::NAN]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_null_equal() {
+        let s1 = Series::new("".into(), &[None::<i32>, None::<i32>, None::<i32>]);
+        let s2 = Series::new("".into(), &[None::<i32>, None::<i32>, None::<i32>]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_infinity_values_mismatch() {
+        let s1 = Series::new("".into(), &[1.0, f64::INFINITY, 3.0]);
+        let s2 = Series::new("".into(), &[1.0, f64::NEG_INFINITY, 3.0]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_infinity_values_match() {
+        let s1 = Series::new("".into(), &[1.0, f64::INFINITY, f64::NEG_INFINITY]);
+        let s2 = Series::new("".into(), &[1.0, f64::INFINITY, f64::NEG_INFINITY]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    // Testing null and nan counts for floats
+    #[test]
+    #[should_panic(expected = "null value mismatch")]
+    fn test_series_check_exact_false_null() {
+        let s1 = Series::new("".into(), &[Some(1.0), None::<f64>, Some(3.0)]);
+        let s2 = Series::new("".into(), &[Some(1.0), Some(2.0), Some(3.0)]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    #[should_panic(expected = "nan value mismatch")]
+    fn test_series_check_exact_false_nan() {
+        let s1 = Series::new("".into(), &[1.0, f64::NAN, 3.0]);
+        let s2 = Series::new("".into(), &[1.0, 2.0, 3.0]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    // Testing sorting operations
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_sorting_unequal() {
+        let s1 = Series::new("".into(), &[Some(1), Some(2), Some(3), None::<i32>]);
+        let s2 = Series::new("".into(), &[Some(2), None::<i32>, Some(3), Some(1)]);
+
+        let options = crate::asserts::SeriesEqualOptions::default();
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    fn test_series_sorting_equal() {
+        let s1 = Series::new("".into(), &[Some(1), Some(2), Some(3), None::<i32>]);
+        let s2 = Series::new("".into(), &[Some(2), None::<i32>, Some(3), Some(1)]);
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_check_order(false);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    // Testing categorical operations
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_categorical_mismatch() {
+        enable_string_cache();
+
+        let s1 = Series::new("".into(), &["apple", "banana", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+        let s2 = Series::new("".into(), &["apple", "orange", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+
+        disable_string_cache();
+    }
+
+    #[test]
+    fn test_series_categorical_match() {
+        let s1 = Series::new("".into(), &["apple", "banana", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+        let s2 = Series::new("".into(), &["apple", "banana", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_categorical_str_mismatch() {
+        let s1 = Series::new("".into(), &["apple", "banana", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+        let s2 = Series::new("".into(), &["apple", "orange", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_categorical_as_str(true);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    #[test]
+    fn test_series_categorical_str_match() {
+        let s1 = Series::new("".into(), &["apple", "banana", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+        let s2 = Series::new("".into(), &["apple", "banana", "cherry"])
+            .cast(&DataType::Categorical(None, Default::default()))
+            .unwrap();
+
+        let options = crate::asserts::SeriesEqualOptions::default().with_categorical_as_str(true);
+
+        assert_series_equal!(custom = &s1, &s2, options);
+    }
+
+    // Testing equality of nested values
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_list_values_int_mismatch() {
+        let s1 = Series::new(
+            "".into(),
+            &[
+                [1, 2, 3].iter().collect::<Series>(),
+                [4, 5, 6].iter().collect::<Series>(),
+                [7, 8, 9].iter().collect::<Series>(),
+            ],
+        );
+
+        let s2 = Series::new(
+            "".into(),
+            &[
+                [0, 2, 3].iter().collect::<Series>(),
+                [4, 7, 6].iter().collect::<Series>(),
+                [7, 8, 10].iter().collect::<Series>(),
+            ],
+        );
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_list_values_int_match() {
+        let s1 = Series::new(
+            "".into(),
+            &[
+                [1, 2, 3].iter().collect::<Series>(),
+                [4, 5, 6].iter().collect::<Series>(),
+                [7, 8, 9].iter().collect::<Series>(),
+            ],
+        );
+
+        let s2 = Series::new(
+            "".into(),
+            &[
+                [1, 2, 3].iter().collect::<Series>(),
+                [4, 5, 6].iter().collect::<Series>(),
+                [7, 8, 9].iter().collect::<Series>(),
+            ],
+        );
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    #[should_panic(expected = "nested value mismatch")]
+    fn test_series_list_values_float_mismatch() {
+        let s1 = Series::new(
+            "".into(),
+            &[
+                [1.1, 2.0, 3.0].iter().collect::<Series>(),
+                [4.0, 5.0, 6.0].iter().collect::<Series>(),
+                [7.0, 8.0, 9.0].iter().collect::<Series>(),
+            ],
+        );
+
+        let s2 = Series::new(
+            "".into(),
+            &[
+                [0.5, 2.0, 3.0].iter().collect::<Series>(),
+                [4.0, 7.5, 6.0].iter().collect::<Series>(),
+                [7.0, 8.0, 10.2].iter().collect::<Series>(),
+            ],
+        );
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_list_values_float_match() {
+        let s1 = Series::new(
+            "".into(),
+            &[
+                [1.1, 2.0, 3.0].iter().collect::<Series>(),
+                [4.0, 5.0, 6.0].iter().collect::<Series>(),
+                [7.0, 8.0, 9.0].iter().collect::<Series>(),
+            ],
+        );
+
+        let s2 = Series::new(
+            "".into(),
+            &[
+                [1.1, 2.0, 3.0].iter().collect::<Series>(),
+                [4.0, 5.0, 6.0].iter().collect::<Series>(),
+                [7.0, 8.0, 9.0].iter().collect::<Series>(),
+            ],
+        );
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_struct_values_str_mismatch() {
+        let field1 = Series::new("field1".into(), &["a", "d", "g"]);
+        let field2 = Series::new("field2".into(), &["b", "e", "h"]);
+
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s1_fields = vec![field1.clone(), field2.clone()];
+        let s1_struct =
+            StructChunked::from_series("".into(), field1.len(), s1_fields.iter()).unwrap();
+        let s1 = s1_struct.into_series();
+
+        let field1_alt = Series::new("field1".into(), &["a", "DIFFERENT", "g"]);
+        let field2_alt = Series::new("field2".into(), &["b", "e", "h"]);
+
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s2_fields = vec![field1_alt.clone(), field2_alt.clone()];
+        let s2_struct =
+            StructChunked::from_series("".into(), field1_alt.len(), s2_fields.iter()).unwrap();
+        let s2 = s2_struct.into_series();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_struct_values_str_match() {
+        let field1 = Series::new("field1".into(), &["a", "d", "g"]);
+        let field2 = Series::new("field2".into(), &["b", "e", "h"]);
+
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s1_fields = vec![field1.clone(), field2.clone()];
+        let s1_struct =
+            StructChunked::from_series("".into(), field1.len(), s1_fields.iter()).unwrap();
+        let s1 = s1_struct.into_series();
+
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s2_fields = vec![field1.clone(), field2.clone()];
+        let s2_struct =
+            StructChunked::from_series("".into(), field1.len(), s2_fields.iter()).unwrap();
+        let s2 = s2_struct.into_series();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_struct_values_mixed_mismatch() {
+        let id = Series::new("id".into(), &[1, 2, 3]);
+        let value = Series::new("value".into(), &["a", "b", "c"]);
+        let active = Series::new("active".into(), &[true, false, true]);
+
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s1_fields = vec![id.clone(), value.clone(), active.clone()];
+        let s1_struct = StructChunked::from_series("".into(), id.len(), s1_fields.iter()).unwrap();
+        let s1 = s1_struct.into_series();
+
+        let id_alt = Series::new("id".into(), &[1, 99, 3]);
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s2_fields = vec![id_alt.clone(), value.clone(), active.clone()];
+        let s2_struct = StructChunked::from_series("".into(), id.len(), s2_fields.iter()).unwrap();
+        let s2 = s2_struct.into_series();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_struct_values_mixed_match() {
+        let id = Series::new("id".into(), &[1, 2, 3]);
+        let value = Series::new("value".into(), &["a", "b", "c"]);
+        let active = Series::new("active".into(), &[true, false, true]);
+
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s1_fields = vec![id.clone(), value.clone(), active.clone()];
+        let s1_struct = StructChunked::from_series("".into(), id.len(), s1_fields.iter()).unwrap();
+        let s1 = s1_struct.into_series();
+
+        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
+        // it can be an array, for example `[field1.clone(), field2.clone()]`.
+        let s2_fields = vec![id.clone(), value.clone(), active.clone()];
+        let s2_struct = StructChunked::from_series("".into(), id.len(), s2_fields.iter()).unwrap();
+        let s2 = s2_struct.into_series();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    // Testing equality of deeply nested values
+    #[test]
+    #[should_panic(expected = "nested value mismatch")]
+    fn test_deeply_nested_list_float_mismatch() {
+        let inner_list_1 = Series::new("inner".into(), &[1.0, 2.0]);
+        let outer_list_1 = Series::new("outer".into(), &[inner_list_1]);
+        let s1 = Series::new("nested".into(), &[outer_list_1]);
+
+        let inner_list_2 = Series::new("inner".into(), &[1.0, 3.0]);
+        let outer_list_2 = Series::new("outer".into(), &[inner_list_2]);
+        let s2 = Series::new("nested".into(), &[outer_list_2]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+    #[test]
+    fn test_deeply_nested_list_float_match() {
+        let inner_list_1 = Series::new("".into(), &[1.0, 2.0]);
+        let outer_list_1 = Series::new("".into(), &[inner_list_1]);
+
+        let s1 = Series::new("".into(), &[outer_list_1]);
+
+        let inner_list_2 = Series::new("".into(), &[1.0, 2.0]);
+        let outer_list_2 = Series::new("".into(), &[inner_list_2]);
+        let s2 = Series::new("".into(), &[outer_list_2]);
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    // Testing equality of temporal types
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_datetime_values_mismatch() {
+        let dt1: i64 = 1672567200000000000;
+        let dt2: i64 = 1672653600000000000;
+        let dt3: i64 = 1672657200000000000;
+
+        let s1 = Series::new("".into(), &[dt1, dt2])
+            .cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))
+            .unwrap();
+        let s2 = Series::new("".into(), &[dt1, dt3])
+            .cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_datetime_values_match() {
+        let dt1: i64 = 1672567200000000000;
+        let dt2: i64 = 1672653600000000000;
+
+        let s1 = Series::new("".into(), &[dt1, dt2])
+            .cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))
+            .unwrap();
+        let s2 = Series::new("".into(), &[dt1, dt2])
+            .cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    // Testing equality of decimal types
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_decimal_values_mismatch() {
+        let s1 = Series::new("".into(), &[1, 2])
+            .cast(&DataType::Decimal(Some(10), Some(2)))
+            .unwrap();
+        let s2 = Series::new("".into(), &[1, 3])
+            .cast(&DataType::Decimal(Some(10), Some(2)))
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_decimal_values_match() {
+        let s1 = Series::new("".into(), &[1, 2])
+            .cast(&DataType::Decimal(Some(10), Some(2)))
+            .unwrap();
+        let s2 = Series::new("".into(), &[1, 2])
+            .cast(&DataType::Decimal(Some(10), Some(2)))
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    // Testing equality of binary types
+    #[test]
+    #[should_panic(expected = "exact value mismatch")]
+    fn test_series_binary_values_mismatch() {
+        let s1 = Series::new("".into(), &[vec![1u8, 2, 3], vec![4, 5, 6]])
+            .cast(&DataType::Binary)
+            .unwrap();
+        let s2 = Series::new("".into(), &[vec![1u8, 2, 3], vec![4, 5, 7]])
+            .cast(&DataType::Binary)
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+
+    #[test]
+    fn test_series_binary_values_match() {
+        let s1 = Series::new("".into(), &[vec![1u8, 2, 3], vec![4, 5, 6]])
+            .cast(&DataType::Binary)
+            .unwrap();
+        let s2 = Series::new("".into(), &[vec![1u8, 2, 3], vec![4, 5, 6]])
+            .cast(&DataType::Binary)
+            .unwrap();
+
+        assert_series_equal!(default = &s1, &s2);
+    }
+}

--- a/crates/polars-testing/src/asserts/series.rs
+++ b/crates/polars-testing/src/asserts/series.rs
@@ -1,28 +1,48 @@
-// **Note:** Some tests and helper functions in this file create collections using `vec![]`
-// where a direct array might seem more concise. However, these are intentionally using
-// `vec![]` to ensure runtime flexibility, support iterator methods like `.iter()`,
-// and satisfy trait bounds requiring `Clone` and `ExactSizeIterator`.
-// The tests that use this start on line 446.
-#![allow(clippy::useless_vec)]
-
+/// Asserts that two series are equal according to the specified options.
+///
+/// This macro compares two Polars Series objects and panics with a detailed error message if they are not equal.
+/// It provides two forms:
+/// - With custom comparison options
+/// - With default comparison options
+///
+/// # Example
+///
+/// ```
+/// use polars_core::prelude::*;
+/// use polars_testing::assert_series_equal;
+/// use polars_testing::asserts::SeriesEqualOptions;
+///
+/// // Create two series to compare
+/// let s1 = Series::new("a".into(), &[1, 2, 3]);
+/// let s2 = Series::new("a".into(), &[1, 2, 3]);
+///
+/// // Assert with default options
+/// assert_series_equal!(&s1, &s2);
+///
+/// // Assert with custom options
+/// let options = SeriesEqualOptions::default()
+///     .with_check_exact(true)
+///     .with_check_dtypes(false);
+/// assert_series_equal!(&s1, &s2, options);
+/// ```
+///
+/// # Panics
+///
+/// Panics when the series are not equal according to the specified comparison criteria.
+///
 #[macro_export]
 macro_rules! assert_series_equal {
-    // **Note:** Allows the user to use the macro with custom options.
-    (custom = $left:expr, $right:expr, $options:expr) => {
-        match $crate::asserts::assert_series_equal($left, $right, $options) {
-            Ok(_) => {},
-            Err(e) => panic!("{}", e),
-        }
-    };
-    // **Note:** Allows the user to use the macro with default options enabled.
-    (default = $left:expr, $right:expr) => {
-        match $crate::asserts::assert_series_equal(
-            $left,
-            $right,
-            $crate::asserts::SeriesEqualOptions::default(),
-        ) {
-            Ok(_) => {},
-            Err(e) => panic!("{}", e),
+    ($left:expr, $right:expr $(, $options:expr)?) => {
+        {
+            #[allow(unused_assignments)]
+            #[allow(unused_mut)]
+            let mut options = $crate::asserts::SeriesEqualOptions::default();
+            $(options = $options;)?
+            
+            match $crate::asserts::assert_series_equal($left, $right, options) {
+                Ok(_) => {},
+                Err(e) => panic!("{}", e),
+            }
         }
     };
 }
@@ -53,7 +73,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1, 2]);
         let s2 = Series::new("".into(), &[1, 2, 3]);
 
-        assert_series_equal!(default = &s1, &s2)
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -62,7 +82,7 @@ mod tests {
         let s1 = Series::new("s1".into(), &[1, 2, 3]);
         let s2 = Series::new("s2".into(), &[1, 2, 3]);
 
-        assert_series_equal!(default = &s1, &s2)
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -72,7 +92,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_names(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -81,7 +101,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1, 2, 3]);
         let s2 = Series::new("".into(), &["1", "2", "3"]);
 
-        assert_series_equal!(default = &s1, &s2)
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -91,7 +111,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_dtypes(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     // Testing basic equality
@@ -101,7 +121,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1, 2, 3]);
         let s2 = Series::new("".into(), &[2, 3, 4]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -109,7 +129,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1, 2, 3]);
         let s2 = Series::new("".into(), &[1, 2, 3]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -118,7 +138,7 @@ mod tests {
         let s1 = Series::new("".into(), &["foo", "bar"]);
         let s2 = Series::new("".into(), &["moo", "car"]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -126,7 +146,7 @@ mod tests {
         let s1 = Series::new("".into(), &["foo", "bar"]);
         let s2 = Series::new("".into(), &["foo", "bar"]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -135,7 +155,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1.1, 2.2, 3.3]);
         let s2 = Series::new("".into(), &[2.2, 3.3, 4.4]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -143,7 +163,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1.1, 2.2, 3.3]);
         let s2 = Series::new("".into(), &[1.1, 2.2, 3.3]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     // Testing float value precision equality
@@ -155,7 +175,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -165,7 +185,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -175,7 +195,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -187,7 +207,7 @@ mod tests {
             .with_check_exact(false)
             .with_rtol(0.01);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -200,7 +220,7 @@ mod tests {
             .with_check_exact(false)
             .with_atol(0.005);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     // Testing equality with special values
@@ -209,7 +229,7 @@ mod tests {
         let s1 = Series::default();
         let s2 = Series::default();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -217,7 +237,7 @@ mod tests {
         let s1 = Series::new("".into(), &[f64::NAN, f64::NAN, f64::NAN]);
         let s2 = Series::new("".into(), &[f64::NAN, f64::NAN, f64::NAN]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -225,7 +245,7 @@ mod tests {
         let s1 = Series::new("".into(), &[None::<i32>, None::<i32>, None::<i32>]);
         let s2 = Series::new("".into(), &[None::<i32>, None::<i32>, None::<i32>]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -234,7 +254,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1.0, f64::INFINITY, 3.0]);
         let s2 = Series::new("".into(), &[1.0, f64::NEG_INFINITY, 3.0]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -242,7 +262,7 @@ mod tests {
         let s1 = Series::new("".into(), &[1.0, f64::INFINITY, f64::NEG_INFINITY]);
         let s2 = Series::new("".into(), &[1.0, f64::INFINITY, f64::NEG_INFINITY]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     // Testing null and nan counts for floats
@@ -254,7 +274,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -265,7 +285,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_exact(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     // Testing sorting operations
@@ -277,7 +297,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default();
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -287,7 +307,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_check_order(false);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     // Testing categorical operations
@@ -303,7 +323,7 @@ mod tests {
             .cast(&DataType::Categorical(None, Default::default()))
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
 
         disable_string_cache();
     }
@@ -317,7 +337,7 @@ mod tests {
             .cast(&DataType::Categorical(None, Default::default()))
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -332,7 +352,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_categorical_as_str(true);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     #[test]
@@ -346,7 +366,7 @@ mod tests {
 
         let options = crate::asserts::SeriesEqualOptions::default().with_categorical_as_str(true);
 
-        assert_series_equal!(custom = &s1, &s2, options);
+        assert_series_equal!(&s1, &s2, options);
     }
 
     // Testing equality of nested values
@@ -371,7 +391,7 @@ mod tests {
             ],
         );
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -394,7 +414,7 @@ mod tests {
             ],
         );
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -418,7 +438,7 @@ mod tests {
             ],
         );
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -441,7 +461,7 @@ mod tests {
             ],
         );
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -450,9 +470,7 @@ mod tests {
         let field1 = Series::new("field1".into(), &["a", "d", "g"]);
         let field2 = Series::new("field2".into(), &["b", "e", "h"]);
 
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s1_fields = vec![field1.clone(), field2.clone()];
+        let s1_fields = [field1.clone(), field2.clone()];
         let s1_struct =
             StructChunked::from_series("".into(), field1.len(), s1_fields.iter()).unwrap();
         let s1 = s1_struct.into_series();
@@ -460,14 +478,12 @@ mod tests {
         let field1_alt = Series::new("field1".into(), &["a", "DIFFERENT", "g"]);
         let field2_alt = Series::new("field2".into(), &["b", "e", "h"]);
 
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s2_fields = vec![field1_alt.clone(), field2_alt.clone()];
+        let s2_fields = [field1_alt.clone(), field2_alt.clone()];
         let s2_struct =
             StructChunked::from_series("".into(), field1_alt.len(), s2_fields.iter()).unwrap();
         let s2 = s2_struct.into_series();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -475,21 +491,17 @@ mod tests {
         let field1 = Series::new("field1".into(), &["a", "d", "g"]);
         let field2 = Series::new("field2".into(), &["b", "e", "h"]);
 
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s1_fields = vec![field1.clone(), field2.clone()];
+        let s1_fields = [field1.clone(), field2.clone()];
         let s1_struct =
             StructChunked::from_series("".into(), field1.len(), s1_fields.iter()).unwrap();
         let s1 = s1_struct.into_series();
 
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s2_fields = vec![field1.clone(), field2.clone()];
+        let s2_fields = [field1.clone(), field2.clone()];
         let s2_struct =
             StructChunked::from_series("".into(), field1.len(), s2_fields.iter()).unwrap();
         let s2 = s2_struct.into_series();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -499,20 +511,16 @@ mod tests {
         let value = Series::new("value".into(), &["a", "b", "c"]);
         let active = Series::new("active".into(), &[true, false, true]);
 
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s1_fields = vec![id.clone(), value.clone(), active.clone()];
+        let s1_fields = [id.clone(), value.clone(), active.clone()];
         let s1_struct = StructChunked::from_series("".into(), id.len(), s1_fields.iter()).unwrap();
         let s1 = s1_struct.into_series();
 
         let id_alt = Series::new("id".into(), &[1, 99, 3]);
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s2_fields = vec![id_alt.clone(), value.clone(), active.clone()];
+        let s2_fields = [id_alt.clone(), value.clone(), active.clone()];
         let s2_struct = StructChunked::from_series("".into(), id.len(), s2_fields.iter()).unwrap();
         let s2 = s2_struct.into_series();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -521,19 +529,15 @@ mod tests {
         let value = Series::new("value".into(), &["a", "b", "c"]);
         let active = Series::new("active".into(), &[true, false, true]);
 
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s1_fields = vec![id.clone(), value.clone(), active.clone()];
+        let s1_fields = [id.clone(), value.clone(), active.clone()];
         let s1_struct = StructChunked::from_series("".into(), id.len(), s1_fields.iter()).unwrap();
         let s1 = s1_struct.into_series();
 
-        // **Note**: This is where Clippy warns about an unnecessary `vec!`. Says 
-        // it can be an array, for example `[field1.clone(), field2.clone()]`.
-        let s2_fields = vec![id.clone(), value.clone(), active.clone()];
+        let s2_fields = [id.clone(), value.clone(), active.clone()];
         let s2_struct = StructChunked::from_series("".into(), id.len(), s2_fields.iter()).unwrap();
         let s2 = s2_struct.into_series();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     // Testing equality of deeply nested values
@@ -548,7 +552,7 @@ mod tests {
         let outer_list_2 = Series::new("outer".into(), &[inner_list_2]);
         let s2 = Series::new("nested".into(), &[outer_list_2]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
     #[test]
     fn test_deeply_nested_list_float_match() {
@@ -561,7 +565,7 @@ mod tests {
         let outer_list_2 = Series::new("".into(), &[inner_list_2]);
         let s2 = Series::new("".into(), &[outer_list_2]);
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     // Testing equality of temporal types
@@ -579,7 +583,7 @@ mod tests {
             .cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -594,7 +598,7 @@ mod tests {
             .cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     // Testing equality of decimal types
@@ -608,7 +612,7 @@ mod tests {
             .cast(&DataType::Decimal(Some(10), Some(2)))
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -620,7 +624,7 @@ mod tests {
             .cast(&DataType::Decimal(Some(10), Some(2)))
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     // Testing equality of binary types
@@ -634,7 +638,7 @@ mod tests {
             .cast(&DataType::Binary)
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 
     #[test]
@@ -646,6 +650,6 @@ mod tests {
             .cast(&DataType::Binary)
             .unwrap();
 
-        assert_series_equal!(default = &s1, &s2);
+        assert_series_equal!(&s1, &s2);
     }
 }

--- a/crates/polars-testing/src/asserts/series.rs
+++ b/crates/polars-testing/src/asserts/series.rs
@@ -38,7 +38,7 @@ macro_rules! assert_series_equal {
             #[allow(unused_mut)]
             let mut options = $crate::asserts::SeriesEqualOptions::default();
             $(options = $options;)?
-            
+
             match $crate::asserts::assert_series_equal($left, $right, options) {
                 Ok(_) => {},
                 Err(e) => panic!("{}", e),

--- a/crates/polars-testing/src/asserts/utils.rs
+++ b/crates/polars-testing/src/asserts/utils.rs
@@ -1,0 +1,458 @@
+use std::ops::{BitAnd, BitOr, BitXor, Not};
+
+use polars_core::datatypes::unpack_dtypes;
+use polars_core::prelude::*;
+use polars_ops::series::abs;
+
+// **Note:** Created a struct with a default implementation
+// for the user to create default arguments. This seems to be the
+// idiomatic approach and resolves Clippy's "too many parameters (9/7)"
+// suggestion.
+pub struct SeriesEqualOptions {
+    pub check_dtypes: bool,
+    pub check_names: bool,
+    pub check_order: bool,
+    pub check_exact: bool,
+    pub rtol: f64,
+    pub atol: f64,
+    pub categorical_as_str: bool,
+}
+
+impl Default for SeriesEqualOptions {
+    fn default() -> Self {
+        Self {
+            check_dtypes: true,
+            check_names: true,
+            check_order: true,
+            check_exact: true,
+            rtol: 1e-5,
+            atol: 1e-8,
+            categorical_as_str: false,
+        }
+    }
+}
+
+impl SeriesEqualOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_check_dtypes(mut self, value: bool) -> Self {
+        self.check_dtypes = value;
+        self
+    }
+
+    pub fn with_check_names(mut self, value: bool) -> Self {
+        self.check_names = value;
+        self
+    }
+
+    pub fn with_check_order(mut self, value: bool) -> Self {
+        self.check_order = value;
+        self
+    }
+
+    pub fn with_check_exact(mut self, value: bool) -> Self {
+        self.check_exact = value;
+        self
+    }
+
+    pub fn with_rtol(mut self, value: f64) -> Self {
+        self.rtol = value;
+        self
+    }
+
+    pub fn with_atol(mut self, value: f64) -> Self {
+        self.atol = value;
+        self
+    }
+
+    pub fn with_categorical_as_str(mut self, value: bool) -> Self {
+        self.categorical_as_str = value;
+        self
+    }
+}
+
+pub fn categorical_dtype_to_string_dtype(dtype: &DataType) -> DataType {
+    match dtype {
+        DataType::Categorical(..) => DataType::String,
+        DataType::List(inner) => {
+            let inner_cast = categorical_dtype_to_string_dtype(inner);
+            DataType::List(Box::new(inner_cast))
+        },
+        DataType::Array(inner, size) => {
+            let inner_cast = categorical_dtype_to_string_dtype(inner);
+            DataType::Array(Box::new(inner_cast), *size)
+        },
+        DataType::Struct(fields) => {
+            let transformed_fields = fields
+                .iter()
+                .map(|field| {
+                    Field::new(
+                        field.name().clone(),
+                        categorical_dtype_to_string_dtype(field.dtype()),
+                    )
+                })
+                .collect::<Vec<Field>>();
+
+            DataType::Struct(transformed_fields)
+        },
+        _ => dtype.clone(),
+    }
+}
+
+pub fn categorical_series_to_string(s: &Series) -> Series {
+    let dtype = s.dtype();
+    let noncat_dtype = categorical_dtype_to_string_dtype(dtype);
+
+    if *dtype != noncat_dtype {
+        s.cast(&noncat_dtype).unwrap()
+    } else {
+        s.clone()
+    }
+}
+
+pub fn comparing_floats(left: &DataType, right: &DataType) -> bool {
+    left.is_float() && right.is_float()
+}
+
+pub fn comparing_lists(left: &DataType, right: &DataType) -> bool {
+    matches!(left, DataType::List(_) | DataType::Array(_, _))
+        && matches!(right, DataType::List(_) | DataType::Array(_, _))
+}
+
+pub fn comparing_structs(left: &DataType, right: &DataType) -> bool {
+    left.is_struct() && right.is_struct()
+}
+
+// **Change**: When translating this code to Rust, there originally was
+// no `unpack_dtypes()` functionality in the code base, so I created it in
+// `polars-core/src/datatypes/dtype.rs` and Gijs merged the PR (#21574).
+pub fn comparing_nested_floats(left: &DataType, right: &DataType) -> bool {
+    if !comparing_lists(left, right) && !comparing_structs(left, right) {
+        return false;
+    }
+
+    let left_dtypes = unpack_dtypes(left, false);
+    let right_dtypes = unpack_dtypes(right, false);
+
+    let left_has_floats = left_dtypes.iter().any(|dt| dt.is_float());
+    let right_has_floats = right_dtypes.iter().any(|dt| dt.is_float());
+
+    left_has_floats && right_has_floats
+}
+
+// **Change:** The Python function originally took both `left` and `right`
+// as input parameters and returned both, but I just made it take a
+// single Series and used tuple destructuring.
+pub fn sort_series(s: &Series) -> PolarsResult<Series> {
+    s.sort(SortOptions::default())
+        .map_err(|_| polars_err!(op = "sort", s.dtype()))
+}
+
+pub fn assert_series_null_values_match(left: &Series, right: &Series) -> PolarsResult<()> {
+    let null_value_mismatch = left.is_null().not_equal(&right.is_null());
+
+    // **Change**: Rather than simply returning the Series as Lists
+    // I thought it made more sense to return null value counts from the
+    // left and right Series
+    if null_value_mismatch.any() {
+        return Err(polars_err!(
+            assertion_error = "Series",
+            "null value mismatch",
+            left.null_count(),
+            right.null_count()
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn assert_series_nan_values_match(left: &Series, right: &Series) -> PolarsResult<()> {
+    if !comparing_floats(left.dtype(), right.dtype()) {
+        return Ok(());
+    }
+    let left_nan = left.is_nan()?;
+    let right_nan = right.is_nan()?;
+
+    let nan_value_mismatch = left_nan.not_equal(&right_nan);
+
+    // **Change**: Rather than simply returning the Series as Lists
+    // I thought it made more sense to return NaN value counts from the
+    // left and right Series
+    let left_nan_count = left_nan.sum().unwrap_or(0);
+    let right_nan_count = right_nan.sum().unwrap_or(0);
+
+    if nan_value_mismatch.any() {
+        return Err(polars_err!(
+            assertion_error = "Series",
+            "nan value mismatch",
+            left_nan_count,
+            right_nan_count
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn assert_series_values_within_tolerance(
+    left: &Series,
+    right: &Series,
+    // **Change**: In Python, this input type is a Series,
+    // but in Rust, to use the `.filter()` method on a Series
+    // the object inside the filter must be a `ChunkedArray`.
+    unequal: &ChunkedArray<BooleanType>,
+    rtol: f64,
+    atol: f64,
+) -> PolarsResult<()> {
+    let left_unequal = left.filter(unequal)?;
+    let right_unequal = right.filter(unequal)?;
+
+    let difference = (&left_unequal - &right_unequal)?;
+    let abs_difference = abs(&difference)?;
+
+    let right_abs = abs(&right_unequal)?;
+
+    // **Change**: The scalar values needed to be converted into Series
+    // so that arithmetic operations between the Series could happen.
+    // I looked through the Rust API documentation and didn't see
+    // any method for multiplying a Series by a scalar.
+    let rtol_series = Series::new("rtol".into(), &[rtol]);
+    let atol_series = Series::new("atol".into(), &[atol]);
+
+    let rtol_part = (&right_abs * &rtol_series)?;
+    let tolerance = (&rtol_part + &atol_series)?;
+
+    let finite_mask = right_unequal.is_finite()?;
+    let diff_within_tol = abs_difference.lt_eq(&tolerance)?;
+    let equal_values = left_unequal.equal(&right_unequal)?;
+
+    let within_tolerance = (diff_within_tol & finite_mask) | equal_values;
+
+    if within_tolerance.all() {
+        Ok(())
+    } else {
+        // **Change**: Rather than simply returning the Series as Lists
+        // I thought it made more sense to return the problematic values in both
+        // left and right Series
+        let exceeded_indices = within_tolerance.not();
+        let problematic_left = left_unequal.filter(&exceeded_indices)?;
+        let problematic_right = right_unequal.filter(&exceeded_indices)?;
+
+        Err(polars_err!(
+            assertion_error = "Series",
+            "values not within tolerance",
+            problematic_left,
+            problematic_right
+        ))
+    }
+}
+
+pub fn assert_series_values_equal(
+    left: &Series,
+    right: &Series,
+    check_order: bool,
+    check_exact: bool,
+    rtol: f64,
+    atol: f64,
+    categorical_as_str: bool,
+) -> PolarsResult<()> {
+    let (left, right) = if categorical_as_str {
+        (
+            categorical_series_to_string(left),
+            categorical_series_to_string(right),
+        )
+    } else {
+        (left.clone(), right.clone())
+    };
+
+    let (left, right) = if !check_order {
+        (sort_series(&left)?, sort_series(&right)?)
+    } else {
+        (left.clone(), right.clone())
+    };
+
+    // **Change**: After looking through the Rust API documentation, it seems
+    // there is no direct `ne_missing()` function in Rust like there is in
+    // Python for Series, so I had to break it down into smaller parts
+    // which can be refactored later, if that functionality is eventually made.
+    let left_null = left.is_null();
+    let right_null = right.is_null();
+    let null_mismatch = left_null.clone().bitxor(right_null.clone());
+
+    let values_equal = left.equal(&right)?;
+    let both_null = left_null.bitand(right_null);
+
+    let combined_equal = values_equal.bitor(both_null);
+    let unequal = combined_equal.not().bitor(null_mismatch);
+
+    if comparing_nested_floats(left.dtype(), right.dtype()) {
+        let filtered_left = left.filter(&unequal)?;
+        let filtered_right = right.filter(&unequal)?;
+
+        match assert_series_nested_values_equal(
+            &filtered_left,
+            &filtered_right,
+            check_exact,
+            rtol,
+            atol,
+            categorical_as_str,
+        ) {
+            Ok(_) => {
+                return Ok(());
+            },
+            Err(_) => {
+                return Err(polars_err!(
+                    assertion_error = "Series",
+                    "nested value mismatch",
+                    left,
+                    right
+                ));
+            },
+        }
+    }
+
+    if !unequal.any() {
+        return Ok(());
+    }
+
+    if check_exact || !left.dtype().is_float() || !right.dtype().is_float() {
+        return Err(polars_err!(
+            assertion_error = "Series",
+            "exact value mismatch",
+            left,
+            right
+        ));
+    }
+
+    assert_series_null_values_match(&left, &right)?;
+    assert_series_nan_values_match(&left, &right)?;
+    assert_series_values_within_tolerance(&left, &right, &unequal, rtol, atol)?;
+
+    Ok(())
+}
+
+pub fn assert_series_nested_values_equal(
+    left: &Series,
+    right: &Series,
+    check_exact: bool,
+    rtol: f64,
+    atol: f64,
+    categorical_as_str: bool,
+) -> PolarsResult<()> {
+    if comparing_lists(left.dtype(), right.dtype()) {
+        let zipped = left.iter().zip(right.iter());
+
+        for (s1, s2) in zipped {
+            if s1.is_null() || s2.is_null() {
+                return Err(polars_err!(
+                    assertion_error = "Series",
+                    "nested value mismatch",
+                    s1,
+                    s2
+                ));
+            } else {
+                // **Change**: This had to convert `AnyValue` to Series because
+                // the input type for `assert_series_values_equal()` are Series
+                // objects and not `AnyValue`, which would cause an error.
+                let s1_series = Series::new("".into(), &[s1.clone()]);
+                let s2_series = Series::new("".into(), &[s2.clone()]);
+
+                // **Change**: Using `explode()` to prevent infinite recursion.
+                // When an `AnyValue` representing a nested structure (like a list) is wrapped in a new Series,
+                // it creates another layer of nesting. Without `explode()`, this would cause infinite recursion
+                // as each recursive call would add more nesting instead of resolving it.
+                // The `explode()` call flattens one level of the nested structure before comparison,
+                // breaking the recursive cycle.
+                match assert_series_values_equal(
+                    &s1_series.explode()?,
+                    &s2_series.explode()?,
+                    true,
+                    check_exact,
+                    rtol,
+                    atol,
+                    categorical_as_str,
+                ) {
+                    Ok(_) => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+    } else {
+        // **Change**: This section had to be modified because
+        // using `unnest()` on a Struct type in Rust creates a DataFrame
+        // not a Series. Thus, I had to find a workaround so that the
+        // `assert_series_values_equal()` function would have the proper
+        // input of Series.
+        let ls = left.struct_()?.clone().unnest();
+        let rs = right.struct_()?.clone().unnest();
+
+        let ls_cols = ls.get_columns();
+        let rs_cols = rs.get_columns();
+
+        for (s1, s2) in ls_cols.iter().zip(rs_cols.iter()) {
+            match assert_series_values_equal(
+                s1.as_series().unwrap(),
+                s2.as_series().unwrap(),
+                true,
+                check_exact,
+                rtol,
+                atol,
+                categorical_as_str,
+            ) {
+                Ok(_) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn assert_series_equal(
+    left: &Series,
+    right: &Series,
+    options: SeriesEqualOptions,
+) -> PolarsResult<()> {
+    // **Change**: The Python code has an `_assert_correct_input_type()`
+    // function to make sure that both inputs are Series. However,
+    // this was not implemented in Rust due to Rust's strict
+    // static type-checking system.
+
+    if left.len() != right.len() {
+        return Err(polars_err!(
+            assertion_error = "Series",
+            "length mismatch",
+            left.len(),
+            right.len()
+        ));
+    }
+
+    if options.check_names && left.name() != right.name() {
+        return Err(polars_err!(
+            assertion_error = "Series",
+            "name mismatch",
+            left.name(),
+            right.name()
+        ));
+    }
+
+    if options.check_dtypes && left.dtype() != right.dtype() {
+        return Err(polars_err!(
+            assertion_error = "Series",
+            "data type mismatch",
+            left.dtype(),
+            right.dtype()
+        ));
+    }
+
+    assert_series_values_equal(
+        left,
+        right,
+        options.check_order,
+        options.check_exact,
+        options.rtol,
+        options.atol,
+        options.categorical_as_str,
+    )
+}

--- a/crates/polars-testing/src/lib.rs
+++ b/crates/polars-testing/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod asserts;


### PR DESCRIPTION
Tagging @coastalwhite since he is overseeing my work on transferring testing utilities from Python to Rust.

Resolves the first major part of this issue: https://github.com/pola-rs/polars/issues/21388

All unit tests pass. Tried to provide extensive coverage of scenarios, many of which are covered in the Python version, but some which are not.

Documentation has not been added yet due to the size of the PR. I am anticipating some comments and I have provided some in-line comments regarding some changes/improvements I implemented at that specific, so to make it easier to go through for Gijs and any other reviewers.

I will remove those comments once they have been addressed and add proper documentation either through an update to the commit or a new branch, depending on what happens. 