### PR TITLE
refactor(python)!: Change Partition API to `base_path` and `file_path`

### DIFF
--- a/crates/polars-core/src/chunked_array/object/registry.rs
+++ b/crates/polars-core/src/chunked_array/object/registry.rs
@@ -21,12 +21,15 @@ use crate::series::{IntoSeries, Series};
 pub type BuilderConstructor =
     Box<dyn Fn(PlSmallStr, usize) -> Box<dyn AnonymousObjectBuilder> + Send + Sync>;
 pub type ObjectConverter = Arc<dyn Fn(AnyValue) -> Box<dyn Any> + Send + Sync>;
+pub type PyObjectConverter = Arc<dyn Fn(AnyValue) -> Box<dyn Any> + Send + Sync>;
 
 pub struct ObjectRegistry {
     /// A function that creates an object builder
     pub builder_constructor: BuilderConstructor,
     // A function that converts AnyValue to Box<dyn Any> of the object type
     object_converter: Option<ObjectConverter>,
+    // A function that converts AnyValue to Box<dyn Any> of the PyObject type
+    pyobject_converter: Option<PyObjectConverter>,
     pub physical_dtype: ArrowDataType,
 }
 
@@ -117,6 +120,7 @@ impl<T: PolarsObject> AnonymousObjectBuilder for ObjectChunkedBuilder<T> {
 pub fn register_object_builder(
     builder_constructor: BuilderConstructor,
     object_converter: ObjectConverter,
+    pyobject_converter: PyObjectConverter,
     physical_dtype: ArrowDataType,
 ) {
     let reg = GLOBAL_OBJECT_REGISTRY.deref();
@@ -125,6 +129,7 @@ pub fn register_object_builder(
     *reg = Some(ObjectRegistry {
         builder_constructor,
         object_converter: Some(object_converter),
+        pyobject_converter: Some(pyobject_converter),
         physical_dtype,
     })
 }
@@ -146,4 +151,10 @@ pub fn get_object_converter() -> ObjectConverter {
     let reg = GLOBAL_OBJECT_REGISTRY.read().unwrap();
     let reg = reg.as_ref().unwrap();
     reg.object_converter.as_ref().unwrap().clone()
+}
+
+pub fn get_pyobject_converter() -> PyObjectConverter {
+    let reg = GLOBAL_OBJECT_REGISTRY.read().unwrap();
+    let reg = reg.as_ref().unwrap();
+    reg.pyobject_converter.as_ref().unwrap().clone()
 }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1075,14 +1075,16 @@ impl LazyFrame {
     #[cfg(feature = "parquet")]
     pub fn sink_parquet_partitioned(
         self,
-        path_f_string: impl AsRef<Path>,
+        base_path: impl AsRef<Path>,
+        file_path_cb: Option<PartitionTargetCallback>,
         variant: PartitionVariant,
         options: ParquetWriteOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
-            path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+            base_path: base_path.as_ref().to_path_buf(),
+            file_path_cb,
             sink_options,
             variant,
             file_type: FileType::Parquet(options),
@@ -1096,14 +1098,16 @@ impl LazyFrame {
     #[cfg(feature = "ipc")]
     pub fn sink_ipc_partitioned(
         self,
-        path_f_string: impl AsRef<Path>,
+        base_path: impl AsRef<Path>,
+        file_path_cb: Option<PartitionTargetCallback>,
         variant: PartitionVariant,
         options: IpcWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
-            path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+            base_path: base_path.as_ref().to_path_buf(),
+            file_path_cb,
             sink_options,
             variant,
             file_type: FileType::Ipc(options),
@@ -1117,14 +1121,16 @@ impl LazyFrame {
     #[cfg(feature = "csv")]
     pub fn sink_csv_partitioned(
         self,
-        path_f_string: impl AsRef<Path>,
+        base_path: impl AsRef<Path>,
+        file_path_cb: Option<PartitionTargetCallback>,
         variant: PartitionVariant,
         options: CsvWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
-            path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+            base_path: base_path.as_ref().to_path_buf(),
+            file_path_cb,
             sink_options,
             variant,
             file_type: FileType::Csv(options),
@@ -1138,14 +1144,16 @@ impl LazyFrame {
     #[cfg(feature = "json")]
     pub fn sink_json_partitioned(
         self,
-        path_f_string: impl AsRef<Path>,
+        base_path: impl AsRef<Path>,
+        file_path_cb: Option<PartitionTargetCallback>,
         variant: PartitionVariant,
         options: JsonWriterOptions,
         cloud_options: Option<polars_io::cloud::CloudOptions>,
         sink_options: SinkOptions,
     ) -> PolarsResult<Self> {
         self.sink(SinkType::Partition(PartitionSinkType {
-            path_f_string: Arc::new(path_f_string.as_ref().to_path_buf()),
+            base_path: base_path.as_ref().to_path_buf(),
+            file_path_cb,
             sink_options,
             variant,
             file_type: FileType::Json(options),

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -649,6 +649,9 @@ impl FileType {
             Self::Csv(_) => "csv",
             #[cfg(feature = "json")]
             Self::Json(_) => "jsonl",
+
+            #[allow(unreachable_patterns)]
+            _ => unreachable!("enable file type features"),
         }
     }
 }

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -427,7 +427,7 @@ impl PartitionTargetContextKey {
         self.name.as_str()
     }
     #[getter]
-    pub fn value(&self) -> pyo3::PyResult<String> {
+    pub fn str_value(&self) -> pyo3::PyResult<String> {
         let value = self
             .raw_value
             .clone()

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -622,7 +622,7 @@ impl FileType {
             #[cfg(feature = "csv")]
             Self::Csv(_) => "csv",
             #[cfg(feature = "json")]
-            Self::Json(_) => "ndjson",
+            Self::Json(_) => "jsonl",
         }
     }
 }

--- a/crates/polars-plan/src/dsl/options.rs
+++ b/crates/polars-plan/src/dsl/options.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use polars_core::error::PolarsResult;
+use polars_core::error::{PolarsResult, to_compute_err};
 use polars_core::prelude::*;
 #[cfg(feature = "csv")]
 use polars_io::csv::write::CsvWriterOptions;
@@ -28,11 +28,13 @@ use polars_time::RollingGroupOptions;
 use polars_utils::IdxSize;
 use polars_utils::arena::Arena;
 use polars_utils::pl_str::PlSmallStr;
+use polars_utils::python_function::PythonFunction;
+use pyo3::Python;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
 
-use super::{AExpr, Expr, ExprIR};
+use super::{AExpr, Expr, ExprIR, SpecialEq};
 use crate::dsl::Selector;
 
 #[derive(Copy, Clone, PartialEq, Debug, Eq, Hash)]
@@ -367,17 +369,124 @@ pub struct FileSinkType {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SinkTypeIR {
     Memory,
     File(FileSinkType),
     Partition(PartitionSinkTypeIR),
 }
 
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+#[derive(Clone)]
+pub struct PartitionTargetContextKey {
+    pub name: PlSmallStr,
+    pub value: PlSmallStr,
+}
+
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub struct PartitionTargetContext {
+    pub part: usize,
+    pub keys: Vec<PartitionTargetContextKey>,
+    pub file_path: PathBuf,
+    pub full_path: PathBuf,
+}
+
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl PartitionTargetContext {
+    #[getter]
+    pub fn part(&self) -> usize {
+        self.part
+    }
+    #[getter]
+    pub fn keys(&self) -> Vec<PartitionTargetContextKey> {
+        self.keys.clone()
+    }
+    #[getter]
+    pub fn file_path(&self) -> &std::path::Path {
+        self.file_path.as_path()
+    }
+    #[getter]
+    pub fn full_path(&self) -> &std::path::Path {
+        self.full_path.as_path()
+    }
+}
+#[cfg(feature = "python")]
+#[pyo3::pymethods]
+impl PartitionTargetContextKey {
+    #[getter]
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+    #[getter]
+    pub fn value(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PartitionTargetCallback {
+    Rust(SpecialEq<Arc<dyn Fn(PartitionTargetContext) -> PolarsResult<PathBuf> + Send + Sync>>),
+    #[cfg(feature = "python")]
+    Python(PythonFunction),
+}
+
+impl PartitionTargetCallback {
+    pub fn call(&self, ctx: PartitionTargetContext) -> PolarsResult<PathBuf> {
+        match self {
+            Self::Rust(f) => f(ctx),
+            #[cfg(feature = "python")]
+            Self::Python(f) => Python::with_gil(|py| {
+                let file_path = f.call1(py, (ctx,)).map_err(to_compute_err)?;
+                let file_path = file_path.extract::<PathBuf>(py).map_err(to_compute_err)?;
+                PolarsResult::Ok(file_path)
+            }),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for PartitionTargetCallback {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[cfg(feature = "python")]
+        {
+            Ok(Self::Python(PythonFunction::deserialize(_deserializer)?))
+        }
+        #[cfg(not(feature = "python"))]
+        {
+            use serde::de::Error;
+            Err(D::Error::custom(
+                "cannot deserialize PartitionOutputCallback",
+            ))
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for PartitionTargetCallback {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+
+        #[cfg(feature = "python")]
+        if let Self::Python(v) = self {
+            return v.serialize(_serializer);
+        }
+
+        Err(S::Error::custom(format!("cannot serialize {:?}", self)))
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PartitionSinkType {
-    pub path_f_string: Arc<PathBuf>,
+    pub base_path: PathBuf,
+    pub file_path_cb: Option<PartitionTargetCallback>,
     pub file_type: FileType,
     pub sink_options: SinkOptions,
     pub variant: PartitionVariant,
@@ -385,9 +494,10 @@ pub struct PartitionSinkType {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PartitionSinkTypeIR {
-    pub path_f_string: Arc<PathBuf>,
+    pub base_path: PathBuf,
+    pub file_path_cb: Option<PartitionTargetCallback>,
     pub file_type: FileType,
     pub sink_options: SinkOptions,
     pub variant: PartitionVariantIR,
@@ -395,7 +505,7 @@ pub struct PartitionSinkTypeIR {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SinkType {
     Memory,
     File(FileSinkType),
@@ -438,7 +548,6 @@ impl SinkTypeIR {
             Self::Memory => {},
             Self::File(f) => f.hash(state),
             Self::Partition(f) => {
-                f.path_f_string.hash(state);
                 f.file_type.hash(state);
                 f.sink_options.hash(state);
                 f.variant.traverse_and_hash(expr_arena, state);
@@ -502,6 +611,22 @@ pub enum FileType {
     #[cfg(feature = "json")]
     Json(JsonWriterOptions),
 }
+
+impl FileType {
+    pub fn extension(&self) -> &'static str {
+        match self {
+            #[cfg(feature = "parquet")]
+            Self::Parquet(_) => "parquet",
+            #[cfg(feature = "ipc")]
+            Self::Ipc(_) => "ipc",
+            #[cfg(feature = "csv")]
+            Self::Csv(_) => "csv",
+            #[cfg(feature = "json")]
+            Self::Json(_) => "ndjson",
+        }
+    }
+}
+
 //
 // Arguments given to `concat`. Differs from `UnionOptions` as the latter is IR state.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -958,7 +958,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 SinkType::Memory => SinkTypeIR::Memory,
                 SinkType::File(f) => SinkTypeIR::File(f),
                 SinkType::Partition(f) => SinkTypeIR::Partition(PartitionSinkTypeIR {
-                    path_f_string: f.path_f_string,
+                    base_path: f.base_path,
+                    file_path_cb: f.file_path_cb,
                     file_type: f.file_type,
                     sink_options: f.sink_options,
                     variant: match f.variant {

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -276,7 +276,8 @@ impl IR {
                     SinkTypeIR::Memory => SinkType::Memory,
                     SinkTypeIR::File(f) => SinkType::File(f),
                     SinkTypeIR::Partition(f) => SinkType::Partition(PartitionSinkType {
-                        path_f_string: f.path_f_string,
+                        base_path: f.base_path,
+                        file_path_cb: f.file_path_cb,
                         file_type: f.file_type,
                         sink_options: f.sink_options,
                         variant: match f.variant {

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -751,7 +751,7 @@ impl PyLazyFrame {
 
         let cloud_options = {
             let cloud_options = parse_cloud_options(
-                target.unformatted_path().to_str().unwrap(),
+                target.base_path().to_str().unwrap(),
                 cloud_options.unwrap_or_default(),
             )?;
             Some(
@@ -773,7 +773,8 @@ impl PyLazyFrame {
                     sink_options.0,
                 ),
                 SinkTarget::Partition(partition) => ldf.sink_parquet_partitioned(
-                    partition.path.as_ref(),
+                    partition.base_path,
+                    partition.file_path_cb.map(PartitionTargetCallback::Python),
                     partition.variant,
                     options,
                     cloud_options,
@@ -811,7 +812,7 @@ impl PyLazyFrame {
         #[cfg(feature = "cloud")]
         let cloud_options = {
             let cloud_options = parse_cloud_options(
-                target.unformatted_path().to_str().unwrap(),
+                target.base_path().to_str().unwrap(),
                 cloud_options.unwrap_or_default(),
             )?;
             Some(
@@ -833,7 +834,8 @@ impl PyLazyFrame {
                     ldf.sink_ipc(path, options, cloud_options, sink_options.0)
                 },
                 SinkTarget::Partition(partition) => ldf.sink_ipc_partitioned(
-                    partition.path.as_ref(),
+                    partition.base_path,
+                    partition.file_path_cb.map(PartitionTargetCallback::Python),
                     partition.variant,
                     options,
                     cloud_options,
@@ -899,7 +901,7 @@ impl PyLazyFrame {
         #[cfg(feature = "cloud")]
         let cloud_options = {
             let cloud_options = parse_cloud_options(
-                target.unformatted_path().to_str().unwrap(),
+                target.base_path().to_str().unwrap(),
                 cloud_options.unwrap_or_default(),
             )?;
             Some(
@@ -921,7 +923,8 @@ impl PyLazyFrame {
                     ldf.sink_csv(path, options, cloud_options, sink_options.0)
                 },
                 SinkTarget::Partition(partition) => ldf.sink_csv_partitioned(
-                    partition.path.as_ref(),
+                    partition.base_path,
+                    partition.file_path_cb.map(PartitionTargetCallback::Python),
                     partition.variant,
                     options,
                     cloud_options,
@@ -949,7 +952,7 @@ impl PyLazyFrame {
 
         let cloud_options = {
             let cloud_options = parse_cloud_options(
-                target.unformatted_path().to_str().unwrap(),
+                target.base_path().to_str().unwrap(),
                 cloud_options.unwrap_or_default(),
             )?;
             Some(
@@ -968,7 +971,8 @@ impl PyLazyFrame {
                     ldf.sink_json(path, options, cloud_options, sink_options.0)
                 },
                 SinkTarget::Partition(partition) => ldf.sink_json_partitioned(
-                    partition.path.as_ref(),
+                    partition.base_path,
+                    partition.file_path_cb.map(PartitionTargetCallback::Python),
                     partition.variant,
                     options,
                     cloud_options,

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -99,10 +99,19 @@ pub unsafe fn register_startup_deps(catch_keyboard_interrupt: bool) {
             });
             Box::new(object) as Box<dyn Any>
         });
+        let pyobject_converter = Arc::new(|av: AnyValue| {
+            let object = Python::with_gil(|py| Wrap(av).into_py_any(py).unwrap());
+            Box::new(object) as Box<dyn Any>
+        });
 
         let object_size = size_of::<ObjectValue>();
         let physical_dtype = ArrowDataType::FixedSizeBinary(object_size);
-        registry::register_object_builder(object_builder, object_converter, physical_dtype);
+        registry::register_object_builder(
+            object_builder,
+            object_converter,
+            pyobject_converter,
+            physical_dtype,
+        );
         // Register SERIES UDF.
         python_dsl::CALL_COLUMNS_UDF_PYTHON = Some(python_function_caller_series);
         // Register DATAFRAME UDF.

--- a/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/by_key.rs
@@ -196,7 +196,7 @@ impl SinkNode for PartitionByKeySinkNode {
             }
 
             let verbose = config::verbose();
-            let mut part = 0;
+            let mut file_idx = 0;
             let mut open_partitions: PlIndexMap<Buffer<u8>, OpenPartition> = PlIndexMap::default();
 
             // Wrap this in a closure so that a failure to send (which signifies a failure) can be
@@ -228,7 +228,9 @@ impl SinkNode for PartitionByKeySinkNode {
                                         base_path.as_path(),
                                         file_path_cb.as_ref(),
                                         super::default_by_key_file_path_cb,
-                                        &mut part,
+                                        file_idx,
+                                        file_idx,
+                                        0,
                                         Some(keys.as_slice()),
                                         &create_new_sink,
                                         sink_input_schema.clone(),
@@ -237,6 +239,8 @@ impl SinkNode for PartitionByKeySinkNode {
                                         verbose,
                                         &state,
                                     ).await?;
+                                    file_idx += 1;
+
                                     let Some((join_handles, sender)) = result else {
                                         return Ok(());
                                     };
@@ -283,7 +287,9 @@ impl SinkNode for PartitionByKeySinkNode {
                             base_path.as_path(),
                             file_path_cb.as_ref(),
                             super::default_by_key_file_path_cb,
-                            &mut part,
+                            file_idx,
+                            file_idx,
+                            0,
                             Some(keys.as_slice()),
                             &create_new_sink,
                             sink_input_schema.clone(),
@@ -292,6 +298,7 @@ impl SinkNode for PartitionByKeySinkNode {
                             verbose,
                             &state
                         ).await?;
+                        file_idx += 1;
                         let Some((mut join_handles, mut sender)) = result else {
                             return Ok(());
                         };

--- a/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/max_size.rs
@@ -5,12 +5,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use polars_core::config;
-use polars_core::prelude::{InitHashMaps, PlHashMap};
+use polars_core::prelude::Column;
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
-use polars_plan::dsl::SinkOptions;
+use polars_plan::dsl::{PartitionTargetCallback, SinkOptions};
+use polars_utils::IdxSize;
 use polars_utils::pl_str::PlSmallStr;
-use polars_utils::{IdxSize, format_pl_smallstr};
 
 use super::CreateNewSinkFn;
 use crate::async_executor::{AbortOnDropHandle, spawn};
@@ -25,8 +25,10 @@ pub struct MaxSizePartitionSinkNode {
     input_schema: SchemaRef,
     max_size: IdxSize,
 
-    path_f_string: Arc<PathBuf>,
+    base_path: PathBuf,
+    file_path_cb: Option<PartitionTargetCallback>,
     create_new: CreateNewSinkFn,
+    ext: PlSmallStr,
 
     sink_options: SinkOptions,
 
@@ -45,8 +47,10 @@ impl MaxSizePartitionSinkNode {
     pub fn new(
         input_schema: SchemaRef,
         max_size: IdxSize,
-        path_f_string: Arc<PathBuf>,
+        base_path: PathBuf,
+        file_path_cb: Option<PartitionTargetCallback>,
         create_new: CreateNewSinkFn,
+        ext: PlSmallStr,
         sink_options: SinkOptions,
     ) -> Self {
         assert!(max_size > 0);
@@ -60,12 +64,18 @@ impl MaxSizePartitionSinkNode {
         Self {
             input_schema,
             max_size,
-            path_f_string,
+            base_path,
+            file_path_cb,
             create_new,
+            ext,
             sink_options,
             num_retire_tasks,
         }
     }
+}
+
+fn default_file_path_cb(ext: &str, part: usize, _columns: Option<&[Column]>) -> PathBuf {
+    PathBuf::from(format!("{part}.{ext}"))
 }
 
 impl SinkNode for MaxSizePartitionSinkNode {
@@ -98,14 +108,12 @@ impl SinkNode for MaxSizePartitionSinkNode {
         let state = state.clone();
         let input_schema = self.input_schema.clone();
         let max_size = self.max_size;
-        let path_f_string = self.path_f_string.clone();
+        let base_path = self.base_path.clone();
+        let file_path_cb = self.file_path_cb.clone();
         let create_new = self.create_new.clone();
+        let ext = self.ext.clone();
         let retire_error = has_error_occurred.clone();
         join_handles.push(spawn(TaskPriority::High, async move {
-            let part_str = PlSmallStr::from_static("part");
-            let mut format_args = PlHashMap::with_capacity(1);
-            format_args.insert(part_str.clone(), PlSmallStr::EMPTY);
-
             struct CurrentSink {
                 sender: SinkSender,
                 join_handles: FuturesUnordered<AbortOnDropHandle<PolarsResult<()>>>,
@@ -127,16 +135,16 @@ impl SinkNode for MaxSizePartitionSinkNode {
                         let current_sink = match current_sink_opt.as_mut() {
                             Some(c) => c,
                             None => {
-                                *format_args.get_mut(&part_str).unwrap() =
-                                    format_pl_smallstr!("{part}");
-                                part += 1;
-
                                 let result = open_new_sink(
-                                    path_f_string.as_path(),
+                                    base_path.as_path(),
+                                    file_path_cb.as_ref(),
+                                    default_file_path_cb,
+                                    &mut part,
+                                    None,
                                     &create_new,
-                                    &format_args,
                                     input_schema.clone(),
                                     "max-size",
+                                    ext.as_str(),
                                     verbose,
                                     &state,
                                 )

--- a/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
@@ -140,7 +140,7 @@ impl SinkNode for PartedPartitionSinkNode {
             }
 
             let verbose = config::verbose();
-            let mut part = 0;
+            let mut file_idx = 0;
             let mut current_sink_opt: Option<CurrentSink> = None;
             let mut lengths = Vec::new();
 
@@ -195,7 +195,9 @@ impl SinkNode for PartedPartitionSinkNode {
                                     base_path.as_path(),
                                     file_path_cb.as_ref(),
                                     super::default_by_key_file_path_cb,
-                                    &mut part,
+                                    file_idx,
+                                    file_idx,
+                                    0,
                                     Some(
                                         parted_df
                                             .select_columns(key_cols.iter().cloned())?
@@ -209,6 +211,7 @@ impl SinkNode for PartedPartitionSinkNode {
                                     &state,
                                 )
                                 .await?;
+                                file_idx += 1;
                                 let Some((join_handles, sender)) = result else {
                                     return Ok(());
                                 };

--- a/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/parted.rs
@@ -6,11 +6,10 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use polars_core::config;
 use polars_core::prelude::row_encode::_get_rows_encoded_ca_unordered;
-use polars_core::prelude::{AnyValue, InitHashMaps, IntoColumn, PlHashMap, PlHashSet};
+use polars_core::prelude::{AnyValue, IntoColumn, PlHashSet};
 use polars_core::schema::SchemaRef;
 use polars_error::PolarsResult;
-use polars_plan::dsl::SinkOptions;
-use polars_utils::format_pl_smallstr;
+use polars_plan::dsl::{PartitionTargetCallback, SinkOptions};
 use polars_utils::pl_str::PlSmallStr;
 
 use super::CreateNewSinkFn;
@@ -18,9 +17,7 @@ use crate::async_executor::{AbortOnDropHandle, spawn};
 use crate::async_primitives::connector::Receiver;
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::execute::StreamingExecutionState;
-use crate::nodes::io_sinks::partition::{
-    SinkSender, insert_key_value_into_format_args, open_new_sink,
-};
+use crate::nodes::io_sinks::partition::{SinkSender, open_new_sink};
 use crate::nodes::io_sinks::{SinkInputPort, SinkNode};
 use crate::nodes::{JoinHandle, Morsel, PhaseOutcome, TaskPriority};
 
@@ -30,8 +27,10 @@ pub struct PartedPartitionSinkNode {
     sink_input_schema: SchemaRef,
 
     key_cols: Arc<[PlSmallStr]>,
-    path_f_string: Arc<PathBuf>,
+    base_path: PathBuf,
+    file_path_cb: Option<PartitionTargetCallback>,
     create_new: CreateNewSinkFn,
+    ext: PlSmallStr,
 
     sink_options: SinkOptions,
     include_key: bool,
@@ -48,11 +47,14 @@ pub struct PartedPartitionSinkNode {
 
 const DEFAULT_RETIRE_TASKS: usize = 1;
 impl PartedPartitionSinkNode {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         input_schema: SchemaRef,
         key_cols: Arc<[PlSmallStr]>,
-        path_f_string: Arc<PathBuf>,
+        base_path: PathBuf,
+        file_path_cb: Option<PartitionTargetCallback>,
         create_new: CreateNewSinkFn,
+        ext: PlSmallStr,
         sink_options: SinkOptions,
         include_key: bool,
     ) -> Self {
@@ -83,8 +85,10 @@ impl PartedPartitionSinkNode {
         Self {
             sink_input_schema,
             key_cols,
-            path_f_string,
+            base_path,
+            file_path_cb,
             create_new,
+            ext,
             sink_options,
             num_retire_tasks,
             include_key,
@@ -122,19 +126,13 @@ impl SinkNode for PartedPartitionSinkNode {
         let state = state.clone();
         let sink_input_schema = self.sink_input_schema.clone();
         let key_cols = self.key_cols.clone();
-        let path_f_string = self.path_f_string.clone();
+        let base_path = self.base_path.clone();
+        let file_path_cb = self.file_path_cb.clone();
         let create_new = self.create_new.clone();
+        let ext = self.ext.clone();
         let include_key = self.include_key;
         let retire_error = has_error_occurred.clone();
         join_handles.push(spawn(TaskPriority::High, async move {
-            let part_str = PlSmallStr::from_static("part");
-            let mut format_args = PlHashMap::with_capacity(1);
-            format_args.insert(part_str.clone(), PlSmallStr::EMPTY);
-            for (i, name) in key_cols.iter().enumerate() {
-                format_args.insert(format_pl_smallstr!("key[{i}].name"), name.clone());
-                format_args.insert(format_pl_smallstr!("key[{i}].value"), PlSmallStr::EMPTY);
-            }
-
             struct CurrentSink {
                 sender: SinkSender,
                 join_handles: FuturesUnordered<AbortOnDropHandle<PolarsResult<()>>>,
@@ -193,18 +191,20 @@ impl SinkNode for PartedPartitionSinkNode {
                         let current_sink = match current_sink_opt.as_mut() {
                             Some(c) => c,
                             None => {
-                                *format_args.get_mut(&part_str).unwrap() =
-                                    format_pl_smallstr!("{part}");
-                                part += 1;
-                                let keys = parted_df.select_columns(key_cols.iter().cloned())?;
-                                insert_key_value_into_format_args(&mut format_args, &keys);
-
                                 let result = open_new_sink(
-                                    path_f_string.as_path(),
+                                    base_path.as_path(),
+                                    file_path_cb.as_ref(),
+                                    super::default_by_key_file_path_cb,
+                                    &mut part,
+                                    Some(
+                                        parted_df
+                                            .select_columns(key_cols.iter().cloned())?
+                                            .as_slice(),
+                                    ),
                                     &create_new,
-                                    &format_args,
                                     sink_input_schema.clone(),
                                     "parted",
+                                    ext.as_str(),
                                     verbose,
                                     &state,
                                 )

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -287,13 +287,15 @@ pub fn lower_ir(
                 }
             },
             SinkTypeIR::Partition(PartitionSinkTypeIR {
-                path_f_string,
+                base_path,
+                file_path_cb,
                 sink_options,
                 variant,
                 file_type,
                 cloud_options,
             }) => {
-                let path_f_string = path_f_string.clone();
+                let base_path = base_path.clone();
+                let file_path_cb = file_path_cb.clone();
                 let sink_options = sink_options.clone();
                 let variant = variant.clone();
                 let file_type = file_type.clone();
@@ -339,7 +341,8 @@ pub fn lower_ir(
                 };
 
                 PhysNodeKind::PartitionSink {
-                    path_f_string,
+                    base_path,
+                    file_path_cb,
                     sink_options,
                     variant,
                     file_type,

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -10,7 +10,8 @@ use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::{
-    FileScan, JoinTypeOptionsIR, PartitionVariantIR, ScanSource, ScanSources, SinkOptions,
+    FileScan, JoinTypeOptionsIR, PartitionTargetCallback, PartitionVariantIR, ScanSource,
+    ScanSources, SinkOptions,
 };
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, FileInfo, IR};
@@ -143,7 +144,8 @@ pub enum PhysNodeKind {
     },
 
     PartitionSink {
-        path_f_string: Arc<PathBuf>,
+        base_path: PathBuf,
+        file_path_cb: Option<PartitionTargetCallback>,
         sink_options: SinkOptions,
         variant: PartitionVariantIR,
         file_type: FileType,

--- a/crates/polars-utils/src/python_function.rs
+++ b/crates/polars-utils/src/python_function.rs
@@ -41,6 +41,26 @@ impl From<PyObject> for PythonObject {
     }
 }
 
+impl<'py> pyo3::conversion::IntoPyObject<'py> for PythonObject {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.0.into_bound(py))
+    }
+}
+
+impl<'py> pyo3::conversion::IntoPyObject<'py> for &PythonObject {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.0.bind(py).clone())
+    }
+}
+
 impl Eq for PythonObject {}
 
 impl PartialEq for PythonObject {

--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -111,6 +111,16 @@ Sink to disk with differing partitioning strategies.
    PartitionMaxSize
    PartitionParted
 
+.. currentmodule:: polars.io.partition
+
+.. autosummary::
+   :toctree: api/
+
+   KeyedPartition
+   BasePartitionContext
+   KeyedPartitionContext
+
+.. currentmodule:: polars
 
 Parquet
 ~~~~~~~

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -168,6 +168,9 @@ from polars.functions import (
 )
 from polars.interchange import CompatLevel
 from polars.io import (
+    BasePartitionContext,
+    KeyedPartition,
+    KeyedPartitionContext,
     PartitionByKey,
     PartitionMaxSize,
     PartitionParted,
@@ -273,6 +276,9 @@ __all__ = [
     "Utf8",
     # polars.io
     "defer",
+    "KeyedPartition",
+    "BasePartitionContext",
+    "KeyedPartitionContext",
     "PartitionByKey",
     "PartitionMaxSize",
     "PartitionParted",

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -12,6 +12,7 @@ from polars.io.ndjson import read_ndjson, scan_ndjson
 from polars.io.parquet import read_parquet, read_parquet_schema, scan_parquet
 from polars.io.partition import (
     BasePartitionContext,
+    KeyedPartition,
     KeyedPartitionContext,
     PartitionByKey,
     PartitionMaxSize,
@@ -26,6 +27,7 @@ __all__ = [
     "PartitionByKey",
     "PartitionMaxSize",
     "PartitionParted",
+    "KeyedPartition",
     "BasePartitionContext",
     "KeyedPartitionContext",
     "read_avro",

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -10,7 +10,13 @@ from polars.io.ipc import read_ipc, read_ipc_schema, read_ipc_stream, scan_ipc
 from polars.io.json import read_json
 from polars.io.ndjson import read_ndjson, scan_ndjson
 from polars.io.parquet import read_parquet, read_parquet_schema, scan_parquet
-from polars.io.partition import PartitionByKey, PartitionMaxSize, PartitionParted
+from polars.io.partition import (
+    BasePartitionContext,
+    KeyedPartitionContext,
+    PartitionByKey,
+    PartitionMaxSize,
+    PartitionParted,
+)
 from polars.io.plugins import _defer as defer
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 from polars.io.spreadsheet import read_excel, read_ods
@@ -20,6 +26,8 @@ __all__ = [
     "PartitionByKey",
     "PartitionMaxSize",
     "PartitionParted",
+    "BasePartitionContext",
+    "KeyedPartitionContext",
     "read_avro",
     "read_clipboard",
     "read_csv",

--- a/py-polars/polars/io/cloud/_utils.py
+++ b/py-polars/polars/io/cloud/_utils.py
@@ -15,7 +15,7 @@ def _first_scan_path(
     elif is_path_or_str_sequence(source) and source:
         return source[0]
     elif isinstance(source, PartitionMaxSize):
-        return source._path
+        return source._base_path
 
     return None
 

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     with contextlib.suppress(ImportError):  # Module not available when building docs
         from polars.polars import PyExpr
 
-    from typing import Callable
+    from typing import Any, Callable
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyPartitioning
@@ -34,14 +34,14 @@ class KeyedPartition:
     KeyedPartitionContext
     """
 
-    def __init__(self, name: str, str_value: str, raw_value: any) -> None:
+    def __init__(self, name: str, str_value: str, raw_value: Any) -> None:
         self.name = name
         self.str_value = str_value
         self.raw_value = raw_value
 
     name: str  #: Name of the key column.
     str_value: str  #: Value of the key as a path and URL safe string.
-    raw_value: any  #: Value of the key for this partition.
+    raw_value: Any  #: Value of the key for this partition.
 
     def hive_name(self) -> str:
         """Get the `key=value`."""

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -34,17 +34,18 @@ class KeyedPartition:
     KeyedPartitionContext
     """
 
-    def __init__(self, name: str, value: str, raw_value: any) -> None:
+    def __init__(self, name: str, str_value: str, raw_value: any) -> None:
         self.name = name
-        self.value = value
+        self.str_value = str_value
+        self.raw_value = raw_value
 
     name: str  #: Name of the key column.
-    value: str  #: Value of the key as a path and URL safe string
+    str_value: str  #: Value of the key as a path and URL safe string.
     raw_value: any  #: Value of the key for this partition.
 
     def hive_name(self) -> str:
         """Get the `key=value`."""
-        return f"{self.name}={self.value}"
+        return f"{self.name}={self.str_value}"
 
 
 class KeyedPartitionContext:
@@ -145,7 +146,9 @@ def _cast_keyed_file_path_cb(
             part_idx=ctx.part_idx,
             in_part_idx=ctx.in_part_idx,
             keys=[
-                KeyedPartition(name=kv.name, value=kv.value, raw_value=kv.raw_value)
+                KeyedPartition(
+                    name=kv.name, str_value=kv.str_value, raw_value=kv.raw_value
+                )
                 for kv in ctx.keys
             ],
             file_path=Path(ctx.file_path),

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -98,7 +98,7 @@ class BasePartitionContext:
 
 
 def _cast_base_file_path_cb(
-    file_path_cb: Callable[[KeyedPartitionContext], Path | str] | None,
+    file_path_cb: Callable[[BasePartitionContext], Path | str] | None,
 ) -> Callable[[BasePartitionContext], Path | str] | None:
     if file_path_cb is None:
         return None

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -300,7 +300,7 @@ class PartitionByKey:
     >>> pl.scan_parquet("/path/to/file.parquet").sink_csv(
     ...     PartitionByKey(
     ...         "./out/",
-    ...         file_path=lambda ctx: f"year={ctx.keys[0].value}.csv",
+    ...         file_path=lambda ctx: f"year={ctx.keys[0].str_value}.csv",
     ...         by="year",
     ...     ),
     ... )  # doctest: +SKIP

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -118,7 +118,7 @@ def test_partition_by_key(
     (io_type["sink"])(
         lf,
         PartitionByKey(
-            tmp_path, file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}", by="a"
+            tmp_path, file_path=lambda ctx: f"{ctx.file_idx}.{io_type['ext']}", by="a"
         ),
         engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on
@@ -155,7 +155,7 @@ def test_partition_by_key(
         lf,
         PartitionByKey(
             tmp_path,
-            file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}",
+            file_path=lambda ctx: f"{ctx.file_idx}.{io_type['ext']}",
             by=pl.col.a.cast(pl.String()),
         ),
         engine="streaming",
@@ -200,7 +200,7 @@ def test_partition_parted(
     (io_type["sink"])(
         lf,
         PartitionParted(
-            tmp_path, file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}", by="a"
+            tmp_path, file_path=lambda ctx: f"{ctx.file_idx}.{io_type['ext']}", by="a"
         ),
         engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on
@@ -230,7 +230,7 @@ def test_partition_parted(
         lf,
         PartitionParted(
             tmp_path,
-            file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}",
+            file_path=lambda ctx: f"{ctx.file_idx}.{io_type['ext']}",
             by=[pl.col.a, pl.col.a.cast(pl.String()).alias("a_str")],
         ),
         engine="streaming",
@@ -255,7 +255,7 @@ def test_partition_parted(
         lf,
         PartitionParted(
             tmp_path,
-            file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}",
+            file_path=lambda ctx: f"{ctx.file_idx}.{io_type['ext']}",
             by=[pl.col.a.cast(pl.String()).alias("a_str")],
             include_key=False,
         ),
@@ -278,7 +278,13 @@ def test_partition_parted(
         min_cols=1,
         excluded_dtypes=[
             pl.Decimal,  # Bug see: https://github.com/pola-rs/polars/issues/21684
+            pl.Duration,  # Bug see: https://github.com/pola-rs/polars/issues/21964
             pl.Categorical,  # We cannot ensure the string cache is properly held.
+            # Generate invalid UTF-8
+            pl.Binary,
+            pl.Struct,
+            pl.Array,
+            pl.List,
         ],
     )
 )
@@ -295,7 +301,7 @@ def test_partition_by_key_parametric(
     (io_type["sink"])(
         df.lazy(),
         PartitionByKey(
-            tmp_path, file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}", by=col1
+            tmp_path, file_path=lambda ctx: f"{ctx.file_idx}.{io_type['ext']}", by=col1
         ),
         engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -6,12 +6,20 @@ import pytest
 from hypothesis import given
 
 import polars as pl
-from polars.io.partition import PartitionByKey, PartitionMaxSize, PartitionParted
+from polars.io.partition import (
+    PartitionByKey,
+    PartitionMaxSize,
+    PartitionParted,
+)
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.testing.parametric.strategies import dataframes
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from polars.io.partition import (
+        BasePartitionContext,
+    )
 
 
 class IOType(TypedDict):
@@ -44,7 +52,7 @@ def test_max_size_partition(
 
     (io_type["sink"])(
         lf,
-        PartitionMaxSize(tmp_path / f"{{part}}.{io_type['ext']}", max_size=max_size),
+        PartitionMaxSize(tmp_path, max_size=max_size),
         engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on
         # one thread is immediately visible on another thread.
@@ -65,6 +73,41 @@ def test_max_size_partition(
 
 
 @pytest.mark.parametrize("io_type", io_types)
+def test_max_size_partition_lambda(
+    tmp_path: Path,
+    io_type: IOType,
+) -> None:
+    length = 17
+    max_size = 3
+    lf = pl.Series("a", range(length), pl.Int64).to_frame().lazy()
+
+    (io_type["sink"])(
+        lf,
+        PartitionMaxSize(
+            tmp_path,
+            file_path=lambda ctx: "abc-" + ctx.unmodified_path,
+            max_size=max_size,
+        ),
+        engine="streaming",
+        # We need to sync here because platforms do not guarantee that a close on
+        # one thread is immediately visible on another thread.
+        #
+        # "Multithreaded processes and close()"
+        # https://man7.org/linux/man-pages/man2/close.2.html
+        sync_on_close="data",
+    )
+
+    i = 0
+    while length > 0:
+        assert (io_type["scan"])(tmp_path / f"abc-{i}.{io_type['ext']}").select(
+            pl.len()
+        ).collect()[0, 0] == min(max_size, length)
+
+        length -= max_size
+        i += 1
+
+
+@pytest.mark.parametrize("io_type", io_types)
 @pytest.mark.write_disk
 def test_partition_by_key(
     tmp_path: Path,
@@ -74,7 +117,7 @@ def test_partition_by_key(
 
     (io_type["sink"])(
         lf,
-        PartitionByKey(tmp_path / f"{{part}}.{io_type['ext']}", by="a"),
+        PartitionByKey(tmp_path, lambda ctx: f"{ctx.part}.{io_type['ext']}", by="a"),
         engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on
         # one thread is immediately visible on another thread.
@@ -152,7 +195,9 @@ def test_partition_parted(
 
     (io_type["sink"])(
         lf,
-        PartitionParted(tmp_path / f"{{part}}.{io_type['ext']}", by="a"),
+        PartitionParted(
+            tmp_path, file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}", by="a"
+        ),
         engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on
         # one thread is immediately visible on another thread.
@@ -180,7 +225,8 @@ def test_partition_parted(
     (io_type["sink"])(
         lf,
         PartitionParted(
-            tmp_path / f"{{part}}.{io_type['ext']}",
+            tmp_path,
+            file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}",
             by=[pl.col.a, pl.col.a.cast(pl.String()).alias("a_str")],
         ),
         engine="streaming",
@@ -204,7 +250,8 @@ def test_partition_parted(
     (io_type["sink"])(
         lf,
         PartitionParted(
-            tmp_path / f"{{part}}.{io_type['ext']}",
+            tmp_path,
+            file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}",
             by=[pl.col.a.cast(pl.String()).alias("a_str")],
             include_key=False,
         ),
@@ -243,7 +290,9 @@ def test_partition_by_key_parametric(
     dfs = df.partition_by(col1)
     (io_type["sink"])(
         df.lazy(),
-        PartitionByKey(tmp_path / f"{{part}}.{io_type['ext']}", by=col1),
+        PartitionByKey(
+            tmp_path, file_path=lambda ctx: f"{ctx.part}.{io_type['ext']}", by=col1
+        ),
         engine="streaming",
         # We need to sync here because platforms do not guarantee that a close on
         # one thread is immediately visible on another thread.
@@ -260,3 +309,31 @@ def test_partition_by_key_parametric(
                 tmp_path / f"{i}.{io_type['ext']}",
             ).collect(),
         )
+
+
+@pytest.mark.parametrize("io_type", io_types)
+def test_max_size_partition_collect_files(tmp_path: Path) -> None:
+    length = 17
+    max_size = 3
+    lf = pl.Series("a", range(length), pl.Int64).to_frame().lazy()
+
+    io_type = io_types[0]
+    output_files = []
+
+    def file_path_cb(ctx: BasePartitionContext) -> Path:
+        output_files.append(ctx.full_path)
+        return ctx.file_path
+
+    (io_type["sink"])(
+        lf,
+        PartitionMaxSize(tmp_path, file_path=file_path_cb, max_size=max_size),
+        engine="streaming",
+        # We need to sync here because platforms do not guarantee that a close on
+        # one thread is immediately visible on another thread.
+        #
+        # "Multithreaded processes and close()"
+        # https://man7.org/linux/man-pages/man2/close.2.html
+        sync_on_close="data",
+    )
+
+    assert output_files == [tmp_path / f"{i}.{io_type['ext']}" for i in range(6)]


### PR DESCRIPTION
This PR makes a breaking change to the currently unstable API for `PartitionMaxSize`, `PartitionByKey` and `PartitionParted`.

> [!TIP]
> **TLDR**: You now provide a `base_path` an optional `file_path` callback. This allows a type-checked, more flexible and pythonic API.

This essentially exchanges the previous adhoc implementation with a more permanent one. This allows for way more flexibility and possibilities around creating files.

```python
# Before: 
lf.sink_parquet(PartitionMaxSize('./{part}.parquet'))

# Now:
lf.sink_parquet(PartitionMaxSize('./'))
```

You now modify the path per file with a callback.

```python
lf.sink_parquet(PartitionByKey(
    './',
    file_path=lambda ctx: f"{ctx.keys[0].str_value}.parquet",
    by="year",
))
```

Fixes #21886.
Fixes #21868.
Fixes #21848.