### PR TITLE
docs(python): Note ordering guarantee for groupby - lazy

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6482,7 +6482,7 @@ class DataFrame:
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
-            Settings this to `True` blocks the possibility
+            Setting this to `True` blocks the possibility
             to run on the streaming engine.
 
             .. note::

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4449,9 +4449,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             This is slower than a default group by.
             Setting this to `True` blocks the possibility
             to run on the streaming engine.
+
+            .. note::
+                Within each group, the order of rows is always preserved, regardless
+                of this argument.
         **named_by
             Additional columns to group by, specified as keyword arguments.
             The columns will be renamed to the keyword used.
+
+        Returns
+        -------
+        GroupBy
+            Object which can be used to perform aggregations.
 
         Examples
         --------


### PR DESCRIPTION
**Motivation**: Follow-up of #9879 as the info is missing for the lazy equivalent.

**Change**:

- Copy the change of #9879 for the lazy data frame `py-polars/polars/lazyframe/frame.py`
- Correct a small typo in the docstring for `group_by()` in `py-polars/polars/dataframe/frame.py`

---

This is my first PR in this project, trying my best to adhere to the contribution standards 🤞 