### PR TITLE
fix: Allow `pivot` on empty frame for all integer index dtypes

### DIFF
--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -76,6 +76,10 @@ fn restore_logical_type(s: &Series, logical_type: &DataType) -> Series {
             let ca = s.u32().unwrap();
             ca.reinterpret_signed().cast(logical_type).unwrap()
         },
+        (dt, DataType::Null) => {
+            let ca = Series::full_null(s.name().clone(), s.len(), dt);
+            ca.into_series()
+        },
         _ => unsafe { s.from_physical_unchecked(logical_type).unwrap() },
     }
 }

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -7,11 +7,12 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars.datatypes.group import INTEGER_DTYPES
 from polars.exceptions import ComputeError, DuplicateError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars._typing import PivotAgg
+    from polars._typing import PivotAgg, PolarsIntegerType
 
 
 def test_pivot() -> None:
@@ -561,3 +562,12 @@ def test_pivot_invalid() -> None:
         match="`index` and `values` cannot both be None in `pivot` operation",
     ):
         pl.DataFrame({"a": [1, 2], "b": [2, 3], "c": [3, 4]}).pivot("a")
+
+
+@pytest.mark.parametrize("dtype", INTEGER_DTYPES)
+def test_pivot_empty_index_dtypes(dtype: PolarsIntegerType) -> None:
+    index = pl.Series([], dtype=dtype)
+    df = pl.DataFrame({"index": index, "on": [], "values": []})
+    result = df.pivot(index="index", on="on", values="values")
+    expected = pl.DataFrame({"index": index})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -564,7 +564,7 @@ def test_pivot_invalid() -> None:
         pl.DataFrame({"a": [1, 2], "b": [2, 3], "c": [3, 4]}).pivot("a")
 
 
-@pytest.mark.parametrize("dtype", INTEGER_DTYPES)
+@pytest.mark.parametrize("dtype", list(INTEGER_DTYPES))
 def test_pivot_empty_index_dtypes(dtype: PolarsIntegerType) -> None:
     index = pl.Series([], dtype=dtype)
     df = pl.DataFrame({"index": index, "on": [], "values": []})

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -7,7 +7,6 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.datatypes.group import INTEGER_DTYPES
 from polars.exceptions import ComputeError, DuplicateError
 from polars.testing import assert_frame_equal
 
@@ -564,7 +563,10 @@ def test_pivot_invalid() -> None:
         pl.DataFrame({"a": [1, 2], "b": [2, 3], "c": [3, 4]}).pivot("a")
 
 
-@pytest.mark.parametrize("dtype", list(INTEGER_DTYPES))
+@pytest.mark.parametrize(
+    "dtype",
+    [pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64],
+)
 def test_pivot_empty_index_dtypes(dtype: PolarsIntegerType) -> None:
     index = pl.Series([], dtype=dtype)
     df = pl.DataFrame({"index": index, "on": [], "values": []})


### PR DESCRIPTION
Fixes #21869.