### PR TITLE
feat(rust): Add support for unordered index values in `ChunkedArray.scatter`

### DIFF
--- a/crates/polars-ops/src/chunked_array/scatter.rs
+++ b/crates/polars-ops/src/chunked_array/scatter.rs
@@ -132,7 +132,11 @@ impl<'a> ChunkedSet<&'a str> for &'a StringChunked {
         let mut ca_iter = self.into_iter().enumerate();
         let mut builder = StringChunkedBuilder::new(self.name().clone(), self.len());
 
-        for (current_idx, current_value) in idx.iter().zip(values) {
+        let mut idx_values_iter: Vec<(_, _)> = idx.iter().zip(values).collect();
+        // Sort by index's elements
+        idx_values_iter.sort_by_key(|&(idx_item, _)| idx_item);
+
+        for (current_idx, current_value) in idx_values_iter {
             for (cnt_idx, opt_val_self) in &mut ca_iter {
                 if cnt_idx == *current_idx as usize {
                     builder.append_option(current_value);
@@ -160,7 +164,11 @@ impl ChunkedSet<bool> for &BooleanChunked {
         let mut ca_iter = self.into_iter().enumerate();
         let mut builder = BooleanChunkedBuilder::new(self.name().clone(), self.len());
 
-        for (current_idx, current_value) in idx.iter().zip(values) {
+        let mut idx_values_iter: Vec<(_, _)> = idx.iter().zip(values).collect();
+        // Sort by index's elements
+        idx_values_iter.sort_by_key(|&(idx_item, _)| idx_item);
+
+        for (current_idx, current_value) in idx_values_iter {
             for (cnt_idx, opt_val_self) in &mut ca_iter {
                 if cnt_idx == *current_idx as usize {
                     builder.append_option(current_value);

--- a/crates/polars-ops/src/chunked_array/scatter.rs
+++ b/crates/polars-ops/src/chunked_array/scatter.rs
@@ -13,22 +13,6 @@ pub trait ChunkedSet<T: Copy> {
     where
         V: IntoIterator<Item = Option<T>>;
 }
-fn check_sorted(idx: &[IdxSize]) -> PolarsResult<()> {
-    if idx.is_empty() {
-        return Ok(());
-    }
-    let mut sorted = true;
-    let mut previous = idx[0];
-    for &i in &idx[1..] {
-        if i < previous {
-            // we will not break here as that prevents SIMD
-            sorted = false;
-        }
-        previous = i;
-    }
-    polars_ensure!(sorted, ComputeError: "set indices must be sorted");
-    Ok(())
-}
 
 trait PolarsOpsNumericType: PolarsNumericType {}
 
@@ -145,7 +129,6 @@ impl<'a> ChunkedSet<&'a str> for &'a StringChunked {
         V: IntoIterator<Item = Option<&'a str>>,
     {
         check_bounds(idx, self.len() as IdxSize)?;
-        check_sorted(idx)?;
         let mut ca_iter = self.into_iter().enumerate();
         let mut builder = StringChunkedBuilder::new(self.name().clone(), self.len());
 
@@ -174,7 +157,6 @@ impl ChunkedSet<bool> for &BooleanChunked {
         V: IntoIterator<Item = Option<bool>>,
     {
         check_bounds(idx, self.len() as IdxSize)?;
-        check_sorted(idx)?;
         let mut ca_iter = self.into_iter().enumerate();
         let mut builder = BooleanChunkedBuilder::new(self.name().clone(), self.len());
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/22383

