### PR TITLE
perf: Use views for binary hash tables and add single-key binary variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ dependencies = [
  "chrono",
  "either",
  "fast-float2",
+ "hashbrown 0.15.2",
  "itoa",
  "num-traits",
  "polars-arrow",

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -33,12 +33,12 @@ pub use mutable::MutableBinaryViewArray;
 use polars_utils::aliases::{InitHashMaps, PlHashMap};
 use private::Sealed;
 
-use crate::array::binview::view::{validate_binary_view, validate_utf8_only};
+use crate::array::binview::view::{validate_binary_views, validate_views_utf8_only};
 use crate::array::iterator::NonNullValuesIter;
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 pub type BinaryViewArray = BinaryViewArrayGeneric<[u8]>;
 pub type Utf8ViewArray = BinaryViewArrayGeneric<str>;
-pub use view::{View, validate_utf8_view};
+pub use view::{View, validate_utf8_views};
 
 use super::Splitable;
 
@@ -316,9 +316,9 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         validity: Option<Bitmap>,
     ) -> PolarsResult<Self> {
         if T::IS_UTF8 {
-            validate_utf8_view(views.as_ref(), buffers.as_ref())?;
+            validate_utf8_views(views.as_ref(), buffers.as_ref())?;
         } else {
-            validate_binary_view(views.as_ref(), buffers.as_ref())?;
+            validate_binary_views(views.as_ref(), buffers.as_ref())?;
         }
 
         if let Some(validity) = &validity {
@@ -561,7 +561,7 @@ impl BinaryViewArray {
     /// Validate the underlying bytes on UTF-8.
     pub fn validate_utf8(&self) -> PolarsResult<()> {
         // SAFETY: views are correct
-        unsafe { validate_utf8_only(&self.views, &self.buffers, &self.buffers) }
+        unsafe { validate_views_utf8_only(&self.views, &self.buffers, 0) }
     }
 
     /// Convert [`BinaryViewArray`] to [`Utf8ViewArray`].

--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -8,7 +8,7 @@ use polars_error::PolarsResult;
 use polars_utils::aliases::{InitHashMaps, PlHashMap};
 
 use crate::array::binview::iterator::MutableBinaryViewValueIter;
-use crate::array::binview::view::validate_utf8_only;
+use crate::array::binview::view::validate_views_utf8_only;
 use crate::array::binview::{
     BinaryViewArrayGeneric, DEFAULT_BLOCK_SIZE, MAX_EXP_BLOCK_SIZE, ViewType,
 };
@@ -632,10 +632,10 @@ impl MutableBinaryViewArray<[u8]> {
         let pushed = self.finish_in_progress();
         // views are correct
         unsafe {
-            validate_utf8_only(
+            validate_views_utf8_only(
                 &self.views[views_offset..],
-                &self.completed_buffers[buffer_offset..],
                 &self.completed_buffers,
+                buffer_offset,
             )?
         }
         // Restore in-progress buffer as we don't want to get too small buffers

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -683,7 +683,7 @@ mod values;
 pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
 pub use binview::{
     BinaryViewArray, BinaryViewArrayGeneric, BinaryViewArrayGenericBuilder, MutableBinaryViewArray,
-    MutablePlBinary, MutablePlString, Utf8ViewArray, View, ViewType, validate_utf8_view,
+    MutablePlBinary, MutablePlString, Utf8ViewArray, View, ViewType,
 };
 pub use boolean::{BooleanArray, BooleanArrayBuilder, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -1,8 +1,8 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 use std::ops::Deref;
 
+use bytemuck::Zeroable;
 use either::Either;
-use num_traits::Zero;
 
 use super::IntoIter;
 use crate::array::{ArrayAccessor, Splitable};
@@ -279,9 +279,9 @@ impl<T: Clone> Buffer<T> {
     }
 }
 
-impl<T: Zero + Copy> Buffer<T> {
+impl<T: Zeroable + Copy> Buffer<T> {
     pub fn zeroed(len: usize) -> Self {
-        vec![T::zero(); len].into()
+        vec![T::zeroed(); len].into()
     }
 }
 
@@ -292,11 +292,18 @@ impl<T> From<Vec<T>> for Buffer<T> {
     }
 }
 
-impl<T> std::ops::Deref for Buffer<T> {
+impl<T> Deref for Buffer<T> {
     type Target = [T];
 
-    #[inline]
+    #[inline(always)]
     fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> AsRef<[T]> for Buffer<T> {
+    #[inline(always)]
+    fn as_ref(&self) -> &[T] {
         self.as_slice()
     }
 }

--- a/crates/polars-compute/Cargo.toml
+++ b/crates/polars-compute/Cargo.toml
@@ -15,10 +15,12 @@ bytemuck = { workspace = true }
 chrono = { workspace = true, optional = true }
 either = { workspace = true }
 fast-float2 = { workspace = true, optional = true }
+hashbrown = { workspace = true }
 itoa = { workspace = true, optional = true }
 num-traits = { workspace = true }
 polars-error = { workspace = true }
 polars-utils = { workspace = true }
+rand = { workspace = true }
 ryu = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 strength_reduce = { workspace = true }

--- a/crates/polars-compute/src/binview_index_map.rs
+++ b/crates/polars-compute/src/binview_index_map.rs
@@ -1,0 +1,315 @@
+use arrow::array::View;
+use hashbrown::hash_table::{
+    Entry as TEntry, HashTable, OccupiedEntry as TOccupiedEntry, VacantEntry as TVacantEntry,
+};
+use polars_utils::IdxSize;
+
+const BASE_KEY_BUFFER_CAPACITY: usize = 1024;
+
+struct Key {
+    hash: u64,
+    view: View,
+}
+
+/// An IndexMap where the keys are [u8] slices or `View`s which are pre-hashed.
+pub struct BinaryViewIndexMap<V> {
+    table: HashTable<IdxSize>,
+    tuples: Vec<(Key, V)>,
+    buffers: Vec<Vec<u8>>,
+
+    // Internal random seed used to keep hash iteration order decorrelated.
+    // We simply store a random odd number and multiply the canonical hash by it.
+    seed: u64,
+}
+
+impl<V> Default for BinaryViewIndexMap<V> {
+    fn default() -> Self {
+        Self {
+            table: HashTable::new(),
+            tuples: Vec::new(),
+            buffers: vec![],
+            seed: rand::random::<u64>() | 1,
+        }
+    }
+}
+
+impl<V> BinaryViewIndexMap<V> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.table.reserve(additional, |i| unsafe {
+            let tuple = self.tuples.get_unchecked(*i as usize);
+            tuple.0.hash.wrapping_mul(self.seed)
+        });
+        self.tuples.reserve(additional);
+    }
+
+    pub fn len(&self) -> IdxSize {
+        self.table.len() as IdxSize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+
+    #[inline]
+    pub fn get(&self, hash: u64, key: &[u8]) -> Option<&V> {
+        unsafe {
+            if key.len() <= View::MAX_INLINE_SIZE as usize {
+                self.get_inline_view(hash, &View::new_inline_unchecked(key))
+            } else {
+                self.get_long_key(hash, key)
+            }
+        }
+    }
+
+    /// # Safety
+    /// The view must be valid in combination with the given buffers.
+    #[inline]
+    pub unsafe fn get_view<B: AsRef<[u8]>>(
+        &self,
+        hash: u64,
+        key: &View,
+        buffers: &[B],
+    ) -> Option<&V> {
+        unsafe {
+            if key.length <= View::MAX_INLINE_SIZE {
+                self.get_inline_view(hash, key)
+            } else {
+                self.get_long_key(hash, key.get_external_slice_unchecked(buffers))
+            }
+        }
+    }
+
+    /// # Safety
+    /// The view must be inlined.
+    pub unsafe fn get_inline_view(&self, hash: u64, key: &View) -> Option<&V> {
+        unsafe {
+            debug_assert!(key.length <= View::MAX_INLINE_SIZE);
+            let idx = self.table.find(hash.wrapping_mul(self.seed), |i| {
+                let t = self.tuples.get_unchecked(*i as usize);
+                *key == t.0.view
+            })?;
+            Some(&self.tuples.get_unchecked(*idx as usize).1)
+        }
+    }
+
+    /// # Safety
+    /// key.len() > View::MAX_INLINE_SIZE
+    pub unsafe fn get_long_key(&self, hash: u64, key: &[u8]) -> Option<&V> {
+        unsafe {
+            debug_assert!(key.len() > View::MAX_INLINE_SIZE as usize);
+            let idx = self.table.find(hash.wrapping_mul(self.seed), |i| {
+                let t = self.tuples.get_unchecked(*i as usize);
+                hash == t.0.hash
+                    && key.len() == t.0.view.length as usize
+                    && key == t.0.view.get_external_slice_unchecked(&self.buffers)
+            })?;
+            Some(&self.tuples.get_unchecked(*idx as usize).1)
+        }
+    }
+
+    #[inline]
+    pub fn entry<'k>(&mut self, hash: u64, key: &'k [u8]) -> Entry<'_, 'k, V> {
+        unsafe {
+            if key.len() <= View::MAX_INLINE_SIZE as usize {
+                self.entry_inline_view(hash, View::new_inline_unchecked(key))
+            } else {
+                self.entry_long_key(hash, key)
+            }
+        }
+    }
+
+    /// # Safety
+    /// The view must be valid in combination with the given buffers.
+    #[inline]
+    pub unsafe fn entry_view<'k, B: AsRef<[u8]>>(
+        &mut self,
+        hash: u64,
+        key: View,
+        buffers: &'k [B],
+    ) -> Entry<'_, 'k, V> {
+        unsafe {
+            if key.length <= View::MAX_INLINE_SIZE {
+                self.entry_inline_view(hash, key)
+            } else {
+                self.entry_long_key(hash, key.get_external_slice_unchecked(buffers))
+            }
+        }
+    }
+
+    /// # Safety
+    /// The view must be inlined.
+    pub unsafe fn entry_inline_view<'k>(&mut self, hash: u64, key: View) -> Entry<'_, 'k, V> {
+        debug_assert!(key.length <= View::MAX_INLINE_SIZE);
+        let entry = self.table.entry(
+            hash.wrapping_mul(self.seed),
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                key == t.0.view
+            },
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                t.0.hash.wrapping_mul(self.seed)
+            },
+        );
+
+        match entry {
+            TEntry::Occupied(o) => Entry::Occupied(OccupiedEntry {
+                entry: o,
+                tuples: &mut self.tuples,
+            }),
+            TEntry::Vacant(v) => Entry::Vacant(VacantEntry {
+                view: key,
+                external: None,
+                hash,
+                entry: v,
+                tuples: &mut self.tuples,
+                buffers: &mut self.buffers,
+            }),
+        }
+    }
+
+    /// # Safety
+    /// key.len() > View::MAX_INLINE_SIZE
+    pub unsafe fn entry_long_key<'k>(&mut self, hash: u64, key: &'k [u8]) -> Entry<'_, 'k, V> {
+        debug_assert!(key.len() > View::MAX_INLINE_SIZE as usize);
+        let entry = self.table.entry(
+            hash.wrapping_mul(self.seed),
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                hash == t.0.hash
+                    && key.len() == t.0.view.length as usize
+                    && key == t.0.view.get_external_slice_unchecked(&self.buffers)
+            },
+            |i| unsafe {
+                let t = self.tuples.get_unchecked(*i as usize);
+                t.0.hash.wrapping_mul(self.seed)
+            },
+        );
+
+        match entry {
+            TEntry::Occupied(o) => Entry::Occupied(OccupiedEntry {
+                entry: o,
+                tuples: &mut self.tuples,
+            }),
+            TEntry::Vacant(v) => Entry::Vacant(VacantEntry {
+                view: View::default(),
+                external: Some(key),
+                hash,
+                entry: v,
+                tuples: &mut self.tuples,
+                buffers: &mut self.buffers,
+            }),
+        }
+    }
+
+    /// Gets the hash, key and value at the given index by insertion order.
+    #[inline(always)]
+    pub fn get_index(&self, idx: IdxSize) -> Option<(u64, &[u8], &V)> {
+        let t = self.tuples.get(idx as usize)?;
+        Some((
+            t.0.hash,
+            unsafe { t.0.view.get_slice_unchecked(&self.buffers) },
+            &t.1,
+        ))
+    }
+
+    /// Gets the hash, key and value at the given index by insertion order.
+    ///
+    /// # Safety
+    /// The index must be less than len().
+    #[inline(always)]
+    pub unsafe fn get_index_unchecked(&self, idx: IdxSize) -> (u64, &[u8], &V) {
+        let t = unsafe { self.tuples.get_unchecked(idx as usize) };
+        unsafe { (t.0.hash, t.0.view.get_slice_unchecked(&self.buffers), &t.1) }
+    }
+
+    /// Iterates over the (hash, key) pairs in insertion order.
+    pub fn iter_hash_keys(&self) -> impl Iterator<Item = (u64, &[u8])> {
+        self.tuples
+            .iter()
+            .map(|t| unsafe { (t.0.hash, t.0.view.get_slice_unchecked(&self.buffers)) })
+    }
+
+    /// Iterates over the values in insertion order.
+    pub fn iter_values(&self) -> impl Iterator<Item = &V> {
+        self.tuples.iter().map(|t| &t.1)
+    }
+}
+
+pub enum Entry<'a, 'k, V> {
+    Occupied(OccupiedEntry<'a, V>),
+    Vacant(VacantEntry<'a, 'k, V>),
+}
+
+pub struct OccupiedEntry<'a, V> {
+    entry: TOccupiedEntry<'a, IdxSize>,
+    tuples: &'a mut Vec<(Key, V)>,
+}
+
+impl<'a, V> OccupiedEntry<'a, V> {
+    #[inline]
+    pub fn index(&self) -> IdxSize {
+        *self.entry.get()
+    }
+
+    #[inline]
+    pub fn into_mut(self) -> &'a mut V {
+        let idx = self.index();
+        unsafe { &mut self.tuples.get_unchecked_mut(idx as usize).1 }
+    }
+}
+
+pub struct VacantEntry<'a, 'k, V> {
+    hash: u64,
+    view: View,                 // Empty when key is not inlined.
+    external: Option<&'k [u8]>, // Only set when not inlined.
+    entry: TVacantEntry<'a, IdxSize>,
+    tuples: &'a mut Vec<(Key, V)>,
+    buffers: &'a mut Vec<Vec<u8>>,
+}
+
+#[allow(clippy::needless_lifetimes)]
+impl<'a, 'k, V> VacantEntry<'a, 'k, V> {
+    #[inline]
+    pub fn index(&self) -> IdxSize {
+        self.tuples.len() as IdxSize
+    }
+
+    #[inline]
+    pub fn insert(self, value: V) -> &'a mut V {
+        unsafe {
+            let tuple_idx: IdxSize = self.tuples.len().try_into().unwrap();
+            let view = if let Some(key) = self.external {
+                if self
+                    .buffers
+                    .last()
+                    .is_none_or(|buf| buf.len() + key.len() > buf.capacity())
+                {
+                    let ideal_next_cap = BASE_KEY_BUFFER_CAPACITY
+                        .checked_shl(self.buffers.len() as u32)
+                        .unwrap();
+                    let next_capacity = std::cmp::max(ideal_next_cap, key.len());
+                    self.buffers.push(Vec::with_capacity(next_capacity));
+                }
+                let buffer_idx = (self.buffers.len() - 1) as u32;
+                let active_buf = self.buffers.last_mut().unwrap_unchecked();
+                let offset = active_buf.len() as u32;
+                active_buf.extend_from_slice(key);
+                View::new_from_bytes(key, buffer_idx, offset)
+            } else {
+                self.view
+            };
+            let tuple_key = Key {
+                hash: self.hash,
+                view,
+            };
+            self.tuples.push((tuple_key, value));
+            self.entry.insert(tuple_idx);
+            &mut self.tuples.last_mut().unwrap_unchecked().1
+        }
+    }
+}

