### PR TITLE
fix: Raise error instead of silently appending NULL in NDJSON parsing

### DIFF
--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -156,9 +156,9 @@ impl<'a> AnyValueBuffer<'a> {
         })
     }
 
-    pub fn reset(&mut self, capacity: usize) -> Series {
+    pub fn reset(&mut self, capacity: usize, strict: bool) -> PolarsResult<Series> {
         use AnyValueBuffer::*;
-        match self {
+        let out = match self {
             Boolean(b) => {
                 let mut new = BooleanChunkedBuilder::new(b.field.name().clone(), capacity);
                 std::mem::swap(&mut new, b);
@@ -258,17 +258,18 @@ impl<'a> AnyValueBuffer<'a> {
                 new.finish().into_series()
             },
             All(dtype, vals) => {
-                let out = Series::from_any_values_and_dtype(PlSmallStr::EMPTY, vals, dtype, false)
-                    .unwrap();
+                let out =
+                    Series::from_any_values_and_dtype(PlSmallStr::EMPTY, vals, dtype, strict)?;
                 let mut new = Vec::with_capacity(capacity);
                 std::mem::swap(&mut new, vals);
                 out
             },
-        }
+        };
+        Ok(out)
     }
 
     pub fn into_series(mut self) -> Series {
-        self.reset(0)
+        self.reset(0, false).unwrap()
     }
 
     pub fn new(dtype: &DataType, capacity: usize) -> AnyValueBuffer<'a> {
@@ -558,9 +559,9 @@ impl<'a> AnyValueBufferTrusted<'a> {
     }
 
     /// Clear `self` and give `capacity`, returning the old contents as a [`Series`].
-    pub fn reset(&mut self, capacity: usize) -> Series {
+    pub fn reset(&mut self, capacity: usize, strict: bool) -> PolarsResult<Series> {
         use AnyValueBufferTrusted::*;
-        match self {
+        let out = match self {
             Boolean(b) => {
                 let mut new = BooleanChunkedBuilder::new(b.field.name().clone(), capacity);
                 std::mem::swap(&mut new, b);
@@ -630,9 +631,9 @@ impl<'a> AnyValueBufferTrusted<'a> {
                 // @Q? Maybe we need to add a length parameter here for ZFS's. I am not very happy
                 // with just setting the length to zero for that case.
                 if b.is_empty() {
-                    return StructChunked::from_series(PlSmallStr::EMPTY, 0, [].iter())
-                        .unwrap()
-                        .into_series();
+                    return Ok(
+                        StructChunked::from_series(PlSmallStr::EMPTY, 0, [].iter())?.into_series()
+                    );
                 }
 
                 let mut min_len = usize::MAX;
@@ -641,15 +642,15 @@ impl<'a> AnyValueBufferTrusted<'a> {
                 let v = b
                     .iter_mut()
                     .map(|(b, name)| {
-                        let mut s = b.reset(capacity);
+                        let mut s = b.reset(capacity, strict)?;
 
                         min_len = min_len.min(s.len());
                         max_len = max_len.max(s.len());
 
                         s.rename(name.clone());
-                        s
+                        Ok(s)
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<PolarsResult<Vec<_>>>()?;
 
                 let length = if min_len == 0 { 0 } else { max_len };
 
@@ -672,11 +673,14 @@ impl<'a> AnyValueBufferTrusted<'a> {
                 Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &swap_vals, dtype, false)
                     .unwrap()
             },
-        }
+        };
+
+        Ok(out)
     }
 
     pub fn into_series(mut self) -> Series {
-        self.reset(0)
+        // unwrap: non-strict does not error.
+        self.reset(0, false).unwrap()
     }
 }
 

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -288,7 +288,7 @@ fn deserialize_all<'a>(
     Ok(out)
 }
 
-/// Wrapper for Value with a human-friendly Display impl for nested types:
+/// Wrapper for serde_json's `Value` with a human-friendly Display impl for nested types:
 ///
 /// * Default: `{"x": Static(U64(1))}`
 /// * ValueDisplay: `{x: 1}`

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -294,7 +294,7 @@ fn deserialize_all<'a>(
 /// * ValueDisplay: `{x: 1}`
 ///
 /// This intended for reading in arbitrary `Value` types into a String type. Note that the output
-/// is not guaranteed to be valid JSON.
+/// is not guaranteed to be valid JSON as we don't do any escaping of e.g. quote/newline values.
 struct ValueDisplay<'a>(&'a Value<'a>);
 
 impl std::fmt::Display for ValueDisplay<'_> {

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -302,7 +302,7 @@ impl std::fmt::Display for ValueDisplay<'_> {
         use Value::*;
 
         match self.0 {
-            Static(s) => write!(f, r#"{s}"#),
+            Static(s) => write!(f, "{s}"),
             String(s) => write!(f, r#""{s}""#),
             Array(a) => {
                 write!(f, "[")?;

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -307,7 +307,7 @@ impl std::fmt::Display for ValueDisplay<'_> {
             Array(a) => {
                 write!(f, "[")?;
 
-                let mut iter = a.as_ref().iter();
+                let mut iter = a.iter();
 
                 for v in (&mut iter).take(1) {
                     write!(f, "{}", ValueDisplay(v))?;

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/thread_local.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/thread_local.rs
@@ -136,7 +136,7 @@ impl SpillPartitions {
                             .iter_mut()
                             .zip(self.output_schema.iter_names())
                             .map(|(b, name)| {
-                                let mut s = b.reset(OB_SIZE);
+                                let mut s = b.reset(OB_SIZE, false).unwrap();
                                 s.rename(name.clone());
                                 s
                             })
@@ -208,7 +208,10 @@ impl SpillPartitions {
                         hashes,
                         chunk_idx,
                         keys: keys_builder.into(),
-                        aggs: spilled_aggs.iter_mut().map(|b| b.reset(0)).collect(),
+                        aggs: spilled_aggs
+                            .iter_mut()
+                            .map(|b| b.reset(0, false).unwrap())
+                            .collect(),
                     },
                 )
             })

--- a/crates/polars/tests/it/io/json.rs
+++ b/crates/polars/tests/it/io/json.rs
@@ -95,7 +95,7 @@ fn read_unordered_json() {
 {"a":1, "b":0.6, "c":false, "d":"text"}
 {"d":1, "c":false, "d":"4", "b":2.0}
 {"b":-3.5, "c":true, "d":"4", "a":5}
-{"d":"text", "a":1, "c":false, "b":0.6}
+{"d":"text", "a":"1", "c":false, "b":0.6}
 {"a":1, "b":2.0, "c":false, "d":"4"}
 {"a":1, "b":-3.5, "c":true, "d":"4"}
 {"a":100000000000000, "b":0.6, "c":false, "d":"text"}

--- a/crates/polars/tests/it/io/json.rs
+++ b/crates/polars/tests/it/io/json.rs
@@ -93,9 +93,9 @@ fn read_unordered_json() {
 {"a":1, "b":2.0, "c":false, "d":"4"}
 {"a":7, "b":-3.5, "c":true, "d":"4"}
 {"a":1, "b":0.6, "c":false, "d":"text"}
-{"d":1, "c":false, "d":"4", "b":2.0}
+{"d":"1", "c":false, "d":"4", "b":2.0}
 {"b":-3.5, "c":true, "d":"4", "a":5}
-{"d":"text", "a":"1", "c":false, "b":0.6}
+{"d":"text", "a":1, "c":false, "b":0.6}
 {"a":1, "b":2.0, "c":false, "d":"4"}
 {"a":1, "b":-3.5, "c":true, "d":"4"}
 {"a":100000000000000, "b":0.6, "c":false, "d":"text"}

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -239,8 +239,8 @@ def test_ndjson_ignore_errors() -> None:
         "SeqNo": [1, 1],
         "Timestamp": [1, 1],
         "Fields": [
-            [{"Name": "added_id", "Value": "2"}, {"Name": "body", "Value": None}],
-            [{"Name": "added_id", "Value": "2"}, {"Name": "body", "Value": None}],
+            [{"Name": "added_id", "Value": "2"}, {"Name": "body", "Value": '{"a": 1}'}],
+            [{"Name": "added_id", "Value": "2"}, {"Name": "body", "Value": '{"a": 1}'}],
         ],
     }
 

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -286,3 +286,26 @@ def test_scan_ndjson_raises_on_parse_error_nested() -> None:
         q.collect(),
         pl.DataFrame({"a": [{"b": None}]}, schema={"a": pl.Struct({"b": pl.Int64})}),
     )
+
+
+def test_scan_ndjson_nested_as_string() -> None:
+    buf = b"""\
+{"a": {"x": 1}, "b": [1,2,3], "c": {"y": null}, "d": [{"k": "abc"}, {"j": "123"}, {"l": 7}]}
+"""
+
+    df = pl.scan_ndjson(
+        buf,
+        schema={"a": pl.String, "b": pl.String, "c": pl.String, "d": pl.String},
+    ).collect()
+
+    assert_frame_equal(
+        df,
+        pl.DataFrame(
+            {
+                "a": '{"x": 1}',
+                "b": "[1, 2, 3]",
+                "c": '{"y": null}',
+                "d": '[{"k": "abc"}, {"j": "123"}, {"l": 7}]',
+            }
+        ),
+    )


### PR DESCRIPTION
We currently always append NULL on parsing errors. This will ensure we only do so when `ignore_errors=True`.
