### PR TITLE
chore: Disable --dist loadgroup in pytest

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -138,10 +138,10 @@ jobs:
 
       - name: Run non-benchmark tests
         working-directory: py-polars
-        run: pytest -m 'not benchmark and not debug' -n auto --dist loadgroup
+        run: pytest -m 'not benchmark and not debug' -n auto
 
       - name: Run non-benchmark tests on new streaming engine
         working-directory: py-polars
         env:
           POLARS_AUTO_NEW_STREAMING: 1
-        run: pytest -n auto --dist loadgroup -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"
+        run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -135,7 +135,7 @@ jobs:
         working-directory: py-polars
         run: >
           pytest
-          -n auto --dist loadgroup
+          -n auto
           -m "not release and not benchmark and not docs"
           -k 'not test_polars_import'
           --cov --cov-report xml:main.xml
@@ -146,7 +146,7 @@ jobs:
           POLARS_FORCE_ASYNC: 1
         run: >
           pytest tests/unit/io/
-          -n auto --dist loadgroup
+          -n auto
           -m "not release and not benchmark and not docs"
           --cov --cov-report xml:async.xml --cov-fail-under=0
 

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -91,13 +91,13 @@ jobs:
 
       - name: Run tests
         if: github.ref_name != 'main'
-        run: pytest -n auto --dist loadgroup -m "not release and not benchmark and not docs"
+        run: pytest -n auto -m "not release and not benchmark and not docs"
 
       - name: Run tests with new streaming engine
         if: github.ref_name != 'main'
         env:
           POLARS_AUTO_NEW_STREAMING: 1
-        run: pytest -n auto --dist loadgroup -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"
+        run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"
 
       - name: Run tests async reader tests
         if: github.ref_name != 'main' && matrix.os != 'windows-latest'

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -69,11 +69,11 @@ pre-commit: fmt clippy  ## Run all code formatting and lint/quality checks
 
 .PHONY: test
 test: .venv build  ## Run fast unittests
-	$(VENV_BIN)/pytest -n auto --dist loadgroup $(PYTEST_ARGS)
+	$(VENV_BIN)/pytest -n auto $(PYTEST_ARGS)
 
 .PHONY: test-all
 test-all: .venv build  ## Run all tests
-	$(VENV_BIN)/pytest -n auto --dist loadgroup -m "slow or not slow"
+	$(VENV_BIN)/pytest -n auto -m "slow or not slow"
 	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: doctest
@@ -92,7 +92,7 @@ docs-clean: .venv  ## Build Python docs (full rebuild)
 
 .PHONY: coverage
 coverage: .venv build  ## Run tests and report coverage
-	$(VENV_BIN)/pytest --cov -n auto --dist loadgroup -m "not release and not benchmark"
+	$(VENV_BIN)/pytest --cov -n auto -m "not release and not benchmark"
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts


### PR DESCRIPTION
This is a bit of an experimental PR. We added `--dist loadgroup` [~1.5 years ago](https://github.com/pola-rs/polars/pull/10469) as a bit of a hack to deal with some flaky tests. However, it seems `--dist loadgroup` is a bit buggy (https://github.com/pytest-dev/pytest-xdist/issues/1189) leading to pytest INTERNAL ERRORs when the Python process isn't exited cleanly, and honestly... we should probably fix whatever tests fail 'because they are ran in the same runner' properly, as that's not a proper excuse for why a test should be allowed to fail.

So let's see how bad the damage is from just turning it off in this PR.