### PR TITLE
fix: Enhance predicate validation and cast safety in `join_where`

### DIFF
--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -429,7 +429,6 @@ fn resolve_join_where(
         .get(last_node)
         .schema(ctxt.lp_arena)
         .into_owned();
-    // let schema_merged = schema_merged.as_ref();
 
     // Perform predicate validation.
     for e in predicates {

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -473,7 +473,7 @@ fn ensure_lossless_binary_comparisons(
     schema_merged: &Schema,
     expr_arena: &mut Arena<AExpr>,
 ) -> PolarsResult<()> {
-    // Ensure that all binary comparisons that use both tables are lossles.
+    // Ensure that all binary comparisons that use both tables are lossless.
     let mut to_replace = Vec::<(Node, DataType)>::with_capacity(expr_arena.len());
     upcast_comparison_nodes(
         node,

--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -2,7 +2,7 @@ use arrow::legacy::error::PolarsResult;
 use either::Either;
 use polars_core::chunked_array::cast::CastOptions;
 use polars_core::error::feature_gated;
-use polars_core::utils::get_numeric_upcast_supertype_lossless;
+use polars_core::utils::{get_numeric_upcast_supertype_lossless, try_get_supertype};
 use polars_utils::format_pl_smallstr;
 use polars_utils::itertools::Itertools;
 
@@ -424,8 +424,6 @@ fn resolve_join_where(
         ctxt,
     )?;
 
-    let mut ae_nodes_stack = Vec::new();
-
     let schema_merged = ctxt
         .lp_arena
         .get(last_node)
@@ -433,20 +431,23 @@ fn resolve_join_where(
         .into_owned();
     let schema_merged = schema_merged.as_ref();
 
+    // Perform predicate validation.
     for e in predicates {
         let predicate = to_expr_ir_ignore_alias(e, ctxt.expr_arena)?;
 
-        debug_assert!(ae_nodes_stack.is_empty());
-        ae_nodes_stack.clear();
-        ae_nodes_stack.push(predicate.node());
+        // Ensure the predicate dtype output of the root node is Boolean
+        let ae = ctxt.expr_arena.get(predicate.node());
+        let dt_out = ae.to_dtype(schema_merged, Context::Default, ctxt.expr_arena)?;
+        polars_ensure!(
+            dt_out == DataType::Boolean,
+            ComputeError: "'join_where' predicates must resolve to boolean"
+        );
 
-        process_join_where_predicate(
-            &mut ae_nodes_stack,
-            0,
+        validate_lossless_table_comparison(
+            predicate.node(),
             schema_left.as_ref(),
             schema_merged,
             ctxt.expr_arena,
-            &mut ExprOrigin::None,
         )?;
 
         ctxt.conversion_optimizer
@@ -467,137 +468,119 @@ fn resolve_join_where(
     Ok((last_node, join_node))
 }
 
+fn ensure_lossless_comparison(
+    left_node: Node,
+    right_node: Node,
+    expr_arena: &mut Arena<AExpr>,
+    schema_merged: &Schema,
+) -> PolarsResult<()> {
+    // Ensure our dtype casts are lossless
+    let left = expr_arena.get(left_node);
+    let right = expr_arena.get(right_node);
+    let dtype_left = left.to_dtype(schema_merged, Context::Default, expr_arena)?;
+    let dtype_right = right.to_dtype(schema_merged, Context::Default, expr_arena)?;
+    if dtype_left != dtype_right {
+        // Ensure that we have a lossless cast between the two types.
+        let dt = if dtype_left.is_primitive_numeric() || dtype_right.is_primitive_numeric() {
+            get_numeric_upcast_supertype_lossless(&dtype_left, &dtype_right).ok_or(
+                PolarsError::SchemaMismatch(
+                    format!(
+                        "'join_where' cannot compare {:?} with {:?}",
+                        dtype_left, dtype_right
+                    )
+                    .into(),
+                ),
+            )
+        } else {
+            try_get_supertype(&dtype_left, &dtype_right)
+        }?;
+
+        // We have unique references to these nodes, so we can mutate in-place.
+        let expr = expr_arena.add(expr_arena.get(left_node).clone());
+        expr_arena.replace(
+            left_node,
+            AExpr::Cast {
+                expr,
+                dtype: dt.clone(),
+                options: CastOptions::Overflowing,
+            },
+        );
+        let expr = expr_arena.add(expr_arena.get(right_node).clone());
+        expr_arena.replace(
+            right_node,
+            AExpr::Cast {
+                expr,
+                dtype: dt,
+                options: CastOptions::Overflowing,
+            },
+        );
+    }
+    Ok(())
+}
+
 /// Performs validation and type-coercion on join_where predicates.
 ///
-/// Validates for all comparison expressions / subexpressions, that:
-/// 1. They reference columns from both sides.
-/// 2. The dtypes of the LHS and RHS are match, or can be casted to a lossless
-///    supertype (and inserts the necessary casting).
-///
-/// We perform (1) by recursing whenever we encounter a comparison expression.
-fn process_join_where_predicate(
-    stack: &mut Vec<Node>,
-    prev_comparison_expr_stack_offset: usize,
+/// If we are dealing with a binary comparison involving columns from exclusively the left table
+/// on the LHS and the right table on the RHS side, ensure that the cast is lossless.
+/// Expressions involving binaries using either table alone we leave up to the user to verify
+/// that they are valid, as they could theoretically be pushed outside of the join.
+fn validate_lossless_table_comparison(
+    predicate: Node,
     schema_left: &Schema,
     schema_merged: &Schema,
     expr_arena: &mut Arena<AExpr>,
-    column_origins: &mut ExprOrigin,
-) -> PolarsResult<()> {
-    while stack.len() > prev_comparison_expr_stack_offset {
-        let ae_node = stack.pop().unwrap();
-        let ae = expr_arena.get(ae_node).clone();
-
-        match ae {
-            AExpr::Column(ref name) => {
-                let origin = if schema_left.contains(name) {
-                    ExprOrigin::Left
-                } else if schema_merged.contains(name) {
-                    ExprOrigin::Right
-                } else {
-                    polars_bail!(ColumnNotFound: "{}", name);
-                };
-
-                *column_origins |= origin;
-            },
-            // This is not actually Origin::Both, but we set this because the test suite expects
-            // this predicate to pass:
-            // * `pl.col("flag_right") == 1`
-            // Observe that it only has a column from one side because it is comparing to a literal.
-            AExpr::Literal(_) => *column_origins = ExprOrigin::Both,
-            AExpr::BinaryExpr {
-                left: left_node,
-                op,
-                right: right_node,
-            } if op.is_comparison_or_bitwise() => {
-                {
-                    let new_stack_offset = stack.len();
-                    stack.extend([right_node, left_node]);
-
-                    // Reset `column_origins` to a `None` state. We will only have 2 possible return states from
-                    // this point:
-                    // * Ok(()), with column_origins @ ExprOrigin::Both
-                    // * Err(_), in which case the value of column_origins doesn't matter.
-                    *column_origins = ExprOrigin::None;
-
-                    process_join_where_predicate(
-                        stack,
-                        new_stack_offset,
-                        schema_left,
-                        schema_merged,
-                        expr_arena,
-                        column_origins,
-                    )?;
-
-                    if *column_origins != ExprOrigin::Both {
-                        polars_bail!(
-                            InvalidOperation:
-                            "'join_where' predicate only refers to columns from a single table: {}",
-                            node_to_expr(ae_node, expr_arena),
-                        )
-                    }
+) -> PolarsResult<ExprOrigin> {
+    let ae = expr_arena.get(predicate).clone();
+    let expr_origin = match ae {
+        AExpr::Column(ref name) => {
+            if schema_left.contains(name) {
+                ExprOrigin::Left
+            } else if schema_merged.contains(name) {
+                ExprOrigin::Right
+            } else {
+                ExprOrigin::None
+            }
+        },
+        AExpr::Literal(..) => ExprOrigin::None,
+        AExpr::Cast { expr: node, .. } => {
+            validate_lossless_table_comparison(node, schema_left, schema_merged, expr_arena)?
+        },
+        AExpr::BinaryExpr {
+            left: left_node,
+            op,
+            right: right_node,
+        } => {
+            // If left and right node has both, ensure the dtypes are valid.
+            let left_origin = validate_lossless_table_comparison(
+                left_node,
+                schema_left,
+                schema_merged,
+                expr_arena,
+            )?;
+            let right_origin = validate_lossless_table_comparison(
+                right_node,
+                schema_left,
+                schema_merged,
+                expr_arena,
+            )?;
+            // We only update casts during comparisons if the operands are from different tables.
+            if op.is_comparison() {
+                match (left_origin, right_origin) {
+                    (ExprOrigin::Left, ExprOrigin::Right)
+                    | (ExprOrigin::Right, ExprOrigin::Left) => {
+                        ensure_lossless_comparison(
+                            left_node,
+                            right_node,
+                            expr_arena,
+                            schema_merged,
+                        )?;
+                    },
+                    _ => (),
                 }
-
-                // Fetch them again in case they were rewritten.
-                let left = expr_arena.get(left_node).clone();
-                let right = expr_arena.get(right_node).clone();
-
-                let resolve_dtype = |ae: &AExpr, node: Node| -> PolarsResult<DataType> {
-                    ae.to_dtype(schema_merged, Context::Default, expr_arena)
-                        .map_err(|e| {
-                            e.context(
-                                format!(
-                                    "could not resolve dtype of join_where predicate (expr: {})",
-                                    node_to_expr(node, expr_arena),
-                                )
-                                .into(),
-                            )
-                        })
-                };
-
-                let dtype_left = resolve_dtype(&left, left_node)?;
-                let dtype_right = resolve_dtype(&right, right_node)?;
-
-                // Note: We only upcast the sides if the expr output dtype is Boolean (i.e. `op` is
-                // a comparison), otherwise the output may change.
-
-                if let Some(dtype) =
-                    get_numeric_upcast_supertype_lossless(&dtype_left, &dtype_right)
-                        .filter(|_| op.is_comparison())
-                {
-                    // We have unique references to these nodes (they are created by this function),
-                    // so we can mutate in-place without causing side effects somewhere else.
-                    let expr = expr_arena.add(expr_arena.get(left_node).clone());
-                    expr_arena.replace(
-                        left_node,
-                        AExpr::Cast {
-                            expr,
-                            dtype: dtype.clone(),
-                            options: CastOptions::Overflowing,
-                        },
-                    );
-
-                    let expr = expr_arena.add(expr_arena.get(right_node).clone());
-                    expr_arena.replace(
-                        right_node,
-                        AExpr::Cast {
-                            expr,
-                            dtype,
-                            options: CastOptions::Overflowing,
-                        },
-                    );
-                } else {
-                    polars_ensure!(
-                        dtype_left == dtype_right,
-                        SchemaMismatch:
-                        "datatypes of join_where comparison don't match - {} on left does not match {} on right \
-                        (expr: {})",
-                        dtype_left, dtype_right, node_to_expr(ae_node, expr_arena),
-                    )
-                }
-            },
-            ae => ae.inputs_rev(stack),
-        }
-    }
-
-    Ok(())
+            }
+            left_origin | right_origin
+        },
+        _ => ExprOrigin::None,
+    };
+    Ok(expr_origin)
 }

--- a/py-polars/tests/unit/operations/test_inequality_join.py
+++ b/py-polars/tests/unit/operations/test_inequality_join.py
@@ -452,15 +452,6 @@ def test_ie_join_with_floats(
     assert_frame_equal(actual, expected, check_row_order=False, check_exact=True)
 
 
-def test_raise_on_ambiguous_name() -> None:
-    df = pl.DataFrame({"id": [1, 2]})
-    with pytest.raises(
-        pl.exceptions.InvalidOperationError,
-        match="'join_where' predicate only refers to columns from a single table",
-    ):
-        df.join_where(df, pl.col("id") >= pl.col("id"))
-
-
 def test_raise_invalid_input_join_where() -> None:
     df = pl.DataFrame({"id": [1, 2]})
     with pytest.raises(
@@ -570,15 +561,23 @@ def test_ie_join_projection_pd_19005() -> None:
     assert out.shape == (0, 2)
 
 
-def test_raise_invalid_predicate() -> None:
-    left = pl.LazyFrame({"a": [1, 2]}).with_row_index()
-    right = pl.LazyFrame({"b": [1, 2]}).with_row_index()
+def test_single_sided_predicate() -> None:
+    left = pl.LazyFrame({"a": [1, -1, 2]}).with_row_index()
+    right = pl.LazyFrame({"b": [1, 2]})
 
-    with pytest.raises(
-        pl.exceptions.InvalidOperationError,
-        match="'join_where' predicate only refers to columns from a single table",
-    ):
-        left.join_where(right, pl.col.index >= pl.col.a).collect()
+    result = (
+        left.join_where(right, pl.col.index >= pl.col.a)
+        .collect()
+        .sort("index", "a", "b")
+    )
+    expected = pl.DataFrame(
+        {
+            "index": pl.Series([1, 1, 2, 2], dtype=pl.get_index_type()),
+            "a": [-1, -1, 2, 2],
+            "b": [1, 2, 1, 2],
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_join_on_strings() -> None:

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1525,14 +1525,14 @@ def test_join_numeric_key_upcast_forbid_float_int() -> None:
 
     for no_optimization in [True, False]:
         with pytest.raises(
-            SchemaError, match="datatypes of join_where comparison don't match"
+            SchemaError, match="'join_where' cannot compare Float64 with Int128"
         ):
             left.join_where(right, pl.col("a") == pl.col("a_right")).collect(
                 no_optimization=no_optimization
             )
 
         with pytest.raises(
-            SchemaError, match="datatypes of join_where comparison don't match"
+            SchemaError, match="'join_where' cannot compare Float64 with Int128"
         ):
             left.join_where(
                 right, pl.col("a") == (pl.col("a") == pl.col("a_right"))
@@ -1990,3 +1990,121 @@ def test_join_categorical_21815() -> None:
         assert_frame_equal(
             cat_payload, expected, check_row_order=False, check_column_order=False
         )
+
+
+def test_join_where_nested_boolean() -> None:
+    df1 = pl.DataFrame({"a": [1, 9, 22], "b": [6, 4, 50]})
+    df2 = pl.DataFrame({"c": [1]})
+
+    predicate = (pl.col("a") < pl.col("b")).cast(pl.Int32) < pl.col("c")
+    result = df1.join_where(df2, predicate)
+    expected = pl.DataFrame(
+        {
+            "a": [9],
+            "b": [4],
+            "c": [1],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_join_where_dtype_upcast() -> None:
+    df1 = pl.DataFrame(
+        {
+            "a": pl.Series([1, 9, 22], dtype=pl.Int8),
+            "b": [6, 4, 50],
+        }
+    )
+    df2 = pl.DataFrame({"c": [10]})
+
+    predicate = (pl.col("a") + (pl.col("b") > 0)) < pl.col("c")
+    result = df1.join_where(df2, predicate)
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series([1], dtype=pl.Int8),
+            "b": [6],
+            "c": [10],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_join_where_valid_dtype_upcast_same_side() -> None:
+    # Unsafe comparisons are all contained entirely within one table (LHS)
+    # Safe comparisons across both tables.
+    df1 = pl.DataFrame(
+        {
+            "a": pl.Series([1, 9, 22], dtype=pl.Float32),
+            "b": [6, 4, 50],
+        }
+    )
+    df2 = pl.DataFrame({"c": [10, 1, 5]})
+
+    predicate = ((pl.col("a") < pl.col("b")).cast(pl.Int32) + 3) < pl.col("c")
+    result = df1.join_where(df2, predicate).sort("a", "b", "c")
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series([1, 1, 9, 9, 22, 22], dtype=pl.Float32),
+            "b": [6, 6, 4, 4, 50, 50],
+            "c": [5, 10, 5, 10, 5, 10],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_join_where_invalid_dtype_upcast_different_side() -> None:
+    # Unsafe comparisons exist across tables.
+    df1 = pl.DataFrame(
+        {
+            "a": pl.Series([1, 9, 22], dtype=pl.Float32),
+            "b": pl.Series([6, 4, 50], dtype=pl.Float64),
+        }
+    )
+    df2 = pl.DataFrame({"c": [10, 1, 5]})
+
+    predicate = ((pl.col("a") >= pl.col("c")) + 3) < 4
+    with pytest.raises(
+        SchemaError, match="'join_where' cannot compare Float32 with Int64"
+    ):
+        df1.join_where(df2, predicate)
+
+    # add in a cast to predicate to fix
+    predicate = ((pl.col("a").cast(pl.UInt8) >= pl.col("c")) + 3) < 4
+    result = df1.join_where(df2, predicate).sort("a", "b", "c")
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series([1, 1, 9], dtype=pl.Float32),
+            "b": pl.Series([6, 6, 4], dtype=pl.Float64),
+            "c": [5, 10, 10],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("dtype", [pl.Int32, pl.Float32])
+def test_join_where_literals(dtype: PolarsDataType) -> None:
+    df1 = pl.DataFrame({"a": pl.Series([0, 1], dtype=dtype)})
+    df2 = pl.DataFrame({"b": pl.Series([1, 2], dtype=dtype)})
+    result = df1.join_where(df2, (pl.col("a") + pl.col("b")) < 2)
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series([0], dtype=dtype),
+            "b": pl.Series([1], dtype=dtype),
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_join_where_categorical_string_compare() -> None:
+    dt = pl.Enum(["a", "b", "c"])
+    df1 = pl.DataFrame({"a": pl.Series(["a", "a", "b", "c"], dtype=dt)})
+    df2 = pl.DataFrame({"b": [1, 6, 4]})
+    predicate = pl.col("a").is_in(["a", "b"]) & (pl.col("b") < 5)
+    result = df1.join_where(df2, predicate).sort("a", "b")
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series(["a", "a", "a", "a", "b", "b"], dtype=dt),
+            "b": [1, 1, 4, 4, 1, 4],
+        }
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -2108,3 +2108,12 @@ def test_join_where_categorical_string_compare() -> None:
         }
     )
     assert_frame_equal(result, expected)
+
+
+def test_join_where_nonboolean_predicate() -> None:
+    df1 = pl.DataFrame({"a": [1, 2, 3]})
+    df2 = pl.DataFrame({"b": [1, 2, 3]})
+    with pytest.raises(
+        ComputeError, match="'join_where' predicates must resolve to boolean"
+    ):
+        df1.join_where(df2, pl.col("a") * 2)


### PR DESCRIPTION
1. Closes #22105
2. Closes #22046
3. Closes #22042
4. Closes #22047
5. Closes #22045

This PR brings brings a few enhancements to `join_where`, which I have been making great use of but hits a few snags:

### 1. One-sided predicates

Currently, predicates must contain columns from both tables being joined. As mentioned in #22105, this doesn't seem like it should be a requirement; one-sided predicates are fairly common in sql and are logically perfectly safe.

```python
df1 = pl.DataFrame({"a": [1, 2, 3]})
df2 = pl.DataFrame({"b": [4, 5]})

# old behavior: 
df1.join_where(df2, pl.col("a") < 3)  # ERROR, predicate must contain columns from both sides

# new behavior
df1.join_where(df2, pl.col("a") < 3)
# shape: (4, 2)
# ┌─────┬─────┐
# │ a   ┆ b   │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 1   ┆ 4   │
# │ 1   ┆ 5   │
# │ 2   ┆ 4   │
# │ 2   ┆ 5   │
# └─────┴─────┘
```

### 2. Allow boolean evaluations in sub-expressions

The current behavior errors if any of part of the sub-expression contains a boolean evaluation (see #22046). This PR fixes this issue. It also has the requirement that a boolean expression comparing values in the left table to the right requires a lossless upcast, for any boolean subexpression.

### 3. Fix multi-column comparison to literals

The current behavior errors if a literal value is used in the predicate. This is actually the same issue as (2) above, but it's not super obvious (see #22042).

```python
# old behavior:
df1.join_where(df2, (pl.col("a") + pl.col("b")) < 7)
# polars.exceptions.SchemaError: datatypes of join_where comparison don't match

# new behavior:
df1.join_where(df2, (pl.col("a") + pl.col("b")) < 7)
# shape: (3, 2)
# ┌─────┬─────┐
# │ a   ┆ b   │
# │ --- ┆ --- │
# │ i64 ┆ i64 │
# ╞═════╪═════╡
# │ 1   ┆ 4   │
# │ 1   ┆ 5   │
# │ 2   ┆ 4   │
# └─────┴─────┘
```

### 4. Allow comparison of categoricals/enums to strings

The current behavior prevents comparisons of categoricals to string literals. This PR fixes this issue (see #22047):

```
df1 = pl.DataFrame({"a": pl.Series(["a", "b"], dtype=pl.Enum(["a", "b"]))})
df2 = pl.DataFrame({"b": [5]})

# current behavior: polars.exceptions.SchemaError
df1.join_where(df2, col("a") == "a")

# new behavior:
df1.join_where(df2, col("a") == "a")
# shape: (1, 2)
# ┌──────┬─────┐
# │ a    ┆ b   │
# │ ---  ┆ --- │
# │ enum ┆ i64 │
# ╞══════╪═════╡
# │ a    ┆ 5   │
# └──────┴─────┘
```

All existing tests pass, except for those that previously detected errors due to one-sided predicates, which have been updated accordingly.

@nameexhaustion I think this is mainly your wheelhouse so a review would be much appreciated.