### PR TITLE
fix: Don't check sortedness in `join_asof` when 'by' groups supplied, but issue warning

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -513,8 +513,8 @@ pub trait AsofJoinBy: IntoDf {
             &left_asof,
             &right_asof,
             tolerance.is_some(),
-            left_by.is_empty() && right_by.is_empty(),
             check_sortedness,
+            !(left_by.is_empty() && right_by.is_empty()),
         )?;
 
         let mut left_by = self_df.select(left_by)?;

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -206,8 +206,8 @@ fn check_asof_columns(
     a: &Series,
     b: &Series,
     has_tolerance: bool,
-    sorted_err: bool,
     check_sortedness: bool,
+    by_groups_present: bool,
 ) -> PolarsResult<()> {
     let dtype_a = a.dtype();
     let dtype_b = b.dtype();
@@ -230,21 +230,11 @@ fn check_asof_columns(
         a.dtype(), b.dtype()
     );
     if check_sortedness {
-        if sorted_err {
+        if by_groups_present {
+            polars_warn!("Sortedness of columns cannot be checked when 'by' groups provided");
+        } else {
             a.ensure_sorted_arg("asof_join")?;
             b.ensure_sorted_arg("asof_join")?;
-        } else {
-            let msg = |side| {
-                format!(
-                    "{side} key of asof join is not sorted.\n\nThis can lead to invalid results. Ensure the asof key is sorted"
-                )
-            };
-            if a.ensure_sorted_arg("asof_join").is_err() {
-                polars_warn!(msg("left"))
-            }
-            if b.ensure_sorted_arg("asof_join").is_err() {
-                polars_warn!(msg("right"))
-            }
         }
     }
     Ok(())
@@ -284,8 +274,8 @@ pub trait AsofJoin: IntoDf {
             left_key,
             right_key,
             tolerance.is_some(),
-            true,
             check_sortedness,
+            false,
         )?;
         let left_key = left_key.to_physical_repr();
         let right_key = right_key.to_physical_repr();

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7296,8 +7296,8 @@ class DataFrame:
                 (i.e., strictly less-than / strictly greater-than).
         check_sortedness
             Check the sortedness of the asof keys. If the keys are not sorted Polars
-            will error, or in case of 'by' argument raise a warning. This might become
-            a hard error in the future.
+            will error. Currently, sortedness cannot be checked if 'by' groups are
+            provided.
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4794,8 +4794,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 (i.e., strictly less-than / strictly greater-than).
         check_sortedness
             Check the sortedness of the asof keys. If the keys are not sorted Polars
-            will error, or in case of 'by' argument raise a warning. This might become
-            a hard error in the future.
+            will error. Currently, sortedness cannot be checked if 'by' groups are
+            provided.
 
 
         Examples


### PR DESCRIPTION
Closes #21693.

When `join_asof` is called with `by` groups, the requirement for sortedness is that the `on` column is sorted within each group. The current behavior issues a warning if the entire column is not sorted, which is not really desirable, as this means warnings will be issued in almost every case where `by` is used (since often the data is sourced first by the group, then by the `on` column).

Instead, since it is currently too expensive to check sortedness on each group individually, we should simply raise a warning that we cannot check for sortedness when `by` groups are provided. Here is the new behavior:

```python
import polars as pl
df = pl.DataFrame({"a": [1, 1, 1, 2, 2, 2], "b": [2, 1, 3, 1, 2, 3]})

df.join_asof(df, on="b")  # no by specified
# InvalidOperationError: argument in operation 'asof_join' is not sorted, please sort the 'expr/series/column' first

df.join_asof(df, on="b", by="a")  # check_sortedness=True is default
# UserWarning: Sortedness of columns cannot be checked when 'by' groups provided

df.join_asof(df, on="b", by="a", check_sortedness=False) # no warning issued
```