### PR TITLE
fix(rust): Fix `str.to_integer` panics for certain inputs

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -96,7 +96,8 @@ pub trait StringNameSpaceImpl: AsString {
                 ca.clone()
             } else {
                 let all_failures = ca.filter(&failure_mask)?;
-                all_failures.slice(0, 10)
+                let unique_failures_args = all_failures.arg_unique()?;
+                all_failures.take(&unique_failures_args.slice(0, 10))?
             };
             let some_error_msg = match base.len() {
                 1 => {

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -96,6 +96,7 @@ pub trait StringNameSpaceImpl: AsString {
                 ca.clone()
             } else {
                 let all_failures = ca.filter(&failure_mask)?;
+                // `.unique()` does not necessarily preserve the original order.
                 let unique_failures_args = all_failures.arg_unique()?;
                 all_failures.take(&unique_failures_args.slice(0, 10))?
             };

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -96,7 +96,7 @@ pub trait StringNameSpaceImpl: AsString {
                 ca.clone()
             } else {
                 let all_failures = ca.filter(&failure_mask)?;
-                all_failures.unique()?.slice(0, 10).sort(false)
+                all_failures.slice(0, 10)
             };
             let some_error_msg = match base.len() {
                 1 => {


### PR DESCRIPTION
## Description
This PR addresses an issue https://github.com/pola-rs/polars/issues/22242 where calling str.to_integer() with strict=True unexpectedly panics for certain inputs.

The problem occurs because the values s and base at line 118 do not always correspond correctly, which leads to the bug. This PR modifies how some_failures is retrieved in original order so that s and base are properly paired, preventing the panic. 
https://github.com/pola-rs/polars/blob/69ad1ba3bd2382c59bd5b2420957d934e6447aa7/crates/polars-ops/src/chunked_array/strings/namespace.rs#L95-L124

close #22242 