### PR TITLE
fix(rust): Improve detection of unsupported %Z format specifier

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -834,6 +834,18 @@ fn to_datetime(
         ambiguous.len()
     );
 
+    // %Z (timezone name) is not supported
+    if options
+        .format
+        .as_ref()
+        .is_some_and(|format| format.contains("%Z"))
+    {
+        polars_bail!(
+            ComputeError:
+            "The '%Z' format specifier (timezone name) is not supported for parsing datetime strings. Use '%z' (UTC offset like '+0100') instead."
+        );
+    }
+
     let tz_aware = match &options.format {
         #[cfg(all(feature = "regex", feature = "timezones"))]
         Some(format) => TZ_AWARE_RE.is_match(format),

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1849,12 +1849,13 @@ def test_tz_aware_with_timezone_directive(
 
 
 def test_local_time_zone_name() -> None:
-    ser = pl.Series(["2020-01-01 03:00ACST"]).str.strptime(
-        pl.Datetime, "%Y-%m-%d %H:%M%Z"
-    )
-    result = ser[0]
-    expected = datetime(2020, 1, 1, 3)
-    assert result == expected
+    with pytest.raises(
+        ComputeError,
+        match=r"The '%Z' format specifier \(timezone name\) is not supported for parsing datetime strings. Use '%z' \(UTC offset like '\+0100'\) instead.",
+    ):
+        pl.Series(["2020-01-01 03:00 ACST"]).str.strptime(
+            pl.Datetime, "%Y-%m-%d %H:%M %Z"
+        )
 
 
 def test_tz_aware_filter_lit() -> None:


### PR DESCRIPTION
This addresses: #22267

The current implementation of `to_datetime` doesn't properly detect the uppercase `%Z` format specifier (for timezone names) and is not being passed to `chrono`. This causes confusion because python does support `%Z`

Usage:
```
data = {
    "date_str": [
        "2025-01-22 13:00:40 EST",
    ]
}

df = pl.DataFrame(data).with_columns(
    pl.col("date_str")
    .str.strptime(pl.Datetime, "%Y-%m-%d %H:%M:%S %Z", strict=True, exact=True)
    .alias("datetime")
)

--------------------

ComputeError: The '%Z' format specifier (timezone name) is not supported for parsing datetime strings. Use '%z' (UTC offset like '+0100') instead.
```
