### PR TITLE
feat: Add options to control Parquet page-index and statistics level

### DIFF
--- a/crates/polars-io/src/parquet/write/options.rs
+++ b/crates/polars-io/src/parquet/write/options.rs
@@ -13,6 +13,8 @@ pub struct ParquetWriteOptions {
     pub compression: ParquetCompression,
     /// Compute and write column statistics.
     pub statistics: StatisticsOptions,
+    /// Compute and write page indexes.
+    pub page_index: bool,
     /// If `None` will be all written to a single row group.
     pub row_group_size: Option<usize>,
     /// if `None` will be 1024^2 bytes

--- a/crates/polars-parquet/src/arrow/write/binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/binary/nested.rs
@@ -29,8 +29,8 @@ where
 
     encode_plain(array, encode_options, &mut buffer);
 
-    let statistics = if options.has_statistics() {
-        Some(build_statistics(array, type_.clone(), &options.statistics))
+    let statistics = if options.has_page_statistics() {
+        Some(build_statistics(array, type_.clone(), &options.statistics).serialize())
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/binview/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/binview/nested.rs
@@ -25,8 +25,8 @@ pub fn array_to_page(
 
     encode_plain(array, encode_options, &mut buffer);
 
-    let statistics = if options.has_statistics() {
-        Some(build_statistics(array, type_.clone(), &options.statistics))
+    let statistics = if options.has_page_statistics() {
+        Some(build_statistics(array, type_.clone(), &options.statistics).serialize())
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/boolean/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/boolean/mod.rs
@@ -1,5 +1,5 @@
 mod basic;
 mod nested;
 
-pub use basic::array_to_page;
+pub use basic::{array_to_page, build_statistics};
 pub use nested::array_to_page as nested_array_to_page;

--- a/crates/polars-parquet/src/arrow/write/boolean/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/boolean/nested.rs
@@ -24,8 +24,8 @@ pub fn array_to_page(
 
     encode_plain(array, encode_options, &mut buffer)?;
 
-    let statistics = if options.has_statistics() {
-        Some(build_statistics(array, &options.statistics))
+    let statistics = if options.has_page_statistics() {
+        Some(build_statistics(array, &options.statistics).serialize())
     } else {
         None
     };

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -470,12 +470,11 @@ pub fn array_to_pages<K: DictionaryKey>(
 
                     let mut buffer = vec![];
                     binary_encode_plain::<i64>(array, EncodeNullability::Required, &mut buffer);
-                    let stats = if options.has_statistics() {
-                        Some(binary_build_statistics(
-                            array,
-                            type_.clone(),
-                            &options.statistics,
-                        ))
+                    let stats = if options.has_page_statistics() {
+                        Some(
+                            binary_build_statistics(array, type_.clone(), &options.statistics)
+                                .serialize(),
+                        )
                     } else {
                         None
                     };
@@ -493,12 +492,11 @@ pub fn array_to_pages<K: DictionaryKey>(
                     let mut buffer = vec![];
                     binview::encode_plain(array, EncodeNullability::Required, &mut buffer);
 
-                    let stats = if options.has_statistics() {
-                        Some(binview::build_statistics(
-                            array,
-                            type_.clone(),
-                            &options.statistics,
-                        ))
+                    let stats = if options.has_page_statistics() {
+                        Some(
+                            binview::build_statistics(array, type_.clone(), &options.statistics)
+                                .serialize(),
+                        )
                     } else {
                         None
                     };
@@ -517,12 +515,11 @@ pub fn array_to_pages<K: DictionaryKey>(
                     let mut buffer = vec![];
                     binview::encode_plain(&array, EncodeNullability::Required, &mut buffer);
 
-                    let stats = if options.has_statistics() {
-                        Some(binview::build_statistics(
-                            &array,
-                            type_.clone(),
-                            &options.statistics,
-                        ))
+                    let stats = if options.has_page_statistics() {
+                        Some(
+                            binview::build_statistics(&array, type_.clone(), &options.statistics)
+                                .serialize(),
+                        )
                     } else {
                         None
                     };
@@ -536,12 +533,11 @@ pub fn array_to_pages<K: DictionaryKey>(
 
                     let mut buffer = vec![];
                     binary_encode_plain::<i64>(values, EncodeNullability::Required, &mut buffer);
-                    let stats = if options.has_statistics() {
-                        Some(binary_build_statistics(
-                            values,
-                            type_.clone(),
-                            &options.statistics,
-                        ))
+                    let stats = if options.has_page_statistics() {
+                        Some(
+                            binary_build_statistics(values, type_.clone(), &options.statistics)
+                                .serialize(),
+                        )
                     } else {
                         None
                     };
@@ -554,7 +550,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                     let mut buffer = vec![];
                     let array = array.values().as_any().downcast_ref().unwrap();
                     fixed_binary_encode_plain(array, EncodeNullability::Required, &mut buffer);
-                    let stats = if options.has_statistics() {
+                    let stats = if options.has_page_statistics() {
                         let stats = fixed_binary_build_statistics(
                             array,
                             type_.clone(),

--- a/crates/polars-parquet/src/arrow/write/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/basic.rs
@@ -119,6 +119,20 @@ where
     array_to_page(array, options, type_, Encoding::Plain, encode_plain)
 }
 
+pub fn array_to_statistics<T, P>(
+    array: &PrimitiveArray<T>,
+    _type: PrimitiveType,
+    options: &StatisticsOptions,
+) -> PrimitiveStatistics<P>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    T: num_traits::AsPrimitive<P>,
+    P: num_traits::AsPrimitive<i64>,
+{
+    build_statistics(array, _type, options)
+}
+
 pub fn array_to_page_integer<T, P>(
     array: &PrimitiveArray<T>,
     options: WriteOptions,
@@ -170,7 +184,7 @@ where
 
     let buffer = encode(array, encode_options, buffer);
 
-    let statistics = if options.has_statistics() {
+    let statistics = if options.has_page_statistics() {
         Some(build_statistics(array, type_.clone(), &options.statistics).serialize())
     } else {
         None

--- a/crates/polars-parquet/src/arrow/write/primitive/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/mod.rs
@@ -1,6 +1,6 @@
 mod basic;
 mod nested;
 
-pub use basic::{array_to_page_integer, array_to_page_plain};
+pub use basic::{array_to_page_integer, array_to_page_plain, array_to_statistics};
 pub(crate) use basic::{build_statistics, encode_plain};
 pub use nested::array_to_page as nested_array_to_page;

--- a/crates/polars-parquet/src/arrow/write/primitive/nested.rs
+++ b/crates/polars-parquet/src/arrow/write/primitive/nested.rs
@@ -33,7 +33,7 @@ where
 
     let buffer = encode_plain(array, encode_options, buffer);
 
-    let statistics = if options.has_statistics() {
+    let statistics = if options.has_page_statistics() {
         Some(build_statistics(array, type_.clone(), &options.statistics).serialize())
     } else {
         None

--- a/crates/polars-parquet/src/parquet/write/mod.rs
+++ b/crates/polars-parquet/src/parquet/write/mod.rs
@@ -25,15 +25,6 @@ pub type RowGroupIterColumns<'a, E> =
 
 pub type RowGroupIter<'a, E> = DynIter<'a, RowGroupIterColumns<'a, E>>;
 
-/// Write options of different interfaces on this crate
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct WriteOptions {
-    /// Whether to write statistics, including indexes
-    pub write_statistics: bool,
-    /// Which Parquet version to use
-    pub version: Version,
-}
-
 /// The parquet version to use
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Version {

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -397,7 +397,7 @@ impl PyDataFrame {
 
     #[cfg(feature = "parquet")]
     #[pyo3(signature = (
-        py_f, compression, compression_level, statistics, row_group_size, data_page_size,
+        py_f, compression, compression_level, statistics, page_index, row_group_size, data_page_size,
         partition_by, partition_chunk_size_bytes, cloud_options, credential_provider, retries
     ))]
     pub fn write_parquet(
@@ -407,6 +407,7 @@ impl PyDataFrame {
         compression: &str,
         compression_level: Option<i32>,
         statistics: Wrap<StatisticsOptions>,
+        page_index: bool,
         row_group_size: Option<usize>,
         data_page_size: Option<usize>,
         partition_by: Option<Vec<String>>,
@@ -442,6 +443,7 @@ impl PyDataFrame {
             return py.enter_polars(|| {
                 let write_options = ParquetWriteOptions {
                     compression,
+                    page_index,
                     statistics: statistics.0,
                     row_group_size,
                     data_page_size,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -723,8 +723,8 @@ impl PyLazyFrame {
 
     #[cfg(all(feature = "streaming", feature = "parquet"))]
     #[pyo3(signature = (
-        target, compression, compression_level, statistics, row_group_size, data_page_size,
-        cloud_options, credential_provider, retries, sink_options
+        target, compression, compression_level, statistics, page_index, row_group_size,
+        data_page_size, cloud_options, credential_provider, retries, sink_options
     ))]
     fn sink_parquet(
         &self,
@@ -733,6 +733,7 @@ impl PyLazyFrame {
         compression: &str,
         compression_level: Option<i32>,
         statistics: Wrap<StatisticsOptions>,
+        page_index: bool,
         row_group_size: Option<usize>,
         data_page_size: Option<usize>,
         cloud_options: Option<Vec<(String, String)>>,
@@ -744,6 +745,7 @@ impl PyLazyFrame {
 
         let options = ParquetWriteOptions {
             compression,
+            page_index,
             statistics: statistics.0,
             row_group_size,
             data_page_size,

--- a/crates/polars/tests/it/io/parquet/arrow/mod.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/mod.rs
@@ -668,6 +668,7 @@ fn integration_write(
     chunks: &[RecordBatchT<Box<dyn Array>>],
 ) -> PolarsResult<Vec<u8>> {
     let options = WriteOptions {
+        page_index: false,
         statistics: StatisticsOptions::full(),
         compression: CompressionOptions::Uncompressed,
         version: Version::V1,
@@ -695,7 +696,7 @@ fn integration_write(
     let mut writer = FileWriter::try_new(writer, schema.clone(), options)?;
 
     for group in row_groups {
-        writer.write(group?)?;
+        writer.write(group?, &[])?;
     }
     writer.end(None)?;
 

--- a/crates/polars/tests/it/io/parquet/arrow/write.rs
+++ b/crates/polars/tests/it/io/parquet/arrow/write.rs
@@ -33,6 +33,7 @@ fn round_trip_opt_stats(
 
     let options = WriteOptions {
         statistics: StatisticsOptions::full(),
+        page_index: false,
         compression,
         version,
         data_page_size: None,
@@ -51,7 +52,7 @@ fn round_trip_opt_stats(
     let mut writer = FileWriter::try_new(writer, schema, options)?;
 
     for group in row_groups {
-        writer.write(group?)?;
+        writer.write(group?, &[])?;
     }
     writer.end(None)?;
 

--- a/crates/polars/tests/it/io/parquet/roundtrip.rs
+++ b/crates/polars/tests/it/io/parquet/roundtrip.rs
@@ -24,6 +24,7 @@ fn round_trip(
 
     let options = WriteOptions {
         statistics: StatisticsOptions::full(),
+        page_index: false,
         compression,
         version,
         data_page_size: None,
@@ -42,7 +43,7 @@ fn round_trip(
     let mut writer = FileWriter::try_new(writer, schema.clone(), options)?;
 
     for group in row_groups {
-        writer.write(group?)?;
+        writer.write(group?, &[])?;
     }
     writer.end(None)?;
 

--- a/crates/polars/tests/it/io/parquet/write/binary.rs
+++ b/crates/polars/tests/it/io/parquet/write/binary.rs
@@ -6,7 +6,7 @@ use polars_parquet::parquet::metadata::Descriptor;
 use polars_parquet::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, Page};
 use polars_parquet::parquet::statistics::BinaryStatistics;
 use polars_parquet::parquet::types::ord_binary;
-use polars_parquet::parquet::write::WriteOptions;
+use polars_parquet::write::WriteOptions;
 
 fn unzip_option(array: &[Option<Vec<u8>>]) -> ParquetResult<(Vec<u8>, Vec<u8>)> {
     // leave the first 4 bytes announcing the length of the def level
@@ -50,7 +50,7 @@ pub fn array_to_page_v1(
 
     buffer.extend_from_slice(&values);
 
-    let statistics = if options.write_statistics {
+    let statistics = if options.has_page_statistics() {
         let statistics = &BinaryStatistics {
             primitive_type: descriptor.primitive_type.clone(),
             null_count: Some((array.len() - array.iter().flatten().count()) as i64),

--- a/crates/polars/tests/it/io/parquet/write/primitive.rs
+++ b/crates/polars/tests/it/io/parquet/write/primitive.rs
@@ -6,7 +6,7 @@ use polars_parquet::parquet::metadata::Descriptor;
 use polars_parquet::parquet::page::{DataPage, DataPageHeader, DataPageHeaderV1, Page};
 use polars_parquet::parquet::statistics::PrimitiveStatistics;
 use polars_parquet::parquet::types::NativeType;
-use polars_parquet::parquet::write::WriteOptions;
+use polars_parquet::write::WriteOptions;
 
 fn unzip_option<T: NativeType>(array: &[Option<T>]) -> ParquetResult<(Vec<u8>, Vec<u8>)> {
     // leave the first 4 bytes announcing the length of the def level
@@ -49,7 +49,7 @@ pub fn array_to_page_v1<T: NativeType>(
 
     buffer.extend_from_slice(&values);
 
-    let statistics = if options.write_statistics {
+    let statistics = if options.has_page_statistics() {
         let statistics = &PrimitiveStatistics {
             primitive_type: descriptor.primitive_type.clone(),
             null_count: Some((array.len() - array.iter().flatten().count()) as i64),

--- a/crates/polars/tests/it/io/parquet/write/sidecar.rs
+++ b/crates/polars/tests/it/io/parquet/write/sidecar.rs
@@ -1,7 +1,9 @@
+use polars::prelude::StatisticsOptions;
 use polars_parquet::parquet::error::ParquetError;
 use polars_parquet::parquet::metadata::SchemaDescriptor;
 use polars_parquet::parquet::schema::types::{ParquetType, PhysicalType};
-use polars_parquet::parquet::write::{FileWriter, Version, WriteOptions, write_metadata_sidecar};
+use polars_parquet::parquet::write::{FileWriter, Version, write_metadata_sidecar};
+use polars_parquet::write::WriteOptions;
 
 #[test]
 fn basic() -> Result<(), ParquetError> {
@@ -19,8 +21,11 @@ fn basic() -> Result<(), ParquetError> {
             writer,
             schema.clone(),
             WriteOptions {
-                write_statistics: true,
+                statistics: StatisticsOptions::default(),
+                page_index: false,
                 version: Version::V2,
+                compression: polars_parquet::write::CompressionOptions::Uncompressed,
+                data_page_size: None,
             },
             None,
         );

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3834,6 +3834,8 @@ class DataFrame:
         compression: ParquetCompression = "zstd",
         compression_level: int | None = None,
         statistics: bool | str | dict[str, bool] = True,
+        page_index: bool = False,
+        column_indexes: bool = True,
         row_group_size: int | None = None,
         data_page_size: int | None = None,
         use_pyarrow: bool = False,
@@ -3884,6 +3886,10 @@ class DataFrame:
               - "max": column maximum value (default: `True`)
               - "distinct_count": number of unique column values (default: `False`)
               - "null_count": number of null values in column (default: `True`)
+              - "level" at which granularity to write statistics either `chunk` or
+              `page`. `None`, (default: `chunk`)
+        page_index:
+            Write write the column and offset indexes.
         row_group_size
             Size of the row groups in number of rows. Defaults to 512^2 rows.
         data_page_size
@@ -3995,6 +4001,7 @@ class DataFrame:
             )
             pyarrow_options["compression_level"] = compression_level
             pyarrow_options["write_statistics"] = statistics
+            pyarrow_options["write_page_index"] = page_index
             pyarrow_options["row_group_size"] = row_group_size
             pyarrow_options["data_page_size"] = data_page_size
 
@@ -4034,6 +4041,7 @@ class DataFrame:
                 "max": True,
                 "distinct_count": False,
                 "null_count": True,
+                "level": "page",
             }
         elif isinstance(statistics, bool) and not statistics:
             statistics = {}
@@ -4043,6 +4051,7 @@ class DataFrame:
                 "max": True,
                 "distinct_count": True,
                 "null_count": True,
+                "level": "page",
             }
 
         if partition_by is not None:
@@ -4057,8 +4066,9 @@ class DataFrame:
             compression,
             compression_level,
             statistics,
-            row_group_size,
-            data_page_size,
+            page_index=page_index,
+            row_group_size=row_group_size,
+            data_page_size=data_page_size,
             partition_by=partition_by,
             partition_chunk_size_bytes=partition_chunk_size_bytes,
             cloud_options=storage_options,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2475,6 +2475,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         compression: str = "zstd",
         compression_level: int | None = None,
         statistics: bool | str | dict[str, bool] = True,
+        page_index: bool,
         row_group_size: int | None = None,
         data_page_size: int | None = None,
         maintain_order: bool = True,
@@ -2538,6 +2539,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
               - "max": column maximum value (default: `True`)
               - "distinct_count": number of unique column values (default: `False`)
               - "null_count": number of null values in column (default: `True`)
+              - "level" at which granularity to write statistics either `chunk` or
+              `page`. `None`, (default: `chunk)
+        page_index:
+            Write write the column and offset indexes.
         row_group_size
             Size of the row groups in number of rows.
             If None (default), the chunks of the `DataFrame` are
@@ -2637,6 +2642,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 "max": True,
                 "distinct_count": False,
                 "null_count": True,
+                "level": "page",
             }
         elif isinstance(statistics, bool) and not statistics:
             statistics = {}
@@ -2646,6 +2652,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 "max": True,
                 "distinct_count": True,
                 "null_count": True,
+                "level": "page",
             }
 
         from polars.io.cloud.credential_provider._builder import (
@@ -2680,6 +2687,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             compression=compression,
             compression_level=compression_level,
             statistics=statistics,
+            page_index=page_index,
             row_group_size=row_group_size,
             data_page_size=data_page_size,
             cloud_options=storage_options,


### PR DESCRIPTION
Since PyArrow does not write page-level metadata by default, our parquet files are much bigger (x2+) for high-cardinality data by default. This at least lets you disable it.