### PR TITLE
ci: Pin to explicit macOS version in code coverage

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -36,7 +36,7 @@ jobs:
   coverage-rust:
     # Running under ubuntu doesn't seem to work:
     # https://github.com/pola-rs/polars/issues/14255
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
I would recommend waiting until after resolving the 1.28 release issues before merging this.
