### PR TITLE
docs(python): Add missing `is_business_day` to documentation reference

### DIFF
--- a/py-polars/docs/source/reference/expressions/temporal.rst
+++ b/py-polars/docs/source/reference/expressions/temporal.rst
@@ -21,6 +21,7 @@ The following methods are available under the `expr.dt` attribute.
     Expr.dt.dst_offset
     Expr.dt.epoch
     Expr.dt.hour
+    Expr.dt.is_business_day
     Expr.dt.is_leap_year
     Expr.dt.iso_year
     Expr.dt.microsecond

--- a/py-polars/docs/source/reference/series/temporal.rst
+++ b/py-polars/docs/source/reference/series/temporal.rst
@@ -21,6 +21,7 @@ The following methods are available under the `Series.dt` attribute.
     Series.dt.dst_offset
     Series.dt.epoch
     Series.dt.hour
+    Series.dt.is_business_day
     Series.dt.is_leap_year
     Series.dt.iso_year
     Series.dt.max


### PR DESCRIPTION
I added the feature but forgot to add it to the docs reference 🤦 