### PR TITLE
fix: Fix `schema_overrides` not taking effect in NDJSON

### DIFF
--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -81,11 +81,16 @@ def test_scan_csv_schema_overwrite_and_dtypes_overwrite(
     io_files_path: Path, file_name: str
 ) -> None:
     file_path = io_files_path / file_name
-    df = pl.scan_csv(
+    q = pl.scan_csv(
         file_path,
         schema_overrides={"calories_foo": pl.String, "fats_g_foo": pl.Float32},
         with_column_names=lambda names: [f"{a}_foo" for a in names],
-    ).collect()
+    )
+
+    assert q.collect_schema().dtypes() == [pl.String, pl.String, pl.Float32, pl.Int64]
+
+    df = q.collect()
+
     assert df.dtypes == [pl.String, pl.String, pl.Float32, pl.Int64]
     assert df.columns == [
         "category_foo",

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -309,3 +309,19 @@ def test_scan_ndjson_nested_as_string() -> None:
             }
         ),
     )
+
+
+def test_scan_ndjson_schema_overwrite_22514() -> None:
+    buf = b"""\
+{"a": 1}
+"""
+
+    q = pl.scan_ndjson(buf)
+
+    # Baseline: Infers as Int64
+    assert q.collect_schema() == {"a": pl.Int64}
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 1}))
+
+    q = pl.scan_ndjson(buf, schema_overrides={"a": pl.String})
+    assert q.collect_schema() == {"a": pl.String}
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": "1"}))


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22514

The lazy schema was not updated with `schema_overrides` in DSL->IR schema inference. In older versions this just meant that `collect_schema()` would return an incorrect schema, as the old NDJSON reader would re-apply the schema_overwrite during execution. But this is problematic for the new-streaming NDJSON source as it scans according to the IR schema.
