### PR TITLE
refactor(rust): Add extend_each_repeated to builders

### DIFF
--- a/crates/polars-arrow/src/array/boolean/builder.rs
+++ b/crates/polars-arrow/src/array/boolean/builder.rs
@@ -67,6 +67,29 @@ impl StaticArrayBuilder for BooleanArrayBuilder {
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
+    fn subslice_extend_each_repeated(
+        &mut self,
+        other: &BooleanArray,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        _share: ShareStrategy,
+    ) {
+        self.values.subslice_extend_each_repeated_from_bitmap(
+            other.values(),
+            start,
+            length,
+            repeats,
+        );
+        self.validity
+            .subslice_extend_each_repeated_from_opt_validity(
+                other.validity(),
+                start,
+                length,
+                repeats,
+            );
+    }
+
     unsafe fn gather_extend(
         &mut self,
         other: &BooleanArray,

--- a/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/builder.rs
@@ -83,6 +83,33 @@ impl StaticArrayBuilder for FixedSizeBinaryArrayBuilder {
         self.length += length.min(other.len().saturating_sub(start));
     }
 
+    fn subslice_extend_each_repeated(
+        &mut self,
+        other: &FixedSizeBinaryArray,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        _share: ShareStrategy,
+    ) {
+        let other_slice = other.values().as_slice();
+        for outer_idx in start..start + length {
+            for _ in 0..repeats {
+                self.values.extend_from_slice(
+                    &other_slice[outer_idx * self.size..(outer_idx + 1) * self.size],
+                );
+            }
+        }
+
+        self.validity
+            .subslice_extend_each_repeated_from_opt_validity(
+                other.validity(),
+                start,
+                length,
+                repeats,
+            );
+        self.length += repeats * length.min(other.len().saturating_sub(start));
+    }
+
     unsafe fn gather_extend(
         &mut self,
         other: &FixedSizeBinaryArray,

--- a/crates/polars-arrow/src/array/fixed_size_list/builder.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/builder.rs
@@ -78,6 +78,34 @@ impl<B: ArrayBuilder> StaticArrayBuilder for FixedSizeListArrayBuilder<B> {
         self.length += length.min(other.len().saturating_sub(start));
     }
 
+    fn subslice_extend_each_repeated(
+        &mut self,
+        other: &FixedSizeListArray,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        share: ShareStrategy,
+    ) {
+        let other_values = &**other.values();
+        self.inner_builder.reserve(repeats * length * self.size);
+        for outer_idx in start..start + length {
+            self.inner_builder.subslice_extend_repeated(
+                other_values,
+                outer_idx * self.size,
+                self.size,
+                repeats,
+                share,
+            );
+        }
+        self.validity
+            .subslice_extend_each_repeated_from_opt_validity(
+                other.validity(),
+                start,
+                length,
+                repeats,
+            );
+    }
+
     unsafe fn gather_extend(
         &mut self,
         other: &FixedSizeListArray,

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -96,7 +96,8 @@ impl<O: Offset, B: ArrayBuilder> StaticArrayBuilder for ListArrayBuilder<O, B> {
         let start_offset = other.offsets()[start].to_usize();
         let stop_offset = other.offsets()[start + length].to_usize();
         self.offsets.reserve(length * repeats);
-        self.inner_builder.reserve((stop_offset - start_offset) * repeats);
+        self.inner_builder
+            .reserve((stop_offset - start_offset) * repeats);
         for offset_idx in start..start + length {
             let sublist_start = other_offsets[offset_idx].to_usize();
             let sublist_stop = other_offsets[offset_idx + 1].to_usize();

--- a/crates/polars-arrow/src/array/list/builder.rs
+++ b/crates/polars-arrow/src/array/list/builder.rs
@@ -82,6 +82,44 @@ impl<O: Offset, B: ArrayBuilder> StaticArrayBuilder for ListArrayBuilder<O, B> {
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
+    fn subslice_extend_each_repeated(
+        &mut self,
+        other: &ListArray<O>,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        share: ShareStrategy,
+    ) {
+        let other_offsets = other.offsets();
+        let other_values = &**other.values();
+
+        let start_offset = other.offsets()[start].to_usize();
+        let stop_offset = other.offsets()[start + length].to_usize();
+        self.offsets.reserve(length * repeats);
+        self.inner_builder.reserve((stop_offset - start_offset) * repeats);
+        for offset_idx in start..start + length {
+            let sublist_start = other_offsets[offset_idx].to_usize();
+            let sublist_stop = other_offsets[offset_idx + 1].to_usize();
+            for _ in 0..repeats {
+                self.offsets.try_push(sublist_stop - sublist_start).unwrap();
+            }
+            self.inner_builder.subslice_extend_repeated(
+                other_values,
+                sublist_start,
+                sublist_stop - sublist_start,
+                repeats,
+                share,
+            );
+        }
+        self.validity
+            .subslice_extend_each_repeated_from_opt_validity(
+                other.validity(),
+                start,
+                length,
+                repeats,
+            );
+    }
+
     unsafe fn gather_extend(
         &mut self,
         other: &ListArray<O>,

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -275,6 +275,17 @@ impl StaticArrayBuilder for NullArrayBuilder {
         self.length += length * repeats;
     }
 
+    fn subslice_extend_each_repeated(
+        &mut self,
+        _other: &NullArray,
+        _start: usize,
+        length: usize,
+        repeats: usize,
+        _share: ShareStrategy,
+    ) {
+        self.length += length * repeats;
+    }
+
     unsafe fn gather_extend(
         &mut self,
         _other: &NullArray,

--- a/crates/polars-arrow/src/array/primitive/builder.rs
+++ b/crates/polars-arrow/src/array/primitive/builder.rs
@@ -70,6 +70,33 @@ impl<T: NativeType> StaticArrayBuilder for PrimitiveArrayBuilder<T> {
             .subslice_extend_from_opt_validity(other.validity(), start, length);
     }
 
+    fn subslice_extend_each_repeated(
+        &mut self,
+        other: &PrimitiveArray<T>,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        _share: ShareStrategy,
+    ) {
+        self.values.reserve(length * repeats);
+
+        for value in other.values()[start..start + length].iter() {
+            unsafe {
+                for _ in 0..repeats {
+                    self.values.push_unchecked(*value);
+                }
+            }
+        }
+
+        self.validity
+            .subslice_extend_each_repeated_from_opt_validity(
+                other.validity(),
+                start,
+                length,
+                repeats,
+            );
+    }
+
     unsafe fn gather_extend(
         &mut self,
         other: &PrimitiveArray<T>,

--- a/crates/polars-arrow/src/array/struct_/builder.rs
+++ b/crates/polars-arrow/src/array/struct_/builder.rs
@@ -86,6 +86,22 @@ impl StaticArrayBuilder for StructArrayBuilder {
         self.length += length.min(other.len().saturating_sub(start));
     }
 
+    fn subslice_extend_each_repeated(
+        &mut self,
+        other: &StructArray,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        share: ShareStrategy,
+    ) {
+        for (builder, other_values) in self.inner_builders.iter_mut().zip(other.values()) {
+            builder.subslice_extend_each_repeated(&**other_values, start, length, repeats, share);
+        }
+        self.validity
+            .subslice_extend_from_opt_validity(other.validity(), start, length);
+        self.length += length.min(other.len().saturating_sub(start));
+    }
+
     unsafe fn gather_extend(
         &mut self,
         other: &StructArray,

--- a/crates/polars-core/src/frame/builder.rs
+++ b/crates/polars-core/src/frame/builder.rs
@@ -115,6 +115,45 @@ impl DataFrameBuilder {
         self.height += length.min(other.height().saturating_sub(start));
     }
 
+    /// Extends this builder with the contents of the given dataframe subslice.
+    /// Each element is repeated repeats times. May panic if other does not
+    /// match the schema of this builder.
+    pub fn subslice_extend_each_repeated(
+        &mut self,
+        other: &DataFrame,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        share: ShareStrategy,
+    ) {
+        let columns = other.get_columns();
+        assert!(self.builders.len() == columns.len());
+        for (builder, column) in self.builders.iter_mut().zip(columns) {
+            match column {
+                Column::Series(s) => {
+                    builder.subslice_extend_each_repeated(s, start, length, repeats, share);
+                },
+                Column::Partitioned(p) => {
+                    // @scalar-opt
+                    builder.subslice_extend_each_repeated(
+                        p.as_materialized_series(),
+                        start,
+                        length,
+                        repeats,
+                        share,
+                    );
+                },
+                Column::Scalar(sc) => {
+                    let len = sc.len().saturating_sub(start).min(length);
+                    let scalar_as_series = sc.scalar().clone().into_series(PlSmallStr::default());
+                    builder.subslice_extend_repeated(&scalar_as_series, 0, 1, len * repeats, share);
+                },
+            }
+        }
+
+        self.height += length.min(other.height().saturating_sub(start));
+    }
+
     /// Extends this builder with the contents of the given dataframe at the given
     /// indices. That is, `other[idxs[i]]` is appended to this builder in order,
     /// for each i=0..idxs.len(). May panic if other does not match the schema


### PR DESCRIPTION
These kernels are needed for the streaming cross-join.