### PR TITLE
refactor(rust): Add ops components for refactored multiscan

### DIFF
--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -85,7 +85,7 @@ impl Column {
     pub fn new_row_index(name: PlSmallStr, offset: IdxSize, length: usize) -> PolarsResult<Column> {
         let length = IdxSize::try_from(length).unwrap_or(IdxSize::MAX);
 
-        if offset.checked_add(IdxSize::MAX).is_none() {
+        if length.checked_add(offset).is_none() {
             polars_bail!(
                 ComputeError:
                 "row index with offset {} overflows on dataframe with height {}",

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -85,7 +85,7 @@ impl Column {
     pub fn new_row_index(name: PlSmallStr, offset: IdxSize, length: usize) -> PolarsResult<Column> {
         let length = IdxSize::try_from(length).unwrap_or(IdxSize::MAX);
 
-        if length.checked_add(offset).is_none() {
+        if offset.checked_add(length).is_none() {
             polars_bail!(
                 ComputeError:
                 "row index with offset {} overflows on dataframe with height {}",

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -75,13 +75,6 @@ impl Column {
         Self::Scalar(ScalarColumn::new(name, scalar, length))
     }
 
-    #[inline]
-    pub fn new_idxsize_range(name: PlSmallStr, range: std::ops::Range<IdxSize>) -> Self {
-        let mut ca = IdxCa::from_vec(name, range.collect());
-        ca.set_sorted_flag(IsSorted::Ascending);
-        ca.into_series().into()
-    }
-
     pub fn new_row_index(name: PlSmallStr, offset: IdxSize, length: usize) -> PolarsResult<Column> {
         let length = IdxSize::try_from(length).unwrap_or(IdxSize::MAX);
 
@@ -93,7 +86,13 @@ impl Column {
             )
         }
 
-        Ok(Column::new_idxsize_range(name, offset..offset + length))
+        let range = offset..offset + length;
+
+        let mut ca = IdxCa::from_vec(name, range.collect());
+        ca.set_sorted_flag(IsSorted::Ascending);
+        let col = ca.into_series().into();
+
+        Ok(col)
     }
 
     // # Materialize

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -474,28 +474,22 @@ impl DataFrame {
         let mut columns = Vec::with_capacity(self.columns.len() + 1);
         let offset = offset.unwrap_or(0);
 
-        let mut ca = IdxCa::from_vec(
-            name,
-            (offset..(self.height() as IdxSize) + offset).collect(),
-        );
-        ca.set_sorted_flag(IsSorted::Ascending);
-        columns.push(ca.into_series().into());
-
+        let col = Column::new_row_index(name, offset, self.height())?;
+        columns.push(col);
         columns.extend_from_slice(&self.columns);
         DataFrame::new(columns)
     }
 
     /// Add a row index column in place.
+    ///
+    /// # Panics
+    /// Panics if the resulting column would reach or overflow IdxSize::MAX.
     pub fn with_row_index_mut(&mut self, name: PlSmallStr, offset: Option<IdxSize>) -> &mut Self {
         let offset = offset.unwrap_or(0);
-        let mut ca = IdxCa::from_vec(
-            name,
-            (offset..(self.height() as IdxSize) + offset).collect(),
-        );
-        ca.set_sorted_flag(IsSorted::Ascending);
+        let col = Column::new_row_index(name, offset, self.height()).unwrap();
 
         self.clear_schema();
-        self.columns.insert(0, ca.into_series().into());
+        self.columns.insert(0, col);
         self
     }
 

--- a/crates/polars-stream/src/nodes/io_sources/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/mod.rs
@@ -15,6 +15,8 @@ use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
 use crate::morsel::SourceToken;
 use crate::nodes::compute_node_prelude::*;
 
+pub mod multi_file_reader;
+
 #[cfg(feature = "csv")]
 pub mod csv;
 #[cfg(feature = "ipc")]

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -160,7 +160,8 @@ impl ApplyExtraOps {
 
                 *reorder = initialized_reorder;
 
-                // Return a `Noop` if our initialized state does not have any operations.
+                // Return a `Noop` if our initialized state does not have any operations. Downstream
+                // can see the `Noop` and avoid running through an extra distributor pipeline.
                 let slf = match slf {
                     Initialized {
                         row_index: None,

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -1,0 +1,240 @@
+//! Implementation of applying the operations during execution.
+use std::sync::Arc;
+
+use polars_core::frame::DataFrame;
+use polars_core::frame::column::ScalarColumn;
+use polars_core::prelude::{AnyValue, Column, DataType, IntoColumn};
+use polars_core::scalar::Scalar;
+use polars_core::schema::SchemaRef;
+use polars_error::PolarsResult;
+use polars_io::RowIndex;
+use polars_io::predicates::ScanIOPredicate;
+use polars_plan::dsl::ScanSources;
+use polars_plan::plans::hive::HivePartitionsDf;
+use polars_utils::IdxSize;
+
+use super::ExtraOperations;
+use super::cast_columns::CastColumns;
+use super::reorder_columns::ReorderColumns;
+
+/// Apply extra operations onto morsels originating from a reader. This should be initialized
+/// per-reader (it contains e.g. file path).
+#[derive(Debug)]
+pub enum ApplyExtraOps {
+    /// Intended to be initialized once, as we expect all morsels coming from a single reader to have
+    /// the same schema. The initialized state can then be executed potentially in parallel by wrapping
+    /// in Arc.
+    Uninitialized {
+        final_output_schema: SchemaRef,
+        projected_file_schema: SchemaRef,
+        extra_ops: ExtraOperations,
+        scan_source_idx: usize,
+        /// This here so that we can get the include file path name if needed.
+        sources: ScanSources,
+        hive_parts: Option<Arc<HivePartitionsDf>>,
+    },
+
+    Initialized {
+        // Note: These fields are ordered according to when they (should be) applied.
+        row_index: Option<RowIndex>,
+        cast_columns: Option<CastColumns>,
+        /// This will have include_file_paths, hive columns, missing columns.
+        extra_columns: Vec<ScalarColumn>,
+        predicate: Option<ScanIOPredicate>,
+        reorder: ReorderColumns,
+    },
+
+    /// No-op.
+    Noop,
+}
+
+impl ApplyExtraOps {
+    pub fn initialize(
+        self,
+        // Schema of the incoming morsels.
+        incoming_schema: &SchemaRef,
+    ) -> PolarsResult<Self> {
+        use ApplyExtraOps::*;
+        match self {
+            Initialized { .. } => panic!("ApplyExtraOps already initialized"),
+            Noop => Ok(Noop),
+
+            Uninitialized {
+                final_output_schema,
+                projected_file_schema,
+                extra_ops:
+                    ExtraOperations {
+                        row_index,
+                        pre_slice,
+                        cast_columns,
+                        missing_columns,
+                        include_file_paths,
+                        predicate,
+                    },
+                scan_source_idx,
+                sources,
+                hive_parts,
+            } => {
+                // This should always be pushed to the reader, or otherwise handled separately.
+                assert!(pre_slice.is_none());
+
+                let cast_columns = if let Some(policy) = cast_columns {
+                    CastColumns::try_init_from_policy(
+                        policy,
+                        &final_output_schema,
+                        incoming_schema,
+                    )?
+                } else {
+                    None
+                };
+
+                let mut extra_columns: Vec<ScalarColumn> = Vec::with_capacity(
+                    final_output_schema.len()
+                        - incoming_schema.len()
+                        - row_index.is_some() as usize,
+                );
+
+                if let Some(policy) = missing_columns {
+                    policy.initialize_policy(
+                        &projected_file_schema,
+                        incoming_schema,
+                        &mut extra_columns,
+                    )?;
+                }
+
+                if let Some(hive_parts) = hive_parts {
+                    extra_columns.extend(hive_parts.df().get_columns().iter().map(|c| {
+                        c.new_from_index(scan_source_idx, 1)
+                            .as_scalar_column()
+                            .unwrap()
+                            .clone()
+                    }))
+                }
+
+                if let Some(file_path_col) = include_file_paths {
+                    extra_columns.push(ScalarColumn::new(
+                        file_path_col,
+                        Scalar::new(
+                            DataType::String,
+                            AnyValue::StringOwned(
+                                sources
+                                    .get(scan_source_idx)
+                                    .unwrap()
+                                    .to_include_path_name()
+                                    .into(),
+                            ),
+                        ),
+                        1,
+                    ))
+                }
+
+                let mut slf = Self::Initialized {
+                    row_index,
+                    cast_columns,
+                    extra_columns,
+                    predicate,
+                    // Initialized below
+                    reorder: ReorderColumns::Passthrough,
+                };
+
+                let schema_before_reorder = if incoming_schema.len() == final_output_schema.len() {
+                    // Incoming schema already has all of the columns, either because no extra columns were needed, or
+                    // the extra columns were attached by the reader (which is just Parquet when it has a predicate).
+                    incoming_schema.clone()
+                } else {
+                    // We use a trick to determine our schema state before reordering by applying onto an empty DataFrame.
+                    // This is much less error prone compared determining it separately.
+                    let mut df = DataFrame::empty_with_schema(incoming_schema);
+                    slf.apply_to_df(&mut df, IdxSize::MAX)?;
+                    df.schema().clone()
+                };
+
+                assert_eq!(schema_before_reorder.len(), final_output_schema.len());
+
+                let initialized_reorder =
+                    ReorderColumns::initialize(&final_output_schema, &schema_before_reorder);
+
+                let Self::Initialized { reorder, .. } = &mut slf else {
+                    unreachable!()
+                };
+
+                *reorder = initialized_reorder;
+
+                // Return a `Noop` if our initialized state does not have any operations.
+                let slf = match slf {
+                    Initialized {
+                        row_index: None,
+                        cast_columns: None,
+                        extra_columns,
+                        predicate: None,
+                        reorder: ReorderColumns::Passthrough,
+                    } if extra_columns.is_empty() => Self::Noop,
+
+                    Initialized { .. } => slf,
+
+                    _ => unreachable!(),
+                };
+
+                Ok(slf)
+            },
+        }
+    }
+
+    /// # Panics
+    /// Panics if `self` is `Uninitialized`
+    pub fn apply_to_df(
+        &self,
+        df: &mut DataFrame,
+        current_row_position: IdxSize,
+    ) -> PolarsResult<()> {
+        let Self::Initialized {
+            row_index,
+            cast_columns,
+            extra_columns,
+            predicate,
+            reorder,
+        } = ({
+            use ApplyExtraOps::*;
+
+            match self {
+                Noop => return Ok(()),
+                Uninitialized { .. } => panic!("ApplyExtraOps not initialized"),
+                Initialized { .. } => self,
+            }
+        })
+        else {
+            unreachable!();
+        };
+
+        if let Some(ri) = row_index {
+            unsafe {
+                df.with_column_unchecked(Column::new_row_index(
+                    ri.name.clone(),
+                    ri.offset.saturating_add(current_row_position),
+                    df.height(),
+                )?)
+            };
+            df.clear_schema();
+        }
+
+        if let Some(cast_columns) = cast_columns {
+            cast_columns.apply_cast(df)?;
+        }
+
+        if !extra_columns.is_empty() {
+            let h = df.height();
+            let cols = unsafe { df.get_columns_mut() };
+            cols.extend(extra_columns.iter().map(|c| c.resize(h).into_column()));
+            df.clear_schema();
+        }
+
+        if let Some(predicate) = predicate {
+            let mask = predicate.predicate.evaluate_io(df)?;
+            *df = df._filter_seq(mask.bool().expect("predicate not boolean"))?;
+        }
+
+        reorder.reorder_columns(df);
+
+        Ok(())
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -88,11 +88,12 @@ impl ApplyExtraOps {
                     None
                 };
 
-                let mut extra_columns: Vec<ScalarColumn> = Vec::with_capacity(
-                    final_output_schema.len()
-                        - incoming_schema.len()
-                        - row_index.is_some() as usize,
-                );
+                let n_expected_extra_columns = final_output_schema.len()
+                    - incoming_schema.len()
+                    - row_index.is_some() as usize;
+
+                let mut extra_columns: Vec<ScalarColumn> =
+                    Vec::with_capacity(n_expected_extra_columns);
 
                 if let Some(policy) = missing_columns {
                     policy.initialize_policy(
@@ -127,6 +128,8 @@ impl ApplyExtraOps {
                         1,
                     ))
                 }
+
+                debug_assert_eq!(extra_columns.len(), n_expected_extra_columns);
 
                 let mut slf = Self::Initialized {
                     row_index,

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -235,6 +235,8 @@ impl ApplyExtraOps {
 
         reorder.reorder_columns(df);
 
+        df.clear_schema();
+
         Ok(())
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
@@ -1,0 +1,45 @@
+use polars_core::frame::DataFrame;
+use polars_core::schema::SchemaRef;
+use polars_error::{PolarsResult, polars_bail};
+
+#[derive(Debug, Clone)]
+pub enum CastColumnsPolicy {
+    /// Raise an error if the datatypes do not match
+    ErrorOnMismatch,
+}
+
+#[derive(Debug)]
+pub struct CastColumns {}
+
+impl CastColumns {
+    pub fn try_init_from_policy(
+        policy: CastColumnsPolicy,
+        target_schema: &SchemaRef,
+        incoming_schema: &SchemaRef,
+    ) -> PolarsResult<Option<Self>> {
+        match policy {
+            CastColumnsPolicy::ErrorOnMismatch => {
+                for (name, dtype) in incoming_schema.iter() {
+                    if let Some(target_dtype) = target_schema.get(name) {
+                        if dtype != target_dtype {
+                            polars_bail!(
+                                SchemaMismatch:
+                                "dtype mismatch for column {}: got: {}, expected: {}",
+                                name, dtype, target_dtype
+                            )
+                        }
+                    } else if cfg!(debug_assertions) {
+                        panic!("impl error: column should exist in casting map")
+                    }
+                }
+
+                Ok(None)
+            },
+        }
+    }
+
+    pub fn apply_cast(&self, _df: &mut DataFrame) -> PolarsResult<()> {
+        unimplemented!()
+        // df.clear_schema(); // remember to do this if cast was applied
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
@@ -2,6 +2,7 @@ use polars_core::frame::DataFrame;
 use polars_core::schema::SchemaRef;
 use polars_error::{PolarsResult, polars_bail};
 
+/// TODO: Eventually move this enum to polars-plan
 #[derive(Debug, Clone)]
 pub enum CastColumnsPolicy {
     /// Raise an error if the datatypes do not match
@@ -24,8 +25,8 @@ impl CastColumns {
                         if dtype != target_dtype {
                             polars_bail!(
                                 SchemaMismatch:
-                                "dtype mismatch for column {}: got: {}, expected: {}",
-                                name, dtype, target_dtype
+                                "data type mismatch for column {}: expected: {}, found: {}",
+                                name, target_dtype, dtype
                             )
                         }
                     } else if cfg!(debug_assertions) {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
@@ -1,0 +1,55 @@
+use polars_core::frame::column::ScalarColumn;
+use polars_core::prelude::AnyValue;
+use polars_core::scalar::Scalar;
+use polars_core::schema::Schema;
+use polars_error::{PolarsResult, polars_bail};
+
+#[derive(Debug, Clone)]
+pub enum MissingColumnsPolicy {
+    Raise,
+    Insert,
+}
+
+impl MissingColumnsPolicy {
+    // Either error or extend `extra_columns` with the missing ones.
+    pub fn initialize_policy(
+        &self,
+        target_schema: &Schema,
+        incoming_schema: &Schema,
+        extra_cols: &mut Vec<ScalarColumn>,
+    ) -> PolarsResult<()> {
+        use MissingColumnsPolicy::*;
+        match self {
+            Raise => {
+                if let Some(col) = target_schema
+                    .iter_names()
+                    .find(|name| !incoming_schema.contains(name))
+                {
+                    polars_bail!(
+                        ComputeError:
+                        "did not find column {}, consider enabling `allow_missing_columns`",
+                        col,
+                    )
+                }
+
+                Ok(())
+            },
+
+            Insert => {
+                extra_cols.extend(
+                    target_schema
+                        .iter()
+                        .filter(|(name, _)| !incoming_schema.contains(name))
+                        .map(|(name, dtype)| {
+                            ScalarColumn::new(
+                                name.clone(),
+                                Scalar::new(dtype.clone(), AnyValue::Null),
+                                1,
+                            )
+                        }),
+                );
+                Ok(())
+            },
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
@@ -27,7 +27,7 @@ impl MissingColumnsPolicy {
                     .find(|name| !incoming_schema.contains(name))
                 {
                     polars_bail!(
-                        ComputeError:
+                        ColumnNotFound:
                         "did not find column {}, consider enabling `allow_missing_columns`",
                         col,
                     )

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
@@ -4,6 +4,7 @@ use polars_core::scalar::Scalar;
 use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_bail};
 
+/// TODO: Eventually move this enum to polars-plan
 #[derive(Debug, Clone)]
 pub enum MissingColumnsPolicy {
     Raise,

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
@@ -1,0 +1,34 @@
+//! Extra operations applied during reads.
+pub mod apply;
+pub mod cast_columns;
+pub mod missing_columns;
+pub mod reorder_columns;
+
+use cast_columns::CastColumnsPolicy;
+use missing_columns::MissingColumnsPolicy;
+use polars_io::RowIndex;
+use polars_io::predicates::ScanIOPredicate;
+use polars_utils::pl_str::PlSmallStr;
+use polars_utils::slice_enum::Slice;
+
+/// Anything aside from reading columns from the file. E.g. row_index, slice, predicate etc.
+///
+/// Note that hive partition columns are tracked separately.
+///
+/// This struct is mainly used as a data model / IR.
+#[derive(Debug, Default, Clone)]
+pub struct ExtraOperations {
+    // Note: These fields are ordered according to when they (should be) applied.
+    pub row_index: Option<RowIndex>,
+    pub pre_slice: Option<Slice>,
+    pub cast_columns: Option<CastColumnsPolicy>,
+    pub missing_columns: Option<MissingColumnsPolicy>,
+    pub include_file_paths: Option<PlSmallStr>,
+    pub predicate: Option<ScanIOPredicate>,
+}
+
+impl ExtraOperations {
+    pub fn has_row_index_or_slice(&self) -> bool {
+        self.row_index.is_some() || self.pre_slice.is_some()
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
@@ -38,8 +38,8 @@ impl ExtraOperations {
 /// TODO: Eventually move this enum to polars-plan
 #[derive(Clone)]
 pub enum SchemaNamesMatchPolicy {
-    /// `ForbidExtra` with the additional requirement that the columns are in
-    /// the same order.
+    /// Errors if there are extra columns, or the columns are not in order.
+    /// Ignores missing columns, that is handled by a different module.
     RequireOrderedExact,
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
@@ -38,8 +38,10 @@ impl ExtraOperations {
 /// TODO: Eventually move this enum to polars-plan
 #[derive(Clone)]
 pub enum SchemaNamesMatchPolicy {
-    /// Errors if there are extra columns, or the columns are not in order.
-    /// Ignores missing columns, that is handled by a different module.
+    /// * If the schema lengths match, ensure that all columns match in the same order
+    /// * Otherwise, ensure that there are no extra columns in the incoming schema that
+    ///   cannot be found in the target schema.
+    ///   * Ignores if the incoming schema is missing columns, this is handled by a separate module.
     RequireOrderedExact,
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
@@ -64,17 +64,15 @@ impl SchemaNamesMatchPolicy {
                             incoming_schema.iter_names().collect::<Vec<_>>(), target_schema.iter_names().collect::<Vec<_>>()
                         )
                     }
-                } else {
-                    if let Some(extra_col) = incoming_schema
-                        .iter_names()
-                        .find(|x| !target_schema.contains(x))
-                    {
-                        polars_bail!(
-                            SchemaMismatch:
-                            "extra column in file outside of expected schema: {}",
-                            extra_col,
-                        )
-                    }
+                } else if let Some(extra_col) = incoming_schema
+                    .iter_names()
+                    .find(|x| !target_schema.contains(x))
+                {
+                    polars_bail!(
+                        SchemaMismatch:
+                        "extra column in file outside of expected schema: {}",
+                        extra_col,
+                    )
                 }
 
                 Ok(())

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/reorder_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/reorder_columns.rs
@@ -1,0 +1,69 @@
+use polars_core::frame::DataFrame;
+use polars_core::schema::SchemaRef;
+
+#[derive(Debug)]
+pub enum ReorderColumns {
+    /// Column indices to take.
+    Gather {
+        indices: Vec<usize>,
+        /// This is only stored for a debug assertion.
+        incoming_schema: SchemaRef,
+    },
+    /// No reordering needed
+    Passthrough,
+}
+
+impl ReorderColumns {
+    /// # Panics
+    /// Panics if schemas do not have the same the same set of column names.
+    pub fn initialize(target_schema: &SchemaRef, incoming_schema: &SchemaRef) -> Self {
+        assert_eq!(target_schema.len(), incoming_schema.len());
+
+        if let Some(first_mismatch_idx) = target_schema
+            .iter_names()
+            .zip(incoming_schema.iter_names())
+            .position(|(l, r)| l != r)
+        {
+            let mut indices = Vec::with_capacity(incoming_schema.len());
+
+            indices.extend(0..first_mismatch_idx);
+            indices.extend(
+                target_schema
+                    .iter_names()
+                    .skip(first_mismatch_idx)
+                    .map(|name| incoming_schema.index_of(name).unwrap()),
+            );
+
+            Self::Gather {
+                indices,
+                incoming_schema: incoming_schema.clone(),
+            }
+        } else {
+            Self::Passthrough
+        }
+    }
+
+    /// Note: The column order of the incoming DataFrame must exactly match that of the schema used
+    /// to initialize this `ReorderColumns`.
+    ///
+    /// # Panics
+    /// Panics if self is uninitialized.
+    pub fn reorder_columns(&self, df: &mut DataFrame) {
+        use ReorderColumns::*;
+
+        match self {
+            Passthrough => {},
+
+            Gather {
+                indices,
+                incoming_schema,
+            } => {
+                debug_assert_eq!(df.schema(), incoming_schema);
+
+                let incoming_cols = df.get_columns();
+                let out = indices.iter().map(|i| incoming_cols[*i].clone()).collect();
+                *df = out;
+            },
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
@@ -1,2 +1,2 @@
-#[allow(unused)]
+#[expect(unused)]
 pub mod extra_ops;

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
@@ -1,0 +1,2 @@
+#[allow(unused)]
+pub mod extra_ops;

--- a/crates/polars-stream/src/nodes/io_sources/multi_scan.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_scan.rs
@@ -311,7 +311,7 @@ fn resolve_source_projection(
     Ok((source_projection.freeze(), missing_columns))
 }
 
-fn scan_predicate_to_mask(
+pub fn scan_predicate_to_mask(
     scan_predicate: &ScanIOPredicate,
     file_schema: &Schema,
     hive_schema: &Schema,
@@ -436,7 +436,7 @@ enum SourceInput {
 }
 
 const DEFAULT_MAX_CONCURRENT_SCANS: usize = 8;
-fn max_concurrent_scans(num_pipelines: usize) -> usize {
+pub fn max_concurrent_scans(num_pipelines: usize) -> usize {
     let max_num_concurrent_scans =
         std::env::var("POLARS_MAX_CONCURRENT_SCANS").map_or(DEFAULT_MAX_CONCURRENT_SCANS, |v| {
             v.parse::<usize>()


### PR DESCRIPTION
Modules for e.g. attaching missing columns, hive columns, and in the future type casting. Note that nothing is hooked up yet.

@coastalwhite 
