### PR TITLE
feat: Add `SPLIT_PART` string function to the SQL interface

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -409,6 +409,13 @@ pub(crate) enum PolarsSQLFunctions {
     /// SELECT RTRIM(column_1) FROM df;
     /// ```
     RTrim,
+    /// SQL 'split_part' function.
+    /// Splits a string into an array of strings using the given delimiter
+    /// and returns the `n`-th part (1-indexed).
+    /// ```sql
+    /// SELECT SPLIT_PART(column_1, ',', 2) FROM df;
+    /// ```
+    SplitPart,
     /// SQL 'starts_with' function.
     /// Returns True if the value starts with the second argument.
     /// ```sql
@@ -879,6 +886,7 @@ impl PolarsSQLFunctions {
             "reverse" => Self::Reverse,
             "right" => Self::Right,
             "rtrim" => Self::RTrim,
+            "split_part" => Self::SplitPart,
             "starts_with" => Self::StartsWith,
             "string_to_array" => Self::StringToArray,
             "strptime" => Self::Strptime,
@@ -1278,6 +1286,27 @@ impl SQLFunctionVisitor<'_> {
                     2 => self.visit_binary(|e, s| e.str().strip_chars_end(s)),
                     _ => {
                         polars_bail!(SQLSyntax: "RTRIM expects 1-2 arguments (found {})", args.len())
+                    },
+                }
+            },
+            SplitPart => {
+                let args = extract_args(function)?;
+                match args.len() {
+                    3 => self.try_visit_ternary(|e, sep, idx| {
+                        let idx = adjust_one_indexed_param(idx, true);
+                        Ok(when(e.clone().is_not_null())
+                            .then(
+                                e.clone()
+                                    .str()
+                                    .split(sep)
+                                    .list()
+                                    .get(idx, true)
+                                    .fill_null(lit("")),
+                            )
+                            .otherwise(e.clone()))
+                    }),
+                    _ => {
+                        polars_bail!(SQLSyntax: "SPLIT_PART expects 3 arguments (found {})", args.len())
                     },
                 }
             },

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1209,7 +1209,7 @@ impl SQLFunctionVisitor<'_> {
             },
             OctetLength => self.visit_unary(|e| e.str().len_bytes()),
             StrPos => {
-                // // note: SQL is 1-indexed; returns zero if no match found
+                // note: SQL is 1-indexed; returns zero if no match found
                 self.visit_binary(|expr, substring| {
                     (expr.str().find(substring, true) + typed_lit(1u32)).fill_null(typed_lit(0u32))
                 })

--- a/py-polars/docs/source/reference/sql/functions/string.rst
+++ b/py-polars/docs/source/reference/sql/functions/string.rst
@@ -18,7 +18,7 @@ String
    * - :ref:`ENDS_WITH <ends_with>`
      - Returns True if the value ends with the second argument.
    * - :ref:`INITCAP <initcap>`
-     - Returns the value with the first letter capitalized.
+     - Converts the first letter of each word to uppercase, and the rest to lowercase.
    * - :ref:`LEFT <left>`
      - Returns the first (leftmost) `n` characters.
    * - :ref:`LENGTH <length>`
@@ -41,16 +41,19 @@ String
      - Returns the last (rightmost) `n` characters.
    * - :ref:`RTRIM <rtrim>`
      - Strips whitespaces from the right.
+   * - :ref:`SPLIT_PART <split_part>`
+     - Splits a string by another substring/delimiter, returning the `n`-th part; note that `n` is 1-indexed.
    * - :ref:`STARTS_WITH <starts_with>`
      - Returns True if the value starts with the second argument.
    * - :ref:`STRING_TO_ARRAY <string_to_array>`
      - Splits a string by another substring/delimiter, returning an array of strings.
    * - :ref:`STRPOS <strpos>`
-     - Returns the index of the given substring in the target string.
+     - Returns the index of the given substring in the target string; note that the result is 1-indexed
+       (returning 0 indicates that the given string was not found).
    * - :ref:`STRPTIME <strptime>`
      - Converts a string to a Datetime using a strftime-compatible formatting string.
    * - :ref:`SUBSTR <substr>`
-     - Returns a portion of the data (first character = 1) in the range [start, start + length].
+     - Returns a slice of the string data in the range [start, start + length]; note that `start` is 1-indexed.
    * - :ref:`TIMESTAMP <timestamp>`
      - Converts a formatted timestamp/datetime string to an actual Datetime value.
    * - :ref:`UPPER <upper>`
@@ -221,27 +224,26 @@ Returns True if the value ends with the second argument.
 
 INITCAP
 -------
-Returns the value with the first letter capitalized.
+Converts the first letter of each word to uppercase, and the rest to lowercase.
 
 **Example:**
 
 .. code-block:: python
 
-    df = pl.DataFrame({"bar": ["zz", "yy", "xx", "ww"]})
+    df = pl.DataFrame({"bar": ["hello world", "HELLO", "wOrLd"]})
     df.sql("""
       SELECT bar, INITCAP(bar) AS baz FROM self
     """)
-    # shape: (4, 2)
-    # ┌─────┬─────┐
-    # │ bar ┆ baz │
-    # │ --- ┆ --- │
-    # │ str ┆ str │
-    # ╞═════╪═════╡
-    # │ zz  ┆ Zz  │
-    # │ yy  ┆ Yy  │
-    # │ xx  ┆ Xx  │
-    # │ ww  ┆ Ww  │
-    # └─────┴─────┘
+    # shape: (3, 2)
+    # ┌─────────────┬─────────────┐
+    # │ bar         ┆ baz         │
+    # │ ---         ┆ ---         │
+    # │ str         ┆ str         │
+    # ╞═════════════╪═════════════╡
+    # │ hello world ┆ Hello World │
+    # │ HELLO       ┆ Hello       │
+    # │ wOrLd       ┆ World       │
+    # └─────────────┴─────────────┘
 
 .. _left:
 
@@ -567,6 +569,37 @@ Strips whitespaces from the right.
     # │ ww     ┆ ww  │
     # └────────┴─────┘
 
+.. _split_part:
+
+SPLIT_PART
+----------
+Splits a string by another substring/delimiter, returning the `n`-th part; note that `n` is 1-indexed.
+
+**Example:**
+
+.. code-block:: python
+
+    df = pl.DataFrame({"s": ["xx,yy,zz", "abc,,xyz,???,hmm", None, ""]})
+    df.sql("""
+      SELECT
+        s,
+        SPLIT_PART(s,',',1) AS "s+1",
+        SPLIT_PART(s,',',3) AS "s+3",
+        SPLIT_PART(s,',',-2) AS "s-2",
+      FROM self
+    """)
+    # shape: (4, 4)
+    # ┌──────────────────┬──────┬──────┬──────┐
+    # │ s                ┆ s+1  ┆ s+3  ┆ s-2  │
+    # │ ---              ┆ ---  ┆ ---  ┆ ---  │
+    # │ str              ┆ str  ┆ str  ┆ str  │
+    # ╞══════════════════╪══════╪══════╪══════╡
+    # │ xx,yy,zz         ┆ xx   ┆ zz   ┆ yy   │
+    # │ abc,,xyz,???,hmm ┆ abc  ┆ xyz  ┆ ???  │
+    # │ null             ┆ null ┆ null ┆ null │
+    # │                  ┆      ┆      ┆      │
+    # └──────────────────┴──────┴──────┴──────┘
+
 .. _starts_with:
 
 STARTS_WITH
@@ -682,7 +715,7 @@ Converts a string to a Datetime using a `chrono strftime <https://docs.rs/chrono
 
 SUBSTR
 ---------
-Returns a slice of the string data (1-indexed) in the range [start, start + length].
+Returns a slice of the string data in the range [start, start + length]; note that `start` is 1-indexed.
 
 **Example:**
 

--- a/py-polars/tests/unit/sql/test_strings.py
+++ b/py-polars/tests/unit/sql/test_strings.py
@@ -381,6 +381,24 @@ def test_string_split() -> None:
     }
 
 
+def test_string_split_part() -> None:
+    df = pl.DataFrame({"s": ["xx,yy,zz", "abc,,xyz,???,hmm", "", None]})
+    res = df.sql(
+        """
+        SELECT
+          SPLIT_PART(s,',',1) AS "s+1",
+          SPLIT_PART(s,',',3) AS "s+3",
+          SPLIT_PART(s,',',-2) AS "s-2",
+        FROM self
+        """
+    )
+    assert res.to_dict(as_series=False) == {
+        "s+1": ["xx", "abc", "", None],
+        "s+3": ["zz", "xyz", "", None],
+        "s-2": ["yy", "???", "", None],
+    }
+
+
 def test_string_substr() -> None:
     df = pl.DataFrame(
         {"scol": ["abcdefg", "abcde", "abc", None], "n": [-2, 3, 2, None]}


### PR DESCRIPTION
Adds SQL support for the `SPLIT_PART`[^1] function, which splits a string by a delimiter and returns the indicated (1-indexed) element.

## Example
```python
import polars as pl
df = pl.DataFrame({"s": ["xx,yy,zz", "abc,,xyz,???,hmm", None, ""]})
df.sql("""
  SELECT
    s,
    SPLIT_PART(s,',',1) AS "s+1",
    SPLIT_PART(s,',',3) AS "s+3",
    SPLIT_PART(s,',',-2) AS "s-2",
  FROM self
""")
# shape: (4, 4)
# ┌──────────────────┬──────┬──────┬──────┐
# │ s                ┆ s+1  ┆ s+3  ┆ s-2  │
# │ ---              ┆ ---  ┆ ---  ┆ ---  │
# │ str              ┆ str  ┆ str  ┆ str  │
# ╞══════════════════╪══════╪══════╪══════╡
# │ xx,yy,zz         ┆ xx   ┆ zz   ┆ yy   │
# │ abc,,xyz,???,hmm ┆ abc  ┆ xyz  ┆ ???  │
# │ null             ┆ null ┆ null ┆ null │
# │                  ┆      ┆      ┆      │
# └──────────────────┴──────┴──────┴──────┘
```

[^1]: https://www.postgresql.org/docs/current/functions-string.html#:~:text=split_part