### PR TITLE
chore: Add POLARS_TIMEOUT_MS for timing out slow Polars tests

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -139,9 +139,12 @@ jobs:
       - name: Run non-benchmark tests
         working-directory: py-polars
         run: pytest -m 'not benchmark and not debug' -n auto
+        env:
+          POLARS_TIMEOUT_MS: 60000
 
       - name: Run non-benchmark tests on new streaming engine
         working-directory: py-polars
         env:
           POLARS_AUTO_NEW_STREAMING: 1
+          POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -133,6 +133,8 @@ jobs:
 
       - name: Run Python tests
         working-directory: py-polars
+        env:
+          POLARS_TIMEOUT_MS: 60000
         run: >
           pytest
           -n auto
@@ -144,6 +146,7 @@ jobs:
         working-directory: py-polars
         env:
           POLARS_FORCE_ASYNC: 1
+          POLARS_TIMEOUT_MS: 60000
         run: >
           pytest tests/unit/io/
           -n auto

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -91,18 +91,22 @@ jobs:
 
       - name: Run tests
         if: github.ref_name != 'main'
+        env:
+          POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not release and not benchmark and not docs"
 
       - name: Run tests with new streaming engine
         if: github.ref_name != 'main'
         env:
           POLARS_AUTO_NEW_STREAMING: 1
+          POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"
 
       - name: Run tests async reader tests
         if: github.ref_name != 'main' && matrix.os != 'windows-latest'
         env:
           POLARS_FORCE_ASYNC: 1
+          POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/
 
       - name: Check import without optional dependencies

--- a/crates/polars-python/src/lib.rs
+++ b/crates/polars-python/src/lib.rs
@@ -36,6 +36,7 @@ pub mod py_modules;
 pub mod series;
 #[cfg(feature = "sql")]
 pub mod sql;
+pub mod timeout;
 pub mod utils;
 
 use crate::conversion::Wrap;

--- a/crates/polars-python/src/timeout.rs
+++ b/crates/polars-python/src/timeout.rs
@@ -1,0 +1,105 @@
+//! A global process-aborting timeout system, mainly intended for testing.
+
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::time::Duration;
+
+use polars::prelude::{InitHashMaps, PlHashSet};
+use polars_utils::priority::Priority;
+
+static TIMEOUT_REQUEST_HANDLER: LazyLock<Sender<TimeoutRequest>> = LazyLock::new(|| {
+    let (send, recv) = channel();
+    std::thread::Builder::new()
+        .name("polars-timeout".to_string())
+        .spawn(move || timeout_thread(recv))
+        .unwrap();
+    send
+});
+
+enum TimeoutRequest {
+    Start(Duration, u64),
+    Cancel(u64),
+}
+
+pub fn get_timeout() -> Option<Duration> {
+    static TIMEOUT_DISABLED: AtomicBool = AtomicBool::new(false);
+
+    // Fast path so we don't have to keep checking environment variables. Make
+    // sure that if you want to use POLARS_TIMEOUT_MS it is set before the first
+    // polars call.
+    if TIMEOUT_DISABLED.load(Ordering::Relaxed) {
+        return None;
+    }
+
+    let Ok(timeout) = std::env::var("POLARS_TIMEOUT_MS") else {
+        TIMEOUT_DISABLED.store(true, Ordering::Relaxed);
+        return None;
+    };
+
+    match timeout.parse() {
+        Ok(ms) => Some(Duration::from_millis(ms)),
+        Err(e) => {
+            eprintln!("failed to parse POLARS_TIMEOUT_MS: {e:?}");
+            None
+        },
+    }
+}
+
+fn timeout_thread(recv: Receiver<TimeoutRequest>) {
+    let mut active_timeouts: PlHashSet<u64> = PlHashSet::new();
+    let mut shortest_timeout: BinaryHeap<Priority<Reverse<Duration>, u64>> = BinaryHeap::new();
+    loop {
+        // Remove cancelled requests.
+        while let Some(Priority(_, id)) = shortest_timeout.peek() {
+            if active_timeouts.contains(id) {
+                break;
+            }
+            shortest_timeout.pop();
+        }
+
+        let request = if let Some(Priority(timeout, _)) = shortest_timeout.peek() {
+            match recv.recv_timeout(timeout.0) {
+                Err(RecvTimeoutError::Timeout) => {
+                    eprintln!("exiting the process, POLARS_TIMEOUT_MS exceeded");
+                    std::thread::sleep(Duration::from_secs_f64(1.0));
+                    std::process::exit(1);
+                },
+                r => r.unwrap(),
+            }
+        } else {
+            recv.recv().unwrap()
+        };
+
+        match request {
+            TimeoutRequest::Start(duration, id) => {
+                shortest_timeout.push(Priority(Reverse(duration), id));
+                active_timeouts.insert(id);
+            },
+            TimeoutRequest::Cancel(id) => {
+                active_timeouts.remove(&id);
+            },
+        }
+    }
+}
+
+pub fn schedule_polars_timeout() -> Option<u64> {
+    static TIMEOUT_ID: AtomicU64 = AtomicU64::new(0);
+
+    let timeout = get_timeout()?;
+    let id = TIMEOUT_ID.fetch_add(1, Ordering::Relaxed);
+    TIMEOUT_REQUEST_HANDLER
+        .send(TimeoutRequest::Start(timeout, id))
+        .unwrap();
+    Some(id)
+}
+
+pub fn cancel_polars_timeout(opt_id: Option<u64>) {
+    if let Some(id) = opt_id {
+        TIMEOUT_REQUEST_HANDLER
+            .send(TimeoutRequest::Cancel(id))
+            .unwrap();
+    }
+}

