### PR TITLE
fix: Check matching lengths for `pl.corr`

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/crates/polars-plan/src/dsl/function_expr/correlation.rs
@@ -26,6 +26,13 @@ impl Display for CorrelationMethod {
 }
 
 pub(super) fn corr(s: &[Column], method: CorrelationMethod) -> PolarsResult<Column> {
+    polars_ensure!(
+        s[0].len() == s[1].len() || s[0].len() == 1 || s[1].len() == 1,
+        length_mismatch = "corr",
+        s[0].len(),
+        s[1].len()
+    );
+
     match method {
         CorrelationMethod::Pearson => pearson_corr(s),
         #[cfg(all(feature = "rank", feature = "propagate_nans"))]

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -143,3 +143,8 @@ def test_kurtosis_same_vals() -> None:
     assert_frame_equal(
         df.select(pl.col("a").kurtosis()), pl.select(a=pl.lit(float("nan")))
     )
+
+
+def test_correction_shape_mismatch_22080() -> None:
+    with pytest.raises(pl.exceptions.ShapeError):
+        pl.select(pl.corr(pl.Series([1, 2]), pl.Series([2, 3, 5])))


### PR DESCRIPTION
Fixes #22080.