### PR TITLE
fix(python): Fix LazyFrame.__contains__ not issuing PerformanceWarning

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -690,6 +690,13 @@ class LazyFrame:
         self._comparison_error("<=")
 
     def __contains__(self, key: str) -> bool:
+        issue_warning(
+            "Determining if a column name is present in a LazyFrame requires"
+            " resolving its schema, which is potentially an expensive"
+            " operation. Use `key in LazyFrame.collect_schema()` to check if"
+            " a column name is in a LazyFrame without this warning.",
+            category=PerformanceWarning,
+        )
         return key in self.collect_schema()
 
     def __copy__(self) -> LazyFrame:

--- a/py-polars/tests/unit/lazyframe/test_lazyframe.py
+++ b/py-polars/tests/unit/lazyframe/test_lazyframe.py
@@ -65,8 +65,8 @@ def test_implode() -> None:
 
 def test_lazyframe_membership_operator() -> None:
     ldf = pl.LazyFrame({"name": ["Jane", "John"], "age": [20, 30]})
-    assert "name" in ldf
-    assert "phone" not in ldf
+    assert "name" in ldf.collect_schema()
+    assert "phone" not in ldf.collect_schema()
 
     # note: cannot use lazyframe in boolean context
     with pytest.raises(TypeError, match="ambiguous"):

--- a/py-polars/tests/unit/lazyframe/test_optimizations.py
+++ b/py-polars/tests/unit/lazyframe/test_optimizations.py
@@ -17,7 +17,7 @@ def test_is_null_followed_by_all() -> None:
     assert (
         r'[[(col("val").count()) == (col("val").null_count())]]' in result_lf.explain()
     )
-    assert "is_null" not in result_lf
+    assert "is_null" not in result_lf.collect_schema()
     assert_frame_equal(expected_df, result_lf.collect())
 
     # verify we don't optimize on chained expressions when last one is not col


### PR DESCRIPTION
Closes #21917 

**Changes**
- Make `LazyFrame.__contains__` emit `PerformanceWarning` and redirection of user to use `collect_schema()` to mirror other methods that causes the schema to be collected. 
- Update tests to call `collect_schema()` directly to prevent emitting the `PerformanceWarning`. 