### PR TITLE
feat: Highlight nodes in streaming phys plan graph

### DIFF
--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -43,7 +43,7 @@ impl NodeStyle {
         }
     }
 
-    /// Returns extra styling attributes (it any) for the graph node.
+    /// Returns extra styling attributes (if any) for the graph node.
     pub fn node_attrs(&self) -> Option<String> {
         match self {
             Self::InMemoryFallback => Some(format!(


### PR DESCRIPTION
This PR adds support for styling the nodes in the streaming physical plan graph and a legend.

Currently any in-memory engine fallback nodes are red,  potentially memory-intensive nodes are yellow.

![graph](https://github.com/user-attachments/assets/e2531858-abd4-498a-becc-1db2727e0dae)
