### PR TITLE
chore: Fix refcount assert being messed up by pytest assertion magic

### DIFF
--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1835,7 +1835,7 @@ def test_extension() -> None:
 
     # foos and sys.getrefcount both have a reference.
     base_count = 2
-    
+
     # We compute the refcount on a separate line otherwise pytest's assert magic
     # might add reference counts.
     rc = sys.getrefcount(foos[0])

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1832,31 +1832,45 @@ def test_extension() -> None:
             return f"foo({self.value})"
 
     foos = [Foo(1), Foo(2), Foo(3)]
-    # foos and sys.getrefcount have a reference.
+
+    # foos and sys.getrefcount both have a reference.
     base_count = 2
-    assert sys.getrefcount(foos[0]) == base_count
+    
+    # We compute the refcount on a separate line otherwise pytest's assert magic
+    # might add reference counts.
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count
 
     df = pl.DataFrame({"groups": [1, 1, 2], "a": foos})
-    assert sys.getrefcount(foos[0]) == base_count + 1
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count + 1
     del df
-    assert sys.getrefcount(foos[0]) == base_count
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count
 
     df = pl.DataFrame({"groups": [1, 1, 2], "a": foos})
-    assert sys.getrefcount(foos[0]) == base_count + 1
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count + 1
 
     out = df.group_by("groups", maintain_order=True).agg(pl.col("a").alias("a"))
-    assert sys.getrefcount(foos[0]) == base_count + 2
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count + 2
     s = out["a"].list.explode()
-    assert sys.getrefcount(foos[0]) == base_count + 3
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count + 3
     del s
-    assert sys.getrefcount(foos[0]) == base_count + 2
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count + 2
 
     assert out["a"].list.explode().to_list() == foos
-    assert sys.getrefcount(foos[0]) == base_count + 2
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count + 2
     del out
-    assert sys.getrefcount(foos[0]) == base_count + 1
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count + 1
     del df
-    assert sys.getrefcount(foos[0]) == base_count
+    rc = sys.getrefcount(foos[0])
+    assert rc == base_count
 
 
 @pytest.mark.parametrize("name", [None, "n", ""])


### PR DESCRIPTION
I upgraded my pytest version and noted they added magic to the `assert` which prints its arguments. But this adds extra reference counts, failing this test.