### PR TITLE
refactor: Use Optional for InitVar type hint

### DIFF
--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Optional
 from collections import OrderedDict, namedtuple
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
@@ -451,7 +452,7 @@ def test_dataclasses_initvar_typing() -> None:
     class ABC:
         x: date
         y: float
-        z: dataclasses.InitVar[list[str]] = None
+        z: dataclasses.InitVar[Optional[list[str]]] = None
 
     # should be able to parse the initvar typing...
     abc = ABC(x=date(1999, 12, 31), y=100.0)


### PR DESCRIPTION
Update type hint from InitVar[list[str]] to InitVar[Optional[list[str]]] to explicitly allow None during initialization, matching the default value and improving type checker accuracy