### PR TITLE
fix: Fix incorrect ternary agg state with mixed columns and scalars

### DIFF
--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -70,7 +70,8 @@ fn finish_as_iters<'a>(
         out = out.explode()?
     }
 
-    ac_truthy.with_values(out, true, None)?;
+    ac_truthy.with_agg_state(AggState::AggregatedList(out));
+
     Ok(ac_truthy)
 }
 

--- a/crates/polars-plan/src/plans/aexpr/scalar.rs
+++ b/crates/polars-plan/src/plans/aexpr/scalar.rs
@@ -21,8 +21,14 @@ pub fn is_scalar_ae(node: Node, expr_arena: &Arena<AExpr>) -> bool {
         AExpr::BinaryExpr { left, right, .. } => {
             is_scalar_ae(*left, expr_arena) && is_scalar_ae(*right, expr_arena)
         },
-        AExpr::Ternary { truthy, falsy, .. } => {
-            is_scalar_ae(*truthy, expr_arena) && is_scalar_ae(*falsy, expr_arena)
+        AExpr::Ternary {
+            predicate,
+            truthy,
+            falsy,
+        } => {
+            is_scalar_ae(*predicate, expr_arena)
+                && is_scalar_ae(*truthy, expr_arena)
+                && is_scalar_ae(*falsy, expr_arena)
         },
         AExpr::Agg(_) | AExpr::Len => true,
         AExpr::Cast { expr, .. } | AExpr::Alias(expr, _) => is_scalar_ae(*expr, expr_arena),

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -621,7 +621,11 @@ def test_when_then_over_22478() -> None:
         }
     )
 
-    assert q.collect_schema() == expect.schema
+    assert q.collect_schema() == {
+        "x": pl.Boolean,
+        "t": pl.Int64,
+        "duration": pl.Int64,
+    }
     assert_frame_equal(q.collect(), expect)
 
     q = pl.LazyFrame({"key": [1, 1, 2, 2, 2]}).with_columns(


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22478

Note, I haven't checked the other uses of `AggregationContext::with_values()` in the codebase.

This does **not** fix:

* https://github.com/pola-rs/polars/issues/22493
  * It (could be) another misuse of `with_values()` for that one
