### PR TITLE
feat: Add `cat.to_lower/upper/titlecase` functions for categorical

### DIFF
--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -32,4 +32,19 @@ impl CategoricalNameSpace {
     pub fn slice(self, offset: i64, length: Option<usize>) -> Expr {
         self.0.map_unary(CategoricalFunction::Slice(offset, length))
     }
+
+    #[cfg(feature = "strings")]
+    pub fn to_uppercase(self) -> Expr {
+        self.0.map_unary(CategoricalFunction::UpperCase)
+    }
+
+    #[cfg(feature = "strings")]
+    pub fn to_lowercase(self) -> Expr {
+        self.0.map_unary(CategoricalFunction::LowerCase)
+    }
+
+    #[cfg(feature = "strings")]
+    pub fn to_titlecase(self) -> Expr {
+        self.0.map_unary(CategoricalFunction::TitleCase)
+    }
 }

--- a/crates/polars-plan/src/dsl/cat.rs
+++ b/crates/polars-plan/src/dsl/cat.rs
@@ -35,16 +35,16 @@ impl CategoricalNameSpace {
 
     #[cfg(feature = "strings")]
     pub fn to_uppercase(self) -> Expr {
-        self.0.map_unary(CategoricalFunction::UpperCase)
+        self.0.map_unary(CategoricalFunction::Uppercase)
     }
 
     #[cfg(feature = "strings")]
     pub fn to_lowercase(self) -> Expr {
-        self.0.map_unary(CategoricalFunction::LowerCase)
+        self.0.map_unary(CategoricalFunction::Lowercase)
     }
 
-    #[cfg(feature = "strings")]
+    #[cfg(all(feature = "strings", feature = "nightly"))]
     pub fn to_titlecase(self) -> Expr {
-        self.0.map_unary(CategoricalFunction::TitleCase)
+        self.0.map_unary(CategoricalFunction::Titlecase)
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -58,8 +58,9 @@ impl CategoricalFunction {
             | C::EndsWith(_)
             | C::Slice(_, _)
             | C::Uppercase
-            | C::Lowercase
-            | C::Titlecase => FunctionOptions::elementwise(),
+            | C::Lowercase => FunctionOptions::elementwise(),
+            #[cfg(all(feature = "strings", feature = "nightly"))]
+            C::Titlecase => FunctionOptions::elementwise(),
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -16,11 +16,11 @@ pub enum CategoricalFunction {
     #[cfg(feature = "strings")]
     Slice(i64, Option<usize>),
     #[cfg(feature = "strings")]
-    UpperCase,
+    Uppercase,
     #[cfg(feature = "strings")]
-    LowerCase,
+    Lowercase,
     #[cfg(feature = "strings")]
-    TitleCase,
+    Titlecase,
 }
 
 impl CategoricalFunction {
@@ -39,11 +39,11 @@ impl CategoricalFunction {
             #[cfg(feature = "strings")]
             Slice(_, _) => mapper.with_dtype(DataType::String),
             #[cfg(feature = "strings")]
-            UpperCase => mapper.with_dtype(DataType::String),
+            Uppercase => mapper.with_dtype(DataType::String),
             #[cfg(feature = "strings")]
-            LowerCase => mapper.with_dtype(DataType::String),
+            Lowercase => mapper.with_dtype(DataType::String),
             #[cfg(feature = "strings")]
-            TitleCase => mapper.with_dtype(DataType::String),
+            Titlecase => mapper.with_dtype(DataType::String),
         }
     }
 
@@ -57,9 +57,9 @@ impl CategoricalFunction {
             | C::StartsWith(_)
             | C::EndsWith(_)
             | C::Slice(_, _)
-            | C::UpperCase
-            | C::LowerCase
-            | C::TitleCase => FunctionOptions::elementwise(),
+            | C::Uppercase
+            | C::Lowercase
+            | C::Titlecase => FunctionOptions::elementwise(),
         }
     }
 }
@@ -80,11 +80,11 @@ impl Display for CategoricalFunction {
             #[cfg(feature = "strings")]
             Slice(_, _) => "slice",
             #[cfg(feature = "strings")]
-            UpperCase => "uppercase",
+            Uppercase => "uppercase",
             #[cfg(feature = "strings")]
-            LowerCase => "lowercase",
+            Lowercase => "lowercase",
             #[cfg(feature = "strings")]
-            TitleCase => "titlecase",
+            Titlecase => "titlecase",
         };
         write!(f, "cat.{s}")
     }
