### PR TITLE
fix: Deadlock in join due to rayon nested task-stealing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1015,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1424,27 @@ name = "ethnum"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -2791,6 +2833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3549,7 @@ dependencies = [
 name = "polars-stream"
 version = "0.46.0"
 dependencies = [
+ "async-channel",
  "async-trait",
  "atomic-waker",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://github.com/pola-rs/polars"
 aho-corasick = "1.1"
 arboard = { version = "3.4.0", default-features = false }
 async-trait = { version = "0.1.59" }
+async-channel = { version = "2.3.1" }
 atoi_simd = "0.16"
 atomic-waker = "1"
 avro-schema = { version = "0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ repository = "https://github.com/pola-rs/polars"
 [workspace.dependencies]
 aho-corasick = "1.1"
 arboard = { version = "3.4.0", default-features = false }
-async-trait = { version = "0.1.59" }
 async-channel = { version = "2.3.1" }
+async-trait = { version = "0.1.59" }
 atoi_simd = "0.16"
 atomic-waker = "1"
 avro-schema = { version = "0.3" }

--- a/crates/polars-stream/Cargo.toml
+++ b/crates/polars-stream/Cargo.toml
@@ -10,6 +10,7 @@ description = "Private crate for the streaming execution engine for the Polars D
 
 [dependencies]
 arrow = { workspace = true }
+async-channel = { workspace = true }
 async-trait = { workspace = true }
 atomic-waker = { workspace = true }
 bitflags = { workspace = true }


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/22135.

This one was very tricky to reason about, but thankfully the debugger showed me what's going on in a stacktrace. I spawned N tasks on the rayon threadpool, and these tasks can send information to each other to process. Only once all information is processed will any of the tasks exit.

The problem is that these tasks also called a gather kernel, and inside this gather kernel a rayon `POOL.join` was called. This causes rayon to task steal one of the outer tasks and start running it nested inside an other, leading to a deadlock.