### PR TITLE
chore(python): Allow `os.PathLike` parameters in `normalize_filepath` util

### DIFF
--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    AnyStr,
     Callable,
     Literal,
     TypeVar,
@@ -220,7 +221,9 @@ def arrlen(obj: Any) -> int | None:
         return None
 
 
-def normalize_filepath(path: str | Path, *, check_not_directory: bool = True) -> str:
+def normalize_filepath(
+    path: os.PathLike[AnyStr] | AnyStr, *, check_not_directory: bool = True
+) -> AnyStr:
     """Create a string path, expanding the home directory if present."""
     # don't use pathlib here as it modifies slashes (s3:// -> s3:/)
     path = os.path.expanduser(path)  # noqa: PTH111

--- a/py-polars/tests/unit/utils/test_various.py
+++ b/py-polars/tests/unit/utils/test_various.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 import pytest
 
-from polars._utils.various import issue_warning
+from polars._utils.various import issue_warning, normalize_filepath
 from polars.exceptions import PerformanceWarning
 
 
@@ -8,3 +10,65 @@ def test_issue_warning() -> None:
     msg = "hello"
     with pytest.warns(PerformanceWarning, match=msg):
         issue_warning(msg, PerformanceWarning)
+
+
+class TestNormalizeFilepath:
+    """Test coverage for `polars/_utils/various.py::normalize_filepath()`."""
+
+    def test_normalize_filepath_str(self) -> None:
+        path = "/dummy/file.py"
+        normalized = normalize_filepath(path)
+        assert type(normalized) is str
+        assert normalized == path
+
+    def test_normalize_filepath_str_normalizes(self) -> None:
+        path = "~/dummy/file.py"
+        normalized = normalize_filepath(path)
+        assert type(normalized) is str
+        assert normalized != path
+
+    def test_normalize_filepath_bytes(self) -> None:
+        path = b"/dummy/file.py"
+        normalized = normalize_filepath(path)
+        assert type(normalized) is bytes
+        assert normalized == path
+
+    def test_normalize_filepath_bytes_normalizes(self) -> None:
+        path = b"~/dummy/file.py"
+        normalized = normalize_filepath(path)
+        assert type(normalized) is bytes
+        assert normalized != path
+
+    def test_normalize_filepath_pathlib(self) -> None:
+        path = Path("/") / "dummy" / "file.py"
+        normalized = normalize_filepath(path)
+        assert type(normalized) is str
+        assert normalized == str(path)
+
+    def test_normalize_filepath_pathlib_normalizes(self) -> None:
+        path = Path("~") / "dummy" / "file.py"
+        normalized = normalize_filepath(path)
+        assert type(normalized) is str
+        assert normalized != str(path)
+        assert normalized == str(Path.home() / "dummy" / "file.py")
+
+    def test_normalize_filepath_custom_pathlike(self) -> None:
+        class CustomPathLike:
+            def __fspath__(self) -> bytes:
+                return b"/dummy/file.py"
+
+        path = CustomPathLike()
+        normalized = normalize_filepath(path)
+        assert type(normalized) is bytes
+        assert normalized == b"/dummy/file.py"
+
+    def test_normalize_filepath_custom_pathlike_normalizes(self) -> None:
+        class CustomPathLike:
+            def __fspath__(self) -> bytes:
+                return b"~/dummy/file.py"
+
+        path = CustomPathLike()
+        normalized = normalize_filepath(path)
+        assert type(normalized) is bytes
+        assert normalized != b"~/dummy/file.py"
+        assert normalized == bytes(Path.home() / "dummy" / "file.py")


### PR DESCRIPTION
Related to https://github.com/pola-rs/polars/issues/17828  

Enables improvements to `read_*`/`scan_*` parameter type hints.
Current implementations of those methods have a few differences in their type hints, so I want to tackle that incrementally.

I have read the contribution guide and added some tests.
Feel free to ask for polish, or just push yourself.