### PR TITLE
feat: Add support for `Int128` parsing/recognition to the SQL interface

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1144,7 +1144,6 @@ impl SQLContext {
                 ..
             } => {
                 if let Some(alias) = alias {
-                    let table_name = alias.name.value.clone();
                     let column_names: Vec<Option<PlSmallStr>> = alias
                         .columns
                         .iter()
@@ -1187,11 +1186,13 @@ impl SQLContext {
                         .collect();
 
                     let lf = DataFrame::new(column_series)?.lazy();
+
                     if *with_offset {
-                        // TODO: support 'WITH ORDINALITY' modifier.
+                        // TODO: support 'WITH ORDINALITY|OFFSET' modifier.
                         //  (note that 'WITH OFFSET' is BigQuery-specific syntax, not PostgreSQL)
-                        polars_bail!(SQLInterface: "UNNEST tables do not (yet) support WITH OFFSET/ORDINALITY");
+                        polars_bail!(SQLInterface: "UNNEST tables do not (yet) support WITH ORDINALITY|OFFSET");
                     }
+                    let table_name = alias.name.value.clone();
                     self.table_map.insert(table_name.clone(), lf.clone());
                     Ok((table_name.clone(), lf))
                 } else {

--- a/py-polars/tests/unit/sql/test_array.py
+++ b/py-polars/tests/unit/sql/test_array.py
@@ -229,7 +229,7 @@ def test_unnest_table_function_errors() -> None:
 
         with pytest.raises(
             SQLInterfaceError,
-            match=r"UNNEST tables do not \(yet\) support WITH OFFSET/ORDINALITY",
+            match=r"UNNEST tables do not \(yet\) support WITH OFFSET|ORDINALITY",
         ):
             ctx.execute("SELECT * FROM UNNEST([1, 2, 3]) tbl (colx) WITH OFFSET")
 

--- a/py-polars/tests/unit/sql/test_cast.py
+++ b/py-polars/tests/unit/sql/test_cast.py
@@ -20,6 +20,7 @@ def test_cast() -> None:
             "e": [-1, 0, None, 1, 2],
         }
     )
+
     # test various dtype casts, using standard ("CAST <col> AS <dtype>")
     # and postgres-specific ("<col>::<dtype>") cast syntax
     with pl.SQLContext(df=df, eager=True) as ctx:
@@ -39,6 +40,7 @@ def test_cast() -> None:
               CAST(b AS SMALLINT) AS b_i16,
               b::bigint AS b_i64,
               d::tinyint AS d_i8,
+              d::hugeint AS d_i128,
               a::int1 AS a_i8,
               a::int2 AS a_i16,
               a::int4 AS a_i32,
@@ -77,6 +79,7 @@ def test_cast() -> None:
         "b_i16": pl.Int16,
         "b_i64": pl.Int64,
         "d_i8": pl.Int8,
+        "d_i128": pl.Int128,
         "a_i8": pl.Int8,
         "a_i16": pl.Int16,
         "a_i32": pl.Int32,
@@ -113,11 +116,11 @@ def test_cast() -> None:
         (5.0, 5.5, 2.0),
     ]
     assert res.select(cs.integer()).rows() == [
-        (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-        (2, 2, 2, 0, 2, 2, 2, 2, 2, 0, 2, 2, 2, 2),
-        (3, 3, 3, 1, 3, 3, 3, 3, 3, 1, 3, 3, 3, 3),
-        (4, 4, 4, 0, 4, 4, 4, 4, 4, 0, 4, 4, 4, 4),
-        (5, 5, 5, 1, 5, 5, 5, 5, 5, 1, 5, 5, 5, 5),
+        (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+        (2, 2, 2, 0, 0, 2, 2, 2, 2, 2, 0, 2, 2, 2, 2),
+        (3, 3, 3, 1, 1, 3, 3, 3, 3, 3, 1, 3, 3, 3, 3),
+        (4, 4, 4, 0, 0, 4, 4, 4, 4, 4, 0, 4, 4, 4, 4),
+        (5, 5, 5, 1, 1, 5, 5, 5, 5, 5, 1, 5, 5, 5, 5),
     ]
     assert res.select(cs.string()).rows() == [
         ("1", "1.1", "true"),


### PR DESCRIPTION
The SQL interface now parses/recognises Int128 (aka: HUGEINT[^1]) types.

This means the following casts are all now valid:
* `CAST(value AS HUGEINT)`
* `CAST(value AS INT128)`
* `value::hugeint`
* `value::int128`

## Example

```python
import polars as pl

df = pl.DataFrame({"value": [-2**32, 2**48]})

df.sql("""
  SELECT *, value::int128 AS value128
  FROM self
""")
# shape: (2, 2)
# ┌─────────────────┬─────────────────┐
# │ value           ┆ value128        │
# │ ---             ┆ ---             │
# │ i64             ┆ i128            │
# ╞═════════════════╪═════════════════╡
# │ -4294967296     ┆ -4294967296     │
# │ 281474976710656 ┆ 281474976710656 │
# └─────────────────┴─────────────────┘
```

[^1]: [Integer Types](https://duckdb.org/docs/stable/sql/data_types/numeric.html#integer-types)