### PR TITLE
refactor(rust): Improve zip state update

### DIFF
--- a/crates/polars-stream/src/nodes/zip.rs
+++ b/crates/polars-stream/src/nodes/zip.rs
@@ -154,8 +154,6 @@ impl ComputeNode for ZipNode {
         assert!(send.len() == 1);
         assert!(recv.len() == self.input_heads.len());
 
-        let any_input_blocked = recv.contains(&PortState::Blocked);
-
         let mut all_broadcast = true;
         let mut all_done_or_broadcast = true;
         let mut at_least_one_non_broadcast_done = false;
@@ -187,26 +185,31 @@ impl ComputeNode for ZipNode {
 
         let all_output_sent = all_done_or_broadcast && !all_broadcast;
 
-        let new_recv_state = if send[0] == PortState::Done || all_output_sent {
+        // Are we completely done?
+        if send[0] == PortState::Done || all_output_sent {
             for input_head in &mut self.input_heads {
                 input_head.clear();
             }
             send[0] = PortState::Done;
-            PortState::Done
-        } else if send[0] == PortState::Blocked || any_input_blocked {
-            send[0] = if any_input_blocked {
+            recv.fill(PortState::Done);
+            return Ok(());
+        }
+
+        let num_inputs_blocked = recv.iter().filter(|r| **r == PortState::Blocked).count();
+        send[0] = if num_inputs_blocked > 0 {
+            PortState::Blocked
+        } else {
+            PortState::Ready
+        };
+
+        let num_total_blocked = num_inputs_blocked + (send[0] == PortState::Blocked) as usize;
+        for r in recv {
+            let num_others_blocked = num_total_blocked - (*r == PortState::Blocked) as usize;
+            *r = if num_others_blocked > 0 {
                 PortState::Blocked
             } else {
                 PortState::Ready
             };
-            PortState::Blocked
-        } else {
-            send[0] = PortState::Ready;
-            PortState::Ready
-        };
-
-        for r in recv {
-            *r = new_recv_state;
         }
         Ok(())
     }


### PR DESCRIPTION
The previous update would send `Blocked` to all inputs if any of them is blocked, but the zip should ignore an inputs own status and only consider the blocking status of the others when deciding whether or not to send to that input we are ready to receive from it.

For example, consider the following input scenario:

```
send:    R
recv: R R B R
```

In this scenario the old code would reply blocked to everything:


```
send:    B
recv: B B B B
```

But the following reply is more accurate:

```
send:    B
recv: B B R B
```

after all, should the third input switch to ready, everyone is ready.