### PR TITLE
fix(python): Remove redundant print statement in `assert_frame_schema_equal()`

### DIFF
--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -177,7 +177,6 @@ def _assert_frame_schema_equal(
     if check_dtypes:
         left_schema_dict, right_schema_dict = dict(left_schema), dict(right_schema)
         if check_column_order or left_schema_dict != right_schema_dict:
-            print(left_schema_dict, right_schema_dict)
             detail = "dtypes do not match"
             raise_assertion_error(objects, detail, left_schema_dict, right_schema_dict)
 


### PR DESCRIPTION
This does not resolve a particular issue. It is just a quick fix for a small error that I noticed while working on converting `assert_frame_equal()` from Python to Rust, supervised by @coastalwhite. I just ran an example and it still exists in the current iteration of `py-polars`.

There is a redundant `print()` statement before the `raise_assertion_error()` which essentially just prints the same exact information as the assertion error, resulting in output that looks like:

```python
{'a': Int64, 'b': Float64, 'c': String, 'd': Boolean} {'a': Float64, 'b': Float64, 'c': String, 'd': Int64}

Assertion Error: DataFrames are different (dtypes do not match)
[left]:  {'a': Int64, 'b': Float64, 'c': String, 'd': Boolean}
[right]: {'a': Float64, 'b': Float64, 'c': String, 'd': Int64}
```

Removal of the redundant `print()` statement would make the output shorter and remove duplicate information:

```python
Assertion Error: DataFrames are different (dtypes do not match)
[left]:  {'a': Int64, 'b': Float64, 'c': String, 'd': Boolean}
[right]: {'a': Float64, 'b': Float64, 'c': String, 'd': Int64}
```

It only occurs in that section of the `assert_frame_equal()` code source code. I am assuming it was just a left in debugging statement when the code was being written. 