### PR TITLE
refactor(rust): Add a slice enum to polars-utils

### DIFF
--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -30,6 +30,7 @@ pub mod pl_str;
 pub mod priority;
 pub mod select;
 pub mod slice;
+pub mod slice_enum;
 pub mod sort;
 pub mod sparse_init_vec;
 pub mod sync;

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -1,0 +1,80 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum Slice {
+    /// Or zero
+    Positive {
+        offset: usize,
+        len: usize,
+    },
+    Negative {
+        offset_from_end: usize,
+        len: usize,
+    },
+}
+
+impl Slice {
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        match self {
+            Slice::Positive { len, .. } => *len,
+            Slice::Negative { len, .. } => *len,
+        }
+    }
+
+    /// Returns the equivalent slice to apply from an offsetted position.
+    ///
+    /// # Panics
+    /// Panics if self is negative.
+    pub fn offsetted(self, position: usize) -> Self {
+        let Slice::Positive { offset, len } = self else {
+            panic!("expected positive slice");
+        };
+
+        let (offset, len) = if position <= offset {
+            (offset - position, len)
+        } else {
+            let n_past_offset = position - offset;
+            (0, len.saturating_sub(n_past_offset))
+        };
+
+        Slice::Positive { offset, len }
+    }
+}
+
+impl From<(usize, usize)> for Slice {
+    fn from((offset, len): (usize, usize)) -> Self {
+        Slice::Positive { offset, len }
+    }
+}
+
+impl From<(i64, usize)> for Slice {
+    fn from((offset, len): (i64, usize)) -> Self {
+        if offset >= 0 {
+            Slice::Positive {
+                offset: offset as usize,
+                len,
+            }
+        } else {
+            Slice::Negative {
+                offset_from_end: -offset as usize,
+                len,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Slice;
+
+    #[test]
+    fn test_slice_offset() {
+        assert_eq!(
+            Slice::Positive { offset: 3, len: 10 }.offsetted(1),
+            Slice::Positive { offset: 2, len: 10 }
+        );
+        assert_eq!(
+            Slice::Positive { offset: 3, len: 10 }.offsetted(5),
+            Slice::Positive { offset: 0, len: 8 }
+        );
+    }
+}

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -55,7 +55,7 @@ impl From<(i64, usize)> for Slice {
             }
         } else {
             Slice::Negative {
-                offset_from_end: -offset as usize,
+                offset_from_end: usize::try_from(-offset).unwrap(),
                 len,
             }
         }

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -50,7 +50,7 @@ impl From<(i64, usize)> for Slice {
     fn from((offset, len): (i64, usize)) -> Self {
         if offset >= 0 {
             Slice::Positive {
-                offset: offset as usize,
+                offset: usize::try_from(offset).unwrap(),
                 len,
             }
         } else {


### PR DESCRIPTION
Introduces a slice enum with explicitly named fields to avoid confusion.

Will be used initially in the new-streaming multi file refactor, and can also be added later to e.g. the DSL if we want.