@@ -106,11 +106,11 @@ impl From<CategoricalFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "strings")]
             Slice(offset, length) => map!(slice, offset, length),
             #[cfg(feature = "strings")]
-            UpperCase => map!(to_uppercase),
+            Uppercase => map!(to_uppercase),
             #[cfg(feature = "strings")]
-            LowerCase => map!(to_lowercase),
-            #[cfg(feature = "strings")]
-            TitleCase => map!(to_titlecase),
+            Lowercase => map!(to_lowercase),
+            #[cfg(all(feature = "strings", feature = "nightly"))]
+            Titlecase => map!(to_titlecase),
         }
     }
 }
@@ -241,6 +241,7 @@ fn to_lowercase(c: &Column) -> PolarsResult<Column> {
 }
 
 #[cfg(feature = "strings")]
+#[cfg(feature = "nightly")]
 fn to_titlecase(c: &Column) -> PolarsResult<Column> {
     apply_to_cats_str(c, |s| s.to_titlecase())
 }

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -19,7 +19,7 @@ pub enum CategoricalFunction {
     Uppercase,
     #[cfg(feature = "strings")]
     Lowercase,
-    #[cfg(feature = "strings")]
+    #[cfg(all(feature = "strings", feature = "nightly"))]
     Titlecase,
 }
 
@@ -42,7 +42,7 @@ impl CategoricalFunction {
             Uppercase => mapper.with_dtype(DataType::String),
             #[cfg(feature = "strings")]
             Lowercase => mapper.with_dtype(DataType::String),
-            #[cfg(feature = "strings")]
+            #[cfg(all(feature = "strings", feature = "nightly"))]
             Titlecase => mapper.with_dtype(DataType::String),
         }
     }
@@ -83,7 +83,7 @@ impl Display for CategoricalFunction {
             Uppercase => "uppercase",
             #[cfg(feature = "strings")]
             Lowercase => "lowercase",
-            #[cfg(feature = "strings")]
+            #[cfg(all(feature = "strings", feature = "nightly"))]
             Titlecase => "titlecase",
         };
         write!(f, "cat.{s}")

--- a/crates/polars-python/src/expr/categorical.rs
+++ b/crates/polars-python/src/expr/categorical.rs
@@ -37,6 +37,7 @@ impl PyExpr {
         self.inner.clone().cat().to_lowercase().into()
     }
 
+    #[cfg(feature = "nightly")]
     fn cat_to_titlecase(&self) -> Self {
         self.inner.clone().cat().to_titlecase().into()
     }

--- a/crates/polars-python/src/expr/categorical.rs
+++ b/crates/polars-python/src/expr/categorical.rs
@@ -28,4 +28,16 @@ impl PyExpr {
     fn cat_slice(&self, offset: i64, length: Option<usize>) -> Self {
         self.inner.clone().cat().slice(offset, length).into()
     }
+
+    fn cat_to_uppercase(&self) -> Self {
+        self.inner.clone().cat().to_uppercase().into()
+    }
+
+    fn cat_to_lowercase(&self) -> Self {
+        self.inner.clone().cat().to_lowercase().into()
+    }
+
+    fn cat_to_titlecase(&self) -> Self {
+        self.inner.clone().cat().to_titlecase().into()
+    }
 }

--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -11,7 +11,7 @@ description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 [dependencies]
 polars-core = { workspace = true, features = ["rows"] }
 polars-error = { workspace = true }
-polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "dtype-decimal", "dtype-struct", "is_in", "list_eval", "log", "meta", "offset_by", "regex", "round_series", "sign", "string_normalize", "string_reverse", "strings", "timezones", "trigonometry"] }
+polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-categorical", "dtype-date", "dtype-decimal", "dtype-struct", "is_in", "list_eval", "log", "meta", "offset_by", "regex", "round_series", "sign", "string_normalize", "string_reverse", "strings", "timezones", "trigonometry"] }
 polars-ops = { workspace = true }
 polars-plan = { workspace = true }
 polars-time = { workspace = true }
