### PR TITLE
fix: Fix interpolate on dtype Decimal

### DIFF
--- a/py-polars/tests/unit/operations/test_interpolate.py
+++ b/py-polars/tests/unit/operations/test_interpolate.py
@@ -141,7 +141,7 @@ def test_interpolate_temporal_nearest(
 
 
 @pytest.mark.parametrize(
-    ("input", "scale", "method", "expected"),
+    ("input", "scale", "method", "output"),
     # note the lack of rounding (1.66 vs 1.67)
     [
         ([1.0, None, 3.0], 2, "linear", [1.0, 2.0, 3.0]),
@@ -151,12 +151,12 @@ def test_interpolate_temporal_nearest(
     ],
 )
 def test_interpolate_decimal_22475(
-    input: list[Any], scale: int, method: InterpolationMethod, expected: list[Any]
+    input: list[Any], scale: int, method: InterpolationMethod, output: list[Any]
 ) -> None:
     df = pl.DataFrame({"data": input})
     df_decimal = df.with_columns(pl.col("data").cast(pl.Decimal(scale=scale)))
     out = df_decimal.with_columns(pl.col("data").interpolate(method=method))
-    expected = pl.DataFrame({"data": expected}).with_columns(
+    expected = pl.DataFrame({"data": output}).with_columns(
         pl.col("data").cast(pl.Decimal(scale=2))
     )
     assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/operations/test_interpolate.py
+++ b/py-polars/tests/unit/operations/test_interpolate.py
@@ -10,7 +10,7 @@ from polars.testing import assert_frame_equal
 from tests.unit.conftest import NUMERIC_DTYPES
 
 if TYPE_CHECKING:
-    from polars._typing import PolarsDataType, PolarsTemporalType
+    from polars._typing import InterpolationMethod, PolarsDataType, PolarsTemporalType
 
 from zoneinfo import ZoneInfo
 
@@ -138,3 +138,25 @@ def test_interpolate_temporal_nearest(
     assert result.collect_schema()["a"] == input_dtype
     expected = pl.DataFrame({"a": output}, schema={"a": input_dtype})
     assert_frame_equal(result.collect(), expected)
+
+
+@pytest.mark.parametrize(
+    ("input", "scale", "method", "expected"),
+    # note the lack of rounding (1.66 vs 1.67)
+    [
+        ([1.0, None, 3.0], 2, "linear", [1.0, 2.0, 3.0]),
+        ([1.0, None, None, 2.0], 2, "linear", [1.0, 1.33, 1.66, 2.0]),
+        ([1.0, None, 3.0], 2, "nearest", [1.0, 3.0, 3.0]),
+        ([1.0, None, None, 2.0], 2, "nearest", [1.0, 1.0, 2.0, 2.0]),
+    ],
+)
+def test_interpolate_decimal_22475(
+    input: list[Any], scale: int, method: InterpolationMethod, expected: list[Any]
+) -> None:
+    df = pl.DataFrame({"data": input})
+    df_decimal = df.with_columns(pl.col("data").cast(pl.Decimal(scale=scale)))
+    out = df_decimal.with_columns(pl.col("data").interpolate(method=method))
+    expected = pl.DataFrame({"data": expected}).with_columns(
+        pl.col("data").cast(pl.Decimal(scale=2))
+    )
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
Fixes #22475. 

This includes `linear` and `nearest` methods.

Needs review. Consider:
* Return type is `Decimal`, not `f64`. Are we good with that?
* The interpolation is subject to accumulated precision gaps. See the test where interpolating `[1.0, None, None, 2.0]` returns `1.66` and not `1.67` for the second missing value. Below you can find an example edge case, e.g. when `step < 1` in physical and `n_steps` is high, see `signed_interp()` code. An alternative strategy would be to hold on to the Decimal type deeper into the implementation and/or update the algorithm (to be investigated).
* I was somehow expecting `cast()` to work similar to the other types but it doesn't - it casts an `Int128: 123` with `scale=2` to `123.00`. Most likely by design, still investigating.
* The use of unsafe code could be avoided by using `into_decimal()`, but I don't think that makes it better.

<details>
<summary>Example edge case details</summary>

```python
    df = pl.DataFrame({"data": [1, None, None, None, 3]})
    df_decimal = df.with_columns(pl.col("data").cast(pl.Decimal(scale=0)))
    print(df_decimal.with_columns(pl.col("data").interpolate()))
```
note how it is stuck on 1 as `step = 0` in this case
```
shape: (5, 1)
┌──────────────┐
│ data         │
│ ---          │
│ decimal[*,0] │
╞══════════════╡
│ 1            │
│ 1            │
│ 1            │
│ 1            │
│ 3            │
└──────────────┘
```
</details>
