### PR TITLE
feat: Add rolling min/max for temporals

### DIFF
--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -312,7 +312,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
             dt => {
                 polars_ensure!(
-                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    dt.is_primitive_numeric() && !dt.is_unknown(),
                     op = "rolling_min_by",
                     dt
                 );
@@ -352,7 +352,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
             dt => {
                 polars_ensure!(
-                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    dt.is_primitive_numeric() && !dt.is_unknown(),
                     op = "rolling_min",
                     dt
                 );
@@ -393,7 +393,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
             dt => {
                 polars_ensure!(
-                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    dt.is_primitive_numeric() && !dt.is_unknown(),
                     op = "rolling_max_by",
                     dt
                 );
@@ -433,7 +433,7 @@ pub trait SeriesOpsTime: AsSeries {
             },
             dt => {
                 polars_ensure!(
-                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    dt.is_primitive_numeric() && !dt.is_unknown(),
                     op = "rolling_max",
                     dt
                 );

--- a/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/dispatch.rs
@@ -298,19 +298,26 @@ pub trait SeriesOpsTime: AsSeries {
     ) -> PolarsResult<Series> {
         let s = self.as_series().clone();
 
-        // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
-        if s.dtype() == &DataType::Boolean {
-            return s
-                .cast(&DataType::UInt8)?
-                .rolling_min_by(by, options)?
-                .cast(&DataType::Boolean);
+        let dt = s.dtype();
+        match dt {
+            // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
+            &DataType::Boolean => {
+                return s
+                    .cast(&DataType::UInt8)?
+                    .rolling_min_by(by, options)?
+                    .cast(&DataType::Boolean);
+            },
+            dt if dt.is_temporal() => {
+                return s.to_physical_repr().rolling_min_by(by, options)?.cast(dt);
+            },
+            dt => {
+                polars_ensure!(
+                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    op = "rolling_min_by",
+                    dt
+                );
+            },
         }
-
-        polars_ensure!(
-            s.dtype().is_primitive_numeric() && !s.dtype().is_unknown(),
-            op = "rolling_min_by",
-            s.dtype()
-        );
 
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
@@ -331,21 +338,28 @@ pub trait SeriesOpsTime: AsSeries {
             s = s.to_float()?;
         }
 
-        // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
-        if s.dtype() == &DataType::Boolean {
-            return s
-                .cast(&DataType::UInt8)?
-                .rolling_min(options)?
-                .cast(&DataType::Boolean);
+        let dt = s.dtype();
+        match dt {
+            // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
+            &DataType::Boolean => {
+                return s
+                    .cast(&DataType::UInt8)?
+                    .rolling_min(options)?
+                    .cast(&DataType::Boolean);
+            },
+            dt if dt.is_temporal() => {
+                return s.to_physical_repr().rolling_min(options)?.cast(dt);
+            },
+            dt => {
+                polars_ensure!(
+                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    op = "rolling_min",
+                    dt
+                );
+            },
         }
 
-        polars_ensure!(
-            s.dtype().is_primitive_numeric() && !s.dtype().is_unknown(),
-            op = "rolling_min",
-            s.dtype()
-        );
-
-        with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+        with_match_physical_numeric_polars_type!(dt, |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
             rolling_agg(
                 ca,
@@ -365,19 +379,26 @@ pub trait SeriesOpsTime: AsSeries {
     ) -> PolarsResult<Series> {
         let s = self.as_series().clone();
 
-        // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
-        if s.dtype() == &DataType::Boolean {
-            return s
-                .cast(&DataType::UInt8)?
-                .rolling_max_by(by, options)?
-                .cast(&DataType::Boolean);
+        let dt = s.dtype();
+        match dt {
+            // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
+            &DataType::Boolean => {
+                return s
+                    .cast(&DataType::UInt8)?
+                    .rolling_max_by(by, options)?
+                    .cast(&DataType::Boolean);
+            },
+            dt if dt.is_temporal() => {
+                return s.to_physical_repr().rolling_max_by(by, options)?.cast(dt);
+            },
+            dt => {
+                polars_ensure!(
+                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    op = "rolling_max_by",
+                    dt
+                );
+            },
         }
-
-        polars_ensure!(
-            s.dtype().is_primitive_numeric() && !s.dtype().is_unknown(),
-            op = "rolling_max_by",
-            s.dtype()
-        );
 
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
@@ -398,19 +419,26 @@ pub trait SeriesOpsTime: AsSeries {
             s = s.to_float()?;
         }
 
-        // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
-        if s.dtype() == &DataType::Boolean {
-            return s
-                .cast(&DataType::UInt8)?
-                .rolling_max(options)?
-                .cast(&DataType::Boolean);
+        let dt = s.dtype();
+        match dt {
+            // Our rolling kernels don't yet support boolean, use UInt8 as a workaround for now.
+            &DataType::Boolean => {
+                return s
+                    .cast(&DataType::UInt8)?
+                    .rolling_max(options)?
+                    .cast(&DataType::Boolean);
+            },
+            dt if dt.is_temporal() => {
+                return s.to_physical_repr().rolling_max(options)?.cast(dt);
+            },
+            dt => {
+                polars_ensure!(
+                    dt.is_primitive_numeric() || !dt.is_unknown(),
+                    op = "rolling_max",
+                    dt
+                );
+            },
         }
-
-        polars_ensure!(
-            s.dtype().is_primitive_numeric() && !s.dtype().is_unknown(),
-            op = "rolling_max",
-            s.dtype()
-        );
 
         with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
             let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -21,7 +21,11 @@ from tests.unit.conftest import INTEGER_DTYPES
 if TYPE_CHECKING:
     from hypothesis.strategies import SearchStrategy
 
-    from polars._typing import ClosedInterval, PolarsDataType, TimeUnit
+    from polars._typing import (
+        ClosedInterval,
+        PolarsDataType,
+        TimeUnit,
+    )
 
 
 @pytest.fixture
@@ -259,63 +263,140 @@ def test_rolling_by_non_temporal_window_size() -> None:
         df.with_columns(pl.col("a").rolling_sum_by("b", "2i", closed="left"))
 
 
-def test_rolling_extrema() -> None:
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.UInt8,
+        pl.Int64,
+        pl.Float32,
+        pl.Float64,
+        pl.Time,
+        pl.Date,
+        pl.Datetime("ms"),
+        pl.Datetime("us"),
+        pl.Datetime("ns"),
+        pl.Datetime("ns", "Asia/Kathmandu"),
+        pl.Duration("ms"),
+        pl.Duration("us"),
+        pl.Duration("ns"),
+    ],
+)
+def test_rolling_extrema(dtype: PolarsDataType) -> None:
     # sorted data and nulls flags trigger different kernels
     df = (
-        pl.DataFrame(
-            {
-                "col1": pl.int_range(0, 7, eager=True),
-                "col2": pl.int_range(0, 7, eager=True).reverse(),
-            }
+        (
+            pl.DataFrame(
+                {
+                    "col1": pl.int_range(0, 7, eager=True),
+                    "col2": pl.int_range(0, 7, eager=True).reverse(),
+                }
+            )
         )
-    ).with_columns(
-        pl.when(pl.int_range(0, pl.len(), eager=False) < 2)
-        .then(None)
-        .otherwise(pl.all())
-        .name.suffix("_nulls")
+        .with_columns(
+            pl.when(pl.int_range(0, pl.len(), eager=False) < 2)
+            .then(None)
+            .otherwise(pl.all())
+            .name.suffix("_nulls")
+        )
+        .cast(dtype)
     )
 
-    assert df.select([pl.all().rolling_min(3)]).to_dict(as_series=False) == {
+    expected = {
         "col1": [None, None, 0, 1, 2, 3, 4],
         "col2": [None, None, 4, 3, 2, 1, 0],
         "col1_nulls": [None, None, None, None, 2, 3, 4],
         "col2_nulls": [None, None, None, None, 2, 1, 0],
     }
+    result = df.select([pl.all().rolling_min(3)])
+    assert result.to_dict(as_series=False) == {
+        k: pl.Series(v, dtype=dtype).to_list() for k, v in expected.items()
+    }
 
-    assert df.select([pl.all().rolling_max(3)]).to_dict(as_series=False) == {
+    expected = {
         "col1": [None, None, 2, 3, 4, 5, 6],
         "col2": [None, None, 6, 5, 4, 3, 2],
         "col1_nulls": [None, None, None, None, 4, 5, 6],
         "col2_nulls": [None, None, None, None, 4, 3, 2],
     }
+    result = df.select([pl.all().rolling_max(3)])
+    assert result.to_dict(as_series=False) == {
+        k: pl.Series(v, dtype=dtype).to_list() for k, v in expected.items()
+    }
 
     # shuffled data triggers other kernels
     df = df.select([pl.all().shuffle(0)])
-    assert df.select([pl.all().rolling_min(3)]).to_dict(as_series=False) == {
+    expected = {
         "col1": [None, None, 0, 0, 1, 2, 2],
         "col2": [None, None, 0, 2, 1, 1, 1],
         "col1_nulls": [None, None, None, None, None, 2, 2],
         "col2_nulls": [None, None, None, None, None, 1, 1],
     }
+    result = df.select([pl.all().rolling_min(3)])
+    assert result.to_dict(as_series=False) == {
+        k: pl.Series(v, dtype=dtype).to_list() for k, v in expected.items()
+    }
 
-    assert df.select([pl.all().rolling_max(3)]).to_dict(as_series=False) == {
+    result = df.select([pl.all().rolling_max(3)])
+    expected = {
         "col1": [None, None, 6, 4, 5, 5, 5],
         "col2": [None, None, 6, 6, 5, 4, 4],
         "col1_nulls": [None, None, None, None, None, 5, 5],
         "col2_nulls": [None, None, None, None, None, 4, 4],
     }
+    assert result.to_dict(as_series=False) == {
+        k: pl.Series(v, dtype=dtype).to_list() for k, v in expected.items()
+    }
 
 
-def test_rolling_group_by_extrema() -> None:
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pl.UInt8,
+        pl.Int64,
+        pl.Float32,
+        pl.Float64,
+        pl.Time,
+        pl.Date,
+        pl.Datetime("ms"),
+        pl.Datetime("us"),
+        pl.Datetime("ns"),
+        pl.Datetime("ns", "Asia/Kathmandu"),
+        pl.Duration("ms"),
+        pl.Duration("us"),
+        pl.Duration("ns"),
+    ],
+)
+def test_rolling_group_by_extrema(dtype: PolarsDataType) -> None:
     # ensure we hit different branches so create
 
     df = pl.DataFrame(
         {
             "col1": pl.arange(0, 7, eager=True).reverse(),
         }
-    ).with_columns(pl.col("col1").reverse().alias("index"))
+    ).with_columns(
+        pl.col("col1").reverse().alias("index"),
+        pl.col("col1").cast(dtype),
+    )
 
-    assert (
+    expected = {
+        "col1_list": pl.Series(
+            [
+                [6],
+                [6, 5],
+                [6, 5, 4],
+                [5, 4, 3],
+                [4, 3, 2],
+                [3, 2, 1],
+                [2, 1, 0],
+            ],
+            dtype=pl.List(dtype),
+        ).to_list(),
+        "col1_min": pl.Series([6, 5, 4, 3, 2, 1, 0], dtype=dtype).to_list(),
+        "col1_max": pl.Series([6, 6, 6, 5, 4, 3, 2], dtype=dtype).to_list(),
+        "col1_first": pl.Series([6, 6, 6, 5, 4, 3, 2], dtype=dtype).to_list(),
+        "col1_last": pl.Series([6, 5, 4, 3, 2, 1, 0], dtype=dtype).to_list(),
+    }
+    result = (
         df.rolling(
             index_column="index",
             period="3i",
@@ -330,21 +411,8 @@ def test_rolling_group_by_extrema() -> None:
             ]
         )
         .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
-    ).to_dict(as_series=False) == {
-        "col1_list": [
-            [6],
-            [6, 5],
-            [6, 5, 4],
-            [5, 4, 3],
-            [4, 3, 2],
-            [3, 2, 1],
-            [2, 1, 0],
-        ],
-        "col1_min": [6, 5, 4, 3, 2, 1, 0],
-        "col1_max": [6, 6, 6, 5, 4, 3, 2],
-        "col1_first": [6, 6, 6, 5, 4, 3, 2],
-        "col1_last": [6, 5, 4, 3, 2, 1, 0],
-    }
+    )
+    assert result.to_dict(as_series=False) == expected
 
     # ascending order
 
@@ -352,9 +420,12 @@ def test_rolling_group_by_extrema() -> None:
         {
             "col1": pl.arange(0, 7, eager=True),
         }
-    ).with_columns(pl.col("col1").alias("index"))
+    ).with_columns(
+        pl.col("col1").alias("index"),
+        pl.col("col1").cast(dtype),
+    )
 
-    assert (
+    result = (
         df.rolling(
             index_column="index",
             period="3i",
@@ -369,30 +440,38 @@ def test_rolling_group_by_extrema() -> None:
             ]
         )
         .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
-    ).to_dict(as_series=False) == {
-        "col1_list": [
-            [0],
-            [0, 1],
-            [0, 1, 2],
-            [1, 2, 3],
-            [2, 3, 4],
-            [3, 4, 5],
-            [4, 5, 6],
-        ],
-        "col1_min": [0, 0, 0, 1, 2, 3, 4],
-        "col1_max": [0, 1, 2, 3, 4, 5, 6],
-        "col1_first": [0, 0, 0, 1, 2, 3, 4],
-        "col1_last": [0, 1, 2, 3, 4, 5, 6],
+    )
+    expected = {
+        "col1_list": pl.Series(
+            [
+                [0],
+                [0, 1],
+                [0, 1, 2],
+                [1, 2, 3],
+                [2, 3, 4],
+                [3, 4, 5],
+                [4, 5, 6],
+            ],
+            dtype=pl.List(dtype),
+        ).to_list(),
+        "col1_min": pl.Series([0, 0, 0, 1, 2, 3, 4], dtype=dtype).to_list(),
+        "col1_max": pl.Series([0, 1, 2, 3, 4, 5, 6], dtype=dtype).to_list(),
+        "col1_first": pl.Series([0, 0, 0, 1, 2, 3, 4], dtype=dtype).to_list(),
+        "col1_last": pl.Series([0, 1, 2, 3, 4, 5, 6], dtype=dtype).to_list(),
     }
+    assert result.to_dict(as_series=False) == expected
 
     # shuffled data.
     df = pl.DataFrame(
         {
             "col1": pl.arange(0, 7, eager=True).shuffle(1),
         }
-    ).with_columns(pl.col("col1").sort().alias("index"))
+    ).with_columns(
+        pl.col("col1").cast(dtype),
+        pl.col("col1").sort().alias("index"),
+    )
 
-    assert (
+    result = (
         df.rolling(
             index_column="index",
             period="3i",
@@ -405,19 +484,24 @@ def test_rolling_group_by_extrema() -> None:
             ]
         )
         .select(["col1_list", "col1_min", "col1_max"])
-    ).to_dict(as_series=False) == {
-        "col1_list": [
-            [3],
-            [3, 4],
-            [3, 4, 5],
-            [4, 5, 6],
-            [5, 6, 2],
-            [6, 2, 1],
-            [2, 1, 0],
-        ],
-        "col1_min": [3, 3, 3, 4, 2, 1, 0],
-        "col1_max": [3, 4, 5, 6, 6, 6, 2],
+    )
+    expected = {
+        "col1_list": pl.Series(
+            [
+                [3],
+                [3, 4],
+                [3, 4, 5],
+                [4, 5, 6],
+                [5, 6, 2],
+                [6, 2, 1],
+                [2, 1, 0],
+            ],
+            dtype=pl.List(dtype),
+        ).to_list(),
+        "col1_min": pl.Series([3, 3, 3, 4, 2, 1, 0], dtype=dtype).to_list(),
+        "col1_max": pl.Series([3, 4, 5, 6, 6, 6, 2], dtype=dtype).to_list(),
     }
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_rolling_slice_pushdown() -> None:


### PR DESCRIPTION
Closes #22251. Also `rolling_min_by` and `rolling_max_by`.

```python
import polars as pl

df = pl.DataFrame({
    "col1": pl.int_range(0, 7, eager=True),
    "col2": pl.int_range(0, 7, eager=True).reverse(),
}).with_columns(
    pl.when(pl.int_range(0, pl.len(), eager=False) < 2)
    .then(None)
    .otherwise(pl.all())
    .name.suffix("_nulls")
).cast(pl.Date)
# shape: (7, 4)
# ┌────────────┬────────────┬────────────┬────────────┐
# │ col1       ┆ col2       ┆ col1_nulls ┆ col2_nulls │
# │ ---        ┆ ---        ┆ ---        ┆ ---        │
# │ date       ┆ date       ┆ date       ┆ date       │
# ╞════════════╪════════════╪════════════╪════════════╡
# │ 1970-01-01 ┆ 1970-01-07 ┆ null       ┆ null       │
# │ 1970-01-02 ┆ 1970-01-06 ┆ null       ┆ null       │
# │ 1970-01-03 ┆ 1970-01-05 ┆ 1970-01-03 ┆ 1970-01-05 │
# │ 1970-01-04 ┆ 1970-01-04 ┆ 1970-01-04 ┆ 1970-01-04 │
# │ 1970-01-05 ┆ 1970-01-03 ┆ 1970-01-05 ┆ 1970-01-03 │
# │ 1970-01-06 ┆ 1970-01-02 ┆ 1970-01-06 ┆ 1970-01-02 │
# │ 1970-01-07 ┆ 1970-01-01 ┆ 1970-01-07 ┆ 1970-01-01 │
# └────────────┴────────────┴────────────┴────────────┘

df.select([pl.all().rolling_min(3)])
# shape: (7, 4)
# ┌────────────┬────────────┬────────────┬────────────┐
# │ col1       ┆ col2       ┆ col1_nulls ┆ col2_nulls │
# │ ---        ┆ ---        ┆ ---        ┆ ---        │
# │ date       ┆ date       ┆ date       ┆ date       │
# ╞════════════╪════════════╪════════════╪════════════╡
# │ null       ┆ null       ┆ null       ┆ null       │
# │ null       ┆ null       ┆ null       ┆ null       │
# │ 1970-01-01 ┆ 1970-01-05 ┆ null       ┆ null       │
# │ 1970-01-02 ┆ 1970-01-04 ┆ null       ┆ null       │
# │ 1970-01-03 ┆ 1970-01-03 ┆ 1970-01-03 ┆ 1970-01-03 │
# │ 1970-01-04 ┆ 1970-01-02 ┆ 1970-01-04 ┆ 1970-01-02 │
# │ 1970-01-05 ┆ 1970-01-01 ┆ 1970-01-05 ┆ 1970-01-01 │
# └────────────┴────────────┴────────────┴────────────┘

df.select([pl.all().rolling_max(3)])
# shape: (7, 4)
# ┌────────────┬────────────┬────────────┬────────────┐
# │ col1       ┆ col2       ┆ col1_nulls ┆ col2_nulls │
# │ ---        ┆ ---        ┆ ---        ┆ ---        │
# │ date       ┆ date       ┆ date       ┆ date       │
# ╞════════════╪════════════╪════════════╪════════════╡
# │ null       ┆ null       ┆ null       ┆ null       │
# │ null       ┆ null       ┆ null       ┆ null       │
# │ 1970-01-03 ┆ 1970-01-07 ┆ null       ┆ null       │
# │ 1970-01-04 ┆ 1970-01-06 ┆ null       ┆ null       │
# │ 1970-01-05 ┆ 1970-01-05 ┆ 1970-01-05 ┆ 1970-01-05 │
# │ 1970-01-06 ┆ 1970-01-04 ┆ 1970-01-06 ┆ 1970-01-04 │
# │ 1970-01-07 ┆ 1970-01-03 ┆ 1970-01-07 ┆ 1970-01-03 │
# └────────────┴────────────┴────────────┴────────────┘
```