### PR TITLE
fix: Throw errors on failing recursive strict casting

### DIFF
--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -1,4 +1,5 @@
 use either::Either;
+use polars_utils::cowbox::CowBox;
 
 use super::specification::try_check_offsets_bounds;
 use super::{Array, GenericBinaryArray, Splitable};
@@ -429,6 +430,10 @@ impl<O: Offset> Array for BinaryArray<O> {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -3,6 +3,7 @@
 
 mod builder;
 pub use builder::*;
+use polars_utils::cowbox::CowBox;
 mod ffi;
 pub(super) mod fmt;
 mod iterator;
@@ -668,6 +669,10 @@ impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
 
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -1,5 +1,6 @@
 use either::Either;
 use polars_error::{PolarsResult, polars_bail};
+use polars_utils::cowbox::CowBox;
 
 use super::{Array, Splitable};
 use crate::array::iterator::NonNullValuesIter;
@@ -401,6 +402,10 @@ impl Array for BooleanArray {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -19,6 +19,7 @@ mod value_map;
 pub use iterator::*;
 pub use mutable::*;
 use polars_error::{PolarsResult, polars_bail};
+use polars_utils::cowbox::CowBox;
 
 use super::primitive::PrimitiveArray;
 use super::specification::check_indexes;
@@ -421,6 +422,10 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -11,6 +11,7 @@ pub use builder::*;
 mod mutable;
 pub use mutable::*;
 use polars_error::{PolarsResult, polars_bail, polars_ensure};
+use polars_utils::cowbox::CowBox;
 
 /// The Arrow's equivalent to an immutable `Vec<Option<[u8; size]>>`.
 /// Cloning and slicing this struct is `O(1)`.
@@ -229,6 +230,10 @@ impl Array for FixedSizeBinaryArray {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -9,6 +9,7 @@ pub(super) mod fmt;
 mod iterator;
 
 use polars_error::{PolarsResult, polars_bail};
+use polars_utils::cowbox::CowBox;
 
 /// An array representing a (key, value), both of arbitrary logical types.
 #[derive(Clone)]
@@ -191,6 +192,10 @@ impl Array for MapArray {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -85,6 +85,9 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     /// When the validity is [`None`], all slots are valid.
     fn validity(&self) -> Option<&Bitmap>;
 
+    /// Propagate nulls down to masked-out values in lower nesting levels.
+    fn propagate_nulls(&self) -> CowBox<dyn Array>;
+
     /// The number of null slots on this [`Array`].
     /// # Implementation
     /// This is `O(1)` since the number of null elements is pre-computed.
@@ -703,6 +706,7 @@ pub use list::{ListArray, ListArrayBuilder, ListValuesIter, MutableListArray};
 pub use map::MapArray;
 pub use null::{MutableNullArray, NullArray, NullArrayBuilder};
 use polars_error::PolarsResult;
+use polars_utils::cowbox::CowBox;
 pub use primitive::*;
 pub use static_array::{ParameterFreeDtypeStaticArray, StaticArray};
 pub use static_array_collect::{ArrayCollectIterExt, ArrayFromIter, ArrayFromIterDtype};

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 
 use polars_error::{PolarsResult, polars_bail};
+use polars_utils::cowbox::CowBox;
 use polars_utils::IdxSize;
 
 use super::Splitable;
@@ -99,6 +100,10 @@ impl Array for NullArray {
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         // Nulls with invalid nulls are also nulls.
         self.clone().boxed()
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use either::Either;
+use polars_utils::cowbox::CowBox;
 
 use super::{Array, Splitable};
 use crate::array::iterator::NonNullValuesIter;
@@ -491,6 +492,10 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -1,4 +1,5 @@
 use polars_error::{PolarsResult, polars_bail, polars_err};
+use polars_utils::cowbox::CowBox;
 
 use super::{Array, Splitable, new_empty_array, new_null_array};
 use crate::bitmap::Bitmap;
@@ -347,6 +348,10 @@ impl Array for UnionArray {
 
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a union array")
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -1,4 +1,5 @@
 use either::Either;
+use polars_utils::cowbox::CowBox;
 
 use super::specification::try_check_utf8;
 use super::{Array, GenericBinaryArray, Splitable};
@@ -536,6 +537,10 @@ impl<O: Offset> Array for Utf8Array<O> {
     #[inline]
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -462,11 +462,13 @@ impl ChunkCast for BooleanChunked {
 /// So this implementation casts the inner type
 impl ChunkCast for ListChunked {
     fn cast_with_options(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Series> {
+        let ca = self.propagate_nulls();
+
         use DataType::*;
         match dtype {
             List(child_type) => {
-                match (self.inner_dtype(), &**child_type) {
-                    (old, new) if old == new => Ok(self.clone().into_series()),
+                match (ca.inner_dtype(), &**child_type) {
+                    (old, new) if old == new => Ok(ca.into_owned().into_series()),
                     #[cfg(feature = "dtype-categorical")]
                     (dt, Categorical(None, _) | Enum(_, _))
                         if !matches!(dt, Categorical(_, _) | Enum(_, _) | String | Null) =>
@@ -475,12 +477,12 @@ impl ChunkCast for ListChunked {
                     },
                     _ => {
                         // ensure the inner logical type bubbles up
-                        let (arr, child_type) = cast_list(self, child_type, options)?;
+                        let (arr, child_type) = cast_list(ca.as_ref(), child_type, options)?;
                         // SAFETY: we just cast so the dtype matches.
                         // we must take this path to correct for physical types.
                         unsafe {
                             Ok(Series::from_chunks_and_dtype_unchecked(
-                                self.name().clone(),
+                                ca.name().clone(),
                                 vec![arr],
                                 &List(Box::new(child_type)),
                             ))
@@ -497,12 +499,12 @@ impl ChunkCast for ListChunked {
                 polars_ensure!(!matches!(&**child_type, Categorical(_, _)), InvalidOperation: "array of categorical is not yet supported");
 
                 // cast to the physical type to avoid logical chunks.
-                let chunks = cast_chunks(self.chunks(), &physical_type, options)?;
+                let chunks = cast_chunks(ca.chunks(), &physical_type, options)?;
                 // SAFETY: we just cast so the dtype matches.
                 // we must take this path to correct for physical types.
                 unsafe {
                     Ok(Series::from_chunks_and_dtype_unchecked(
-                        self.name().clone(),
+                        ca.name().clone(),
                         chunks,
                         &Array(child_type.clone(), *width),
                     ))
@@ -511,7 +513,7 @@ impl ChunkCast for ListChunked {
             _ => {
                 polars_bail!(
                     InvalidOperation: "cannot cast List type (inner: '{:?}', to: '{:?}')",
-                    self.inner_dtype(),
+                    ca.inner_dtype(),
                     dtype,
                 )
             },
@@ -532,28 +534,30 @@ impl ChunkCast for ListChunked {
 #[cfg(feature = "dtype-array")]
 impl ChunkCast for ArrayChunked {
     fn cast_with_options(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Series> {
+        let ca = self.propagate_nulls();
+
         use DataType::*;
         match dtype {
             Array(child_type, width) => {
                 polars_ensure!(
-                    *width == self.width(),
+                    *width == ca.width(),
                     InvalidOperation: "cannot cast Array to a different width"
                 );
 
-                match (self.inner_dtype(), &**child_type) {
-                    (old, new) if old == new => Ok(self.clone().into_series()),
+                match (ca.inner_dtype(), &**child_type) {
+                    (old, new) if old == new => Ok(ca.into_owned().into_series()),
                     #[cfg(feature = "dtype-categorical")]
                     (dt, Categorical(None, _) | Enum(_, _)) if !matches!(dt, String) => {
                         polars_bail!(InvalidOperation: "cannot cast Array inner type: '{:?}' to dtype: {:?}", dt, child_type)
                     },
                     _ => {
                         // ensure the inner logical type bubbles up
-                        let (arr, child_type) = cast_fixed_size_list(self, child_type, options)?;
+                        let (arr, child_type) = cast_fixed_size_list(ca.as_ref(), child_type, options)?;
                         // SAFETY: we just cast so the dtype matches.
                         // we must take this path to correct for physical types.
                         unsafe {
                             Ok(Series::from_chunks_and_dtype_unchecked(
-                                self.name().clone(),
+                                ca.name().clone(),
                                 vec![arr],
                                 &Array(Box::new(child_type), *width),
                             ))
@@ -564,12 +568,12 @@ impl ChunkCast for ArrayChunked {
             List(child_type) => {
                 let physical_type = dtype.to_physical();
                 // cast to the physical type to avoid logical chunks.
-                let chunks = cast_chunks(self.chunks(), &physical_type, options)?;
+                let chunks = cast_chunks(ca.chunks(), &physical_type, options)?;
                 // SAFETY: we just cast so the dtype matches.
                 // we must take this path to correct for physical types.
                 unsafe {
                     Ok(Series::from_chunks_and_dtype_unchecked(
-                        self.name().clone(),
+                        ca.name().clone(),
                         chunks,
                         &List(child_type.clone()),
                     ))
@@ -578,7 +582,7 @@ impl ChunkCast for ArrayChunked {
             _ => {
                 polars_bail!(
                     InvalidOperation: "cannot cast Array type (inner: '{:?}', to: '{:?}')",
-                    self.inner_dtype(),
+                    ca.inner_dtype(),
                     dtype,
                 )
             },

--- a/crates/polars-core/src/chunked_array/flags.rs
+++ b/crates/polars-core/src/chunked_array/flags.rs
@@ -16,6 +16,11 @@ bitflags::bitflags! {
         const IS_SORTED_ASC = 0x01;
         const IS_SORTED_DSC = 0x02;
         const CAN_FAST_EXPLODE_LIST = 0x04;
+
+        /// Recursive version of `CAN_FAST_EXPLODE_LIST`.
+        const HAS_TRIMMED_MASKED = 0x08;
+        /// All masked out values have their nulls propagated.
+        const HAS_PROPAGATED_NULLS = 0x10;
     }
 }
 
@@ -112,5 +117,13 @@ impl StatisticsFlags {
 
     pub fn can_fast_explode_list(&self) -> bool {
         self.contains(Self::CAN_FAST_EXPLODE_LIST)
+    }
+
+    pub fn has_propagated_nulls(&self) -> bool {
+        self.contains(Self::HAS_PROPAGATED_NULLS)
+    }
+
+    pub fn has_trimmed_masked(&self) -> bool {
+        self.contains(Self::HAS_TRIMMED_MASKED)
     }
 }

--- a/crates/polars-core/src/chunked_array/object/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/mod.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 use arrow::bitmap::Bitmap;
 use arrow::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow::buffer::Buffer;
+use polars_utils::cowbox::CowBox;
 use polars_utils::total_ord::TotalHash;
 
 use crate::prelude::*;
@@ -220,6 +221,10 @@ where
             None => 0,
             Some(validity) => validity.unset_bits(),
         }
+    }
+
+    fn propagate_nulls(&self) -> CowBox<dyn Array> {
+        CowBox::Borrowed(self)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -30,6 +30,7 @@ mod for_each;
 pub mod full;
 pub mod gather;
 pub(crate) mod nulls;
+mod propagate_nulls;
 mod reverse;
 #[cfg(feature = "rolling_window")]
 pub(crate) mod rolling_window;
@@ -38,15 +39,18 @@ pub mod search_sorted;
 mod set;
 mod shift;
 pub mod sort;
+mod trim_masked;
 #[cfg(feature = "algorithm_group_by")]
 pub(crate) mod unique;
 #[cfg(feature = "zip_with")]
 pub mod zip;
 
 pub use chunkops::_set_check_length;
+pub use propagate_nulls::ChunkPropagateNulls;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 pub use sort::options::*;
+pub use trim_masked::ChunkTrimMasked;
 
 use crate::chunked_array::cast::CastOptions;
 use crate::series::{BitRepr, IsSorted};

--- a/crates/polars-core/src/chunked_array/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/struct_/mod.rs
@@ -383,16 +383,10 @@ impl StructChunked {
         )
     }
 
-    /// Set the outer nulls into the inner arrays, and clear the outer validity.
+    /// Set the outer nulls into the inner arrays.
     pub(crate) fn propagate_nulls(&mut self) {
-        if self.null_count > 0 {
-            // SAFETY:
-            // We keep length and dtypes the same.
-            unsafe {
-                for arr in self.downcast_iter_mut() {
-                    *arr = arr.propagate_nulls()
-                }
-            }
+        if let Cow::Owned(ca) = ChunkPropagateNulls::propagate_nulls(self) {
+            *self = ca;
         }
     }
 

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -600,6 +600,20 @@ impl DataType {
         }
     }
 
+    pub fn contains_list_recursive(&self) -> bool {
+        use DataType as D;
+        match self {
+            D::List(_) => true,
+            #[cfg(feature = "dtype-array")]
+            D::Array(inner, _) => inner.contains_list_recursive(),
+            #[cfg(feature = "dtype-struct")]
+            D::Struct(fields) => fields
+                .iter()
+                .any(|field| field.dtype.contains_list_recursive()),
+            _ => false,
+        }
+    }
+
     /// Check if type is sortable
     pub fn is_ord(&self) -> bool {
         #[cfg(feature = "dtype-categorical")]

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -125,7 +125,7 @@ impl Series {
             Struct(_) => {
                 let mut ca =
                     StructChunked::from_chunks_and_dtype_unchecked(name, chunks, dtype.clone());
-                ca.propagate_nulls();
+                StructChunked::propagate_nulls(&mut ca);
                 ca.into_series()
             },
             #[cfg(feature = "object")]
@@ -485,7 +485,7 @@ impl Series {
                 unsafe {
                     let mut ca =
                         StructChunked::from_chunks_and_dtype_unchecked(name, chunks, dtype);
-                    ca.propagate_nulls();
+                    StructChunked::propagate_nulls(&mut ca);
                     Ok(ca.into_series())
                 }
             },

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -171,6 +171,13 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }
 
+    fn propagate_nulls(&self) -> Option<Series> {
+        match self.0.propagate_nulls() {
+            Cow::Borrowed(_) => None,
+            Cow::Owned(ca) => Some(ca.into_series()),
+        }
+    }
+
     fn cast(&self, dtype: &DataType, options: CastOptions) -> PolarsResult<Series> {
         self.0.cast_with_options(dtype, options)
     }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -159,6 +159,13 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }
 
+    fn propagate_nulls(&self) -> Option<Series> {
+        match self.0.propagate_nulls() {
+            Cow::Borrowed(_) => None,
+            Cow::Owned(ca) => Some(ca.into_series()),
+        }
+    }
+
     fn cast(&self, dtype: &DataType, cast_options: CastOptions) -> PolarsResult<Series> {
         self.0.cast_with_options(dtype, cast_options)
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -162,6 +162,13 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         self.0.new_from_index(_index, _length).into_series()
     }
 
+    fn propagate_nulls(&self) -> Option<Series> {
+        match self.0.propagate_nulls() {
+            Cow::Borrowed(_) => None,
+            Cow::Owned(ca) => Some(ca.into_series()),
+        }
+    }
+
     fn cast(&self, dtype: &DataType, cast_options: CastOptions) -> PolarsResult<Series> {
         self.0.cast_with_options(dtype, cast_options)
     }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -378,6 +378,14 @@ pub trait SeriesTrait:
     /// ```
     fn new_from_index(&self, _index: usize, _length: usize) -> Series;
 
+    /// Propagate down nulls in nested types.
+    ///
+    /// - `None` if nothing needed to be done.
+    /// - `Some(series)` if something changed.
+    fn propagate_nulls(&self) -> Option<Series> {
+        None
+    }
+
     fn cast(&self, _dtype: &DataType, options: CastOptions) -> PolarsResult<Series>;
 
     /// Get a single value by index. Don't use this operation for loops as a runtime cast is

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cell;
 pub mod chunks;
 pub mod clmul;
 mod config;
+pub mod cowbox;
 pub mod cpuid;
 pub mod error;
 pub mod floor_divmod;


### PR DESCRIPTION
Fixes #22260.

This introduces:
- `ChunkPropagateNulls` to recursively propagate nulls to each nesting level
- `ChunkTrimMasked` to recursively trim masked out list elements