### PR TITLE
feat: Add `cat.slice`

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -46,6 +46,8 @@ use polars_core::prelude::*;
 pub use split::*;
 #[cfg(feature = "strings")]
 pub use strip::*;
+#[cfg(feature = "strings")]
+pub use substring::{substring_ternary_offsets_value, update_view};
 
 pub trait AsString {
     fn as_string(&self) -> &StringChunked;

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -92,7 +92,7 @@ fn substring_ternary_offsets(
     ))
 }
 
-fn substring_ternary_offsets_value(str_val: &str, offset: i64, length: u64) -> (usize, usize) {
+pub fn substring_ternary_offsets_value(str_val: &str, offset: i64, length: u64) -> (usize, usize) {
     // Fast-path: always empty string.
     if length == 0 || offset >= str_val.len() as i64 {
         return (0, 0);
@@ -137,7 +137,7 @@ fn substring_ternary(
     unsafe { opt_str_val.map(|str_val| str_val.get_unchecked(start..end)) }
 }
 
-fn update_view(mut view: View, start: usize, end: usize, val: &str) -> View {
+pub fn update_view(mut view: View, start: usize, end: usize, val: &str) -> View {
     let length = (end - start) as u32;
     view.length = length;
 

--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -36,4 +36,12 @@ impl CategoricalNameSpace {
                 suffix,
             )))
     }
+
+    #[cfg(feature = "strings")]
+    pub fn slice(self, offset: i64, length: Option<usize>) -> Expr {
+        self.0
+            .map_private(FunctionExpr::Categorical(CategoricalFunction::Slice(
+                offset, length,
+            )))
+    }
 }

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -13,6 +13,8 @@ pub enum CategoricalFunction {
     StartsWith(String),
     #[cfg(feature = "strings")]
     EndsWith(String),
+    #[cfg(feature = "strings")]
+    Slice(i64, Option<usize>),
 }
 
 impl CategoricalFunction {
@@ -28,6 +30,8 @@ impl CategoricalFunction {
             StartsWith(_) => mapper.with_dtype(DataType::Boolean),
             #[cfg(feature = "strings")]
             EndsWith(_) => mapper.with_dtype(DataType::Boolean),
+            #[cfg(feature = "strings")]
+            Slice(_, _) => mapper.with_dtype(DataType::String),
         }
     }
 }
@@ -45,6 +49,8 @@ impl Display for CategoricalFunction {
             StartsWith(_) => "starts_with",
             #[cfg(feature = "strings")]
             EndsWith(_) => "ends_with",
+            #[cfg(feature = "strings")]
+            Slice(_, _) => "slice",
         };
         write!(f, "cat.{s}")
     }
@@ -63,6 +69,8 @@ impl From<CategoricalFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             StartsWith(prefix) => map!(starts_with, prefix.as_str()),
             #[cfg(feature = "strings")]
             EndsWith(suffix) => map!(ends_with, suffix.as_str()),
+            #[cfg(feature = "strings")]
+            Slice(offset, length) => map!(slice, offset, length),
         }
     }
 }
