### PR TITLE
feat(python): Add an `eager` parameter to `pl.coalesce`

### DIFF
--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -634,9 +634,9 @@ def from_repr(data: str) -> DataFrame | Series:
 
     Notes
     -----
-    This function handles the default UTF8_FULL and UTF8_FULL_CONDENSED DataFrame
-    tables (with or without rounded corners). Truncated columns/rows are omitted,
-    wrapped headers are accounted for, and dtypes automatically identified.
+    This function handles the default UTF8_FULL (and UTF8_FULL_CONDENSED) DataFrame
+    tables, with or without rounded corners. Truncated columns/rows are omitted,
+    wrapped headers are accounted for, and dtypes are automatically identified.
 
     Currently compound/nested dtypes such as List and Struct are not supported;
     neither are Object dtypes.

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2056,8 +2056,9 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
     condition
         Boolean expression to evaluate
     eager
-        Evaluate immediately and return a `Series`. If set to `False` (default),
-        return an expression instead.
+        Evaluate immediately and return a `Series`; this requires that the given
+        condition is itself a `Series`. If set to `False` (default), return
+        an expression instead.
 
     See Also
     --------
@@ -2081,7 +2082,7 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
     if eager:
         if not isinstance(condition, pl.Series):
             msg = (
-                "expected 'Series' in 'arg_where' if 'eager=True', got"
+                "expected Series in 'arg_where' if 'eager=True', got"
                 f" {type(condition).__name__!r}"
             )
             raise ValueError(msg)
@@ -2091,7 +2092,35 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
         return wrap_expr(plr.arg_where(condition))
 
 
-def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
+@overload
+def coalesce(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    eager: Literal[False] = ...,
+) -> Expr: ...
+
+
+@overload
+def coalesce(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    eager: Literal[True],
+) -> Series: ...
+
+
+@overload
+def coalesce(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    eager: bool,
+) -> Expr | Series: ...
+
+
+def coalesce(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    eager: bool = False,
+) -> Expr | Series:
     """
     Folds the columns from left to right, keeping the first non-null value.
 
@@ -2102,6 +2131,10 @@ def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Exp
         names, other non-expression inputs are parsed as literals.
     *more_exprs
         Additional columns to coalesce, specified as positional arguments.
+    eager
+        Evaluate immediately and return a `Series`; this requires that at least one
+        of the given arguments is a `Series`. If set to `False` (default), return
+        an expression instead.
 
     Examples
     --------
@@ -2112,7 +2145,8 @@ def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Exp
     ...         "c": [5, None, 3, None],
     ...     }
     ... )
-    >>> df.with_columns(pl.coalesce(["a", "b", "c", 10]).alias("d"))
+
+    >>> df.with_columns(pl.coalesce("a", "b", "c", 10).alias("d"))
     shape: (4, 4)
     ┌──────┬──────┬──────┬─────┐
     │ a    ┆ b    ┆ c    ┆ d   │
@@ -2124,6 +2158,7 @@ def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Exp
     │ null ┆ null ┆ 3    ┆ 3   │
     │ null ┆ null ┆ null ┆ 10  │
     └──────┴──────┴──────┴─────┘
+
     >>> df.with_columns(pl.coalesce(pl.col(["a", "b", "c"]), 10.0).alias("d"))
     shape: (4, 4)
     ┌──────┬──────┬──────┬──────┐
@@ -2136,9 +2171,29 @@ def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Exp
     │ null ┆ null ┆ 3    ┆ 3.0  │
     │ null ┆ null ┆ null ┆ 10.0 │
     └──────┴──────┴──────┴──────┘
+
+    >>> s1 = pl.Series("a", [None, 2, None])
+    >>> s2 = pl.Series("b", [1, None, 3])
+    >>> pl.coalesce(s1, s2, eager=True)
+    shape: (3,)
+    Series: 'a' [i64]
+    [
+        1
+        2
+        3
+    ]
     """
