### PR TITLE
chore(rust): Cleanup `polars-python` lifetimes

### DIFF
--- a/crates/polars-python/src/batched_csv.rs
+++ b/crates/polars-python/src/batched_csv.rs
@@ -135,7 +135,7 @@ impl PyBatchedCsv {
         })
     }
 
-    fn next_batches(&self, py: Python, n: usize) -> PyResult<Option<Vec<PyDataFrame>>> {
+    fn next_batches(&self, py: Python<'_>, n: usize) -> PyResult<Option<Vec<PyDataFrame>>> {
         let reader = &self.reader;
         let batches = py.enter_polars(move || reader.lock().unwrap().next_batches(n))?;
 

--- a/crates/polars-python/src/catalog/unity.rs
+++ b/crates/polars-python/src/catalog/unity.rs
@@ -84,7 +84,7 @@ impl PyCatalogClient {
     }
 
     #[pyo3(signature = (catalog_name))]
-    pub fn list_namespaces(&self, py: Python, catalog_name: &str) -> PyResult<PyObject> {
+    pub fn list_namespaces(&self, py: Python<'_>, catalog_name: &str) -> PyResult<PyObject> {
         let v = py.enter_polars(|| {
             pl_async::get_runtime().block_in_place_on(self.client().list_namespaces(catalog_name))
         })?;
@@ -113,7 +113,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (catalog_name, namespace))]
     pub fn list_tables(
         &self,
-        py: Python,
+        py: Python<'_>,
         catalog_name: &str,
         namespace: &str,
     ) -> PyResult<PyObject> {
@@ -147,7 +147,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (table_name, catalog_name, namespace))]
     pub fn get_table_info(
         &self,
-        py: Python,
+        py: Python<'_>,
         table_name: &str,
         catalog_name: &str,
         namespace: &str,
@@ -168,7 +168,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (table_id, write))]
     pub fn get_table_credentials(
         &self,
-        py: Python,
+        py: Python<'_>,
         table_id: &str,
         write: bool,
     ) -> PyResult<PyObject> {
@@ -235,7 +235,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (catalog_name, namespace, table_name, cloud_options, credential_provider, retries))]
     pub fn scan_table(
         &self,
-        py: Python,
+        py: Python<'_>,
         catalog_name: &str,
         namespace: &str,
         table_name: &str,
@@ -274,7 +274,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (catalog_name, comment, storage_root))]
     pub fn create_catalog(
         &self,
-        py: Python,
+        py: Python<'_>,
         catalog_name: &str,
         comment: Option<&str>,
         storage_root: Option<&str>,
@@ -293,7 +293,7 @@ impl PyCatalogClient {
     }
 
     #[pyo3(signature = (catalog_name, force))]
-    pub fn delete_catalog(&self, py: Python, catalog_name: &str, force: bool) -> PyResult<()> {
+    pub fn delete_catalog(&self, py: Python<'_>, catalog_name: &str, force: bool) -> PyResult<()> {
         py.allow_threads(|| {
             pl_async::get_runtime()
                 .block_in_place_on(self.client().delete_catalog(catalog_name, force))
@@ -304,7 +304,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (catalog_name, namespace, comment, storage_root))]
     pub fn create_namespace(
         &self,
-        py: Python,
+        py: Python<'_>,
         catalog_name: &str,
         namespace: &str,
         comment: Option<&str>,
@@ -327,7 +327,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (catalog_name, namespace, force))]
     pub fn delete_namespace(
         &self,
-        py: Python,
+        py: Python<'_>,
         catalog_name: &str,
         namespace: &str,
         force: bool,
@@ -348,7 +348,7 @@ impl PyCatalogClient {
     ))]
     pub fn create_table(
         &self,
-        py: Python,
+        py: Python<'_>,
         catalog_name: &str,
         namespace: &str,
         table_name: &str,
@@ -388,7 +388,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (catalog_name, namespace, table_name))]
     pub fn delete_table(
         &self,
-        py: Python,
+        py: Python<'_>,
         catalog_name: &str,
         namespace: &str,
         table_name: &str,
@@ -405,7 +405,7 @@ impl PyCatalogClient {
 
     #[pyo3(signature = (type_json))]
     #[staticmethod]
-    pub fn type_json_to_polars_type(py: Python, type_json: &str) -> PyResult<PyObject> {
+    pub fn type_json_to_polars_type(py: Python<'_>, type_json: &str) -> PyResult<PyObject> {
         Ok(Wrap(parse_type_json_str(type_json).map_err(to_py_err)?)
             .into_pyobject(py)?
             .unbind())
@@ -414,7 +414,7 @@ impl PyCatalogClient {
     #[pyo3(signature = (catalog_info_cls, namespace_info_cls, table_info_cls, column_info_cls))]
     #[staticmethod]
     pub fn init_classes(
-        py: Python,
+        py: Python<'_>,
         catalog_info_cls: Py<PyAny>,
         namespace_info_cls: Py<PyAny>,
         table_info_cls: Py<PyAny>,
@@ -434,7 +434,7 @@ impl PyCatalogClient {
 }
 
 fn catalog_info_to_pyobject(
-    py: Python,
+    py: Python<'_>,
     CatalogInfo {
         name,
         comment,
@@ -472,7 +472,7 @@ fn catalog_info_to_pyobject(
 }
 
 fn namespace_info_to_pyobject(
-    py: Python,
+    py: Python<'_>,
     NamespaceInfo {
         name,
         comment,
@@ -506,7 +506,7 @@ fn namespace_info_to_pyobject(
         .call((), Some(&dict))
 }
 
-fn table_info_to_pyobject(py: Python, table_info: TableInfo) -> PyResult<Bound<'_, PyAny>> {
+fn table_info_to_pyobject(py: Python<'_>, table_info: TableInfo) -> PyResult<Bound<'_, PyAny>> {
     let TableInfo {
         name,
         table_id,
@@ -590,7 +590,7 @@ fn table_info_to_pyobject(py: Python, table_info: TableInfo) -> PyResult<Bound<'
 }
 
 fn properties_to_pyobject(
-    py: Python,
+    py: Python<'_>,
     properties: PlHashMap<PlSmallStr, String>,
 ) -> Bound<'_, PyDict> {
     let dict = PyDict::new(py);

--- a/crates/polars-python/src/cloud.rs
+++ b/crates/polars-python/src/cloud.rs
@@ -57,7 +57,7 @@ pub fn _execute_ir_plan_with_gpu(ir_plan_ser: Vec<u8>, py: Python) -> PyResult<P
 
 /// Prepare the IR for execution by the Polars GPU engine.
 fn gpu_post_opt(
-    py: Python,
+    py: Python<'_>,
     root: Node,
     lp_arena: &mut Arena<IR>,
     expr_arena: &mut Arena<AExpr>,

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -112,21 +112,21 @@ pub(crate) fn get_series(obj: &Bound<'_, PyAny>) -> PyResult<Series> {
     Ok(s.extract::<PySeries>()?.series)
 }
 
-pub(crate) fn to_series(py: Python, s: PySeries) -> PyResult<Bound<PyAny>> {
+pub(crate) fn to_series(py: Python<'_>, s: PySeries) -> PyResult<Bound<PyAny>> {
     let series = pl_series(py).bind(py);
     let constructor = series.getattr(intern!(py, "_from_pyseries"))?;
     constructor.call1((s,))
 }
 
-impl<'a> FromPyObject<'a> for Wrap<PlSmallStr> {
-    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<PlSmallStr> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         Ok(Wrap((&*ob.extract::<PyBackedStr>()?).into()))
     }
 }
 
 #[cfg(feature = "csv")]
-impl<'a> FromPyObject<'a> for Wrap<NullValues> {
-    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<NullValues> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         if let Ok(s) = ob.extract::<PyBackedStr>() {
             Ok(Wrap(NullValues::AllColumnsSingle((&*s).into())))
         } else if let Ok(s) = ob.extract::<Vec<PyBackedStr>>() {
@@ -148,7 +148,7 @@ impl<'a> FromPyObject<'a> for Wrap<NullValues> {
     }
 }
 
-fn struct_dict<'py, 'a>(
+fn struct_dict<'a, 'py>(
     py: Python<'py>,
     vals: impl Iterator<Item = AnyValue<'a>>,
     flds: &[Field],
@@ -495,8 +495,8 @@ impl<'py> IntoPyObject<'py> for Wrap<TimeUnit> {
 }
 
 #[cfg(feature = "parquet")]
-impl<'s> FromPyObject<'s> for Wrap<StatisticsOptions> {
-    fn extract_bound(ob: &Bound<'s, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for Wrap<StatisticsOptions> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let mut statistics = StatisticsOptions::empty();
 
         let dict = ob.downcast::<PyDict>()?;
@@ -521,9 +521,9 @@ impl<'s> FromPyObject<'s> for Wrap<StatisticsOptions> {
     }
 }
 
-impl<'s> FromPyObject<'s> for Wrap<Row<'s>> {
-    fn extract_bound(ob: &Bound<'s, PyAny>) -> PyResult<Self> {
-        let vals = ob.extract::<Vec<Wrap<AnyValue<'s>>>>()?;
+impl<'py> FromPyObject<'py> for Wrap<Row<'static>> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let vals = ob.extract::<Vec<Wrap<AnyValue<'static>>>>()?;
         let vals = reinterpret_vec(vals);
         Ok(Wrap(Row(vals)))
     }
@@ -694,8 +694,8 @@ impl From<PyObject> for ObjectValue {
     }
 }
 
-impl<'a> FromPyObject<'a> for ObjectValue {
-    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for ObjectValue {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         Ok(ObjectValue {
             inner: ob.to_owned().unbind(),
         })
@@ -728,8 +728,8 @@ impl Default for ObjectValue {
     }
 }
 
-impl<'a, T: NativeType + FromPyObject<'a>> FromPyObject<'a> for Wrap<Vec<T>> {
-    fn extract_bound(obj: &Bound<'a, PyAny>) -> PyResult<Self> {
+impl<'py, T: NativeType + FromPyObject<'py>> FromPyObject<'py> for Wrap<Vec<T>> {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         let seq = obj.downcast::<PySequence>()?;
         let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
         for item in seq.try_iter()? {
@@ -1465,8 +1465,8 @@ where
 #[derive(Debug, Copy, Clone)]
 pub struct PyCompatLevel(pub CompatLevel);
 
-impl<'a> FromPyObject<'a> for PyCompatLevel {
-    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for PyCompatLevel {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         Ok(PyCompatLevel(if let Ok(level) = ob.extract::<u16>() {
             if let Ok(compat_level) = CompatLevel::with_level(level) {
                 compat_level

--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -15,7 +15,7 @@ impl PyDataFrame {
     #[staticmethod]
     #[pyo3(signature = (data, schema=None, infer_schema_length=None))]
     pub fn from_rows(
-        py: Python,
+        py: Python<'_>,
         data: Vec<Wrap<Row>>,
         schema: Option<Wrap<Schema>>,
         infer_schema_length: Option<usize>,
@@ -28,7 +28,7 @@ impl PyDataFrame {
     #[staticmethod]
     #[pyo3(signature = (data, schema=None, schema_overrides=None, strict=true, infer_schema_length=None))]
     pub fn from_dicts(
-        py: Python,
+        py: Python<'_>,
         data: &Bound<PyAny>,
         schema: Option<Wrap<Schema>>,
         schema_overrides: Option<Wrap<Schema>>,
@@ -72,7 +72,7 @@ impl PyDataFrame {
 
     #[staticmethod]
     pub fn from_arrow_record_batches(
-        py: Python,
+        py: Python<'_>,
         rb: Vec<Bound<PyAny>>,
         schema: Bound<PyAny>,
     ) -> PyResult<Self> {
@@ -161,11 +161,11 @@ where
     Schema::from_iter(fields)
 }
 
-fn dicts_to_rows<'a>(
-    data: &Bound<'a, PyAny>,
-    names: &'a [String],
+fn dicts_to_rows(
+    data: &Bound<'_, PyAny>,
+    names: &[String],
     strict: bool,
-) -> PyResult<Vec<Row<'a>>> {
+) -> PyResult<Vec<Row<'static>>> {
     let py = data.py();
     let mut rows = Vec::with_capacity(data.len()?);
     let null_row = Row::new(vec![AnyValue::Null; names.len()]);
@@ -193,11 +193,11 @@ fn dicts_to_rows<'a>(
     Ok(rows)
 }
 
-fn mappings_to_rows<'a>(
-    data: &Bound<'a, PyAny>,
-    names: &'a [String],
+fn mappings_to_rows(
+    data: &Bound<'_, PyAny>,
+    names: &[String],
     strict: bool,
-) -> PyResult<Vec<Row<'a>>> {
+) -> PyResult<Vec<Row<'static>>> {
     let py = data.py();
     let mut rows = Vec::with_capacity(data.len()?);
     let null_row = Row::new(vec![AnyValue::Null; names.len()]);

--- a/crates/polars-python/src/dataframe/export.rs
+++ b/crates/polars-python/src/dataframe/export.rs
@@ -74,7 +74,11 @@ impl PyDataFrame {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_arrow(&mut self, py: Python, compat_level: PyCompatLevel) -> PyResult<Vec<PyObject>> {
+    pub fn to_arrow(
+        &mut self,
+        py: Python<'_>,
+        compat_level: PyCompatLevel,
+    ) -> PyResult<Vec<PyObject>> {
         py.enter_polars_ok(|| self.df.align_chunks_par())?;
         let pyarrow = py.import("pyarrow")?;
 
@@ -160,7 +164,7 @@ impl PyDataFrame {
     #[allow(unused_variables)]
     #[pyo3(signature = (requested_schema=None))]
     fn __arrow_c_stream__<'py>(
-        &'py mut self,
+        &mut self,
         py: Python<'py>,
         requested_schema: Option<PyObject>,
     ) -> PyResult<Bound<'py, PyCapsule>> {

--- a/crates/polars-python/src/dataframe/general.rs
+++ b/crates/polars-python/src/dataframe/general.rs
@@ -49,50 +49,50 @@ impl PyDataFrame {
             .collect()
     }
 
-    pub fn add(&self, py: Python, s: &PySeries) -> PyResult<Self> {
+    pub fn add(&self, py: Python<'_>, s: &PySeries) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df + &s.series)
     }
 
-    pub fn sub(&self, py: Python, s: &PySeries) -> PyResult<Self> {
+    pub fn sub(&self, py: Python<'_>, s: &PySeries) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df - &s.series)
     }
 
-    pub fn mul(&self, py: Python, s: &PySeries) -> PyResult<Self> {
+    pub fn mul(&self, py: Python<'_>, s: &PySeries) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df * &s.series)
     }
 
-    pub fn div(&self, py: Python, s: &PySeries) -> PyResult<Self> {
+    pub fn div(&self, py: Python<'_>, s: &PySeries) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df / &s.series)
     }
 
-    pub fn rem(&self, py: Python, s: &PySeries) -> PyResult<Self> {
+    pub fn rem(&self, py: Python<'_>, s: &PySeries) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df % &s.series)
     }
 
-    pub fn add_df(&self, py: Python, s: &Self) -> PyResult<Self> {
+    pub fn add_df(&self, py: Python<'_>, s: &Self) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df + &s.df)
     }
 
-    pub fn sub_df(&self, py: Python, s: &Self) -> PyResult<Self> {
+    pub fn sub_df(&self, py: Python<'_>, s: &Self) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df - &s.df)
     }
 
-    pub fn mul_df(&self, py: Python, s: &Self) -> PyResult<Self> {
+    pub fn mul_df(&self, py: Python<'_>, s: &Self) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df * &s.df)
     }
 
-    pub fn div_df(&self, py: Python, s: &Self) -> PyResult<Self> {
+    pub fn div_df(&self, py: Python<'_>, s: &Self) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df / &s.df)
     }
 
-    pub fn rem_df(&self, py: Python, s: &Self) -> PyResult<Self> {
+    pub fn rem_df(&self, py: Python<'_>, s: &Self) -> PyResult<Self> {
         py.enter_polars_df(|| &self.df % &s.df)
     }
 
     #[pyo3(signature = (n, with_replacement, shuffle, seed=None))]
     pub fn sample_n(
         &self,
-        py: Python,
+        py: Python<'_>,
         n: &PySeries,
         with_replacement: bool,
         shuffle: bool,
@@ -104,7 +104,7 @@ impl PyDataFrame {
     #[pyo3(signature = (frac, with_replacement, shuffle, seed=None))]
     pub fn sample_frac(
         &self,
-        py: Python,
+        py: Python<'_>,
         frac: &PySeries,
         with_replacement: bool,
         shuffle: bool,
@@ -176,14 +176,14 @@ impl PyDataFrame {
         self.df.is_empty()
     }
 
-    pub fn hstack(&self, py: Python, columns: Vec<PySeries>) -> PyResult<Self> {
+    pub fn hstack(&self, py: Python<'_>, columns: Vec<PySeries>) -> PyResult<Self> {
         let columns = columns.to_series();
         // @scalar-opt
         let columns = columns.into_iter().map(Into::into).collect::<Vec<_>>();
         py.enter_polars_df(|| self.df.hstack(&columns))
     }
 
-    pub fn hstack_mut(&mut self, py: Python, columns: Vec<PySeries>) -> PyResult<()> {
+    pub fn hstack_mut(&mut self, py: Python<'_>, columns: Vec<PySeries>) -> PyResult<()> {
         let columns = columns.to_series();
         // @scalar-opt
         let columns = columns.into_iter().map(Into::into).collect::<Vec<_>>();
@@ -191,16 +191,16 @@ impl PyDataFrame {
         Ok(())
     }
 
-    pub fn vstack(&self, py: Python, other: &PyDataFrame) -> PyResult<Self> {
+    pub fn vstack(&self, py: Python<'_>, other: &PyDataFrame) -> PyResult<Self> {
         py.enter_polars_df(|| self.df.vstack(&other.df))
     }
 
-    pub fn vstack_mut(&mut self, py: Python, other: &PyDataFrame) -> PyResult<()> {
+    pub fn vstack_mut(&mut self, py: Python<'_>, other: &PyDataFrame) -> PyResult<()> {
         py.enter_polars(|| self.df.vstack_mut(&other.df))?;
         Ok(())
     }
 
-    pub fn extend(&mut self, py: Python, other: &PyDataFrame) -> PyResult<()> {
+    pub fn extend(&mut self, py: Python<'_>, other: &PyDataFrame) -> PyResult<()> {
         py.enter_polars(|| self.df.extend(&other.df))?;
         Ok(())
     }
@@ -245,17 +245,17 @@ impl PyDataFrame {
         Ok(series)
     }
 
-    pub fn select(&self, py: Python, columns: Vec<PyBackedStr>) -> PyResult<Self> {
+    pub fn select(&self, py: Python<'_>, columns: Vec<PyBackedStr>) -> PyResult<Self> {
         py.enter_polars_df(|| self.df.select(columns.iter().map(|x| &**x)))
     }
 
-    pub fn gather(&self, py: Python, indices: Wrap<Vec<IdxSize>>) -> PyResult<Self> {
+    pub fn gather(&self, py: Python<'_>, indices: Wrap<Vec<IdxSize>>) -> PyResult<Self> {
         let indices = indices.0;
         let indices = IdxCa::from_vec("".into(), indices);
         py.enter_polars_df(|| self.df.take(&indices))
     }
 
-    pub fn gather_with_series(&self, py: Python, indices: &PySeries) -> PyResult<Self> {
+    pub fn gather_with_series(&self, py: Python<'_>, indices: &PySeries) -> PyResult<Self> {
         let indices = indices.series.idx().map_err(PyPolarsErr::from)?;
         py.enter_polars_df(|| self.df.take(indices))
     }
@@ -282,7 +282,7 @@ impl PyDataFrame {
     }
 
     #[pyo3(signature = (offset, length=None))]
-    pub fn slice(&self, py: Python, offset: i64, length: Option<usize>) -> PyResult<Self> {
+    pub fn slice(&self, py: Python<'_>, offset: i64, length: Option<usize>) -> PyResult<Self> {
         py.enter_polars_df(|| {
             Ok(self
                 .df
@@ -290,11 +290,11 @@ impl PyDataFrame {
         })
     }
 
-    pub fn head(&self, py: Python, n: usize) -> PyResult<Self> {
+    pub fn head(&self, py: Python<'_>, n: usize) -> PyResult<Self> {
         py.enter_polars_df(|| Ok(self.df.head(Some(n))))
     }
 
-    pub fn tail(&self, py: Python, n: usize) -> PyResult<Self> {
+    pub fn tail(&self, py: Python<'_>, n: usize) -> PyResult<Self> {
         py.enter_polars_df(|| Ok(self.df.tail(Some(n))))
     }
 
@@ -306,7 +306,7 @@ impl PyDataFrame {
         py.enter_polars_series(|| self.df.is_duplicated())
     }
 
-    pub fn equals(&self, py: Python, other: &PyDataFrame, null_equal: bool) -> PyResult<bool> {
+    pub fn equals(&self, py: Python<'_>, other: &PyDataFrame, null_equal: bool) -> PyResult<bool> {
         if null_equal {
             py.enter_polars_ok(|| self.df.equals_missing(&other.df))
         } else {
@@ -317,7 +317,7 @@ impl PyDataFrame {
     #[pyo3(signature = (name, offset=None))]
     pub fn with_row_index(
         &self,
-        py: Python,
+        py: Python<'_>,
         name: &str,
         offset: Option<IdxSize>,
     ) -> PyResult<Self> {
@@ -381,7 +381,7 @@ impl PyDataFrame {
     #[pyo3(signature = (on, index, value_name=None, variable_name=None))]
     pub fn unpivot(
         &self,
-        py: Python,
+        py: Python<'_>,
         on: Vec<PyBackedStr>,
         index: Vec<PyBackedStr>,
         value_name: Option<&str>,
@@ -402,7 +402,7 @@ impl PyDataFrame {
     #[pyo3(signature = (on, index, values, maintain_order, sort_columns, aggregate_expr, separator))]
     pub fn pivot_expr(
         &self,
-        py: Python,
+        py: Python<'_>,
         on: Vec<String>,
         index: Option<Vec<String>>,
         values: Option<Vec<String>>,
@@ -428,7 +428,7 @@ impl PyDataFrame {
 
     pub fn partition_by(
         &self,
-        py: Python,
+        py: Python<'_>,
         by: Vec<String>,
         maintain_order: bool,
         include_key: bool,
@@ -452,7 +452,7 @@ impl PyDataFrame {
     #[pyo3(signature = (columns, separator, drop_first=false))]
     pub fn to_dummies(
         &self,
-        py: Python,
+        py: Python<'_>,
         columns: Option<Vec<String>>,
         separator: Option<&str>,
         drop_first: bool,
@@ -509,7 +509,7 @@ impl PyDataFrame {
 
     pub fn hash_rows(
         &mut self,
-        py: Python,
+        py: Python<'_>,
         k0: u64,
         k1: u64,
         k2: u64,
@@ -524,7 +524,7 @@ impl PyDataFrame {
     #[pyo3(signature = (keep_names_as, column_names))]
     pub fn transpose(
         &mut self,
-        py: Python,
+        py: Python<'_>,
         keep_names_as: Option<&str>,
         column_names: &Bound<PyAny>,
     ) -> PyResult<Self> {
@@ -540,7 +540,7 @@ impl PyDataFrame {
 
     pub fn upsample(
         &self,
-        py: Python,
+        py: Python<'_>,
         by: Vec<String>,
         index_column: &str,
         every: &str,
@@ -558,7 +558,7 @@ impl PyDataFrame {
 
     pub fn to_struct(
         &self,
-        py: Python,
+        py: Python<'_>,
         name: &str,
         invalid_indices: Vec<usize>,
     ) -> PyResult<PySeries> {
@@ -622,11 +622,7 @@ impl PyDataFrame {
 
     /// Internal utility function to allow direct access to the row encoding from python.
     #[pyo3(signature = (opts))]
-    fn _row_encode<'py>(
-        &'py self,
-        py: Python<'py>,
-        opts: Vec<(bool, bool, bool)>,
-    ) -> PyResult<PySeries> {
+    fn _row_encode(&self, py: Python<'_>, opts: Vec<(bool, bool, bool)>) -> PyResult<PySeries> {
         py.enter_polars_series(|| {
             let name = PlSmallStr::from_static("row_enc");
             let is_unordered = opts.first().is_some_and(|(_, _, v)| *v);

--- a/crates/polars-python/src/dataframe/io.rs
+++ b/crates/polars-python/src/dataframe/io.rs
@@ -30,7 +30,7 @@ impl PyDataFrame {
     row_index, eol_char, raise_if_empty, truncate_ragged_lines, decimal_comma, schema)
 )]
     pub fn read_csv(
-        py: Python,
+        py: Python<'_>,
         py_f: Bound<PyAny>,
         infer_schema_length: Option<usize>,
         chunk_size: usize,
@@ -131,7 +131,7 @@ impl PyDataFrame {
     #[cfg(feature = "parquet")]
     #[pyo3(signature = (py_f, columns, projection, n_rows, row_index, low_memory, parallel, use_statistics, rechunk))]
     pub fn read_parquet(
-        py: Python,
+        py: Python<'_>,
         py_f: PyObject,
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
@@ -183,7 +183,7 @@ impl PyDataFrame {
     #[cfg(feature = "json")]
     #[pyo3(signature = (py_f, infer_schema_length, schema, schema_overrides))]
     pub fn read_json(
-        py: Python,
+        py: Python<'_>,
         py_f: Bound<PyAny>,
         infer_schema_length: Option<usize>,
         schema: Option<Wrap<Schema>>,
@@ -213,7 +213,7 @@ impl PyDataFrame {
     #[cfg(feature = "json")]
     #[pyo3(signature = (py_f, ignore_errors, schema, schema_overrides))]
     pub fn read_ndjson(
-        py: Python,
+        py: Python<'_>,
         py_f: Bound<PyAny>,
         ignore_errors: bool,
         schema: Option<Wrap<Schema>>,
@@ -240,7 +240,7 @@ impl PyDataFrame {
     #[cfg(feature = "ipc")]
     #[pyo3(signature = (py_f, columns, projection, n_rows, row_index, memory_map))]
     pub fn read_ipc(
-        py: Python,
+        py: Python<'_>,
         py_f: Bound<PyAny>,
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
@@ -270,7 +270,7 @@ impl PyDataFrame {
     #[cfg(feature = "ipc_streaming")]
     #[pyo3(signature = (py_f, columns, projection, n_rows, row_index, rechunk))]
     pub fn read_ipc_stream(
-        py: Python,
+        py: Python<'_>,
         py_f: Bound<PyAny>,
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
@@ -298,7 +298,7 @@ impl PyDataFrame {
     #[cfg(feature = "avro")]
     #[pyo3(signature = (py_f, columns, projection, n_rows))]
     pub fn read_avro(
-        py: Python,
+        py: Python<'_>,
         py_f: PyObject,
         columns: Option<Vec<String>>,
         projection: Option<Vec<usize>>,
@@ -317,7 +317,7 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "json")]
-    pub fn write_json(&mut self, py: Python, py_f: PyObject) -> PyResult<()> {
+    pub fn write_json(&mut self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
         py.enter_polars(|| {
             // TODO: Cloud support
@@ -331,7 +331,7 @@ impl PyDataFrame {
     #[cfg(feature = "ipc_streaming")]
     pub fn write_ipc_stream(
         &mut self,
-        py: Python,
+        py: Python<'_>,
         py_f: PyObject,
         compression: Wrap<Option<IpcCompression>>,
         compat_level: PyCompatLevel,
@@ -349,7 +349,7 @@ impl PyDataFrame {
     #[pyo3(signature = (py_f, compression, name))]
     pub fn write_avro(
         &mut self,
-        py: Python,
+        py: Python<'_>,
         py_f: PyObject,
         compression: Wrap<Option<AvroCompression>>,
         name: String,

--- a/crates/polars-python/src/dataframe/serde.rs
+++ b/crates/polars-python/src/dataframe/serde.rs
@@ -13,7 +13,7 @@ use crate::utils::EnterPolarsExt;
 #[pymethods]
 impl PyDataFrame {
     /// Serialize into binary data.
-    fn serialize_binary(&mut self, py: Python, py_f: PyObject) -> PyResult<()> {
+    fn serialize_binary(&mut self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let mut writer = BufWriter::new(file);
 
@@ -22,7 +22,7 @@ impl PyDataFrame {
 
     /// Deserialize a file-like object containing binary data into a DataFrame.
     #[staticmethod]
-    fn deserialize_binary(py: Python, py_f: PyObject) -> PyResult<Self> {
+    fn deserialize_binary(py: Python<'_>, py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let mut file = BufReader::new(file);
 
@@ -31,7 +31,7 @@ impl PyDataFrame {
 
     /// Serialize into a JSON string.
     #[cfg(feature = "json")]
-    pub fn serialize_json(&mut self, py: Python, py_f: PyObject) -> PyResult<()> {
+    pub fn serialize_json(&mut self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         py.enter_polars(|| {
@@ -43,7 +43,7 @@ impl PyDataFrame {
     /// Deserialize a file-like object containing JSON string data into a DataFrame.
     #[staticmethod]
     #[cfg(feature = "json")]
-    pub fn deserialize_json(py: Python, py_f: Bound<PyAny>) -> PyResult<Self> {
+    pub fn deserialize_json(py: Python<'_>, py_f: Bound<PyAny>) -> PyResult<Self> {
         let mut mmap_bytes_r = get_mmap_bytes_reader(&py_f)?;
 
         py.enter_polars(move || {

--- a/crates/polars-python/src/expr/general.rs
+++ b/crates/polars-python/src/expr/general.rs
@@ -946,7 +946,7 @@ impl PyExpr {
     }
 
     #[pyo3(signature = (schema))]
-    fn skip_batch_predicate(&self, py: Python, schema: Wrap<Schema>) -> PyResult<Option<Self>> {
+    fn skip_batch_predicate(&self, py: Python<'_>, schema: Wrap<Schema>) -> PyResult<Option<Self>> {
         let mut aexpr_arena = Arena::new();
         py.enter_polars(|| {
             let node = to_aexpr(self.inner.clone(), &mut aexpr_arena)?;

--- a/crates/polars-python/src/file.rs
+++ b/crates/polars-python/src/file.rs
@@ -268,7 +268,7 @@ pub(crate) enum PythonScanSourceInput {
 }
 
 pub(crate) fn try_get_pyfile(
-    py: Python,
+    py: Python<'_>,
     py_f: Bound<'_, PyAny>,
     write: bool,
 ) -> PyResult<(EitherRustPythonFile, Option<PathBuf>)> {

--- a/crates/polars-python/src/functions/io.rs
+++ b/crates/polars-python/src/functions/io.rs
@@ -14,7 +14,7 @@ use crate::prelude::ArrowDataType;
 
 #[cfg(feature = "ipc")]
 #[pyfunction]
-pub fn read_ipc_schema(py: Python, py_f: PyObject) -> PyResult<Bound<PyDict>> {
+pub fn read_ipc_schema(py: Python<'_>, py_f: PyObject) -> PyResult<Bound<PyDict>> {
     use arrow::io::ipc::read::read_file_metadata;
     let metadata = match get_either_file(py_f, false)? {
         EitherRustPythonFile::Rust(r) => {
@@ -30,7 +30,7 @@ pub fn read_ipc_schema(py: Python, py_f: PyObject) -> PyResult<Bound<PyDict>> {
 
 #[cfg(feature = "parquet")]
 #[pyfunction]
-pub fn read_parquet_schema(py: Python, py_f: PyObject) -> PyResult<Bound<PyDict>> {
+pub fn read_parquet_schema(py: Python<'_>, py_f: PyObject) -> PyResult<Bound<PyDict>> {
     use polars_parquet::read::{infer_schema, read_metadata};
 
     let metadata = match get_either_file(py_f, false)? {

--- a/crates/polars-python/src/functions/lazy.rs
+++ b/crates/polars-python/src/functions/lazy.rs
@@ -124,7 +124,7 @@ pub fn collect_all(
     lfs: Vec<PyLazyFrame>,
     engine: Wrap<Engine>,
     optflags: PyOptFlags,
-    py: Python,
+    py: Python<'_>,
 ) -> PyResult<Vec<PyDataFrame>> {
     let plans = lfs_to_plans(lfs);
     let dfs =
@@ -145,7 +145,7 @@ pub fn collect_all_with_callback(
     engine: Wrap<Engine>,
     optflags: PyOptFlags,
     lambda: PyObject,
-    py: Python,
+    py: Python<'_>,
 ) {
     let plans = lfs.into_iter().map(|lf| lf.ldf.logical_plan).collect();
     let result = py
@@ -514,7 +514,7 @@ pub fn lit(value: &Bound<'_, PyAny>, allow_object: bool, is_scalar: bool) -> PyR
 #[pyfunction]
 #[pyo3(signature = (pyexpr, lambda, output_type, map_groups, returns_scalar))]
 pub fn map_mul(
-    py: Python,
+    py: Python<'_>,
     pyexpr: Vec<PyExpr>,
     lambda: PyObject,
     output_type: Option<Wrap<DataType>>,

--- a/crates/polars-python/src/functions/range.rs
+++ b/crates/polars-python/src/functions/range.rs
@@ -19,7 +19,7 @@ pub fn int_range(start: PyExpr, end: PyExpr, step: i64, dtype: Wrap<DataType>) -
 /// Eager version of `int_range` to avoid overhead from the expression engine.
 #[pyfunction]
 pub fn eager_int_range(
-    py: Python,
+    py: Python<'_>,
     lower: &Bound<'_, PyAny>,
     upper: &Bound<'_, PyAny>,
     step: &Bound<'_, PyAny>,

--- a/crates/polars-python/src/interop/arrow/to_py.rs
+++ b/crates/polars-python/src/interop/arrow/to_py.rs
@@ -36,7 +36,7 @@ pub(crate) fn to_py_array(
 /// RecordBatch to Python.
 pub(crate) fn to_py_rb(
     rb: &RecordBatch,
-    py: Python,
+    py: Python<'_>,
     pyarrow: &Bound<PyModule>,
 ) -> PyResult<PyObject> {
     let mut arrays = Vec::with_capacity(rb.width());
@@ -67,7 +67,7 @@ pub(crate) fn to_py_rb(
 /// Export a series to a C stream via a PyCapsule according to the Arrow PyCapsule Interface
 /// https://arrow.apache.org/docs/dev/format/CDataInterface/PyCapsuleInterface.html
 pub(crate) fn series_to_stream<'py>(
-    series: &'py Series,
+    series: &Series,
     py: Python<'py>,
 ) -> PyResult<Bound<'py, PyCapsule>> {
     let field = series.field().to_arrow(CompatLevel::newest());
@@ -78,7 +78,7 @@ pub(crate) fn series_to_stream<'py>(
 }
 
 pub(crate) fn dataframe_to_stream<'py>(
-    df: &'py DataFrame,
+    df: &DataFrame,
     py: Python<'py>,
 ) -> PyResult<Bound<'py, PyCapsule>> {
     let iter = Box::new(DataFrameStreamIterator::new(df));

--- a/crates/polars-python/src/interop/arrow/to_rust.rs
+++ b/crates/polars-python/src/interop/arrow/to_rust.rs
@@ -93,7 +93,11 @@ pub fn array_to_rust(obj: &Bound<PyAny>) -> PyResult<ArrayRef> {
     }
 }
 
-pub fn to_rust_df(py: Python, rb: &[Bound<PyAny>], schema: Bound<PyAny>) -> PyResult<DataFrame> {
+pub fn to_rust_df(
+    py: Python<'_>,
+    rb: &[Bound<PyAny>],
+    schema: Bound<PyAny>,
+) -> PyResult<DataFrame> {
     let ArrowDataType::Struct(fields) = field_to_rust_arrow(schema)?.dtype else {
         return Err(PyPolarsErr::Other("invalid top-level schema".into()).into());
     };

--- a/crates/polars-python/src/interop/numpy/to_numpy_df.rs
+++ b/crates/polars-python/src/interop/numpy/to_numpy_df.rs
@@ -21,7 +21,7 @@ impl PyDataFrame {
     /// Convert this DataFrame to a NumPy ndarray.
     fn to_numpy(
         &self,
-        py: Python,
+        py: Python<'_>,
         order: Wrap<IndexOrder>,
         writable: bool,
         allow_copy: bool,
@@ -31,7 +31,7 @@ impl PyDataFrame {
 }
 
 pub(super) fn df_to_numpy(
-    py: Python,
+    py: Python<'_>,
     df: &DataFrame,
     order: IndexOrder,
     writable: bool,
@@ -67,7 +67,7 @@ pub(super) fn df_to_numpy(
 }
 
 /// Create a NumPy view of the given DataFrame.
-fn try_df_to_numpy_view(py: Python, df: &DataFrame, allow_nulls: bool) -> Option<PyObject> {
+fn try_df_to_numpy_view(py: Python<'_>, df: &DataFrame, allow_nulls: bool) -> Option<PyObject> {
     let first_dtype = check_df_dtypes_support_view(df)?;
 
     // TODO: Check for nested nulls using `series_contains_null` util when we support Array types.
@@ -172,7 +172,7 @@ where
 }
 
 /// Create a NumPy view of a numeric DataFrame.
-fn numeric_df_to_numpy_view<T>(py: Python, df: &DataFrame, owner: PyObject) -> PyObject
+fn numeric_df_to_numpy_view<T>(py: Python<'_>, df: &DataFrame, owner: PyObject) -> PyObject
 where
     T: PolarsNumericType,
     T::Native: Element,
@@ -202,7 +202,7 @@ where
     }
 }
 /// Create a NumPy view of a Datetime or Duration DataFrame.
-fn temporal_df_to_numpy_view(py: Python, df: &DataFrame, owner: PyObject) -> PyObject {
+fn temporal_df_to_numpy_view(py: Python<'_>, df: &DataFrame, owner: PyObject) -> PyObject {
     let s = df.get_columns().first().unwrap();
     let phys = s.to_physical_repr();
     let ca = phys.i64().unwrap();
@@ -225,7 +225,7 @@ fn temporal_df_to_numpy_view(py: Python, df: &DataFrame, owner: PyObject) -> PyO
 }
 
 fn df_to_numpy_with_copy(
-    py: Python,
+    py: Python<'_>,
     df: &DataFrame,
     order: IndexOrder,
     writable: bool,
@@ -237,7 +237,7 @@ fn df_to_numpy_with_copy(
     }
 }
 fn try_df_to_numpy_numeric_supertype(
-    py: Python,
+    py: Python<'_>,
     df: &DataFrame,
     order: IndexOrder,
 ) -> Option<PyObject> {
@@ -253,7 +253,7 @@ fn try_df_to_numpy_numeric_supertype(
 }
 
 fn df_columns_to_numpy(
-    py: Python,
+    py: Python<'_>,
     df: &DataFrame,
     order: IndexOrder,
     writable: bool,

--- a/crates/polars-python/src/interop/numpy/utils.rs
+++ b/crates/polars-python/src/interop/numpy/utils.rs
@@ -11,7 +11,7 @@ use pyo3::types::PyTuple;
 
 /// Create a NumPy ndarray view of the data.
 pub(super) unsafe fn create_borrowed_np_array<I>(
-    py: Python,
+    py: Python<'_>,
     dtype: Bound<PyArrayDescr>,
     mut shape: Dim<I>,
     flags: c_int,
@@ -71,7 +71,7 @@ pub(super) fn series_contains_null(s: &Series) -> bool {
 
 /// Reshape the first dimension of a NumPy array to the given height and width.
 pub(super) fn reshape_numpy_array(
-    py: Python,
+    py: Python<'_>,
     arr: PyObject,
     height: usize,
     width: usize,
@@ -95,10 +95,10 @@ pub(super) fn reshape_numpy_array(
 }
 
 /// Get the NumPy temporal data type associated with the given Polars [`DataType`].
-pub(super) fn polars_dtype_to_np_temporal_dtype<'a>(
-    py: Python<'a>,
+pub(super) fn polars_dtype_to_np_temporal_dtype<'py>(
+    py: Python<'py>,
     dtype: &DataType,
-) -> Bound<'a, PyArrayDescr> {
+) -> Bound<'py, PyArrayDescr> {
     use numpy::datetime::{Datetime, Timedelta, units};
     match dtype {
         DataType::Datetime(TimeUnit::Milliseconds, _) => {

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -578,7 +578,7 @@ impl PyLazyFrame {
         py.enter_polars(|| self.ldf.describe_optimized_plan_tree())
     }
 
-    fn to_dot(&self, py: Python, optimized: bool) -> PyResult<String> {
+    fn to_dot(&self, py: Python<'_>, optimized: bool) -> PyResult<String> {
         py.enter_polars(|| self.ldf.to_dot(optimized))
     }
 
@@ -717,7 +717,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (lambda_post_opt=None))]
     fn profile(
         &self,
-        py: Python,
+        py: Python<'_>,
         lambda_post_opt: Option<PyObject>,
     ) -> PyResult<(PyDataFrame, PyDataFrame)> {
         let (df, time_df) = py.enter_polars(|| {
@@ -736,7 +736,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (engine, lambda_post_opt=None))]
     fn collect(
         &self,
-        py: Python,
+        py: Python<'_>,
         engine: Wrap<Engine>,
         lambda_post_opt: Option<PyObject>,
     ) -> PyResult<PyDataFrame> {
@@ -755,7 +755,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (engine, lambda))]
     fn collect_with_callback(
         &self,
-        py: Python,
+        py: Python<'_>,
         engine: Wrap<Engine>,
         lambda: PyObject,
     ) -> PyResult<()> {
@@ -790,7 +790,7 @@ impl PyLazyFrame {
     ))]
     fn sink_parquet(
         &self,
-        py: Python,
+        py: Python<'_>,
         target: SinkTarget,
         compression: &str,
         compression_level: Option<i32>,
@@ -860,7 +860,7 @@ impl PyLazyFrame {
     ))]
     fn sink_ipc(
         &self,
-        py: Python,
+        py: Python<'_>,
         target: SinkTarget,
         compression: Wrap<Option<IpcCompression>>,
         compat_level: PyCompatLevel,
@@ -924,7 +924,7 @@ impl PyLazyFrame {
     ))]
     fn sink_csv(
         &self,
-        py: Python,
+        py: Python<'_>,
         target: SinkTarget,
         include_bom: bool,
         include_header: bool,
@@ -1013,7 +1013,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (target, cloud_options, credential_provider, retries, sink_options))]
     fn sink_json(
         &self,
-        py: Python,
+        py: Python<'_>,
         target: SinkTarget,
         cloud_options: Option<Vec<(String, String)>>,
         credential_provider: Option<PyObject>,
@@ -1059,7 +1059,7 @@ impl PyLazyFrame {
         .map_err(Into::into)
     }
 
-    fn fetch(&self, py: Python, n_rows: usize) -> PyResult<PyDataFrame> {
+    fn fetch(&self, py: Python<'_>, n_rows: usize) -> PyResult<PyDataFrame> {
         let ldf = self.ldf.clone();
         py.enter_polars_df(|| ldf.fetch(n_rows))
     }

--- a/crates/polars-python/src/lazyframe/serde.rs
+++ b/crates/polars-python/src/lazyframe/serde.rs
@@ -12,7 +12,7 @@ use crate::utils::EnterPolarsExt;
 #[allow(clippy::should_implement_trait)]
 impl PyLazyFrame {
     /// Serialize into binary data.
-    fn serialize_binary(&self, py: Python, py_f: PyObject) -> PyResult<()> {
+    fn serialize_binary(&self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         py.enter_polars(|| self.ldf.logical_plan.serialize_versioned(writer))
@@ -20,7 +20,7 @@ impl PyLazyFrame {
 
     /// Serialize into a JSON string.
     #[cfg(feature = "json")]
-    fn serialize_json(&self, py: Python, py_f: PyObject) -> PyResult<()> {
+    fn serialize_json(&self, py: Python<'_>, py_f: PyObject) -> PyResult<()> {
         let file = get_file_like(py_f, true)?;
         let writer = BufWriter::new(file);
         py.enter_polars(|| {
@@ -31,7 +31,7 @@ impl PyLazyFrame {
 
     /// Deserialize a file-like object containing binary data into a LazyFrame.
     #[staticmethod]
-    fn deserialize_binary(py: Python, py_f: PyObject) -> PyResult<Self> {
+    fn deserialize_binary(py: Python<'_>, py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let reader = BufReader::new(file);
 
@@ -42,7 +42,7 @@ impl PyLazyFrame {
     /// Deserialize a file-like object containing JSON string data into a LazyFrame.
     #[staticmethod]
     #[cfg(feature = "json")]
-    fn deserialize_json(py: Python, py_f: PyObject) -> PyResult<Self> {
+    fn deserialize_json(py: Python<'_>, py_f: PyObject) -> PyResult<Self> {
         // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
         // so don't bother with files.
         let mut json = String::new();

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -16,7 +16,7 @@ use crate::PyDataFrame;
 use crate::lazyframe::visit::PyExprIR;
 
 fn scan_type_to_pyobject(
-    py: Python,
+    py: Python<'_>,
     scan_type: &FileScan,
     cloud_options: &Option<CloudOptions>,
 ) -> PyResult<PyObject> {

--- a/crates/polars-python/src/map/dataframe.rs
+++ b/crates/polars-python/src/map/dataframe.rs
@@ -27,10 +27,10 @@ fn get_iters_skip(df: &DataFrame, n: usize) -> Vec<std::iter::Skip<SeriesIter>> 
 }
 
 // the return type is Union[PySeries, PyDataFrame] and a boolean indicating if it is a dataframe or not
-pub fn apply_lambda_unknown<'a>(
-    df: &'a DataFrame,
-    py: Python<'a>,
-    lambda: Bound<'a, PyAny>,
+pub fn apply_lambda_unknown<'py>(
+    df: &DataFrame,
+    py: Python<'py>,
+    lambda: Bound<'py, PyAny>,
     inference_size: usize,
 ) -> PyResult<(PyObject, bool)> {
     let mut null_count = 0;
@@ -109,8 +109,8 @@ pub fn apply_lambda_unknown<'a>(
                 .into_py_any(py)?,
                 false,
             ));
-        } else if out.extract::<Wrap<Row<'a>>>().is_ok() {
-            let first_value = out.extract::<Wrap<Row<'a>>>().unwrap().0;
+        } else if out.extract::<Wrap<Row<'static>>>().is_ok() {
+            let first_value = out.extract::<Wrap<Row<'static>>>().unwrap().0;
             return Ok((
                 PyDataFrame::from(
                     apply_lambda_with_rows_output(
@@ -140,15 +140,15 @@ Then return a Series object."
     Err(PyPolarsErr::Other("Could not determine output type".into()).into())
 }
 
-fn apply_iter<'a, T>(
-    df: &'a DataFrame,
-    py: Python<'a>,
-    lambda: Bound<'a, PyAny>,
+fn apply_iter<'py, T>(
+    df: &DataFrame,
+    py: Python<'py>,
+    lambda: Bound<'py, PyAny>,
     init_null_count: usize,
     skip: usize,
-) -> impl Iterator<Item = PyResult<Option<T>>> + 'a
+) -> impl Iterator<Item = PyResult<Option<T>>>
 where
-    T: FromPyObject<'a>,
+    T: FromPyObject<'py>,
 {
     let mut iters = get_iters_skip(df, init_null_count + skip);
     ((init_null_count + skip)..df.height()).map(move |_| {
@@ -159,16 +159,16 @@ where
 }
 
 /// Apply a lambda with a primitive output type
-pub fn apply_lambda_with_primitive_out_type<'a, D>(
-    df: &'a DataFrame,
-    py: Python<'a>,
-    lambda: Bound<'a, PyAny>,
+pub fn apply_lambda_with_primitive_out_type<'py, D>(
+    df: &DataFrame,
+    py: Python<'py>,
+    lambda: Bound<'py, PyAny>,
     init_null_count: usize,
     first_value: Option<D::Native>,
 ) -> PyResult<ChunkedArray<D>>
 where
     D: PyPolarsNumericType,
-    D::Native: IntoPyObject<'a> + FromPyObject<'a>,
+    D::Native: IntoPyObject<'py> + FromPyObject<'py>,
 {
     let skip = usize::from(first_value.is_some());
     if init_null_count == df.height() {
@@ -189,10 +189,10 @@ where
 }
 
 /// Apply a lambda with a boolean output type
-pub fn apply_lambda_with_bool_out_type<'a>(
-    df: &'a DataFrame,
-    py: Python,
-    lambda: Bound<'a, PyAny>,
+pub fn apply_lambda_with_bool_out_type(
+    df: &DataFrame,
+    py: Python<'_>,
+    lambda: Bound<'_, PyAny>,
     init_null_count: usize,
     first_value: Option<bool>,
 ) -> PyResult<ChunkedArray<BooleanType>> {
@@ -215,10 +215,10 @@ pub fn apply_lambda_with_bool_out_type<'a>(
 }
 
 /// Apply a lambda with string output type
-pub fn apply_lambda_with_string_out_type<'a>(
-    df: &'a DataFrame,
-    py: Python,
-    lambda: Bound<'a, PyAny>,
+pub fn apply_lambda_with_string_out_type(
+    df: &DataFrame,
+    py: Python<'_>,
+    lambda: Bound<'_, PyAny>,
     init_null_count: usize,
     first_value: Option<PyBackedStr>,
 ) -> PyResult<StringChunked> {
@@ -241,10 +241,10 @@ pub fn apply_lambda_with_string_out_type<'a>(
 }
 
 /// Apply a lambda with list output type
-pub fn apply_lambda_with_list_out_type<'a>(
-    df: &'a DataFrame,
-    py: Python,
-    lambda: Bound<'a, PyAny>,
+pub fn apply_lambda_with_list_out_type(
+    df: &DataFrame,
+    py: Python<'_>,
+    lambda: Bound<'_, PyAny>,
     init_null_count: usize,
     first_value: Option<&Series>,
     dt: &DataType,
@@ -285,12 +285,12 @@ pub fn apply_lambda_with_list_out_type<'a>(
     }
 }
 
-pub fn apply_lambda_with_rows_output<'a>(
-    df: &'a DataFrame,
-    py: Python,
-    lambda: Bound<'a, PyAny>,
+pub fn apply_lambda_with_rows_output(
+    df: &DataFrame,
+    py: Python<'_>,
+    lambda: Bound<'_, PyAny>,
     init_null_count: usize,
-    first_value: Row<'a>,
+    first_value: Row<'static>,
     inference_size: usize,
 ) -> PolarsResult<DataFrame> {
     let width = first_value.0.len();

--- a/crates/polars-python/src/map/lazy.rs
+++ b/crates/polars-python/src/map/lazy.rs
@@ -12,7 +12,7 @@ use crate::{PyExpr, Wrap};
 pub(crate) trait ToSeries {
     fn to_series(
         &self,
-        py: Python,
+        py: Python<'_>,
         py_polars_module: &Py<PyModule>,
         name: &str,
     ) -> PolarsResult<Series>;
@@ -21,7 +21,7 @@ pub(crate) trait ToSeries {
 impl ToSeries for PyObject {
     fn to_series(
         &self,
-        py: Python,
+        py: Python<'_>,
         py_polars_module: &Py<PyModule>,
         name: &str,
     ) -> PolarsResult<Series> {
@@ -65,7 +65,7 @@ impl ToSeries for PyObject {
 }
 
 pub(crate) fn call_lambda_with_series(
-    py: Python,
+    py: Python<'_>,
     s: &Series,
     lambda: &PyObject,
 ) -> PyResult<PyObject> {
@@ -171,7 +171,7 @@ pub fn map_single(
 }
 
 pub(crate) fn call_lambda_with_columns_slice(
-    py: Python,
+    py: Python<'_>,
     s: &[Column],
     lambda: &PyObject,
     pypolars: &Py<PyModule>,
@@ -196,7 +196,7 @@ pub(crate) fn call_lambda_with_columns_slice(
 
 pub fn map_mul(
     pyexpr: &[PyExpr],
-    py: Python,
+    py: Python<'_>,
     lambda: PyObject,
     output_type: Option<Wrap<DataType>>,
     map_groups: bool,

--- a/crates/polars-python/src/map/mod.rs
+++ b/crates/polars-python/src/map/mod.rs
@@ -34,11 +34,11 @@ impl PyPolarsNumericType for Int128Type {}
 impl PyPolarsNumericType for Float32Type {}
 impl PyPolarsNumericType for Float64Type {}
 
-fn iterator_to_struct<'a>(
-    py: Python,
-    it: impl Iterator<Item = PyResult<Option<Bound<'a, PyAny>>>>,
+fn iterator_to_struct<'py>(
+    py: Python<'py>,
+    it: impl Iterator<Item = PyResult<Option<Bound<'py, PyAny>>>>,
     init_null_count: usize,
-    first_value: AnyValue<'a>,
+    first_value: AnyValue<'static>,
     name: PlSmallStr,
     capacity: usize,
 ) -> PyResult<PySeries> {

--- a/crates/polars-python/src/series/aggregation.rs
+++ b/crates/polars-python/src/series/aggregation.rs
@@ -12,7 +12,7 @@ fn scalar_to_py(scalar: PyResult<Scalar>, py: Python<'_>) -> PyResult<Bound<'_, 
 
 #[pymethods]
 impl PySeries {
-    fn any(&self, py: Python, ignore_nulls: bool) -> PyResult<Option<bool>> {
+    fn any(&self, py: Python<'_>, ignore_nulls: bool) -> PyResult<Option<bool>> {
         py.enter_polars(|| {
             let s = self.series.bool()?;
             PolarsResult::Ok(if ignore_nulls {
@@ -23,7 +23,7 @@ impl PySeries {
         })
     }
 
-    fn all(&self, py: Python, ignore_nulls: bool) -> PyResult<Option<bool>> {
+    fn all(&self, py: Python<'_>, ignore_nulls: bool) -> PyResult<Option<bool>> {
         py.enter_polars(|| {
             let s = self.series.bool()?;
             PolarsResult::Ok(if ignore_nulls {

--- a/crates/polars-python/src/series/arithmetic.rs
+++ b/crates/polars-python/src/series/arithmetic.rs
@@ -6,19 +6,19 @@ use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PySeries {
-    fn add(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn add(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series + &other.series)
     }
-    fn sub(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn sub(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series - &other.series)
     }
-    fn mul(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn mul(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series * &other.series)
     }
-    fn div(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn div(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series / &other.series)
     }
-    fn rem(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn rem(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series % &other.series)
     }
 }
@@ -27,7 +27,7 @@ macro_rules! impl_arithmetic {
     ($name:ident, $type:ty, $operand:tt) => {
         #[pymethods]
         impl PySeries {
-            fn $name(&self, py: Python, other: $type) -> PyResult<Self> {
+            fn $name(&self, py: Python<'_>, other: $type) -> PyResult<Self> {
                 py.enter_polars_series(|| Ok({&self.series $operand other}))
             }
         }
@@ -93,7 +93,7 @@ macro_rules! impl_rhs_arithmetic {
     ($name:ident, $type:ty, $operand:ident) => {
         #[pymethods]
         impl PySeries {
-            fn $name(&self, py: Python, other: $type) -> PyResult<Self> {
+            fn $name(&self, py: Python<'_>, other: $type) -> PyResult<Self> {
                 py.enter_polars_series(|| Ok(other.$operand(&self.series)))
             }
         }

--- a/crates/polars-python/src/series/buffers.rs
+++ b/crates/polars-python/src/series/buffers.rs
@@ -43,8 +43,8 @@ impl<'py> IntoPyObject<'py> for BufferInfo {
         (self.pointer, self.offset, self.length).into_pyobject(py)
     }
 }
-impl<'a> FromPyObject<'a> for BufferInfo {
-    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+impl<'py> FromPyObject<'py> for BufferInfo {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let (pointer, offset, length) = ob.extract()?;
         Ok(Self {
             pointer,
@@ -257,7 +257,7 @@ impl PySeries {
     #[staticmethod]
     #[pyo3(signature = (dtype, data, validity=None))]
     unsafe fn _from_buffers(
-        py: Python,
+        py: Python<'_>,
         dtype: Wrap<DataType>,
         data: Vec<PySeries>,
         validity: Option<PySeries>,

--- a/crates/polars-python/src/series/comparison.rs
+++ b/crates/polars-python/src/series/comparison.rs
@@ -7,27 +7,27 @@ use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PySeries {
-    fn eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
+    fn eq(&self, py: Python<'_>, rhs: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| self.series.equal(&rhs.series))
     }
 
-    fn neq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
+    fn neq(&self, py: Python<'_>, rhs: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| self.series.not_equal(&rhs.series))
     }
 
-    fn gt(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
+    fn gt(&self, py: Python<'_>, rhs: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| self.series.gt(&rhs.series))
     }
 
-    fn gt_eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
+    fn gt_eq(&self, py: Python<'_>, rhs: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| self.series.gt_eq(&rhs.series))
     }
 
-    fn lt(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
+    fn lt(&self, py: Python<'_>, rhs: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| self.series.lt(&rhs.series))
     }
 
-    fn lt_eq(&self, py: Python, rhs: &PySeries) -> PyResult<Self> {
+    fn lt_eq(&self, py: Python<'_>, rhs: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| self.series.lt_eq(&rhs.series))
     }
 }
@@ -36,7 +36,7 @@ macro_rules! impl_op {
     ($op:ident, $name:ident, $type:ty) => {
         #[pymethods]
         impl PySeries {
-            fn $name(&self, py: Python, rhs: $type) -> PyResult<Self> {
+            fn $name(&self, py: Python<'_>, rhs: $type) -> PyResult<Self> {
                 py.enter_polars_series(|| self.series.$op(rhs))
             }
         }
@@ -161,7 +161,7 @@ macro_rules! impl_decimal {
     ($name:ident, $method:ident) => {
         #[pymethods]
         impl PySeries {
-            fn $name(&self, py: Python, rhs: PyDecimal) -> PyResult<Self> {
+            fn $name(&self, py: Python<'_>, rhs: PyDecimal) -> PyResult<Self> {
                 let rhs = Series::new(
                     PlSmallStr::from_static("decimal"),
                     &[AnyValue::Decimal(rhs.0, rhs.1)],

--- a/crates/polars-python/src/series/construction.rs
+++ b/crates/polars-python/src/series/construction.rs
@@ -52,7 +52,7 @@ fn mmap_numpy_array<T: Element + NativeType>(name: &str, array: &Bound<PyArray1<
 impl PySeries {
     #[staticmethod]
     fn new_bool(
-        py: Python,
+        py: Python<'_>,
         name: &str,
         array: &Bound<PyArray1<bool>>,
         _strict: bool,
@@ -64,7 +64,7 @@ impl PySeries {
 
     #[staticmethod]
     fn new_f32(
-        py: Python,
+        py: Python<'_>,
         name: &str,
         array: &Bound<PyArray1<f32>>,
         nan_is_null: bool,
@@ -86,7 +86,7 @@ impl PySeries {
 
     #[staticmethod]
     fn new_f64(
-        py: Python,
+        py: Python<'_>,
         name: &str,
         array: &Bound<PyArray1<f64>>,
         nan_is_null: bool,
@@ -130,11 +130,15 @@ impl PySeries {
     }
 }
 
-fn new_primitive<'a, T>(name: &str, values: &'a Bound<PyAny>, _strict: bool) -> PyResult<PySeries>
+fn new_primitive<'py, T>(
+    name: &str,
+    values: &Bound<'py, PyAny>,
+    _strict: bool,
+) -> PyResult<PySeries>
 where
     T: PolarsNumericType,
     ChunkedArray<T>: IntoSeries,
-    T::Native: FromPyObject<'a>,
+    T::Native: FromPyObject<'py>,
 {
     let len = values.len()?;
     let mut builder = PrimitiveChunkedBuilder::<T>::new(name.into(), len);
@@ -179,11 +183,11 @@ init_method_opt!(new_opt_i128, Int128Type, i64);
 init_method_opt!(new_opt_f32, Float32Type, f32);
 init_method_opt!(new_opt_f64, Float64Type, f64);
 
-fn convert_to_avs<'a>(
-    values: &'a Bound<'a, PyAny>,
+fn convert_to_avs(
+    values: &Bound<'_, PyAny>,
     strict: bool,
     allow_object: bool,
-) -> PyResult<Vec<AnyValue<'a>>> {
+) -> PyResult<Vec<AnyValue<'static>>> {
     values
         .try_iter()?
         .map(|v| py_object_to_any_value(&(v?).as_borrowed(), strict, allow_object))
@@ -309,7 +313,7 @@ impl PySeries {
     }
 
     #[staticmethod]
-    pub fn new_object(py: Python, name: &str, values: Vec<ObjectValue>, _strict: bool) -> Self {
+    pub fn new_object(py: Python<'_>, name: &str, values: Vec<ObjectValue>, _strict: bool) -> Self {
         #[cfg(feature = "object")]
         {
             let mut validity = BitmapBuilder::with_capacity(values.len());

--- a/crates/polars-python/src/series/export.rs
+++ b/crates/polars-python/src/series/export.rs
@@ -146,7 +146,7 @@ impl PySeries {
 
     /// Return the underlying Arrow array.
     #[allow(clippy::wrong_self_convention)]
-    fn to_arrow(&mut self, py: Python, compat_level: PyCompatLevel) -> PyResult<PyObject> {
+    fn to_arrow(&mut self, py: Python<'_>, compat_level: PyCompatLevel) -> PyResult<PyObject> {
         self.rechunk(py, true)?;
         let pyarrow = py.import("pyarrow")?;
 
@@ -160,14 +160,14 @@ impl PySeries {
     #[allow(unused_variables)]
     #[pyo3(signature = (requested_schema=None))]
     fn __arrow_c_stream__<'py>(
-        &'py self,
+        &self,
         py: Python<'py>,
         requested_schema: Option<PyObject>,
     ) -> PyResult<Bound<'py, PyCapsule>> {
         series_to_stream(&self.series, py)
     }
 
-    pub fn _export(&mut self, _py: Python, location: usize) {
+    pub fn _export(&mut self, _py: Python<'_>, location: usize) {
         let export = polars_ffi::version_0::export_series(&self.series);
         unsafe {
             (location as *mut SeriesExport).write(export);

--- a/crates/polars-python/src/series/general.rs
+++ b/crates/polars-python/src/series/general.rs
@@ -74,7 +74,7 @@ impl PySeries {
     }
 
     #[cfg(feature = "dtype-array")]
-    fn reshape(&self, py: Python, dims: Vec<i64>) -> PyResult<Self> {
+    fn reshape(&self, py: Python<'_>, dims: Vec<i64>) -> PyResult<Self> {
         let dims = dims
             .into_iter()
             .map(ReshapeDimension::new)
@@ -106,7 +106,7 @@ impl PySeries {
         }
     }
 
-    pub fn rechunk(&mut self, py: Python, in_place: bool) -> PyResult<Option<Self>> {
+    pub fn rechunk(&mut self, py: Python<'_>, in_place: bool) -> PyResult<Option<Self>> {
         let series = py.enter_polars_ok(|| self.series.rechunk())?;
         if in_place {
             self.series = series;
@@ -117,7 +117,7 @@ impl PySeries {
     }
 
     /// Get a value by index.
-    fn get_index(&self, py: Python, index: usize) -> PyResult<PyObject> {
+    fn get_index(&self, py: Python<'_>, index: usize) -> PyResult<PyObject> {
         let av = match self.series.get(index) {
             Ok(v) => v,
             Err(PolarsError::OutOfBounds(err)) => {
@@ -136,7 +136,7 @@ impl PySeries {
     }
 
     /// Get a value by index, allowing negative indices.
-    fn get_index_signed(&self, py: Python, index: isize) -> PyResult<PyObject> {
+    fn get_index_signed(&self, py: Python<'_>, index: isize) -> PyResult<PyObject> {
         let index = if index < 0 {
             match self.len().checked_sub(index.unsigned_abs()) {
                 Some(v) => v,
@@ -152,15 +152,15 @@ impl PySeries {
         self.get_index(py, index)
     }
 
-    fn bitand(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn bitand(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series & &other.series)
     }
 
-    fn bitor(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn bitor(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series | &other.series)
     }
 
-    fn bitxor(&self, py: Python, other: &PySeries) -> PyResult<Self> {
+    fn bitxor(&self, py: Python<'_>, other: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| &self.series ^ &other.series)
     }
 
@@ -201,14 +201,14 @@ impl PySeries {
         Ok(())
     }
 
-    fn extend(&mut self, py: Python, other: &PySeries) -> PyResult<()> {
+    fn extend(&mut self, py: Python<'_>, other: &PySeries) -> PyResult<()> {
         py.enter_polars(|| {
             self.series.extend(&other.series)?;
             PolarsResult::Ok(())
         })
     }
 
-    fn new_from_index(&self, py: Python, index: usize, length: usize) -> PyResult<Self> {
+    fn new_from_index(&self, py: Python<'_>, index: usize, length: usize) -> PyResult<Self> {
         if index >= self.series.len() {
             Err(PyValueError::new_err("index is out of bounds"))
         } else {
@@ -216,7 +216,7 @@ impl PySeries {
         }
     }
 
-    fn filter(&self, py: Python, filter: &PySeries) -> PyResult<Self> {
+    fn filter(&self, py: Python<'_>, filter: &PySeries) -> PyResult<Self> {
         let filter_series = &filter.series;
         if let Ok(ca) = filter_series.bool() {
             py.enter_polars_series(|| self.series.filter(ca))
@@ -227,7 +227,7 @@ impl PySeries {
 
     fn sort(
         &mut self,
-        py: Python,
+        py: Python<'_>,
         descending: bool,
         nulls_last: bool,
         multithreaded: bool,
@@ -242,7 +242,7 @@ impl PySeries {
         })
     }
 
-    fn gather_with_series(&self, py: Python, indices: &PySeries) -> PyResult<Self> {
+    fn gather_with_series(&self, py: Python<'_>, indices: &PySeries) -> PyResult<Self> {
         py.enter_polars_series(|| self.series.take(indices.series.idx()?))
     }
 
@@ -256,7 +256,7 @@ impl PySeries {
 
     fn equals(
         &self,
-        py: Python,
+        py: Python<'_>,
         other: &PySeries,
         check_dtypes: bool,
         check_names: bool,
@@ -294,7 +294,7 @@ impl PySeries {
         self.series.clone().into()
     }
 
-    fn zip_with(&self, py: Python, mask: &PySeries, other: &PySeries) -> PyResult<Self> {
+    fn zip_with(&self, py: Python<'_>, mask: &PySeries, other: &PySeries) -> PyResult<Self> {
         let mask = mask.series.bool().map_err(PyPolarsErr::from)?;
         py.enter_polars_series(|| self.series.zip_with(mask, &other.series))
     }
@@ -302,7 +302,7 @@ impl PySeries {
     #[pyo3(signature = (separator, drop_first=false))]
     fn to_dummies(
         &self,
-        py: Python,
+        py: Python<'_>,
         separator: Option<&str>,
         drop_first: bool,
     ) -> PyResult<PyDataFrame> {
@@ -356,7 +356,7 @@ impl PySeries {
         ))
     }
 
-    fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
+    fn __setstate__(&mut self, py: Python<'_>, state: PyObject) -> PyResult<()> {
         // Used in pickle/pickling
 
         use pyo3::pybacked::PyBackedBytes;
@@ -370,17 +370,17 @@ impl PySeries {
         }
     }
 
-    fn skew(&self, py: Python, bias: bool) -> PyResult<Option<f64>> {
+    fn skew(&self, py: Python<'_>, bias: bool) -> PyResult<Option<f64>> {
         py.enter_polars(|| self.series.skew(bias))
     }
 
-    fn kurtosis(&self, py: Python, fisher: bool, bias: bool) -> PyResult<Option<f64>> {
+    fn kurtosis(&self, py: Python<'_>, fisher: bool, bias: bool) -> PyResult<Option<f64>> {
         py.enter_polars(|| self.series.kurtosis(fisher, bias))
     }
 
     fn cast(
         &self,
-        py: Python,
+        py: Python<'_>,
         dtype: Wrap<DataType>,
         strict: bool,
         wrap_numerical: bool,
@@ -405,7 +405,7 @@ impl PySeries {
         })
     }
 
-    fn is_sorted(&self, py: Python, descending: bool, nulls_last: bool) -> PyResult<bool> {
+    fn is_sorted(&self, py: Python<'_>, descending: bool, nulls_last: bool) -> PyResult<bool> {
         let options = SortOptions {
             descending,
             nulls_last,
@@ -420,17 +420,17 @@ impl PySeries {
         self.series.clear().into()
     }
 
-    fn head(&self, py: Python, n: usize) -> PyResult<Self> {
+    fn head(&self, py: Python<'_>, n: usize) -> PyResult<Self> {
         py.enter_polars_series(|| Ok(self.series.head(Some(n))))
     }
 
-    fn tail(&self, py: Python, n: usize) -> PyResult<Self> {
+    fn tail(&self, py: Python<'_>, n: usize) -> PyResult<Self> {
         py.enter_polars_series(|| Ok(self.series.tail(Some(n))))
     }
 
     fn value_counts(
         &self,
-        py: Python,
+        py: Python<'_>,
         sort: bool,
         parallel: bool,
         name: String,
@@ -454,9 +454,9 @@ impl PySeries {
 
     /// Internal utility function to allow direct access to the row encoding from python.
     #[pyo3(signature = (dtypes, opts))]
-    fn _row_decode<'py>(
-        &'py self,
-        py: Python<'py>,
+    fn _row_decode(
+        &self,
+        py: Python<'_>,
         dtypes: Vec<(String, Wrap<DataType>)>,
         opts: Vec<(bool, bool, bool)>,
     ) -> PyResult<PyDataFrame> {
@@ -541,7 +541,7 @@ macro_rules! impl_set_with_mask {
             #[pyo3(signature = (filter, value))]
             fn $name(
                 &self,
-                py: Python,
+                py: Python<'_>,
                 filter: &PySeries,
                 value: Option<$native>,
             ) -> PyResult<Self> {

--- a/crates/polars-python/src/series/import.rs
+++ b/crates/polars-python/src/series/import.rs
@@ -32,7 +32,7 @@ fn validate_pycapsule_name(capsule: &Bound<PyCapsule>, expected_name: &str) -> P
 
 /// Import `__arrow_c_array__` across Python boundary
 pub(crate) fn call_arrow_c_array<'py>(
-    ob: &'py Bound<PyAny>,
+    ob: &Bound<'py, PyAny>,
 ) -> PyResult<(Bound<'py, PyCapsule>, Bound<'py, PyCapsule>)> {
     if !ob.hasattr("__arrow_c_array__")? {
         return Err(PyValueError::new_err(
@@ -77,7 +77,7 @@ pub(crate) fn import_array_pycapsules(
 }
 
 /// Import `__arrow_c_stream__` across Python boundary.
-fn call_arrow_c_stream<'py>(ob: &'py Bound<PyAny>) -> PyResult<Bound<'py, PyCapsule>> {
+fn call_arrow_c_stream<'py>(ob: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyCapsule>> {
     if !ob.hasattr("__arrow_c_stream__")? {
         return Err(PyValueError::new_err(
             "Expected an object with dunder __arrow_c_stream__",

--- a/crates/polars-python/src/series/scatter.rs
+++ b/crates/polars-python/src/series/scatter.rs
@@ -7,7 +7,7 @@ use crate::utils::EnterPolarsExt;
 
 #[pymethods]
 impl PySeries {
-    fn scatter(&mut self, py: Python, idx: PySeries, values: PySeries) -> PyResult<()> {
+    fn scatter(&mut self, py: Python<'_>, idx: PySeries, values: PySeries) -> PyResult<()> {
         // we take the value because we want a ref count of 1 so that we can
         // have mutable access cheaply via _get_inner_mut().
         let s = std::mem::take(&mut self.series);


### PR DESCRIPTION
I noticed a lot of mixed lifetime's in `polars-python`. This fixes the following causes:
- `py: Python<'a>` for some generic lifetime `'a`: Python's lifetime should be `'py` by convention
- `Bound<'a, _>` for some generic lifetime `'a`: Bound lifetime should be `'py` by convention
- `&'py Bound<'_, _>` or `&'py self`: references should not be bound to the `'py` lifetime, because the lifetime of the GIL is not the same as the lifetime of a reference.