### PR TITLE
perf: Lower is_in to bitmap-output semi-join in new streaming engine

### DIFF
--- a/crates/polars-expr/src/groups/mod.rs
+++ b/crates/polars-expr/src/groups/mod.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 
+use arrow::bitmap::BitmapBuilder;
 use polars_core::prelude::*;
 use polars_utils::IdxSize;
 use polars_utils::cardinality_sketch::CardinalitySketch;
@@ -76,9 +77,22 @@ pub trait Grouper: Any + Send + Sync {
         &self,
         groupers: &[Box<dyn Grouper>],
         keys: &HashKeys,
-        probe_matches: &mut Vec<IdxSize>,
         partitioner: &HashPartitioner,
         invert: bool,
+        probe_matches: &mut Vec<IdxSize>,
+    );
+
+    /// Returns for each key if it is found in the groupers. If invert is true
+    /// it returns true if it isn't found.
+    /// # Safety
+    /// All groupers must have the same schema.
+    unsafe fn contains_key_partitioned_groupers(
+        &self,
+        groupers: &[Box<dyn Grouper>],
+        keys: &HashKeys,
+        partitioner: &HashPartitioner,
+        invert: bool,
+        contains_key: &mut BitmapBuilder,
     );
 
     fn as_any(&self) -> &dyn Any;

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -263,6 +263,7 @@ fn visualize_plan_rec(
             left_on,
             right_on,
             args,
+            output_bool: _,
         } => {
             let mut label = if matches!(
                 phys_sm[node_key].kind,
@@ -280,12 +281,14 @@ fn visualize_plan_rec(
             };
             write!(label, r"\nleft_on:\n{}", fmt_exprs(left_on, expr_arena)).unwrap();
             write!(label, r"\nright_on:\n{}", fmt_exprs(right_on, expr_arena)).unwrap();
-            write!(
-                label,
-                r"\nhow: {}",
-                escape_graphviz(&format!("{:?}", args.how))
-            )
-            .unwrap();
+            if args.how.is_equi() {
+                write!(
+                    label,
+                    r"\nhow: {}",
+                    escape_graphviz(&format!("{:?}", args.how))
+                )
+                .unwrap();
+            }
             if args.nulls_equal {
                 write!(label, r"\njoin-nulls").unwrap();
             }

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -268,11 +268,19 @@ fn visualize_plan_rec(
             let label = match phys_sm[node_key].kind {
                 PhysNodeKind::EquiJoin { .. } if args.how.is_equi() => "equi-join",
                 PhysNodeKind::EquiJoin { .. } => "in-memory-join",
-                PhysNodeKind::SemiAntiJoin { output_bool: false, .. } if args.how == JoinType::Semi => "semi-join",
-                PhysNodeKind::SemiAntiJoin { output_bool: false, .. } if args.how == JoinType::Anti => "anti-join",
-                PhysNodeKind::SemiAntiJoin { output_bool: true, .. } if args.how == JoinType::Semi => "is-in",
-                PhysNodeKind::SemiAntiJoin { output_bool: true, .. } if args.how == JoinType::Anti => "is-not-in",
-                _ => unreachable!()
+                PhysNodeKind::SemiAntiJoin {
+                    output_bool: false, ..
+                } if args.how == JoinType::Semi => "semi-join",
+                PhysNodeKind::SemiAntiJoin {
+                    output_bool: false, ..
+                } if args.how == JoinType::Anti => "anti-join",
+                PhysNodeKind::SemiAntiJoin {
+                    output_bool: true, ..
+                } if args.how == JoinType::Semi => "is-in",
+                PhysNodeKind::SemiAntiJoin {
+                    output_bool: true, ..
+                } if args.how == JoinType::Anti => "is-not-in",
+                _ => unreachable!(),
             };
             let mut label = label.to_string();
             write!(label, r"\nleft_on:\n{}", fmt_exprs(left_on, expr_arena)).unwrap();

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -265,20 +265,16 @@ fn visualize_plan_rec(
             args,
             output_bool: _,
         } => {
-            let mut label = if matches!(
-                phys_sm[node_key].kind,
-                PhysNodeKind::EquiJoin { .. } | PhysNodeKind::SemiAntiJoin { .. }
-            ) {
-                if args.how.is_equi() {
-                    "equi-join".to_string()
-                } else if args.how == JoinType::Semi {
-                    "semi-join".to_string()
-                } else {
-                    "anti-join".to_string()
-                }
-            } else {
-                "in-memory-join".to_string()
+            let label = match phys_sm[node_key].kind {
+                PhysNodeKind::EquiJoin { .. } if args.how.is_equi() => "equi-join",
+                PhysNodeKind::EquiJoin { .. } => "in-memory-join",
+                PhysNodeKind::SemiAntiJoin { output_bool: false, .. } if args.how == JoinType::Semi => "semi-join",
+                PhysNodeKind::SemiAntiJoin { output_bool: false, .. } if args.how == JoinType::Anti => "anti-join",
+                PhysNodeKind::SemiAntiJoin { output_bool: true, .. } if args.how == JoinType::Semi => "is-in",
+                PhysNodeKind::SemiAntiJoin { output_bool: true, .. } if args.how == JoinType::Anti => "is-not-in",
+                _ => unreachable!()
             };
+            let mut label = label.to_string();
             write!(label, r"\nleft_on:\n{}", fmt_exprs(left_on, expr_arena)).unwrap();
             write!(label, r"\nright_on:\n{}", fmt_exprs(right_on, expr_arena)).unwrap();
             if args.how.is_equi() {

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{Field, InitHashMaps, PlHashMap, PlHashSet};
+use polars_core::prelude::{DataType, Field, InitHashMaps, PlHashMap, PlHashSet};
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::PolarsResult;
 use polars_expr::planner::get_expr_depth_limit;
 use polars_expr::state::ExecutionState;
 use polars_expr::{ExpressionConversionState, create_physical_expr};
+use polars_ops::frame::{JoinArgs, JoinType};
 use polars_plan::plans::AExpr;
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
 use polars_plan::prelude::*;
@@ -536,6 +537,74 @@ fn lower_exprs_with_ctx(
                 let node_key = build_input_independent_node_with_ctx(&[inner_expr], ctx)?;
                 input_streams.insert(PhysStream::first(node_key));
                 transformed_exprs.push(ctx.expr_arena.add(AExpr::Column(out_name)));
+            },
+
+            AExpr::Function {
+                input: ref inner_exprs,
+                function: FunctionExpr::Boolean(BooleanFunction::IsIn { nulls_equal }),
+                options: _,
+            } if {
+                let input_schema = &ctx.phys_sm[input.node].output_schema;
+                let left_dt = inner_exprs[0]
+                    .dtype(input_schema, Context::Default, ctx.expr_arena)
+                    .unwrap();
+                let right_dt = inner_exprs[1]
+                    .dtype(input_schema, Context::Default, ctx.expr_arena)
+                    .unwrap();
+                left_dt == right_dt
+            } =>
+            {
+                // Translate left and right side separately (they could have different lengths).
+                let left_on_name = unique_column_name();
+                let right_on_name = unique_column_name();
+                let (trans_input_left, trans_expr_left) =
+                    lower_exprs_with_ctx(input, &[inner_exprs[0].node()], ctx)?;
+                let (trans_input_right, trans_expr_right) =
+                    lower_exprs_with_ctx(input, &[inner_exprs[1].node()], ctx)?;
+
+                // We have to ensure the left input has the right name for the semi-anti-join to
+                // generate the correct output name.
+                let left_col_expr = ctx.expr_arena.add(AExpr::Column(left_on_name.clone()));
+                let left_select_stream = build_select_stream_with_ctx(
+                    trans_input_left,
+                    &[ExprIR::new(
+                        trans_expr_left[0],
+                        OutputName::Alias(left_on_name.clone()),
+                    )],
+                    ctx,
+                )?;
+
+                let node_kind = PhysNodeKind::SemiAntiJoin {
+                    input_left: left_select_stream,
+                    input_right: trans_input_right,
+                    left_on: vec![ExprIR::new(
+                        left_col_expr,
+                        OutputName::Alias(left_on_name.clone()),
+                    )],
+                    right_on: vec![ExprIR::new(
+                        trans_expr_right[0],
+                        OutputName::Alias(right_on_name),
+                    )],
+                    args: JoinArgs {
+                        how: JoinType::Semi,
+                        validation: Default::default(),
+                        suffix: None,
+                        slice: None,
+                        nulls_equal,
+                        coalesce: Default::default(),
+                        maintain_order: Default::default(),
+                    },
+                    output_bool: true,
+                };
+
+                // SemiAntiJoin with output_bool returns a column with the same name as the first
+                // input column.
+                let output_schema = Schema::from_iter([(left_on_name.clone(), DataType::Boolean)]);
+                let node_key = ctx
+                    .phys_sm
+                    .insert(PhysNode::new(Arc::new(output_schema), node_kind));
+                input_streams.insert(PhysStream::first(node_key));
+                transformed_exprs.push(left_col_expr);
             },
 
             ref node @ AExpr::Function {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -831,6 +831,7 @@ pub fn lower_ir(
                             left_on: trans_left_on,
                             right_on: trans_right_on,
                             args: args.clone(),
+                            output_bool: false,
                         },
                     ))
                 };

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -252,6 +252,7 @@ pub enum PhysNodeKind {
         left_on: Vec<ExprIR>,
         right_on: Vec<ExprIR>,
         args: JoinArgs,
+        output_bool: bool,
     },
 
     /// Generic fallback for (as-of-yet) unsupported streaming joins.


### PR DESCRIPTION
I didn't add a fast-path for when the number of keys is very low, and I also currently always goes through the row encoding, so it might be a bit slower for some queries. But this should be a good improvement down the line.