### PR TITLE
fix: Fix csv serializer panic by supporting ScalarColumn in as_single_chunk

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -562,15 +562,7 @@ impl DataFrame {
     pub fn as_single_chunk(&mut self) -> &mut Self {
         // Don't parallelize this. Memory overhead
         for s in &mut self.columns {
-            match s {
-                Column::Series(s) => {
-                    *s = s.rechunk().into();
-                },
-                Column::Scalar(_) => {
-                    *s = s.rechunk();
-                },
-                Column::Partitioned(_) => {},
-            }
+            *s = s.rechunk();
         }
         self
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -562,8 +562,14 @@ impl DataFrame {
     pub fn as_single_chunk(&mut self) -> &mut Self {
         // Don't parallelize this. Memory overhead
         for s in &mut self.columns {
-            if let Column::Series(s) = s {
-                *s = s.rechunk().into();
+            match s {
+                Column::Series(s) => {
+                    *s = s.rechunk().into();
+                },
+                Column::Scalar(_) => {
+                    *s = s.rechunk();
+                },
+                Column::Partitioned(_) => {},
             }
         }
         self


### PR DESCRIPTION
Fixes #20273

Request review:

* See Issue #20273 for detailed observations
* Consider commit 962b576 as part of review, which contained the breaking change where `as_single_chunk()` dropped support for ScalarColumn.
* The equivalent `as_single_chunk_par()` works as expected (no panic observed)
* Question: is the incoming df (the result from cross_join and filter in the MRE) as expected? It has multiple chunks, some of which are empty, and uses ScalarColumn or SeriesColumn depending on the number of rows filter (1 vs 2+ respectively). Debug traces are available on request.