--- a/crates/polars-compute/src/lib.rs
+++ b/crates/polars-compute/src/lib.rs
@@ -9,6 +9,7 @@ use arrow::types::NativeType;
 
 pub mod arithmetic;
 pub mod arity;
+pub mod binview_index_map;
 pub mod bitwise;
 #[cfg(feature = "approx_unique")]
 pub mod cardinality;

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -6,7 +6,7 @@ use arrow::compute::utils::combine_validities_and_many;
 use polars_core::error::polars_err;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::row_encode::_get_rows_encoded_unordered;
-use polars_core::prelude::{BinaryChunked, ChunkedArray, DataType, PlRandomState, PolarsDataType};
+use polars_core::prelude::{ChunkedArray, DataType, PlRandomState, PolarsDataType};
 use polars_core::series::Series;
 use polars_utils::IdxSize;
 use polars_utils::cardinality_sketch::CardinalitySketch;

--- a/crates/polars-expr/src/idx_table/binview.rs
+++ b/crates/polars-expr/src/idx_table/binview.rs
@@ -1,0 +1,374 @@
+#![allow(clippy::unnecessary_cast)] // Clippy doesn't recognize that IdxSize and u64 can be different.
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use arrow::array::{Array, View};
+use arrow::buffer::Buffer;
+use polars_compute::binview_index_map::{BinaryViewIndexMap, Entry};
+use polars_utils::idx_vec::UnitVec;
+use polars_utils::itertools::Itertools;
+use polars_utils::unitvec;
+
+use super::*;
+use crate::hash_keys::HashKeys;
+
+pub struct BinviewKeyIdxTable {
+    // These AtomicU64s actually are IdxSizes, but we use the top bit of the
+    // first index in each to mark keys during probing.
+    idx_map: BinaryViewIndexMap<UnitVec<AtomicU64>>,
+    idx_offset: IdxSize,
+    null_keys: Vec<IdxSize>,
+    nulls_emitted: AtomicBool,
+}
+
+impl BinviewKeyIdxTable {
+    pub fn new() -> Self {
+        Self {
+            idx_map: BinaryViewIndexMap::default(),
+            idx_offset: 0,
+            null_keys: Vec::new(),
+            nulls_emitted: AtomicBool::new(false),
+        }
+    }
+
+    /// # Safety
+    /// The view must be valid for the buffers.
+    #[inline(always)]
+    unsafe fn probe_one<const MARK_MATCHES: bool>(
+        &self,
+        key_idx: IdxSize,
+        hash: u64,
+        key: &View,
+        buffers: &[Buffer<u8>],
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+    ) -> bool {
+        if let Some(idxs) = unsafe { self.idx_map.get_view(hash, key, buffers) } {
+            for idx in &idxs[..] {
+                // Create matches, making sure to clear top bit.
+                table_match.push((idx.load(Ordering::Relaxed) & !(1 << 63)) as IdxSize);
+                probe_match.push(key_idx);
+            }
+
+            // Mark if necessary. This action is idempotent so doesn't need
+            // atomic fetch_or to do it atomically.
+            if MARK_MATCHES {
+                let first_idx = unsafe { idxs.get_unchecked(0) };
+                let first_idx_val = first_idx.load(Ordering::Relaxed);
+                if first_idx_val >> 63 == 0 {
+                    first_idx.store(first_idx_val | (1 << 63), Ordering::Relaxed);
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// # Safety
+    /// The views must be valid for the buffers.
+    unsafe fn probe_impl<
+        'a,
+        const MARK_MATCHES: bool,
+        const EMIT_UNMATCHED: bool,
+        const NULL_IS_VALID: bool,
+    >(
+        &self,
+        keys: impl Iterator<Item = (IdxSize, u64, Option<&'a View>)>,
+        buffers: &[Buffer<u8>],
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+        limit: IdxSize,
+    ) -> IdxSize {
+        let mut keys_processed = 0;
+        for (key_idx, hash, key) in keys {
+            let found_match = if let Some(key) = key {
+                self.probe_one::<MARK_MATCHES>(
+                    key_idx,
+                    hash,
+                    key,
+                    buffers,
+                    table_match,
+                    probe_match,
+                )
+            } else if NULL_IS_VALID {
+                for idx in &self.null_keys {
+                    table_match.push(*idx);
+                    probe_match.push(key_idx);
+                }
+                if MARK_MATCHES && !self.nulls_emitted.load(Ordering::Relaxed) {
+                    self.nulls_emitted.store(true, Ordering::Relaxed);
+                }
+                !self.null_keys.is_empty()
+            } else {
+                false
+            };
+
+            if EMIT_UNMATCHED && !found_match {
+                table_match.push(IdxSize::MAX);
+                probe_match.push(key_idx);
+            }
+
+            keys_processed += 1;
+            if table_match.len() >= limit as usize {
+                break;
+            }
+        }
+        keys_processed
+    }
+
+    /// # Safety
+    /// The views must be valid for the buffers.
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn probe_dispatch<'a>(
+        &self,
+        keys: impl Iterator<Item = (IdxSize, u64, Option<&'a View>)>,
+        buffers: &[Buffer<u8>],
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+        mark_matches: bool,
+        emit_unmatched: bool,
+        null_is_valid: bool,
+        limit: IdxSize,
+    ) -> IdxSize {
+        match (mark_matches, emit_unmatched, null_is_valid) {
+            (false, false, false) => self.probe_impl::<false, false, false>(
+                keys,
+                buffers,
+                table_match,
+                probe_match,
+                limit,
+            ),
+            (false, false, true) => self.probe_impl::<false, false, true>(
+                keys,
+                buffers,
+                table_match,
+                probe_match,
+                limit,
+            ),
+            (false, true, false) => self.probe_impl::<false, true, false>(
+                keys,
+                buffers,
+                table_match,
+                probe_match,
+                limit,
+            ),
+            (false, true, true) => {
+                self.probe_impl::<false, true, true>(keys, buffers, table_match, probe_match, limit)
+            },
+            (true, false, false) => self.probe_impl::<true, false, false>(
+                keys,
+                buffers,
+                table_match,
+                probe_match,
+                limit,
+            ),
+            (true, false, true) => {
+                self.probe_impl::<true, false, true>(keys, buffers, table_match, probe_match, limit)
+            },
+            (true, true, false) => {
+                self.probe_impl::<true, true, false>(keys, buffers, table_match, probe_match, limit)
+            },
+            (true, true, true) => {
+                self.probe_impl::<true, true, true>(keys, buffers, table_match, probe_match, limit)
+            },
+        }
+    }
+}
+
+impl IdxTable for BinviewKeyIdxTable {
+    fn new_empty(&self) -> Box<dyn IdxTable> {
+        Box::new(Self::new())
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.idx_map.reserve(additional);
+    }
+
+    fn num_keys(&self) -> IdxSize {
+        self.idx_map.len()
+    }
+
+    fn insert_keys(&mut self, _hash_keys: &HashKeys, _track_unmatchable: bool) {
+        // Isn't needed anymore, but also don't want to remove the code from the other implementations.
+        unimplemented!()
+    }
+
+    unsafe fn insert_keys_subset(
+        &mut self,
+        hash_keys: &HashKeys,
+        subset: &[IdxSize],
+        track_unmatchable: bool,
+    ) {
+        let HashKeys::Binview(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+        let new_idx_offset = (self.idx_offset as usize)
+            .checked_add(subset.len())
+            .unwrap();
+        assert!(
+            new_idx_offset < IdxSize::MAX as usize,
+            "overly large index in BinviewKeyIdxTable"
+        );
+
+        unsafe {
+            let buffers = hash_keys.keys.data_buffers();
+            let views = hash_keys.keys.views();
+            if let Some(validity) = hash_keys.keys.validity() {
+                for (i, subset_idx) in subset.iter().enumerate_idx() {
+                    let hash = hash_keys.hashes.value_unchecked(*subset_idx as usize);
+                    let key = views.get_unchecked(*subset_idx as usize);
+                    let idx = self.idx_offset + i;
+                    if validity.get_bit_unchecked(*subset_idx as usize) {
+                        match self.idx_map.entry_view(hash, *key, buffers) {
+                            Entry::Occupied(o) => {
+                                o.into_mut().push(AtomicU64::new(idx as u64));
+                            },
+                            Entry::Vacant(v) => {
+                                v.insert(unitvec![AtomicU64::new(idx as u64)]);
+                            },
+                        }
+                    } else if track_unmatchable | hash_keys.null_is_valid {
+                        self.null_keys.push(idx);
+                    }
+                }
+            } else {
+                for (i, subset_idx) in subset.iter().enumerate_idx() {
+                    let hash = hash_keys.hashes.value_unchecked(*subset_idx as usize);
+                    let key = views.get_unchecked(*subset_idx as usize);
+                    let idx = self.idx_offset + i;
+                    match self.idx_map.entry_view(hash, *key, buffers) {
+                        Entry::Occupied(o) => {
+                            o.into_mut().push(AtomicU64::new(idx as u64));
+                        },
+                        Entry::Vacant(v) => {
+                            v.insert(unitvec![AtomicU64::new(idx as u64)]);
+                        },
+                    }
+                }
+            }
+        }
+
+        self.idx_offset = new_idx_offset as IdxSize;
+    }
+
+    fn probe(
+        &self,
+        _hash_keys: &HashKeys,
+        _table_match: &mut Vec<IdxSize>,
+        _probe_match: &mut Vec<IdxSize>,
+        _mark_matches: bool,
+        _emit_unmatched: bool,
+        _limit: IdxSize,
+    ) -> IdxSize {
+        // Isn't needed anymore, but also don't want to remove the code from the other implementations.
+        unimplemented!()
+    }
+
+    unsafe fn probe_subset(
+        &self,
+        hash_keys: &HashKeys,
+        subset: &[IdxSize],
+        table_match: &mut Vec<IdxSize>,
+        probe_match: &mut Vec<IdxSize>,
+        mark_matches: bool,
+        emit_unmatched: bool,
+        limit: IdxSize,
+    ) -> IdxSize {
+        let HashKeys::Binview(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+
+        unsafe {
+            let buffers = hash_keys.keys.data_buffers();
+            let views = hash_keys.keys.views();
+            if let Some(validity) = hash_keys.keys.validity() {
+                let iter = subset.iter().map(|i| {
+                    (
+                        *i,
+                        hash_keys.hashes.value_unchecked(*i as usize),
+                        if validity.get_bit_unchecked(*i as usize) {
+                            Some(views.get_unchecked(*i as usize))
+                        } else {
+                            None
+                        },
+                    )
+                });
+                self.probe_dispatch(
+                    iter,
+                    buffers,
+                    table_match,
+                    probe_match,
+                    mark_matches,
+                    emit_unmatched,
+                    hash_keys.null_is_valid,
+                    limit,
+                )
+            } else {
+                let iter = subset.iter().map(|i| {
+                    (
+                        *i,
+                        hash_keys.hashes.value_unchecked(*i as usize),
+                        Some(views.get_unchecked(*i as usize)),
+                    )
+                });
+                self.probe_dispatch(
+                    iter,
+                    buffers,
+                    table_match,
+                    probe_match,
+                    mark_matches,
+                    emit_unmatched,
+                    false, // Whether or not nulls are valid doesn't matter.
+                    limit,
+                )
+            }
+        }
+    }
+
+    fn unmarked_keys(
+        &self,
+        out: &mut Vec<IdxSize>,
+        mut offset: IdxSize,
+        limit: IdxSize,
+    ) -> IdxSize {
+        out.clear();
+
+        let mut keys_processed = 0;
+        if !self.nulls_emitted.load(Ordering::Relaxed) {
+            if (offset as usize) < self.null_keys.len() {
+                out.extend(
+                    self.null_keys[offset as usize..]
+                        .iter()
+                        .copied()
+                        .take(limit as usize),
+                );
+                keys_processed += out.len() as IdxSize;
+                offset += out.len() as IdxSize;
+                if out.len() >= limit as usize {
+                    return keys_processed;
+                }
+            }
+            offset -= self.null_keys.len() as IdxSize;
+        }
+
+        while let Some((_, _, idxs)) = self.idx_map.get_index(offset) {
+            let first_idx = unsafe { idxs.get_unchecked(0) };
+            let first_idx_val = first_idx.load(Ordering::Relaxed);
+            if first_idx_val >> 63 == 0 {
+                for idx in &idxs[..] {
+                    out.push((idx.load(Ordering::Relaxed) & !(1 << 63)) as IdxSize);
+                }
+            }
+
+            keys_processed += 1;
+            offset += 1;
+            if out.len() >= limit as usize {
+                break;
+            }
+        }
+
+        keys_processed
+    }
+}

--- a/crates/polars-expr/src/idx_table/mod.rs
+++ b/crates/polars-expr/src/idx_table/mod.rs
@@ -5,6 +5,7 @@ use polars_utils::IdxSize;
 
 use crate::hash_keys::HashKeys;
 
+mod binview;
 mod row_encoded;
 mod single_key;
 
@@ -104,6 +105,8 @@ pub fn new_idx_table(key_schema: Arc<Schema>) -> Box<dyn IdxTable> {
             DataType::Decimal(_, _) => Box::new(SKIT::<Int128Type>::new()),
             #[cfg(feature = "dtype-categorical")]
             DataType::Enum(_, _) => Box::new(SKIT::<UInt32Type>::new()),
+
+            DataType::String | DataType::Binary => Box::new(binview::BinviewKeyIdxTable::new()),
 
             _ => Box::new(row_encoded::RowEncodedIdxTable::new()),
         }

--- a/crates/polars-expr/src/idx_table/row_encoded.rs
+++ b/crates/polars-expr/src/idx_table/row_encoded.rs
@@ -4,7 +4,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use arrow::array::Array;
-use polars_utils::idx_map::bytes_idx_map::{BytesIndexMap, Entry};
+use polars_compute::binview_index_map::{BinaryViewIndexMap, Entry};
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::itertools::Itertools;
 use polars_utils::unitvec;
@@ -16,7 +16,7 @@ use crate::hash_keys::HashKeys;
 pub struct RowEncodedIdxTable {
     // These AtomicU64s actually are IdxSizes, but we use the top bit of the
     // first index in each to mark keys during probing.
-    idx_map: BytesIndexMap<UnitVec<AtomicU64>>,
+    idx_map: BinaryViewIndexMap<UnitVec<AtomicU64>>,
     idx_offset: IdxSize,
     null_keys: Vec<IdxSize>,
 }
@@ -24,7 +24,7 @@ pub struct RowEncodedIdxTable {
 impl RowEncodedIdxTable {
     pub fn new() -> Self {
         Self {
-            idx_map: BytesIndexMap::new(),
+            idx_map: BinaryViewIndexMap::new(),
             idx_offset: 0,
             null_keys: Vec::new(),
         }


### PR DESCRIPTION
Around a ~30% speedup on this microbenchmark:

```python
import polars as pl
import timeit

df = pl.DataFrame({"x": pl.int_range(10_000_000, eager=True).cast(pl.String)})
print(timeit.timeit(lambda: df.lazy().join(df.lazy(), on="x").collect(engine="streaming"), number=10) / 10)
```