### PR TITLE
feat(python): When reporting unexpected types in errors, module-qualify the typename

### DIFF
--- a/py-polars/polars/_utils/getitem.py
+++ b/py-polars/polars/_utils/getitem.py
@@ -7,7 +7,7 @@ import polars._reexport as pl
 import polars.functions as F
 from polars._utils.constants import U32_MAX
 from polars._utils.slice import PolarsSlice
-from polars._utils.various import range_to_slice
+from polars._utils.various import qualified_type_name, range_to_slice
 from polars.datatypes.classes import (
     Boolean,
     Int8,
@@ -72,7 +72,7 @@ def get_series_item_by_key(
         try:
             indices = pl.Series("", key, dtype=Int64)
         except TypeError:
-            msg = f"cannot select elements using Sequence with elements of type {type(first).__name__!r}"
+            msg = f"cannot select elements using Sequence with elements of type {qualified_type_name(first)!r}"
             raise TypeError(msg) from None
 
         indices = _convert_series_to_indices(indices, s.len())
@@ -86,7 +86,7 @@ def get_series_item_by_key(
         indices = _convert_np_ndarray_to_indices(key, s.len())
         return _select_elements_by_index(s, indices)
 
-    msg = f"cannot select elements using key of type {type(key).__name__!r}: {key!r}"
+    msg = f"cannot select elements using key of type {qualified_type_name(key)!r}: {key!r}"
     raise TypeError(msg)
 
 
@@ -216,7 +216,7 @@ def _select_columns(
         elif isinstance(first, str):
             return _select_columns_by_name(df, key)  # type: ignore[arg-type]
         else:
-            msg = f"cannot select columns using Sequence with elements of type {type(first).__name__!r}"
+            msg = f"cannot select columns using Sequence with elements of type {qualified_type_name(first)!r}"
             raise TypeError(msg)
 
     elif isinstance(key, pl.Series):
@@ -254,7 +254,9 @@ def _select_columns(
             msg = f"cannot select columns using NumPy array of type {key.dtype}"
             raise TypeError(msg)
 
-    msg = f"cannot select columns using key of type {type(key).__name__!r}: {key!r}"
+    msg = (
+        f"cannot select columns using key of type {qualified_type_name(key)!r}: {key!r}"
+    )
     raise TypeError(msg)
 
 
@@ -322,7 +324,7 @@ def _select_rows(
         return _select_rows_by_index(df, indices)
 
     else:
-        msg = f"cannot select rows using key of type {type(key).__name__!r}: {key!r}"
+        msg = f"cannot select rows using key of type {qualified_type_name(key)!r}: {key!r}"
         raise TypeError(msg)
 
 

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -702,3 +702,31 @@ def display_dot_graph(
         plt.imshow(img)
         plt.show()
         return None
+
+
+def qualified_type_name(obj: Any, *, qualify_polars: bool = False) -> str:
+    """
+    Return the module-qualified name of the given object as a string.
+
+    Parameters
+    ----------
+    obj
+        The object to get the qualified name for.
+    qualify_polars
+        If False (default), omit the module path for our own (Polars) objects.
+    """
+    if isinstance(obj, type):
+        module = obj.__module__
+        name = obj.__name__
+    else:
+        module = obj.__class__.__module__
+        name = obj.__class__.__name__
+
+    if (
+        not module
+        or module == "builtins"
+        or (not qualify_polars and module.startswith("polars."))
+    ):
+        return name
+
+    return f"{module}.{name}"

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -21,7 +21,11 @@ from polars._utils.deprecation import (
     issue_deprecation_warning,
 )
 from polars._utils.pycapsule import is_pycapsule, pycapsule_to_frame
-from polars._utils.various import _cast_repr_strings_with_schema, issue_warning
+from polars._utils.various import (
+    _cast_repr_strings_with_schema,
+    issue_warning,
+    qualified_type_name,
+)
 from polars._utils.wrap import wrap_df, wrap_s
 from polars.datatypes import N_INFER_DEFAULT, Categorical, String
 from polars.dependencies import _check_for_pyarrow
@@ -493,7 +497,7 @@ def from_arrow(
             )
         )
 
-    msg = f"expected PyArrow Table, Array, or one or more RecordBatches; got {type(data).__name__!r}"
+    msg = f"expected PyArrow Table, Array, or one or more RecordBatches; got {qualified_type_name(data)!r}"
     raise TypeError(msg)
 
 
@@ -616,7 +620,7 @@ def from_pandas(
             )
         )
     else:
-        msg = f"expected pandas DataFrame or Series, got {type(data).__name__!r}"
+        msg = f"expected pandas DataFrame or Series, got {qualified_type_name(data)!r}"
         raise TypeError(msg)
 
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -56,6 +56,7 @@ from polars._utils.various import (
     no_default,
     normalize_filepath,
     parse_version,
+    qualified_type_name,
     scale_bytes,
     warn_null_comparison,
 )
@@ -4935,7 +4936,7 @@ class DataFrame:
                 cols.insert(index, column)  # type: ignore[arg-type]
                 self._df = self.select(cols)._df
             else:
-                msg = f"column must be a Series or Expr, got {column!r} (type={type(column)})"
+                msg = f"column must be a Series or Expr, got {column!r} (type={qualified_type_name(column)})"
                 raise TypeError(msg)
         return self
 
@@ -7505,19 +7506,21 @@ class DataFrame:
         └─────────────┴────────────┴────────────┴──────┘
         """
         if not isinstance(other, DataFrame):
-            msg = f"expected `other` join table to be a DataFrame, got {type(other).__name__!r}"
+            msg = f"expected `other` join table to be a DataFrame, not {qualified_type_name(other)!r}"
             raise TypeError(msg)
 
         if on is not None:
             if not isinstance(on, (str, pl.Expr)):
-                msg = f"expected `on` to be str or Expr, got {type(on).__name__!r}"
+                msg = (
+                    f"expected `on` to be str or Expr, got {qualified_type_name(on)!r}"
+                )
                 raise TypeError(msg)
         else:
             if not isinstance(left_on, (str, pl.Expr)):
-                msg = f"expected `left_on` to be str or Expr, got {type(left_on).__name__!r}"
+                msg = f"expected `left_on` to be str or Expr, got {qualified_type_name(left_on)!r}"
                 raise TypeError(msg)
             elif not isinstance(right_on, (str, pl.Expr)):
-                msg = f"expected `right_on` to be str or Expr, got {type(right_on).__name__!r}"
+                msg = f"expected `right_on` to be str or Expr, got {qualified_type_name(right_on)!r}"
                 raise TypeError(msg)
 
         return (
@@ -7751,7 +7754,7 @@ class DataFrame:
         For joining on columns with categorical data, see :class:`polars.StringCache`.
         """
         if not isinstance(other, DataFrame):
-            msg = f"expected `other` join table to be a DataFrame, got {type(other).__name__!r}"
+            msg = f"expected `other` join table to be a DataFrame, not {qualified_type_name(other)!r}"
             raise TypeError(msg)
 
         return (
@@ -7840,7 +7843,7 @@ class DataFrame:
         └─────┴─────┴─────┴───────┴──────┴──────┴──────┴─────────────┘
         """
         if not isinstance(other, DataFrame):
-            msg = f"expected `other` join table to be a DataFrame, got {type(other).__name__!r}"
+            msg = f"expected `other` join table to be a DataFrame, not {qualified_type_name(other)!r}"
             raise TypeError(msg)
 
         return (
@@ -10864,7 +10867,7 @@ class DataFrame:
 
         elif by_predicate is not None:
             if not isinstance(by_predicate, pl.Expr):
-                msg = f"expected `by_predicate` to be an expression, got {type(by_predicate).__name__!r}"
+                msg = f"expected `by_predicate` to be an expression, got {qualified_type_name(by_predicate)!r}"
                 raise TypeError(msg)
             rows = self.filter(by_predicate).rows()
             n_rows = len(rows)

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -355,6 +355,8 @@ def maybe_cast(el: Any, dtype: PolarsDataType) -> Any:
         try:
             el = py_type(el)  # type: ignore[call-arg]
         except Exception:
-            msg = f"cannot convert Python type {type(el).__name__!r} to {dtype!r}"
+            from polars._utils.various import qualified_type_name
+
+            msg = f"cannot convert Python type {qualified_type_name(el)!r} to {dtype!r}"
             raise TypeError(msg) from None
     return el

--- a/py-polars/polars/datatypes/group.py
+++ b/py-polars/polars/datatypes/group.py
@@ -62,8 +62,11 @@ class DataTypeGroup(frozenset):  # type: ignore[type-arg]
         """
         for it in items:
             if not isinstance(it, (DataType, DataTypeClass)):
-                msg = f"DataTypeGroup items must be dtypes; found {type(it).__name__!r}"
+                from polars._utils.various import qualified_type_name
+
+                msg = f"DataTypeGroup items must be dtypes; found {qualified_type_name(it)!r}"
                 raise TypeError(msg)
+
         dtype_group = super().__new__(cls, items)
         dtype_group._match_base_type = match_base_type
         return dtype_group

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polars._utils.various import qualified_type_name
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
@@ -181,7 +182,7 @@ class ExprCatNameSpace:
         └────────┘
         """
         if not isinstance(prefix, str):
-            msg = f"'prefix' must be a string; found {type(prefix)!r}"
+            msg = f"'prefix' must be a string; found {qualified_type_name(prefix)!r}"
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.cat_starts_with(prefix))
 
@@ -234,7 +235,7 @@ class ExprCatNameSpace:
         └────────┘
         """
         if not isinstance(suffix, str):
-            msg = f"'suffix' must be a string; found {type(suffix)!r}"
+            msg = f"'suffix' must be a string; found {qualified_type_name(suffix)!r}"
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.cat_ends_with(suffix))
 

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -9,6 +9,7 @@ from polars._utils.convert import parse_as_duration_string
 from polars._utils.deprecation import deprecate_function, deprecate_nonkeyword_arguments
 from polars._utils.parse import parse_into_expression, parse_into_list_of_expressions
 from polars._utils.unstable import unstable
+from polars._utils.various import qualified_type_name
 from polars._utils.wrap import wrap_expr
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 
@@ -539,7 +540,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────────┴─────────────────────────┴─────────────────────┘
         """
         if not isinstance(time, (dt.time, pl.Expr)):
-            msg = f"expected 'time' to be a Python time or Polars expression, found {type(time).__name__!r}"
+            msg = f"expected 'time' to be a Python time or Polars expression, found {qualified_type_name(time)!r}"
             raise TypeError(msg)
         time = parse_into_expression(time)
         return wrap_expr(self._pyexpr.dt_combine(time, time_unit))

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -12,7 +12,7 @@ from polars._utils.deprecation import (
 )
 from polars._utils.parse import parse_into_expression
 from polars._utils.unstable import unstable
-from polars._utils.various import find_stacklevel, no_default
+from polars._utils.various import find_stacklevel, no_default, qualified_type_name
 from polars._utils.wrap import wrap_expr
 from polars.datatypes import Date, Datetime, Time, parse_into_dtype
 from polars.datatypes.constants import N_INFER_DEFAULT
@@ -847,7 +847,9 @@ class ExprStringNameSpace:
         └──────────────┴──────────────┘
         """
         if not isinstance(fill_char, str):
-            msg = f"pad_start expects a `str`, given a `{type(fill_char)}`"
+            msg = (
+                f"pad_start expects a `str`, given a {qualified_type_name(fill_char)!r}"
+            )
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.str_pad_start(length, fill_char))
 
@@ -884,7 +886,7 @@ class ExprStringNameSpace:
         └──────────────┴──────────────┘
         """
         if not isinstance(fill_char, str):
-            msg = f"pad_end expects a `str`, given a `{type(fill_char)}`"
+            msg = f"pad_end expects a `str`, given a {qualified_type_name(fill_char)!r}"
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.str_pad_end(length, fill_char))
 
@@ -1640,7 +1642,7 @@ class ExprStringNameSpace:
         └─────────────────────────────────┴───────────────────────┴──────────┘
         """
         if not isinstance(pattern, str):
-            msg = f"extract_groups expects a `str`, given a `{type(pattern)}`"
+            msg = f"extract_groups expects a `str`, given a {qualified_type_name(pattern)!r}"
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.str_extract_groups(pattern))
 

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -4,6 +4,7 @@ import os
 from typing import TYPE_CHECKING
 
 from polars._utils.parse import parse_into_list_of_expressions
+from polars._utils.various import qualified_type_name
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
@@ -27,7 +28,7 @@ class ExprStructNameSpace:
         elif isinstance(item, int):
             return wrap_expr(self._pyexpr.struct_field_by_index(item))
         else:
-            msg = f"expected type 'int | str', got {type(item).__name__!r} ({item!r})"
+            msg = f"expected type 'int | str', got {qualified_type_name(item)!r} ({item!r})"
             raise TypeError(msg)
 
     def field(self, name: str | list[str], *more_names: str) -> Expr:

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, get_args
 import polars._reexport as pl
 from polars import functions as F
 from polars._typing import ConcatMethod
-from polars._utils.various import ordered_unique
+from polars._utils.various import ordered_unique, qualified_type_name
 from polars._utils.wrap import wrap_df, wrap_expr, wrap_ldf, wrap_s
 from polars.exceptions import InvalidOperationError
 
@@ -178,7 +178,7 @@ def concat(
 
     if how.startswith("align"):
         if not isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
-            msg = f"{how!r} strategy is not supported for {type(elems[0]).__name__!r}"
+            msg = f"{how!r} strategy is not supported for {qualified_type_name(elems[0])!r}"
             raise TypeError(msg)
 
         # establish common columns, maintaining the order in which they appear
@@ -296,7 +296,7 @@ def concat(
     elif isinstance(first, pl.Expr):
         return wrap_expr(plr.concat_expr([e._pyexpr for e in elems], rechunk))
     else:
-        msg = f"did not expect type: {type(first).__name__!r} in `concat`"
+        msg = f"did not expect type: {qualified_type_name(first)!r} in `concat`"
         raise TypeError(msg)
 
     if rechunk:

--- a/py-polars/polars/functions/escape_regex.py
+++ b/py-polars/polars/functions/escape_regex.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextlib
 
+from polars._utils.various import qualified_type_name
+
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
 import polars._reexport as pl
@@ -21,7 +23,7 @@ def escape_regex(s: str) -> str:
         msg = "escape_regex function is unsupported for `Expr`, you may want use `Expr.str.escape_regex` instead"
         raise TypeError(msg)
     elif not isinstance(s, str):
-        msg = f"escape_regex function supports only `str` type, got `{type(s)}`"
+        msg = f"escape_regex function supports only `str` type, got `{qualified_type_name(s)}`"
         raise TypeError(msg)
 
     return plr.escape_regex(s)

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -18,7 +18,7 @@ from polars._utils.parse import (
     parse_into_list_of_expressions,
 )
 from polars._utils.unstable import issue_unstable_warning, unstable
-from polars._utils.various import extend_bool
+from polars._utils.various import extend_bool, qualified_type_name
 from polars._utils.wrap import wrap_df, wrap_expr
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Datetime, Int64
 from polars.lazyframe.opt_flags import OptFlags
@@ -1483,10 +1483,10 @@ def arctan2(y: str | Expr, x: str | Expr) -> Expr:
     if isinstance(x, str):
         x = F.col(x)
     if not hasattr(x, "_pyexpr"):
-        msg = f"`arctan2` expected a `str` or `Expr` got a `{type(x).__name__}`"
+        msg = f"`arctan2` expected a `str` or `Expr` got a `{qualified_type_name(x)}`"
         raise TypeError(msg)
     if not hasattr(y, "_pyexpr"):
-        msg = f"`arctan2` expected a `str` or `Expr` got a `{type(y).__name__}`"
+        msg = f"`arctan2` expected a `str` or `Expr` got a `{qualified_type_name(y)}`"
         raise TypeError(msg)
 
     return wrap_expr(plr.arctan2(y._pyexpr, x._pyexpr))

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 from polars import functions as F
 from polars._utils.parse import parse_into_expression
+from polars._utils.various import qualified_type_name
 from polars._utils.wrap import wrap_expr
 from polars.datatypes import (
     Array,
@@ -139,7 +140,7 @@ def repeat(
     if isinstance(n, int):
         n = F.lit(n)
     if not hasattr(n, "_pyexpr"):
-        msg = f"`n` parameter of `repeat expected a `int` or `Expr` got a `{type(n).__name__}`"
+        msg = f"`n` parameter of `repeat expected a `int` or `Expr` got a `{qualified_type_name(n)}`"
         raise TypeError(msg)
     value = parse_into_expression(value, str_as_lit=True, dtype=dtype)
     expr = wrap_expr(plr.repeat(value, n._pyexpr, dtype))

--- a/py-polars/polars/interchange/from_dataframe.py
+++ b/py-polars/polars/interchange/from_dataframe.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 import polars.functions as F
+from polars._utils.various import qualified_type_name
 from polars.datatypes import Boolean, Enum, Int64, String, UInt8, UInt32
 from polars.exceptions import InvalidOperationError
 from polars.interchange.dataframe import PolarsDataFrame
@@ -40,7 +41,7 @@ def from_dataframe(df: SupportsInterchange, *, allow_copy: bool = True) -> DataF
         return df._df
 
     if not hasattr(df, "__dataframe__"):
-        msg = f"`df` of type {type(df).__name__!r} does not support the dataframe interchange protocol"
+        msg = f"`df` of type {qualified_type_name(df)!r} does not support the dataframe interchange protocol"
         raise TypeError(msg)
 
     return _from_dataframe(

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -15,6 +15,7 @@ from polars._utils.various import (
     is_path_or_str_sequence,
     is_str_sequence,
     normalize_filepath,
+    qualified_type_name,
 )
 from polars._utils.wrap import wrap_df, wrap_ldf
 from polars.datatypes import N_INFER_DEFAULT, String, parse_into_dtype
@@ -626,7 +627,7 @@ def _read_csv_impl(
         elif isinstance(schema_overrides, Sequence):
             dtype_slice = schema_overrides
         else:
-            msg = f"`schema_overrides` should be of type list or dict, got {type(schema_overrides).__name__!r}"
+            msg = f"`schema_overrides` should be of type list or dict, got {qualified_type_name(schema_overrides)!r}"
             raise TypeError(msg)
 
     processed_null_values = _process_null_values(null_values)
@@ -1287,7 +1288,7 @@ def scan_csv(
         raise TypeError(msg)
 
     if not new_columns and isinstance(schema_overrides, Sequence):
-        msg = f"expected 'schema_overrides' dict, found {type(schema_overrides).__name__!r}"
+        msg = f"expected 'schema_overrides' dict, found {qualified_type_name(schema_overrides)!r}"
         raise TypeError(msg)
     elif new_columns:
         if with_column_names:

--- a/py-polars/polars/io/database/functions.py
+++ b/py-polars/polars/io/database/functions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+from polars._utils.various import qualified_type_name
 from polars.datatypes import N_INFER_DEFAULT
 from polars.dependencies import import_optional
 from polars.io.database._cursor_proxies import ODBCCursorProxy
@@ -422,7 +423,7 @@ def read_database_uri(
     from polars.io.database._utils import _read_sql_adbc, _read_sql_connectorx
 
     if not isinstance(uri, str):
-        msg = f"expected connection to be a URI string; found {type(uri).__name__!r}"
+        msg = f"expected connection to be a URI string; found {qualified_type_name(uri)!r}"
         raise TypeError(msg)
     elif engine is None:
         engine = "connectorx"

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
 from polars import functions as F
+from polars._utils.various import qualified_type_name
 from polars.datatypes import (
     Date,
     Datetime,
@@ -443,7 +444,7 @@ def _xl_setup_table_columns(
             dtype_formats.update(dict.fromkeys(tp, dtype_formats.pop(tp)))
     for fmt in dtype_formats.values():
         if not isinstance(fmt, str):
-            msg = f"invalid dtype_format value: {fmt!r} (expected format string, got {type(fmt).__name__!r})"
+            msg = f"invalid dtype_format value: {fmt!r} (expected format string, got {qualified_type_name(fmt)!r})"
             raise TypeError(msg)
 
     # inject sparkline/row-total placeholder(s)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -50,6 +50,7 @@ from polars._utils.various import (
     issue_warning,
     normalize_filepath,
     parse_percentiles,
+    qualified_type_name,
 )
 from polars._utils.wrap import wrap_df, wrap_expr
 from polars.datatypes import (
@@ -168,7 +169,7 @@ def _to_sink_target(
     elif isinstance(path, PartitioningScheme):
         return path._py_partitioning
     else:
-        msg = f"`path` argument has an invalid type '{type(path)}' and cannot be turned into a sink target"
+        msg = f"`path` argument has invalid type {qualified_type_name(path)!r}, and cannot be turned into a sink target"
         raise TypeError(msg)
 
 
@@ -5317,7 +5318,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────┴────────────┴────────────┴──────┘
         """
         if not isinstance(other, LazyFrame):
-            msg = f"expected `other` join table to be a LazyFrame, not a {type(other).__name__!r}"
+            msg = f"expected `other` join table to be a LazyFrame, not {qualified_type_name(other)!r}"
             raise TypeError(msg)
 
         if isinstance(on, (str, pl.Expr)):
@@ -5568,7 +5569,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┴─────┴───────┴───────────┘
         """
         if not isinstance(other, LazyFrame):
-            msg = f"expected `other` join table to be a LazyFrame, not a {type(other).__name__!r}"
+            msg = f"expected `other` join table to be a LazyFrame, not {qualified_type_name(other)!r}"
             raise TypeError(msg)
 
         if maintain_order is None:
@@ -5713,7 +5714,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┴─────┴───────┴──────┴──────┴──────┴─────────────┘
         """
         if not isinstance(other, LazyFrame):
-            msg = f"expected `other` join table to be a LazyFrame, not a {type(other).__name__!r}"
+            msg = f"expected `other` join table to be a LazyFrame, not {qualified_type_name(other)!r}"
             raise TypeError(msg)
 
         pyexprs = parse_into_list_of_expressions(*predicates)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -48,6 +48,7 @@ from polars._utils.various import (
     _is_generator,
     no_default,
     parse_version,
+    qualified_type_name,
     scale_bytes,
     sphinx_accessor,
     warn_null_comparison,
@@ -1425,7 +1426,7 @@ class Series:
                         phys_arg._s.rechunk(in_place=True)
                     args.append(phys_arg._s.to_numpy_view())
                 else:
-                    msg = f"unsupported type {type(arg).__name__!r} for {arg!r}"
+                    msg = f"unsupported type {qualified_type_name(arg)!r} for {arg!r}"
                     raise TypeError(msg)
 
             # Get minimum dtype needed to be able to cast all input arguments to the

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
-from polars._utils.various import BUILDING_SPHINX_DOCS, sphinx_accessor
+from polars._utils.various import (
+    BUILDING_SPHINX_DOCS,
+    qualified_type_name,
+    sphinx_accessor,
+)
 from polars._utils.wrap import wrap_df
 from polars.schema import Schema
 from polars.series.utils import expr_dispatch
@@ -35,7 +39,7 @@ class StructNameSpace:
         elif isinstance(item, str):
             return self.field(item)
         else:
-            msg = f"expected type 'int | str', got {type(item).__name__!r}"
+            msg = f"expected type 'int | str', got {qualified_type_name(item)!r}"
             raise TypeError(msg)
 
     def _ipython_key_completions_(self) -> list[str]:

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -14,7 +14,7 @@ from polars._typing import FrameType
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.pycapsule import is_pycapsule
 from polars._utils.unstable import issue_unstable_warning
-from polars._utils.various import _get_stack_locals
+from polars._utils.various import _get_stack_locals, qualified_type_name
 from polars._utils.wrap import wrap_ldf
 from polars.convert import from_arrow, from_pandas
 from polars.dataframe import DataFrame
@@ -81,7 +81,7 @@ def _ensure_lazyframe(obj: Any) -> LazyFrame:
     ):
         return from_arrow(obj).lazy()  # type: ignore[union-attr]
     else:
-        msg = f"Unrecognised frame type: {type(obj)}"
+        msg = f"Unrecognised frame type: {qualified_type_name(obj)}"
         raise ValueError(msg)
 
 

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -661,6 +661,6 @@ def test_escape_regex() -> None:
 
     with pytest.raises(
         TypeError,
-        match="escape_regex function supports only `str` type, got `<class 'int'>`",
+        match="escape_regex function supports only `str` type, got `int`",
     ):
         pl.escape_regex(3)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -137,15 +137,21 @@ def test_join_lazy_on_df() -> None:
 
     with pytest.raises(
         TypeError,
-        match="expected `other` .* to be a LazyFrame.* not a 'DataFrame'",
+        match="expected `other` .* to be a LazyFrame.* not 'DataFrame'",
     ):
         df_left.lazy().join(df_right, on="Id")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
-        match="expected `other` .* to be a LazyFrame.* not a 'DataFrame'",
+        match="expected `other` .* to be a LazyFrame.* not 'DataFrame'",
     ):
         df_left.lazy().join_asof(df_right, on="Id")  # type: ignore[arg-type]
+
+    with pytest.raises(
+        TypeError,
+        match="expected `other` .* to be a LazyFrame.* not 'pandas.core.frame.DataFrame'",
+    ):
+        df_left.lazy().join_asof(df_right.to_pandas(), on="Id")  # type: ignore[arg-type]
 
 
 def test_projection_update_schema_missing_column() -> None:

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -9,6 +9,7 @@ import pytest
 import polars as pl
 import polars.selectors as cs
 from polars._typing import SelectorType
+from polars._utils.various import qualified_type_name
 from polars.exceptions import ColumnNotFoundError, InvalidOperationError
 from polars.selectors import expand_selector, is_selector
 from polars.testing import assert_frame_equal
@@ -18,7 +19,7 @@ from tests.unit.conftest import INTEGER_DTYPES, TEMPORAL_DTYPES
 def assert_repr_equals(item: Any, expected: str) -> None:
     """Assert that the repr of an item matches the expected string."""
     if not isinstance(expected, str):
-        msg = f"'expected' must be a string; found {type(expected)}"
+        msg = f"`expected` must be a string; found {qualified_type_name(expected)!r}"
         raise TypeError(msg)
     assert repr(item) == expected
 


### PR DESCRIPTION
Closes #22387.

Clarifies the given/problematic type. Improvement not limited to the `join` methods (as reported in the linked issue); applies to _all_ errors where we report external type names -

## Example

```python
import polars as pl
df1 = pl.DataFrame({
    "id": [1, 2, 3],
    "val": ["aa", "bb", "cc"],
})
df2 = pl.DataFrame({
    "id": [1, 3],
    "tag": ["xxxx", "yyyy"],
})
```

#### Before:
_(bare typename; potentially ambiguous)_
```python
df1.join(df2.to_pandas(), how="full", on="id")
# TypeError: 
#   expected `other` join table to be a DataFrame, got 'DataFrame'
```

#### After:
_(module-qualified typename; unambiguous)_
```python
df1.join(df2.to_pandas(), how="full", on="id")
# TypeError:
#   expected `other` join table to be a DataFrame, got 'pandas.core.frame.DataFrame'
```