### PR TITLE
fix: Ensure list append uses correct dtype for scalar path

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -639,6 +639,7 @@ pub trait ListNameSpaceImpl: AsList {
                 .flat_map(|s| {
                     let lst = s.list().unwrap();
                     lst.get_as_series(0)
+                        .map(|s| s.cast(&inner_super_type).unwrap())
                 })
                 .collect::<Vec<_>>();
             // there was a None, so all values will be None


### PR DESCRIPTION
Closes #21924.

Calling `get_as_series` downcasts the RHS scalar to the physical (i32 in the case of `pl.Date`) hence the error seen in the issue. This ensures it's properly recast to the logical.