### PR TITLE
fix: Ensure SQL dot-notation for nested column fields resolves correctly

### DIFF
--- a/py-polars/tests/unit/sql/test_structs.py
+++ b/py-polars/tests/unit/sql/test_structs.py
@@ -4,6 +4,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import SQLSyntaxError, StructFieldNotFoundError
+from polars.polars import SQLInterfaceError
 from polars.testing import assert_frame_equal
 
 
@@ -17,6 +18,47 @@ def df_struct() -> pl.DataFrame:
             "other": [{"n": 1.5}, {"n": None}, {"n": -0.5}],
         }
     ).select(pl.struct(pl.all()).alias("json_msg"))
+
+
+def test_struct_field_nested_dot_notation_22107() -> None:
+    # ensure dot-notation references the given name at the right level of nesting
+    df = pl.DataFrame(
+        {
+            "id": ["012345", "987654"],
+            "name": ["A Book", "Another Book"],
+            "author": [
+                {"id": "888888", "name": "Iain M. Banks"},
+                {"id": "444444", "name": "Dan Abnett"},
+            ],
+        }
+    )
+
+    res = df.sql("SELECT id, author.id AS author_id FROM self ORDER BY id")
+    assert res.to_dict(as_series=False) == {
+        "id": ["012345", "987654"],
+        "author_id": ["888888", "444444"],
+    }
+
+    for name in ("author.name", "self.author.name"):
+        res = df.sql(f"SELECT {name} FROM self ORDER BY id")
+        assert res.to_dict(as_series=False) == {"name": ["Iain M. Banks", "Dan Abnett"]}
+
+    for name in ("name", "self.name"):
+        res = df.sql(f"SELECT {name} FROM self ORDER BY self.id DESC")
+        assert res.to_dict(as_series=False) == {"name": ["Another Book", "A Book"]}
+
+    # expected errors
+    with pytest.raises(
+        SQLInterfaceError,
+        match="no table or struct column named 'foo' found",
+    ):
+        df.sql("SELECT foo.id FROM self ORDER BY id")
+
+    with pytest.raises(
+        SQLInterfaceError,
+        match="no column named 'foo' found",
+    ):
+        df.sql("SELECT self.foo FROM self ORDER BY id")
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/sql/test_structs.py
+++ b/py-polars/tests/unit/sql/test_structs.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
-from polars.exceptions import SQLSyntaxError, StructFieldNotFoundError
-from polars.polars import SQLInterfaceError
+from polars.exceptions import (
+    SQLInterfaceError,
+    SQLSyntaxError,
+    StructFieldNotFoundError,
+)
 from polars.testing import assert_frame_equal
 
 


### PR DESCRIPTION
Closes #22107.

If we had a column in the table root with the same name as a field in a nested column, and used dot-notation to refer to the nested column, we could incorrectly resolve to the root-level column with that name instead.

**Note:** using the dedicated/non-ambiguous operator `->` works correctly in all cases (eg: `author -> 'id' AS author_id`); the issue only occurred with dot-notation, as that _also_ covers table identifiers (eg: `tbl.column`) so it has to disambiguate usage.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "id": ["012345", "987654"],
    "name": ["A Book", "Another Book"],
    "author": [
        {"id": "888888", "name": "Iain M. Banks"},
        {"id": "444444", "name": "Dan Abnett"},
    ],
})
```
* ### Before
  Column `author.id` incorrectly resolves to `id`.
  (Only occurs if a column called `id` is also present in the table root).
  ```python
  df.sql("SELECT id, author.id AS author_id FROM self")
  # shape: (2, 2)
  # ┌────────┬───────────┐
  # │ id     ┆ author_id │
  # │ ---    ┆ ---       │
  # │ str    ┆ str       │
  # ╞════════╪═══════════╡
  # │ 012345 ┆ 012345    │
  # │ 987654 ┆ 987654    │
  # └────────┴───────────┘
  ```


* ### After
  Column `author.id` resolves correctly:
  ```python
  df.sql("SELECT id, author.id AS author_id FROM self")
  # shape: (2, 2)
  # ┌────────┬───────────┐
  # │ id     ┆ author_id │
  # │ ---    ┆ ---       │
  # │ str    ┆ str       │
  # ╞════════╪═══════════╡
  # │ 012345 ┆ 888888    │
  # │ 987654 ┆ 444444    │
  # └────────┴───────────┘
  ```