### PR TITLE
chore: Deprecate duplicate `backward_fill` and `forward_fill` interface

### DIFF
--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1173,11 +1173,9 @@ fn test_fill_forward() -> PolarsResult<()> {
 
     let out = df
         .lazy()
-        .select([col("b").forward_fill(None).over_with_options(
-            [col("a")],
-            None,
-            WindowMapping::Join,
-        )])
+        .select([col("b")
+            .fill_null_with_strategy(FillNullStrategy::Forward(FillNullLimit::None))
+            .over_with_options([col("a")], None, WindowMapping::Join)])
         .collect()?;
     let agg = out.column("b")?.list()?;
 

--- a/crates/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/crates/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -89,14 +89,6 @@ pub(super) fn repeat_by(s: &[Column]) -> PolarsResult<Column> {
         .map(|ok| ok.into_column())
 }
 
-pub(super) fn backward_fill(s: &Column, limit: FillNullLimit) -> PolarsResult<Column> {
-    s.fill_null(FillNullStrategy::Backward(limit))
-}
-
-pub(super) fn forward_fill(s: &Column, limit: FillNullLimit) -> PolarsResult<Column> {
-    s.fill_null(FillNullStrategy::Forward(limit))
-}
-
 pub(super) fn max_horizontal(s: &mut [Column]) -> PolarsResult<Option<Column>> {
     polars_ops::prelude::max_horizontal(s)
 }

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -328,12 +328,6 @@ pub enum FunctionExpr {
         /// Pickle serialized keyword arguments.
         kwargs: Arc<[u8]>,
     },
-    BackwardFill {
-        limit: FillNullLimit,
-    },
-    ForwardFill {
-        limit: FillNullLimit,
-    },
     MaxHorizontal,
     MinHorizontal,
     SumHorizontal {
@@ -579,7 +573,6 @@ impl Hash for FunctionExpr {
             RLEID => {},
             ToPhysical => {},
             SetSortedFlag(is_sorted) => is_sorted.hash(state),
-            BackwardFill { limit } | ForwardFill { limit } => limit.hash(state),
             #[cfg(feature = "ewma")]
             EwmMean { options } => options.hash(state),
             #[cfg(feature = "ewma_by")]
@@ -775,8 +768,6 @@ impl Display for FunctionExpr {
             SetSortedFlag(_) => "set_sorted",
             #[cfg(feature = "ffi_plugin")]
             FfiPlugin { lib, symbol, .. } => return write!(f, "{lib}:{symbol}"),
-            BackwardFill { .. } => "backward_fill",
-            ForwardFill { .. } => "forward_fill",
             MaxHorizontal => "max_horizontal",
             MinHorizontal => "min_horizontal",
             SumHorizontal { .. } => "sum_horizontal",
@@ -1189,8 +1180,6 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn ColumnsUdf>> {
                     kwargs.as_ref()
                 )
             },
-            BackwardFill { limit } => map!(dispatch::backward_fill, limit),
-            ForwardFill { limit } => map!(dispatch::forward_fill, limit),
             MaxHorizontal => wrap!(dispatch::max_horizontal),
             MinHorizontal => wrap!(dispatch::min_horizontal),
             SumHorizontal { ignore_nulls } => wrap!(dispatch::sum_horizontal, ignore_nulls),

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -329,8 +329,6 @@ impl FunctionExpr {
                 symbol,
                 kwargs,
             } => unsafe { plugin::plugin_field(fields, lib, symbol.as_ref(), kwargs) },
-            BackwardFill { .. } => mapper.with_same_dtype(),
-            ForwardFill { .. } => mapper.with_same_dtype(),
             MaxHorizontal => mapper.map_to_supertype(),
             MinHorizontal => mapper.map_to_supertype(),
             SumHorizontal { .. } => {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -884,16 +884,6 @@ impl Expr {
         )
     }
 
-    /// Fill missing value with next non-null.
-    pub fn backward_fill(self, limit: FillNullLimit) -> Self {
-        self.apply_private(FunctionExpr::BackwardFill { limit })
-    }
-
-    /// Fill missing value with previous non-null.
-    pub fn forward_fill(self, limit: FillNullLimit) -> Self {
-        self.apply_private(FunctionExpr::ForwardFill { limit })
-    }
-
     /// Round underlying floating point array to given decimal numbers.
     #[cfg(feature = "round_series")]
     pub fn round(self, decimals: u32) -> Self {

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -367,14 +367,6 @@ impl PyExpr {
             .into()
     }
 
-    fn backward_fill(&self, limit: FillNullLimit) -> Self {
-        self.inner.clone().backward_fill(limit).into()
-    }
-
-    fn forward_fill(&self, limit: FillNullLimit) -> Self {
-        self.inner.clone().forward_fill(limit).into()
-    }
-
     #[pyo3(signature = (n, fill_value=None))]
     fn shift(&self, n: Self, fill_value: Option<Self>) -> Self {
         let expr = self.inner.clone();

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1243,8 +1243,6 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::FfiPlugin { .. } => {
                     return Err(PyNotImplementedError::new_err("ffi plugin"));
                 },
-                FunctionExpr::BackwardFill { limit } => ("backward_fill", limit).into_py_any(py),
-                FunctionExpr::ForwardFill { limit } => ("forward_fill", limit).into_py_any(py),
                 FunctionExpr::SumHorizontal { ignore_nulls } => {
                     ("sum_horizontal", ignore_nulls).into_py_any(py)
                 },

--- a/py-polars/docs/source/reference/expressions/modify_select.rst
+++ b/py-polars/docs/source/reference/expressions/modify_select.rst
@@ -9,7 +9,6 @@ Manipulation/selection
     Expr.append
     Expr.arg_sort
     Expr.arg_true
-    Expr.backward_fill
     Expr.bottom_k
     Expr.bottom_k_by
     Expr.cast
@@ -25,7 +24,6 @@ Manipulation/selection
     Expr.filter
     Expr.flatten
     Expr.floor
-    Expr.forward_fill
     Expr.gather
     Expr.gather_every
     Expr.get

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7158,7 +7158,7 @@ class DataFrame:
         ... ).set_sorted("time")
         >>> df.upsample(
         ...     time_column="time", every="1mo", group_by="groups", maintain_order=True
-        ... ).select(pl.all().forward_fill())
+        ... ).select(pl.all().fill_null(strategy="forward"))
         shape: (7, 3)
         ┌─────────────────────┬────────┬────────┐
         │ time                ┆ groups ┆ values │

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1406,14 +1406,15 @@ class Expr:
         │ 4   ┆ 10      ┆ 4               │
         └─────┴─────────┴─────────────────┘
 
-        Null values are excluded, but can also be filled by calling `forward_fill`.
+        Null values are excluded, but can also be filled by calling
+        `fill_null(strategy="forward")`.
 
         >>> df = pl.DataFrame({"values": [None, 10, None, 8, 9, None, 16, None]})
         >>> df.with_columns(
         ...     pl.col("values").cum_sum().alias("value_cum_sum"),
         ...     pl.col("values")
         ...     .cum_sum()
-        ...     .forward_fill()
+        ...     .fill_null(strategy="forward")
         ...     .alias("value_cum_sum_all_filled"),
         ... )
         shape: (8, 3)
@@ -1526,12 +1527,16 @@ class Expr:
         └─────┴─────────┴─────────────────┘
 
 
-        Null values are excluded, but can also be filled by calling `forward_fill`.
+        Null values are excluded, but can also be filled by calling
+        `fill_null(strategy="forward")`.
 
         >>> df = pl.DataFrame({"values": [None, 10, None, 8, 9, None, 16, None]})
         >>> df.with_columns(
         ...     pl.col("values").cum_max().alias("cum_max"),
-        ...     pl.col("values").cum_max().forward_fill().alias("cum_max_all_filled"),
+        ...     pl.col("values")
+        ...     .cum_max()
+        ...     .fill_null(strategy="forward")
+        ...     .alias("cum_max_all_filled"),
         ... )
         shape: (8, 3)
         ┌────────┬─────────┬────────────────────┐

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2647,8 +2647,7 @@ class Expr:
 
         See Also
         --------
-        backward_fill
-        forward_fill
+        fill_null
 
         Examples
         --------
@@ -2852,9 +2851,15 @@ class Expr:
         fill_value = parse_into_expression(value, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.fill_nan(fill_value))
 
+    @deprecate_function(
+        'Use `.fill_null(strategy="forward")` instead.', version="1.27.0"
+    )
     def forward_fill(self, limit: int | None = None) -> Expr:
         """
         Fill missing values with the last non-null value.
+
+        .. deprecated:: 1.27.0
+            Use :meth:`fill_null` with `strategy="forward"`.
 
         Parameters
         ----------
@@ -2863,34 +2868,20 @@ class Expr:
 
         See Also
         --------
-        backward_fill
+        fill_null
         shift
-
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [1, 2, None],
-        ...         "b": [4, None, 6],
-        ...     }
-        ... )
-        >>> df.select(pl.all().forward_fill())
-        shape: (3, 2)
-        ┌─────┬─────┐
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 1   ┆ 4   │
-        │ 2   ┆ 4   │
-        │ 2   ┆ 6   │
-        └─────┴─────┘
         """
-        return self._from_pyexpr(self._pyexpr.forward_fill(limit))
+        return self.fill_null(strategy="forward", limit=limit)
 
+    @deprecate_function(
+        'Use `.fill_null(strategy="backward")` instead.', version="1.27.0"
+    )
     def backward_fill(self, limit: int | None = None) -> Expr:
         """
         Fill missing values with the next non-null value.
+
+        .. deprecated:: 1.27.0
+            Use :meth:`fill_null` with `strategy="backward"`.
 
         Parameters
         ----------
@@ -2899,42 +2890,10 @@ class Expr:
 
         See Also
         --------
-        forward_fill
+        fill_null
         shift
-
-        Examples
-        --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [1, 2, None],
-        ...         "b": [4, None, 6],
-        ...         "c": [None, None, 2],
-        ...     }
-        ... )
-        >>> df.select(pl.all().backward_fill())
-        shape: (3, 3)
-        ┌──────┬─────┬─────┐
-        │ a    ┆ b   ┆ c   │
-        │ ---  ┆ --- ┆ --- │
-        │ i64  ┆ i64 ┆ i64 │
-        ╞══════╪═════╪═════╡
-        │ 1    ┆ 4   ┆ 2   │
-        │ 2    ┆ 6   ┆ 2   │
-        │ null ┆ 6   ┆ 2   │
-        └──────┴─────┴─────┘
-        >>> df.select(pl.all().backward_fill(limit=1))
-        shape: (3, 3)
-        ┌──────┬─────┬──────┐
-        │ a    ┆ b   ┆ c    │
-        │ ---  ┆ --- ┆ ---  │
-        │ i64  ┆ i64 ┆ i64  │
-        ╞══════╪═════╪══════╡
-        │ 1    ┆ 4   ┆ null │
-        │ 2    ┆ 6   ┆ 2    │
-        │ null ┆ 6   ┆ 2    │
-        └──────┴─────┴──────┘
         """
-        return self._from_pyexpr(self._pyexpr.backward_fill(limit))
+        return self.fill_null(strategy="backward", limit=limit)
 
     def reverse(self) -> Expr:
         """

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1959,8 +1959,8 @@ def test_fill_null() -> None:
     )
 
     assert df.select(
-        pl.all().forward_fill().name.suffix("_forward"),
-        pl.all().backward_fill().name.suffix("_backward"),
+        pl.all().fill_null(strategy="forward").name.suffix("_forward"),
+        pl.all().fill_null(strategy="backward").name.suffix("_backward"),
     ).to_dict(as_series=False) == {
         "c_forward": [
             ["Apple", "Orange"],
@@ -2020,11 +2020,11 @@ def test_forward_fill() -> None:
 
 def test_backward_fill() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
-    fill = df.select(pl.col("a").backward_fill())["a"]
+    fill = df.select(pl.col("a").fill_null(strategy="backward"))["a"]
     assert_series_equal(fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
     df = pl.DataFrame({"a": [None, 1, None]})
-    fill = df.select(pl.col("a").backward_fill())["a"]
+    fill = df.select(pl.col("a").fill_null(strategy="backward"))["a"]
     assert_series_equal(fill, pl.Series("a", [1, 1, None]).cast(pl.Int64))
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2008,23 +2008,28 @@ def test_fill_nan() -> None:
     assert df.fill_nan(2.0).dtypes == [pl.Float64, pl.Datetime]
 
 
+#
 def test_forward_fill() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
-    fill = df.select(pl.col("a").forward_fill())["a"]
+    with pytest.deprecated_call():
+        fill = df.select(pl.col("a").forward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [1, 1, 3]).cast(pl.Float64))
 
     df = pl.DataFrame({"a": [None, 1, None]})
-    fill = df.select(pl.col("a").forward_fill())["a"]
+    with pytest.deprecated_call():
+        fill = df.select(pl.col("a").forward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [None, 1, 1]).cast(pl.Int64))
 
 
 def test_backward_fill() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
-    fill = df.select(pl.col("a").fill_null(strategy="backward"))["a"]
+    with pytest.deprecated_call():
+        fill = df.select(pl.col("a").backward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
     df = pl.DataFrame({"a": [None, 1, None]})
-    fill = df.select(pl.col("a").fill_null(strategy="backward"))["a"]
+    with pytest.deprecated_call():
+        fill = df.select(pl.col("a").backward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [1, 1, None]).cast(pl.Int64))
 
 

--- a/py-polars/tests/unit/dataframe/test_upsample.py
+++ b/py-polars/tests/unit/dataframe/test_upsample.py
@@ -42,7 +42,7 @@ def test_upsample(time_zone: str | None, tzinfo: ZoneInfo | timezone | None) -> 
         every="1mo",
         group_by="admin",
         maintain_order=True,
-    ).select(pl.all().forward_fill())
+    ).select(pl.all().fill_null(strategy="forward"))
 
     # this print will panic if timezones feature is not activated
     # don't remove
@@ -234,7 +234,7 @@ def test_upsample_sorted_only_within_group() -> None:
         every="1mo",
         group_by="admin",
         maintain_order=True,
-    ).select(pl.all().forward_fill())
+    ).select(pl.all().fill_null(strategy="forward"))
 
     expected = pl.DataFrame(
         {

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -707,7 +707,9 @@ def test_fill_null() -> None:
 
 def test_backward_fill() -> None:
     ldf = pl.LazyFrame({"a": [1.0, None, 3.0]})
-    col_a_backward_fill = ldf.select([pl.col("a").backward_fill()]).collect()["a"]
+    col_a_backward_fill = ldf.select(
+        [pl.col("a").fill_null(strategy="backward")]
+    ).collect()["a"]
     assert_series_equal(col_a_backward_fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -49,7 +49,7 @@ def test_group_by() -> None:
     )
 
     # check if this query runs and thus column names propagate
-    df.group_by("b").agg(pl.col("c").forward_fill()).explode("c")
+    df.group_by("b").agg(pl.col("c").fill_null(strategy="forward")).explode("c")
 
     # get a specific column
     result = df.group_by("b", maintain_order=True).agg(pl.count("a"))


### PR DESCRIPTION
This was a duplicate of `.fill_null(strategy="backward"/"forward")`, so deprecating in favor of those.