### PR TITLE
fix: Safe unroll of overlapping groups

### DIFF
--- a/crates/polars-core/src/frame/group_by/position.rs
+++ b/crates/polars-core/src/frame/group_by/position.rs
@@ -586,6 +586,9 @@ impl<'a> ParallelIterator for GroupsTypeParIter<'a> {
 
 #[derive(Debug)]
 pub struct GroupPositions {
+    // SAFETY: sliced is a shallow clone of original
+    // It emulates a shared reference, not an exclusive reference
+    // Its data must not be mutated through direct access
     sliced: ManuallyDrop<GroupsType>,
     // Unsliced buffer
     original: Arc<GroupsType>,
@@ -656,15 +659,27 @@ impl GroupPositions {
         match self.sliced.deref_mut() {
             GroupsType::Idx(_) => self,
             GroupsType::Slice { rolling: false, .. } => self,
-            GroupsType::Slice {
-                groups, rolling, ..
-            } => {
-                let mut offset = 0 as IdxSize;
-                for g in groups.iter_mut() {
-                    g[0] = offset;
-                    offset += g[1];
-                }
-                *rolling = false;
+            GroupsType::Slice { groups, .. } => {
+                // SAFETY: sliced is a shallow partial clone of original.
+                // A new owning Vec is required per GH issue #21859
+                let mut cum_offset = 0 as IdxSize;
+                let groups: Vec<_> = groups
+                    .iter()
+                    .map(|[_, len]| {
+                        let new = [cum_offset, *len];
+                        cum_offset += *len;
+                        new
+                    })
+                    .collect();
+
+                #[allow(clippy::forget_non_drop)]
+                std::mem::forget(self.sliced);
+
+                self.sliced = ManuallyDrop::new(GroupsType::Slice {
+                    groups,
+                    rolling: false,
+                });
+
                 self
             },
         }

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -62,6 +62,52 @@ def test_rolling_group_by_overlapping_groups(dtype: PolarsIntegerType) -> None:
     )
 
 
+# TODO: This test requires the environment variable to be set prior to starting
+# the thread pool, which implies prior to import. The test is only valid when
+# run in isolation, and invalid otherwise because of xdist import caching.
+# See GH issue #22070
+def test_rolling_group_by_overlapping_groups_21859_a(monkeypatch: Any) -> None:
+    monkeypatch.setenv("POLARS_MAX_THREADS", "1")
+    # assert pl.thread_pool_size() == 1 # pending resolution, see TODO
+    df = pl.select(
+        pl.date_range(pl.date(2023, 1, 1), pl.date(2023, 1, 5))
+    ).with_row_index()
+
+    out = df.rolling(index_column="date", period="1y").agg(
+        a1=pl.when(pl.col("date") >= pl.col("date"))
+        .then(pl.col("index").cast(pl.Int64).cum_sum())
+        .last(),
+        a2=pl.when(pl.col("date") >= pl.col("date"))
+        .then(pl.col("index").cast(pl.Int64).cum_sum())
+        .last(),
+    )["a1", "a2"]
+    expected = pl.DataFrame({"a1": [0, 1, 3, 6, 10], "a2": [0, 1, 3, 6, 10]})
+    assert_frame_equal(out, expected)
+
+
+# TODO: This test requires the environment variable to be set prior to starting
+# the thread pool, which implies prior to import. The test is only valid when
+# run in isolation, and invalid otherwise because of xdist import caching.
+# See GH issue #22070
+def test_rolling_group_by_overlapping_groups_21859_b(monkeypatch: Any) -> None:
+    monkeypatch.setenv("POLARS_MAX_THREADS", "1")
+    # assert pl.thread_pool_size() == 1 # pending resolution, see TODO
+    df = pl.DataFrame({"a": [20, 30, 40]})
+    out = (
+        df.with_row_index()
+        .with_columns(pl.col("index"))
+        .cast(pl.Int64)
+        .rolling(index_column="index", period="3i")
+        .agg(
+            # trigger the apply on the expression engine
+            pl.col("a").map_elements(lambda x: x).sum().alias("a1"),
+            pl.col("a").map_elements(lambda x: x).sum().alias("a2"),
+        )["a1", "a2"]
+    )
+    expected = pl.DataFrame({"a1": [20, 50, 90], "a2": [20, 50, 90]})
+    assert_frame_equal(out, expected)
+
+
 @pytest.mark.parametrize("input", [[pl.col("b").sum()], pl.col("b").sum()])
 @pytest.mark.parametrize("dtype", [pl.UInt32, pl.UInt64, pl.Int32, pl.Int64])
 def test_rolling_agg_input_types(input: Any, dtype: PolarsIntegerType) -> None:


### PR DESCRIPTION
Fixes #21859

Context
The bug originated when shallow clone of GroupPositions was introduced:

commit 7ccb3ae (HEAD)
Author: Ritchie Vink ritchie46@gmail.com
Date: Fri Jan 24 10:55:48 2025 +0100

fix: Don't deep clone manuallydrop in GroupsPosition (#20886)


Kindly review:
1) The fix does a late (lazy) new Vec allocation inside unroll(). Is this consistent with the intended functionality?
2) Is the use of std::mem::forget() as part of the fix desired or needed?
3) The approach introduced in 7ccb3ae is unsafe and the safety contract is not clear (at least to me), nor how it will be enforced. Should another approach not be considered (e.g. perhaps crate owning_ref)? A better understanding of the desired behavior would help evaluating alternative approaches.
4) Note: the pytest/xdist framework does not honor the POLARS_MAX_THREADS environment variable monkeypatch, see newly opened issue #22070. The submitted tests are sound (fail before / succeed after), but the environment control monkeypatch is only working in isolation, not in bulk.
