### PR TITLE
refactor(rust): Remove `FileType` in favor of `ReaderCapabilities` for new-streaming multiscan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,6 +3500,7 @@ version = "0.46.0"
 dependencies = [
  "async-trait",
  "atomic-waker",
+ "bitflags",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-queue",

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -12,6 +12,7 @@ description = "Private crate for the streaming execution engine for the Polars D
 arrow = { workspace = true }
 async-trait = { workspace = true }
 atomic-waker = { workspace = true }
+bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-deque = { workspace = true }
 crossbeam-queue = { workspace = true }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/cast_columns.rs
@@ -3,9 +3,10 @@ use polars_core::schema::SchemaRef;
 use polars_error::{PolarsResult, polars_bail};
 
 /// TODO: Eventually move this enum to polars-plan
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum CastColumnsPolicy {
     /// Raise an error if the datatypes do not match
+    #[default]
     ErrorOnMismatch,
 }
 

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/missing_columns.rs
@@ -5,8 +5,9 @@ use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_bail};
 
 /// TODO: Eventually move this enum to polars-plan
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum MissingColumnsPolicy {
+    #[default]
     Raise,
     Insert,
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
@@ -23,8 +23,8 @@ pub struct ExtraOperations {
     // Note: These fields are ordered according to when they (should be) applied.
     pub row_index: Option<RowIndex>,
     pub pre_slice: Option<Slice>,
-    pub cast_columns: Option<CastColumnsPolicy>,
-    pub missing_columns: Option<MissingColumnsPolicy>,
+    pub cast_columns_policy: CastColumnsPolicy,
+    pub missing_columns_policy: MissingColumnsPolicy,
     pub include_file_paths: Option<PlSmallStr>,
     pub predicate: Option<ScanIOPredicate>,
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/builder.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/builder.rs
@@ -7,27 +7,12 @@ use polars_io::cloud::CloudOptions;
 use polars_plan::dsl::ScanSource;
 
 use super::FileReader;
-
-/// `FileReaderType` to avoid confusion with a `FileType` enum from polars-plan.
-#[derive(Debug, Clone, PartialEq)]
-pub enum FileReaderType {
-    #[cfg(feature = "parquet")]
-    Parquet,
-    #[cfg(feature = "ipc")]
-    #[expect(unused)]
-    Ipc,
-    #[cfg(feature = "csv")]
-    #[expect(unused)]
-    Csv,
-    #[cfg(feature = "json")]
-    NDJson,
-    /// So that we can compile when all feature flags disabled.
-    #[expect(unused)]
-    Unknown,
-}
+use super::capabilities::ReaderCapabilities;
 
 pub trait FileReaderBuilder: Debug + Send + Sync + 'static {
-    fn file_type(&self) -> FileReaderType;
+    fn reader_name(&self) -> &str;
+
+    fn reader_capabilities(&self) -> ReaderCapabilities;
 
     fn build_file_reader(
         &self,

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
@@ -1,0 +1,11 @@
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct ReaderCapabilities: u8 {
+        const ROW_INDEX          = 1 << 0;
+        const PRE_SLICE          = 1 << 1;
+        const NEGATIVE_PRE_SLICE = 1 << 2;
+        const FILTER             = 1 << 3;
+    }
+}

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -20,13 +20,25 @@ impl Slice {
         }
     }
 
+    /// Returns the end position of the slice (offset + len).
+    ///
+    /// # Panics
+    /// Panics if self is negative.
+    pub fn end_position(&self) -> usize {
+        let Slice::Positive { offset, len } = self.clone() else {
+            panic!("cannot use end() on a negative slice");
+        };
+
+        offset.saturating_add(len)
+    }
+
     /// Returns the equivalent slice to apply from an offsetted position.
     ///
     /// # Panics
     /// Panics if self is negative.
     pub fn offsetted(self, position: usize) -> Self {
         let Slice::Positive { offset, len } = self else {
-            panic!("expected positive slice");
+            panic!("cannot use offsetted() on a negative slice");
         };
 
         let (offset, len) = if position <= offset {
@@ -37,6 +49,35 @@ impl Slice {
         };
 
         Slice::Positive { offset, len }
+    }
+
+    /// Restricts the bounds of the slice to within a number of rows. Negative slices will also
+    /// be translated to the positive equivalent.
+    pub fn restrict_to_bounds(self, n_rows: usize) -> Self {
+        match self {
+            Slice::Positive { offset, len } => {
+                let offset = offset.min(n_rows);
+                let len = len.min(n_rows - offset);
+                Slice::Positive { offset, len }
+            },
+            Slice::Negative {
+                offset_from_end,
+                len,
+            } => {
+                if n_rows >= offset_from_end {
+                    // Trim extra starting rows
+                    let offset = n_rows - offset_from_end;
+                    let len = len.min(n_rows - offset);
+                    Slice::Positive { offset, len }
+                } else {
+                    // Slice offset goes past start of data.
+                    let stop_at_n_from_end = offset_from_end.saturating_sub(len);
+                    let len = n_rows.saturating_sub(stop_at_n_from_end);
+
+                    Slice::Positive { offset: 0, len }
+                }
+            },
+        }
     }
 }
 
@@ -75,6 +116,42 @@ mod tests {
         assert_eq!(
             Slice::Positive { offset: 3, len: 10 }.offsetted(5),
             Slice::Positive { offset: 0, len: 8 }
+        );
+    }
+
+    #[test]
+    fn test_slice_restrict_to_bounds() {
+        assert_eq!(
+            Slice::Positive { offset: 3, len: 10 }.restrict_to_bounds(7),
+            Slice::Positive { offset: 3, len: 4 },
+        );
+        assert_eq!(
+            Slice::Positive { offset: 3, len: 10 }.restrict_to_bounds(0),
+            Slice::Positive { offset: 0, len: 0 },
+        );
+        assert_eq!(
+            Slice::Positive { offset: 3, len: 10 }.restrict_to_bounds(1),
+            Slice::Positive { offset: 1, len: 0 },
+        );
+        assert_eq!(
+            Slice::Positive { offset: 2, len: 0 }.restrict_to_bounds(10),
+            Slice::Positive { offset: 2, len: 0 },
+        );
+        assert_eq!(
+            Slice::Negative {
+                offset_from_end: 3,
+                len: 1
+            }
+            .restrict_to_bounds(4),
+            Slice::Positive { offset: 1, len: 1 },
+        );
+        assert_eq!(
+            Slice::Negative {
+                offset_from_end: 3,
+                len: 1
+            }
+            .restrict_to_bounds(1),
+            Slice::Positive { offset: 0, len: 0 },
         );
     }
 }


### PR DESCRIPTION
ref https://github.com/pola-rs/polars/pull/21839#discussion_r2002959813

This will allow us to push operations into external IO implementations in a much more generic way.

Also adds `Slice::end_position()`, `Slice::restrict_to_bounds()` and some other drive-bys.

@coastalwhite 
