### PR TITLE
chore: Undeprecate `backward_fill` and `forward_fill`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2856,15 +2856,11 @@ class Expr:
         fill_value = parse_into_expression(value, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.fill_nan(fill_value))
 
-    @deprecate_function(
-        'Use `.fill_null(strategy="forward")` instead.', version="1.27.0"
-    )
     def forward_fill(self, limit: int | None = None) -> Expr:
         """
         Fill missing values with the last non-null value.
 
-        .. deprecated:: 1.27.0
-            Use :meth:`fill_null` with `strategy="forward"`.
+        This is an alias of `.fill_null(strategy="forward")`.
 
         Parameters
         ----------
@@ -2878,15 +2874,11 @@ class Expr:
         """
         return self.fill_null(strategy="forward", limit=limit)
 
-    @deprecate_function(
-        'Use `.fill_null(strategy="backward")` instead.', version="1.27.0"
-    )
     def backward_fill(self, limit: int | None = None) -> Expr:
         """
         Fill missing values with the next non-null value.
 
-        .. deprecated:: 1.27.0
-            Use :meth:`fill_null` with `strategy="backward"`.
+        This is an alias of `.fill_null(strategy="backward")`.
 
         Parameters
         ----------

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2011,25 +2011,21 @@ def test_fill_nan() -> None:
 #
 def test_forward_fill() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
-    with pytest.deprecated_call():
-        fill = df.select(pl.col("a").forward_fill())["a"]
+    fill = df.select(pl.col("a").forward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [1, 1, 3]).cast(pl.Float64))
 
     df = pl.DataFrame({"a": [None, 1, None]})
-    with pytest.deprecated_call():
-        fill = df.select(pl.col("a").forward_fill())["a"]
+    fill = df.select(pl.col("a").forward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [None, 1, 1]).cast(pl.Int64))
 
 
 def test_backward_fill() -> None:
     df = pl.DataFrame({"a": [1.0, None, 3.0]})
-    with pytest.deprecated_call():
-        fill = df.select(pl.col("a").backward_fill())["a"]
+    fill = df.select(pl.col("a").backward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
     df = pl.DataFrame({"a": [None, 1, None]})
-    with pytest.deprecated_call():
-        fill = df.select(pl.col("a").backward_fill())["a"]
+    fill = df.select(pl.col("a").backward_fill())["a"]
     assert_series_equal(fill, pl.Series("a", [1, 1, None]).cast(pl.Int64))
 
 


### PR DESCRIPTION
After having discussed it again internally, we are okay keeping these aliases around.

Fixes #22155.