### PR TITLE
fix: Don't rechunk elementwise

### DIFF
--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -457,7 +457,7 @@ impl PyExpr {
     fn rechunk(&self) -> Self {
         self.inner
             .clone()
-            .map(|s| Ok(Some(s.rechunk())), GetOutput::same_type())
+            .apply(|s| Ok(Some(s.rechunk())), GetOutput::same_type())
             .into()
     }
 

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -299,6 +299,13 @@ def test_expression_appends() -> None:
     assert out.to_series().to_list() == [None, None, None, 1, 1, 2]
 
 
+@pytest.mark.may_fail_auto_streaming
+def test_with_columns_rechunk() -> None:
+    df = pl.DataFrame({"a": pl.Series([1, 2]).extend_constant(None, 1)})
+    assert df["a"].n_chunks() == 2
+    assert df.with_columns(pl.col("a").rechunk())["a"].n_chunks() == 1
+
+
 def test_arr_contains() -> None:
     df_groups = pl.DataFrame(
         {


### PR DESCRIPTION
Fixes #22262.

This feels a little hacky since `apply` is meant to be used in a `GroupBy`, but it works without any (known) side-effects. `rechunk` is a bit unique in it that it sort of _is_ an aggregation function that explodes the result back to the original size.