### PR TITLE
fix: Check dtype to avoid panic with mixed types in min/max_horizontal

### DIFF
--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -85,6 +85,7 @@ where
 
 fn min_max_binary_columns(left: &Column, right: &Column, min: bool) -> PolarsResult<Column> {
     if left.dtype().to_physical().is_primitive_numeric()
+        && right.dtype().to_physical().is_primitive_numeric()
         && left.null_count() == 0
         && right.null_count() == 0
         && left.len() == right.len()


### PR DESCRIPTION
Fixes #21835

(A prior attempt PR #21845 was closed by myself and can be ignored - I accidentally messed something up in git).