### PR TITLE
fix(rust): Without the new_streaming feature, `Engine::Auto` always select in memory engine

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -752,7 +752,10 @@ impl LazyFrame {
         if engine == Engine::Auto {
             engine = match payload {
                 SinkType::Memory => Engine::InMemory,
+                #[cfg(feature = "new_streaming")]
                 SinkType::File { .. } | SinkType::Partition { .. } => Engine::Streaming,
+                #[cfg(not(feature = "new_streaming"))]
+                _ => Engine::InMemory,
             };
         }
         // Gpu uses some hacks to dispatch.


### PR DESCRIPTION
If the new_streaming feature is not present (e.g. in the current pyodide build), I believe panic may occur when using the sink functions.