### PR TITLE
fix: Fix incorrect filter after `LazyFrame.rename().select()`

### DIFF
--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/keys.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/keys.rs
@@ -25,14 +25,3 @@ pub(super) fn predicate_to_key(predicate: Node, expr_arena: &Arena<AExpr>) -> Pl
         PlSmallStr::from_str(HIDDEN_DELIMITER)
     }
 }
-
-pub(super) fn key_has_name(key: &str, name: &str) -> bool {
-    if key.contains(HIDDEN_DELIMITER) {
-        for root_name in key.split(HIDDEN_DELIMITER) {
-            if root_name == name {
-                return true;
-            }
-        }
-    }
-    key == name
-}

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -479,21 +479,15 @@ impl PredicatePushDown<'_> {
                 if function.allow_predicate_pd() {
                     match function {
                         FunctionIR::Rename { existing, new, .. } => {
-                            let local_predicates =
-                                process_rename(&mut acc_predicates, expr_arena, existing, new)?;
-                            let lp = self.pushdown_and_continue(
+                            process_rename(&mut acc_predicates, expr_arena, existing, new);
+
+                            self.pushdown_and_continue(
                                 lp,
                                 acc_predicates,
                                 lp_arena,
                                 expr_arena,
                                 false,
-                            )?;
-                            Ok(self.optional_apply_predicate(
-                                lp,
-                                local_predicates,
-                                lp_arena,
-                                expr_arena,
-                            ))
+                            )
                         },
                         FunctionIR::Explode { columns, .. } => {
                             let condition = |name: &PlSmallStr| columns.iter().any(|s| s == name);

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/rename.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/rename.rs
@@ -1,24 +1,6 @@
 use polars_utils::pl_str::PlSmallStr;
 
 use super::*;
-use crate::prelude::optimizer::predicate_pushdown::keys::{key_has_name, predicate_to_key};
-
-fn remove_any_key_referencing_renamed(
-    new: &str,
-    acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
-    local_predicates: &mut Vec<ExprIR>,
-) {
-    let mut move_to_local = vec![];
-    for key in acc_predicates.keys() {
-        if key_has_name(key, new) {
-            move_to_local.push(key.clone())
-        }
-    }
-
-    for key in move_to_local {
-        local_predicates.push(acc_predicates.remove(&key).unwrap())
-    }
-}
 
 pub(super) fn process_rename(
     acc_predicates: &mut PlHashMap<PlSmallStr, ExprIR>,
@@ -26,41 +8,15 @@ pub(super) fn process_rename(
     existing: &[PlSmallStr],
     new: &[PlSmallStr],
 ) -> PolarsResult<Vec<ExprIR>> {
-    let mut local_predicates = vec![];
-    for (existing, new) in existing.iter().zip(new.iter()) {
-        let has_existing = acc_predicates.contains_key(existing.as_str());
-        let has_new = acc_predicates.contains_key(new.as_str());
-        let has_both = has_existing && has_new;
+    let rename_map: PlHashMap<PlSmallStr, PlSmallStr> =
+        new.iter().cloned().zip(existing.iter().cloned()).collect();
 
-        // swapping path add to local for now
-        if has_both {
-            // Search for the key and add it to local because swapping is more complicated
-            if let Some(to_local) = acc_predicates.remove(new.as_str()) {
-                local_predicates.push(to_local);
-            } else {
-                // The keys can be combined eg. `a AND b AND c` in this case replacing/finding
-                // the key that should be renamed is more complicated, so for now
-                // we just move it to local.
-                remove_any_key_referencing_renamed(new, acc_predicates, &mut local_predicates)
-            }
-            continue;
-        }
-        // simple new name path
-        else {
-            // Find the key and update the predicate as well as the key
-            // This ensure the optimization is pushed down.
-            if let Some(mut e) = acc_predicates.remove(new.as_str()) {
-                let new_node =
-                    rename_matching_aexpr_leaf_names(e.node(), expr_arena, new, existing.clone());
-                e.set_node(new_node);
-                acc_predicates.insert(predicate_to_key(new_node, expr_arena), e);
-            } else {
-                // The keys can be combined eg. `a AND b AND c` in this case replacing/finding
-                // the key that should be renamed is more complicated, so for now
-                // we just move it to local.
-                remove_any_key_referencing_renamed(new, acc_predicates, &mut local_predicates)
-            }
+    if !rename_map.is_empty() {
+        for (_, expr_ir) in acc_predicates.iter_mut() {
+            map_column_references(expr_ir, expr_arena, &rename_map);
         }
     }
-    Ok(local_predicates)
+
+    // TODO: Remove
+    Ok(vec![])
 }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/rename.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/rename.rs
@@ -7,7 +7,7 @@ pub(super) fn process_rename(
     expr_arena: &mut Arena<AExpr>,
     existing: &[PlSmallStr],
     new: &[PlSmallStr],
-) -> PolarsResult<Vec<ExprIR>> {
+) {
     let rename_map: PlHashMap<PlSmallStr, PlSmallStr> =
         new.iter().cloned().zip(existing.iter().cloned()).collect();
 
@@ -16,7 +16,4 @@ pub(super) fn process_rename(
             map_column_references(expr_ir, expr_arena, &rename_map);
         }
     }
-
-    // TODO: Remove
-    Ok(vec![])
 }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -386,7 +386,7 @@ pub fn pushdown_eligibility(
 
 /// Maps column references within an expression. Used to handle column renaming when pushing
 /// predicates.
-pub(super) fn map_column_references<'a>(
+pub(super) fn map_column_references(
     expr: &mut ExprIR,
     expr_arena: &mut Arena<AExpr>,
     rename_map: &PlHashMap<PlSmallStr, PlSmallStr>,
@@ -453,7 +453,7 @@ pub(super) fn map_column_references<'a>(
 
             // Safety: Checked in pre_visit()
             Ok(AexprNode::new(
-                self.column_nodes.get(new_colname.as_str()).unwrap().clone(),
+                *self.column_nodes.get(new_colname.as_str()).unwrap(),
             ))
         }
     }

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -2,6 +2,7 @@ use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 
 use super::keys::*;
+use crate::plans::visitor::{AexprNode, RewriteRecursion, RewritingVisitor, TreeWalker};
 use crate::prelude::*;
 fn combine_by_and(left: Node, right: Node, arena: &mut Arena<AExpr>) -> Node {
     arena.add(AExpr::BinaryExpr {
@@ -380,5 +381,80 @@ pub fn pushdown_eligibility(
             Ok((PushdownEligibility::NoPushdown, alias_to_col_map))
         },
         _ => Ok((PushdownEligibility::Partial { to_local }, alias_to_col_map)),
+    }
+}
+
+/// Maps column references within an expression. Used to handle column renaming when pushing
+/// predicates.
+pub(super) fn map_column_references<'a>(
+    expr: &mut ExprIR,
+    expr_arena: &mut Arena<AExpr>,
+    rename_map: &PlHashMap<PlSmallStr, PlSmallStr>,
+) {
+    if rename_map.is_empty() {
+        return;
+    }
+
+    let node = AexprNode::new(expr.node())
+        .rewrite(
+            &mut MapColumnReferences {
+                rename_map,
+                column_nodes: PlHashMap::with_capacity(rename_map.len()),
+            },
+            expr_arena,
+        )
+        .unwrap()
+        .node();
+
+    expr.set_node(node);
+
+    struct MapColumnReferences<'a> {
+        rename_map: &'a PlHashMap<PlSmallStr, PlSmallStr>,
+        column_nodes: PlHashMap<&'a str, Node>,
+    }
+
+    impl RewritingVisitor for MapColumnReferences<'_> {
+        type Node = AexprNode;
+        type Arena = Arena<AExpr>;
+
+        fn pre_visit(
+            &mut self,
+            node: &Self::Node,
+            arena: &mut Self::Arena,
+        ) -> polars_core::prelude::PolarsResult<crate::prelude::visitor::RewriteRecursion> {
+            let AExpr::Column(colname) = arena.get(node.node()) else {
+                return Ok(RewriteRecursion::NoMutateAndContinue);
+            };
+
+            if !self.rename_map.contains_key(colname) {
+                return Ok(RewriteRecursion::NoMutateAndContinue);
+            }
+
+            Ok(RewriteRecursion::MutateAndContinue)
+        }
+
+        fn mutate(
+            &mut self,
+            node: Self::Node,
+            arena: &mut Self::Arena,
+        ) -> polars_core::prelude::PolarsResult<Self::Node> {
+            let AExpr::Column(colname) = arena.get(node.node()) else {
+                unreachable!();
+            };
+
+            let new_colname = self.rename_map.get(colname).unwrap();
+
+            if !self.column_nodes.contains_key(new_colname.as_str()) {
+                self.column_nodes.insert(
+                    new_colname.as_str(),
+                    arena.add(AExpr::Column(new_colname.clone())),
+                );
+            }
+
+            // Safety: Checked in pre_visit()
+            Ok(AexprNode::new(
+                self.column_nodes.get(new_colname.as_str()).unwrap().clone(),
+            ))
+        }
     }
 }

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -216,29 +216,6 @@ pub fn column_node_to_name(node: ColumnNode, arena: &Arena<AExpr>) -> &PlSmallSt
     }
 }
 
-/// If the leaf names match `current`, the node will be replaced
-/// with a renamed expression.
-pub(crate) fn rename_matching_aexpr_leaf_names(
-    node: Node,
-    arena: &mut Arena<AExpr>,
-    current: &str,
-    new_name: PlSmallStr,
-) -> Node {
-    let mut leaves = aexpr_to_column_nodes_iter(node, arena);
-
-    if leaves.any(|node| matches!(arena.get(node.0), AExpr::Column(name) if &**name == current)) {
-        // we convert to expression as we cannot easily copy the aexpr.
-        let mut new_expr = node_to_expr(node, arena);
-        new_expr = new_expr.map_expr(|e| match e {
-            Expr::Column(name) if &*name == current => Expr::Column(new_name.clone()),
-            e => e,
-        });
-        to_aexpr(new_expr, arena).expect("infallible")
-    } else {
-        node
-    }
-}
-
 /// Get all leaf column expressions in the expression tree.
 pub(crate) fn expr_to_leaf_column_exprs_iter(expr: &Expr) -> impl Iterator<Item = &Expr> {
     expr.into_iter().flat_map(|e| match e {

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -685,3 +685,67 @@ def test_predicate_filtering_against_nulls() -> None:
         df.remove(pl.col("num").eq_missing(None)),
     ):
         assert res["num"].to_list() == [1, 2, 4]
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        (
+            (
+                pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+                .rename({"a": "A", "b": "a"})
+                .select("A", "c")
+                .filter(pl.col("A") == 1)
+            ),
+            pl.DataFrame({"A": 1, "c": 3}),
+        ),
+        (
+            (
+                pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+                .rename({"b": "a", "a": "A"})
+                .select("A", "c")
+                .filter(pl.col("A") == 1)
+            ),
+            pl.DataFrame({"A": 1, "c": 3}),
+        ),
+        (
+            (
+                pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+                .rename({"a": "b", "b": "a"})
+                .select("a", "b", "c")
+                .filter(pl.col("b") == 1)
+            ),
+            pl.DataFrame({"a": 2, "b": 1, "c": 3}),
+        ),
+        (
+            (
+                pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+                .rename({"a": "b", "b": "a"})
+                .select("b", "c")
+                .filter(pl.col("b") == 1)
+            ),
+            pl.DataFrame({"b": 1, "c": 3}),
+        ),
+        (
+            (
+                pl.LazyFrame({"a": [1], "b": [2], "c": [3]})
+                .rename({"b": "a", "a": "b"})
+                .select("a", "b", "c")
+                .filter(pl.col("b") == 1)
+            ),
+            pl.DataFrame({"a": 2, "b": 1, "c": 3}),
+        ),
+    ],
+)
+def test_predicate_pushdown_lazy_rename_22373(
+    query: pl.LazyFrame,
+    expected: pl.DataFrame,
+) -> None:
+    assert_frame_equal(
+        query.collect(),
+        expected,
+    )
+
+    # Ensure filter is pushed past rename
+    plan = query.explain()
+    assert plan.index("FILTER") > plan.index("RENAME")


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22373

The current handling of `Rename` in predicate pushdown uses some complex logic to remove predicates. In this PR, we simplify by observing that all columns within a `Rename` are guaranteed to exist in the input node (with maybe a different name), so we can just pass all of the predicates through after mapping the column references.
