### PR TITLE
perf: Lower Expr.(n_)unique to group_by on streaming engine

### DIFF
--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -642,14 +642,17 @@ def test_categorical_fill_null_stringcache() -> None:
 
 @pytest.mark.usefixtures("test_global_and_local")
 def test_fast_unique_flag_from_arrow() -> None:
-    df = pl.DataFrame(
-        {
-            "colB": ["1", "2", "3", "4", "5", "5", "5", "5"],
-        }
-    ).with_columns([pl.col("colB").cast(pl.Categorical)])
+    with pl.StringCache():
+        df = pl.DataFrame(
+            {
+                "colB": ["1", "2", "3", "4", "5", "5", "5", "5"],
+            }
+        ).with_columns([pl.col("colB").cast(pl.Categorical)])
 
-    filtered = df.to_arrow().filter([True, False, True, True, False, True, True, True])
-    assert pl.from_arrow(filtered).select(pl.col("colB").n_unique()).item() == 4  # type: ignore[union-attr]
+        filtered = df.to_arrow().filter(
+            [True, False, True, True, False, True, True, True]
+        )
+        assert pl.from_arrow(filtered).select(pl.col("colB").n_unique()).item() == 4  # type: ignore[union-attr]
 
 
 @pytest.mark.usefixtures("test_global_and_local")
@@ -943,44 +946,49 @@ def test_perfect_group_by_19950() -> None:
 
 @pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_unique() -> None:
-    s = pl.Series(["a", "b", None], dtype=pl.Categorical)
-    assert s.n_unique() == 3
-    assert s.unique().sort().to_list() == [None, "a", "b"]
+    with pl.StringCache():
+        s = pl.Series(["a", "b", None], dtype=pl.Categorical)
+        assert s.n_unique() == 3
+        assert s.unique().sort().to_list() == [None, "a", "b"]
 
 
 @pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_unique_20539() -> None:
-    df = pl.DataFrame({"number": [1, 1, 2, 2, 3], "letter": ["a", "b", "b", "c", "c"]})
-
-    result = (
-        df.cast({"letter": pl.Categorical})
-        .group_by("number")
-        .agg(
-            unique=pl.col("letter").unique(maintain_order=True),
-            unique_with_order=pl.col("letter").unique(maintain_order=True),
+    with pl.StringCache():
+        df = pl.DataFrame(
+            {"number": [1, 1, 2, 2, 3], "letter": ["a", "b", "b", "c", "c"]}
         )
-    )
 
-    assert result.sort("number").to_dict(as_series=False) == {
-        "number": [1, 2, 3],
-        "unique": [["a", "b"], ["b", "c"], ["c"]],
-        "unique_with_order": [["a", "b"], ["b", "c"], ["c"]],
-    }
+        result = (
+            df.cast({"letter": pl.Categorical})
+            .group_by("number")
+            .agg(
+                unique=pl.col("letter").unique(maintain_order=True),
+                unique_with_order=pl.col("letter").unique(maintain_order=True),
+            )
+        )
+
+        assert result.sort("number").to_dict(as_series=False) == {
+            "number": [1, 2, 3],
+            "unique": [["a", "b"], ["b", "c"], ["c"]],
+            "unique_with_order": [["a", "b"], ["b", "c"], ["c"]],
+        }
 
 
 @pytest.mark.usefixtures("test_global_and_local")
 def test_categorical_prefill() -> None:
-    # https://github.com/pola-rs/polars/pull/20547#issuecomment-2569473443
-    # test_compare_categorical_single
-    assert (pl.Series(["a"], dtype=pl.Categorical) < "a").to_list() == [False]
+    with pl.StringCache():
+        # https://github.com/pola-rs/polars/pull/20547#issuecomment-2569473443
+        # test_compare_categorical_single
+        assert (pl.Series(["a"], dtype=pl.Categorical) < "a").to_list() == [False]
 
-    # test_unique_categorical
-    a = pl.Series(["a"], dtype=pl.Categorical)
-    assert a.unique().to_list() == ["a"]
+        # test_unique_categorical
+        a = pl.Series(["a"], dtype=pl.Categorical)
+        assert a.unique().to_list() == ["a"]
 
-    s = pl.Series(["1", "2", "3"], dtype=pl.Categorical)
-    s = s.filter([True, False, True])
-    assert s.n_unique() == 2
+        s = pl.Series(["1", "2", "3"], dtype=pl.Categorical)
+        s = s.filter([True, False, True])
+        assert s.n_unique() == 2
 
 
 @pytest.mark.may_fail_auto_streaming  # not implemented

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -682,8 +682,10 @@ def test_fill_null() -> None:
 
 def test_unique() -> None:
     ser = pl.Series([D("1.1"), D("1.1"), D("2.2")])
+    uniq = pl.Series([D("1.1"), D("2.2")])
 
-    assert ser.unique().to_list() == [D("1.1"), D("2.2")]
+    assert_series_equal(ser.unique(maintain_order=False), uniq, check_order=False)
+    assert_series_equal(ser.unique(maintain_order=True), uniq)
     assert ser.n_unique() == 2
     assert ser.arg_unique().to_list() == [0, 2]
 

--- a/py-polars/tests/unit/datatypes/test_float.py
+++ b/py-polars/tests/unit/datatypes/test_float.py
@@ -72,14 +72,14 @@ def test_sorted_nan_max_12931(descending: bool) -> None:
                 "x",
                 [
                     -0.0,
-                    0.0,
                     float("-nan"),
-                    float("nan"),
-                    1.0,
+                    0.0,
                     None,
+                    1.0,
+                    float("nan"),
                 ],
             ),
