### PR TITLE
fix: Ensure floating-point accuracy in `hist`

### DIFF
--- a/py-polars/tests/unit/operations/test_hist.py
+++ b/py-polars/tests/unit/operations/test_hist.py
@@ -536,3 +536,14 @@ def test_hist_include_lower_22056() -> None:
             }
         )
     assert_frame_equal(result, expected)
+
+
+def test_hist_ulp_edge_22234() -> None:
+    # Uniform path
+    s = pl.Series([1.0, 1e-16, 1.3e-16, -1.0])
+    result = s.hist(bin_count=2)
+    assert result["count"].to_list() == [1, 3]
+
+    # Manual path
+    result = s.hist(bins=[-1, 0, 1])
+    assert result["count"].to_list() == [1, 3]


### PR DESCRIPTION
Closes #22234

Two minor adjustments:

1. When user-supplied bins are provided, the slow path is always taken. This guarantees that the user's bins are *always* respected. The prior implementation attempted to detect if the bins were uniformly distributed using a heuristic, but that heuristic can be foiled, and we were bound to encounter an issue on this sometime in the future.

2. In the fast path (now only when `bin_count` is supplied), the index calculation might generate results > 1 ULP of the bin edges in some cases, resulting in an invalid index, as see in the linked issue. There, we have `1.0 - 1e-17 == 1.0`:

    ```pycon
    >>> import polars as pl
    >>> pl.Series([1.0]) - 1e-17 == 1.0
    shape: (1,)
    Series: '' [bool]
    [
            true
    ]
    ```

    There is now a check to see whether the value should be moved to an adjacent bucket. This check encompasses a prior check, so performance should not be affected.