### PR TITLE
fix: Datetime parser was incorrectly parsing 8-digit fractional seconds when format specified to expect 9

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -23,8 +23,11 @@ fn update_and_parse<T: atoi_simd::Parse>(
     let new_offset = offset + incr;
     let bytes = vals.get(offset..new_offset)?;
     let (val, parsed) = atoi_simd::parse_any(bytes).ok()?;
-    if parsed == 0 {
-        None
+    if parsed != incr {
+        panic!(
+            "Invariant when calling StrpTimeState.parse was not upheld. Expected {} parsed digits, got {}.",
+            incr, parsed
+        );
     } else {
         Some((val, new_offset))
     }
@@ -220,18 +223,27 @@ pub(super) fn fmt_len(fmt: &[u8]) -> Option<u16> {
                     b'S' => cnt += 2,
                     b'9' => {
                         cnt += 9;
-                        debug_assert_eq!(iter.next(), Some(&b'f'));
-                        return Some(cnt);
+                        if matches!(iter.next(), Some(&b'f')) && iter.next().is_none() {
+                            return Some(cnt);
+                        } else {
+                            return None;
+                        }
                     },
                     b'6' => {
                         cnt += 6;
-                        debug_assert_eq!(iter.next(), Some(&b'f'));
-                        return Some(cnt);
+                        if matches!(iter.next(), Some(&b'f')) && iter.next().is_none() {
+                            return Some(cnt);
+                        } else {
+                            return None;
+                        }
                     },
                     b'3' => {
                         cnt += 3;
-                        debug_assert_eq!(iter.next(), Some(&b'f'));
-                        return Some(cnt);
+                        if matches!(iter.next(), Some(&b'f')) && iter.next().is_none() {
+                            return Some(cnt);
+                        } else {
+                            return None;
+                        }
                     },
                     _ => return None,
                 },

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2405,6 +2405,25 @@ time
     )
 
 
+def test_csv_try_parse_dates_leading_zero_8_digits_22167() -> None:
+    result = pl.read_csv(
+        io.StringIO(
+            "a\n2025-04-06T18:56:42.617736974Z\n2025-04-06T18:57:42.77756192Z\n2025-04-06T18:58:44.56928733Z"
+        ),
+        try_parse_dates=True,
+    )
+    expected = pl.DataFrame(
+        {
+            "a": [
+                datetime(2025, 4, 6, 18, 56, 42, 617736, tzinfo=timezone.utc),
+                datetime(2025, 4, 6, 18, 57, 42, 777561, tzinfo=timezone.utc),
+                datetime(2025, 4, 6, 18, 58, 44, 569287, tzinfo=timezone.utc),
+            ]
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
 @pytest.mark.may_fail_auto_streaming  # read->scan_csv dispatch
 def test_csv_read_time_schema_overrides() -> None:
     df = pl.Series("time", [0]).cast(pl.Time()).to_frame()

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -760,3 +760,14 @@ def test_out_of_ns_range_no_tu_specified_13592() -> None:
 def test_wrong_format_percent() -> None:
     with pytest.raises(InvalidOperationError):
         pl.Series(["2019-01-01"]).str.strptime(pl.Date, format="d%")
+
+
+def test_polars_parser_fooled_by_trailing_nonsense_22167() -> None:
+    with pytest.raises(InvalidOperationError):
+        pl.Series(["2025-04-06T18:57:42.77756192Z"]).str.to_datetime(
+            "%Y-%m-%dT%H:%M:%S.%9fcabbagebananapotato"
+        )
+    with pytest.raises(InvalidOperationError):
+        pl.Series(["2025-04-06T18:57:42.77756192Z"]).str.to_datetime(
+            "%Y-%m-%dT%H:%M:%S.%9f#z"
+        )

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -771,6 +771,14 @@ def test_polars_parser_fooled_by_trailing_nonsense_22167() -> None:
         pl.Series(["2025-04-06T18:57:42.77756192Z"]).str.to_datetime(
             "%Y-%m-%dT%H:%M:%S.%9f#z"
         )
+    with pytest.raises(InvalidOperationError):
+        pl.Series(["2025-04-06T18:57:42.77Z"]).str.to_datetime(
+            "%Y-%m-%dT%H:%M:%S.%3f#z"
+        )
+    with pytest.raises(InvalidOperationError):
+        pl.Series(["2025-04-06T18:57:42.77123Z"]).str.to_datetime(
+            "%Y-%m-%dT%H:%M:%S.%6f#z"
+        )
 
 
 def test_strptime_empty_input_22214() -> None:


### PR DESCRIPTION
closes https://github.com/pola-rs/polars/issues/22167

~~Exploring this further, as this nominally fixes the issue but isn't the end of the story~~ done, much happier with the current fix