### PR TITLE
feat: Support additional unsigned int aliases in the SQL interface

### DIFF
--- a/crates/polars-sql/src/types.rs
+++ b/crates/polars-sql/src/types.rs
@@ -175,16 +175,15 @@ pub(crate) fn map_sql_dtype_to_polars(dtype: &SQLDataType) -> PolarsResult<DataT
         // ---------------------------------
         SQLDataType::Custom(ObjectName(idents), _) => match idents.as_slice() {
             [Ident { value, .. }] => match value.to_lowercase().as_str() {
-                // common alias for 128bit int type (duckdb, etc.)
-                "hugeint" => DataType::Int128,
                 // these integer types are not supported by the PostgreSQL core distribution,
                 // but they ARE available via `pguint` (https://github.com/petere/pguint), an
-                // extension maintained by one of the PostgreSQL core developers.
+                // extension maintained by one of the PostgreSQL core developers, and/or DuckDB.
+                "hugeint" => DataType::Int128,
                 "int1" => DataType::Int8,
-                "uint1" => DataType::UInt8,
-                "uint2" => DataType::UInt16,
-                "uint4" | "uint" => DataType::UInt32,
-                "uint8" => DataType::UInt64,
+                "uint1" | "utinyint" => DataType::UInt8,
+                "uint2" | "usmallint" => DataType::UInt16,
+                "uint4" | "uinteger" | "uint" => DataType::UInt32,
+                "uint8" | "ubigint" => DataType::UInt64,
                 _ => {
                     polars_bail!(SQLInterface: "datatype {:?} is not currently supported", value)
                 },

--- a/py-polars/tests/unit/sql/test_cast.py
+++ b/py-polars/tests/unit/sql/test_cast.py
@@ -53,6 +53,10 @@ def test_cast() -> None:
               b::uint4 AS b_u32,
               b::uint8 AS b_u64,
               CAST(a AS BIGINT UNSIGNED) AS a_u64,
+              b::utinyint AS b_u8,
+              b::usmallint AS b_u16,
+              a::uinteger AS a_u32,
+              d::ubigint AS d_u64,
 
               -- string/binary
               CAST(a AS CHAR) AS a_char,
@@ -90,6 +94,10 @@ def test_cast() -> None:
         "b_u32": pl.UInt32,
         "b_u64": pl.UInt64,
         "a_u64": pl.UInt64,
+        "b_u8": pl.UInt8,
+        "b_u16": pl.UInt16,
+        "a_u32": pl.UInt32,
+        "d_u64": pl.UInt64,
         "a_char": pl.String,
         "b_varchar": pl.String,
         "c_blob": pl.Binary,
@@ -116,11 +124,11 @@ def test_cast() -> None:
         (5.0, 5.5, 2.0),
     ]
     assert res.select(cs.integer()).rows() == [
-        (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
-        (2, 2, 2, 0, 0, 2, 2, 2, 2, 2, 0, 2, 2, 2, 2),
-        (3, 3, 3, 1, 1, 3, 3, 3, 3, 3, 1, 3, 3, 3, 3),
-        (4, 4, 4, 0, 0, 4, 4, 4, 4, 4, 0, 4, 4, 4, 4),
-        (5, 5, 5, 1, 1, 5, 5, 5, 5, 5, 1, 5, 5, 5, 5),
+        (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+        (2, 2, 2, 0, 0, 2, 2, 2, 2, 2, 0, 2, 2, 2, 2, 2, 2, 2, 0),
+        (3, 3, 3, 1, 1, 3, 3, 3, 3, 3, 1, 3, 3, 3, 3, 3, 3, 3, 1),
+        (4, 4, 4, 0, 0, 4, 4, 4, 4, 4, 0, 4, 4, 4, 4, 4, 4, 4, 0),
+        (5, 5, 5, 1, 1, 5, 5, 5, 5, 5, 1, 5, 5, 5, 5, 5, 5, 5, 1),
     ]
     assert res.select(cs.string()).rows() == [
         ("1", "1.1", "true"),


### PR DESCRIPTION
Minor update, adding recognition/support for the following unsigned integer aliases (we already support all of the same aliases without the leading `"U"`):

* `UTINYINT`
* `USMALLINT`
* `UINTEGER`
* `UBIGINT`

(ref: https://duckdb.org/docs/stable/sql/data_types/numeric.html#integer-types)