### PR TITLE
feat: Minor improvements to EXPLAIN plan output

### DIFF
--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -202,7 +202,7 @@ def test_lazy_row_index_no_push_down(foods_file_path: Path) -> None:
         .explain(predicate_pushdown=True)
     )
     # related to row count is not pushed.
-    assert 'FILTER [(col("index")) == (1)] FROM' in plan
+    assert 'FILTER [(col("index")) == (1)]\nFROM' in plan
     # unrelated to row count is pushed.
     assert 'SELECTION: [(col("category")) == (String(vegetables))]' in plan
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1614,7 +1614,8 @@ def test_join_where_predicate_type_coercion_21009() -> None:
 
     plan = q1.explain().splitlines()
     assert plan[0].strip().startswith("FILTER")
-    assert plan[1].strip().startswith("INNER JOIN")
+    assert plan[1] == "FROM"
+    assert plan[2].strip().startswith("INNER JOIN")
 
     q2 = left_frame.join_where(
         right_frame,
@@ -1624,7 +1625,8 @@ def test_join_where_predicate_type_coercion_21009() -> None:
 
     plan = q2.explain().splitlines()
     assert plan[0].strip().startswith("FILTER")
-    assert plan[1].strip().startswith("INNER JOIN")
+    assert plan[1] == "FROM"
+    assert plan[2].strip().startswith("INNER JOIN")
 
     assert_frame_equal(q1.collect(), q2.collect())
 

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -280,7 +280,7 @@ def test_literal_series_expr_predicate_pushdown() -> None:
         lf.filter(pl.col("x") > 0).filter(pl.col("x").is_in([0, 1])),
         lf.remove(pl.col("x") <= 0).remove(~pl.col("x").is_in([0, 1])),
     ):
-        assert re.search(r"FILTER .* FROM\n\s*DF", res.explain()) is not None
+        assert re.search(r"FILTER .*\nFROM\n\s*DF", res.explain(), re.DOTALL)
         assert res.collect().to_series().to_list() == [1]
 
 
@@ -292,7 +292,7 @@ def test_multi_alias_pushdown() -> None:
 
     print(plan)
     assert plan.count("FILTER") == 1
-    assert re.search(r"FILTER.*FROM\n\s*DF", plan) is not None
+    assert re.search(r"FILTER.*FROM\n\s*DF", plan, re.DOTALL) is not None
 
     with pytest.warns(UserWarning, match="Comparisons with None always result in null"):
         # confirm we aren't using `eq_missing` in the query plan (denoted as " ==v ")
@@ -319,7 +319,9 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
     plan = actual.explain()
 
     assert (
-        re.search(r'FILTER \[\(col\("key"\)\) == \(5\)\]\s*FROM\n\s*DF', plan)
+        re.search(
+            r'FILTER \[\(col\("key"\)\) == \(5\)\]\s*FROM\n\s*DF', plan, re.DOTALL
+        )
         is not None
     )
     assert plan.count("FILTER") == 1
@@ -335,7 +337,7 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
 
     plan = actual.explain()
     assert plan.count("FILTER") == 1
-    assert re.search(r"FILTER.*FROM\n\s*DF", plan) is not None
+    assert re.search(r"FILTER.*FROM\n\s*DF", plan, re.DOTALL) is not None
     actual = (
         lf.with_columns(
             (pl.col("value") * 2).over("key", "key_2").alias("value_2"),
@@ -348,7 +350,9 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
     plan = actual.explain()
     assert plan.count("FILTER") == 2
     assert (
-        re.search(r'FILTER \[\(col\("key"\)\) == \(5\)\]\s*FROM\n\s*DF', plan)
+        re.search(
+            r'FILTER \[\(col\("key"\)\) == \(5\)\]\s*FROM\n\s*DF', plan, re.DOTALL
+        )
         is not None
     )
 
@@ -363,7 +367,9 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
     plan = actual.explain()
     assert plan.count("FILTER") == 2
     assert (
-        re.search(r'FILTER \[\(col\("key"\)\) == \(5\)\]\s*FROM\n\s*DF', plan)
+        re.search(
+            r'FILTER \[\(col\("key"\)\) == \(5\)\]\s*FROM\n\s*DF', plan, re.DOTALL
+        )
         is not None
     )
 
@@ -380,7 +386,7 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
     plan = actual.explain()
     assert plan.count("FILTER") == 1
     assert "FILTER" in plan
-    assert re.search(r"FILTER.*FROM\n\s*DF", plan) is None
+    assert re.search(r"FILTER.*FROM\n\s*DF", plan, re.DOTALL) is None
     # Ensure the implementation doesn't accidentally push a window expression
     # that only refers to the common window keys.
     actual = lf.with_columns(
@@ -388,7 +394,7 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
     ).filter(pl.len().over("key") == 1)
 
     plan = actual.explain()
-    assert re.search(r"FILTER.*FROM\n\s*DF", plan) is None
+    assert re.search(r"FILTER.*FROM\n\s*DF", plan, re.DOTALL) is None
     assert plan.count("FILTER") == 1
 
     # Test window in filter
@@ -403,7 +409,9 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
         is not None
     )
     assert (
-        re.search(r'FILTER \[\(col\("key"\)\) == \(1\)\]\s*FROM\n\s*DF', plan)
+        re.search(
+            r'FILTER \[\(col\("key"\)\) == \(1\)\]\s*FROM\n\s*DF', plan, re.DOTALL
+        )
         is not None
     )
 
@@ -546,7 +554,7 @@ def test_predicate_slice_pushdown_list_gather_17492() -> None:
         .explain()
     )
 
-    assert re.search(r"FILTER.*FROM\n\s*DF", plan) is not None
+    assert re.search(r"FILTER.*FROM\n\s*DF", plan, re.DOTALL) is not None
 
     # Also check slice pushdown
     q = lf.with_columns(pl.col("val").list.get(1).alias("b")).slice(1, 1)


### PR DESCRIPTION
A small indent fix, and a minor readability improvement:

* The `explain` formatting had some hardcoded `"\t"` chars which should instead have been the calculated `sub_indent`, leading to misaligned `GroupBy` plan output.
* Fixed this, and assigned an `indent_increment` var so we don't have a magic const (`2`) determining indent growth with increasing depth :)
*  Put `FROM` on a standalone line to improve readability; it was too easily lost at the end of even just a handful of columns/expressions, and it's quite an important marker.

## Example
```python
import polars as pl

lf = pl.LazyFrame({
    "key": ["xx", "yy", "zz", "xx", "zz", "zz"],
    "v1": [15, 25, 10, 20, 20, 20],
    "v2": [-33, 20, 44, -2, 16, 71],
}).group_by(
    pl.col("key"),
).agg(pl.col("v1","v2").sum())

print(lf.explain())
```
### Before:
_(rogue `"\t"` char, trailing `FROM`)_
```rust
AGGREGATE
	[col("val1").sum(), col("val2").sum()] BY [col("key")] FROM
  DF ["key", "val1", "val2"]; PROJECT["val1", "val2", "key"] 3/3 COLUMNS
```
### After:
_(consistent indent, clearer positioning of `FROM`)_
```rust
AGGREGATE
  [col("val1").sum(), col("val2").sum()] BY [col("key")]
  FROM
  DF ["key", "val1", "val2"]; PROJECT["val1", "val2", "key"] 3/3 COLUMNS
```