### PR TITLE
fix: Fix collect_all type-coercion

### DIFF
--- a/py-polars/polars/lazyframe/opt_flags.py
+++ b/py-polars/polars/lazyframe/opt_flags.py
@@ -25,6 +25,7 @@ class OptFlags:
         self._pyoptflags = PyOptFlags.empty()
 
         self._pyoptflags.type_check = _type_check
+        self._pyoptflags.type_coercion = _type_coercion
         self._pyoptflags.predicate_pushdown = predicate_pushdown
         self._pyoptflags.projection_pushdown = projection_pushdown
         self._pyoptflags.simplify_expression = simplify_expression

--- a/py-polars/tests/unit/lazyframe/test_collect_all.py
+++ b/py-polars/tests/unit/lazyframe/test_collect_all.py
@@ -1,0 +1,20 @@
+from typing import cast
+
+import pytest
+
+import polars as pl
+
+
+def test_collect_all_type_coercion_21805() -> None:
+    df = pl.LazyFrame({"A": [1.0, 2.0]})
+    df = df.with_columns(pl.col("A").shift().fill_null(2))
+    assert pl.collect_all([df])[0]["A"].to_list() == [2.0, 1.0]
+
+
+@pytest.mark.parametrize("no_optimization", [False, True])
+def test_collect_all(df: pl.DataFrame, no_optimization: bool) -> None:
+    lf1 = df.lazy().select(pl.col("int").sum())
+    lf2 = df.lazy().select((pl.col("floats") * 2).sum())
+    out = pl.collect_all([lf1, lf2], no_optimization=no_optimization)
+    assert cast(int, out[0].item()) == 6
+    assert cast(float, out[1].item()) == 12.0

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -928,15 +928,6 @@ def test_join_suffix() -> None:
     assert out.columns == ["a", "b", "c", "b_bar", "c_bar"]
 
 
-@pytest.mark.parametrize("no_optimization", [False, True])
-def test_collect_all(df: pl.DataFrame, no_optimization: bool) -> None:
-    lf1 = df.lazy().select(pl.col("int").sum())
-    lf2 = df.lazy().select((pl.col("floats") * 2).sum())
-    out = pl.collect_all([lf1, lf2], no_optimization=no_optimization)
-    assert cast(int, out[0].item()) == 6
-    assert cast(float, out[1].item()) == 12.0
-
-
 def test_collect_unexpected_kwargs(df: pl.DataFrame) -> None:
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         df.lazy().collect(common_subexpr_elim=False)  # type: ignore[call-overload]


### PR DESCRIPTION
@coastalwhite FYI.


Might we worth a patch given that running a query without type-coercion is utterly broken.