### PR TITLE
fix(python): Use absolute paths by defaults for plugins

### DIFF
--- a/py-polars/polars/plugins.py
+++ b/py-polars/polars/plugins.py
@@ -33,7 +33,7 @@ def register_plugin_function(
     cast_to_supertype: bool = False,
     input_wildcard_expansion: bool = False,
     pass_name_to_apply: bool = False,
-    use_abs_path: bool = False,
+    use_abs_path: bool = True,
 ) -> Expr:
     """
     Register a plugin function.


### PR DESCRIPTION
In the current state plugins don't work, because `dlopen` searches for relative paths with respect to the current directory, which is usually not the same as the virtual env root directory (and in general I don't think we should assume something about what the current working directory is).
For now I changed the default of `use_abs_path` to `True` as a quick bugfix, maybe there is a way to solve it using some `dlopen` tricks (some smart usage of `LD_LIBRARY_PATH` or such?), but I couldn't get it to work.