### PR TITLE
fix: Handle floating point precision issue at histogram breakpoints

### DIFF
--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -113,7 +113,13 @@ where
                 let idx = scale * (item - min_break);
                 let idx_floor = idx.floor();
                 let idx = if idx == idx_floor {
-                    idx - 1.0
+                    /* If value appears to be on a boundary, check if it's actually above the boundary */
+                    let boundary_idx = idx_floor as usize;
+                    if boundary_idx < breaks.len() && item > breaks[boundary_idx] {
+                        idx_floor 
+                    } else {
+                        idx - 1.0
+                    }
                 } else {
                     idx_floor
                 };


### PR DESCRIPTION
Addresses precision issue highlighted in #22234 by checking the value is greater than the breakpoint boundary