### PR TITLE
fix(rust): Fix unnest() not working on empty struct columns 

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/to_struct.rs
+++ b/crates/polars-ops/src/chunked_array/list/to_struct.rs
@@ -12,8 +12,8 @@ pub enum ListToStructArgs {
     InferWidth {
         infer_field_strategy: ListToStructWidthStrategy,
         get_index_name: Option<NameGenerator>,
-        /// If this is 0, it means unbounded.
-        max_fields: usize,
+        /// If this is None, it means unbounded.
+        max_fields: Option<usize>,
     },
 }
 
@@ -44,9 +44,9 @@ impl ListToStructArgs {
             )),
             Self::InferWidth {
                 get_index_name,
-                max_fields,
+                max_fields: Some(max_fields),
                 ..
-            } if *max_fields > 0 => {
+            } => {
                 let get_index_name_func = get_index_name.as_ref().map_or(
                     &_default_struct_name_gen as &dyn Fn(usize) -> PlSmallStr,
                     |x| x.0.as_ref(),
@@ -104,7 +104,7 @@ impl ListToStructArgs {
                     },
                 };
 
-                if *max_fields > 0 {
+                if let Some(max_fields) = max_fields {
                     inferred.min(*max_fields)
                 } else {
                     inferred

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -331,7 +331,9 @@ fn expand_struct_fields(
     names: &[PlSmallStr],
     exclude: &PlHashSet<PlSmallStr>,
 ) -> PolarsResult<()> {
-    let first_name = names[0].as_ref();
+    let Some(first_name) = names.first() else {
+        return Ok(());
+    };
     if names.len() == 1 && first_name == "*" || is_regex_projection(first_name) {
         let Expr::Function { input, .. } = struct_expr else {
             unreachable!()

--- a/crates/polars-python/src/expr/list.rs
+++ b/crates/polars-python/src/expr/list.rs
@@ -212,7 +212,7 @@ impl PyExpr {
         &self,
         width_strat: Wrap<ListToStructWidthStrategy>,
         name_gen: Option<PyObject>,
-        upper_bound: usize,
+        upper_bound: Option<usize>,
     ) -> PyResult<Self> {
         let name_gen = name_gen.map(|lambda| {
             NameGenerator::from_func(move |idx: usize| {

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1096,7 +1096,7 @@ class ExprListNameSpace:
         self,
         n_field_strategy: ListToStructWidthStrategy = "first_non_null",
         fields: Sequence[str] | Callable[[int], str] | None = None,
-        upper_bound: int = 0,
+        upper_bound: int | None = None,
         *,
         _eager: bool = False,
     ) -> Expr:

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -915,11 +915,10 @@ class ListNameSpace:
             s.to_frame()
             .select(
                 F.col(s.name).list.to_struct(
-                    # note: in eager mode, 'upper_bound' is always zero, as (unlike
+                    # note: in eager mode, 'upper_bound' is always None, as (unlike
                     # in lazy mode) there is no need to determine/track the schema.
                     n_field_strategy,
                     fields,
-                    upper_bound=0,
                     _eager=True,
                 )
             )

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -558,6 +558,13 @@ def test_to_struct() -> None:
         pl.DataFrame({"one": ["12", "56", "90"], "two": ["34", "78", "00"]}),
     )
 
+def test_to_struct_empty() -> None:
+    df = pl.DataFrame(
+        {"y": [[], [], []]}, schema={"y": pl.List(pl.Int64)}
+    )
+    empty_df = df.select(pl.col("y").list.to_struct(fields = []).struct.unnest())
+    assert empty_df.shape == (0, 0)
+
 
 def test_sort() -> None:
     a = pl.Series("a", [2, 1, 3])


### PR DESCRIPTION
### Current issue 

This PR aims to fix #22381. Currently, unnesting an empty `list` to a `struct` does not work as expected. 

This is due to two reasons: 

1. `expand_struct_fields` expects a 0-index to exist when converting a `list` to a `struct`: 
```rust
fn expand_struct_fields(
    names: &[PlSmallStr],
    exclude: &PlHashSet<PlSmallStr>,
) -> PolarsResult<()> {
    // this is where it breaks:
    let first_name = names[0].as_ref();
    if names.len() == 1 && first_name == "*" || is_regex_projection(first_name) {
        let Expr::Function { input, .. } = struct_expr else {
            unreachable!()
 ``` 

2. `InferWidth` doesn't work with `upper_bound = 0` as this is the default value. However, when wanting to specify `upper_bound = 0` (e.g. for an empty struct) - this fails and is not possible as in `crates/polars-ops/src/chunked_array/list/to_struct.rs`, we directly jump into the unknown datatype branch, leading to issues in `crates/polars-plan/src/plans/conversion/expr_expansion.rs`.

To address 1), I replaced the 0-indexing by a `.first()` check and return `Ok(())` otherwise - which is fine, as we only ever get to this branch in the case of an empty list and to address 2) I made `upper_bound` an `Option<usize>` such that `upper_bound = 0` can now be a valid value.

