### PR TITLE
fix: Incorrect multithread path taken for aggregations

### DIFF
--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -761,10 +761,17 @@ where
     #[cfg(not(debug_assertions))]
     let thread_boundary = 100_000;
 
+    // Temporary until categorical min/max multithreading implementation is corrected.
+    #[cfg(feature = "dtype-categorical")]
+    let is_categorical = matches!(s.dtype(), &DataType::Categorical(_, _));
+    #[cfg(not(feature = "dtype-categorical"))]
+    let is_categorical = false;
     // threading overhead/ splitting work stealing is costly..
+
     if !allow_threading
         || s.len() < thread_boundary
         || POOL.current_thread_has_pending_tasks().unwrap_or(false)
+        || is_categorical
     {
         return f(s);
     }

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -762,7 +762,7 @@ where
     let thread_boundary = 100_000;
 
     // threading overhead/ splitting work stealing is costly..
-    if allow_threading
+    if !allow_threading
         || s.len() < thread_boundary
         || POOL.current_thread_has_pending_tasks().unwrap_or(false)
     {

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -365,51 +365,17 @@ fn create_physical_expr_inner(
             let input = create_physical_expr_inner(expr, ctxt, expr_arena, schema, state)?;
             polars_ensure!(!(state.has_implode() && matches!(ctxt, Context::Aggregation)), InvalidOperation: "'implode' followed by an aggregation is not allowed");
             state.local.has_implode |= matches!(agg, IRAggExpr::Implode(_));
-            let mut allow_threading = state.allow_threading;
+            let allow_threading = state.allow_threading;
 
             match ctxt {
                 Context::Default if !matches!(agg, IRAggExpr::Quantile { .. }) => {
                     use {GroupByMethod as GBM, IRAggExpr as I};
 
                     let groupby = match agg {
-                        I::Min { propagate_nans, .. } => {
-                            #[cfg(feature = "dtype-categorical")]
-                            {
-                                let field = expr_arena.get(expression).to_field(
-                                    schema,
-                                    Context::Aggregation,
-                                    expr_arena,
-                                )?;
-                                if let DataType::Categorical(_, _) = field.dtype {
-                                    // Categoricals cannot use multithreaded min/max algorithm.
-                                    allow_threading = false;
-                                }
-                            }
-                            if *propagate_nans {
-                                GBM::NanMin
-                            } else {
-                                GBM::Min
-                            }
-                        },
-                        I::Max { propagate_nans, .. } => {
-                            #[cfg(feature = "dtype-categorical")]
-                            {
-                                let field = expr_arena.get(expression).to_field(
-                                    schema,
-                                    Context::Aggregation,
-                                    expr_arena,
-                                )?;
-                                if let DataType::Categorical(_, _) = field.dtype {
-                                    // Categoricals cannot use multithreaded min/max algorithm.
-                                    allow_threading = false;
-                                }
-                            }
-                            if *propagate_nans {
-                                GBM::NanMax
-                            } else {
-                                GBM::Max
-                            }
-                        },
+                        I::Min { propagate_nans, .. } if *propagate_nans => GBM::NanMin,
+                        I::Min { .. } => GBM::Min,
+                        I::Max { propagate_nans, .. } if *propagate_nans => GBM::NanMax,
+                        I::Max { .. } => GBM::Max,
                         I::Median(_) => GBM::Median,
                         I::NUnique(_) => GBM::NUnique,
                         I::First(_) => GBM::First,

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -380,10 +380,8 @@ fn create_physical_expr_inner(
                                     Context::Aggregation,
                                     expr_arena,
                                 )?;
-                                if let DataType::Categorical(_, CategoricalOrdering::Lexical) =
-                                    field.dtype
-                                {
-                                    // Lexical Categoricals cannot use multithreaded min/max algorithm.
+                                if let DataType::Categorical(_, _) = field.dtype {
+                                    // Categoricals cannot use multithreaded min/max algorithm.
                                     allow_threading = false;
                                 }
                             }
@@ -401,10 +399,8 @@ fn create_physical_expr_inner(
                                     Context::Aggregation,
                                     expr_arena,
                                 )?;
-                                if let DataType::Categorical(_, CategoricalOrdering::Lexical) =
-                                    field.dtype
-                                {
-                                    // Lexical Categoricals cannot use multithreaded min/max algorithm.
+                                if let DataType::Categorical(_, _) = field.dtype {
+                                    // Categoricals cannot use multithreaded min/max algorithm.
                                     allow_threading = false;
                                 }
                             }

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -373,16 +373,19 @@ fn create_physical_expr_inner(
 
                     let groupby = match agg {
                         I::Min { propagate_nans, .. } => {
-                            let field = expr_arena.get(expression).to_field(
-                                schema,
-                                Context::Aggregation,
-                                expr_arena,
-                            )?;
-                            if let DataType::Categorical(_, CategoricalOrdering::Lexical) =
-                                field.dtype
+                            #[cfg(feature = "dtype-categorical")]
                             {
-                                // Lexical Categoricals cannot use multithreaded min/max algorithm.
-                                allow_threading = false;
+                                let field = expr_arena.get(expression).to_field(
+                                    schema,
+                                    Context::Aggregation,
+                                    expr_arena,
+                                )?;
+                                if let DataType::Categorical(_, CategoricalOrdering::Lexical) =
+                                    field.dtype
+                                {
+                                    // Lexical Categoricals cannot use multithreaded min/max algorithm.
+                                    allow_threading = false;
+                                }
                             }
                             if *propagate_nans {
                                 GBM::NanMin
@@ -391,16 +394,19 @@ fn create_physical_expr_inner(
                             }
                         },
                         I::Max { propagate_nans, .. } => {
-                            let field = expr_arena.get(expression).to_field(
-                                schema,
-                                Context::Aggregation,
-                                expr_arena,
-                            )?;
-                            if let DataType::Categorical(_, CategoricalOrdering::Lexical) =
-                                field.dtype
+                            #[cfg(feature = "dtype-categorical")]
                             {
-                                // Lexical Categoricals cannot use multithreaded min/max algorithm.
-                                allow_threading = false;
+                                let field = expr_arena.get(expression).to_field(
+                                    schema,
+                                    Context::Aggregation,
+                                    expr_arena,
+                                )?;
+                                if let DataType::Categorical(_, CategoricalOrdering::Lexical) =
+                                    field.dtype
+                                {
+                                    // Lexical Categoricals cannot use multithreaded min/max algorithm.
+                                    allow_threading = false;
+                                }
                             }
                             if *propagate_nans {
                                 GBM::NanMax


### PR DESCRIPTION
Fixes #21325.

Currently, for aggregations, polars takes the wrong path when `allow_threading` is false, and tries to multithread with only one thread. Conversely, it *never* multithreads when `allow_threading` is true. This PR fixes this.

Once this path is enabled, we have to disable multithreading for categorical min/max, as the multithreaded path is the one that causes problems in the linked issue. The current algorithm `slice`s categorical columns into separate components and computes `min/max` on each, and in the process (I think) a new revmap is computed for each slice and results in the wrong result, or for some other reason (the proper min physical isn't returned in each sub-slice). So I have disabled multithreading in the IR planner--let me know if this is the proper place to do this.