### PR TITLE
fix: Raise `ColumnNotFoundError` for missing columns in `join_where`

### DIFF
--- a/crates/polars-plan/src/plans/conversion/join.rs
+++ b/crates/polars-plan/src/plans/conversion/join.rs
@@ -515,7 +515,7 @@ fn build_upcast_node_list(
             } else if schema_merged.contains(name) {
                 ExprOrigin::Right
             } else {
-                ExprOrigin::None
+                polars_bail!(ColumnNotFound: "{}", name);
             }
         },
         AExpr::Literal(..) => ExprOrigin::None,


### PR DESCRIPTION
Fixes #22257.

This was a regression I inadvertently introduced in #22112.