### PR TITLE
fix(rust): Panic in `GroupBySinkState::into_source` with empty locals

### DIFF
--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -110,6 +110,9 @@ impl GroupBySinkState {
         output_schema: &Schema,
         mut locals: Vec<LocalGroupBySinkState>,
     ) -> PolarsResult<DataFrame> {
+        if locals.is_empty() {
+            return Ok(DataFrame::empty_with_schema(output_schema));
+        }
         let mut group_idxs = Vec::new();
         let mut combined = locals.pop().unwrap();
         for local in locals {
@@ -133,6 +136,9 @@ impl GroupBySinkState {
         output_schema: &Schema,
         locals: Vec<LocalGroupBySinkState>,
     ) -> PolarsResult<DataFrame> {
+        if locals.is_empty() {
+            return Ok(DataFrame::empty_with_schema(output_schema));
+        }
         let partitioner = HashPartitioner::new(num_partitions, 0);
         POOL.install(|| {
             let l_partitions: Vec<_> = locals


### PR DESCRIPTION
Fixes a sporadic panic in the streaming engine when running queries containing GroupBy with empty inputs. The node can update state and switch from a sink to a source before `spawn` is called, meaning the locals are still empty. Managed to reproduce only a few times in the cloud:
```python:
    lf = pl.LazyFrame(
        {},
        schema={
            "id": pl.Int32,
            "x": pl.Int32,
        },
    )

    q1 = (
        lf.filter(pl.col("id") == 0)
        .join(lf, how="left", left_on="id", right_on="id")
        .group_by("id")
        .agg(pl.col("x").sum())
    )

    print(pc.spawn_blocking(q1, dst=tmp_dst, distributed=True).plan())
```

```
AGGREGATE
  [col("x").sum()] BY [col("id")]
  FROM
  simple π 2/3 ["id", "x"]
    LEFT JOIN:
    LEFT PLAN ON: [col("id")]
      FILTER [(col("id")) == (0)]
      FROM
        DF ["id", "x"]; PROJECT["id", "x"] 2/2 COLUMNS
    RIGHT PLAN ON: [col("id")]
      DF ["id", "x"]; PROJECT["id", "x"] 2/2 COLUMNS
    END LEFT JOIN
```

<details>
<summary>Stack trace</summary>

```
A panic occurred panic.payload="called `Option::unwrap()` on a `None` value" panic.location="/home/kuba/polars/crates/polars-stream/src/nodes/group_by.rs:114:41" panic.backtrace=   0: tracing_panic::panic_hook
             at /home/kuba/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-panic-0.1.2/src/lib.rs:74:25
   1: core::ops::function::Fn::call
             at /home/kuba/.rustup/toolchains/nightly-2025-03-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:79:5
   2: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/alloc/src/boxed.rs:1984:9
   3: std::panicking::rust_panic_with_hook
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/std/src/panicking.rs:839:13
   4: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/std/src/panicking.rs:697:13
   5: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/std/src/sys/backtrace.rs:168:18
   6: rust_begin_unwind
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/std/src/panicking.rs:695:5
   7: core::panicking::panic_fmt
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/core/src/panicking.rs:75:14
   8: core::panicking::panic
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/core/src/panicking.rs:145:5
   9: core::option::unwrap_failed
             at /rustc/b74da9613a8cb5ba67a985f71325be0b7b16c0dd/library/core/src/option.rs:2015:5
  10: core::option::Option<T>::unwrap
             at /home/kuba/.rustup/toolchains/nightly-2025-03-07-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:978:21
  11: polars_stream::nodes::group_by::GroupBySinkState::combine_locals
             at /home/kuba/polars/crates/polars-stream/src/nodes/group_by.rs:114:28
  12: polars_stream::nodes::group_by::GroupBySinkState::into_source
             at /home/kuba/polars/crates/polars-stream/src/nodes/group_by.rs:221:13
  13: <polars_stream::nodes::group_by::GroupByNode as polars_stream::nodes::ComputeNode>::update_state
             at /home/kuba/polars/crates/polars-stream/src/nodes/group_by.rs:290:51
  14: polars_stream::graph::Graph::update_all_states
             at /home/kuba/polars/crates/polars-stream/src/graph.rs:100:13
  15: polars_stream::execute::execute_graph
             at /home/kuba/polars/crates/polars-stream/src/execute.rs:279:9
  16: polars_stream::skeleton::run_query
             at /home/kuba/polars/crates/polars-stream/src/skeleton.rs:51:23
  17: pc_worker_executor::tasks::query::perform_query
             at ./crates/pc-worker-executor/src/tasks/query/mod.rs:91:23
```

</details>