### PR TITLE
fix(rust): Improve error message for mismatched input lengths

### DIFF
--- a/crates/polars-ops/src/chunked_array/cov.rs
+++ b/crates/polars-ops/src/chunked_array/cov.rs
@@ -4,7 +4,7 @@ use polars_core::prelude::*;
 use polars_core::utils::align_chunks_binary;
 
 /// Compute the covariance between two columns.
-pub fn cov<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>, ddof: u8) -> Option<f64>
+pub fn cov<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>, ddof: u8) -> PolarsResult<Option<f64>>
 where
     T: PolarsNumericType,
     T::Native: AsPrimitive<f64>,
@@ -13,13 +13,13 @@ where
     let (a, b) = align_chunks_binary(a, b);
     let mut out = CovState::default();
     for (a, b) in a.downcast_iter().zip(b.downcast_iter()) {
-        out.combine(&polars_compute::var_cov::cov(a, b))
+        out.combine(&polars_compute::var_cov::cov(a, b)?)
     }
-    out.finalize(ddof)
+    Ok(out.finalize(ddof))
 }
 
 /// Compute the pearson correlation between two columns.
-pub fn pearson_corr<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) -> Option<f64>
+pub fn pearson_corr<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) -> PolarsResult<Option<f64>>
 where
     T: PolarsNumericType,
     T::Native: AsPrimitive<f64>,
@@ -28,7 +28,7 @@ where
     let (a, b) = align_chunks_binary(a, b);
     let mut out = PearsonState::default();
     for (a, b) in a.downcast_iter().zip(b.downcast_iter()) {
-        out.combine(&polars_compute::var_cov::pearson_corr(a, b))
+        out.combine(&polars_compute::var_cov::pearson_corr(a, b)?)
     }
-    Some(out.finalize())
+    Ok(Some(out.finalize()))
 }

--- a/crates/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/crates/polars-plan/src/dsl/function_expr/correlation.rs
@@ -42,18 +42,18 @@ fn covariance(s: &[Column], ddof: u8) -> PolarsResult<Column> {
     use polars_ops::chunked_array::cov::cov;
     let ret = match a.dtype() {
         DataType::Float32 => {
-            let ret = cov(a.f32().unwrap(), b.f32().unwrap(), ddof).map(|v| v as f32);
+            let ret = cov(a.f32().unwrap(), b.f32().unwrap(), ddof)?.map(|v| v as f32);
             return Ok(Column::new(name, &[ret]));
         },
-        DataType::Float64 => cov(a.f64().unwrap(), b.f64().unwrap(), ddof),
-        DataType::Int32 => cov(a.i32().unwrap(), b.i32().unwrap(), ddof),
-        DataType::Int64 => cov(a.i64().unwrap(), b.i64().unwrap(), ddof),
-        DataType::UInt32 => cov(a.u32().unwrap(), b.u32().unwrap(), ddof),
-        DataType::UInt64 => cov(a.u64().unwrap(), b.u64().unwrap(), ddof),
+        DataType::Float64 => cov(a.f64().unwrap(), b.f64().unwrap(), ddof)?,
+        DataType::Int32 => cov(a.i32().unwrap(), b.i32().unwrap(), ddof)?,
+        DataType::Int64 => cov(a.i64().unwrap(), b.i64().unwrap(), ddof)?,
+        DataType::UInt32 => cov(a.u32().unwrap(), b.u32().unwrap(), ddof)?,
+        DataType::UInt64 => cov(a.u64().unwrap(), b.u64().unwrap(), ddof)?,
         _ => {
             let a = a.cast(&DataType::Float64)?;
             let b = b.cast(&DataType::Float64)?;
-            cov(a.f64().unwrap(), b.f64().unwrap(), ddof)
+            cov(a.f64().unwrap(), b.f64().unwrap(), ddof)?
         },
     };
     Ok(Column::new(name, &[ret]))
@@ -67,17 +67,17 @@ fn pearson_corr(s: &[Column]) -> PolarsResult<Column> {
     use polars_ops::chunked_array::cov::pearson_corr;
     let ret = match a.dtype() {
         DataType::Float32 => {
-            let ret = pearson_corr(a.f32().unwrap(), b.f32().unwrap()).map(|v| v as f32);
+            let ret = pearson_corr(a.f32().unwrap(), b.f32().unwrap())?.map(|v| v as f32);
             return Ok(Column::new(name.clone(), &[ret]));
         },
-        DataType::Float64 => pearson_corr(a.f64().unwrap(), b.f64().unwrap()),
-        DataType::Int32 => pearson_corr(a.i32().unwrap(), b.i32().unwrap()),
-        DataType::Int64 => pearson_corr(a.i64().unwrap(), b.i64().unwrap()),
-        DataType::UInt32 => pearson_corr(a.u32().unwrap(), b.u32().unwrap()),
+        DataType::Float64 => pearson_corr(a.f64().unwrap(), b.f64().unwrap())?,
+        DataType::Int32 => pearson_corr(a.i32().unwrap(), b.i32().unwrap())?,
+        DataType::Int64 => pearson_corr(a.i64().unwrap(), b.i64().unwrap())?,
+        DataType::UInt32 => pearson_corr(a.u32().unwrap(), b.u32().unwrap())?,
         _ => {
             let a = a.cast(&DataType::Float64)?;
             let b = b.cast(&DataType::Float64)?;
-            pearson_corr(a.f64().unwrap(), b.f64().unwrap())
+            pearson_corr(a.f64().unwrap(), b.f64().unwrap())?
         },
     };
     Ok(Column::new(name, &[ret]))


### PR DESCRIPTION
Closes: [#22080](https://github.com/pola-rs/polars/issues/22080)

## Overview
This PR improves the error handling in corr and pearson_corr functions by replacing a panic assertion with a descriptive PolarsError::ComputeError.

Previously, when input Series to corr had mismatched lengths, Polars would panic with an unhelpful Rust assertion error.
This PR introduces a proper ComputeError with a clear and actionable message:
"Input Series to corr must have the same length, but got lengths {} and {}."
This improves the developer experience and allows for cleaner error propagation in the future.

Ouptut log
```
polars.exceptions.ComputeError: Input Series must have the same length but got 2 and 3.
```

## Notes
Removed redundant input length validation in CovState::new() and PearsonState::new() since the check is already performed in cov() and pearson_corr().