-            pl.Series("x", [None, 0.0, 1.0, float("nan")]),
+            pl.Series("x", [0.0, float("nan"), None, 1.0]),
         ),
         (
             # No nulls
@@ -87,24 +87,27 @@ def test_sorted_nan_max_12931(descending: bool) -> None:
                 "x",
                 [
                     -0.0,
-                    0.0,
                     float("-nan"),
-                    float("nan"),
+                    0.0,
                     1.0,
+                    float("nan"),
                 ],
             ),
-            pl.Series("x", [0.0, 1.0, float("nan")]),
+            pl.Series("x", [0.0, float("nan"), 1.0]),
         ),
     ],
 )
 def test_unique(s: pl.Series, expect: pl.Series) -> None:
-    out = s.unique()
+    out = s.unique(maintain_order=False)
+    assert_series_equal(expect, out, check_order=False)
+
+    out = s.unique(maintain_order=True)
     assert_series_equal(expect, out)
 
     out = s.n_unique()  # type: ignore[assignment]
     assert expect.len() == out
 
-    out = s.gather(s.arg_unique()).sort()
+    out = s.gather(s.arg_unique())
     assert_series_equal(expect, out)
 
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2108,7 +2108,7 @@ def test_truncate_by_multiple_weeks_diffs() -> None:
         pl.col("ts").dt.truncate("1w").alias("1w"),
         pl.col("ts").dt.truncate("2w").alias("2w"),
         pl.col("ts").dt.truncate("3w").alias("3w"),
-    ).select(pl.all().diff().drop_nulls().unique())
+    ).select(pl.all().diff().drop_nulls().unique(maintain_order=True))
     expected = pl.DataFrame(
         {
             "1w": [timedelta(0), timedelta(days=7)],

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -93,9 +93,9 @@ def test_unique() -> None:
     assert_frame_equal(result, expected)
 
     s0 = pl.Series("a", [1, 2, None, 2])
-    expected = pl.Series("a", [1, 2, None])
-    assert_series_equal(s0.unique(maintain_order=True), expected)
-    assert_series_equal(s0.unique(maintain_order=False), expected, check_order=False)
+    expected_s = pl.Series("a", [1, 2, None])
+    assert_series_equal(s0.unique(maintain_order=True), expected_s)
+    assert_series_equal(s0.unique(maintain_order=False), expected_s, check_order=False)
 
 
 def test_struct_unique_df() -> None:

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -93,8 +93,9 @@ def test_unique() -> None:
     assert_frame_equal(result, expected)
 
     s0 = pl.Series("a", [1, 2, None, 2])
-    # test if the null is included
-    assert s0.unique().to_list() == [None, 1, 2]
+    expected = pl.Series("a", [1, 2, None])
+    assert_series_equal(s0.unique(maintain_order=True), expected)
+    assert_series_equal(s0.unique(maintain_order=False), expected, check_order=False)
 
 
 def test_struct_unique_df() -> None:
@@ -142,14 +143,15 @@ def test_unique_null(maintain_order: bool) -> None:
 )
 @pytest.mark.usefixtures("test_global_and_local")
 def test_unique_categorical(input: list[str | None], output: list[str | None]) -> None:
-    s = pl.Series(input, dtype=pl.Categorical)
-    result = s.unique(maintain_order=True)
-    expected = pl.Series(output, dtype=pl.Categorical)
-    assert_series_equal(result, expected)
+    with pl.StringCache():
+        s = pl.Series(input, dtype=pl.Categorical)
+        result = s.unique(maintain_order=True)
+        expected = pl.Series(output, dtype=pl.Categorical)
+        assert_series_equal(result, expected)
 
-    result = s.unique(maintain_order=False).sort()
-    expected = pl.Series(output, dtype=pl.Categorical)
-    assert_series_equal(result, expected)
+        result = s.unique(maintain_order=False)
+        expected = pl.Series(output, dtype=pl.Categorical)
+        assert_series_equal(result, expected, check_order=False)
 
 
 def test_unique_categorical_global() -> None:


### PR DESCRIPTION
These are equivalent to a zero-aggregate `group_by`, possibly followed by a length reduction.