### PR TITLE
fix: Incorrect length BinaryArray/ListBuilder

### DIFF
--- a/crates/polars-arrow/src/array/binary/builder.rs
+++ b/crates/polars-arrow/src/array/binary/builder.rs
@@ -53,7 +53,7 @@ impl<O: Offset> StaticArrayBuilder for BinaryArrayBuilder<O> {
     }
 
     fn len(&self) -> usize {
-        self.offsets.len()
+        self.offsets.len_proxy()
     }
 
     fn extend_nulls(&mut self, length: usize) {

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -52,7 +52,7 @@ impl<O: Offset, B: ArrayBuilder> StaticArrayBuilder for ListArrayBuilder<O, B> {
     }
 
     fn len(&self) -> usize {
-        self.offsets.len()
+        self.offsets.len_proxy()
     }
 
     fn extend_nulls(&mut self, length: usize) {

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -680,7 +680,7 @@ pub mod iterator;
 mod binview;
 mod values;
 
-pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
+pub use binary::{BinaryArray, BinaryArrayBuilder, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
 pub use binview::{
     BinaryViewArray, BinaryViewArrayGeneric, BinaryViewArrayGenericBuilder, MutableBinaryViewArray,
     MutablePlBinary, MutablePlString, Utf8ViewArray, View, ViewType,

--- a/crates/polars-arrow/src/offset.rs
+++ b/crates/polars-arrow/src/offset.rs
@@ -211,12 +211,6 @@ impl<O: Offset> Offsets<O> {
         self.0.len() - 1
     }
 
-    #[inline]
-    /// Returns the number of offsets in this container.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
     /// Returns the byte slice stored in this buffer
     #[inline]
     pub fn as_slice(&self) -> &[O] {
@@ -241,7 +235,7 @@ impl<O: Offset> Offsets<O> {
         if additional == 1 {
             self.0.push(offset)
         } else {
-            self.0.resize(self.len() + additional, offset)
+            self.0.resize(self.0.len() + additional, offset)
         }
     }
 


### PR DESCRIPTION
A confusion between `.len()` and `.len_proxy()`.