### PR TITLE
perf: Turn on `parallel=prefiltered` by default for new streaming

### DIFF
--- a/crates/polars-io/src/parquet/read/read_impl.rs
+++ b/crates/polars-io/src/parquet/read/read_impl.rs
@@ -1399,6 +1399,7 @@ pub fn calc_prefilter_cost(mask: &arrow::bitmap::Bitmap) -> f64 {
     (num_edges / rg_len).clamp(0.0, 1.0)
 }
 
+#[derive(Clone, Copy)]
 pub enum PrefilterMaskSetting {
     Auto,
     Pre,

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -383,6 +383,7 @@ impl ParquetReadImpl {
         }
 
         RowGroupDecoder {
+            num_pipelines: self.config.num_pipelines,
             projected_arrow_schema,
             row_index,
             predicate: self.predicate.clone(),

--- a/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
+++ b/crates/polars-stream/src/nodes/io_sources/parquet/init.rs
@@ -382,6 +382,9 @@ impl ParquetReadImpl {
             )
         }
 
+        let predicate_arrow_field_indices = Arc::new(predicate_arrow_field_indices);
+        let non_predicate_arrow_field_indices = Arc::new(non_predicate_arrow_field_indices);
+
         RowGroupDecoder {
             num_pipelines: self.config.num_pipelines,
             projected_arrow_schema,


### PR DESCRIPTION
This turns on `parallel=prefiltered` by default when there is a `predicate` on prefiltered.

This also does some other QOL changes.
- Decoding of `live` and `dead` columns is now parallelized. This is still not optimal as it could be parallelized, but already much better than before.
- If a `pre-slice` now consumes an entire row group, it does not block prefiltering for that row group.
- Fixed a panic when a prefilter only took `live_columns` and the `row_index`.