### PR TITLE
fix: Move type coercion for `pl.duration` to planner

### DIFF
--- a/crates/polars-ops/src/series/ops/duration.rs
+++ b/crates/polars-ops/src/series/ops/duration.rs
@@ -12,14 +12,14 @@ pub fn impl_duration(s: &[Column], time_unit: TimeUnit) -> PolarsResult<Column> 
     }
 
     // TODO: Handle overflow for UInt64
-    let weeks = s[0].cast(&DataType::Int64).unwrap();
-    let days = s[1].cast(&DataType::Int64).unwrap();
-    let hours = s[2].cast(&DataType::Int64).unwrap();
-    let minutes = s[3].cast(&DataType::Int64).unwrap();
-    let seconds = s[4].cast(&DataType::Int64).unwrap();
-    let mut milliseconds = s[5].cast(&DataType::Int64).unwrap();
-    let mut microseconds = s[6].cast(&DataType::Int64).unwrap();
-    let mut nanoseconds = s[7].cast(&DataType::Int64).unwrap();
+    let weeks = &s[0];
+    let days = &s[1];
+    let hours = &s[2];
+    let minutes = &s[3];
+    let seconds = &s[4];
+    let mut milliseconds = s[5].clone();
+    let mut microseconds = s[6].clone();
+    let mut nanoseconds = s[7].clone();
 
     let is_scalar = |s: &Column| s.len() == 1;
     let is_zero_scalar = |s: &Column| is_scalar(s) && s.get(0).unwrap() == AnyValue::Int64(0);
@@ -71,19 +71,19 @@ pub fn impl_duration(s: &[Column], time_unit: TimeUnit) -> PolarsResult<Column> 
         TimeUnit::Microseconds => MICROSECONDS,
         TimeUnit::Milliseconds => MILLISECONDS,
     };
-    if !is_zero_scalar(&seconds) {
+    if !is_zero_scalar(seconds) {
         duration = (duration + seconds * multiplier)?;
     }
-    if !is_zero_scalar(&minutes) {
+    if !is_zero_scalar(minutes) {
         duration = (duration + minutes * multiplier * 60)?;
     }
-    if !is_zero_scalar(&hours) {
+    if !is_zero_scalar(hours) {
         duration = (duration + hours * multiplier * 60 * 60)?;
     }
-    if !is_zero_scalar(&days) {
+    if !is_zero_scalar(days) {
         duration = (duration + days * multiplier * SECONDS_IN_DAY)?;
     }
-    if !is_zero_scalar(&weeks) {
+    if !is_zero_scalar(weeks) {
         duration = (duration + weeks * multiplier * SECONDS_IN_DAY * 7)?;
     }
 

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -428,6 +428,7 @@ impl OptimizationRule for TypeCoercionRule {
                     options,
                 })
             },
+            #[cfg(feature = "temporal")]
             AExpr::Function {
                 function: ref function @ FunctionExpr::TemporalExpr(TemporalFunction::Duration(_)),
                 ref input,

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -217,3 +217,8 @@ def test_comparison_with_string_raises_9461() -> None:
     df = pl.DataFrame({"duration": [timedelta(hours=2)]})
     with pytest.raises(pl.exceptions.InvalidOperationError):
         df.filter(pl.col("duration") > "1h")
+
+
+def test_duration_invalid_cast_22258() -> None:
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        pl.select(a=pl.duration(days=[1, 2, 3, 4]))

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -221,4 +221,4 @@ def test_comparison_with_string_raises_9461() -> None:
 
 def test_duration_invalid_cast_22258() -> None:
     with pytest.raises(pl.exceptions.InvalidOperationError):
-        pl.select(a=pl.duration(days=[1, 2, 3, 4]))
+        pl.select(a=pl.duration(days=[1, 2, 3, 4]))  # type: ignore[arg-type]

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -255,7 +255,7 @@ def test_unique_check_order_20480() -> None:
 def test_predicate_pushdown_unique() -> None:
     q = (
         pl.LazyFrame({"id": [1, 2, 3]})
-        .with_columns(pl.date(2024, 1, 1) + pl.duration(days=[1, 2, 3]))  # type: ignore[arg-type]
+        .with_columns(pl.date(2024, 1, 1) + pl.duration(days=pl.Series([1, 2, 3])))  # type: ignore[arg-type]
         .unique()
     )
 


### PR DESCRIPTION
Fixes #22258.