### PR TITLE
fix(python): Handle pytz named timezone in `lit`

### DIFF
--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -21,6 +21,7 @@ _POLARS_CLOUD_AVAILABLE = True
 _PYARROW_AVAILABLE = True
 _PYDANTIC_AVAILABLE = True
 _PYICEBERG_AVAILABLE = True
+_PYTZ_AVAILABLE = True
 
 
 class _LazyModule(ModuleType):
@@ -164,6 +165,7 @@ if TYPE_CHECKING:
     import pyarrow
     import pydantic
     import pyiceberg
+    import pytz
 else:
     # infrequently-used builtins
     dataclasses, _ = _lazy_import("dataclasses")
@@ -185,6 +187,7 @@ else:
     pydantic, _PYDANTIC_AVAILABLE = _lazy_import("pydantic")
     pyiceberg, _PYICEBERG_AVAILABLE = _lazy_import("pyiceberg")
     gevent, _GEVENT_AVAILABLE = _lazy_import("gevent")
+    pytz, _PYTZ_AVAILABLE = _lazy_import("pytz")
 
 
 @cache
@@ -219,6 +222,12 @@ def _check_for_pyarrow(obj: Any, *, check_type: bool = True) -> bool:
 def _check_for_pydantic(obj: Any, *, check_type: bool = True) -> bool:
     return _PYDANTIC_AVAILABLE and _might_be(
         cast(Hashable, type(obj) if check_type else obj), "pydantic"
+    )
+
+
+def _check_for_pytz(obj: Any, *, check_type: bool = True) -> bool:
+    return _PYTZ_AVAILABLE and _might_be(
+        cast(Hashable, type(obj) if check_type else obj), "pytz"
     )
 
 
