### PR TITLE
perf: Avoid alloc_zeroed in decompression

### DIFF
--- a/crates/polars-arrow/src/io/ipc/read/read_basic.rs
+++ b/crates/polars-arrow/src/io/ipc/read/read_basic.rs
@@ -17,8 +17,9 @@ fn read_swapped<T: NativeType, R: Read + Seek>(
     is_little_endian: bool,
 ) -> PolarsResult<()> {
     // Slow case where we must reverse bits.
+    #[expect(clippy::slow_vector_initialization)] // Avoid alloc_zeroed, leads to syscall.
     let mut slice = Vec::new();
-    slice.resize(length * size_of::<T>(), 0); // Avoid alloc_zeroed, leads to syscall.
+    slice.resize(length * size_of::<T>(), 0);
     reader.read_exact(&mut slice)?;
 
     let chunks = slice.chunks_exact(size_of::<T>());
@@ -270,8 +271,9 @@ fn read_compressed_bitmap<R: Read + Seek>(
     reader: &mut R,
     scratch: &mut Vec<u8>,
 ) -> PolarsResult<Vec<u8>> {
+    #[expect(clippy::slow_vector_initialization)] // Avoid alloc_zeroed, leads to syscall.
     let mut buffer = Vec::new();
-    buffer.resize(length.div_ceil(8), 0); // Avoid alloc_zeroed, leads to syscall.
+    buffer.resize(length.div_ceil(8), 0);
 
     scratch.clear();
     scratch.try_reserve(bytes)?;

--- a/crates/polars-arrow/src/io/ipc/read/read_basic.rs
+++ b/crates/polars-arrow/src/io/ipc/read/read_basic.rs
@@ -16,8 +16,9 @@ fn read_swapped<T: NativeType, R: Read + Seek>(
     buffer: &mut Vec<T>,
     is_little_endian: bool,
 ) -> PolarsResult<()> {
-    // slow case where we must reverse bits
-    let mut slice = vec![0u8; length * size_of::<T>()];
+    // Slow case where we must reverse bits.
+    let mut slice = Vec::new();
+    slice.resize(length * size_of::<T>(), 0); // Avoid alloc_zeroed, leads to syscall.
     reader.read_exact(&mut slice)?;
 
     let chunks = slice.chunks_exact(size_of::<T>());
@@ -269,7 +270,8 @@ fn read_compressed_bitmap<R: Read + Seek>(
     reader: &mut R,
     scratch: &mut Vec<u8>,
 ) -> PolarsResult<Vec<u8>> {
-    let mut buffer = vec![0; length.div_ceil(8)];
+    let mut buffer = Vec::new();
+    buffer.resize(length.div_ceil(8), 0); // Avoid alloc_zeroed, leads to syscall.
 
     scratch.clear();
     scratch.try_reserve(bytes)?;


### PR DESCRIPTION
This very simple change was actually a huge performance boost on large machines when not running with `POLARS_THP=1`. If you call `vec![0; n]` it leads to `alloc_zeroed` which jemalloc implements (when transparent huge pages aren't enabled) by calling `MADV_DONTNEED`. This is the correct behavior if you allocate a huge piece of zeroed memory but only touch parts of it, as then the operating system will zero-fill pages for you on pagefault.

However, in these decompression cases we allocate a zero-buffer and then immediately completely fill it. Avoiding the constant syscalls here by simply doing a `memset` is way better.