### PR TITLE
fix(rust): Fix to_integer panicing on invalid base

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -72,7 +72,7 @@ pub trait StringNameSpaceImpl: AsString {
                 polars_bail!(ComputeError: "`to_integer` called with invalid base '{base}'");
             }
 
-            Num::from_str_radix(s, base)
+            <i64 as Num>::from_str_radix(s, base)
                 .map_err(|err| polars_err!(ComputeError: "failed to parse int: {err}"))
         };
 
@@ -108,7 +108,7 @@ pub trait StringNameSpaceImpl: AsString {
                     some_failures
                         .get(0)
                         .zip(base_failures.get(0))
-                        .and_then(|(s, base)| Num::from_str_radix(s, base).err())
+                        .and_then(|(s, base)| <i64 as Num>::from_str_radix(s, base).err())
                         .map_or_else(
                             || unreachable!("failed to extract ParseIntError"),
                             |e| format!("{}", e),

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -67,20 +67,16 @@ pub trait StringNameSpaceImpl: AsString {
     fn to_integer(&self, base: &UInt32Chunked, strict: bool) -> PolarsResult<Int64Chunked> {
         let ca = self.as_string();
 
-        let parse = |s: &str, base: u32| -> PolarsResult<i64> {
-            if !(2..=36).contains(&base) {
-                polars_bail!(ComputeError: "`to_integer` called with invalid base '{base}'");
-            }
-
-            <i64 as Num>::from_str_radix(s, base)
-                .map_err(|err| polars_err!(ComputeError: "failed to parse int: {err}"))
-        };
-
         let f = |opt_s: Option<&str>, opt_base: Option<u32>| -> PolarsResult<Option<i64>> {
             let (Some(s), Some(base)) = (opt_s, opt_base) else {
                 return Ok(None);
             };
-            parse(s, base).map(Some)
+
+            if !(2..=36).contains(&base) {
+                polars_bail!(ComputeError: "`to_integer` called with invalid base '{base}'");
+            }
+
+            Ok(<i64 as Num>::from_str_radix(s, base).ok())
         };
         let out = broadcast_try_binary_elementwise(ca, base, f)?;
         if strict && ca.null_count() != out.null_count() {

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -69,13 +69,15 @@ pub trait StringNameSpaceImpl: AsString {
 
         let parse = |opt_s: Option<&str>, opt_base: Option<u32>| -> PolarsResult<i64> {
             match (opt_s, opt_base) {
-                (_, Some(2..36)) => Err(PolarsError::ComputeError("invalid base".into())),
-                (Some(s), Some(base)) => match <i64 as Num>::from_str_radix(s, base) {
-                    Ok(t) => Ok(t),
-                    Err(parse_int_error) => Err(PolarsError::ComputeError(
-                        format!("parse int error: {}", parse_int_error).into(),
-                    )),
+                (Some(s), Some(base)) if (2..=36).contains(&base) => {
+                    match <i64 as Num>::from_str_radix(s, base) {
+                        Ok(t) => Ok(t),
+                        Err(parse_int_error) => Err(PolarsError::ComputeError(
+                            format!("parse int error: {}", parse_int_error).into(),
+                        )),
+                    }
                 },
+                (Some(_), Some(_)) => Err(PolarsError::ComputeError("invalid base".into())),
                 (None, Some(_)) => Err(PolarsError::ComputeError(
                     "Cannot parse string without a numeric string".into(),
                 )),

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{DataType, Field, InitHashMaps, PlHashMap, PlHashSet};
+use polars_core::prelude::{DataType, Field, FillNullStrategy, InitHashMaps, PlHashMap, PlHashSet};
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::PolarsResult;
 use polars_expr::state::ExecutionState;

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars_core::frame::DataFrame;
-use polars_core::prelude::{DataType, Field, FillNullStrategy, InitHashMaps, PlHashMap, PlHashSet};
+use polars_core::prelude::{DataType, Field, InitHashMaps, PlHashMap, PlHashSet};
 use polars_core::schema::{Schema, SchemaExt};
 use polars_error::PolarsResult;
 use polars_expr::state::ExecutionState;

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -460,17 +460,20 @@ def test_str_to_integer_invalid_base() -> None:
         check_exact=True,
     )
 
-    assert_series_equal(
-        numbers.str.to_integer(base=pl.Series([0, 1, 100, 1000]), strict=False),
-        pl.Series([None, None, None, None]).cast(pl.Int64),
-        check_exact=True,
-    )
-
     with pytest.raises(ComputeError):
         numbers.str.to_integer(base=100)
 
+    df = pl.DataFrame({"str": numbers, "base": [0, 1, 100, 1000]})
+
+    assert_frame_equal(
+        df.select(
+            pl.col("str").str.to_integer(base=pl.col("base"), strict=False).alias("out")
+        ),
+        pl.DataFrame({"out": pl.Series([None, None, None, None]).cast(pl.Int64)}),
+    )
+
     with pytest.raises(ComputeError):
-        numbers.str.to_integer(base=pl.Series([0, 1, 100, 1000]))
+        df.select(pl.col("str").str.to_integer(base=pl.col("base")))
 
 
 def test_str_to_integer_base_expr() -> None:

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -452,6 +452,27 @@ def test_str_to_integer() -> None:
         hex.str.to_integer(base=16)
 
 
+def test_str_to_integer_invalid_base() -> None:
+    numbers = pl.Series(["1", "ZZZ", "-ABCZZZ", None])
+    assert_series_equal(
+        numbers.str.to_integer(base=100, strict=False),
+        pl.Series([None, None, None, None]).cast(pl.Int64),
+        check_exact=True,
+    )
+
+    assert_series_equal(
+        numbers.str.to_integer(base=pl.Series([0, 1, 100, 1000]), strict=False),
+        pl.Series([None, None, None, None]).cast(pl.Int64),
+        check_exact=True,
+    )
+
+    with pytest.raises(ComputeError):
+        numbers.str.to_integer(base=100)
+
+    with pytest.raises(ComputeError):
+        numbers.str.to_integer(base=pl.Series([0, 1, 100, 1000]))
+
+
 def test_str_to_integer_base_expr() -> None:
     df = pl.DataFrame(
         {"str": ["110", "ff00", "234", None, "130"], "base": [2, 16, 10, 8, None]}

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -463,7 +463,7 @@ def test_str_to_integer_invalid_base() -> None:
     with pytest.raises(ComputeError):
         numbers.str.to_integer(base=100)
 
-    df = pl.DataFrame({"str": numbers, "base": [0, 1, 100, 1000]})
+    df = pl.DataFrame({"str": numbers, "base": [0, 1, 100, None]})
 
     assert_frame_equal(
         df.select(

--- a/py-polars/tests/unit/operations/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/operations/namespaces/string/test_string.py
@@ -452,28 +452,15 @@ def test_str_to_integer() -> None:
         hex.str.to_integer(base=16)
 
 
-def test_str_to_integer_invalid_base() -> None:
+@pytest.mark.parametrize("strict", [False, True])
+def test_str_to_integer_invalid_base(strict: bool) -> None:
     numbers = pl.Series(["1", "ZZZ", "-ABCZZZ", None])
-    assert_series_equal(
-        numbers.str.to_integer(base=100, strict=False),
-        pl.Series([None, None, None, None]).cast(pl.Int64),
-        check_exact=True,
-    )
-
     with pytest.raises(ComputeError):
-        numbers.str.to_integer(base=100)
+        numbers.str.to_integer(base=100, strict=strict)
 
     df = pl.DataFrame({"str": numbers, "base": [0, 1, 100, None]})
-
-    assert_frame_equal(
-        df.select(
-            pl.col("str").str.to_integer(base=pl.col("base"), strict=False).alias("out")
-        ),
-        pl.DataFrame({"out": pl.Series([None, None, None, None]).cast(pl.Int64)}),
-    )
-
     with pytest.raises(ComputeError):
-        df.select(pl.col("str").str.to_integer(base=pl.col("base")))
+        df.select(pl.col("str").str.to_integer(base=pl.col("base"), strict=strict))
 
 
 def test_str_to_integer_base_expr() -> None:


### PR DESCRIPTION
fixes #22033

https://github.com/pola-rs/polars/issues/22033

Attempting to parse a number with an invalid base will now produce a ComputeError.