### PR TITLE
feat: Support Cast in IO plugin predicates

### DIFF
--- a/crates/polars-plan/src/plans/python/predicate.rs
+++ b/crates/polars-plan/src/plans/python/predicate.rs
@@ -33,6 +33,7 @@ fn accept_as_io_predicate(e: &Expr) -> bool {
                 && accept_as_io_predicate(falsy)
                 && accept_as_io_predicate(predicate)
         },
+        Expr::Cast { expr, .. } => accept_as_io_predicate(expr),
         Expr::Alias(_, _) => true,
         Expr::AnonymousFunction { input, options, .. } | Expr::Function { input, options, .. } => {
             options.is_elementwise() && input.iter().all(accept_as_io_predicate)


### PR DESCRIPTION
closes #21790

In the linked issue, setting the schema to be nanosecond precision, forces a cast on the column to compare to the python datetime, which was previously not getting pushed down to the IO plugin.