### PR TITLE
docs: Make python/rust getting-started consistent and clarify performance risk of infer_schema_length=None

### DIFF
--- a/crates/polars-io/src/csv/read/options.rs
+++ b/crates/polars-io/src/csv/read/options.rs
@@ -224,7 +224,9 @@ impl CsvReadOptions {
         self
     }
 
-    /// Number of rows to use for schema inference. Pass [None] to use all rows.
+    /// Set the number of rows to use when inferring the csv schema.
+    /// The default is 100 rows.
+    /// Setting to [None] will do a full table scan, which is very slow.
     pub fn with_infer_schema_length(mut self, infer_schema_length: Option<usize>) -> Self {
         self.infer_schema_length = infer_schema_length;
         self

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -77,8 +77,8 @@ impl LazyCsvReader {
     }
 
     /// Set the number of rows to use when inferring the csv schema.
-    /// the default is 100 rows.
-    /// Setting to `None` will do a full table scan, very slow.
+    /// The default is 100 rows.
+    /// Setting to [None] will do a full table scan, which is very slow.
     #[must_use]
     pub fn with_infer_schema_length(mut self, num_rows: Option<usize>) -> Self {
         self.read_options.infer_schema_length = num_rows;

--- a/docs/source/src/rust/user-guide/getting-started.rs
+++ b/docs/source/src/rust/user-guide/getting-started.rs
@@ -27,7 +27,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_separator(b',')
         .finish(&mut df)?;
     let df_csv = CsvReadOptions::default()
-        .with_infer_schema_length(None)
         .with_has_header(true)
         .with_parse_options(CsvParseOptions::default().with_try_parse_dates(true))
         .try_into_reader_with_file_path(Some("docs/assets/data/output.csv".into()))?

--- a/docs/source/user-guide/transformations/time-series/parsing.md
+++ b/docs/source/user-guide/transformations/time-series/parsing.md
@@ -27,6 +27,10 @@ is set to `True`:
 --8<-- "python/user-guide/transformations/time-series/parsing.py:df"
 ```
 
+This flag will trigger schema inference on a number of rows, as configured by the
+`infer_schema_length` setting (100 rows by default). Schema inference is computationally expensive
+and can slow down file loading if a high number of rows is used.
+
 On the other hand binary formats such as parquet have a schema that is respected by Polars.
 
 ## Casting strings to dates


### PR DESCRIPTION
This PR resolves #21298.

Context: the user guide getting started section has sample code that is inconsistent between Python and Rust. The Rust code sample sets 'infer_schema_length' to None, triggering a full table scan using computationally intensive schema inference logic. The Python code uses the default of 100 rows. Therefore, the Rust code has significant negative performance degradation when used on large tables.

Proposed changes:
- Make the user guide getting started code consistent between Python and Rust, switching to the default value.
- Document the performance risk in the user guide transformations/time-series/parsing/ section.
- Make the Rust reference method documentation for 'with_infer_schema_length' consistent and clear across the different implementations.