### PR TITLE
chore: Display the operation behind `in-memory-map`

### DIFF
--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -9,6 +9,8 @@ use recursive::recursive;
 use self::ir::dot::ScanSourcesDisplay;
 use crate::prelude::*;
 
+const INDENT_INCREMENT: usize = 2;
+
 pub struct IRDisplay<'a> {
     is_streaming: bool,
     lp: IRPlanRef<'a>,
@@ -62,7 +64,7 @@ impl AsExpr for ExprIR {
 
 #[allow(clippy::too_many_arguments)]
 fn write_scan(
-    f: &mut Formatter,
+    f: &mut dyn fmt::Write,
     name: &str,
     sources: &ScanSources,
     indent: usize,
@@ -151,10 +153,9 @@ impl<'a> IRDisplay<'a> {
 
     #[recursive]
     fn _format(&self, f: &mut Formatter, indent: usize) -> fmt::Result {
-        let indent_increment = 2;
         let indent = if self.is_streaming {
             writeln!(f, "{:indent$}STREAMING:", "")?;
-            indent + indent_increment
+            indent + INDENT_INCREMENT
         } else {
             if indent != 0 {
                 writeln!(f)?;
@@ -162,40 +163,15 @@ impl<'a> IRDisplay<'a> {
             indent
         };
 
-        let sub_indent = indent + indent_increment;
+        let sub_indent = indent + INDENT_INCREMENT;
         use IR::*;
 
-        match self.root() {
-            #[cfg(feature = "python")]
-            PythonScan { options } => {
-                let total_columns = options.schema.len();
-                let n_columns = options
-                    .with_columns
-                    .as_ref()
-                    .map(|s| s.len() as i64)
-                    .unwrap_or(-1);
-
-                let predicate = match &options.predicate {
-                    PythonPredicate::Polars(e) => Some(self.display_expr(e)),
-                    PythonPredicate::PyArrow(_) => None,
-                    PythonPredicate::None => None,
-                };
-
-                write_scan(
-                    f,
-                    "PYTHON",
-                    &ScanSources::default(),
-                    indent,
-                    n_columns,
-                    total_columns,
-                    &predicate,
-                    options
-                        .n_rows
-                        .map(|len| polars_utils::slice_enum::Slice::Positive { offset: 0, len }),
-                    None,
-                )
-            },
+        let ir_node = self.root();
+        let schema = ir_node.schema(self.lp.lp_arena);
+        let schema = schema.as_ref();
+        match ir_node {
             Union { inputs, options } => {
+                write_ir_non_recursive(f, ir_node, self.lp.expr_arena, schema, indent)?;
                 let name = if let Some(slice) = options.slice {
                     format!("SLICED UNION: {slice:?}")
                 } else {
@@ -206,8 +182,7 @@ impl<'a> IRDisplay<'a> {
                 // - 0 => UNION ... END UNION
                 // - 1 => PLAN 0, PLAN 1, ... PLAN N
                 // - 2 => actual formatting of plans
-                let sub_sub_indent = sub_indent + indent_increment;
-                write!(f, "{:indent$}{name}", "")?;
+                let sub_sub_indent = sub_indent + INDENT_INCREMENT;
                 for (i, plan) in inputs.iter().enumerate() {
                     write!(f, "\n{:sub_indent$}PLAN {i}:", "")?;
                     self.with_root(*plan)._format(f, sub_sub_indent)?;
@@ -215,118 +190,19 @@ impl<'a> IRDisplay<'a> {
                 write!(f, "\n{:indent$}END {name}", "")
             },
             HConcat { inputs, .. } => {
-                let sub_sub_indent = sub_indent + indent_increment;
-                write!(f, "{:indent$}HCONCAT", "")?;
+                let sub_sub_indent = sub_indent + INDENT_INCREMENT;
+                write_ir_non_recursive(f, ir_node, self.lp.expr_arena, schema, indent)?;
                 for (i, plan) in inputs.iter().enumerate() {
                     write!(f, "\n{:sub_indent$}PLAN {i}:", "")?;
                     self.with_root(*plan)._format(f, sub_sub_indent)?;
                 }
                 write!(f, "\n{:indent$}END HCONCAT", "")
             },
-            Cache {
-                input,
-                id,
-                cache_hits,
-            } => {
-                write!(
-                    f,
-                    "{:indent$}CACHE[id: {:x}, cache_hits: {}]",
-                    "", *id, *cache_hits
-                )?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
-            Scan {
-                sources,
-                file_info,
-                predicate,
-                scan_type,
-                unified_scan_args,
-                hive_parts: _,
-                output_schema: _,
-            } => {
-                let n_columns = unified_scan_args
-                    .projection
-                    .as_ref()
-                    .map(|columns| columns.len() as i64)
-                    .unwrap_or(-1);
-
-                let predicate = predicate.as_ref().map(|p| self.display_expr(p));
-
-                write_scan(
-                    f,
-                    (&**scan_type).into(),
-                    sources,
-                    indent,
-                    n_columns,
-                    file_info.schema.len(),
-                    &predicate,
-                    unified_scan_args.pre_slice.clone(),
-                    unified_scan_args.row_index.as_ref(),
-                )
-            },
-            Filter { predicate, input } => {
-                let predicate = self.display_expr(predicate);
-                // this one is writeln because we don't increase indent (which inserts a line)
-                write!(f, "{:indent$}FILTER {predicate}", "")?;
-                write!(f, "\n{:indent$}FROM", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
-            DataFrameScan {
-                schema,
-                output_schema,
-                ..
-            } => {
-                let total_columns = schema.len();
-                let (n_columns, projected) = if let Some(schema) = output_schema {
-                    (
-                        format!("{}", schema.len()),
-                        format_list_truncated!(schema.iter_names(), 4, '"'),
-                    )
-                } else {
-                    ("*".to_string(), "".to_string())
-                };
-                write!(
-                    f,
-                    "{:indent$}DF {}; PROJECT{} {}/{} COLUMNS",
-                    "",
-                    format_list_truncated!(schema.iter_names(), 4, '"'),
-                    projected,
-                    n_columns,
-                    total_columns,
-                )
-            },
-            Select { expr, input, .. } => {
-                // @NOTE: Maybe there should be a clear delimiter here?
-                let exprs = self.display_expr_slice(expr);
-                write!(f, "{:indent$}SELECT {exprs}", "")?;
-                write!(f, "\n{:indent$}FROM", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
-            Sort {
-                input, by_column, ..
-            } => {
-                let by_column = self.display_expr_slice(by_column);
-                write!(f, "{:indent$}SORT BY {by_column}", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
-            GroupBy {
-                input,
-                keys,
-                aggs,
-                apply,
-                ..
-            } => {
-                let keys = self.display_expr_slice(keys);
-                write!(f, "{:indent$}AGGREGATE", "")?;
-                if apply.is_some() {
-                    write!(f, "\n{:sub_indent$}MAP_GROUPS BY {keys}", "")?;
-                    write!(f, "\n{:sub_indent$}FROM", "")?;
-                } else {
-                    let aggs = self.display_expr_slice(aggs);
-                    write!(f, "\n{:sub_indent$}{aggs} BY {keys}", "")?;
-                    write!(f, "\n{:sub_indent$}FROM", "")?;
-                }
-                self.with_root(*input)._format(f, sub_indent)
+            GroupBy { input, .. } => {
+                write_ir_non_recursive(f, ir_node, self.lp.expr_arena, schema, indent)?;
+                write!(f, "\n{:sub_indent$}FROM", "")?;
+                self.with_root(*input)._format(f, sub_indent)?;
+                Ok(())
             },
             Join {
                 input_left,
@@ -359,89 +235,52 @@ impl<'a> IRDisplay<'a> {
                     write!(f, "\n{:indent$}END {how} JOIN", "")
                 }
             },
-            HStack { input, exprs, .. } => {
-                // @NOTE: Maybe there should be a clear delimiter here?
-                let exprs = self.display_expr_slice(exprs);
-
-                write!(f, "{:indent$} WITH_COLUMNS:", "",)?;
-                write!(f, "\n{:indent$} {exprs} ", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
-            Distinct { input, options } => {
-                write!(
-                    f,
-                    "{:indent$}UNIQUE[maintain_order: {:?}, keep_strategy: {:?}] BY {:?}",
-                    "", options.maintain_order, options.keep_strategy, options.subset
-                )?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
-            Slice { input, offset, len } => {
-                write!(f, "{:indent$}SLICE[offset: {offset}, len: {len}]", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
             MapFunction {
                 input, function, ..
             } => {
                 if let Some(streaming_lp) = function.to_streaming_lp() {
                     IRDisplay::new_streaming(streaming_lp)._format(f, indent)
                 } else {
-                    write!(f, "{:indent$}{function}", "")?;
+                    write_ir_non_recursive(f, ir_node, self.lp.expr_arena, schema, indent)?;
                     self.with_root(*input)._format(f, sub_indent)
                 }
             },
-            ExtContext { input, .. } => {
-                write!(f, "{:indent$}EXTERNAL_CONTEXT", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
-            Sink { input, payload, .. } => {
-                let name = match payload {
-                    SinkTypeIR::Memory => "SINK (memory)",
-                    SinkTypeIR::File { .. } => "SINK (file)",
-                    SinkTypeIR::Partition { .. } => "SINK (partition)",
-                };
-                write!(f, "{:indent$}{name}", "")?;
-                self.with_root(*input)._format(f, sub_indent)
-            },
             SinkMultiple { inputs } => {
+                write_ir_non_recursive(f, ir_node, self.lp.expr_arena, schema, indent)?;
+
                 // 3 levels of indentation
                 // - 0 => SINK_MULTIPLE ... END SINK_MULTIPLE
                 // - 1 => PLAN 0, PLAN 1, ... PLAN N
                 // - 2 => actual formatting of plans
                 let sub_sub_indent = sub_indent + 2;
-                write!(f, "{:indent$}SINK_MULTIPLE", "")?;
                 for (i, plan) in inputs.iter().enumerate() {
                     write!(f, "\n{:sub_indent$}PLAN {i}:", "")?;
                     self.with_root(*plan)._format(f, sub_sub_indent)?;
                 }
                 write!(f, "\n{:indent$}END SINK_MULTIPLE", "")
             },
-            SimpleProjection { input, columns } => {
-                let num_columns = columns.as_ref().len();
-                let total_columns = self.lp.lp_arena.get(*input).schema(self.lp.lp_arena).len();
-
-                let columns = ColumnsDisplay(columns.as_ref());
-                write!(
-                    f,
-                    "{:indent$}simple π {num_columns}/{total_columns} [{columns}]",
-                    ""
-                )?;
-
-                self.with_root(*input)._format(f, sub_indent)
-            },
             #[cfg(feature = "merge_sorted")]
             MergeSorted {
                 input_left,
                 input_right,
-                key,
+                key: _,
             } => {
-                write!(f, "{:indent$}MERGE SORTED ON '{key}':", "")?;
+                write_ir_non_recursive(f, ir_node, self.lp.expr_arena, schema, indent)?;
+                write!(f, ":")?;
+
                 write!(f, "\n{:indent$}LEFT PLAN:", "")?;
                 self.with_root(*input_left)._format(f, sub_indent)?;
                 write!(f, "\n{:indent$}RIGHT PLAN:", "")?;
                 self.with_root(*input_right)._format(f, sub_indent)?;
                 write!(f, "\n{:indent$}END MERGE_SORTED", "")
             },
-            Invalid => write!(f, "{:indent$}INVALID", ""),
+            ir_node => {
+                write_ir_non_recursive(f, ir_node, self.lp.expr_arena, schema, indent)?;
+                for input in ir_node.get_inputs().iter() {
+                    self.with_root(*input)._format(f, sub_indent)?;
+                }
+                Ok(())
+            },
         }
     }
 }
@@ -798,4 +637,279 @@ impl fmt::Debug for RangeLiteralValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "range({}, {})", self.low, self.high)
     }
+}
+
+pub fn write_ir_non_recursive(
+    f: &mut dyn fmt::Write,
+    ir: &IR,
+    expr_arena: &Arena<AExpr>,
+    schema: &Schema,
+    indent: usize,
+) -> fmt::Result {
+    match ir {
+        #[cfg(feature = "python")]
+        IR::PythonScan { options } => {
+            let total_columns = options.schema.len();
+            let n_columns = options
+                .with_columns
+                .as_ref()
+                .map(|s| s.len() as i64)
+                .unwrap_or(-1);
+
+            let predicate = match &options.predicate {
+                PythonPredicate::Polars(e) => Some(e.display(expr_arena)),
+                PythonPredicate::PyArrow(_) => None,
+                PythonPredicate::None => None,
+            };
+
+            write_scan(
+                f,
+                "PYTHON",
+                &ScanSources::default(),
+                indent,
+                n_columns,
+                total_columns,
+                &predicate,
+                options
+                    .n_rows
+                    .map(|len| polars_utils::slice_enum::Slice::Positive { offset: 0, len }),
+                None,
+            )
+        },
+        IR::Slice {
+            input: _,
+            offset,
+            len,
+        } => {
+            write!(f, "{:indent$}SLICE[offset: {offset}, len: {len}]", "")
+        },
+        IR::Filter {
+            input: _,
+            predicate,
+        } => {
+            let predicate = predicate.display(expr_arena);
+            // this one is writeln because we don't increase indent (which inserts a line)
+            write!(f, "{:indent$}FILTER {predicate}", "")?;
+            write!(f, "\n{:indent$}FROM", "")
+        },
+        IR::Scan {
+            sources,
+            file_info,
+            predicate,
+            scan_type,
+            unified_scan_args,
+            hive_parts: _,
+            output_schema: _,
+        } => {
+            let n_columns = unified_scan_args
+                .projection
+                .as_ref()
+                .map(|columns| columns.len() as i64)
+                .unwrap_or(-1);
+
+            let predicate = predicate.as_ref().map(|p| p.display(expr_arena));
+
+            write_scan(
+                f,
+                (&**scan_type).into(),
+                sources,
+                indent,
+                n_columns,
+                file_info.schema.len(),
+                &predicate,
+                unified_scan_args.pre_slice.clone(),
+                unified_scan_args.row_index.as_ref(),
+            )
+        },
+        IR::DataFrameScan {
+            df: _,
+            schema,
+            output_schema,
+        } => {
+            let total_columns = schema.len();
+            let (n_columns, projected) = if let Some(schema) = output_schema {
+                (
+                    format!("{}", schema.len()),
+                    format_list_truncated!(schema.iter_names(), 4, '"'),
+                )
+            } else {
+                ("*".to_string(), "".to_string())
+            };
+            write!(
+                f,
+                "{:indent$}DF {}; PROJECT{} {}/{} COLUMNS",
+                "",
+                format_list_truncated!(schema.iter_names(), 4, '"'),
+                projected,
+                n_columns,
+                total_columns,
+            )
+        },
+        IR::SimpleProjection { input: _, columns } => {
+            let num_columns = columns.as_ref().len();
+            let total_columns = schema.len();
+
+            let columns = ColumnsDisplay(columns.as_ref());
+            write!(
+                f,
+                "{:indent$}simple π {num_columns}/{total_columns} [{columns}]",
+                ""
+            )
+        },
+        IR::Select {
+            input: _,
+            expr,
+            schema: _,
+            options: _,
+        } => {
+            // @NOTE: Maybe there should be a clear delimiter here?
+            let exprs = ExprIRSliceDisplay {
+                exprs: expr,
+                expr_arena,
+            };
+            write!(f, "{:indent$}SELECT {exprs}", "")?;
+            Ok(())
+        },
+        IR::Sort {
+            input: _,
+            by_column,
+            slice: _,
+            sort_options: _,
+        } => {
+            let by_column = ExprIRSliceDisplay {
+                exprs: by_column,
+                expr_arena,
+            };
+            write!(f, "{:indent$}SORT BY {by_column}", "")
+        },
+        IR::Cache {
+            input: _,
+            id,
+            cache_hits,
+        } => write!(
+            f,
+            "{:indent$}CACHE[id: {:x}, cache_hits: {}]",
+            "", *id, *cache_hits
+        ),
+        IR::GroupBy {
+            input: _,
+            keys,
+            aggs,
+            schema: _,
+            maintain_order: _,
+            options: _,
+            apply,
+        } => write_group_by(f, indent, expr_arena, keys, aggs, apply.as_deref()),
+        IR::Join {
+            input_left: _,
+            input_right: _,
+            schema: _,
+            left_on,
+            right_on,
+            options,
+        } => {
+            let left_on = ExprIRSliceDisplay {
+                exprs: left_on,
+                expr_arena,
+            };
+            let right_on = ExprIRSliceDisplay {
+                exprs: right_on,
+                expr_arena,
+            };
+
+            // Fused cross + filter (show as nested loop join)
+            if let Some(JoinTypeOptionsIR::Cross { predicate }) = &options.options {
+                let predicate = predicate.display(expr_arena);
+                write!(f, "{:indent$}NESTED_LOOP JOIN ON {predicate}", "")?;
+            } else {
+                let how = &options.args.how;
+                write!(f, "{:indent$}{how} JOIN", "")?;
+                write!(f, "\n{:indent$}LEFT PLAN ON: {left_on}", "")?;
+                write!(f, "\n{:indent$}RIGHT PLAN ON: {right_on}", "")?;
+            }
+
+            Ok(())
+        },
+        IR::HStack {
+            input: _,
+            exprs,
+            schema: _,
+            options: _,
+        } => {
+            // @NOTE: Maybe there should be a clear delimiter here?
+            let exprs = ExprIRSliceDisplay { exprs, expr_arena };
+
+            write!(f, "{:indent$} WITH_COLUMNS:", "",)?;
+            write!(f, "\n{:indent$} {exprs} ", "")
+        },
+        IR::Distinct { input: _, options } => {
+            write!(
+                f,
+                "{:indent$}UNIQUE[maintain_order: {:?}, keep_strategy: {:?}] BY {:?}",
+                "", options.maintain_order, options.keep_strategy, options.subset
+            )
+        },
+        IR::MapFunction { input: _, function } => write!(f, "{:indent$}{function}", ""),
+        IR::Union { inputs: _, options } => {
+            let name = if let Some(slice) = options.slice {
+                format!("SLICED UNION: {slice:?}")
+            } else {
+                "UNION".to_string()
+            };
+            write!(f, "{:indent$}{name}", "")
+        },
+        IR::HConcat {
+            inputs: _,
+            schema: _,
+            options: _,
+        } => write!(f, "{:indent$}HCONCAT", ""),
+        IR::ExtContext {
+            input: _,
+            contexts: _,
+            schema: _,
+        } => write!(f, "{:indent$}EXTERNAL_CONTEXT", ""),
+        IR::Sink { input: _, payload } => {
+            let name = match payload {
+                SinkTypeIR::Memory => "SINK (memory)",
+                SinkTypeIR::File { .. } => "SINK (file)",
+                SinkTypeIR::Partition { .. } => "SINK (partition)",
+            };
+            write!(f, "{:indent$}{name}", "")
+        },
+        IR::SinkMultiple { inputs: _ } => write!(f, "{:indent$}SINK_MULTIPLE", ""),
+        IR::MergeSorted {
+            input_left: _,
+            input_right: _,
+            key,
+        } => write!(f, "{:indent$}MERGE SORTED ON '{key}'", ""),
+        IR::Invalid => write!(f, "{:indent$}INVALID", ""),
+    }
+}
+
+pub fn write_group_by(
+    f: &mut dyn fmt::Write,
+    indent: usize,
+    expr_arena: &Arena<AExpr>,
+    keys: &[ExprIR],
+    aggs: &[ExprIR],
+    apply: Option<&dyn DataFrameUdf>,
+) -> fmt::Result {
+    let sub_indent = indent + INDENT_INCREMENT;
+    let keys = ExprIRSliceDisplay {
+        exprs: keys,
+        expr_arena,
+    };
+    write!(f, "{:indent$}AGGREGATE", "")?;
+    if apply.is_some() {
+        write!(f, "\n{:sub_indent$}MAP_GROUPS BY {keys}", "")?;
+        write!(f, "\n{:sub_indent$}FROM", "")?;
+    } else {
+        let aggs = ExprIRSliceDisplay {
+            exprs: aggs,
+            expr_arena,
+        };
+        write!(f, "\n{:sub_indent$}{aggs} BY {keys}", "")?;
+    }
+
+    Ok(())
 }

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -877,6 +877,7 @@ pub fn write_ir_non_recursive(
             write!(f, "{:indent$}{name}", "")
         },
         IR::SinkMultiple { inputs: _ } => write!(f, "{:indent$}SINK_MULTIPLE", ""),
+        #[cfg(feature = "merge_sorted")]
         IR::MergeSorted {
             input_left: _,
             input_right: _,

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::fmt;
 
 pub use dot::{EscapeLabel, IRDotDisplay, PathsDisplay, ScanSourcesDisplay};
-pub use format::{ExprIRDisplay, IRDisplay};
+pub use format::{ExprIRDisplay, IRDisplay, write_group_by, write_ir_non_recursive};
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::unitvec;

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -7,7 +7,7 @@ use polars_error::{PolarsResult, polars_err};
 use polars_expr::state::ExecutionState;
 use polars_mem_engine::create_physical_plan;
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
-use polars_plan::plans::{AExpr, DataFrameUdf, IR, IRAggExpr, NaiveExprMerger};
+use polars_plan::plans::{AExpr, DataFrameUdf, IR, IRAggExpr, NaiveExprMerger, write_group_by};
 use polars_plan::prelude::GroupbyOptions;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::pl_str::PlSmallStr;
@@ -15,7 +15,7 @@ use polars_utils::unique_column_name;
 use recursive::recursive;
 use slotmap::SlotMap;
 
-use super::{ExprCache, PhysNode, PhysNodeKey, PhysNodeKind, PhysStream};
+use super::{ExprCache, PhysNode, PhysNodeKey, PhysNodeKind, PhysStream, StreamingLowerIRContext};
 use crate::physical_plan::lower_expr::{
     build_select_stream, compute_output_schema, is_elementwise_rec_cached,
     is_fake_elementwise_function, is_input_independent,
@@ -34,6 +34,7 @@ fn build_group_by_fallback(
     apply: Option<Arc<dyn DataFrameUdf>>,
     expr_arena: &mut Arena<AExpr>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
+    format_str: Option<String>,
 ) -> PolarsResult<PhysStream> {
     let input_schema = phys_sm[input.node].output_schema.clone();
     let lmdf = Arc::new(LateMaterializedDataFrame::default());
@@ -64,6 +65,7 @@ fn build_group_by_fallback(
                 let mut state = ExecutionState::new();
                 executor.lock().execute(&mut state)
             }),
+            format_str,
         },
     };
 
@@ -266,6 +268,7 @@ fn try_build_streaming_group_by(
     expr_arena: &mut Arena<AExpr>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
     expr_cache: &mut ExprCache,
+    ctx: StreamingLowerIRContext,
 ) -> Option<PolarsResult<PhysStream>> {
     if apply.is_some() || maintain_order {
         return None; // TODO
@@ -345,7 +348,7 @@ fn try_build_streaming_group_by(
     }
 
     let pre_select =
-        build_select_stream(input, &input_exprs, expr_arena, phys_sm, expr_cache).ok()?;
+        build_select_stream(input, &input_exprs, expr_arena, phys_sm, expr_cache, ctx).ok()?;
 
     let input_schema = &phys_sm[pre_select.node].output_schema;
     let group_by_output_schema = compute_output_schema(
@@ -369,6 +372,7 @@ fn try_build_streaming_group_by(
         expr_arena,
         phys_sm,
         expr_cache,
+        ctx,
     );
     let out = if let Some((offset, len)) = options.slice {
         post_select.map(|s| build_slice_stream(s, offset, len, phys_sm))
@@ -390,6 +394,7 @@ pub fn build_group_by_stream(
     expr_arena: &mut Arena<AExpr>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
     expr_cache: &mut ExprCache,
+    ctx: StreamingLowerIRContext,
 ) -> PolarsResult<PhysStream> {
     let streaming = try_build_streaming_group_by(
         input,
@@ -401,10 +406,16 @@ pub fn build_group_by_stream(
         expr_arena,
         phys_sm,
         expr_cache,
+        ctx,
     );
     if let Some(stream) = streaming {
         stream
     } else {
+        let format_str = ctx.prepare_visualization.then(|| {
+            let mut buffer = String::new();
+            write_group_by(&mut buffer, 0, expr_arena, keys, aggs, apply.as_deref()).unwrap();
+            buffer
+        });
         build_group_by_fallback(
             input,
             keys,
@@ -415,6 +426,7 @@ pub fn build_group_by_stream(
             apply,
             expr_arena,
             phys_sm,
+            format_str,
         )
     }
 }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -12,7 +12,9 @@ use polars_plan::dsl::{
     ExtraColumnsPolicy, FileScan, FileSinkType, PartitionSinkTypeIR, PartitionVariantIR, SinkTypeIR,
 };
 use polars_plan::plans::expr_ir::{ExprIR, OutputName};
-use polars_plan::plans::{AExpr, Context, FunctionIR, IR, IRAggExpr, LiteralValue};
+use polars_plan::plans::{
+    AExpr, Context, FunctionIR, IR, IRAggExpr, LiteralValue, write_ir_non_recursive,
+};
 use polars_plan::prelude::GroupbyOptions;
 use polars_utils::arena::{Arena, Node};
 use polars_utils::itertools::Itertools;
@@ -66,6 +68,7 @@ fn build_filter_stream(
     expr_arena: &mut Arena<AExpr>,
     phys_sm: &mut SlotMap<PhysNodeKey, PhysNode>,
     expr_cache: &mut ExprCache,
+    ctx: StreamingLowerIRContext,
 ) -> PolarsResult<PhysStream> {
     let predicate = predicate.clone();
     let cols_and_predicate = phys_sm[input.node]
@@ -80,8 +83,14 @@ fn build_filter_stream(
         })
         .chain([predicate])
         .collect_vec();
-    let (trans_input, mut trans_cols_and_predicate) =
-        lower_exprs(input, &cols_and_predicate, expr_arena, phys_sm, expr_cache)?;
+    let (trans_input, mut trans_cols_and_predicate) = lower_exprs(
+        input,
+        &cols_and_predicate,
+        expr_arena,
+        phys_sm,
+        expr_cache,
+        ctx,
+    )?;
 
     let filter_schema = phys_sm[trans_input.node].output_schema.clone();
     let filter = PhysNodeKind::Filter {
@@ -97,10 +106,17 @@ fn build_filter_stream(
         expr_arena,
         phys_sm,
         expr_cache,
+        ctx,
     )
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct StreamingLowerIRContext {
+    pub prepare_visualization: bool,
+}
+
 #[recursive::recursive]
+#[allow(clippy::too_many_arguments)]
 pub fn lower_ir(
     node: Node,
     ir_arena: &mut Arena<IR>,
@@ -109,6 +125,7 @@ pub fn lower_ir(
     schema_cache: &mut PlHashMap<Node, Arc<Schema>>,
     expr_cache: &mut ExprCache,
     cache_nodes: &mut PlHashMap<usize, PhysStream>,
+    ctx: StreamingLowerIRContext,
 ) -> PolarsResult<PhysStream> {
     // Helper macro to simplify recursive calls.
     macro_rules! lower_ir {
@@ -121,6 +138,7 @@ pub fn lower_ir(
                 schema_cache,
                 expr_cache,
                 cache_nodes,
+                ctx,
             )
         };
     }
@@ -140,7 +158,9 @@ pub fn lower_ir(
         IR::Select { input, expr, .. } => {
             let selectors = expr.clone();
             let phys_input = lower_ir!(*input)?;
-            return build_select_stream(phys_input, &selectors, expr_arena, phys_sm, expr_cache);
+            return build_select_stream(
+                phys_input, &selectors, expr_arena, phys_sm, expr_cache, ctx,
+            );
         },
 
         IR::HStack { input, exprs, .. }
@@ -177,7 +197,7 @@ pub fn lower_ir(
             }
             let selectors = selectors.into_values().collect_vec();
             return build_length_preserving_select_stream(
-                phys_input, &selectors, expr_arena, phys_sm, expr_cache,
+                phys_input, &selectors, expr_arena, phys_sm, expr_cache, ctx,
             );
         },
 
@@ -191,7 +211,9 @@ pub fn lower_ir(
         IR::Filter { input, predicate } => {
             let predicate = predicate.clone();
             let phys_input = lower_ir!(*input)?;
-            return build_filter_stream(phys_input, predicate, expr_arena, phys_sm, expr_cache);
+            return build_filter_stream(
+                phys_input, predicate, expr_arena, phys_sm, expr_cache, ctx,
+            );
         },
 
         IR::DataFrameScan {
@@ -372,10 +394,23 @@ pub fn lower_ir(
                 },
 
                 function => {
+                    let format_str = ctx.prepare_visualization.then(|| {
+                        let mut buffer = String::new();
+                        write_ir_non_recursive(
+                            &mut buffer,
+                            ir_arena.get(node),
+                            expr_arena,
+                            phys_sm.get(phys_input.node).unwrap().output_schema.as_ref(),
+                            0,
+                        )
+                        .unwrap();
+                        buffer
+                    });
                     let map = Arc::new(move |df| function.evaluate(df));
                     PhysNodeKind::InMemoryMap {
                         input: phys_input,
                         map,
+                        format_str,
                     }
                 },
             }
@@ -717,7 +752,7 @@ pub fn lower_ir(
 
                     if let Some(predicate) = predicate_post {
                         stream = build_filter_stream(
-                            stream, predicate, expr_arena, phys_sm, expr_cache,
+                            stream, predicate, expr_arena, phys_sm, expr_cache, ctx,
                         )?;
                     }
 
@@ -775,6 +810,7 @@ pub fn lower_ir(
                 expr_arena,
                 phys_sm,
                 expr_cache,
+                ctx,
             );
         },
         IR::Join {
@@ -809,10 +845,22 @@ pub fn lower_ir(
                     let col_expr = expr_arena.add(AExpr::Column(name.clone()));
                     aug_right_on.push(ExprIR::new(col_expr, OutputName::ColumnLhs(name.clone())));
                 }
-                let (trans_input_left, mut trans_left_on) =
-                    lower_exprs(phys_left, &aug_left_on, expr_arena, phys_sm, expr_cache)?;
-                let (trans_input_right, mut trans_right_on) =
-                    lower_exprs(phys_right, &aug_right_on, expr_arena, phys_sm, expr_cache)?;
+                let (trans_input_left, mut trans_left_on) = lower_exprs(
+                    phys_left,
+                    &aug_left_on,
+                    expr_arena,
+                    phys_sm,
+                    expr_cache,
+                    ctx,
+                )?;
+                let (trans_input_right, mut trans_right_on) = lower_exprs(
+                    phys_right,
+                    &aug_right_on,
+                    expr_arena,
+                    phys_sm,
+                    expr_cache,
+                    ctx,
+                )?;
                 trans_left_on.drain(left_on.len()..);
                 trans_right_on.drain(right_on.len()..);
 
@@ -887,6 +935,18 @@ pub fn lower_ir(
                     None,
                 )?);
 
+                let format_str = ctx.prepare_visualization.then(|| {
+                    let mut buffer = String::new();
+                    write_ir_non_recursive(
+                        &mut buffer,
+                        ir_arena.get(node),
+                        expr_arena,
+                        phys_sm.get(phys_input.node).unwrap().output_schema.as_ref(),
+                        0,
+                    )
+                    .unwrap();
+                    buffer
+                });
                 let distinct_node = PhysNode {
                     output_schema,
                     kind: PhysNodeKind::InMemoryMap {
@@ -896,6 +956,7 @@ pub fn lower_ir(
                             let mut state = ExecutionState::new();
                             executor.lock().execute(&mut state)
                         }),
+                        format_str,
                     },
                 };
 
@@ -961,6 +1022,7 @@ pub fn lower_ir(
                 expr_arena,
                 phys_sm,
                 expr_cache,
+                ctx,
             )?;
 
             if options.keep_strategy == UniqueKeepStrategy::None {
@@ -975,7 +1037,8 @@ pub fn lower_ir(
                 });
                 let predicate =
                     ExprIR::new(predicate_aexpr, OutputName::ColumnLhs(unique_name.clone()));
-                stream = build_filter_stream(stream, predicate, expr_arena, phys_sm, expr_cache)?;
+                stream =
+                    build_filter_stream(stream, predicate, expr_arena, phys_sm, expr_cache, ctx)?;
             }
 
             // Restore column order and drop the temporary length column if any.
@@ -986,7 +1049,7 @@ pub fn lower_ir(
                     ExprIR::new(col_expr, OutputName::ColumnLhs(name.clone()))
                 })
                 .collect_vec();
-            stream = build_select_stream(stream, &exprs, expr_arena, phys_sm, expr_cache)?;
+            stream = build_select_stream(stream, &exprs, expr_arena, phys_sm, expr_cache, ctx)?;
 
             // We didn't pass the slice earlier to build_group_by_stream because
             // we might have the intermediate keep = "none" filter.

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -381,7 +381,11 @@ fn to_graph_rec<'a>(
             }
         },
 
-        InMemoryMap { input, map } => {
+        InMemoryMap {
+            input,
+            map,
+            format_str: _,
+        } => {
             let input_schema = ctx.phys_sm[input.node].output_schema.clone();
             let input_key = to_graph_rec(input.node, ctx)?;
             ctx.graph.add_node(


### PR DESCRIPTION
This now properly shows what is behind an `in-memory-map` and does some drive by clean-up on the plan.

```python
import polars as pl

(
    pl.LazyFrame({"x": [1], "y": [1], "j": [1]})
        .select(pl.col.x.median(), pl.col.j.rolling_max(window_size=10))
        .map_batches(lambda df: df)
        .group_by('x', maintain_order=True).agg(pl.col.j)
        .show_graph(engine='streaming', plan_stage='physical')
)
```

![image](https://github.com/user-attachments/assets/f55ea1f3-a481-49ad-9328-7fda70390c06)