### PR TITLE
feat(rust): Add DoubleEndedIterator for CatIter

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -474,6 +474,18 @@ impl<'a> Iterator for CatIter<'a> {
     }
 }
 
+impl DoubleEndedIterator for CatIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|item| {
+            item.map(|idx| {
+                // SAFETY:
+                // all categories are in bound
+                unsafe { self.rev.get_unchecked(idx) }
+            })
+        })
+    }
+}
+
 impl ExactSizeIterator for CatIter<'_> {}
 
 #[cfg(test)]


### PR DESCRIPTION
Added a missing DoubleEndedIterator implementation for CatIter.