### PR TITLE
fix: Allow set input to `list.set_*` operations

### DIFF
--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import warnings
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
 import polars._reexport as pl
@@ -1235,7 +1235,7 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.list_eval(expr._pyexpr, parallel))
 
-    def set_union(self, other: IntoExpr) -> Expr:
+    def set_union(self, other: IntoExpr | Collection[Any]) -> Expr:
         """
         Compute the SET UNION between the elements in this list and the elements of `other`.
 
@@ -1267,10 +1267,15 @@ class ExprListNameSpace:
         │ [5, 6, 7] ┆ [6, 8]       ┆ [5, 6, 7, 8]  │
         └───────────┴──────────────┴───────────────┘
         """  # noqa: W505.
-        other = parse_into_expression(other, str_as_lit=False)
+        if isinstance(other, Collection) and not isinstance(other, str):
+            if not isinstance(other, (Sequence, pl.Series, pl.DataFrame)):
+                other = list(other)  # eg: set, frozenset, etc
+            other = F.lit(other)._pyexpr
+        else:
+            other = parse_into_expression(other)
         return wrap_expr(self._pyexpr.list_set_operation(other, "union"))
 
-    def set_difference(self, other: IntoExpr) -> Expr:
+    def set_difference(self, other: IntoExpr | Collection[Any]) -> Expr:
         """
         Compute the SET DIFFERENCE between the elements in this list and the elements of `other`.
 
@@ -1304,10 +1309,15 @@ class ExprListNameSpace:
         --------
         polars.Expr.list.diff: Calculates the n-th discrete difference of every sublist.
         """  # noqa: W505.
-        other = parse_into_expression(other, str_as_lit=False)
+        if isinstance(other, Collection) and not isinstance(other, str):
+            if not isinstance(other, (Sequence, pl.Series, pl.DataFrame)):
+                other = list(other)  # eg: set, frozenset, etc
+            other = F.lit(other)._pyexpr
+        else:
+            other = parse_into_expression(other)
         return wrap_expr(self._pyexpr.list_set_operation(other, "difference"))
 
-    def set_intersection(self, other: IntoExpr) -> Expr:
+    def set_intersection(self, other: IntoExpr | Collection[Any]) -> Expr:
         """
         Compute the SET INTERSECTION between the elements in this list and the elements of `other`.
 
@@ -1337,10 +1347,15 @@ class ExprListNameSpace:
         │ [5, 6, 7] ┆ [6, 8]       ┆ [6]          │
         └───────────┴──────────────┴──────────────┘
         """  # noqa: W505.
-        other = parse_into_expression(other, str_as_lit=False)
+        if isinstance(other, Collection) and not isinstance(other, str):
+            if not isinstance(other, (Sequence, pl.Series, pl.DataFrame)):
+                other = list(other)  # eg: set, frozenset, etc
+            other = F.lit(other)._pyexpr
+        else:
+            other = parse_into_expression(other)
         return wrap_expr(self._pyexpr.list_set_operation(other, "intersection"))
 
-    def set_symmetric_difference(self, other: IntoExpr) -> Expr:
+    def set_symmetric_difference(self, other: IntoExpr | Collection[Any]) -> Expr:
         """
         Compute the SET SYMMETRIC DIFFERENCE between the elements in this list and the elements of `other`.
 
@@ -1370,5 +1385,10 @@ class ExprListNameSpace:
         │ [5, 6, 7] ┆ [6, 8]       ┆ [8, 5, 7] │
         └───────────┴──────────────┴───────────┘
         """  # noqa: W505.
-        other = parse_into_expression(other, str_as_lit=False)
+        if isinstance(other, Collection) and not isinstance(other, str):
+            if not isinstance(other, (Sequence, pl.Series, pl.DataFrame)):
+                other = list(other)  # eg: set, frozenset, etc
+            other = F.lit(other)._pyexpr
+        else:
+            other = parse_into_expression(other)
         return wrap_expr(self._pyexpr.list_set_operation(other, "symmetric_difference"))

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -7,7 +7,7 @@ from polars._utils.wrap import wrap_s
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Collection, Sequence
     from datetime import date, datetime, time
 
     from polars import Expr, Series
@@ -955,7 +955,7 @@ class ListNameSpace:
         ]
         """
 
-    def set_union(self, other: Series) -> Series:
+    def set_union(self, other: Series | Collection[Any]) -> Series:
         """
         Compute the SET UNION between the elements in this list and the elements of `other`.
 
@@ -979,7 +979,7 @@ class ListNameSpace:
         ]
         """  # noqa: W505
 
-    def set_difference(self, other: Series) -> Series:
+    def set_difference(self, other: Series | Collection[Any]) -> Series:
         """
         Compute the SET DIFFERENCE between the elements in this list and the elements of `other`.
 
@@ -1007,7 +1007,7 @@ class ListNameSpace:
         ]
         """  # noqa: W505
 
-    def set_intersection(self, other: Series) -> Series:
+    def set_intersection(self, other: Series | Collection[Any]) -> Series:
         """
         Compute the SET INTERSECTION between the elements in this list and the elements of `other`.
 
@@ -1031,7 +1031,7 @@ class ListNameSpace:
         ]
         """  # noqa: W505
 
-    def set_symmetric_difference(self, other: Series) -> Series:
+    def set_symmetric_difference(self, other: Series | Collection[Any]) -> Series:
         """
         Compute the SET SYMMETRIC DIFFERENCE between the elements in this list and the elements of `other`.
 

--- a/py-polars/tests/unit/operations/test_sets.py
+++ b/py-polars/tests/unit/operations/test_sets.py
@@ -4,6 +4,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import CategoricalRemappingWarning
+from polars.testing import assert_series_equal
 
 
 def test_set_intersection_13765() -> None:
@@ -78,3 +79,19 @@ def test_set_invalid_types() -> None:
             .over("a", mapping_strategy="join")
             .list.set_intersection([1])
         )
+
+
+@pytest.mark.parametrize("input", [[], [1, 2], [1, None]])
+@pytest.mark.parametrize(
+    "set_op",
+    [
+        "set_union",
+        "set_intersection",
+        "set_difference",
+        "set_symmetric_difference",
+    ],
+)
+def test_set_opts_set_input(input: list[list[int | None]], set_op: str) -> None:
+    a = pl.Series([[1, 2, 3], [], [None, 3], [5, 6, 7]])
+    op = getattr(a.list, set_op)
+    assert_series_equal(op(input).list.sort(), op(set(input)).list.sort())


### PR DESCRIPTION
Closes #21905.

```python
import polars as pl

a = pl.Series([[1, 2, 3], [], [None, 3], [5, 6, 7]])

# previously errored
a.list.set_intersection({1, 2, None})
# shape: (4,)
# Series: '' [list[i64]]
# [
#         [1, 2]
#         []
#         [null]
#         []
# ]