@@ -101,12 +109,14 @@ fn _get_cat_phys_map(ca: &CategoricalChunked) -> (StringChunked, Series) {
 
 /// Fast path: apply a string function to the categories of a categorical column and broadcast the
 /// result back to the array.
-fn apply_to_cats<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
+// fn apply_to_cats<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
+fn apply_to_cats<F, T>(c: &Column, mut op: F) -> PolarsResult<Column>
 where
     F: FnMut(&StringChunked) -> ChunkedArray<T>,
     ChunkedArray<T>: IntoSeries,
     T: PolarsDataType<HasViews = FalseT, IsStruct = FalseT, IsNested = FalseT>,
 {
+    let ca = c.categorical()?;
     let (categories, phys) = _get_cat_phys_map(ca);
     let result = op(&categories);
     // SAFETY: physical idx array is valid.
@@ -116,12 +126,13 @@ where
 
 /// Fast path: apply a binary function to the categories of a categorical column and broadcast the
 /// result back to the array.
-fn apply_to_cats_binary<F, T>(ca: &CategoricalChunked, mut op: F) -> PolarsResult<Column>
+fn apply_to_cats_binary<F, T>(c: &Column, mut op: F) -> PolarsResult<Column>
 where
     F: FnMut(&BinaryChunked) -> ChunkedArray<T>,
     ChunkedArray<T>: IntoSeries,
     T: PolarsDataType<HasViews = FalseT, IsStruct = FalseT, IsNested = FalseT>,
 {
+    let ca = c.categorical()?;
     let (categories, phys) = _get_cat_phys_map(ca);
     let result = op(&categories.as_binary());
     // SAFETY: physical idx array is valid.
@@ -130,25 +141,38 @@ where
 }
 
 #[cfg(feature = "strings")]
-fn len_bytes(s: &Column) -> PolarsResult<Column> {
-    let ca = s.categorical()?;
-    apply_to_cats(ca, |s| s.str_len_bytes())
+fn len_bytes(c: &Column) -> PolarsResult<Column> {
+    apply_to_cats(c, |s| s.str_len_bytes())
 }
 
 #[cfg(feature = "strings")]
-fn len_chars(s: &Column) -> PolarsResult<Column> {
-    let ca = s.categorical()?;
-    apply_to_cats(ca, |s| s.str_len_chars())
+fn len_chars(c: &Column) -> PolarsResult<Column> {
+    apply_to_cats(c, |s| s.str_len_chars())
 }
 
 #[cfg(feature = "strings")]
-fn starts_with(s: &Column, prefix: &str) -> PolarsResult<Column> {
-    let ca = s.categorical()?;
-    apply_to_cats(ca, |s| s.starts_with(prefix))
+fn starts_with(c: &Column, prefix: &str) -> PolarsResult<Column> {
+    apply_to_cats(c, |s| s.starts_with(prefix))
 }
 
 #[cfg(feature = "strings")]
-fn ends_with(s: &Column, suffix: &str) -> PolarsResult<Column> {
-    let ca = s.categorical()?;
-    apply_to_cats_binary(ca, |s| s.as_binary().ends_with(suffix.as_bytes()))
+fn ends_with(c: &Column, suffix: &str) -> PolarsResult<Column> {
+    apply_to_cats_binary(c, |s| s.as_binary().ends_with(suffix.as_bytes()))
+}
+
+#[cfg(feature = "strings")]
+fn slice(c: &Column, offset: i64, length: Option<usize>) -> PolarsResult<Column> {
+    let length = length.unwrap_or(usize::MAX) as u64;
+    let ca = c.categorical()?;
+    let (categories, phys) = _get_cat_phys_map(ca);
+
+    let result = unsafe {
+        categories.apply_views(|view, val| {
+            let (start, end) = substring_ternary_offsets_value(val, offset, length);
+            update_view(view, start, end, val)
+        })
+    };
+    // SAFETY: physical idx array is valid.
+    let out = unsafe { result.take_unchecked(phys.idx().unwrap()) };
+    Ok(out.into_column())
 }

--- a/crates/polars-python/src/expr/categorical.rs
+++ b/crates/polars-python/src/expr/categorical.rs
@@ -23,4 +23,9 @@ impl PyExpr {
     fn cat_ends_with(&self, suffix: String) -> Self {
         self.inner.clone().cat().ends_with(suffix).into()
     }
+
+    #[pyo3(signature = (offset, length=None))]
+    fn cat_slice(&self, offset: i64, length: Option<usize>) -> Self {
+        self.inner.clone().cat().slice(offset, length).into()
+    }
 }

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -272,7 +272,8 @@ class ExprCatNameSpace:
         ...             ["pear", None, "papaya", "dragonfruit"],
         ...             dtype=pl.Categorical,
         ...         )
-        ...     },
+        ...     }
+        ... )
         >>> df.with_columns(pl.col("s").cat.slice(-3).alias("slice"))
         shape: (4, 2)
         ┌─────────────┬───────┐

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -237,3 +237,68 @@ class ExprCatNameSpace:
             msg = f"'suffix' must be a string; found {type(suffix)!r}"
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.cat_ends_with(suffix))
+
+    def slice(self, offset: int, length: int | None = None) -> Expr:
+        """
+        Extract a substring from each string value.
+
+        Parameters
+        ----------
+        offset
+            Start index. Negative indexing is supported.
+        length
+            Length of the slice. If set to `None` (default), the slice is taken to the
+            end of the string.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`String`.
+
+        Notes
+        -----
+        Both the `offset` and `length` inputs are defined in terms of the number
+        of characters in the (UTF8) string. A character is defined as a
+        `Unicode scalar value`_. A single character is represented by a single byte
+        when working with ASCII text, and a maximum of 4 bytes otherwise.
+
+        .. _Unicode scalar value: https://www.unicode.org/glossary/#unicode_scalar_value
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "s": pl.Series(
+        ...             ["pear", None, "papaya", "dragonfruit"],
+        ...             dtype=pl.Categorical,
+        ...         )
+        ...     },
+        >>> df.with_columns(pl.col("s").cat.slice(-3).alias("slice"))
+        shape: (4, 2)
+        ┌─────────────┬───────┐
+        │ s           ┆ slice │
+        │ ---         ┆ ---   │
+        │ cat         ┆ str   │
+        ╞═════════════╪═══════╡
+        │ pear        ┆ ear   │
+        │ null        ┆ null  │
+        │ papaya      ┆ aya   │
+        │ dragonfruit ┆ uit   │
+        └─────────────┴───────┘
+
+        Using the optional `length` parameter
+
+        >>> df.with_columns(pl.col("s").cat.slice(4, length=3).alias("slice"))
+        shape: (4, 2)
+        ┌─────────────┬───────┐
+        │ s           ┆ slice │
+        │ ---         ┆ ---   │
+        │ cat         ┆ str   │
+        ╞═════════════╪═══════╡
+        │ pear        ┆       │
+        │ null        ┆ null  │
+        │ papaya      ┆ ya    │
+        │ dragonfruit ┆ onf   │
+        └─────────────┴───────┘
+        """
+        return wrap_expr(self._pyexpr.cat_slice(offset, length))

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -240,7 +240,7 @@ class ExprCatNameSpace:
 
     def slice(self, offset: int, length: int | None = None) -> Expr:
         """
-        Extract a substring from each string value.
+        Extract a substring from the string representation of each value.
 
         Parameters
         ----------

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -242,7 +242,7 @@ class CatNameSpace:
 
     def slice(self, offset: int, length: int | None = None) -> Series:
         """
-        Extract a substring from each string value.
+        Extract a substring from the string representation of each string value.
 
         Parameters
         ----------

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -239,3 +239,55 @@ class CatNameSpace:
             null
         ]
         """
+
+    def slice(self, offset: int, length: int | None = None) -> Series:
+        """
+        Extract a substring from each string value.
+
+        Parameters
+        ----------
+        offset
+            Start index. Negative indexing is supported.
+        length
+            Length of the slice. If set to `None` (default), the slice is taken to the
+            end of the string.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`String`.
+
+        Notes
+        -----
+        Both the `offset` and `length` inputs are defined in terms of the number
+        of characters in the (UTF8) string. A character is defined as a
+        `Unicode scalar value`_. A single character is represented by a single byte
+        when working with ASCII text, and a maximum of 4 bytes otherwise.
+
+        .. _Unicode scalar value: https://www.unicode.org/glossary/#unicode_scalar_value
+
+        Examples
+        --------
+        >>> s = pl.Series(["pear", None, "papaya", "dragonfruit"], dtype=pl.Categorical)
+        >>> s.cat.slice(-3)
+        shape: (4,)
+        Series: '' [str]
+        [
+            "ear"
+            null
+            "aya"
+            "uit"
+        ]
+
+        Using the optional `length` parameter
+
+        >>> s.cat.slice(4, length=3)
+        shape: (4,)
+        Series: '' [str]
+        [
+            ""
+            null
+            "ya"
+            "onf"
+        ]
+        """

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -276,3 +276,28 @@ def test_starts_ends_with() -> None:
 
     with pytest.raises(TypeError, match="'suffix' must be a string; found"):
         df.select(pl.col("a").cat.ends_with(None))  # type: ignore[arg-type]
+
+
+def test_cat_slice() -> None:
+    df = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [
+                    "foobar",
+                    "barfoo",
+                    "foobar",
+                    "x",
+                    None,
+                ],
+                dtype=pl.Categorical,
+            )
+        }
+    )
+    assert df["a"].cat.slice(-3).to_list() == ["bar", "foo", "bar", "x", None]
+    assert df.select([pl.col("a").cat.slice(2, 4)])["a"].to_list() == [
+        "obar",
+        "rfoo",
+        "obar",
+        "",
+        None,
+    ]


### PR DESCRIPTION
As with the other categorical string operations this doesn't allow expression input, as that would negate the whole benefit from performing the operation on categoricals.

```pycon
>>> import polars as pl
>>> s = pl.Series(["foobar", "barfoo", "x", None], dtype=pl.Categorical)
>>> s.cat.slice(1, 3)
shape: (4,)
Series: '' [str]
[
        "oob"
        "arf"
        ""
        null
]
```