### PR TITLE
fix(rust): Ensure at least one column projected for AnonymousScan

### DIFF
--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -4,6 +4,7 @@ use polars_ops::prelude::ClosedInterval;
 use polars_utils::slice_enum::Slice;
 
 use super::*;
+use crate::dsl;
 
 #[test]
 #[cfg(feature = "parquet")]
@@ -687,6 +688,54 @@ fn scan_anonymous_fn_with_options() -> PolarsResult<()> {
     let df = q.collect()?;
 
     assert_eq!(df.shape(), (3, 2));
+    Ok(())
+}
+
+#[test]
+fn scan_anonymous_fn_count() -> PolarsResult<()> {
+    struct MyScan {}
+
+    impl AnonymousScan for MyScan {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn allows_projection_pushdown(&self) -> bool {
+            true
+        }
+
+        fn scan(&self, scan_opts: AnonymousScanArgs) -> PolarsResult<DataFrame> {
+            assert_eq!(scan_opts.with_columns.as_deref(), Some(&["A".into()][..]));
+
+            Ok(fruits_cars()
+                .select(scan_opts.with_columns.unwrap().iter().cloned())
+                .unwrap())
+        }
+    }
+
+    let function = Arc::new(MyScan {});
+
+    let args = ScanArgsAnonymous {
+        schema: Some(fruits_cars().schema().clone()),
+        ..ScanArgsAnonymous::default()
+    };
+
+    let df = LazyFrame::anonymous_scan(function, args)?
+        .select(&[dsl::len()])
+        .collect()
+        .unwrap();
+
+    assert_eq!(df.get_columns().len(), 1);
+    assert_eq!(df.get_columns()[0].len(), 1);
+    assert_eq!(
+        df.get_columns()[0]
+            .cast(&DataType::UInt32)
+            .unwrap()
+            .as_materialized_series()
+            .first(),
+        Scalar::new(DataType::UInt32, AnyValue::UInt32(5))
+    );
+
     Ok(())
 }
 

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -36,7 +36,8 @@ impl DslBuilder {
         Ok(DslPlan::Scan {
             sources: ScanSources::Buffers(Arc::default()),
             file_info: Some(FileInfo {
-                schema,
+                schema: schema.clone(),
+                reader_schema: Some(either::Either::Right(schema)),
                 ..Default::default()
             }),
             unified_scan_args: Box::new(unified_scan_args),

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -469,8 +469,9 @@ impl ProjectionPushDown {
                             .cloned()
                             .collect();
 
+                            unified_scan_args.projection = Some(projection.clone());
+
                             if projection.is_empty() {
-                                unified_scan_args.projection = Some(Arc::from([]));
                                 output_schema = Some(Default::default());
                                 break;
                             }
@@ -558,10 +559,6 @@ impl ProjectionPushDown {
                     predicate,
                     unified_scan_args,
                 };
-
-                if self.is_count_star {
-                    return Ok(lp);
-                }
 
                 Ok(lp)
             },


### PR DESCRIPTION
Restores some code deleted in https://github.com/pola-rs/polars/pull/22363 - we shouldn't assume all implementors of `AnonymousScan` are able to project 0-width frames.

Also does some refactoring to make the control flow of the code slightly cleaner.