@@ -35,6 +35,7 @@ binary_encoding = ["polars-lazy/binary_encoding"]
 bitwise = ["polars-lazy/bitwise"]
 csv = ["polars-lazy/csv"]
 diagonal_concat = ["polars-lazy/diagonal_concat"]
+dtype-categorical = ["polars-lazy/dtype-categorical"]
 dtype-decimal = ["polars-lazy/dtype-decimal"]
 ipc = ["polars-lazy/ipc"]
 json = ["polars-lazy/json", "polars-plan/json", "polars-plan/extract_jsonpath"]

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1144,6 +1144,7 @@ impl SQLFunctionVisitor<'_> {
                     self.try_visit_unary(|e| {
                         let dt = e.to_field(schema, Context::default())?.dtype;
                         match dt {
+                            #[cfg(feature = "dtype-categorical")]
                             DataType::Categorical(..) | DataType::Enum(..) => {
                                 Ok(e.cat().to_titlecase())
                             },
@@ -1183,6 +1184,7 @@ impl SQLFunctionVisitor<'_> {
                     self.try_visit_unary(|e| {
                         let dt = e.to_field(schema, Context::default())?.dtype;
                         match dt {
+                            #[cfg(feature = "dtype-categorical")]
                             DataType::Categorical(..) | DataType::Enum(..) => {
                                 Ok(e.cat().to_lowercase())
                             },
@@ -1433,6 +1435,7 @@ impl SQLFunctionVisitor<'_> {
                     self.try_visit_unary(|e| {
                         let dt = e.to_field(schema, Context::default())?.dtype;
                         match dt {
+                            #[cfg(feature = "dtype-categorical")]
                             DataType::Categorical(..) | DataType::Enum(..) => {
                                 Ok(e.cat().to_uppercase())
                             },

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -362,6 +362,7 @@ dtype-categorical = [
   "polars-core/dtype-categorical",
   "polars-io/dtype-categorical",
   "polars-lazy?/dtype-categorical",
+  "polars-sql?/dtype-categorical",
   "polars-ops/dtype-categorical",
 ]
 dtype-struct = [

--- a/py-polars/docs/source/reference/expressions/categories.rst
+++ b/py-polars/docs/source/reference/expressions/categories.rst
@@ -13,4 +13,9 @@ The following methods are available under the `expr.cat` attribute.
     Expr.cat.get_categories
     Expr.cat.len_bytes
     Expr.cat.len_chars
+    Expr.cat.slice
     Expr.cat.starts_with
+    Expr.cat.to_lowercase
+    Expr.cat.to_titlecase
+    Expr.cat.to_uppercase
+

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -303,3 +303,83 @@ class ExprCatNameSpace:
         └─────────────┴───────┘
         """
         return wrap_expr(self._pyexpr.cat_slice(offset, length))
+
+    def to_uppercase(self) -> Expr:
+        """
+        Modify and return string representations as their uppercase equivalent.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"foo": pl.Series(["cat", "dog"], dtype=pl.Categorical)})
+        >>> df.with_columns(foo_upper=pl.col("foo").cat.to_uppercase())
+        shape: (2, 2)
+        ┌─────┬───────────┐
+        │ foo ┆ foo_upper │
+        │ --- ┆ ---       │
+        │ cat ┆ str       │
+        ╞═════╪═══════════╡
+        │ cat ┆ CAT       │
+        │ dog ┆ DOG       │
+        └─────┴───────────┘
+        """
+        return wrap_expr(self._pyexpr.cat_to_uppercase())
+
+    def to_lowercase(self) -> Expr:
+        """
+        Modify and return string representations as their lowercase equivalent.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"foo": pl.Series(["CAT", "DOG"], dtype=pl.Categorical)})
+        >>> df.with_columns(foo_lower=pl.col("foo").cat.to_lowercase())
+        shape: (2, 2)
+        ┌─────┬───────────┐
+        │ foo ┆ foo_lower │
+        │ --- ┆ ---       │
+        │ cat ┆ str       │
+        ╞═════╪═══════════╡
+        │ CAT ┆ cat       │
+        │ DOG ┆ dog       │
+        └─────┴───────────┘
+        """
+        return wrap_expr(self._pyexpr.cat_to_lowercase())
+
+    def to_titlecase(self) -> Expr:
+        """
+        Modify and return string representations as their titlecase equivalent.
+
+        Notes
+        -----
+        This is a form of case transform where the first letter of each word is
+        capitalized, with the rest of the word in lowercase. Non-alphanumeric
+        characters define the word boundaries.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "quotes": pl.Series(
+        ...             [
+        ...                 "'e.t. phone home'",
+        ...                 "you talkin' to me?",
+        ...                 "to infinity,and BEYOND!",
+        ...             ],
+        ...             dtype=pl.Categorical,
+        ...         )
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     quotes_title=pl.col("quotes").cat.to_titlecase(),
+        ... )
+        shape: (3, 2)
+        ┌─────────────────────────┬─────────────────────────┐
+        │ quotes                  ┆ quotes_title            │
+        │ ---                     ┆ ---                     │
+        │ cat                     ┆ str                     │
+        ╞═════════════════════════╪═════════════════════════╡
+        │ 'e.t. phone home'       ┆ 'E.T. Phone Home'       │
+        │ you talkin' to me?      ┆ You Talkin' To Me?      │
+        │ to infinity,and BEYOND! ┆ To Infinity,And Beyond! │
+        └─────────────────────────┴─────────────────────────┘
+        """
+        return wrap_expr(self._pyexpr.cat_to_titlecase())

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -291,3 +291,66 @@ class CatNameSpace:
             "onf"
         ]
         """
+
+    def to_uppercase(self) -> Series:
+        """
+        Modify and return string representation as their uppercase equivalent.
+
+        Examples
+        --------
+        >>> s = pl.Series("foo", ["cat", "dog"], dtype=pl.Categorical)
+        >>> s.cat.to_uppercase()
+        shape: (2,)
+        Series: 'foo' [str]
+        [
+            "CAT"
+            "DOG"
+        ]
+        """
+
+    def to_lowercase(self) -> Series:
+        """
+        Modify and return string representation as their lowercase equivalent.
+
+        Examples
+        --------
+        >>> s = pl.Series("foo", ["CAT", "DOG"], dtype=pl.Categorical)
+        >>> s.cat.to_lowercase()
+        shape: (2,)
+        Series: 'foo' [str]
+        [
+            "cat"
+            "dog"
+        ]
+        """
+
+    def to_titlecase(self) -> Series:
+        """
+        Modify and return string representation as their titlecase equivalent.
+
+        Notes
+        -----
+        This is a form of case transform where the first letter of each word is
+        capitalized, with the rest of the word in lowercase. Non-alphanumeric
+        characters define the word boundaries.
+
+        Examples
+        --------
+        >>> s = pl.Series(
+        ...     "quotes",
+        ...     [
+        ...         "'e.t. phone home'",
+        ...         "you talkin' to me?",
+        ...         "to infinity,and BEYOND!",
+        ...     ],
+        ...     dtype=pl.Categorical,
+        ... )
+        >>> s.cat.to_titlecase()
+        shape: (3,)
+        Series: 'quotes' [str]
+        [
+            "'E.T. Phone Home'"
+            "You Talkin' To Me?"
+            "To Infinity,And Beyond!"
+        ]
+        """

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -372,3 +372,72 @@ def test_titlecase() -> None:
     ):
         assert ex_str == act, f"{ex_str} != {act}"
         assert ex_py == act, f"{ex_py} != {act}"
+
+
+def test_sql_lowercase() -> None:
+    dt = pl.Enum(["A", "B", "C", "D", "E"])
+    df = pl.DataFrame(
+        {
+            "enum_col": pl.Series(["A", "B", "C", "D", "A"], dtype=dt),
+            "int_col": [1, 2, 3, 4, 5],
+        }
+    )
+
+    result = (
+        pl.SQLContext({"sql_table": df})
+        .execute("SELECT * FROM sql_table WHERE LOWER(enum_col) = 'a';")
+        .collect()
+    )
+    expected = pl.DataFrame(
+        {
+            "enum_col": pl.Series(["A", "A"], dtype=dt),
+            "int_col": [1, 5],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_sql_uppercase() -> None:
+    dt = pl.Enum(["a", "b", "c", "d", "e"])
+    df = pl.DataFrame(
+        {
+            "enum_col": pl.Series(["a", "b", "c", "d", "a"], dtype=dt),
+            "int_col": [1, 2, 3, 4, 5],
+        }
+    )
+
+    result = (
+        pl.SQLContext({"sql_table": df})
+        .execute("SELECT * FROM sql_table WHERE UPPER(enum_col) = 'A';")
+        .collect()
+    )
+    expected = pl.DataFrame(
+        {
+            "enum_col": pl.Series(["a", "a"], dtype=dt),
+            "int_col": [1, 5],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_sql_titlecase() -> None:
+    dt = pl.Enum(["aa", "bb", "cc", "dd", "ee"])
+    df = pl.DataFrame(
+        {
+            "enum_col": pl.Series(["aa", "bb", "cc", "dd", "aa"], dtype=dt),
+            "int_col": [1, 2, 3, 4, 5],
+        }
+    )
+
+    result = (
+        pl.SQLContext({"sql_table": df})
+        .execute("SELECT * FROM sql_table WHERE INITCAP(enum_col) = 'Aa';")
+        .collect()
+    )
+    expected = pl.DataFrame(
+        {
+            "enum_col": pl.Series(["aa", "aa"], dtype=dt),
+            "int_col": [1, 5],
+        }
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/operations/namespaces/test_categorical.py
@@ -301,3 +301,74 @@ def test_cat_slice() -> None:
         "",
         None,
     ]
+
+
+@pytest.mark.usefixtures("test_global_and_local")
+def test_cat_to_lowercase() -> None:
+    s = pl.Series(["Hello", "WORLD"], dtype=pl.Categorical)
+    expected = pl.Series(["hello", "world"])
+    assert_series_equal(s.cat.to_lowercase(), expected)
+
+
+@pytest.mark.usefixtures("test_global_and_local")
+def test_cat_to_uppercase() -> None:
+    s = pl.Series(["Hello", "WORLD"], dtype=pl.Categorical)
+    expected = pl.Series(["HELLO", "WORLD"])
+    assert_series_equal(s.cat.to_uppercase(), expected)
+
+
+def test_titlecase() -> None:
+    df = pl.DataFrame(
+        {
+            "misc": pl.Series(
+                [
+                    "welcome to my world",
+                    "double  space",
+                    "and\ta\t tab",
+                    "by jean-paul sartre, 'esq'",
+                    "SOMETIMES/life/gives/you/a/2nd/chance",
+                ],
+                dtype=pl.Categorical,
+            )
+        }
+    )
+    expected = [
+        "Welcome To My World",
+        "Double  Space",
+        "And\tA\t Tab",
+        "By Jean-Paul Sartre, 'Esq'",
+        "Sometimes/Life/Gives/You/A/2nd/Chance",
+    ]
+    actual = df.select(pl.col("misc").cat.to_titlecase()).to_series()
+    for ex, act in zip(expected, actual):
+        assert ex == act, f"{ex} != {act}"
+
+    df = pl.DataFrame(
+        {
+            "quotes": pl.Series(
+                [
+                    "'e.t. phone home'",
+                    "you talkin' to me?",
+                    "i feel the need--the need for speed",
+                    "to infinity,and BEYOND!",
+                    "say 'what' again!i dare you - I\u00a0double-dare you!",
+                    "What.we.got.here... is#failure#to#communicate",
+                ],
+                dtype=pl.Categorical,
+            )
+        }
+    )
+    expected_str = [
+        "'E.T. Phone Home'",
+        "You Talkin' To Me?",
+        "I Feel The Need--The Need For Speed",
+        "To Infinity,And Beyond!",
+        "Say 'What' Again!I Dare You - I\u00a0Double-Dare You!",
+        "What.We.Got.Here... Is#Failure#To#Communicate",
+    ]
+    expected_py = [s.title() for s in df["quotes"].to_list()]
+    for ex_str, ex_py, act in zip(
+        expected_str, expected_py, df["quotes"].cat.to_titlecase()
+    ):
+        assert ex_str == act, f"{ex_str} != {act}"
+        assert ex_py == act, f"{ex_py} != {act}"


### PR DESCRIPTION
Should resolve the not-planned #21728.

This also combines the string and binary functions into a single function, so there is now just one category operator function, which is a simplifying improvement. There is now more uniformity across the different `cat` namespace functions.

Will have to go back and enable prior `cat.*` functions in `polars-sql`, as that required a bit more finagling, will do in followup PR.