### PR TITLE
chore: Install pytorch for 3.13 on Windows

### DIFF
--- a/py-polars/requirements-ci.txt
+++ b/py-polars/requirements-ci.txt
@@ -3,6 +3,6 @@
 # (installable via `make requirements-all`)
 # -------------------------------------------------------
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch; python_version < '3.13' or platform_system != 'Windows'  # torch provides no wheel for Python 3.13 on Windows
+torch
 jax[cpu]
 pyiceberg>=0.7.1


### PR DESCRIPTION
I noticed the constraint in #22355 - it looks like this was resolved in the [latest pytorch release](https://download.pytorch.org/whl/cpu).

![image](https://github.com/user-attachments/assets/0d0e09bb-f898-467b-babd-ddecf0e34924)
