### PR TITLE
refactor(rust): Add MorselLinearizer convenience wrapper

### DIFF
--- a/crates/polars-stream/src/async_primitives/mod.rs
+++ b/crates/polars-stream/src/async_primitives/mod.rs
@@ -1,5 +1,6 @@
 pub mod connector;
 pub mod distributor_channel;
 pub mod linearizer;
+pub mod morsel_linearizer;
 pub mod task_parker;
 pub mod wait_group;

--- a/crates/polars-stream/src/async_primitives/mod.rs
+++ b/crates/polars-stream/src/async_primitives/mod.rs
@@ -1,7 +1,7 @@
 pub mod connector;
 pub mod distributor_channel;
 pub mod linearizer;
-#[allow(unused)]
+#[expect(unused)]
 pub mod morsel_linearizer;
 pub mod task_parker;
 pub mod wait_group;

--- a/crates/polars-stream/src/async_primitives/mod.rs
+++ b/crates/polars-stream/src/async_primitives/mod.rs
@@ -1,6 +1,7 @@
 pub mod connector;
 pub mod distributor_channel;
 pub mod linearizer;
+#[allow(unused)]
 pub mod morsel_linearizer;
 pub mod task_parker;
 pub mod wait_group;

--- a/crates/polars-stream/src/async_primitives/morsel_linearizer.rs
+++ b/crates/polars-stream/src/async_primitives/morsel_linearizer.rs
@@ -1,0 +1,34 @@
+//! Saves us from typing `Priority<Reverse<...` everywhere.
+use std::cmp::Reverse;
+
+use polars_utils::priority::Priority;
+
+use super::linearizer::{Inserter, Linearizer};
+use crate::morsel::{Morsel, MorselSeq};
+
+pub struct MorselLinearizer(Linearizer<Priority<Reverse<MorselSeq>, Morsel>>);
+pub struct MorselInserter(Inserter<Priority<Reverse<MorselSeq>, Morsel>>);
+
+impl MorselLinearizer {
+    pub fn new(num_inserters: usize, buffer_size: usize) -> (Self, Vec<MorselInserter>) {
+        let (lin, inserters) = Linearizer::new(num_inserters, buffer_size);
+
+        (
+            MorselLinearizer(lin),
+            inserters.into_iter().map(MorselInserter).collect(),
+        )
+    }
+
+    pub async fn get(&mut self) -> Option<Morsel> {
+        self.0.get().await.map(|x| x.1)
+    }
+}
+
+impl MorselInserter {
+    pub async fn insert(&mut self, morsel: Morsel) -> Result<(), Morsel> {
+        self.0
+            .insert(Priority(Reverse(morsel.seq()), morsel))
+            .await
+            .map_err(|Priority(_, v)| v)
+    }
+}


### PR DESCRIPTION
Makes it so that we can type:

* `linearizer: MorselLinearizer` instead of `Linearizer<Priority<Reverse<MorselSeq>, Morsel>>)`
* `.insert(morsel)` instead of `.insert(Priority(Reverse(morsel.seq()), morsel))`

@orlp 
