### PR TITLE
refactor(rust): Improve new-streaming multiscan physical plan visualization

### DIFF
--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -241,7 +241,8 @@ impl<'a> IRDisplay<'a> {
                 predicate,
                 scan_type,
                 unified_scan_args,
-                ..
+                hive_parts: _,
+                output_schema: _,
             } => {
                 let n_columns = unified_scan_args
                     .projection

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -206,7 +206,7 @@ fn visualize_plan_rec(
             }
 
             if let Some(col_name) = include_file_paths {
-                write!(f, "\nfile path column: '{}'", col_name).unwrap();
+                write!(f, "\nfile path column: {}", col_name).unwrap();
             }
 
             if let Some(pre_slice) = pre_slice {
@@ -229,7 +229,11 @@ fn visualize_plan_rec(
             }
 
             if let Some(v) = hive_parts.as_ref().map(|h| h.df().width()) {
-                write!(f, "\nhive: {} columns", v).unwrap();
+                write!(f, "\nhive: {} column", v).unwrap();
+
+                if v != 1 {
+                    write!(f, "s").unwrap();
+                }
             }
 
             (out, &[][..])

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -9,11 +9,11 @@ use polars_io::RowIndex;
 use polars_io::cloud::CloudOptions;
 use polars_ops::frame::JoinArgs;
 use polars_plan::dsl::{
-    CastColumnsPolicy, FileScan, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback,
-    PartitionVariantIR, ScanSource, ScanSources, SinkOptions, SinkTarget,
+    CastColumnsPolicy, JoinTypeOptionsIR, MissingColumnsPolicy, PartitionTargetCallback,
+    PartitionVariantIR, ScanSources, SinkOptions, SinkTarget,
 };
 use polars_plan::plans::hive::HivePartitionsDf;
-use polars_plan::plans::{AExpr, DataFrameUdf, FileInfo, IR};
+use polars_plan::plans::{AExpr, DataFrameUdf, IR};
 use polars_plan::prelude::expr_ir::ExprIR;
 
 mod fmt;
@@ -24,7 +24,7 @@ mod to_graph;
 
 pub use fmt::visualize_plan;
 use polars_plan::dsl::ExtraColumnsPolicy;
-use polars_plan::prelude::{FileType, UnifiedScanArgs};
+use polars_plan::prelude::FileType;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
 use polars_utils::slice_enum::Slice;
@@ -220,16 +220,6 @@ pub enum PhysNodeKind {
         file_schema: SchemaRef,
     },
 
-    #[expect(unused)]
-    FileScan {
-        scan_source: ScanSource,
-        file_info: FileInfo,
-        predicate: Option<ExprIR>,
-        output_schema: Option<SchemaRef>,
-        scan_type: Box<FileScan>,
-        unified_scan_args: Box<UnifiedScanArgs>,
-    },
-
     #[cfg(feature = "python")]
     PythonScan {
         options: polars_plan::plans::python::PythonOptions,
@@ -300,7 +290,6 @@ fn visit_node_inputs_mut(
         match &mut phys_sm[node].kind {
             PhysNodeKind::InMemorySource { .. }
             | PhysNodeKind::MultiScan { .. }
-            | PhysNodeKind::FileScan { .. }
             | PhysNodeKind::InputIndependentSelect { .. } => {},
             #[cfg(feature = "python")]
             PhysNodeKind::PythonScan { .. } => {},

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -551,22 +551,6 @@ fn to_graph_rec<'a>(
             )
         },
 
-        FileScan { scan_type, .. } => {
-            use polars_plan::prelude::FileScan;
-
-            match scan_type.as_ref() {
-                #[cfg(feature = "parquet")]
-                FileScan::Parquet { .. } => unreachable!(),
-                #[cfg(feature = "ipc")]
-                FileScan::Ipc { .. } => unreachable!(),
-                #[cfg(feature = "csv")]
-                FileScan::Csv { .. } => unreachable!(),
-                #[cfg(feature = "json")]
-                FileScan::NDJson { .. } => unreachable!(),
-                FileScan::Anonymous { .. } => todo!(),
-            }
-        },
-
         GroupBy { input, key, aggs } => {
             let input_key = to_graph_rec(input.node, ctx)?;
 


### PR DESCRIPTION
Note, this also removes the unused `PhysNodeKind::FileScan` node, we are now always using `MultiScan`.

**Before**
![image](https://github.com/user-attachments/assets/44efecf9-b14c-4999-890a-c9226bec2c85)

**After**
![image](https://github.com/user-attachments/assets/6f7f1909-64a4-4e5d-a6d4-4cc13cd1a28f)
