### PR TITLE
fix: Invalid values were triggering panics instead of returning ``null`` in `dt.to_date` / `dt.to_datetime`

### DIFF
--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -24,10 +24,7 @@ fn update_and_parse<T: atoi_simd::Parse>(
     let bytes = vals.get(offset..new_offset)?;
     let (val, parsed) = atoi_simd::parse_any(bytes).ok()?;
     if parsed != incr {
-        panic!(
-            "Invariant when calling StrpTimeState.parse was not upheld. Expected {} parsed digits, got {}.",
-            incr, parsed
-        );
+        None
     } else {
         Some((val, new_offset))
     }

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -787,3 +787,22 @@ def test_strptime_empty_input_22214() -> None:
     assert s.str.strptime(pl.Time, "%H:%M:%S%.f").is_empty()
     assert s.str.strptime(pl.Date, "%Y-%m-%d").is_empty()
     assert s.str.strptime(pl.Datetime, "%Y-%m-%d %H:%M%#z").is_empty()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "31/12/2022",
+        "banana",
+        "12-345-678",
+        "12-345-67",
+        "12-345-6789",
+        "123*45*678",
+        "123x45x678",
+        "123x45x678x",
+    ],
+)
+def test_matching_strings_but_different_format_22495(value: str) -> None:
+    s = pl.Series("my_strings", [value])
+    result = s.str.to_date("%Y-%m-%d", strict=False).item()
+    assert result is None


### PR DESCRIPTION
closes #22495