### PR TITLE
fix(python): Relative path resolution for plugin libraries

### DIFF
--- a/py-polars/polars/plugins.py
+++ b/py-polars/polars/plugins.py
@@ -148,7 +148,9 @@ def _resolve_file_path(path: Path, *, use_abs_path: bool = False) -> Path:
         return path.resolve()
     else:
         try:
-            relpath = path.relative_to(venv_path)
+            relpath = path.relative_to(
+                venv_path.parent
+            )  # relative path should resolve to the parent of the venv
         except (
             ValueError
         ):  # If the path is not inside the venv use absolute path instead

--- a/py-polars/tests/unit/test_plugins.py
+++ b/py-polars/tests/unit/test_plugins.py
@@ -60,7 +60,8 @@ def test_resolve_plugin_path(tmp_path: Path, use_abs_path: bool) -> None:
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(sys, "prefix", str(mock_venv))
         expected_full_path = mock_venv_lib / "lib1.so"
-        expected_relative_path = expected_full_path.relative_to(mock_venv)
+        venv_parent = mock_venv.parent
+        expected_relative_path = expected_full_path.relative_to(venv_parent)
 
         if use_abs_path:
             result = _resolve_plugin_path(mock_venv_lib, use_abs_path=use_abs_path)


### PR DESCRIPTION
My PR #21675 calculates plugin path as relative to `sys.prefix`. This misses the root of the virtual environment. The relative path should instead be calculated using the parent of `sys.prefix`