### PR TITLE
debug join performance

### DIFF
--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -308,5 +308,7 @@ pub fn execute_graph(
         }
     }
 
+    crate::utils::print_trace_stats();
+
     Ok(out)
 }

--- a/crates/polars-stream/src/nodes/in_memory_map.rs
+++ b/crates/polars-stream/src/nodes/in_memory_map.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 
 use polars_core::schema::Schema;

--- a/crates/polars-stream/src/nodes/in_memory_sink.rs
+++ b/crates/polars-stream/src/nodes/in_memory_sink.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -62,7 +63,7 @@ impl ComputeNode for InMemorySinkNode {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
                 let mut morsels = Vec::new();
-                while let Ok(mut morsel) = recv.recv().await {
+                while let Ok(mut morsel) = recv.recv().trace_await().await {
                     morsel.take_consume_token();
                     morsels.push(morsel);
                 }

--- a/crates/polars-stream/src/nodes/in_memory_source.rs
+++ b/crates/polars-stream/src/nodes/in_memory_source.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -97,11 +98,11 @@ impl ComputeNode for InMemorySourceNode {
                     let morsel_seq = MorselSeq::new(seq).offset_by(slf.seq_offset);
                     let mut morsel = Morsel::new(df, morsel_seq, source_token.clone());
                     morsel.set_consume_token(wait_group.token());
-                    if send.send(morsel).await.is_err() {
+                    if send.send(morsel).trace_await().await.is_err() {
                         break;
                     }
 
-                    wait_group.wait().await;
+                    wait_group.wait().trace_await().await;
                     if source_token.stop_requested() {
                         break;
                     }

--- a/crates/polars-stream/src/nodes/input_independent_select.rs
+++ b/crates/polars-stream/src/nodes/input_independent_select.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 
 use polars_core::POOL;

--- a/crates/polars-stream/src/nodes/io_sinks/csv.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/csv.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::cmp::Reverse;
 use std::path::PathBuf;
 
@@ -81,8 +82,8 @@ impl SinkNode for CsvSinkNode {
                 let mut allocation_size = DEFAULT_ALLOCATION_SIZE;
                 let options = options.clone();
 
-                while let Ok((mut rx, mut lin_tx)) = pass_rx.recv().await {
-                    while let Ok(morsel) = rx.recv().await {
+                while let Ok((mut rx, mut lin_tx)) = pass_rx.recv().trace_await().await {
+                    while let Ok(morsel) = rx.recv().trace_await().await {
                         let (df, seq, _, consume_token) = morsel.into_inner();
 
                         let mut buffer = Vec::with_capacity(allocation_size);
@@ -105,7 +106,7 @@ impl SinkNode for CsvSinkNode {
                         writer.write_batch(&df)?;
 
                         allocation_size = allocation_size.max(buffer.len());
-                        if lin_tx.insert(Priority(Reverse(seq), buffer)).await.is_err() {
+                        if lin_tx.insert(Priority(Reverse(seq), buffer)).trace_await().await.is_err() {
                             return Ok(());
                         }
                         drop(consume_token); // Keep the consume_token until here to increase the
@@ -130,7 +131,7 @@ impl SinkNode for CsvSinkNode {
             use tokio::io::AsyncWriteExt;
 
             if sink_options.mkdir {
-                polars_io::utils::mkdir::tokio_mkdir_recursive(path.as_path()).await?;
+                polars_io::utils::mkdir::tokio_mkdir_recursive(path.as_path()).trace_await().await?;
             }
 
             let mut file = polars_io::utils::file::Writeable::try_new(
@@ -150,9 +151,9 @@ impl SinkNode for CsvSinkNode {
 
             let mut file = file.try_into_async_writeable()?;
 
-            while let Ok(mut lin_rx) = io_rx.recv().await {
-                while let Some(Priority(_, buffer)) = lin_rx.get().await {
-                    file.write_all(&buffer).await?;
+            while let Ok(mut lin_rx) = io_rx.recv().trace_await().await {
+                while let Some(Priority(_, buffer)) = lin_rx.get().trace_await().await {
+                    file.write_all(&buffer).trace_await().await?;
                 }
             }
 
@@ -161,16 +162,16 @@ impl SinkNode for CsvSinkNode {
                     sink_options.sync_on_close,
                     file,
                 )
-                .await?;
+                .trace_await().await?;
             }
 
-            file.close().await?;
+            file.close().trace_await().await?;
 
             PolarsResult::Ok(())
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
-                .await
+                .trace_await().await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));
     }

--- a/crates/polars-stream/src/nodes/io_sinks/json.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/json.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::cmp::Reverse;
 use std::path::PathBuf;
 
@@ -71,8 +72,8 @@ impl SinkNode for NDJsonSinkNode {
                 // allocations, we adjust to that over time.
                 let mut allocation_size = DEFAULT_ALLOCATION_SIZE;
 
-                while let Ok((mut rx, mut lin_tx)) = pass_rx.recv().await {
-                    while let Ok(morsel) = rx.recv().await {
+                while let Ok((mut rx, mut lin_tx)) = pass_rx.recv().trace_await().await {
+                    while let Ok(morsel) = rx.recv().trace_await().await {
                         let (df, seq, _, consume_token) = morsel.into_inner();
 
                         let mut buffer = Vec::with_capacity(allocation_size);
@@ -81,7 +82,7 @@ impl SinkNode for NDJsonSinkNode {
                         writer.write_batch(&df)?;
 
                         allocation_size = allocation_size.max(buffer.len());
-                        if lin_tx.insert(Priority(Reverse(seq), buffer)).await.is_err() {
+                        if lin_tx.insert(Priority(Reverse(seq), buffer)).trace_await().await.is_err() {
                             return Ok(());
                         }
                         drop(consume_token); // Keep the consume_token until here to increase the
@@ -103,18 +104,18 @@ impl SinkNode for NDJsonSinkNode {
             use tokio::io::AsyncWriteExt;
 
             if sink_options.mkdir {
-                polars_io::utils::mkdir::tokio_mkdir_recursive(path.as_path()).await?;
+                polars_io::utils::mkdir::tokio_mkdir_recursive(path.as_path()).trace_await().await?;
             }
 
             let mut file = polars_io::utils::file::AsyncWriteable::try_new(
                 path.to_str().unwrap(),
                 cloud_options.as_ref(),
             )
-            .await?;
+            .trace_await().await?;
 
-            while let Ok(mut lin_rx) = io_rx.recv().await {
-                while let Some(Priority(_, buffer)) = lin_rx.get().await {
-                    file.write_all(&buffer).await?;
+            while let Ok(mut lin_rx) = io_rx.recv().trace_await().await {
+                while let Some(Priority(_, buffer)) = lin_rx.get().trace_await().await {
+                    file.write_all(&buffer).trace_await().await?;
                 }
             }
 
@@ -123,16 +124,16 @@ impl SinkNode for NDJsonSinkNode {
                     sink_options.sync_on_close,
                     file,
                 )
-                .await?;
+                .trace_await().await?;
             }
 
-            file.close().await?;
+            file.close().trace_await().await?;
 
             PolarsResult::Ok(())
         });
         join_handles.push(spawn(TaskPriority::Low, async move {
             io_task
-                .await
+                .trace_await().await
                 .unwrap_or_else(|e| Err(std::io::Error::from(e).into()))
         }));
     }

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/chunk_reader.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 
 use polars_core::schema::{SchemaExt, SchemaRef};

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_distributor.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/line_batch_distributor.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use polars_core::config;
 use polars_error::PolarsResult;
 use polars_io::prelude::json_lines;
@@ -109,7 +110,7 @@ impl LineBatchDistributor {
                             bytes: full_chunk,
                             chunk_idx,
                         })
-                        .await
+                        .trace_await().await
                         .is_err()
                 {
                     break;

--- a/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ndjson/mod.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::cmp::Reverse;
 use std::ops::Range;
 use std::sync::Arc;
@@ -353,14 +354,14 @@ impl SourceNode for NDJsonSourceNode {
         ));
 
         join_handles.push(spawn(TaskPriority::Low, async move {
-            let mut row_count = line_batch_distributor_task_handle.await?;
+            let mut row_count = line_batch_distributor_task_handle.trace_await().await?;
 
             if verbose {
                 eprintln!("[NDJSON source]: line batch distributor handle returned");
             }
 
             for handle in line_batch_processor_handles {
-                let n_rows_processed = handle.await?;
+                let n_rows_processed = handle.trace_await().await?;
                 if needs_total_row_count {
                     row_count = row_count.checked_add(n_rows_processed).unwrap();
                 }
@@ -400,7 +401,7 @@ impl SourceNode for NDJsonSourceNode {
             }
 
             if let Some(handle) = opt_post_process_handle {
-                handle.await?;
+                handle.trace_await().await?;
             }
 
             if verbose {
@@ -412,7 +413,7 @@ impl SourceNode for NDJsonSourceNode {
 
         join_handles.push(spawn(TaskPriority::Low, async move {
             // Every phase we are given a new send port.
-            while let Ok(phase_output) = output_recv.recv().await {
+            while let Ok(phase_output) = output_recv.recv().trace_await().await {
                 let source_token = SourceToken::new();
                 let morsel_senders = phase_output.port.parallel();
 
@@ -421,14 +422,14 @@ impl SourceNode for NDJsonSourceNode {
                 for (phase_tx_senders, port) in phase_tx_senders.iter_mut().zip(morsel_senders) {
                     let (outcome, wait_group, morsel_output) =
                         MorselOutput::from_port(port, source_token.clone());
-                    _ = phase_tx_senders.send(morsel_output).await;
+                    _ = phase_tx_senders.send(morsel_output).trace_await().await;
                     morsel_outcomes.push((outcome, wait_group));
                 }
 
                 let mut is_finished = true;
 
                 for (outcome, wait_group) in morsel_outcomes.into_iter() {
-                    wait_group.wait().await;
+                    wait_group.wait().trace_await().await;
                     is_finished &= outcome.did_finish();
                 }
 

--- a/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/mod.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 
 use polars_core::config;
@@ -183,20 +184,20 @@ impl SourceNode for ParquetSourceNode {
             }
 
             // Every phase we are given a new send port.
-            while let Ok(phase_output) = output_recv.recv().await {
+            while let Ok(phase_output) = output_recv.recv().trace_await().await {
                 let source_token = SourceToken::new();
                 let morsel_senders = phase_output.port.parallel();
                 let mut morsel_outcomes = Vec::with_capacity(morsel_senders.len());
                 for (send_to, port) in send_to.iter_mut().zip(morsel_senders) {
                     let (outcome, wait_group, morsel_output) =
                         MorselOutput::from_port(port, source_token.clone());
-                    _ = send_to.send(morsel_output).await;
+                    _ = send_to.send(morsel_output).trace_await().await;
                     morsel_outcomes.push((outcome, wait_group));
                 }
 
                 let mut is_finished = true;
                 for (outcome, wait_group) in morsel_outcomes.into_iter() {
-                    wait_group.wait().await;
+                    wait_group.wait().trace_await().await;
                     is_finished &= outcome.did_finish();
                 }
 
@@ -211,25 +212,25 @@ impl SourceNode for ParquetSourceNode {
             // Safety
             // * We dropped the receivers on the line above
             // * This function is only called once.
-            _ = morsel_stream_task_handle.await.unwrap();
+            _ = morsel_stream_task_handle.trace_await().await.unwrap();
             Ok(())
         }));
 
         join_handles.extend(recv_from.into_iter().zip(raw_morsel_receivers).map(
             |(mut recv_from, mut raw_morsel_rx)| {
                 spawn(TaskPriority::Low, async move {
-                    'port_recv: while let Ok(mut morsel_output) = recv_from.recv().await {
+                    'port_recv: while let Ok(mut morsel_output) = recv_from.recv().trace_await().await {
                         let wait_group = WaitGroup::default();
 
-                        while let Ok((df, seq)) = raw_morsel_rx.recv().await {
+                        while let Ok((df, seq)) = raw_morsel_rx.recv().trace_await().await {
                             let mut morsel =
                                 Morsel::new(df, seq, morsel_output.source_token.clone());
                             morsel.set_consume_token(wait_group.token());
-                            if morsel_output.port.send(morsel).await.is_err() {
+                            if morsel_output.port.send(morsel).trace_await().await.is_err() {
                                 break;
                             }
 
-                            wait_group.wait().await;
+                            wait_group.wait().trace_await().await;
                             if morsel_output.source_token.stop_requested() {
                                 morsel_output.outcome.stop();
                                 continue 'port_recv;
@@ -282,11 +283,11 @@ impl MultiScanable for ParquetSourceNode {
                         },
                         cloud_options.as_ref(),
                     )
-                    .await?;
+                    .trace_await().await?;
 
-                metadata_utils::read_parquet_metadata_bytes(&byte_source, verbose).await
+                metadata_utils::read_parquet_metadata_bytes(&byte_source, verbose).trace_await().await
             })
-            .await
+            .trace_await().await
             .unwrap()?;
 
         let file_metadata = polars_parquet::parquet::read::deserialize_metadata(

--- a/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/row_group_data_fetch.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -123,7 +124,7 @@ impl RowGroupDataFetcher {
 
                         let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+                        let bytes_map = current_byte_source.get_ranges(&mut ranges).trace_await().await?;
 
                         assert_eq!(bytes_map.len(), n_ranges);
 
@@ -141,7 +142,7 @@ impl RowGroupDataFetcher {
 
                         let n_ranges = ranges.len();
 
-                        let bytes_map = current_byte_source.get_ranges(&mut ranges).await?;
+                        let bytes_map = current_byte_source.get_ranges(&mut ranges).trace_await().await?;
 
                         assert_eq!(bytes_map.len(), n_ranges);
 

--- a/crates/polars-stream/src/nodes/joins/in_memory.rs
+++ b/crates/polars-stream/src/nodes/joins/in_memory.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 
 use polars_core::schema::Schema;

--- a/crates/polars-stream/src/nodes/joins/mod.rs
+++ b/crates/polars-stream/src/nodes/joins/mod.rs
@@ -1,2 +1,3 @@
+use crate::utils::TraceAwait;
 pub mod equi_join;
 pub mod in_memory;

--- a/crates/polars-stream/src/nodes/map.rs
+++ b/crates/polars-stream/src/nodes/map.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use polars_plan::plans::DataFrameUdf;
 
 use super::compute_node_prelude::*;
+use crate::utils::TraceAwait;
 
 /// A simple mapping node. Assumes the given udf is elementwise.
 pub struct MapNode {
@@ -46,9 +47,9 @@ impl ComputeNode for MapNode {
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                while let Ok(morsel) = recv.recv().await {
+                while let Ok(morsel) = recv.recv().trace_await().await {
                     let morsel = morsel.try_map(|df| slf.map.call_udf(df))?;
-                    if send.send(morsel).await.is_err() {
+                    if send.send(morsel).trace_await().await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/nodes/mod.rs
+++ b/crates/polars-stream/src/nodes/mod.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 pub mod filter;
 pub mod group_by;
 pub mod in_memory_map;

--- a/crates/polars-stream/src/nodes/negative_slice.rs
+++ b/crates/polars-stream/src/nodes/negative_slice.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -121,7 +122,7 @@ impl ComputeNode for NegativeSliceNode {
                 assert!(send_ports[0].is_none());
                 let max_buffer_needed = self.slice_offset.unsigned_abs() as usize;
                 join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                    while let Ok(morsel) = recv.recv().await {
+                    while let Ok(morsel) = recv.recv().trace_await().await {
                         buffer.total_len += morsel.df().height();
                         buffer.frames.push_back(morsel.into_df());
 

--- a/crates/polars-stream/src/nodes/select.rs
+++ b/crates/polars-stream/src/nodes/select.rs
@@ -1,3 +1,4 @@
+use crate::utils::TraceAwait;
 use std::sync::Arc;
 
 use polars_core::prelude::IntoColumn;
@@ -53,11 +54,11 @@ impl ComputeNode for SelectNode {
         for (mut recv, mut send) in receivers.into_iter().zip(senders) {
             let slf = &*self;
             join_handles.push(scope.spawn_task(TaskPriority::High, async move {
-                while let Ok(morsel) = recv.recv().await {
+                while let Ok(morsel) = recv.recv().trace_await().await {
                     let (df, seq, source_token, consume_token) = morsel.into_inner();
                     let mut selected = Vec::new();
                     for selector in slf.selectors.iter() {
-                        let s = selector.evaluate(&df, &state.in_memory_exec_state).await?;
+                        let s = selector.evaluate(&df, &state.in_memory_exec_state).trace_await().await?;
                         selected.push(s.into_column());
                     }
 
@@ -74,7 +75,7 @@ impl ComputeNode for SelectNode {
                         morsel.set_consume_token(token);
                     }
 
-                    if send.send(morsel).await.is_err() {
+                    if send.send(morsel).trace_await().await.is_err() {
                         break;
                     }
                 }

--- a/crates/polars-stream/src/utils/mod.rs
+++ b/crates/polars-stream/src/utils/mod.rs
@@ -1,3 +1,101 @@
 pub mod in_memory_linearize;
 pub mod late_materialized_df;
 pub mod task_handles_ext;
+
+use std::future::Future;
+use std::panic::Location;
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use polars_core::prelude::PlHashMap;
+
+static ENABLE: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("POLARS_TRACED_AWAIT").as_deref() == Ok("1"));
+
+static LOCAL_TRACERS: LazyLock<Mutex<Vec<Arc<Mutex<TraceStats>>>>> =
+    LazyLock::new(|| Mutex::default());
+
+thread_local!(
+    static LOCAL_TRACER: Arc<Mutex<TraceStats>> = {
+        let arc = Arc::new(Mutex::new(TraceStats::default()));
+        LOCAL_TRACERS.lock().push(arc.clone());
+        arc
+    };
+);
+
+#[derive(Default)]
+struct TraceStats {
+    calls: PlHashMap<&'static Location<'static>, (usize, Duration)>,
+}
+
+impl TraceStats {
+    fn add(&mut self, loc: &'static Location<'static>, calls: usize, dur: Duration) {
+        let c = self.calls.entry(loc).or_default();
+        c.0 += calls;
+        c.1 += dur;
+    }
+
+    fn combine(&mut self, other: &Self) {
+        for (loc, (calls, total_dur)) in &other.calls {
+            self.add(*loc, *calls, *total_dur);
+        }
+    }
+}
+
+pub fn print_trace_stats() {
+    let mut stats = TraceStats::default();
+    for local_tracer in LOCAL_TRACERS.lock().iter() {
+        stats.combine(&*local_tracer.lock());
+    }
+
+    for (loc, (calls, total_dur)) in stats.calls {
+        eprintln!(
+            "{}:{}: {:>10} {}",
+            loc.file(),
+            loc.line(),
+            calls,
+            total_dur.as_millis()
+        );
+    }
+}
+
+pub trait TraceAwait: Sized + Future + Send {
+    #[track_caller]
+    fn trace_await(self) -> impl Future<Output = Self::Output> + Send {
+        let caller_location = Location::caller();
+
+        async move {
+            if !*ENABLE {
+                return self.await;
+            }
+
+            // static ID: AtomicUsize = AtomicUsize::new(0);
+            // let local_id = ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            // eprintln!(
+            //     "begin_await {} {}:{}",
+            //     local_id,
+            //     caller_location.file(),
+            //     caller_location.line()
+            // );
+
+            let start = Instant::now();
+            let out = self.await;
+            let elapsed = start.elapsed();
+            LOCAL_TRACER.with(|tracer| {
+                tracer.lock().add(caller_location, 1, elapsed);
+            });
+
+            // eprintln!(
+            //     "finish_await {} {}:{}",
+            //     local_id,
+            //     caller_location.file(),
+            //     caller_location.line()
+            // );
+
+            out
+        }
+    }
+}
+
+impl<F: Sized + Future + Send> TraceAwait for F {}


### PR DESCRIPTION
@orlp 

(locations based on this branch)

`POLARS_TRACED_AWAIT=1 POLARS_JOIN_SAMPLE_LIMIT=100000000 python ...`

<details>
<summary>old</summary>

```
| location                                               | n_calls | wait_millis | n_calls_slow | wait_millis_slow | extra_millis |
|--------------------------------------------------------|---------|-------------|--------------|------------------|--------------|
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:136 | 13973   | 31035       | 13973        | 106328           | 75293        |
| crates/polars-stream/src/nodes/joins/equi_join.rs:262  | 66      | 49234       | 66           | 114853           | 65619        |
| crates/polars-stream/src/nodes/simple_projection.rs:65 | 18260   | 44179       | 18260        | 103073           | 58894        |
| crates/polars-stream/src/nodes/joins/equi_join.rs:995  | 18205   | 44277       | 18205        | 103078           | 58801        |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:271 | 6982    | 4585        | 6982         | 11365            | 6780         |
| crates/polars-stream/src/nodes/simple_projection.rs:54 | 18271   | 5033        | 18271        | 11767            | 6734         |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:205 | 13963   | 4812        | 13963        | 11459            | 6647         |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:70      | 18261   | 4836        | 18261        | 11445            | 6609         |
| crates/polars-stream/src/nodes/joins/equi_join.rs:1575 | 11      | 4870        | 11           | 11463            | 6593         |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:264     | 1       | 4877        | 1            | 11470            | 6593         |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:291 | 1       | 4897        | 1            | 11490            | 6593         |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:214     | 15      | 19          | 15           | 20               | 1            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:324  | 68      | 0           | 68           | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:131  | 66      | 0           | 66           | 0                | 0            |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:262     | 1       | 0           | 1            | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:826  | 66      | 0           | 66           | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:521  | 22      | 0           | 22           | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:530  | 11      | 0           | 11           | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:452  | 22      | 0           | 22           | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:259  | 66      | 0           | 66           | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:1012 | 55      | 0           | 55           | 0                | 0            |
| crates/polars-stream/src/nodes/in_memory_source.rs:101 | 66      | 0           | 66           | 0                | 0            |
| crates/polars-stream/src/nodes/joins/equi_join.rs:837  | 55      | 1           | 55           | 1                | 0            |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:68      | 2       | 0           | 2            | 0                | 0            |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:98      | 2       | 0           | 2            | 0                | 0            |
| crates/polars-stream/src/nodes/in_memory_source.rs:105 | 66      | 1           | 66           | 0                | -1           |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:80      | 13960   | 4           | 13960        | 3                | -1           |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:224 | 6981    | 63          | 6981         | 11               | -52          |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:174 | 13962   | 73          | 13962        | 2                | -71          |
```
</details>

```
| location                                               | n_awaits | await_millis | n_polls | poll_millis | n_awaits_slow | await_millis_slow | n_polls_slow | poll_millis_slow |
|--------------------------------------------------------|----------|--------------|---------|-------------|---------------|-------------------|--------------|------------------|
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:136 | 13973    | 114512       | 27787   | 0           | +0            | +312317           | +155         | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:262  | 66       | 183058       | 132     | 0           | +0            | +281098           | +0           | +0               |
| crates/polars-stream/src/nodes/simple_projection.rs:65 | 18260    | 164116       | 18618   | 0           | +0            | +252018           | -147         | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:995  | 18205    | 164503       | 36132   | 0           | +0            | +251834           | +129         | +0               |
| crates/polars-stream/src/nodes/simple_projection.rs:54 | 18271    | 18855        | 36233   | 0           | +0            | +29085            | +144         | +0               |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:271 | 6982     | 17250        | 13556   | 0           | +0            | +28618            | +313         | +0               |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:205 | 13963    | 18000        | 23760   | 0           | +0            | +28508            | +662         | +0               |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:291 | 1        | 18331        | 2       | 0           | +0            | +28345            | +0           | +0               |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:264     | 1        | 18255        | 2       | 0           | +0            | +28337            | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:1575 | 11       | 18234        | 22      | 0           | +0            | +28326            | +0           | +0               |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:70      | 18261    | 18123        | 36501   | 0           | +0            | +28311            | +15          | +0               |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:214     | 15       | 76           | 23      | 0           | +0            | +6                | +0           | +0               |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:80      | 13960    | 13           | 13960   | 0           | +0            | +4                | +0           | +0               |
| crates/polars-stream/src/nodes/in_memory_source.rs:105 | 66       | 9            | 131     | 0           | +0            | +3                | -1           | +0               |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:262     | 1        | 0            | 1       | 0           | +0            | +0                | +0           | +0               |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:98      | 2        | 0            | 2       | 0           | +0            | +0                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:259  | 66       | 0            | 66      | 0           | +0            | +0                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:452  | 22       | 1            | 23      | 0           | +0            | +0                | +1           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:521  | 22       | 0            | 33      | 0           | +0            | +0                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:826  | 66       | 0            | 121     | 0           | +0            | +0                | +0           | +0               |
| crates/polars-stream/src/nodes/in_memory_source.rs:101 | 66       | 1            | 66      | 0           | +0            | -1                | +0           | +0               |
| crates/polars-stream/src/nodes/io_sinks/mod.rs:68      | 2        | 1            | 4       | 0           | +0            | -1                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:131  | 66       | 1            | 66      | 0           | +0            | -1                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:837  | 55       | 5            | 55      | 0           | +0            | -1                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:324  | 68       | 7            | 134     | 0           | +0            | -4                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:530  | 11       | 10           | 11      | 0           | +0            | -6                | +0           | +0               |
| crates/polars-stream/src/nodes/joins/equi_join.rs:1012 | 55       | 12           | 109     | 0           | +0            | -11               | +1           | +0               |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:224 | 6981     | 251          | 7408    | 0           | +0            | -171              | -340         | +0               |
| crates/polars-stream/src/nodes/io_sinks/parquet.rs:174 | 13962    | 523          | 14143   | 0           | +0            | -505              | -181         | +0               |
```

<details>
<summary>script</summary>

```python
import polars as pl
from pathlib import Path

lhs = (
    pl.Series("raw", [Path(".env/trace").read_text()])
    .str.strip_chars_end("\n")
    .str.split("\n")
    .list.explode()
    .to_frame()
    .filter(pl.first().str.starts_with("crates/"))
    .with_columns(
        pl.first().str.replace(": ", "", literal=True).str.replace_all(r"\s+", " ")
    )
    .select(
        pl.first()
        .str.split_exact(" ", 4)
        .struct.rename_fields(
            ["location", "n_awaits", "await_millis", "n_polls", "poll_millis"]
        )
        .struct.unnest()
    )
)

rhs = (
    pl.Series("raw", [Path(".env/trace2").read_text()])
    .str.strip_chars_end("\n")
    .str.split("\n")
    .list.explode()
    .to_frame()
    .filter(pl.first().str.starts_with("crates/"))
    .with_columns(
        pl.first().str.replace(": ", "", literal=True).str.replace_all(r"\s+", " ")
    )
    .select(
        pl.first()
        .str.split_exact(" ", 4)
        .struct.rename_fields(
            ["location", "n_awaits", "await_millis", "n_polls", "poll_millis"]
        )
        .struct.unnest()
    )
)

v = (
    lhs.join(rhs, on="location", how="full", coalesce=True, suffix="_slow")
    .with_columns(pl.exclude("location").cast(pl.Int64))
    .with_columns(
        pl.col(f"{x}_slow") - pl.col(x)
        for x in ["n_awaits", "await_millis", "n_polls", "poll_millis"]
    )
    .sort("await_millis_slow", "location", descending=[True, False])
    .with_columns(
        pl.when((c := pl.col("^.*_slow$")) >= 0)
        .then("+" + c.cast(pl.String))
        .otherwise(c.cast(pl.String))
        .name.keep()
    )
)

with pl.Config(
    tbl_formatting="ASCII_MARKDOWN",
    fmt_str_lengths=999,
    tbl_width_chars=999,
    tbl_hide_column_data_types=True,
    tbl_rows=999,
    tbl_cols=999,
):
    print(v)

```

</details>
