### PR TITLE
Add `repeat_by` to `Series`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -7610,6 +7610,26 @@ class Series:
         return pl.DataFrame._from_pydf(self._s._row_decode(list(dtypes), list(fields)))
 
 
+    def repeat_by(self, by: int | IntoExprColumn) -> Self:
+        """
+        Repeat the elements in this Series as specified in the given expression.
+
+        The repeated elements are expanded into a List.
+
+        Parameters
+        ----------
+        by
+            Numeric column that determines how often the values will be repeated.
+            The column will be coerced to UInt32. Give this dtype to make the coercion
+            a no-op.
+
+        Returns
+        -------
+        Expr
+            Expression of data type List, where the inner data type is equal to the
+            original data type.
+        """
+
 def _resolve_temporal_dtype(
     dtype: PolarsDataType | None,
     ndtype: np.dtype[np.datetime64] | np.dtype[np.timedelta64],

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -7609,7 +7609,6 @@ class Series:
         """
         return pl.DataFrame._from_pydf(self._s._row_decode(list(dtypes), list(fields)))
 
-
     def repeat_by(self, by: int | IntoExprColumn) -> Self:
         """
         Repeat the elements in this Series as specified in the given expression.
@@ -7629,6 +7628,7 @@ class Series:
             Expression of data type List, where the inner data type is equal to the
             original data type.
         """
+
 
 def _resolve_temporal_dtype(
     dtype: PolarsDataType | None,

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2229,10 +2229,6 @@ def test_construction_large_nested_u64_17231() -> None:
 
 
 def test_repeat_by() -> None:
-    calculated=pl.select(
-        a = pl.Series('a', [1, 2]).repeat_by(2)
-    )
-    expected=pl.select(
-        a = pl.Series('a', [[1,1], [2,2]])
-    )
+    calculated=pl.select(a=pl.Series('a', [1, 2]).repeat_by(2))
+    expected=pl.select(a=pl.Series('a', [[1, 1], [2, 2]]))
     assert calculated.equals(expected)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2229,6 +2229,6 @@ def test_construction_large_nested_u64_17231() -> None:
 
 
 def test_repeat_by() -> None:
-    calculated=pl.select(a=pl.Series('a', [1, 2]).repeat_by(2))
-    expected=pl.select(a=pl.Series('a', [[1, 1], [2, 2]]))
+    calculated = pl.select(a=pl.Series("a", [1, 2]).repeat_by(2))
+    expected = pl.select(a=pl.Series("a", [[1, 1], [2, 2]]))
     assert calculated.equals(expected)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2226,3 +2226,13 @@ def test_construction_large_nested_u64_17231() -> None:
     dtype = pl.Struct({"f0": pl.List(pl.UInt64)})
 
     assert pl.Series(values, dtype=dtype).to_list() == values
+
+
+def test_repeat_by() -> None:
+    calculated=pl.select(
+        a = pl.Series('a', [1, 2]).repeat_by(2)
+    )
+    expected=pl.select(
+        a = pl.Series('a', [[1,1], [2,2]])
+    )
+    assert calculated.equals(expected)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/22067

I expected to have to do some plumbing to connect the `Expr` method to the `Series` method. I'm really impressed with the `@expr_dispatch` decorator, that is a really neat trick!