### PR TITLE
fix: Add `i128` as supertype to boolean

### DIFF
--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -195,9 +195,11 @@ pub fn get_supertype_with_options(
 
 
             #[cfg(feature = "dtype-i128")]
-            (a, Int128) if a.is_integer() => Some(Int128),
+            (a, Int128) if a.is_integer() | a.is_bool() => Some(Int128),
             #[cfg(feature = "dtype-i128")]
             (a, Int128) if a.is_float() => Some(Float64),
+            #[cfg(feature = "dtype-i128")]
+
 
             (Int32, Boolean) => Some(Int32),
             #[cfg(feature = "dtype-i8")]


### PR DESCRIPTION
Closes #22136 

```python
import polars as pl

pl.Series([True]) + pl.Series([1], dtype=pl.Int128)
# shape: (1,)
# Series: '' [i128]
# [
#         2
# ]
```