### PR TITLE
feat: Dispatch scans to new-streaming by default

### DIFF
--- a/crates/polars-mem-engine/src/lib.rs
+++ b/crates/polars-mem-engine/src/lib.rs
@@ -6,5 +6,8 @@ mod prelude;
 pub use executors::Executor;
 #[cfg(feature = "python")]
 pub use planner::python_scan_predicate;
-pub use planner::{create_multiple_physical_plans, create_physical_plan, create_scan_predicate};
+pub use planner::{
+    StreamingExecutorBuilder, create_multiple_physical_plans, create_physical_plan,
+    create_scan_predicate,
+};
 pub use predicate::ScanPredicate;

--- a/crates/polars-plan/src/dsl/file_scan.rs
+++ b/crates/polars-plan/src/dsl/file_scan.rs
@@ -158,20 +158,6 @@ impl Hash for FileScan {
 }
 
 impl FileScan {
-    pub(crate) fn remove_metadata(&mut self) {
-        match self {
-            #[cfg(feature = "parquet")]
-            Self::Parquet { metadata, .. } => {
-                *metadata = None;
-            },
-            #[cfg(feature = "ipc")]
-            Self::Ipc { metadata, .. } => {
-                *metadata = None;
-            },
-            _ => {},
-        }
-    }
-
     pub fn flags(&self) -> ScanFlags {
         match self {
             #[cfg(feature = "csv")]

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -12,7 +12,7 @@ mod semi_anti_join;
 use arrow::Either;
 use polars_core::datatypes::PlHashSet;
 use polars_core::prelude::*;
-use polars_io::{RowIndex, hive};
+use polars_io::RowIndex;
 use recursive::recursive;
 #[cfg(feature = "semi_anti_join")]
 use semi_anti_join::process_semi_anti_join;
@@ -433,13 +433,16 @@ impl ProjectionPushDown {
             Scan {
                 sources,
                 mut file_info,
-                mut hive_parts,
+                hive_parts,
                 scan_type,
                 predicate,
                 mut file_options,
                 mut output_schema,
             } => {
-                if self.is_count_star && !self.in_new_streaming_engine {
+                // TODO: Remove
+                let in_new_streaming_engine = true;
+
+                if self.is_count_star && !in_new_streaming_engine {
                     ctx.process_count_star_at_scan(&file_info.schema, expr_arena);
                 }
 
@@ -495,102 +498,13 @@ impl ProjectionPushDown {
                         }
                     }
 
-                    output_schema = if let Some(ref with_columns) = file_options.with_columns {
+                    output_schema = if file_options.with_columns.is_some() {
                         let mut schema = update_scan_schema(
                             &ctx.acc_projections,
                             expr_arena,
                             &file_info.schema,
                             scan_type.sort_projection(&file_options),
                         )?;
-
-                        if !self.in_new_streaming_engine {
-                            // Cull the hive partitions that are not projected out.
-                            hive_parts = if let Some(mut hive_parts) = hive_parts {
-                                let (_, projected_indices) = hive_parts
-                                    .get_projection_schema_and_indices(
-                                        &with_columns.iter().cloned().collect::<PlHashSet<_>>(),
-                                    );
-                                hive_parts.apply_projection(&projected_indices);
-                                Some(hive_parts)
-                            } else {
-                                None
-                            };
-                        }
-
-                        if let Some(ref hive_parts) = hive_parts {
-                            // @TODO:
-                            // This is a hack to support both old multiscan handling and new
-                            // multiscan handling.
-                            if !self.in_new_streaming_engine {
-                                // Skip reading hive columns from the file.
-                                let partition_schema = hive_parts.schema();
-                                file_options.with_columns = file_options.with_columns.map(|x| {
-                                    x.iter()
-                                        .filter(|x| !partition_schema.contains(x))
-                                        .cloned()
-                                        .collect::<Arc<[_]>>()
-                                });
-
-                                let mut out = Schema::with_capacity(schema.len());
-
-                                // Ensure the ordering of `schema` matches what the reader will give -
-                                // namely, if a hive column also exists in the file it will be projected
-                                // based on its position in the file. This is extremely important for the
-                                // new-streaming engine.
-
-                                // row_index is separate
-                                let opt_row_index_col_name = file_options
-                                    .row_index
-                                    .as_ref()
-                                    .map(|v| &v.name)
-                                    .filter(|v| schema.contains(v))
-                                    .cloned();
-
-                                if let Some(name) = &opt_row_index_col_name {
-                                    out.insert_at_index(
-                                        0,
-                                        name.clone(),
-                                        schema.get(name).unwrap().clone(),
-                                    )
-                                    .unwrap();
-                                }
-
-                                {
-                                    let df_fields_iter = &mut schema
-                                        .iter()
-                                        .filter(|fld| {
-                                            !partition_schema.contains(fld.0)
-                                                && Some(fld.0) != opt_row_index_col_name.as_ref()
-                                        })
-                                        .map(|(a, b)| (a.clone(), b.clone()));
-
-                                    let hive_fields_iter = &mut partition_schema
-                                        .iter()
-                                        .map(|(a, b)| (a.clone(), b.clone()));
-
-                                    // `schema` also contains the `row_index` column here, so we don't need to handle it
-                                    // separately.
-
-                                    macro_rules! do_merge {
-                                        ($schema:expr) => {
-                                            hive::merge_sorted_to_schema_order_impl(
-                                                df_fields_iter,
-                                                hive_fields_iter,
-                                                &mut out,
-                                                &|v| $schema.index_of(&v.0),
-                                            )
-                                        };
-                                    }
-
-                                    match file_info.reader_schema.as_ref().unwrap() {
-                                        Either::Left(reader_schema) => do_merge!(reader_schema),
-                                        Either::Right(reader_schema) => do_merge!(reader_schema),
-                                    }
-                                }
-
-                                schema = out;
-                            }
-                        }
 
                         if let Some(ref file_path_col) = file_options.include_file_paths {
                             if let Some(i) = schema.index_of(file_path_col) {
@@ -601,12 +515,6 @@ impl ProjectionPushDown {
 
                         Some(Arc::new(schema))
                     } else {
-                        if !self.in_new_streaming_engine {
-                            file_options.with_columns = maybe_init_projection_excluding_hive(
-                                file_info.reader_schema.as_ref().unwrap(),
-                                hive_parts.as_ref().map(|h| h.schema()),
-                            );
-                        }
                         None
                     };
                 }
@@ -662,7 +570,7 @@ impl ProjectionPushDown {
                 // TODO: Our scans don't perfectly give the right projection order with combinations
                 // of hive columns that exist in the file, so we always add a `Select {}` node here.
 
-                if self.in_new_streaming_engine {
+                if in_new_streaming_engine {
                     Ok(lp)
                 } else {
                     let builder = IRBuilder::from_lp(lp, expr_arena, lp_arena);

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -11,6 +11,7 @@ mod inner {
 
     pub struct SlicePushDown {
         pub streaming: bool,
+        #[expect(unused)]
         pub new_streaming: bool,
         scratch: UnitVec<Node>,
     }
@@ -205,7 +206,7 @@ impl SlicePushDown {
                 mut file_options,
                 predicate,
                 scan_type,
-            }, Some(state)) if matches!(&*scan_type, FileScan::Csv { .. }) && predicate.is_none() && self.new_streaming =>  {
+            }, Some(state)) if matches!(&*scan_type, FileScan::Csv { .. }) && predicate.is_none()  =>  {
                 file_options.pre_slice = Some((state.offset, state.len as usize));
 
                 let lp = Scan {
@@ -220,30 +221,7 @@ impl SlicePushDown {
 
                 Ok(lp)
             },
-            #[cfg(feature = "csv")]
-            (Scan {
-                sources,
-                file_info,
-                hive_parts,
-                output_schema,
-                mut file_options,
-                predicate,
-                scan_type,
-            }, Some(state)) if predicate.is_none() && state.offset >= 0 && matches!(&*scan_type, FileScan::Csv{..}) =>  {
-                file_options.pre_slice = Some((0, state.offset as usize + state.len as usize));
 
-                let lp = Scan {
-                    sources,
-                    file_info,
-                    hive_parts,
-                    output_schema,
-                    scan_type,
-                    file_options,
-                    predicate,
-                };
-
-                self.no_pushdown_finish_opt(lp, Some(state), lp_arena)
-            },
             #[cfg(feature = "json")]
             (Scan {
                 sources,
@@ -253,7 +231,7 @@ impl SlicePushDown {
                 mut file_options,
                 predicate,
                 scan_type,
-            }, Some(state)) if predicate.is_none() && self.new_streaming && matches!(&*scan_type, FileScan::NDJson {.. }) =>  {
+            }, Some(state)) if predicate.is_none() && matches!(&*scan_type, FileScan::NDJson {.. }) =>  {
                 file_options.pre_slice = Some((state.offset, state.len as usize));
 
                 let lp = Scan {
@@ -302,7 +280,7 @@ impl SlicePushDown {
                 mut file_options,
                 predicate,
                 scan_type,
-            }, Some(state)) if self.new_streaming && predicate.is_none() && matches!(&*scan_type, FileScan::Ipc{..})=>  {
+            }, Some(state)) if predicate.is_none() && matches!(&*scan_type, FileScan::Ipc{..})=>  {
                 file_options.pre_slice = Some((state.offset, state.len as usize));
 
                 let lp = Scan {

--- a/crates/polars-python/src/cloud.rs
+++ b/crates/polars-python/src/cloud.rs
@@ -46,6 +46,7 @@ pub fn _execute_ir_plan_with_gpu(ir_plan_ser: Vec<u8>, py: Python) -> PyResult<P
         ir_plan.lp_top,
         &mut ir_plan.lp_arena,
         &mut ir_plan.expr_arena,
+        None,
     )
     .map_err(PyPolarsErr::from)?;
 

--- a/crates/polars-stream/src/lib.rs
+++ b/crates/polars-stream/src/lib.rs
@@ -9,6 +9,7 @@ pub use skeleton::run_query;
 mod execute;
 pub(crate) mod expression;
 mod graph;
+pub use skeleton::{QueryResult, StreamingQuery};
 mod morsel;
 mod nodes;
 mod physical_plan;

--- a/crates/polars-stream/src/nodes/io_sources/ipc.rs
+++ b/crates/polars-stream/src/nodes/io_sources/ipc.rs
@@ -47,6 +47,7 @@ pub mod builder {
 
     #[derive(Debug)]
     pub struct IpcReaderBuilder {
+        #[expect(unused)]
         pub first_metadata: Option<Arc<FileMetadata>>,
     }
 
@@ -66,16 +67,20 @@ pub mod builder {
             &self,
             source: ScanSource,
             cloud_options: Option<Arc<CloudOptions>>,
-            scan_source_idx: usize,
+            #[expect(unused)] scan_source_idx: usize,
         ) -> Box<dyn FileReader> {
             let scan_source = source;
             let verbose = config::verbose();
 
-            let metadata: Option<Arc<FileMetadata>> = if scan_source_idx == 0 {
-                self.first_metadata.clone()
-            } else {
-                None
-            };
+            // FIXME: For some reason the metadata does not match on idx == 0, and we end up with
+            // * ComputeError: out-of-spec: InvalidBuffersLength { buffers_size: 1508, file_size: 763 }
+            //
+            // let metadata: Option<Arc<FileMetadata>> = if scan_source_idx == 0 {
+            //     self.first_metadata.clone()
+            // } else {
+            //     None
+            // };
+            let metadata = None;
 
             let reader = IpcFileReader {
                 scan_source,

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
@@ -117,7 +117,7 @@ fn scan_predicate_to_mask(
 
     if verbose {
         eprintln!(
-            "[MultiScan]: Predicate pushdown allows skipping {} / {} sources",
+            "[MultiScan]: Predicate pushdown allows skipping {} / {} files",
             mask.set_bits(),
             mask.len()
         );

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -246,7 +246,7 @@ impl MultiScanTaskInitializer {
                     projected_file_schema,
                     missing_columns_policy,
                     full_file_schema,
-                    check_schema_names: None,
+                    check_schema_names: self.config.check_schema_names.clone(),
                 },
                 num_pipelines,
                 verbose,

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -52,6 +52,7 @@ fn build_group_by_fallback(
         group_by_lp_node,
         &mut lp_arena,
         expr_arena,
+        None,
     )?);
 
     let group_by_node = PhysNode {

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -30,6 +30,7 @@ use polars_utils::slice_enum::Slice;
 use slotmap::{SecondaryMap, SlotMap};
 pub use to_graph::physical_plan_to_graph;
 
+use crate::nodes::io_sources::multi_file_reader::extra_ops::SchemaNamesMatchPolicy;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::builder::FileReaderBuilder;
 use crate::physical_plan::lower_expr::ExprCache;
 
@@ -212,17 +213,9 @@ pub enum PhysNodeKind {
         hive_parts: Option<HivePartitionsDf>,
         allow_missing_columns: bool,
         include_file_paths: Option<PlSmallStr>,
+        check_schema_names: Option<SchemaNamesMatchPolicy>,
 
-        /// Schema that all files are coerced into.
-        ///
-        /// - Does include the `row_index`.
-        /// - Does include `include_file_paths`.
-        /// - Does include the hive columns.
-        ///
-        /// Each file may never contain more column than are given in this schema.
-        ///
-        /// Each file should contain exactly all the columns ignoring the hive columns i.f.f.
-        /// `allow_missing_columns == false`.
+        /// Schema of columns contained in the file. Does not contain external columns (e.g. hive / row_index).
         file_schema: SchemaRef,
     },
 

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -416,6 +416,7 @@ fn to_graph_rec<'a>(
                 sort_node,
                 &mut lp_arena,
                 ctx.expr_arena,
+                None,
             )?);
 
             let input_key = to_graph_rec(input.node, ctx)?;
@@ -478,6 +479,7 @@ fn to_graph_rec<'a>(
             predicate,
             hive_parts,
             allow_missing_columns,
+            check_schema_names,
             include_file_paths,
             file_schema,
         } => {
@@ -514,6 +516,7 @@ fn to_graph_rec<'a>(
                     hive_parts.map(Arc::new),
                     include_file_paths.clone(),
                     *allow_missing_columns,
+                    check_schema_names.clone(),
                 ),
                 [],
             )
@@ -614,6 +617,7 @@ fn to_graph_rec<'a>(
                 join_node,
                 &mut lp_arena,
                 ctx.expr_arena,
+                None,
             )?);
 
             ctx.graph.add_node(
@@ -903,6 +907,7 @@ fn to_graph_rec<'a>(
             let hive_parts = None;
             let include_file_paths = None;
             let allow_missing_columns = false;
+            let check_schema_names = None;
 
             ctx.graph.add_node(
                 nodes::io_sources::multi_file_reader::MultiFileReader::new(
@@ -918,6 +923,7 @@ fn to_graph_rec<'a>(
                     hive_parts,
                     include_file_paths,
                     allow_missing_columns,
+                    check_schema_names,
                 ),
                 [],
             )

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -10,15 +10,16 @@ use polars_plan::prelude::expr_ir::ExprIR;
 use polars_utils::arena::{Arena, Node};
 use slotmap::{SecondaryMap, SlotMap};
 
-use crate::physical_plan::PhysNodeKind;
+use crate::graph::{Graph, GraphNodeKey};
+use crate::physical_plan::{PhysNode, PhysNodeKey, PhysNodeKind};
 
 /// Executes the IR with the streaming engine.
 ///
 /// Unsupported operations can fall back to the in-memory engine.
 ///
 /// Returns:
-/// - `Ok(Ok(DataFrame))` when collecting to a single sink.
-/// - `Ok(Err(Vec<DataFrame>))` when collecting to multiple sinks.
+/// - `Ok(QueryResult::Single(DataFrame))` when collecting to a single sink.
+/// - `Ok(QueryResult::Multiple(Vec<DataFrame>))` when collecting to multiple sinks.
 /// - `Err` if the IR can't be executed.
 ///
 /// Returned `DataFrame`s contain data only for memory sinks,
@@ -27,56 +28,126 @@ pub fn run_query(
     node: Node,
     ir_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,
-) -> PolarsResult<Result<DataFrame, Vec<DataFrame>>> {
-    if let Ok(visual_path) = std::env::var("POLARS_VISUALIZE_IR") {
-        let plan = IRPlan {
-            lp_top: node,
-            lp_arena: ir_arena.clone(),
-            expr_arena: expr_arena.clone(),
+) -> PolarsResult<QueryResult> {
+    StreamingQuery::build(node, ir_arena, expr_arena)?.execute()
+}
+
+pub struct StreamingQuery {
+    top_ir: IR,
+    graph: Graph,
+    root_phys_node: PhysNodeKey,
+    phys_sm: SlotMap<PhysNodeKey, PhysNode>,
+    phys_to_graph: SecondaryMap<PhysNodeKey, GraphNodeKey>,
+}
+
+impl StreamingQuery {
+    pub fn build(
+        node: Node,
+        ir_arena: &mut Arena<IR>,
+        expr_arena: &mut Arena<AExpr>,
+    ) -> PolarsResult<Self> {
+        if let Ok(visual_path) = std::env::var("POLARS_VISUALIZE_IR") {
+            let plan = IRPlan {
+                lp_top: node,
+                lp_arena: ir_arena.clone(),
+                expr_arena: expr_arena.clone(),
+            };
+            let visualization = plan.display_dot().to_string();
+            std::fs::write(visual_path, visualization).unwrap();
+        }
+        let mut phys_sm = SlotMap::with_capacity_and_key(ir_arena.len());
+        let root_phys_node =
+            crate::physical_plan::build_physical_plan(node, ir_arena, expr_arena, &mut phys_sm)?;
+        if let Ok(visual_path) = std::env::var("POLARS_VISUALIZE_PHYSICAL_PLAN") {
+            let visualization =
+                crate::physical_plan::visualize_plan(root_phys_node, &phys_sm, expr_arena);
+            std::fs::write(visual_path, visualization).unwrap();
+        }
+
+        let (mut graph, phys_to_graph) =
+            crate::physical_plan::physical_plan_to_graph(root_phys_node, &phys_sm, expr_arena)?;
+
+        let top_ir = ir_arena.get(node).clone();
+
+        let out = StreamingQuery {
+            top_ir,
+            graph,
+            root_phys_node,
+            phys_sm,
+            phys_to_graph,
         };
-        let visualization = plan.display_dot().to_string();
-        std::fs::write(visual_path, visualization).unwrap();
-    }
-    let mut phys_sm = SlotMap::with_capacity_and_key(ir_arena.len());
-    let root = crate::physical_plan::build_physical_plan(node, ir_arena, expr_arena, &mut phys_sm)?;
-    if let Ok(visual_path) = std::env::var("POLARS_VISUALIZE_PHYSICAL_PLAN") {
-        let visualization = crate::physical_plan::visualize_plan(root, &phys_sm, expr_arena);
-        std::fs::write(visual_path, visualization).unwrap();
+
+        Ok(out)
     }
 
-    let (mut graph, phys_to_graph) =
-        crate::physical_plan::physical_plan_to_graph(root, &phys_sm, expr_arena)?;
+    pub fn execute(self) -> PolarsResult<QueryResult> {
+        let StreamingQuery {
+            top_ir,
+            mut graph,
+            root_phys_node,
+            phys_sm,
+            phys_to_graph,
+        } = self;
 
-    crate::async_executor::clear_task_wait_statistics();
-    let mut results = crate::execute::execute_graph(&mut graph)?;
+        crate::async_executor::clear_task_wait_statistics();
+        let mut results = crate::execute::execute_graph(&mut graph)?;
 
-    if std::env::var("POLARS_TRACK_WAIT_STATS").as_deref() == Ok("1") {
-        let mut stats = crate::async_executor::get_task_wait_statistics();
-        stats.sort_by_key(|(_l, w)| Reverse(*w));
-        eprintln!("Time spent waiting for async tasks:");
-        for (loc, wait_time) in stats {
-            eprintln!("{}:{} - {:?}", loc.file(), loc.line(), wait_time);
+        if std::env::var("POLARS_TRACK_WAIT_STATS").as_deref() == Ok("1") {
+            let mut stats = crate::async_executor::get_task_wait_statistics();
+            stats.sort_by_key(|(_l, w)| Reverse(*w));
+            eprintln!("Time spent waiting for async tasks:");
+            for (loc, wait_time) in stats {
+                eprintln!("{}:{} - {:?}", loc.file(), loc.line(), wait_time);
+            }
+        }
+
+        match top_ir {
+            IR::SinkMultiple { inputs } => {
+                let phys_node = &phys_sm[root_phys_node];
+                let PhysNodeKind::SinkMultiple { sinks } = phys_node.kind() else {
+                    unreachable!();
+                };
+
+                Ok(QueryResult::Multiple(
+                    sinks
+                        .iter()
+                        .map(|phys_node_key| {
+                            results
+                                .remove(phys_to_graph[*phys_node_key])
+                                .unwrap_or_else(DataFrame::empty)
+                        })
+                        .collect(),
+                ))
+            },
+            _ => Ok(QueryResult::Single(
+                results
+                    .remove(phys_to_graph[root_phys_node])
+                    .unwrap_or_else(DataFrame::empty),
+            )),
+        }
+    }
+}
+
+pub enum QueryResult {
+    Single(DataFrame),
+    /// Collected to multiple in-memory sinks
+    Multiple(Vec<DataFrame>),
+}
+
+impl QueryResult {
+    pub fn unwrap_single(self) -> DataFrame {
+        use QueryResult::*;
+        match self {
+            Single(df) => df,
+            Multiple(_) => panic!(),
         }
     }
 
-    match ir_arena.get(node) {
-        IR::SinkMultiple { inputs } => {
-            let phys_node = &phys_sm[root];
-            let PhysNodeKind::SinkMultiple { sinks } = phys_node.kind() else {
-                unreachable!();
-            };
-
-            Ok(Err(sinks
-                .iter()
-                .map(|phys_node_key| {
-                    results
-                        .remove(phys_to_graph[*phys_node_key])
-                        .unwrap_or_else(DataFrame::empty)
-                })
-                .collect()))
-        },
-        _ => Ok(Ok(results
-            .remove(phys_to_graph[root])
-            .unwrap_or_else(DataFrame::empty))),
+    pub fn unwrap_multiple(self) -> Vec<DataFrame> {
+        use QueryResult::*;
+        match self {
+            Single(_) => panic!(),
+            Multiple(dfs) => dfs,
+        }
     }
 }

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -120,7 +120,7 @@ def test_hive_partitioned_predicate_pushdown_skips_correct_number_of_files(
 
     q = pl.scan_parquet(root / "**/*.parquet", hive_partitioning=True)
     assert q.filter(pl.col("a").is_in([1, 4])).collect().shape == (2, 2)
-    assert "hive partitioning: skipped 3 files" in capfd.readouterr().err
+    assert "allows skipping 3 / 5" in capfd.readouterr().err
 
     # Ensure the CSE can work with hive partitions.
     q = q.filter(pl.col("a").gt(2))
@@ -834,7 +834,7 @@ def test_hive_predicate_dates_14712(
         tmp_path, partition_by="a"
     )
     pl.scan_parquet(tmp_path).filter(pl.col("a") != datetime(2024, 1, 1)).collect()
-    assert "hive partitioning: skipped 1 files" in capfd.readouterr().err
+    assert "allows skipping 1 / 1" in capfd.readouterr().err
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Test is only for Windows paths")

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -88,9 +88,7 @@ def test_ipc_list_arg(io_files_path: Path) -> None:
     assert df.row(0) == ("vegetables", 45, 0.5, 2)
 
 
-@pytest.mark.may_fail_auto_streaming
 def test_scan_ipc_local_with_async(
-    capfd: Any,
     monkeypatch: Any,
     io_files_path: Path,
 ) -> None:
@@ -108,6 +106,3 @@ def test_scan_ipc_local_with_async(
             }
         ),
     )
-
-    captured = capfd.readouterr().err
-    assert "ASYNC READING FORCED" in captured

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -235,14 +235,8 @@ def test_parquet_is_in_statistics(monkeypatch: Any, capfd: Any, tmp_path: Path) 
         assert_frame_equal(result, df.filter(pred))
 
     captured = capfd.readouterr().err
-    assert (
-        "parquet row group must be read, statistics not sufficient for predicate."
-        in captured
-    )
-    assert (
-        "parquet row group can be skipped, the statistics were sufficient to apply the predicate."
-        in captured
-    )
+    assert "Predicate pushdown: reading 1 / 1 row groups" in captured
+    assert "Predicate pushdown: reading 0 / 1 row groups" in captured
 
 
 @pytest.mark.write_disk
@@ -271,14 +265,8 @@ def test_parquet_statistics(monkeypatch: Any, capfd: Any, tmp_path: Path) -> Non
         assert_frame_equal(result, df.filter(pred))
 
     captured = capfd.readouterr().err
-    assert (
-        "parquet row group must be read, statistics not sufficient for predicate."
-        in captured
-    )
-    assert (
-        "parquet row group can be skipped, the statistics were sufficient"
-        " to apply the predicate." in captured
-    )
+
+    assert "Predicate pushdown: reading 1 / 2 row groups" in captured
 
 
 @pytest.mark.write_disk
@@ -452,10 +440,10 @@ def test_parquet_schema_mismatch_panic_17067(tmp_path: Path, streaming: bool) ->
     pl.DataFrame({"c": [1, 2, 3], "d": [4, 5, 6]}).write_parquet(tmp_path / "2.parquet")
 
     if streaming:
-        with pytest.raises(pl.exceptions.ColumnNotFoundError):
+        with pytest.raises(pl.exceptions.SchemaError):
             pl.scan_parquet(tmp_path).collect(engine="streaming")
     else:
-        with pytest.raises(pl.exceptions.ColumnNotFoundError):
+        with pytest.raises(pl.exceptions.SchemaError):
             pl.scan_parquet(tmp_path).collect(engine="in-memory")
 
 
@@ -665,6 +653,11 @@ def test_parquet_unaligned_schema_read(tmp_path: Path) -> None:
     )
 
     assert_frame_equal(
+        lf.with_row_index().select("a").collect(engine="in-memory"),
+        pl.DataFrame({"a": [1, 2, 3]}),
+    )
+
+    assert_frame_equal(
         lf.select("b", "a").collect(engine="in-memory"),
         pl.DataFrame({"b": [10, 11, 12], "a": [1, 2, 3]}),
     )
@@ -676,6 +669,9 @@ def test_parquet_unaligned_schema_read(tmp_path: Path) -> None:
 
     with pytest.raises(pl.exceptions.SchemaError):
         lf.collect(engine="in-memory")
+
+    with pytest.raises(pl.exceptions.SchemaError):
+        lf.with_row_index().collect(engine="in-memory")
 
 
 @pytest.mark.write_disk
@@ -791,13 +787,8 @@ def test_parquet_schema_arg(
             allow_missing_columns=allow_missing_columns,
         )
 
-        # Streaming currently defaults to not erroring
-        if streaming:
-            lf.collect(engine="streaming")
-            continue
-
         with pytest.raises(pl.exceptions.SchemaError):
-            lf.collect(engine="streaming" if streaming else "in-memory")  # type: ignore[call-overload, redundant-expr]
+            lf.collect(engine="streaming" if streaming else "in-memory")
 
     lf = pl.scan_parquet(paths, parallel=parallel, schema=schema).select("a")
 

--- a/py-polars/tests/unit/io/test_scan.py
+++ b/py-polars/tests/unit/io/test_scan.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import os
 from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
@@ -28,21 +27,6 @@ def _enable_force_async(monkeypatch: pytest.MonkeyPatch) -> None:
     """Modifies the provided monkeypatch context."""
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     monkeypatch.setenv("POLARS_FORCE_ASYNC", "1")
-
-
-def _assert_force_async(capfd: Any, data_file_extension: str) -> None:
-    if (
-        os.getenv("POLARS_AUTO_NEW_STREAMING", os.getenv("POLARS_FORCE_NEW_STREAMING"))
-        == "1"
-    ):
-        return
-
-    """Calls `capfd.readouterr`, consuming the captured output so far."""
-    if data_file_extension == ".ndjson":
-        return
-
-    captured = capfd.readouterr().err
-    assert captured.count("ASYNC READING FORCED") >= 1
 
 
 def _scan(
@@ -208,9 +192,6 @@ def test_scan(
 
     df = _scan(data_file.path, data_file.df.schema).collect()
 
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
-
     assert_frame_equal(df, data_file.df)
 
 
@@ -222,9 +203,6 @@ def test_scan_with_limit(
         _enable_force_async(monkeypatch)
 
     df = _scan(data_file.path, data_file.df.schema).limit(4483).collect()
-
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
 
     assert_frame_equal(
         df,
@@ -248,9 +226,6 @@ def test_scan_with_filter(
         .filter(pl.col("sequence") % 2 == 0)
         .collect()
     )
-
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
 
     assert_frame_equal(
         df,
@@ -276,9 +251,6 @@ def test_scan_with_filter_and_limit(
         .collect()
     )
 
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
-
     assert_frame_equal(
         df,
         pl.DataFrame(
@@ -303,9 +275,6 @@ def test_scan_with_limit_and_filter(
         .collect()
     )
 
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
-
     assert_frame_equal(
         df,
         pl.DataFrame(
@@ -328,9 +297,6 @@ def test_scan_with_row_index_and_limit(
         .limit(4483)
         .collect()
     )
-
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
 
     assert_frame_equal(
         df,
@@ -357,9 +323,6 @@ def test_scan_with_row_index_and_filter(
         .collect()
     )
 
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
-
     assert_frame_equal(
         df,
         pl.DataFrame(
@@ -385,9 +348,6 @@ def test_scan_with_row_index_limit_and_filter(
         .filter(pl.col("sequence") % 2 == 0)
         .collect()
     )
-
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
 
     assert_frame_equal(
         df,
@@ -418,9 +378,6 @@ def test_scan_with_row_index_projected_out(
         .collect()
     )
 
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
-
     assert_frame_equal(df, data_file.df.select(subset))
 
 
@@ -440,9 +397,6 @@ def test_scan_with_row_index_filter_and_limit(
         .limit(4483)
         .collect()
     )
-
-    if force_async:
-        _assert_force_async(capfd, data_file.path.suffix)
 
     assert_frame_equal(
         df,

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -231,24 +231,12 @@ def test_parquet_eq_statistics(
         assert_frame_equal(result, df.filter(pred))
 
     captured = capfd.readouterr().err
-    if streaming:
-        assert (
-            "[ParquetFileReader]: Predicate pushdown: reading 1 / 1 row groups"
-            in captured
-        )
-        assert (
-            "[ParquetFileReader]: Predicate pushdown: reading 0 / 1 row groups"
-            in captured
-        )
-    else:
-        assert (
-            "parquet row group must be read, statistics not sufficient for predicate."
-            in captured
-        )
-        assert (
-            "parquet row group can be skipped, the statistics were sufficient"
-            " to apply the predicate." in captured
-        )
+    assert (
+        "[ParquetFileReader]: Predicate pushdown: reading 1 / 1 row groups" in captured
+    )
+    assert (
+        "[ParquetFileReader]: Predicate pushdown: reading 0 / 1 row groups" in captured
+    )
 
 
 @pytest.mark.write_disk


### PR DESCRIPTION
Hacks included in this PR:
* For `scan_csv`, `allow_missing_columns` is conditionally toggled to `true` based on whether the user provided a schema to mimic the current API behavior.
  * TODO: Fix by adding https://github.com/pola-rs/polars/issues/21996, we will need to wait until 2.0 to change the behavior
* Conditionally enables (the newly added) `SchemaNamesMatchPolicy::ForbidExtra` only if there is no projection. Note this matches what the in-mem engine does but it's not technically correct
  * TODO: Fix by resolving https://github.com/pola-rs/polars/issues/22218
