### PR TITLE
fix: Panic on bitwise op between Series and Expr

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -670,31 +670,43 @@ class Series:
         return self.len()
 
     def __and__(self, other: Any) -> Self:
+        if isinstance(other, pl.Expr):
+            return F.lit(self) & other
         if not isinstance(other, Series):
             other = Series([other])
         return self._from_pyseries(self._s.bitand(other._s))
 
     def __rand__(self, other: Any) -> Series:
+        if isinstance(other, pl.Expr):
+            return other & F.lit(self)
         if not isinstance(other, Series):
             other = Series([other])
         return other & self
 
     def __or__(self, other: Any) -> Self:
+        if isinstance(other, pl.Expr):
+            return F.lit(self) | other
         if not isinstance(other, Series):
             other = Series([other])
         return self._from_pyseries(self._s.bitor(other._s))
 
     def __ror__(self, other: Any) -> Series:
+        if isinstance(other, pl.Expr):
+            return other | F.lit(self)
         if not isinstance(other, Series):
             other = Series([other])
         return other | self
 
     def __xor__(self, other: Any) -> Self:
+        if isinstance(other, pl.Expr):
+            return F.lit(self) ^ other
         if not isinstance(other, Series):
             other = Series([other])
         return self._from_pyseries(self._s.bitxor(other._s))
 
     def __rxor__(self, other: Any) -> Series:
+        if isinstance(other, pl.Expr):
+            return other ^ F.lit(self)
         if not isinstance(other, Series):
             other = Series([other])
         return other ^ self


### PR DESCRIPTION
Fixes this bug:

```python
>>> s = pl.Series([1])
>>> pl.lit(1) + s
<Expr ['[(dyn int: 1) + (Series)]'] at 0x2B1CCD1D0>
>>> s + pl.lit(1)
<Expr ['[(Series) + (dyn int: 1)]'] at 0x2B133A8D0>
>>> pl.lit(1) & s
<Expr ['[(dyn int: 1) & (Series)]'] at 0x2B1B7E550>
>>> s & pl.lit(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/orlp/.localpython/lib/python3.11/site-packages/polars/series/series.py", line 666, in __and__
    return self._from_pyseries(self._s.bitand(other._s))
                               ^^^^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.ComputeError: cannot cast 'Object' type
```