### PR TITLE
fix: Resolve streaming panic on multiple `merge_sorted`

### DIFF
--- a/crates/polars-stream/src/nodes/merge_sorted.rs
+++ b/crates/polars-stream/src/nodes/merge_sorted.rs
@@ -195,16 +195,6 @@ impl ComputeNode for MergeSortedNode {
                 send[0] = PortState::Done;
             },
 
-            // If the output port is blocked, the input port is blocked as well.
-            (PortState::Blocked, _, _) => {
-                if recv[0] != PortState::Done {
-                    recv[0] = PortState::Blocked;
-                }
-                if recv[1] != PortState::Done {
-                    recv[1] = PortState::Blocked;
-                }
-            },
-
             // If one of the two ports is blocked such that we cannot produce data anymore, block
             // the other input port and output port.
             (_, PortState::Blocked, _) if self.left_unmerged.is_empty() => {

--- a/py-polars/tests/unit/operations/test_merge_sorted.py
+++ b/py-polars/tests/unit/operations/test_merge_sorted.py
@@ -311,10 +311,12 @@ def test_merge_sorted_categorical_21952() -> None:
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-def test_merge_sorted_chain_streaming_21789(streaming: bool) -> None:
+def test_merge_sorted_chain_streaming_21789_a(streaming: bool) -> None:
     lf0 = pl.LazyFrame({"foo": ["a1", "a2"], "n": [10, 20]})
     lf1 = pl.LazyFrame({"foo": ["b1", "b2"], "n": [11, 21]})
     lf2 = pl.LazyFrame({"foo": ["c1", "c2"], "n": [12, 22]})
+
+    pq = lf0.merge_sorted(lf1, key="n").merge_sorted(lf2, key="n")
 
     expected = pl.DataFrame(
         {
@@ -323,7 +325,30 @@ def test_merge_sorted_chain_streaming_21789(streaming: bool) -> None:
         }
     )
 
-    pq = lf0.merge_sorted(lf1, key="n").merge_sorted(lf2, key="n")
+    out = pq.collect(engine="streaming" if streaming else "in-memory")
+
+    assert_frame_equal(out, expected)
+
+
+# The following expression triggers [Blocked, Ready] [Ready] in merge_sorted.
+@pytest.mark.parametrize("streaming", [False, True])
+def test_merge_sorted_chain_streaming_21789_b(streaming: bool) -> None:
+    lf0 = pl.LazyFrame({"foo": ["a1", "a2"], "n": [10, 20]})
+    lf1 = pl.LazyFrame({"foo": ["b1", "b2"], "n": [11, 21]})
+    lf2 = pl.LazyFrame({"foo": ["c1", "c2"], "n": [12, 22]})
+    lf3 = pl.LazyFrame({"foo": ["d1", "d2"], "n": [13, 23]})
+
+    lf01 = lf0.merge_sorted(lf1, key="n").top_k(3, by="n").sort(by="n")
+    lf23 = lf2.merge_sorted(lf3, key="n")
+    pq = lf01.merge_sorted(lf23, key="n").bottom_k(6, by="n").sort(by="n")
+
+    expected = pl.DataFrame(
+        {
+            "foo": ["b1", "c1", "d1", "a2", "b2", "c2"],
+            "n": [11, 12, 13, 20, 21, 22],
+        }
+    )
+
     out = pq.collect(engine="streaming" if streaming else "in-memory")
 
     assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #21789

This (tactically) fixes the problem as reported (MRE), but expert input and review is required to assess the integrity of the modified `update_all_states` function and ensure we are not breaking anything (I doubt it).

Note, a precise definition of the `PortState` states and documentation of the state exchange algorithm would help me and others review the logic. If that is available, kindly share.