### PR TITLE
fix: Fix glob expansion matching extra files

### DIFF
--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -389,9 +389,6 @@ mod test {
         let url = "s3://bucket/folder/**/data.parquet";
         let cloud_location = CloudLocation::new(url, true).unwrap();
 
-        dbg!(&cloud_location.prefix);
-        dbg!(&cloud_location.expansion);
-
         let a = Matcher::new(cloud_location.prefix, cloud_location.expansion.as_deref()).unwrap();
 
         assert!(!a.is_matching("folder/_data.parquet"));

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -273,7 +273,7 @@ mod test {
                 scheme: "s3".into(),
                 bucket: "a".into(),
                 prefix: "b/".into(),
-                expansion: Some("^([^/]*)\\.c$".into()),
+                expansion: Some("^[^/]*\\.c$".into()),
             }
         );
         assert_eq!(

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -23,7 +23,7 @@ pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Opt
     // (offset, len, replacement)
     let mut replacements: Vec<(usize, usize, &[u8])> = vec![];
 
-    // after_last_slash
+    // The position after the last slash before glob characters begin.
     // `a/b/c*/`
     //      ^
     let mut pos: usize = if let Some(after_last_slash) = memchr::memchr2(b'*', b'[', url.as_bytes())
@@ -47,6 +47,9 @@ pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Opt
         }
 
         let (len, replace): (usize, &[u8]) = match &url[pos..] {
+            // Accept:
+            // - `**/`
+            // - `**` only if it is the end of the url
             v if v.starts_with("**") && (v.len() == 2 || v.as_bytes()[2] == b'/') => {
                 (3, b"(.*/)?" as _)
             },

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -33,6 +33,7 @@ pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Opt
                 .rposition(|x| *x == b'/')
                 .map_or(0, |x| 1 + x)
         }) {
+        // First value is used as the starting point later.
         replacements.push((after_last_slash, 0, &[]));
         after_last_slash
     } else {

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -51,12 +51,14 @@ pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Opt
             // - `**/`
             // - `**` only if it is the end of the url
             v if v.starts_with("**") && (v.len() == 2 || v.as_bytes()[2] == b'/') => {
+                // Wrapping in a capture group ensures we also match non-nested paths.
                 (3, b"(.*/)?" as _)
             },
             v if v.starts_with("**") => {
                 polars_bail!(ComputeError: "invalid ** glob pattern")
             },
-            v if v.starts_with('*') => (1, b"([^/]*)" as _),
+            v if v.starts_with('*') => (1, b"[^/]*" as _),
+            // Dots need to be escaped in regex.
             v if v.starts_with('.') => (1, b"\\." as _),
             _ => {
                 pos += 1;

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -27,8 +27,7 @@ pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Opt
     //      ^
     let mut pos: usize = if let Some(after_last_slash) = memchr::memchr2(b'*', b'.', url.as_bytes())
         .map(|i| {
-            url[..i]
-                .as_bytes()
+            url.as_bytes()[..i]
                 .iter()
                 .rposition(|x| *x == b'/')
                 .map_or(0, |x| 1 + x)
@@ -39,8 +38,8 @@ pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Opt
         usize::MAX
     };
 
-    while pos < url.as_bytes().len() {
-        match memchr::memchr(b'*', url[pos..].as_bytes()) {
+    while pos < url.len() {
+        match memchr::memchr(b'*', &url.as_bytes()[pos..]) {
             None => break,
             Some(i) => pos += i,
         }
@@ -69,7 +68,7 @@ pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Opt
     let prefix = Cow::Borrowed(&url[..replacements[0].0]);
 
     let mut pos = replacements[0].0;
-    let mut expansion = Vec::with_capacity(url.as_bytes().len() - pos);
+    let mut expansion = Vec::with_capacity(url.len() - pos);
     expansion.push(b'^');
 
     for (offset, len, replace) in replacements {

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -304,15 +304,15 @@ mod test {
         );
         assert_eq!(
             extract_prefix_expansion("a/**/*b").unwrap(),
-            ("a/".into(), Some("^(.*/)?([^/]*)b$".into()))
+            ("a/".into(), Some("^(.*/)?[^/]*b$".into()))
         );
         assert_eq!(
             extract_prefix_expansion("a/**/data/*b").unwrap(),
-            ("a/".into(), Some("^(.*/)?data/([^/]*)b$".into()))
+            ("a/".into(), Some("^(.*/)?data/[^/]*b$".into()))
         );
         assert_eq!(
             extract_prefix_expansion("a/*b").unwrap(),
-            ("a/".into(), Some("^([^/]*)b$".into()))
+            ("a/".into(), Some("^[^/]*b$".into()))
         );
     }
 

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -20,6 +20,7 @@ const DELIMITER: char = '/';
 /// 2. a regular expression representation of the rest.
 pub(crate) fn extract_prefix_expansion(url: &str) -> PolarsResult<(Cow<str>, Option<String>)> {
     let url = url.strip_prefix('/').unwrap_or(url);
+    // (offset, len, replacement)
     let mut replacements: Vec<(usize, usize, &[u8])> = vec![];
 
     // after_last_slash

--- a/crates/polars-io/src/path_utils/hugging_face.rs
+++ b/crates/polars-io/src/path_utils/hugging_face.rs
@@ -1,5 +1,6 @@
 // Hugging Face path resolution support
 
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 
@@ -256,10 +257,10 @@ pub(super) async fn expand_paths_hf(
         let (prefix, expansion) = if glob {
             extract_prefix_expansion(rel_path)?
         } else {
-            (path_parts.path.clone(), None)
+            (Cow::Owned(path_parts.path.clone()), None)
         };
         let expansion_matcher = &if expansion.is_some() {
-            Some(Matcher::new(prefix.as_str().into(), expansion.as_deref())?)
+            Some(Matcher::new(prefix.to_string(), expansion.as_deref())?)
         } else {
             None
         };
@@ -284,7 +285,7 @@ pub(super) async fn expand_paths_hf(
         hive_idx_tracker.update(repo_location.get_file_uri(rel_path).len(), path_idx)?;
 
         assert!(stack.is_empty());
-        stack.push_back(prefix.to_string());
+        stack.push_back(prefix.into_owned());
 
         while let Some(rel_path) = stack.pop_front() {
             assert!(entries.is_empty());


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/21736

We do globs by converting first converting to regex (I assume to avoid a dependency). This PR rewrites the conversion and fixes the wildcard `**` glob accidentally matching extra files.

Previously we would convert `**` to `.*` in regex, but this would cause e.g. `a/**/b` to match `a/<dir>/xb`. It is now instead translated to `(.*/)?` to ensure the matching is halted at the last forward-slash.
