### PR TITLE
fix: Type hint of `cs.exclude()` is `SelectorType` instead of `Expr`

### DIFF
--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -1850,7 +1850,7 @@ def exclude(
         | Collection[str | PolarsDataType | SelectorType | Expr]
     ),
     *more_columns: str | PolarsDataType | SelectorType | Expr,
-) -> Expr:
+) -> SelectorType:
     """
     Select all columns except those matching the given columns, datatypes, or selectors.
 


### PR DESCRIPTION
Mentioned in #https://github.com/pola-rs/polars/issues/21585

Most other selectors return `SelectorType` so I don't see why this one shouldn't.