### PR TITLE
refactor(rust): Introduce and use `UnifiedScanArgs`

### DIFF
--- a/crates/polars-io/src/options.rs
+++ b/crates/polars-io/src/options.rs
@@ -24,13 +24,28 @@ pub struct HiveOptions {
     pub try_parse_dates: bool,
 }
 
-impl Default for HiveOptions {
-    fn default() -> Self {
+impl HiveOptions {
+    pub fn new_enabled() -> Self {
         Self {
             enabled: Some(true),
             hive_start_idx: 0,
             schema: None,
             try_parse_dates: true,
         }
+    }
+
+    pub fn new_disabled() -> Self {
+        Self {
+            enabled: Some(false),
+            hive_start_idx: 0,
+            schema: None,
+            try_parse_dates: false,
+        }
+    }
+}
+
+impl Default for HiveOptions {
+    fn default() -> Self {
+        Self::new_enabled()
     }
 }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -2138,7 +2138,7 @@ impl LazyFrame {
             {
                 let DslPlan::Scan {
                     sources,
-                    mut file_options,
+                    mut unified_scan_args,
                     scan_type,
                     file_info,
                     cached_ir: _,
@@ -2147,14 +2147,14 @@ impl LazyFrame {
                     unreachable!()
                 };
 
-                file_options.row_index = Some(RowIndex {
+                unified_scan_args.row_index = Some(RowIndex {
                     name,
                     offset: offset.unwrap_or(0),
                 });
 
                 DslPlan::Scan {
                     sources,
-                    file_options,
+                    unified_scan_args,
                     scan_type,
                     file_info,
                     cached_ir: Default::default(),
@@ -2603,7 +2603,9 @@ mod streaming_dispatch {
         expr_arena: &mut Arena<AExpr>,
     ) -> PolarsResult<Box<dyn Executor>> {
         let rechunk = match ir_arena.get(node) {
-            IR::Scan { file_options, .. } => file_options.rechunk,
+            IR::Scan {
+                unified_scan_args, ..
+            } => unified_scan_args.rechunk,
             _ => false,
         };
 

--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -229,13 +229,13 @@ pub(crate) fn insert_streaming_nodes(
             },
             Scan {
                 scan_type,
-                file_options,
+                unified_scan_args,
                 ..
             } if scan_type.streamable()
-                && file_options
-                    .pre_slice
-                    .map(|slice| slice.0 >= 0)
-                    .unwrap_or(true) =>
+                && matches!(
+                    &unified_scan_args.pre_slice,
+                    None | Some(polars_utils::slice_enum::Slice::Positive { .. })
+                ) =>
             {
                 if state.streamable {
                     state.sources.push(root);

--- a/crates/polars-lazy/src/scan/anonymous_scan.rs
+++ b/crates/polars-lazy/src/scan/anonymous_scan.rs
@@ -1,5 +1,6 @@
 use polars_core::prelude::*;
-use polars_io::RowIndex;
+use polars_io::{HiveOptions, RowIndex};
+use polars_utils::slice_enum::Slice;
 
 use crate::prelude::*;
 
@@ -30,13 +31,31 @@ impl LazyFrame {
         function: Arc<dyn AnonymousScan>,
         args: ScanArgsAnonymous,
     ) -> PolarsResult<Self> {
+        let schema = match args.schema {
+            Some(s) => s,
+            None => function.schema(args.infer_schema_length)?,
+        };
+
         let mut lf: LazyFrame = DslBuilder::anonymous_scan(
             function,
-            args.schema,
-            args.infer_schema_length,
-            args.skip_rows,
-            args.n_rows,
-            args.name,
+            AnonymousScanOptions {
+                skip_rows: args.skip_rows,
+                fmt_str: args.name,
+            },
+            UnifiedScanArgs {
+                schema: Some(schema),
+                cloud_options: None,
+                hive_options: HiveOptions::new_disabled(),
+                rechunk: false,
+                cache: false,
+                glob: false,
+                projection: None,
+                row_index: None,
+                pre_slice: args.n_rows.map(|len| Slice::Positive { offset: 0, len }),
+                cast_columns_policy: CastColumnsPolicy::ErrorOnMismatch,
+                missing_columns_policy: MissingColumnsPolicy::Raise,
+                include_file_paths: None,
+            },
         )?
         .build()
         .into();

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 use polars_core::prelude::*;
 use polars_io::cloud::CloudOptions;
 use polars_io::{HiveOptions, RowIndex};
-use polars_plan::dsl::{DslPlan, FileScan, ScanSources};
-use polars_plan::prelude::{FileScanOptions, NDJsonReadOptions};
+use polars_plan::dsl::{CastColumnsPolicy, DslPlan, FileScan, MissingColumnsPolicy, ScanSources};
+use polars_plan::prelude::{NDJsonReadOptions, UnifiedScanArgs};
+use polars_utils::slice_enum::Slice;
 
 use crate::prelude::LazyFrame;
 use crate::scan::file_list_reader::LazyFileListReader;
@@ -122,23 +123,20 @@ impl LazyJsonLineReader {
 
 impl LazyFileListReader for LazyJsonLineReader {
     fn finish(self) -> PolarsResult<LazyFrame> {
-        let file_options = Box::new(FileScanOptions {
-            pre_slice: self.n_rows.map(|x| (0, x)),
-            with_columns: None,
-            cache: false,
-            row_index: self.row_index,
+        let unified_scan_args = UnifiedScanArgs {
+            schema: None,
+            cloud_options: self.cloud_options,
+            hive_options: HiveOptions::new_disabled(),
             rechunk: self.rechunk,
-            file_counter: 0,
-            hive_options: HiveOptions {
-                enabled: Some(false),
-                hive_start_idx: 0,
-                schema: None,
-                try_parse_dates: true,
-            },
+            cache: false,
             glob: true,
+            projection: None,
+            row_index: self.row_index,
+            pre_slice: self.n_rows.map(|len| Slice::Positive { offset: 0, len }),
+            cast_columns_policy: CastColumnsPolicy::ErrorOnMismatch,
+            missing_columns_policy: MissingColumnsPolicy::Raise,
             include_file_paths: self.include_file_paths,
-            allow_missing_columns: false,
-        });
+        };
 
         let options = NDJsonReadOptions {
             n_threads: None,
@@ -150,15 +148,12 @@ impl LazyFileListReader for LazyJsonLineReader {
             schema_overwrite: self.schema_overwrite,
         };
 
-        let scan_type = Box::new(FileScan::NDJson {
-            options,
-            cloud_options: self.cloud_options,
-        });
+        let scan_type = Box::new(FileScan::NDJson { options });
 
         Ok(LazyFrame::from(DslPlan::Scan {
             sources: self.sources,
             file_info: None,
-            file_options,
+            unified_scan_args: Box::new(unified_scan_args),
             scan_type,
             cached_ir: Default::default(),
         }))

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use polars_core::prelude::*;
 use polars_io::cloud::CloudOptions;
 use polars_io::parquet::read::ParallelStrategy;
+use polars_io::prelude::ParquetOptions;
 use polars_io::{HiveOptions, RowIndex};
+use polars_utils::slice_enum::Slice;
 
 use crate::prelude::*;
 
@@ -63,30 +65,44 @@ impl LazyParquetReader {
 impl LazyFileListReader for LazyParquetReader {
     /// Get the final [LazyFrame].
     fn finish(self) -> PolarsResult<LazyFrame> {
-        let row_index = self.args.row_index;
+        let parquet_options = ParquetOptions {
+            schema: self.args.schema,
+            parallel: self.args.parallel,
+            low_memory: self.args.low_memory,
+            use_statistics: self.args.use_statistics,
+        };
 
-        let mut lf: LazyFrame = DslBuilder::scan_parquet(
-            self.sources,
-            self.args.n_rows,
-            self.args.cache,
-            self.args.parallel,
-            None,
-            self.args.rechunk,
-            self.args.low_memory,
-            self.args.cloud_options,
-            self.args.use_statistics,
-            self.args.schema,
-            self.args.hive_options,
-            self.args.glob,
-            self.args.include_file_paths,
-            self.args.allow_missing_columns,
-        )?
-        .build()
-        .into();
+        let unified_scan_args = UnifiedScanArgs {
+            schema: None,
+            cloud_options: self.args.cloud_options,
+            hive_options: self.args.hive_options,
+            rechunk: self.args.rechunk,
+            cache: self.args.cache,
+            glob: self.args.glob,
+            projection: None,
+            // Note: We call `with_row_index()` on the LazyFrame below
+            row_index: None,
+            pre_slice: self
+                .args
+                .n_rows
+                .map(|len| Slice::Positive { offset: 0, len }),
+            cast_columns_policy: CastColumnsPolicy::ErrorOnMismatch,
+            missing_columns_policy: if self.args.allow_missing_columns {
+                MissingColumnsPolicy::Insert
+            } else {
+                MissingColumnsPolicy::Raise
+            },
+            include_file_paths: self.args.include_file_paths,
+        };
+
+        let mut lf: LazyFrame =
+            DslBuilder::scan_parquet(self.sources, parquet_options, unified_scan_args)?
+                .build()
+                .into();
 
         // It's a bit hacky, but this row_index function updates the schema.
-        if let Some(row_index) = row_index {
-            lf = lf.with_row_index(row_index.name.clone(), Some(row_index.offset))
+        if let Some(row_index) = self.args.row_index {
+            lf = lf.with_row_index(row_index.name, Some(row_index.offset))
         }
 
         Ok(lf)

--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -63,8 +63,10 @@ fn test_cse_unions() -> PolarsResult<()> {
                 cache_count += 1;
                 true
             },
-            Scan { file_options, .. } => {
-                if let Some(columns) = &file_options.with_columns {
+            Scan {
+                unified_scan_args, ..
+            } => {
+                if let Some(columns) = &unified_scan_args.projection {
                     columns.len() == 2
                 } else {
                     false

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -1,6 +1,7 @@
 use polars_io::RowIndex;
 #[cfg(feature = "is_between")]
 use polars_ops::prelude::ClosedInterval;
+use polars_utils::slice_enum::Slice;
 
 use super::*;
 
@@ -399,7 +400,9 @@ fn test_scan_parquet_limit_9001() {
             let sliced = options.slice.unwrap();
             sliced.1 == 3
         },
-        IR::Scan { file_options, .. } => file_options.pre_slice == Some((0, 3)),
+        IR::Scan {
+            unified_scan_args, ..
+        } => unified_scan_args.pre_slice == Some(Slice::Positive { offset: 0, len: 3 }),
         _ => true,
     });
 }

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -6,8 +6,11 @@ pub(crate) fn row_index_at_scan(q: LazyFrame) -> bool {
     let lp = q.optimize(&mut lp_arena, &mut expr_arena).unwrap();
 
     (&lp_arena).iter(lp).any(|(_, lp)| {
-        if let IR::Scan { file_options, .. } = lp {
-            file_options.row_index.is_some()
+        if let IR::Scan {
+            unified_scan_args, ..
+        } = lp
+        {
+            unified_scan_args.row_index.is_some()
         } else {
             false
         }
@@ -51,7 +54,9 @@ fn slice_at_scan(q: LazyFrame) -> bool {
     (&lp_arena).iter(lp).any(|(_, lp)| {
         use IR::*;
         match lp {
-            Scan { file_options, .. } => file_options.pre_slice.is_some(),
+            Scan {
+                unified_scan_args, ..
+            } => unified_scan_args.pre_slice.is_some(),
             _ => false,
         }
     })

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -67,7 +67,7 @@ where
             sources,
             file_info,
             hive_parts,
-            file_options,
+            unified_scan_args,
             predicate,
             output_schema,
             scan_type,
@@ -98,7 +98,7 @@ where
                         sources,
                         file_info.reader_schema.clone().unwrap().unwrap_right(),
                         options,
-                        file_options,
+                        unified_scan_args,
                         verbose,
                     )?;
                     Ok(Box::new(src) as Box<dyn Source>)
@@ -106,7 +106,6 @@ where
                 #[cfg(feature = "parquet")]
                 FileScan::Parquet {
                     options: parquet_options,
-                    cloud_options,
                     metadata,
                 } => panic!("Parquet no longer supported for old streaming engine"),
                 _ => todo!(),

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -1,11 +1,6 @@
 use std::sync::Arc;
 
 use polars_core::prelude::*;
-use polars_io::HiveOptions;
-#[cfg(any(feature = "parquet", feature = "csv", feature = "ipc"))]
-use polars_io::RowIndex;
-#[cfg(any(feature = "parquet", feature = "ipc", feature = "csv"))]
-use polars_io::cloud::CloudOptions;
 #[cfg(feature = "csv")]
 use polars_io::csv::read::CsvReadOptions;
 #[cfg(feature = "ipc")]
@@ -28,45 +23,26 @@ impl From<DslPlan> for DslBuilder {
 impl DslBuilder {
     pub fn anonymous_scan(
         function: Arc<dyn AnonymousScan>,
-        schema: Option<SchemaRef>,
-        infer_schema_length: Option<usize>,
-        skip_rows: Option<usize>,
-        n_rows: Option<usize>,
-        name: &'static str,
+        options: AnonymousScanOptions,
+        unified_scan_args: UnifiedScanArgs,
     ) -> PolarsResult<Self> {
-        let schema = match schema {
-            Some(s) => s,
-            None => function.schema(infer_schema_length)?,
-        };
-
-        let file_info = FileInfo::new(schema.clone(), None, (n_rows, n_rows.unwrap_or(usize::MAX)));
-        let file_options = Box::new(FileScanOptions {
-            pre_slice: n_rows.map(|x| (0, x)),
-            with_columns: None,
-            cache: false,
-            row_index: None,
-            rechunk: false,
-            file_counter: Default::default(),
-            // TODO: Support Hive partitioning.
-            hive_options: HiveOptions {
-                enabled: Some(false),
-                ..Default::default()
-            },
-            glob: false,
-            include_file_paths: None,
-            allow_missing_columns: false,
-        });
+        let schema = unified_scan_args.schema.clone().ok_or_else(|| {
+            polars_err!(
+                ComputeError:
+                "anonymous scan requires schema to be specified in unified_scan_args"
+            )
+        })?;
 
         Ok(DslPlan::Scan {
             sources: ScanSources::Buffers(Arc::default()),
-            file_info: Some(file_info),
-            file_options,
+            file_info: Some(FileInfo {
+                schema,
+                ..Default::default()
+            }),
+            unified_scan_args: Box::new(unified_scan_args),
             scan_type: Box::new(FileScan::Anonymous {
                 function,
-                options: Arc::new(AnonymousScanOptions {
-                    fmt_str: name,
-                    skip_rows,
-                }),
+                options: Arc::new(options),
             }),
             cached_ir: Default::default(),
         }
@@ -77,44 +53,15 @@ impl DslBuilder {
     #[allow(clippy::too_many_arguments)]
     pub fn scan_parquet(
         sources: ScanSources,
-        n_rows: Option<usize>,
-        cache: bool,
-        parallel: polars_io::parquet::read::ParallelStrategy,
-        row_index: Option<RowIndex>,
-        rechunk: bool,
-        low_memory: bool,
-        cloud_options: Option<CloudOptions>,
-        use_statistics: bool,
-        schema: Option<SchemaRef>,
-        hive_options: HiveOptions,
-        glob: bool,
-        include_file_paths: Option<PlSmallStr>,
-        allow_missing_columns: bool,
+        options: ParquetOptions,
+        unified_scan_args: UnifiedScanArgs,
     ) -> PolarsResult<Self> {
-        let options = Box::new(FileScanOptions {
-            with_columns: None,
-            cache,
-            pre_slice: n_rows.map(|x| (0, x)),
-            rechunk,
-            row_index,
-            file_counter: Default::default(),
-            hive_options,
-            glob,
-            include_file_paths,
-            allow_missing_columns,
-        });
         Ok(DslPlan::Scan {
             sources,
             file_info: None,
-            file_options: options,
+            unified_scan_args: Box::new(unified_scan_args),
             scan_type: Box::new(FileScan::Parquet {
-                options: ParquetOptions {
-                    schema,
-                    parallel,
-                    low_memory,
-                    use_statistics,
-                },
-                cloud_options,
+                options,
                 metadata: None,
             }),
             cached_ir: Default::default(),
@@ -127,32 +74,14 @@ impl DslBuilder {
     pub fn scan_ipc(
         sources: ScanSources,
         options: IpcScanOptions,
-        n_rows: Option<usize>,
-        cache: bool,
-        row_index: Option<RowIndex>,
-        rechunk: bool,
-        cloud_options: Option<CloudOptions>,
-        hive_options: HiveOptions,
-        include_file_paths: Option<PlSmallStr>,
+        unified_scan_args: UnifiedScanArgs,
     ) -> PolarsResult<Self> {
         Ok(DslPlan::Scan {
             sources,
             file_info: None,
-            file_options: Box::new(FileScanOptions {
-                with_columns: None,
-                cache,
-                pre_slice: n_rows.map(|x| (0, x)),
-                rechunk,
-                row_index,
-                file_counter: Default::default(),
-                hive_options,
-                glob: true,
-                include_file_paths,
-                allow_missing_columns: false,
-            }),
+            unified_scan_args: Box::new(unified_scan_args),
             scan_type: Box::new(FileScan::Ipc {
                 options,
-                cloud_options,
                 metadata: None,
             }),
             cached_ir: Default::default(),
@@ -164,39 +93,14 @@ impl DslBuilder {
     #[cfg(feature = "csv")]
     pub fn scan_csv(
         sources: ScanSources,
-        read_options: CsvReadOptions,
-        cache: bool,
-        cloud_options: Option<CloudOptions>,
-        glob: bool,
-        include_file_paths: Option<PlSmallStr>,
+        options: CsvReadOptions,
+        unified_scan_args: UnifiedScanArgs,
     ) -> PolarsResult<Self> {
-        // This gets partially moved by FileScanOptions
-        let read_options_clone = read_options.clone();
-
-        let options = Box::new(FileScanOptions {
-            with_columns: None,
-            cache,
-            pre_slice: read_options_clone.n_rows.map(|x| (0, x)),
-            rechunk: read_options_clone.rechunk,
-            row_index: read_options_clone.row_index,
-            file_counter: Default::default(),
-            // TODO: Support Hive partitioning.
-            hive_options: HiveOptions {
-                enabled: Some(false),
-                ..Default::default()
-            },
-            glob,
-            include_file_paths,
-            allow_missing_columns: false,
-        });
         Ok(DslPlan::Scan {
             sources,
             file_info: None,
-            file_options: options,
-            scan_type: Box::new(FileScan::Csv {
-                options: read_options,
-                cloud_options,
-            }),
+            unified_scan_args: Box::new(unified_scan_args),
+            scan_type: Box::new(FileScan::Csv { options }),
             cached_ir: Default::default(),
         }
         .into())

--- a/crates/polars-plan/src/dsl/file_scan.rs
+++ b/crates/polars-plan/src/dsl/file_scan.rs
@@ -1,5 +1,6 @@
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 
+use polars_io::cloud::CloudOptions;
 #[cfg(feature = "csv")]
 use polars_io::csv::read::CsvReadOptions;
 #[cfg(feature = "ipc")]
@@ -8,6 +9,8 @@ use polars_io::ipc::IpcScanOptions;
 use polars_io::parquet::metadata::FileMetadataRef;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::read::ParquetOptions;
+use polars_io::{HiveOptions, RowIndex};
+use polars_utils::slice_enum::Slice;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::IntoStaticStr;
@@ -26,29 +29,25 @@ bitflags::bitflags! {
 // TODO: Arc<> some of the options and the cloud options.
 pub enum FileScan {
     #[cfg(feature = "csv")]
-    Csv {
-        options: CsvReadOptions,
-        cloud_options: Option<polars_io::cloud::CloudOptions>,
-    },
+    Csv { options: CsvReadOptions },
+
     #[cfg(feature = "json")]
-    NDJson {
-        options: NDJsonReadOptions,
-        cloud_options: Option<polars_io::cloud::CloudOptions>,
-    },
+    NDJson { options: NDJsonReadOptions },
+
     #[cfg(feature = "parquet")]
     Parquet {
         options: ParquetOptions,
-        cloud_options: Option<polars_io::cloud::CloudOptions>,
         #[cfg_attr(feature = "serde", serde(skip))]
         metadata: Option<FileMetadataRef>,
     },
+
     #[cfg(feature = "ipc")]
     Ipc {
         options: IpcScanOptions,
-        cloud_options: Option<polars_io::cloud::CloudOptions>,
         #[cfg_attr(feature = "serde", serde(skip))]
         metadata: Option<Arc<arrow::io::ipc::read::FileMetadata>>,
     },
+
     #[cfg_attr(feature = "serde", serde(skip))]
     Anonymous {
         options: Arc<AnonymousScanOptions>,
@@ -72,12 +71,12 @@ impl FileScan {
         }
     }
 
-    pub(crate) fn sort_projection(&self, _file_options: &FileScanOptions) -> bool {
+    pub(crate) fn sort_projection(&self, _has_row_index: bool) -> bool {
         match self {
             #[cfg(feature = "csv")]
             Self::Csv { .. } => true,
             #[cfg(feature = "ipc")]
-            Self::Ipc { .. } => _file_options.row_index.is_some(),
+            Self::Ipc { .. } => _has_row_index,
             #[cfg(feature = "parquet")]
             Self::Parquet { .. } => false,
             #[allow(unreachable_patterns)]
@@ -101,124 +100,141 @@ impl FileScan {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MissingColumnsPolicy {
     #[default]
     Raise,
+    /// Inserts full-NULL columns for the missing ones.
     Insert,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CastColumnsPolicy {
     /// Raise an error if the datatypes do not match
     #[default]
     ErrorOnMismatch,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExtraColumnsPolicy {
-    Ignore,
     /// Error if there are extra columns outside the target schema.
+    #[default]
     Raise,
+    Ignore,
 }
 
-impl PartialEq for FileScan {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            #[cfg(feature = "csv")]
-            (
-                FileScan::Csv {
-                    options: l,
-                    cloud_options: c_l,
-                },
-                FileScan::Csv {
-                    options: r,
-                    cloud_options: c_r,
-                },
-            ) => l == r && c_l == c_r,
-            #[cfg(feature = "parquet")]
-            (
-                FileScan::Parquet {
-                    options: opt_l,
-                    cloud_options: c_l,
-                    ..
-                },
-                FileScan::Parquet {
-                    options: opt_r,
-                    cloud_options: c_r,
-                    ..
-                },
-            ) => opt_l == opt_r && c_l == c_r,
-            #[cfg(feature = "ipc")]
-            (
-                FileScan::Ipc {
-                    options: l,
-                    cloud_options: c_l,
-                    ..
-                },
-                FileScan::Ipc {
-                    options: r,
-                    cloud_options: c_r,
-                    ..
-                },
-            ) => l == r && c_l == c_r,
-            #[cfg(feature = "json")]
-            (
-                FileScan::NDJson {
-                    options: l,
-                    cloud_options: c_l,
-                },
-                FileScan::NDJson {
-                    options: r,
-                    cloud_options: c_r,
-                },
-            ) => l == r && c_l == c_r,
-            _ => false,
+/// Scan arguments shared across different scan types.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct UnifiedScanArgs {
+    /// User-provided schema of the file. Will be inferred during IR conversion
+    /// if None.
+    pub schema: Option<SchemaRef>,
+    pub cloud_options: Option<CloudOptions>,
+    pub hive_options: HiveOptions,
+
+    pub rechunk: bool,
+    pub cache: bool,
+    pub glob: bool,
+
+    pub projection: Option<Arc<[PlSmallStr]>>,
+    pub row_index: Option<RowIndex>,
+    /// Slice applied before predicates
+    pub pre_slice: Option<Slice>,
+
+    pub cast_columns_policy: CastColumnsPolicy,
+    pub missing_columns_policy: MissingColumnsPolicy,
+    pub include_file_paths: Option<PlSmallStr>,
+}
+
+/// Manual impls of Eq/Hash, as some fields are `Arc<T>` where T does not have Eq/Hash. For these
+/// fields we compare the pointer addresses instead.
+mod _file_scan_eq_hash {
+    use std::hash::{Hash, Hasher};
+    use std::sync::Arc;
+
+    use super::FileScan;
+
+    impl PartialEq for FileScan {
+        fn eq(&self, other: &Self) -> bool {
+            FileScanEqHashWrap::from(self) == FileScanEqHashWrap::from(other)
         }
     }
-}
 
-impl Eq for FileScan {}
+    impl Eq for FileScan {}
 
-impl Hash for FileScan {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        std::mem::discriminant(self).hash(state);
-        match self {
-            #[cfg(feature = "csv")]
-            FileScan::Csv {
-                options,
-                cloud_options,
-            } => {
-                options.hash(state);
-                cloud_options.hash(state);
-            },
-            #[cfg(feature = "parquet")]
-            FileScan::Parquet {
-                options,
-                cloud_options,
-                metadata: _,
-            } => {
-                options.hash(state);
-                cloud_options.hash(state);
-            },
-            #[cfg(feature = "ipc")]
-            FileScan::Ipc {
-                options,
-                cloud_options,
-                metadata: _,
-            } => {
-                options.hash(state);
-                cloud_options.hash(state);
-            },
-            #[cfg(feature = "json")]
-            FileScan::NDJson {
-                options,
-                cloud_options,
-            } => {
-                options.hash(state);
-                cloud_options.hash(state)
-            },
-            FileScan::Anonymous { options, .. } => options.hash(state),
+    impl Hash for FileScan {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            FileScanEqHashWrap::from(self).hash(state)
         }
+    }
+
+    /// # Hash / Eq safety
+    /// * All usizes originate from `Arc<>`s, and the lifetime of this enum is bound to that of the
+    ///   input ref.
+    #[derive(PartialEq, Hash)]
+    pub enum FileScanEqHashWrap<'a> {
+        #[cfg(feature = "csv")]
+        Csv {
+            options: &'a polars_io::csv::read::CsvReadOptions,
+        },
+
+        #[cfg(feature = "json")]
+        NDJson {
+            options: &'a crate::prelude::NDJsonReadOptions,
+        },
+
+        #[cfg(feature = "parquet")]
+        Parquet {
+            options: &'a polars_io::prelude::ParquetOptions,
+            metadata: Option<usize>,
+        },
+
+        #[cfg(feature = "ipc")]
+        Ipc {
+            options: &'a polars_io::prelude::IpcScanOptions,
+            metadata: Option<usize>,
+        },
+
+        Anonymous {
+            options: &'a crate::dsl::AnonymousScanOptions,
+            function: usize,
+        },
+    }
+
+    impl<'a> From<&'a FileScan> for FileScanEqHashWrap<'a> {
+        fn from(value: &'a FileScan) -> Self {
+            match value {
+                #[cfg(feature = "csv")]
+                FileScan::Csv { options } => FileScanEqHashWrap::Csv { options },
+
+                #[cfg(feature = "json")]
+                FileScan::NDJson { options } => FileScanEqHashWrap::NDJson { options },
+
+                #[cfg(feature = "parquet")]
+                FileScan::Parquet { options, metadata } => FileScanEqHashWrap::Parquet {
+                    options,
+                    metadata: metadata.as_ref().map(arc_as_ptr),
+                },
+
+                #[cfg(feature = "ipc")]
+                FileScan::Ipc { options, metadata } => FileScanEqHashWrap::Ipc {
+                    options,
+                    metadata: metadata.as_ref().map(arc_as_ptr),
+                },
+
+                FileScan::Anonymous { options, function } => FileScanEqHashWrap::Anonymous {
+                    options,
+                    function: arc_as_ptr(function),
+                },
+            }
+        }
+    }
+
+    fn arc_as_ptr<T: ?Sized>(arc: &Arc<T>) -> usize {
+        Arc::as_ptr(arc) as *const () as usize
     }
 }

--- a/crates/polars-plan/src/dsl/options/mod.rs
+++ b/crates/polars-plan/src/dsl/options/mod.rs
@@ -16,7 +16,6 @@ use polars_io::ipc::IpcWriterOptions;
 use polars_io::json::JsonWriterOptions;
 #[cfg(feature = "parquet")]
 use polars_io::parquet::write::ParquetWriteOptions;
-use polars_io::{HiveOptions, RowIndex};
 #[cfg(feature = "iejoin")]
 use polars_ops::frame::IEJoinOptions;
 use polars_ops::frame::{CrossJoinFilter, CrossJoinOptions, JoinTypeOptions};
@@ -187,25 +186,6 @@ pub struct UnpivotArgsDSL {
     pub index: Vec<Selector>,
     pub variable_name: Option<PlSmallStr>,
     pub value_name: Option<PlSmallStr>,
-}
-
-pub type FileCount = u32;
-
-#[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-/// Generic options for all file types.
-pub struct FileScanOptions {
-    // Slice applied before predicates
-    pub pre_slice: Option<(i64, usize)>,
-    pub with_columns: Option<Arc<[PlSmallStr]>>,
-    pub cache: bool,
-    pub row_index: Option<RowIndex>,
-    pub rechunk: bool,
-    pub file_counter: FileCount,
-    pub hive_options: HiveOptions,
-    pub glob: bool,
-    pub include_file_paths: Option<PlSmallStr>,
-    pub allow_missing_columns: bool,
 }
 
 #[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -36,7 +36,7 @@ pub enum DslPlan {
         sources: ScanSources,
         /// Materialized at IR except for AnonymousScan.
         file_info: Option<FileInfo>,
-        file_options: Box<FileScanOptions>,
+        unified_scan_args: Box<UnifiedScanArgs>,
         scan_type: Box<FileScan>,
         /// Local use cases often repeatedly collect the same `LazyFrame` (e.g. in interactive notebook use-cases),
         /// so we cache the IR conversion here, as the path expansion can be quite slow (especially for cloud paths).
@@ -155,7 +155,7 @@ impl Clone for DslPlan {
             Self::PythonScan { options } => Self::PythonScan { options: options.clone() },
             Self::Filter { input, predicate } => Self::Filter { input: input.clone(), predicate: predicate.clone() },
             Self::Cache { input, id } => Self::Cache { input: input.clone(), id: id.clone() },
-            Self::Scan { sources, file_info, file_options, scan_type, cached_ir } => Self::Scan { sources: sources.clone(), file_info: file_info.clone(), file_options: file_options.clone(), scan_type: scan_type.clone(), cached_ir: cached_ir.clone() },
+            Self::Scan { sources, file_info, unified_scan_args, scan_type, cached_ir } => Self::Scan { sources: sources.clone(), file_info: file_info.clone(), unified_scan_args: unified_scan_args.clone(), scan_type: scan_type.clone(), cached_ir: cached_ir.clone() },
             Self::DataFrameScan { df, schema, } => Self::DataFrameScan { df: df.clone(), schema: schema.clone(),  },
             Self::Select { expr, input, options } => Self::Select { expr: expr.clone(), input: input.clone(), options: options.clone() },
             Self::GroupBy { input, keys, aggs,  apply, maintain_order, options } => Self::GroupBy { input: input.clone(), keys: keys.clone(), aggs: aggs.clone(), apply: apply.clone(), maintain_order: maintain_order.clone(), options: options.clone() },

--- a/crates/polars-plan/src/dsl/scan_sources.rs
+++ b/crates/polars-plan/src/dsl/scan_sources.rs
@@ -13,7 +13,7 @@ use polars_io::{expand_paths, expand_paths_hive, expanded_from_single_directory}
 use polars_utils::mmap::MemSlice;
 use polars_utils::pl_str::PlSmallStr;
 
-use super::FileScanOptions;
+use super::UnifiedScanArgs;
 
 /// Set of sources to scan from
 ///
@@ -159,42 +159,42 @@ impl Eq for ScanSources {}
 impl ScanSources {
     pub fn expand_paths(
         &self,
-        file_options: &FileScanOptions,
+        scan_args: &UnifiedScanArgs,
         #[allow(unused_variables)] cloud_options: Option<&CloudOptions>,
     ) -> PolarsResult<Self> {
         match self {
             Self::Paths(paths) => Ok(Self::Paths(expand_paths(
                 paths,
-                file_options.glob,
+                scan_args.glob,
                 cloud_options,
             )?)),
             v => Ok(v.clone()),
         }
     }
 
-    /// This will update `file_options.hive_options.enabled` to `true` if the existing value is `None`
+    /// This will update `scan_args.hive_options.enabled` to `true` if the existing value is `None`
     /// and the paths are expanded from a single directory. Otherwise the existing value is maintained.
     #[cfg(any(feature = "ipc", feature = "parquet"))]
     pub fn expand_paths_with_hive_update(
         &self,
-        file_options: &mut FileScanOptions,
+        scan_args: &mut UnifiedScanArgs,
         #[allow(unused_variables)] cloud_options: Option<&CloudOptions>,
     ) -> PolarsResult<Self> {
         match self {
             Self::Paths(paths) => {
                 let (expanded_paths, hive_start_idx) = expand_paths_hive(
                     paths,
-                    file_options.glob,
+                    scan_args.glob,
                     cloud_options,
-                    file_options.hive_options.enabled.unwrap_or(false),
+                    scan_args.hive_options.enabled.unwrap_or(false),
                 )?;
 
-                if file_options.hive_options.enabled.is_none()
+                if scan_args.hive_options.enabled.is_none()
                     && expanded_from_single_directory(paths, expanded_paths.as_ref())
                 {
-                    file_options.hive_options.enabled = Some(true);
+                    scan_args.hive_options.enabled = Some(true);
                 }
-                file_options.hive_options.hive_start_idx = hive_start_idx;
+                scan_args.hive_options.hive_start_idx = hive_start_idx;
 
                 Ok(Self::Paths(expanded_paths))
             },

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -134,7 +134,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
         DslPlan::Scan {
             sources,
             file_info,
-            file_options,
+            unified_scan_args: mut unified_scan_args_box,
             scan_type,
             cached_ir,
         } => {
@@ -143,14 +143,17 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
             let mut cached_ir = cached_ir.lock().unwrap();
 
             if cached_ir.is_none() {
-                let mut file_options = file_options.clone();
+                let cloud_options = unified_scan_args_box.cloud_options.clone();
+                let cloud_options = cloud_options.as_ref();
+
+                let unified_scan_args = unified_scan_args_box.as_mut();
                 let mut scan_type = scan_type.clone();
 
-                if let Some(hive_schema) = file_options.hive_options.schema.as_deref() {
-                    match file_options.hive_options.enabled {
+                if let Some(hive_schema) = unified_scan_args.hive_options.schema.as_deref() {
+                    match unified_scan_args.hive_options.enabled {
                         // Enable hive_partitioning if it is unspecified but a non-empty hive_schema given
                         None if !hive_schema.is_empty() => {
-                            file_options.hive_options.enabled = Some(true)
+                            unified_scan_args.hive_options.enabled = Some(true)
                         },
                         // hive_partitioning was explicitly disabled
                         Some(false) => polars_bail!(
@@ -161,31 +164,28 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     }
                 }
 
-                let sources = match &*scan_type {
-                    #[cfg(feature = "parquet")]
-                    FileScan::Parquet { cloud_options, .. } => sources
-                        .expand_paths_with_hive_update(&mut file_options, cloud_options.as_ref())?,
-                    #[cfg(feature = "ipc")]
-                    FileScan::Ipc { cloud_options, .. } => sources
-                        .expand_paths_with_hive_update(&mut file_options, cloud_options.as_ref())?,
-                    #[cfg(feature = "csv")]
-                    FileScan::Csv { cloud_options, .. } => {
-                        sources.expand_paths(&file_options, cloud_options.as_ref())?
-                    },
-                    #[cfg(feature = "json")]
-                    FileScan::NDJson { cloud_options, .. } => {
-                        sources.expand_paths(&file_options, cloud_options.as_ref())?
-                    },
-                    FileScan::Anonymous { .. } => sources,
-                };
+                let sources =
+                    match &*scan_type {
+                        #[cfg(feature = "parquet")]
+                        FileScan::Parquet { .. } => sources
+                            .expand_paths_with_hive_update(unified_scan_args, cloud_options)?,
+                        #[cfg(feature = "ipc")]
+                        FileScan::Ipc { .. } => sources
+                            .expand_paths_with_hive_update(unified_scan_args, cloud_options)?,
+                        #[cfg(feature = "csv")]
+                        FileScan::Csv { .. } => {
+                            sources.expand_paths(unified_scan_args, cloud_options)?
+                        },
+                        #[cfg(feature = "json")]
+                        FileScan::NDJson { .. } => {
+                            sources.expand_paths(unified_scan_args, cloud_options)?
+                        },
+                        FileScan::Anonymous { .. } => sources,
+                    };
 
                 let mut file_info = match &mut *scan_type {
                     #[cfg(feature = "parquet")]
-                    FileScan::Parquet {
-                        options,
-                        cloud_options,
-                        metadata,
-                    } => {
+                    FileScan::Parquet { options, metadata } => {
                         if let Some(schema) = &options.schema {
                             // We were passed a schema, we don't have to call `parquet_file_info`,
                             // but this does mean we don't have `row_estimation` and `first_metadata`.
@@ -199,8 +199,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         } else {
                             let (file_info, md) = scans::parquet_file_info(
                                 &sources,
-                                &file_options,
-                                cloud_options.as_ref(),
+                                unified_scan_args.row_index.as_ref(),
+                                cloud_options,
                             )
                             .map_err(|e| e.context(failed_here!(parquet scan)))?;
 
@@ -209,46 +209,39 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         }
                     },
                     #[cfg(feature = "ipc")]
-                    FileScan::Ipc {
-                        cloud_options,
-                        metadata,
-                        ..
-                    } => {
-                        let (file_info, md) =
-                            scans::ipc_file_info(&sources, &file_options, cloud_options.as_ref())
-                                .map_err(|e| e.context(failed_here!(ipc scan)))?;
+                    FileScan::Ipc { metadata, .. } => {
+                        let (file_info, md) = scans::ipc_file_info(
+                            &sources,
+                            unified_scan_args.row_index.as_ref(),
+                            cloud_options,
+                        )
+                        .map_err(|e| e.context(failed_here!(ipc scan)))?;
                         *metadata = Some(Arc::new(md));
                         file_info
                     },
                     #[cfg(feature = "csv")]
-                    FileScan::Csv {
-                        options,
-                        cloud_options,
-                    } => {
+                    FileScan::Csv { options } => {
                         // TODO: This is a hack. We conditionally set `allow_missing_columns` to
                         // mimic existing behavior, but this should be taken from a user provided
                         // parameter instead.
                         if options.schema.is_some() && options.has_header {
-                            file_options.allow_missing_columns = true;
+                            unified_scan_args.missing_columns_policy = MissingColumnsPolicy::Insert;
                         }
 
                         scans::csv_file_info(
                             &sources,
-                            &file_options,
+                            unified_scan_args.row_index.as_ref(),
                             options,
-                            cloud_options.as_ref(),
+                            cloud_options,
                         )
                         .map_err(|e| e.context(failed_here!(csv scan)))?
                     },
                     #[cfg(feature = "json")]
-                    FileScan::NDJson {
+                    FileScan::NDJson { options } => scans::ndjson_file_info(
+                        &sources,
+                        unified_scan_args.row_index.as_ref(),
                         options,
                         cloud_options,
-                    } => scans::ndjson_file_info(
-                        &sources,
-                        &file_options,
-                        options,
-                        cloud_options.as_ref(),
                     )
                     .map_err(|e| e.context(failed_here!(ndjson scan)))?,
                     FileScan::Anonymous { .. } => {
@@ -256,13 +249,13 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     },
                 };
 
-                if file_options.hive_options.enabled.is_none() {
+                if unified_scan_args.hive_options.enabled.is_none() {
                     // We expect this to be `Some(_)` after this point. If it hasn't been auto-enabled
                     // we explicitly set it to disabled.
-                    file_options.hive_options.enabled = Some(false);
+                    unified_scan_args.hive_options.enabled = Some(false);
                 }
 
-                let hive_parts = if file_options.hive_options.enabled.unwrap()
+                let hive_parts = if unified_scan_args.hive_options.enabled.unwrap()
                     && file_info.reader_schema.is_some()
                 {
                     let paths = sources.as_paths().ok_or_else(|| {
@@ -274,8 +267,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
 
                     hive_partitions_from_paths(
                         paths,
-                        file_options.hive_options.hive_start_idx,
-                        file_options.hive_options.schema.clone(),
+                        unified_scan_args.hive_options.hive_start_idx,
+                        unified_scan_args.hive_options.schema.clone(),
                         match file_info.reader_schema.as_ref().unwrap() {
                             Either::Left(v) => {
                                 owned = Some(Schema::from_arrow_schema(v.as_ref()));
@@ -283,7 +276,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                             },
                             Either::Right(v) => v.as_ref(),
                         },
-                        file_options.hive_options.try_parse_dates,
+                        unified_scan_args.hive_options.try_parse_dates,
                     )?
                 } else {
                     None
@@ -292,29 +285,30 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                 if let Some(ref hive_parts) = hive_parts {
                     let hive_schema = hive_parts.schema();
                     file_info.update_schema_with_hive_schema(hive_schema.clone());
-                } else if let Some(hive_schema) = file_options.hive_options.schema.clone() {
+                } else if let Some(hive_schema) = unified_scan_args.hive_options.schema.clone() {
                     // We hit here if we are passed the `hive_schema` to `scan_parquet` but end up with an empty file
                     // list during path expansion. In this case we still want to return an empty DataFrame with this
                     // schema.
                     file_info.update_schema_with_hive_schema(hive_schema);
                 }
 
-                file_options.include_file_paths =
-                    file_options
-                        .include_file_paths
-                        .filter(|_| match &*scan_type {
-                            #[cfg(feature = "parquet")]
-                            FileScan::Parquet { .. } => true,
-                            #[cfg(feature = "ipc")]
-                            FileScan::Ipc { .. } => true,
-                            #[cfg(feature = "csv")]
-                            FileScan::Csv { .. } => true,
-                            #[cfg(feature = "json")]
-                            FileScan::NDJson { .. } => true,
-                            FileScan::Anonymous { .. } => false,
-                        });
+                unified_scan_args.include_file_paths = unified_scan_args
+                    .include_file_paths
+                    .as_ref()
+                    .filter(|_| match &*scan_type {
+                        #[cfg(feature = "parquet")]
+                        FileScan::Parquet { .. } => true,
+                        #[cfg(feature = "ipc")]
+                        FileScan::Ipc { .. } => true,
+                        #[cfg(feature = "csv")]
+                        FileScan::Csv { .. } => true,
+                        #[cfg(feature = "json")]
+                        FileScan::NDJson { .. } => true,
+                        FileScan::Anonymous { .. } => false,
+                    })
+                    .cloned();
 
-                if let Some(ref file_path_col) = file_options.include_file_paths {
+                if let Some(ref file_path_col) = unified_scan_args.include_file_paths {
                     let schema = Arc::make_mut(&mut file_info.schema);
 
                     if schema.contains(file_path_col) {
@@ -331,7 +325,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     )?;
                 }
 
-                file_options.with_columns = if file_info.reader_schema.is_some() {
+                unified_scan_args.projection = if file_info.reader_schema.is_some() {
                     maybe_init_projection_excluding_hive(
                         file_info.reader_schema.as_ref().unwrap(),
                         hive_parts.as_ref().map(|h| h.schema()),
@@ -340,7 +334,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                     None
                 };
 
-                if let Some(row_index) = &file_options.row_index {
+                if let Some(row_index) = &unified_scan_args.row_index {
                     let schema = Arc::make_mut(&mut file_info.schema);
                     *schema = schema
                         .new_inserting_at_index(0, row_index.name.clone(), IDX_DTYPE)
@@ -355,6 +349,8 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         output_schema: None,
                     }
                 } else {
+                    let unified_scan_args = unified_scan_args_box;
+
                     IR::Scan {
                         sources,
                         file_info,
@@ -362,7 +358,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         predicate: None,
                         scan_type,
                         output_schema: None,
-                        file_options,
+                        unified_scan_args,
                     }
                 };
 

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -69,17 +69,17 @@ impl IR {
                     predicate: _,
                     scan_type,
                     output_schema: _,
-                    file_options,
+                    unified_scan_args,
                 } = ir.clone()
                 else {
                     unreachable!()
                 };
 
                 DslPlan::Scan {
-                    sources: sources.clone(),
-                    file_info: Some(file_info.clone()),
-                    scan_type: scan_type.clone(),
-                    file_options: file_options.clone(),
+                    sources,
+                    file_info: Some(file_info),
+                    scan_type,
+                    unified_scan_args,
                     cached_ir: Arc::new(Mutex::new(Some(ir))),
                 }
             },

--- a/crates/polars-plan/src/plans/functions/count.rs
+++ b/crates/polars-plan/src/plans/functions/count.rs
@@ -22,6 +22,7 @@ use super::*;
 pub fn count_rows(
     sources: &ScanSources,
     scan_type: &FileScan,
+    cloud_options: Option<&CloudOptions>,
     alias: Option<PlSmallStr>,
 ) -> PolarsResult<DataFrame> {
     #[cfg(not(any(
@@ -43,30 +44,18 @@ pub fn count_rows(
     {
         let count: PolarsResult<usize> = match scan_type {
             #[cfg(feature = "csv")]
-            FileScan::Csv {
-                options,
-                cloud_options,
-            } => count_all_rows_csv(sources, options),
+            FileScan::Csv { options } => count_all_rows_csv(sources, options),
             #[cfg(feature = "parquet")]
-            FileScan::Parquet { cloud_options, .. } => {
-                count_rows_parquet(sources, cloud_options.as_ref())
-            },
+            FileScan::Parquet { .. } => count_rows_parquet(sources, cloud_options),
             #[cfg(feature = "ipc")]
-            FileScan::Ipc {
-                options,
-                cloud_options,
-                metadata,
-            } => count_rows_ipc(
+            FileScan::Ipc { options, metadata } => count_rows_ipc(
                 sources,
                 #[cfg(feature = "cloud")]
-                cloud_options.as_ref(),
+                cloud_options,
                 metadata.as_deref(),
             ),
             #[cfg(feature = "json")]
-            FileScan::NDJson {
-                options,
-                cloud_options,
-            } => count_rows_ndjson(sources, cloud_options.as_ref()),
+            FileScan::NDJson { options } => count_rows_ndjson(sources, cloud_options),
             FileScan::Anonymous { .. } => {
                 unreachable!()
             },

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -244,15 +244,18 @@ impl<'a> IRDotDisplay<'a> {
                 hive_parts: _,
                 predicate,
                 scan_type,
-                file_options: options,
+                unified_scan_args,
                 output_schema: _,
             } => {
                 let name: &str = (&**scan_type).into();
                 let path = ScanSourcesDisplay(sources);
-                let with_columns = options.with_columns.as_ref().map(|cols| cols.as_ref());
+                let with_columns = unified_scan_args
+                    .projection
+                    .as_ref()
+                    .map(|cols| cols.as_ref());
                 let with_columns = NumColumns(with_columns);
                 let total_columns =
-                    file_info.schema.len() - usize::from(options.row_index.is_some());
+                    file_info.schema.len() - usize::from(unified_scan_args.row_index.is_some());
 
                 write_label(f, id, |f| {
                     write!(f, "{name} SCAN {path}\nπ {with_columns}/{total_columns};",)?;
@@ -261,7 +264,7 @@ impl<'a> IRDotDisplay<'a> {
                         write!(f, "\nσ {}", self.display_expr(predicate))?;
                     }
 
-                    if let Some(row_index) = options.row_index.as_ref() {
+                    if let Some(row_index) = unified_scan_args.row_index.as_ref() {
                         write!(f, "\nrow index: {} (+{})", row_index.name, row_index.offset)?;
                     }
 

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display, Formatter};
 use polars_core::schema::Schema;
 use polars_io::RowIndex;
 use polars_utils::format_list_truncated;
+use polars_utils::slice_enum::Slice;
 use recursive::recursive;
 
 use self::ir::dot::ScanSourcesDisplay;
@@ -68,7 +69,7 @@ fn write_scan(
     n_columns: i64,
     total_columns: usize,
     predicate: &Option<ExprIRDisplay<'_>>,
-    slice: Option<(i64, usize)>,
+    pre_slice: Option<Slice>,
     row_index: Option<&RowIndex>,
 ) -> fmt::Result {
     write!(
@@ -91,8 +92,8 @@ fn write_scan(
     if let Some(predicate) = predicate {
         write!(f, "\n{:indent$}SELECTION: {predicate}", "")?;
     }
-    if let Some(slice) = slice {
-        write!(f, "\n{:indent$}SLICE: {slice:?}", "")?;
+    if let Some(pre_slice) = pre_slice {
+        write!(f, "\n{:indent$}SLICE: {pre_slice:?}", "")?;
     }
     if let Some(row_index) = row_index {
         write!(f, "\n{:indent$}ROW_INDEX: {}", "", row_index.name)?;
@@ -188,7 +189,9 @@ impl<'a> IRDisplay<'a> {
                     n_columns,
                     total_columns,
                     &predicate,
-                    options.n_rows.map(|x| (0, x)),
+                    options
+                        .n_rows
+                        .map(|len| polars_utils::slice_enum::Slice::Positive { offset: 0, len }),
                     None,
                 )
             },
@@ -237,11 +240,11 @@ impl<'a> IRDisplay<'a> {
                 file_info,
                 predicate,
                 scan_type,
-                file_options,
+                unified_scan_args,
                 ..
             } => {
-                let n_columns = file_options
-                    .with_columns
+                let n_columns = unified_scan_args
+                    .projection
                     .as_ref()
                     .map(|columns| columns.len() as i64)
                     .unwrap_or(-1);
@@ -256,8 +259,8 @@ impl<'a> IRDisplay<'a> {
                     n_columns,
                     file_info.schema.len(),
                     &predicate,
-                    file_options.pre_slice,
-                    file_options.row_index.as_ref(),
+                    unified_scan_args.pre_slice.clone(),
+                    unified_scan_args.row_index.as_ref(),
                 )
             },
             Filter { predicate, input } => {

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -101,19 +101,20 @@ impl IR {
                 hive_parts,
                 output_schema,
                 predicate,
-                file_options: options,
+                unified_scan_args,
                 scan_type,
             } => {
                 let mut new_predicate = None;
                 if predicate.is_some() {
                     new_predicate = exprs.pop()
                 }
+
                 Scan {
                     sources: sources.clone(),
                     file_info: file_info.clone(),
                     hive_parts: hive_parts.clone(),
                     output_schema: output_schema.clone(),
-                    file_options: options.clone(),
+                    unified_scan_args: unified_scan_args.clone(),
                     predicate: new_predicate,
                     scan_type: scan_type.clone(),
                 }

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -61,7 +61,7 @@ pub enum IR {
         output_schema: Option<SchemaRef>,
         scan_type: Box<FileScan>,
         /// generic options that can be used for all file types.
-        file_options: Box<FileScanOptions>,
+        unified_scan_args: Box<UnifiedScanArgs>,
     },
     DataFrameScan {
         df: Arc<DataFrame>,

--- a/crates/polars-plan/src/plans/optimizer/delay_rechunk.rs
+++ b/crates/polars-plan/src/plans/optimizer/delay_rechunk.rs
@@ -50,10 +50,9 @@ impl OptimizationRule for DelayRechunk {
                 if let Some(node) = input_node {
                     match lp_arena.get_mut(node) {
                         Scan {
-                            file_options: options,
-                            ..
+                            unified_scan_args, ..
                         } => {
-                            options.rechunk = false;
+                            unified_scan_args.rechunk = false;
                         },
                         Union { options, .. } => {
                             options.rechunk = false;

--- a/crates/polars-plan/src/plans/schema.rs
+++ b/crates/polars-plan/src/plans/schema.rs
@@ -29,7 +29,7 @@ impl DslPlan {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FileInfo {
     /// Schema of the physical file.
@@ -44,6 +44,17 @@ pub struct FileInfo {
     /// - known size
     /// - estimated size (set to usize::max if unknown).
     pub row_estimation: (Option<usize>, usize),
+}
+
+// Manual default because `row_estimation.1` needs to be `usize::MAX`.
+impl Default for FileInfo {
+    fn default() -> Self {
+        FileInfo {
+            schema: Default::default(),
+            reader_schema: None,
+            row_estimation: (None, usize::MAX),
+        }
+    }
 }
 
 impl FileInfo {

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -80,13 +80,13 @@ impl Hash for HashableEqLP<'_> {
                 predicate,
                 output_schema: _,
                 scan_type,
-                file_options,
+                unified_scan_args,
             } => {
                 // We don't have to traverse the schema, hive partitions etc. as they are derivative from the paths.
                 scan_type.hash(state);
                 sources.hash(state);
                 hash_option_expr(predicate, self.expr_arena, state);
-                file_options.hash(state);
+                unified_scan_args.hash(state);
             },
             IR::DataFrameScan {
                 df,
@@ -261,7 +261,7 @@ impl HashableEqLP<'_> {
                     predicate: pred_l,
                     output_schema: _,
                     scan_type: stl,
-                    file_options: ol,
+                    unified_scan_args: ol,
                 },
                 IR::Scan {
                     sources: pr,
@@ -270,10 +270,10 @@ impl HashableEqLP<'_> {
                     predicate: pred_r,
                     output_schema: _,
                     scan_type: str,
-                    file_options: or,
+                    unified_scan_args: or,
                 },
             ) => {
-                pl.as_paths() == pr.as_paths()
+                pl == pr
                     && stl == str
                     && ol == or
                     && opt_expr_ir_eq(pred_l, pred_r, self.expr_arena)

--- a/crates/polars-python/src/lazyframe/visit.rs
+++ b/crates/polars-python/src/lazyframe/visit.rs
@@ -58,7 +58,7 @@ impl NodeTraverser {
     // Increment major on breaking changes to the IR (e.g. renaming
     // fields, reordering tuples), minor on backwards compatible
     // changes (e.g. exposing a new expression node).
-    const VERSION: Version = (6, 0);
+    const VERSION: Version = (7, 0);
 
     pub fn new(root: Node, lp_arena: Arena<IR>, expr_arena: Arena<AExpr>) -> Self {
         Self {

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -2,9 +2,10 @@
 use polars::prelude::JoinTypeOptionsIR;
 use polars::prelude::python_dsl::PythonScanSource;
 use polars_core::prelude::IdxSize;
+use polars_io::cloud::CloudOptions;
 use polars_ops::prelude::JoinType;
 use polars_plan::plans::IR;
-use polars_plan::prelude::{FileCount, FileScan, FileScanOptions, FunctionIR, PythonPredicate};
+use polars_plan::prelude::{FileScan, FunctionIR, PythonPredicate, UnifiedScanArgs};
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{PyNotImplementedError, PyValueError};
 use pyo3::prelude::*;
@@ -13,13 +14,14 @@ use super::expr_nodes::PyGroupbyOptions;
 use crate::PyDataFrame;
 use crate::lazyframe::visit::PyExprIR;
 
-fn scan_type_to_pyobject(py: Python, scan_type: &FileScan) -> PyResult<PyObject> {
+fn scan_type_to_pyobject(
+    py: Python,
+    scan_type: &FileScan,
+    cloud_options: &Option<CloudOptions>,
+) -> PyResult<PyObject> {
     match scan_type {
         #[cfg(feature = "csv")]
-        FileScan::Csv {
-            options,
-            cloud_options,
-        } => {
+        FileScan::Csv { options } => {
             let options = serde_json::to_string(options)
                 .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
             let cloud_options = serde_json::to_string(cloud_options)
@@ -27,11 +29,7 @@ fn scan_type_to_pyobject(py: Python, scan_type: &FileScan) -> PyResult<PyObject>
             Ok(("csv", options, cloud_options).into_py_any(py)?)
         },
         #[cfg(feature = "parquet")]
-        FileScan::Parquet {
-            options,
-            cloud_options,
-            ..
-        } => {
+        FileScan::Parquet { options, .. } => {
             let options = serde_json::to_string(options)
                 .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;
             let cloud_options = serde_json::to_string(cloud_options)
@@ -80,19 +78,22 @@ pub struct Filter {
 #[pyclass]
 #[derive(Clone)]
 pub struct PyFileOptions {
-    inner: FileScanOptions,
+    inner: UnifiedScanArgs,
 }
 
 #[pymethods]
 impl PyFileOptions {
     #[getter]
     fn n_rows(&self) -> Option<(i64, usize)> {
-        self.inner.pre_slice
+        self.inner
+            .pre_slice
+            .clone()
+            .map(|slice| <(i64, usize)>::try_from(slice).unwrap())
     }
     #[getter]
     fn with_columns(&self) -> Option<Vec<&str>> {
         self.inner
-            .with_columns
+            .projection
             .as_ref()?
             .iter()
             .map(|x| x.as_str())
@@ -113,10 +114,6 @@ impl PyFileOptions {
     #[getter]
     fn rechunk(&self, _py: Python<'_>) -> bool {
         self.inner.rechunk
-    }
-    #[getter]
-    fn file_counter(&self, _py: Python<'_>) -> FileCount {
-        self.inner.file_counter
     }
     #[getter]
     fn hive_options(&self, _py: Python<'_>) -> PyResult<PyObject> {
@@ -369,7 +366,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             predicate,
             output_schema: _,
             scan_type,
-            file_options,
+            unified_scan_args,
         } => Scan {
             paths: sources
                 .into_paths()
@@ -379,9 +376,9 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             file_info: py.None(),
             predicate: predicate.as_ref().map(|e| e.into()),
             file_options: PyFileOptions {
-                inner: (**file_options).clone(),
+                inner: (**unified_scan_args).clone(),
             },
-            scan_type: scan_type_to_pyobject(py, scan_type)?,
+            scan_type: scan_type_to_pyobject(py, scan_type, &unified_scan_args.cloud_options)?,
         }
         .into_py_any(py),
         IR::DataFrameScan {
@@ -611,6 +608,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                 FunctionIR::FastCount {
                     sources,
                     scan_type,
+                    cloud_options,
                     alias,
                 } => {
                     let sources = sources
@@ -620,7 +618,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
                         })?
                         .into_py_any(py)?;
 
-                    let scan_type = scan_type_to_pyobject(py, scan_type)?;
+                    let scan_type = scan_type_to_pyobject(py, scan_type, cloud_options)?;
 
                     let alias = alias
                         .as_ref()

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
@@ -32,7 +32,7 @@ impl MultiScanTaskInitializer {
         Arc<Mutex<BridgeState>>,
     ) {
         assert!(self.config.num_pipelines() > 0);
-        let verbose = self.config.verbose();
+        let verbose = self.config.verbose;
 
         if verbose {
             eprintln!(
@@ -48,7 +48,7 @@ impl MultiScanTaskInitializer {
         let (bridge_handle, bridge_recv_port_tx, send_phase_chan_to_bridge) =
             spawn_bridge(bridge_state.clone());
 
-        let verbose = self.config.verbose();
+        let verbose = self.config.verbose;
 
         let background_tasks_handle = AbortOnDropHandle::new(async_executor::spawn(
             TaskPriority::Low,

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/predicate.rs
@@ -24,7 +24,7 @@ impl MultiScanTaskInitializer {
                     self.config.projected_file_schema.as_ref(),
                     hive_parts.schema(),
                     hive_parts,
-                    self.config.verbose(),
+                    self.config.verbose,
                 )?;
 
                 return Ok((

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
@@ -47,7 +47,7 @@ pub async fn resolve_to_positive_slice(
 
 /// Translates a negative slice to positive slice.
 async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<ResolvedSliceInfo> {
-    let verbose = config.verbose();
+    let verbose = config.verbose;
 
     let pre_slice @ Slice::Negative {
         offset_from_end,

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -184,7 +184,7 @@ fn visualize_plan_rec(
             output_schema: _,
             scan_type,
             predicate,
-            file_options,
+            unified_scan_args,
         } => {
             let name = match &**scan_type {
                 #[cfg(feature = "parquet")]
@@ -207,9 +207,9 @@ fn visualize_plan_rec(
 
             {
                 let total_columns =
-                    file_info.schema.len() - usize::from(file_options.row_index.is_some());
-                let n_columns = file_options
-                    .with_columns
+                    file_info.schema.len() - usize::from(unified_scan_args.row_index.is_some());
+                let n_columns = unified_scan_args
+                    .projection
                     .as_ref()
                     .map(|columns| columns.len());
 
@@ -220,12 +220,12 @@ fn visualize_plan_rec(
                 }
             }
 
-            if let Some(polars_io::RowIndex { name, offset }) = &file_options.row_index {
+            if let Some(polars_io::RowIndex { name, offset }) = &unified_scan_args.row_index {
                 write!(f, r#"\nrow index: name: "{}", offset: {}"#, name, offset).unwrap();
             }
 
-            if let Some((offset, len)) = file_options.pre_slice {
-                write!(f, "\nslice: offset: {}, len: {}", offset, len).unwrap();
+            if let Some(slice) = unified_scan_args.pre_slice.as_ref() {
+                write!(f, "\nslice: {:?}", slice).unwrap();
             }
 
             if let Some(predicate) = predicate.as_ref() {

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -9,8 +9,8 @@ use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::{
-    FileScan, JoinTypeOptionsIR, PartitionTargetCallback, PartitionVariantIR, ScanSource,
-    ScanSources, SinkOptions, SinkTarget,
+    CastColumnsPolicy, FileScan, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback,
+    PartitionVariantIR, ScanSource, ScanSources, SinkOptions, SinkTarget,
 };
 use polars_plan::plans::hive::HivePartitionsDf;
 use polars_plan::plans::{AExpr, DataFrameUdf, FileInfo, IR};
@@ -24,7 +24,7 @@ mod to_graph;
 
 pub use fmt::visualize_plan;
 use polars_plan::dsl::ExtraColumnsPolicy;
-use polars_plan::prelude::{FileScanOptions, FileType};
+use polars_plan::prelude::{FileType, UnifiedScanArgs};
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::slice_enum::Slice;
@@ -211,8 +211,9 @@ pub enum PhysNodeKind {
         predicate: Option<ExprIR>,
 
         hive_parts: Option<HivePartitionsDf>,
-        allow_missing_columns: bool,
         include_file_paths: Option<PlSmallStr>,
+        cast_columns_policy: CastColumnsPolicy,
+        missing_columns_policy: MissingColumnsPolicy,
         extra_columns_policy: ExtraColumnsPolicy,
 
         /// Schema of columns contained in the file. Does not contain external columns (e.g. hive / row_index).
@@ -226,7 +227,7 @@ pub enum PhysNodeKind {
         predicate: Option<ExprIR>,
         output_schema: Option<SchemaRef>,
         scan_type: Box<FileScan>,
-        file_options: Box<FileScanOptions>,
+        unified_scan_args: Box<UnifiedScanArgs>,
     },
 
     #[cfg(feature = "python")]

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 
 use parking_lot::Mutex;
 use polars_core::prelude::PlRandomState;
@@ -29,6 +30,7 @@ use crate::graph::{Graph, GraphNodeKey};
 use crate::morsel::{MorselSeq, get_ideal_morsel_size};
 use crate::nodes;
 use crate::nodes::io_sinks::SinkComputeNode;
+use crate::nodes::io_sources::multi_file_reader::MultiFileReaderConfig;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::builder::FileReaderBuilder;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::capabilities::ReaderCapabilities;
 use crate::physical_plan::lower_expr::compute_output_schema;
@@ -478,8 +480,9 @@ fn to_graph_rec<'a>(
             pre_slice,
             predicate,
             hive_parts,
-            allow_missing_columns,
+            missing_columns_policy,
             extra_columns_policy,
+            cast_columns_policy,
             include_file_paths,
             file_schema,
         } => {
@@ -502,22 +505,48 @@ fn to_graph_rec<'a>(
                 .transpose()?
                 .map(|p| p.to_io(None, file_schema.clone()));
 
+            let sources = scan_sources.clone();
+            let file_reader_builder = file_reader_builder.clone();
+            let cloud_options = cloud_options.clone();
+
+            let final_output_schema = output_schema.clone();
+            let projected_file_schema = projected_file_schema.clone();
+            let full_file_schema = file_schema.clone();
+
+            let row_index = row_index.clone();
+            let pre_slice = pre_slice.clone();
+            let hive_parts = hive_parts.map(Arc::new);
+            let include_file_paths = include_file_paths.clone();
+            let missing_columns_policy = missing_columns_policy.clone();
+            let extra_columns_policy = extra_columns_policy.clone();
+            let cast_columns_policy = cast_columns_policy.clone();
+
+            let verbose = config::verbose();
+
             ctx.graph.add_node(
-                nodes::io_sources::multi_file_reader::MultiFileReader::new(
-                    scan_sources.clone(),
-                    file_reader_builder.clone(),
-                    cloud_options.clone(),
-                    output_schema.clone(),
-                    projected_file_schema.clone(),
-                    file_schema.clone(),
-                    row_index.clone(),
-                    pre_slice.clone(),
-                    predicate,
-                    hive_parts.map(Arc::new),
-                    include_file_paths.clone(),
-                    *allow_missing_columns,
-                    extra_columns_policy.clone(),
-                ),
+                nodes::io_sources::multi_file_reader::MultiFileReader::new(Arc::new(
+                    MultiFileReaderConfig {
+                        sources,
+                        file_reader_builder,
+                        cloud_options,
+                        final_output_schema,
+                        projected_file_schema,
+                        full_file_schema,
+                        row_index,
+                        pre_slice,
+                        predicate,
+                        hive_parts,
+                        include_file_paths,
+                        missing_columns_policy,
+                        extra_columns_policy,
+                        cast_columns_policy,
+                        // Initialized later
+                        num_pipelines: AtomicUsize::new(0),
+                        n_readers_pre_init:
+                            nodes::io_sources::multi_file_reader::DEFAULT_N_READERS_PRE_INIT,
+                        verbose,
+                    },
+                )),
                 [],
             )
         },
@@ -887,7 +916,7 @@ fn to_graph_rec<'a>(
                 },
             };
 
-            use polars_plan::dsl::ExtraColumnsPolicy;
+            use polars_plan::dsl::{CastColumnsPolicy, ExtraColumnsPolicy, MissingColumnsPolicy};
 
             use crate::nodes::io_sources::batch::builder::BatchFnReaderBuilder;
             use crate::nodes::io_sources::batch::{BatchFnReader, GetBatchState};
@@ -911,34 +940,45 @@ fn to_graph_rec<'a>(
             }) as Arc<dyn FileReaderBuilder>;
 
             // Give multiscan a single scan source. (It doesn't actually read from this).
-            let scan_sources = ScanSources::Paths(Arc::from([PathBuf::from("python-scan-0")]));
+            let sources = ScanSources::Paths(Arc::from([PathBuf::from("python-scan-0")]));
             let cloud_options = None;
+            let final_output_schema = output_schema.clone();
             let projected_file_schema = output_schema.clone();
-            let file_schema = output_schema.clone();
+            let full_file_schema = output_schema.clone();
             let row_index = None;
             let pre_slice = None;
             let predicate = None;
             let hive_parts = None;
             let include_file_paths = None;
-            let allow_missing_columns = false;
+            let missing_columns_policy = MissingColumnsPolicy::Raise;
             let extra_columns_policy = ExtraColumnsPolicy::Ignore;
+            let cast_columns_policy = CastColumnsPolicy::ErrorOnMismatch;
+            let verbose = config::verbose();
 
             ctx.graph.add_node(
-                nodes::io_sources::multi_file_reader::MultiFileReader::new(
-                    scan_sources.clone(),
-                    file_reader_builder,
-                    cloud_options,
-                    output_schema,
-                    projected_file_schema.clone(),
-                    file_schema.clone(),
-                    row_index,
-                    pre_slice,
-                    predicate,
-                    hive_parts,
-                    include_file_paths,
-                    allow_missing_columns,
-                    extra_columns_policy,
-                ),
+                nodes::io_sources::multi_file_reader::MultiFileReader::new(Arc::new(
+                    MultiFileReaderConfig {
+                        sources,
+                        file_reader_builder,
+                        cloud_options,
+                        final_output_schema,
+                        projected_file_schema,
+                        full_file_schema,
+                        row_index,
+                        pre_slice,
+                        predicate,
+                        hive_parts,
+                        include_file_paths,
+                        missing_columns_policy,
+                        extra_columns_policy,
+                        cast_columns_policy,
+                        // Initialized later
+                        num_pipelines: AtomicUsize::new(0),
+                        n_readers_pre_init:
+                            nodes::io_sources::multi_file_reader::DEFAULT_N_READERS_PRE_INIT,
+                        verbose,
+                    },
+                )),
                 [],
             )
         },

--- a/crates/polars-stream/src/utils/late_materialized_df.rs
+++ b/crates/polars-stream/src/utils/late_materialized_df.rs
@@ -6,7 +6,7 @@ use polars_core::schema::Schema;
 use polars_error::PolarsResult;
 use polars_plan::dsl::{FileScan, ScanSources};
 use polars_plan::plans::{AnonymousScan, AnonymousScanArgs, FileInfo, IR};
-use polars_plan::prelude::{AnonymousScanOptions, FileScanOptions};
+use polars_plan::prelude::{AnonymousScanOptions, UnifiedScanArgs};
 
 /// Used to insert a dataframe into in-memory-engine query plan after the query
 /// plan has been made.
@@ -35,7 +35,7 @@ impl LateMaterializedDataFrame {
                 options,
                 function: self,
             }),
-            file_options: Box::new(FileScanOptions::default()),
+            unified_scan_args: Box::new(UnifiedScanArgs::default()),
         }
     }
 }

--- a/crates/polars-utils/src/slice_enum.rs
+++ b/crates/polars-utils/src/slice_enum.rs
@@ -1,7 +1,8 @@
 use std::num::TryFromIntError;
 use std::ops::Range;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Slice {
     /// Or zero
     Positive {
@@ -23,13 +24,20 @@ impl Slice {
         }
     }
 
+    pub fn len_mut(&mut self) -> &mut usize {
+        match self {
+            Slice::Positive { len, .. } => len,
+            Slice::Negative { len, .. } => len,
+        }
+    }
+
     /// Returns the end position of the slice (offset + len).
     ///
     /// # Panics
     /// Panics if self is negative.
     pub fn end_position(&self) -> usize {
         let Slice::Positive { offset, len } = self.clone() else {
-            panic!("cannot use end() on a negative slice");
+            panic!("cannot use end_position() on a negative slice");
         };
 
         offset.saturating_add(len)


### PR DESCRIPTION
This will contain arguments that are common to all scan types, and will simplify things for us later when adding features to the scans.

Internally this is essentially a renaming of `FileScanOptions` and adding some extra fields (e.g. `*_policy` configs).

Changes
* Moved `cloud_options` out of the scan type enum, it is now in the UnifiedScanArgs
* Replaces `(i64, size)` with the recently added `polars_utils::slice_enum::Slice` for `pre_slice`

**Todos**
* LazyFileListReaders still need to be updated to use this in a follow up PR.
