### PR TITLE
fix(python): Limit number of threads, in order to run tests faster

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -31,6 +31,10 @@ env:
   CARGO_LLVM_COV_TARGET_DIR: ${{ github.workspace }}/target
   # We use the stable ABI, silences error from PyO3 that the system Python is too new.
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
+  # For a CPU with N cores, `pytest -n auto` runs N threads, and by default
+  # Polars starts N threads. That means N×N threads, which is a lot of extra
+  # time fighting over only N cores. So we limit to 2×N cores.
+  POLARS_MAX_THREADS: 2
 
 jobs:
   coverage-rust:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,6 +26,10 @@ env:
   RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
   RUST_BACKTRACE: 1
   PYTHONUTF8: 1
+  # For a CPU with N cores, `pytest -n auto` runs N threads, and by default
+  # Polars starts N threads. That means N×N threads, which is a lot of extra
+  # time fighting over only N cores. So we limit to 2×N cores.
+  POLARS_MAX_THREADS: 2
 
 defaults:
   run:


### PR DESCRIPTION
Given runner with N cores, run Python tests with 2×N threads instead of N² threads, to reduce contention and overly small chunks.

In theory this should speed up Python test run times.