--- a/crates/polars-python/src/utils.rs
+++ b/crates/polars-python/src/utils.rs
@@ -11,6 +11,7 @@ use pyo3::{PyErr, PyResult, Python};
 use crate::dataframe::PyDataFrame;
 use crate::error::PyPolarsErr;
 use crate::series::PySeries;
+use crate::timeout::{cancel_polars_timeout, schedule_polars_timeout};
 
 // was redefined because I could not get feature flags activated?
 #[macro_export]
@@ -101,7 +102,9 @@ impl EnterPolarsExt for Python<'_> {
         T: Ungil + Send,
         E: Ungil + Send + Into<PyPolarsErr>,
     {
+        let timeout = schedule_polars_timeout();
         let ret = self.allow_threads(|| catch_keyboard_interrupt(AssertUnwindSafe(f)));
+        cancel_polars_timeout(timeout);
         match ret {
             Ok(Ok(ret)) => Ok(ret),
             Ok(Err(err)) => Err(PyErr::from(err.into())),

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -69,11 +69,11 @@ pre-commit: fmt clippy  ## Run all code formatting and lint/quality checks
 
 .PHONY: test
 test: .venv build  ## Run fast unittests
-	$(VENV_BIN)/pytest -n auto $(PYTEST_ARGS)
+	POLARS_TIMEOUT_MS=60000 $(VENV_BIN)/pytest -n auto $(PYTEST_ARGS)
 
 .PHONY: test-all
 test-all: .venv build  ## Run all tests
-	$(VENV_BIN)/pytest -n auto -m "slow or not slow"
+	POLARS_TIMEOUT_MS=60000 $(VENV_BIN)/pytest -n auto -m "slow or not slow"
 	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: doctest
@@ -92,7 +92,7 @@ docs-clean: .venv  ## Build Python docs (full rebuild)
 
 .PHONY: coverage
 coverage: .venv build  ## Run tests and report coverage
-	$(VENV_BIN)/pytest --cov -n auto -m "not release and not benchmark"
+	POLARS_TIMEOUT_MS=60000 $(VENV_BIN)/pytest --cov -n auto -m "not release and not benchmark"
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts


### PR DESCRIPTION
This adds the environment variable `POLARS_TIMEOUT_MS` that when set will cause any call to any Polars function automatically exit the process with an error if the function still isn't finished after that many milliseconds has passed. This is useful for figuring out with `pytest` which test is hanging, if any.

I've also turned it on in the CI and Makefile when testing, defaulting to 60 seconds. This may need to be raised, we'll see.


If the environment variable `POLARS_TIMEOUT_MS` is not set when the first call to a Polars function is made, the mechanic is disabled entirely for performance.