### PR TITLE
refactor(rust): Pass around StreamingExecutionState, containing num_pipelines and ExecutionState

### DIFF
--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -9,6 +9,15 @@ use crate::async_executor;
 use crate::graph::{Graph, GraphNode, GraphNodeKey, LogicalPipeKey, PortState};
 use crate::pipe::PhysicalPipe;
 
+#[derive(Clone)]
+pub struct StreamingExecutionState {
+    // The number of parallel pipelines we have within each stream.
+    pub num_pipelines: usize,
+
+    // The ExecutionState passed to any non-streaming operations.
+    pub in_memory_exec_state: ExecutionState,
+}
+
 /// Finds all runnable pipeline blockers in the graph, that is, nodes which:
 ///  - Only have blocked output ports.
 ///  - Have at least one ready input port connected to a ready output port.
@@ -104,12 +113,12 @@ fn run_subgraph(
     graph: &mut Graph,
     nodes: &PlHashSet<GraphNodeKey>,
     pipes: &[LogicalPipeKey],
-    num_pipelines: usize,
+    state: &StreamingExecutionState,
 ) -> PolarsResult<()> {
     // Construct physical pipes for the logical pipes we'll use.
     let mut physical_pipes = SecondaryMap::new();
     for pipe_key in pipes.iter().copied() {
-        physical_pipes.insert(pipe_key, PhysicalPipe::new(num_pipelines));
+        physical_pipes.insert(pipe_key, PhysicalPipe::new(state.num_pipelines));
     }
 
     // We do a topological sort of the graph: we want to spawn each node,
@@ -131,7 +140,6 @@ fn run_subgraph(
         }
     }
 
