### PR TITLE
fix: Fallback predicate filter for `min=max` with `is_in`

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -438,7 +438,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 // The above case does always cover the fallback path. Since there
                                 // is code that relies on the `min==max` always filtering normally,
                                 // we add it here.
-                                let fallback_expr = expr_arena.add(AExpr::Function {
+                                let exact_not_in = expr_arena.add(AExpr::Function {
                                     input: vec![
                                         ExprIR::new(col_min, OutputName::Alias(PlSmallStr::EMPTY)),
                                         ExprIR::new(lv_node, OutputName::Alias(PlSmallStr::EMPTY)),
@@ -449,7 +449,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                                     options: BooleanFunction::IsIn { nulls_equal }
                                         .function_options(),
                                 });
-                                let fallback_expr = expr_arena.add(AExpr::Function {
+                                let exact_not_in = expr_arena.add(AExpr::Function {
                                     input: vec![ExprIR::new(
                                         fallback_expr,
                                         OutputName::Alias(PlSmallStr::EMPTY),
@@ -457,7 +457,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                                     function: FunctionExpr::Boolean(BooleanFunction::Not),
                                     options: BooleanFunction::Not.function_options(),
                                 });
-                                let fallback_expr = and!(min_is_max, has_no_nulls, fallback_expr);
+                                let exact_not_in = and!(min_is_max, has_no_nulls, fallback_expr);
 
                                 Some(or!(fallback_expr, min_max_is_in))
                             },

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -459,7 +459,7 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 });
                                 let exact_not_in = and!(min_is_max, has_no_nulls, fallback_expr);
 
-                                Some(or!(fallback_expr, min_max_is_in))
+                                Some(or!(exact_not_in, min_max_is_in))
                             },
                             _ => None,
                         }

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -12,7 +12,7 @@ use super::super::evaluate::{constant_evaluate, into_column};
 use super::super::{AExpr, BooleanFunction, Operator, OutputName};
 use crate::dsl::FunctionExpr;
 use crate::plans::predicates::get_binary_expr_col_and_lv;
-use crate::plans::{aexpr_to_leaf_names_iter, rename_columns, ExprIR, LiteralValue};
+use crate::plans::{ExprIR, LiteralValue, aexpr_to_leaf_names_iter, rename_columns};
 use crate::prelude::FunctionOptions;
 
 /// Return a new boolean expression determines whether a batch can be skipped based on min, max and
@@ -46,9 +46,7 @@ fn aexpr_to_skip_batch_predicate_rec(
     use Operator as O;
 
     macro_rules! rec {
-        ($node:expr) => {{
-            aexpr_to_skip_batch_predicate_rec($node, expr_arena, schema, depth + 1)
-        }};
+        ($node:expr) => {{ aexpr_to_skip_batch_predicate_rec($node, expr_arena, schema, depth + 1) }};
     }
     macro_rules! and {
         ($l:expr, $($r:expr),+ $(,)?) => {{
@@ -87,19 +85,13 @@ fn aexpr_to_skip_batch_predicate_rec(
         ($op:ident, $l:expr, $r:expr) => {{ binexpr!(op: O::$op, $l, $r) }};
     }
     macro_rules! lt {
-        ($l:expr, $r:expr) => {{
-            binexpr!(Lt, $l, $r)
-        }};
+        ($l:expr, $r:expr) => {{ binexpr!(Lt, $l, $r) }};
     }
     macro_rules! gt {
-        ($l:expr, $r:expr) => {{
-            binexpr!(Gt, $l, $r)
-        }};
+        ($l:expr, $r:expr) => {{ binexpr!(Gt, $l, $r) }};
     }
     macro_rules! eq {
-        ($l:expr, $r:expr) => {{
-            binexpr!(Eq, $l, $r)
-        }};
+        ($l:expr, $r:expr) => {{ binexpr!(Eq, $l, $r) }};
     }
     macro_rules! null_count {
         ($i:expr) => {{
@@ -170,29 +162,15 @@ fn aexpr_to_skip_batch_predicate_rec(
         }};
     }
     macro_rules! col {
-        (len) => {{
-            col!(PlSmallStr::from_static("len"))
-        }};
-        ($name:expr) => {{
-            expr_arena.add(AExpr::Column($name))
-        }};
-        (min: $name:expr) => {{
-            col!(format_pl_smallstr!("{}_min", $name))
-        }};
-        (max: $name:expr) => {{
-            col!(format_pl_smallstr!("{}_max", $name))
-        }};
-        (null_count: $name:expr) => {{
-            col!(format_pl_smallstr!("{}_nc", $name))
-        }};
+        (len) => {{ col!(PlSmallStr::from_static("len")) }};
+        ($name:expr) => {{ expr_arena.add(AExpr::Column($name)) }};
+        (min: $name:expr) => {{ col!(format_pl_smallstr!("{}_min", $name)) }};
+        (max: $name:expr) => {{ col!(format_pl_smallstr!("{}_max", $name)) }};
+        (null_count: $name:expr) => {{ col!(format_pl_smallstr!("{}_nc", $name)) }};
     }
     macro_rules! lv {
-        ($lv:expr) => {{
-            expr_arena.add(AExpr::Literal(Scalar::from($lv).into()))
-        }};
-        (idx: $lv:expr) => {{
-            expr_arena.add(AExpr::Literal(LiteralValue::new_idxsize($lv)))
-        }};
+        ($lv:expr) => {{ expr_arena.add(AExpr::Literal(Scalar::from($lv).into())) }};
+        (idx: $lv:expr) => {{ expr_arena.add(AExpr::Literal(LiteralValue::new_idxsize($lv))) }};
     }
 
     let specialized = (|| {

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -374,7 +374,8 @@ fn aexpr_to_skip_batch_predicate_rec(
             } => match function {
                 FunctionExpr::Boolean(f) => match f {
                     #[cfg(feature = "is_in")]
-                    BooleanFunction::IsIn { .. } => {
+                    BooleanFunction::IsIn { nulls_equal } => {
+                        let nulls_equal = *nulls_equal;
                         let lv_node = input[1].node();
                         match (
                             into_column(input[0].node(), expr_arena, schema, 0),
@@ -426,7 +427,39 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 let lv_has_not_nulls = has_no_nulls!(lv_node);
                                 let null_case = or!(lv_has_not_nulls, col_has_no_nulls);
 
-                                Some(and!(null_case, expr))
+                                let min_max_is_in = and!(null_case, expr);
+
+                                let col_nc = col!(null_count: col);
+
+                                let min_is_max = binexpr!(Eq, col_min, col_max); // Eq so that (None == None) == None
+                                let idx_zero = lv!(idx: 0);
+                                let has_no_nulls = eq!(col_nc, idx_zero);
+
+                                // The above case does always cover the fallback path. Since there
+                                // is code that relies on the `min==max` always filtering normally,
+                                // we add it here.
+                                let fallback_expr = expr_arena.add(AExpr::Function {
+                                    input: vec![
+                                        ExprIR::new(col_min, OutputName::Alias(PlSmallStr::EMPTY)),
+                                        ExprIR::new(lv_node, OutputName::Alias(PlSmallStr::EMPTY)),
+                                    ],
+                                    function: FunctionExpr::Boolean(BooleanFunction::IsIn {
+                                        nulls_equal,
+                                    }),
+                                    options: BooleanFunction::IsIn { nulls_equal }
+                                        .function_options(),
+                                });
+                                let fallback_expr = expr_arena.add(AExpr::Function {
+                                    input: vec![ExprIR::new(
+                                        fallback_expr,
+                                        OutputName::Alias(PlSmallStr::EMPTY),
+                                    )],
+                                    function: FunctionExpr::Boolean(BooleanFunction::Not),
+                                    options: BooleanFunction::Not.function_options(),
+                                });
+                                let fallback_expr = and!(min_is_max, has_no_nulls, fallback_expr);
+
+                                Some(or!(fallback_expr, min_max_is_in))
                             },
                             _ => None,
                         }

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -12,7 +12,7 @@ use super::super::evaluate::{constant_evaluate, into_column};
 use super::super::{AExpr, BooleanFunction, Operator, OutputName};
 use crate::dsl::FunctionExpr;
 use crate::plans::predicates::get_binary_expr_col_and_lv;
-use crate::plans::{ExprIR, LiteralValue, aexpr_to_leaf_names_iter, rename_columns};
+use crate::plans::{aexpr_to_leaf_names_iter, rename_columns, ExprIR, LiteralValue};
 use crate::prelude::FunctionOptions;
 
 /// Return a new boolean expression determines whether a batch can be skipped based on min, max and
@@ -46,7 +46,9 @@ fn aexpr_to_skip_batch_predicate_rec(
     use Operator as O;
 
     macro_rules! rec {
-        ($node:expr) => {{ aexpr_to_skip_batch_predicate_rec($node, expr_arena, schema, depth + 1) }};
+        ($node:expr) => {{
+            aexpr_to_skip_batch_predicate_rec($node, expr_arena, schema, depth + 1)
+        }};
     }
     macro_rules! and {
         ($l:expr, $($r:expr),+ $(,)?) => {{
@@ -85,13 +87,19 @@ fn aexpr_to_skip_batch_predicate_rec(
         ($op:ident, $l:expr, $r:expr) => {{ binexpr!(op: O::$op, $l, $r) }};
     }
     macro_rules! lt {
-        ($l:expr, $r:expr) => {{ binexpr!(Lt, $l, $r) }};
+        ($l:expr, $r:expr) => {{
+            binexpr!(Lt, $l, $r)
+        }};
     }
     macro_rules! gt {
-        ($l:expr, $r:expr) => {{ binexpr!(Gt, $l, $r) }};
+        ($l:expr, $r:expr) => {{
+            binexpr!(Gt, $l, $r)
+        }};
     }
     macro_rules! eq {
-        ($l:expr, $r:expr) => {{ binexpr!(Eq, $l, $r) }};
+        ($l:expr, $r:expr) => {{
+            binexpr!(Eq, $l, $r)
+        }};
     }
     macro_rules! null_count {
         ($i:expr) => {{
@@ -162,15 +170,29 @@ fn aexpr_to_skip_batch_predicate_rec(
         }};
     }
     macro_rules! col {
-        (len) => {{ col!(PlSmallStr::from_static("len")) }};
-        ($name:expr) => {{ expr_arena.add(AExpr::Column($name)) }};
-        (min: $name:expr) => {{ col!(format_pl_smallstr!("{}_min", $name)) }};
-        (max: $name:expr) => {{ col!(format_pl_smallstr!("{}_max", $name)) }};
-        (null_count: $name:expr) => {{ col!(format_pl_smallstr!("{}_nc", $name)) }};
+        (len) => {{
+            col!(PlSmallStr::from_static("len"))
+        }};
+        ($name:expr) => {{
+            expr_arena.add(AExpr::Column($name))
+        }};
+        (min: $name:expr) => {{
+            col!(format_pl_smallstr!("{}_min", $name))
+        }};
+        (max: $name:expr) => {{
+            col!(format_pl_smallstr!("{}_max", $name))
+        }};
+        (null_count: $name:expr) => {{
+            col!(format_pl_smallstr!("{}_nc", $name))
+        }};
     }
     macro_rules! lv {
-        ($lv:expr) => {{ expr_arena.add(AExpr::Literal(Scalar::from($lv).into())) }};
-        (idx: $lv:expr) => {{ expr_arena.add(AExpr::Literal(LiteralValue::new_idxsize($lv))) }};
+        ($lv:expr) => {{
+            expr_arena.add(AExpr::Literal(Scalar::from($lv).into()))
+        }};
+        (idx: $lv:expr) => {{
+            expr_arena.add(AExpr::Literal(LiteralValue::new_idxsize($lv)))
+        }};
     }
 
     let specialized = (|| {
@@ -451,13 +473,13 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 });
                                 let exact_not_in = expr_arena.add(AExpr::Function {
                                     input: vec![ExprIR::new(
-                                        fallback_expr,
+                                        exact_not_in,
                                         OutputName::Alias(PlSmallStr::EMPTY),
                                     )],
                                     function: FunctionExpr::Boolean(BooleanFunction::Not),
                                     options: BooleanFunction::Not.function_options(),
                                 });
-                                let exact_not_in = and!(min_is_max, has_no_nulls, fallback_expr);
+                                let exact_not_in = and!(min_is_max, has_no_nulls, exact_not_in);
 
                                 Some(or!(exact_not_in, min_max_is_in))
                             },

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -134,7 +134,7 @@ def test_hive_partitioned_predicate_pushdown_skips_correct_number_of_files(
 
 
 @pytest.mark.write_disk
-def test_hive_streaming_pushdown_is_in(tmp_path: Path) -> None:
+def test_hive_streaming_pushdown_is_in_22212(tmp_path: Path) -> None:
     (
         pl.DataFrame({"x": range(5)}).write_parquet(
             tmp_path,

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -133,6 +133,25 @@ def test_hive_partitioned_predicate_pushdown_skips_correct_number_of_files(
     assert result.to_dict(as_series=False) == expected
 
 
+@pytest.mark.write_disk
+def test_hive_streaming_pushdown_is_in(tmp_path: Path) -> None:
+    (
+        pl.DataFrame({"x": range(5)}).write_parquet(
+            tmp_path,
+            partition_by="x",
+        )
+    )
+
+    lf = pl.scan_parquet(tmp_path, hive_partitioning=True).filter(
+        pl.col("x").is_in([1, 4])
+    )
+
+    assert_frame_equal(
+        lf.collect(engine="streaming", predicate_pushdown=False),
+        lf.collect(engine="streaming", predicate_pushdown=True),
+    )
+
+
 @pytest.mark.xdist_group("streaming")
 @pytest.mark.write_disk
 @pytest.mark.parametrize("streaming", [True, False])


### PR DESCRIPTION
Fixes #22212.