### PR TITLE
refactor: Change dynamic literals to be separate category

### DIFF
--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -118,31 +118,83 @@ impl Serialize for AnyValue<'_> {
         let name = "AnyValue";
         match self {
             AnyValue::Null => serializer.serialize_unit_variant(name, 0, "Null"),
+
             AnyValue::Int8(v) => serializer.serialize_newtype_variant(name, 1, "Int8", v),
             AnyValue::Int16(v) => serializer.serialize_newtype_variant(name, 2, "Int16", v),
             AnyValue::Int32(v) => serializer.serialize_newtype_variant(name, 3, "Int32", v),
             AnyValue::Int64(v) => serializer.serialize_newtype_variant(name, 4, "Int64", v),
-            AnyValue::Int128(v) => serializer.serialize_newtype_variant(name, 4, "Int128", v),
-            AnyValue::UInt8(v) => serializer.serialize_newtype_variant(name, 5, "UInt8", v),
-            AnyValue::UInt16(v) => serializer.serialize_newtype_variant(name, 6, "UInt16", v),
-            AnyValue::UInt32(v) => serializer.serialize_newtype_variant(name, 7, "UInt32", v),
-            AnyValue::UInt64(v) => serializer.serialize_newtype_variant(name, 8, "UInt64", v),
-            AnyValue::Float32(v) => serializer.serialize_newtype_variant(name, 9, "Float32", v),
-            AnyValue::Float64(v) => serializer.serialize_newtype_variant(name, 10, "Float64", v),
-            AnyValue::List(v) => serializer.serialize_newtype_variant(name, 11, "List", v),
-            AnyValue::Boolean(v) => serializer.serialize_newtype_variant(name, 12, "Bool", v),
-            // both string variants same number
-            AnyValue::String(v) => serializer.serialize_newtype_variant(name, 13, "StringOwned", v),
+            AnyValue::Int128(v) => serializer.serialize_newtype_variant(name, 5, "Int128", v),
+            AnyValue::UInt8(v) => serializer.serialize_newtype_variant(name, 6, "UInt8", v),
+            AnyValue::UInt16(v) => serializer.serialize_newtype_variant(name, 7, "UInt16", v),
+            AnyValue::UInt32(v) => serializer.serialize_newtype_variant(name, 8, "UInt32", v),
+            AnyValue::UInt64(v) => serializer.serialize_newtype_variant(name, 9, "UInt64", v),
+            AnyValue::Float32(v) => serializer.serialize_newtype_variant(name, 10, "Float32", v),
+            AnyValue::Float64(v) => serializer.serialize_newtype_variant(name, 11, "Float64", v),
+            AnyValue::List(v) => serializer.serialize_newtype_variant(name, 12, "List", v),
+            AnyValue::Boolean(v) => serializer.serialize_newtype_variant(name, 13, "Bool", v),
+
+            // both variants same number
+            AnyValue::String(v) => serializer.serialize_newtype_variant(name, 14, "StringOwned", v),
             AnyValue::StringOwned(v) => {
-                serializer.serialize_newtype_variant(name, 13, "StringOwned", v.as_str())
+                serializer.serialize_newtype_variant(name, 14, "StringOwned", v.as_str())
             },
-            AnyValue::Binary(v) => serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v),
+
+            // both variants same number
+            AnyValue::Binary(v) => serializer.serialize_newtype_variant(name, 15, "BinaryOwned", v),
             AnyValue::BinaryOwned(v) => {
-                serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v)
+                serializer.serialize_newtype_variant(name, 15, "BinaryOwned", v)
             },
-            _ => Err(serde::ser::Error::custom(
-                "Unknown data type. Cannot serialize",
-            )),
+
+            #[cfg(feature = "dtype-date")]
+            AnyValue::Date(v) => serializer.serialize_newtype_variant(name, 16, "Date", v),
+            // both variants same number
+            #[cfg(feature = "dtype-datetime")]
+            AnyValue::Datetime(v, tu, tz) => serializer.serialize_newtype_variant(
+                name,
+                17,
+                "DatetimeOwned",
+                &(*v, *tu, tz.map(|v| v.as_str())),
+            ),
+            #[cfg(feature = "dtype-datetime")]
+            AnyValue::DatetimeOwned(v, tu, tz) => serializer.serialize_newtype_variant(
+                name,
+                17,
+                "DatetimeOwned",
+                &(*v, *tu, tz.as_deref().map(|v| v.as_str())),
+            ),
+            #[cfg(feature = "dtype-duration")]
+            AnyValue::Duration(v, tu) => {
+                serializer.serialize_newtype_variant(name, 18, "Duration", &(*v, *tu))
+            },
+            #[cfg(feature = "dtype-time")]
+            AnyValue::Time(v) => serializer.serialize_newtype_variant(name, 19, "Time", v),
+
+            // Not 100% sure how to deal with these.
+            #[cfg(feature = "dtype-categorical")]
+            AnyValue::Categorical(..) | AnyValue::CategoricalOwned(..) => Err(
+                serde::ser::Error::custom("Cannot serialize categorical value."),
+            ),
+            #[cfg(feature = "dtype-categorical")]
+            AnyValue::Enum(..) | AnyValue::EnumOwned(..) => {
+                Err(serde::ser::Error::custom("Cannot serialize enum value."))
+            },
+
+            #[cfg(feature = "dtype-array")]
+            AnyValue::Array(v, width) => {
+                serializer.serialize_newtype_variant(name, 22, "Array", &(v, *width))
+            },
+            #[cfg(feature = "object")]
+            AnyValue::Object(_) | AnyValue::ObjectOwned(_) => {
+                Err(serde::ser::Error::custom("Cannot serialize object value."))
+            },
+            #[cfg(feature = "dtype-struct")]
+            AnyValue::Struct(_, _, _) | AnyValue::StructOwned(_) => {
+                Err(serde::ser::Error::custom("Cannot serialize struct value."))
+            },
+            #[cfg(feature = "dtype-decimal")]
+            AnyValue::Decimal(v, scale) => {
+                serializer.serialize_newtype_variant(name, 25, "Decimal", &(*v, *scale))
+            },
         }
     }
 }
@@ -153,8 +205,18 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
     where
         D: Deserializer<'a>,
     {
-        #[repr(u8)]
-        enum AvField {
+        macro_rules! define_av_field {
+            ($($variant:ident,)+) => {
+                #[derive(Deserialize, Serialize)]
+                enum AvField {
+                    $($variant,)+
+                }
+                const VARIANTS: &'static [&'static str] = &[
+                    $(stringify!($variant),)+
+                ];
+            };
+        }
+        define_av_field! {
             Null,
             Int8,
             Int16,
@@ -171,109 +233,17 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
             Bool,
             StringOwned,
             BinaryOwned,
-        }
-        const VARIANTS: &[&str] = &[
-            "Null",
-            "UInt8",
-            "UInt16",
-            "UInt32",
-            "UInt64",
-            "Int8",
-            "Int16",
-            "Int32",
-            "Int64",
-            "Int128",
-            "Float32",
-            "Float64",
-            "List",
-            "Boolean",
-            "StringOwned",
-            "BinaryOwned",
-        ];
-        const LAST: u8 = unsafe { std::mem::transmute::<_, u8>(AvField::BinaryOwned) };
-
-        struct FieldVisitor;
-
-        impl Visitor<'_> for FieldVisitor {
-            type Value = AvField;
-
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-                write!(formatter, "an integer between 0-{LAST}")
-            }
-
-            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                let field: u8 = NumCast::from(v).ok_or_else(|| {
-                    serde::de::Error::invalid_value(
-                        Unexpected::Signed(v),
-                        &"expected value that fits into u8",
-                    )
-                })?;
-
-                // SAFETY:
-                // we are repr: u8 and check last value that we are in bounds
-                let field = unsafe {
-                    if field <= LAST {
-                        std::mem::transmute::<u8, AvField>(field)
-                    } else {
-                        return Err(serde::de::Error::invalid_value(
-                            Unexpected::Signed(v),
-                            &"expected value that fits into AnyValue's number of fields",
-                        ));
-                    }
-                };
-                Ok(field)
-            }
-
-            fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                self.visit_bytes(v.as_bytes())
-            }
-
-            fn visit_bytes<E>(self, v: &[u8]) -> std::result::Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                let field = match v {
-                    b"Null" => AvField::Null,
-                    b"Int8" => AvField::Int8,
-                    b"Int16" => AvField::Int16,
-                    b"Int32" => AvField::Int32,
-                    b"Int64" => AvField::Int64,
-                    b"Int128" => AvField::Int128,
-                    b"UInt8" => AvField::UInt8,
-                    b"UInt16" => AvField::UInt16,
-                    b"UInt32" => AvField::UInt32,
-                    b"UInt64" => AvField::UInt64,
-                    b"Float32" => AvField::Float32,
-                    b"Float64" => AvField::Float64,
-                    b"List" => AvField::List,
-                    b"Bool" => AvField::Bool,
-                    b"StringOwned" | b"String" => AvField::StringOwned,
-                    b"BinaryOwned" | b"Binary" => AvField::BinaryOwned,
-                    _ => {
-                        return Err(serde::de::Error::unknown_variant(
-                            &String::from_utf8_lossy(v),
-                            VARIANTS,
-                        ));
-                    },
-                };
-                Ok(field)
-            }
-        }
-
-        impl<'a> Deserialize<'a> for AvField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-            where
-                D: Deserializer<'a>,
-            {
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
+            Date,
+            DatetimeOwned,
+            Duration,
+            Time,
+            CategoricalOwned,
+            EnumOwned,
+            Array,
+            Object,
+            Struct,
+            Decimal,
+        };
 
         struct OuterVisitor;
 
@@ -350,6 +320,44 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
                         let value = variant.newtype_variant()?;
                         AnyValue::BinaryOwned(value)
                     },
