### PR TITLE
docs(python): Separate `interpolate` operations for `DataFrame` and `Expr`

### DIFF
--- a/docs/source/_build/API_REFERENCE_LINKS.yml
+++ b/docs/source/_build/API_REFERENCE_LINKS.yml
@@ -23,6 +23,7 @@ python:
   cs.temporal: https://docs.pola.rs/api/python/stable/reference/selectors.html#polars.selectors.temporal
   DataFrame: https://docs.pola.rs/api/python/stable/reference/dataframe/index.html
   DataFrame.explode: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.explode.html
+  DataFrame.interpolate: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.interpolate.html
   date_range: https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.date_range.html
   datetime_range: https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.datetime_range.html
   describe: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.describe.html
@@ -72,7 +73,7 @@ python:
   group_by_dynamic: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.group_by_dynamic.html
   head: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.head.html
   implode: https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.implode.html
-  interpolate: https://docs.pola.rs/api/python/stable/reference/dataframe/api/polars.DataFrame.interpolate.html
+  interpolate: https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.interpolate.html
   is_between: https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.is_between.html
   is_duplicated: https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.is_duplicated.html
   is_null: https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.is_null.html

--- a/docs/source/user-guide/transformations/time-series/resampling.md
+++ b/docs/source/user-guide/transformations/time-series/resampling.md
@@ -40,7 +40,7 @@ strategy to replace the nulls with the previous non-null value:
 
 In this example we instead fill the nulls by linear interpolation:
 
-{{code_block('user-guide/transformations/time-series/resampling','upsample2',['upsample','interpolate','fill_null'])}}
+{{code_block('user-guide/transformations/time-series/resampling','upsample2',['upsample','DataFrame.interpolate','fill_null'])}}
 
 ```python exec="on" result="text" session="user-guide/transformations/ts/resampling"
 --8<-- "python/user-guide/transformations/time-series/resampling.py:upsample2"


### PR DESCRIPTION
It looks like both `DataFrame.interpolate()` and `Expr.interpolate()` are used in the docs. However, the current references only point to `DataFrame.interpolate()`, leading to incorrect references for [fill-with-interpolation of missing data](https://docs.pola.rs/user-guide/expressions/missing-data/#fill-with-interpolation). This PR fixes the issue.