### PR TITLE
fix(python): Ensure numpy `isinstance` check is lazy (avoid forcing the dependency)

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -182,7 +182,7 @@ def lit(
     if dtype:
         return wrap_expr(plr.lit(value, allow_object, is_scalar=True)).cast(dtype)
 
-    if isinstance(value, np.generic):
+    if _check_for_numpy(value) and isinstance(value, np.generic):
         # note: the item() is a py-native datetime/timedelta when units < 'ns'
         if isinstance(item := value.item(), (datetime, timedelta)):
             return lit(item)


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/pull/22177#discussion_r2066129875.

Ensures the `np.generic` check is behind a lazy dependency gate ("oops" 😅).