### PR TITLE
feat: Add SQL support for checking array values with `IN` and `NOT IN` expressions

### DIFF
--- a/py-polars/tests/unit/sql/test_array.py
+++ b/py-polars/tests/unit/sql/test_array.py
@@ -232,9 +232,3 @@ def test_unnest_table_function_errors() -> None:
             match=r"UNNEST tables do not \(yet\) support WITH OFFSET|ORDINALITY",
         ):
             ctx.execute("SELECT * FROM UNNEST([1, 2, 3]) tbl (colx) WITH OFFSET")
-
-        with pytest.raises(
-            SQLInterfaceError,
-            match="nested array literals are not currently supported",
-        ):
-            pl.sql_expr("[[1,2,3]] AS nested")


### PR DESCRIPTION
Tweaked `SQLExprVisitor::array_expr_to_series` implementation to resolve a `FnMut` ownership/referencing issue that was preventing SQL support for using array literals within `IN` and `NOT IN` expressions.

(Also opportunistically closes #22463 to avoid triggering a `DeprecationWarning`).

## Example

```python
import polars as pl

df = pl.DataFrame({
    "rowid": [4, 3, 2, 1],
    "values": [[1, 2], [3, 4], [5, 6], [7, 8]],
})

df.sql(
    """
    SELECT * FROM self
    WHERE values IN ([0], [5,6], [1,2], [8,8,8])
    ORDER BY "rowid"
    """
)
# shape: (2, 2)
# ┌───────┬───────────┐
# │ rowid ┆ values    │
# │ ---   ┆ ---       │
# │ i64   ┆ list[i64] │
# ╞═══════╪═══════════╡
# │ 2     ┆ [5, 6]    │
# │ 4     ┆ [1, 2]    │
# └───────┴───────────┘
```