### PR TITLE
perf: Enable THP by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[env]
-# Tune jemalloc (https://github.com/pola-rs/polars/issues/18088).
-JEMALLOC_SYS_WITH_MALLOC_CONF = "dirty_decay_ms:500,muzzy_decay_ms:-1,thp:always,metadata_thp:always"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [env]
 # Tune jemalloc (https://github.com/pola-rs/polars/issues/18088).
-JEMALLOC_SYS_WITH_MALLOC_CONF = "dirty_decay_ms:500,muzzy_decay_ms:-1"
+JEMALLOC_SYS_WITH_MALLOC_CONF = "dirty_decay_ms:500,muzzy_decay_ms:-1,thp:always,metadata_thp:always"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -18,9 +18,11 @@ pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "extension-module"
 mimalloc = { version = "0.1", default-features = false }
 
 # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).
-[target.'cfg(all(target_family = "unix", not(target_os = "emscripten"), not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
+[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls", "background_threads"] }
 
+[target.'cfg(all(target_family = "unix", target_os = "macos", not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
+tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls"] }
 either = { workspace = true }
 
 [features]

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -18,11 +18,9 @@ pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "extension-module"
 mimalloc = { version = "0.1", default-features = false }
 
 # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).
-[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
+[target.'cfg(all(target_family = "unix", not(target_os = "emscripten"), not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls", "background_threads"] }
 
-[target.'cfg(all(target_family = "unix", target_os = "macos", not(allocator = "mimalloc"), not(allocator = "default")))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls"] }
 either = { workspace = true }
 
 [features]

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -4,12 +4,15 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     # This must be done before importing the Polars Rust bindings, otherwise we
     # might execute illegal instructions.
     import polars._cpu_check
+
     polars._cpu_check.check_cpu_flags()
-    
+
     # We also configure the allocator before importing the Polars Rust bindings.
     # See https://github.com/pola-rs/polars/issues/18088,
     # https://github.com/pola-rs/polars/pull/21829.
-    import sys, os
+    import os
+    import sys
+
     jemalloc_conf = "dirty_decay_ms:500,muzzy_decay_ms:-1"
     if sys.platform == "linux":
         # We only enable this on Linux, otherwise jemalloc gives warnings.
@@ -21,6 +24,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     # Initialize polars on the rust side. This function is highly
     # unsafe and should only be called once.
     from polars.polars import __register_startup_deps
+
     __register_startup_deps()
 
 from typing import Any

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -1,19 +1,26 @@
 import contextlib
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
-    # ensure the object constructor is known by polars
-    # we set this once on import
-
-    # This must be done before importing the Polars Rust bindings.
+    # This must be done before importing the Polars Rust bindings, otherwise we
+    # might execute illegal instructions.
     import polars._cpu_check
-
     polars._cpu_check.check_cpu_flags()
+    
+    # We also configure the allocator before importing the Polars Rust bindings.
+    # See https://github.com/pola-rs/polars/issues/18088,
+    # https://github.com/pola-rs/polars/pull/21829.
+    import sys, os
+    jemalloc_conf = "dirty_decay_ms:500,muzzy_decay_ms:-1"
+    if sys.platform == "linux":
+        # We only enable this on Linux, otherwise jemalloc gives warnings.
+        jemalloc_conf += ",thp:always,metadata_thp:always"
+    if override := os.environ.get("_RJEM_MALLOC_CONF"):
+        jemalloc_conf += "," + override
+    os.environ["_RJEM_MALLOC_CONF"] = jemalloc_conf
 
-    # we also set other function pointers needed
-    # on the rust side. This function is highly
+    # Initialize polars on the rust side. This function is highly
     # unsafe and should only be called once.
     from polars.polars import __register_startup_deps
-
     __register_startup_deps()
 
 from typing import Any

--- a/py-polars/src/allocator.rs
+++ b/py-polars/src/allocator.rs
@@ -4,30 +4,8 @@
     target_family = "unix",
     not(target_os = "emscripten"),
 ))]
-mod jemalloc {
-    #[global_allocator]
-    static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-    use std::ffi::{CStr, c_char, c_void};
-
-    #[unsafe(export_name = "_rjem_malloc_message")]
-    pub static mut MALLOC_MESSAGE: unsafe extern "C" fn(cbopaque: *mut c_void, s: *const c_char) =
-        suppress_jemalloc_warnings;
-
-    extern "C" fn suppress_jemalloc_warnings(_cbopaque: *mut c_void, s: *const c_char) {
-        unsafe {
-            let bytes = CStr::from_ptr(s).to_bytes();
-            if let Ok(rs) = core::str::from_utf8(&bytes) {
-                if rs.contains("option background_thread currently supports pthread only")
-                    || rs.contains("No THP support")
-                {
-                    return;
-                }
-            }
-            libc::write(libc::STDERR_FILENO, bytes.as_ptr().cast(), bytes.len());
-        }
-    }
-}
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 
 #[cfg(all(

--- a/py-polars/src/allocator.rs
+++ b/py-polars/src/allocator.rs
@@ -7,7 +7,6 @@
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-
 #[cfg(all(
     not(allocator = "default"),
     any(


### PR DESCRIPTION
If a system supports THP (transparent huge pages) but has it set by default to only use it when `madvise` is called (which is the default on for example Ubuntu server), then we wouldn't use THP before this PR. This PR ensures that jemalloc will `madvise` every allocation with `MADV_HUGEPAGE` so that they will be used on such systems.

On PDS-H SF=10 and SF=100 I observed performance increases of 15-20% with the new streaming engine. I expect THP to pretty much always be beneficial for Polars unless we start swapping memory in random access patterns (but arguably when you reach that point you have already lost as an OLAP system).

If for whatever reason you find THP to be a regression, please do let us know, in the meantime you can specify the env variable `_RJEM_MALLOC_CONF=thp:never,metadata_thp:never` to disable it again.

---

~~The PR does contain a bit of a questionable linker hack to hide jemalloc's warnings on systems that don't support THP. I hope this doesn't break any builds.~~

I've switched to setting the jemalloc flags in Python now, right before importing the Polars library. This was the only way I could think of to disable setting the THP flag for non-linux systems, as that causes jemalloc to print warnings. I failed in trying to silence these warnings.