### PR TITLE
refactor(rust): Dispatch new-streaming IPC source to updated multiscan

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc.rs
@@ -3,41 +3,92 @@ use std::io::Cursor;
 use std::ops::Range;
 use std::sync::Arc;
 
-use polars_core::config;
+use arrow::array::TryExtend;
+use async_trait::async_trait;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::DataType;
-use polars_core::schema::{Schema, SchemaExt, SchemaRef};
-use polars_core::utils::arrow::array::TryExtend;
-use polars_core::utils::arrow::bitmap::Bitmap;
+use polars_core::schema::{Schema, SchemaExt};
 use polars_core::utils::arrow::io::ipc::read::{
-    FileMetadata, FileReader, ProjectionInfo, get_row_count_from_blocks, prepare_projection,
-    read_file_metadata,
+    FileMetadata, ProjectionInfo, get_row_count_from_blocks, prepare_projection, read_file_metadata,
 };
-use polars_core::utils::slice_offsets;
 use polars_error::{ErrString, PolarsError, PolarsResult, polars_err};
 use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
-use polars_io::ipc::IpcScanOptions;
-use polars_io::utils::columns_to_projection;
 use polars_plan::dsl::{ScanSource, ScanSourceRef};
-use polars_plan::plans::FileInfo;
-use polars_plan::prelude::FileScanOptions;
 use polars_utils::IdxSize;
 use polars_utils::mmap::MemSlice;
-use polars_utils::pl_str::PlSmallStr;
 use polars_utils::priority::Priority;
+use polars_utils::slice_enum::Slice;
 
-use super::multi_scan::MultiScanable;
-use super::{RowRestriction, SourceNode, SourceOutput};
-use crate::async_executor::spawn;
-use crate::async_primitives::connector::Receiver;
+use super::multi_file_reader::reader_interface::output::FileReaderOutputRecv;
+use super::multi_file_reader::reader_interface::{BeginReadArgs, calc_row_position_after_slice};
+use crate::async_executor::{AbortOnDropHandle, JoinHandle, TaskPriority, spawn};
 use crate::async_primitives::distributor_channel::distributor_channel;
 use crate::async_primitives::linearizer::Linearizer;
-use crate::async_primitives::wait_group::WaitGroup;
-use crate::execute::StreamingExecutionState;
-use crate::morsel::{SourceToken, get_ideal_morsel_size};
-use crate::nodes::{JoinHandle, Morsel, MorselSeq, TaskPriority};
+use crate::morsel::{Morsel, MorselSeq, SourceToken, get_ideal_morsel_size};
+use crate::nodes::io_sources::multi_file_reader::reader_interface::output::FileReaderOutputSend;
+use crate::nodes::io_sources::multi_file_reader::reader_interface::{
+    FileReader, FileReaderCallbacks,
+};
 use crate::{DEFAULT_DISTRIBUTOR_BUFFER_SIZE, DEFAULT_LINEARIZER_BUFFER_SIZE};
+
+pub mod builder {
+    use std::sync::Arc;
+
+    use arrow::io::ipc::read::FileMetadata;
+    use polars_core::config;
+    use polars_io::cloud::CloudOptions;
+    use polars_plan::dsl::ScanSource;
+
+    use super::IpcFileReader;
+    use crate::nodes::io_sources::multi_file_reader::reader_interface::FileReader;
+    use crate::nodes::io_sources::multi_file_reader::reader_interface::builder::FileReaderBuilder;
+    use crate::nodes::io_sources::multi_file_reader::reader_interface::capabilities::ReaderCapabilities;
+
+    #[derive(Debug)]
+    pub struct IpcReaderBuilder {
+        pub first_metadata: Option<Arc<FileMetadata>>,
+    }
+
+    #[cfg(feature = "ipc")]
+    impl FileReaderBuilder for IpcReaderBuilder {
+        fn reader_name(&self) -> &str {
+            "ipc"
+        }
+
+        fn reader_capabilities(&self) -> ReaderCapabilities {
+            use ReaderCapabilities as RC;
+
+            RC::ROW_INDEX | RC::PRE_SLICE | RC::NEGATIVE_PRE_SLICE
+        }
+
+        fn build_file_reader(
+            &self,
+            source: ScanSource,
+            cloud_options: Option<Arc<CloudOptions>>,
+            scan_source_idx: usize,
+        ) -> Box<dyn FileReader> {
+            let scan_source = source;
+            let verbose = config::verbose();
+
+            let metadata: Option<Arc<FileMetadata>> = if scan_source_idx == 0 {
+                self.first_metadata.clone()
+            } else {
+                None
+            };
+
+            let reader = IpcFileReader {
+                scan_source,
+                cloud_options,
+                metadata,
+                verbose,
+                init_data: None,
+            };
+
+            Box::new(reader) as Box<dyn FileReader>
+        }
+    }
+}
 
 const ROW_COUNT_OVERFLOW_ERR: PolarsError = PolarsError::ComputeError(ErrString::new_static(
     "\
@@ -45,112 +96,21 @@ IPC file produces more than 2^32 rows; \
 consider compiling with polars-bigidx feature (polars-u64-idx package on python)",
 ));
 
