### PR TITLE
fix(rust): Fix rust -> python -> rust for map_batches

### DIFF
--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -10,7 +10,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
-use pyo3::types::PyList;
+use pyo3::types::{PyList, PyType};
 
 use self::row_encode::{_get_rows_encoded_ca, _get_rows_encoded_ca_unordered};
 use super::PyDataFrame;
@@ -600,6 +600,24 @@ impl PyDataFrame {
             // Be careful not to drop `e` here as that should be dropped by the ffi consumer
             unsafe { core::ptr::write(location.add(i), e) };
         }
+    }
+
+    /// Import [`Self`] via polars-ffi
+    /// # Safety
+    /// [`location`] should be an address that contains [`width`] properly initialized
+    /// [`SeriesExport`]s
+    #[classmethod]
+    pub unsafe fn _import_columns(
+        _cls: &Bound<PyType>,
+        location: usize,
+        width: usize,
+    ) -> PyResult<Self> {
+        use polars_ffi::version_0::import_df;
+
+        let location = location as *mut SeriesExport;
+
+        let df = unsafe { import_df(location, width) }.map_err(PyPolarsErr::from)?;
+        Ok(PyDataFrame { df })
     }
 
     /// Internal utility function to allow direct access to the row encoding from python.

--- a/crates/polars-python/src/expr/rolling.rs
+++ b/crates/polars-python/src/expr/rolling.rs
@@ -2,10 +2,11 @@ use polars::prelude::*;
 use pyo3::prelude::*;
 use pyo3::types::PyFloat;
 
+use crate::PyExpr;
 use crate::conversion::Wrap;
 use crate::error::PyPolarsErr;
