### PR TITLE
fix: Check count correctness in csv

### DIFF
--- a/crates/polars-io/src/csv/read/read_impl.rs
+++ b/crates/polars-io/src/csv/read/read_impl.rs
@@ -441,7 +441,9 @@ impl<'a> CoreReader<'a> {
                         let result = slf
                             .read_chunk(b, projection, 0, count, Some(0), b.len())
                             .and_then(|mut df| {
-                                debug_assert!(df.height() <= count);
+                                // This can trigger if you have quote chars in the middle of csv
+                                // fields.
+                                polars_ensure!(df.height() <= count, ComputeError: "csv is malformed\n\nConsider checking if the quote characters are correct");
 
                                 if slf.n_rows.is_some() {
                                     total_line_count.fetch_add(df.height(), Ordering::Relaxed);

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2605,3 +2605,12 @@ def test_csv_write_scalar_empty_chunk_20273(filter_value: int, expected: str) ->
     df2 = pl.DataFrame({"c": [99]})
     df3 = df1.join(df2, how="cross").filter(pl.col("a").eq(filter_value))
     assert df3.write_csv() == expected
+
+
+def test_csv_quote_in_str_22395() -> None:
+    with pytest.raises(pl.ComputeError):
+        pl.read_csv(b"""\
+        a,b
+        1,2"3
+        4,5
+        """)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2608,7 +2608,7 @@ def test_csv_write_scalar_empty_chunk_20273(filter_value: int, expected: str) ->
 
 
 def test_csv_quote_in_str_22395() -> None:
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.exceptions.ComputeError):
         pl.read_csv(b"""\
         a,b
         1,2"3


### PR DESCRIPTION
Will check the count afterwards, as checking for a quote char in the middle of every is very expensive and this seems very rare.