### PR TITLE
fix: Clear NaNs due to zero-weight division in rolling var/std

### DIFF
--- a/crates/polars-compute/src/var_cov.rs
+++ b/crates/polars-compute/src/var_cov.rs
@@ -61,6 +61,14 @@ impl VarState {
         }
     }
 
+    fn clear_zero_weight_nan(&mut self) {
+        // Clear NaNs due to division by zero.
+        if self.weight == 0.0 {
+            self.mean = 0.0;
+            self.dp = 0.0;
+        }
+    }
+
     pub(crate) fn new_single(x: f64) -> Self {
         let mut out = Self::default();
         out.insert_one(x);
@@ -76,6 +84,7 @@ impl VarState {
         self.dp += (new_mean - x) * delta_mean;
         self.weight = new_weight;
         self.mean = new_mean;
+        self.clear_zero_weight_nan();
     }
 
     pub fn remove_one(&mut self, x: f64) {
@@ -87,6 +96,7 @@ impl VarState {
         self.dp -= (new_mean - x) * delta_mean;
         self.weight = new_weight;
         self.mean = new_mean;
+        self.clear_zero_weight_nan();
     }
 
     pub fn combine(&mut self, other: &Self) {
@@ -101,6 +111,7 @@ impl VarState {
         self.dp += other.dp + other.weight * (new_mean - other.mean) * delta_mean;
         self.weight = new_weight;
         self.mean = new_mean;
+        self.clear_zero_weight_nan();
     }
 
     pub fn finalize(&self, ddof: u8) -> Option<f64> {

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -564,3 +564,10 @@ def test_rolling_bool() -> None:
         assert out["sum_a"].to_list() == out["sum_a_ref"].to_list()
         assert out["max_a"].to_list() == out["max_a_ref"].to_list()
         assert out["min_a"].to_list() == out["min_a_ref"].to_list()
+
+
+def test_rolling_var_zero_weight() -> None:
+    assert_series_equal(
+        pl.Series([1.0, None, 1.0, 2.0]).rolling_var(2),
+        pl.Series([None, None, None, 0.5]),
+    )


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/21758.