### PR TITLE
perf: Fix quadratic behavior when casting Enums

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -149,11 +149,19 @@ impl CategoricalChunked {
         };
         // Make a mapping from old idx to new idx
         let old_rev_map = self.get_rev_map();
+
+        // Create map of old category -> idx for fast lookup.
+        let old_categories = old_rev_map.get_categories();
+        let old_idx_map: PlHashMap<&str, u32> = old_categories
+            .values_iter()
+            .zip(0..old_categories.len() as u32)
+            .collect();
+
         #[allow(clippy::unnecessary_cast)]
         let idx_map: PlHashMap<u32, u32> = categories
             .values_iter()
             .enumerate_idx()
-            .filter_map(|(new_idx, s)| old_rev_map.find(s).map(|old_idx| (old_idx, new_idx as u32)))
+            .filter_map(|(new_idx, s)| old_idx_map.get(s).map(|old_idx| (*old_idx, new_idx as u32)))
             .collect();
 
         // Loop over the physicals and try get new idx


### PR DESCRIPTION
Closes #21984.

(On debug build, so probably much slower than a pip build, but still shows speedup):

### Before

```
table cast: 0.052s
direct cast: 118.639s
```

### After
```
table cast: 0.074s
direct cast: 0.063s
```

<details>
<summary>Show test script</summary>

```python
import numpy as np

import polars as pl
from time import perf_counter

np.random.seed(0)


def random_Enum_Series():
    series = pl.Series(np.random.choice(list("ACGT"), size=(50_000, 10))).map_elements(
        "".join, return_dtype=pl.String
    )
    series = series.cast(pl.Enum(series.unique(maintain_order=True)))
    return series


a = random_Enum_Series()
b = random_Enum_Series()
enum_type = pl.Enum(
    pl.concat([a.cat.get_categories(), b.cat.get_categories()]).unique(
        maintain_order=True
    )
)


def cast_to_enum(series, enum_type):
    # Get categories as Series
    old_categories = series.cat.get_categories()
    new_categories = enum_type.categories

    # Create mapping table (old index to new index)
    mapping = (
        pl.DataFrame({"value": old_categories})
        .with_columns(old_index=pl.int_range(len(old_categories)))
        .join(
            pl.DataFrame({"value": new_categories}).with_columns(
                new_index=pl.int_range(len(new_categories))
            ),
            on="value",
            how="left",
        )
        .select("old_index", "new_index")
    )

    # Join with original indices
    original_indices = series.to_physical().alias("old_index")
    remapped = (
        original_indices.to_frame()
        .join(mapping, on="old_index", how="left")
        .get_column("new_index")
    )

    # Create new Enum series
    return remapped.cast(enum_type)

t = perf_counter()
fast = cast_to_enum(a, enum_type)  # takes ~10 ms
t = perf_counter() - t
print(f"table cast: {t:0.3f}s")

t = perf_counter()
slow = a.cast(enum_type)  # takes ~5 s
t = perf_counter() - t
print(f"direct cast: {t:0.3f}s")


assert slow.equals(fast)
assert slow.dtype == fast.dtype
```
</details>