### PR TITLE
perf: Use optimize rolling_quantile with varying window sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,6 +3094,7 @@ dependencies = [
  "rand",
  "ryu",
  "serde",
+ "skiplist",
  "strength_reduce",
  "strum_macros",
  "version_check",
@@ -4602,6 +4603,15 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "skiplist"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eec25f46463fcdc5e02f388c2780b1b58e01be81a8378e62ec60931beccc3f6"
+dependencies = [
+ "rand",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ atomic-waker = "1"
 avro-schema = { version = "0.3" }
 base64 = "0.22.0"
 bincode = "1.3.3"
+skiplist = "0.5.1"
 bitflags = "2"
 bytemuck = { version = "1.22", features = ["derive", "extern_crate_alloc"] }
 bytes = { version = "1.10" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ atomic-waker = "1"
 avro-schema = { version = "0.3" }
 base64 = "0.22.0"
 bincode = "1.3.3"
-skiplist = "0.5.1"
 bitflags = "2"
 bytemuck = { version = "1.22", features = ["derive", "extern_crate_alloc"] }
 bytes = { version = "1.10" }
@@ -77,6 +76,7 @@ serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_json = "1"
 simd-json = { version = "0.14", features = ["known-key"] }
 simdutf8 = "0.1.4"
+skiplist = "0.5.1"
 slotmap = "1"
 sqlparser = "0.53"
 stacker = "0.1"

--- a/crates/polars-compute/Cargo.toml
+++ b/crates/polars-compute/Cargo.toml
@@ -23,6 +23,7 @@ polars-utils = { workspace = true }
 rand = { workspace = true }
 ryu = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+skiplist = { workspace = true }
 strength_reduce = { workspace = true }
 strum_macros = { workspace = true }
 

--- a/crates/polars-compute/src/rolling/min_max.rs
+++ b/crates/polars-compute/src/rolling/min_max.rs
@@ -61,6 +61,7 @@ impl<'a, T: NativeType, P: MinMaxPolicy> RollingAggWindowNulls<'a, T> for MinMax
         start: usize,
         end: usize,
         params: Option<RollingFnParams>,
+        _window_size: Option<usize>,
     ) -> Self {
         assert!(params.is_none());
         let mut slf = Self {
@@ -99,7 +100,13 @@ impl<'a, T: NativeType, P: MinMaxPolicy> RollingAggWindowNulls<'a, T> for MinMax
 }
 
 impl<'a, T: NativeType, P: MinMaxPolicy> RollingAggWindowNoNulls<'a, T> for MinMaxWindow<'a, T, P> {
-    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self {
+    fn new(
+        slice: &'a [T],
+        start: usize,
+        end: usize,
+        params: Option<RollingFnParams>,
+        _window_size: Option<usize>,
+    ) -> Self {
         assert!(params.is_none());
         let mut slf = Self {
             values: slice,

--- a/crates/polars-compute/src/rolling/no_nulls/mean.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/mean.rs
@@ -20,9 +20,15 @@ impl<
         + Sub<Output = T>,
 > RollingAggWindowNoNulls<'a, T> for MeanWindow<'a, T>
 {
-    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self {
+    fn new(
+        slice: &'a [T],
+        start: usize,
+        end: usize,
+        params: Option<RollingFnParams>,
+        window_size: Option<usize>,
+    ) -> Self {
         Self {
-            sum: SumWindow::new(slice, start, end, params),
+            sum: SumWindow::new(slice, start, end, params, window_size),
         }
     }
 

--- a/crates/polars-compute/src/rolling/no_nulls/mod.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/mod.rs
@@ -20,7 +20,13 @@ pub use sum::*;
 use super::*;
 
 pub trait RollingAggWindowNoNulls<'a, T: NativeType> {
-    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self;
+    fn new(
+        slice: &'a [T],
+        start: usize,
+        end: usize,
+        params: Option<RollingFnParams>,
+        window_size: Option<usize>,
+    ) -> Self;
 
     /// Update and recompute the window
     ///
@@ -44,7 +50,7 @@ where
 {
     let len = values.len();
     let (start, end) = det_offsets_fn(0, window_size, len);
-    let mut agg_window = Agg::new(values, start, end, params);
+    let mut agg_window = Agg::new(values, start, end, params, Some(window_size));
     if let Some(validity) = create_validity(min_periods, len, window_size, &det_offsets_fn) {
         if validity.iter().all(|x| !x) {
             return Ok(Box::new(PrimitiveArray::<T>::new_null(

--- a/crates/polars-compute/src/rolling/no_nulls/moment.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/moment.rs
@@ -26,7 +26,13 @@ impl<T: ToPrimitive + Copy, M: StateUpdate> MomentWindow<'_, T, M> {
 impl<'a, T: NativeType + IsFloat + Float + ToPrimitive + FromPrimitive, M: StateUpdate>
     RollingAggWindowNoNulls<'a, T> for MomentWindow<'a, T, M>
 {
-    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self {
+    fn new(
+        slice: &'a [T],
+        start: usize,
+        end: usize,
+        params: Option<RollingFnParams>,
+        _window_size: Option<usize>,
+    ) -> Self {
         let mut out = Self {
             slice,
             moment: M::new(params),

--- a/crates/polars-compute/src/rolling/no_nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/quantile.rs
@@ -28,22 +28,28 @@ impl<
         + Sub<Output = T>,
 > RollingAggWindowNoNulls<'a, T> for QuantileWindow<'a, T>
 {
-    fn new(slice: &'a [T], start: usize, end: usize, params: Option<RollingFnParams>) -> Self {
+    fn new(
+        slice: &'a [T],
+        start: usize,
+        end: usize,
+        params: Option<RollingFnParams>,
+        window_size: Option<usize>,
+    ) -> Self {
         let params = params.unwrap();
         let RollingFnParams::Quantile(params) = params else {
             unreachable!("expected Quantile params");
         };
 
         Self {
-            sorted: SortedBuf::new(slice, start, end),
+            sorted: SortedBuf::new(slice, start, end, window_size),
             prob: params.prob,
             method: params.method,
         }
     }
 
     unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
-        let vals = self.sorted.update(start, end);
-        let length = vals.len();
+        self.sorted.update(start, end);
+        let length = self.sorted.len();
 
         let idx = match self.method {
             Linear => {
@@ -54,11 +60,11 @@ impl<
                 let float_idx_top = (length_f - 1.0) * self.prob;
                 let top_idx = float_idx_top.ceil() as usize;
                 return if idx == top_idx {
-                    Some(unsafe { *vals.get_unchecked(idx) })
+                    Some(self.sorted.get(idx))
                 } else {
                     let proportion = T::from(float_idx_top - idx as f64).unwrap();
-                    let vi = unsafe { *vals.get_unchecked(idx) };
-                    let vj = unsafe { *vals.get_unchecked(top_idx) };
+                    let vi = self.sorted.get(idx);
+                    let vj = self.sorted.get(top_idx);
 
                     Some(proportion * (vj - vi) + vi)
                 };
@@ -70,14 +76,9 @@ impl<
 
                 let top_idx = ((length_f - 1.0) * self.prob).ceil() as usize;
                 return if top_idx == idx {
-                    // SAFETY:
-                    // we are in bounds
-                    Some(unsafe { *vals.get_unchecked(idx) })
+                    Some(self.sorted.get(idx))
                 } else {
-                    // SAFETY:
-                    // we are in bounds
-                    let (mid, mid_plus_1) =
-                        unsafe { (*vals.get_unchecked(idx), *vals.get_unchecked(idx + 1)) };
+                    let (mid, mid_plus_1) = (self.sorted.get(idx), (self.sorted.get(idx + 1)));
 
                     Some((mid + mid_plus_1) / (T::one() + T::one()))
                 };
@@ -94,9 +95,7 @@ impl<
             Equiprobable => ((length as f64 * self.prob).ceil() - 1.0).max(0.0) as usize,
         };
 
-        // SAFETY:
-        // we are in bounds
-        Some(unsafe { *vals.get_unchecked(idx) })
+        Some(self.sorted.get(idx))
     }
 }
 

--- a/crates/polars-compute/src/rolling/no_nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/no_nulls/sum.rs
@@ -75,7 +75,13 @@ impl<
         + Add<Output = T>,
 > RollingAggWindowNoNulls<'a, T> for SumWindow<'a, T>
 {
-    fn new(slice: &'a [T], start: usize, end: usize, _params: Option<RollingFnParams>) -> Self {
+    fn new(
+        slice: &'a [T],
+        start: usize,
+        end: usize,
+        _params: Option<RollingFnParams>,
+        _window_size: Option<usize>,
+    ) -> Self {
         let (sum, err) = sum_kahan(&slice[start..end]);
         Self {
             slice,

--- a/crates/polars-compute/src/rolling/nulls/mean.rs
+++ b/crates/polars-compute/src/rolling/nulls/mean.rs
@@ -23,9 +23,10 @@ impl<
         start: usize,
         end: usize,
         params: Option<RollingFnParams>,
+        window_size: Option<usize>,
     ) -> Self {
         Self {
-            sum: SumWindow::new(slice, validity, start, end, params),
+            sum: SumWindow::new(slice, validity, start, end, params, window_size),
         }
     }
 

--- a/crates/polars-compute/src/rolling/nulls/mod.rs
+++ b/crates/polars-compute/src/rolling/nulls/mod.rs
@@ -22,6 +22,7 @@ pub trait RollingAggWindowNulls<'a, T: NativeType> {
         start: usize,
         end: usize,
         params: Option<RollingFnParams>,
+        window_size: Option<usize>,
     ) -> Self;
 
     /// # Safety
@@ -48,7 +49,8 @@ where
     let len = values.len();
     let (start, end) = det_offsets_fn(0, window_size, len);
     // SAFETY; we are in bounds
-    let mut agg_window = unsafe { Agg::new(values, validity, start, end, params) };
+    let mut agg_window =
+        unsafe { Agg::new(values, validity, start, end, params, Some(window_size)) };
 
     let mut validity = create_validity(min_periods, len, window_size, det_offsets_fn)
         .unwrap_or_else(|| {

--- a/crates/polars-compute/src/rolling/nulls/moment.rs
+++ b/crates/polars-compute/src/rolling/nulls/moment.rs
@@ -45,6 +45,7 @@ impl<'a, T: NativeType + ToPrimitive + IsFloat + FromPrimitive, M: StateUpdate>
         start: usize,
         end: usize,
         params: Option<RollingFnParams>,
+        _window_size: Option<usize>,
     ) -> Self {
         let mut out = Self {
             slice,

--- a/crates/polars-compute/src/rolling/nulls/quantile.rs
+++ b/crates/polars-compute/src/rolling/nulls/quantile.rs
@@ -33,27 +33,27 @@ impl<
         start: usize,
         end: usize,
         params: Option<RollingFnParams>,
+        window_size: Option<usize>,
     ) -> Self {
         let params = params.unwrap();
         let RollingFnParams::Quantile(params) = params else {
             unreachable!("expected Quantile params");
         };
         Self {
-            sorted: SortedBufNulls::new(slice, validity, start, end),
+            sorted: SortedBufNulls::new(slice, validity, start, end, window_size),
             prob: params.prob,
             method: params.method,
         }
     }
 
     unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
-        let (values, null_count) = self.sorted.update(start, end);
+        let null_count = self.sorted.update(start, end);
+        let length = self.sorted.len();
         // The min periods_issue will be taken care of when actually rolling
-        if null_count == values.len() {
+        if null_count == length {
             return None;
         }
         // Nulls are guaranteed to be at the front
-        let values = &values[null_count..];
-        let length = values.len();
 
         let mut idx = match self.method {
             QuantileMethod::Nearest => ((length as f64) * self.prob) as usize,
@@ -73,7 +73,7 @@ impl<
             QuantileMethod::Midpoint => {
                 let top_idx = ((length as f64 - 1.0) * self.prob).ceil() as usize;
                 Some(
-                    (values.get_unchecked(idx).unwrap() + values.get_unchecked(top_idx).unwrap())
+                    (self.sorted.get(idx).unwrap() + self.sorted.get(top_idx).unwrap())
                         / T::from::<f64>(2.0f64).unwrap(),
                 )
             },
@@ -82,18 +82,17 @@ impl<
                 let top_idx = f64::ceil(float_idx) as usize;
 
                 if top_idx == idx {
-                    Some(values.get_unchecked(idx).unwrap())
+                    Some(self.sorted.get(idx).unwrap())
                 } else {
                     let proportion = T::from(float_idx - idx as f64).unwrap();
                     Some(
                         proportion
-                            * (values.get_unchecked(top_idx).unwrap()
-                                - values.get_unchecked(idx).unwrap())
-                            + values.get_unchecked(idx).unwrap(),
+                            * (self.sorted.get(top_idx).unwrap() - self.sorted.get(idx).unwrap())
+                            + self.sorted.get(idx).unwrap(),
                     )
                 }
             },
-            _ => Some(values.get_unchecked(idx).unwrap()),
+            _ => Some(self.sorted.get(idx).unwrap()),
         }
     }
 

--- a/crates/polars-compute/src/rolling/nulls/sum.rs
+++ b/crates/polars-compute/src/rolling/nulls/sum.rs
@@ -69,6 +69,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + AddAssign
         start: usize,
         end: usize,
         _params: Option<RollingFnParams>,
+        _window_size: Option<usize>,
     ) -> Self {
         let mut out = Self {
             slice,

--- a/crates/polars-compute/src/rolling/window.rs
+++ b/crates/polars-compute/src/rolling/window.rs
@@ -9,7 +9,7 @@ pub(super) struct SortedBuf<'a, T: NativeType> {
     last_start: usize,
     last_end: usize,
     // values within the window that we keep sorted
-    buf: OrderedSkipList<T>,
+    pub buf: OrderedSkipList<T>,
 }
 
 impl<'a, T: NativeType + PartialOrd + Copy> SortedBuf<'a, T> {
@@ -89,7 +89,7 @@ pub(super) struct SortedBufNulls<'a, T: NativeType> {
     last_start: usize,
     last_end: usize,
     // values within the window that we keep sorted
-    buf: OrderedSkipList<Option<T>>,
+    pub buf: OrderedSkipList<Option<T>>,
     pub null_count: usize,
 }
 

--- a/crates/polars-compute/src/rolling/window.rs
+++ b/crates/polars-compute/src/rolling/window.rs
@@ -1,4 +1,4 @@
-#![allow(unsafe_op_in_unsafe_fn)]
+use ::skiplist::OrderedSkipList;
 use polars_utils::total_ord::TotalOrd;
 
 use super::*;
@@ -9,19 +9,36 @@ pub(super) struct SortedBuf<'a, T: NativeType> {
     last_start: usize,
     last_end: usize,
     // values within the window that we keep sorted
-    buf: Vec<T>,
+    buf: OrderedSkipList<T>,
 }
 
-impl<'a, T: NativeType> SortedBuf<'a, T> {
-    pub(super) fn new(slice: &'a [T], start: usize, end: usize) -> Self {
-        let mut buf = slice[start..end].to_vec();
-        buf.sort_by(TotalOrd::tot_cmp);
-        Self {
+impl<'a, T: NativeType + PartialOrd + Copy> SortedBuf<'a, T> {
+    pub(super) fn new(
+        slice: &'a [T],
+        start: usize,
+        end: usize,
+        max_window_size: Option<usize>,
+    ) -> Self {
+        let mut buf = if let Some(max_window_size) = max_window_size {
+            OrderedSkipList::with_capacity(max_window_size)
+        } else {
+            OrderedSkipList::new()
+        };
+        unsafe { buf.sort_by(TotalOrd::tot_cmp) };
+        let mut out = Self {
             slice,
             last_start: start,
             last_end: end,
             buf,
-        }
+        };
+        let init = &slice[start..end];
+        out.reset(init);
+        out
+    }
+
+    fn reset(&mut self, slice: &[T]) {
+        self.buf.clear();
+        self.buf.extend(slice.iter().copied());
     }
 
     /// Update the window position by setting the `start` index and the `end` index.
@@ -29,46 +46,39 @@ impl<'a, T: NativeType> SortedBuf<'a, T> {
     /// # Safety
     /// The caller must ensure that `start` and `end` are within bounds of `self.slice`
     ///
-    pub(super) unsafe fn update(&mut self, start: usize, end: usize) -> &[T] {
+    pub(super) unsafe fn update(&mut self, start: usize, end: usize) {
         // swap the whole buffer
         if start >= self.last_end {
             self.buf.clear();
-            let new_window = self.slice.get_unchecked(start..end);
-            self.buf.extend_from_slice(new_window);
-            self.buf.sort_by(TotalOrd::tot_cmp);
+            let new_window = unsafe { self.slice.get_unchecked(start..end) };
+            self.reset(new_window);
         } else {
             // remove elements that should leave the window
             for idx in self.last_start..start {
                 // SAFETY:
-                // we are in bounds
-                let val = self.slice.get_unchecked(idx);
-                // SAFETY:
-                // value is present in buf
-                let remove_idx = self
-                    .buf
-                    .binary_search_by(|a| a.tot_cmp(val))
-                    .unwrap_unchecked();
-                // this is O(n) but we need a sorted window
-                self.buf.remove(remove_idx);
+                // in bounds
+                let val = unsafe { self.slice.get_unchecked(idx) };
+                self.buf.remove(val);
             }
 
             // insert elements that enter the window, but insert them sorted
             for idx in self.last_end..end {
                 // SAFETY:
                 // we are in bounds
-                let val = *self.slice.get_unchecked(idx);
-                let insertion_idx = self
-                    .buf
-                    .binary_search_by(|a| a.tot_cmp(&val))
-                    .unwrap_or_else(|insertion_idx| insertion_idx);
-
-                // this is O(n) but we need a sorted window
-                self.buf.insert(insertion_idx, val);
+                let val = unsafe { *self.slice.get_unchecked(idx) };
+                self.buf.insert(val);
             }
         }
         self.last_start = start;
         self.last_end = end;
-        &self.buf
+    }
+
+    pub(super) fn get(&self, index: usize) -> T {
+        self.buf[index]
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.buf.len()
     }
 }
 
@@ -79,14 +89,14 @@ pub(super) struct SortedBufNulls<'a, T: NativeType> {
     last_start: usize,
     last_end: usize,
     // values within the window that we keep sorted
-    buf: Vec<Option<T>>,
+    buf: OrderedSkipList<Option<T>>,
     pub null_count: usize,
 }
 
-impl<'a, T: NativeType> SortedBufNulls<'a, T> {
+impl<'a, T: NativeType + PartialOrd> SortedBufNulls<'a, T> {
     unsafe fn fill_and_sort_buf(&mut self, start: usize, end: usize) {
         self.null_count = 0;
-        let iter = (start..end).map(|idx| {
+        let iter = (start..end).map(|idx| unsafe {
             if self.validity.get_bit_unchecked(idx) {
                 Some(*self.slice.get_unchecked(idx))
             } else {
@@ -97,7 +107,6 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
 
         self.buf.clear();
         self.buf.extend(iter);
-        self.buf.sort_by(TotalOrd::tot_cmp);
     }
 
     pub(super) unsafe fn new(
@@ -105,8 +114,14 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
         validity: &'a Bitmap,
         start: usize,
         end: usize,
+        max_window_size: Option<usize>,
     ) -> Self {
-        let buf = Vec::with_capacity(end - start);
+        let mut buf = if let Some(max_window_size) = max_window_size {
+            OrderedSkipList::with_capacity(max_window_size)
+        } else {
+            OrderedSkipList::new()
+        };
+        unsafe { buf.sort_by(TotalOrd::tot_cmp) };
 
         // sort_opt_buf(&mut buf);
         let mut out = Self {
@@ -117,7 +132,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
             buf,
             null_count: 0,
         };
-        out.fill_and_sort_buf(start, end);
+        unsafe { out.fill_and_sort_buf(start, end) };
         out
     }
 
@@ -126,81 +141,52 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
     /// # Safety
     /// The caller must ensure that `start` and `end` are within bounds of `self.slice`
     ///
-    pub(super) unsafe fn update(&mut self, start: usize, end: usize) -> (&[Option<T>], usize) {
+    pub(super) unsafe fn update(&mut self, start: usize, end: usize) -> usize {
         // swap the whole buffer
         if start >= self.last_end {
-            self.fill_and_sort_buf(start, end);
+            unsafe { self.fill_and_sort_buf(start, end) };
         } else {
             // remove elements that should leave the window
             for idx in self.last_start..start {
                 // SAFETY:
                 // we are in bounds
-                let val = if self.validity.get_bit_unchecked(idx) {
-                    Some(*self.slice.get_unchecked(idx))
+                let val = if unsafe { self.validity.get_bit_unchecked(idx) } {
+                    unsafe { Some(*self.slice.get_unchecked(idx)) }
                 } else {
                     self.null_count -= 1;
                     None
                 };
-
-                // SAFETY:
-                // value is present in buf
-                let remove_idx = self
-                    .buf
-                    .binary_search_by(|a| a.tot_cmp(&val))
-                    .unwrap_unchecked();
-                // this is O(n) but we need a sorted window
-                self.buf.remove(remove_idx);
+                self.buf.remove(&val);
             }
 
             // insert elements that enter the window, but insert them sorted
             for idx in self.last_end..end {
                 // SAFETY:
                 // we are in bounds
-                let val = if self.validity.get_bit_unchecked(idx) {
-                    Some(*self.slice.get_unchecked(idx))
+                let val = if unsafe { self.validity.get_bit_unchecked(idx) } {
+                    unsafe { Some(*self.slice.get_unchecked(idx)) }
                 } else {
                     self.null_count += 1;
                     None
                 };
-                let insertion_idx = self
-                    .buf
-                    .binary_search_by(|a| a.tot_cmp(&val))
-                    .unwrap_or_else(|insertion_idx| insertion_idx);
 
-                // this is O(n) but we need a sorted window
-                self.buf.insert(insertion_idx, val);
+                self.buf.insert(val);
             }
         }
         self.last_start = start;
         self.last_end = end;
-        (&self.buf, self.null_count)
+        self.null_count
     }
 
     pub(super) fn is_valid(&self, min_periods: usize) -> bool {
         ((self.last_end - self.last_start) - self.null_count) >= min_periods
     }
-}
 
-#[cfg(test)]
-mod test {
-    use super::*;
+    pub(super) fn len(&self) -> usize {
+        self.buf.len()
+    }
 
-    #[test]
-    fn test_sorted_buf() {
-        unsafe {
-            let values = &[1, 3, 4, 6, 2, -1, 9];
-
-            let mut sorted_window = SortedBuf::new(values, 0, 3);
-            let window = sorted_window.update(1, 4);
-            assert_eq!(window, &[3, 4, 6]);
-            let window = sorted_window.update(2, 5);
-            assert_eq!(window, &[2, 4, 6]);
-            let window = sorted_window.update(3, 6);
-            assert_eq!(window, &[-1, 2, 6]);
-            let window = sorted_window.update(3, 7);
-            assert_eq!(window, &[-1, 2, 6, 9]);
-            let window = sorted_window.update(4, 7);
-            assert_eq!(window, &[-1, 2, 9]);
-        }
+    pub(super) fn get(&self, idx: usize) -> Option<T> {
+        self.buf[idx]
     }
 }

--- a/crates/polars-compute/src/rolling/window.rs
+++ b/crates/polars-compute/src/rolling/window.rs
@@ -89,7 +89,7 @@ pub(super) struct SortedBufNulls<'a, T: NativeType> {
     last_start: usize,
     last_end: usize,
     // values within the window that we keep sorted
-    pub buf: OrderedSkipList<Option<T>>,
+    buf: OrderedSkipList<Option<T>>,
     pub null_count: usize,
 }
 

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -86,7 +86,7 @@ where
     // start with a dummy index, will be overwritten on first iteration.
     // SAFETY:
     // we are in bounds
-    let mut agg_window = unsafe { Agg::new(values, validity, 0, 0, params) };
+    let mut agg_window = unsafe { Agg::new(values, validity, 0, 0, params, None) };
 
     let mut validity = MutableBitmap::with_capacity(output_len);
     validity.extend_constant(output_len, true);
@@ -136,7 +136,7 @@ where
         return PrimitiveArray::new(T::PRIMITIVE.into(), out.into(), None);
     }
     // start with a dummy index, will be overwritten on first iteration.
-    let mut agg_window = Agg::new(values, 0, 0, params);
+    let mut agg_window = Agg::new(values, 0, 0, params, None);
 
     offsets
         .map(|(start, len)| {

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -35,7 +35,7 @@ where
         )));
     }
     // start with a dummy index, will be overwritten on first iteration.
-    let mut agg_window = Agg::new(values, 0, 0, params);
+    let mut agg_window = Agg::new(values, 0, 0, params, None);
 
     let out = offsets
         .map(|result| {
@@ -98,7 +98,7 @@ where
     }
     let sorting_indices = sorting_indices.expect("`sorting_indices` should have been set");
     // start with a dummy index, will be overwritten on first iteration.
-    let mut agg_window = Agg::new(values, 0, 0, params);
+    let mut agg_window = Agg::new(values, 0, 0, params, None);
 
     let mut out = zeroed_vec(values.len());
     let mut validity: Option<MutableBitmap> = None;


### PR DESCRIPTION
closes #22343

Uses the proposed skiplist crate. There are some optimizations we can still do, but that requires vendoring or a native implementation. This is something we can look into later. 