### PR TITLE
fix: Make `replace` and `replace_strict` mapping use list literals

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -234,7 +234,7 @@ mod test {
         builder.append_null();
 
         let out = builder.finish();
-        let out = out.explode().unwrap();
+        let out = out.explode(false).unwrap();
         assert_eq!(out.len(), 7);
         assert_eq!(out.get(6).unwrap(), AnyValue::Null);
     }

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -597,7 +597,7 @@ mod test {
             },
             _ => panic!(),
         }
-        let flat = aggregated.explode()?;
+        let flat = aggregated.explode(false)?;
         let ca = flat.categorical().unwrap();
         let vals = ca.iter_str().map(|v| v.unwrap()).collect::<Vec<_>>();
         assert_eq!(vals, &["a", "b", "c"]);

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -8,7 +8,7 @@ use crate::prelude::*;
 use crate::series::implementations::null::NullChunked;
 
 pub(crate) trait ExplodeByOffsets {
-    fn explode_by_offsets(&self, offsets: &[i64]) -> Series;
+    fn explode_by_offsets(&self, offsets: &[i64], skip_empty: bool) -> Series;
 }
 
 unsafe fn unset_nulls(
@@ -34,7 +34,7 @@ impl<T> ExplodeByOffsets for ChunkedArray<T>
 where
     T: PolarsIntegerType,
 {
-    fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
+    fn explode_by_offsets(&self, offsets: &[i64], skip_empty: bool) -> Series {
         debug_assert_eq!(self.chunks.len(), 1);
         let arr = self.downcast_iter().next().unwrap();
 
@@ -67,7 +67,7 @@ where
 
             for &o in &offsets[1..] {
                 let o = o as usize;
-                if o == last {
+                if !skip_empty && o == last {
                     if start != last {
                         #[cfg(debug_assertions)]
                         new_values.extend_from_slice(&values[start..last]);
@@ -114,7 +114,7 @@ where
         } else {
             for &o in &offsets[1..] {
                 let o = o as usize;
-                if o == last {
+                if !skip_empty && o == last {
                     if start != last {
                         unsafe { new_values.extend_from_slice(values.get_unchecked(start..last)) };
                     }
@@ -150,31 +150,31 @@ where
 }
 
 impl ExplodeByOffsets for Float32Chunked {
-    fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
+    fn explode_by_offsets(&self, offsets: &[i64], skip_empty: bool) -> Series {
         self.apply_as_ints(|s| {
             let ca = s.u32().unwrap();
-            ca.explode_by_offsets(offsets)
+            ca.explode_by_offsets(offsets, skip_empty)
         })
     }
 }
 impl ExplodeByOffsets for Float64Chunked {
-    fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
+    fn explode_by_offsets(&self, offsets: &[i64], skip_empty: bool) -> Series {
         self.apply_as_ints(|s| {
             let ca = s.u64().unwrap();
-            ca.explode_by_offsets(offsets)
+            ca.explode_by_offsets(offsets, skip_empty)
         })
     }
 }
 
 impl ExplodeByOffsets for NullChunked {
-    fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
+    fn explode_by_offsets(&self, offsets: &[i64], skip_empty: bool) -> Series {
         let mut last_offset = offsets[0];
 
         let mut len = 0;
         for &offset in &offsets[1..] {
             // If offset == last_offset we have an empty list and a new row is inserted,
             // therefore we always increase at least 1.
-            len += std::cmp::max(offset - last_offset, 1) as usize;
+            len += std::cmp::max(offset - last_offset, i64::from(!skip_empty)) as usize;
             last_offset = offset;
         }
         NullChunked::new(self.name.clone(), len).into_series()
@@ -182,7 +182,7 @@ impl ExplodeByOffsets for NullChunked {
 }
 
 impl ExplodeByOffsets for BooleanChunked {
-    fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
+    fn explode_by_offsets(&self, offsets: &[i64], skip_empty: bool) -> Series {
         debug_assert_eq!(self.chunks.len(), 1);
         let arr = self.downcast_iter().next().unwrap();
 
@@ -193,7 +193,7 @@ impl ExplodeByOffsets for BooleanChunked {
         let mut last = start;
         for &o in &offsets[1..] {
             let o = o as usize;
-            if o == last {
+            if !skip_empty && o == last {
                 if start != last {
                     let vals = arr.slice_typed(start, last - start);
 
@@ -283,12 +283,12 @@ mod test {
         assert!(ca._can_fast_explode());
 
         // normal explode
-        let exploded = ca.explode()?;
+        let exploded = ca.explode(false)?;
         let out: Vec<_> = exploded.i32()?.into_no_null_iter().collect();
         assert_eq!(out, &[1, 2, 3, 3, 1, 2]);
 
         // sliced explode
-        let exploded = ca.slice(0, 1).explode()?;
+        let exploded = ca.slice(0, 1).explode(false)?;
         let out: Vec<_> = exploded.i32()?.into_no_null_iter().collect();
         assert_eq!(out, &[1, 2, 3, 3]);
 
@@ -310,7 +310,7 @@ mod test {
             .unwrap();
 
         let ca = builder.finish();
-        let exploded = ca.explode()?;
+        let exploded = ca.explode(false)?;
         assert_eq!(
             Vec::from(exploded.i32()?),
             &[Some(1), Some(2), None, Some(3)]
@@ -335,7 +335,7 @@ mod test {
             .unwrap();
 
         let ca = builder.finish();
-        let exploded = ca.explode()?;
+        let exploded = ca.explode(false)?;
         assert_eq!(
             Vec::from(exploded.i32()?),
             &[Some(1), None, Some(2), None, Some(3), Some(4)]
@@ -381,7 +381,7 @@ mod test {
             .unwrap();
 
         let ca = builder.finish();
-        let exploded = ca.explode()?;
+        let exploded = ca.explode(false)?;
         assert_eq!(
             Vec::from(exploded.str()?),
             &[Some("abc"), None, Some("de"), None, Some("fg"), None]
@@ -406,7 +406,7 @@ mod test {
             .unwrap();
 
         let ca = builder.finish();
-        let exploded = ca.explode()?;
+        let exploded = ca.explode(false)?;
         assert_eq!(
             Vec::from(exploded.bool()?),
             &[Some(true), None, Some(false), None, Some(true), Some(true)]

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -82,11 +82,11 @@ pub trait ChunkAnyValue {
 
 /// Explode/flatten a List or String Series
 pub trait ChunkExplode {
-    fn explode(&self) -> PolarsResult<Series> {
-        self.explode_and_offsets().map(|t| t.0)
+    fn explode(&self, skip_empty: bool) -> PolarsResult<Series> {
+        self.explode_and_offsets(skip_empty).map(|t| t.0)
     }
     fn offsets(&self) -> PolarsResult<OffsetsBuffer<i64>>;
-    fn explode_and_offsets(&self) -> PolarsResult<(Series, OffsetsBuffer<i64>)>;
+    fn explode_and_offsets(&self, skip_empty: bool) -> PolarsResult<(Series, OffsetsBuffer<i64>)>;
 }
 
 pub trait ChunkBytes {

--- a/crates/polars-core/src/frame/column/mod.rs
+++ b/crates/polars-core/src/frame/column/mod.rs
@@ -1158,8 +1158,10 @@ impl Column {
         }
     }
 
-    pub fn explode(&self) -> PolarsResult<Column> {
-        self.as_materialized_series().explode().map(Column::from)
+    pub fn explode(&self, skip_empty: bool) -> PolarsResult<Column> {
+        self.as_materialized_series()
+            .explode(skip_empty)
+            .map(Column::from)
     }
     pub fn implode(&self) -> PolarsResult<ListChunked> {
         self.as_materialized_series().implode()

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -11,9 +11,9 @@ use crate::series::IsSorted;
 
 fn get_exploded(series: &Series) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
     match series.dtype() {
-        DataType::List(_) => series.list().unwrap().explode_and_offsets(),
+        DataType::List(_) => series.list().unwrap().explode_and_offsets(false),
         #[cfg(feature = "dtype-array")]
-        DataType::Array(_, _) => series.array().unwrap().explode_and_offsets(),
+        DataType::Array(_, _) => series.array().unwrap().explode_and_offsets(false),
         _ => polars_bail!(opq = explode, series.dtype()),
     }
 }
@@ -34,7 +34,7 @@ impl DataFrame {
         let mut df = self.clone();
         if self.is_empty() {
             for s in &columns {
-                df.with_column(s.as_materialized_series().explode()?)?;
+                df.with_column(s.as_materialized_series().explode(false)?)?;
             }
             return Ok(df);
         }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -627,11 +627,11 @@ impl Series {
     }
 
     /// Explode a list Series. This expands every item to a new row..
-    pub fn explode(&self) -> PolarsResult<Series> {
+    pub fn explode(&self, skip_empty: bool) -> PolarsResult<Series> {
         match self.dtype() {
-            DataType::List(_) => self.list().unwrap().explode(),
+            DataType::List(_) => self.list().unwrap().explode(skip_empty),
             #[cfg(feature = "dtype-array")]
-            DataType::Array(_, _) => self.array().unwrap().explode(),
+            DataType::Array(_, _) => self.array().unwrap().explode(skip_empty),
             _ => Ok(self.clone()),
         }
     }

--- a/crates/polars-core/src/series/ops/reshape.rs
+++ b/crates/polars-core/src/series/ops/reshape.rs
@@ -227,7 +227,7 @@ impl Series {
 
         let s = self;
         let s = if let DataType::List(_) = s.dtype() {
-            Cow::Owned(s.explode()?)
+            Cow::Owned(s.explode(true)?)
         } else {
             Cow::Borrowed(s)
         };
@@ -338,7 +338,7 @@ mod test {
             let out = s.reshape_list(&dims)?;
             assert_eq!(out.len(), list_len);
             assert!(matches!(out.dtype(), DataType::List(_)));
-            assert_eq!(out.explode()?.len(), 4);
+            assert_eq!(out.explode(false)?.len(), 4);
         }
 
         Ok(())

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -604,7 +604,7 @@ impl PartitionedAggregation for AggregationExpr {
                 offsets.push(length_so_far);
 
                 let mut process_group = |ca: ListChunked| -> PolarsResult<()> {
-                    let s = ca.explode()?;
+                    let s = ca.explode(false)?;
                     length_so_far += s.len() as i64;
                     offsets.push(length_so_far);
                     values.push(s.chunks()[0].clone());

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -91,7 +91,7 @@ impl ApplyExpr {
         ca: ListChunked,
     ) -> PolarsResult<AggregationContext<'a>> {
         let c = if self.function_returns_scalar {
-            let out = ca.explode().unwrap();
+            let out = ca.explode(false).unwrap();
             // if the explode doesn't return the same len, it wasn't scalar.
             polars_ensure!(out.len() == ca.len(), InvalidOperation: "expected scalar for expr: {}, got {}", self.expr, &out);
             ac.update_groups = UpdateGroups::No;

--- a/crates/polars-expr/src/expressions/mod.rs
+++ b/crates/polars-expr/src/expressions/mod.rs
@@ -501,7 +501,7 @@ impl<'a> AggregationContext<'a> {
             AggState::AggregatedScalar(c) => (c, groups),
             AggState::Literal(c) => (c, groups),
             AggState::AggregatedList(c) => {
-                let flattened = c.explode().unwrap();
+                let flattened = c.explode(false).unwrap();
                 let groups = groups.into_owned();
                 // unroll the possible flattened state
                 // say we have groups with overlapping windows:
@@ -552,7 +552,7 @@ impl<'a> AggregationContext<'a> {
                     }
                 }
 
-                Cow::Owned(c.explode().unwrap())
+                Cow::Owned(c.explode(false).unwrap())
             },
             AggState::AggregatedScalar(c) => Cow::Borrowed(c),
             AggState::Literal(c) => Cow::Borrowed(c),

--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -393,7 +393,7 @@ impl PhysicalExpr for SortByExpr {
         // group_by operation - we must ensure that we are as well.
         if ordered_by_group_operation {
             let s = ac_in.aggregated();
-            ac_in.with_values(s.explode().unwrap(), false, None)?;
+            ac_in.with_values(s.explode(false).unwrap(), false, None)?;
         }
 
         ac_in.with_groups(groups.into_sliceable());

--- a/crates/polars-expr/src/expressions/ternary.rs
+++ b/crates/polars-expr/src/expressions/ternary.rs
@@ -67,7 +67,7 @@ fn finish_as_iters<'a>(
         // Exploded list should be equal to groups length.
         list_vals_len == ac_truthy.groups.len()
     {
-        out = out.explode()?
+        out = out.explode(false)?
     }
 
     ac_truthy.with_agg_state(AggState::AggregatedList(out));

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -533,7 +533,7 @@ impl PhysicalExpr for WindowExpr {
                 Ok(out.into_column())
             },
             Explode => {
-                let mut out = ac.aggregated().explode()?;
+                let mut out = ac.aggregated().explode(false)?;
                 if let Some(name) = &self.out_name {
                     out.rename(name.clone());
                 }
@@ -543,7 +543,7 @@ impl PhysicalExpr for WindowExpr {
                 // TODO!
                 // investigate if sorted arrays can be return directly
                 let out_column = ac.aggregated();
-                let flattened = out_column.explode()?;
+                let flattened = out_column.explode(false)?;
                 // we extend the lifetime as we must convince the compiler that ac lives
                 // long enough. We drop `GrouBy` when we are done with `ac`.
                 let ac = unsafe {

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -502,10 +502,13 @@ fn create_physical_expr_inner(
                 expr: node_to_expr(expression, expr_arena),
             }))
         },
-        Explode(expr) => {
+        Explode { expr, skip_empty } => {
             let input = create_physical_expr_inner(*expr, ctxt, expr_arena, schema, state)?;
+            let skip_empty = *skip_empty;
             let function = SpecialEq::new(Arc::new(
-                move |c: &mut [polars_core::frame::column::Column]| c[0].explode().map(Some),
+                move |c: &mut [polars_core::frame::column::Column]| {
+                    c[0].explode(skip_empty).map(Some)
+                },
             ) as Arc<dyn ColumnsUdf>);
 
             let field = expr_arena

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -249,7 +249,7 @@ fn test_binary_agg_context_0() -> PolarsResult<()> {
         .unwrap();
 
     let out = out.column("foo")?;
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     let out = out.str()?;
     assert_eq!(
         Vec::from(out),
@@ -293,7 +293,7 @@ fn test_binary_agg_context_1() -> PolarsResult<()> {
     // [90, 90]
     // [7, 90]
     let out = out.column("vals")?;
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     let out = out.i32()?;
     assert_eq!(
         Vec::from(out),
@@ -314,7 +314,7 @@ fn test_binary_agg_context_1() -> PolarsResult<()> {
     // [90, 90]
     // [90, 7]
     let out = out.column("vals")?;
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     let out = out.i32()?;
     assert_eq!(
         Vec::from(out),
@@ -344,7 +344,7 @@ fn test_binary_agg_context_2() -> PolarsResult<()> {
     // 3 - [3, 4] = [0, -1]
     // 5 - [5, 6] = [0, -1]
     let out = out.column("vals")?;
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     let out = out.i32()?;
     assert_eq!(
         Vec::from(out),
@@ -362,7 +362,7 @@ fn test_binary_agg_context_2() -> PolarsResult<()> {
     // [3, 4] - 3 = [0, 1]
     // [5, 6] - 5 = [0, 1]
     let out = out.column("vals")?;
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     let out = out.i32()?;
     assert_eq!(
         Vec::from(out),
@@ -459,7 +459,7 @@ fn take_aggregations() -> PolarsResult<()> {
         .sort(["user"], Default::default())
         .collect()?;
     let s = out.column("ordered")?;
-    let flat = s.explode()?;
+    let flat = s.explode(false)?;
     let flat = flat.str()?;
     let vals = flat.into_no_null_iter().collect::<Vec<_>>();
     assert_eq!(vals, ["a", "b", "c", "a", "a"]);

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1041,7 +1041,7 @@ fn test_group_by_cum_sum() -> PolarsResult<()> {
         .collect()?;
 
     assert_eq!(
-        Vec::from(out.column("vals")?.explode()?.i32()?),
+        Vec::from(out.column("vals")?.explode(false)?.i32()?),
         [1, 5, 11, 3, 12, 20]
             .iter()
             .copied()
@@ -1302,7 +1302,7 @@ fn test_sort_by() -> PolarsResult<()> {
         .group_by_stable([col("b")])
         .agg([col("a").sort_by([col("b"), col("c")], SortMultipleOptions::default())])
         .collect()?;
-    let a = out.column("a")?.explode()?;
+    let a = out.column("a")?.explode(false)?;
     assert_eq!(
         Vec::from(a.i32().unwrap()),
         &[Some(3), Some(1), Some(2), Some(5), Some(4)]
@@ -1315,7 +1315,7 @@ fn test_sort_by() -> PolarsResult<()> {
         .agg([col("a").sort_by([col("b"), col("c")], SortMultipleOptions::default())])
         .collect()?;
 
-    let a = out.column("a")?.explode()?;
+    let a = out.column("a")?.explode(false)?;
     assert_eq!(
         Vec::from(a.i32().unwrap()),
         &[Some(3), Some(1), Some(2), Some(5), Some(4)]
@@ -1698,7 +1698,7 @@ fn test_single_ranked_group() -> PolarsResult<()> {
             .over_with_options([col("group")], None, WindowMapping::Join)])
         .collect()?;
 
-    let out = out.column("value")?.explode()?;
+    let out = out.column("value")?.explode(false)?;
     let out = out.f64()?;
     assert_eq!(
         Vec::from(out),
@@ -1767,7 +1767,7 @@ fn test_is_in() -> PolarsResult<()> {
         )])
         .collect()?;
     let out = out.column("cars").unwrap();
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     let out = out.bool().unwrap();
     assert_eq!(
         Vec::from(out),
@@ -1785,7 +1785,7 @@ fn test_is_in() -> PolarsResult<()> {
         .collect()?;
 
     let out = out.column("cars").unwrap();
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     let out = out.bool().unwrap();
     assert_eq!(
         Vec::from(out),

--- a/crates/polars-ops/src/chunked_array/list/min_max.rs
+++ b/crates/polars-ops/src/chunked_array/list/min_max.rs
@@ -95,7 +95,7 @@ pub(super) fn list_min_function(ca: &ListChunked) -> PolarsResult<Series> {
                     let sc = s.min_reduce()?;
                     Ok(sc.into_series(s.name().clone()))
                 })?
-                .explode()
+                .explode(false)
                 .unwrap()
                 .into_series()
                 .cast(dt),
@@ -206,7 +206,7 @@ pub(super) fn list_max_function(ca: &ListChunked) -> PolarsResult<Series> {
                     let sc = s.max_reduce()?;
                     Ok(sc.into_series(s.name().clone()))
                 })?
-                .explode()
+                .explode(false)
                 .unwrap()
                 .into_series()
                 .cast(dt),

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -489,7 +489,7 @@ pub trait ListNameSpaceImpl: AsList {
                         list_ca.inner_dtype(),
                     )
                 } else {
-                    let s = list_ca.explode()?;
+                    let s = list_ca.explode(false)?;
                     idx_ca
                         .into_iter()
                         .map(|opt_idx| {
@@ -503,7 +503,7 @@ pub trait ListNameSpaceImpl: AsList {
                 Ok(out.into_series())
             },
             (_, 1) => {
-                let idx_ca = idx_ca.explode()?;
+                let idx_ca = idx_ca.explode(false)?;
 
                 use DataType as D;
                 match idx_ca.dtype() {

--- a/crates/polars-ops/src/chunked_array/list/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/list/sum_mean.rs
@@ -112,7 +112,7 @@ pub(super) fn sum_with_nulls(ca: &ListChunked, inner_dtype: &DataType) -> Polars
                     .sum_reduce()
                     .map(|sc| sc.into_series(PlSmallStr::EMPTY))
             })?
-            .explode()
+            .explode(false)
             .unwrap()
             .into_series()
             .cast(dt)?,

--- a/crates/polars-ops/src/chunked_array/strings/find_many.rs
+++ b/crates/polars-ops/src/chunked_array/strings/find_many.rs
@@ -41,7 +41,7 @@ pub fn contains_any(
         return Ok(BooleanChunked::full_null(ca.name().clone(), ca.len()));
     }
 
-    let patterns = patterns.explode()?;
+    let patterns = patterns.explode(true)?;
     let patterns = patterns.str()?;
     let ac = build_ac(patterns, ascii_case_insensitive)?;
 
@@ -88,9 +88,9 @@ pub fn replace_all(
         return Ok(StringChunked::full_null(ca.name().clone(), ca.len()));
     }
 
-    let patterns = patterns.explode()?;
+    let patterns = patterns.explode(true)?;
     let patterns = patterns.str()?;
-    let replace_with = replace_with.explode()?;
+    let replace_with = replace_with.explode(true)?;
     let replace_with = replace_with.str()?;
 
     let replace_with = if replace_with.len() == 1 && patterns.len() > 1 {
@@ -165,7 +165,7 @@ pub fn extract_many(
             },
         },
         (_, 1) => {
-            let patterns = patterns.explode()?;
+            let patterns = patterns.explode(true)?;
             let patterns = patterns.str()?;
             let ac = build_ac(patterns, ascii_case_insensitive)?;
             let mut builder =
@@ -256,7 +256,7 @@ pub fn find_many(
             },
         },
         (_, 1) => {
-            let patterns = patterns.explode()?;
+            let patterns = patterns.explode(true)?;
             let patterns = patterns.str()?;
             let ac = build_ac(patterns, ascii_case_insensitive)?;
             let mut builder = B::new(ca.name().clone(), ca.len(), ca.len() * 2, DataType::UInt32);

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -238,7 +238,7 @@ where
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.as_ref().as_ref();
                 is_in_helper_ca(ca_in, other, nulls_equal)
             } else {
@@ -253,7 +253,7 @@ where
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.as_ref().as_ref();
                 is_in_helper_ca(ca_in, other, nulls_equal)
             } else {
@@ -312,7 +312,7 @@ fn is_in_binary(
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.binary()?;
                 is_in_helper_ca(ca_in, other, nulls_equal)
             } else {
@@ -327,7 +327,7 @@ fn is_in_binary(
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.binary()?;
                 is_in_helper_ca(ca_in, other, nulls_equal)
             } else {
@@ -380,7 +380,7 @@ fn is_in_boolean(
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.bool()?;
                 is_in_boolean_broadcast(ca_in, other, nulls_equal)
             } else {
@@ -395,7 +395,7 @@ fn is_in_boolean(
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.bool()?;
                 is_in_boolean_broadcast(ca_in, other, nulls_equal)
             } else {
@@ -562,7 +562,7 @@ fn is_in_null(s: &Series, other: &Series, nulls_equal: bool) -> PolarsResult<Boo
                         return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                     }
 
-                    let other = other.explode()?;
+                    let other = other.explode(true)?;
                     BooleanChunked::from_iter_values(
                         ca_in.name().clone(),
                         std::iter::repeat_n(other.has_nulls(), ca_in.len()),
@@ -581,7 +581,7 @@ fn is_in_null(s: &Series, other: &Series, nulls_equal: bool) -> PolarsResult<Boo
                         return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                     }
 
-                    let other = other.explode()?;
+                    let other = other.explode(true)?;
                     BooleanChunked::from_iter_values(
                         ca_in.name().clone(),
                         std::iter::repeat_n(other.has_nulls(), ca_in.len()),
@@ -662,7 +662,7 @@ fn is_in_row_encoded(
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.binary_offset()?;
                 is_in_helper_ca(&ca_in, other, nulls_equal)
             } else {
@@ -683,7 +683,7 @@ fn is_in_row_encoded(
                     return Ok(BooleanChunked::full_null(ca_in.name().clone(), ca_in.len()));
                 }
 
-                let other = other.explode()?;
+                let other = other.explode(true)?;
                 let other = other.binary_offset()?;
                 is_in_helper_ca(&ca_in, other, nulls_equal)
             } else {

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -39,8 +39,8 @@ pub fn replace(s: &Series, old: &ListChunked, new: &ListChunked) -> PolarsResult
         nyi = "`replace` with a replacement pattern per row"
     );
 
-    let old = old.explode()?;
-    let new = new.explode()?;
+    let old = old.explode(true)?;
+    let new = new.explode(true)?;
 
     if old.is_empty() {
         return Ok(s.clone());
@@ -83,8 +83,8 @@ pub fn replace_or_default(
         nyi = "`replace_strict` with a replacement pattern per row"
     );
 
-    let old = old.explode()?;
-    let new = new.explode()?;
+    let old = old.explode(true)?;
+    let new = new.explode(true)?;
 
     polars_ensure!(
         default.len() == s.len() || default.len() == 1,
@@ -136,8 +136,8 @@ pub fn replace_strict(
         nyi = "`replace_strict` with a replacement pattern per row"
     );
 
-    let old = old.explode()?;
-    let new = new.explode()?;
+    let old = old.explode(true)?;
+    let new = new.explode(true)?;
 
     if old.is_empty() {
         polars_ensure!(

--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -179,6 +179,8 @@ impl ArrayNameSpace {
     /// Returns a column with a separate row for every array element.
     pub fn explode(self) -> Expr {
         self.0
-            .map_unary(FunctionExpr::ArrayExpr(ArrayFunction::Explode))
+            .map_unary(FunctionExpr::ArrayExpr(ArrayFunction::Explode {
+                skip_empty: false,
+            }))
     }
 }

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -118,7 +118,10 @@ pub enum Expr {
         function: FunctionExpr,
         options: FunctionOptions,
     },
-    Explode(Arc<Expr>),
+    Explode {
+        input: Arc<Expr>,
+        skip_empty: bool,
+    },
     Filter {
         input: Arc<Expr>,
         by: Arc<Expr>,
@@ -296,7 +299,10 @@ impl Hash for Expr {
                 sort_options.hash(state);
             },
             Expr::Agg(input) => input.hash(state),
-            Expr::Explode(input) => input.hash(state),
+            Expr::Explode { input, skip_empty } => {
+                skip_empty.hash(state);
+                input.hash(state)
+            },
             Expr::Window {
                 function,
                 partition_by,

--- a/crates/polars-plan/src/dsl/format.rs
+++ b/crates/polars-plan/src/dsl/format.rs
@@ -39,7 +39,14 @@ impl fmt::Debug for Expr {
             },
             Nth(i) => write!(f, "nth({i})"),
             Len => write!(f, "len()"),
-            Explode(expr) => write!(f, "{expr:?}.explode()"),
+            Explode {
+                input: expr,
+                skip_empty: false,
+            } => write!(f, "{expr:?}.explode()"),
+            Explode {
+                input: expr,
+                skip_empty: true,
+            } => write!(f, "{expr:?}.explode(skip_empty)"),
             Alias(expr, name) => write!(f, "{expr:?}.alias(\"{name}\")"),
             Column(name) => write!(f, "col(\"{name}\")"),
             Literal(v) => write!(f, "{v:?}"),

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -31,7 +31,9 @@ pub enum ArrayFunction {
     #[cfg(feature = "array_count")]
     CountMatches,
     Shift,
-    Explode,
+    Explode {
+        skip_empty: bool,
+    },
     Concat,
 }
 
@@ -69,7 +71,7 @@ impl ArrayFunction {
             #[cfg(feature = "array_count")]
             CountMatches => mapper.with_dtype(IDX_DTYPE),
             Shift => mapper.with_same_dtype(),
-            Explode => mapper.try_map_to_array_inner_dtype(),
+            Explode { .. } => mapper.try_map_to_array_inner_dtype(),
         }
     }
 
@@ -100,7 +102,7 @@ impl ArrayFunction {
             | A::Get(_)
             | A::Join(_)
             | A::Shift => FunctionOptions::elementwise(),
-            A::Explode => FunctionOptions::row_separable(),
+            A::Explode { .. } => FunctionOptions::row_separable(),
         }
     }
 }
@@ -143,7 +145,7 @@ impl Display for ArrayFunction {
             #[cfg(feature = "array_count")]
             CountMatches => "count_matches",
             Shift => "shift",
-            Explode => "explode",
+            Explode { .. } => "explode",
         };
         write!(f, "arr.{name}")
     }
@@ -179,7 +181,7 @@ impl From<ArrayFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
             #[cfg(feature = "array_count")]
             CountMatches => map_as_slice!(count_matches),
             Shift => map_as_slice!(shift),
-            Explode => map_as_slice!(explode),
+            Explode { skip_empty } => map_as_slice!(explode, skip_empty),
         }
     }
 }
@@ -325,8 +327,8 @@ pub(super) fn shift(s: &[Column]) -> PolarsResult<Column> {
     ca.array_shift(n.as_materialized_series()).map(Column::from)
 }
 
-fn explode(c: &[Column]) -> PolarsResult<Column> {
-    c[0].explode()
+fn explode(c: &[Column], skip_empty: bool) -> PolarsResult<Column> {
+    c[0].explode(skip_empty)
 }
 
 fn concat_arr(args: &[Column]) -> PolarsResult<Column> {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -249,7 +249,10 @@ impl Expr {
 
     /// Explode the String/List column.
     pub fn explode(self) -> Self {
-        Expr::Explode(Arc::new(self))
+        Expr::Explode {
+            input: Arc::new(self),
+            skip_empty: false,
+        }
     }
 
     /// Slice the Series.

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -13,7 +13,7 @@ use super::*;
 // (Major, Minor)
 // Add a field -> increment minor
 // Remove or modify a field -> increment major and reset minor
-pub static DSL_VERSION: (u16, u16) = (1, 0);
+pub static DSL_VERSION: (u16, u16) = (2, 0);
 static DSL_MAGIC_BYTES: &[u8] = b"DSL_VERSION";
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/polars-plan/src/plans/aexpr/mod.rs
+++ b/crates/polars-plan/src/plans/aexpr/mod.rs
@@ -142,7 +142,10 @@ impl From<IRAggExpr> for GroupByMethod {
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "ir_serde", derive(Serialize, Deserialize))]
 pub enum AExpr {
-    Explode(Node),
+    Explode {
+        expr: Node,
+        skip_empty: bool,
+    },
     Alias(Node, PlSmallStr),
     Column(PlSmallStr),
     Literal(LiteralValue),

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -185,7 +185,7 @@ fn aexpr_to_skip_batch_predicate_rec(
         }
 
         match expr_arena.get(e) {
-            AExpr::Explode(_) => None,
+            AExpr::Explode { .. } => None,
             AExpr::Alias(_, _) => None,
             AExpr::Column(_) => None,
             AExpr::Literal(_) => None,
@@ -399,7 +399,10 @@ fn aexpr_to_skip_batch_predicate_rec(
                                 //      )
                                 let col = col.clone();
 
-                                let lv_node_exploded = expr_arena.add(AExpr::Explode(lv_node));
+                                let lv_node_exploded = expr_arena.add(AExpr::Explode {
+                                    expr: lv_node,
+                                    skip_empty: true,
+                                });
                                 let lv_min =
                                     expr_arena.add(AExpr::Agg(crate::plans::IRAggExpr::Min {
                                         input: lv_node_exploded,

--- a/crates/polars-plan/src/plans/aexpr/properties.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties.rs
@@ -26,7 +26,7 @@ impl AExpr {
             Alias(_, _) | BinaryExpr { .. } | Column(_) | Ternary { .. } | Cast { .. } => true,
 
             Agg { .. }
-            | Explode(_)
+            | Explode { .. }
             | Filter { .. }
             | Gather { .. }
             | Len

--- a/crates/polars-plan/src/plans/aexpr/schema.rs
+++ b/crates/polars-plan/src/plans/aexpr/schema.rs
@@ -144,7 +144,7 @@ impl AExpr {
                 let e = ctx.arena.get(*function);
                 e.to_field_impl(ctx, agg_list)
             },
-            Explode(expr) => {
+            Explode { expr, .. } => {
                 // `Explode` is a "flatten" operation, which is not the same as returning a scalar.
                 // Namely, it should be auto-imploded in the aggregation context, so we don't update
                 // the `agg_list` state here.

--- a/crates/polars-plan/src/plans/aexpr/traverse.rs
+++ b/crates/polars-plan/src/plans/aexpr/traverse.rs
@@ -42,7 +42,7 @@ impl AExpr {
             AnonymousFunction { input, .. } | Function { input, .. } => {
                 container.extend(input.iter().rev().map(|e| e.node()))
             },
-            Explode(e) => container.extend([*e]),
+            Explode { expr: e, .. } => container.extend([*e]),
             Window {
                 function,
                 partition_by,
@@ -71,7 +71,7 @@ impl AExpr {
             Column(_) | Literal(_) | Len => return self,
             Alias(input, _) => input,
             Cast { expr, .. } => expr,
-            Explode(input) => input,
+            Explode { expr, .. } => expr,
             BinaryExpr { left, right, .. } => {
                 *left = inputs[0];
                 *right = inputs[1];

--- a/crates/polars-plan/src/plans/conversion/expr_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_to_ir.rs
@@ -115,7 +115,10 @@ pub(super) fn to_aexpr_impl(
 ) -> PolarsResult<Node> {
     let owned = Arc::unwrap_or_clone;
     let v = match expr {
-        Expr::Explode(expr) => AExpr::Explode(to_aexpr_impl(owned(expr), arena, state)?),
+        Expr::Explode { input, skip_empty } => AExpr::Explode {
+            expr: to_aexpr_impl(owned(input), arena, state)?,
+            skip_empty,
+        },
         Expr::Alias(e, name) => {
             if state.prune_alias {
                 if state.output_name.is_none() && !state.ignore_alias {

--- a/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
+++ b/crates/polars-plan/src/plans/conversion/ir_to_dsl.rs
@@ -6,7 +6,10 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
     let expr = expr_arena.get(node).clone();
 
     match expr {
-        AExpr::Explode(node) => Expr::Explode(Arc::new(node_to_expr(node, expr_arena))),
+        AExpr::Explode { expr, skip_empty } => Expr::Explode {
+            input: Arc::new(node_to_expr(expr, expr_arena)),
+            skip_empty,
+        },
         AExpr::Alias(expr, name) => {
             let exp = node_to_expr(expr, expr_arena);
             Expr::Alias(Arc::new(exp), name)

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -391,9 +391,13 @@ impl Display for ExprIRDisplay<'_> {
                 }
             },
             Len => write!(f, "len()"),
-            Explode(expr) => {
+            Explode { expr, skip_empty } => {
                 let expr = self.with_root(expr);
-                write!(f, "{expr}.explode()")
+                if *skip_empty {
+                    write!(f, "{expr}.explode(skip_empty)")
+                } else {
+                    write!(f, "{expr}.explode()")
+                }
             },
             Alias(expr, name) => {
                 let expr = self.with_root(expr);

--- a/crates/polars-plan/src/plans/ir/tree_format.rs
+++ b/crates/polars-plan/src/plans/ir/tree_format.rs
@@ -24,7 +24,14 @@ pub struct TreeFmtAExpr<'a>(&'a AExpr);
 impl fmt::Display for TreeFmtAExpr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self.0 {
-            AExpr::Explode(_) => "explode",
+            AExpr::Explode {
+                expr: _,
+                skip_empty: false,
+            } => "explode",
+            AExpr::Explode {
+                expr: _,
+                skip_empty: true,
+            } => "explode(skip_empty)",
             AExpr::Alias(_, name) => return write!(f, "alias({})", name),
             AExpr::Column(name) => return write!(f, "col({})", name),
             AExpr::Literal(lv) => return write!(f, "lit({lv:?})"),

--- a/crates/polars-plan/src/plans/iterator.rs
+++ b/crates/polars-plan/src/plans/iterator.rs
@@ -72,7 +72,7 @@ macro_rules! push_expr {
             // as the root columns/ input columns by `_suffix` and `_keep_name` etc.
             AnonymousFunction { input, .. } => input.$iter().rev().for_each(|e| $push_owned($c, e)),
             Function { input, .. } => input.$iter().rev().for_each(|e| $push_owned($c, e)),
-            Explode(e) => $push($c, e),
+            Explode { input, .. } => $push($c, input),
             Window {
                 function,
                 partition_by,

--- a/crates/polars-plan/src/plans/visitor/expr.rs
+++ b/crates/polars-plan/src/plans/visitor/expr.rs
@@ -75,7 +75,7 @@ impl TreeWalker for Expr {
             }),
             Ternary { predicate, truthy, falsy } => Ternary { predicate: am(predicate, &mut f)?, truthy: am(truthy, &mut f)?, falsy: am(falsy, f)? },
             Function { input, function, options } => Function { input: input.into_iter().map(f).collect::<Result<_, _>>()?, function, options },
-            Explode(expr) => Explode(am(expr, f)?),
+            Explode { input, skip_empty } => Explode { input: am(input, f)?, skip_empty },
             Filter { input, by } => Filter { input: am(input, &mut f)?, by: am(by, f)? },
             Window { function, partition_by, order_by, options } => {
                 let partition_by = partition_by.into_iter().map(&mut f).collect::<Result<_, _>>()?;
@@ -184,8 +184,17 @@ impl AExpr {
             | (Filter { .. }, Filter { .. })
             | (Ternary { .. }, Ternary { .. })
             | (Len, Len)
-            | (Slice { .. }, Slice { .. })
-            | (Explode(_), Explode(_)) => true,
+            | (Slice { .. }, Slice { .. }) => true,
+            (
+                Explode {
+                    expr: _,
+                    skip_empty: l_skip_empty,
+                },
+                Explode {
+                    expr: _,
+                    skip_empty: r_skip_empty,
+                },
+            ) => l_skip_empty == r_skip_empty,
             (
                 SortBy {
                     sort_options: l_sort_options,

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -532,7 +532,7 @@ impl PyGroupbyOptions {
 
 pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
     match expr {
-        AExpr::Explode(_) => Err(PyNotImplementedError::new_err("explode")),
+        AExpr::Explode { .. } => Err(PyNotImplementedError::new_err("explode")),
         AExpr::Alias(inner, name) => Alias {
             expr: inner.0,
             name: name.into_py_any(py)?,

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -1692,7 +1692,7 @@ impl ExprSqlProjectionHeightBehavior {
 
                 Literal(v) => !v.is_scalar(),
 
-                Explode(_) | Filter { .. } | Gather { .. } | Slice { .. } => true,
+                Explode { .. } | Filter { .. } | Gather { .. } | Slice { .. } => true,
 
                 Agg { .. } | Len => true,
 

--- a/crates/polars-stream/src/physical_plan/lower_group_by.rs
+++ b/crates/polars-stream/src/physical_plan/lower_group_by.rs
@@ -127,7 +127,7 @@ fn try_lower_elementwise_scalar_agg_expr(
         // in a streaming fashion but they change the length of the input which
         // means the same filter/explode should also be applied to the key
         // column, which is not (yet) supported.
-        AExpr::Explode(_) | AExpr::Filter { .. } => None,
+        AExpr::Explode { .. } | AExpr::Filter { .. } => None,
 
         AExpr::BinaryExpr { left, op, right } => {
             let (left, op, right) = (*left, *op, *right);

--- a/crates/polars-testing/src/asserts/utils.rs
+++ b/crates/polars-testing/src/asserts/utils.rs
@@ -439,8 +439,8 @@ pub fn assert_series_nested_values_equal(
                 let s2_series = Series::new("".into(), &[s2.clone()]);
 
                 match assert_series_values_equal(
-                    &s1_series.explode()?,
-                    &s2_series.explode()?,
+                    &s1_series.explode(false)?,
+                    &s2_series.explode(false)?,
                     true,
                     check_exact,
                     rtol,

--- a/crates/polars/tests/it/core/list.rs
+++ b/crates/polars/tests/it/core/list.rs
@@ -10,7 +10,7 @@ fn test_to_list_logical() -> PolarsResult<()> {
     // check if dtype is maintained all the way to formatting
     assert!(s.contains("[2021-01-01, 2021-01-02, 2021-01-03]"));
 
-    let expl = out.explode().unwrap();
+    let expl = out.explode(false).unwrap();
     assert_eq!(expl.dtype(), &DataType::Date);
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -358,7 +358,7 @@ fn test_binary_group_consistency() -> PolarsResult<()> {
 
     assert_eq!(out.dtype(), &DataType::List(Box::new(DataType::String)));
     assert_eq!(
-        out.explode()?
+        out.explode(false)?
             .str()?
             .into_no_null_iter()
             .collect::<Vec<_>>(),

--- a/crates/polars/tests/it/lazy/expressions/slice.rs
+++ b/crates/polars/tests/it/lazy/expressions/slice.rs
@@ -17,7 +17,7 @@ fn test_slice_args() -> PolarsResult<()> {
     .agg([col("vals").slice(lit(0i64), (len() * lit(0.2)).cast(DataType::Int32))])
     .collect()?;
 
-    let out = df.column("vals")?.explode()?;
+    let out = df.column("vals")?.explode(false)?;
     let out = out.i32().unwrap();
     assert_eq!(
         out.into_no_null_iter().collect::<Vec<_>>(),

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -178,7 +178,7 @@ fn test_literal_window_fn() -> PolarsResult<()> {
 
     let out = out.column("foo")?;
     assert!(matches!(out.dtype(), DataType::List(_)));
-    let flat = out.explode()?;
+    let flat = out.explode(false)?;
     let flat = flat.i32()?;
     assert_eq!(
         Vec::from(flat),

--- a/crates/polars/tests/it/lazy/group_by.rs
+++ b/crates/polars/tests/it/lazy/group_by.rs
@@ -122,7 +122,7 @@ fn test_group_by_agg_list_with_not_aggregated() -> PolarsResult<()> {
         .collect()?;
 
     let out = out.column("value")?;
-    let out = out.explode()?;
+    let out = out.explode(false)?;
     assert_eq!(
         out,
         Column::new("value".into(), &[0, 2, 1, 3, 2, 2, 7, 2, 3, 1, 2, 1])

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2348,7 +2348,7 @@ class Expr:
         │ 2         ┆ 1    ┆ null      │
         └───────────┴──────┴───────────┘
         """
-        element = parse_into_expression(element, str_as_lit=True, list_as_series=False)
+        element = parse_into_expression(element, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.index_of(element))
 
     def search_sorted(
@@ -10409,8 +10409,8 @@ class Expr:
                     "`new` argument is required if `old` argument is not a Mapping type"
                 )
                 raise TypeError(msg)
-            new = pl.Series(old.values())
-            old = pl.Series(old.keys())
+            new = list(old.values())
+            old = list(old.keys())
         else:
             if isinstance(old, Sequence) and not isinstance(old, (str, pl.Series)):
                 old = pl.Series(old)
@@ -10605,11 +10605,11 @@ class Expr:
                     "`new` argument is required if `old` argument is not a Mapping type"
                 )
                 raise TypeError(msg)
-            new = pl.Series(old.values())
-            old = pl.Series(old.keys())
+            new = list(old.values())
+            old = list(old.keys())
 
-        old = parse_into_expression(old, str_as_lit=True, list_as_series=True)  # type: ignore[arg-type]
-        new = parse_into_expression(new, str_as_lit=True, list_as_series=True)  # type: ignore[arg-type]
+        old = parse_into_expression(old, str_as_lit=True)  # type: ignore[arg-type]
+        new = parse_into_expression(new, str_as_lit=True)  # type: ignore[arg-type]
 
         default = (
             None

--- a/py-polars/tests/unit/operations/test_replace_strict.py
+++ b/py-polars/tests/unit/operations/test_replace_strict.py
@@ -424,3 +424,16 @@ def test_replace_strict_unique_22134() -> None:
         pl.DataFrame({"mapped_column": ["Jelly", "Soap"]}),
         check_row_order=False,
     )
+
+
+def test_replace_strict_nested_mapping_22554() -> None():
+    assert_series_equal(
+        pl.Series([1, 2, 3]).replace_strict(
+            {
+                1: [42],
+                2: [13],
+                3: [37],
+            }
+        ),
+        pl.Series([[42], [13], [37]]),
+    )

--- a/py-polars/tests/unit/operations/test_replace_strict.py
+++ b/py-polars/tests/unit/operations/test_replace_strict.py
@@ -426,7 +426,7 @@ def test_replace_strict_unique_22134() -> None:
     )
 
 
-def test_replace_strict_nested_mapping_22554() -> None():
+def test_replace_strict_nested_mapping_22554() -> None:
     assert_series_equal(
         pl.Series([1, 2, 3]).replace_strict(
             {


### PR DESCRIPTION
This PR also introduces an internal `.explode(skip_empty: bool)` option to move explode behavior to what is described in #17664.

Fixes #22554.