### PR TITLE
fix: Skip `test_interpolate_vs_numpy` test on Mac

### DIFF
--- a/py-polars/tests/unit/operations/test_interpolate_by.py
+++ b/py-polars/tests/unit/operations/test_interpolate_by.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from datetime import date
 from typing import TYPE_CHECKING
 
@@ -162,6 +163,7 @@ def test_interpolate_by_trailing_nulls(dataset: str) -> None:
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="numpy interp float precision")
 @given(data=st.data(), x_dtype=st.sampled_from([pl.Date, pl.Float64]))
 def test_interpolate_vs_numpy(data: st.DataObject, x_dtype: pl.DataType) -> None:
     if x_dtype == pl.Float64:


### PR DESCRIPTION
Closes #22348.

Numpy runs into precision issues here, which was causing the test failure (see discussion/diagnosis in the linked issue). There may be a better way to solve this, but this will at least clean up the CI failures.

Edit: Welp, this fixed one of the tests at least. There's still a remaining one it looks like.