### PR TITLE
perf: Improve join performance for expanding joins

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -11721,8 +11721,9 @@ class DataFrame:
 
         Notes
         -----
-        This is syntactic sugar for a left/inner join, with an optional coalesce
-        when `include_nulls = False`
+        This is syntactic sugar for a left/inner join that preserves the order
+        of the left `DataFrame` by default, with an optional coalesce when
+        `include_nulls = False`.
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -11685,6 +11685,7 @@ class DataFrame:
         left_on: str | Sequence[str] | None = None,
         right_on: str | Sequence[str] | None = None,
         include_nulls: bool = False,
+        maintain_order: MaintainOrderJoin | None = "left",
     ) -> DataFrame:
         """
         Update the values in this `DataFrame` with the values in `other`.
@@ -11713,6 +11714,10 @@ class DataFrame:
         include_nulls
             Overwrite values in the left frame with null values from the right frame.
             If set to `False` (default), null values in the right frame are ignored.
+        maintain_order : {'none', 'left', 'right', 'left_right', 'right_left'}
+            Which order of rows from the inputs to preserve. See :func:`~DataFrame.join`
+            for details. Unlike `join` this function preserves the left order by
+            default.
 
         Notes
         -----
@@ -11819,6 +11824,7 @@ class DataFrame:
                 left_on=left_on,
                 right_on=right_on,
                 include_nulls=include_nulls,
+                maintain_order=maintain_order,
             )
             .collect(_eager=True)
         )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -7781,7 +7781,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Notes
         -----
-        This is syntactic sugar for a left/inner join, with an optional coalesce when
+        This is syntactic sugar for a left/inner join that preserves the order
+        of the left `DataFrame` by default, with an optional coalesce when
         `include_nulls = False`.
 
         Examples

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -7745,6 +7745,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         left_on: str | Sequence[str] | None = None,
         right_on: str | Sequence[str] | None = None,
         include_nulls: bool = False,
+        maintain_order: MaintainOrderJoin | None = "left",
     ) -> LazyFrame:
         """
         Update the values in this `LazyFrame` with the values in `other`.
@@ -7773,6 +7774,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         include_nulls
             Overwrite values in the left frame with null values from the right frame.
             If set to `False` (default), null values in the right frame are ignored.
+        maintain_order : {'none', 'left', 'right', 'left_right', 'right_left'}
+            Which order of rows from the inputs to preserve. See :func:`~LazyFrame.join`
+            for details. Unlike `join` this function preserves the left order by
+            default.
 
         Notes
         -----
@@ -7949,6 +7954,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 how=how,
                 suffix=tmp_name,
                 coalesce=True,
+                maintain_order=maintain_order,
             )
             .with_columns(
                 (

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -1142,7 +1142,7 @@ def test_lazy_cache_same_key() -> None:
         (pl.col("a") - pl.col("a_mult")).alias("a"), pl.col("c")
     )
     expected = pl.LazyFrame({"a": [-1, 2, 7], "c": ["x", "y", "z"]})
-    assert_frame_equal(result, expected)
+    assert_frame_equal(result, expected, check_row_order=False)
 
 
 @pytest.mark.may_fail_auto_streaming

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -220,7 +220,11 @@ def test_collapse_joins() -> None:
     e = inner_join.explain()
     assert "INNER JOIN" in e
     assert "FILTER" not in e
-    assert_frame_equal(inner_join.collect(collapse_joins=False), inner_join.collect(), check_row_order=False)
+    assert_frame_equal(
+        inner_join.collect(collapse_joins=False),
+        inner_join.collect(),
+        check_row_order=False,
+    )
 
     inner_join = cross.filter(pl.col.x == pl.col.a)
     e = inner_join.explain()

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -220,7 +220,7 @@ def test_collapse_joins() -> None:
     e = inner_join.explain()
     assert "INNER JOIN" in e
     assert "FILTER" not in e
-    assert_frame_equal(inner_join.collect(collapse_joins=False), inner_join.collect())
+    assert_frame_equal(inner_join.collect(collapse_joins=False), inner_join.collect(), check_row_order=False)
 
     inner_join = cross.filter(pl.col.x == pl.col.a)
     e = inner_join.explain()

--- a/py-polars/tests/unit/operations/test_is_sorted.py
+++ b/py-polars/tests/unit/operations/test_is_sorted.py
@@ -255,7 +255,7 @@ def test_sorted_flag_after_streaming_join() -> None:
     df2 = pl.DataFrame({"x": [4, 2, 3, 1], "z": [1, 4, 9, 1]})
     assert (
         df1.lazy()
-        .join(df2.lazy(), on="x", how="left")
+        .join(df2.lazy(), on="x", how="left", maintain_order="left")
         .collect(engine="old-streaming")["x"]  # type: ignore[call-overload]
         .flags["SORTED_ASC"]
     )

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -157,9 +157,15 @@ def test_deprecated() -> None:
     other = pl.DataFrame({"a": [1, 2], "c": [3, 4]})
     result = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [3, 4]})
 
