### PR TITLE
fix: Memory leaks in SharedStorage

### DIFF
--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -398,8 +398,11 @@ impl Bitmap {
         // We intentionally leak 1MiB of zeroed memory once so we don't have to
         // refcount it.
         const GLOBAL_ZERO_SIZE: usize = 1024 * 1024;
-        static GLOBAL_ZEROES: LazyLock<SharedStorage<u8>> =
-            LazyLock::new(|| SharedStorage::from_static(vec![0; GLOBAL_ZERO_SIZE].leak()));
+        static GLOBAL_ZEROES: LazyLock<SharedStorage<u8>> = LazyLock::new(|| {
+            let mut ss = SharedStorage::from_vec(vec![0; GLOBAL_ZERO_SIZE]);
+            ss.leak();
+            ss
+        });
 
         let bytes_needed = length.div_ceil(8);
         let storage = if bytes_needed <= GLOBAL_ZERO_SIZE {

--- a/crates/polars-arrow/src/storage.rs
+++ b/crates/polars-arrow/src/storage.rs
@@ -40,13 +40,23 @@ enum BackingStorage {
         vtable: &'static VecVTable,
     },
     InternalArrowArray(InternalArrowArray),
+
+    /// Backed by some external method which we do not need to take care of,
+    /// but we still should refcount and drop the SharedStorageInner.
+    External,
+
+    /// Both the backing storage and the SharedStorageInner are leaked, no
+    /// refcounting is done. This technically should be a flag on
+    /// SharedStorageInner instead of being here, but that would add 8 more
+    /// bytes to SharedStorageInner, so here it is.
+    Leaked,
 }
 
 struct SharedStorageInner<T> {
     ref_count: AtomicU64,
     ptr: *mut T,
     length_in_bytes: usize,
-    backing: Option<BackingStorage>,
+    backing: BackingStorage,
     // https://github.com/rust-lang/rfcs/blob/master/text/0769-sound-generic-drop.md#phantom-data
     phantom: PhantomData<T>,
 }
@@ -63,10 +73,10 @@ impl<T> SharedStorageInner<T> {
             ref_count: AtomicU64::new(1),
             ptr,
             length_in_bytes,
-            backing: Some(BackingStorage::Vec {
+            backing: BackingStorage::Vec {
                 original_capacity,
                 vtable: VecVTable::new_static::<T>(),
-            }),
+            },
             phantom: PhantomData,
         }
     }
