### PR TITLE
fix: Bug in `.unique()` followed by `.slice()`

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3012,13 +3012,6 @@ impl DataFrame {
                 let groups = groups.slice(offset, len);
                 df._apply_columns_par(&|s| unsafe { s.agg_first(&groups) })
             },
-            (UniqueKeepStrategy::First | UniqueKeepStrategy::Any, false) => {
-                let gb = df.group_by(names)?;
-                let groups = gb.get_groups();
-                let (offset, len) = slice.unwrap_or((0, groups.len()));
-                let groups = groups.slice(offset, len);
-                df._apply_columns_par(&|s| unsafe { s.agg_first(&groups) })
-            },
             (UniqueKeepStrategy::Last, true) => {
                 // maintain order by last values, so the sorted groups are not correct as they
                 // are sorted by the first value
@@ -3043,6 +3036,13 @@ impl DataFrame {
                     out = out.slice(offset, len);
                 }
                 return Ok(out);
+            },
+            (UniqueKeepStrategy::First | UniqueKeepStrategy::Any, false) => {
+                let gb = df.group_by(names)?;
+                let groups = gb.get_groups();
+                let (offset, len) = slice.unwrap_or((0, groups.len()));
+                let groups = groups.slice(offset, len);
+                df._apply_columns_par(&|s| unsafe { s.agg_first(&groups) })
             },
             (UniqueKeepStrategy::Last, false) => {
                 let gb = df.group_by(names)?;

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1946,13 +1946,6 @@ impl LazyFrame {
             maintain_order: true,
             keep_strategy,
         };
-        if keep_strategy == UniqueKeepStrategy::Last {
-            let reversed = self.reverse();
-            let lp = reversed.get_plan_builder().distinct(options).build();
-            let df = Self::from_logical_plan(lp, opt_state);
-            return df.reverse();
-        }
-
         let lp = self.get_plan_builder().distinct(options).build();
         Self::from_logical_plan(lp, opt_state)
     }
@@ -1989,12 +1982,6 @@ impl LazyFrame {
             maintain_order: false,
             keep_strategy,
         };
-        if keep_strategy == UniqueKeepStrategy::Last {
-            let reversed = self.reverse();
-            let lp = reversed.get_plan_builder().distinct(options).build();
-            let df = Self::from_logical_plan(lp, opt_state);
-            return df.reverse();
-        }
         let lp = self.get_plan_builder().distinct(options).build();
         Self::from_logical_plan(lp, opt_state)
     }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1946,6 +1946,13 @@ impl LazyFrame {
             maintain_order: true,
             keep_strategy,
         };
+        if keep_strategy == UniqueKeepStrategy::Last {
+            let reversed = self.reverse();
+            let lp = reversed.get_plan_builder().distinct(options).build();
+            let df = Self::from_logical_plan(lp, opt_state);
+            return df.reverse();
+        }
+
         let lp = self.get_plan_builder().distinct(options).build();
         Self::from_logical_plan(lp, opt_state)
     }
@@ -1982,6 +1989,12 @@ impl LazyFrame {
             maintain_order: false,
             keep_strategy,
         };
+        if keep_strategy == UniqueKeepStrategy::Last {
+            let reversed = self.reverse();
+            let lp = reversed.get_plan_builder().distinct(options).build();
+            let df = Self::from_logical_plan(lp, opt_state);
+            return df.reverse();
+        }
         let lp = self.get_plan_builder().distinct(options).build();
         Self::from_logical_plan(lp, opt_state)
     }

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -293,6 +293,6 @@ def test_unique_lengths_21654() -> None:
 
 def test_unique_with_slice_22470() -> None:
     lf = pl.LazyFrame({"x": [0, 1, 2, 3, 4, 5, 6, 7, 3, 4, 5, 6, 7, 8, 9, 10]})
-    result = lf.unique(keep="last", maintain_order=True).tail().collect()
-    expected = pl.DataFrame({"x": [6, 7, 8, 9, 10]})
+    result = lf.unique(keep="last", maintain_order=True).slice(3, 4).collect()
+    expected = pl.DataFrame({"x": [3, 4, 5, 6]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -291,7 +291,7 @@ def test_unique_lengths_21654() -> None:
         assert df.unique().height == n
 
 
-def test_unique_with_slice_22470() -> None:
+def test_unique_keep_last_with_slice_22470() -> None:
     lf = pl.LazyFrame({"x": [0, 1, 2, 3, 4, 5, 6, 7, 3, 4, 5, 6, 7, 8, 9, 10]})
     result = lf.unique(keep="last", maintain_order=True).slice(3, 4).collect()
     expected = pl.DataFrame({"x": [3, 4, 5, 6]})

--- a/py-polars/tests/unit/operations/unique/test_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_unique.py
@@ -289,3 +289,10 @@ def test_unique_lengths_21654() -> None:
     for n in range(0, 1000, 37):
         df = pl.DataFrame({"x": pl.int_range(n, eager=True)})
         assert df.unique().height == n
+
+
+def test_unique_with_slice_22470() -> None:
+    lf = pl.LazyFrame({"x": [0, 1, 2, 3, 4, 5, 6, 7, 3, 4, 5, 6, 7, 8, 9, 10]})
+    result = lf.unique(keep="last", maintain_order=True).tail().collect()
+    expected = pl.DataFrame({"x": [6, 7, 8, 9, 10]})
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/22470

This PR updates `unique_impl` to always slice after computing the full result, instead of slicing intermediate data (like groups or masks).
It also fixes the `UniqueKeepStrategy::None ` case, which previously could cause a shape mismatch when slicing the mask before filtering.