### PR TITLE
feat: Show physical stage graph

### DIFF
--- a/crates/polars-lazy/src/dot.rs
+++ b/crates/polars-lazy/src/dot.rs
@@ -13,4 +13,33 @@ impl LazyFrame {
 
         Ok(lp.display_dot().to_string())
     }
+
+    /// Get a dot language representation of the physical plan.
+    pub fn to_dot_phys(&self, optimized: bool, engine: Engine) -> PolarsResult<String> {
+        let mut lf = self.clone();
+        lf = match engine {
+            Engine::Streaming => lf.with_new_streaming(true),
+            _ => lf,
+        };
+
+        let mut lp = if optimized {
+            lf.to_alp_optimized()
+        } else {
+            lf.to_alp()
+        }?;
+
+        match engine {
+            Engine::Streaming => polars_stream::visualize_physical_plan(
+                lp.lp_top,
+                &mut lp.lp_arena,
+                &mut lp.expr_arena,
+            ),
+            Engine::Auto => polars_bail!(ComputeError: "no engine selected"),
+            Engine::OldStreaming => {
+                polars_bail!(ComputeError: "old streaming engine is not supported")
+            },
+            Engine::InMemory => polars_bail!(ComputeError: "in-memory engine is not supported"),
+            Engine::Gpu => polars_bail!(ComputeError: "gpu engine is not supported"),
+        }
+    }
 }

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -531,6 +531,10 @@ impl PyLazyFrame {
         py.enter_polars(|| self.ldf.to_dot(optimized))
     }
 
+    fn to_dot_phys(&self, py: Python, optimized: bool, engine: Wrap<Engine>) -> PyResult<String> {
+        py.enter_polars(|| self.ldf.to_dot_phys(optimized, engine.0))
+    }
+
     fn optimization_toggle(
         &self,
         type_coercion: bool,

--- a/crates/polars-stream/src/lib.rs
+++ b/crates/polars-stream/src/lib.rs
@@ -4,7 +4,7 @@ mod skeleton;
 
 use std::sync::LazyLock;
 
-pub use skeleton::run_query;
+pub use skeleton::{run_query, visualize_physical_plan};
 
 mod execute;
 pub(crate) mod expression;

--- a/crates/polars-stream/src/skeleton.rs
+++ b/crates/polars-stream/src/skeleton.rs
@@ -32,6 +32,22 @@ pub fn run_query(
     StreamingQuery::build(node, ir_arena, expr_arena)?.execute()
 }
 
+/// Visualizes the physical plan as a dot graph.
+pub fn visualize_physical_plan(
+    node: Node,
+    ir_arena: &mut Arena<IR>,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<String> {
+    let mut phys_sm = SlotMap::with_capacity_and_key(ir_arena.len());
+
+    let root_phys_node =
+        crate::physical_plan::build_physical_plan(node, ir_arena, expr_arena, &mut phys_sm)?;
+
+    let out = crate::physical_plan::visualize_plan(root_phys_node, &phys_sm, expr_arena);
+
+    Ok(out)
+}
+
 pub struct StreamingQuery {
     top_ir: IR,
     graph: Graph,

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -315,6 +315,8 @@ EngineType: TypeAlias = Union[
     Literal["auto", "in-memory", "streaming", "gpu"], "GPUEngine"
 ]
 
+PlanStage: TypeAlias = Literal["ir", "phys"]
+
 FileSource: TypeAlias = Union[
     str,
     Path,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
         Label,
         MaintainOrderJoin,
         Orientation,
+        PlanStage,
         PolarsDataType,
         PythonDataType,
         RollingInterpolationMethod,
@@ -1251,6 +1252,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         collapse_joins: bool = True,
         streaming: bool = False,
         engine: EngineType = "auto",
+        plan_stage: PlanStage = "ir",
         _check_order: bool = True,
     ) -> str | None:
         """
@@ -1312,6 +1314,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             .. note::
                The GPU engine does not support streaming, if streaming
                is enabled then GPU execution is switched off.
+        plan_stage : {'ir', 'phys'}
+            Select the stage to display.
 
         Examples
         --------
@@ -1349,7 +1353,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             new_streaming=engine == "streaming",
         )
 
-        dot = _ldf.to_dot(optimized)
+        if plan_stage == "ir":
+            dot = _ldf.to_dot(optimized)
+        elif plan_stage == "phys":
+            dot = _ldf.to_dot_phys(optimized, engine)
+        else:
+            error_msg = f"invalid plan stage '{plan_stage}'"
+            raise TypeError(error_msg)
+
         return display_dot_graph(
             dot=dot,
             show=show,

--- a/py-polars/tests/unit/test_show_graph.py
+++ b/py-polars/tests/unit/test_show_graph.py
@@ -1,7 +1,7 @@
 import polars as pl
 
 
-def test_show_graph() -> None:
+def test_show_graph_ir() -> None:
     # only test raw output, otherwise we need graphviz and matplotlib
     ldf = pl.LazyFrame(
         {
@@ -11,5 +11,19 @@ def test_show_graph() -> None:
         }
     )
     query = ldf.group_by("a", maintain_order=True).agg(pl.all().sum()).sort("a")
-    out = query.show_graph(raw_output=True)
+    out = query.show_graph(raw_output=True, plan_stage="ir")
+    assert isinstance(out, str)
+
+
+def test_show_graph_phys() -> None:
+    # only test raw output, otherwise we need graphviz and matplotlib
+    ldf = pl.LazyFrame(
+        {
+            "a": ["a", "b", "a", "b", "b", "c"],
+            "b": [1, 2, 3, 4, 5, 6],
+            "c": [6, 5, 4, 3, 2, 1],
+        }
+    )
+    query = ldf.group_by("a", maintain_order=True).agg(pl.all().sum()).sort("a")
+    out = query.show_graph(raw_output=True, plan_stage="phys", engine="streaming")
     assert isinstance(out, str)


### PR DESCRIPTION
This PR adds a new `plan_stage` parameter to `show_graph` to allow displaying the physical stage graph. Currently only the streaming engine is supported.

A new function `visualize_physical_plan` is added to `polars-stream` to expose the functionality.