### PR TITLE
fix: Make bottom interval closed in `hist`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -10143,11 +10143,10 @@ class Expr:
         Parameters
         ----------
         bins
-            Discretizations to make.
-            If None given, we determine the boundaries based on the data.
+            Bin edges. If None given, we determine the edges based on the data.
         bin_count
-            If no bins provided, this will be used to determine
-            the distance of the bins
+            If `bins` is not provided, `bin_count` uniform bins are created that fully
+            encompass the data.
         include_breakpoint
             Include a column that indicates the upper breakpoint.
         include_category
@@ -10167,7 +10166,7 @@ class Expr:
         │ --- │
         │ u32 │
         ╞═════╡
-        │ 1   │
+        │ 3   │
         │ 2   │
         └─────┘
         >>> df.select(
@@ -10181,7 +10180,7 @@ class Expr:
         │ ---                  │
         │ struct[3]            │
         ╞══════════════════════╡
-        │ {2.0,"(1.0, 2.0]",1} │
+        │ {2.0,"[1.0, 2.0]",3} │
         │ {3.0,"(2.0, 3.0]",2} │
         └──────────────────────┘
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2484,11 +2484,10 @@ class Series:
         Parameters
         ----------
         bins
-            Discretizations to make.
-            If None given, we determine the boundaries based on the data.
+            Bin edges. If None given, we determine the edges based on the data.
         bin_count
-            If no bins provided, this will be used to determine
-            the distance of the bins.
+            If `bins` is not provided, `bin_count` uniform bins are created that fully
+            encompass the data.
         include_breakpoint
             Include a column that indicates the upper breakpoint.
         include_category
@@ -2503,16 +2502,16 @@ class Series:
         >>> a = pl.Series("a", [1, 3, 8, 8, 2, 1, 3])
         >>> a.hist(bin_count=4)
         shape: (4, 3)
-        ┌────────────┬───────────────┬───────┐
-        │ breakpoint ┆ category      ┆ count │
-        │ ---        ┆ ---           ┆ ---   │
-        │ f64        ┆ cat           ┆ u32   │
-        ╞════════════╪═══════════════╪═══════╡
-        │ 2.75       ┆ (0.993, 2.75] ┆ 3     │
-        │ 4.5        ┆ (2.75, 4.5]   ┆ 2     │
-        │ 6.25       ┆ (4.5, 6.25]   ┆ 0     │
-        │ 8.0        ┆ (6.25, 8.0]   ┆ 2     │
-        └────────────┴───────────────┴───────┘
+        ┌────────────┬─────────────┬───────┐
+        │ breakpoint ┆ category    ┆ count │
+        │ ---        ┆ ---         ┆ ---   │
+        │ f64        ┆ cat         ┆ u32   │
+        ╞════════════╪═════════════╪═══════╡
+        │ 2.75       ┆ [1.0, 2.75] ┆ 3     │
+        │ 4.5        ┆ (2.75, 4.5] ┆ 2     │
+        │ 6.25       ┆ (4.5, 6.25] ┆ 0     │
+        │ 8.0        ┆ (6.25, 8.0] ┆ 2     │
+        └────────────┴─────────────┴───────┘
         """
         out = (
             self.to_frame()

--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -24,7 +24,7 @@ def test_hist_empty_data_no_inputs() -> None:
                 ),
                 "category": pl.Series(
                     [
-                        "(0.0, 0.1]",
+                        "[0.0, 0.1]",
                         "(0.1, 0.2]",
                         "(0.2, 0.3]",
                         "(0.3, 0.4]",
@@ -84,7 +84,7 @@ def test_hist_empty_data_valid_edges() -> None:
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([2.0, 3.0], dtype=pl.Float64),
-            "category": pl.Series(["(1.0, 2.0]", "(2.0, 3.0]"], dtype=pl.Categorical),
+            "category": pl.Series(["[1.0, 2.0]", "(2.0, 3.0]"], dtype=pl.Categorical),
             "count": pl.Series([0, 0], dtype=pl.UInt32),
         }
     )
@@ -126,7 +126,7 @@ def test_hist_empty_data_single_bin_count() -> None:
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([1.0], dtype=pl.Float64),
-            "category": pl.Series(["(0.0, 1.0]"], dtype=pl.Categorical),
+            "category": pl.Series(["[0.0, 1.0]"], dtype=pl.Categorical),
             "count": pl.Series([0], dtype=pl.UInt32),
         }
     )
@@ -142,7 +142,7 @@ def test_hist_empty_data_valid_bin_count() -> None:
             "breakpoint": pl.Series([0.2, 0.4, 0.6, 0.8, 1.0], dtype=pl.Float64),
             "category": pl.Series(
                 [
-                    "(0.0, 0.2]",
+                    "[0.0, 0.2]",
                     "(0.2, 0.4]",
                     "(0.4, 0.6]",
                     "(0.6, 0.8]",
@@ -178,7 +178,7 @@ def test_hist_bin_outside_data() -> None:
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([-9.0], dtype=pl.Float64),
-            "category": pl.Series(["(-10.0, -9.0]"], dtype=pl.Categorical),
+            "category": pl.Series(["[-10.0, -9.0]"], dtype=pl.Categorical),
             "count": pl.Series([0], dtype=pl.UInt32),
         }
     )
@@ -192,7 +192,7 @@ def test_hist_bins_between_data() -> None:
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([10.5], dtype=pl.Float64),
-            "category": pl.Series(["(4.5, 10.5]"], dtype=pl.Categorical),
+            "category": pl.Series(["[4.5, 10.5]"], dtype=pl.Categorical),
             "count": pl.Series([0], dtype=pl.UInt32),
         }
     )
@@ -206,8 +206,8 @@ def test_hist_bins_first_edge() -> None:
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([3.0, 4.0], dtype=pl.Float64),
-            "category": pl.Series(["(2.0, 3.0]", "(3.0, 4.0]"], dtype=pl.Categorical),
-            "count": pl.Series([0, 0], dtype=pl.UInt32),
+            "category": pl.Series(["[2.0, 3.0]", "(3.0, 4.0]"], dtype=pl.Categorical),
+            "count": pl.Series([1, 0], dtype=pl.UInt32),
         }
     )
     assert_frame_equal(result, expected)
@@ -222,7 +222,7 @@ def test_hist_bins_last_edge() -> None:
             "breakpoint": pl.Series([0.0, 99.0, 100.0], dtype=pl.Float64),
             "category": pl.Series(
                 [
-                    "(-4.0, 0.0]",
+                    "[-4.0, 0.0]",
                     "(0.0, 99.0]",
                     "(99.0, 100.0]",
                 ],
@@ -241,7 +241,7 @@ def test_hist_single_value_single_bin_count() -> None:
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([1.5], dtype=pl.Float64),
-            "category": pl.Series(["(0.5, 1.5]"], dtype=pl.Categorical),
+            "category": pl.Series(["[0.5, 1.5]"], dtype=pl.Categorical),
             "count": pl.Series([1], dtype=pl.UInt32),
         }
     )
@@ -251,13 +251,11 @@ def test_hist_single_value_single_bin_count() -> None:
 @StringCache()
 def test_hist_single_bin_count() -> None:
     s = pl.Series([-5, 2, 0, 1, 99], dtype=pl.Int32)
-    span = (99 - (-5)) * 0.001
-    lower_bin = -5 - span
     result = s.hist(bin_count=1)
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([99.0], dtype=pl.Float64),
-            "category": pl.Series([f"({lower_bin}, 99.0]"], dtype=pl.Categorical),
+            "category": pl.Series(["[-5.0, 99.0]"], dtype=pl.Categorical),
             "count": pl.Series([5], dtype=pl.UInt32),
         }
     )
@@ -272,7 +270,7 @@ def test_hist_partial_covering() -> None:
         {
             "breakpoint": pl.Series([2.5, 50.0, 105.0], dtype=pl.Float64),
             "category": pl.Series(
-                ["(-1.5, 2.5]", "(2.5, 50.0]", "(50.0, 105.0]"], dtype=pl.Categorical
+                ["[-1.5, 2.5]", "(2.5, 50.0]", "(50.0, 105.0]"], dtype=pl.Categorical
             ),
             "count": pl.Series([3, 0, 1], dtype=pl.UInt32),
         }
@@ -288,7 +286,7 @@ def test_hist_full_covering() -> None:
         {
             "breakpoint": pl.Series([2.5, 50.0, 105.0], dtype=pl.Float64),
             "category": pl.Series(
-                ["(-5.5, 2.5]", "(2.5, 50.0]", "(50.0, 105.0]"], dtype=pl.Categorical
+                ["[-5.5, 2.5]", "(2.5, 50.0]", "(50.0, 105.0]"], dtype=pl.Categorical
             ),
             "count": pl.Series([4, 0, 1], dtype=pl.UInt32),
         }
@@ -305,8 +303,8 @@ def test_hist_more_bins_than_data() -> None:
     span = 99 - (-5)
     width = span / 8
     breaks = [-5 + width * i for i in range(8 + 1)]
-    breaks[0] -= span * 0.001
     categories = [f"({breaks[i]}, {breaks[i + 1]}]" for i in range(8)]
+    categories[0] = f"[{categories[0][1:]}"
 
     expected = pl.DataFrame(
         {
@@ -326,7 +324,7 @@ def test_hist() -> None:
         {
             "breakpoint": pl.Series([2.75, 4.5, 6.25, 8.0], dtype=pl.Float64),
             "category": pl.Series(
-                ["(0.993, 2.75]", "(2.75, 4.5]", "(4.5, 6.25]", "(6.25, 8.0]"],
+                ["[1.0, 2.75]", "(2.75, 4.5]", "(4.5, 6.25]", "(6.25, 8.0]"],
                 dtype=pl.Categorical,
             ),
             "count": pl.Series([3, 2, 0, 2], dtype=pl.get_index_type()),
@@ -346,7 +344,7 @@ def test_hist_all_null() -> None:
             ),
             "category": pl.Series(
                 [
-                    "(0.0, 0.1]",
+                    "[0.0, 0.1]",
                     "(0.1, 0.2]",
                     "(0.2, 0.3]",
                     "(0.3, 0.4]",
@@ -453,7 +451,7 @@ def test_hist_same_values_20030() -> None:
     expected = pl.DataFrame(
         {
             "breakpoint": pl.Series([1.0, 1.5], dtype=pl.Float64),
-            "category": pl.Series(["(0.5, 1.0]", "(1.0, 1.5]"], dtype=pl.Categorical),
+            "category": pl.Series(["[0.5, 1.0]", "(1.0, 1.5]"], dtype=pl.Categorical),
             "count": pl.Series([2, 0], dtype=pl.get_index_type()),
         }
     )
@@ -468,7 +466,7 @@ def test_hist_breakpoint_accuracy() -> None:
         {
             "breakpoint": pl.Series([2.0, 3.0, 4.0], dtype=pl.Float64),
             "category": pl.Series(
-                ["(0.997, 2.0]", "(2.0, 3.0]", "(3.0, 4.0]"], dtype=pl.Categorical
+                ["[1.0, 2.0]", "(2.0, 3.0]", "(3.0, 4.0]"], dtype=pl.Categorical
             ),
             "count": pl.Series([2, 1, 1], dtype=pl.get_index_type()),
         }
@@ -492,7 +490,7 @@ def test_hist_ensure_max_value_20879() -> None:
                 ),
                 "category": pl.Series(
                     [
-                        "(-0.340667, 2.111111]",
+                        "[-0.333333, 2.111111]",
                         "(2.111111, 4.555556]",
                         "(4.555556, 7.0]",
                     ],
@@ -513,7 +511,7 @@ def test_hist_ignore_nans_21082() -> None:
                 "breakpoint": pl.Series([0.25, 0.5, 0.75, 1.0], dtype=pl.Float64),
                 "category": pl.Series(
                     [
-                        "(-0.001, 0.25]",
+                        "[-0.001, 0.25]",
                         "(0.25, 0.5]",
                         "(0.5, 0.75]",
                         "(0.75, 1.0]",
@@ -521,6 +519,20 @@ def test_hist_ignore_nans_21082() -> None:
                     dtype=pl.Categorical,
                 ),
                 "count": pl.Series([1, 1, 0, 1], dtype=pl.get_index_type()),
+            }
+        )
+    assert_frame_equal(result, expected)
+
+
+def test_hist_include_lower_22056() -> None:
+    s = pl.Series("a", [1, 5])
+    with pl.StringCache():
+        result = s.hist(bins=[1, 5], include_category=True)
+        expected = pl.DataFrame(
+            {
+                "breakpoint": pl.Series([5.0], dtype=pl.Float64),
+                "category": pl.Series(["[1.0, 5.0]"], dtype=pl.Categorical),
+                "count": pl.Series([2], dtype=pl.get_index_type()),
             }
         )
     assert_frame_equal(result, expected)


### PR DESCRIPTION
Closes #22056.

The old implementation made an attempt to follow pandas logic in that, when bins are automatically determined, the lowest edge is extended by a small amount. This allowed all intervals to remain left-open and include all of the data.

This results in ugly bins and also resulted in the issue above, where a user-supplied bins were respected, but the left-most bin was still open, and so if a data point fell on that edge, it was not counted. This was technically correct based on the logic, but is undoubtedly *not* what users want.

This PR simply makes the first bin closed, and all others left-open. It simplifies the internal logic (no more `pad_lower` argument) and has the side-effect of having all uniformly-spaced bins when `bin_counts` is provided (no more extending the left edge). I know we have flip-flopped a bit on `hist`. If someone disagrees with this new approach I'm happy to flip back, but this seems much simpler to me.

New behavior:

```pycon
>>> import polars as pl
>>> s = pl.Series([.5, 2.8, 9.1])
>>> s.hist(bin_count=5)
shape: (5, 3)
┌────────────┬──────────────┬───────┐
│ breakpoint ┆ category     ┆ count │
│ ---        ┆ ---          ┆ ---   │
│ f64        ┆ cat          ┆ u32   │
╞════════════╪══════════════╪═══════╡
│ 2.22       ┆ [0.5, 2.22]  ┆ 1     │ <-- note the closed interval
│ 3.94       ┆ (2.22, 3.94] ┆ 1     │
│ 5.66       ┆ (3.94, 5.66] ┆ 0     │
│ 7.38       ┆ (5.66, 7.38] ┆ 0     │
│ 9.1        ┆ (7.38, 9.1]  ┆ 1     │
└────────────┴──────────────┴───────┘
```

Example from OP issue:

```pycon
>>> import polars as pl
>>> s = pl.Series('a', [1, 5])
>>> s.hist(bins=[1, 5])
shape: (1, 3)
┌────────────┬────────────┬───────┐
│ breakpoint ┆ category   ┆ count │
│ ---        ┆ ---        ┆ ---   │
│ f64        ┆ cat        ┆ u32   │
╞════════════╪════════════╪═══════╡
│ 5.0        ┆ [1.0, 5.0] ┆ 2     │
└────────────┴────────────┴───────┘
```