### PR TITLE
fix: Error instead of panick for invalid durations in `dt.offset_by()` and `dt.round()`

### DIFF
--- a/crates/polars-time/src/offset_by.rs
+++ b/crates/polars-time/src/offset_by.rs
@@ -72,7 +72,7 @@ pub fn impl_offset_by(ts: &Series, offsets: &Series) -> PolarsResult<Series> {
     let preserve_sortedness = match offsets.len() {
         1 => match offsets.get(0) {
             Some(offset) => {
-                let offset = Duration::parse(offset);
+                let offset = Duration::try_parse(offset)?;
                 offset.is_constant_duration(tz.as_deref())
             },
             None => false,

--- a/crates/polars-time/src/round.rs
+++ b/crates/polars-time/src/round.rs
@@ -26,7 +26,7 @@ impl PolarsRound for DatetimeChunked {
         // Let's check if we can use a fastpath...
         if every.len() == 1 {
             if let Some(every) = every.get(0) {
-                let every_parsed = Duration::parse(every);
+                let every_parsed = Duration::try_parse(every)?;
                 if every_parsed.negative {
                     polars_bail!(ComputeError: "cannot round a Datetime to a negative duration")
                 }
@@ -99,7 +99,7 @@ impl PolarsRound for DateChunked {
         let out = match every.len() {
             1 => {
                 if let Some(every) = every.get(0) {
-                    let every = Duration::parse(every);
+                    let every = Duration::try_parse(every)?;
                     if every.negative {
                         polars_bail!(ComputeError: "cannot round a Date to a negative duration")
                     }

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_datetime.py
@@ -212,6 +212,13 @@ def test_offset_by_sortedness(
     assert not result.flags["SORTED_DESC"]
 
 
+def test_offset_by_invalid_duration() -> None:
+    with pytest.raises(
+        InvalidOperationError, match="expected leading integer in the duration string"
+    ):
+        pl.Series([datetime(2022, 3, 20, 5, 7)]).dt.offset_by("P")
+
+
 def test_dt_datetime_date_time_invalid() -> None:
     with pytest.raises(ComputeError, match="expected Datetime or Date"):
         pl.Series([time(23)]).dt.date()
@@ -626,6 +633,13 @@ def test_round_negative() -> None:
         ComputeError, match="cannot round a Datetime to a negative duration"
     ):
         pl.Series([datetime(1895, 5, 7)]).dt.round("-1m")
+
+
+def test_round_invalid_duration() -> None:
+    with pytest.raises(
+        InvalidOperationError, match="expected leading integer in the duration string"
+    ):
+        pl.Series([datetime(2022, 3, 20, 5, 7)]).dt.round("P")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #21955 (but doesn't address the [comment](https://github.com/pola-rs/polars/issues/21955#issuecomment-2763965816) on invalid durations containing only a digit)

**Before**
```python
import polars as pl
pl.Series(["2025-03-27"]).str.to_date().dt.offset_by("P")
pl.Series(["2025-03-27"]).str.to_date().dt.round("P")

pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: InvalidOperation(ErrString("expected leading integer in the duration string, found P"))
```

**After**

```
polars.exceptions.InvalidOperationError: expected leading integer in the duration string, found P
```