### PR TITLE
fix(python): Fix panic when constructing DF from pyarrow due to duplicate field names

### DIFF
--- a/crates/polars-python/src/interop/arrow/to_rust.rs
+++ b/crates/polars-python/src/interop/arrow/to_rust.rs
@@ -97,6 +97,38 @@ pub fn to_rust_df(py: Python, rb: &[Bound<PyAny>], schema: Bound<PyAny>) -> PyRe
     let ArrowDataType::Struct(fields) = field_to_rust_arrow(schema)?.dtype else {
         return Err(PyPolarsErr::Other("invalid top-level schema".into()).into());
     };
+
+    {
+        // Verify that field names are not duplicated. Arrow permits duplicate field names, we do not.
+        // Required to uphold safety invariants for unsafe block below.
+        // Uses std HashMap for DOS resistance
+        use std::collections::HashMap;
+
+        let mut field_map: HashMap<PlSmallStr, u64> = HashMap::new();
+        fields.iter().for_each(|field| {
+            field_map
+                .entry(field.name.clone())
+                .and_modify(|c| {
+                    *c += 1;
+                })
+                .or_insert(1);
+        });
+        let duplicate_fields: Vec<_> = field_map
+            .into_iter()
+            .filter_map(|(k, v)| (v > 1).then_some(k))
+            .collect();
+        if !duplicate_fields.is_empty() {
+            return Err(PyPolarsErr::Polars(PolarsError::Duplicate(
+                format!(
+                    "column appears more than once; names must be unique: {:?}",
+                    duplicate_fields
+                )
+                .into(),
+            ))
+            .into());
+        }
+    }
+
     let schema = ArrowSchema::from_iter(fields);
 
     if rb.is_empty() {

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-from collections import Counter
 from collections.abc import Generator, Mapping, Sequence
 from datetime import date, datetime, time, timedelta
 from functools import singledispatch
@@ -52,7 +51,7 @@ from polars.dependencies import (
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
-from polars.exceptions import DataOrientationWarning, DuplicateError, ShapeError
+from polars.exceptions import DataOrientationWarning, ShapeError
 from polars.meta import thread_pool_size
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -1176,12 +1175,6 @@ def arrow_to_pydf(
 
     # supply the arrow schema so the metadata is intact
     pydf = PyDataFrame.from_arrow_record_batches(batches, data.schema)
-
-    # arrow tables allow duplicate names; we don't
-    if len(data.columns) != pydf.width():
-        col_name, _ = Counter(column_names).most_common(1)[0]
-        msg = f"column {col_name!r} appears more than once; names must be unique"
-        raise DuplicateError(msg)
 
     if rechunk:
         pydf = pydf.rechunk()

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -730,12 +730,17 @@ def test_init_arrow_dupes() -> None:
         arrays=[
             pa.array([1, 2, 3], type=pa.int32()),
             pa.array([4, 5, 6], type=pa.int32()),
+            pa.array(
+                [7, 8, 9], type=pa.decimal128(38, 10)
+            ),  # included as this triggers a panic during construction alongside duplicate fields
         ],
-        schema=pa.schema([("col", pa.int32()), ("col", pa.int32())]),
+        schema=pa.schema(
+            [("col", pa.int32()), ("col", pa.int32()), ("col3", pa.decimal128(38, 10))]
+        ),
     )
     with pytest.raises(
         DuplicateError,
-        match="column 'col' appears more than once; names must be unique",
+        match=r"""column appears more than once; names must be unique: \["col"\]""",
     ):
         pl.DataFrame(tbl)
 


### PR DESCRIPTION
Resolves #22113 

This PR adds pre-checks to the rust code responsible for converting pyarrow tables into a polars DataFrame to prevent panics that appear to result from the unsafe construction of a DF without checking column uniqueness first.

Existing python post-checks are removed and a decimal column has been inserted into the existing test to cover the case that currently panics.