### PR TITLE
refactor(rust): Add updated multiscan pipeline

### DIFF
--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -471,6 +471,10 @@ pub struct ScanIOPredicate {
 }
 impl ScanIOPredicate {
     pub fn set_external_constant_columns(&mut self, constant_columns: Vec<(PlSmallStr, Scalar)>) {
+        if constant_columns.is_empty() {
+            return;
+        }
+
         let mut live_columns = self.live_columns.as_ref().clone();
         for (c, _) in constant_columns.iter() {
             live_columns.swap_remove(c);

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -100,6 +100,14 @@ impl ScanSource {
     pub fn run_async(&self) -> bool {
         self.as_scan_source_ref().run_async()
     }
+
+    pub fn is_cloud_url(&self) -> bool {
+        if let ScanSource::Path(path) = self {
+            polars_io::is_cloud_url(path.as_ref())
+        } else {
+            false
+        }
+    }
 }
 
 /// An iterator for [`ScanSources`]

--- a/crates/polars-plan/src/plans/hive.rs
+++ b/crates/polars-plan/src/plans/hive.rs
@@ -102,6 +102,12 @@ impl HivePartitionsDf {
     }
 }
 
+impl From<DataFrame> for HivePartitionsDf {
+    fn from(value: DataFrame) -> Self {
+        Self(value)
+    }
+}
+
 /// Note: Returned hive partitions are ordered by their position in the `reader_schema`
 ///
 /// # Safety

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/apply.rs
@@ -12,6 +12,7 @@ use polars_io::predicates::ScanIOPredicate;
 use polars_plan::dsl::ScanSource;
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_utils::IdxSize;
+use polars_utils::slice_enum::Slice;
 
 use super::ExtraOperations;
 use super::cast_columns::CastColumns;
@@ -37,6 +38,7 @@ pub enum ApplyExtraOps {
     Initialized {
         // Note: These fields are ordered according to when they (should be) applied.
         row_index: Option<RowIndex>,
+        pre_slice: Option<Slice>,
         cast_columns: Option<CastColumns>,
         /// This will have include_file_paths, hive columns, missing columns.
         extra_columns: Vec<ScalarColumn>,
@@ -75,8 +77,10 @@ impl ApplyExtraOps {
                 scan_source_idx,
                 hive_parts,
             } => {
-                // This should always be pushed to the reader, or otherwise handled separately.
-                assert!(pre_slice.is_none());
+                // Negative slice should have been resolved earlier.
+                if let Some(Slice::Negative { .. }) = pre_slice {
+                    panic!("impl error: negative pre_slice at post")
+                }
 
                 let cast_columns = CastColumns::try_init_from_policy(
                     cast_columns_policy,
@@ -126,6 +130,7 @@ impl ApplyExtraOps {
 
                 let mut slf = Self::Initialized {
                     row_index,
+                    pre_slice,
                     cast_columns,
                     extra_columns,
                     predicate,
@@ -166,6 +171,7 @@ impl ApplyExtraOps {
                 let slf = match slf {
                     Initialized {
                         row_index: None,
+                        pre_slice: None,
                         cast_columns: None,
                         extra_columns,
                         predicate: None,
@@ -191,6 +197,7 @@ impl ApplyExtraOps {
     ) -> PolarsResult<()> {
         let Self::Initialized {
             row_index,
+            pre_slice,
             cast_columns,
             extra_columns,
             predicate,
@@ -216,6 +223,17 @@ impl ApplyExtraOps {
                     df.height(),
                 )?)
             };
+        }
+
+        if let Some(pre_slice) = pre_slice.clone() {
+            let Slice::Positive { offset, len } = pre_slice
+                .offsetted(usize::try_from(current_row_position).unwrap())
+                .restrict_to_bounds(df.height())
+            else {
+                unreachable!()
+            };
+
+            *df = df.slice(i64::try_from(offset).unwrap(), len)
         }
 
         if let Some(cast_columns) = cast_columns {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
@@ -52,8 +52,6 @@ impl MultiScanTaskInitializer {
         let background_tasks_handle = AbortOnDropHandle::new(async_executor::spawn(
             TaskPriority::Low,
             async move {
-                // Note: We don't mutate `self.config` and we don't use it at runtime. All resolved
-                // information become variables in this scope.
                 let (skip_files_mask, predicate) = self.initialize_predicate()?;
 
                 if verbose {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
@@ -1,0 +1,117 @@
+pub mod predicate;
+pub mod slice;
+
+use std::sync::{Arc, Mutex};
+
+use polars_error::PolarsResult;
+
+use super::MultiFileReaderConfig;
+use super::bridge::BridgeState;
+use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
+use crate::async_primitives::connector::{self};
+use crate::async_primitives::wait_group::WaitToken;
+use crate::morsel::Morsel;
+use crate::nodes::io_sources::multi_file_reader::bridge::spawn_bridge;
+
+pub struct MultiScanTaskInitializer {
+    pub(super) config: Arc<MultiFileReaderConfig>,
+}
+
+impl MultiScanTaskInitializer {
+    pub fn new(config: Arc<MultiFileReaderConfig>) -> Self {
+        Self { config }
+    }
+
+    #[expect(clippy::type_complexity)]
+    pub fn spawn_background_tasks(
+        self,
+    ) -> (
+        AbortOnDropHandle<PolarsResult<()>>,
+        connector::Sender<(connector::Sender<Morsel>, WaitToken)>,
+        Arc<Mutex<BridgeState>>,
+    ) {
+        assert!(self.config.num_pipelines() > 0);
+        let verbose = self.config.verbose();
+
+        if verbose {
+            eprintln!(
+                "[MultiScanTaskInitializer]: spawn_background_tasks(), {} sources, reader name: {}, {:?}",
+                self.config.sources.len(),
+                self.config.file_reader_builder.reader_name(),
+                self.config.file_reader_builder.reader_capabilities(),
+            )
+        }
+
+        let bridge_state = Arc::new(Mutex::new(BridgeState::NotYetStarted));
+
+        let (bridge_handle, bridge_recv_port_tx, send_phase_chan_to_bridge) =
+            spawn_bridge(bridge_state.clone());
+
+        let verbose = self.config.verbose();
+
+        let background_tasks_handle = AbortOnDropHandle::new(async_executor::spawn(
+            TaskPriority::Low,
+            async move {
+                // Note: We don't mutate `self.config` and we don't use it at runtime. All resolved
+                // information become variables in this scope.
+                let (skip_files_mask, predicate) = self.initialize_predicate()?;
+
+                if verbose {
+                    eprintln!(
+                        "[MultiScanTaskInitializer]: \
+                        predicate: {:?}, \
+                        skip files mask: {:?}, \
+                        predicate to reader: {:?}",
+                        self.config.predicate.is_some().then_some("<predicate>"),
+                        skip_files_mask.is_some().then_some("<skip_files>"),
+                        predicate.is_some().then_some("<predicate>"),
+                    )
+                }
+
+                #[expect(clippy::never_loop)]
+                loop {
+                    if skip_files_mask
+                        .as_ref()
+                        .is_some_and(|x| x.unset_bits() == 0)
+                    {
+                        if verbose {
+                            eprintln!(
+                                "[MultiScanTaskInitializer]: early return (skip_files_mask / predicate)"
+                            )
+                        }
+                    } else if self.config.pre_slice.as_ref().is_some_and(|x| x.len() == 0) {
+                        if cfg!(debug_assertions) {
+                            panic!("should quit earlier");
+                        }
+
+                        if verbose {
+                            eprintln!(
+                                "[MultiScanTaskInitializer]: early return (pre_slice.len == 0)"
+                            )
+                        }
+                    } else {
+                        break;
+                    }
+
+                    return Ok(());
+                }
+
+                let predicate = predicate.cloned();
+
+                self.init_and_run(bridge_recv_port_tx, skip_files_mask, predicate)
+                    .await?
+                    .await?;
+
+                bridge_handle.await;
+
+                Ok(())
+            },
+        ));
+
+        (
+            background_tasks_handle,
+            send_phase_chan_to_bridge,
+            bridge_state,
+        )
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
@@ -1,0 +1,32 @@
+use arrow::bitmap::Bitmap;
+use polars_error::PolarsResult;
+use polars_io::predicates::ScanIOPredicate;
+
+use super::MultiScanTaskInitializer;
+
+impl MultiScanTaskInitializer {
+    /// # Returns
+    /// `(skip_files_mask, scan_predicate)`
+    ///
+    /// TODO: Move logic here, rename to `evaluate_on_constant_columns`.
+    pub fn initialize_predicate(&self) -> PolarsResult<(Option<Bitmap>, Option<&ScanIOPredicate>)> {
+        if let Some(predicate) = &self.config.predicate {
+            if let Some(hive_parts) = self.config.hive_parts.as_ref() {
+                let (skip_files_mask, need_pred_for_inner_readers) =
+                    crate::nodes::io_sources::multi_scan::scan_predicate_to_mask(
+                        predicate,
+                        self.config.projected_file_schema.as_ref(),
+                        hive_parts.schema(),
+                        hive_parts,
+                    )?;
+
+                return Ok((
+                    skip_files_mask,
+                    need_pred_for_inner_readers.then_some(predicate),
+                ));
+            }
+        }
+
+        Ok((None, self.config.predicate.as_ref()))
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
@@ -154,8 +154,7 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
 
     let scan_source_idx = config.sources.len() - n_files_from_end;
     let initialized_readers = Some((scan_source_idx, initialized_readers));
-    let resolved_slice =
-        pre_slice.restrict_to_bounds(usize::try_from(n_rows_seen).unwrap_or(usize::MAX));
+    let resolved_slice = pre_slice.restrict_to_bounds(usize::try_from(n_rows_seen).unwrap());
 
     if verbose {
         eprintln!(

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
@@ -1,0 +1,200 @@
+use std::collections::VecDeque;
+
+use futures::StreamExt;
+use polars_error::PolarsResult;
+use polars_io::RowIndex;
+use polars_utils::IdxSize;
+use polars_utils::slice_enum::Slice;
+
+use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
+use crate::nodes::io_sources::multi_file_reader::MultiFileReaderConfig;
+use crate::nodes::io_sources::multi_file_reader::reader_interface::FileReader;
+
+pub struct ResolvedSliceInfo {
+    pub scan_source_idx: usize,
+    pub row_index: Option<RowIndex>,
+    /// This should always be positive slice.
+    pub pre_slice: Option<Slice>,
+    /// If we resolved a negative slice we keep the initialized readers here (with a limit). For
+    /// Parquet this can save a duplicate metadata fetch/decode.
+    ///
+    /// This will be in-order - i.e. `pop_front()` corresponds to the next reader.
+    #[expect(clippy::type_complexity)]
+    pub initialized_readers: Option<(usize, VecDeque<(Box<dyn FileReader>, IdxSize)>)>,
+}
+
+pub async fn resolve_to_positive_slice(
+    config: &MultiFileReaderConfig,
+) -> PolarsResult<ResolvedSliceInfo> {
+    match config.pre_slice.clone() {
+        None => Ok(ResolvedSliceInfo {
+            scan_source_idx: 0,
+            row_index: config.row_index.clone(),
+            pre_slice: None,
+            initialized_readers: None,
+        }),
+
+        pre_slice @ Some(Slice::Positive { .. }) => Ok(ResolvedSliceInfo {
+            scan_source_idx: 0,
+            row_index: config.row_index.clone(),
+            pre_slice,
+            initialized_readers: None,
+        }),
+
+        Some(_) => resolve_negative_slice(config).await,
+    }
+}
+
+/// Translates a negative slice to positive slice.
+async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<ResolvedSliceInfo> {
+    let verbose = config.verbose();
+
+    let pre_slice @ Slice::Negative {
+        offset_from_end,
+        len: slice_len,
+    } = config.pre_slice.clone().unwrap()
+    else {
+        unreachable!()
+    };
+
+    if verbose {
+        eprintln!(
+            "resolve_negative_slice(): {:?}",
+            Slice::Negative {
+                offset_from_end,
+                len: slice_len,
+            }
+        )
+    }
+
+    // Avoid traversal if we have no len.
+    if slice_len == 0 {
+        return Ok(ResolvedSliceInfo {
+            scan_source_idx: config.sources.len(),
+            row_index: config.row_index.clone(),
+            pre_slice: Some(Slice::Positive { offset: 0, len: 0 }),
+            initialized_readers: None,
+        });
+    }
+
+    let mut initialized_readers = VecDeque::with_capacity(
+        config
+            .sources
+            .len()
+            .min(config.num_pipelines().saturating_add(4)),
+    );
+
+    let mut readers_init_iter = futures::stream::iter((0..config.sources.len()).rev())
+        .map(|scan_source_idx| {
+            let sources = config.sources.clone();
+            let cloud_options = config.cloud_options.clone();
+            let file_reader_builder = config.file_reader_builder.clone();
+
+            AbortOnDropHandle::new(async_executor::spawn(TaskPriority::Low, async move {
+                let mut reader =
+                    sources
+                        .get(scan_source_idx)
+                        .unwrap()
+                        .into_owned()
+                        .map(|source| {
+                            file_reader_builder.build_file_reader(source, cloud_options.clone())
+                        })?;
+
+                if verbose {
+                    eprintln!(
+                        "resolve_negative_slice(): init scan source {}",
+                        scan_source_idx
+                    );
+                }
+
+                reader.initialize().await?;
+                PolarsResult::Ok(reader)
+            }))
+        })
+        .buffered(config.n_readers_pre_init.min(config.sources.len()));
+
+    let n_rows_needed = IdxSize::try_from(offset_from_end).unwrap();
+    let slice_len_idxsize = IdxSize::try_from(slice_len).unwrap_or(IdxSize::MAX);
+
+    let mut n_rows_seen: IdxSize = 0;
+    let mut n_rows_trimmed: IdxSize = 0;
+    let mut n_files_from_end: usize = 0;
+
+    while let Some(file_reader) = readers_init_iter.next().await.transpose()? {
+        let n_rows = file_reader.n_rows_in_file().await?;
+
+        // push_front: we are walking in reverse
+        initialized_readers.push_front((file_reader, n_rows));
+
+        n_rows_seen = n_rows_seen.saturating_add(n_rows);
+        n_files_from_end += 1;
+
+        let n_rows_this_file = n_rows;
+
+        // Trim readers from end that are already past slice_len.
+        while initialized_readers.len() > 1 {
+            // `current_rows_held` we exclude the latest file, as the slice offset could begin
+            // from any position within that file, meaning that the file could have extra rows
+            // that do not contribute to the slice_len.
+            let current_rows_held = n_rows_seen - n_rows_trimmed.saturating_add(n_rows_this_file);
+            let extra_rows_held = current_rows_held.saturating_sub(slice_len_idxsize);
+
+            if extra_rows_held < initialized_readers.back().unwrap().1 {
+                break;
+            }
+
+            n_rows_trimmed =
+                n_rows_trimmed.saturating_add(initialized_readers.pop_back().unwrap().1)
+        }
+
+        if n_rows_seen >= n_rows_needed {
+            break;
+        }
+    }
+
+    let scan_source_idx = config.sources.len() - n_files_from_end;
+    let initialized_readers = Some((scan_source_idx, initialized_readers));
+    let resolved_slice =
+        pre_slice.restrict_to_bounds(usize::try_from(n_rows_seen).unwrap_or(usize::MAX));
+
+    if verbose {
+        eprintln!(
+            "resolve_negative_slice(): resolved to {:?}",
+            &resolved_slice,
+        );
+    }
+
+    if slice_len == 0 {
+        return Ok(ResolvedSliceInfo {
+            scan_source_idx: config.sources.len(),
+            row_index: config.row_index.clone(),
+            pre_slice: Some(Slice::Positive { offset: 0, len: 0 }),
+            initialized_readers: None,
+        });
+    }
+
+    let mut row_index = config.row_index.clone();
+
+    if let Some(row_index) = row_index.as_mut() {
+        if verbose {
+            eprintln!("resolve_negative_slice(): continuing scan to resolve row index");
+        }
+
+        let mut n_rows_skipped_from_start: IdxSize = 0;
+
+        // Fully traverse to the beginning to update the row index offset.
+        while let Some(reader) = readers_init_iter.next().await.transpose()? {
+            let n_rows = reader.n_rows_in_file().await?;
+            n_rows_skipped_from_start = n_rows_skipped_from_start.saturating_add(n_rows);
+        }
+
+        row_index.offset = row_index.offset.saturating_add(n_rows_skipped_from_start);
+    }
+
+    Ok(ResolvedSliceInfo {
+        scan_source_idx,
+        row_index,
+        pre_slice: Some(resolved_slice),
+        initialized_readers,
+    })
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
@@ -120,7 +120,7 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
     let mut n_rows_trimmed: IdxSize = 0;
     let mut n_files_from_end: usize = 0;
 
-    while let Some(file_reader) = readers_init_iter.next().await.transpose()? {
+    while let Some(mut file_reader) = readers_init_iter.next().await.transpose()? {
         let n_rows = file_reader.n_rows_in_file().await?;
 
         // push_front: we are walking in reverse
@@ -182,7 +182,7 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
         let mut n_rows_skipped_from_start: IdxSize = 0;
 
         // Fully traverse to the beginning to update the row index offset.
-        while let Some(reader) = readers_init_iter.next().await.transpose()? {
+        while let Some(mut reader) = readers_init_iter.next().await.transpose()? {
             let n_rows = reader.n_rows_in_file().await?;
             n_rows_skipped_from_start = n_rows_skipped_from_start.saturating_add(n_rows);
         }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/mod.rs
@@ -1,6 +1,325 @@
-#[expect(unused)]
 pub mod bridge;
-#[expect(unused)]
 pub mod extra_ops;
+pub mod initialization;
+pub mod post_apply_pipeline;
 #[expect(unused)]
 pub mod reader_interface;
+pub mod reader_pipelines;
+
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Arc, Mutex};
+
+use bridge::BridgeState;
+use initialization::MultiScanTaskInitializer;
+use polars_core::config;
+use polars_core::schema::SchemaRef;
+use polars_error::PolarsResult;
+use polars_io::cloud::CloudOptions;
+use polars_io::predicates::ScanIOPredicate;
+use polars_io::{RowIndex, pl_async};
+use polars_plan::dsl::ScanSources;
+use polars_plan::plans::hive::HivePartitionsDf;
+use polars_utils::format_pl_smallstr;
+use polars_utils::pl_str::PlSmallStr;
+use polars_utils::slice_enum::Slice;
+use reader_interface::builder::FileReaderBuilder;
+
+use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
+use crate::async_primitives::connector;
+use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
+use crate::execute::StreamingExecutionState;
+use crate::graph::PortState;
+use crate::morsel::Morsel;
+use crate::nodes::ComputeNode;
+
+// Some parts are called MultiFileReader for now to avoid conflict with existing MultiScan.
+
+pub struct MultiFileReaderConfig {
+    sources: ScanSources,
+    file_reader_builder: Arc<dyn FileReaderBuilder>,
+    cloud_options: Option<Arc<CloudOptions>>,
+
+    /// Final output schema of MultiScan node. Includes all e.g. row index / missing columns / file paths / hive etc.
+    final_output_schema: SchemaRef,
+    /// Columns to be projected from the file.
+    projected_file_schema: SchemaRef,
+    /// Full schema of the file. Used for complaining about extra columns.
+    full_file_schema: SchemaRef,
+
+    row_index: Option<RowIndex>,
+    pre_slice: Option<Slice>,
+    predicate: Option<ScanIOPredicate>,
+
+    hive_parts: Option<Arc<HivePartitionsDf>>,
+    include_file_paths: Option<PlSmallStr>,
+    allow_missing_columns: bool,
+
+    num_pipelines: AtomicUsize,
+    /// Number of readers to initialize concurrently. e.g. Parquet will want to fetch metadata in this
+    /// step.
+    n_readers_pre_init: usize,
+
+    verbose: AtomicBool,
+}
+
+impl MultiFileReaderConfig {
+    fn num_pipelines(&self) -> usize {
+        self.num_pipelines
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn verbose(&self) -> bool {
+        self.verbose.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+enum MultiScanState {
+    Uninitialized {
+        config: Arc<MultiFileReaderConfig>,
+    },
+
+    Initialized {
+        send_phase_tx_to_bridge: connector::Sender<(connector::Sender<Morsel>, WaitToken)>,
+        /// Wait group sent to the bridge, only dropped when a disconnect happens at the bridge.
+        wait_group: WaitGroup,
+        bridge_state: Arc<Mutex<BridgeState>>,
+        /// Single join handle for all background tasks. Note, this does not include the bridge.
+        join_handle: AbortOnDropHandle<PolarsResult<()>>,
+    },
+
+    Finished,
+}
+
+pub struct MultiFileReader {
+    name: PlSmallStr,
+    state: MultiScanState,
+    verbose: bool,
+}
+
+impl MultiFileReader {
+    #[expect(clippy::too_many_arguments)]
+    #[expect(unused)]
+    pub fn new(
+        sources: ScanSources,
+        file_reader_builder: Arc<dyn FileReaderBuilder>,
+        cloud_options: Option<Arc<CloudOptions>>,
+
+        final_output_schema: SchemaRef,
+        projected_file_schema: SchemaRef,
+        full_file_schema: SchemaRef,
+
+        row_index: Option<RowIndex>,
+        pre_slice: Option<Slice>,
+        predicate: Option<ScanIOPredicate>,
+
+        hive_parts: Option<Arc<HivePartitionsDf>>,
+        include_file_paths: Option<PlSmallStr>,
+        allow_missing_columns: bool,
+    ) -> Self {
+        let name = format_pl_smallstr!("MultiScan[{}]", file_reader_builder.reader_name());
+
+        MultiFileReader {
+            name,
+            state: MultiScanState::Uninitialized {
+                config: Arc::new(MultiFileReaderConfig {
+                    sources,
+                    file_reader_builder,
+                    cloud_options,
+                    final_output_schema,
+                    projected_file_schema,
+                    full_file_schema,
+                    row_index,
+                    pre_slice,
+                    predicate,
+                    hive_parts,
+                    include_file_paths,
+                    allow_missing_columns,
+                    num_pipelines: AtomicUsize::new(0),
+                    n_readers_pre_init: 3,
+                    verbose: AtomicBool::new(false),
+                }),
+            },
+            verbose: config::verbose(),
+        }
+    }
+}
+
+impl ComputeNode for MultiFileReader {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn update_state(
+        &mut self,
+        recv: &mut [crate::graph::PortState],
+        send: &mut [crate::graph::PortState],
+        _state: &StreamingExecutionState,
+    ) -> polars_error::PolarsResult<()> {
+        use MultiScanState::*;
+        assert!(recv.is_empty());
+        assert!(send.len() == 1);
+
+        send[0] = if send[0] == PortState::Done {
+            self.state = Finished;
+
+            PortState::Done
+        } else {
+            // Refresh first - in case there is an error we end here instead of ending when we go
+            // into spawn.
+            async_executor::task_scope(|s| {
+                pl_async::get_runtime()
+                    .block_on(s.spawn_task(TaskPriority::High, self.state.refresh(self.verbose)))
+            })?;
+
+            match self.state {
+                Uninitialized { .. } | Initialized { .. } => PortState::Ready,
+                Finished => PortState::Done,
+            }
+        };
+
+        Ok(())
+    }
+
+    fn spawn<'env, 's>(
+        &'env mut self,
+        scope: &'s crate::async_executor::TaskScope<'s, 'env>,
+        recv_ports: &mut [Option<crate::pipe::RecvPort<'_>>],
+        send_ports: &mut [Option<crate::pipe::SendPort<'_>>],
+        state: &StreamingExecutionState,
+        join_handles: &mut Vec<crate::async_executor::JoinHandle<polars_error::PolarsResult<()>>>,
+    ) {
+        assert!(recv_ports.is_empty() && send_ports.len() == 1);
+
+        let phase_morsel_tx = send_ports[0].take().unwrap().serial();
+        let num_pipelines = state.num_pipelines;
+        let verbose = self.verbose;
+
+        join_handles.push(scope.spawn_task(TaskPriority::Low, async move {
+            use MultiScanState::*;
+
+            self.state.initialize(num_pipelines, verbose);
+            self.state.refresh(verbose).await?;
+
+            match &mut self.state {
+                Uninitialized { .. } => unreachable!(),
+
+                Finished => return Ok(()),
+
+                Initialized {
+                    send_phase_tx_to_bridge,
+                    wait_group,
+                    ..
+                } => {
+                    use crate::async_primitives::connector::SendError;
+
+                    match send_phase_tx_to_bridge.try_send((phase_morsel_tx, wait_group.token())) {
+                        Ok(_) => wait_group.wait().await,
+
+                        // Should never: We only send the next value once the wait token is dropped.
+                        Err(SendError::Full(_)) => unreachable!(),
+
+                        // Bridge has disconnected from the reader side. We know this because
+                        // we are still holding `send_phase_tx_to_bridge`.
+                        Err(SendError::Closed(_)) => {
+                            if verbose {
+                                eprintln!("[MultiFileReader]: Bridge disconnected")
+                            }
+
+                            let Initialized { join_handle, .. } =
+                                std::mem::replace(&mut self.state, Finished)
+                            else {
+                                unreachable!()
+                            };
+
+                            join_handle.await?;
+
+                            return Ok(());
+                        },
+                    }
+                },
+            }
+
+            self.state.refresh(verbose).await
+        }));
+    }
+}
+
+impl MultiScanState {
+    /// Refresh the state. This checks the bridge state if `self` is initialized and updates accordingly.
+    async fn refresh(&mut self, verbose: bool) -> PolarsResult<()> {
+        use MultiScanState::*;
+        use bridge::StopReason;
+
+        // Take, so that if we error below the state will be left as finished.
+        let slf = std::mem::replace(self, MultiScanState::Finished);
+
+        let slf = match slf {
+            Uninitialized { .. } | Finished => slf,
+
+            #[expect(clippy::blocks_in_conditions)]
+            Initialized {
+                send_phase_tx_to_bridge,
+                wait_group,
+                bridge_state,
+                join_handle,
+            } => match { *bridge_state.lock().unwrap() } {
+                BridgeState::NotYetStarted | BridgeState::Running => Initialized {
+                    send_phase_tx_to_bridge,
+                    wait_group,
+                    bridge_state,
+                    join_handle,
+                },
+
+                // Never the case: holding `send_phase_tx_to_bridge` guarantees this.
+                BridgeState::Stopped(StopReason::ComputeNodeDisconnected) => unreachable!(),
+
+                // If we are disconnected from the reader side, it could mean an error. Joining on
+                // the handle should catch this.
+                BridgeState::Stopped(StopReason::ReadersDisconnected) => {
+                    if verbose {
+                        eprintln!("[MultiScanState]: Readers disconnected")
+                    }
+
+                    *self = Finished;
+                    join_handle.await?;
+                    Finished
+                },
+            },
+        };
+
+        *self = slf;
+
+        Ok(())
+    }
+
+    /// Initialize state if not yet initialized.
+    fn initialize(&mut self, num_pipelines: usize, verbose: bool) {
+        use MultiScanState::*;
+
+        let slf = std::mem::replace(self, Finished);
+
+        let Uninitialized { config } = slf else {
+            *self = slf;
+            return;
+        };
+
+        config
+            .num_pipelines
+            .store(num_pipelines, std::sync::atomic::Ordering::Relaxed);
+        config
+            .verbose
+            .store(verbose, std::sync::atomic::Ordering::Relaxed);
+
+        let (join_handle, send_phase_tx_to_bridge, bridge_state) =
+            MultiScanTaskInitializer::new(config).spawn_background_tasks();
+
+        let wait_group = WaitGroup::default();
+
+        *self = Initialized {
+            send_phase_tx_to_bridge,
+            wait_group,
+            bridge_state,
+            join_handle,
+        };
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/post_apply_pipeline/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/post_apply_pipeline/mod.rs
@@ -1,0 +1,229 @@
+use std::sync::Arc;
+
+use polars_error::PolarsResult;
+use polars_utils::IdxSize;
+
+use crate::async_executor::{self, AbortOnDropHandle, TaskPriority};
+use crate::async_primitives::distributor_channel::distributor_channel;
+use crate::async_primitives::morsel_linearizer::{MorselInserter, MorselLinearizer};
+use crate::async_primitives::{connector, distributor_channel};
+use crate::morsel::Morsel;
+use crate::nodes::io_sources::multi_file_reader::bridge::BridgeRecvPort;
+use crate::nodes::io_sources::multi_file_reader::extra_ops::apply::ApplyExtraOps;
+use crate::nodes::io_sources::multi_file_reader::reader_interface::output::FileReaderOutputRecv;
+
+/// Pool kept alive for the duration of MultiScan, reused across files.
+pub struct PostApplyPool {
+    workers: Vec<WorkerData>,
+    reader_in_progress: bool,
+}
+
+struct WorkerData {
+    task_data_tx: connector::Sender<TaskData>,
+    notify_success_rx: connector::Receiver<()>,
+    handle: AbortOnDropHandle<PolarsResult<()>>,
+}
+
+impl PostApplyPool {
+    pub fn new(num_pipelines: usize) -> Self {
+        let workers = (0..num_pipelines)
+            .map(|_| {
+                let (task_data_tx, task_data_rx) = connector::connector();
+                let (notify_success_tx, notify_success_rx) = connector::connector();
+
+                let handle = AbortOnDropHandle::new(async_executor::spawn(
+                    TaskPriority::Low,
+                    PostApplyWorker {
+                        rx: task_data_rx,
+                        notify_success: notify_success_tx,
+                    }
+                    .run(),
+                ));
+
+                WorkerData {
+                    task_data_tx,
+                    notify_success_rx,
+                    handle,
+                }
+            })
+            .collect();
+
+        Self {
+            workers,
+            reader_in_progress: false,
+        }
+    }
+
+    /// `wait_current_reader` should be awaited on afterwards to catch errors from this file.
+    ///
+    /// # Panics
+    /// Panics if called more than 2 times in succession without `wait_current_reader` in between.
+    pub async fn run_with_reader(
+        &mut self,
+        mut reader_port: FileReaderOutputRecv,
+        ops_applier: Arc<ApplyExtraOps>,
+        // We have this because initialization of `ops_applier` causes `reader_port` to have the
+        // first morsel consumed.
+        first_morsel: Morsel,
+    ) -> PolarsResult<BridgeRecvPort> {
+        assert!(
+            !self.reader_in_progress,
+            "previous reader still in progress"
+        );
+
+        let (mut distr_tx, distr_receivers) = distributor_channel(self.workers.len(), 1);
+
+        // Distributor
+        {
+            let ops_applier = ops_applier.clone();
+            async_executor::spawn(TaskPriority::Low, async move {
+                // Number of rows received from this reader.
+                let mut n_rows_received: IdxSize = 0;
+
+                let mut morsel = first_morsel;
+
+                // Should only run the pipeline if we have an operation we need to apply.
+                let ApplyExtraOps::Initialized { pre_slice, .. } = ops_applier.as_ref() else {
+                    unreachable!();
+                };
+
+                loop {
+                    let h = morsel.df().height();
+                    let h = IdxSize::try_from(h).unwrap_or(IdxSize::MAX);
+
+                    // We hit this if a reader does not support PRE_SLICE.
+                    if pre_slice.clone().is_some_and(|x| {
+                        x.offsetted(usize::try_from(n_rows_received).unwrap()).len() == 0
+                    }) {
+                        // Note: We do not return any flag indicating that we have reached end of slice
+                        // from this context. The read should be stopped on a higher level by using
+                        // the `row_position_on_end_tx` callback from the reader.
+                        break;
+                    }
+
+                    if distr_tx.send((morsel, n_rows_received)).await.is_err() {
+                        break;
+                    }
+
+                    n_rows_received = n_rows_received.saturating_add(h);
+
+                    let Ok(v) = reader_port.recv().await else {
+                        break;
+                    };
+
+                    morsel = v;
+                }
+            })
+        };
+
+        let (rx, senders) = MorselLinearizer::new(self.workers.len(), 1);
+
+        for (
+            WorkerData {
+                task_data_tx,
+                notify_success_rx: _,
+                handle,
+            },
+            (reader_morsel_rx, morsel_tx),
+        ) in self
+            .workers
+            .iter_mut()
+            .zip(distr_receivers.into_iter().zip(senders))
+        {
+            let ops_applier = ops_applier.clone();
+            use crate::async_primitives::connector::SendError;
+
+            match task_data_tx.try_send(TaskData {
+                reader_morsel_rx,
+                ops_applier,
+                morsel_tx,
+            }) {
+                Err(SendError::Full(_)) => panic!("impl error: worker rx port full"),
+                Err(SendError::Closed(_)) => return Err(handle.await.unwrap_err()),
+                Ok(_) => {},
+            }
+        }
+
+        self.reader_in_progress = true;
+
+        Ok(BridgeRecvPort::Linearized { rx })
+    }
+
+    pub async fn wait_current_reader(&mut self) -> PolarsResult<()> {
+        if !self.reader_in_progress {
+            return Ok(());
+        }
+
+        for WorkerData {
+            task_data_tx: _,
+            notify_success_rx,
+            handle,
+        } in self.workers.iter_mut()
+        {
+            if notify_success_rx.recv().await.is_err() {
+                return Err(handle.await.unwrap_err());
+            }
+        }
+
+        self.reader_in_progress = false;
+
+        Ok(())
+    }
+
+    /// Note: This should not be called if any other function previously returned an error.
+    pub async fn shutdown(self) -> PolarsResult<()> {
+        for WorkerData {
+            task_data_tx,
+            notify_success_rx,
+            handle,
+        } in self.workers.into_iter()
+        {
+            drop(task_data_tx);
+            drop(notify_success_rx);
+            handle.await?;
+        }
+
+        Ok(())
+    }
+}
+
+struct PostApplyWorker {
+    rx: connector::Receiver<TaskData>,
+    notify_success: connector::Sender<()>,
+}
+
+struct TaskData {
+    reader_morsel_rx: distributor_channel::Receiver<(Morsel, IdxSize)>,
+    ops_applier: Arc<ApplyExtraOps>,
+    morsel_tx: MorselInserter,
+}
+
+impl PostApplyWorker {
+    async fn run(self) -> PolarsResult<()> {
+        let PostApplyWorker {
+            mut rx,
+            mut notify_success,
+        } = self;
+
+        while let Ok(TaskData {
+            mut reader_morsel_rx,
+            ops_applier,
+            mut morsel_tx,
+        }) = rx.recv().await
+        {
+            while let Ok((mut morsel, row_offset)) = reader_morsel_rx.recv().await {
+                ops_applier.apply_to_df(morsel.df_mut(), row_offset)?;
+
+                if morsel_tx.insert(morsel).await.is_err() {
+                    break;
+                }
+            }
+
+            if notify_success.send(()).await.is_err() {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/post_apply_pipeline/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/post_apply_pipeline/mod.rs
@@ -12,7 +12,8 @@ use crate::nodes::io_sources::multi_file_reader::bridge::BridgeRecvPort;
 use crate::nodes::io_sources::multi_file_reader::extra_ops::apply::ApplyExtraOps;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::output::FileReaderOutputRecv;
 
-/// Pool kept alive for the duration of MultiScan, reused across files.
+/// Pool of workers to apply operations on morsels originating from a reader.
+/// Kept alive for the duration of the multiscan.
 pub struct PostApplyPool {
     workers: Vec<WorkerData>,
     reader_in_progress: bool,
@@ -57,7 +58,7 @@ impl PostApplyPool {
     /// `wait_current_reader` should be awaited on afterwards to catch errors from this file.
     ///
     /// # Panics
-    /// Panics if called more than 2 times in succession without `wait_current_reader` in between.
+    /// Panics if called twice without `wait_current_reader` in between.
     pub async fn run_with_reader(
         &mut self,
         mut reader_port: FileReaderOutputRecv,

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
@@ -7,7 +7,7 @@ bitflags! {
         ///
         /// Readers may want to implement this if they implement any of:
         /// * NEGATIVE_PRE_SLICE
-        /// * FILTER
+        /// * SPECIALIZED_FILTER
         ///
         /// If any of the above operations are requested alongside ROW_INDEX, they cannot be pushed
         /// into the reader if ROW_INDEX is not supported in the reader.

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
@@ -3,6 +3,15 @@ use bitflags::bitflags;
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub struct ReaderCapabilities: u8 {
+        /// ROW_INDEX: Readers may want to implement this if they implement any of:
+        /// * NEGATIVE_PRE_SLICE
+        /// * FILTER
+        ///
+        /// If any of the above operations are requested alongside ROW_INDEX, they cannot be pushed
+        /// into the reader if ROW_INDEX is not supported in the reader.
+        ///
+        /// ROW_INDEX will not be needed (or called) for PRE_SLICE, as it gets optimized to be applied
+        /// after the PRE_SLICE instead by adjusting the offset.
         const ROW_INDEX          = 1 << 0;
         const PRE_SLICE          = 1 << 1;
         const NEGATIVE_PRE_SLICE = 1 << 2;

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/capabilities.rs
@@ -3,7 +3,9 @@ use bitflags::bitflags;
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub struct ReaderCapabilities: u8 {
-        /// ROW_INDEX: Readers may want to implement this if they implement any of:
+        /// Supports attaching a row index column.
+        ///
+        /// Readers may want to implement this if they implement any of:
         /// * NEGATIVE_PRE_SLICE
         /// * FILTER
         ///
@@ -13,8 +15,14 @@ bitflags! {
         /// ROW_INDEX will not be needed (or called) for PRE_SLICE, as it gets optimized to be applied
         /// after the PRE_SLICE instead by adjusting the offset.
         const ROW_INDEX          = 1 << 0;
+
+        /// Supports slicing with offsets relative to the start of the file (i.e. `offset >= 0 / Slice::Positive`).
         const PRE_SLICE          = 1 << 1;
+
+        /// Supports slicing with offsets relative to the end of the file (i.e. `offset < 0 / Slice::Negative`)
         const NEGATIVE_PRE_SLICE = 1 << 2;
-        const FILTER             = 1 << 3;
+
+        /// Supports specialized filtering (e.g. through the use of metadata).
+        const SPECIALIZED_FILTER = 1 << 3;
     }
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -16,6 +16,7 @@ use polars_utils::slice_enum::Slice;
 use super::extra_ops::cast_columns::CastColumnsPolicy;
 use super::extra_ops::missing_columns::MissingColumnsPolicy;
 use crate::async_executor::JoinHandle;
+use crate::async_primitives::connector;
 
 /// Interface to read a single file
 #[async_trait]
@@ -36,7 +37,7 @@ pub trait FileReader: Send + Sync {
     /// Note: The default implementation of this dispatches to `begin_read`, so should not be
     /// called from there.
     async fn n_rows_in_file(&self) -> PolarsResult<IdxSize> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
+        let (tx, mut rx) = connector::connector();
 
         let (morsel_receivers, handle) = self.begin_read(BeginReadArgs {
             // Passing 0-0 slice indicates to the reader that we want the full row count, but it can
@@ -51,7 +52,7 @@ pub trait FileReader: Send + Sync {
 
         drop(morsel_receivers);
 
-        match rx.await {
+        match rx.recv().await {
             Ok(v) => Ok(v),
             // It is an impl error if nothing is returned on a non-error case.
             Err(_) => Err(handle.await.unwrap_err()),
@@ -66,7 +67,7 @@ pub trait FileReader: Send + Sync {
             return self.n_rows_in_file().await;
         }
 
-        let (tx, rx) = tokio::sync::oneshot::channel();
+        let (tx, mut rx) = connector::connector();
 
         let (mut morsel_receivers, handle) = self.begin_read(BeginReadArgs {
             pre_slice,
@@ -77,7 +78,7 @@ pub trait FileReader: Send + Sync {
             ..Default::default()
         })?;
 
-        // We are using the `row_position_on_end` callback, this means we must fully consume all of
+        // We are using the `n_rows_sent_tx` callback, this means we must fully consume all of
         // the morsels sent by the reader.
         //
         // Note:
@@ -86,7 +87,7 @@ pub trait FileReader: Send + Sync {
         //   from a non-zero offset.
         while morsel_receivers.recv().await.is_ok() {}
 
-        match rx.await {
+        match rx.recv().await {
             Ok(v) => Ok(v),
             // It is an impl error if nothing is returned on a non-error case.
             Err(_) => Err(handle.await.unwrap_err()),
@@ -108,7 +109,6 @@ pub struct BeginReadArgs {
     /// A reader may wish to use this if it is applying predicates.
     ///
     /// This can be ignored by the reader, as the policy is also applied in post.
-    #[expect(unused)]
     pub cast_columns_policy: CastColumnsPolicy,
     /// User-configured policy for when columns are not found in the file.
     ///
@@ -141,35 +141,59 @@ impl Default for BeginReadArgs {
     }
 }
 
-#[derive(Debug, Default)]
-/// We have this to avoid a footgun of accidentally swapping the arguments.
+/// Note, these are oneshot, but we are using the connector as tokio's oneshot channel deadlocks
+/// on our async runtime. Not sure exactly why, seems to be something to do with the waker.
+#[derive(Default)]
 pub struct FileReaderCallbacks {
     /// Full file schema
-    pub file_schema_tx: Option<tokio::sync::oneshot::Sender<SchemaRef>>,
+    pub file_schema_tx: Option<connector::Sender<SchemaRef>>,
 
     /// Callback for full row count. Avoid using this as it can trigger a full row count depending
-    /// on the source. Prefer instead to use `row_position_on_end`, which can be much faster.
+    /// on the source. Prefer instead to use `n_rows_sent_tx`, which can be much faster.
     ///
     /// Notes:
-    /// * All readers must ensure that this count is sent if requested, even if the output port
-    ///   closes prematurely, or a slice is sent.
+    /// * The reader must ensure that this count is sent if requested, even if the output port
+    ///   closes prematurely, or a slice is sent. This is unless the reader encounters an error.
     /// * Some readers will only send this after their output morsels to be fully consumed (or if
     ///   their output port is dropped), so you should not block morsel consumption on waiting for this.
-    pub n_rows_in_file_tx: Option<tokio::sync::oneshot::Sender<IdxSize>>,
+    pub n_rows_in_file_tx: Option<connector::Sender<IdxSize>>,
 
-    /// Returns the row position reached by this reader.
+    /// Callback that can either be the total row count of the file, or the number of rows that the
+    /// reader will have processed upon finishing if a slice was requested.
     ///
-    /// The returned value indicates how much of a requested slice was consumed (or the full row
-    /// count if there was none). This is only guaranteed to be the case if the morsels of this
-    /// reader are fully consumed (i.e. no premature stopping), and the reader finishes with an Ok(()) result.
+    /// This callback should be sent as soon as possible, as it can be a serial dependency for the
+    /// next reader.
     ///
-    /// In all other cases, the behavior is subject to reader-specific implementation details and is
-    /// generally not well-defined - i.e. it could be any of:
-    /// * An upfront calculated position based on the total row count
-    /// * An arbitrary position in the file where the reader is currently positioned
-    /// * Not sent at all
-    /// * etc.
-    pub row_position_on_end_tx: Option<tokio::sync::oneshot::Sender<IdxSize>>,
+    /// A reader that knows its total row count upfront will be able to send this value immediately
+    /// (e.g. Parquet). Other readers (e.g. CSV) would generally keep a counter of how many rows they
+    /// have seen and return this after finishing.
+    ///
+    /// The returned value is useful for determining how much of a requested slice is consumed by a reader.
+    /// It is more efficient than `n_rows_in_file_tx` as it allows the reader to stop early if it hits the
+    /// end of a requested slice.
+    pub row_position_on_end_tx: Option<connector::Sender<IdxSize>>,
+}
+
+impl std::fmt::Debug for FileReaderCallbacks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let FileReaderCallbacks {
+            file_schema_tx,
+            n_rows_in_file_tx,
+            row_position_on_end_tx,
+        } = self;
+
+        f.write_str(&format!(
+            "\
+        FileReaderCallbacks: \
+        file_schema_tx: {:?} \
+        n_rows_in_file_tx: {:?} \
+        row_position_on_end_tx: {:?} \
+        ",
+            file_schema_tx.as_ref().map(|_| ""),
+            n_rows_in_file_tx.as_ref().map(|_| ""),
+            row_position_on_end_tx.as_ref().map(|_| "")
+        ))
+    }
 }
 
 /// Calculate from a known total row count.

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -78,7 +78,7 @@ pub trait FileReader: Send + Sync {
             ..Default::default()
         })?;
 
-        // We are using the `n_rows_sent_tx` callback, this means we must fully consume all of
+        // We are using the `row_position_on_end_tx` callback, this means we must fully consume all of
         // the morsels sent by the reader.
         //
         // Note:
@@ -150,7 +150,7 @@ pub struct FileReaderCallbacks {
     pub file_schema_tx: Option<connector::Sender<SchemaRef>>,
 
     /// Callback for full row count. Avoid using this as it can trigger a full row count depending
-    /// on the source. Prefer instead to use `n_rows_sent_tx`, which can be much faster.
+    /// on the source. Prefer instead to use `row_position_on_end_tx`, which can be much faster.
     ///
     /// Notes:
     /// * The reader must ensure that this count is sent if requested, even if the output port

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -142,7 +142,8 @@ impl Default for BeginReadArgs {
 }
 
 /// Note, these are oneshot, but we are using the connector as tokio's oneshot channel deadlocks
-/// on our async runtime. Not sure exactly why, seems to be something to do with the waker.
+/// on our async runtime. Not sure exactly why - a task wakeup seems to be lost somewhere.
+/// (See https://github.com/pola-rs/polars/pull/21916).
 #[derive(Default)]
 pub struct FileReaderCallbacks {
     /// Full file schema

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -166,7 +166,8 @@ pub struct FileReaderCallbacks {
     ///
     /// Readers that know their total row count upfront can send this as a pre-calculated position
     /// in the file based on the requested slice (if any). Readers that don't have this information
-    /// may instead track their position in the file during reads and send this value after finishing.
+    /// may instead track their position in the file during reading and send this value after
+    /// finishing.
     ///
     /// The returned value is useful for determining how much of a requested slice is consumed by a reader.
     /// It is more efficient than `n_rows_in_file_tx` as it allows the reader to stop early if it hits the

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -81,7 +81,7 @@ pub trait FileReader: Send + Sync {
             ..Default::default()
         })?;
 
-        // We are using the `row_position_on_end_tx` callback, this means we must fully consume all of
+        // We are using the `row_position_on_end` callback, this means we must fully consume all of
         // the morsels sent by the reader.
         //
         // Note:

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_interface/mod.rs
@@ -28,7 +28,7 @@ pub trait FileReader: Send + Sync {
 
     /// Begin reading the file into morsels.
     fn begin_read(
-        &self,
+        &mut self,
         args: BeginReadArgs,
     ) -> PolarsResult<(FileReaderOutputRecv, JoinHandle<PolarsResult<()>>)>;
 
@@ -36,7 +36,7 @@ pub trait FileReader: Send + Sync {
     ///
     /// Note: The default implementation of this dispatches to `begin_read`, so should not be
     /// called from there.
-    async fn n_rows_in_file(&self) -> PolarsResult<IdxSize> {
+    async fn n_rows_in_file(&mut self) -> PolarsResult<IdxSize> {
         let (tx, mut rx) = connector::connector();
 
         let (morsel_receivers, handle) = self.begin_read(BeginReadArgs {
@@ -62,7 +62,10 @@ pub trait FileReader: Send + Sync {
     /// Returns the row position after applying a slice.
     ///
     /// This is essentially `n_rows_in_file`, but potentially with early stopping.
-    async fn row_position_after_slice(&self, pre_slice: Option<Slice>) -> PolarsResult<IdxSize> {
+    async fn row_position_after_slice(
+        &mut self,
+        pre_slice: Option<Slice>,
+    ) -> PolarsResult<IdxSize> {
         if pre_slice.is_none() {
             return self.n_rows_in_file().await;
         }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -449,7 +449,7 @@ impl ReaderStarter {
 
             // Note: We do set_external_columns later below to avoid blocking this loop.
             let predicate = if extra_ops_post.predicate.is_some()
-                && reader_capabilities.contains(ReaderCapabilities::FILTER)
+                && reader_capabilities.contains(ReaderCapabilities::SPECIALIZED_FILTER)
                 && extra_ops_post.row_index.is_none()
                 && extra_ops_post.pre_slice.is_none()
             {

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -343,7 +343,7 @@ impl ReaderStarter {
                 break;
             }
 
-            let Some((scan_source_idx, scan_source, reader, opt_n_rows_in_file)) =
+            let Some((scan_source_idx, scan_source, mut reader, opt_n_rows_in_file)) =
                 readers_init_iter.next().await.transpose()?
             else {
                 if verbose {
@@ -553,7 +553,7 @@ async fn start_reader_impl(
     let StartReaderArgsPerFile {
         scan_source,
         scan_source_idx,
-        reader,
+        mut reader,
         mut begin_read_args,
         extra_ops_post,
     } = args_this_file;

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -1,0 +1,774 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use arrow::bitmap::Bitmap;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use polars_core::prelude::{AnyValue, DataType};
+use polars_core::scalar::Scalar;
+use polars_core::schema::SchemaRef;
+use polars_error::PolarsResult;
+use polars_io::predicates::ScanIOPredicate;
+use polars_plan::dsl::ScanSource;
+use polars_plan::plans::hive::HivePartitionsDf;
+use polars_utils::IdxSize;
+use polars_utils::slice_enum::Slice;
+
+use crate::async_executor::{self, AbortOnDropHandle, JoinHandle, TaskPriority};
+use crate::async_primitives::connector;
+use crate::async_primitives::wait_group::{WaitGroup, WaitToken};
+use crate::morsel::Morsel;
+use crate::nodes::io_sources::multi_file_reader::bridge::BridgeRecvPort;
+use crate::nodes::io_sources::multi_file_reader::extra_ops::apply::ApplyExtraOps;
+use crate::nodes::io_sources::multi_file_reader::extra_ops::cast_columns::CastColumnsPolicy;
+use crate::nodes::io_sources::multi_file_reader::extra_ops::missing_columns::MissingColumnsPolicy;
+use crate::nodes::io_sources::multi_file_reader::extra_ops::{
+    ExtraOperations, SchemaNamesMatchPolicy,
+};
+use crate::nodes::io_sources::multi_file_reader::initialization::MultiScanTaskInitializer;
+use crate::nodes::io_sources::multi_file_reader::initialization::slice::{
+    ResolvedSliceInfo, resolve_to_positive_slice,
+};
+use crate::nodes::io_sources::multi_file_reader::post_apply_pipeline::PostApplyPool;
+use crate::nodes::io_sources::multi_file_reader::reader_interface::capabilities::ReaderCapabilities;
+use crate::nodes::io_sources::multi_file_reader::reader_interface::output::FileReaderOutputRecv;
+use crate::nodes::io_sources::multi_file_reader::reader_interface::{
+    BeginReadArgs, FileReader, FileReaderCallbacks,
+};
+use crate::nodes::io_sources::multi_scan::max_concurrent_scans;
+
+impl MultiScanTaskInitializer {
+    /// Generic reader pipeline that should work for all file types and configurations
+    pub async fn init_and_run(
+        self,
+        bridge_recv_port_tx: connector::Sender<BridgeRecvPort>,
+        skip_files_mask: Option<Bitmap>,
+        predicate: Option<ScanIOPredicate>,
+    ) -> PolarsResult<JoinHandle<PolarsResult<()>>> {
+        let verbose = self.config.verbose();
+        let reader_capabilities = self.config.file_reader_builder.reader_capabilities();
+
+        // Row index should only be pushed if we have a predicate or negative slice as there is a
+        // serial synchronization cost.
+        if self.config.row_index.is_some() {
+            debug_assert!(
+                self.config.predicate.is_some()
+                    || matches!(self.config.pre_slice, Some(Slice::Negative { .. }))
+            );
+        }
+
+        let ResolvedSliceInfo {
+            scan_source_idx,
+            row_index,
+            pre_slice,
+            initialized_readers,
+        } = match self.config.pre_slice {
+            Some(Slice::Negative { .. })
+                if self.config.sources.len() == 1
+                    && reader_capabilities.contains(ReaderCapabilities::NEGATIVE_PRE_SLICE)
+                    && (self.config.row_index.is_none()
+                        || reader_capabilities.contains(ReaderCapabilities::ROW_INDEX)) =>
+            {
+                if verbose {
+                    eprintln!("[MultiScanTaskInitializer]: Single file negative slice");
+                }
+
+                ResolvedSliceInfo {
+                    scan_source_idx: 0,
+                    row_index: self.config.row_index.clone(),
+                    pre_slice: self.config.pre_slice.clone(),
+                    initialized_readers: None,
+                }
+            },
+            _ => {
+                if let Some(Slice::Negative { .. }) = self.config.pre_slice {
+                    if verbose {
+                        eprintln!(
+                            "[MultiScanTaskInitializer]: Begin resolving negative slice to positive"
+                        );
+                    }
+                }
+
+                resolve_to_positive_slice(&self.config).await?
+            },
+        };
+
+        let extra_ops = ExtraOperations {
+            row_index,
+            pre_slice,
+            missing_columns_policy: if self.config.allow_missing_columns {
+                MissingColumnsPolicy::Insert
+            } else {
+                MissingColumnsPolicy::Raise
+            },
+            // TODO: Expose config for this
+            cast_columns_policy: CastColumnsPolicy::ErrorOnMismatch,
+            include_file_paths: self.config.include_file_paths.clone(),
+            predicate,
+        };
+
+        if verbose {
+            eprintln!(
+                "[MultiScanTaskInitializer]: \
+                scan_source_idx: {} \
+                extra_ops: {:?} \
+                ",
+                scan_source_idx, &extra_ops,
+            )
+        }
+
+        // Pre-initialized readers if we resolved a negative slice.
+        let mut initialized_readers: VecDeque<(Box<dyn FileReader>, IdxSize)> = initialized_readers
+            .map(|(idx, readers)| {
+                // Sanity check
+                assert_eq!(idx, scan_source_idx);
+                readers
+            })
+            .unwrap_or_default();
+
+        let has_row_index_or_slice = extra_ops.has_row_index_or_slice();
+
+        let config = self.config.clone();
+
+        // Buffered initialization stream.
+        let readers_init_iter = {
+            let skip_files_mask = skip_files_mask.clone();
+
+            // If a negative slice was initialized, the length of the initialized readers will be the exact
+            // stopping position.
+            let end = if initialized_readers.is_empty() {
+                self.config.sources.len()
+            } else {
+                scan_source_idx + initialized_readers.len()
+            };
+
+            let range = scan_source_idx..end;
+
+            if verbose {
+                eprintln!(
+                    "\
+                    [MultiScanTaskInitializer]: Readers init range: {:?} ({} / {} files)",
+                    &range,
+                    range.len(),
+                    self.config.sources.len(),
+                )
+            }
+
+            futures::stream::iter(range)
+                .map(move |scan_source_idx| {
+                    let cloud_options = config.cloud_options.clone();
+                    let file_reader_builder = config.file_reader_builder.clone();
+                    let sources = config.sources.clone();
+                    let skip_files_mask = skip_files_mask.clone();
+
+                    let maybe_initialized = initialized_readers.pop_front();
+                    let scan_source = sources.get(scan_source_idx).unwrap().into_owned();
+
+                    AbortOnDropHandle::new(async_executor::spawn(TaskPriority::Low, async move {
+                        let (scan_source, reader, n_rows_in_file) = async {
+                            if verbose {
+                                eprintln!("[MultiScan]: Initialize source {}", scan_source_idx);
+                            }
+
+                            let scan_source = scan_source?;
+
+                            if let Some((reader, n_rows_in_file)) = maybe_initialized {
+                                return PolarsResult::Ok((
+                                    scan_source,
+                                    reader,
+                                    Some(n_rows_in_file),
+                                ));
+                            }
+
+                            let mut reader = file_reader_builder
+                                .build_file_reader(scan_source.clone(), cloud_options);
+
+                            // Skip initialization if this file is filtered, this can save some cloud calls / metadata deserialization.
+                            // Downstream must also check against `skip_files_mask` and avoid calling any functions on this reader
+                            // if it is filtered out.
+                            if !has_row_index_or_slice
+                                && skip_files_mask.is_some_and(|x| x.get_bit(scan_source_idx))
+                            {
+                                return Ok((scan_source, reader, None));
+                            }
+
+                            reader.initialize().await?;
+                            PolarsResult::Ok((scan_source, reader, None))
+                        }
+                        .await?;
+
+                        Ok((scan_source_idx, scan_source, reader, n_rows_in_file))
+                    }))
+                })
+                .buffered(
+                    self.config
+                        .n_readers_pre_init
+                        .min(self.config.sources.len()),
+                )
+        };
+
+        let sources = self.config.sources.clone();
+        let readers_init_iter = readers_init_iter.boxed();
+        let hive_parts = self.config.hive_parts.clone();
+        let final_output_schema = self.config.final_output_schema.clone();
+        let projected_file_schema = self.config.projected_file_schema.clone();
+        let full_file_schema = self.config.full_file_schema.clone();
+        let num_pipelines = self.config.num_pipelines();
+        let max_concurrent_scans = max_concurrent_scans(num_pipelines).min(sources.len());
+
+        let (started_reader_tx, started_reader_rx) =
+            tokio::sync::mpsc::channel(max_concurrent_scans.max(2) - 1);
+
+        let reader_starter_handle = AbortOnDropHandle::new(async_executor::spawn(
+            TaskPriority::Low,
+            ReaderStarter {
+                reader_capabilities,
+                n_sources: sources.len(),
+
+                readers_init_iter,
+                started_reader_tx,
+                max_concurrent_scans,
+                skip_files_mask,
+                extra_ops,
+                constant_args: StartReaderArgsConstant {
+                    hive_parts,
+                    final_output_schema,
+                    projected_file_schema,
+                    full_file_schema,
+                    // TODO: Expose config for this and default to not checking.
+                    check_schema_names: Some(SchemaNamesMatchPolicy::RequireOrderedExact),
+                },
+                num_pipelines,
+                verbose,
+            }
+            .run(),
+        ));
+
+        let attach_to_bridge_handle = AbortOnDropHandle::new(async_executor::spawn(
+            TaskPriority::Low,
+            AttachReaderToBridge {
+                started_reader_rx,
+                bridge_recv_port_tx,
+                num_pipelines,
+                verbose,
+            }
+            .run(),
+        ));
+
+        let handle = async_executor::spawn(TaskPriority::Low, async move {
+            attach_to_bridge_handle.await?;
+            reader_starter_handle.await?;
+            Ok(())
+        });
+
+        Ok(handle)
+    }
+}
+
+/// Starts readers, potentially multiple at the same time if it can.
+struct ReaderStarter {
+    reader_capabilities: ReaderCapabilities,
+    #[expect(clippy::type_complexity)]
+    readers_init_iter:
+        BoxStream<'static, PolarsResult<(usize, ScanSource, Box<dyn FileReader>, Option<IdxSize>)>>,
+    n_sources: usize,
+    started_reader_tx: tokio::sync::mpsc::Sender<(
+        AbortOnDropHandle<PolarsResult<StartedReaderState>>,
+        WaitToken,
+    )>,
+    max_concurrent_scans: usize,
+    skip_files_mask: Option<Bitmap>,
+    extra_ops: ExtraOperations,
+    constant_args: StartReaderArgsConstant,
+    num_pipelines: usize,
+    verbose: bool,
+}
+
+impl ReaderStarter {
+    async fn run(self) -> PolarsResult<()> {
+        let ReaderStarter {
+            reader_capabilities,
+            mut readers_init_iter,
+            n_sources,
+            started_reader_tx,
+            max_concurrent_scans,
+            skip_files_mask,
+            extra_ops,
+            constant_args,
+            num_pipelines,
+            verbose,
+        } = self;
+
+        // Note: This is unused if we aren't slicing or row indexing.
+        let mut current_row_position: IdxSize = 0;
+
+        if !extra_ops.has_row_index_or_slice() {
+            // Set to IdxSize::MAX if we expect it to be unused. This way if it is incorrectly being
+            // used it should cause an error.
+            current_row_position = IdxSize::MAX;
+        }
+
+        if verbose {
+            eprintln!(
+                "[ReaderStarter]: max_concurrent_scans: {}",
+                max_concurrent_scans
+            )
+        }
+
+        let wait_group = WaitGroup::default();
+
+        loop {
+            // Note: This loop should only do basic bookkeeping (e.g. slice position) and reader initialization.
+            // It should avoid doing compute as much as possible - those should instead be done in the spawned task.
+
+            let pre_slice_this_file = extra_ops.pre_slice.clone().map(|x| match x {
+                Slice::Positive { .. } => x.offsetted(current_row_position as usize),
+                Slice::Negative { .. } => x,
+            });
+
+            if pre_slice_this_file.is_some() && verbose {
+                eprintln!(
+                    "[ReaderStarter]: current_row_position: {}, pre_slice_this_file: {:?}",
+                    current_row_position,
+                    pre_slice_this_file.as_ref().unwrap(),
+                )
+            }
+
+            if pre_slice_this_file.as_ref().is_some_and(|x| x.len() == 0) {
+                if verbose {
+                    eprintln!("[ReaderStarter]: Stopping (pre_slice)")
+                }
+                break;
+            }
+
+            let Some((scan_source_idx, scan_source, reader, opt_n_rows_in_file)) =
+                readers_init_iter.next().await.transpose()?
+            else {
+                if verbose {
+                    eprintln!("[ReaderStarter]: Stopping (no more readers)")
+                }
+                break;
+            };
+
+            if verbose {
+                eprintln!("[ReaderStarter]: scan_source_idx: {}", scan_source_idx)
+            }
+
+            if skip_files_mask
+                .as_ref()
+                .is_some_and(|x| x.get_bit(scan_source_idx))
+            {
+                if verbose {
+                    eprintln!(
+                        "[ReaderStarter]: Skip read of file index {} (skip_files_mask)",
+                        scan_source_idx
+                    )
+                }
+
+                // Should never: Negative slice should only hit this loop in the case:
+                // * Single NDJSON file that is not filtered out.
+                if extra_ops.has_row_index_or_slice() {
+                    if let Some(Slice::Negative { .. }) = pre_slice_this_file {
+                        unreachable!();
+                    }
+
+                    current_row_position = current_row_position.saturating_add(
+                        reader.row_position_after_slice(pre_slice_this_file).await?,
+                    );
+                }
+
+                continue;
+            }
+
+            let row_index_this_file = extra_ops.row_index.clone().map(|mut ri| {
+                ri.offset = ri.offset.saturating_add(current_row_position);
+                ri
+            });
+
+            let extra_ops_this_file = ExtraOperations {
+                row_index: row_index_this_file,
+                pre_slice: pre_slice_this_file.clone(),
+                // Other operations don't need updating per file
+                ..extra_ops.clone()
+            };
+
+            let (row_position_on_end_tx, n_rows_sent_tx_rx) =
+                if extra_ops.has_row_index_or_slice() && n_sources - scan_source_idx > 1 {
+                    let (mut tx, rx) = connector::connector();
+
+                    // See if we have the value leftover from negative slice initialization, so we don't duplicate row counting.
+                    if let Some(mut n_rows) = opt_n_rows_in_file {
+                        if let Some(pre_slice) = pre_slice_this_file {
+                            n_rows = IdxSize::try_from(
+                                pre_slice
+                                    .restrict_to_bounds(usize::try_from(n_rows).unwrap())
+                                    .end_position(),
+                            )
+                            .unwrap_or(IdxSize::MAX);
+                        }
+
+                        _ = tx.try_send(n_rows);
+                        (None, Some(rx))
+                    } else {
+                        (Some(tx), Some(rx))
+                    }
+                } else {
+                    (None, None)
+                };
+
+            // Note: If a reader does not support this we can also have the post apply pipeline do
+            // this callback for us (but it will be slightly slower).
+            let callbacks = FileReaderCallbacks {
+                row_position_on_end_tx,
+                ..Default::default()
+            };
+
+            let mut extra_ops_post = extra_ops_this_file;
+
+            let row_index = if reader_capabilities.contains(ReaderCapabilities::ROW_INDEX) {
+                extra_ops_post.row_index.take()
+            } else {
+                None
+            };
+
+            let pre_slice = match &extra_ops_post.pre_slice {
+                Some(Slice::Positive { .. })
+                    if reader_capabilities.contains(ReaderCapabilities::PRE_SLICE) =>
+                {
+                    extra_ops_post.pre_slice.take()
+                },
+                Some(Slice::Negative { .. })
+                    if reader_capabilities.contains(ReaderCapabilities::NEGATIVE_PRE_SLICE) =>
+                {
+                    extra_ops_post.pre_slice.take()
+                },
+                _ => None,
+            };
+
+            // Note: We do set_external_columns later below to avoid blocking this loop.
+            let predicate = if extra_ops_post.predicate.is_some()
+                && reader_capabilities.contains(ReaderCapabilities::FILTER)
+                && extra_ops_post.row_index.is_none()
+                && extra_ops_post.pre_slice.is_none()
+            {
+                extra_ops_post.predicate.take()
+            } else {
+                None
+            };
+
+            let begin_read_args = BeginReadArgs {
+                projected_schema: constant_args.projected_file_schema.clone(),
+                row_index,
+                pre_slice,
+                predicate,
+                cast_columns_policy: extra_ops_post.cast_columns_policy.clone(),
+                missing_columns_policy: extra_ops_post.missing_columns_policy.clone(),
+                num_pipelines,
+                callbacks,
+            };
+
+            let start_args_this_file = StartReaderArgsPerFile {
+                scan_source,
+                scan_source_idx,
+                reader,
+                begin_read_args,
+                extra_ops_post,
+            };
+
+            let reader_start_task_handle = AbortOnDropHandle::new(async_executor::spawn(
+                TaskPriority::Low,
+                start_reader_impl(constant_args.clone(), start_args_this_file),
+            ));
+
+            if started_reader_tx
+                .send((reader_start_task_handle, wait_group.token()))
+                .await
+                .is_err()
+            {
+                break;
+            };
+
+            // If we have row index or slice, we must wait for the row position callback before
+            // we can start the next reader. This will be very fast for e.g. Parquet / IPC, but
+            // for CSV / NDJSON this will be slower.
+            //
+            // Note: If this reader ends early due to an error, we may start the next reader with an incorrect
+            // row position. But downstream will never connect the next reader to the bridge as it should join
+            // on this reader and already exit from the error.
+            //
+            // TODO:
+            // * Parallelize the CSV row count
+            // * NDJSON skips rows (i.e. non-zero offset) in a single-threaded manner.
+            if let Some(mut rx) = n_rows_sent_tx_rx {
+                if let Ok(n) = rx.recv().await {
+                    current_row_position = current_row_position.saturating_add(n);
+                }
+            }
+
+            if max_concurrent_scans == 1 {
+                if verbose {
+                    eprintln!("[ReaderStarter]: max_concurrent_scans is 1, waiting..")
+                }
+
+                wait_group.wait().await;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Constant over the file list.
+#[derive(Clone)]
+struct StartReaderArgsConstant {
+    hive_parts: Option<Arc<HivePartitionsDf>>,
+    final_output_schema: SchemaRef,
+    projected_file_schema: SchemaRef,
+    full_file_schema: SchemaRef,
+    check_schema_names: Option<SchemaNamesMatchPolicy>,
+}
+
+struct StartReaderArgsPerFile {
+    scan_source: ScanSource,
+    scan_source_idx: usize,
+    reader: Box<dyn FileReader>,
+    begin_read_args: BeginReadArgs,
+    extra_ops_post: ExtraOperations,
+}
+
+async fn start_reader_impl(
+    constant_args: StartReaderArgsConstant,
+    args_this_file: StartReaderArgsPerFile,
+) -> PolarsResult<StartedReaderState> {
+    let StartReaderArgsConstant {
+        hive_parts,
+        final_output_schema,
+        projected_file_schema,
+        full_file_schema,
+        check_schema_names,
+    } = constant_args;
+
+    let StartReaderArgsPerFile {
+        scan_source,
+        scan_source_idx,
+        reader,
+        mut begin_read_args,
+        extra_ops_post,
+    } = args_this_file;
+
+    let pre_slice_to_reader = begin_read_args.pre_slice.clone();
+
+    let file_schema_rx = if check_schema_names.is_some() {
+        // Upstream should not have any reason to attach this.
+        assert!(begin_read_args.callbacks.file_schema_tx.is_none());
+        let (tx, rx) = connector::connector();
+        begin_read_args.callbacks.file_schema_tx = Some(tx);
+        Some(rx)
+    } else {
+        None
+    };
+
+    if let Some(predicate) = begin_read_args.predicate.as_mut() {
+        let mut external_predicate_cols = Vec::with_capacity(
+            hive_parts.as_ref().map_or(0, |x| x.df().width())
+                + extra_ops_post.include_file_paths.is_some() as usize,
+        );
+
+        if let Some(hp) = &hive_parts {
+            external_predicate_cols.extend(
+                hp.df()
+                    .get_columns()
+                    .iter()
+                    .filter(|c| predicate.live_columns.contains(c.name()))
+                    .map(|c| {
+                        (
+                            c.name().clone(),
+                            Scalar::new(
+                                c.dtype().clone(),
+                                c.get(scan_source_idx).unwrap().into_static(),
+                            ),
+                        )
+                    }),
+            );
+        }
+
+        if let Some(col_name) = extra_ops_post.include_file_paths.clone() {
+            external_predicate_cols.push((
+                col_name,
+                Scalar::new(
+                    DataType::String,
+                    AnyValue::StringOwned(
+                        scan_source
+                            .as_scan_source_ref()
+                            .to_include_path_name()
+                            .into(),
+                    ),
+                ),
+            ))
+        }
+
+        predicate.set_external_constant_columns(external_predicate_cols);
+    }
+
+    let (mut reader_output_port, reader_handle) = reader.begin_read(begin_read_args)?;
+
+    let reader_handle = AbortOnDropHandle::new(reader_handle);
+
+    if let Some(policy) = check_schema_names {
+        if let Ok(this_file_schema) = file_schema_rx.unwrap().recv().await {
+            policy.apply_policy(full_file_schema, this_file_schema)?;
+        } else {
+            drop(reader_output_port);
+            return Err(reader_handle.await.unwrap_err());
+        }
+    }
+
+    let first_morsel = reader_output_port.recv().await.ok();
+
+    let ops_applier = if let Some(morsel) = first_morsel.as_ref() {
+        let final_output_schema = final_output_schema.clone();
+        let projected_file_schema = projected_file_schema.clone();
+        let mut extra_ops = extra_ops_post;
+
+        // The offset of the row index sent to the post apply pipeline should be the row position of
+        // the first morsel sent by the reader.
+        if let Some(ri) = extra_ops.row_index.as_mut() {
+            let offset_by = pre_slice_to_reader.as_ref().map_or(0, |x| {
+                let Slice::Positive { offset, .. } = x else {
+                    unreachable!()
+                };
+                IdxSize::try_from(*offset).unwrap_or(IdxSize::MAX)
+            });
+
+            ri.offset = ri.offset.saturating_add(offset_by);
+        }
+
+        ApplyExtraOps::Uninitialized {
+            final_output_schema,
+            projected_file_schema,
+            extra_ops,
+            scan_source: scan_source.clone(),
+            scan_source_idx,
+            hive_parts,
+        }
+        .initialize(morsel.df().schema())?
+    } else {
+        ApplyExtraOps::Noop
+    };
+
+    let state = StartedReaderState {
+        reader_output_port,
+        first_morsel,
+        ops_applier,
+        reader_handle,
+    };
+
+    Ok(state)
+}
+
+/// State for a reader that has been started.
+struct StartedReaderState {
+    reader_output_port: FileReaderOutputRecv,
+    first_morsel: Option<Morsel>,
+    ops_applier: ApplyExtraOps,
+    reader_handle: AbortOnDropHandle<PolarsResult<()>>,
+}
+
+struct AttachReaderToBridge {
+    started_reader_rx: tokio::sync::mpsc::Receiver<(
+        AbortOnDropHandle<PolarsResult<StartedReaderState>>,
+        WaitToken,
+    )>,
+    bridge_recv_port_tx: connector::Sender<BridgeRecvPort>,
+    num_pipelines: usize,
+    verbose: bool,
+}
+
+impl AttachReaderToBridge {
+    async fn run(self) -> PolarsResult<()> {
+        let AttachReaderToBridge {
+            mut started_reader_rx,
+            mut bridge_recv_port_tx,
+            num_pipelines,
+            verbose,
+        } = self;
+
+        let mut n_readers_received: usize = 0;
+
+        let mut post_apply_pool: Option<PostApplyPool> = None;
+
+        while let Some((init_task_handle, wait_token)) = started_reader_rx.recv().await {
+            n_readers_received = n_readers_received.saturating_add(1);
+
+            if verbose {
+                eprintln!(
+                    "[AttachReaderToBridge]: got reader, n_readers_received: {}",
+                    n_readers_received
+                );
+            }
+
+            let StartedReaderState {
+                reader_output_port,
+                first_morsel,
+                ops_applier,
+                reader_handle,
+            } = init_task_handle.await?;
+
+            if let Some(first_morsel) = first_morsel {
+                match ops_applier {
+                    ApplyExtraOps::Noop => {
+                        if verbose {
+                            eprintln!("[AttachReaderToBridge]: ApplyExtraOps::Noop");
+                        }
+
+                        if bridge_recv_port_tx
+                            .send(BridgeRecvPort::Direct {
+                                rx: reader_output_port,
+                                first_morsel: Some(first_morsel),
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    },
+
+                    ApplyExtraOps::Initialized { .. } => {
+                        if verbose {
+                            eprintln!("[AttachReaderToBridge]: ApplyExtraOps::Initialized");
+                        }
+
+                        let post_apply_pool = post_apply_pool
+                            .get_or_insert_with(|| PostApplyPool::new(num_pipelines));
+
+                        let bridge_recv_port = post_apply_pool
+                            .run_with_reader(
+                                reader_output_port,
+                                Arc::new(ops_applier),
+                                first_morsel,
+                            )
+                            .await?;
+
+                        if bridge_recv_port_tx.send(bridge_recv_port).await.is_err() {
+                            break;
+                        }
+
+                        post_apply_pool.wait_current_reader().await?;
+                    },
+
+                    ApplyExtraOps::Uninitialized { .. } => unreachable!(),
+                }
+            }
+
+            drop(wait_token);
+            reader_handle.await?;
+        }
+
+        // Catch errors
+        if let Some(post_apply_pool) = post_apply_pool {
+            post_apply_pool.shutdown().await?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -394,7 +394,7 @@ impl ReaderStarter {
                 ..extra_ops.clone()
             };
 
-            let (row_position_on_end_tx, n_rows_sent_tx_rx) =
+            let (row_position_on_end_tx, row_position_on_end_rx) =
                 if extra_ops.has_row_index_or_slice() && n_sources - scan_source_idx > 1 {
                     let (mut tx, rx) = connector::connector();
 
@@ -501,7 +501,7 @@ impl ReaderStarter {
             // TODO:
             // * Parallelize the CSV row count
             // * NDJSON skips rows (i.e. non-zero offset) in a single-threaded manner.
-            if let Some(mut rx) = n_rows_sent_tx_rx {
+            if let Some(mut rx) = row_position_on_end_rx {
                 if let Ok(n) = rx.recv().await {
                     current_row_position = current_row_position.saturating_add(n);
                 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -570,6 +570,13 @@ async fn start_reader_impl(
         None
     };
 
+    // Should not have both of these set, as the `n_rows_in_file` will cause the `row_position_on_end`
+    // callback to be unnecessarily blocked in CSV and NDJSON.
+    debug_assert!(
+        !(begin_read_args.callbacks.row_position_on_end_tx.is_some()
+            && begin_read_args.callbacks.n_rows_in_file_tx.is_some()),
+    );
+
     if let Some(predicate) = begin_read_args.predicate.as_mut() {
         let mut external_predicate_cols = Vec::with_capacity(
             hive_parts.as_ref().map_or(0, |x| x.df().width())

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/mod.rs
@@ -1,0 +1,2 @@
+//! See [`crate::nodes::io_sources::multi_file_reader::initialization`] for dispatch.
+mod generic;

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -1,3 +1,6 @@
+use std::num::TryFromIntError;
+use std::ops::Range;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Slice {
     /// Or zero
@@ -99,6 +102,29 @@ impl From<(i64, usize)> for Slice {
                 offset_from_end: usize::try_from(-offset).unwrap(),
                 len,
             }
+        }
+    }
+}
+
+impl TryFrom<Slice> for (i64, usize) {
+    type Error = TryFromIntError;
+
+    fn try_from(value: Slice) -> Result<Self, Self::Error> {
+        match value {
+            Slice::Positive { offset, len } => Ok((i64::try_from(offset)?, len)),
+            Slice::Negative {
+                offset_from_end,
+                len,
+            } => Ok((-i64::try_from(offset_from_end)?, len)),
+        }
+    }
+}
+
+impl From<Slice> for Range<usize> {
+    fn from(value: Slice) -> Self {
+        match value {
+            Slice::Positive { offset, len } => offset..offset.checked_add(len).unwrap(),
+            Slice::Negative { .. } => panic!("cannot convert negative slice into range"),
         }
     }
 }


### PR DESCRIPTION
PR contains an updated multiscan pipeline implementation. This is not hooked up yet - it is currently missing the IR lowering and refactoring of the individual readers to use the updated pipeline.

Some improvements include:
* Replacing monomorphized `<T: MultiScanable>` with `dyn FileReader`
* Generalized operation pushdown into the readers based on `ReaderCapabilities` (slice/predicate)
* Faster early stopping for some file formats when scanning with positive slice via `row_position_on_end`
* Faster negative slice resolution using concurrent row counting
* Parallelized post-apply pipeline (for missing columns, row index, column casting, reordering etc.)

The effects of these optimizations differ across file types - I will have more concrete benchmark numbers for them per file type in follow-up PRs.

@coastalwhite 
