### PR TITLE
refactor(rust): Improve code re-use for groupby and delete unused code

### DIFF
--- a/crates/polars-expr/src/groups/mod.rs
+++ b/crates/polars-expr/src/groups/mod.rs
@@ -3,7 +3,6 @@ use std::any::Any;
 use arrow::bitmap::BitmapBuilder;
 use polars_core::prelude::*;
 use polars_utils::IdxSize;
-use polars_utils::cardinality_sketch::CardinalitySketch;
 use polars_utils::hashing::HashPartitioner;
 
 use crate::hash_keys::HashKeys;
@@ -21,10 +20,6 @@ pub trait Grouper: Any + Send + Sync {
     /// Returns the number of groups in this Grouper.
     fn num_groups(&self) -> IdxSize;
 
-    /// Inserts the given keys into this Grouper, extending groups_idxs with
-    /// the group index of keys[i].
-    fn insert_keys(&mut self, keys: HashKeys, group_idxs: &mut Vec<IdxSize>);
-
     /// Inserts the given subset of keys into this Grouper. If groups_idxs is
     /// passed it is extended such with the group index of keys[subset[i]].
     ///
@@ -38,10 +33,6 @@ pub trait Grouper: Any + Send + Sync {
     );
 
     /// Adds the given Grouper into this one, mutating groups_idxs such that
-    /// the ith group of other now has group index group_idxs[i] in self.
-    fn combine(&mut self, other: &dyn Grouper, group_idxs: &mut Vec<IdxSize>);
-
-    /// Adds the given Grouper into this one, mutating groups_idxs such that
     /// the group subset[i] of other now has group index group_idxs[i] in self.
     ///
     /// # Safety
@@ -51,18 +42,6 @@ pub trait Grouper: Any + Send + Sync {
         other: &dyn Grouper,
         subset: &[IdxSize],
         group_idxs: &mut Vec<IdxSize>,
-    );
-
-    /// Generate partition indices.
-    ///
-    /// After this function partitions_idxs[i] will contain the indices for
-    /// partition i, and sketches[i] will contain a cardinality sketch for
-    /// partition i.
-    fn gen_partition_idxs(
-        &self,
-        partitioner: &HashPartitioner,
-        partition_idxs: &mut [Vec<IdxSize>],
-        sketches: &mut [CardinalitySketch],
     );
 
     /// Returns the keys in this Grouper in group order, that is the key for

--- a/crates/polars-expr/src/groups/row_encoded.rs
+++ b/crates/polars-expr/src/groups/row_encoded.rs
@@ -1,6 +1,5 @@
 use arrow::array::Array;
 use polars_row::RowEncodingOptions;
-use polars_utils::cardinality_sketch::CardinalitySketch;
 use polars_utils::idx_map::bytes_idx_map::{BytesIndexMap, Entry};
 use polars_utils::itertools::Itertools;
 use polars_utils::vec::PushUnchecked;
@@ -81,29 +80,6 @@ impl Grouper for RowEncodedHashGrouper {
         self.idx_map.len()
     }
 
-    fn insert_keys(&mut self, keys: HashKeys, group_idxs: &mut Vec<IdxSize>) {
-        let HashKeys::RowEncoded(keys) = keys else {
-            unreachable!()
-        };
-        assert!(!keys.hashes.has_nulls());
-
-        unsafe {
-            if keys.keys.has_nulls() {
-                group_idxs.reserve(keys.keys.len() - keys.keys.null_count());
-                for (idx, hash) in keys.hashes.values_iter().enumerate() {
-                    if let Some(key) = keys.keys.get_unchecked(idx) {
-                        group_idxs.push_unchecked(self.insert_key(*hash, key));
-                    }
-                }
-            } else {
-                group_idxs.reserve(keys.hashes.len());
-                for (hash, key) in keys.hashes.values_iter().zip(keys.keys.values_iter()) {
-                    group_idxs.push_unchecked(self.insert_key(*hash, key));
-                }
-            }
-        }
-    }
-
     unsafe fn insert_keys_subset(
         &mut self,
         keys: &HashKeys,
@@ -113,53 +89,23 @@ impl Grouper for RowEncodedHashGrouper {
         let HashKeys::RowEncoded(keys) = keys else {
             unreachable!()
         };
-        assert!(!keys.hashes.has_nulls());
 
         unsafe {
-            if keys.keys.has_nulls() {
-                let groups = subset.iter().filter_map(|idx| {
-                    if let Some(key) = keys.keys.get_unchecked(*idx as usize) {
-                        let hash = keys.hashes.value_unchecked(*idx as usize);
-                        Some(self.insert_key(hash, key))
-                    } else {
-                        None
+            if let Some(group_idxs) = group_idxs {
+                group_idxs.reserve(keys.keys.len() - keys.keys.null_count());
+                keys.for_each_hash_subset(subset, |idx, opt_hash| {
+                    if let Some(hash) = opt_hash {
+                        let key = keys.keys.value_unchecked(idx as usize);
+                        group_idxs.push_unchecked(self.insert_key(hash, key));
                     }
                 });
-
-                if let Some(group_idxs) = group_idxs {
-                    group_idxs.reserve(keys.keys.len() - keys.keys.null_count());
-                    group_idxs.extend(groups);
-                } else {
-                    groups.for_each(drop);
-                }
             } else {
-                let groups = subset.iter().map(|idx| {
-                    let hash = keys.hashes.value_unchecked(*idx as usize);
-                    let key = keys.keys.value_unchecked(*idx as usize);
-                    self.insert_key(hash, key)
+                keys.for_each_hash_subset(subset, |idx, opt_hash| {
+                    if let Some(hash) = opt_hash {
+                        let key = keys.keys.value_unchecked(idx as usize);
+                        self.insert_key(hash, key);
+                    }
                 });
-
-                if let Some(group_idxs) = group_idxs {
-                    group_idxs.reserve(keys.hashes.len());
-                    group_idxs.extend(groups);
-                } else {
-                    groups.for_each(drop);
-                }
-            }
-        }
-    }
-
-    fn combine(&mut self, other: &dyn Grouper, group_idxs: &mut Vec<IdxSize>) {
-        let other = other.as_any().downcast_ref::<Self>().unwrap();
-
-        // TODO: cardinality estimation.
-        self.idx_map.reserve(other.idx_map.len() as usize);
-
-        unsafe {
-            group_idxs.clear();
-            group_idxs.reserve(other.idx_map.len() as usize);
-            for (hash, key) in other.idx_map.iter_hash_keys() {
-                group_idxs.push_unchecked(self.insert_key(hash, key));
             }
         }
     }
@@ -192,40 +138,6 @@ impl Grouper for RowEncodedHashGrouper {
                 key_rows.push_unchecked(key);
             }
             self.finalize_keys(key_rows)
-        }
-    }
-
-    fn gen_partition_idxs(
-        &self,
-        partitioner: &HashPartitioner,
-        partition_idxs: &mut [Vec<IdxSize>],
-        sketches: &mut [CardinalitySketch],
-    ) {
-        let num_partitions = partitioner.num_partitions();
-        assert!(partition_idxs.len() == num_partitions);
-        assert!(sketches.len() == num_partitions);
-
-        // Two-pass algorithm to prevent reallocations.
-        let mut partition_sizes = vec![0; num_partitions];
-        unsafe {
-            for (hash, _key) in self.idx_map.iter_hash_keys() {
-                let p_idx = partitioner.hash_to_partition(hash);
-                *partition_sizes.get_unchecked_mut(p_idx) += 1;
-                sketches.get_unchecked_mut(p_idx).insert(hash);
-            }
-        }
-
-        for (partition, sz) in partition_idxs.iter_mut().zip(partition_sizes) {
-            partition.clear();
-            partition.reserve(sz);
-        }
-
-        unsafe {
-            for (i, (hash, _key)) in self.idx_map.iter_hash_keys().enumerate() {
-                let p_idx = partitioner.hash_to_partition(hash);
-                let p = partition_idxs.get_unchecked_mut(p_idx);
-                p.push_unchecked(i as IdxSize);
-            }
         }
     }
 

--- a/crates/polars-expr/src/hash_keys.rs
+++ b/crates/polars-expr/src/hash_keys.rs
@@ -201,11 +201,35 @@ impl HashKeys {
         }
     }
 
-    pub fn for_each_hash<F: FnMut(Option<u64>)>(&self, f: F) {
+    /// Calls f with the index of and hash of each element in this HashKeys.
+    ///
+    /// If the element is null and null_is_valid is false the respective hash
+    /// will be None.
+    pub fn for_each_hash<F: FnMut(IdxSize, Option<u64>)>(&self, f: F) {
         match self {
             HashKeys::RowEncoded(s) => s.for_each_hash(f),
             HashKeys::Single(s) => s.for_each_hash(f),
             HashKeys::Binview(s) => s.for_each_hash(f),
+        }
+    }
+
+    /// Calls f with the index of and hash of each element in the given
+    /// subset of indices of the HashKeys.
+    ///
+    /// If the element is null and null_is_valid is false the respective hash
+    /// will be None.
+    ///
+    /// # Safety
+    /// The indices in the subset must be in-bounds.
+    pub unsafe fn for_each_hash_subset<F: FnMut(IdxSize, Option<u64>)>(
+        &self,
+        subset: &[IdxSize],
+        f: F,
+    ) {
+        match self {
+            HashKeys::RowEncoded(s) => s.for_each_hash_subset(subset, f),
+            HashKeys::Single(s) => s.for_each_hash_subset(subset, f),
+            HashKeys::Binview(s) => s.for_each_hash_subset(subset, f),
         }
     }
 
@@ -226,7 +250,7 @@ impl HashKeys {
                 IdxSize::MAX
             };
             partitions.reserve(self.len());
-            self.for_each_hash(|opt_h| {
+            self.for_each_hash(|_idx, opt_h| {
                 partitions.push_unchecked(
                     opt_h
                         .map(|h| partitioner.hash_to_partition(h) as IdxSize)
@@ -273,8 +297,7 @@ impl HashKeys {
         assert!(partition_idxs.len() == partitioner.num_partitions());
         assert!(!BUILD_SKETCHES || sketches.len() == partitioner.num_partitions());
 
-        let mut idx = 0;
-        self.for_each_hash(|opt_h| {
+        self.for_each_hash(|idx, opt_h| {
             if let Some(h) = opt_h {
                 unsafe {
                     // SAFETY: we assured the number of partitions matches.
@@ -290,12 +313,11 @@ impl HashKeys {
                     partition_idxs.get_unchecked_mut(0).push(idx);
                 }
             }
-            idx += 1;
         });
     }
 
     pub fn sketch_cardinality(&self, sketch: &mut CardinalitySketch) {
-        self.for_each_hash(|opt_h| {
+        self.for_each_hash(|_idx, opt_h| {
             sketch.insert(opt_h.unwrap_or(0));
         })
     }
@@ -318,17 +340,23 @@ pub struct RowEncodedKeys {
 }
 
 impl RowEncodedKeys {
-    pub fn for_each_hash<F: FnMut(Option<u64>)>(&self, mut f: F) {
-        if self.keys.has_nulls() {
-            let validity = self.keys.validity().unwrap();
-            for (hash, is_v) in self.hashes.values_iter().zip(validity) {
-                if is_v { f(Some(*hash)) } else { f(None) }
-            }
-        } else {
-            for hash in self.hashes.values_iter() {
-                f(Some(*hash))
-            }
-        }
+    pub fn for_each_hash<F: FnMut(IdxSize, Option<u64>)>(&self, f: F) {
+        for_each_hash_prehashed(self.hashes.values().as_slice(), self.keys.validity(), f);
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn for_each_hash_subset<F: FnMut(IdxSize, Option<u64>)>(
+        &self,
+        subset: &[IdxSize],
+        f: F,
+    ) {
+        for_each_hash_subset_prehashed(
+            self.hashes.values().as_slice(),
+            self.keys.validity(),
+            subset,
+            f,
+        );
     }
 
     /// # Safety
@@ -354,9 +382,21 @@ pub struct SingleKeys {
 }
 
 impl SingleKeys {
-    pub fn for_each_hash<F: FnMut(Option<u64>)>(&self, f: F) {
+    pub fn for_each_hash<F: FnMut(IdxSize, Option<u64>)>(&self, f: F) {
         downcast_single_key_ca!(self.keys, |keys| {
-            for_each_hash(keys, f, &self.random_state);
+            for_each_hash_single(keys, f, &self.random_state);
+        })
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn for_each_hash_subset<F: FnMut(IdxSize, Option<u64>)>(
+        &self,
+        subset: &[IdxSize],
+        f: F,
+    ) {
+        downcast_single_key_ca!(self.keys, |keys| {
+            for_each_hash_subset_single(keys, subset, f, &self.random_state);
         })
     }
 
@@ -371,27 +411,6 @@ impl SingleKeys {
     }
 }
 
-fn for_each_hash<T, F>(keys: &ChunkedArray<T>, mut f: F, random_state: &PlRandomState)
-where
-    T: PolarsDataType,
-    for<'a> <T as PolarsDataType>::Physical<'a>: TotalHash,
-    F: FnMut(Option<u64>),
-{
-    if keys.has_nulls() {
-        for arr in keys.downcast_iter() {
-            for opt_k in arr.iter() {
-                f(opt_k.map(|k| random_state.tot_hash_one(k)))
-            }
-        }
-    } else {
-        for arr in keys.downcast_iter() {
-            for k in arr.values_iter() {
-                f(Some(random_state.tot_hash_one(k)))
-            }
-        }
-    }
-}
-
 /// Pre-hashed binary view keys with prehashing.
 #[derive(Clone, Debug)]
 pub struct BinviewKeys {
@@ -401,27 +420,23 @@ pub struct BinviewKeys {
 }
 
 impl BinviewKeys {
-    pub fn for_each_hash<F: FnMut(Option<u64>)>(&self, mut f: F) {
-        if self.keys.has_nulls() {
-            let hash_slice = self.hashes.values().as_slice();
-            if let Some(validity) = self.keys.validity() {
-                for (i, v) in validity.iter().enumerate() {
-                    if v {
-                        f(Some(unsafe { *hash_slice.get_unchecked(i) }));
-                    } else {
-                        f(None);
-                    }
-                }
-            } else {
-                for h in self.hashes.values_iter() {
-                    f(Some(*h))
-                }
-            }
-        } else {
-            for h in self.hashes.values_iter() {
-                f(Some(*h));
-            }
-        }
+    pub fn for_each_hash<F: FnMut(IdxSize, Option<u64>)>(&self, f: F) {
+        for_each_hash_prehashed(self.hashes.values().as_slice(), self.keys.validity(), f);
+    }
+
+    /// # Safety
+    /// The indices must be in-bounds.
+    pub unsafe fn for_each_hash_subset<F: FnMut(IdxSize, Option<u64>)>(
+        &self,
+        subset: &[IdxSize],
+        f: F,
+    ) {
+        for_each_hash_subset_prehashed(
+            self.hashes.values().as_slice(),
+            self.keys.validity(),
+            subset,
+            f,
+        );
     }
 
     /// # Safety
@@ -435,6 +450,102 @@ impl BinviewKeys {
             ),
             keys: polars_compute::gather::binview::take_binview_unchecked(&self.keys, &idx_arr),
             null_is_valid: self.null_is_valid,
+        }
+    }
+}
+
+fn for_each_hash_prehashed<F: FnMut(IdxSize, Option<u64>)>(
+    hashes: &[u64],
+    opt_v: Option<&Bitmap>,
+    mut f: F,
+) {
+    if let Some(validity) = opt_v {
+        for (idx, (is_v, hash)) in validity.iter().zip(hashes).enumerate_idx() {
+            if is_v {
+                f(idx, Some(*hash))
+            } else {
+                f(idx, None)
+            }
+        }
+    } else {
+        for (idx, h) in hashes.iter().enumerate_idx() {
+            f(idx, Some(*h));
+        }
+    }
+}
+
+/// # Safety
+/// The indices must be in-bounds.
+unsafe fn for_each_hash_subset_prehashed<F: FnMut(IdxSize, Option<u64>)>(
+    hashes: &[u64],
+    opt_v: Option<&Bitmap>,
+    subset: &[IdxSize],
+    mut f: F,
+) {
+    if let Some(validity) = opt_v {
+        for idx in subset {
+            let hash = *hashes.get_unchecked(*idx as usize);
+            let is_v = validity.get_bit_unchecked(*idx as usize);
+            if is_v {
+                f(*idx, Some(hash))
+            } else {
+                f(*idx, None)
+            }
+        }
+    } else {
+        for idx in subset {
+            f(*idx, Some(*hashes.get_unchecked(*idx as usize)));
+        }
+    }
+}
+
+fn for_each_hash_single<T, F>(keys: &ChunkedArray<T>, mut f: F, random_state: &PlRandomState)
+where
+    T: PolarsDataType,
+    for<'a> <T as PolarsDataType>::Physical<'a>: TotalHash,
+    F: FnMut(IdxSize, Option<u64>),
+{
+    let mut idx = 0;
+    if keys.has_nulls() {
+        for arr in keys.downcast_iter() {
+            for opt_k in arr.iter() {
+                f(idx, opt_k.map(|k| random_state.tot_hash_one(k)));
+                idx += 1;
+            }
+        }
+    } else {
+        for arr in keys.downcast_iter() {
+            for k in arr.values_iter() {
+                f(idx, Some(random_state.tot_hash_one(k)));
+                idx += 1;
+            }
+        }
+    }
+}
+
+/// # Safety
+/// The indices must be in-bounds.
+unsafe fn for_each_hash_subset_single<T, F>(
+    keys: &ChunkedArray<T>,
+    subset: &[IdxSize],
+    mut f: F,
+    random_state: &PlRandomState,
+) where
+    T: PolarsDataType,
+    for<'a> <T as PolarsDataType>::Physical<'a>: TotalHash,
+    F: FnMut(IdxSize, Option<u64>),
+{
+    let keys_arr = keys.downcast_as_array();
+
+    if keys_arr.has_nulls() {
+        for idx in subset {
+            let opt_k = keys_arr.get_unchecked(*idx as usize);
+            f(*idx, opt_k.map(|k| random_state.tot_hash_one(k)));
+        }
+    } else {
+        for idx in subset {
+            let k = keys_arr.value_unchecked(*idx as usize);
+            f(*idx, Some(random_state.tot_hash_one(k)));
         }
     }
 }

--- a/crates/polars-expr/src/hot_groups/row_encoded.rs
+++ b/crates/polars-expr/src/hot_groups/row_encoded.rs
@@ -52,10 +52,9 @@ impl HotGrouper for RowEncodedHashHotGrouper {
         cold_idxs.reserve(keys.hashes.len());
 
         unsafe {
-            let mut idx = 0;
-            keys.for_each_hash(|opt_h| {
+            keys.for_each_hash(|idx, opt_h| {
                 if let Some(h) = opt_h {
-                    let key = keys.keys.value_unchecked(idx);
+                    let key = keys.keys.value_unchecked(idx as usize);
                     let opt_g = self.table.insert_key(h, key, |ev_h, ev_k| {
                         self.evicted_key_hashes.push(ev_h);
                         self.evicted_key_offsets.try_push(ev_k.len()).unwrap();
@@ -68,8 +67,6 @@ impl HotGrouper for RowEncodedHashHotGrouper {
                         cold_idxs.push_unchecked(idx as IdxSize);
                     }
                 }
-
-                idx += 1;
             });
         }
     }


### PR DESCRIPTION
This reuse will make it easier to write the single-key variants.