### PR TITLE
feat: Allow setting default time unit in config

### DIFF
--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -331,6 +331,14 @@ impl StringNameSpace {
         ambiguous: Expr,
     ) -> Expr {
         // If time_unit is None, try to infer it from the format or set a default
+
+        let default_time_unit = match std::env::var("POLARS_DEFAULT_TIME_UNIT").as_deref() {
+            Ok("ns") => TimeUnit::Nanoseconds,
+            Ok("us") => TimeUnit::Microseconds,
+            Ok("ms") => TimeUnit::Milliseconds,
+            _ => TimeUnit::Microseconds,
+        };
+
         let time_unit = match (&options.format, time_unit) {
             (_, Some(time_unit)) => time_unit,
             (Some(format), None) => {
@@ -342,7 +350,7 @@ impl StringNameSpace {
                     TimeUnit::Microseconds
                 }
             },
-            (None, None) => TimeUnit::Microseconds,
+            (None, None) => default_time_unit,
         };
 
         self.strptime(DataType::Datetime(time_unit, time_zone), options, ambiguous)

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -1531,8 +1531,8 @@ class Config(contextlib.ContextDecorator):
         Examples
         --------
         >>> ser = pl.Series(["2025-01-01"])
-        >>> pl.Config.set_default_time_unit("ms")
-        >>> ser.str.to_datetime()
+        >>> with pl.Config(default_time_unit="ms"):
+        ...     ser.str.to_datetime()
         shape: (1,)
         Series: '' [datetime[ms]]
         [

--- a/py-polars/tests/unit/test_config.py
+++ b/py-polars/tests/unit/test_config.py
@@ -919,6 +919,23 @@ def test_truncated_rows_cols_values_ascii() -> None:
         )
 
 
+def test_default_time_unit() -> None:
+    ser = pl.Series(["2025-01-01"])
+    assert ser.str.to_datetime().dtype == pl.Datetime("us")
+
+    pl.Config.set_default_time_unit("ms")
+    assert ser.str.to_datetime().dtype == pl.Datetime("ms")
+
+    pl.Config.set_default_time_unit("ns")
+    assert ser.str.to_datetime().dtype == pl.Datetime("ns")
+
+    with (
+        pytest.raises(ValueError, match="invalid time unit: 'abc'"),
+        pl.Config(set_default_time_unit="abc"),  # type: ignore[arg-type]
+    ):
+        pass
+
+
 def test_warn_unstable(recwarn: pytest.WarningsRecorder) -> None:
     issue_unstable_warning()
     assert len(recwarn) == 0
@@ -996,6 +1013,7 @@ def test_warn_unstable(recwarn: pytest.WarningsRecorder) -> None:
         ("POLARS_TABLE_WIDTH", "set_tbl_width_chars", 80, "80"),
         ("POLARS_VERBOSE", "set_verbose", True, "1"),
         ("POLARS_WARN_UNSTABLE", "warn_unstable", True, "1"),
+        ("POLARS_DEFAULT_TIME_UNIT", "set_default_time_unit", "ms", "ms"),
     ],
 )
 def test_unset_config_env_vars(


### PR DESCRIPTION
This PR is related to #21957. It implements the default time unit for `str.to_datetime()`. 

This functionality is particularly useful when working with a codebase that deals with `.csv` files and `pandas` .

## Example Usage

```
with pl.Config(default_time_unit='ns'):
    df = pl.DataFrame({"ts": ['2025-01-01', '2025-01-02']}).with_columns(pl.col("ts").str.to_datetime())
    print(df)
```

Output: 

```
shape: (2, 1)
┌─────────────────────┐
│ ts                  │
│ ---                 │
│ datetime[ns]        │
╞═════════════════════╡
│ 2025-01-01 00:00:00 │
│ 2025-01-02 00:00:00 │
└─────────────────────┘
```