-use crate::map::lazy::call_lambda_with_series;
-use crate::{PyExpr, PySeries};
+use crate::map::lazy::{ToSeries, call_lambda_with_series};
+use crate::py_modules::polars;
 
 #[pymethods]
 impl PyExpr {
@@ -383,12 +384,13 @@ impl PyExpr {
         };
         let function = move |s: &Series| {
             Python::with_gil(|py| {
-                let out = call_lambda_with_series(py, s.clone(), &lambda)
-                    .expect("python function failed");
+                let out = call_lambda_with_series(py, s, &lambda).expect("python function failed");
                 match out.getattr(py, "_s") {
                     Ok(pyseries) => {
-                        let pyseries = pyseries.extract::<PySeries>(py).unwrap();
-                        pyseries.series
+                        let Ok(s) = pyseries
+                            .to_series(py, polars(py), s.name())
+                            .map_err(|e| panic!("{e:?}"));
+                        s
                     },
                     Err(_) => {
                         let obj = out;
@@ -397,7 +399,7 @@ impl PyExpr {
                         let dtype = s.dtype();
 
                         use DataType::*;
-                        let result = match dtype {
+                        let Ok(s) = match dtype {
                             UInt8 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -513,14 +515,9 @@ impl PyExpr {
                                 Float64Chunked::from_slice(PlSmallStr::EMPTY, &[v]).into_series()
                             }),
                             dt => panic!("{dt:?} not implemented"),
-                        };
-
-                        match result {
-                            Ok(s) => s,
-                            Err(e) => {
-                                panic!("{e:?}")
-                            },
                         }
+                        .map_err(|e| panic!("{e:?}"));
+                        s
                     },
                 }
             })

--- a/crates/polars-python/src/map/lazy.rs
+++ b/crates/polars-python/src/map/lazy.rs
@@ -1,11 +1,11 @@
-use std::mem::ManuallyDrop;
+use std::mem::{ManuallyDrop, MaybeUninit};
 
 use polars::prelude::*;
-use pyo3::ffi::Py_uintptr_t;
+use polars_ffi::version_0::SeriesExport;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::PyList;
 
-use crate::py_modules::{pl_series, polars};
+use crate::py_modules::{pl_series, polars, polars_rs};
 use crate::series::PySeries;
 use crate::{PyExpr, Wrap};
 
@@ -49,37 +49,14 @@ impl ToSeries for PyObject {
             Ok(pyseries) => pyseries.series,
             // This happens if the executed Polars is not from this source.
             // Currently only happens in PC-workers
-            // For now use arrow to convert
-            // Eventually we must use Polars' Series Export as that can deal with
-            // multiple chunks
             Err(_) => {
-                use arrow::ffi;
-                let kwargs = PyDict::new(py);
-                kwargs.set_item("in_place", true).unwrap();
+                let mut export: MaybeUninit<SeriesExport> = MaybeUninit::uninit();
                 py_pyseries
-                    .call_method(py, "rechunk", (), Some(&kwargs))
-                    .map_err(|e| polars_err!(ComputeError: "could not rechunk: {e}"))?;
-
-                // Prepare a pointer to receive the Array struct.
-                let array = Box::new(ffi::ArrowArray::empty());
-                let schema = Box::new(ffi::ArrowSchema::empty());
-
-                let array_ptr = &*array as *const ffi::ArrowArray;
-                let schema_ptr = &*schema as *const ffi::ArrowSchema;
-                // SAFETY:
-                // this is unsafe as it write to the pointers we just prepared
-                py_pyseries
-                    .call_method1(
-                        py,
-                        "_export_arrow_to_c",
-                        (array_ptr as Py_uintptr_t, schema_ptr as Py_uintptr_t),
-                    )
-                    .map_err(|e| polars_err!(ComputeError: "{e}"))?;
-
+                    .call_method1(py, "_export", (&raw mut export as usize,))
+                    .unwrap();
                 unsafe {
-                    let field = ffi::import_field_from_c(schema.as_ref())?;
-                    let array = ffi::import_array_from_c(*array, field.dtype)?;
-                    Series::from_arrow(field.name, array)?
+                    let export = export.assume_init();
+                    polars_ffi::version_0::import_series(export)?
                 }
             },
         };
@@ -92,15 +69,33 @@ pub(crate) fn call_lambda_with_series(
     s: &Series,
     lambda: &PyObject,
 ) -> PyResult<PyObject> {
-    let mut export = ManuallyDrop::new(polars_ffi::version_0::export_series(s));
-    let plseries = pl_series(py).bind(py);
+    let pypolars = polars(py).bind(py);
 
-    let s_location = &raw mut export;
-    let python_series_wrapper = plseries
-        .getattr("_import")
+    // create a PySeries struct/object for Python
+    let pyseries = PySeries::new(s.clone());
+    // Wrap this PySeries object in the python side Series wrapper
+    let mut python_series_wrapper = pypolars
+        .getattr("wrap_s")
         .unwrap()
-        .call1((s_location as usize,))
+        .call1((pyseries,))
         .unwrap();
+
+    if !python_series_wrapper
+        .getattr("_s")
+        .unwrap()
+        .is_instance(polars_rs(py).getattr(py, "PySeries").unwrap().bind(py))
+        .unwrap()
+    {
+        let mut export = ManuallyDrop::new(polars_ffi::version_0::export_series(s));
+        let plseries = pl_series(py).bind(py);
+
+        let s_location = &raw mut export;
+        python_series_wrapper = plseries
+            .getattr("_import")
+            .unwrap()
+            .call1((s_location as usize,))
+            .unwrap()
+    }
     lambda.call1(py, (python_series_wrapper,))
 }
 

--- a/crates/polars-python/src/on_startup.rs
+++ b/crates/polars-python/src/on_startup.rs
@@ -9,6 +9,8 @@ use polars_core::chunked_array::object::{registry, set_polars_allow_extension};
 use polars_core::error::PolarsError::ComputeError;
 use polars_error::PolarsWarning;
 use polars_error::signals::register_polars_keyboard_interrupt_hook;
+use polars_ffi::version_0::SeriesExport;
+use polars_plan::plans::python_df_to_rust;
 use polars_utils::python_convert_registry::{FromPythonConvertRegistry, PythonConvertRegistry};
 use pyo3::prelude::*;
 use pyo3::{IntoPyObjectExt, intern};
@@ -17,11 +19,11 @@ use crate::Wrap;
 use crate::dataframe::PyDataFrame;
 use crate::map::lazy::{ToSeries, call_lambda_with_series};
 use crate::prelude::ObjectValue;
-use crate::py_modules::{pl_utils, polars};
+use crate::py_modules::{pl_df, pl_utils, polars};
 
 fn python_function_caller_series(s: Column, lambda: &PyObject) -> PolarsResult<Column> {
     Python::with_gil(|py| {
-        let object = call_lambda_with_series(py, s.clone().take_materialized_series(), lambda)
+        let object = call_lambda_with_series(py, s.as_materialized_series(), lambda)
             .map_err(|s| ComputeError(format!("{}", s).into()))?;
         object.to_series(py, polars(py), s.name()).map(Column::from)
     })
@@ -30,32 +32,26 @@ fn python_function_caller_series(s: Column, lambda: &PyObject) -> PolarsResult<C
 fn python_function_caller_df(df: DataFrame, lambda: &PyObject) -> PolarsResult<DataFrame> {
     Python::with_gil(|py| {
         // create a PyDataFrame struct/object for Python
-        let pydf = PyDataFrame::new(df);
+        let pldf = pl_df(py).bind(py);
+        let width = df.width();
+        // Don't resize the Vec to avoid calling SeriesExport's Drop impl
+        // The import takes ownership and is responsible for dropping
+        let mut columns: Vec<SeriesExport> = Vec::with_capacity(width);
+        unsafe {
+            PyDataFrame { df }._export_columns(columns.as_mut_ptr() as usize);
+        }
         // Wrap this PyDataFrame object in the python side DataFrame wrapper
-        let python_df_wrapper = polars(py)
-            .getattr(py, "wrap_df")
+        let python_df_wrapper = pldf
+            .getattr("_import_columns")
             .unwrap()
-            .call1(py, (pydf,))
+            .call1((columns.as_mut_ptr() as usize, width))
             .unwrap();
         // call the lambda and get a python side df wrapper
         let result_df_wrapper = lambda.call1(py, (python_df_wrapper,)).map_err(|e| {
             PolarsError::ComputeError(format!("User provided python function failed: {e}").into())
         })?;
-        // unpack the wrapper in a PyDataFrame
-        let py_pydf = result_df_wrapper.getattr(py, "_df").map_err(|_| {
-            let pytype = result_df_wrapper.bind(py).get_type();
-            PolarsError::ComputeError(
-                format!("Expected 'LazyFrame.map' to return a 'DataFrame', got a '{pytype}'",)
-                    .into(),
-            )
-        })?;
 
-        // Downcast to Rust
-        let pydf = py_pydf.extract::<PyDataFrame>(py).unwrap();
-        // Finally get the actual DataFrame
-        let df = pydf.df;
-
-        Ok(df)
+        python_df_to_rust(py, result_df_wrapper.into_bound(py))
     })
 }
 

--- a/crates/polars-python/src/py_modules.rs
+++ b/crates/polars-python/src/py_modules.rs
@@ -4,6 +4,7 @@ use pyo3::sync::GILOnceCell;
 static POLARS: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
 static UTILS: GILOnceCell<PyObject> = GILOnceCell::new();
 static SERIES: GILOnceCell<PyObject> = GILOnceCell::new();
+static DATAFRAME: GILOnceCell<PyObject> = GILOnceCell::new();
 
 pub(crate) fn polars(py: Python<'_>) -> &Py<PyModule> {
     POLARS.get_or_init(py, || py.import("polars").unwrap().unbind())
@@ -15,4 +16,8 @@ pub(crate) fn pl_utils(py: Python<'_>) -> &PyObject {
 
 pub(crate) fn pl_series(py: Python<'_>) -> &PyObject {
     SERIES.get_or_init(py, || polars(py).getattr(py, "Series").unwrap())
+}
+
+pub(crate) fn pl_df(py: Python<'_>) -> &PyObject {
+    DATAFRAME.get_or_init(py, || polars(py).getattr(py, "DataFrame").unwrap())
 }

--- a/crates/polars-python/src/py_modules.rs
+++ b/crates/polars-python/src/py_modules.rs
@@ -2,12 +2,17 @@ use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
 
 static POLARS: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
+static POLARS_RS: GILOnceCell<PyObject> = GILOnceCell::new();
 static UTILS: GILOnceCell<PyObject> = GILOnceCell::new();
 static SERIES: GILOnceCell<PyObject> = GILOnceCell::new();
 static DATAFRAME: GILOnceCell<PyObject> = GILOnceCell::new();
 
 pub(crate) fn polars(py: Python<'_>) -> &Py<PyModule> {
     POLARS.get_or_init(py, || py.import("polars").unwrap().unbind())
+}
+
+pub(crate) fn polars_rs(py: Python<'_>) -> &PyObject {
+    POLARS_RS.get_or_init(py, || polars(py).getattr(py, "polars").unwrap())
 }
 
 pub(crate) fn pl_utils(py: Python<'_>) -> &PyObject {

--- a/crates/polars-python/src/series/export.rs
+++ b/crates/polars-python/src/series/export.rs
@@ -1,4 +1,5 @@
 use polars_core::prelude::*;
+use polars_ffi::version_0::SeriesExport;
 use pyo3::IntoPyObjectExt;
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyList};
@@ -164,5 +165,12 @@ impl PySeries {
         requested_schema: Option<PyObject>,
     ) -> PyResult<Bound<'py, PyCapsule>> {
         series_to_stream(&self.series, py)
+    }
+
+    pub fn _export(&mut self, _py: Python, location: usize) {
+        let export = polars_ffi::version_0::export_series(&self.series);
+        unsafe {
+            (location as *mut SeriesExport).write(export);
+        }
     }
 }

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -602,6 +602,10 @@ class DataFrame:
         self._df.replace(column, new_column._s)
         return self
 
+    @classmethod
+    def _import_columns(cls, pointer: int, width: int) -> DataFrame:
+        return cls._from_pydf(PyDataFrame._import_columns(pointer, width))
+
     @property
     @unstable()
     def plot(self) -> DataFramePlot:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -393,6 +393,10 @@ class Series:
         """
         return cls._from_pyseries(PySeries._import_arrow_from_c(name, pointers))
 
+    @classmethod
+    def _import(cls, pointer: int) -> Self:
+        return cls._from_pyseries(PySeries._import(pointer))
+
     def _export_arrow_to_c(self, out_ptr: int, out_schema_ptr: int) -> None:
         """
         Export to a C ArrowArray and C ArrowSchema struct, given their pointers.

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -98,7 +98,7 @@ def test_lazy_map_schema() -> None:
 
     with pytest.raises(
         ComputeError,
-        match="expected a polars.DataFrame; got",
+        match="Expected 'LazyFrame.map' to return a 'DataFrame', got a",
     ):
         df.lazy().map_batches(custom).collect()  # type: ignore[arg-type]
 

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -98,7 +98,7 @@ def test_lazy_map_schema() -> None:
 
     with pytest.raises(
         ComputeError,
-        match="Expected 'LazyFrame.map' to return a 'DataFrame', got a",
+        match="expected a polars.DataFrame; got",
     ):
         df.lazy().map_batches(custom).collect()  # type: ignore[arg-type]
 


### PR DESCRIPTION
This uses polars-ffi to convert between python and rust to support calling
python UDFs from rust polars. This is primarily used in polars-cloud.

As a consequence, this also fixes map_rolling and numpy ufuncs in polars-cloud
