### PR TITLE
fix: Incorrect rounding for very large/small numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
  "hex",
  "indexmap",
  "jsonpath_lib_polars_vendor",
+ "libm",
  "memchr",
  "num-traits",
  "polars-arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ hex = "0.4.3"
 indexmap = { version = "2", features = ["std", "serde"] }
 itoa = "1.0.6"
 libc = "0.2"
+libm = "0.2"
 memchr = "2.6"
 memmap = { package = "memmap2", version = "0.9" }
 ndarray = { version = "0.16", default-features = false }

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -27,6 +27,7 @@ either = { workspace = true }
 hashbrown = { workspace = true }
 hex = { workspace = true, optional = true }
 indexmap = { workspace = true }
+libm = { workspace = true }
 memchr = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true, optional = true, features = ["small_rng", "std"] }

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_round.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_round.py
@@ -244,3 +244,38 @@ def test_round_unequal_length_22018(as_date: bool) -> None:
 
     with pytest.raises(pl.exceptions.ShapeError):
         s.dt.round(pl.Series(["30m", "20m"]))
+
+
+def test_round_small() -> None:
+    small = 1.234e-320
+    small_s = pl.Series([small])
+    assert small_s.round().item() == 0.0
+    assert small_s.round(320).item() == 1e-320
+    assert small_s.round(321).item() == 1.2e-320
+    assert small_s.round(322).item() == 1.23e-320
+    assert small_s.round(323).item() == 1.234e-320
+    assert small_s.round(324).item() == small
+    assert small_s.round(1000).item() == small
+
+    assert small_s.round_sig_figs(1).item() == 1e-320
+    assert small_s.round_sig_figs(2).item() == 1.2e-320
+    assert small_s.round_sig_figs(3).item() == 1.23e-320
+    assert small_s.round_sig_figs(4).item() == 1.234e-320
+    assert small_s.round_sig_figs(5).item() == small
+    assert small_s.round_sig_figs(1000).item() == small
+
+
+def test_round_big() -> None:
+    big = 1.234e308
+    max_err = big / 10**10
+    big_s = pl.Series([big])
+    assert big_s.round().item() == big
+    assert big_s.round(1).item() == big
+    assert big_s.round(100).item() == big
+
+    assert abs(big_s.round_sig_figs(1).item() - 1e308) <= max_err
+    assert abs(big_s.round_sig_figs(2).item() - 1.2e308) <= max_err
+    assert abs(big_s.round_sig_figs(3).item() - 1.23e308) <= max_err
+    assert abs(big_s.round_sig_figs(4).item() - 1.234e308) <= max_err
+    assert abs(big_s.round_sig_figs(4).item() - big) <= max_err
+    assert big_s.round_sig_figs(100).item() == big


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/22166.

In general fixes behavior for rounding very large or small numbers which would otherwise return `NaN`s or infinities.