### PR TITLE
fix: Maintain float32 type in partitioned group-by

### DIFF
--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -580,7 +580,7 @@ impl PartitionedAggregation for AggregationExpr {
                         let mask = agg_count.equal(0 as IdxSize);
                         let agg_count = agg_count.set(&mask, None).unwrap().into_series();
 
-                        let agg_s = &agg_s / &agg_count;
+                        let agg_s = &agg_s / &agg_count.cast(agg_s.dtype()).unwrap();
                         Ok(agg_s?.with_name(new_name).into_column())
                     },
                     _ => Ok(Column::full_null(


### PR DESCRIPTION
fixes #22328

We can prune that code soon and dispatch to the new streaming engine.