### PR TITLE
feat(rust): Expose `FunctionIR::FastCount` in the python visitor

### DIFF
--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -13,10 +13,7 @@ use super::expr_nodes::PyGroupbyOptions;
 use crate::PyDataFrame;
 use crate::lazyframe::visit::PyExprIR;
 
-fn scan_type_to_pyobject<'py>(
-    py: Python<'py>,
-    scan_type: &FileScan,
-) -> PyResult<PyObject> {
+fn scan_type_to_pyobject<'py>(py: Python<'py>, scan_type: &FileScan) -> PyResult<PyObject> {
     match scan_type {
         #[cfg(feature = "csv")]
         FileScan::Csv {

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -13,7 +13,7 @@ use super::expr_nodes::PyGroupbyOptions;
 use crate::PyDataFrame;
 use crate::lazyframe::visit::PyExprIR;
 
-fn scan_type_to_pyobject<'py>(py: Python<'py>, scan_type: &FileScan) -> PyResult<PyObject> {
+fn scan_type_to_pyobject(py: Python, scan_type: &FileScan) -> PyResult<PyObject> {
     match scan_type {
         #[cfg(feature = "csv")]
         FileScan::Csv {
@@ -381,7 +381,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             file_options: PyFileOptions {
                 inner: (**file_options).clone(),
             },
-            scan_type: scan_type_to_pyobject(py, &**scan_type)?,
+            scan_type: scan_type_to_pyobject(py, scan_type)?,
         }
         .into_py_any(py),
         IR::DataFrameScan {
@@ -620,7 +620,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                         })?
                         .into_py_any(py)?;
 
-                    let scan_type = scan_type_to_pyobject(py, &**scan_type)?;
+                    let scan_type = scan_type_to_pyobject(py, scan_type)?;
 
                     let alias = alias
                         .as_ref()

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -616,7 +616,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                 } => {
                     let sources = sources
                         .into_paths()
-                        .ok_or_else(|| PyNotImplementedError::new_err("FastCount with BytesIO sources"))?
+                        .ok_or_else(|| {
+                            PyNotImplementedError::new_err("FastCount with BytesIO sources")
+                        })?
                         .into_py_any(py)?;
                 
                     let scan_type = match &**scan_type {
@@ -644,7 +646,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                             ("parquet", options, cloud_options).into_py_any(py)?
                         },
                         #[cfg(feature = "ipc")]
-                        FileScan::Ipc { .. } => return Err(PyNotImplementedError::new_err("ipc scan")),
+                        FileScan::Ipc { .. } => {
+                            return Err(PyNotImplementedError::new_err("ipc scan"));
+                        },
                         #[cfg(feature = "json")]
                         FileScan::NDJson { options, .. } => {
                             let options = serde_json::to_string(options)
@@ -652,16 +656,19 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                             ("ndjson", options).into_py_any(py)?
                         },
                         FileScan::Anonymous { .. } => {
-                            return Err(PyNotImplementedError::new_err("anonymous scan in FastCount"));
+                            return Err(PyNotImplementedError::new_err(
+                                "anonymous scan in FastCount",
+                            ));
                         },
                     };
+                
                     let alias = alias
-                    .as_ref()
-                    .map(|a| a.as_str())
-                    .map_or_else(|| Ok(py.None()), |s| s.into_py_any(py))?;
+                        .as_ref()
+                        .map(|a| a.as_str())
+                        .map_or_else(|| Ok(py.None()), |s| s.into_py_any(py))?;
                 
                     ("fast_count", sources, scan_type, alias).into_py_any(py)?
-                }
+                },
             },
         }
         .into_py_any(py),

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -49,12 +49,9 @@ fn scan_type_to_pyobject<'py>(
                 .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
             Ok(("ndjson", options).into_py_any(py)?)
         },
-        FileScan::Anonymous { .. } => {
-            Err(PyNotImplementedError::new_err("anonymous scan"))
-        },
+        FileScan::Anonymous { .. } => Err(PyNotImplementedError::new_err("anonymous scan")),
     }
 }
-
 
 #[pyclass]
 /// Scan a table with an optional predicate from a python function

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -620,7 +620,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                             PyNotImplementedError::new_err("FastCount with BytesIO sources")
                         })?
                         .into_py_any(py)?;
-                
+
                     let scan_type = match &**scan_type {
                         #[cfg(feature = "csv")]
                         FileScan::Csv {
@@ -661,12 +661,12 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                             ));
                         },
                     };
-                
+
                     let alias = alias
                         .as_ref()
                         .map(|a| a.as_str())
                         .map_or_else(|| Ok(py.None()), |s| s.into_py_any(py))?;
-                
+
                     ("fast_count", sources, scan_type, alias).into_py_any(py)?
                 },
             },


### PR DESCRIPTION
Exposes `FunctionIR::FastCount` in the Python visitor. It allows the Polars GPU executor to detect `.select(pl.len())` plans without reading the full dataset. This is needed to avoid unnecessary I/O and improve performance when only the row count is required.