-    np.testing.assert_equal(df.join(other=other, on="a", maintain_order="left").to_numpy(), result.to_numpy())
     np.testing.assert_equal(
-        df.lazy().join(other=other.lazy(), on="a", maintain_order="left").collect().to_numpy(),
+        df.join(other=other, on="a", maintain_order="left").to_numpy(),
+        result.to_numpy(),
+    )
+    np.testing.assert_equal(
+        df.lazy()
+        .join(other=other.lazy(), on="a", maintain_order="left")
+        .collect()
+        .to_numpy(),
         result.to_numpy(),
     )
 
@@ -348,13 +354,15 @@ def test_join_chunks_alignment_4720() -> None:
             on=["index1", "index2", "index3"],
             how="left",
         ),
-        pl.DataFrame({
-            "index1": [0, 0, 1, 1],
-            "index2": [10, 10, 11, 11],
-            "index3": [100, 101, 100, 101],
-        }),
-        check_row_order=False
-        )
+        pl.DataFrame(
+            {
+                "index1": [0, 0, 1, 1],
+                "index2": [10, 10, 11, 11],
+                "index3": [100, 101, 100, 101],
+            }
+        ),
+        check_row_order=False,
+    )
 
     assert_frame_equal(
         df1.join(df2, how="cross").join(
@@ -362,12 +370,14 @@ def test_join_chunks_alignment_4720() -> None:
             on=["index3", "index1", "index2"],
             how="left",
         ),
-        pl.DataFrame({
-            "index1": [0, 0, 1, 1],
-            "index2": [10, 10, 11, 11],
-            "index3": [100, 101, 100, 101],
-        }),
-        check_row_order=False
+        pl.DataFrame(
+            {
+                "index1": [0, 0, 1, 1],
+                "index2": [10, 10, 11, 11],
+                "index3": [100, 101, 100, 101],
+            }
+        ),
+        check_row_order=False,
     )
 
 
@@ -823,7 +833,9 @@ def test_join_validation_many_keys() -> None:
 def test_full_outer_join_bool() -> None:
     df1 = pl.DataFrame({"id": [True, False], "val": [1, 2]})
     df2 = pl.DataFrame({"id": [True, False], "val": [0, -1]})
