### PR TITLE
fix: Revert #22017 and improve block(_in_place)_on doc comment

### DIFF
--- a/crates/polars-stream/src/execute.rs
+++ b/crates/polars-stream/src/execute.rs
@@ -233,7 +233,7 @@ fn run_subgraph(
         if std::env::var("POLARS_TRACK_WAIT_STATS").as_deref() == Ok("1") {
             async_executor::track_task_wait_statistics(true);
         }
-        let ret = polars_io::pl_async::get_runtime().block_in_place_on(async move {
+        let ret = polars_io::pl_async::get_runtime().block_on(async move {
             for handle in join_handles {
                 handle.await?;
             }


### PR DESCRIPTION
This panic on calling the blocking `run_query` on a tokio task is a feature, not a bug.