-    let execution_state = ExecutionState::default();
     async_executor::task_scope(|scope| {
         // Using SlotMap::iter_mut we can get simultaneous mutable references. By storing them and
         // removing the references from the secondary map as we do our topological sort we ensure
@@ -170,7 +178,7 @@ fn run_subgraph(
                 scope,
                 &mut recv_ports[..],
                 &mut send_ports[..],
-                &execution_state,
+                state,
                 &mut join_handles,
             );
 
@@ -247,6 +255,11 @@ pub fn execute_graph(
     let num_pipelines = POOL.current_num_threads();
     async_executor::set_num_threads(num_pipelines);
 
+    let state = StreamingExecutionState {
+        num_pipelines,
+        in_memory_exec_state: ExecutionState::default(),
+    };
+
     // Ensure everything is properly connected.
     for (node_key, node) in &graph.nodes {
         for (i, input) in node.inputs.iter().enumerate() {
@@ -259,15 +272,11 @@ pub fn execute_graph(
         }
     }
 
-    for node in graph.nodes.values_mut() {
-        node.compute.initialize(num_pipelines);
-    }
-
     loop {
         if polars_core::config::verbose() {
             eprintln!("polars-stream: updating graph state");
         }
-        graph.update_all_states()?;
+        graph.update_all_states(&state)?;
         let (nodes, pipes) = find_runnable_subgraph(graph);
         if polars_core::config::verbose() {
             for node in &nodes {
@@ -280,7 +289,7 @@ pub fn execute_graph(
         if nodes.is_empty() {
             break;
         }
-        run_subgraph(graph, &nodes, &pipes, num_pipelines)?;
+        run_subgraph(graph, &nodes, &pipes, &state)?;
         if polars_core::config::verbose() {
             eprintln!("polars-stream: done running graph phase");
         }

--- a/crates/polars-stream/src/graph.rs
+++ b/crates/polars-stream/src/graph.rs
@@ -1,6 +1,7 @@
 use polars_error::PolarsResult;
 use slotmap::{Key, SecondaryMap, SlotMap};
 
+use crate::execute::StreamingExecutionState;
 use crate::nodes::ComputeNode;
 
 slotmap::new_key_type! {
@@ -70,7 +71,7 @@ impl Graph {
     }
 
     /// Updates all the nodes' states until a fixed point is reached.
-    pub fn update_all_states(&mut self) -> PolarsResult<()> {
+    pub fn update_all_states(&mut self, state: &StreamingExecutionState) -> PolarsResult<()> {
         let mut to_update: Vec<_> = self.nodes.keys().collect();
         let mut scheduled_for_update: SecondaryMap<GraphNodeKey, ()> =
             self.nodes.keys().map(|k| (k, ())).collect();
@@ -97,7 +98,7 @@ impl Graph {
                 );
             }
             node.compute
-                .update_state(&mut recv_state, &mut send_state)?;
+                .update_state(&mut recv_state, &mut send_state, state)?;
             if verbose {
                 eprintln!(
                     "updating {}, after: {recv_state:?} {send_state:?}",

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -49,7 +49,7 @@ impl GroupBySinkState {
         &'env mut self,
         scope: &'s TaskScope<'s, 'env>,
         receivers: Vec<Receiver<Morsel>>,
-        state: &'s ExecutionState,
+        state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(receivers.len() >= self.local.len());
@@ -74,7 +74,7 @@ impl GroupBySinkState {
                     let df = morsel.into_df();
                     let mut key_columns = Vec::new();
                     for selector in key_selectors {
-                        let s = selector.evaluate(&df, state).await?;
+                        let s = selector.evaluate(&df, &state.in_memory_exec_state).await?;
                         key_columns.push(s.into_column());
                     }
                     let keys = DataFrame::new_with_broadcast_len(key_columns, df.height())?;
@@ -91,7 +91,7 @@ impl GroupBySinkState {
                             reduction.resize(local.grouper.num_groups());
                             reduction.update_groups(
                                 selector
-                                    .evaluate(&df, state)
+                                    .evaluate(&df, &state.in_memory_exec_state)
                                     .await?
                                     .as_materialized_series(),
                                 &group_idxs,
@@ -203,7 +203,6 @@ impl GroupBySinkState {
     }
 
     fn into_source(self, output_schema: &Schema) -> PolarsResult<InMemorySourceNode> {
-        let num_pipelines = self.local.len();
         let num_rows: usize = self
             .local
             .iter()
@@ -223,9 +222,7 @@ impl GroupBySinkState {
             Self::combine_locals_parallel(num_partitions, output_schema, self.local)
         };
 
-        let mut source_node = InMemorySourceNode::new(Arc::new(df?), MorselSeq::default());
-        source_node.initialize(num_pipelines);
-        Ok(source_node)
+        Ok(InMemorySourceNode::new(Arc::new(df?), MorselSeq::default()))
     }
 }
 
@@ -268,7 +265,12 @@ impl ComputeNode for GroupByNode {
         "group_by"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(recv.len() == 1 && send.len() == 1);
 
         // State transitions.
@@ -288,7 +290,7 @@ impl ComputeNode for GroupByNode {
             },
             // Defer to source node implementation.
             GroupByState::Source(src) => {
-                src.update_state(&mut [], send)?;
+                src.update_state(&mut [], send, state)?;
                 if send[0] == PortState::Done {
                     self.state = GroupByState::Done;
                 }
@@ -320,7 +322,7 @@ impl ComputeNode for GroupByNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        state: &'s ExecutionState,
+        state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(send_ports.len() == 1 && recv_ports.len() == 1);

--- a/crates/polars-stream/src/nodes/in_memory_sink.rs
+++ b/crates/polars-stream/src/nodes/in_memory_sink.rs
@@ -26,7 +26,12 @@ impl ComputeNode for InMemorySinkNode {
         "in_memory_sink"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(send.is_empty());
         assert!(recv.len() == 1);
 
@@ -47,7 +52,7 @@ impl ComputeNode for InMemorySinkNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && send_ports.is_empty());

--- a/crates/polars-stream/src/nodes/in_memory_source.rs
+++ b/crates/polars-stream/src/nodes/in_memory_source.rs
@@ -28,17 +28,22 @@ impl ComputeNode for InMemorySourceNode {
         "in_memory_source"
     }
 
-    fn initialize(&mut self, num_pipelines: usize) {
-        let len = self.source.as_ref().unwrap().height();
-        let ideal_morsel_count = (len / get_ideal_morsel_size()).max(1);
-        let morsel_count = ideal_morsel_count.next_multiple_of(num_pipelines);
-        self.morsel_size = len.div_ceil(morsel_count).max(1);
-        self.seq = AtomicU64::new(0);
-    }
-
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(recv.is_empty());
         assert!(send.len() == 1);
+
+        if self.morsel_size == 0 {
+            let len = self.source.as_ref().unwrap().height();
+            let ideal_morsel_count = (len / get_ideal_morsel_size()).max(1);
+            let morsel_count = ideal_morsel_count.next_multiple_of(state.num_pipelines);
+            self.morsel_size = len.div_ceil(morsel_count).max(1);
+            self.seq = AtomicU64::new(0);
+        }
 
         // As a temporary hack for some nodes (like the FunctionIR::FastCount)
         // node that rely on an empty input, always ensure we send at least one
@@ -64,7 +69,7 @@ impl ComputeNode for InMemorySourceNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.is_empty() && send_ports.len() == 1);

--- a/crates/polars-stream/src/nodes/io_sinks/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/ipc.rs
@@ -10,7 +10,6 @@ use polars_core::utils::arrow::io::ipc::write::{
     encode_array, encode_new_dictionaries,
 };
 use polars_error::PolarsResult;
-use polars_expr::state::ExecutionState;
 use polars_io::SerWriter;
 use polars_io::cloud::CloudOptions;
 use polars_io::ipc::{IpcWriter, IpcWriterOptions};
@@ -26,6 +25,7 @@ use crate::async_executor::spawn;
 use crate::async_primitives::connector::{Receiver, connector};
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
+use crate::execute::StreamingExecutionState;
 use crate::nodes::{JoinHandle, PhaseOutcome, TaskPriority};
 
 pub struct IpcSinkNode {
@@ -70,17 +70,16 @@ impl SinkNode for IpcSinkNode {
 
     fn spawn_sink(
         &mut self,
-        num_pipelines: usize,
         recv_port_rx: Receiver<(PhaseOutcome, SinkInputPort)>,
-        _state: &ExecutionState,
+        state: &StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         // Buffer task -> Encode tasks
         let (dist_tx, dist_rxs) =
-            distributor_channel(num_pipelines, DEFAULT_SINK_DISTRIBUTOR_BUFFER_SIZE);
+            distributor_channel(state.num_pipelines, DEFAULT_SINK_DISTRIBUTOR_BUFFER_SIZE);
         // Encode tasks -> Collect task
         let (mut lin_rx, lin_txs) =
-            Linearizer::new(num_pipelines, DEFAULT_SINK_LINEARIZER_BUFFER_SIZE);
+            Linearizer::new(state.num_pipelines, DEFAULT_SINK_LINEARIZER_BUFFER_SIZE);
         // Collect task -> IO task
         let (mut io_tx, mut io_rx) = connector::<(Vec<EncodedData>, EncodedData)>();
 

--- a/crates/polars-stream/src/nodes/io_sinks/json.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/json.rs
@@ -2,7 +2,6 @@ use std::cmp::Reverse;
 use std::path::PathBuf;
 
 use polars_error::PolarsResult;
-use polars_expr::state::ExecutionState;
 use polars_io::cloud::CloudOptions;
 use polars_io::json::BatchedWriter;
 use polars_io::utils::file::AsyncWriteable;
@@ -12,6 +11,7 @@ use polars_utils::priority::Priority;
 use super::{SinkInputPort, SinkNode};
 use crate::async_executor::spawn;
 use crate::async_primitives::connector::Receiver;
+use crate::execute::StreamingExecutionState;
 use crate::nodes::io_sinks::parallelize_receive_task;
 use crate::nodes::{JoinHandle, PhaseOutcome, TaskPriority};
 
@@ -48,15 +48,14 @@ impl SinkNode for NDJsonSinkNode {
 
     fn spawn_sink(
         &mut self,
-        num_pipelines: usize,
         recv_port_rx: Receiver<(PhaseOutcome, SinkInputPort)>,
-        _state: &ExecutionState,
+        state: &StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         let (pass_rxs, mut io_rx) = parallelize_receive_task(
             join_handles,
             recv_port_rx,
-            num_pipelines,
+            state.num_pipelines,
             self.sink_options.maintain_order,
         );
 

--- a/crates/polars-stream/src/nodes/io_sinks/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/mod.rs
@@ -5,7 +5,6 @@ use polars_core::frame::DataFrame;
 use polars_core::prelude::Column;
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
-use polars_expr::state::ExecutionState;
 
 use super::{
     ComputeNode, JoinHandle, Morsel, PhaseOutcome, PortState, RecvPort, SendPort, TaskScope,
@@ -15,6 +14,7 @@ use crate::async_primitives::connector::{Receiver, Sender, connector};
 use crate::async_primitives::distributor_channel;
 use crate::async_primitives::linearizer::{Inserter, Linearizer};
 use crate::async_primitives::wait_group::WaitGroup;
+use crate::execute::StreamingExecutionState;
 use crate::nodes::TaskPriority;
 
 #[cfg(feature = "csv")]
@@ -150,15 +150,15 @@ pub trait SinkNode {
     fn name(&self) -> &str;
 
     fn is_sink_input_parallel(&self) -> bool;
+
     fn do_maintain_order(&self) -> bool {
         true
     }
 
     fn spawn_sink(
         &mut self,
-        num_pipelines: usize,
         recv_ports_recv: Receiver<(PhaseOutcome, SinkInputPort)>,
-        state: &ExecutionState,
+        state: &StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     );
 }
@@ -172,7 +172,6 @@ struct StartedSinkComputeNode {
 /// A [`ComputeNode`] to wrap a [`SinkNode`].
 pub struct SinkComputeNode {
     sink: Box<dyn SinkNode + Send + Sync>,
-    num_pipelines: usize,
     started: Option<StartedSinkComputeNode>,
 }
 
@@ -180,7 +179,6 @@ impl SinkComputeNode {
     pub fn new(sink: Box<dyn SinkNode + Send + Sync>) -> Self {
         Self {
             sink,
-            num_pipelines: 0,
             started: None,
         }
     }
@@ -196,13 +194,12 @@ impl ComputeNode for SinkComputeNode {
     fn name(&self) -> &str {
         self.sink.name()
     }
-    fn initialize(&mut self, num_pipelines: usize) {
-        self.num_pipelines = num_pipelines;
-    }
+
     fn update_state(
         &mut self,
         recv: &mut [PortState],
         _send: &mut [PortState],
+        _state: &StreamingExecutionState,
     ) -> PolarsResult<()> {
         if recv[0] != PortState::Done {
             recv[0] = PortState::Ready;
@@ -229,7 +226,7 @@ impl ComputeNode for SinkComputeNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        state: &'s ExecutionState,
+        state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert_eq!(recv_ports.len(), 1);
@@ -240,8 +237,7 @@ impl ComputeNode for SinkComputeNode {
             let (tx, rx) = connector();
             let mut join_handles = Vec::new();
 
-            self.sink
-                .spawn_sink(self.num_pipelines, rx, state, &mut join_handles);
+            self.sink.spawn_sink(rx, state, &mut join_handles);
             // One of the tasks might throw an error. In which case, we need to cancel all
             // handles and find the error.
             let join_handles: FuturesUnordered<_> =

--- a/crates/polars-stream/src/nodes/io_sources/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc.rs
@@ -15,7 +15,6 @@ use polars_core::utils::arrow::io::ipc::read::{
 };
 use polars_core::utils::slice_offsets;
 use polars_error::{ErrString, PolarsError, PolarsResult, polars_err};
-use polars_expr::state::ExecutionState;
 use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
 use polars_io::ipc::IpcScanOptions;
@@ -35,6 +34,7 @@ use crate::async_primitives::connector::Receiver;
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
 use crate::async_primitives::wait_group::WaitGroup;
+use crate::execute::StreamingExecutionState;
 use crate::morsel::{SourceToken, get_ideal_morsel_size};
 use crate::nodes::{JoinHandle, Morsel, MorselSeq, TaskPriority};
 use crate::{DEFAULT_DISTRIBUTOR_BUFFER_SIZE, DEFAULT_LINEARIZER_BUFFER_SIZE};
@@ -191,12 +191,12 @@ impl SourceNode for IpcSourceNode {
 
     fn spawn_source(
         &mut self,
-        num_pipelines: usize,
         mut output_recv: Receiver<SourceOutput>,
-        _state: &ExecutionState,
+        state: &StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
         unrestricted_row_count: Option<tokio::sync::oneshot::Sender<IdxSize>>,
     ) {
+        let num_pipelines = state.num_pipelines;
         // Split size for morsels.
         let max_morsel_size = get_max_morsel_size();
         let source_token = SourceToken::new();

--- a/crates/polars-stream/src/nodes/io_sources/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/mod.rs
@@ -6,15 +6,14 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use polars_core::config;
 use polars_error::PolarsResult;
-use polars_expr::state::ExecutionState;
 use polars_io::predicates::ScanIOPredicate;
 use polars_utils::IdxSize;
 
-use super::{ComputeNode, JoinHandle, Morsel, PortState, RecvPort, SendPort, TaskPriority};
 use crate::async_executor::AbortOnDropHandle;
 use crate::async_primitives::connector::{Receiver, Sender, connector};
 use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
 use crate::morsel::SourceToken;
+use crate::nodes::compute_node_prelude::*;
 
 #[cfg(feature = "csv")]
 pub mod csv;
@@ -41,7 +40,6 @@ struct StartedSourceComputeNode {
 /// A [`ComputeNode`] to wrap a [`SourceNode`].
 pub struct SourceComputeNode<T: SourceNode + Send + Sync> {
     source: T,
-    num_pipelines: usize,
     started: Option<StartedSourceComputeNode>,
 }
 
@@ -49,7 +47,6 @@ impl<T: SourceNode + Send + Sync> SourceComputeNode<T> {
     pub fn new(source: T) -> Self {
         Self {
             source,
-            num_pipelines: 0,
             started: None,
         }
     }
@@ -60,14 +57,11 @@ impl<T: SourceNode> ComputeNode for SourceComputeNode<T> {
         self.source.name()
     }
 
-    fn initialize(&mut self, num_pipelines: usize) {
-        self.num_pipelines = num_pipelines;
-    }
-
     fn update_state(
         &mut self,
         recv: &mut [PortState],
         send: &mut [PortState],
+        _state: &StreamingExecutionState,
     ) -> polars_error::PolarsResult<()> {
         assert!(recv.is_empty());
         assert_eq!(send.len(), 1);
@@ -92,7 +86,7 @@ impl<T: SourceNode> ComputeNode for SourceComputeNode<T> {
         scope: &'s super::TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        state: &'s ExecutionState,
+        state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.is_empty());
@@ -103,8 +97,7 @@ impl<T: SourceNode> ComputeNode for SourceComputeNode<T> {
             let (tx, rx) = connector();
             let mut join_handles = Vec::new();
 
-            self.source
-                .spawn_source(self.num_pipelines, rx, state, &mut join_handles, None);
+            self.source.spawn_source(rx, state, &mut join_handles, None);
             // One of the tasks might throw an error. In which case, we need to cancel all
             // handles and find the error.
             let join_handles: FuturesUnordered<_> =
@@ -285,9 +278,8 @@ pub trait SourceNode: Sized + Send + Sync {
     /// count before slicing and predicate filtering).
     fn spawn_source(
         &mut self,
-        num_pipelines: usize,
         output_recv: Receiver<SourceOutput>,
-        state: &ExecutionState,
+        state: &StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
         unrestricted_row_count: Option<tokio::sync::oneshot::Sender<IdxSize>>,
     );

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -136,13 +136,12 @@ impl SourceNode for ParquetSourceNode {
 
     fn spawn_source(
         &mut self,
-        num_pipelines: usize,
         mut output_recv: Receiver<SourceOutput>,
-        _state: &ExecutionState,
+        state: &StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
         unrestricted_row_count: Option<tokio::sync::oneshot::Sender<IdxSize>>,
     ) {
-        let (mut send_to, recv_from) = (0..num_pipelines)
+        let (mut send_to, recv_from) = (0..state.num_pipelines)
             .map(|_| connector())
             .collect::<(Vec<_>, Vec<_>)>();
 
@@ -155,7 +154,7 @@ impl SourceNode for ParquetSourceNode {
                 .unwrap_or(16_777_216);
 
             Config {
-                num_pipelines,
+                num_pipelines: state.num_pipelines,
                 row_group_prefetch_size,
                 min_values_per_thread,
             }

--- a/crates/polars-stream/src/nodes/map.rs
+++ b/crates/polars-stream/src/nodes/map.rs
@@ -20,7 +20,12 @@ impl ComputeNode for MapNode {
         "map"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(recv.len() == 1 && send.len() == 1);
         recv.swap_with_slice(send);
         Ok(())
@@ -31,7 +36,7 @@ impl ComputeNode for MapNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && send_ports.len() == 1);

--- a/crates/polars-stream/src/nodes/merge_sorted.rs
+++ b/crates/polars-stream/src/nodes/merge_sorted.rs
@@ -174,7 +174,12 @@ impl ComputeNode for MergeSortedNode {
         "merge_sorted"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert_eq!(send.len(), 1);
         assert_eq!(recv.len(), 2);
 
@@ -226,7 +231,7 @@ impl ComputeNode for MergeSortedNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert_eq!(recv_ports.len(), 2);

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -28,6 +28,7 @@ mod compute_node_prelude {
 
     pub use super::ComputeNode;
     pub use crate::async_executor::{JoinHandle, TaskPriority, TaskScope};
+    pub use crate::execute::StreamingExecutionState;
     pub use crate::graph::PortState;
     pub use crate::morsel::{Morsel, MorselSeq};
     pub use crate::pipe::{RecvPort, SendPort};
@@ -37,14 +38,11 @@ use compute_node_prelude::*;
 
 use self::io_sources::PhaseOutcomeToken;
 use crate::async_primitives::wait_group::WaitToken;
+use crate::execute::StreamingExecutionState;
 
 pub trait ComputeNode: Send {
     /// The name of this node.
     fn name(&self) -> &str;
-
-    /// Called once before the first execution phase to indicate with how many
-    /// pipelines we will execute the graph.
-    fn initialize(&mut self, _num_pipelines: usize) {}
 
     /// Update the state of this node given the state of our input and output
     /// ports. May be called multiple times until fully resolved for each
@@ -57,7 +55,12 @@ pub trait ComputeNode: Send {
     /// Similarly, for each output pipe `send` will contain the respective
     /// state of the input port that pipe is connected to when called, and you
     /// must update it to contain the desired state of your output port.
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()>;
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        state: &StreamingExecutionState,
+    ) -> PolarsResult<()>;
 
     /// If this node (in its current state) is a pipeline blocker, and whether
     /// this is memory intensive or not.
@@ -72,7 +75,7 @@ pub trait ComputeNode: Send {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        state: &'s ExecutionState,
+        state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     );
 

--- a/crates/polars-stream/src/nodes/multiplexer.rs
+++ b/crates/polars-stream/src/nodes/multiplexer.rs
@@ -34,7 +34,12 @@ impl ComputeNode for MultiplexerNode {
         "multiplexer"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(recv.len() == 1 && !send.is_empty());
 
         // Initialize buffered streams, and mark those for which the receiver
@@ -94,7 +99,7 @@ impl ComputeNode for MultiplexerNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && !send_ports.is_empty());

--- a/crates/polars-stream/src/nodes/negative_slice.rs
+++ b/crates/polars-stream/src/nodes/negative_slice.rs
@@ -25,7 +25,6 @@ pub struct NegativeSliceNode {
     state: NegativeSliceState,
     slice_offset: i64,
     length: usize,
-    num_pipelines: usize,
 }
 
 impl NegativeSliceNode {
@@ -35,7 +34,6 @@ impl NegativeSliceNode {
             state: NegativeSliceState::Buffering(Buffer::default()),
             slice_offset,
             length,
-            num_pipelines: 0,
         }
     }
 }
@@ -45,11 +43,12 @@ impl ComputeNode for NegativeSliceNode {
         "negative_slice"
     }
 
-    fn initialize(&mut self, num_pipelines: usize) {
-        self.num_pipelines = num_pipelines;
-    }
-
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         use NegativeSliceState::*;
 
         if send[0] == PortState::Done || self.length == 0 {
@@ -84,9 +83,8 @@ impl ComputeNode for NegativeSliceNode {
                 } else {
                     let mut df = accumulate_dataframes_vertical_unchecked(buffer.frames.drain(..));
                     df = df.slice(signed_start_offset, self.length);
-                    let mut node = InMemorySourceNode::new(Arc::new(df), MorselSeq::default());
-                    node.initialize(self.num_pipelines);
-                    self.state = Source(node);
+                    self.state =
+                        Source(InMemorySourceNode::new(Arc::new(df), MorselSeq::default()));
                 }
             }
         }
@@ -98,7 +96,7 @@ impl ComputeNode for NegativeSliceNode {
             },
             Source(node) => {
                 recv[0] = PortState::Done;
-                node.update_state(&mut [], send)?;
+                node.update_state(&mut [], send, state)?;
             },
             Done => {
                 recv[0] = PortState::Done;
@@ -113,7 +111,7 @@ impl ComputeNode for NegativeSliceNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        state: &'s ExecutionState,
+        state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && send_ports.len() == 1);

--- a/crates/polars-stream/src/nodes/ordered_union.rs
+++ b/crates/polars-stream/src/nodes/ordered_union.rs
@@ -23,7 +23,12 @@ impl ComputeNode for OrderedUnionNode {
         "ordered_union"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(self.cur_input_idx <= recv.len() && send.len() == 1);
 
         // Skip inputs that are done.
@@ -54,7 +59,7 @@ impl ComputeNode for OrderedUnionNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         let ready_count = recv_ports.iter().filter(|r| r.is_some()).count();

--- a/crates/polars-stream/src/nodes/simple_projection.rs
+++ b/crates/polars-stream/src/nodes/simple_projection.rs
@@ -24,7 +24,12 @@ impl ComputeNode for SimpleProjectionNode {
         "simple_projection"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(recv.len() == 1 && send.len() == 1);
         recv.swap_with_slice(send);
         Ok(())
@@ -35,7 +40,7 @@ impl ComputeNode for SimpleProjectionNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && send_ports.len() == 1);

--- a/crates/polars-stream/src/nodes/streaming_slice.rs
+++ b/crates/polars-stream/src/nodes/streaming_slice.rs
@@ -7,7 +7,6 @@ pub struct StreamingSliceNode {
     start_offset: usize,
     length: usize,
     stream_offset: usize,
-    num_pipelines: usize,
 }
 
 impl StreamingSliceNode {
@@ -16,7 +15,6 @@ impl StreamingSliceNode {
             start_offset,
             length,
             stream_offset: 0,
-            num_pipelines: 0,
         }
     }
 }
@@ -26,11 +24,12 @@ impl ComputeNode for StreamingSliceNode {
         "streaming_slice"
     }
 
-    fn initialize(&mut self, num_pipelines: usize) {
-        self.num_pipelines = num_pipelines;
-    }
-
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         if self.stream_offset >= self.start_offset + self.length || self.length == 0 {
             recv[0] = PortState::Done;
             send[0] = PortState::Done;
@@ -45,7 +44,7 @@ impl ComputeNode for StreamingSliceNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && send_ports.len() == 1);

--- a/crates/polars-stream/src/nodes/with_row_index.rs
+++ b/crates/polars-stream/src/nodes/with_row_index.rs
@@ -26,7 +26,12 @@ impl ComputeNode for WithRowIndexNode {
         "with_row_index"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(recv.len() == 1 && send.len() == 1);
         recv.swap_with_slice(send);
         Ok(())
@@ -37,7 +42,7 @@ impl ComputeNode for WithRowIndexNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(recv_ports.len() == 1 && send_ports.len() == 1);

--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -141,7 +141,12 @@ impl ComputeNode for ZipNode {
         "zip"
     }
 
-    fn update_state(&mut self, recv: &mut [PortState], send: &mut [PortState]) -> PolarsResult<()> {
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
         assert!(send.len() == 1);
         assert!(recv.len() == self.input_heads.len());
 
@@ -207,7 +212,7 @@ impl ComputeNode for ZipNode {
         scope: &'s TaskScope<'s, 'env>,
         recv_ports: &mut [Option<RecvPort<'_>>],
         send_ports: &mut [Option<SendPort<'_>>],
-        _state: &'s ExecutionState,
+        _state: &'s StreamingExecutionState,
         join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
     ) {
         assert!(send_ports.len() == 1);


### PR DESCRIPTION
This removes the annoying `initialize` step some nodes had to do to keep around `num_pipelines`, and should make us more consistent in using the same `ExecutionState` everywhere.