### PR TITLE
perf: Enable common subplan elimination across plans in `collect_all`

### DIFF
--- a/crates/polars-mem-engine/src/lib.rs
+++ b/crates/polars-mem-engine/src/lib.rs
@@ -4,5 +4,5 @@ mod predicate;
 mod prelude;
 
 pub use executors::Executor;
-pub use planner::{create_physical_plan, create_scan_predicate};
+pub use planner::{create_multiple_physical_plans, create_physical_plan, create_scan_predicate};
 pub use predicate::ScanPredicate;

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -349,7 +349,7 @@ fn create_physical_plan_impl(
                 },
             }
         },
-        SinkMultiple { .. } => unreachable!("should have been called differently"),
+        SinkMultiple { .. } => unreachable!("returns multiple dataframes and is handled separately in polars-lazy"),
         Union { inputs, options } => {
             let inputs = state.with_new_branch(|new_state| {
                 inputs

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -349,6 +349,7 @@ fn create_physical_plan_impl(
                 },
             }
         },
+        SinkMultiple { .. } => unreachable!("should have been called differently"),
         Union { inputs, options } => {
             let inputs = state.with_new_branch(|new_state| {
                 inputs

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -349,7 +349,9 @@ fn create_physical_plan_impl(
                 },
             }
         },
-        SinkMultiple { .. } => unreachable!("returns multiple dataframes and is handled separately in polars-lazy"),
+        SinkMultiple { .. } => {
+            unreachable!("returns multiple dataframes and is handled separately in polars-lazy")
+        },
         Union { inputs, options } => {
             let inputs = state.with_new_branch(|new_state| {
                 inputs

--- a/crates/polars-plan/src/client/check.rs
+++ b/crates/polars-plan/src/client/check.rs
@@ -68,7 +68,9 @@ impl DslPlan {
             | MapFunction { input, .. }
             | Sink { input, .. }
             | Cache { input, .. } => scratch.push(input),
-            Union { inputs, .. } | HConcat { inputs, .. } => scratch.extend(inputs),
+            Union { inputs, .. } | HConcat { inputs, .. } | SinkMultiple { inputs } => {
+                scratch.extend(inputs)
+            },
             Join {
                 input_left,
                 input_right,

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -28,7 +28,10 @@ pub enum DslPlan {
         predicate: Expr,
     },
     /// Cache the input at this point in the LP
-    Cache { input: Arc<DslPlan>, id: usize },
+    Cache {
+        input: Arc<DslPlan>,
+        id: usize,
+    },
     Scan {
         sources: ScanSources,
         /// Materialized at IR except for AnonymousScan.
@@ -121,6 +124,9 @@ pub enum DslPlan {
         input: Arc<DslPlan>,
         payload: SinkType,
     },
+    SinkMultiple {
+        inputs: Vec<DslPlan>,
+    },
     #[cfg(feature = "merge_sorted")]
     MergeSorted {
         input_left: Arc<DslPlan>,
@@ -162,6 +168,7 @@ impl Clone for DslPlan {
             Self::HConcat { inputs, options } => Self::HConcat { inputs: inputs.clone(), options: options.clone() },
             Self::ExtContext { input, contexts, } => Self::ExtContext { input: input.clone(), contexts: contexts.clone() },
             Self::Sink { input, payload } => Self::Sink { input: input.clone(), payload: payload.clone() },
+            Self::SinkMultiple { inputs } => Self::SinkMultiple { inputs: inputs.clone() },
             #[cfg(feature = "merge_sorted")]
             Self::MergeSorted { input_left, input_right, key } => Self::MergeSorted { input_left: input_left.clone(), input_right: input_right.clone(), key: key.clone() },
             Self::IR {node, dsl, version} => Self::IR {node: *node, dsl: dsl.clone(), version: *version},

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -986,6 +986,14 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             let lp = IR::Sink { input, payload };
             return run_conversion(lp, ctxt, "sink");
         },
+        DslPlan::SinkMultiple { inputs } => {
+            let inputs = inputs
+                .into_iter()
+                .map(|lp| to_alp_impl(lp, ctxt))
+                .collect::<PolarsResult<Vec<_>>>()
+                .map_err(|e| e.context(failed_here!(vertical concat)))?;
+            IR::SinkMultiple { inputs }
+        },
         #[cfg(feature = "merge_sorted")]
         DslPlan::MergeSorted {
             input_left,

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -296,6 +296,13 @@ impl IR {
                 };
                 DslPlan::Sink { input, payload }
             },
+            IR::SinkMultiple { inputs } => {
+                let inputs = inputs
+                    .into_iter()
+                    .map(|node| convert_to_lp(node, lp_arena))
+                    .collect();
+                DslPlan::SinkMultiple { inputs }
+            },
             #[cfg(feature = "merge_sorted")]
             IR::MergeSorted {
                 input_left,

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -315,6 +315,13 @@ impl<'a> IRDotDisplay<'a> {
                     })
                 })?;
             },
+            SinkMultiple { inputs } => {
+                for input in inputs {
+                    self.with_root(*input)._format(f, Some(id), last)?;
+                }
+
+                write_label(f, id, |f| f.write_str("SINK MULTIPLE"))?;
+            },
             SimpleProjection { input, columns } => {
                 let num_columns = columns.as_ref().len();
                 let total_columns = self.lp.lp_arena.get(*input).schema(self.lp.lp_arena).len();

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -397,6 +397,19 @@ impl<'a> IRDisplay<'a> {
                 write!(f, "{:indent$}{name}", "")?;
                 self.with_root(*input)._format(f, sub_indent)
             },
+            SinkMultiple { inputs } => {
+                // 3 levels of indentation
+                // - 0 => SINK_MULTIPLE ... END SINK_MULTIPLE
+                // - 1 => PLAN 0, PLAN 1, ... PLAN N
+                // - 2 => actual formatting of plans
+                let sub_sub_indent = sub_indent + 2;
+                write!(f, "{:indent$}SINK_MULTIPLE", "")?;
+                for (i, plan) in inputs.iter().enumerate() {
+                    write!(f, "\n{:sub_indent$}PLAN {i}:", "")?;
+                    self.with_root(*plan)._format(f, sub_sub_indent)?;
+                }
+                write!(f, "\n{:indent$}END SINK_MULTIPLE", "")
+            },
             SimpleProjection { input, columns } => {
                 let num_columns = columns.as_ref().len();
                 let total_columns = self.lp.lp_arena.get(*input).schema(self.lp.lp_arena).len();

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -140,6 +140,7 @@ impl IR {
                 input: inputs.pop().unwrap(),
                 payload: payload.clone(),
             },
+            SinkMultiple { .. } => SinkMultiple { inputs },
             SimpleProjection { columns, .. } => SimpleProjection {
                 input: inputs.pop().unwrap(),
                 columns: columns.clone(),
@@ -162,7 +163,12 @@ impl IR {
     pub fn copy_exprs(&self, container: &mut Vec<ExprIR>) {
         use IR::*;
         match self {
-            Slice { .. } | Cache { .. } | Distinct { .. } | Union { .. } | MapFunction { .. } => {},
+            Slice { .. }
+            | Cache { .. }
+            | Distinct { .. }
+            | Union { .. }
+            | MapFunction { .. }
+            | SinkMultiple { .. } => {},
             Sort { by_column, .. } => container.extend_from_slice(by_column),
             Filter { predicate, .. } => container.push(predicate.clone()),
             Select { expr, .. } => container.extend_from_slice(expr),
@@ -209,11 +215,7 @@ impl IR {
     {
         use IR::*;
         let input = match self {
-            Union { inputs, .. } => {
-                container.extend(inputs.iter().cloned());
-                return;
-            },
-            HConcat { inputs, .. } => {
+            Union { inputs, .. } | HConcat { inputs, .. } | SinkMultiple { inputs } => {
                 container.extend(inputs.iter().cloned());
                 return;
             },

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -148,6 +148,11 @@ pub enum IR {
         input: Node,
         payload: SinkTypeIR,
     },
+    /// Node that allows for multiple plans to be executed in parallel with common subplan
+    /// elimination and everything.
+    SinkMultiple {
+        inputs: Vec<Node>,
+    },
     #[cfg(feature = "merge_sorted")]
     MergeSorted {
         input_left: Node,

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -360,6 +360,14 @@ impl<'a> TreeFmtNode<'a> {
                         ),
                         vec![self.lp_node(None, *input)],
                     ),
+                    SinkMultiple { inputs } => ND(
+                        wh(h, "SINK_MULTIPLE"),
+                        inputs
+                            .iter()
+                            .enumerate()
+                            .map(|(i, lp_root)| self.lp_node(Some(format!("PLAN {i}:")), *lp_root))
+                            .collect(),
+                    ),
                     SimpleProjection { input, columns } => {
                         let num_columns = columns.as_ref().len();
                         let total_columns = lp.lp_arena.get(*input).schema(lp.lp_arena).len();

--- a/crates/polars-plan/src/plans/optimizer/collect_members.rs
+++ b/crates/polars-plan/src/plans/optimizer/collect_members.rs
@@ -24,6 +24,7 @@ impl UniqueScans {
 
 pub(super) struct MemberCollector {
     pub(crate) has_joins_or_unions: bool,
+    pub(crate) has_sink_multiple: bool,
     pub(crate) has_cache: bool,
     pub(crate) has_ext_context: bool,
     pub(crate) has_filter_with_join_input: bool,
@@ -38,6 +39,7 @@ impl MemberCollector {
     pub(super) fn new() -> Self {
         Self {
             has_joins_or_unions: false,
+            has_sink_multiple: false,
             has_cache: false,
             has_ext_context: false,
             has_filter_with_join_input: false,
@@ -52,6 +54,7 @@ impl MemberCollector {
         use IR::*;
         for (_node, alp) in lp_arena.iter(root) {
             match alp {
+                SinkMultiple { .. } => self.has_sink_multiple = true,
                 Join { .. } | Union { .. } => self.has_joins_or_unions = true,
                 Filter { input, .. } => {
                     self.has_filter_with_join_input |= matches!(lp_arena.get(*input), Join { options, .. } if options.args.how.is_cross())

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -142,8 +142,10 @@ More information on the new streaming engine: https://github.com/pola-rs/polars/
     #[cfg(feature = "cse")]
     let _cse_plan_changed = if comm_subplan_elim {
         let members = get_or_init_members!();
-
-        if members.has_joins_or_unions && members.has_duplicate_scans() && !members.has_cache {
+        if (members.has_sink_multiple || members.has_joins_or_unions)
+            && members.has_duplicate_scans()
+            && !members.has_cache
+        {
             if verbose {
                 eprintln!("found multiple sources; run comm_subplan_elim")
             }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -718,10 +718,10 @@ impl PredicatePushDown<'_> {
 
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, true)
             },
-            // Pushed down passed these nodes
-            lp @ Sink { .. } => {
+            lp @ Sink { .. } | lp @ SinkMultiple { .. } => {
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
             },
+            // Pushed down passed these nodes
             lp @ HStack { .. }
             | lp @ Select { .. }
             | lp @ SimpleProjection { .. }

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -822,7 +822,7 @@ impl ProjectionPushDown {
             } => process_hconcat(self, inputs, schema, options, ctx, lp_arena, expr_arena),
             lp @ Union { .. } => process_generic(self, lp, ctx, lp_arena, expr_arena),
             // These nodes only have inputs and exprs, so we can use same logic.
-            lp @ Slice { .. } | lp @ Sink { .. } => {
+            lp @ Slice { .. } | lp @ Sink { .. } | lp @ SinkMultiple { .. } => {
                 process_generic(self, lp, ctx, lp_arena, expr_arena)
             },
             Cache { .. } => {

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -561,7 +561,7 @@ impl SlicePushDown {
                 let lp = HConcat {inputs, schema, options};
                 self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
             }
-            (lp @ Sink { .. }, _) => {
+            (lp @ Sink { .. }, _) | (lp @ SinkMultiple { .. }, _) => {
                 // Slice can always be pushed down for sinks
                 self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
             }

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -181,6 +181,7 @@ impl Hash for HashableEqLP<'_> {
             IR::Sink { input: _, payload } => {
                 payload.traverse_and_hash(self.expr_arena, state);
             },
+            IR::SinkMultiple { .. } => {},
             IR::Cache {
                 input: _,
                 id,

--- a/crates/polars-python/src/lazyframe/mod.rs
+++ b/crates/polars-python/src/lazyframe/mod.rs
@@ -1,6 +1,7 @@
 mod exitable;
 #[cfg(feature = "pymethods")]
 mod general;
+mod optflags;
 #[cfg(feature = "pymethods")]
 mod serde;
 mod sink;
@@ -9,7 +10,7 @@ pub mod visitor;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use exitable::PyInProcessQuery;
-use polars::prelude::{Engine, LazyFrame};
+use polars::prelude::{Engine, LazyFrame, OptFlags};
 use pyo3::exceptions::PyValueError;
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyAnyMethods;
@@ -25,9 +26,22 @@ pub struct PyLazyFrame {
     pub ldf: LazyFrame,
 }
 
+#[pyclass]
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyOptFlags {
+    pub inner: OptFlags,
+}
+
 impl From<LazyFrame> for PyLazyFrame {
     fn from(ldf: LazyFrame) -> Self {
         PyLazyFrame { ldf }
+    }
+}
+
+impl From<OptFlags> for PyOptFlags {
+    fn from(inner: OptFlags) -> Self {
+        PyOptFlags { inner }
     }
 }
 

--- a/crates/polars-python/src/lazyframe/optflags.rs
+++ b/crates/polars-python/src/lazyframe/optflags.rs
@@ -1,0 +1,55 @@
+use polars::prelude::OptFlags;
+use pyo3::pymethods;
+
+use super::PyOptFlags;
+
+macro_rules! flag_getter_setters {
+    ($(($flag:ident, $getter:ident, $setter:ident))+) => {
+        #[pymethods]
+        impl PyOptFlags {
+            #[staticmethod]
+            pub fn empty() -> Self {
+                Self {
+                    inner: OptFlags::empty()
+                }
+            }
+
+            pub fn no_optimizations(&mut self) {
+                self.inner.remove(OptFlags::PREDICATE_PUSHDOWN);
+                self.inner.remove(OptFlags::PROJECTION_PUSHDOWN);
+                self.inner.remove(OptFlags::COMM_SUBPLAN_ELIM);
+                self.inner.remove(OptFlags::COMM_SUBEXPR_ELIM);
+                self.inner.remove(OptFlags::CLUSTER_WITH_COLUMNS);
+                self.inner.remove(OptFlags::COLLAPSE_JOINS);
+                self.inner.remove(OptFlags::CHECK_ORDER_OBSERVE);
+                self.inner.remove(OptFlags::SIMPLIFY_EXPR);
+                self.inner.remove(OptFlags::SLICE_PUSHDOWN);
+            }
+
+            $(
+            #[getter]
+            fn $getter(&self) -> bool {
+                self.inner.contains(OptFlags::$flag)
+            }
+            #[setter]
+            fn $setter(&mut self, value: bool) {
+                self.inner.set(OptFlags::$flag, value)
+            }
+            )+
+        }
+    };
+}
+
+flag_getter_setters! {
+    (PROJECTION_PUSHDOWN, get_projection_pushdown, set_projection_pushdown)
+    (PREDICATE_PUSHDOWN, get_predicate_pushdown, set_predicate_pushdown)
+    (CLUSTER_WITH_COLUMNS, get_cluster_with_columns, set_cluster_with_columns)
+    (TYPE_COERCION, get_type_coercion, set_type_coercion)
+    (SIMPLIFY_EXPR, get_simplify_expression, set_simplify_expression)
+    (TYPE_CHECK, get_type_check, set_type_check)
+    (SLICE_PUSHDOWN, get_slice_pushdown, set_slice_pushdown)
+    (COMM_SUBPLAN_ELIM, get_comm_subplan_elim, set_comm_subplan_elim)
+    (COMM_SUBEXPR_ELIM, get_comm_subexpr_elim, set_comm_subexpr_elim)
+    (COLLAPSE_JOINS, get_collapse_joins, set_collapse_joins)
+    (CHECK_ORDER_OBSERVE, get_check_order_observe, set_check_order_observe)
+}

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -647,6 +647,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
         } => Err(PyNotImplementedError::new_err(
             "Not expecting to see a Sink node",
         )),
+        IR::SinkMultiple { .. } => Err(PyNotImplementedError::new_err(
+            "Not expecting to see a SinkMultiple node",
+        )),
         #[cfg(feature = "merge_sorted")]
         IR::MergeSorted {
             input_left,

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -46,6 +46,12 @@ fn visualize_plan_rec(
             ),
             &[][..],
         ),
+        PhysNodeKind::SinkMultiple { sinks } => {
+            for sink in sinks {
+                visualize_plan_rec(*sink, phys_sm, expr_arena, visited, out);
+            }
+            return;
+        },
         PhysNodeKind::Select {
             input,
             selectors,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -350,6 +350,21 @@ pub fn lower_ir(
             },
         },
 
+        IR::SinkMultiple { inputs } => {
+            let mut sinks = Vec::with_capacity(inputs.len());
+            for input in inputs.clone() {
+                let phys_node_stream = match ir_arena.get(input) {
+                    IR::Sink { .. } => lower_ir!(input)?,
+                    _ => lower_ir!(ir_arena.add(IR::Sink {
+                        input,
+                        payload: SinkTypeIR::Memory
+                    }))?,
+                };
+                sinks.push(phys_node_stream.node);
+            }
+            PhysNodeKind::SinkMultiple { sinks }
+        },
+
         #[cfg(feature = "merge_sorted")]
         IR::MergeSorted {
             input_left,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -300,8 +300,8 @@ pub fn lower_ir(
                 let cloud_options = cloud_options.clone();
 
                 let mut input = lower_ir!(*input)?;
-                let input_schema = match &variant {
-                    PartitionVariantIR::MaxSize(_) => output_schema.clone(),
+                match &variant {
+                    PartitionVariantIR::MaxSize(_) => {},
                     PartitionVariantIR::ByKey {
                         key_exprs,
                         include_key: _,
@@ -310,12 +310,13 @@ pub fn lower_ir(
                             polars_bail!(InvalidOperation: "cannot partition by-key without key expressions");
                         }
 
-                        let mut select_output_schema = output_schema.as_ref().clone();
+                        let input_schema = &phys_sm[input.node].output_schema;
+                        let mut select_output_schema = input_schema.as_ref().clone();
                         for key_expr in key_exprs.iter() {
                             select_output_schema.insert(
                                 key_expr.output_name().clone(),
                                 key_expr
-                                    .dtype(output_schema.as_ref(), Context::Default, expr_arena)?
+                                    .dtype(input_schema.as_ref(), Context::Default, expr_arena)?
                                     .clone(),
                             );
                         }
@@ -330,23 +331,17 @@ pub fn lower_ir(
                             },
                         });
                         input = PhysStream::first(node);
-
-                        select_output_schema
                     },
                 };
 
-                let node_kind = PhysNodeKind::PartitionSink {
+                PhysNodeKind::PartitionSink {
                     path_f_string,
                     sink_options,
                     variant,
                     file_type,
                     input,
                     cloud_options,
-                };
-                // We need to correct the schema here as the ByKey might adjust the schema before
-                // it gets passed to the PartitionSink.
-                let node_key = phys_sm.insert(PhysNode::new(input_schema, node_kind));
-                return Ok(PhysStream::first(node_key));
+                }
             },
         },
 

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -54,6 +54,10 @@ impl PhysNode {
             kind,
         }
     }
+
+    pub fn kind(&self) -> &PhysNodeKind {
+        &self.kind
+    }
 }
 
 /// A handle representing a physical stream of data with a fixed schema in the
@@ -145,6 +149,10 @@ pub enum PhysNodeKind {
         file_type: FileType,
         input: PhysStream,
         cloud_options: Option<CloudOptions>,
+    },
+
+    SinkMultiple {
+        sinks: Vec<PhysNodeKey>,
     },
 
     /// Generic fallback for (as-of-yet) unsupported streaming mappings.
@@ -327,6 +335,13 @@ fn visit_node_inputs_mut(
                 for input in inputs {
                     rec!(input.node);
                     visit(input);
+                }
+            },
+
+            PhysNodeKind::SinkMultiple { sinks } => {
+                for sink in sinks {
+                    rec!(*sink);
+                    visit(&mut PhysStream::first(*sink));
                 }
             },
         }

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -103,6 +103,15 @@ fn to_graph_rec<'a>(
             nodes::in_memory_source::InMemorySourceNode::new(df.clone(), MorselSeq::default()),
             [],
         ),
+        SinkMultiple { sinks } => {
+            // @NOTE: This is always the root node and gets ignored by the physical_plan anyway so
+            // we give one of the inputs back.
+            let node = to_graph_rec(sinks[0], ctx)?;
+            for sink in &sinks[1..] {
+                to_graph_rec(*sink, ctx)?;
+            }
+            return Ok(node);
+        },
 
         StreamingSlice {
             input,

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -10,11 +10,13 @@ use polars_plan::prelude::expr_ir::ExprIR;
 use polars_utils::arena::{Arena, Node};
 use slotmap::{SecondaryMap, SlotMap};
 
+use crate::physical_plan::PhysNodeKind;
+
 pub fn run_query(
     node: Node,
     ir_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
-) -> PolarsResult<Option<DataFrame>> {
+) -> PolarsResult<Result<DataFrame, Vec<DataFrame>>> {
     if let Ok(visual_path) = std::env::var("POLARS_VISUALIZE_IR") {
         let plan = IRPlan {
             lp_top: node,
@@ -30,6 +32,7 @@ pub fn run_query(
         let visualization = crate::physical_plan::visualize_plan(root, &phys_sm, expr_arena);
         std::fs::write(visual_path, visualization).unwrap();
     }
+
     let (mut graph, phys_to_graph) =
         crate::physical_plan::physical_plan_to_graph(root, &phys_sm, expr_arena)?;
 
@@ -45,5 +48,24 @@ pub fn run_query(
         }
     }
 
-    Ok(results.remove(phys_to_graph[root]))
+    match ir_arena.get(node) {
+        IR::SinkMultiple { inputs } => {
+            let phys_node = &phys_sm[root];
+            let PhysNodeKind::SinkMultiple { sinks } = phys_node.kind() else {
+                unreachable!();
+            };
+
+            Ok(Err(sinks
+                .iter()
+                .map(|phys_node_key| {
+                    results
+                        .remove(phys_to_graph[*phys_node_key])
+                        .unwrap_or_else(DataFrame::empty)
+                })
+                .collect()))
+        },
+        _ => Ok(Ok(results
+            .remove(phys_to_graph[root])
+            .unwrap_or_else(DataFrame::empty))),
+    }
 }

--- a/py-polars/polars/lazyframe/__init__.py
+++ b/py-polars/polars/lazyframe/__init__.py
@@ -1,7 +1,9 @@
 from polars.lazyframe.engine_config import GPUEngine
 from polars.lazyframe.frame import LazyFrame
+from polars.lazyframe.opt_flags import OptFlags
 
 __all__ = [
     "GPUEngine",
     "LazyFrame",
+    "OptFlags",
 ]

--- a/py-polars/polars/lazyframe/opt_flags.py
+++ b/py-polars/polars/lazyframe/opt_flags.py
@@ -1,0 +1,119 @@
+from polars.polars import PyOptFlags
+
+
+class OptFlags:
+    """Optimization flags used during query optimization."""
+
+    _pyoptflags: PyOptFlags
+
+    def __init__(
+        self,
+        *,
+        _type_check: bool = True,
+        _type_coercion: bool = True,
+        predicate_pushdown: bool = True,
+        projection_pushdown: bool = True,
+        simplify_expression: bool = True,
+        slice_pushdown: bool = True,
+        comm_subplan_elim: bool = True,
+        comm_subexpr_elim: bool = True,
+        cluster_with_columns: bool = True,
+        collapse_joins: bool = True,
+        check_order_observe: bool = True,
+    ) -> None:
+        self._pyoptflags = PyOptFlags.empty()
+
+        self._pyoptflags.type_check = _type_check
+        self._pyoptflags.predicate_pushdown = predicate_pushdown
+        self._pyoptflags.projection_pushdown = projection_pushdown
+        self._pyoptflags.simplify_expression = simplify_expression
+        self._pyoptflags.slice_pushdown = slice_pushdown
+        self._pyoptflags.comm_subplan_elim = comm_subplan_elim
+        self._pyoptflags.comm_subexpr_elim = comm_subexpr_elim
+        self._pyoptflags.collapse_joins = collapse_joins
+        self._pyoptflags.check_order_observe = check_order_observe
+
+    def no_optimizations(self) -> None:
+        """Remove selected optimizations."""
+        self._pyoptflags.no_optimizations()
+
+    @property
+    def projection_pushdown(self) -> bool:
+        """Only read columns that are used later in the query."""
+        return self._pyoptflags.projection_pushdown
+
+    @projection_pushdown.setter
+    def projection_pushdown(self, value: bool) -> None:
+        self._pyoptflags.projection_pushdown = value
+
+    @property
+    def predicate_pushdown(self) -> bool:
+        """Apply predicates/filters as early as possible."""
+        return self._pyoptflags.predicate_pushdown
+
+    @predicate_pushdown.setter
+    def predicate_pushdown(self, value: bool) -> None:
+        self._pyoptflags.predicate_pushdown = value
+
+    @property
+    def cluster_with_columns(self) -> bool:
+        """Cluster sequential `with_columns` calls to independent calls."""
+        return self._pyoptflags.cluster_with_columns
+
+    @cluster_with_columns.setter
+    def cluster_with_columns(self, value: bool) -> None:
+        self._pyoptflags.cluster_with_columns = value
+
+    @property
+    def simplify_expression(self) -> bool:
+        """Run many expression optimization rules until fixed point."""
+        return self._pyoptflags.simplify_expression
+
+    @simplify_expression.setter
+    def simplify_expression(self, value: bool) -> None:
+        self._pyoptflags.simplify_expression = value
+
+    @property
+    def slice_pushdown(self) -> bool:
+        """Pushdown slices/limits."""
+        return self._pyoptflags.slice_pushdown
+
+    @slice_pushdown.setter
+    def slice_pushdown(self, value: bool) -> None:
+        self._pyoptflags.slice_pushdown = value
+
+    @property
+    def common_subplan_elim(self) -> bool:
+        """Elide duplicate plans and caches their outputs."""
+        return self._pyoptflags.common_subplan_elim
+
+    @common_subplan_elim.setter
+    def common_subplan_elim(self, value: bool) -> None:
+        self._pyoptflags.common_subplan_elim = value
+
+    @property
+    def common_subexpr_elim(self) -> bool:
+        """Elide duplicate expressions and caches their outputs."""
+        return self._pyoptflags.common_subexpr_elim
+
+    @common_subexpr_elim.setter
+    def common_subexpr_elim(self, value: bool) -> None:
+        self._pyoptflags.common_subexpr_elim = value
+
+    @property
+    def collapse_joins(self) -> bool:
+        """Collapse slower joins with filters into faster joins."""
+        return self._pyoptflags.collapse_joins
+
+    @collapse_joins.setter
+    def collapse_joins(self, value: bool) -> None:
+        self._pyoptflags.collapse_joins = value
+
+    @property
+    def check_order_observe(self) -> bool:
+        """Do not maintain order if the order would not be observed."""
+        return self._pyoptflags.check_order_observe
+
+    @check_order_observe.setter
+    def check_order_observe(self, value: bool) -> None:
+        self._pyoptflags.check_order_observe = value

--- a/py-polars/polars/lazyframe/opt_flags.py
+++ b/py-polars/polars/lazyframe/opt_flags.py
@@ -1,4 +1,7 @@
-from polars.polars import PyOptFlags
+import contextlib
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyOptFlags
 
 
 class OptFlags:

--- a/py-polars/polars/lazyframe/opt_flags.py
+++ b/py-polars/polars/lazyframe/opt_flags.py
@@ -7,8 +7,6 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 class OptFlags:
     """Optimization flags used during query optimization."""
 
-    _pyoptflags: PyOptFlags
-
     def __init__(
         self,
         *,

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -17,7 +17,7 @@ use polars_python::expr::PyExpr;
 use polars_python::functions::PyStringCacheHolder;
 #[cfg(not(target_arch = "wasm32"))]
 use polars_python::lazyframe::PyInProcessQuery;
-use polars_python::lazyframe::{PyLazyFrame, PyPartitioning};
+use polars_python::lazyframe::{PyLazyFrame, PyOptFlags, PyPartitioning};
 use polars_python::lazygroupby::PyLazyGroupBy;
 use polars_python::series::PySeries;
 #[cfg(feature = "sql")]
@@ -90,6 +90,7 @@ fn polars(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PySeries>().unwrap();
     m.add_class::<PyDataFrame>().unwrap();
     m.add_class::<PyLazyFrame>().unwrap();
+    m.add_class::<PyOptFlags>().unwrap();
     #[cfg(not(target_arch = "wasm32"))]
     m.add_class::<PyInProcessQuery>().unwrap();
     m.add_class::<PyLazyGroupBy>().unwrap();

--- a/py-polars/tests/unit/io/test_sink.py
+++ b/py-polars/tests/unit/io/test_sink.py
@@ -44,8 +44,9 @@ def test_mkdir(tmp_path: Path, scan: Any, sink: Any, engine: EngineType) -> None
         (pl.scan_ndjson, pl.LazyFrame.sink_ndjson),
     ],
 )
+@pytest.mark.parametrize("engine", ["in-memory", "streaming"])
 @pytest.mark.write_disk
-def test_lazy_sinks(tmp_path: Path, scan: Any, sink: Any) -> None:
+def test_lazy_sinks(tmp_path: Path, scan: Any, sink: Any, engine: EngineType) -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     lf1 = sink(df.lazy(), tmp_path / "a", lazy=True)
     lf2 = sink(df.lazy(), tmp_path / "b", lazy=True)
@@ -53,7 +54,7 @@ def test_lazy_sinks(tmp_path: Path, scan: Any, sink: Any) -> None:
     assert not Path(tmp_path / "a").exists()
     assert not Path(tmp_path / "b").exists()
 
-    pl.collect_all([lf1, lf2])
+    pl.collect_all([lf1, lf2], engine=engine)
 
     assert_frame_equal(scan(tmp_path / "a").collect(), df)
     assert_frame_equal(scan(tmp_path / "b").collect(), df)


### PR DESCRIPTION
This is a long requested feature that allows for caching repeated computations in a single `collect_all`. In the in-memory engine, this means less repeated computation if LazyFrames perform partially the same computations. For the new streaming engine, it is all combined into a single physical plan.

Fixes #5821.
Fixes #8369.
Fixes #13065.