@@ -74,12 +84,12 @@ impl<T> SharedStorageInner<T> {
 
 impl<T> Drop for SharedStorageInner<T> {
     fn drop(&mut self) {
-        match self.backing.take() {
-            Some(BackingStorage::InternalArrowArray(a)) => drop(a),
-            Some(BackingStorage::Vec {
+        match core::mem::replace(&mut self.backing, BackingStorage::External) {
+            BackingStorage::InternalArrowArray(a) => drop(a),
+            BackingStorage::Vec {
                 original_capacity,
                 vtable,
-            }) => unsafe {
+            } => unsafe {
                 // Drop the elements in our slice.
                 if std::mem::needs_drop::<T>() {
                     core::ptr::drop_in_place(core::ptr::slice_from_raw_parts_mut(
@@ -89,9 +99,11 @@ impl<T> Drop for SharedStorageInner<T> {
                 }
 
                 // Free the buffer.
-                (vtable.drop_buffer)(self.ptr.cast(), original_capacity);
+                if original_capacity > 0 {
+                    (vtable.drop_buffer)(self.ptr.cast(), original_capacity);
+                }
             },
-            None => {},
+            BackingStorage::External | BackingStorage::Leaked => {},
         }
     }
 }
@@ -114,10 +126,10 @@ impl<T> SharedStorage<T> {
     const fn empty() -> Self {
         assert!(align_of::<T>() <= 1 << 30);
         static INNER: SharedStorageInner<()> = SharedStorageInner {
-            ref_count: AtomicU64::new(2), // Never used, but 2 so it won't pass exclusivity tests.
+            ref_count: AtomicU64::new(1),
             ptr: core::ptr::without_provenance_mut(1 << 30), // Very overaligned for any T.
             length_in_bytes: 0,
-            backing: None,
+            backing: BackingStorage::Leaked,
             phantom: PhantomData,
         };
 
@@ -132,10 +144,10 @@ impl<T> SharedStorage<T> {
         let length_in_bytes = slice.len() * size_of::<T>();
         let ptr = slice.as_ptr().cast_mut();
         let inner = SharedStorageInner {
-            ref_count: AtomicU64::new(2), // Never used, but 2 so it won't pass exclusivity tests.
+            ref_count: AtomicU64::new(1),
             ptr,
             length_in_bytes,
-            backing: None,
+            backing: BackingStorage::External,
             phantom: PhantomData,
         };
         Self {
@@ -156,12 +168,27 @@ impl<T> SharedStorage<T> {
             ref_count: AtomicU64::new(1),
             ptr: ptr.cast_mut(),
             length_in_bytes: len * size_of::<T>(),
-            backing: Some(BackingStorage::InternalArrowArray(arr)),
+            backing: BackingStorage::InternalArrowArray(arr),
             phantom: PhantomData,
         };
         Self {
             inner: NonNull::new(Box::into_raw(Box::new(inner))).unwrap(),
             phantom: PhantomData,
+        }
+    }
+
+    /// Leaks this SharedStorage such that it and its inner value is never
+    /// dropped. In return no refcounting needs to be performed.
+    ///
+    /// The SharedStorage must be exclusive.
+    pub fn leak(&mut self) {
+        assert!(self.is_exclusive());
+        unsafe {
+            let inner = &mut *self.inner.as_ptr();
+            core::mem::forget(core::mem::replace(
+                &mut inner.backing,
+                BackingStorage::Leaked,
+            ));
         }
     }
 }
@@ -234,20 +261,6 @@ impl<T> SharedStorage<T> {
 
     /// Try to take the vec backing this SharedStorage, leaving this as an empty slice.
     pub fn try_take_vec(&mut self) -> Option<Vec<T>> {
-        // We may only go back to a Vec if we originally came from a Vec
-        // where the desired size/align matches the original.
-        let Some(BackingStorage::Vec {
-            original_capacity,
-            vtable,
-        }) = self.inner().backing
-        else {
-            return None;
-        };
-
-        if vtable.size != size_of::<T>() || vtable.align != align_of::<T>() {
-            return None;
-        }
-
         // If there are other references we can't get an exclusive reference.
         if !self.is_exclusive() {
             return None;
@@ -256,10 +269,26 @@ impl<T> SharedStorage<T> {
         let ret;
         unsafe {
             let inner = &mut *self.inner.as_ptr();
+
+            // We may only go back to a Vec if we originally came from a Vec
+            // where the desired size/align matches the original.
+            let BackingStorage::Vec {
+                original_capacity,
+                vtable,
+            } = &mut inner.backing
+            else {
+                return None;
+            };
+
+            if vtable.size != size_of::<T>() || vtable.align != align_of::<T>() {
+                return None;
+            }
+
+            // Steal vec from inner.
             let len = inner.length_in_bytes / size_of::<T>();
-            ret = Vec::from_raw_parts(inner.ptr, len, original_capacity);
+            ret = Vec::from_raw_parts(inner.ptr, len, *original_capacity);
+            *original_capacity = 0;
             inner.length_in_bytes = 0;
-            inner.backing = None;
         }
         Some(ret)
     }
@@ -342,7 +371,7 @@ impl<T> Deref for SharedStorage<T> {
 impl<T> Clone for SharedStorage<T> {
     fn clone(&self) -> Self {
         let inner = self.inner();
-        if inner.backing.is_some() {
+        if !matches!(inner.backing, BackingStorage::Leaked) {
             // Ordering semantics copied from Arc<T>.
             inner.ref_count.fetch_add(1, Ordering::Relaxed);
         }
@@ -356,7 +385,7 @@ impl<T> Clone for SharedStorage<T> {
 impl<T> Drop for SharedStorage<T> {
     fn drop(&mut self) {
         let inner = self.inner();
-        if inner.backing.is_none() {
+        if matches!(inner.backing, BackingStorage::Leaked) {
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/21732.

We leaked a small amount of memory every time one of two things happens:

1. `SharedStorage::from_static` was called.
2. `SharedStorage::try_into_vec`/`SharedStorage::try_take_vec` was called.

In both cases the cause is very similar: they would set the `backing_storage` to `None`. A side-effect of this is that this would disable refcounting, which was intended for eternally-leaked `SharedStorage`s, but would incorrectly leak the `SharedStorageInner` here.

In both cases the amount of leaked memory was only 48 bytes, but this could be amplified quite significantly due to causing extra fragmentation.