### PR TITLE
perf: Add single-key variants of streaming group_by

### DIFF
--- a/crates/polars-arrow/src/array/binview/builder.rs
+++ b/crates/polars-arrow/src/array/binview/builder.rs
@@ -87,7 +87,7 @@ impl<V: ViewType + ?Sized> BinaryViewArrayGenericBuilder<V> {
         self.buffer_set.push(PLACEHOLDER_BUFFER.clone()) // Push placeholder so active_buffer_idx stays valid.
     }
 
-    fn push_value_ignore_validity(&mut self, bytes: &V) {
+    pub fn push_value_ignore_validity(&mut self, bytes: &V) {
         let bytes = bytes.to_bytes();
         self.total_bytes_len += bytes.len();
         unsafe {
@@ -103,6 +103,14 @@ impl<V: ViewType + ?Sized> BinaryViewArrayGenericBuilder<V> {
             };
             self.views.push(view);
         }
+    }
+
+    /// # Safety
+    /// The view must be inline.
+    pub unsafe fn push_inline_view_ignore_validity(&mut self, view: View) {
+        debug_assert!(view.is_inline());
+        self.total_bytes_len += view.length as usize;
+        self.views.push(view);
     }
 
     fn switch_active_stealing_bufferset_to(&mut self, buffer_set: &Arc<[Buffer<u8>]>) {

--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -55,6 +55,11 @@ impl View {
     pub const MAX_INLINE_SIZE: u32 = 12;
 
     #[inline(always)]
+    pub fn is_inline(&self) -> bool {
+        self.length <= Self::MAX_INLINE_SIZE
+    }
+
+    #[inline(always)]
     pub fn as_u128(self) -> u128 {
         unsafe { std::mem::transmute(self) }
     }

--- a/crates/polars-expr/src/groups/binview.rs
+++ b/crates/polars-expr/src/groups/binview.rs
@@ -85,20 +85,6 @@ impl BinviewHashGrouper {
             DataFrame::new(vec![Column::from(s)]).unwrap()
         }
     }
-
-    // fn finalize_keys(&self, keys: Vec<T::Physical<'static>>) -> DataFrame {
-    //     let mut keys = T::Array::from_vec(keys, self.dtype.to_physical().to_arrow(CompatLevel::newest()));
-    //     if self.null_idx < IdxSize::MAX {
-    //         let mut validity = MutableBitmap::new();
-    //         validity.extend_constant(keys.len(), true);
-    //         validity.set(self.null_idx as usize, false);
-    //         keys = keys.with_validity_typed(Some(validity.freeze()));
-    //     }
-    //     unsafe {
-    //         let s = Series::from_chunks_and_dtype_unchecked(self.name.clone(), vec![Box::new(keys)], &self.dtype);
-    //         DataFrame::new(vec![Column::from(s)]).unwrap()
-    //     }
-    // }
 }
 
 impl Grouper for BinviewHashGrouper {

--- a/crates/polars-expr/src/groups/binview.rs
+++ b/crates/polars-expr/src/groups/binview.rs
@@ -1,0 +1,289 @@
+use arrow::array::{Array, BinaryViewArrayGeneric, View, ViewType};
+use arrow::bitmap::{Bitmap, MutableBitmap};
+use arrow::buffer::Buffer;
+use polars_compute::binview_index_map::{BinaryViewIndexMap, Entry};
+
+use super::*;
+use crate::hash_keys::HashKeys;
+
+#[derive(Default)]
+pub struct BinviewHashGrouper {
+    name: PlSmallStr,
+    dtype: DataType,
+    idx_map: BinaryViewIndexMap<()>,
+    null_idx: IdxSize,
+}
+
+impl BinviewHashGrouper {
+    pub fn new(name: PlSmallStr, dtype: DataType) -> Self {
+        Self {
+            name,
+            dtype,
+            idx_map: BinaryViewIndexMap::default(),
+            null_idx: IdxSize::MAX,
+        }
+    }
+
+    /// # Safety
+    /// The view must be valid for the given buffer set.
+    #[inline(always)]
+    unsafe fn insert_key(&mut self, hash: u64, view: View, buffers: &Arc<[Buffer<u8>]>) -> IdxSize {
+        unsafe {
+            match self.idx_map.entry_view(hash, view, buffers) {
+                Entry::Occupied(o) => o.index(),
+                Entry::Vacant(v) => {
+                    let index = v.index();
+                    v.insert(());
+                    index
+                },
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn insert_null(&mut self) -> IdxSize {
+        if self.null_idx == IdxSize::MAX {
+            self.null_idx = self.idx_map.push_unmapped_empty_entry(());
+        }
+        self.null_idx
+    }
+
+    /// # Safety
+    /// The view must be valid for the given buffer set.
+    #[inline(always)]
+    unsafe fn contains_key(&self, hash: u64, view: &View, buffers: &Arc<[Buffer<u8>]>) -> bool {
+        unsafe { self.idx_map.get_view(hash, view, buffers).is_some() }
+    }
+
+    #[inline(always)]
+    fn contains_null(&self) -> bool {
+        self.null_idx < IdxSize::MAX
+    }
+
+    /// # Safety
+    /// The views must be valid for the given buffers.
+    unsafe fn finalize_keys<V: ViewType + ?Sized>(
+        &self,
+        views: Buffer<View>,
+        buffers: Arc<[Buffer<u8>]>,
+        validity: Option<Bitmap>,
+    ) -> DataFrame {
+        unsafe {
+            let arrow_dtype = self.dtype.to_arrow(CompatLevel::newest());
+            let keys = BinaryViewArrayGeneric::<V>::new_unchecked_unknown_md(
+                arrow_dtype,
+                views,
+                buffers,
+                validity,
+                None,
+            );
+            let s = Series::from_chunks_and_dtype_unchecked(
+                self.name.clone(),
+                vec![Box::new(keys)],
+                &self.dtype,
+            );
+            DataFrame::new(vec![Column::from(s)]).unwrap()
+        }
+    }
+
+    // fn finalize_keys(&self, keys: Vec<T::Physical<'static>>) -> DataFrame {
+    //     let mut keys = T::Array::from_vec(keys, self.dtype.to_physical().to_arrow(CompatLevel::newest()));
+    //     if self.null_idx < IdxSize::MAX {
+    //         let mut validity = MutableBitmap::new();
+    //         validity.extend_constant(keys.len(), true);
+    //         validity.set(self.null_idx as usize, false);
+    //         keys = keys.with_validity_typed(Some(validity.freeze()));
+    //     }
+    //     unsafe {
+    //         let s = Series::from_chunks_and_dtype_unchecked(self.name.clone(), vec![Box::new(keys)], &self.dtype);
+    //         DataFrame::new(vec![Column::from(s)]).unwrap()
+    //     }
+    // }
+}
+
+impl Grouper for BinviewHashGrouper {
+    fn new_empty(&self) -> Box<dyn Grouper> {
+        Box::new(Self::new(self.name.clone(), self.dtype.clone()))
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.idx_map.reserve(additional);
+    }
+
+    fn num_groups(&self) -> IdxSize {
+        self.idx_map.len()
+    }
+
+    unsafe fn insert_keys_subset(
+        &mut self,
+        hash_keys: &HashKeys,
+        subset: &[IdxSize],
+        group_idxs: Option<&mut Vec<IdxSize>>,
+    ) {
+        let HashKeys::Binview(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+
+        unsafe {
+            let views = hash_keys.keys.views().as_slice();
+            let buffers = hash_keys.keys.data_buffers();
+            if let Some(validity) = hash_keys.keys.validity() {
+                if hash_keys.null_is_valid {
+                    let groups = subset.iter().map(|idx| {
+                        if validity.get_bit_unchecked(*idx as usize) {
+                            let hash = hash_keys.hashes.value_unchecked(*idx as usize);
+                            let view = views.get_unchecked(*idx as usize);
+                            self.insert_key(hash, *view, buffers)
+                        } else {
+                            self.insert_null()
+                        }
+                    });
+                    if let Some(group_idxs) = group_idxs {
+                        group_idxs.reserve(subset.len());
+                        group_idxs.extend(groups);
+                    } else {
+                        groups.for_each(drop);
+                    }
+                } else {
+                    let groups = subset.iter().filter_map(|idx| {
+                        if validity.get_bit_unchecked(*idx as usize) {
+                            let hash = hash_keys.hashes.value_unchecked(*idx as usize);
+                            let view = views.get_unchecked(*idx as usize);
+                            Some(self.insert_key(hash, *view, buffers))
+                        } else {
+                            None
+                        }
+                    });
+                    if let Some(group_idxs) = group_idxs {
+                        group_idxs.reserve(subset.len());
+                        group_idxs.extend(groups);
+                    } else {
+                        groups.for_each(drop);
+                    }
+                }
+            } else {
+                let groups = subset.iter().map(|idx| {
+                    let hash = hash_keys.hashes.value_unchecked(*idx as usize);
+                    let view = views.get_unchecked(*idx as usize);
+                    self.insert_key(hash, *view, buffers)
+                });
+                if let Some(group_idxs) = group_idxs {
+                    group_idxs.reserve(subset.len());
+                    group_idxs.extend(groups);
+                } else {
+                    groups.for_each(drop);
+                }
+            }
+        }
+    }
+
+    fn get_keys_in_group_order(&self) -> DataFrame {
+        let buffers: Arc<[_]> = self
+            .idx_map
+            .buffers()
+            .iter()
+            .map(|b| Buffer::from(b.to_vec()))
+            .collect();
+        let views = self.idx_map.iter_hash_views().map(|(_h, v)| v).collect();
+        let validity = if self.null_idx < IdxSize::MAX {
+            let mut validity = MutableBitmap::new();
+            validity.extend_constant(self.idx_map.len() as usize, true);
+            validity.set(self.null_idx as usize, false);
+            Some(validity.freeze())
+        } else {
+            None
+        };
+
+        unsafe {
+            match &self.dtype {
+                DataType::Binary => self.finalize_keys::<[u8]>(views, buffers, validity),
+                DataType::String => self.finalize_keys::<str>(views, buffers, validity),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// # Safety
+    /// All groupers must be a BinviewHashGrouper.
+    unsafe fn probe_partitioned_groupers(
+        &self,
+        groupers: &[Box<dyn Grouper>],
+        hash_keys: &HashKeys,
+        partitioner: &HashPartitioner,
+        invert: bool,
+        probe_matches: &mut Vec<IdxSize>,
+    ) {
+        let HashKeys::Binview(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+        assert!(partitioner.num_partitions() == groupers.len());
+
+        unsafe {
+            let null_p = partitioner.null_partition();
+            let buffers = hash_keys.keys.data_buffers();
+            let views = hash_keys.keys.views().as_slice();
+            hash_keys.for_each_hash(|idx, opt_h| {
+                let has_group = if let Some(h) = opt_h {
+                    let p = partitioner.hash_to_partition(h);
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const BinviewHashGrouper);
+                    let view = views.get_unchecked(idx as usize);
+                    grouper.contains_key(h, view, buffers)
+                } else {
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(null_p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const BinviewHashGrouper);
+                    grouper.contains_null()
+                };
+
+                if has_group != invert {
+                    probe_matches.push(idx);
+                }
+            });
+        }
+    }
+
+    /// # Safety
+    /// All groupers must be a BinviewHashGrouper.
+    unsafe fn contains_key_partitioned_groupers(
+        &self,
+        groupers: &[Box<dyn Grouper>],
+        hash_keys: &HashKeys,
+        partitioner: &HashPartitioner,
+        invert: bool,
+        contains_key: &mut BitmapBuilder,
+    ) {
+        let HashKeys::Binview(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+        assert!(partitioner.num_partitions() == groupers.len());
+
+        unsafe {
+            let null_p = partitioner.null_partition();
+            let buffers = hash_keys.keys.data_buffers();
+            let views = hash_keys.keys.views().as_slice();
+            hash_keys.for_each_hash(|idx, opt_h| {
+                let has_group = if let Some(h) = opt_h {
+                    let p = partitioner.hash_to_partition(h);
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const BinviewHashGrouper);
+                    let view = views.get_unchecked(idx as usize);
+                    grouper.contains_key(h, view, buffers)
+                } else {
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(null_p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const BinviewHashGrouper);
+                    grouper.contains_null()
+                };
+
+                contains_key.push(has_group != invert);
+            });
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/polars-expr/src/groups/mod.rs
+++ b/crates/polars-expr/src/groups/mod.rs
@@ -7,7 +7,9 @@ use polars_utils::hashing::HashPartitioner;
 
 use crate::hash_keys::HashKeys;
 
+mod binview;
 mod row_encoded;
+mod single_key;
 
 /// A Grouper maps keys to groups, such that duplicate keys map to the same group.
 pub trait Grouper: Any + Send + Sync {
@@ -30,18 +32,6 @@ pub trait Grouper: Any + Send + Sync {
         keys: &HashKeys,
         subset: &[IdxSize],
         group_idxs: Option<&mut Vec<IdxSize>>,
-    );
-
-    /// Adds the given Grouper into this one, mutating groups_idxs such that
-    /// the group subset[i] of other now has group index group_idxs[i] in self.
-    ///
-    /// # Safety
-    /// For all i, subset[i] < other.len().
-    unsafe fn gather_combine(
-        &mut self,
-        other: &dyn Grouper,
-        subset: &[IdxSize],
-        group_idxs: &mut Vec<IdxSize>,
     );
 
     /// Returns the keys in this Grouper in group order, that is the key for
@@ -78,5 +68,49 @@ pub trait Grouper: Any + Send + Sync {
 }
 
 pub fn new_hash_grouper(key_schema: Arc<Schema>) -> Box<dyn Grouper> {
-    Box::new(row_encoded::RowEncodedHashGrouper::new(key_schema))
+    if key_schema.len() > 1 {
+        Box::new(row_encoded::RowEncodedHashGrouper::new(key_schema))
+    } else {
+        use single_key::SingleKeyHashGrouper as SK;
+        let (name, dt) = key_schema.get_at_index(0).unwrap();
+        let (name, dt) = (name.clone(), dt.clone());
+        match dt {
+            #[cfg(feature = "dtype-u8")]
+            DataType::UInt8 => Box::new(SK::<UInt8Type>::new(name, dt)),
+            #[cfg(feature = "dtype-u16")]
+            DataType::UInt16 => Box::new(SK::<UInt16Type>::new(name, dt)),
+            DataType::UInt32 => Box::new(SK::<UInt32Type>::new(name, dt)),
+            DataType::UInt64 => Box::new(SK::<UInt64Type>::new(name, dt)),
+            #[cfg(feature = "dtype-i8")]
+            DataType::Int8 => Box::new(SK::<Int8Type>::new(name, dt)),
+            #[cfg(feature = "dtype-i16")]
+            DataType::Int16 => Box::new(SK::<Int16Type>::new(name, dt)),
+            DataType::Int32 => Box::new(SK::<Int32Type>::new(name, dt)),
+            DataType::Int64 => Box::new(SK::<Int64Type>::new(name, dt)),
+            #[cfg(feature = "dtype-i128")]
+            DataType::Int128 => Box::new(SK::<Int128Type>::new(name, dt)),
+            DataType::Float32 => Box::new(SK::<Float32Type>::new(name, dt)),
+            DataType::Float64 => Box::new(SK::<Float64Type>::new(name, dt)),
+
+            #[cfg(feature = "dtype-date")]
+            DataType::Date => Box::new(SK::<Int32Type>::new(name, dt)),
+            #[cfg(feature = "dtype-datetime")]
+            DataType::Datetime(_, _) => Box::new(SK::<Int64Type>::new(name, dt)),
+            #[cfg(feature = "dtype-duration")]
+            DataType::Duration(_) => Box::new(SK::<Int64Type>::new(name, dt)),
+            #[cfg(feature = "dtype-time")]
+            DataType::Time => Box::new(SK::<Int64Type>::new(name, dt)),
+
+            #[cfg(feature = "dtype-decimal")]
+            DataType::Decimal(_, _) => Box::new(SK::<Int128Type>::new(name, dt)),
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Enum(_, _) => Box::new(SK::<UInt32Type>::new(name, dt)),
+
+            DataType::String | DataType::Binary => {
+                Box::new(binview::BinviewHashGrouper::new(name, dt))
+            },
+
+            _ => Box::new(row_encoded::RowEncodedHashGrouper::new(key_schema)),
+        }
+    }
 }

--- a/crates/polars-expr/src/groups/row_encoded.rs
+++ b/crates/polars-expr/src/groups/row_encoded.rs
@@ -92,7 +92,7 @@ impl Grouper for RowEncodedHashGrouper {
 
         unsafe {
             if let Some(group_idxs) = group_idxs {
-                group_idxs.reserve(keys.keys.len() - keys.keys.null_count());
+                group_idxs.reserve(subset.len());
                 keys.for_each_hash_subset(subset, |idx, opt_hash| {
                     if let Some(hash) = opt_hash {
                         let key = keys.keys.value_unchecked(idx as usize);
@@ -106,27 +106,6 @@ impl Grouper for RowEncodedHashGrouper {
                         self.insert_key(hash, key);
                     }
                 });
-            }
-        }
-    }
-
-    unsafe fn gather_combine(
-        &mut self,
-        other: &dyn Grouper,
-        subset: &[IdxSize],
-        group_idxs: &mut Vec<IdxSize>,
-    ) {
-        let other = other.as_any().downcast_ref::<Self>().unwrap();
-
-        // TODO: cardinality estimation.
-        self.idx_map.reserve(subset.len());
-
-        unsafe {
-            group_idxs.clear();
-            group_idxs.reserve(subset.len());
-            for i in subset {
-                let (hash, key, ()) = other.idx_map.get_index_unchecked(*i);
-                group_idxs.push_unchecked(self.insert_key(hash, key));
             }
         }
     }

--- a/crates/polars-expr/src/groups/single_key.rs
+++ b/crates/polars-expr/src/groups/single_key.rs
@@ -1,0 +1,250 @@
+use arrow::array::Array;
+use arrow::bitmap::MutableBitmap;
+use polars_utils::idx_map::total_idx_map::{Entry, TotalIndexMap};
+use polars_utils::total_ord::{TotalEq, TotalHash};
+use polars_utils::vec::PushUnchecked;
+
+use super::*;
+use crate::hash_keys::{HashKeys, for_each_hash_single};
+
+#[derive(Default)]
+pub struct SingleKeyHashGrouper<T: PolarsDataType> {
+    name: PlSmallStr,
+    dtype: DataType,
+    idx_map: TotalIndexMap<T::Physical<'static>, ()>,
+    null_idx: IdxSize,
+}
+
+impl<K, T: PolarsDataType> SingleKeyHashGrouper<T>
+where
+    for<'a> T: PolarsDataType<Physical<'a> = K>,
+    K: Default + TotalHash + TotalEq,
+{
+    pub fn new(name: PlSmallStr, dtype: DataType) -> Self {
+        Self {
+            name,
+            dtype,
+            idx_map: TotalIndexMap::default(),
+            null_idx: IdxSize::MAX,
+        }
+    }
+
+    #[inline(always)]
+    fn insert_key(&mut self, key: T::Physical<'static>) -> IdxSize {
+        match self.idx_map.entry(key) {
+            Entry::Occupied(o) => o.index(),
+            Entry::Vacant(v) => {
+                let index = v.index();
+                v.insert(());
+                index
+            },
+        }
+    }
+
+    #[inline(always)]
+    fn insert_null(&mut self) -> IdxSize {
+        if self.null_idx == IdxSize::MAX {
+            self.null_idx = self.idx_map.push_unmapped_entry(T::Physical::default(), ());
+        }
+        self.null_idx
+    }
+
+    #[inline(always)]
+    fn contains_key(&self, key: &T::Physical<'static>) -> bool {
+        self.idx_map.get(key).is_some()
+    }
+
+    #[inline(always)]
+    fn contains_null(&self) -> bool {
+        self.null_idx < IdxSize::MAX
+    }
+
+    fn finalize_keys(&self, keys: Vec<T::Physical<'static>>) -> DataFrame {
+        let mut keys = T::Array::from_vec(
+            keys,
+            self.dtype.to_physical().to_arrow(CompatLevel::newest()),
+        );
+        if self.null_idx < IdxSize::MAX {
+            let mut validity = MutableBitmap::new();
+            validity.extend_constant(keys.len(), true);
+            validity.set(self.null_idx as usize, false);
+            keys = keys.with_validity_typed(Some(validity.freeze()));
+        }
+        unsafe {
+            let s = Series::from_chunks_and_dtype_unchecked(
+                self.name.clone(),
+                vec![Box::new(keys)],
+                &self.dtype,
+            );
+            DataFrame::new(vec![Column::from(s)]).unwrap()
+        }
+    }
+}
+
+impl<K, T: PolarsDataType> Grouper for SingleKeyHashGrouper<T>
+where
+    for<'a> T: PolarsDataType<Physical<'a> = K>,
+    K: Default + TotalHash + TotalEq + Clone + Send + Sync + 'static,
+{
+    fn new_empty(&self) -> Box<dyn Grouper> {
+        Box::new(Self::new(self.name.clone(), self.dtype.clone()))
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.idx_map.reserve(additional);
+    }
+
+    fn num_groups(&self) -> IdxSize {
+        self.idx_map.len()
+    }
+
+    unsafe fn insert_keys_subset(
+        &mut self,
+        hash_keys: &HashKeys,
+        subset: &[IdxSize],
+        group_idxs: Option<&mut Vec<IdxSize>>,
+    ) {
+        let HashKeys::Single(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+        let ca: &ChunkedArray<T> = hash_keys.keys.as_phys_any().downcast_ref().unwrap();
+        let arr = ca.downcast_as_array();
+
+        unsafe {
+            if arr.has_nulls() {
+                if hash_keys.null_is_valid {
+                    let groups = subset.iter().map(|idx| {
+                        let opt_k = arr.get_unchecked(*idx as usize);
+                        if let Some(k) = opt_k {
+                            self.insert_key(k)
+                        } else {
+                            self.insert_null()
+                        }
+                    });
+                    if let Some(group_idxs) = group_idxs {
+                        group_idxs.reserve(subset.len());
+                        group_idxs.extend(groups);
+                    } else {
+                        groups.for_each(drop);
+                    }
+                } else {
+                    let groups = subset.iter().filter_map(|idx| {
+                        let opt_k = arr.get_unchecked(*idx as usize);
+                        opt_k.map(|k| self.insert_key(k))
+                    });
+                    if let Some(group_idxs) = group_idxs {
+                        group_idxs.reserve(subset.len());
+                        group_idxs.extend(groups);
+                    } else {
+                        groups.for_each(drop);
+                    }
+                }
+            } else {
+                let groups = subset.iter().map(|idx| {
+                    let k = arr.value_unchecked(*idx as usize);
+                    self.insert_key(k)
+                });
+                if let Some(group_idxs) = group_idxs {
+                    group_idxs.reserve(subset.len());
+                    group_idxs.extend(groups);
+                } else {
+                    groups.for_each(drop);
+                }
+            }
+        }
+    }
+
+    fn get_keys_in_group_order(&self) -> DataFrame {
+        unsafe {
+            let mut key_rows = Vec::with_capacity(self.idx_map.len() as usize);
+            for key in self.idx_map.iter_keys() {
+                key_rows.push_unchecked(key.clone());
+            }
+            self.finalize_keys(key_rows)
+        }
+    }
+
+    /// # Safety
+    /// All groupers must be a SingleKeyHashGrouper<T>.
+    unsafe fn probe_partitioned_groupers(
+        &self,
+        groupers: &[Box<dyn Grouper>],
+        hash_keys: &HashKeys,
+        partitioner: &HashPartitioner,
+        invert: bool,
+        probe_matches: &mut Vec<IdxSize>,
+    ) {
+        let HashKeys::Single(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+        let ca: &ChunkedArray<T> = hash_keys.keys.as_phys_any().downcast_ref().unwrap();
+        let arr = ca.downcast_as_array();
+        assert!(partitioner.num_partitions() == groupers.len());
+
+        unsafe {
+            let null_p = partitioner.null_partition();
+            for_each_hash_single(ca, &hash_keys.random_state, |idx, opt_h| {
+                let has_group = if let Some(h) = opt_h {
+                    let p = partitioner.hash_to_partition(h);
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const SingleKeyHashGrouper<T>);
+                    let key = arr.value_unchecked(idx as usize);
+                    grouper.contains_key(&key)
+                } else {
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(null_p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const SingleKeyHashGrouper<T>);
+                    grouper.contains_null()
+                };
+
+                if has_group != invert {
+                    probe_matches.push(idx);
+                }
+            });
+        }
+    }
+
+    /// # Safety
+    /// All groupers must be a SingleKeyHashGrouper<T>.
+    unsafe fn contains_key_partitioned_groupers(
+        &self,
+        groupers: &[Box<dyn Grouper>],
+        hash_keys: &HashKeys,
+        partitioner: &HashPartitioner,
+        invert: bool,
+        contains_key: &mut BitmapBuilder,
+    ) {
+        let HashKeys::Single(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+        let ca: &ChunkedArray<T> = hash_keys.keys.as_phys_any().downcast_ref().unwrap();
+        let arr = ca.downcast_as_array();
+        assert!(partitioner.num_partitions() == groupers.len());
+
+        unsafe {
+            let null_p = partitioner.null_partition();
+            for_each_hash_single(ca, &hash_keys.random_state, |idx, opt_h| {
+                let has_group = if let Some(h) = opt_h {
+                    let p = partitioner.hash_to_partition(h);
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const SingleKeyHashGrouper<T>);
+                    let key = arr.value_unchecked(idx as usize);
+                    grouper.contains_key(&key)
+                } else {
+                    let dyn_grouper: &dyn Grouper = &**groupers.get_unchecked(null_p);
+                    let grouper =
+                        &*(dyn_grouper as *const dyn Grouper as *const SingleKeyHashGrouper<T>);
+                    grouper.contains_null()
+                };
+
+                contains_key.push(has_group != invert);
+            });
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/polars-expr/src/hot_groups/binview.rs
+++ b/crates/polars-expr/src/hot_groups/binview.rs
@@ -1,0 +1,200 @@
+use arrow::array::builder::StaticArrayBuilder;
+use arrow::array::{BinaryViewArrayGenericBuilder, PrimitiveArray, View};
+use arrow::bitmap::MutableBitmap;
+use arrow::buffer::Buffer;
+use polars_utils::vec::PushUnchecked;
+
+use super::*;
+use crate::hash_keys::BinviewKeys;
+use crate::hot_groups::fixed_index_table::FixedIndexTable;
+
+pub struct BinviewHashHotGrouper {
+    // The views in this table when not inline are stored in the vec.
+    table: FixedIndexTable<(u64, View, Vec<u8>)>,
+    evicted_key_hashes: Vec<u64>,
+    evicted_keys: BinaryViewArrayGenericBuilder<[u8]>,
+    null_idx: IdxSize,
+}
+
+impl BinviewHashHotGrouper {
+    pub fn new(max_groups: usize) -> Self {
+        Self {
+            table: FixedIndexTable::new(max_groups.try_into().unwrap()),
+            evicted_key_hashes: Vec::new(),
+            evicted_keys: BinaryViewArrayGenericBuilder::new(ArrowDataType::BinaryView),
+            null_idx: IdxSize::MAX,
+        }
+    }
+
+    /// # Safety
+    /// The view must be valid for the given buffer set.
+    #[inline(always)]
+    unsafe fn insert_key(
+        &mut self,
+        hash: u64,
+        view: View,
+        buffers: &Arc<[Buffer<u8>]>,
+    ) -> Option<EvictIdx> {
+        unsafe {
+            let mut evict = |ev_h: &u64, ev_view: &View, ev_buffer: &Vec<u8>| {
+                self.evicted_key_hashes.push(*ev_h);
+                if ev_view.is_inline() {
+                    self.evicted_keys.push_inline_view_ignore_validity(*ev_view);
+                } else {
+                    self.evicted_keys
+                        .push_value_ignore_validity(ev_buffer.as_slice());
+                }
+            };
+            if view.is_inline() {
+                self.table.insert_key(
+                    hash,
+                    (),
+                    |_, b| view == b.1,
+                    |_| (hash, view, Vec::new()),
+                    |_, ev_k| {
+                        let (ev_h, ev_view, ev_buffer) = ev_k;
+                        evict(ev_h, ev_view, ev_buffer);
+                        *ev_h = hash;
+                        *ev_view = view;
+                        ev_buffer.clear();
+                    },
+                )
+            } else {
+                let bytes = view.get_external_slice_unchecked(buffers);
+                self.table.insert_key(
+                    hash,
+                    (),
+                    |_, b| {
+                        // We only reach here if the hash matched, so jump straight to full comparison.
+                        bytes == b.2
+                    },
+                    |_| (hash, view, bytes.to_vec()),
+                    |_, ev_k| {
+                        let (ev_h, ev_view, ev_buffer) = ev_k;
+                        evict(ev_h, ev_view, ev_buffer);
+                        *ev_h = hash;
+                        *ev_view = view;
+                        ev_buffer.clear();
+                        ev_buffer.extend_from_slice(bytes);
+                    },
+                )
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn insert_null(&mut self) -> Option<EvictIdx> {
+        if self.null_idx == IdxSize::MAX {
+            self.null_idx = self
+                .table
+                .push_unmapped_key((0, View::default(), Vec::new()));
+        }
+        Some(EvictIdx::new(self.null_idx, false))
+    }
+}
+
+impl HotGrouper for BinviewHashHotGrouper {
+    fn new_empty(&self, max_groups: usize) -> Box<dyn HotGrouper> {
+        Box::new(Self::new(max_groups))
+    }
+
+    fn num_groups(&self) -> IdxSize {
+        self.table.len() as IdxSize
+    }
+
+    fn insert_keys(
+        &mut self,
+        hash_keys: &HashKeys,
+        hot_idxs: &mut Vec<IdxSize>,
+        hot_group_idxs: &mut Vec<EvictIdx>,
+        cold_idxs: &mut Vec<IdxSize>,
+    ) {
+        let HashKeys::Binview(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+
+        hot_idxs.reserve(hash_keys.keys.len());
+        hot_group_idxs.reserve(hash_keys.keys.len());
+        cold_idxs.reserve(hash_keys.keys.len());
+
+        let mut push_g = |idx: usize, opt_g: Option<EvictIdx>| unsafe {
+            if let Some(g) = opt_g {
+                hot_idxs.push_unchecked(idx as IdxSize);
+                hot_group_idxs.push_unchecked(g);
+            } else {
+                cold_idxs.push_unchecked(idx as IdxSize);
+            }
+        };
+
+        unsafe {
+            let views = hash_keys.keys.views().as_slice();
+            let buffers = hash_keys.keys.data_buffers();
+            if hash_keys.null_is_valid {
+                hash_keys.for_each_hash(|idx, opt_h| {
+                    if let Some(h) = opt_h {
+                        let view = views.get_unchecked(idx as usize);
+                        push_g(idx as usize, self.insert_key(h, *view, buffers));
+                    } else {
+                        push_g(idx as usize, self.insert_null());
+                    }
+                });
+            } else {
+                hash_keys.for_each_hash(|idx, opt_h| {
+                    if let Some(h) = opt_h {
+                        let view = views.get_unchecked(idx as usize);
+                        push_g(idx as usize, self.insert_key(h, *view, buffers));
+                    }
+                });
+            }
+        }
+    }
+
+    fn keys(&self) -> HashKeys {
+        unsafe {
+            let mut hashes = Vec::with_capacity(self.table.len());
+            let mut keys_builder = BinaryViewArrayGenericBuilder::new(ArrowDataType::BinaryView);
+            keys_builder.reserve(self.table.len());
+            for (h, view, buf) in self.table.keys() {
+                hashes.push_unchecked(*h);
+                if view.is_inline() {
+                    keys_builder.push_inline_view_ignore_validity(*view);
+                } else {
+                    keys_builder.push_value_ignore_validity(buf.as_slice());
+                }
+            }
+
+            let hashes = PrimitiveArray::from_vec(hashes);
+            let mut keys = keys_builder.freeze();
+            let null_is_valid = self.null_idx < IdxSize::MAX;
+            if null_is_valid {
+                let mut validity = MutableBitmap::new();
+                validity.extend_constant(keys.len(), true);
+                validity.set(self.null_idx as usize, false);
+                keys = keys.with_validity_typed(Some(validity.freeze()));
+            }
+            HashKeys::Binview(BinviewKeys {
+                hashes,
+                keys,
+                null_is_valid,
+            })
+        }
+    }
+
+    fn num_evictions(&self) -> usize {
+        self.evicted_keys.len()
+    }
+
+    fn take_evicted_keys(&mut self) -> HashKeys {
+        let hashes = core::mem::take(&mut self.evicted_key_hashes);
+        let keys = self.evicted_keys.freeze_reset();
+        HashKeys::Binview(BinviewKeys {
+            hashes: PrimitiveArray::from_vec(hashes),
+            keys,
+            null_is_valid: false,
+        })
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/polars-expr/src/hot_groups/mod.rs
+++ b/crates/polars-expr/src/hot_groups/mod.rs
@@ -6,8 +6,10 @@ use polars_utils::IdxSize;
 use crate::EvictIdx;
 use crate::hash_keys::HashKeys;
 
+mod binview;
 mod fixed_index_table;
 mod row_encoded;
+mod single_key;
 
 /// A HotGrouper maps keys to groups, such that duplicate keys map to the same
 /// group. Unlike a Grouper it has a fixed size and will cause evictions rather
@@ -42,7 +44,53 @@ pub trait HotGrouper: Any + Send + Sync {
 }
 
 pub fn new_hash_hot_grouper(key_schema: Arc<Schema>, num_groups: usize) -> Box<dyn HotGrouper> {
-    Box::new(row_encoded::RowEncodedHashHotGrouper::new(
-        key_schema, num_groups,
-    ))
+    if key_schema.len() > 1 {
+        Box::new(row_encoded::RowEncodedHashHotGrouper::new(
+            key_schema, num_groups,
+        ))
+    } else {
+        use single_key::SingleKeyHashHotGrouper as SK;
+        let dt = key_schema.get_at_index(0).unwrap().1.clone();
+        let ng = num_groups;
+        match dt {
+            #[cfg(feature = "dtype-u8")]
+            DataType::UInt8 => Box::new(SK::<UInt8Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-u16")]
+            DataType::UInt16 => Box::new(SK::<UInt16Type>::new(dt, ng)),
+            DataType::UInt32 => Box::new(SK::<UInt32Type>::new(dt, ng)),
+            DataType::UInt64 => Box::new(SK::<UInt64Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-i8")]
+            DataType::Int8 => Box::new(SK::<Int8Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-i16")]
+            DataType::Int16 => Box::new(SK::<Int16Type>::new(dt, ng)),
+            DataType::Int32 => Box::new(SK::<Int32Type>::new(dt, ng)),
+            DataType::Int64 => Box::new(SK::<Int64Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-i128")]
+            DataType::Int128 => Box::new(SK::<Int128Type>::new(dt, ng)),
+            DataType::Float32 => Box::new(SK::<Float32Type>::new(dt, ng)),
+            DataType::Float64 => Box::new(SK::<Float64Type>::new(dt, ng)),
+
+            #[cfg(feature = "dtype-date")]
+            DataType::Date => Box::new(SK::<Int32Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-datetime")]
+            DataType::Datetime(_, _) => Box::new(SK::<Int64Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-duration")]
+            DataType::Duration(_) => Box::new(SK::<Int64Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-time")]
+            DataType::Time => Box::new(SK::<Int64Type>::new(dt, ng)),
+
+            #[cfg(feature = "dtype-decimal")]
+            DataType::Decimal(_, _) => Box::new(SK::<Int128Type>::new(dt, ng)),
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Enum(_, _) => Box::new(SK::<UInt32Type>::new(dt, ng)),
+
+            DataType::String | DataType::Binary => {
+                Box::new(binview::BinviewHashHotGrouper::new(ng))
+            },
+
+            _ => Box::new(row_encoded::RowEncodedHashHotGrouper::new(
+                key_schema, num_groups,
+            )),
+        }
+    }
 }

--- a/crates/polars-expr/src/hot_groups/single_key.rs
+++ b/crates/polars-expr/src/hot_groups/single_key.rs
@@ -1,0 +1,177 @@
+use std::hash::BuildHasher;
+
+use arrow::array::Array;
+use arrow::bitmap::MutableBitmap;
+use polars_utils::total_ord::{BuildHasherTotalExt, TotalEq, TotalHash};
+use polars_utils::vec::PushUnchecked;
+
+use super::*;
+use crate::hash_keys::SingleKeys;
+use crate::hot_groups::fixed_index_table::FixedIndexTable;
+
+pub struct SingleKeyHashHotGrouper<T: PolarsDataType> {
+    dtype: DataType,
+    table: FixedIndexTable<T::Physical<'static>>,
+    evicted_keys: Vec<T::Physical<'static>>,
+    null_idx: IdxSize,
+    random_state: PlRandomState,
+}
+
+impl<K, T: PolarsDataType> SingleKeyHashHotGrouper<T>
+where
+    ChunkedArray<T>: IntoSeries,
+    for<'a> T: PolarsDataType<Physical<'a> = K>,
+    K: Default + TotalHash + TotalEq + Send + Sync + 'static,
+{
+    pub fn new(dtype: DataType, max_groups: usize) -> Self {
+        Self {
+            dtype,
+            table: FixedIndexTable::new(max_groups.try_into().unwrap()),
+            evicted_keys: Vec::new(),
+            null_idx: IdxSize::MAX,
+            random_state: PlRandomState::default(),
+        }
+    }
+
+    #[inline(always)]
+    fn insert_key<R: BuildHasher>(
+        &mut self,
+        k: T::Physical<'static>,
+        random_state: &R,
+    ) -> Option<EvictIdx> {
+        let h = random_state.tot_hash_one(&k);
+        self.table.insert_key(
+            h,
+            k,
+            |a, b| a.tot_eq(b),
+            |k| k,
+            |k, ev_k| self.evicted_keys.push(core::mem::replace(ev_k, k)),
+        )
+    }
+
+    #[inline(always)]
+    fn insert_null(&mut self) -> Option<EvictIdx> {
+        if self.null_idx == IdxSize::MAX {
+            self.null_idx = self.table.push_unmapped_key(T::Physical::default());
+        }
+        Some(EvictIdx::new(self.null_idx, false))
+    }
+
+    fn finalize_keys(&self, keys: Vec<T::Physical<'static>>, add_mask: bool) -> HashKeys {
+        let mut keys = T::Array::from_vec(
+            keys,
+            self.dtype.to_physical().to_arrow(CompatLevel::newest()),
+        );
+        if add_mask && self.null_idx < IdxSize::MAX {
+            let mut validity = MutableBitmap::new();
+            validity.extend_constant(keys.len(), true);
+            validity.set(self.null_idx as usize, false);
+            keys = keys.with_validity_typed(Some(validity.freeze()));
+        }
+
+        unsafe {
+            let s = Series::from_chunks_and_dtype_unchecked(
+                PlSmallStr::EMPTY,
+                vec![Box::new(keys)],
+                &self.dtype,
+            );
+            HashKeys::Single(SingleKeys {
+                keys: s,
+                null_is_valid: self.null_idx < IdxSize::MAX,
+                random_state: self.random_state,
+            })
+        }
+    }
+}
+
+impl<K, T> HotGrouper for SingleKeyHashHotGrouper<T>
+where
+    ChunkedArray<T>: IntoSeries,
+    for<'a> T: PolarsDataType<Physical<'a> = K>,
+    K: Default + TotalHash + TotalEq + Clone + Send + Sync + 'static,
+{
+    fn new_empty(&self, max_groups: usize) -> Box<dyn HotGrouper> {
+        Box::new(Self::new(self.dtype.clone(), max_groups))
+    }
+
+    fn num_groups(&self) -> IdxSize {
+        self.table.len() as IdxSize
+    }
+
+    fn insert_keys(
+        &mut self,
+        hash_keys: &HashKeys,
+        hot_idxs: &mut Vec<IdxSize>,
+        hot_group_idxs: &mut Vec<EvictIdx>,
+        cold_idxs: &mut Vec<IdxSize>,
+    ) {
+        let HashKeys::Single(hash_keys) = hash_keys else {
+            unreachable!()
+        };
+
+        // Preserve random state if non-empty.
+        if !hash_keys.keys.is_empty() {
+            self.random_state = hash_keys.random_state;
+        }
+
+        let keys: &ChunkedArray<T> = hash_keys.keys.as_phys_any().downcast_ref().unwrap();
+        hot_idxs.reserve(keys.len());
+        hot_group_idxs.reserve(keys.len());
+        cold_idxs.reserve(keys.len());
+
+        let mut push_g = |idx: usize, opt_g: Option<EvictIdx>| unsafe {
+            if let Some(g) = opt_g {
+                hot_idxs.push_unchecked(idx as IdxSize);
+                hot_group_idxs.push_unchecked(g);
+            } else {
+                cold_idxs.push_unchecked(idx as IdxSize);
+            }
+        };
+
+        let mut idx = 0;
+        for arr in keys.downcast_iter() {
+            if arr.has_nulls() {
+                if hash_keys.null_is_valid {
+                    for opt_k in arr.iter() {
+                        if let Some(k) = opt_k {
+                            push_g(idx, self.insert_key(k, &hash_keys.random_state));
+                        } else {
+                            push_g(idx, self.insert_null());
+                        }
+                        idx += 1;
+                    }
+                } else {
+                    for opt_k in arr.iter() {
+                        if let Some(k) = opt_k {
+                            push_g(idx, self.insert_key(k, &hash_keys.random_state));
+                        }
+                        idx += 1;
+                    }
+                }
+            } else {
+                for k in arr.values_iter() {
+                    let g = self.insert_key(k, &hash_keys.random_state);
+                    push_g(idx, g);
+                    idx += 1;
+                }
+            }
+        }
+    }
+
+    fn keys(&self) -> HashKeys {
+        self.finalize_keys(self.table.keys().to_vec(), true)
+    }
+
+    fn num_evictions(&self) -> usize {
+        self.evicted_keys.len()
+    }
+
+    fn take_evicted_keys(&mut self) -> HashKeys {
+        let keys = core::mem::take(&mut self.evicted_keys);
+        self.finalize_keys(keys, false)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/polars-expr/src/lib.rs
+++ b/crates/polars-expr/src/lib.rs
@@ -16,15 +16,18 @@ pub use crate::planner::{ExpressionConversionState, create_physical_expr};
 pub struct EvictIdx(IdxSize);
 
 impl EvictIdx {
+    #[inline(always)]
     pub fn new(idx: IdxSize, should_evict: bool) -> Self {
         debug_assert!(idx >> (IdxSize::BITS - 1) == 0);
         Self(idx | ((should_evict as IdxSize) << (IdxSize::BITS - 1)))
     }
 
+    #[inline(always)]
     pub fn idx(&self) -> usize {
         (self.0 & ((1 << (IdxSize::BITS - 1)) - 1)) as usize
     }
 
+    #[inline(always)]
     pub fn should_evict(&self) -> bool {
         (self.0 >> (IdxSize::BITS - 1)) != 0
     }

--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -135,7 +135,7 @@ impl GroupBySinkState {
                         key_columns.push(s.into_column());
                     }
                     let keys = DataFrame::new_with_broadcast_len(key_columns, df.height())?;
-                    let hash_keys = HashKeys::from_df(&keys, *random_state, true, true);
+                    let hash_keys = HashKeys::from_df(&keys, *random_state, true, false);
 
                     hot_idxs.clear();
                     hot_group_idxs.clear();

--- a/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
+++ b/crates/polars-stream/src/nodes/joins/semi_anti_join.rs
@@ -33,7 +33,7 @@ async fn select_keys(
         &keys,
         params.random_state,
         params.nulls_equal,
-        true,
+        false,
     ))
 }
 

--- a/crates/polars-utils/src/hashing.rs
+++ b/crates/polars-utils/src/hashing.rs
@@ -108,6 +108,12 @@ impl HashPartitioner {
         ((shuffled as u128 * self.num_partitions as u128) >> 64) as usize
     }
 
+    /// The partition nulls are put into.
+    #[inline(always)]
+    pub fn null_partition(&self) -> usize {
+        0
+    }
+
     #[inline(always)]
     pub fn num_partitions(&self) -> usize {
         self.num_partitions

--- a/crates/polars-utils/src/idx_map/bytes_idx_map.rs
+++ b/crates/polars-utils/src/idx_map/bytes_idx_map.rs
@@ -56,11 +56,11 @@ impl<V> BytesIndexMap<V> {
     }
 
     pub fn len(&self) -> IdxSize {
-        self.table.len() as IdxSize
+        self.tuples.len() as IdxSize
     }
 
     pub fn is_empty(&self) -> bool {
-        self.table.is_empty()
+        self.tuples.is_empty()
     }
 
     pub fn get(&self, hash: u64, key: &[u8]) -> Option<&V> {

--- a/crates/polars-utils/src/idx_map/total_idx_map.rs
+++ b/crates/polars-utils/src/idx_map/total_idx_map.rs
@@ -33,11 +33,11 @@ impl<K: TotalHash + TotalEq, V> TotalIndexMap<K, V> {
     }
 
     pub fn len(&self) -> IdxSize {
-        self.table.len() as IdxSize
+        self.tuples.len() as IdxSize
     }
 
     pub fn is_empty(&self) -> bool {
-        self.table.is_empty()
+        self.tuples.is_empty()
     }
 
     pub fn get(&self, key: &K) -> Option<&V> {
@@ -74,6 +74,15 @@ impl<K: TotalHash + TotalEq, V> TotalIndexMap<K, V> {
                 tuples: &mut self.tuples,
             }),
         }
+    }
+
+    /// Insert a key which will never be mapped to. Returns the index of the entry.
+    ///
+    /// This is useful for entries which are handled externally.
+    pub fn push_unmapped_entry(&mut self, key: K, value: V) -> IdxSize {
+        let ret = self.tuples.len() as IdxSize;
+        self.tuples.push((key, value));
+        ret
     }
 
     /// Gets the key and value at the given index by insertion order.


### PR DESCRIPTION
This is a lot faster than going through the row encoding and doing string comparisons.