-    exprs = parse_into_list_of_expressions(exprs, *more_exprs)
-    return wrap_expr(plr.coalesce(exprs))
+    if eager:
+        exprs = [exprs, *more_exprs]
+        if not (series := [e for e in exprs if isinstance(e, pl.Series)]):
+            msg = "expected at least one Series in 'coalesce' if 'eager=True'"
+            raise ValueError(msg)
+
+        exprs = [(e.name if isinstance(e, pl.Series) else e) for e in exprs]
+        return pl.DataFrame(series).select(coalesce(exprs, eager=False)).to_series()
+    else:
+        exprs = parse_into_list_of_expressions(exprs, *more_exprs)
+        return wrap_expr(plr.coalesce(exprs))
 
 
 @overload

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -431,41 +431,52 @@ def test_coalesce() -> None:
             "c": [5, None, 3, None],
         }
     )
-
-    # List inputs
+    # list inputs
     expected = pl.Series("d", [1, 2, 3, 10]).to_frame()
     result = df.select(pl.coalesce(["a", "b", "c", 10]).alias("d"))
     assert_frame_equal(expected, result)
 
-    # Positional inputs
+    # positional inputs
     expected = pl.Series("d", [1.0, 2.0, 3.0, 10.0]).to_frame()
     result = df.select(pl.coalesce(pl.col(["a", "b", "c"]), 10.0).alias("d"))
     assert_frame_equal(result, expected)
 
 
+def test_coalesce_eager() -> None:
+    # eager/series inputs
+    s1 = pl.Series("colx", [None, 2, None])
+    s2 = pl.Series("coly", [1, None, None])
+    s3 = pl.Series("colz", [None, None, 3])
+
+    res = pl.coalesce(s1, s2, s3, eager=True)
+    expected = pl.Series("colx", [1, 2, 3])
+    assert_series_equal(expected, res)
+
+    for zero in (0, pl.lit(0)):
+        res = pl.coalesce(s1, zero, eager=True)
+        expected = pl.Series("colx", [0, 2, 0])
+        assert_series_equal(expected, res)
+
+        res = pl.coalesce(zero, s1, eager=True)
+        expected = pl.Series("literal", [0, 0, 0])
+        assert_series_equal(expected, res)
+
+    with pytest.raises(
+        ValueError,
+        match="expected at least one Series in 'coalesce' if 'eager=True'",
+    ):
+        pl.coalesce("x", "y", eager=True)
+
+
 def test_overflow_diff() -> None:
-    df = pl.DataFrame(
-        {
-            "a": [20, 10, 30],
-        }
-    )
+    df = pl.DataFrame({"a": [20, 10, 30]})
     assert df.select(pl.col("a").cast(pl.UInt64).diff()).to_dict(as_series=False) == {
         "a": [None, -10, 20]
     }
 
 
 def test_fill_null_unknown_output_type() -> None:
-    df = pl.DataFrame(
-        {
-            "a": [
-                None,
-                2,
-                3,
-                4,
-                5,
-            ]
-        }
-    )
+    df = pl.DataFrame({"a": [None, 2, 3, 4, 5]})
     assert df.with_columns(
         np.exp(pl.col("a")).fill_null(pl.lit(1, pl.Float64))
     ).to_dict(as_series=False) == {


### PR DESCRIPTION
Closes #22075.

Adds `eager` flag to `pl.coalesce` (as with other such functions, this requires that at least one of the inputs is a `Series`, otherwise there is nothing that can be materialised).

## Example

```python
import polars as pl

s1 = pl.Series("colx", [None,2,None,None])
s2 = pl.Series("coly", [1,None,None,None])
s3 = pl.Series("colz", [None,None,3,None])

pl.coalesce(s1, s2, s3, 4, eager=True)
# shape: (4,)
# Series: 'colx' [i64]
# [
#     1
#     2
#     3
#     4
# ]
```