### PR TITLE
fix: Return input instead of panicking if empty subset in `drop_nulls()` and `drop_nans()`

### DIFF
--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -137,30 +137,45 @@ impl DslBuilder {
     }
 
     pub fn drop_nans(self, subset: Option<Vec<Expr>>) -> Self {
-        let exprs = match subset {
-            Some(subset) if !subset.is_empty() => subset
-                .into_iter()
-                .map(|v| v.is_not_nan())
-                .collect::<Vec<_>>(),
-            _ => vec![
+        if let Some(subset) = subset {
+            if subset.is_empty() {
+                return self;
+            }
+            self.filter(
+                all_horizontal(
+                    subset
+                        .into_iter()
+                        .map(|v| v.is_not_nan())
+                        .collect::<Vec<_>>(),
+                )
+                .unwrap(),
+            )
+        } else {
+            self.filter(
                 // TODO: when Decimal supports NaN, include here
-                dtype_cols([DataType::Float32, DataType::Float64]).is_not_nan(),
-            ],
-        };
-
-        self.filter(all_horizontal(exprs).unwrap())
+                all_horizontal([dtype_cols([DataType::Float32, DataType::Float64]).is_not_nan()])
+                    .unwrap(),
+            )
+        }
     }
 
     pub fn drop_nulls(self, subset: Option<Vec<Expr>>) -> Self {
-        let exprs = match subset {
-            Some(subset) if !subset.is_empty() => subset
-                .into_iter()
-                .map(|v| v.is_not_null())
-                .collect::<Vec<_>>(),
-            _ => vec![all().is_not_null()],
-        };
-
-        self.filter(all_horizontal(exprs).unwrap())
+        if let Some(subset) = subset {
+            if subset.is_empty() {
+                return self;
+            }
+            self.filter(
+                all_horizontal(
+                    subset
+                        .into_iter()
+                        .map(|v| v.is_not_null())
+                        .collect::<Vec<_>>(),
+                )
+                .unwrap(),
+            )
+        } else {
+            self.filter(all_horizontal([all().is_not_null()]).unwrap())
+        }
     }
 
     pub fn fill_nan(self, fill_value: Expr) -> Self {

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -137,45 +137,30 @@ impl DslBuilder {
     }
 
     pub fn drop_nans(self, subset: Option<Vec<Expr>>) -> Self {
-        if let Some(subset) = subset {
-            if subset.len() == 0 {
-                return self;
-            }
-            self.filter(
-                all_horizontal(
-                    subset
-                        .into_iter()
-                        .map(|v| v.is_not_nan())
-                        .collect::<Vec<_>>(),
-                )
-                .unwrap(),
-            )
-        } else {
-            self.filter(
+        let exprs = match subset {
+            Some(subset) if !subset.is_empty() => subset
+                .into_iter()
+                .map(|v| v.is_not_nan())
+                .collect::<Vec<_>>(),
+            _ => vec![
                 // TODO: when Decimal supports NaN, include here
-                all_horizontal([dtype_cols([DataType::Float32, DataType::Float64]).is_not_nan()])
-                    .unwrap(),
-            )
-        }
+                dtype_cols([DataType::Float32, DataType::Float64]).is_not_nan(),
+            ],
+        };
+
+        self.filter(all_horizontal(exprs).unwrap())
     }
 
     pub fn drop_nulls(self, subset: Option<Vec<Expr>>) -> Self {
-        if let Some(subset) = subset {
-            if subset.len() == 0 {
-                return self;
-            }
-            self.filter(
-                all_horizontal(
-                    subset
-                        .into_iter()
-                        .map(|v| v.is_not_null())
-                        .collect::<Vec<_>>(),
-                )
-                .unwrap(),
-            )
-        } else {
-            self.filter(all_horizontal([all().is_not_null()]).unwrap())
-        }
+        let exprs = match subset {
+            Some(subset) if !subset.is_empty() => subset
+                .into_iter()
+                .map(|v| v.is_not_null())
+                .collect::<Vec<_>>(),
+            _ => vec![all().is_not_null()],
+        };
+
+        self.filter(all_horizontal(exprs).unwrap())
     }
 
     pub fn fill_nan(self, fill_value: Expr) -> Self {

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -138,6 +138,9 @@ impl DslBuilder {
 
     pub fn drop_nans(self, subset: Option<Vec<Expr>>) -> Self {
         if let Some(subset) = subset {
+            if subset.len() == 0 {
+                return self;
+            }
             self.filter(
                 all_horizontal(
                     subset
@@ -158,6 +161,9 @@ impl DslBuilder {
 
     pub fn drop_nulls(self, subset: Option<Vec<Expr>>) -> Self {
         if let Some(subset) = subset {
+            if subset.len() == 0 {
+                return self;
+            }
             self.filter(
                 all_horizontal(
                     subset

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -96,7 +96,7 @@ def test_drop_nulls_misc() -> None:
     }
 
 
-def test_drop_nulls_empty_input() -> None:
+def test_drop_nulls_empty_subset() -> None:
     df = pl.DataFrame({"a": [1]})
     assert_frame_equal(df.drop_nulls([]), df)
     assert_frame_equal(df.drop_nulls(()), df)
@@ -160,7 +160,7 @@ def test_drop_nan_ignore_null_3525() -> None:
     ]
 
 
-def test_drop_nans_empty_input() -> None:
+def test_drop_nans_empty_subset() -> None:
     df = pl.DataFrame({"a": [1]})
     assert_frame_equal(df.drop_nans([]), df)
     assert_frame_equal(df.drop_nans(()), df)

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -98,9 +98,8 @@ def test_drop_nulls_misc() -> None:
 
 def test_drop_nulls_empty_subset() -> None:
     df = pl.DataFrame({"a": [1, None]})
-    expected = pl.DataFrame({"a": [1]})
-    assert_frame_equal(df.drop_nulls([]), expected)
-    assert_frame_equal(df.drop_nulls(()), expected)
+    assert_frame_equal(df.drop_nulls([]), df)
+    assert_frame_equal(df.drop_nulls(()), df)
 
 
 def test_drop_columns() -> None:
@@ -163,9 +162,8 @@ def test_drop_nan_ignore_null_3525() -> None:
 
 def test_drop_nans_empty_subset() -> None:
     df = pl.DataFrame({"a": [1.0, float("NaN")]})
-    expected = pl.DataFrame({"a": [1.0]})
-    assert_frame_equal(df.drop_nans([]), expected)
-    assert_frame_equal(df.drop_nans(()), expected)
+    assert_frame_equal(df.drop_nans([]), df)
+    assert_frame_equal(df.drop_nans(()), df)
 
 
 def test_drop_without_parameters() -> None:

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -96,6 +96,12 @@ def test_drop_nulls_misc() -> None:
     }
 
 
+def test_drop_nulls_empty_input() -> None:
+    df = pl.DataFrame({"a": [1]})
+    assert_frame_equal(df.drop_nulls([]), df)
+    assert_frame_equal(df.drop_nulls(()), df)
+
+
 def test_drop_columns() -> None:
     out = pl.LazyFrame({"a": [1], "b": [2], "c": [3]}).drop(["a", "b"])
     assert out.collect_schema().names() == ["c"]
@@ -152,6 +158,12 @@ def test_drop_nan_ignore_null_3525() -> None:
         3.0,
         4.0,
     ]
+
+
+def test_drop_nans_empty_input() -> None:
+    df = pl.DataFrame({"a": [1]})
+    assert_frame_equal(df.drop_nans([]), df)
+    assert_frame_equal(df.drop_nans(()), df)
 
 
 def test_drop_without_parameters() -> None:

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -97,9 +97,10 @@ def test_drop_nulls_misc() -> None:
 
 
 def test_drop_nulls_empty_subset() -> None:
-    df = pl.DataFrame({"a": [1]})
-    assert_frame_equal(df.drop_nulls([]), df)
-    assert_frame_equal(df.drop_nulls(()), df)
+    df = pl.DataFrame({"a": [1, None]})
+    expected = pl.DataFrame({"a": [1]})
+    assert_frame_equal(df.drop_nulls([]), expected)
+    assert_frame_equal(df.drop_nulls(()), expected)
 
 
 def test_drop_columns() -> None:
@@ -161,9 +162,10 @@ def test_drop_nan_ignore_null_3525() -> None:
 
 
 def test_drop_nans_empty_subset() -> None:
-    df = pl.DataFrame({"a": [1]})
-    assert_frame_equal(df.drop_nans([]), df)
-    assert_frame_equal(df.drop_nans(()), df)
+    df = pl.DataFrame({"a": [1.0, float("NaN")]})
+    expected = pl.DataFrame({"a": [1.0]})
+    assert_frame_equal(df.drop_nans([]), expected)
+    assert_frame_equal(df.drop_nans(()), expected)
 
 
 def test_drop_without_parameters() -> None:


### PR DESCRIPTION
Fixes #22605

Listed here: https://gist.github.com/devdanzin/dc2ef895928fc5758ea66a1ccf2eedd2

Ping @devdanzin

---

**Before:**

```python
import polars as pl
pl.DataFrame({"a": [1.0, float("nan")]}).drop_nans([])
```
```
pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: ComputeError(ErrString("cannot return empty fold because the number of output rows is unknown"))
```

**After:**

```python
import polars as pl
pl.DataFrame({"a": [1.0, float("nan")]}).drop_nans([])
```
```
shape: (2, 1)
┌─────┐
│ a   │
│ --- │
│ f64 │
╞═════╡
│ 1.0 │
│ NaN │
└─────┘
```