-    assert df1.join(df2, on="id", how="full", maintain_order="right").to_dict(as_series=False) == {
+    assert df1.join(df2, on="id", how="full", maintain_order="right").to_dict(
+        as_series=False
+    ) == {
         "id": [True, False],
         "val": [1, 2],
         "id_right": [True, False],
@@ -1231,15 +1243,13 @@ def test_array_explode_join_19763() -> None:
 
 
 def test_join_full_19814() -> None:
-    schema={"a": pl.Int64, "c": pl.Categorical}
-    a = pl.LazyFrame(
-        {"a": [1], "c": [None]}, schema=schema
-    )
+    schema = {"a": pl.Int64, "c": pl.Categorical}
+    a = pl.LazyFrame({"a": [1], "c": [None]}, schema=schema)
     b = pl.LazyFrame({"a": [1, 3, 4]})
     assert_frame_equal(
         a.join(b, on="a", how="full", coalesce=True).collect(),
         pl.DataFrame({"a": [1, 3, 4], "c": [None, None, None]}, schema=schema),
-        check_row_order=False
+        check_row_order=False,
     )
 
 

--- a/py-polars/tests/unit/operations/test_join_right.py
+++ b/py-polars/tests/unit/operations/test_join_right.py
@@ -117,5 +117,5 @@ def test_join_right_different_multikey() -> None:
     right = pl.LazyFrame({"c": [1, 2], "d": [1, 2]})
     result = left.join(right, left_on=["a", "b"], right_on=["c", "d"], how="right")
     expected = pl.DataFrame({"c": [1, 2], "d": [1, 2]})
-    assert_frame_equal(result.collect(), expected)
+    assert_frame_equal(result.collect(), expected, check_row_order=False)
     assert result.collect_schema() == expected.schema

--- a/py-polars/tests/unit/operations/test_join_right.py
+++ b/py-polars/tests/unit/operations/test_join_right.py
@@ -8,7 +8,9 @@ def test_right_join_schemas() -> None:
     b = pl.DataFrame({"a": [1, 3], "b": [1, 3], "c": [1, 3]})
 
     # coalesces the join key, so the key of the right table remains
-    assert a.join(b, on="a", how="right", coalesce=True, maintain_order="right").to_dict(as_series=False) == {
+    assert a.join(
+        b, on="a", how="right", coalesce=True, maintain_order="right"
+    ).to_dict(as_series=False) == {
         "b": [1, 3],
         "a": [1, 3],
         "b_right": [1, 3],
@@ -100,9 +102,9 @@ def test_join_right_different_key() -> None:
             "ham2": ["a", "b", "d"],
         }
     )
-    assert df.join(other_df, left_on="ham1", right_on="ham2", how="right", maintain_order="right").to_dict(
-        as_series=False
-    ) == {
+    assert df.join(
+        other_df, left_on="ham1", right_on="ham2", how="right", maintain_order="right"
+    ).to_dict(as_series=False) == {
         "foo": [1, 2, None],
         "bar": [6.0, 7.0, None],
         "apple": ["x", "y", "z"],

--- a/py-polars/tests/unit/operations/test_join_right.py
+++ b/py-polars/tests/unit/operations/test_join_right.py
@@ -8,7 +8,7 @@ def test_right_join_schemas() -> None:
     b = pl.DataFrame({"a": [1, 3], "b": [1, 3], "c": [1, 3]})
 
     # coalesces the join key, so the key of the right table remains
-    assert a.join(b, on="a", how="right", coalesce=True).to_dict(as_series=False) == {
+    assert a.join(b, on="a", how="right", coalesce=True, maintain_order="right").to_dict(as_series=False) == {
         "b": [1, 3],
         "a": [1, 3],
         "b_right": [1, 3],
@@ -100,7 +100,7 @@ def test_join_right_different_key() -> None:
             "ham2": ["a", "b", "d"],
         }
     )
-    assert df.join(other_df, left_on="ham1", right_on="ham2", how="right").to_dict(
+    assert df.join(other_df, left_on="ham1", right_on="ham2", how="right", maintain_order="right").to_dict(
         as_series=False
     ) == {
         "foo": [1, 2, None],

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -261,12 +261,16 @@ def test_non_coalescing_streaming_left_join() -> None:
 
     q = df1.join(df2, on="a", how="left", coalesce=False)
     assert q.explain(engine="old-streaming").startswith("STREAMING")  # type: ignore[arg-type]
-    assert q.collect(engine="streaming").to_dict(as_series=False) == {
-        "a": [1, 2, 3],
-        "b": ["a", "b", "c"],
-        "a_right": [1, 2, None],
-        "c": ["j", "i", None],
-    }
+    assert_frame_equal(
+        q.collect(engine="streaming"),
+        pl.DataFrame({
+            "a": [1, 2, 3],
+            "b": ["a", "b", "c"],
+            "a_right": [1, 2, None],
+            "c": ["j", "i", None],
+        }),
+        check_row_order=False
+    )
 
 
 @pytest.mark.write_disk

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -263,13 +263,15 @@ def test_non_coalescing_streaming_left_join() -> None:
     assert q.explain(engine="old-streaming").startswith("STREAMING")  # type: ignore[arg-type]
     assert_frame_equal(
         q.collect(engine="streaming"),
-        pl.DataFrame({
-            "a": [1, 2, 3],
-            "b": ["a", "b", "c"],
-            "a_right": [1, 2, None],
-            "c": ["j", "i", None],
-        }),
-        check_row_order=False
+        pl.DataFrame(
+            {
+                "a": [1, 2, 3],
+                "b": ["a", "b", "c"],
+                "a_right": [1, 2, None],
+                "c": ["j", "i", None],
+            }
+        ),
+        check_row_order=False,
     )
 
 

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -34,7 +34,7 @@ def test_cse_rename_cross_join_5405() -> None:
             "D": [5, None, None, 6],
         }
     )
-    assert_frame_equal(result, expected)
+    assert_frame_equal(result, expected, check_row_order=False)
 
 
 def test_union_duplicates() -> None:
@@ -106,7 +106,7 @@ def test_cse_schema_6081() -> None:
             "min_value": [1, 1, 2],
         }
     )
-    assert_frame_equal(result, expected)
+    assert_frame_equal(result, expected, check_row_order=False)
 
 
 def test_cse_9630() -> None:

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -321,8 +321,12 @@ def test_join_suffix_collision_9562() -> None:
     )
     df.join(other_df, on="ham")
     assert df.lazy().join(
-        other_df.lazy(), how="inner", left_on="ham", right_on="ham", suffix="m",
-        maintain_order="right"
+        other_df.lazy(),
+        how="inner",
+        left_on="ham",
+        right_on="ham",
+        suffix="m",
+        maintain_order="right",
     ).select("ham").collect().to_dict(as_series=False) == {"ham": ["a", "b"]}
 
 
@@ -400,7 +404,10 @@ def test_projection_pushdown_full_outer_join_duplicates() -> None:
     df1 = pl.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}).lazy()
     df2 = pl.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}).lazy()
     assert (
-        df1.join(df2, on="a", how="full", maintain_order="right").with_columns(c=0).select("a", "c").collect()
+        df1.join(df2, on="a", how="full", maintain_order="right")
+        .with_columns(c=0)
+        .select("a", "c")
+        .collect()
     ).to_dict(as_series=False) == {"a": [1, 2, 3], "c": [0, 0, 0]}
 
 

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -321,7 +321,8 @@ def test_join_suffix_collision_9562() -> None:
     )
     df.join(other_df, on="ham")
     assert df.lazy().join(
-        other_df.lazy(), how="inner", left_on="ham", right_on="ham", suffix="m"
+        other_df.lazy(), how="inner", left_on="ham", right_on="ham", suffix="m",
+        maintain_order="right"
     ).select("ham").collect().to_dict(as_series=False) == {"ham": ["a", "b"]}
 
 
@@ -399,7 +400,7 @@ def test_projection_pushdown_full_outer_join_duplicates() -> None:
     df1 = pl.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}).lazy()
     df2 = pl.DataFrame({"a": [1, 2, 3], "b": [10, 20, 30]}).lazy()
     assert (
-        df1.join(df2, on="a", how="full").with_columns(c=0).select("a", "c").collect()
+        df1.join(df2, on="a", how="full", maintain_order="right").with_columns(c=0).select("a", "c").collect()
     ).to_dict(as_series=False) == {"a": [1, 2, 3], "c": [0, 0, 0]}
 
 


### PR DESCRIPTION
For joins that expand a lot due to many matches the strict requirements of the linearizer made us mostly single-threaded. For unordered joins it now relabels the morsel sequence ids to mitigate that, but for a proper solution we should use unordered linearizers to 'linearize' unordered streams.