+                    (AvField::Date, variant) => feature_gated!("dtype-date", {
+                        let value = variant.newtype_variant()?;
+                        AnyValue::Date(value)
+                    }),
+                    (AvField::DatetimeOwned, variant) => feature_gated!("dtype-datetime", {
+                        let (value, time_unit, time_zone) = variant.newtype_variant()?;
+                        AnyValue::DatetimeOwned(value, time_unit, time_zone)
+                    }),
+                    (AvField::Duration, variant) => feature_gated!("dtype-duration", {
+                        let (value, time_unit) = variant.newtype_variant()?;
+                        AnyValue::Duration(value, time_unit)
+                    }),
+                    (AvField::Time, variant) => feature_gated!("dtype-time", {
+                        let value = variant.newtype_variant()?;
+                        AnyValue::Time(value)
+                    }),
+                    (AvField::CategoricalOwned, _) => feature_gated!("dtype-categorical", {
+                        return Err(serde::de::Error::custom(
+                            "unable to deserialize categorical",
+                        ));
+                    }),
+                    (AvField::EnumOwned, _) => feature_gated!("dtype-categorical", {
+                        return Err(serde::de::Error::custom("unable to deserialize enum"));
+                    }),
+                    (AvField::Array, variant) => feature_gated!("dtype-array", {
+                        let (s, width) = variant.newtype_variant()?;
+                        AnyValue::Array(s, width)
+                    }),
+                    (AvField::Object, _) => feature_gated!("object", {
+                        return Err(serde::de::Error::custom("unable to deserialize object"));
+                    }),
+                    (AvField::Struct, _) => feature_gated!("dtype-struct", {
+                        return Err(serde::de::Error::custom("unable to deserialize struct"));
+                    }),
+                    (AvField::Decimal, variant) => feature_gated!("dtype-decimal", {
+                        let (v, scale) = variant.newtype_variant()?;
+                        AnyValue::Decimal(v, scale)
+                    }),
                 };
                 Ok(out)
             }

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -534,6 +534,9 @@ impl DataType {
     pub fn is_date(&self) -> bool {
         matches!(self, DataType::Date)
     }
+    pub fn is_datetime(&self) -> bool {
+        matches!(self, DataType::Datetime(..))
+    }
 
     pub fn is_object(&self) -> bool {
         #[cfg(feature = "object")]

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -45,7 +45,7 @@ use polars_utils::nulls::IsNull;
 use polars_utils::total_ord::TotalHash;
 pub use schema::SchemaExtPl;
 #[cfg(feature = "serde")]
-use serde::de::{EnumAccess, Error, Unexpected, VariantAccess, Visitor};
+use serde::de::{EnumAccess, VariantAccess, Visitor};
 #[cfg(any(feature = "serde", feature = "serde-lazy"))]
 use serde::{Deserialize, Serialize};
 #[cfg(any(feature = "serde", feature = "serde-lazy"))]

--- a/crates/polars-core/src/scalar/from.rs
+++ b/crates/polars-core/src/scalar/from.rs
@@ -29,4 +29,5 @@ impl_from! {
     (f32, Float32, Float32)
     (f64, Float64, Float64)
     (PlSmallStr, StringOwned, String)
+    (Vec<u8>, BinaryOwned, Binary)
 }

--- a/crates/polars-core/src/scalar/mod.rs
+++ b/crates/polars-core/src/scalar/mod.rs
@@ -1,10 +1,15 @@
 mod from;
+mod new;
 pub mod reduce;
 
+use std::hash::Hash;
+
+use polars_error::PolarsResult;
 use polars_utils::pl_str::PlSmallStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::chunked_array::cast::CastOptions;
 use crate::datatypes::{AnyValue, DataType};
 use crate::prelude::{Column, Series};
 
@@ -13,6 +18,13 @@ use crate::prelude::{Column, Series};
 pub struct Scalar {
     dtype: DataType,
     value: AnyValue<'static>,
+}
+
+impl Hash for Scalar {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.dtype.hash(state);
+        self.value.hash_impl(state, true);
+    }
 }
 
 impl Default for Scalar {
@@ -26,12 +38,26 @@ impl Default for Scalar {
 
 impl Scalar {
     #[inline(always)]
-    pub fn new(dtype: DataType, value: AnyValue<'static>) -> Self {
+    pub const fn new(dtype: DataType, value: AnyValue<'static>) -> Self {
         Self { dtype, value }
     }
 
-    pub fn null(dtype: DataType) -> Self {
+    pub const fn null(dtype: DataType) -> Self {
         Self::new(dtype, AnyValue::Null)
+    }
+
+    pub fn cast_with_options(self, dtype: &DataType, options: CastOptions) -> PolarsResult<Self> {
+        if self.dtype() == dtype {
+            return Ok(self);
+        }
+
+        // @Optimize: If we have fully fleshed out casting semantics, we could just specify the
+        // cast on AnyValue.
+        let s = self
+            .into_series(PlSmallStr::from_static("scalar"))
+            .cast_with_options(dtype, options)?;
+        let value = s.get(0).unwrap();
+        Ok(Self::new(s.dtype().clone(), value.into_static()))
     }
 
     #[inline(always)]

--- a/crates/polars-core/src/scalar/new.rs
+++ b/crates/polars-core/src/scalar/new.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+use super::Scalar;
+use crate::prelude::{AnyValue, DataType, TimeUnit, TimeZone};
+
+impl Scalar {
+    pub fn new_datetime(value: i64, time_unit: TimeUnit, tz: Option<TimeZone>) -> Self {
+        Scalar::new(
+            DataType::Datetime(time_unit, tz.clone()),
+            AnyValue::DatetimeOwned(value, time_unit, tz.map(Arc::new)),
+        )
+    }
+    pub fn new_duration(value: i64, time_unit: TimeUnit) -> Self {
+        Scalar::new(
+            DataType::Duration(time_unit),
+            AnyValue::Duration(value, time_unit),
+        )
+    }
+    pub fn new_date(value: i32) -> Self {
+        Scalar::new(DataType::Date, AnyValue::Date(value))
+    }
+}

--- a/crates/polars-core/src/scalar/new.rs
+++ b/crates/polars-core/src/scalar/new.rs
@@ -4,19 +4,24 @@ use super::Scalar;
 use crate::prelude::{AnyValue, DataType, TimeUnit, TimeZone};
 
 impl Scalar {
+    #[cfg(feature = "dtype-date")]
+    pub fn new_date(value: i32) -> Self {
+        Scalar::new(DataType::Date, AnyValue::Date(value))
+    }
+
+    #[cfg(feature = "dtype-datetime")]
     pub fn new_datetime(value: i64, time_unit: TimeUnit, tz: Option<TimeZone>) -> Self {
         Scalar::new(
             DataType::Datetime(time_unit, tz.clone()),
             AnyValue::DatetimeOwned(value, time_unit, tz.map(Arc::new)),
         )
     }
+
+    #[cfg(feature = "dtype-duration")]
     pub fn new_duration(value: i64, time_unit: TimeUnit) -> Self {
         Scalar::new(
             DataType::Duration(time_unit),
             AnyValue::Duration(value, time_unit),
         )
-    }
-    pub fn new_date(value: i32) -> Self {
-        Scalar::new(DataType::Date, AnyValue::Date(value))
     }
 }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -107,7 +107,7 @@ use crate::utils::{Wrap, handle_casting_failures, materialize_dyn_int};
 /// [ChunkCompareIneq trait](crate::chunked_array::ops::ChunkCompareIneq).
 ///
 /// ## Iterators
-/// The Series variants contain differently typed [ChunkedArray](crate::chunked_array::ChunkedArray)s.
+/// The Series variants contain differently typed [ChunkedArray]s.
 /// These structs can be turned into iterators, making it possible to use any function/ closure you want
 /// on a Series.
 ///

--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -17,103 +17,73 @@ impl LiteralExpr {
     }
 
     fn as_column(&self) -> PolarsResult<Column> {
-        use LiteralValue::*;
-        let s = match &self.0 {
-            #[cfg(feature = "dtype-i8")]
-            Int8(v) => Int8Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            #[cfg(feature = "dtype-i16")]
-            Int16(v) => Int16Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            Int32(v) => Int32Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            Int64(v) => Int64Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            #[cfg(feature = "dtype-i128")]
-            Int128(v) => Int128Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            #[cfg(feature = "dtype-u8")]
-            UInt8(v) => UInt8Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            #[cfg(feature = "dtype-u16")]
-            UInt16(v) => UInt16Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            UInt32(v) => UInt32Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            UInt64(v) => UInt64Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            Float32(v) => Float32Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            Float64(v) => Float64Chunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            #[cfg(feature = "dtype-decimal")]
-            Decimal(v, scale) => Int128Chunked::full(get_literal_name().clone(), *v, 1)
-                .into_decimal_unchecked(None, *scale)
-                .into_column(),
-            Boolean(v) => BooleanChunked::full(get_literal_name().clone(), *v, 1).into_column(),
-            Null => {
-                polars_core::prelude::Series::new_null(get_literal_name().clone(), 1).into_column()
-            },
-            Range { low, high, dtype } => match dtype {
-                DataType::Int32 => {
-                    polars_ensure!(
-                        *low >= i32::MIN as i64 && *high <= i32::MAX as i64,
-                        ComputeError: "range not within bounds of `Int32`: [{}, {}]", *low, *high
-                    );
-                    let low = *low as i32;
-                    let high = *high as i32;
-                    let ca: NoNull<Int32Chunked> = (low..high).collect();
-                    ca.into_inner().into_column()
-                },
-                DataType::Int64 => {
-                    let low = *low;
-                    let high = *high;
-                    let ca: NoNull<Int64Chunked> = (low..high).collect();
-                    ca.into_inner().into_column()
-                },
-                DataType::UInt32 => {
-                    polars_ensure!(
-                        *low >= 0 && *high <= u32::MAX as i64,
-                        ComputeError: "range not within bounds of `UInt32`: [{}, {}]", *low, *high
-                    );
-                    let low = *low as u32;
-                    let high = *high as u32;
-                    let ca: NoNull<UInt32Chunked> = (low..high).collect();
-                    ca.into_inner().into_column()
-                },
-                dt => polars_bail!(
-                    InvalidOperation: "datatype `{}` is not supported as range", dt
-                ),
-            },
-            String(v) => StringChunked::full(get_literal_name().clone(), v, 1).into_column(),
-            Binary(v) => BinaryChunked::full(get_literal_name().clone(), v, 1).into_column(),
-            #[cfg(feature = "dtype-datetime")]
-            DateTime(timestamp, tu, tz) => {
-                Int64Chunked::full(get_literal_name().clone(), *timestamp, 1)
-                    .into_datetime(*tu, tz.clone())
-                    .into_column()
-            },
-            #[cfg(feature = "dtype-duration")]
-            Duration(v, tu) => Int64Chunked::full(get_literal_name().clone(), *v, 1)
-                .into_duration(*tu)
-                .into_column(),
-            #[cfg(feature = "dtype-date")]
-            Date(v) => Int32Chunked::full(get_literal_name().clone(), *v, 1)
-                .into_date()
-                .into_column(),
-            #[cfg(feature = "dtype-time")]
-            Time(v) => {
-                if !(0..NANOSECONDS_IN_DAY).contains(v) {
-                    polars_bail!(
-                        InvalidOperation: "value `{v}` is out-of-range for `time` which can be 0 - {}",
-                        NANOSECONDS_IN_DAY - 1
-                    );
-                }
+        use LiteralValue as L;
+        let column = match &self.0 {
+            L::Scalar(sc) => {
+                #[expect(clippy::single_match)]
+                match sc.as_any_value() {
+                    AnyValue::Time(v) => {
+                        if !(0..NANOSECONDS_IN_DAY).contains(&v) {
+                            polars_bail!(
+                                InvalidOperation: "value `{v}` is out-of-range for `time` which can be 0 - {}",
+                                NANOSECONDS_IN_DAY - 1
+                            );
+                        }
+                    },
+                    _ => {},
+                };
 
-                Int64Chunked::full(get_literal_name().clone(), *v, 1)
-                    .into_time()
-                    .into_column()
+                sc.clone().into_column(get_literal_name().clone())
             },
-            Series(series) => series.deref().clone().into_column(),
-            OtherScalar(s) => s.clone().into_column(get_literal_name().clone()),
-            lv @ (Int(_) | Float(_) | StrCat(_)) => polars_core::prelude::Series::from_any_values(
+            L::Series(s) => s.deref().clone().into_column(),
+            lv @ L::Dyn(_) => polars_core::prelude::Series::from_any_values(
                 get_literal_name().clone(),
                 &[lv.to_any_value().unwrap()],
                 false,
             )
             .unwrap()
             .into_column(),
+            L::Range(RangeLiteralValue { low, high, dtype }) => {
+                let low = *low;
+                let high = *high;
+                match dtype {
+                    DataType::Int32 => {
+                        polars_ensure!(
+                            low >= i32::MIN as i128 && high <= i32::MAX as i128,
+                            ComputeError: "range not within bounds of `Int32`: [{}, {}]", low, high
+                        );
+                        let low = low as i32;
+                        let high = high as i32;
+                        let ca: NoNull<Int32Chunked> = (low..high).collect();
+                        ca.into_inner().into_column()
+                    },
+                    DataType::Int64 => {
+                        polars_ensure!(
+                            low >= i64::MIN as i128 && high <= i64::MAX as i128,
+                            ComputeError: "range not within bounds of `Int32`: [{}, {}]", low, high
+                        );
+                        let low = low as i64;
+                        let high = high as i64;
+                        let ca: NoNull<Int64Chunked> = (low..high).collect();
+                        ca.into_inner().into_column()
+                    },
+                    DataType::UInt32 => {
+                        polars_ensure!(
+                            low >= u32::MIN as i128 && high <= u32::MAX as i128,
+                            ComputeError: "range not within bounds of `UInt32`: [{}, {}]", low, high
+                        );
+                        let low = low as u32;
+                        let high = high as u32;
+                        let ca: NoNull<UInt32Chunked> = (low..high).collect();
+                        ca.into_inner().into_column()
+                    },
+                    dt => polars_bail!(
+                        InvalidOperation: "datatype `{}` is not supported as range", dt
+                    ),
+                }
+            },
         };
-        Ok(s)
+        Ok(column)
     }
 }
 

--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -22,6 +22,7 @@ impl LiteralExpr {
             L::Scalar(sc) => {
                 #[expect(clippy::single_match)]
                 match sc.as_any_value() {
+                    #[cfg(feature = "dtype-time")]
                     AnyValue::Time(v) => {
                         if !(0..NANOSECONDS_IN_DAY).contains(&v) {
                             polars_bail!(

--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -20,19 +20,15 @@ impl LiteralExpr {
         use LiteralValue as L;
         let column = match &self.0 {
             L::Scalar(sc) => {
-                #[expect(clippy::single_match)]
-                match sc.as_any_value() {
-                    #[cfg(feature = "dtype-time")]
-                    AnyValue::Time(v) => {
-                        if !(0..NANOSECONDS_IN_DAY).contains(&v) {
-                            polars_bail!(
-                                InvalidOperation: "value `{v}` is out-of-range for `time` which can be 0 - {}",
-                                NANOSECONDS_IN_DAY - 1
-                            );
-                        }
-                    },
-                    _ => {},
-                };
+                #[cfg(feature = "dtype-time")]
+                if let AnyValue::Time(v) = sc.value() {
+                    if !(0..NANOSECONDS_IN_DAY).contains(v) {
+                        polars_bail!(
+                            InvalidOperation: "value `{v}` is out-of-range for `time` which can be 0 - {}",
+                            NANOSECONDS_IN_DAY - 1
+                        );
+                    }
+                }
 
                 sc.clone().into_column(get_literal_name().clone())
             },

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -587,7 +587,7 @@ fn test_simplify_expr() {
     .unwrap();
     let plan = node_to_lp(lp_top, &expr_arena, &mut lp_arena);
     assert!(
-        matches!(plan, DslPlan::Select{ expr, ..} if matches!(&expr[0], Expr::BinaryExpr{left, ..} if **left == Expr::Literal(LiteralValue::Float(2.0))))
+        matches!(plan, DslPlan::Select{ expr, ..} if matches!(&expr[0], Expr::BinaryExpr{left, ..} if **left == Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(2.0)))))
     );
 }
 

--- a/crates/polars-plan/src/dsl/format.rs
+++ b/crates/polars-plan/src/dsl/format.rs
@@ -42,11 +42,7 @@ impl fmt::Debug for Expr {
             Explode(expr) => write!(f, "{expr:?}.explode()"),
             Alias(expr, name) => write!(f, "{expr:?}.alias(\"{name}\")"),
             Column(name) => write!(f, "col(\"{name}\")"),
-            Literal(v) => {
-                use std::fmt::Write;
-                let mut f = EscapeLabel(f);
-                write!(f, "{v:?}")
-            },
+            Literal(v) => write!(f, "{v:?}"),
             BinaryExpr { left, op, right } => write!(f, "[({left:?}) {op:?} ({right:?})]"),
             Sort { expr, options } => {
                 if options.descending {

--- a/crates/polars-plan/src/dsl/format.rs
+++ b/crates/polars-plan/src/dsl/format.rs
@@ -43,15 +43,9 @@ impl fmt::Debug for Expr {
             Alias(expr, name) => write!(f, "{expr:?}.alias(\"{name}\")"),
             Column(name) => write!(f, "col(\"{name}\")"),
             Literal(v) => {
-                match v {
-                    LiteralValue::String(v) => {
-                        // dot breaks with debug fmt due to \"
-                        write!(f, "String({v})")
-                    },
-                    _ => {
-                        write!(f, "{v:?}")
-                    },
-                }
+                use std::fmt::Write;
+                let mut f = EscapeLabel(f);
+                write!(f, "{v:?}")
             },
             BinaryExpr { left, op, right } => write!(f, "[({left:?}) {op:?} ({right:?})]"),
             Sort { expr, options } => {

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -174,8 +174,11 @@ impl DatetimeArgs {
         };
 
         Some(
-            Expr::Literal(LiteralValue::DateTime(ts, self.time_unit, None))
-                .alias(PlSmallStr::from_static("datetime")),
+            Expr::Literal(LiteralValue::Scalar(Scalar::new(
+                DataType::Datetime(self.time_unit, None),
+                AnyValue::Datetime(ts, self.time_unit, None),
+            )))
+            .alias(PlSmallStr::from_static("datetime")),
         )
     }
 }
@@ -400,8 +403,11 @@ impl DurationArgs {
         };
 
         Some(
-            Expr::Literal(LiteralValue::Duration(d, self.time_unit))
-                .alias(PlSmallStr::from_static("duration")),
+            Expr::Literal(LiteralValue::Scalar(Scalar::new(
+                DataType::Duration(self.time_unit),
+                AnyValue::Duration(d, self.time_unit),
+            )))
+            .alias(PlSmallStr::from_static("duration")),
         )
     }
 }

--- a/crates/polars-plan/src/dsl/meta.rs
+++ b/crates/polars-plan/src/dsl/meta.rs
@@ -97,7 +97,7 @@ impl MetaNameSpace {
                 expr,
                 dtype: DataType::Datetime(_, _),
                 options: CastOptions::Strict,
-            } if matches!(&**expr, Expr::Literal(LiteralValue::DateTime(_, _, _))) => true,
+            } if matches!(&**expr, Expr::Literal(LiteralValue::Scalar(sc)) if matches!(sc.as_any_value(), AnyValue::Datetime(..))) => true,
             _ => false,
         })
     }

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -169,17 +169,16 @@ fn aexpr_to_skip_batch_predicate_rec(
         (null_count: $name:expr) => {{ col!(format_pl_smallstr!("{}_nc", $name)) }};
     }
     macro_rules! lv {
-        ($lv:expr) => {{ expr_arena.add(AExpr::Literal(LiteralValue::OtherScalar(Scalar::from($lv)))) }};
+        ($lv:expr) => {{ expr_arena.add(AExpr::Literal(Scalar::from($lv).into())) }};
         (idx: $lv:expr) => {{ expr_arena.add(AExpr::Literal(LiteralValue::new_idxsize($lv))) }};
-        (bool: $lv:expr) => {{ expr_arena.add(AExpr::Literal(LiteralValue::Boolean($lv))) }};
     }
 
     let specialized = (|| {
         if let Some(Some(lv)) = constant_evaluate(e, expr_arena, schema, 0) {
             if let Some(av) = lv.to_any_value() {
                 return match av {
-                    AnyValue::Null => Some(lv!(bool: true)),
-                    AnyValue::Boolean(b) => Some(lv!(bool: !b)),
+                    AnyValue::Null => Some(lv!(true)),
+                    AnyValue::Boolean(b) => Some(lv!(!b)),
                     _ => None,
                 };
             }
@@ -216,7 +215,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                             lv, lv_node,
                             null: {
                                 if matches!(op, O::Eq) {
-                                    lv!(bool: false)
+                                    lv!(false)
                                 } else {
                                     let col_nc = col!(null_count: col);
                                     let idx_zero = lv!(idx: 0);
@@ -265,7 +264,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                             lv, lv_node,
                             null: {
                                 if matches!(op, O::NotEq) {
-                                    lv!(bool: false)
+                                    lv!(false)
                                 } else {
                                     let col_nc = col!(null_count: col);
                                     let len = col!(len);

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -565,7 +565,9 @@ fn expand_function_inputs(
             *input = rewrite_projections(core::mem::take(input), schema, &[], opt_flags)?;
             if input.is_empty() && !options.flags.contains(FunctionFlags::ALLOW_EMPTY_INPUTS) {
                 // Needed to visualize the error
-                *input = vec![Expr::Literal(LiteralValue::Null)];
+                *input = vec![Expr::Literal(LiteralValue::Scalar(Scalar::null(
+                    DataType::Null,
+                )))];
                 polars_bail!(InvalidOperation: "expected at least 1 input in {}", e)
             }
             Ok(e)

--- a/crates/polars-plan/src/plans/conversion/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_to_ir.rs
@@ -94,22 +94,12 @@ fn to_aexpr_impl_materialized_lit(
     // Already convert `Lit Float and Lit Int` expressions that are not used in a binary / function expression.
     // This means they can be materialized immediately
     let e = match expr {
-        Expr::Literal(lv @ LiteralValue::Int(_) | lv @ LiteralValue::Float(_)) => {
-            let av = lv.to_any_value().unwrap();
-            Expr::Literal(LiteralValue::from(av))
-        },
-        Expr::Alias(inner, name)
-            if matches!(
-                &*inner,
-                Expr::Literal(LiteralValue::Int(_) | LiteralValue::Float(_))
-            ) =>
-        {
-            let Expr::Literal(lv @ LiteralValue::Int(_) | lv @ LiteralValue::Float(_)) = &*inner
-            else {
+        Expr::Literal(lv @ LiteralValue::Dyn(_)) => Expr::Literal(lv.materialize()),
+        Expr::Alias(inner, name) if matches!(&*inner, Expr::Literal(LiteralValue::Dyn(_))) => {
+            let Expr::Literal(lv) = &*inner else {
                 unreachable!()
             };
-            let av = lv.to_any_value().unwrap();
-            Expr::Alias(Arc::new(Expr::Literal(LiteralValue::from(av))), name)
+            Expr::Alias(Arc::new(Expr::Literal(lv.clone().materialize())), name)
         },
         e => e,
     };

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -3,8 +3,9 @@ mod functions;
 #[cfg(feature = "is_in")]
 mod is_in;
 
+use arrow::temporal_conversions::SECONDS_IN_DAY;
 use binary::process_binary;
-use polars_compute::cast::temporal::{SECONDS_IN_DAY, time_unit_multiple};
+use polars_compute::cast::temporal::time_unit_multiple;
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::prelude::*;
 use polars_core::utils::{get_supertype, get_supertype_with_options, materialize_dyn_int};
@@ -407,39 +408,25 @@ fn try_inline_literal_cast(
             let s = s.cast_with_options(dtype, options)?;
             LiteralValue::Series(SpecialEq::new(s))
         },
-        LiteralValue::StrCat(s) => {
-            let av = AnyValue::String(s).strict_cast(dtype);
-
-            match av {
-                None => return Ok(None),
-                Some(av) => av.into(),
-            }
-        },
-        // We generate cast literal datetimes, so ensure we cast upon conversion
-        // to create simpler expr trees.
-        #[cfg(feature = "dtype-datetime")]
-        LiteralValue::DateTime(ts, tu, None) if dtype.is_date() => {
-            let from_size = time_unit_multiple(tu.to_arrow()) * SECONDS_IN_DAY;
-            LiteralValue::Date((*ts / from_size) as i32)
-        },
-        lv @ (LiteralValue::Int(_) | LiteralValue::Float(_)) => {
-            let av = lv.to_any_value().ok_or_else(
-                || polars_err!(InvalidOperation: "literal value: {:?} too large for Polars", lv),
-            )?;
-            let av = av.strict_cast(dtype);
-
-            match av {
-                None => return Ok(None),
-                Some(av) => av.into(),
-            }
-        },
-        LiteralValue::Null => match dtype {
+        LiteralValue::Dyn(dyn_value) => dyn_value.clone().try_materialize_to_dtype(dtype)?.into(),
+        lv if lv.is_null() => match dtype {
             DataType::Unknown(UnknownKind::Float | UnknownKind::Int(_) | UnknownKind::Str) => {
-                LiteralValue::Null
+                LiteralValue::untyped_null()
             },
             _ => return Ok(None),
         },
-        _ => {
+        lv => {
+            // We generate cast literal datetimes, so ensure we cast upon conversion
+            // to create simpler expr trees.
+            if let LiteralValue::Scalar(sc) = &lv {
+                if dtype.is_date() {
+                    if let AnyValue::Datetime(ts, tu, None) = sc.value() {
+                        let from_size = time_unit_multiple(tu.to_arrow()) * SECONDS_IN_DAY;
+                        return Ok(Some(Scalar::new_date((*ts / from_size) as i32).into()));
+                    }
+                }
+            }
+
             let Some(av) = lv.to_any_value() else {
                 return Ok(None);
             };

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -74,15 +74,15 @@ impl<'a> IRDotDisplay<'a> {
         }
     }
 
-    fn display_expr(&self, expr: &'a ExprIR) -> Escape<ExprIRDisplay<'a>> {
-        Escape(expr.display(self.lp.expr_arena))
+    fn display_expr(&self, expr: &'a ExprIR) -> ExprIRDisplay<'a> {
+        expr.display(self.lp.expr_arena)
     }
 
-    fn display_exprs(&self, exprs: &'a [ExprIR]) -> Escape<ExprIRSliceDisplay<'a, ExprIR>> {
-        Escape(ExprIRSliceDisplay {
+    fn display_exprs(&self, exprs: &'a [ExprIR]) -> ExprIRSliceDisplay<'a, ExprIR> {
+        ExprIRSliceDisplay {
             exprs,
             expr_arena: self.lp.expr_arena,
-        })
+        }
     }
 
     fn _format(
@@ -458,15 +458,5 @@ impl fmt::Display for IRDotDisplay<'_> {
         writeln!(f, "}}")?;
 
         Ok(())
-    }
-}
-
-struct Escape<T>(T);
-
-impl<T: std::fmt::Display> fmt::Display for Escape<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::fmt::Write;
-        let mut f = EscapeLabel(f);
-        write!(f, "{}", self.0)
     }
 }

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -74,15 +74,15 @@ impl<'a> IRDotDisplay<'a> {
         }
     }
 
-    fn display_expr(&self, expr: &'a ExprIR) -> ExprIRDisplay<'a> {
-        expr.display(self.lp.expr_arena)
+    fn display_expr(&self, expr: &'a ExprIR) -> Escape<ExprIRDisplay<'a>> {
+        Escape(expr.display(self.lp.expr_arena))
     }
 
-    fn display_exprs(&self, exprs: &'a [ExprIR]) -> ExprIRSliceDisplay<'a, ExprIR> {
-        ExprIRSliceDisplay {
+    fn display_exprs(&self, exprs: &'a [ExprIR]) -> Escape<ExprIRSliceDisplay<'a, ExprIR>> {
+        Escape(ExprIRSliceDisplay {
             exprs,
             expr_arena: self.lp.expr_arena,
-        }
+        })
     }
 
     fn _format(
@@ -458,5 +458,15 @@ impl fmt::Display for IRDotDisplay<'_> {
         writeln!(f, "}}")?;
 
         Ok(())
+    }
+}
+
+struct Escape<T>(T);
+
+impl<T: std::fmt::Display> fmt::Display for Escape<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use std::fmt::Write;
+        let mut f = EscapeLabel(f);
+        write!(f, "{}", self.0)
     }
 }

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -557,11 +557,7 @@ impl Display for ExprIRDisplay<'_> {
                 write!(f, "{expr}.alias(\"{name}\")")
             },
             Column(name) => write!(f, "col(\"{name}\")"),
-            Literal(v) => {
-                use std::fmt::Write;
-                let mut f = EscapeLabel(f);
-                write!(f, "{v:?}")
-            },
+            Literal(v) => write!(f, "{v:?}"),
             BinaryExpr { left, op, right } => {
                 let left = self.with_root(left);
                 let right = self.with_root(right);

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -1,6 +1,5 @@
 use std::fmt::{self, Display, Formatter};
 
-use polars_core::datatypes::AnyValue;
 use polars_core::schema::Schema;
 use polars_io::RowIndex;
 use polars_utils::format_list_truncated;
@@ -559,15 +558,9 @@ impl Display for ExprIRDisplay<'_> {
             },
             Column(name) => write!(f, "col(\"{name}\")"),
             Literal(v) => {
-                match v {
-                    LiteralValue::String(v) => {
-                        // dot breaks with debug fmt due to \"
-                        write!(f, "String({v})")
-                    },
-                    _ => {
-                        write!(f, "{v:?}")
-                    },
-                }
+                use std::fmt::Write;
+                let mut f = EscapeLabel(f);
+                write!(f, "{v:?}")
             },
             BinaryExpr { left, op, right } => {
                 let left = self.with_root(left);
@@ -775,9 +768,8 @@ impl fmt::Debug for LiteralValue {
         use LiteralValue::*;
 
         match self {
-            Binary(_) => write!(f, "[binary value]"),
-            Range { low, high, .. } => write!(f, "range({low}, {high})"),
-            Series(s) => {
+            Self::Scalar(sc) => write!(f, "{}", sc.value()),
+            Self::Series(s) => {
                 let name = s.name();
                 if name.is_empty() {
                     write!(f, "Series")
@@ -785,15 +777,25 @@ impl fmt::Debug for LiteralValue {
                     write!(f, "Series[{name}]")
                 }
             },
-            Float(v) => {
-                let av = AnyValue::Float64(*v);
-                write!(f, "dyn float: {}", av)
-            },
-            Int(v) => write!(f, "dyn int: {}", v),
-            _ => {
-                let av = self.to_any_value().unwrap();
-                write!(f, "{av}")
-            },
+            Range(range) => fmt::Debug::fmt(range, f),
+            Dyn(d) => fmt::Debug::fmt(d, f),
         }
+    }
+}
+
+impl fmt::Debug for DynLiteralValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Int(v) => write!(f, "dyn int: {v}"),
+            Self::Float(v) => write!(f, "dyn float: {}", v),
+            Self::Str(v) => write!(f, "dyn str: {v}"),
+            Self::List(_) => todo!(),
+        }
+    }
+}
+
+impl fmt::Debug for RangeLiteralValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "range({}, {})", self.low, self.high)
     }
 }

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -2,6 +2,7 @@ use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "temporal")]
 use chrono::{Duration as ChronoDuration, NaiveDate, NaiveDateTime};
+use polars_core::chunked_array::cast::CastOptions;
 use polars_core::prelude::*;
 use polars_core::utils::materialize_dyn_int;
 use polars_utils::hashing::hash_to_partition;
@@ -13,65 +14,174 @@ use crate::prelude::*;
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum LiteralValue {
-    Null,
-    /// A binary true or false.
-    Boolean(bool),
-    /// A UTF8 encoded string type.
-    String(PlSmallStr),
-    /// A raw binary array
-    Binary(Vec<u8>),
-    /// An unsigned 8-bit integer number.
-    #[cfg(feature = "dtype-u8")]
-    UInt8(u8),
-    /// An unsigned 16-bit integer number.
-    #[cfg(feature = "dtype-u16")]
-    UInt16(u16),
-    /// An unsigned 32-bit integer number.
-    UInt32(u32),
-    /// An unsigned 64-bit integer number.
-    UInt64(u64),
-    /// An 8-bit integer number.
-    #[cfg(feature = "dtype-i8")]
-    Int8(i8),
-    /// A 16-bit integer number.
-    #[cfg(feature = "dtype-i16")]
-    Int16(i16),
-    /// A 32-bit integer number.
-    Int32(i32),
-    /// A 64-bit integer number.
-    Int64(i64),
-    #[cfg(feature = "dtype-i128")]
-    /// A 128-bit integer number.
-    Int128(i128),
-    /// A 32-bit floating point number.
-    Float32(f32),
-    /// A 64-bit floating point number.
-    Float64(f64),
-    /// A 128-bit decimal number with a maximum scale of 38.
-    #[cfg(feature = "dtype-decimal")]
-    Decimal(i128, usize),
-    Range {
-        low: i64,
-        high: i64,
-        dtype: DataType,
-    },
-    #[cfg(feature = "dtype-date")]
-    Date(i32),
-    #[cfg(feature = "dtype-datetime")]
-    DateTime(i64, TimeUnit, Option<TimeZone>),
-    #[cfg(feature = "dtype-duration")]
-    Duration(i64, TimeUnit),
-    #[cfg(feature = "dtype-time")]
-    Time(i64),
-    Series(SpecialEq<Series>),
-    OtherScalar(Scalar),
-    // Used for dynamic languages
-    Float(f64),
-    // Used for dynamic languages
+pub enum DynLiteralValue {
+    Str(PlSmallStr),
     Int(i128),
-    // Dynamic string, still needs to be made concrete.
-    StrCat(PlSmallStr),
+    Float(f64),
+    List(DynListLiteralValue),
+}
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum DynListLiteralValue {
+    Str(Box<[Option<PlSmallStr>]>),
+    Int(Box<[Option<i128>]>),
+    Float(Box<[Option<f64>]>),
+    List(Box<[Option<DynListLiteralValue>]>),
+}
+
+impl Hash for DynLiteralValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Str(i) => i.hash(state),
+            Self::Int(i) => i.hash(state),
+            Self::Float(i) => i.to_ne_bytes().hash(state),
+            Self::List(i) => i.hash(state),
+        }
+    }
+}
+
+impl Hash for DynListLiteralValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Str(i) => i.hash(state),
+            Self::Int(i) => i.hash(state),
+            Self::Float(i) => i
+                .iter()
+                .for_each(|i| i.map(|i| i.to_ne_bytes()).hash(state)),
+            Self::List(i) => i.hash(state),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct RangeLiteralValue {
+    pub low: i128,
+    pub high: i128,
+    pub dtype: DataType,
+}
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum LiteralValue {
+    /// A dynamically inferred literal value. This needs to be materialized into a specific type.
+    Dyn(DynLiteralValue),
+    Scalar(Scalar),
+    Series(SpecialEq<Series>),
+    Range(RangeLiteralValue),
+}
+
+pub enum MaterializedLiteralValue {
+    Scalar(Scalar),
+    Series(Series),
+}
+
+impl DynListLiteralValue {
+    pub fn try_materialize_to_dtype(self, dtype: &DataType) -> PolarsResult<Scalar> {
+        let Some(inner_dtype) = dtype.inner_dtype() else {
+            polars_bail!(InvalidOperation: "conversion from list literal to `{dtype}` failed.");
+        };
+
+        let s = match self {
+            DynListLiteralValue::Str(vs) => {
+                StringChunked::from_iter_options(PlSmallStr::from_static("literal"), vs.into_iter())
+                    .into_series()
+            },
+            DynListLiteralValue::Int(vs) => {
+                Int128Chunked::from_iter_options(PlSmallStr::from_static("literal"), vs.into_iter())
+                    .into_series()
+            },
+            DynListLiteralValue::Float(vs) => Float64Chunked::from_iter_options(
+                PlSmallStr::from_static("literal"),
+                vs.into_iter(),
+            )
+            .into_series(),
+            DynListLiteralValue::List(_) => todo!("nested lists"),
+        };
+
+        let s = s.cast_with_options(inner_dtype, CastOptions::Strict)?;
+        let value = match dtype {
+            DataType::List(_) => AnyValue::List(s),
+            DataType::Array(_, size) => AnyValue::Array(s, *size),
+            _ => unreachable!(),
+        };
+
+        Ok(Scalar::new(dtype.clone(), value))
+    }
+}
+
+impl DynLiteralValue {
+    pub fn try_materialize_to_dtype(self, dtype: &DataType) -> PolarsResult<Scalar> {
+        match self {
+            DynLiteralValue::Str(s) => {
+                Ok(Scalar::from(s).cast_with_options(dtype, CastOptions::Strict)?)
+            },
+            DynLiteralValue::Int(i) => {
+                Ok(Scalar::from(i).cast_with_options(dtype, CastOptions::Strict)?)
+            },
+            DynLiteralValue::Float(f) => {
+                Ok(Scalar::from(f).cast_with_options(dtype, CastOptions::Strict)?)
+            },
+            DynLiteralValue::List(dyn_list_value) => dyn_list_value.try_materialize_to_dtype(dtype),
+        }
+    }
+}
+
+impl RangeLiteralValue {
+    pub fn try_materialize_to_series(self, dtype: &DataType) -> PolarsResult<Series> {
+        fn handle_range_oob(range: &RangeLiteralValue, to_dtype: &DataType) -> PolarsResult<()> {
+            polars_bail!(
+                InvalidOperation:
+                "conversion from `{}` to `{to_dtype}` failed for range({}, {})",
+                range.dtype, range.low, range.high,
+            )
+        }
+
+        let s = match dtype {
+            DataType::Int32 => {
+                if self.low < i32::MIN as i128 || self.high > i32::MAX as i128 {
+                    handle_range_oob(&self, dtype)?;
+                }
+
+                new_int_range::<Int32Type>(
+                    self.low as i32,
+                    self.high as i32,
+                    1,
+                    PlSmallStr::from_static("range"),
+                )
+                .unwrap()
+            },
+            DataType::Int64 => {
+                if self.low < i64::MIN as i128 || self.high > i64::MAX as i128 {
+                    handle_range_oob(&self, dtype)?;
+                }
+
+                new_int_range::<Int64Type>(
+                    self.low as i64,
+                    self.high as i64,
+                    1,
+                    PlSmallStr::from_static("range"),
+                )
+                .unwrap()
+            },
+            DataType::UInt32 => {
+                if self.low < u32::MIN as i128 || self.high > u32::MAX as i128 {
+                    handle_range_oob(&self, dtype)?;
+                }
+                new_int_range::<UInt32Type>(
+                    self.low as u32,
+                    self.high as u32,
+                    1,
+                    PlSmallStr::from_static("range"),
+                )
+                .unwrap()
+            },
+            _ => polars_bail!(InvalidOperation: "unsupported range datatype `{dtype}`"),
+        };
+
+        Ok(s)
+    }
 }
 
 impl LiteralValue {
@@ -91,9 +201,76 @@ impl LiteralValue {
         }
     }
 
+    pub fn try_materialize_to_dtype(
+        self,
+        dtype: &DataType,
+    ) -> PolarsResult<MaterializedLiteralValue> {
+        use LiteralValue as L;
+        match self {
+            L::Dyn(dyn_value) => dyn_value
+                .try_materialize_to_dtype(dtype)
+                .map(MaterializedLiteralValue::Scalar),
+            L::Scalar(sc) => Ok(MaterializedLiteralValue::Scalar(
+                sc.cast_with_options(dtype, CastOptions::Strict)?,
+            )),
+            L::Range(range) => {
+                let Some(inner_dtype) = dtype.inner_dtype() else {
+                    polars_bail!(
+                        InvalidOperation: "cannot turn `{}` range into `{dtype}`",
+                        range.dtype
+                    );
+                };
+
+                let s = range.try_materialize_to_series(inner_dtype)?;
+                let value = match dtype {
+                    DataType::List(_) => AnyValue::List(s),
+                    DataType::Array(_, size) => AnyValue::Array(s, *size),
+                    _ => unreachable!(),
+                };
+                Ok(MaterializedLiteralValue::Scalar(Scalar::new(
+                    dtype.clone(),
+                    value,
+                )))
+            },
+            L::Series(s) => Ok(MaterializedLiteralValue::Series(
+                s.cast_with_options(dtype, CastOptions::Strict)?,
+            )),
+        }
+    }
+
+    pub fn extract_usize(&self) -> PolarsResult<usize> {
+        macro_rules! cast_usize {
+            ($v:expr) => {
+                usize::try_from($v).map_err(
+                    |_| polars_err!(InvalidOperation: "cannot convert value {} to usize", $v)
+                )
+            }
+        }
+        match &self {
+            Self::Dyn(DynLiteralValue::Int(v)) => cast_usize!(*v),
+            Self::Scalar(sc) => match sc.as_any_value() {
+                AnyValue::UInt8(v) => Ok(v as usize),
+                AnyValue::UInt16(v) => Ok(v as usize),
+                AnyValue::UInt32(v) => cast_usize!(v),
+                AnyValue::UInt64(v) => cast_usize!(v),
+                AnyValue::Int8(v) => cast_usize!(v),
+                AnyValue::Int16(v) => cast_usize!(v),
+                AnyValue::Int32(v) => cast_usize!(v),
+                AnyValue::Int64(v) => cast_usize!(v),
+                AnyValue::Int128(v) => cast_usize!(v),
+                _ => {
+                    polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
+                },
+            },
+            _ => {
+                polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
+            },
+        }
+    }
+
     pub fn materialize(self) -> Self {
         match self {
-            LiteralValue::Int(_) | LiteralValue::Float(_) | LiteralValue::StrCat(_) => {
+            LiteralValue::Dyn(_) => {
                 let av = self.to_any_value().unwrap();
                 av.into()
             },
@@ -106,77 +283,19 @@ impl LiteralValue {
     }
 
     pub fn to_any_value(&self) -> Option<AnyValue> {
-        use LiteralValue::*;
         let av = match self {
-            Null => AnyValue::Null,
-            Boolean(v) => AnyValue::Boolean(*v),
-            #[cfg(feature = "dtype-u8")]
-            UInt8(v) => AnyValue::UInt8(*v),
-            #[cfg(feature = "dtype-u16")]
-            UInt16(v) => AnyValue::UInt16(*v),
-            UInt32(v) => AnyValue::UInt32(*v),
-            UInt64(v) => AnyValue::UInt64(*v),
-            #[cfg(feature = "dtype-i8")]
-            Int8(v) => AnyValue::Int8(*v),
-            #[cfg(feature = "dtype-i16")]
-            Int16(v) => AnyValue::Int16(*v),
-            Int32(v) => AnyValue::Int32(*v),
-            Int64(v) => AnyValue::Int64(*v),
-            #[cfg(feature = "dtype-i128")]
-            Int128(v) => AnyValue::Int128(*v),
-            Float32(v) => AnyValue::Float32(*v),
-            Float64(v) => AnyValue::Float64(*v),
-            #[cfg(feature = "dtype-decimal")]
-            Decimal(v, scale) => AnyValue::Decimal(*v, *scale),
-            String(v) => AnyValue::String(v),
-            #[cfg(feature = "dtype-duration")]
-            Duration(v, tu) => AnyValue::Duration(*v, *tu),
-            #[cfg(feature = "dtype-date")]
-            Date(v) => AnyValue::Date(*v),
-            #[cfg(feature = "dtype-datetime")]
-            DateTime(v, tu, tz) => AnyValue::Datetime(*v, *tu, tz.as_ref()),
-            #[cfg(feature = "dtype-time")]
-            Time(v) => AnyValue::Time(*v),
-            Series(_) => return None,
-            Int(v) => materialize_dyn_int(*v),
-            Float(v) => AnyValue::Float64(*v),
-            StrCat(v) => AnyValue::String(v),
-            Range { low, high, dtype } => {
-                let opt_s = match dtype {
-                    DataType::Int32 => {
-                        if *low < i32::MIN as i64 || *high > i32::MAX as i64 {
-                            return None;
-                        }
-
-                        let low = *low as i32;
-                        let high = *high as i32;
-                        new_int_range::<Int32Type>(low, high, 1, PlSmallStr::from_static("range"))
-                            .ok()
-                    },
-                    DataType::Int64 => {
-                        let low = *low;
-                        let high = *high;
-                        new_int_range::<Int64Type>(low, high, 1, PlSmallStr::from_static("range"))
-                            .ok()
-                    },
-                    DataType::UInt32 => {
-                        if *low < 0 || *high > u32::MAX as i64 {
-                            return None;
-                        }
-                        let low = *low as u32;
-                        let high = *high as u32;
-                        new_int_range::<UInt32Type>(low, high, 1, PlSmallStr::from_static("range"))
-                            .ok()
-                    },
-                    _ => return None,
-                };
-                match opt_s {
-                    Some(s) => AnyValue::List(s),
-                    None => return None,
-                }
+            Self::Scalar(sc) => sc.value().clone(),
+            Self::Range(range) => {
+                let s = range.clone().try_materialize_to_series(&range.dtype).ok()?;
+                AnyValue::List(s)
             },
-            Binary(v) => AnyValue::Binary(v),
-            OtherScalar(s) => s.value().clone(),
+            Self::Series(_) => return None,
+            Self::Dyn(d) => match d {
+                DynLiteralValue::Int(v) => materialize_dyn_int(*v),
+                DynLiteralValue::Float(v) => AnyValue::Float64(*v),
+                DynLiteralValue::Str(v) => AnyValue::String(v),
+                DynLiteralValue::List(_) => todo!(),
+            },
         };
         Some(av)
     }
@@ -184,63 +303,71 @@ impl LiteralValue {
     /// Getter for the `DataType` of the value
     pub fn get_datatype(&self) -> DataType {
         match self {
-            LiteralValue::Boolean(_) => DataType::Boolean,
-            #[cfg(feature = "dtype-u8")]
-            LiteralValue::UInt8(_) => DataType::UInt8,
-            #[cfg(feature = "dtype-u16")]
-            LiteralValue::UInt16(_) => DataType::UInt16,
-            LiteralValue::UInt32(_) => DataType::UInt32,
-            LiteralValue::UInt64(_) => DataType::UInt64,
-            #[cfg(feature = "dtype-i8")]
-            LiteralValue::Int8(_) => DataType::Int8,
-            #[cfg(feature = "dtype-i16")]
-            LiteralValue::Int16(_) => DataType::Int16,
-            LiteralValue::Int32(_) => DataType::Int32,
-            LiteralValue::Int64(_) => DataType::Int64,
-            #[cfg(feature = "dtype-i128")]
-            LiteralValue::Int128(_) => DataType::Int128,
-            LiteralValue::Float32(_) => DataType::Float32,
-            LiteralValue::Float64(_) => DataType::Float64,
-            #[cfg(feature = "dtype-decimal")]
-            LiteralValue::Decimal(_, scale) => DataType::Decimal(None, Some(*scale)),
-            LiteralValue::String(_) => DataType::String,
-            LiteralValue::Binary(_) => DataType::Binary,
-            LiteralValue::Range { dtype, .. } => dtype.clone(),
-            #[cfg(feature = "dtype-date")]
-            LiteralValue::Date(_) => DataType::Date,
-            #[cfg(feature = "dtype-datetime")]
-            LiteralValue::DateTime(_, tu, tz) => DataType::Datetime(*tu, tz.clone()),
-            #[cfg(feature = "dtype-duration")]
-            LiteralValue::Duration(_, tu) => DataType::Duration(*tu),
-            LiteralValue::Series(s) => s.dtype().clone(),
-            LiteralValue::Null => DataType::Null,
-            #[cfg(feature = "dtype-time")]
-            LiteralValue::Time(_) => DataType::Time,
-            LiteralValue::Int(v) => DataType::Unknown(UnknownKind::Int(*v)),
-            LiteralValue::Float(_) => DataType::Unknown(UnknownKind::Float),
-            LiteralValue::StrCat(_) => DataType::Unknown(UnknownKind::Str),
-            LiteralValue::OtherScalar(s) => s.dtype().clone(),
+            Self::Dyn(d) => match d {
+                DynLiteralValue::Int(v) => DataType::Unknown(UnknownKind::Int(*v)),
+                DynLiteralValue::Float(_) => DataType::Unknown(UnknownKind::Float),
+                DynLiteralValue::Str(_) => DataType::Unknown(UnknownKind::Str),
+                DynLiteralValue::List(_) => todo!(),
+            },
+            Self::Scalar(sc) => sc.dtype().clone(),
+            Self::Series(s) => s.dtype().clone(),
+            Self::Range(s) => s.dtype.clone(),
         }
     }
 
     pub fn new_idxsize(value: IdxSize) -> Self {
-        #[cfg(feature = "bigidx")]
-        {
-            LiteralValue::UInt64(value)
+        LiteralValue::Scalar(value.into())
+    }
+
+    pub fn extract_str(&self) -> Option<&str> {
+        match self {
+            LiteralValue::Dyn(DynLiteralValue::Str(s)) => Some(s.as_str()),
+            LiteralValue::Scalar(sc) => match sc.value() {
+                AnyValue::String(s) => Some(s),
+                AnyValue::StringOwned(s) => Some(s),
+                _ => None,
+            },
+            _ => None,
         }
-        #[cfg(not(feature = "bigidx"))]
-        {
-            LiteralValue::UInt32(value)
+    }
+
+    pub fn extract_binary(&self) -> Option<&[u8]> {
+        match self {
+            LiteralValue::Scalar(sc) => match sc.value() {
+                AnyValue::Binary(s) => Some(s),
+                AnyValue::BinaryOwned(s) => Some(s),
+                _ => None,
+            },
+            _ => None,
         }
     }
 
     pub fn is_null(&self) -> bool {
         match self {
-            Self::Null => true,
-            Self::OtherScalar(sc) => sc.is_null(),
+            Self::Scalar(sc) => sc.is_null(),
             Self::Series(s) => s.len() == 1 && s.null_count() == 1,
             _ => false,
         }
+    }
+
+    pub fn bool(&self) -> Option<bool> {
+        match self {
+            LiteralValue::Scalar(s) => match s.as_any_value() {
+                AnyValue::Boolean(b) => Some(b),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub const fn untyped_null() -> Self {
+        Self::Scalar(Scalar::null(DataType::Null))
+    }
+}
+
+impl From<Scalar> for LiteralValue {
+    fn from(value: Scalar) -> Self {
+        Self::Scalar(value)
     }
 }
 
@@ -264,85 +391,37 @@ impl TypedLiteral for &str {}
 
 impl Literal for PlSmallStr {
     fn lit(self) -> Expr {
-        Expr::Literal(LiteralValue::String(self))
+        Expr::Literal(Scalar::from(self).into())
     }
 }
 
 impl Literal for String {
     fn lit(self) -> Expr {
-        Expr::Literal(LiteralValue::String(PlSmallStr::from_string(self)))
+        Expr::Literal(Scalar::from(PlSmallStr::from_string(self)).into())
     }
 }
 
 impl Literal for &str {
     fn lit(self) -> Expr {
-        Expr::Literal(LiteralValue::String(PlSmallStr::from_str(self)))
+        Expr::Literal(Scalar::from(PlSmallStr::from_str(self)).into())
     }
 }
 
 impl Literal for Vec<u8> {
     fn lit(self) -> Expr {
-        Expr::Literal(LiteralValue::Binary(self))
+        Expr::Literal(Scalar::from(self).into())
     }
 }
 
 impl Literal for &[u8] {
     fn lit(self) -> Expr {
-        Expr::Literal(LiteralValue::Binary(self.to_vec()))
+        Expr::Literal(Scalar::from(self.to_vec()).into())
     }
 }
 
 impl From<AnyValue<'_>> for LiteralValue {
-    fn from(value: AnyValue) -> Self {
-        match value {
-            AnyValue::Null => Self::Null,
-            AnyValue::Boolean(b) => Self::Boolean(b),
-            AnyValue::String(s) => Self::String(PlSmallStr::from_str(s)),
-            AnyValue::Binary(b) => Self::Binary(b.to_vec()),
-            #[cfg(feature = "dtype-u8")]
-            AnyValue::UInt8(u) => Self::UInt8(u),
-            #[cfg(feature = "dtype-u16")]
-            AnyValue::UInt16(u) => Self::UInt16(u),
-            AnyValue::UInt32(u) => Self::UInt32(u),
-            AnyValue::UInt64(u) => Self::UInt64(u),
-            #[cfg(feature = "dtype-i8")]
-            AnyValue::Int8(i) => Self::Int8(i),
-            #[cfg(feature = "dtype-i16")]
-            AnyValue::Int16(i) => Self::Int16(i),
-            AnyValue::Int32(i) => Self::Int32(i),
-            AnyValue::Int64(i) => Self::Int64(i),
-            AnyValue::Float32(f) => Self::Float32(f),
-            AnyValue::Float64(f) => Self::Float64(f),
-            #[cfg(feature = "dtype-decimal")]
-            AnyValue::Decimal(v, scale) => Self::Decimal(v, scale),
-            #[cfg(feature = "dtype-date")]
-            AnyValue::Date(v) => LiteralValue::Date(v),
-            #[cfg(feature = "dtype-datetime")]
-            AnyValue::Datetime(value, tu, tz) => LiteralValue::DateTime(value, tu, tz.cloned()),
-            #[cfg(feature = "dtype-datetime")]
-            AnyValue::DatetimeOwned(value, tu, tz) => {
-                LiteralValue::DateTime(value, tu, tz.as_ref().map(AsRef::as_ref).cloned())
-            },
-            #[cfg(feature = "dtype-duration")]
-            AnyValue::Duration(value, tu) => LiteralValue::Duration(value, tu),
-            #[cfg(feature = "dtype-time")]
-            AnyValue::Time(v) => LiteralValue::Time(v),
-            AnyValue::List(l) => Self::Series(SpecialEq::new(l)),
-            AnyValue::StringOwned(o) => Self::String(o),
-            #[cfg(feature = "dtype-categorical")]
-            AnyValue::Categorical(c, rev_mapping, arr) | AnyValue::Enum(c, rev_mapping, arr) => {
-                if arr.is_null() {
-                    Self::String(PlSmallStr::from_str(rev_mapping.get(c)))
-                } else {
-                    unsafe {
-                        Self::String(PlSmallStr::from_str(
-                            arr.deref_unchecked().value(c as usize),
-                        ))
-                    }
-                }
-            },
-            _ => LiteralValue::OtherScalar(Scalar::new(value.dtype(), value.into_static())),
-        }
+    fn from(value: AnyValue<'_>) -> Self {
+        Self::Scalar(Scalar::new(value.dtype(), value.into_static()))
     }
 }
 
@@ -350,7 +429,7 @@ macro_rules! make_literal {
     ($TYPE:ty, $SCALAR:ident) => {
         impl Literal for $TYPE {
             fn lit(self) -> Expr {
-                Expr::Literal(LiteralValue::$SCALAR(self))
+                Expr::Literal(Scalar::from(self).into())
             }
         }
     };
@@ -360,7 +439,7 @@ macro_rules! make_literal_typed {
     ($TYPE:ty, $SCALAR:ident) => {
         impl TypedLiteral for $TYPE {
             fn typed_lit(self) -> Expr {
-                Expr::Literal(LiteralValue::$SCALAR(self))
+                Expr::Literal(Scalar::from(self).into())
             }
         }
     };
@@ -370,7 +449,9 @@ macro_rules! make_dyn_lit {
     ($TYPE:ty, $SCALAR:ident) => {
         impl Literal for $TYPE {
             fn lit(self) -> Expr {
-                Expr::Literal(LiteralValue::$SCALAR(self.try_into().unwrap()))
+                Expr::Literal(LiteralValue::Dyn(DynLiteralValue::$SCALAR(
+                    self.try_into().unwrap(),
+                )))
             }
         }
     };
@@ -379,30 +460,23 @@ macro_rules! make_dyn_lit {
 make_literal!(bool, Boolean);
 make_literal_typed!(f32, Float32);
 make_literal_typed!(f64, Float64);
-#[cfg(feature = "dtype-i8")]
 make_literal_typed!(i8, Int8);
-#[cfg(feature = "dtype-i16")]
 make_literal_typed!(i16, Int16);
 make_literal_typed!(i32, Int32);
 make_literal_typed!(i64, Int64);
-#[cfg(feature = "dtype-u8")]
+make_literal_typed!(i128, Int128);
 make_literal_typed!(u8, UInt8);
-#[cfg(feature = "dtype-u16")]
 make_literal_typed!(u16, UInt16);
 make_literal_typed!(u32, UInt32);
 make_literal_typed!(u64, UInt64);
 
 make_dyn_lit!(f32, Float);
 make_dyn_lit!(f64, Float);
-#[cfg(feature = "dtype-i8")]
 make_dyn_lit!(i8, Int);
-#[cfg(feature = "dtype-i16")]
 make_dyn_lit!(i16, Int);
 make_dyn_lit!(i32, Int);
 make_dyn_lit!(i64, Int);
-#[cfg(feature = "dtype-u8")]
 make_dyn_lit!(u8, Int);
-#[cfg(feature = "dtype-u16")]
 make_dyn_lit!(u16, Int);
 make_dyn_lit!(u32, Int);
 make_dyn_lit!(u64, Int);
@@ -414,7 +488,7 @@ pub const NULL: Null = Null {};
 
 impl Literal for Null {
     fn lit(self) -> Expr {
-        Expr::Literal(LiteralValue::Null)
+        Expr::Literal(LiteralValue::Scalar(Scalar::null(DataType::Null)))
     }
 }
 
@@ -422,17 +496,23 @@ impl Literal for Null {
 impl Literal for NaiveDateTime {
     fn lit(self) -> Expr {
         if in_nanoseconds_window(&self) {
-            Expr::Literal(LiteralValue::DateTime(
-                self.and_utc().timestamp_nanos_opt().unwrap(),
-                TimeUnit::Nanoseconds,
-                None,
-            ))
+            Expr::Literal(
+                Scalar::new_datetime(
+                    self.and_utc().timestamp_nanos_opt().unwrap(),
+                    TimeUnit::Nanoseconds,
+                    None,
+                )
+                .into(),
+            )
         } else {
-            Expr::Literal(LiteralValue::DateTime(
-                self.and_utc().timestamp_micros(),
-                TimeUnit::Microseconds,
-                None,
-            ))
+            Expr::Literal(
+                Scalar::new_datetime(
+                    self.and_utc().timestamp_micros(),
+                    TimeUnit::Microseconds,
+                    None,
+                )
+                .into(),
+            )
         }
     }
 }
@@ -441,12 +521,12 @@ impl Literal for NaiveDateTime {
 impl Literal for ChronoDuration {
     fn lit(self) -> Expr {
         if let Some(value) = self.num_nanoseconds() {
-            Expr::Literal(LiteralValue::Duration(value, TimeUnit::Nanoseconds))
+            Expr::Literal(Scalar::new_duration(value, TimeUnit::Nanoseconds).into())
         } else {
-            Expr::Literal(LiteralValue::Duration(
-                self.num_microseconds().unwrap(),
-                TimeUnit::Microseconds,
-            ))
+            Expr::Literal(
+                Scalar::new_duration(self.num_microseconds().unwrap(), TimeUnit::Microseconds)
+                    .into(),
+            )
         }
     }
 }
@@ -460,10 +540,13 @@ impl Literal for Duration {
             self
         );
         let ns = self.duration_ns();
-        Expr::Literal(LiteralValue::Duration(
-            if self.negative() { -ns } else { ns },
-            TimeUnit::Nanoseconds,
-        ))
+        Expr::Literal(
+            Scalar::new_duration(
+                if self.negative() { -ns } else { ns },
+                TimeUnit::Nanoseconds,
+            )
+            .into(),
+        )
     }
 }
 
@@ -488,7 +571,7 @@ impl Literal for LiteralValue {
 
 impl Literal for Scalar {
     fn lit(self) -> Expr {
-        Expr::Literal(LiteralValue::OtherScalar(self))
+        Expr::Literal(self.into())
     }
 }
 
@@ -525,16 +608,9 @@ impl Hash for LiteralValue {
                     rng = rng.rotate_right(17).wrapping_add(RANDOM);
                 }
             },
-            LiteralValue::Range { low, high, dtype } => {
-                low.hash(state);
-                high.hash(state);
-                dtype.hash(state)
-            },
-            _ => {
-                if let Some(v) = self.to_any_value() {
-                    v.hash_impl(state, true)
-                }
-            },
+            LiteralValue::Range(range) => range.hash(state),
+            LiteralValue::Scalar(sc) => sc.hash(state),
+            LiteralValue::Dyn(d) => d.hash(state),
         }
     }
 }

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -102,7 +102,7 @@ impl DynListLiteralValue {
                 {
                     Int64Chunked::from_iter_options(
                         PlSmallStr::from_static("literal"),
-                        vs.into_iter().map(|v| v as i64),
+                        vs.into_iter().map(|v| v.map(|v| v as i64)),
                     )
                     .into_series()
                 }

--- a/crates/polars-plan/src/plans/optimizer/cse/cse_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/cse/cse_expr.rs
@@ -304,7 +304,7 @@ impl ExprIdentifierVisitor<'_> {
             AExpr::Window { .. } => REFUSE_SKIP,
             // Don't allow this for now, as we can get `null().cast()` in ternary expressions.
             // TODO! Add a typed null
-            AExpr::Literal(LiteralValue::Null) => REFUSE_NO_MEMBER,
+            AExpr::Literal(LiteralValue::Scalar(sc)) if sc.is_null() => REFUSE_NO_MEMBER,
             AExpr::Literal(s) => {
                 match s {
                     LiteralValue::Series(s) => {

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -22,45 +22,67 @@ macro_rules! eval_binary_same_type {
     ($lhs:expr, $rhs:expr, |$l: ident, $r: ident| $ret: expr) => {{
         if let (AExpr::Literal(lit_left), AExpr::Literal(lit_right)) = ($lhs, $rhs) {
             match (lit_left, lit_right) {
-                (LiteralValue::Float32($l), LiteralValue::Float32($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Float32($ret)))
+                (LiteralValue::Scalar(l), LiteralValue::Scalar(r)) => {
+                    match (l.as_any_value(), r.as_any_value()) {
+                        (AnyValue::Float32($l), AnyValue::Float32($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<f32>>::from($ret).into()))
+                        },
+                        (AnyValue::Float64($l), AnyValue::Float64($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<f64>>::from($ret).into()))
+                        },
+
+                        (AnyValue::Int8($l), AnyValue::Int8($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<i8>>::from($ret).into()))
+                        },
+                        (AnyValue::Int16($l), AnyValue::Int16($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<i16>>::from($ret).into()))
+                        },
+                        (AnyValue::Int32($l), AnyValue::Int32($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<i32>>::from($ret).into()))
+                        },
+                        (AnyValue::Int64($l), AnyValue::Int64($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<i64>>::from($ret).into()))
+                        },
+                        (AnyValue::Int128($l), AnyValue::Int128($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<i128>>::from($ret).into()))
+                        },
+
+                        (AnyValue::UInt8($l), AnyValue::UInt8($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<u8>>::from($ret).into()))
+                        },
+                        (AnyValue::UInt16($l), AnyValue::UInt16($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<u16>>::from($ret).into()))
+                        },
+                        (AnyValue::UInt32($l), AnyValue::UInt32($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<u32>>::from($ret).into()))
+                        },
+                        (AnyValue::UInt64($l), AnyValue::UInt64($r)) => {
+                            Some(AExpr::Literal(<Scalar as From<u64>>::from($ret).into()))
+                        },
+
+                        _ => None,
+                    }
+                    .into()
                 },
-                (LiteralValue::Float64($l), LiteralValue::Float64($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Float64($ret)))
+                (
+                    LiteralValue::Dyn(DynLiteralValue::Float($l)),
+                    LiteralValue::Dyn(DynLiteralValue::Float($r)),
+                ) => {
+                    let $l = *$l;
+                    let $r = *$r;
+                    Some(AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(
+                        $ret,
+                    ))))
                 },
-                #[cfg(feature = "dtype-i8")]
-                (LiteralValue::Int8($l), LiteralValue::Int8($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Int8($ret)))
-                },
-                #[cfg(feature = "dtype-i16")]
-                (LiteralValue::Int16($l), LiteralValue::Int16($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Int16($ret)))
-                },
-                (LiteralValue::Int32($l), LiteralValue::Int32($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Int32($ret)))
-                },
-                (LiteralValue::Int64($l), LiteralValue::Int64($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Int64($ret)))
-                },
-                #[cfg(feature = "dtype-u8")]
-                (LiteralValue::UInt8($l), LiteralValue::UInt8($r)) => {
-                    Some(AExpr::Literal(LiteralValue::UInt8($ret)))
-                },
-                #[cfg(feature = "dtype-u16")]
-                (LiteralValue::UInt16($l), LiteralValue::UInt16($r)) => {
-                    Some(AExpr::Literal(LiteralValue::UInt16($ret)))
-                },
-                (LiteralValue::UInt32($l), LiteralValue::UInt32($r)) => {
-                    Some(AExpr::Literal(LiteralValue::UInt32($ret)))
-                },
-                (LiteralValue::UInt64($l), LiteralValue::UInt64($r)) => {
-                    Some(AExpr::Literal(LiteralValue::UInt64($ret)))
-                },
-                (LiteralValue::Float($l), LiteralValue::Float($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Float($ret)))
-                },
-                (LiteralValue::Int($l), LiteralValue::Int($r)) => {
-                    Some(AExpr::Literal(LiteralValue::Int($ret)))
+                (
+                    LiteralValue::Dyn(DynLiteralValue::Int($l)),
+                    LiteralValue::Dyn(DynLiteralValue::Int($r)),
+                ) => {
+                    let $l = *$l;
+                    let $r = *$r;
+                    Some(AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(
+                        $ret,
+                    ))))
                 },
                 _ => None,
             }
@@ -74,49 +96,33 @@ macro_rules! eval_binary_cmp_same_type {
     ($lhs:expr, $operand: tt, $rhs:expr) => {{
     if let (AExpr::Literal(lit_left), AExpr::Literal(lit_right)) = ($lhs, $rhs) {
         match (lit_left, lit_right) {
-            (LiteralValue::Float32(x), LiteralValue::Float32(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x.to_total_ord() $operand y.to_total_ord())))
-            }
-            (LiteralValue::Float64(x), LiteralValue::Float64(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x.to_total_ord() $operand y.to_total_ord())))
-            }
-            #[cfg(feature = "dtype-i8")]
-            (LiteralValue::Int8(x), LiteralValue::Int8(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            #[cfg(feature = "dtype-i16")]
-            (LiteralValue::Int16(x), LiteralValue::Int16(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            (LiteralValue::Int32(x), LiteralValue::Int32(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            (LiteralValue::Int64(x), LiteralValue::Int64(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            #[cfg(feature = "dtype-u8")]
-            (LiteralValue::UInt8(x), LiteralValue::UInt8(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            #[cfg(feature = "dtype-u16")]
-            (LiteralValue::UInt16(x), LiteralValue::UInt16(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            (LiteralValue::UInt32(x), LiteralValue::UInt32(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            (LiteralValue::UInt64(x), LiteralValue::UInt64(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            (LiteralValue::Boolean(x), LiteralValue::Boolean(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
+            (LiteralValue::Scalar(l), LiteralValue::Scalar(r)) => match (l.as_any_value(), r.as_any_value()) {
+                (AnyValue::Float32(l), AnyValue::Float32(r)) => Some(AExpr::Literal({ let x: bool = l.to_total_ord() $operand r.to_total_ord(); Scalar::from(x) }.into())),
+                (AnyValue::Float64(l), AnyValue::Float64(r)) => Some(AExpr::Literal({ let x: bool = l.to_total_ord() $operand r.to_total_ord(); Scalar::from(x) }.into())),
+
+                (AnyValue::Boolean(l), AnyValue::Boolean(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+
+                (AnyValue::Int8(l), AnyValue::Int8(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+                (AnyValue::Int16(l), AnyValue::Int16(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+                (AnyValue::Int32(l), AnyValue::Int32(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+                (AnyValue::Int64(l), AnyValue::Int64(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+                (AnyValue::Int128(l), AnyValue::Int128(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+
+                (AnyValue::UInt8(l), AnyValue::UInt8(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+                (AnyValue::UInt16(l), AnyValue::UInt16(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+                (AnyValue::UInt32(l), AnyValue::UInt32(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+                (AnyValue::UInt64(l), AnyValue::UInt64(r)) => Some(AExpr::Literal({ let x: bool = l $operand r; Scalar::from(x) }.into())),
+
+                _ => None,
+            }.into(),
+            (LiteralValue::Dyn(DynLiteralValue::Float(l)), LiteralValue::Dyn(DynLiteralValue::Float(r))) => {
+                let x: bool = l.to_total_ord() $operand r.to_total_ord();
+                Some(AExpr::Literal(Scalar::from(x).into()))
             },
-            (LiteralValue::Int(x), LiteralValue::Int(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
-            (LiteralValue::Float(x), LiteralValue::Float(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
-            }
+            (LiteralValue::Dyn(DynLiteralValue::Int(l)), LiteralValue::Dyn(DynLiteralValue::Int(r))) => {
+                let x: bool = l $operand r;
+                Some(AExpr::Literal(Scalar::from(x).into()))
+            },
             _ => None,
         }
     } else {
@@ -147,7 +153,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 right,
             } if matches!(
                 expr_arena.get(*left),
-                AExpr::Literal(LiteralValue::Boolean(true))
+                AExpr::Literal(lv) if lv.bool() == Some(true)
             ) && in_filter =>
             {
                 // Only in filter as we might change the name from "literal"
@@ -161,7 +167,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 right,
             } if matches!(
                 expr_arena.get(*right),
-                AExpr::Literal(LiteralValue::Boolean(true))
+                AExpr::Literal(lv) if lv.bool() == Some(true)
             ) =>
             {
                 Some(expr_arena.get(*left).clone())
@@ -177,10 +183,10 @@ impl OptimizationRule for SimplifyBooleanRule {
             } if matches!(expr_arena.get(*left), AExpr::Literal(_))
                 && matches!(
                     expr_arena.get(*right),
-                    AExpr::Literal(LiteralValue::Boolean(false))
+                    AExpr::Literal(lv) if lv.bool() == Some(false)
                 ) =>
             {
-                Some(AExpr::Literal(LiteralValue::Boolean(false)))
+                Some(AExpr::Literal(Scalar::from(false).into()))
             },
 
             // false AND x -> false
@@ -192,10 +198,10 @@ impl OptimizationRule for SimplifyBooleanRule {
                 right,
             } if matches!(
                 expr_arena.get(*left),
-                AExpr::Literal(LiteralValue::Boolean(false))
+                AExpr::Literal(lv) if lv.bool() == Some(false)
             ) && matches!(expr_arena.get(*right), AExpr::Literal(_)) =>
             {
-                Some(AExpr::Literal(LiteralValue::Boolean(false)))
+                Some(AExpr::Literal(Scalar::from(false).into()))
             },
 
             // false or x => x
@@ -205,7 +211,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 right,
             } if matches!(
                 expr_arena.get(*left),
-                AExpr::Literal(LiteralValue::Boolean(false))
+                AExpr::Literal(lv) if lv.bool() == Some(false)
             ) && in_filter =>
             {
                 // Only in filter as we might change the name from "literal"
@@ -220,7 +226,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 ..
             } if matches!(
                 expr_arena.get(*right),
-                AExpr::Literal(LiteralValue::Boolean(false))
+                AExpr::Literal(lv) if lv.bool() == Some(false)
             ) =>
             {
                 Some(expr_arena.get(*left).clone())
@@ -236,10 +242,10 @@ impl OptimizationRule for SimplifyBooleanRule {
             } if matches!(expr_arena.get(*left), AExpr::Literal(_))
                 && matches!(
                     expr_arena.get(*right),
-                    AExpr::Literal(LiteralValue::Boolean(true))
+                    AExpr::Literal(lv) if lv.bool() == Some(true)
                 ) =>
             {
-                Some(AExpr::Literal(LiteralValue::Boolean(true)))
+                Some(AExpr::Literal(Scalar::from(true).into()))
             },
 
             // x OR true => true
@@ -251,10 +257,10 @@ impl OptimizationRule for SimplifyBooleanRule {
                 right,
             } if matches!(
                 expr_arena.get(*left),
-                AExpr::Literal(LiteralValue::Boolean(true))
+                    AExpr::Literal(lv) if lv.bool() == Some(true)
             ) && matches!(expr_arena.get(*right), AExpr::Literal(_)) =>
             {
-                Some(AExpr::Literal(LiteralValue::Boolean(true)))
+                Some(AExpr::Literal(Scalar::from(true).into()))
             },
             AExpr::Function {
                 input,
@@ -272,18 +278,24 @@ impl OptimizationRule for SimplifyBooleanRule {
 }
 
 fn eval_negate(ae: &AExpr) -> Option<AExpr> {
+    use std::ops::Neg;
     let out = match ae {
         AExpr::Literal(lv) => match lv {
-            #[cfg(feature = "dtype-i8")]
-            LiteralValue::Int8(v) => LiteralValue::Int8(-*v),
-            #[cfg(feature = "dtype-i16")]
-            LiteralValue::Int16(v) => LiteralValue::Int16(-*v),
-            LiteralValue::Int32(v) => LiteralValue::Int32(-*v),
-            LiteralValue::Int64(v) => LiteralValue::Int64(-*v),
-            LiteralValue::Float32(v) => LiteralValue::Float32(-*v),
-            LiteralValue::Float64(v) => LiteralValue::Float64(-*v),
-            LiteralValue::Float(v) => LiteralValue::Float(-*v),
-            LiteralValue::Int(v) => LiteralValue::Int(-*v),
+            LiteralValue::Scalar(sc) => match sc.as_any_value() {
+                AnyValue::Int8(v) => Scalar::from(v.checked_neg()?),
+                AnyValue::Int16(v) => Scalar::from(v.checked_neg()?),
+                AnyValue::Int32(v) => Scalar::from(v.checked_neg()?),
+                AnyValue::Int64(v) => Scalar::from(v.checked_neg()?),
+                AnyValue::Float32(v) => Scalar::from(v.neg()),
+                AnyValue::Float64(v) => Scalar::from(v.neg()),
+                _ => return None,
+            }
+            .into(),
+            LiteralValue::Dyn(d) => LiteralValue::Dyn(match d {
+                DynLiteralValue::Int(v) => DynLiteralValue::Int(v.checked_neg()?),
+                DynLiteralValue::Float(v) => DynLiteralValue::Float(v.neg()),
+                _ => return None,
+            }),
             _ => return None,
         },
         _ => return None,
@@ -296,10 +308,8 @@ where
     F: Fn(bool, bool) -> bool,
 {
     if let (AExpr::Literal(lit_left), AExpr::Literal(lit_right)) = (left, right) {
-        return match (lit_left, lit_right) {
-            (LiteralValue::Boolean(x), LiteralValue::Boolean(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(operation(*x, *y))))
-            },
+        return match (lit_left.bool(), lit_right.bool()) {
+            (Some(x), Some(y)) => Some(AExpr::Literal(Scalar::from(operation(x, y)).into())),
             _ => None,
         };
     }
@@ -564,56 +574,97 @@ impl OptimizationRule for SimplifyExprRule {
                             (left_aexpr, right_aexpr)
                         {
                             match (lit_left, lit_right) {
-                                (LiteralValue::Float32(x), LiteralValue::Float32(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Float32(x / y)))
+                                (LiteralValue::Scalar(l), LiteralValue::Scalar(r)) => {
+                                    match (l.as_any_value(), r.as_any_value()) {
+                                        (AnyValue::Float32(x), AnyValue::Float32(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<f32>>::from(x / y).into(),
+                                            ))
+                                        },
+                                        (AnyValue::Float64(x), AnyValue::Float64(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<f64>>::from(x / y).into(),
+                                            ))
+                                        },
+
+                                        (AnyValue::Int8(x), AnyValue::Int8(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<i8>>::from(
+                                                    x.wrapping_floor_div_mod(y).0,
+                                                )
+                                                .into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int16(x), AnyValue::Int16(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<i16>>::from(
+                                                    x.wrapping_floor_div_mod(y).0,
+                                                )
+                                                .into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int32(x), AnyValue::Int32(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<i32>>::from(
+                                                    x.wrapping_floor_div_mod(y).0,
+                                                )
+                                                .into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int64(x), AnyValue::Int64(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<i64>>::from(
+                                                    x.wrapping_floor_div_mod(y).0,
+                                                )
+                                                .into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int128(x), AnyValue::Int128(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<i128>>::from(
+                                                    x.wrapping_floor_div_mod(y).0,
+                                                )
+                                                .into(),
+                                            ))
+                                        },
+
+                                        (AnyValue::UInt8(x), AnyValue::UInt8(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<u8>>::from(x / y).into(),
+                                            ))
+                                        },
+                                        (AnyValue::UInt16(x), AnyValue::UInt16(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<u16>>::from(x / y).into(),
+                                            ))
+                                        },
+                                        (AnyValue::UInt32(x), AnyValue::UInt32(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<u32>>::from(x / y).into(),
+                                            ))
+                                        },
+                                        (AnyValue::UInt64(x), AnyValue::UInt64(y)) => {
+                                            Some(AExpr::Literal(
+                                                <Scalar as From<u64>>::from(x / y).into(),
+                                            ))
+                                        },
+
+                                        _ => None,
+                                    }
                                 },
-                                (LiteralValue::Float64(x), LiteralValue::Float64(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Float64(x / y)))
+
+                                (
+                                    LiteralValue::Dyn(DynLiteralValue::Float(x)),
+                                    LiteralValue::Dyn(DynLiteralValue::Float(y)),
+                                ) => {
+                                    Some(AExpr::Literal(<Scalar as From<f64>>::from(x / y).into()))
                                 },
-                                (LiteralValue::Float(x), LiteralValue::Float(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Float64(x / y)))
-                                },
-                                #[cfg(feature = "dtype-i8")]
-                                (LiteralValue::Int8(x), LiteralValue::Int8(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Int8(
-                                        x.wrapping_floor_div_mod(*y).0,
-                                    )))
-                                },
-                                #[cfg(feature = "dtype-i16")]
-                                (LiteralValue::Int16(x), LiteralValue::Int16(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Int16(
-                                        x.wrapping_floor_div_mod(*y).0,
-                                    )))
-                                },
-                                (LiteralValue::Int32(x), LiteralValue::Int32(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Int32(
-                                        x.wrapping_floor_div_mod(*y).0,
-                                    )))
-                                },
-                                (LiteralValue::Int64(x), LiteralValue::Int64(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Int64(
-                                        x.wrapping_floor_div_mod(*y).0,
-                                    )))
-                                },
-                                (LiteralValue::Int(x), LiteralValue::Int(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Int(
-                                        x.wrapping_floor_div_mod(*y).0,
-                                    )))
-                                },
-                                #[cfg(feature = "dtype-u8")]
-                                (LiteralValue::UInt8(x), LiteralValue::UInt8(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::UInt8(x / y)))
-                                },
-                                #[cfg(feature = "dtype-u16")]
-                                (LiteralValue::UInt16(x), LiteralValue::UInt16(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::UInt16(x / y)))
-                                },
-                                (LiteralValue::UInt32(x), LiteralValue::UInt32(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::UInt32(x / y)))
-                                },
-                                (LiteralValue::UInt64(x), LiteralValue::UInt64(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::UInt64(x / y)))
-                                },
+                                (
+                                    LiteralValue::Dyn(DynLiteralValue::Int(x)),
+                                    LiteralValue::Dyn(DynLiteralValue::Int(y)),
+                                ) => Some(AExpr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(
+                                    x.wrapping_floor_div_mod(*y).0,
+                                )))),
                                 _ => None,
                             }
                         } else {
@@ -625,45 +676,75 @@ impl OptimizationRule for SimplifyExprRule {
                             (left_aexpr, right_aexpr)
                         {
                             match (lit_left, lit_right) {
-                                (LiteralValue::Float32(x), LiteralValue::Float32(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Float32(x / y)))
+                                (LiteralValue::Scalar(l), LiteralValue::Scalar(r)) => {
+                                    match (l.as_any_value(), r.as_any_value()) {
+                                        (AnyValue::Float32(x), AnyValue::Float32(y)) => {
+                                            Some(AExpr::Literal(Scalar::from(x / y).into()))
+                                        },
+                                        (AnyValue::Float64(x), AnyValue::Float64(y)) => {
+                                            Some(AExpr::Literal(Scalar::from(x / y).into()))
+                                        },
+
+                                        (AnyValue::Int8(x), AnyValue::Int8(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int16(x), AnyValue::Int16(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int32(x), AnyValue::Int32(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int64(x), AnyValue::Int64(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+                                        (AnyValue::Int128(x), AnyValue::Int128(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+
+                                        (AnyValue::UInt8(x), AnyValue::UInt8(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+                                        (AnyValue::UInt16(x), AnyValue::UInt16(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+                                        (AnyValue::UInt32(x), AnyValue::UInt32(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+                                        (AnyValue::UInt64(x), AnyValue::UInt64(y)) => {
+                                            Some(AExpr::Literal(
+                                                Scalar::from(x as f64 / y as f64).into(),
+                                            ))
+                                        },
+
+                                        _ => None,
+                                    }
                                 },
-                                (LiteralValue::Float64(x), LiteralValue::Float64(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Float64(x / y)))
-                                },
-                                (LiteralValue::Float(x), LiteralValue::Float(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Float(x / y)))
-                                },
-                                #[cfg(feature = "dtype-i8")]
-                                (LiteralValue::Int8(x), LiteralValue::Int8(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                #[cfg(feature = "dtype-i16")]
-                                (LiteralValue::Int16(x), LiteralValue::Int16(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                (LiteralValue::Int32(x), LiteralValue::Int32(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                (LiteralValue::Int64(x), LiteralValue::Int64(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                #[cfg(feature = "dtype-u8")]
-                                (LiteralValue::UInt8(x), LiteralValue::UInt8(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                #[cfg(feature = "dtype-u16")]
-                                (LiteralValue::UInt16(x), LiteralValue::UInt16(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                (LiteralValue::UInt32(x), LiteralValue::UInt32(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                (LiteralValue::UInt64(x), LiteralValue::UInt64(y)) => Some(
-                                    AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
-                                ),
-                                (LiteralValue::Int(x), LiteralValue::Int(y)) => {
-                                    Some(AExpr::Literal(LiteralValue::Float(*x as f64 / *y as f64)))
+
+                                (
+                                    LiteralValue::Dyn(DynLiteralValue::Float(x)),
+                                    LiteralValue::Dyn(DynLiteralValue::Float(y)),
+                                ) => Some(AExpr::Literal(Scalar::from(*x / *y).into())),
+                                (
+                                    LiteralValue::Dyn(DynLiteralValue::Int(x)),
+                                    LiteralValue::Dyn(DynLiteralValue::Int(y)),
+                                ) => {
+                                    Some(AExpr::Literal(Scalar::from(*x as f64 / *y as f64).into()))
                                 },
                                 _ => None,
                             }
@@ -672,7 +753,7 @@ impl OptimizationRule for SimplifyExprRule {
                         }
                     },
                     Modulus => eval_binary_same_type!(left_aexpr, right_aexpr, |l, r| l
-                        .wrapping_floor_div_mod(*r)
+                        .wrapping_floor_div_mod(r)
                         .1),
                     Lt => eval_binary_cmp_same_type!(left_aexpr, <, right_aexpr),
                     Gt => eval_binary_cmp_same_type!(left_aexpr, >, right_aexpr),
@@ -686,7 +767,7 @@ impl OptimizationRule for SimplifyExprRule {
                     Or | LogicalOr => eval_bitwise(left_aexpr, right_aexpr, |l, r| l | r),
                     Xor => eval_bitwise(left_aexpr, right_aexpr, |l, r| l ^ r),
                     FloorDivide => eval_binary_same_type!(left_aexpr, right_aexpr, |l, r| l
-                        .wrapping_floor_div_mod(*r)
+                        .wrapping_floor_div_mod(r)
                         .0),
                 };
                 if out.is_some() {
@@ -705,19 +786,4 @@ impl OptimizationRule for SimplifyExprRule {
         };
         Ok(out)
     }
-}
-
-#[test]
-#[cfg(feature = "dtype-i8")]
-fn test_expr_to_aexp() {
-    use super::*;
-
-    let expr = Expr::Literal(LiteralValue::Int8(0));
-    let mut arena = Arena::new();
-    let aexpr = to_aexpr(expr, &mut arena).unwrap();
-    assert_eq!(aexpr, Node(0));
-    assert!(matches!(
-        arena.get(aexpr),
-        AExpr::Literal(LiteralValue::Int8(0))
-    ))
 }

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/simplify_functions.rs
@@ -201,8 +201,8 @@ pub(super) fn optimize_functions(
                     ..
                 } => Some(expr_arena.get(input[0].node()).clone()),
                 // not(lit x) => !x
-                AExpr::Literal(LiteralValue::Boolean(b)) => {
-                    Some(AExpr::Literal(LiteralValue::Boolean(!b)))
+                AExpr::Literal(lv) if lv.bool().is_some() => {
+                    Some(AExpr::Literal(Scalar::from(!lv.bool().unwrap()).into()))
                 },
                 // not(x.is_null) => x.is_not_null
                 AExpr::Function {

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -117,9 +117,10 @@ pub(crate) fn all_return_scalar(e: &Expr) -> bool {
 }
 
 pub fn has_null(current_expr: &Expr) -> bool {
-    has_expr(current_expr, |e| {
-        matches!(e, Expr::Literal(LiteralValue::Null))
-    })
+    has_expr(
+        current_expr,
+        |e| matches!(e, Expr::Literal(LiteralValue::Scalar(sc)) if sc.is_null()),
+    )
 }
 
 pub fn aexpr_output_name(node: Node, arena: &Arena<AExpr>) -> PolarsResult<PlSmallStr> {

--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -1,5 +1,6 @@
 use polars::lazy::dsl;
 use polars::prelude::*;
+use polars_plan::plans::DynLiteralValue;
 use polars_plan::prelude::UnionArgs;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
@@ -455,10 +456,10 @@ pub fn lit(value: &Bound<'_, PyAny>, allow_object: bool, is_scalar: bool) -> PyR
             .extract::<i128>()
             .map_err(|e| polars_err!(InvalidOperation: "integer too large for Polars: {e}"))
             .map_err(PyPolarsErr::from)?;
-        Ok(Expr::Literal(LiteralValue::Int(v)).into())
+        Ok(Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(v))).into())
     } else if let Ok(float) = value.downcast::<PyFloat>() {
         let val = float.extract::<f64>()?;
-        Ok(Expr::Literal(LiteralValue::Float(val)).into())
+        Ok(Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(val))).into())
     } else if let Ok(pystr) = value.downcast::<PyString>() {
         Ok(dsl::lit(pystr.to_string()).into())
     } else if let Ok(series) = value.extract::<PySeries>() {

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -9,8 +9,7 @@ use polars_lazy::dsl::Expr;
 use polars_lazy::dsl::ListNameSpaceExtension;
 use polars_ops::chunked_array::UnicodeForm;
 use polars_plan::dsl::{coalesce, concat_str, len, max_horizontal, min_horizontal, when};
-use polars_plan::plans::{LiteralValue, typed_lit};
-use polars_plan::prelude::LiteralValue::Null;
+use polars_plan::plans::{DynLiteralValue, LiteralValue, typed_lit};
 use polars_plan::prelude::{StrptimeOptions, col, cols, lit};
 use polars_utils::pl_str::PlSmallStr;
 use sqlparser::ast::helpers::attached_token::AttachedToken;
@@ -978,7 +977,7 @@ impl SQLFunctionVisitor<'_> {
                     1 => self.visit_unary(|e| e.round(0)),
                     2 => self.try_visit_binary(|e, decimals| {
                         Ok(e.round(match decimals {
-                            Expr::Literal(LiteralValue::Int(n)) => {
+                            Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => {
                                 if n >= 0 { n as u32 } else {
                                     polars_bail!(SQLInterface: "ROUND does not currently support negative decimals value ({})", args[1])
                                 }
@@ -1046,7 +1045,7 @@ impl SQLFunctionVisitor<'_> {
                 match args.len() {
                     2 => self.visit_binary(|l: Expr, r: Expr| {
                         when(l.clone().eq(r))
-                            .then(lit(LiteralValue::Null))
+                            .then(lit(LiteralValue::untyped_null()))
                             .otherwise(l)
                     }),
                     _ => {
@@ -1060,7 +1059,8 @@ impl SQLFunctionVisitor<'_> {
             // ----
             DatePart => self.try_visit_binary(|part, e| {
                 match part {
-                    Expr::Literal(LiteralValue::String(p)) => {
+                    Expr::Literal(p) if p.extract_str().is_some() => {
+                        let p = p.extract_str().unwrap();
                         // note: 'DATE_PART' and 'EXTRACT' are minor syntactic
                         // variations on otherwise identical functionality
                         parse_extract_date_part(
@@ -1106,7 +1106,7 @@ impl SQLFunctionVisitor<'_> {
                 } else {
                     self.try_visit_variadic(|exprs: &[Expr]| {
                         match &exprs[0] {
-                            Expr::Literal(LiteralValue::String(s)) => Ok(concat_str(&exprs[1..], s, true)),
+                            Expr::Literal(lv) if lv.extract_str().is_some() => Ok(concat_str(&exprs[1..], lv.extract_str().unwrap(), true)),
                             _ => polars_bail!(SQLSyntax: "CONCAT_WS 'separator' must be a literal string (found {:?})", exprs[0]),
                         }
                     })
@@ -1127,9 +1127,9 @@ impl SQLFunctionVisitor<'_> {
             InitCap => self.visit_unary(|e| e.str().to_titlecase()),
             Left => self.try_visit_binary(|e, length| {
                 Ok(match length {
-                    Expr::Literal(Null) => lit(Null),
-                    Expr::Literal(LiteralValue::Int(0)) => lit(""),
-                    Expr::Literal(LiteralValue::Int(n)) => {
+                    Expr::Literal(lv) if lv.is_null() => lit(lv),
+                    Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(0))) => lit(""),
+                    Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => {
                         let len = if n > 0 {
                             lit(n)
                         } else {
@@ -1153,7 +1153,9 @@ impl SQLFunctionVisitor<'_> {
             LTrim => {
                 let args = extract_args(function)?;
                 match args.len() {
-                    1 => self.visit_unary(|e| e.str().strip_chars_start(lit(Null))),
+                    1 => self.visit_unary(|e| {
+                        e.str().strip_chars_start(lit(LiteralValue::untyped_null()))
+                    }),
                     2 => self.visit_binary(|e, s| e.str().strip_chars_start(s)),
                     _ => {
                         polars_bail!(SQLSyntax: "LTRIM expects 1-2 arguments (found {})", args.len())
@@ -1204,7 +1206,9 @@ impl SQLFunctionVisitor<'_> {
                     3 => self.try_visit_ternary(|e, pat, flags| {
                         Ok(e.str().contains(
                             match (pat, flags) {
-                                (Expr::Literal(LiteralValue::String(s)), Expr::Literal(LiteralValue::String(f))) => {
+                                (Expr::Literal(s_lv), Expr::Literal(f_lv)) if s_lv.extract_str().is_some() && f_lv.extract_str().is_some() => {
+                                    let s = s_lv.extract_str().unwrap();
+                                    let f = f_lv.extract_str().unwrap();
                                     if f.is_empty() {
                                         polars_bail!(SQLSyntax: "invalid/empty 'flags' for REGEXP_LIKE ({})", args[2]);
                                     };
@@ -1232,32 +1236,38 @@ impl SQLFunctionVisitor<'_> {
             Reverse => self.visit_unary(|e| e.str().reverse()),
             Right => self.try_visit_binary(|e, length| {
                 Ok(match length {
-                    Expr::Literal(Null) => lit(Null),
-                    Expr::Literal(LiteralValue::Int(0)) => typed_lit(""),
-                    Expr::Literal(LiteralValue::Int(n)) => {
+                    Expr::Literal(lv) if lv.is_null() => lit(lv),
+                    Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(0))) => typed_lit(""),
+                    Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => {
                         let n: i64 = n.try_into().unwrap();
                         let offset = if n < 0 {
                             lit(n.abs())
                         } else {
                             e.clone().str().len_chars().cast(DataType::Int32) - lit(n)
                         };
-                        e.str().slice(offset, lit(Null))
+                        e.str().slice(offset, lit(LiteralValue::untyped_null()))
                     },
                     Expr::Literal(v) => {
                         polars_bail!(SQLSyntax: "invalid 'n_chars' for RIGHT ({:?})", v)
                     },
                     _ => when(length.clone().lt(lit(0)))
-                        .then(e.clone().str().slice(length.clone().abs(), lit(Null)))
+                        .then(
+                            e.clone()
+                                .str()
+                                .slice(length.clone().abs(), lit(LiteralValue::untyped_null())),
+                        )
                         .otherwise(e.clone().str().slice(
                             e.clone().str().len_chars().cast(DataType::Int32) - length.clone(),
-                            lit(Null),
+                            lit(LiteralValue::untyped_null()),
                         )),
                 })
             }),
             RTrim => {
                 let args = extract_args(function)?;
                 match args.len() {
-                    1 => self.visit_unary(|e| e.str().strip_chars_end(lit(Null))),
+                    1 => self.visit_unary(|e| {
+                        e.str().strip_chars_end(lit(LiteralValue::untyped_null()))
+                    }),
                     2 => self.visit_binary(|e, s| e.str().strip_chars_end(s)),
                     _ => {
                         polars_bail!(SQLSyntax: "RTRIM expects 1-2 arguments (found {})", args.len())
@@ -1313,25 +1323,25 @@ impl SQLFunctionVisitor<'_> {
                     // note: SQL is 1-indexed, hence the need for adjustments
                     2 => self.try_visit_binary(|e, start| {
                         Ok(match start {
-                            Expr::Literal(Null) => lit(Null),
-                            Expr::Literal(LiteralValue::Int(n)) if n <= 0 => e,
-                            Expr::Literal(LiteralValue::Int(n)) => e.str().slice(lit(n - 1), lit(Null)),
+                            Expr::Literal(lv) if lv.is_null() => lit(lv),
+                            Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) if n <= 0 => e,
+                            Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => e.str().slice(lit(n - 1), lit(LiteralValue::untyped_null())),
                             Expr::Literal(_) => polars_bail!(SQLSyntax: "invalid 'start' for SUBSTR ({})", args[1]),
                             _ => start.clone() + lit(1),
                         })
                     }),
                     3 => self.try_visit_ternary(|e: Expr, start: Expr, length: Expr| {
                         Ok(match (start.clone(), length.clone()) {
-                            (Expr::Literal(Null), _) | (_, Expr::Literal(Null)) => lit(Null),
-                            (_, Expr::Literal(LiteralValue::Int(n))) if n < 0 => {
+                            (Expr::Literal(lv), _) | (_, Expr::Literal(lv)) if lv.is_null() => lit(lv),
+                            (_, Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n)))) if n < 0 => {
                                 polars_bail!(SQLSyntax: "SUBSTR does not support negative length ({})", args[2])
                             },
-                            (Expr::Literal(LiteralValue::Int(n)), _) if n > 0 => e.str().slice(lit(n - 1), length.clone()),
-                            (Expr::Literal(LiteralValue::Int(n)), _) => {
+                            (Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))), _) if n > 0 => e.str().slice(lit(n - 1), length.clone()),
+                            (Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))), _) => {
                                 e.str().slice(lit(0), (length.clone() + lit(n - 1)).clip_min(lit(0)))
                             },
                             (Expr::Literal(_), _) => polars_bail!(SQLSyntax: "invalid 'start' for SUBSTR ({})", args[1]),
-                            (_, Expr::Literal(LiteralValue::Float(_))) => {
+                            (_, Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(_)))) => {
                                 polars_bail!(SQLSyntax: "invalid 'length' for SUBSTR ({})", args[1])
                             },
                             _ => {
@@ -1361,14 +1371,14 @@ impl SQLFunctionVisitor<'_> {
                 match args.len() {
                     2 => self.try_visit_binary(|e, q| {
                         let value = match q {
-                            Expr::Literal(LiteralValue::Float(f)) => {
+                            Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(f))) => {
                                 if (0.0..=1.0).contains(&f) {
                                     Expr::from(f)
                                 } else {
                                     polars_bail!(SQLSyntax: "QUANTILE_CONT value must be between 0 and 1 ({})", args[1])
                                 }
                             },
-                            Expr::Literal(LiteralValue::Int(n)) => {
+                            Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => {
                                 if (0..=1).contains(&n) {
                                     Expr::from(n as f64)
                                 } else {
@@ -1387,14 +1397,14 @@ impl SQLFunctionVisitor<'_> {
                 match args.len() {
                     2 => self.try_visit_binary(|e, q| {
                         let value = match q {
-                            Expr::Literal(LiteralValue::Float(f)) => {
+                            Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(f))) => {
                                 if (0.0..=1.0).contains(&f) {
                                     Expr::from(f)
                                 } else {
                                     polars_bail!(SQLSyntax: "QUANTILE_DISC value must be between 0 and 1 ({})", args[1])
                                 }
                             },
-                            Expr::Literal(LiteralValue::Int(n)) => {
+                            Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => {
                                 if (0..=1).contains(&n) {
                                     Expr::from(n as f64)
                                 } else {
@@ -1441,14 +1451,15 @@ impl SQLFunctionVisitor<'_> {
             Columns => {
                 let active_schema = self.active_schema;
                 self.try_visit_unary(|e: Expr| match e {
-                    Expr::Literal(LiteralValue::String(pat)) => {
+                    Expr::Literal(lv) if lv.extract_str().is_some() => {
+                        let pat = lv.extract_str().unwrap();
                         if pat == "*" {
                             polars_bail!(
                                 SQLSyntax: "COLUMNS('*') is not a valid regex; \
                                 did you mean COLUMNS(*)?"
                             )
                         };
-                        let pat = match pat.as_str() {
+                        let pat = match pat {
                             _ if pat.starts_with('^') && pat.ends_with('$') => pat.to_string(),
                             _ if pat.starts_with('^') => format!("{}.*$", pat),
                             _ if pat.ends_with('$') => format!("^.*{}", pat),
@@ -1684,7 +1695,9 @@ impl SQLFunctionVisitor<'_> {
                         FunctionArgumentClause::Limit(limit_expr) => {
                             let limit = parse_sql_expr(&limit_expr, self.ctx, self.active_schema)?;
                             match limit {
-                                Expr::Literal(LiteralValue::Int(n)) if n >= 0 => {
+                                Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n)))
+                                    if n >= 0 =>
+                                {
                                     base = base.head(Some(n as usize))
                                 },
                                 _ => {
@@ -1713,17 +1726,19 @@ impl SQLFunctionVisitor<'_> {
             }),
             #[cfg(feature = "list_eval")]
             3 => self.try_visit_ternary(|e, sep, null_value| match null_value {
-                Expr::Literal(LiteralValue::String(v)) => Ok(if v.is_empty() {
-                    e.cast(DataType::List(Box::from(DataType::String)))
-                        .list()
-                        .join(sep, true)
-                } else {
-                    e.cast(DataType::List(Box::from(DataType::String)))
-                        .list()
-                        .eval(col("").fill_null(lit(v)), false)
-                        .list()
-                        .join(sep, false)
-                }),
+                Expr::Literal(lv) if lv.extract_str().is_some() => {
+                    Ok(if lv.extract_str().unwrap().is_empty() {
+                        e.cast(DataType::List(Box::from(DataType::String)))
+                            .list()
+                            .join(sep, true)
+                    } else {
+                        e.cast(DataType::List(Box::from(DataType::String)))
+                            .list()
+                            .eval(col("").fill_null(lit(lv.extract_str().unwrap())), false)
+                            .list()
+                            .join(sep, false)
+                    })
+                },
                 _ => {
                     polars_bail!(SQLSyntax: "invalid null value for ARRAY_TO_STRING ({})", args[2])
                 },

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -11,7 +11,7 @@ use std::ops::Div;
 
 use polars_core::prelude::*;
 use polars_lazy::prelude::*;
-use polars_plan::prelude::LiteralValue::Null;
+use polars_plan::plans::DynLiteralValue;
 use polars_plan::prelude::typed_lit;
 use polars_time::Duration;
 use rand::distributions::Alphanumeric;
@@ -312,7 +312,9 @@ impl SQLExprVisitor<'_> {
             polars_bail!(SQLInterface: "ESCAPE char for LIKE/ILIKE is not currently supported; found '{}'", escape_char.clone().unwrap());
         }
         let pat = match self.visit_expr(pattern) {
-            Ok(Expr::Literal(LiteralValue::String(s))) => s,
+            Ok(Expr::Literal(lv)) if lv.extract_str().is_some() => {
+                PlSmallStr::from_str(lv.extract_str().unwrap())
+            },
             _ => {
                 polars_bail!(SQLSyntax: "LIKE/ILIKE pattern must be a string literal; found {}", pattern)
             },
@@ -362,11 +364,12 @@ impl SQLExprVisitor<'_> {
     fn convert_temporal_strings(&mut self, left: &Expr, right: &Expr) -> Expr {
         if let (Some(name), Some(s), expr_dtype) = match (left, right) {
             // identify "col <op> string" expressions
-            (Expr::Column(name), Expr::Literal(LiteralValue::String(s))) => {
-                (Some(name.clone()), Some(s), None)
+            (Expr::Column(name), Expr::Literal(lv)) if lv.extract_str().is_some() => {
+                (Some(name.clone()), Some(lv.extract_str().unwrap()), None)
             },
             // identify "CAST(expr AS type) <op> string" and/or "expr::type <op> string" expressions
-            (Expr::Cast { expr, dtype, .. }, Expr::Literal(LiteralValue::String(s))) => {
+            (Expr::Cast { expr, dtype, .. }, Expr::Literal(lv)) if lv.extract_str().is_some() => {
+                let s = lv.extract_str().unwrap();
                 match &**expr {
                     Expr::Column(name) => (Some(name.clone()), Some(s), Some(dtype)),
                     _ => (None, Some(s), Some(dtype)),
@@ -530,21 +533,23 @@ impl SQLExprVisitor<'_> {
             // Regular expression operators
             // ----
             SQLBinaryOperator::PGRegexMatch => match rhs {  // "x ~ y"
-                Expr::Literal(LiteralValue::String(_)) => lhs.str().contains(rhs, true),
+                Expr::Literal(ref lv) if lv.extract_str().is_some() => lhs.str().contains(rhs, true),
                 _ => polars_bail!(SQLSyntax: "invalid pattern for '~' operator: {:?}", rhs),
             },
             SQLBinaryOperator::PGRegexNotMatch => match rhs {  // "x !~ y"
-                Expr::Literal(LiteralValue::String(_)) => lhs.str().contains(rhs, true).not(),
+                Expr::Literal(ref lv) if lv.extract_str().is_some() => lhs.str().contains(rhs, true).not(),
                 _ => polars_bail!(SQLSyntax: "invalid pattern for '!~' operator: {:?}", rhs),
             },
             SQLBinaryOperator::PGRegexIMatch => match rhs {  // "x ~* y"
-                Expr::Literal(LiteralValue::String(pat)) => {
+                Expr::Literal(ref lv) if lv.extract_str().is_some() => {
+                    let pat = lv.extract_str().unwrap();
                     lhs.str().contains(lit(format!("(?i){}", pat)), true)
                 },
                 _ => polars_bail!(SQLSyntax: "invalid pattern for '~*' operator: {:?}", rhs),
             },
             SQLBinaryOperator::PGRegexNotIMatch => match rhs {  // "x !~* y"
-                Expr::Literal(LiteralValue::String(pat)) => {
+                Expr::Literal(ref lv) if lv.extract_str().is_some() => {
+                    let pat = lv.extract_str().unwrap();
                     lhs.str().contains(lit(format!("(?i){}", pat)), true).not()
                 },
                 _ => {
@@ -584,14 +589,15 @@ impl SQLExprVisitor<'_> {
             // JSON/Struct field access operators
             // ----
             SQLBinaryOperator::Arrow | SQLBinaryOperator::LongArrow => match rhs {  // "x -> y", "x ->> y"
-                Expr::Literal(LiteralValue::String(path)) => {
-                    let mut expr = self.struct_field_access_expr(&lhs, &path, false)?;
+                Expr::Literal(lv) if lv.extract_str().is_some() => {
+                    let path = lv.extract_str().unwrap();
+                    let mut expr = self.struct_field_access_expr(&lhs, path, false)?;
                     if let SQLBinaryOperator::LongArrow = op {
                         expr = expr.cast(DataType::String);
                     }
                     expr
                 },
-                Expr::Literal(LiteralValue::Int(idx)) => {
+                Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(idx))) => {
                     let mut expr = self.struct_field_access_expr(&lhs, &idx.to_string(), true)?;
                     if let SQLBinaryOperator::LongArrow = op {
                         expr = expr.cast(DataType::String);
@@ -603,14 +609,18 @@ impl SQLExprVisitor<'_> {
                 },
             },
             SQLBinaryOperator::HashArrow | SQLBinaryOperator::HashLongArrow => {  // "x #> y", "x #>> y"
-                if let Expr::Literal(LiteralValue::String(path)) = rhs {
-                    let mut expr = self.struct_field_access_expr(&lhs, &path, true)?;
-                    if let SQLBinaryOperator::HashLongArrow = op {
-                        expr = expr.cast(DataType::String);
+                match rhs {
+                    Expr::Literal(lv) if lv.extract_str().is_some() => {
+                        let path = lv.extract_str().unwrap();
+                        let mut expr = self.struct_field_access_expr(&lhs, path, true)?;
+                        if let SQLBinaryOperator::HashLongArrow = op {
+                            expr = expr.cast(DataType::String);
+                        }
+                        expr
+                    },
+                    _ => {
+                        polars_bail!(SQLSyntax: "invalid json/struct path-extract definition: {:?}", rhs)
                     }
-                    expr
-                } else {
-                    polars_bail!(SQLSyntax: "invalid json/struct path-extract definition: {:?}", rhs)
                 }
             },
             other => {
@@ -626,10 +636,18 @@ impl SQLExprVisitor<'_> {
         let expr = self.visit_expr(expr)?;
         Ok(match (op, expr.clone()) {
             // simplify the parse tree by special-casing common unary +/- ops
-            (UnaryOperator::Plus, Expr::Literal(LiteralValue::Int(n))) => lit(n),
-            (UnaryOperator::Plus, Expr::Literal(LiteralValue::Float(n))) => lit(n),
-            (UnaryOperator::Minus, Expr::Literal(LiteralValue::Int(n))) => lit(-n),
-            (UnaryOperator::Minus, Expr::Literal(LiteralValue::Float(n))) => lit(-n),
+            (UnaryOperator::Plus, Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n)))) => {
+                lit(n)
+            },
+            (UnaryOperator::Plus, Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(n)))) => {
+                lit(n)
+            },
+            (UnaryOperator::Minus, Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n)))) => {
+                lit(-n)
+            },
+            (UnaryOperator::Minus, Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Float(n)))) => {
+                lit(-n)
+            },
             // general case
             (UnaryOperator::Plus, _) => lit(0) + expr,
             (UnaryOperator::Minus, _) => lit(0) - expr,
@@ -779,7 +797,7 @@ impl SQLExprVisitor<'_> {
                 };
                 lit(hex::decode(x.clone()).unwrap())
             },
-            SQLValue::Null => Expr::Literal(LiteralValue::Null),
+            SQLValue::Null => Expr::Literal(LiteralValue::untyped_null()),
             SQLValue::Number(s, _) => {
                 // Check for existence of decimal separator dot
                 if s.contains('.') {
@@ -844,7 +862,9 @@ impl SQLExprVisitor<'_> {
                 // note: for PostgreSQL this represents a BIT literal (eg: b'10101') not BYTE
                 let bytes_literal = bitstring_to_bytes_literal(b)?;
                 match bytes_literal {
-                    Expr::Literal(LiteralValue::Binary(v)) => AnyValue::BinaryOwned(v.to_vec()),
+                    Expr::Literal(lv) if lv.extract_binary().is_some() => {
+                        AnyValue::BinaryOwned(lv.extract_binary().unwrap().to_vec())
+                    },
                     _ => {
                         polars_bail!(SQLInterface: "failed to parse bitstring literal: {:?}", b)
                     },
@@ -893,16 +913,24 @@ impl SQLExprVisitor<'_> {
         let expr = self.visit_expr(expr)?;
         let trim_what = trim_what.as_ref().map(|e| self.visit_expr(e)).transpose()?;
         let trim_what = match trim_what {
-            Some(Expr::Literal(LiteralValue::String(val))) => Some(val),
+            Some(Expr::Literal(lv)) if lv.extract_str().is_some() => {
+                Some(PlSmallStr::from_str(lv.extract_str().unwrap()))
+            },
             None => None,
             _ => return self.err(&expr),
         };
         Ok(match (trim_where, trim_what) {
-            (None | Some(TrimWhereField::Both), None) => expr.str().strip_chars(lit(Null)),
+            (None | Some(TrimWhereField::Both), None) => {
+                expr.str().strip_chars(lit(LiteralValue::untyped_null()))
+            },
             (None | Some(TrimWhereField::Both), Some(val)) => expr.str().strip_chars(lit(val)),
-            (Some(TrimWhereField::Leading), None) => expr.str().strip_chars_start(lit(Null)),
+            (Some(TrimWhereField::Leading), None) => expr
+                .str()
+                .strip_chars_start(lit(LiteralValue::untyped_null())),
             (Some(TrimWhereField::Leading), Some(val)) => expr.str().strip_chars_start(lit(val)),
-            (Some(TrimWhereField::Trailing), None) => expr.str().strip_chars_end(lit(Null)),
+            (Some(TrimWhereField::Trailing), None) => expr
+                .str()
+                .strip_chars_end(lit(LiteralValue::untyped_null())),
             (Some(TrimWhereField::Trailing), Some(val)) => expr.str().strip_chars_end(lit(val)),
         })
     }
@@ -948,7 +976,7 @@ impl SQLExprVisitor<'_> {
             }
             let else_res = match else_result {
                 Some(else_res) => self.visit_expr(else_res)?,
-                None => lit(Null), // ELSE clause is optional; when omitted, it is implicitly NULL
+                None => lit(LiteralValue::untyped_null()), // ELSE clause is optional; when omitted, it is implicitly NULL
             };
             if let Some(operand_expr) = operand {
                 let first_operand_expr = self.visit_expr(operand_expr)?;
@@ -1193,23 +1221,23 @@ pub(crate) fn parse_extract_date_part(expr: Expr, field: &DateTimeField) -> Pola
 /// be adjusted from 1-indexed (SQL) to 0-indexed (Rust/Polars)
 pub(crate) fn adjust_one_indexed_param(idx: Expr, null_if_zero: bool) -> Expr {
     match idx {
-        Expr::Literal(Null) => lit(Null),
-        Expr::Literal(LiteralValue::Int(0)) => {
+        Expr::Literal(sc) if sc.is_null() => lit(LiteralValue::untyped_null()),
+        Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(0))) => {
             if null_if_zero {
-                lit(Null)
+                lit(LiteralValue::untyped_null())
             } else {
                 idx
             }
         },
-        Expr::Literal(LiteralValue::Int(n)) if n < 0 => idx,
-        Expr::Literal(LiteralValue::Int(n)) => lit(n - 1),
+        Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) if n < 0 => idx,
+        Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => lit(n - 1),
         // TODO: when 'saturating_sub' is available, should be able
         //  to streamline the when/then/otherwise block below -
         _ => when(idx.clone().gt(lit(0)))
             .then(idx.clone() - lit(1))
             .otherwise(if null_if_zero {
                 when(idx.clone().eq(lit(0)))
-                    .then(lit(Null))
+                    .then(lit(LiteralValue::untyped_null()))
                     .otherwise(idx.clone())
             } else {
                 idx.clone()

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -1,6 +1,5 @@
 use polars_core::prelude::*;
 use polars_lazy::prelude::*;
-use polars_plan::prelude::LiteralValue::Null;
 use polars_sql::*;
 
 #[test]
@@ -58,8 +57,14 @@ fn test_string_functions() {
                 .str()
                 .strip_chars_end(lit("x"))
                 .alias("trim_a_trailing"),
-            col("a").str().strip_chars_start(lit(Null)).alias("ltrim_a"),
-            col("a").str().strip_chars_end(lit(Null)).alias("rtrim_a"),
+            col("a")
+                .str()
+                .strip_chars_start(lit(LiteralValue::untyped_null()))
+                .alias("ltrim_a"),
+            col("a")
+                .str()
+                .strip_chars_end(lit(LiteralValue::untyped_null()))
+                .alias("rtrim_a"),
             col("a")
                 .str()
                 .strip_chars_start(lit("-"))

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -65,7 +65,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
             .then(lit("unexpected"))
             .when(col("a").eq(lit("a1".to_string())))
             .then(lit("good hit"))
-            .otherwise(Expr::Literal(LiteralValue::Null))
+            .otherwise(Expr::Literal(LiteralValue::untyped_null()))
             .alias("b"),
         )
         .collect()?;
@@ -99,7 +99,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
             .then(lit("ok2"))
             .when(lit(true))
             .then(lit("ft"))
-            .otherwise(Expr::Literal(LiteralValue::Null))
+            .otherwise(Expr::Literal(LiteralValue::untyped_null()))
             .alias("c"),
         )
         .collect()?;
@@ -219,7 +219,7 @@ fn test_when_then_otherwise_sum_in_agg() -> PolarsResult<()> {
         .group_by([col("groups")])
         .agg([when(all().exclude(["groups"]).sum().eq(lit(1)))
             .then(all().exclude(["groups"]).sum())
-            .otherwise(lit(NULL))])
+            .otherwise(lit(LiteralValue::untyped_null()))])
         .sort(["groups"], Default::default());
 
     let expected = df![

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1331,6 +1331,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
 
         dot = _ldf.to_dot(optimized)
+        print(dot)
         return display_dot_graph(
             dot=dot,
             show=show,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1331,7 +1331,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
 
         dot = _ldf.to_dot(optimized)
-        print(dot)
         return display_dot_graph(
             dot=dot,
             show=show,

--- a/py-polars/tests/docs/test_user_guide.py
+++ b/py-polars/tests/docs/test_user_guide.py
@@ -38,5 +38,4 @@ def _change_test_dir() -> Iterator[None]:
 @pytest.mark.parametrize("path", snippet_paths)
 @pytest.mark.usefixtures("_change_test_dir")
 def test_run_python_snippets(path: Path) -> None:
-    print(path)
     runpy.run_path(str(path))

--- a/py-polars/tests/docs/test_user_guide.py
+++ b/py-polars/tests/docs/test_user_guide.py
@@ -38,4 +38,5 @@ def _change_test_dir() -> Iterator[None]:
 @pytest.mark.parametrize("path", snippet_paths)
 @pytest.mark.usefixtures("_change_test_dir")
 def test_run_python_snippets(path: Path) -> None:
+    print(path)
     runpy.run_path(str(path))

--- a/py-polars/tests/unit/functions/test_when_then.py
+++ b/py-polars/tests/unit/functions/test_when_then.py
@@ -252,7 +252,7 @@ def test_comp_incompatible_enum_dtype() -> None:
 
     with pytest.raises(
         InvalidOperationError,
-        match="conversion from `str` to `enum` failed in column 'literal'",
+        match="conversion from `str` to `enum` failed in column 'scalar'",
     ):
         df.with_columns(
             pl.when(pl.col("a") == "a").then(pl.col("a")).otherwise(pl.lit("c"))

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -204,7 +204,7 @@ def test_lazy_row_index_no_push_down(foods_file_path: Path) -> None:
     # related to row count is not pushed.
     assert 'FILTER [(col("index")) == (1)]\nFROM' in plan
     # unrelated to row count is pushed.
-    assert 'SELECTION: [(col("category")) == (String(vegetables))]' in plan
+    assert 'SELECTION: [(col("category")) == ("vegetables")]' in plan
 
 
 @pytest.mark.write_disk


### PR DESCRIPTION
This changes `LiteralValue` from its whole own thing to being the following.

```rust
pub enum LiteralValue {
    /// A dynamically inferred literal value. This needs to be materialized into a specific type.
    Dyn(DynLiteralValue),
    Scalar(Scalar),
    Series(SpecialEq<Series>),
    Range(RangeLiteralValue),
}

pub enum DynLiteralValue {
    Str(PlSmallStr),
    Int(i128),
    Float(f64),
}
```

This will now make things very clear when we start materializing types. This will also allow for DynList etc.