### PR TITLE
fix: Remove outdated depth warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,6 +3145,7 @@ dependencies = [
  "polars-utils",
  "rand",
  "rayon",
+ "recursive",
 ]
 
 [[package]]

--- a/crates/polars-expr/Cargo.toml
+++ b/crates/polars-expr/Cargo.toml
@@ -24,6 +24,7 @@ polars-time = { workspace = true, optional = true }
 polars-utils = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+recursive = { workspace = true }
 
 [features]
 nightly = ["polars-core/nightly", "polars-plan/nightly"]

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -1,6 +1,7 @@
 use polars_core::prelude::*;
 use polars_plan::prelude::expr_ir::ExprIR;
 use polars_plan::prelude::*;
+use recursive::recursive;
 
 use crate::expressions as phys_expr;
 use crate::expressions::*;
@@ -97,47 +98,28 @@ pub struct ExpressionConversionState {
     // settings per expression
     // those are reset every expression
     local: LocalConversionState,
-    depth_limit: u16,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 struct LocalConversionState {
     has_implode: bool,
     has_window: bool,
     has_lit: bool,
-    // Max depth an expression may have.
-    // 0 is unlimited.
-    depth_limit: u16,
-}
-
-impl Default for LocalConversionState {
-    fn default() -> Self {
-        Self {
-            has_lit: false,
-            has_implode: false,
-            has_window: false,
-            depth_limit: 500,
-        }
-    }
 }
 
 impl ExpressionConversionState {
-    pub fn new(allow_threading: bool, depth_limit: u16) -> Self {
+    pub fn new(allow_threading: bool) -> Self {
         Self {
-            depth_limit,
             allow_threading,
             has_windows: false,
             local: LocalConversionState {
-                depth_limit,
                 ..Default::default()
             },
         }
     }
+
     fn reset(&mut self) {
-        self.local = LocalConversionState {
-            depth_limit: self.depth_limit,
-            ..Default::default()
-        }
+        self.local = LocalConversionState::default();
     }
 
     fn has_implode(&self) -> bool {
@@ -147,19 +129,6 @@ impl ExpressionConversionState {
     fn set_window(&mut self) {
         self.has_windows = true;
         self.local.has_window = true;
-    }
-
-    fn check_depth(&mut self) {
-        if self.local.depth_limit > 0 {
-            self.local.depth_limit -= 1;
-
-            if self.local.depth_limit == 0 {
-                let depth = get_expr_depth_limit().unwrap();
-                polars_warn!(format!(
-                    "encountered expression deeper than {depth} elements; this may overflow the stack, consider refactoring"
-                ))
-            }
-        }
     }
 }
 
@@ -183,6 +152,7 @@ pub fn create_physical_expr(
     }
 }
 
+#[recursive]
 fn create_physical_expr_inner(
     expression: Node,
     ctxt: Context,
@@ -191,8 +161,6 @@ fn create_physical_expr_inner(
     state: &mut ExpressionConversionState,
 ) -> PolarsResult<Arc<dyn PhysicalExpr>> {
     use AExpr::*;
-
-    state.check_depth();
 
     match expr_arena.get(expression) {
         Len => Ok(Arc::new(phys_expr::CountExpr::new())),

--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -62,7 +62,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
                 Context::Default,
                 &arena,
                 &schema,
-                &mut ExpressionConversionState::new(true, 0),
+                &mut ExpressionConversionState::new(true),
             )?;
 
             let state = ExecutionState::new();

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -637,7 +637,7 @@ impl LazyFrame {
                     Context::Default,
                     expr_arena,
                     schema,
-                    &mut ExpressionConversionState::new(true, 0),
+                    &mut ExpressionConversionState::new(true),
                 )
                 .ok()?;
                 let io_expr = phys_expr_to_io_expr(phys_expr);

--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -43,6 +43,6 @@ pub(crate) fn prepare_expression_for_context(
         ctxt,
         &expr_arena,
         &input_schema,
-        &mut ExpressionConversionState::new(true, 0),
+        &mut ExpressionConversionState::new(true),
     )
 }

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -56,7 +56,7 @@ fn to_physical_piped_expr(
         Context::Default,
         expr_arena,
         schema,
-        &mut ExpressionConversionState::new(false, 0),
+        &mut ExpressionConversionState::new(false),
     )
     .map(|e| Arc::new(Wrap(e)) as Arc<dyn PhysicalPipedExpr>)
 }

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -4,7 +4,6 @@ use polars_core::frame::DataFrame;
 use polars_core::prelude::{DataType, Field, InitHashMaps, PlHashMap, PlHashSet};
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::PolarsResult;
-use polars_expr::planner::get_expr_depth_limit;
 use polars_expr::state::ExecutionState;
 use polars_expr::{ExpressionConversionState, create_physical_expr};
 use polars_ops::frame::{JoinArgs, JoinType};
@@ -384,8 +383,7 @@ fn build_fallback_node_with_ctx(
     };
 
     let output_schema = schema_for_select(input_stream, exprs, ctx)?;
-    let expr_depth_limit = get_expr_depth_limit()?;
-    let mut conv_state = ExpressionConversionState::new(false, expr_depth_limit);
+    let mut conv_state = ExpressionConversionState::new(false);
     let phys_exprs = exprs
         .iter()
         .map(|expr| {

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -6,7 +6,7 @@ use polars_core::prelude::PlRandomState;
 use polars_core::schema::Schema;
 use polars_error::{PolarsResult, polars_bail, polars_ensure, polars_err};
 use polars_expr::groups::new_hash_grouper;
-use polars_expr::planner::{ExpressionConversionState, create_physical_expr, get_expr_depth_limit};
+use polars_expr::planner::{ExpressionConversionState, create_physical_expr};
 use polars_expr::reduce::into_reduction;
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::{create_physical_plan, create_scan_predicate};
@@ -75,13 +75,12 @@ pub fn physical_plan_to_graph(
 ) -> PolarsResult<(Graph, SecondaryMap<PhysNodeKey, GraphNodeKey>)> {
     // Get the number of threads from the rayon thread-pool as that respects our config.
     let num_pipelines = POOL.current_num_threads();
-    let expr_depth_limit = get_expr_depth_limit()?;
     let mut ctx = GraphConversionContext {
         phys_sm,
         expr_arena,
         graph: Graph::with_capacity(phys_sm.len()),
         phys_to_graph: SecondaryMap::with_capacity(phys_sm.len()),
-        expr_conversion_state: ExpressionConversionState::new(false, expr_depth_limit),
+        expr_conversion_state: ExpressionConversionState::new(false),
         num_pipelines,
     };
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/22028.

We used to have this warning because we could overflow the stack. Now we added `#[recursive]` tags to prevent this stack overflow so things should just work. The warning had false-positives anyway because it didn't correctly track depth.