### PR TITLE
fix(rust): Fix chaining pl.lit(<list>) with .list.get(pl.col(...))

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -572,6 +572,48 @@ pub(super) fn get(s: &mut [Column], null_on_oob: bool) -> PolarsResult<Option<Co
                 .map(Column::from)
                 .map(Some)
         },
+        _ if ca.len() == 1 => {
+            if ca.null_count() > 0 {
+                return Ok(Some(Column::full_null(
+                    ca.name().clone(),
+                    index.len(),
+                    ca.inner_dtype(),
+                )));
+            }
+            let tmp = ca.rechunk();
+            let arr = tmp.downcast_as_array();
+            let offsets = arr.offsets().as_slice();
+            let start = offsets[0];
+            let end = offsets[1];
+            let out_of_bounds = |offset| offset >= end || offset < start || start == end;
+            let take_by: IdxCa = index
+                .iter()
+                .map(|opt_idx| match opt_idx {
+                    Some(idx) => {
+                        let offset = if idx >= 0 { start + idx } else { end + idx };
+                        if out_of_bounds(offset) {
+                            if null_on_oob {
+                                Ok(None)
+                            } else {
+                                polars_bail!(ComputeError: "get index is out of bounds");
+                            }
+                        } else {
+                            let Ok(offset) = IdxSize::try_from(offset) else {
+                                polars_bail!(ComputeError: "get index is out of bounds");
+                            };
+                            Ok(Some(offset))
+                        }
+                    },
+                    None => Ok(None),
+                })
+                .collect::<Result<IdxCa, _>>()?;
+
+            let s = Series::try_from((ca.name().clone(), arr.values().clone())).unwrap();
+            unsafe { s.take_unchecked(&take_by) }
+                .cast(ca.inner_dtype())
+                .map(Column::from)
+                .map(Some)
+        },
         len => polars_bail!(
             ComputeError:
             "`list.get` expression got an index array of length {} while the list has {} elements",

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -852,6 +852,14 @@ def test_null_list_categorical_16405() -> None:
     assert_frame_equal(df, expected)
 
 
+def test_list_get_literal_broadcast_21463():
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    df = df.with_columns(x=pl.lit([1, 2, 3, 4]))
+    expected = df.with_columns(b=pl.col("x").list.get(pl.col("a"))).drop("x")
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    actual = df.with_columns(b=pl.lit([1, 2, 3, 4]).list.get(pl.col("a")))
+    assert expected.equals(actual)
+
 def test_sort() -> None:
     def tc(a: list[Any], b: list[Any]) -> None:
         a_s = pl.Series("l", a, pl.List(pl.Int64))

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -852,7 +852,7 @@ def test_null_list_categorical_16405() -> None:
     assert_frame_equal(df, expected)
 
 
-def test_list_get_literal_broadcast_21463():
+def test_list_get_literal_broadcast_21463() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     df = df.with_columns(x=pl.lit([1, 2, 3, 4]))
     expected = df.with_columns(b=pl.col("x").list.get(pl.col("a"))).drop("x")

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -860,6 +860,7 @@ def test_list_get_literal_broadcast_21463() -> None:
     actual = df.with_columns(b=pl.lit([1, 2, 3, 4]).list.get(pl.col("a")))
     assert expected.equals(actual)
 
+
 def test_sort() -> None:
     def tc(a: list[Any], b: list[Any]) -> None:
         a_s = pl.Series("l", a, pl.List(pl.Int64))


### PR DESCRIPTION
### Background 

Currently, list.get handles only two patterns:
1. Scalar index (index.len() == 1): one index for each list.
2. Per‑list indexing (index.len() == ca.len()): one index per list in the column.

Any other combination including a single list with multiple indices falls through to the match arm (which is what happens in https://github.com/pola-rs/polars/issues/21463), which throws an error:

```
polars.exceptions.ComputeError: `list.get` expression got an index array of length 3 while the list has 1 elements
```

### Changes 

I added a new match arm for exactly the scenario when there’s one list (ca.len() == 1) but index.len() > 1—to sort of “broadcast” the list across all requested positions. 

Now: 
```
import polars as pl

df = pl.DataFrame({"a": [1, 2, 3]})
df.with_columns(b=pl.lit([1, 2, 3, 4]).list.get(pl.col("a")))
```

produces: 

```
shape: (3, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ i64 ┆ i64 │
╞═════╪═════╡
│ 1   ┆ 2   │
│ 2   ┆ 3   │
│ 3   ┆ 4   │
└─────┴─────┘
``` 

instead of throwing an error and thereby resolves #21463 