### PR TITLE
feat(python): Add an `eager` parameter to `pl.cov`

### DIFF
--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -216,6 +216,30 @@ def test_concat_vertical() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_cov() -> None:
+    s1 = pl.Series("a", [10, 37, -40])
+    s2 = pl.Series("b", [70, -10, 35])
+
+    # lazy/expression
+    lf = pl.LazyFrame([s1, s2])
+    res1 = lf.select(
+        x=pl.cov("a", "b"),
+        y=pl.cov("a", "b", ddof=2),
+    ).collect()
+
+    # eager/series
+    res2 = (
+        pl.cov(s1, s2, eager=True).alias("x"),
+        pl.cov(s1, s2, eager=True, ddof=2).alias("y"),
+    )
+
+    # expect same result from both approaches
+    for idx, (r1, r2) in enumerate(zip(res1, res2)):
+        expected_value = -645.8333333333 if idx == 0 else -1291.6666666666
+        assert pytest.approx(expected_value) == r1.item()
+        assert_series_equal(r1, r2)
+
+
 def test_corr() -> None:
     s1 = pl.Series("a", [10, 37, -40])
     s2 = pl.Series("b", [70, -10, 35])

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -66,20 +66,18 @@ def test_cov_corr_f32_type() -> None:
 
 def test_cov(fruits_cars: pl.DataFrame) -> None:
     ldf = fruits_cars.lazy()
-    cov_a_b = pl.cov(pl.col("A"), pl.col("B"))
-    cov_ab = pl.cov("A", "B")
-    assert cast(float, ldf.select(cov_a_b).collect().item()) == -2.5
-    assert cast(float, ldf.select(cov_ab).collect().item()) == -2.5
+    for cov_ab in (pl.cov(pl.col("A"), pl.col("B")), pl.cov("A", "B")):
+        assert cast(float, ldf.select(cov_ab).collect().item()) == -2.5
 
 
 def test_std(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.lazy().std().collect()["A"][0] == pytest.approx(
-        1.5811388300841898
-    )
+    res = fruits_cars.lazy().std().collect()
+    assert res["A"][0] == pytest.approx(1.5811388300841898)
 
 
 def test_var(fruits_cars: pl.DataFrame) -> None:
-    assert fruits_cars.lazy().var().collect()["A"][0] == pytest.approx(2.5)
+    res = fruits_cars.lazy().var().collect()
+    assert res["A"][0] == pytest.approx(2.5)
 
 
 def test_max(fruits_cars: pl.DataFrame) -> None:


### PR DESCRIPTION
Ref: #22081, #22097.

If we're adding an `eager` param to `corr`, it's consistent to have it on `cov` too.