### PR TITLE
chore: Only use pytorch index-url for `pytorch` package

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -93,6 +93,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          check-latest: true
 
       - name: Install uv
         run: |

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -285,3 +285,13 @@ exclude_lines = [
   "if TYPE_CHECKING:",
   "from typing_extensions import ",
 ]
+
+[[tool.uv.index]]
+name = "pytorch"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch", marker = "python_version < '3.1.3' or sys_platform != 'win32'" },
+]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -293,5 +293,5 @@ explicit = true
 
 [tool.uv.sources]
 torch = [
-  { index = "pytorch", marker = "python_version < '3.1.3' or sys_platform != 'win32'" },
+  { index = "pytorch" },
 ]

--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -2,7 +2,6 @@
 # Packages that we require for unit tests that run on CI
 # (installable via `make requirements-all`)
 # -------------------------------------------------------
---extra-index-url https://download.pytorch.org/whl/cpu
 torch
 jax[cpu]
 pyiceberg>=0.7.1


### PR DESCRIPTION
**Note**: I am not 100% sure I have done this right so someone more familiar with project setup please review!

---

While ~~trying to fix~~ (whoops, triggered issue close keyword) work on #22348 (with no success so far), I discovered that by using `--extra-index-url` in `requirements-ci.txt`

https://github.com/pola-rs/polars/blob/3cfa7cdb1ba4ed9b570214887b4179e5f54f66d9/py-polars/requirements-ci.txt#L5

we were inadvertently using the pytorch repo for many package installations, including numpy, since when you use `--extra-index-url` it becomes prioritized ([see docs](https://docs.astral.sh/uv/configuration/indexes/#-index-url-and-extra-index-url)) over PyPi. This was causing packages to be installed from pytorch instead of PyPi, and subsequently was not installing the latest version. For example, pytorch's latest available `numpy` is 2.1.2, whereas PyPi has 2.2.5.

I believe this helps ensure we're testing on the latest version of more packages. @MarcoGorelli I think I saw your comment on an issue somewhere so I think you may have helped set up the extra-index-url bit, is that true?