@@ -306,11 +315,13 @@ __all__ = [
     "pydantic",
     "pyiceberg",
     "pyarrow",
+    "pytz",
     # lazy utilities
     "_check_for_numpy",
     "_check_for_pandas",
     "_check_for_pyarrow",
     "_check_for_pydantic",
+    "_check_for_pytz",
     # exported flags/guards
     "_ALTAIR_AVAILABLE",
     "_DELTALAKE_AVAILABLE",

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 import polars._reexport as pl
 from polars._utils.wrap import wrap_expr
 from polars.datatypes import Date, Datetime, Duration
-from polars.dependencies import _check_for_numpy
+from polars.dependencies import _check_for_numpy, _check_for_pytz, pytz
 from polars.dependencies import numpy as np
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -90,10 +90,10 @@ def lit(
         else:
             # value has time zone, but dtype does not: keep value time zone
             if dtype_tz is None:
-                if isinstance(value_tz, ZoneInfo) or getattr(
-                    value_tz,
-                    "zone",  # handle pytz named timezone.
-                    None,
+                if isinstance(value_tz, ZoneInfo) or (
+                    _check_for_pytz(value_tz)
+                    and isinstance(value_tz, pytz.tzinfo.BaseTzInfo)
+                    and value_tz.zone is not None
                 ):
                     # named timezone
                     tz = str(value_tz)

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -90,7 +90,11 @@ def lit(
         else:
             # value has time zone, but dtype does not: keep value time zone
             if dtype_tz is None:
-                if isinstance(value_tz, ZoneInfo):
+                if isinstance(value_tz, ZoneInfo) or getattr(
+                    value_tz,
+                    "zone",  # handle pytz named timezone.
+                    None,
+                ):
                     # named timezone
                     tz = str(value_tz)
                 else:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -580,6 +580,8 @@ def test_convert_pandas_timezone_info() -> None:
                 # timezone.
                 assert df_ts.tzinfo == ZoneInfo("UTC")
             else:
+                assert df_ts.tzinfo is not None
+                assert ts.tzinfo is not None
                 assert df_ts.tzinfo.utcoffset(df_ts) == ts.tzinfo.utcoffset(ts), (
                     df_ts,
                     ts,

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -555,37 +555,59 @@ def test_read_utc_times_parquet() -> None:
     assert df_in["Timestamp"][0] == datetime(2022, 1, 1, 0, 0, tzinfo=tz)
 
 
-def test_convert_pandas_timezone_info() -> None:
-    # Pandas support all of the following timezone and the pandas parsing behavior is
-    # - timezone name: pytz.timezone on <=2.x and ZoneInfo on 3.x.
-    # - timezone offset: datetime.timedelta.
-    # pytz.timezone.
-    ts1 = pd.Timestamp("20200101 00:00", tz=pytz.timezone("America/New_York"))
-    # ZoneInfo.
-    ts2 = pd.Timestamp("20200101 00:00", tz=ZoneInfo("America/New_York"))
-    # pytz.FixedOffset
-    ts3 = pd.Timestamp("20200101 00:00", tz=pytz.FixedOffset(-300))
-    # datetime.timedelta.
-    ts4 = pd.Timestamp("20200101 00:00", tz=timezone(timedelta(days=-1, seconds=68400)))
+@pytest.mark.parametrize(
+    "ts",
+    [
+        # Pandas support all of the following timezone and the pandas parsing behavior
+        # is
+        # - timezone name: pytz.timezone on <=2.x and ZoneInfo on 3.x.
+        # - timezone offset: datetime.timedelta.
+        # pytz.timezone.
+        # ZoneInfo.
+        # pytz.FixedOffset
+        # datetime.timedelta.
+        pd.Timestamp("20200101 00:00", tz=pytz.timezone("America/New_York")),
+        pd.Timestamp("20200101 00:00", tz=ZoneInfo("America/New_York")),
+        # TODO: polars currently doesn't retain FixedOffset timezone. They will be
+        # converted to UTC. Uncomment the following two tests once we support
+        # FixedOffset timezone.
+        # pd.Timestamp("20200101 00:00", tz=pytz.FixedOffset(-300)),
+        # pd.Timestamp("20200101 00:00", tz=timezone(timedelta(days=-1, seconds=68400)))
+    ],
+)
+def test_convert_pandas_timezone_info(ts: pd.Timestamp) -> None:
+    df1 = pl.DataFrame({"date": [ts]})
+    df2 = pl.select(date=pl.lit(ts))
 
-    for ts in (ts1, ts2, ts3, ts4):
-        df1 = pl.DataFrame({"date": [ts]})
-        df2 = pl.select(date=pl.lit(ts))
-        for df in (df1, df2):
-            df_ts = df["date"][0]
-            assert df_ts == ts, (df_ts, ts)
-            if ts is ts3 or ts is ts4:
-                # TODO: polars currently doesn't retain FixedOffset timezone. They will
-                # be converted to UTC. Remove this branch once we support FixedOffset
-                # timezone.
-                assert df_ts.tzinfo == ZoneInfo("UTC")
-            else:
-                assert df_ts.tzinfo is not None
-                assert ts.tzinfo is not None
-                assert df_ts.tzinfo.utcoffset(df_ts) == ts.tzinfo.utcoffset(ts), (
-                    df_ts,
-                    ts,
-                )
+    for df in (df1, df2):
+        df_ts = df["date"][0]
+        assert df_ts == ts, (df_ts, ts)
+        assert df_ts.tzinfo is not None
+        assert ts.tzinfo is not None
+        assert df_ts.tzinfo.utcoffset(df_ts) == ts.tzinfo.utcoffset(ts), (
+            df_ts,
+            ts,
+        )
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [
+        pd.Timestamp("20200101 00:00", tz=pytz.FixedOffset(-300)),
+        pd.Timestamp("20200101 00:00", tz=timezone(timedelta(days=-1, seconds=68400))),
+    ],
+)
+def test_convert_pandas_timezone_info_fixed_offset(ts: pd.Timestamp) -> None:
+    # TODO: polars currently doesn't retain FixedOffset timezone. They will
+    # be converted to UTC. Remove this test once we support FixedOffset
+    # timezone. See test_convert_pandas_timezone_info for more details.
+    df1 = pl.DataFrame({"date": [ts]})
+    df2 = pl.select(date=pl.lit(ts))
+
+    for df in (df1, df2):
+        df_ts = df["date"][0]
+        assert df_ts == ts, (df_ts, ts)
+        assert df_ts.tzinfo == ZoneInfo("UTC")
 
 
 def test_asof_join_tolerance_grouper() -> None:


### PR DESCRIPTION
Closes #21595.

When #21003 introduced handling on FixedOffset timezone, it only handled `zoneinfo.ZoneInfo` named timezone so `pytz` named timezone got converted to UTC. This PR fixed that. Also added tests to test all valid timezone objects.

## Previously
```python
print(pl.DataFrame([[ts]]).with_columns(pl.lit(ts).alias("ts")))
shape: (1, 2)
┌────────────────────────────────┬─────────────────────────┐
│ column_0                       ┆ ts                      │
│ ---                            ┆ ---                     │
│ datetime[μs, America/New_York] ┆ datetime[μs, UTC]       │
╞════════════════════════════════╪═════════════════════════╡
│ 2020-01-01 00:00:00 EST        ┆ 2020-01-01 05:00:00 UTC │
└────────────────────────────────┴─────────────────────────┘
```

### Now
```python
print(pl.DataFrame([[ts]]).with_columns(pl.lit(ts).alias("ts")))
shape: (1, 2)
┌────────────────────────────────┬────────────────────────────────┐
│ column_0                       ┆ ts                             │
│ ---                            ┆ ---                            │
│ datetime[μs, America/New_York] ┆ datetime[μs, America/New_York] │
╞════════════════════════════════╪════════════════════════════════╡
│ 2020-01-01 00:00:00 EST        ┆ 2020-01-01 00:00:00 EST        │
└────────────────────────────────┴────────────────────────────────┘
```