### PR TITLE
build(python): Build free-threaded wheels for python `3.13t`

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -95,6 +95,7 @@ jobs:
         # macos-15 is aarch64
         os: [ubuntu-latest, macos-13, macos-15, windows-latest, windows-11-arm]
         architecture: [x86-64, aarch64]
+        python-version: [abi3, 3.13t]
         exclude:
           - os: windows-latest
             architecture: aarch64
@@ -181,13 +182,13 @@ jobs:
         if: matrix.os != 'windows-11-arm'
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version == 'abi3' && env.PYTHON_VERSION || matrix.python-version }}
 
       - name: Set up Python (ARM64 Windows)
         if: matrix.os == 'windows-11-arm'
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_WIN_ARM64 }}
+          python-version: ${{ matrix.python-version == 'abi3' && env.PYTHON_VERSION_WIN_ARM64 || matrix.python-version }}
 
       # Otherwise can't find `tomlq` after `pip install yq`
       - name: Add Python scripts folder to GITHUB_PATH (ARM64 Windows)

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.12', '3.13']
+        python-version: ['3.9', '3.12', '3.13', '3.13t']
         include:
           - os: windows-latest
             python-version: '3.13'
@@ -63,7 +63,12 @@ jobs:
           echo "$GITHUB_WORKSPACE/py-polars/.venv/$BIN" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/py-polars/.venv" >> $GITHUB_ENV
 
+      - name: Install maturin
+        if: matrix.python-version == '3.13t'
+        run: pip install maturin
+
       - name: Install Python dependencies
+        if: matrix.python-version != '3.13t'
         run: |
           pip install uv
           # Install typing-extensions separately whilst the `--extra-index-url` in `requirements-ci.txt`
@@ -90,27 +95,27 @@ jobs:
           pytest tests/docs/test_user_guide.py -m docs
 
       - name: Run tests
-        if: github.ref_name != 'main'
+        if: github.ref_name != 'main' && matrix.python-version != '3.13t'
         env:
           POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not release and not benchmark and not docs"
 
       - name: Run tests with new streaming engine
-        if: github.ref_name != 'main'
+        if: github.ref_name != 'main' && matrix.python-version != '3.13t'
         env:
           POLARS_AUTO_NEW_STREAMING: 1
           POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not may_fail_auto_streaming and not slow and not write_disk and not release and not docs and not hypothesis and not benchmark and not ci_only"
 
       - name: Run tests async reader tests
-        if: github.ref_name != 'main' && matrix.os != 'windows-latest'
+        if: github.ref_name != 'main' && matrix.os != 'windows-latest' && matrix.python-version != '3.13t'
         env:
           POLARS_FORCE_ASYNC: 1
           POLARS_TIMEOUT_MS: 60000
         run: pytest -n auto -m "not release and not benchmark and not docs" tests/unit/io/
 
       - name: Check import without optional dependencies
-        if: github.ref_name != 'main' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
+        if: github.ref_name != 'main' && matrix.os == 'ubuntu-latest' && (matrix.python-version == '3.13' || matrix.python-version == '3.13t')
         run: |
           declare -a deps=("pandas"
           "pyarrow"


### PR DESCRIPTION
Because #22015 is merged, it is now possible for users to install polars on free-threaded python using the source-distribution. But it is currently not straight forward to run the test suite on free-threaded because of incompatible packages (see #21914). So to get accommodate users who want to test polars on free-threaded python we can provide the wheels for easy installation. This currently forces python to enable the GIL at runtime with a warning that `polars` is not compatible, so for most users this is safe to use. But users that want to proceed and test it without the GIL then they can run python with `PYTHON_GIL=0`. 

This also enables basic ci coverage by build/installing polars on `3.13t` and doing a basic import test. Full ci coverage will be worked on in #21914.

If you deem this to early, you can close this PR.

closes #22454