### PR TITLE
perf: Improve InputIndependentSelect by delegating to InMemorySourceNode

### DIFF
--- a/crates/polars-stream/src/expression.rs
+++ b/crates/polars-stream/src/expression.rs
@@ -34,4 +34,8 @@ impl StreamExpr {
             self.inner.evaluate(df, state)
         }
     }
+    
+    pub fn evaluate_blocking(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
+        self.inner.evaluate(df, state)
+    }
 }

--- a/crates/polars-stream/src/expression.rs
+++ b/crates/polars-stream/src/expression.rs
@@ -34,8 +34,12 @@ impl StreamExpr {
             self.inner.evaluate(df, state)
         }
     }
-    
-    pub fn evaluate_blocking(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Column> {
+
+    pub fn evaluate_blocking(
+        &self,
+        df: &DataFrame,
+        state: &ExecutionState,
+    ) -> PolarsResult<Column> {
         self.inner.evaluate(df, state)
     }
 }

--- a/crates/polars-stream/src/nodes/input_independent_select.rs
+++ b/crates/polars-stream/src/nodes/input_independent_select.rs
@@ -1,19 +1,28 @@
+use std::sync::Arc;
+
 use polars_core::prelude::IntoColumn;
+use polars_core::POOL;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::prelude::*;
 
 use super::compute_node_prelude::*;
 use crate::expression::StreamExpr;
-use crate::morsel::SourceToken;
+use crate::nodes::in_memory_source::InMemorySourceNode;
 
-pub struct InputIndependentSelectNode {
-    selectors: Vec<StreamExpr>,
-    done: bool,
+pub enum InputIndependentSelectNode {
+    ToSelect {
+        selectors: Vec<StreamExpr>,
+        num_pipelines: usize,
+    },
+    Source(InMemorySourceNode),
+    Done,
 }
 
 impl InputIndependentSelectNode {
     pub fn new(selectors: Vec<StreamExpr>) -> Self {
-        Self {
+        Self::ToSelect {
             selectors,
-            done: false,
+            num_pipelines: 0,
         }
     }
 }
@@ -23,14 +32,51 @@ impl ComputeNode for InputIndependentSelectNode {
         "input_independent_select"
     }
 
+    fn initialize(&mut self, num_pipelines_: usize) {
+        match self {
+            Self::ToSelect { num_pipelines, .. } => *num_pipelines = num_pipelines_,
+            _ => unreachable!(),
+        }
+    }
+
     fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
         assert!(recv.is_empty() && send.len() == 1);
-        send[0] = if send[0] == PortState::Done || self.done {
-            PortState::Done
-        } else {
-            PortState::Ready
-        };
-        Ok(())
+        if send[0] == PortState::Done {
+            *self = Self::Done;
+            return Ok(());
+        }
+
+        POOL.install(|| {
+            if let Self::ToSelect {
+                selectors,
+                num_pipelines,
+            } = self
+            {
+                let empty_df = DataFrame::empty();
+                let state = ExecutionState::new();
+                let selected: Result<Vec<_>, _> = selectors
+                    .par_iter()
+                    .map(|selector| {
+                        let s = selector.evaluate_blocking(&empty_df, &state)?;
+                        PolarsResult::Ok(s.into_column())
+                    })
+                    .collect();
+                let ret = DataFrame::new_with_broadcast(selected?)?;
+                let mut src_node = InMemorySourceNode::new(Arc::new(ret), MorselSeq::default());
+                src_node.initialize(*num_pipelines);
+                *self = InputIndependentSelectNode::Source(src_node);
+            }
+            PolarsResult::Ok(())
+        })?;
+
+        match self {
+            Self::ToSelect { .. } => unreachable!(),
+            Self::Source(src) => src.update_state(recv, send),
+            Self::Done => {
+                send[0] = PortState::Done;
+                Ok(())
+            },
+        }
     }
 
     fn spawn<'env, 's>(
@@ -42,23 +88,9 @@ impl ComputeNode for InputIndependentSelectNode {
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.is_empty() && send_ports.len() == 1);
-        let mut sender = send_ports[0].take().unwrap().serial();
-
-        join_handles.push(scope.spawn_task(TaskPriority::Low, async move {
-            let empty_df = DataFrame::empty();
-            let mut selected = Vec::new();
-            for selector in self.selectors.iter() {
-                let s = selector.evaluate(&empty_df, state).await?;
-                selected.push(s.into_column());
-            }
-
-            let ret = DataFrame::new_with_broadcast(selected)?;
-            let seq = MorselSeq::default();
-            let source_token = SourceToken::new();
-            let morsel = Morsel::new(ret, seq, source_token);
-            sender.send(morsel).await.ok();
-            self.done = true;
-            Ok(())
-        }));
+        let Self::Source(src) = self else {
+            unreachable!()
+        };
+        src.spawn(scope, recv_ports, send_ports, state, join_handles);
     }
 }

--- a/crates/polars-stream/src/nodes/input_independent_select.rs
+++ b/crates/polars-stream/src/nodes/input_independent_select.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use polars_core::prelude::IntoColumn;
 use polars_core::POOL;
+use polars_core::prelude::IntoColumn;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::prelude::*;
 


### PR DESCRIPTION
This used to just send one (possibly giant) morsel which inhibits parallelism down the line.