-pub struct IpcSourceNode {
-    memslice: MemSlice,
-    metadata: Arc<FileMetadata>,
+struct IpcFileReader {
+    scan_source: ScanSource,
+    cloud_options: Option<Arc<CloudOptions>>,
+    metadata: Option<Arc<FileMetadata>>,
+    verbose: bool,
 
-    row_index: Option<RowIndex>,
-    slice: Range<usize>,
-
-    file_info: FileInfo,
-    projection_info: Option<ProjectionInfo>,
-
-    rechunk: bool,
+    init_data: Option<InitializedState>,
 }
 
-impl IpcSourceNode {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        source: ScanSource,
-        file_info: FileInfo,
-        options: IpcScanOptions,
-        cloud_options: Option<CloudOptions>,
-        file_options: FileScanOptions,
-        mut metadata: Option<Arc<FileMetadata>>,
-    ) -> PolarsResult<Self> {
-        // All these things should be handled by the MultiScan node
-        assert!(file_options.include_file_paths.is_none());
-        assert!(!file_options.allow_missing_columns);
-
-        let IpcScanOptions = options;
-
-        let FileScanOptions {
-            pre_slice: slice,
-            with_columns,
-            cache: _, // @TODO
-            row_index,
-            rechunk,
-            file_counter: _,
-            hive_options: _,
-            glob: _,
-            include_file_paths: _,
-            allow_missing_columns: _,
-        } = file_options;
-
-        let memslice = {
-            if let ScanSourceRef::Path(p) = source.as_scan_source_ref() {
-                if source.run_async() {
-                    polars_io::file_cache::init_entries_from_uri_list(
-                        &[Arc::from(p.to_str().unwrap())],
-                        cloud_options.as_ref(),
-                    )?;
-                }
-            }
-
-            // check_latest: IR resolution does not download IPC.
-
-            source
-                .as_scan_source_ref()
-                .to_memslice_async_check_latest(source.run_async())?
-        };
-
-        #[allow(clippy::match_single_binding)]
-        let metadata = match metadata.take() {
-            // TODO: Don't know why, this metadata does not match the file. This was during testing
-            // against a cloud scan:
-            // * ComputeError: out-of-spec: InvalidBuffersLength { buffers_size: 7200, file_size: 453 }
-            // Some(md) => md,
-            _ => Arc::new(read_file_metadata(&mut std::io::Cursor::new(
-                memslice.as_ref(),
-            ))?),
-        };
-
-        // Always create a slice. If no slice was given, just make the biggest slice possible.
-        let slice = match slice {
-            None => (0, usize::MAX),
-            Some((offset, length)) if offset < 0 => {
-                let file_num_rows = get_row_count_from_blocks(
-                    &mut std::io::Cursor::new(memslice.as_ref()),
-                    &metadata.blocks,
-                )?;
-                slice_offsets(offset, length, file_num_rows as usize)
-            },
-            Some((offset, length)) => (offset as usize, length),
-        };
-        let (offset, length) = slice;
-        let slice = offset..offset + length;
-
-        let projection = with_columns
-            .as_ref()
-            .map(|cols| columns_to_projection(cols, &metadata.schema))
-            .transpose()?;
-        let projection_info = projection
-            .as_ref()
-            .map(|p| prepare_projection(&metadata.schema, p.clone()));
-
-        Ok(IpcSourceNode {
-            memslice,
-            metadata,
-
-            slice,
-            row_index,
-
-            projection_info,
-            file_info,
-
-            rechunk,
-        })
-    }
+#[derive(Clone)]
+struct InitializedState {
+    memslice: MemSlice,
+    file_metadata: Arc<FileMetadata>,
+    // Lazily initialized - getting this involves iterating record batches.
+    n_rows_in_file: Option<IdxSize>,
 }
 
 /// Move `slice` forward by `n` and return the slice until then.
@@ -180,36 +140,175 @@ fn get_max_morsel_size() -> usize {
         .max(1)
 }
 
-impl SourceNode for IpcSourceNode {
-    fn name(&self) -> &str {
-        "ipc_source"
+#[async_trait]
+impl FileReader for IpcFileReader {
+    async fn initialize(&mut self) -> PolarsResult<()> {
+        if self.init_data.is_some() {
+            return Ok(());
+        }
+
+        // check_latest: IR resolution does not download IPC.
+        // TODO: Streaming reads
+        if let ScanSourceRef::Path(p) = self.scan_source.as_scan_source_ref() {
+            polars_io::file_cache::init_entries_from_uri_list(
+                &[Arc::from(p.to_str().unwrap())],
+                self.cloud_options.as_deref(),
+            )?;
+        }
+
+        let memslice = self
+            .scan_source
+            .as_scan_source_ref()
+            .to_memslice_async_check_latest(self.scan_source.run_async())?;
+
+        let file_metadata = if let Some(v) = self.metadata.clone() {
+            v
+        } else {
+            Arc::new(read_file_metadata(&mut std::io::Cursor::new(
+                memslice.as_ref(),
+            ))?)
+        };
+
+        self.init_data = Some(InitializedState {
+            memslice,
+            file_metadata,
+            n_rows_in_file: None,
+        });
+
+        Ok(())
     }
 
-    fn is_source_output_parallel(&self, _is_receiver_serial: bool) -> bool {
-        false
-    }
-
-    fn spawn_source(
+    fn begin_read(
         &mut self,
-        mut output_recv: Receiver<SourceOutput>,
-        state: &StreamingExecutionState,
-        join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
-        unrestricted_row_count: Option<tokio::sync::oneshot::Sender<IdxSize>>,
-    ) {
-        let num_pipelines = state.num_pipelines;
+        args: BeginReadArgs,
+    ) -> PolarsResult<(FileReaderOutputRecv, JoinHandle<PolarsResult<()>>)> {
+        let verbose = self.verbose;
+
+        let InitializedState {
+            memslice,
+            file_metadata,
+            n_rows_in_file: _,
+        } = self.init_data.clone().unwrap();
+
+        let BeginReadArgs {
+            projected_schema,
+            row_index,
+            pre_slice: pre_slice_arg,
+            predicate: None,
+            cast_columns_policy: _,
+            missing_columns_policy: _,
+            num_pipelines,
+            callbacks:
+                FileReaderCallbacks {
+                    file_schema_tx,
+                    n_rows_in_file_tx,
+                    row_position_on_end_tx,
+                },
+        } = args
+        else {
+            panic!("unsupported args: {:?}", &args)
+        };
+
+        let file_schema_pl = std::cell::LazyCell::new(|| {
+            Arc::new(Schema::from_arrow_schema(file_metadata.schema.as_ref()))
+        });
+
+        let normalized_pre_slice = if let Some(pre_slice) = pre_slice_arg.clone() {
+            Some(pre_slice.restrict_to_bounds(usize::try_from(self._n_rows_in_file()?).unwrap()))
+        } else {
+            None
+        };
+
+        if let Some(mut n_rows_in_file_tx) = n_rows_in_file_tx {
+            _ = n_rows_in_file_tx.try_send(self._n_rows_in_file()?);
+        }
+
+        if let Some(mut row_position_on_end_tx) = row_position_on_end_tx {
+            _ = row_position_on_end_tx
+                .try_send(self._row_position_after_slice(normalized_pre_slice.clone())?);
+        }
+
+        if let Some(mut file_schema_tx) = file_schema_tx {
+            _ = file_schema_tx.try_send(file_schema_pl.clone());
+        }
+
+        if normalized_pre_slice.as_ref().is_some_and(|x| x.len() == 0) {
+            let (_, rx) = FileReaderOutputSend::new_serial();
+
+            if verbose {
+                eprintln!(
+                    "[IpcFileReader]: early return: \
+                    n_rows_in_file: {} \
+                    pre_slice: {:?} \
+                    resolved_pre_slice: {:?} \
+                    ",
+                    self._n_rows_in_file()?,
+                    pre_slice_arg,
+                    normalized_pre_slice
+                )
+            }
+
+            return Ok((rx, spawn(TaskPriority::Low, std::future::ready(Ok(())))));
+        }
+
+        // Prepare parameters for tasks
+
+        // Always create a slice. If no slice was given, just make the biggest slice possible.
+        let slice: Range<usize> = normalized_pre_slice
+            .clone()
+            .map_or(0..usize::MAX, Range::<usize>::from);
+
+        // Avoid materializing projection info if we are projecting all the columns of this file.
+        let projection_indices: Option<Vec<usize>> = if let Some(first_mismatch_idx) =
+            (0..file_metadata.schema.len().min(projected_schema.len())).find(|&i| {
+                file_metadata.schema.get_at_index(i).unwrap().0
+                    != projected_schema.get_at_index(i).unwrap().0
+            }) {
+            let mut out = Vec::with_capacity(file_metadata.schema.len());
+
+            out.extend(0..first_mismatch_idx);
+
+            out.extend(
+                (first_mismatch_idx..projected_schema.len()).filter_map(|i| {
+                    file_metadata
+                        .schema
+                        .index_of(projected_schema.get_at_index(i).unwrap().0)
+                }),
+            );
+
+            Some(out)
+        } else if file_metadata.schema.len() > projected_schema.len() {
+            // Names match up to projected schema len.
+            Some((0..projected_schema.len()).collect::<Vec<_>>())
+        } else {
+            // Name order matches up to `file_metadata.schema.len()`, we are projecting all columns
+            // in this file.
+            None
+        };
+
+        if verbose {
+            eprintln!(
+                "[IpcFileReader]: \
+                project: {} / {}, \
+                pre_slice: {:?}, \
+                resolved_pre_slice: {:?} \
+                ",
+                projection_indices
+                    .as_ref()
+                    .map_or(file_metadata.schema.len(), |x| x.len()),
+                file_metadata.schema.len(),
+                pre_slice_arg,
+                normalized_pre_slice
+            )
+        }
+
+        let projection_info: Option<ProjectionInfo> =
+            projection_indices.map(|indices| prepare_projection(&file_metadata.schema, indices));
+
         // Split size for morsels.
         let max_morsel_size = get_max_morsel_size();
-        let source_token = SourceToken::new();
 
-        let Self {
-            memslice,
-            metadata,
-            row_index,
-            slice,
-            projection_info,
-            file_info: _,
-            rechunk,
-        } = self;
+        let metadata = file_metadata;
 
         /// Messages sent from Walker task to Decoder tasks.
         struct BatchMessage {
@@ -218,6 +317,8 @@ impl SourceNode for IpcSourceNode {
             block_range: Range<usize>,
             morsel_seq_base: u64,
         }
+
+        let (mut morsel_sender, morsel_rx) = FileReaderOutputSend::new_serial();
 
         // Walker task -> Decoder tasks.
         let (mut batch_tx, batch_rxs) =
@@ -229,38 +330,27 @@ impl SourceNode for IpcSourceNode {
                 *DEFAULT_LINEARIZER_BUFFER_SIZE,
             );
 
-        // Distributor task.
-        //
-        // Shuffles morsels from `n` producers amongst `n` consumers.
+        // Explicitly linearize here to redistribute morsels from large record batches.
         //
         // If record batches in the source IPC file are large, one decoder might produce many
         // morsels at the same time. At the same time, other decoders might not produce anything.
         // Therefore, we would like to distribute the output of a single decoder task over the
         // available output pipelines.
-        join_handles.push(spawn(TaskPriority::High, async move {
-            // Every phase we are given a new send port.
-            'phase_loop: while let Ok(phase_output) = output_recv.recv().await {
-                let mut sender = phase_output.port.serial();
-                let source_token = SourceToken::new();
-                let wait_group = WaitGroup::default();
+        //
+        // Note, we can theoretically use `FileReaderOutputSend::parallel()` as it also linearizes
+        // internally, but this behavior is an implementation detail rather than a guarantee.
+        let distributor_handle = AbortOnDropHandle::new(spawn(TaskPriority::High, async move {
+            // Note: We don't use this (it is handled by the bridge). But morsels require a source token.
+            let source_token = SourceToken::new();
 
-                while let Some(Priority(Reverse(seq), df)) = decoded_rx.get().await {
-                    let mut morsel = Morsel::new(df, seq, source_token.clone());
-                    morsel.set_consume_token(wait_group.token());
+            while let Some(Priority(Reverse(seq), df)) = decoded_rx.get().await {
+                let morsel = Morsel::new(df, seq, source_token.clone());
 
-                    if sender.send(morsel).await.is_err() {
-                        return Ok(());
-                    }
-
-                    wait_group.wait().await;
-                    if source_token.stop_requested() {
-                        phase_output.outcome.stop();
-                        continue 'phase_loop;
-                    }
+                if morsel_sender.send_morsel(morsel).await.is_err() {
+                    break;
                 }
-
-                break;
             }
+
             PolarsResult::Ok(())
         }));
 
@@ -270,19 +360,23 @@ impl SourceNode for IpcSourceNode {
         // Then, all record batches are concatenated into a DataFrame. If the resulting DataFrame
         // is too large, which happens when we have one very large block, the DataFrame is split
         // into smaller pieces an spread among the pipelines.
-        let decoder_tasks = decoded_tx.into_iter().zip(batch_rxs)
+        let decoder_handles = decoded_tx
+            .into_iter()
+            .zip(batch_rxs)
             .map(|(mut send, mut rx)| {
                 let memslice = memslice.clone();
                 let metadata = metadata.clone();
-                let rechunk = *rechunk;
                 let row_index = row_index.clone();
                 let projection_info = projection_info.clone();
-                spawn(TaskPriority::Low, async move {
+                AbortOnDropHandle::new(spawn(TaskPriority::Low, async move {
                     // Amortize allocations.
                     let mut data_scratch = Vec::new();
                     let mut message_scratch = Vec::new();
 
-                    let schema = projection_info.as_ref().map_or(metadata.schema.as_ref(), |ProjectionInfo { schema, .. }| schema);
+                    let schema = projection_info.as_ref().map_or(
+                        metadata.schema.as_ref(),
+                        |ProjectionInfo { schema, .. }| schema,
+                    );
                     let pl_schema = schema
                         .iter()
                         .map(|(n, f)| (n.clone(), DataType::from_arrow_field(f)))
@@ -301,7 +395,9 @@ impl SourceNode for IpcSourceNode {
                         let mut df = if pl_schema.is_empty() {
                             DataFrame::empty_with_height(slice.len())
                         } else {
-                            let mut reader = FileReader::new_with_projection_info(
+                            use polars_core::utils::arrow::io::ipc;
+
+                            let mut reader = ipc::read::FileReader::new_with_projection_info(
                                 Cursor::new(memslice.as_ref()),
                                 metadata.as_ref().clone(),
                                 projection_info.clone(),
@@ -322,9 +418,6 @@ impl SourceNode for IpcSourceNode {
                             (data_scratch, message_scratch) = reader.take_scratches();
                             df = df.slice(slice.start as i64, slice.len());
 
-                            if rechunk {
-                                df.rechunk_mut();
-                            }
                             df
                         };
 
@@ -335,20 +428,29 @@ impl SourceNode for IpcSourceNode {
 
                         // If the block is very large, we want to split the block amongst the
                         // pipelines. That will at least allow some parallelism.
-                        if df.height() > max_morsel_size && config::verbose() {
-                            eprintln!("IPC source encountered a (too) large record batch of {} rows. Splitting and continuing.", df.height());
+                        if df.height() > max_morsel_size && verbose {
+                            eprintln!(
+                                "IpcFileReader encountered a (too) large record batch \
+                                of {} rows. Splitting and continuing.",
+                                df.height()
+                            );
                         }
+
                         for i in 0..df.height().div_ceil(max_morsel_size) {
                             let morsel_df = df.slice((i * max_morsel_size) as i64, max_morsel_size);
                             let seq = MorselSeq::new(morsel_seq_base + i as u64);
-                            if send.insert(Priority(Reverse(seq), morsel_df)).await.is_err() {
+                            if send
+                                .insert(Priority(Reverse(seq), morsel_df))
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
                         }
                     }
 
                     PolarsResult::Ok(())
-                })
+                }))
             })
             .collect::<Vec<_>>();
 
@@ -361,18 +463,7 @@ impl SourceNode for IpcSourceNode {
         // Walker task.
         //
         // Walks all the sources and supplies block ranges to the decoder tasks.
-        join_handles.push(spawn(TaskPriority::Low, async move {
-            // Calculate the unrestricted row count if needed.
-            if let Some(rc) = unrestricted_row_count {
-                let num_rows = get_row_count_from_blocks(
-                    &mut std::io::Cursor::new(memslice.as_ref()),
-                    &metadata.blocks,
-                )?;
-                let num_rows = IdxSize::try_from(num_rows)
-                    .map_err(|_| polars_err!(bigidx, ctx = "ipc file", size = num_rows))?;
-                _ = rc.send(num_rows);
-            }
-
+        let walker_handle = AbortOnDropHandle::new(spawn(TaskPriority::Low, async move {
             let mut morsel_seq: u64 = 0;
             let mut row_idx_offset: IdxSize = row_index.as_ref().map_or(0, |ri| ri.offset);
             let mut slice: Range<usize> = slice;
@@ -388,7 +479,9 @@ impl SourceNode for IpcSourceNode {
             let sliced_batch_size_limit = slice.len().div_ceil(num_pipelines);
             let batch_block_limit = metadata.blocks.len().div_ceil(num_pipelines);
 
-            let mut reader = FileReader::new_with_projection_info(
+            use polars_core::utils::arrow::io::ipc;
+
+            let mut reader = ipc::read::FileReader::new_with_projection_info(
                 Cursor::new(memslice.as_ref()),
                 metadata.as_ref().clone(),
                 projection_info.clone(),
@@ -465,10 +558,6 @@ impl SourceNode for IpcSourceNode {
                             block_range,
                         };
 
-                        if source_token.stop_requested() {
-                            break 'read;
-                        }
-
                         if batch_tx.send(message).await.is_err() {
                             // This should only happen if the receiver of the decoder
                             // has broken off, meaning no further input will be needed.
@@ -492,99 +581,63 @@ impl SourceNode for IpcSourceNode {
                 }
             } // 'read
 
-            drop(batch_tx); // Inform decoder tasks to stop.
-            for decoder_task in decoder_tasks {
-                decoder_task.await?;
-            }
-
             PolarsResult::Ok(())
         }));
+
+        Ok((
+            morsel_rx,
+            spawn(TaskPriority::Low, async move {
+                distributor_handle.await?;
+
+                for handle in decoder_handles {
+                    handle.await?;
+                }
+
+                walker_handle.await?;
+                Ok(())
+            }),
+        ))
+    }
+
+    async fn n_rows_in_file(&mut self) -> PolarsResult<IdxSize> {
+        self._n_rows_in_file()
+    }
+
+    async fn row_position_after_slice(
+        &mut self,
+        pre_slice: Option<Slice>,
+    ) -> PolarsResult<IdxSize> {
+        self._row_position_after_slice(pre_slice)
     }
 }
 
-impl MultiScanable for IpcSourceNode {
-    type ReadOptions = IpcScanOptions;
+impl IpcFileReader {
+    fn _n_rows_in_file(&mut self) -> PolarsResult<IdxSize> {
+        let InitializedState {
+            memslice,
+            file_metadata,
+            n_rows_in_file,
+        } = self.init_data.as_mut().unwrap();
 
-    const BASE_NAME: &'static str = "ipc";
+        if n_rows_in_file.is_none() {
+            let n_rows: i64 = get_row_count_from_blocks(
+                &mut std::io::Cursor::new(memslice.as_ref()),
+                &file_metadata.blocks,
+            )?;
 
-    const SPECIALIZED_PRED_PD: bool = false;
+            let n_rows = IdxSize::try_from(n_rows)
+                .map_err(|_| polars_err!(bigidx, ctx = "ipc file", size = n_rows))?;
 
-    async fn new(
-        source: ScanSource,
-        options: &Self::ReadOptions,
-        cloud_options: Option<&CloudOptions>,
-        row_index: Option<PlSmallStr>,
-    ) -> PolarsResult<Self> {
-        let options = options.clone();
-
-        // TODO
-        // * `to_memslice_async_check_latest` being a non-async function is not ideal.
-        // * This is also downloading the whole file even if there is a projection
-        let memslice = {
-            if let ScanSourceRef::Path(p) = source.as_scan_source_ref() {
-                polars_io::file_cache::init_entries_from_uri_list(
-                    &[Arc::from(p.to_str().unwrap())],
-                    cloud_options,
-                )?;
-            }
-
-            source
-                .as_scan_source_ref()
-                .to_memslice_async_check_latest(source.run_async())?
-        };
-        let metadata = Arc::new(read_file_metadata(&mut std::io::Cursor::new(
-            memslice.as_ref(),
-        ))?);
-
-        let arrow_schema = metadata.schema.clone();
-        let schema = Schema::from_arrow_schema(arrow_schema.as_ref());
-        let schema = Arc::new(schema);
-
-        let mut file_options = FileScanOptions::default();
-        if let Some(name) = row_index {
-            file_options.row_index = Some(RowIndex { name, offset: 0 });
+            *n_rows_in_file = Some(n_rows);
         }
 
-        let file_info = FileInfo::new(
-            schema,
-            Some(rayon::iter::Either::Left(arrow_schema)),
-            (None, usize::MAX),
-        );
-
-        IpcSourceNode::new(
-            source,
-            file_info,
-            options,
-            cloud_options.cloned(),
-            file_options,
-            Some(metadata),
-        )
+        Ok(n_rows_in_file.unwrap())
     }
 
-    fn with_projection(&mut self, projection: Option<&Bitmap>) {
-        self.projection_info = projection.map(|p| {
-            let p = p.true_idx_iter().collect();
-            prepare_projection(&self.metadata.schema, p)
-        });
-    }
-    fn with_row_restriction(&mut self, row_restriction: Option<RowRestriction>) {
-        self.slice = 0..usize::MAX;
-        if let Some(row_restriction) = row_restriction {
-            match row_restriction {
-                RowRestriction::Slice(slice) => self.slice = slice,
-                RowRestriction::Predicate(_) => unreachable!(),
-            }
-        }
-    }
-
-    async fn unrestricted_row_count(&mut self) -> PolarsResult<IdxSize> {
-        get_row_count_from_blocks(
-            &mut std::io::Cursor::new(self.memslice.as_ref()),
-            &self.metadata.blocks,
-        )
-        .map(|v| v as IdxSize)
-    }
-    async fn physical_schema(&mut self) -> PolarsResult<SchemaRef> {
-        Ok(self.file_info.schema.clone())
+    fn _row_position_after_slice(&mut self, pre_slice: Option<Slice>) -> PolarsResult<IdxSize> {
+        Ok(calc_row_position_after_slice(
+            self._n_rows_in_file()?,
+            pre_slice,
+        ))
     }
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -504,6 +504,18 @@ pub fn lower_ir(
                     ) as Arc<dyn FileReaderBuilder>,
                     cloud_options,
                 )),
+                #[cfg(feature = "ipc")]
+                FileScan::Ipc {
+                    options: polars_io::ipc::IpcScanOptions {},
+                    cloud_options,
+                    metadata: first_metadata,
+                } => Some((
+                    Arc::new(crate::nodes::io_sources::ipc::builder::IpcReaderBuilder {
+                        first_metadata: first_metadata.clone(),
+                    }) as Arc<dyn FileReaderBuilder>,
+                    cloud_options,
+                )),
+
                 #[cfg(feature = "json")]
                 FileScan::NDJson {
                     options,

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -528,30 +528,7 @@ fn to_graph_rec<'a>(
                     #[cfg(feature = "parquet")]
                     polars_plan::dsl::FileScan::Parquet { .. } => unreachable!(),
                     #[cfg(feature = "ipc")]
-                    polars_plan::dsl::FileScan::Ipc {
-                        options,
-                        cloud_options,
-                        ..
-                    } => ctx.graph.add_node(
-                        nodes::io_sources::SourceComputeNode::new(
-                            nodes::io_sources::multi_scan::MultiScanNode::<
-                                nodes::io_sources::ipc::IpcSourceNode,
-                            >::new(
-                                scan_sources.clone(),
-                                hive_parts.clone().map(Arc::new),
-                                *allow_missing_columns,
-                                include_file_paths.clone(),
-                                file_schema.clone(),
-                                projection.clone(),
-                                row_index.clone(),
-                                row_restriction.clone(),
-                                predicate,
-                                options.clone(),
-                                cloud_options.clone(),
-                            ),
-                        ),
-                        [],
-                    ),
+                    polars_plan::dsl::FileScan::Ipc { .. } => unreachable!(),
                     #[cfg(feature = "csv")]
                     polars_plan::dsl::FileScan::Csv {
                         options,
@@ -641,28 +618,7 @@ fn to_graph_rec<'a>(
                     #[cfg(feature = "parquet")]
                     FileScan::Parquet { .. } => unreachable!(),
                     #[cfg(feature = "ipc")]
-                    FileScan::Ipc {
-                        options,
-                        cloud_options,
-                        metadata: first_metadata,
-                    } => {
-                        // Should have been rewritten in terms of separate streaming nodes.
-                        assert!(predicate.is_none());
-
-                        ctx.graph.add_node(
-                            nodes::io_sources::SourceComputeNode::new(
-                                nodes::io_sources::ipc::IpcSourceNode::new(
-                                    scan_source,
-                                    file_info,
-                                    options,
-                                    cloud_options,
-                                    *file_options,
-                                    first_metadata,
-                                )?,
-                            ),
-                            [],
-                        )
-                    },
+                    FileScan::Ipc { .. } => unreachable!(),
                     #[cfg(feature = "csv")]
                     FileScan::Csv { options, .. } => {
                         assert!(predicate.is_none());

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -348,8 +348,8 @@ def test_schema_mismatch_type_mismatch(
 @pytest.mark.parametrize(
     ("scan", "write", "ext"),
     [
-        (pl.scan_ipc, pl.DataFrame.write_ipc, "ipc"),
         # (pl.scan_parquet, pl.DataFrame.write_parquet, "parquet"), # TODO: _
+        # (pl.scan_ipc, pl.DataFrame.write_ipc, "ipc"), # TODO: _
         pytest.param(
             pl.scan_csv,
             pl.DataFrame.write_csv,


### PR DESCRIPTION
Also does some drive-by refactoring.

#### Benchmarks on 100x 1M IPC files (50 cols each):
Performance is essentially identical.

Tested on AWS `c6gn.8xlarge`. Files are on local disk.

* `head(10_000_000)` (first 10 files)
```python
# Before (pypi 1.26.0)
8.03s user 3.97s system 780% cpu 1.538 total
# After
8.07s user 4.30s system 826% cpu 1.498 total
```

* `tail(10_000_000)` (last 10 files)
```python
# Before (pypi 1.26.0)
8.11s user 4.00s system 773% cpu 1.564 total
# After
8.11s user 4.56s system 845% cpu 1.498 total
```
