### PR TITLE
feat: Add `RoundMode` for Decimal and Float

### DIFF
--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1511,7 +1511,7 @@ fn test_round_after_agg() -> PolarsResult<()> {
         .agg([col("A")
             .cast(DataType::Float32)
             .mean()
-            .round(2)
+            .round(2, polars_ops::series::RoundMode::default())
             .alias("foo")])
         .collect()?;
 
@@ -1545,7 +1545,7 @@ fn test_round_after_agg() -> PolarsResult<()> {
         .lazy()
         .group_by_stable([col("groups")])
         .agg([((col("b") * col("c")).sum() / col("b").sum())
-            .round(2)
+            .round(2, polars_ops::series::RoundMode::default())
             .alias("foo")])
         .collect()?;
 

--- a/crates/polars-ops/src/series/ops/mod.rs
+++ b/crates/polars-ops/src/series/ops/mod.rs
@@ -55,7 +55,7 @@ mod rle;
 #[cfg(feature = "rolling_window")]
 mod rolling;
 #[cfg(feature = "round_series")]
-mod round;
+pub mod round;
 #[cfg(feature = "search_sorted")]
 mod search_sorted;
 #[cfg(feature = "to_dummies")]

--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -1,82 +1,169 @@
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
+use serde::{Deserialize, Serialize};
+use strum_macros::IntoStaticStr;
 
 use crate::series::ops::SeriesSealed;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoStaticStr)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[strum(serialize_all = "snake_case")]
+#[derive(Default)]
+pub enum RoundMode {
+    #[default]
+    HalfToEven,
+    HalfAwayFromZero,
+}
+
 pub trait RoundSeries: SeriesSealed {
     /// Round underlying floating point array to given decimal.
-    fn round(&self, decimals: u32) -> PolarsResult<Series> {
+    fn round(&self, decimals: u32, mode: RoundMode) -> PolarsResult<Series> {
         let s = self.as_series();
 
         if let Ok(ca) = s.f32() {
-            return if decimals == 0 {
-                let s = ca.apply_values(|val| val.round()).into_series();
-                Ok(s)
-            } else if decimals >= 326 {
-                // More precise than smallest denormal.
-                Ok(s.clone())
-            } else {
-                // Note we do the computation on f64 floats to not lose precision
-                // when the computation is done, we cast to f32
-                let multiplier = 10.0_f64.powi(decimals as i32);
-                let s = ca
-                    .apply_values(|val| {
-                        let ret = ((val as f64 * multiplier).round() / multiplier) as f32;
-                        if ret.is_finite() {
-                            ret
-                        } else {
-                            // We return the original value which is correct both for overflows and non-finite inputs.
-                            val
-                        }
-                    })
-                    .into_series();
-                Ok(s)
-            };
+            match mode {
+                RoundMode::HalfToEven => {
+                    return if decimals == 0 {
+                        let s = ca.apply_values(|val| val.round_ties_even()).into_series();
+                        Ok(s)
+                    } else if decimals >= 326 {
+                        // More precise than smallest denormal.
+                        Ok(s.clone())
+                    } else {
+                        // Note we do the computation on f64 floats to not lose precision
+                        // when the computation is done, we cast to f32
+                        let multiplier = 10.0_f64.powi(decimals as i32);
+                        let s = ca
+                            .apply_values(|val| {
+                                let ret = ((val as f64 * multiplier).round_ties_even() / multiplier)
+                                    as f32;
+                                if ret.is_finite() {
+                                    ret
+                                } else {
+                                    // We return the original value which is correct both for overflows and non-finite inputs.
+                                    val
+                                }
+                            })
+                            .into_series();
+                        Ok(s)
+                    };
+                },
+                RoundMode::HalfAwayFromZero => {
+                    return if decimals == 0 {
+                        let s = ca.apply_values(|val| val.round()).into_series();
+                        Ok(s)
+                    } else if decimals >= 326 {
+                        // More precise than smallest denormal.
+                        Ok(s.clone())
+                    } else {
+                        // Note we do the computation on f64 floats to not lose precision
+                        // when the computation is done, we cast to f32
+                        let multiplier = 10.0_f64.powi(decimals as i32);
+                        let s = ca
+                            .apply_values(|val| {
+                                let ret = ((val as f64 * multiplier).round_ties_even() / multiplier)
+                                    as f32;
+                                if ret.is_finite() {
+                                    ret
+                                } else {
+                                    // We return the original value which is correct both for overflows and non-finite inputs.
+                                    val
+                                }
+                            })
+                            .into_series();
+                        Ok(s)
+                    };
+                },
+            }
         }
         if let Ok(ca) = s.f64() {
-            return if decimals == 0 {
-                let s = ca.apply_values(|val| val.round()).into_series();
-                Ok(s)
-            } else if decimals >= 326 {
-                // More precise than smallest denormal.
-                Ok(s.clone())
-            } else if decimals >= 300 {
-                // We're getting into unrepresentable territory for the multiplier
-                // here, split up the 10^n multiplier into 2^n and 5^n.
-                let mul2 = libm::scalbn(1.0, decimals as i32);
-                let invmul2 = 1.0 / mul2; // Still exact for any valid value of decimals.
-                let mul5 = 5.0_f64.powi(decimals as i32);
-                let s = ca
-                    .apply_values(|val| {
-                        let ret = (val * mul2 * mul5).round() / mul5 * invmul2;
-                        if ret.is_finite() {
-                            ret
-                        } else {
-                            // We return the original value which is correct both for overflows and non-finite inputs.
-                            val
-                        }
-                    })
-                    .into_series();
-                Ok(s)
-            } else {
-                let multiplier = 10.0_f64.powi(decimals as i32);
-                let s = ca
-                    .apply_values(|val| {
-                        let ret = (val * multiplier).round() / multiplier;
-                        if ret.is_finite() {
-                            ret
-                        } else {
-                            // We return the original value which is correct both for overflows and non-finite inputs.
-                            val
-                        }
-                    })
-                    .into_series();
-                Ok(s)
-            };
+            match mode {
+                RoundMode::HalfToEven => {
+                    return if decimals == 0 {
+                        let s = ca.apply_values(|val| val.round_ties_even()).into_series();
+                        Ok(s)
+                    } else if decimals >= 326 {
+                        // More precise than smallest denormal.
+                        Ok(s.clone())
+                    } else if decimals >= 300 {
+                        // We're getting into unrepresentable territory for the multiplier
+                        // here, split up the 10^n multiplier into 2^n and 5^n.
+                        let mul2 = libm::scalbn(1.0, decimals as i32);
+                        let invmul2 = 1.0 / mul2; // Still exact for any valid value of decimals.
+                        let mul5 = 5.0_f64.powi(decimals as i32);
+                        let s = ca
+                            .apply_values(|val| {
+                                let ret = (val * mul2 * mul5).round_ties_even() / mul5 * invmul2;
+                                if ret.is_finite() {
+                                    ret
+                                } else {
+                                    // We return the original value which is correct both for overflows and non-finite inputs.
+                                    val
+                                }
+                            })
+                            .into_series();
+                        Ok(s)
+                    } else {
+                        let multiplier = 10.0_f64.powi(decimals as i32);
+                        let s = ca
+                            .apply_values(|val| {
+                                let ret = (val * multiplier).round_ties_even() / multiplier;
+                                if ret.is_finite() {
+                                    ret
+                                } else {
+                                    // We return the original value which is correct both for overflows and non-finite inputs.
+                                    val
+                                }
+                            })
+                            .into_series();
+                        Ok(s)
+                    };
+                },
+                RoundMode::HalfAwayFromZero => {
+                    return if decimals == 0 {
+                        let s = ca.apply_values(|val| val.round()).into_series();
+                        Ok(s)
+                    } else if decimals >= 326 {
+                        // More precise than smallest denormal.
+                        Ok(s.clone())
+                    } else if decimals >= 300 {
+                        // We're getting into unrepresentable territory for the multiplier
+                        // here, split up the 10^n multiplier into 2^n and 5^n.
+                        let mul2 = libm::scalbn(1.0, decimals as i32);
+                        let invmul2 = 1.0 / mul2; // Still exact for any valid value of decimals.
+                        let mul5 = 5.0_f64.powi(decimals as i32);
+                        let s = ca
+                            .apply_values(|val| {
+                                let ret = (val * mul2 * mul5).round() / mul5 * invmul2;
+                                if ret.is_finite() {
+                                    ret
+                                } else {
+                                    // We return the original value which is correct both for overflows and non-finite inputs.
+                                    val
+                                }
+                            })
+                            .into_series();
+                        Ok(s)
+                    } else {
+                        let multiplier = 10.0_f64.powi(decimals as i32);
+                        let s = ca
+                            .apply_values(|val| {
+                                let ret = (val * multiplier).round() / multiplier;
+                                if ret.is_finite() {
+                                    ret
+                                } else {
+                                    // We return the original value which is correct both for overflows and non-finite inputs.
+                                    val
+                                }
+                            })
+                            .into_series();
+                        Ok(s)
+                    };
+                },
+            }
         }
         #[cfg(feature = "dtype-decimal")]
         if let Some(ca) = s.try_decimal() {
-            let precision = ca.precision();
             let scale = ca.scale() as u32;
 
             if scale <= decimals {
@@ -87,27 +174,42 @@ pub trait RoundSeries: SeriesSealed {
             let multiplier = 10i128.pow(decimal_delta);
             let threshold = multiplier / 2;
 
-            let ca = ca
-                .apply_values(|v| {
-                    // We use rounding=ROUND_HALF_EVEN
-                    let rem = v % multiplier;
-                    let is_v_floor_even = ((v - rem) / multiplier) % 2 == 0;
+            let res = match mode {
+                RoundMode::HalfToEven => ca.apply_values(|v| {
+                    let rem_big = v % (2 * multiplier);
+                    let is_v_floor_even = rem_big.abs() < multiplier;
+                    let rem = if is_v_floor_even {
+                        rem_big
+                    } else if rem_big > 0 {
+                        rem_big - multiplier
+                    } else {
+                        rem_big + multiplier
+                    };
+
                     let threshold = threshold + i128::from(is_v_floor_even);
                     let round_offset = if rem.abs() >= threshold {
-                        multiplier
+                        if v < 0 { -multiplier } else { multiplier }
                     } else {
                         0
                     };
-                    let round_offset = if v < 0 { -round_offset } else { round_offset };
                     v - rem + round_offset
-                })
-                .into_decimal_unchecked(precision, scale as usize);
-
-            return Ok(ca.into_series());
+                }),
+                RoundMode::HalfAwayFromZero => ca.apply_values(|v| {
+                    let rem = v % multiplier;
+                    let round_offset = if rem.abs() >= threshold {
+                        if v < 0 { -multiplier } else { multiplier }
+                    } else {
+                        0
+                    };
+                    v - rem + round_offset
+                }),
+            };
+            return Ok(res
+                .into_decimal_unchecked(ca.precision(), scale as usize)
+                .into_series());
         }
 
-        polars_ensure!(s.dtype().is_primitive_numeric(), InvalidOperation: "round can only be used on numeric types" );
-        Ok(s.clone())
+        polars_bail!(InvalidOperation: "round can only be used on numeric types (f32, f64, or decimal)");
     }
 
     fn round_sig_figs(&self, digits: i32) -> PolarsResult<Series> {
@@ -266,7 +368,7 @@ mod test {
     #[test]
     fn test_round_series() {
         let series = Series::new("a".into(), &[1.003, 2.23222, 3.4352]);
-        let out = series.round(2).unwrap();
+        let out = series.round(2, RoundMode::default()).unwrap();
         let ca = out.f64().unwrap();
         assert_eq!(ca.get(0), Some(1.0));
     }

--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -1,5 +1,6 @@
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
 

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -269,6 +269,7 @@ pub enum FunctionExpr {
     #[cfg(feature = "round_series")]
     Round {
         decimals: u32,
+        mode: RoundMode,
     },
     #[cfg(feature = "round_series")]
     RoundSF {
@@ -523,7 +524,10 @@ impl Hash for FunctionExpr {
             Exp => {},
             Unique(a) => a.hash(state),
             #[cfg(feature = "round_series")]
-            Round { decimals } => decimals.hash(state),
+            Round { decimals, mode } => {
+                decimals.hash(state);
+                mode.hash(state);
+            },
             #[cfg(feature = "round_series")]
             FunctionExpr::RoundSF { digits } => digits.hash(state),
             #[cfg(feature = "round_series")]
@@ -1097,7 +1101,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn ColumnsUdf>> {
             Exp => map!(log::exp),
             Unique(stable) => map!(unique::unique, stable),
             #[cfg(feature = "round_series")]
-            Round { decimals } => map!(round::round, decimals),
+            Round { decimals, mode } => map!(round::round, decimals, mode),
             #[cfg(feature = "round_series")]
             RoundSF { digits } => map!(round::round_sig_figs, digits),
             #[cfg(feature = "round_series")]

--- a/crates/polars-plan/src/dsl/function_expr/round.rs
+++ b/crates/polars-plan/src/dsl/function_expr/round.rs
@@ -1,7 +1,9 @@
+use polars_ops::series::round::RoundMode;
+
 use super::*;
 
-pub(super) fn round(c: &Column, decimals: u32) -> PolarsResult<Column> {
-    c.try_apply_unary_elementwise(|s| s.round(decimals))
+pub(super) fn round(c: &Column, decimals: u32, mode: RoundMode) -> PolarsResult<Column> {
+    c.try_apply_unary_elementwise(|s| s.round(decimals, mode))
 }
 
 pub(super) fn round_sig_figs(c: &Column, digits: i32) -> PolarsResult<Column> {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -772,8 +772,8 @@ impl Expr {
 
     /// Round underlying floating point array to given decimal numbers.
     #[cfg(feature = "round_series")]
-    pub fn round(self, decimals: u32) -> Self {
-        self.map_unary(FunctionExpr::Round { decimals })
+    pub fn round(self, decimals: u32, mode: RoundMode) -> Self {
+        self.map_unary(FunctionExpr::Round { decimals, mode })
     }
 
     /// Round to a number of significant figures.

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -835,6 +835,21 @@ impl<'py> FromPyObject<'py> for Wrap<ClosedWindow> {
     }
 }
 
+impl<'py> FromPyObject<'py> for Wrap<RoundMode> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let parsed = match &*ob.extract::<PyBackedStr>()? {
+            "half_to_even" => RoundMode::HalfToEven,
+            "half_away_from_zero" => RoundMode::HalfAwayFromZero,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "`mode` must be one of {{'half_to_even', 'half_away_from_zero'}}, got {v}",
+                )));
+            },
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
 #[cfg(feature = "csv")]
 impl<'py> FromPyObject<'py> for Wrap<CsvEncoding> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -461,8 +461,8 @@ impl PyExpr {
             .into()
     }
 
-    fn round(&self, decimals: u32) -> Self {
-        self.inner.clone().round(decimals).into()
+    fn round(&self, decimals: u32, mode: Wrap<RoundMode>) -> Self {
+        self.inner.clone().round(decimals, mode.0).into()
     }
 
     fn round_sig_figs(&self, digits: i32) -> Self {

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -1183,7 +1183,9 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                 FunctionExpr::Log1p => ("log1p",).into_py_any(py),
                 FunctionExpr::Exp => ("exp",).into_py_any(py),
                 FunctionExpr::Unique(maintain_order) => ("unique", maintain_order).into_py_any(py),
-                FunctionExpr::Round { decimals } => ("round", decimals).into_py_any(py),
+                FunctionExpr::Round { decimals, mode } => {
+                    ("round", decimals, Into::<&str>::into(mode)).into_py_any(py)
+                },
                 FunctionExpr::RoundSF { digits } => ("round_sig_figs", digits).into_py_any(py),
                 FunctionExpr::Floor => ("floor",).into_py_any(py),
                 FunctionExpr::Ceil => ("ceil",).into_py_any(py),

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -8,6 +8,7 @@ use polars_lazy::dsl::Expr;
 #[cfg(feature = "list_eval")]
 use polars_lazy::dsl::ListNameSpaceExtension;
 use polars_ops::chunked_array::UnicodeForm;
+use polars_ops::series::RoundMode;
 use polars_plan::dsl::{coalesce, concat_str, len, max_horizontal, min_horizontal, when};
 use polars_plan::plans::{DynLiteralValue, LiteralValue, typed_lit};
 use polars_plan::prelude::{StrptimeOptions, col, cols, lit};
@@ -989,7 +990,7 @@ impl SQLFunctionVisitor<'_> {
             Round => {
                 let args = extract_args(function)?;
                 match args.len() {
-                    1 => self.visit_unary(|e| e.round(0)),
+                    1 => self.visit_unary(|e| e.round(0, RoundMode::default())),
                     2 => self.try_visit_binary(|e, decimals| {
                         Ok(e.round(match decimals {
                             Expr::Literal(LiteralValue::Dyn(DynLiteralValue::Int(n))) => {
@@ -998,7 +999,7 @@ impl SQLFunctionVisitor<'_> {
                                 }
                             },
                             _ => polars_bail!(SQLSyntax: "invalid value for ROUND decimals ({})", args[1]),
-                        }))
+                        }, RoundMode::default()))
                     }),
                     _ => polars_bail!(SQLSyntax: "ROUND expects 1-2 arguments (found {})", args.len()),
                 }

--- a/docs/source/src/rust/user-guide/expressions/expression-expansion.rs
+++ b/docs/source/src/rust/user-guide/expressions/expression-expansion.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .lazy()
         .with_column(
             (cols(["price", "day_high", "day_low", "year_high", "year_low"]) / lit(eur_usd_rate))
-                .round(2),
+                .round(2, RoundMode::default()),
         )
         .collect()?;
     println!("{}", result);
@@ -32,11 +32,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --8<-- [start:expression-list]
     let exprs = [
-        (col("price") / lit(eur_usd_rate)).round(2),
-        (col("day_high") / lit(eur_usd_rate)).round(2),
-        (col("day_low") / lit(eur_usd_rate)).round(2),
-        (col("year_high") / lit(eur_usd_rate)).round(2),
-        (col("year_low") / lit(eur_usd_rate)).round(2),
+        (col("price") / lit(eur_usd_rate)).round(2, RoundMode::default()),
+        (col("day_high") / lit(eur_usd_rate)).round(2, RoundMode::default()),
+        (col("day_low") / lit(eur_usd_rate)).round(2, RoundMode::default()),
+        (col("year_high") / lit(eur_usd_rate)).round(2, RoundMode::default()),
+        (col("year_low") / lit(eur_usd_rate)).round(2, RoundMode::default()),
     ];
 
     let result2 = df.clone().lazy().with_columns(exprs).collect()?;
@@ -47,7 +47,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = df
         .clone()
         .lazy()
-        .with_column((dtype_col(&DataType::Float64) / lit(eur_usd_rate)).round(2))
+        .with_column(
+            (dtype_col(&DataType::Float64) / lit(eur_usd_rate)).round(2, RoundMode::default()),
+        )
         .collect()?;
     println!("{}", result);
     // --8<-- [end:col-with-dtype]
@@ -57,7 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clone()
         .lazy()
         .with_column(
-            (dtype_cols([DataType::Float32, DataType::Float64]) / lit(eur_usd_rate)).round(2),
+            (dtype_cols([DataType::Float32, DataType::Float64]) / lit(eur_usd_rate))
+                .round(2, RoundMode::default()),
         )
         .collect()?;
     println!("{}", result.equals(&result2));

--- a/docs/source/src/rust/user-guide/getting-started.rs
+++ b/docs/source/src/rust/user-guide/getting-started.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .select([
             col("name"),
             (cols(["weight", "height"]) * lit(0.95))
-                .round(2)
+                .round(2, RoundMode::default())
                 .name()
                 .suffix("-5%"),
         ])
@@ -118,7 +118,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .group_by([(col("birthdate").dt().year() / lit(10) * lit(10)).alias("decade")])
         .agg([
             len().alias("sample_size"),
-            col("weight").mean().round(2).alias("avg_weight"),
+            col("weight")
+                .mean()
+                .round(2, RoundMode::default())
+                .alias("avg_weight"),
             col("height").max().alias("tallest"),
         ])
         .collect()?;
@@ -139,7 +142,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             col("name"),
             cols(["weight", "height"])
                 .mean()
-                .round(2)
+                .round(2, RoundMode::default())
                 .name()
                 .prefix("avg_"),
         ])

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -129,6 +129,7 @@ PivotAgg: TypeAlias = Literal[
 ]
 RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
 Roll: TypeAlias = Literal["raise", "forward", "backward"]
+RoundMode: TypeAlias = Literal["half_to_even", "half_away_from_zero"]
 SerializationFormat: TypeAlias = Literal["binary", "json"]
 Endianness: TypeAlias = Literal["little", "big"]
 SizeUnit: TypeAlias = Literal[

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
         PolarsDataType,
         RankMethod,
         RollingInterpolationMethod,
+        RoundMode,
         SchemaDict,
         SearchSortedSide,
         SerializationFormat,
@@ -1637,7 +1638,7 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.ceil())
 
-    def round(self, decimals: int = 0) -> Expr:
+    def round(self, decimals: int = 0, mode: RoundMode = "half_to_even") -> Expr:
         """
         Round underlying floating point data by `decimals` digits.
 
@@ -1662,7 +1663,7 @@ class Expr:
         │ 1.2 │
         └─────┘
         """
-        return self._from_pyexpr(self._pyexpr.round(decimals))
+        return self._from_pyexpr(self._pyexpr.round(decimals, mode))
 
     def round_sig_figs(self, digits: int) -> Expr:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -136,6 +136,7 @@ if TYPE_CHECKING:
         PythonLiteral,
         RankMethod,
         RollingInterpolationMethod,
+        RoundMode,
         SearchSortedSide,
         SeriesBuffers,
         SingleIndexSelector,
@@ -5061,7 +5062,7 @@ class Series:
         ]
         """
 
-    def round(self, decimals: int = 0) -> Series:
+    def round(self, decimals: int = 0, mode: RoundMode = "half_to_even") -> Series:
         """
         Round underlying floating point data by `decimals` digits.
 


### PR DESCRIPTION
fix #21800 (though as @orlp mentioned there are theoretically more round modes to add)

# Current Problem ⚠️ 
- current `round` expression has no `mode` and is inconsistent 
  - `Decimal`: uses "half to even"
  - `Float`: uses "half away from zero"

# PR Solution 🍀 
- implement missing round modes
  - `Decimal`: implement "half away from zero"
  - `Float`: implement "half to even"
- set "half to even" as default for float & decimal

## Example
```python
df = pl.DataFrame(
    {
        "f64": [-3.5, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5],
        "d": ["-3.5", "-2.5", "-1.5", "-0.5", "0.5", "1.5", "2.5", "3.5"],
    },
    schema={
        "f64": pl.Float64,
        "d": pl.Decimal(scale=1),
    },
)

df.with_columns(
    pl.all().round().name.suffix("_default"),
    pl.all().round(mode="half_away_from_zero").name.suffix("_away_from_zero"),
    pl.all().round(mode="half_to_even").name.suffix("_to_even"),
)

shape: (8, 8)
┌──────┬──────────────┬─────────────┬──────────────┬────────────────────┬──────────────────┬─────────────┬──────────────┐
│ f64  ┆ d            ┆ f64_default ┆ d_default    ┆ f64_away_from_zero ┆ d_away_from_zero ┆ f64_to_even ┆ d_to_even    │
│ ---  ┆ ---          ┆ ---         ┆ ---          ┆ ---                ┆ ---              ┆ ---         ┆ ---          │
│ f64  ┆ decimal[*,1] ┆ f64         ┆ decimal[*,1] ┆ f64                ┆ decimal[*,1]     ┆ f64         ┆ decimal[*,1] │
╞══════╪══════════════╪═════════════╪══════════════╪════════════════════╪══════════════════╪═════════════╪══════════════╡
│ -3.5 ┆ -3.5         ┆ -4.0        ┆ -4.0         ┆ -4.0               ┆ -4.0             ┆ -4.0        ┆ -4.0         │
│ -2.5 ┆ -2.5         ┆ -2.0        ┆ -2.0         ┆ -3.0               ┆ -3.0             ┆ -2.0        ┆ -2.0         │
│ -1.5 ┆ -1.5         ┆ -2.0        ┆ -2.0         ┆ -2.0               ┆ -2.0             ┆ -2.0        ┆ -2.0         │
│ -0.5 ┆ -0.5         ┆ -0.0        ┆ 0.0          ┆ -1.0               ┆ -1.0             ┆ -0.0        ┆ 0.0          │
│ 0.5  ┆ 0.5          ┆ 0.0         ┆ 0.0          ┆ 1.0                ┆ 1.0              ┆ 0.0         ┆ 0.0          │
│ 1.5  ┆ 1.5          ┆ 2.0         ┆ 2.0          ┆ 2.0                ┆ 2.0              ┆ 2.0         ┆ 2.0          │
│ 2.5  ┆ 2.5          ┆ 2.0         ┆ 2.0          ┆ 3.0                ┆ 3.0              ┆ 2.0         ┆ 2.0          │
│ 3.5  ┆ 3.5          ┆ 4.0         ┆ 4.0          ┆ 4.0                ┆ 4.0              ┆ 4.0         ┆ 4.0          │
└──────┴──────────────┴─────────────┴──────────────┴────────────────────┴──────────────────┴─────────────┴──────────────┘
```

# Open
- there are other round modes that can be implemented later 


---

@orlp @wence- 
sorry for creating another PR (old: #21883). I was overwhelmed and stuck in merge/rebase hell.
I implemented your requests. Please have a look 🤓 