### PR TITLE
refactor: Don't store name/dtype in grouper

### DIFF
--- a/crates/polars-stream/src/nodes/group_by.rs
+++ b/crates/polars-stream/src/nodes/group_by.rs
@@ -431,8 +431,8 @@ struct GroupByPartition {
 }
 
 impl GroupByPartition {
-    fn into_df(self, output_schema: &Schema) -> PolarsResult<DataFrame> {
-        let mut out = self.grouper.get_keys_in_group_order();
+    fn into_df(self, key_schema: &Schema, output_schema: &Schema) -> PolarsResult<DataFrame> {
+        let mut out = self.grouper.get_keys_in_group_order(key_schema);
         let out_names = output_schema.iter_names().skip(out.width());
         for (mut r, name) in self.grouped_reductions.into_iter().zip(out_names) {
             unsafe {
@@ -451,6 +451,7 @@ enum GroupByState {
 
 pub struct GroupByNode {
     state: GroupByState,
+    key_schema: Arc<Schema>,
     output_schema: Arc<Schema>,
 }
 
@@ -499,6 +500,7 @@ impl GroupByNode {
                 locals,
                 partitioner,
             }),
+            key_schema,
             output_schema,
         }
     }
@@ -534,7 +536,7 @@ impl ComputeNode for GroupByNode {
                 let dfs = POOL.install(|| {
                     partitions
                         .into_par_iter()
-                        .map(|p| p.into_df(&self.output_schema))
+                        .map(|p| p.into_df(&self.key_schema, &self.output_schema))
                         .collect::<Result<Vec<_>, _>>()
                 })?;
 


### PR DESCRIPTION
Not sure yet if I want to end up nesting these, but in the case we do, we don't waste space on this for each grouper.