### PR TITLE
fix: Resolve `get()` SchemaMismatch panic

### DIFF
--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -167,7 +167,12 @@ impl GatherExpr {
             };
 
             ac.with_values(taken, true, Some(&self.expr))?;
-            ac.with_update_groups(UpdateGroups::WithSeriesLen);
+            
+            if self.returns_scalar {
+                ac.with_update_groups(UpdateGroups::No);
+            } else {
+                ac.with_update_groups(UpdateGroups::WithSeriesLen);
+            }
             Ok(ac)
         } else {
             self.gather_aggregated_expensive(ac, idx)
@@ -234,7 +239,12 @@ impl GatherExpr {
                     };
 
                     ac.with_values(taken, true, Some(&self.expr))?;
-                    ac.with_update_groups(UpdateGroups::WithSeriesLen);
+
+                    if self.returns_scalar {
+                        ac.with_update_groups(UpdateGroups::No);
+                    } else {
+                        ac.with_update_groups(UpdateGroups::WithSeriesLen);
+                    }
                     Ok(ac)
                 },
             }

--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -166,7 +166,7 @@ impl GatherExpr {
                 taken.as_list().into_column()
             };
 
-            ac.with_values(taken, true, Some(&self.expr))?;
+            ac.with_values_and_args(taken, true, Some(&self.expr), false, self.returns_scalar)?;
 
             if self.returns_scalar {
                 ac.with_update_groups(UpdateGroups::No);

--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -167,7 +167,7 @@ impl GatherExpr {
             };
 
             ac.with_values(taken, true, Some(&self.expr))?;
-            
+
             if self.returns_scalar {
                 ac.with_update_groups(UpdateGroups::No);
             } else {


### PR DESCRIPTION
fixes #21610 
fixes #21553 
addresses panic but does not fix #22250 (*)
pending investigation #20478 (similar pattern, suspect different location in the code)

Kindly review. This addresses the panic's, but I am not confident stating this is the (only) right solution given the rich expression set.

Context from debugging: the `get()` gets mapped to `gather()` with `returns_scalar` set to `true`. This generates an aggregation context with state `AggregatedScalar` with inner `[i64]` but with `update_groups` set to `WithSeriesLen`. Later on, when `groups()` is called, the code panics. This only happens in advanced expressions, as `groups()` is not called unless needed. The submitted PR mimics the aggregation context from functions such as `first()` or `min()`, not `gather()`.

The other solution track I was considering is to extend the `update_group` logic for `AggregatedScalar`, but I can use some guidance to evaluate if that would make sense (probably not).

(*) Regarding #22250, where can I find documentation on the use of negative integers in `get(index)`? The documentation states for `index` "An expression that leads to a UInt32 index". Perhaps I am missing something..
