### PR TITLE
chore: Make interpolate fix more robust

### DIFF
--- a/py-polars/tests/unit/operations/test_interpolate_by.py
+++ b/py-polars/tests/unit/operations/test_interpolate_by.py
@@ -228,7 +228,7 @@ def test_interpolate_vs_numpy(data: st.DataObject, x_dtype: pl.DataType) -> None
     ]
 
     # We increase the absolute error threshold, numpy has some instability, see #22348.
-    assert_series_equal(result, expected, atol=1e-7)
+    assert_series_equal(result, expected, atol=1e-4)
     result_from_unsorted = (
         dataframe.sort("ts", descending=True)
         .with_columns(pl.col("value").interpolate_by("ts"))


### PR DESCRIPTION
The error threshold in my previous fix was still too strict.