### PR TITLE
fix: Fix index out of bounds panic on parquet prefiltering

### DIFF
--- a/crates/polars-stream/src/async_primitives/mod.rs
+++ b/crates/polars-stream/src/async_primitives/mod.rs
@@ -2,5 +2,6 @@ pub mod connector;
 pub mod distributor_channel;
 pub mod linearizer;
 pub mod morsel_linearizer;
+pub mod opt_spawned_future;
 pub mod task_parker;
 pub mod wait_group;

--- a/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
+++ b/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
@@ -30,7 +30,10 @@ where
 
 /// Parallelizes an iterator of futures, where the first future is kept on the current thread.
 ///
-/// Note that this means the first future in the returned array does not run until polled.
+/// This is an optimization to retain some data on the current thread. If there is only 1 future,
+/// then all data is kept on the current thread and spawn is not called at all.
+///
+/// Note this means the first future in the returned array does not run until polled.
 ///
 /// # Panics
 /// Panics if the iterator has less than `futures_iter_length` items.

--- a/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
+++ b/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
@@ -3,7 +3,7 @@ use pin_project_lite::pin_project;
 use crate::async_executor::{AbortOnDropHandle, TaskPriority, spawn};
 
 pin_project! {
-    /// Represents a potentially spawned future
+    /// Represents a potentially spawned future.
     #[project = OptSpawnedFutureProj]
     pub enum OptSpawnedFuture<F, O> {
         Local { #[pin] fut: F },
@@ -28,9 +28,13 @@ where
     }
 }
 
-/// Parallelizes an iterator of futures. The first future does not get spawned, and instead runs
-/// on the current thread.
-pub fn parallelize<I, F, O>(
+/// Parallelizes an iterator of futures, where the first future is kept on the current thread.
+///
+/// Note that this means the first future in the returned array does not run until polled.
+///
+/// # Panics
+/// Panics if the iterator has less than `futures_iter_length` items.
+pub fn parallelize_first_to_local<I, F, O>(
     futures_iter: I,
     futures_iter_length: usize,
 ) -> Vec<OptSpawnedFuture<F, O>>

--- a/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
+++ b/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
@@ -1,0 +1,59 @@
+use pin_project_lite::pin_project;
+
+use crate::async_executor::{AbortOnDropHandle, TaskPriority, spawn};
+
+pin_project! {
+    /// Represents a potentially spawned future
+    #[project = OptSpawnedFutureProj]
+    pub enum OptSpawnedFuture<F, O> {
+        Local { #[pin] fut: F },
+        Spawned { #[pin] handle: AbortOnDropHandle<O> }
+    }
+}
+
+impl<F, O> Future for OptSpawnedFuture<F, O>
+where
+    F: Future<Output = O>,
+{
+    type Output = O;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match self.project() {
+            OptSpawnedFutureProj::Local { fut } => fut.poll(cx),
+            OptSpawnedFutureProj::Spawned { handle } => handle.poll(cx),
+        }
+    }
+}
+
+/// Parallelizes an iterator of futures. The first future does not get spawned, and instead runs
+/// on the current thread.
+pub fn parallelize<I, F, O>(
+    futures_iter: I,
+    futures_iter_length: usize,
+) -> Vec<OptSpawnedFuture<F, O>>
+where
+    I: IntoIterator<Item = F>,
+    F: Future<Output = O> + Send + 'static,
+    O: Send + 'static,
+{
+    if futures_iter_length == 0 {
+        return vec![];
+    }
+
+    let mut futures = Vec::with_capacity(futures_iter_length);
+    let mut futures_iter = futures_iter.into_iter();
+
+    // The local future must come first to ensure we don't block polling it.
+    futures.push(OptSpawnedFuture::Local {
+        fut: futures_iter.next().unwrap(),
+    });
+
+    futures.extend((1..futures_iter_length).map(|_| OptSpawnedFuture::Spawned {
+        handle: AbortOnDropHandle::new(spawn(TaskPriority::Low, futures_iter.next().unwrap())),
+    }));
+
+    futures
+}

--- a/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
+++ b/crates/polars-stream/src/async_primitives/opt_spawned_future.rs
@@ -28,12 +28,15 @@ where
     }
 }
 
-/// Parallelizes an iterator of futures, where the first future is kept on the current thread.
+/// Parallelizes an iterator of futures across the computational async runtime.
 ///
-/// This is an optimization to retain some data on the current thread. If there is only 1 future,
-/// then all data is kept on the current thread and spawn is not called at all.
+/// As an optimization for cache access, the first future is kept on the current thread. If there
+/// is only 1 future, then all data is kept on the current thread and spawn is not called at all.
 ///
-/// Note this means the first future in the returned array does not run until polled.
+/// Note this means the first future in the returned Vec does not run until polled.
+///
+/// Note that dropping the Vec will call abort on all spawned futures, as this is intended to be
+/// used for compute.
 ///
 /// # Panics
 /// Panics if the iterator has less than `futures_iter_length` items.


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22452

There was originally a function that implemented parallelism by writing something along the lines of:
```rust
let handles = (remainder..total).step_by(n_per_thread).map(|offset| spawn(decode[offset..offset + n_per_thread]))

// Evaluate remainder on this thread
(0..remainder).map(..)

for handle in handles { handle.await }
```

This got copied, but the copy began from 0 instead of `remainder`, which would cause OOB on the last partition:
```rust
(0..total).step_by(n_per_thread).map(|offset| tasks[offset..offset + n_per_thread])
```

Essentially, the original function was very prone to human error when being copied 😄

The intention behind the original function was that if we were to parallelize N tasks, we would keep and evaluate 1 of those tasks on the current thread, as all the data should already be in thread-local cache, and this would save a spawn (or not spawn at all if there was only 1 task).

In this PR I've introduced `parallelize_first_to_local()` to do exactly the above, but with the logic encapsulated into a function. The caller would only need to call it and then await on each of the returned futures.
