### PR TITLE
refactor: Unify function flags into 1 bitset

### DIFF
--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -17,15 +17,11 @@ pub struct ApplyExpr {
     inputs: Vec<Arc<dyn PhysicalExpr>>,
     function: SpecialEq<Arc<dyn ColumnsUdf>>,
     expr: Expr,
-    collect_groups: ApplyOptions,
-    function_returns_scalar: bool,
+    flags: FunctionFlags,
     function_operates_on_scalar: bool,
-    allow_rename: bool,
-    pass_name_to_apply: bool,
     input_schema: SchemaRef,
     allow_threading: bool,
     check_lengths: bool,
-    allow_group_aware: bool,
     output_field: Field,
     inlined_eval: OnceLock<Option<Column>>,
 }
@@ -40,31 +36,23 @@ impl ApplyExpr {
         allow_threading: bool,
         input_schema: SchemaRef,
         output_field: Field,
-        returns_scalar: bool,
+        function_operates_on_scalar: bool,
     ) -> Self {
-        #[cfg(debug_assertions)]
-        if matches!(options.collect_groups, ApplyOptions::ElementWise)
-            && options.flags.contains(FunctionFlags::RETURNS_SCALAR)
-        {
-            panic!(
-                "expr {:?} is not implemented correctly. 'returns_scalar' and 'elementwise' are mutually exclusive",
-                expr
-            )
-        }
+        debug_assert!(
+            !options.is_length_preserving()
+                || !options.flags.contains(FunctionFlags::RETURNS_SCALAR),
+            "expr {expr:?} is not implemented correctly. 'returns_scalar' and 'elementwise' are mutually exclusive",
+        );
 
         Self {
             inputs,
             function,
             expr,
-            collect_groups: options.collect_groups,
-            function_returns_scalar: options.flags.contains(FunctionFlags::RETURNS_SCALAR),
-            function_operates_on_scalar: returns_scalar,
-            allow_rename: options.flags.contains(FunctionFlags::ALLOW_RENAME),
-            pass_name_to_apply: options.flags.contains(FunctionFlags::PASS_NAME_TO_APPLY),
+            flags: options.flags,
+            function_operates_on_scalar,
             input_schema,
             allow_threading,
             check_lengths: options.check_lengths(),
-            allow_group_aware: options.flags.contains(FunctionFlags::ALLOW_GROUP_AWARE),
             output_field,
             inlined_eval: Default::default(),
         }
@@ -90,7 +78,7 @@ impl ApplyExpr {
         mut ac: AggregationContext<'a>,
         ca: ListChunked,
     ) -> PolarsResult<AggregationContext<'a>> {
-        let c = if self.function_returns_scalar {
+        let c = if self.flags.returns_scalar() {
             let out = ca.explode(false).unwrap();
             // if the explode doesn't return the same len, it wasn't scalar.
             polars_ensure!(out.len() == ca.len(), InvalidOperation: "expected scalar for expr: {}, got {}", self.expr, &out);
@@ -101,7 +89,13 @@ impl ApplyExpr {
             ca.into_series().into()
         };
 
-        ac.with_values_and_args(c, true, None, false, self.function_returns_scalar)?;
+        ac.with_values_and_args(
+            c,
+            true,
+            None,
+            false,
+            self.flags.returns_scalar(),
+        )?;
 
         Ok(ac)
     }
@@ -151,7 +145,10 @@ impl ApplyExpr {
         let f = |opt_s: Option<Series>| match opt_s {
             None => Ok(None),
             Some(mut s) => {
-                if self.pass_name_to_apply {
+                if self
+                    .flags
+                    .contains(FunctionFlags::PASS_NAME_TO_APPLY)
+                {
                     s.rename(name.clone());
                 }
                 Ok(self
@@ -179,7 +176,7 @@ impl ApplyExpr {
                 // })?
                 let out: ListChunked = POOL.install(|| iter.collect::<PolarsResult<_>>())?;
 
-                if self.function_returns_scalar {
+                if self.flags.returns_scalar() {
                     debug_assert_eq!(&DataType::List(Box::new(dtype)), out.dtype());
                 } else {
                     debug_assert_eq!(&dtype, out.dtype());
@@ -242,7 +239,12 @@ impl ApplyExpr {
         // then unpack the lists and finally create iterators from this list chunked arrays.
         let mut iters = acs
             .iter_mut()
-            .map(|ac| ac.iter_groups(self.pass_name_to_apply))
+            .map(|ac| {
+                ac.iter_groups(
+                    self.flags
+                        .contains(FunctionFlags::PASS_NAME_TO_APPLY),
+                )
+            })
             .collect::<Vec<_>>();
 
         // Length of the items to iterate over.
@@ -329,7 +331,7 @@ impl PhysicalExpr for ApplyExpr {
             self.inputs.iter().map(f).collect::<PolarsResult<Vec<_>>>()
         }?;
 
-        if self.allow_rename {
+        if self.flags.contains(FunctionFlags::ALLOW_RENAME) {
             self.eval_and_flatten(&mut inputs)
         } else {
             let in_name = inputs[0].name().clone();
@@ -363,27 +365,27 @@ impl PhysicalExpr for ApplyExpr {
         state: &ExecutionState,
     ) -> PolarsResult<AggregationContext<'a>> {
         polars_ensure!(
-            self.allow_group_aware,
+            self.flags.contains(FunctionFlags::ALLOW_GROUP_AWARE),
             expr = self.expr,
             ComputeError: "this expression cannot run in the group_by context",
         );
         if self.inputs.len() == 1 {
             let mut ac = self.inputs[0].evaluate_on_groups(df, groups, state)?;
 
-            match self.collect_groups {
-                ApplyOptions::ApplyList => {
+            match self.flags.is_elementwise() {
+                false if self.flags.contains(FunctionFlags::APPLY_LIST) => {
                     let c = self.eval_and_flatten(&mut [ac.aggregated()])?;
                     ac.with_values(c, true, Some(&self.expr))?;
                     Ok(ac)
                 },
-                ApplyOptions::GroupWise => self.apply_single_group_aware(ac),
-                ApplyOptions::ElementWise => self.apply_single_elementwise(ac),
+                false => self.apply_single_group_aware(ac),
+                true => self.apply_single_elementwise(ac),
             }
         } else {
             let mut acs = self.prepare_multiple_inputs(df, groups, state)?;
 
-            match self.collect_groups {
-                ApplyOptions::ApplyList => {
+            match self.flags.is_elementwise() {
+                false if self.flags.contains(FunctionFlags::APPLY_LIST) => {
                     let mut c = acs.iter_mut().map(|ac| ac.aggregated()).collect::<Vec<_>>();
                     let c = self.eval_and_flatten(&mut c)?;
                     // take the first aggregation context that as that is the input series
@@ -392,8 +394,8 @@ impl PhysicalExpr for ApplyExpr {
                     ac.with_values(c, true, Some(&self.expr))?;
                     Ok(ac)
                 },
-                ApplyOptions::GroupWise => self.apply_multiple_group_aware(acs, df),
-                ApplyOptions::ElementWise => {
+                false => self.apply_multiple_group_aware(acs, df),
+                true => {
                     let mut has_agg_list = false;
                     let mut has_agg_scalar = false;
                     let mut has_not_agg = false;
@@ -425,14 +427,14 @@ impl PhysicalExpr for ApplyExpr {
         self.expr.to_field(input_schema, Context::Default)
     }
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
-        if self.inputs.len() == 1 && matches!(self.collect_groups, ApplyOptions::ElementWise) {
+        if self.inputs.len() == 1 && self.flags.is_elementwise() {
             Some(self)
         } else {
             None
         }
     }
     fn is_scalar(&self) -> bool {
-        self.function_returns_scalar || self.function_operates_on_scalar
+        self.flags.returns_scalar() || self.function_operates_on_scalar
     }
 }
 
@@ -510,7 +512,7 @@ impl PartitionedAggregation for ApplyExpr {
         let a = self.inputs[0].as_partitioned_aggregator().unwrap();
         let s = a.evaluate_partitioned(df, groups, state)?;
 
-        if self.allow_rename {
+        if self.flags.contains(FunctionFlags::ALLOW_RENAME) {
             self.eval_and_flatten(&mut [s])
         } else {
             let in_name = s.name().clone();

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -89,13 +89,7 @@ impl ApplyExpr {
             ca.into_series().into()
         };
 
-        ac.with_values_and_args(
-            c,
-            true,
-            None,
-            false,
-            self.flags.returns_scalar(),
-        )?;
+        ac.with_values_and_args(c, true, None, false, self.flags.returns_scalar())?;
 
         Ok(ac)
     }
@@ -145,10 +139,7 @@ impl ApplyExpr {
         let f = |opt_s: Option<Series>| match opt_s {
             None => Ok(None),
             Some(mut s) => {
-                if self
-                    .flags
-                    .contains(FunctionFlags::PASS_NAME_TO_APPLY)
-                {
+                if self.flags.contains(FunctionFlags::PASS_NAME_TO_APPLY) {
                     s.rename(name.clone());
                 }
                 Ok(self
@@ -239,12 +230,7 @@ impl ApplyExpr {
         // then unpack the lists and finally create iterators from this list chunked arrays.
         let mut iters = acs
             .iter_mut()
-            .map(|ac| {
-                ac.iter_groups(
-                    self.flags
-                        .contains(FunctionFlags::PASS_NAME_TO_APPLY),
-                )
-            })
+            .map(|ac| ac.iter_groups(self.flags.contains(FunctionFlags::PASS_NAME_TO_APPLY)))
             .collect::<Vec<_>>();
 
         // Length of the items to iterate over.

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -306,9 +306,7 @@ impl WindowExpr {
                         },
                         Expr::Function { options, .. }
                         | Expr::AnonymousFunction { options, .. } => {
-                            if options.flags.contains(FunctionFlags::RETURNS_SCALAR)
-                                && matches!(options.collect_groups, ApplyOptions::GroupWise)
-                            {
+                            if options.flags.returns_scalar() {
                                 agg_col = true;
                             }
                         },

--- a/crates/polars-expr/src/planner.rs
+++ b/crates/polars-expr/src/planner.rs
@@ -519,10 +519,7 @@ fn create_physical_expr_inner(
                 vec![input],
                 function,
                 node_to_expr(expression, expr_arena),
-                FunctionOptions {
-                    collect_groups: ApplyOptions::GroupWise,
-                    ..Default::default()
-                },
+                FunctionOptions::groupwise(),
                 state.allow_threading,
                 schema.clone(),
                 field,

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -598,12 +598,7 @@ fn test_anonymous_function_returns_scalar_all_null_20679() {
         input: vec![col("b")],
         function: LazySerde::Deserialized(SpecialEq::new(Arc::new(f))),
         output_type: Default::default(),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            fmt_str: "",
-            flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
-            ..Default::default()
-        },
+        options: FunctionOptions::aggregation().with_fmt_str(""),
     };
 
     let grouped_df = df

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -222,24 +222,6 @@ fn test_filter_null_creation_by_cast() -> PolarsResult<()> {
 }
 
 #[test]
-fn test_predicate_pd_apply() -> PolarsResult<()> {
-    let q = df![
-        "a" => [1, 2, 3],
-    ]?
-    .lazy()
-    .select([
-        // map_list is use in python `col().apply`
-        col("a"),
-        col("a")
-            .map_list(|s| Ok(Some(s)), GetOutput::same_type())
-            .alias("a_applied"),
-    ])
-    .filter(col("a").lt(lit(3)));
-
-    assert!(predicate_at_scan(q));
-    Ok(())
-}
-#[test]
 #[cfg(feature = "cse")]
 fn test_predicate_on_join_suffix_4788() -> PolarsResult<()> {
     let lf = df![

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -83,9 +83,9 @@ impl BooleanFunction {
             ),
             #[cfg(feature = "is_in")]
             B::IsIn { .. } => FunctionOptions::elementwise().with_supertyping(Default::default()),
-            B::AllHorizontal | B::AnyHorizontal => FunctionOptions::elementwise()
-                .with_input_wildcard_expansion(true)
-                .with_allow_empty_inputs(true),
+            B::AllHorizontal | B::AnyHorizontal => FunctionOptions::elementwise().with_flags(|f| {
+                f | FunctionFlags::INPUT_WILDCARD_EXPANSION | FunctionFlags::ALLOW_EMPTY_INPUTS
+            }),
             B::Not => FunctionOptions::elementwise(),
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/business.rs
+++ b/crates/polars-plan/src/dsl/function_expr/business.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::FunctionOptions;
 use crate::dsl::{FieldsMapper, SpecialEq};
 use crate::map_as_slice;
-use crate::prelude::ColumnsUdf;
+use crate::prelude::{ColumnsUdf, FunctionFlags};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
@@ -39,7 +39,9 @@ impl BusinessFunction {
     pub fn function_options(&self) -> FunctionOptions {
         use BusinessFunction as B;
         match self {
-            B::BusinessDayCount { .. } => FunctionOptions::elementwise().with_allow_rename(true),
+            B::BusinessDayCount { .. } => {
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
             B::AddBusinessDay { .. } | B::IsBusinessDay { .. } => FunctionOptions::elementwise(),
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -191,7 +191,7 @@ impl TemporalFunction {
             #[cfg(feature = "timezones")]
             T::ReplaceTimeZone(_, _) => FunctionOptions::elementwise(),
             T::Combine(_) => FunctionOptions::elementwise(),
-            T::DatetimeFunction { .. } => FunctionOptions::elementwise().with_allow_rename(true),
+            T::DatetimeFunction { .. } => FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME),
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -191,7 +191,9 @@ impl TemporalFunction {
             #[cfg(feature = "timezones")]
             T::ReplaceTimeZone(_, _) => FunctionOptions::elementwise(),
             T::Combine(_) => FunctionOptions::elementwise(),
-            T::DatetimeFunction { .. } => FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME),
+            T::DatetimeFunction { .. } => {
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -137,15 +137,11 @@ impl ListFunction {
             #[cfg(feature = "list_gather")]
             L::GatherEvery => FunctionOptions::elementwise(),
             #[cfg(feature = "list_sets")]
-            L::SetOperation(_) => FunctionOptions {
-                collect_groups: ApplyOptions::ElementWise,
-                cast_options: Some(CastingRules::Supertype(SuperTypeOptions {
+            L::SetOperation(_) => FunctionOptions::elementwise()
+                .with_casting_rules(CastingRules::Supertype(SuperTypeOptions {
                     flags: SuperTypeFlags::default() | SuperTypeFlags::ALLOW_IMPLODE_LIST,
-                })),
-
-                flags: FunctionFlags::default() & !FunctionFlags::RETURNS_SCALAR,
-                ..Default::default()
-            },
+                }))
+                .with_flags(|f| f & !FunctionFlags::RETURNS_SCALAR),
             #[cfg(feature = "diff")]
             L::Diff { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "list_drop_nulls")]

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -1294,9 +1294,9 @@ impl FunctionExpr {
             F::ArgUnique => FunctionOptions::groupwise(),
             #[cfg(feature = "rank")]
             F::Rank { .. } => FunctionOptions::groupwise(),
-            F::Repeat => FunctionOptions::groupwise().with_flags(|f| {
-                (f | FunctionFlags::ALLOW_RENAME) & !FunctionFlags::LENGTH_PRESERVING
-            }),
+            F::Repeat => {
+                FunctionOptions::groupwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
             #[cfg(feature = "round_series")]
             F::Clip { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "dtype-struct")]

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -1279,7 +1279,8 @@ impl FunctionExpr {
             F::ShiftAndFill => FunctionOptions::length_preserving(),
             F::Shift => FunctionOptions::length_preserving(),
             F::DropNans => FunctionOptions::row_separable(),
-            F::DropNulls => FunctionOptions::row_separable().with_allow_empty_inputs(true),
+            F::DropNulls => FunctionOptions::row_separable()
+                .with_flags(|f| f | FunctionFlags::ALLOW_EMPTY_INPUTS),
             #[cfg(feature = "mode")]
             F::Mode => FunctionOptions::groupwise(),
             #[cfg(feature = "moment")]
@@ -1293,15 +1294,15 @@ impl FunctionExpr {
             F::ArgUnique => FunctionOptions::groupwise(),
             #[cfg(feature = "rank")]
             F::Rank { .. } => FunctionOptions::groupwise(),
-            F::Repeat => FunctionOptions::groupwise()
-                .with_allow_rename(true)
-                .with_changes_length(true),
+            F::Repeat => FunctionOptions::groupwise().with_flags(|f| {
+                (f | FunctionFlags::ALLOW_RENAME) & !FunctionFlags::LENGTH_PRESERVING
+            }),
             #[cfg(feature = "round_series")]
             F::Clip { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "dtype-struct")]
-            F::AsStruct => FunctionOptions::elementwise()
-                .with_pass_name_to_apply(true)
-                .with_input_wildcard_expansion(true),
+            F::AsStruct => FunctionOptions::elementwise().with_flags(|f| {
+                f | FunctionFlags::PASS_NAME_TO_APPLY | FunctionFlags::INPUT_WILDCARD_EXPANSION
+            }),
             #[cfg(feature = "top_k")]
             F::TopK { .. } => FunctionOptions::groupwise(),
             #[cfg(feature = "top_k")]
@@ -1314,13 +1315,15 @@ impl FunctionExpr {
             | F::CumMax { .. } => FunctionOptions::length_preserving(),
             F::Reverse => FunctionOptions::length_preserving(),
             #[cfg(feature = "dtype-struct")]
-            F::ValueCounts { .. } => FunctionOptions::groupwise().with_pass_name_to_apply(true),
+            F::ValueCounts { .. } => {
+                FunctionOptions::groupwise().with_flags(|f| f | FunctionFlags::PASS_NAME_TO_APPLY)
+            },
             #[cfg(feature = "unique_counts")]
             F::UniqueCounts => FunctionOptions::groupwise(),
             #[cfg(feature = "approx_unique")]
             F::ApproxNUnique => FunctionOptions::aggregation(),
             F::Coalesce => FunctionOptions::elementwise()
-                .with_input_wildcard_expansion(true)
+                .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION)
                 .with_supertyping(Default::default()),
             F::ShrinkType => FunctionOptions::length_preserving(),
             #[cfg(feature = "diff")]
@@ -1346,7 +1349,7 @@ impl FunctionExpr {
             #[cfg(feature = "fused")]
             F::Fused(_) => FunctionOptions::elementwise(),
             F::ConcatExpr(_) => FunctionOptions::groupwise()
-                .with_input_wildcard_expansion(true)
+                .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION)
                 .with_supertyping(Default::default()),
             #[cfg(feature = "cov")]
             F::Correlation { .. } => {
@@ -1355,9 +1358,8 @@ impl FunctionExpr {
             #[cfg(feature = "peaks")]
             F::PeakMin | F::PeakMax => FunctionOptions::length_preserving(),
             #[cfg(feature = "cutqcut")]
-            F::Cut { .. } | F::QCut { .. } => {
-                FunctionOptions::length_preserving().with_pass_name_to_apply(true)
-            },
+            F::Cut { .. } | F::QCut { .. } => FunctionOptions::length_preserving()
+                .with_flags(|f| f | FunctionFlags::PASS_NAME_TO_APPLY),
             #[cfg(feature = "rle")]
             F::RLE => FunctionOptions::groupwise(),
             #[cfg(feature = "rle")]
@@ -1376,12 +1378,11 @@ impl FunctionExpr {
             F::SetSortedFlag(_) => FunctionOptions::elementwise(),
             #[cfg(feature = "ffi_plugin")]
             F::FfiPlugin { flags, .. } => *flags,
-            F::MaxHorizontal | F::MinHorizontal => FunctionOptions::elementwise()
-                .with_input_wildcard_expansion(true)
-                .with_allow_rename(true),
-            F::MeanHorizontal { .. } | F::SumHorizontal { .. } => {
-                FunctionOptions::elementwise().with_input_wildcard_expansion(true)
-            },
+            F::MaxHorizontal | F::MinHorizontal => FunctionOptions::elementwise().with_flags(|f| {
+                f | FunctionFlags::INPUT_WILDCARD_EXPANSION | FunctionFlags::ALLOW_RENAME
+            }),
+            F::MeanHorizontal { .. } | F::SumHorizontal { .. } => FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
             #[cfg(feature = "ewma")]
             F::EwmMean { .. } | F::EwmStd { .. } | F::EwmVar { .. } => {
                 FunctionOptions::length_preserving()

--- a/crates/polars-plan/src/dsl/function_expr/range/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/mod.rs
@@ -21,7 +21,7 @@ use super::{FunctionExpr, FunctionOptions};
 use crate::dsl::SpecialEq;
 use crate::dsl::function_expr::FieldsMapper;
 use crate::map_as_slice;
-use crate::prelude::ColumnsUdf;
+use crate::prelude::{ColumnsUdf, FunctionFlags};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
@@ -154,26 +154,42 @@ impl RangeFunction {
     pub fn function_options(&self) -> FunctionOptions {
         use RangeFunction as R;
         match self {
-            R::IntRange { .. } => FunctionOptions::row_separable().with_allow_rename(true),
-            R::LinearSpace { .. } => FunctionOptions::row_separable().with_allow_rename(true),
+            R::IntRange { .. } => {
+                FunctionOptions::row_separable().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
+            R::LinearSpace { .. } => {
+                FunctionOptions::row_separable().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
             #[cfg(feature = "dtype-date")]
-            R::DateRange { .. } => FunctionOptions::row_separable().with_allow_rename(true),
+            R::DateRange { .. } => {
+                FunctionOptions::row_separable().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
             #[cfg(feature = "dtype-datetime")]
             R::DatetimeRange { .. } => FunctionOptions::row_separable()
-                .with_allow_rename(true)
+                .with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
                 .with_supertyping(Default::default()),
             #[cfg(feature = "dtype-time")]
-            R::TimeRange { .. } => FunctionOptions::row_separable().with_allow_rename(true),
-            R::IntRanges => FunctionOptions::elementwise().with_allow_rename(true),
-            R::LinearSpaces { .. } => FunctionOptions::elementwise().with_allow_rename(true),
+            R::TimeRange { .. } => {
+                FunctionOptions::row_separable().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
+            R::IntRanges => {
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
+            R::LinearSpaces { .. } => {
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
             #[cfg(feature = "dtype-date")]
-            R::DateRanges { .. } => FunctionOptions::elementwise().with_allow_rename(true),
+            R::DateRanges { .. } => {
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
             #[cfg(feature = "dtype-datetime")]
             R::DatetimeRanges { .. } => FunctionOptions::elementwise()
-                .with_allow_rename(true)
+                .with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
                 .with_supertyping(Default::default()),
             #[cfg(feature = "dtype-time")]
-            R::TimeRanges { .. } => FunctionOptions::elementwise().with_allow_rename(true),
+            R::TimeRanges { .. } => {
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -220,7 +220,8 @@ impl StringFunction {
         use StringFunction as S;
         match self {
             #[cfg(feature = "concat_str")]
-            S::ConcatHorizontal { .. } => FunctionOptions::elementwise(),
+            S::ConcatHorizontal { .. } => FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
             #[cfg(feature = "concat_str")]
             S::ConcatVertical { .. } => FunctionOptions::aggregation(),
             #[cfg(feature = "regex")]

--- a/crates/polars-plan/src/dsl/function_expr/struct_.rs
+++ b/crates/polars-plan/src/dsl/function_expr/struct_.rs
@@ -128,17 +128,19 @@ impl StructFunction {
         use StructFunction as S;
         match self {
             S::FieldByIndex(_) | S::FieldByName(_) => {
-                FunctionOptions::elementwise().with_allow_rename(true)
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
             },
             S::RenameFields(_) | S::PrefixFields(_) | S::SuffixFields(_) => {
                 FunctionOptions::elementwise()
             },
             #[cfg(feature = "json")]
             S::JsonEncode => FunctionOptions::elementwise(),
-            S::WithFields => FunctionOptions::elementwise()
-                .with_pass_name_to_apply(true)
-                .with_input_wildcard_expansion(true),
-            S::MultipleFields(_) => FunctionOptions::elementwise().with_allow_rename(true),
+            S::WithFields => FunctionOptions::elementwise().with_flags(|f| {
+                f | FunctionFlags::INPUT_WILDCARD_EXPANSION | FunctionFlags::PASS_NAME_TO_APPLY
+            }),
+            S::MultipleFields(_) => {
+                FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+            },
         }
     }
 }

--- a/crates/polars-plan/src/dsl/functions/business.rs
+++ b/crates/polars-plan/src/dsl/functions/business.rs
@@ -15,10 +15,6 @@ pub fn business_day_count(
             week_mask,
             holidays,
         }),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::ElementWise,
-            flags: FunctionFlags::default() | FunctionFlags::ALLOW_RENAME,
-            ..Default::default()
-        },
+        options: FunctionOptions::elementwise().with_flags(|f| f | FunctionFlags::ALLOW_RENAME),
     }
 }

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -13,9 +13,8 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, separator: &str, ignore_nulls: bool) -
             ignore_nulls,
         }
         .into(),
-        options: FunctionOptions::elementwise().with_flags(|f| {
-            f | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR
-        }),
+        options: FunctionOptions::elementwise()
+            .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
     }
 }
 

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -13,12 +13,9 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, separator: &str, ignore_nulls: bool) -
             ignore_nulls,
         }
         .into(),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::ElementWise,
-            flags: FunctionFlags::default()
-                | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR,
-            ..Default::default()
-        },
+        options: FunctionOptions::elementwise().with_flags(|f| {
+            f | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR
+        }),
     }
 }
 
@@ -61,11 +58,8 @@ pub fn concat_list<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult
     Ok(Expr::Function {
         input: s,
         function: FunctionExpr::ListExpr(ListFunction::Concat),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::ElementWise,
-            flags: FunctionFlags::default() | FunctionFlags::INPUT_WILDCARD_EXPANSION,
-            ..Default::default()
-        },
+        options: FunctionOptions::elementwise()
+            .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
     })
 }
 
@@ -77,11 +71,8 @@ pub fn concat_arr(input: Vec<Expr>) -> PolarsResult<Expr> {
         Ok(Expr::Function {
             input,
             function: FunctionExpr::ArrayExpr(ArrayFunction::Concat),
-            options: FunctionOptions {
-                collect_groups: ApplyOptions::ElementWise,
-                flags: FunctionFlags::default() | FunctionFlags::INPUT_WILDCARD_EXPANSION,
-                ..Default::default()
-            },
+            options: FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
         })
     })
 }

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -46,12 +46,6 @@ where
         Ok(Some(acc))
     });
 
-    let mut flags = FunctionFlags::default() | FunctionFlags::INPUT_WILDCARD_EXPANSION;
-
-    if returns_scalar {
-        flags |= FunctionFlags::RETURNS_SCALAR
-    }
-
     let output_type = return_dtype
         .map(GetOutput::from_type)
         .unwrap_or_else(|| GetOutput::first());
@@ -61,12 +55,13 @@ where
         function,
         // Take the type of the accumulator.
         output_type,
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags,
-            fmt_str: "fold",
-            ..Default::default()
-        },
+        options: FunctionOptions::groupwise()
+            .with_fmt_str("fold")
+            .with_flags(|mut f| {
+                f |= FunctionFlags::INPUT_WILDCARD_EXPANSION;
+                f.set(FunctionFlags::RETURNS_SCALAR, returns_scalar);
+                f
+            }),
     }
 }
 
@@ -104,14 +99,9 @@ where
         input: exprs,
         function,
         output_type: GetOutput::super_type(),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags: FunctionFlags::default()
-                | FunctionFlags::INPUT_WILDCARD_EXPANSION
-                | FunctionFlags::RETURNS_SCALAR,
-            fmt_str: "reduce",
-            ..Default::default()
-        },
+        options: FunctionOptions::aggregation()
+            .with_fmt_str("reduce")
+            .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
     }
 }
 
@@ -152,14 +142,9 @@ where
         input: exprs,
         function,
         output_type: cum_fold_dtype(),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags: FunctionFlags::default()
-                | FunctionFlags::INPUT_WILDCARD_EXPANSION
-                | FunctionFlags::RETURNS_SCALAR,
-            fmt_str: "cum_reduce",
-            ..Default::default()
-        },
+        options: FunctionOptions::aggregation()
+            .with_fmt_str("cum_reduce")
+            .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
     }
 }
 
@@ -199,14 +184,9 @@ where
         input: exprs,
         function,
         output_type: cum_fold_dtype(),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags: FunctionFlags::default()
-                | FunctionFlags::INPUT_WILDCARD_EXPANSION
-                | FunctionFlags::RETURNS_SCALAR,
-            fmt_str: "cum_fold",
-            ..Default::default()
-        },
+        options: FunctionOptions::aggregation()
+            .with_fmt_str("cum_fold")
+            .with_flags(|f| f | FunctionFlags::INPUT_WILDCARD_EXPANSION),
     }
 }
 

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -218,12 +218,9 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
                 time_unit,
                 time_zone,
             }),
-            options: FunctionOptions {
-                collect_groups: ApplyOptions::ElementWise,
-                flags: FunctionFlags::default() | FunctionFlags::ALLOW_RENAME,
-                fmt_str: "datetime",
-                ..Default::default()
-            },
+            options: FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::ALLOW_RENAME)
+                .with_fmt_str("datetime"),
         }),
         // TODO: follow left-hand rule in Polars 2.0.
         PlSmallStr::from_static("datetime"),
@@ -429,10 +426,6 @@ pub fn duration(args: DurationArgs) -> Expr {
             args.nanoseconds,
         ],
         function: FunctionExpr::TemporalExpr(TemporalFunction::Duration(args.time_unit)),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::ElementWise,
-            flags: FunctionFlags::default(),
-            ..Default::default()
-        },
+        options: FunctionOptions::elementwise(),
     }
 }

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -537,6 +537,7 @@ impl Expr {
             function: new_column_udf(f),
             output_type,
             options: FunctionOptions::elementwise()
+                .with_fmt_str("map")
                 .with_flags(|f| f | FunctionFlags::OPTIONAL_RE_ENTRANT),
         }
     }

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -78,7 +78,6 @@ mod file_scan;
 pub use file_scan::*;
 pub use scan_sources::{ScanSource, ScanSourceIter, ScanSourceRef, ScanSources};
 
-use crate::constants::MAP_LIST_NAME;
 pub use crate::plans::lit;
 use crate::prelude::*;
 
@@ -318,13 +317,7 @@ impl Expr {
 
     /// Get the index value that has the minimum value.
     pub fn arg_min(self) -> Self {
-        let options = FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
-            fmt_str: "arg_min",
-            ..Default::default()
-        };
-
+        let options = FunctionOptions::aggregation().with_fmt_str("arg_min");
         self.function_with_options(
             move |c: Column| {
                 Ok(Some(Column::new(
@@ -339,13 +332,7 @@ impl Expr {
 
     /// Get the index value that has the maximum value.
     pub fn arg_max(self) -> Self {
-        let options = FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
-            fmt_str: "arg_max",
-            ..Default::default()
-        };
-
+        let options = FunctionOptions::aggregation().with_fmt_str("arg_max");
         self.function_with_options(
             move |c: Column| {
                 Ok(Some(Column::new(
@@ -362,12 +349,7 @@ impl Expr {
 
     /// Get the index values that would sort this expression.
     pub fn arg_sort(self, sort_options: SortOptions) -> Self {
-        let options = FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            fmt_str: "arg_sort",
-            ..Default::default()
-        };
-
+        let options = FunctionOptions::groupwise().with_fmt_str("arg_sort");
         self.function_with_options(
             move |c: Column| {
                 Ok(Some(
@@ -554,12 +536,8 @@ impl Expr {
             input: vec![self],
             function: new_column_udf(f),
             output_type,
-            options: FunctionOptions {
-                collect_groups: ApplyOptions::ElementWise,
-                fmt_str: "map",
-                flags: FunctionFlags::default() | FunctionFlags::OPTIONAL_RE_ENTRANT,
-                ..Default::default()
-            },
+            options: FunctionOptions::elementwise()
+                .with_flags(|f| f | FunctionFlags::OPTIONAL_RE_ENTRANT),
         }
     }
 
@@ -577,36 +555,7 @@ impl Expr {
             input,
             function: new_column_udf(function),
             output_type,
-            options: FunctionOptions {
-                collect_groups: ApplyOptions::ElementWise,
-                fmt_str: "",
-                ..Default::default()
-            },
-        }
-    }
-
-    /// Apply a function/closure once the logical plan get executed.
-    ///
-    /// This function is very similar to [apply](Expr::apply), but differs in how it handles aggregations.
-    ///
-    ///  * `map` should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
-    ///  * `apply` should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
-    ///  * `map_list` should be used when the function expects a list aggregated series.
-    pub fn map_list<F>(self, function: F, output_type: GetOutput) -> Self
-    where
-        F: Fn(Column) -> PolarsResult<Option<Column>> + 'static + Send + Sync,
-    {
-        let f = move |c: &mut [Column]| function(std::mem::take(&mut c[0]));
-
-        Expr::AnonymousFunction {
-            input: vec![self],
-            function: new_column_udf(f),
-            output_type,
-            options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyList,
-                fmt_str: MAP_LIST_NAME,
-                ..Default::default()
-            },
+            options: FunctionOptions::elementwise().with_fmt_str(""),
         }
     }
 
@@ -649,11 +598,7 @@ impl Expr {
             input: vec![self],
             function: new_column_udf(f),
             output_type,
-            options: FunctionOptions {
-                collect_groups: ApplyOptions::GroupWise,
-                fmt_str: "",
-                ..Default::default()
-            },
+            options: FunctionOptions::groupwise().with_fmt_str(""),
         }
     }
 
@@ -671,11 +616,7 @@ impl Expr {
             input,
             function: new_column_udf(function),
             output_type,
-            options: FunctionOptions {
-                collect_groups: ApplyOptions::GroupWise,
-                fmt_str: "",
-                ..Default::default()
-            },
+            options: FunctionOptions::groupwise().with_fmt_str(""),
         }
     }
 
@@ -743,13 +684,7 @@ impl Expr {
 
     /// Get the product aggregation of an expression.
     pub fn product(self) -> Self {
-        let options = FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
-            fmt_str: "product",
-            ..Default::default()
-        };
-
+        let options = FunctionOptions::aggregation().with_fmt_str("product");
         self.function_with_options(
             move |c: Column| {
                 Some(
@@ -1422,19 +1357,7 @@ impl Expr {
     pub fn replace<E: Into<Expr>>(self, old: E, new: E) -> Expr {
         let old = old.into();
         let new = new.into();
-        let literal_args = is_column_independent(&old) && is_column_independent(&new);
-        let function = FunctionExpr::Replace;
-        let mut options = function.function_options();
-        if !literal_args {
-            // If we search and replace by constants, we can run on batches.
-            // TODO: this optimization should be done during conversion to IR.
-            options.collect_groups = ApplyOptions::GroupWise;
-        }
-        Expr::Function {
-            input: vec![self, old, new],
-            function,
-            options,
-        }
+        self.map_n_ary(FunctionExpr::Replace, [old, new])
     }
 
     #[cfg(feature = "replace")]
@@ -1448,25 +1371,9 @@ impl Expr {
     ) -> Expr {
         let old = old.into();
         let new = new.into();
-
-        // If we replace by constants, we can run on batches.
-        // TODO: this optimization should be done during conversion to IR.
-        let literal_args = is_column_independent(&old) && is_column_independent(&new);
-
-        let mut args = vec![self, old, new];
+        let mut args = vec![old, new];
         args.extend(default.map(Into::into));
-        let function = FunctionExpr::ReplaceStrict { return_dtype };
-        let mut options = function.function_options();
-        if !literal_args {
-            // If we search and replace by constants, we can run on batches.
-            // TODO: this optimization should be done during conversion to IR.
-            options.collect_groups = ApplyOptions::GroupWise;
-        }
-        Expr::Function {
-            input: args,
-            function,
-            options,
-        }
+        self.map_n_ary(FunctionExpr::ReplaceStrict { return_dtype }, args)
     }
 
     #[cfg(feature = "cutqcut")]
@@ -1802,38 +1709,7 @@ where
         input,
         function: new_column_udf(function),
         output_type,
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::ElementWise,
-            fmt_str: "",
-            ..Default::default()
-        },
-    }
-}
-
-/// Apply a function/closure over multiple columns once the logical plan get executed.
-///
-/// This function is very similar to [`apply_multiple`], but differs in how it handles aggregations.
-///
-///  * [`map_multiple`] should be used for operations that are independent of groups, e.g. `multiply * 2`, or `raise to the power`
-///  * [`apply_multiple`] should be used for operations that work on a group of data. e.g. `sum`, `count`, etc.
-///  * [`map_list_multiple`] should be used when the function expects a list aggregated series.
-pub fn map_list_multiple<F, E>(function: F, expr: E, output_type: GetOutput) -> Expr
-where
-    F: Fn(&mut [Column]) -> PolarsResult<Option<Column>> + 'static + Send + Sync,
-    E: AsRef<[Expr]>,
-{
-    let input = expr.as_ref().to_vec();
-
-    Expr::AnonymousFunction {
-        input,
-        function: new_column_udf(function),
-        output_type,
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyList,
-            fmt_str: "",
-            flags: FunctionFlags::default() | FunctionFlags::RETURNS_SCALAR,
-            ..Default::default()
-        },
+        options: FunctionOptions::elementwise().with_fmt_str(""),
     }
 }
 
@@ -1857,23 +1733,16 @@ where
     E: AsRef<[Expr]>,
 {
     let input = expr.as_ref().to_vec();
-    let mut flags = FunctionFlags::default();
-    if returns_scalar {
-        flags |= FunctionFlags::RETURNS_SCALAR;
-    }
-
     Expr::AnonymousFunction {
         input,
         function: new_column_udf(function),
         output_type,
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            // don't set this to true
-            // this is for the caller to decide
-            fmt_str: "",
-            flags,
-            ..Default::default()
-        },
+        options: FunctionOptions::groupwise()
+            .with_fmt_str("")
+            .with_flags(|mut f| {
+                f.set(FunctionFlags::RETURNS_SCALAR, returns_scalar);
+                f
+            }),
     }
 }
 

--- a/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
@@ -226,12 +226,10 @@ impl FunctionOutputField for PythonGetOutput {
 
 impl Expr {
     pub fn map_python(self, func: PythonUdfExpression, agg_list: bool) -> Expr {
-        let (collect_groups, name) = if agg_list {
-            (ApplyOptions::ApplyList, MAP_LIST_NAME)
-        } else if func.is_elementwise {
-            (ApplyOptions::ElementWise, "python_udf")
+        let name = if agg_list {
+            MAP_LIST_NAME
         } else {
-            (ApplyOptions::GroupWise, "python_udf")
+            "python_udf"
         };
 
         let returns_scalar = func.returns_scalar;
@@ -241,6 +239,9 @@ impl Expr {
         let output_type = SpecialEq::new(Arc::new(output_field) as Arc<dyn FunctionOutputField>);
 
         let mut flags = FunctionFlags::default() | FunctionFlags::OPTIONAL_RE_ENTRANT;
+        if agg_list {
+            flags |= FunctionFlags::APPLY_LIST;
+        }
         if returns_scalar {
             flags |= FunctionFlags::RETURNS_SCALAR;
         }
@@ -250,7 +251,6 @@ impl Expr {
             function: new_column_udf(func),
             output_type,
             options: FunctionOptions {
-                collect_groups,
                 fmt_str: name,
                 flags,
                 ..Default::default()

--- a/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_dsl/python_udf.rs
@@ -242,6 +242,9 @@ impl Expr {
         if agg_list {
             flags |= FunctionFlags::APPLY_LIST;
         }
+        if func.is_elementwise {
+            flags.set_elementwise();
+        }
         if returns_scalar {
             flags |= FunctionFlags::RETURNS_SCALAR;
         }

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -260,7 +260,7 @@ impl StringNameSpace {
                 // @HACK. This needs to be done because literals still block predicate pushdown,
                 // but this should be an exception in the predicate pushdown.
                 if is_column_independent {
-                    options.collect_groups = ApplyOptions::ElementWise;
+                    options.set_elementwise();
                 }
                 options
             })

--- a/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
+++ b/crates/polars-plan/src/plans/aexpr/predicates/skip_batches.rs
@@ -576,10 +576,7 @@ fn aexpr_to_skip_batch_predicate_rec(
     let mut expr = expr_arena.add(AExpr::Function {
         input: vec![ExprIR::new(expr, OutputName::Alias(PlSmallStr::EMPTY))],
         function: FunctionExpr::Boolean(BooleanFunction::Not),
-        options: FunctionOptions {
-            collect_groups: crate::plans::ApplyOptions::ElementWise,
-            ..Default::default()
-        },
+        options: FunctionOptions::elementwise(),
     });
     for col in live_columns.keys() {
         let col_min = col!(min: col);

--- a/crates/polars-plan/src/plans/aexpr/properties.rs
+++ b/crates/polars-plan/src/plans/aexpr/properties.rs
@@ -249,7 +249,7 @@ pub fn can_pre_agg(agg: Node, expr_arena: &Arena<AExpr>, _input_schema: &Schema)
                         )
                     },
                     Function { input, options, .. } => {
-                        matches!(options.collect_groups, ApplyOptions::ElementWise)
+                        options.is_elementwise()
                             && input.len() == 1
                             && !has_aggregation(input[0].node())
                     },

--- a/crates/polars-plan/src/plans/aexpr/scalar.rs
+++ b/crates/polars-plan/src/plans/aexpr/scalar.rs
@@ -11,7 +11,7 @@ pub fn is_scalar_ae(node: Node, expr_arena: &Arena<AExpr>) -> bool {
             if options.flags.contains(FunctionFlags::RETURNS_SCALAR) {
                 true
             } else if options.is_elementwise()
-                || !options.flags.contains(FunctionFlags::CHANGES_LENGTH)
+                || options.flags.contains(FunctionFlags::LENGTH_PRESERVING)
             {
                 input.iter().all(|e| e.is_scalar(expr_arena))
             } else {

--- a/crates/polars-plan/src/plans/optimizer/fused.rs
+++ b/crates/polars-plan/src/plans/optimizer/fused.rs
@@ -10,11 +10,8 @@ fn get_expr(input: &[Node], op: FusedOperator, expr_arena: &Arena<AExpr>) -> AEx
         .copied()
         .map(|n| ExprIR::from_node(n, expr_arena))
         .collect();
-    let mut options = FunctionOptions {
-        collect_groups: ApplyOptions::ElementWise,
-        cast_options: Some(CastingRules::cast_to_supertypes()),
-        ..Default::default()
-    };
+    let mut options =
+        FunctionOptions::elementwise().with_casting_rules(CastingRules::cast_to_supertypes());
     // order of operations change because of FMA
     // so we must toggle this check off
     // it is still safe as it is a trusted operation

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -425,17 +425,18 @@ fn string_addition_to_linear_concat(
                         None
                     }
                 },
-                _ => Some(AExpr::Function {
-                    input: vec![left_e, right_e],
-                    function: StringFunction::ConcatHorizontal {
+                _ => {
+                    let function = StringFunction::ConcatHorizontal {
                         delimiter: "".into(),
                         ignore_nulls: false,
-                    }
-                    .into(),
-                    options: FunctionOptions::elementwise().with_flags(|f| {
-                        f | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR
-                    }),
-                }),
+                    };
+                    let options = function.function_options();
+                    Some(AExpr::Function {
+                        input: vec![left_e, right_e],
+                        function: function.into(),
+                        options,
+                    })
+                },
             }
         } else {
             None

--- a/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/simplify_expr/mod.rs
@@ -10,11 +10,8 @@ fn new_null_count(input: &[ExprIR]) -> AExpr {
     AExpr::Function {
         input: input.to_vec(),
         function: FunctionExpr::NullCount,
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
-            flags: FunctionFlags::ALLOW_GROUP_AWARE | FunctionFlags::RETURNS_SCALAR,
-            ..Default::default()
-        },
+        options: FunctionOptions::aggregation()
+            .with_flags(|f| f | FunctionFlags::ALLOW_GROUP_AWARE),
     }
 }
 
@@ -435,13 +432,9 @@ fn string_addition_to_linear_concat(
                         ignore_nulls: false,
                     }
                     .into(),
-                    options: FunctionOptions {
-                        collect_groups: ApplyOptions::ElementWise,
-                        flags: FunctionFlags::default()
-                            | FunctionFlags::INPUT_WILDCARD_EXPANSION
-                                & !FunctionFlags::RETURNS_SCALAR,
-                        ..Default::default()
-                    },
+                    options: FunctionOptions::elementwise().with_flags(|f| {
+                        f | FunctionFlags::INPUT_WILDCARD_EXPANSION & !FunctionFlags::RETURNS_SCALAR
+                    }),
                 }),
             }
         } else {

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_expr.rs
@@ -70,9 +70,7 @@ impl OptimizationRule for SlicePushDown {
                         predicate,
                     })
                 },
-                m @ AnonymousFunction { options, .. }
-                    if matches!(options.collect_groups, ApplyOptions::ElementWise) =>
-                {
+                m @ AnonymousFunction { options, .. } if options.is_elementwise() => {
                     if let AnonymousFunction {
                         mut input,
                         function,
@@ -95,9 +93,7 @@ impl OptimizationRule for SlicePushDown {
                         unreachable!()
                     }
                 },
-                m @ Function { options, .. }
-                    if matches!(options.collect_groups, ApplyOptions::ElementWise) =>
-                {
+                m @ Function { options, .. } if options.is_elementwise() => {
                     if let Function {
                         mut input,
                         function,

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -152,12 +152,11 @@ impl FunctionOptions {
     }
 
     pub fn set_elementwise(&mut self) {
-        self.flags |= FunctionFlags::ROW_SEPARABLE | FunctionFlags::LENGTH_PRESERVING;
+        self.flags.set_elementwise();
     }
 
     pub fn is_elementwise(&self) -> bool {
-        self.flags
-            .contains(FunctionFlags::LENGTH_PRESERVING & FunctionFlags::ROW_SEPARABLE)
+        self.flags.is_elementwise()
     }
 
     pub fn is_length_preserving(&self) -> bool {
@@ -165,7 +164,7 @@ impl FunctionOptions {
     }
 
     pub fn returns_scalar(&self) -> bool {
-        self.flags.contains(FunctionFlags::RETURNS_SCALAR)
+        self.flags.returns_scalar()
     }
 
     pub fn elementwise() -> FunctionOptions {
@@ -176,7 +175,7 @@ impl FunctionOptions {
     }
 
     pub fn elementwise_with_infer() -> FunctionOptions {
-        Self::groupwise()
+        Self::length_preserving()
     }
 
     pub fn row_separable() -> FunctionOptions {

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -78,7 +78,7 @@ bitflags!(
             const ALLOW_EMPTY_INPUTS = 1 << 7;
 
             /// Given a function f and a column of values [v1, ..., vn]
-            /// f is row-seperable i.f.f.
+            /// f is row-separable i.f.f.
             /// f([v1, ..., vn]) = concat(f(v1, ... vm), f(vm+1, ..., vn))
             const ROW_SEPARABLE = 1 << 8;
             /// Given a function f and a column of values [v1, ..., vn]

--- a/crates/polars-plan/src/plans/options.rs
+++ b/crates/polars-plan/src/plans/options.rs
@@ -22,21 +22,6 @@ pub struct DistinctOptionsIR {
     pub slice: Option<(i64, usize)>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum ApplyOptions {
-    /// Collect groups to a list and apply the function over the groups.
-    /// This can be important in aggregation context.
-    /// e.g. [g1, g1, g2] -> [[g1, g1], g2]
-    GroupWise,
-    /// collect groups to a list and then apply
-    /// e.g. [g1, g1, g2] -> list([g1, g1, g2])
-    ApplyList,
-    /// do not collect before apply
-    /// e.g. [g1, g1, g2] -> [g1, g1, g2]
-    ElementWise,
-}
-
 // a boolean that can only be set to `false` safely
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -51,17 +36,15 @@ bitflags!(
         #[repr(transparent)]
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-        pub struct FunctionFlags: u8 {
-            // Raise if use in group by
+        pub struct FunctionFlags: u16 {
+            /// Raise if use in group by
             const ALLOW_GROUP_AWARE = 1 << 0;
-            // For example a `unique` or a `slice`
-            const CHANGES_LENGTH = 1 << 1;
-            // The physical expression may rename the output of this function.
-            // If set to `false` the physical engine will ensure the left input
-            // expression is the output name.
+            /// The physical expression may rename the output of this function.
+            /// If set to `false` the physical engine will ensure the left input
+            /// expression is the output name.
             const ALLOW_RENAME = 1 << 2;
-            // if set, then the `Series` passed to the function in the group_by operation
-            // will ensure the name is set. This is an extra heap allocation per group.
+            /// if set, then the `Series` passed to the function in the group_by operation
+            /// will ensure the name is set. This is an extra heap allocation per group.
             const PASS_NAME_TO_APPLY = 1 << 3;
             /// There can be two ways of expanding wildcards:
             ///
@@ -84,6 +67,8 @@ bitflags!(
             ///
             /// head_1(x) -> {1}
             /// sum(x) -> {4}
+            ///
+            /// mutually exclusive with `RETURNS_SCALAR`
             const RETURNS_SCALAR = 1 << 5;
             /// This can happen with UDF's that use Polars within the UDF.
             /// This can lead to recursively entering the engine and sometimes deadlocks.
@@ -91,8 +76,34 @@ bitflags!(
             const OPTIONAL_RE_ENTRANT = 1 << 6;
             /// Whether this function allows no inputs.
             const ALLOW_EMPTY_INPUTS = 1 << 7;
+
+            /// Given a function f and a column of values [v1, ..., vn]
+            /// f is row-seperable i.f.f.
+            /// f([v1, ..., vn]) = concat(f(v1, ... vm), f(vm+1, ..., vn))
+            const ROW_SEPARABLE = 1 << 8;
+            /// Given a function f and a column of values [v1, ..., vn]
+            /// f is length preserving i.f.f. len(f([v1, ..., vn])) = n
+            ///
+            /// mutually exclusive with `RETURNS_SCALAR`
+            const LENGTH_PRESERVING = 1 << 9;
+            /// Aggregate the values of the expression into a list before applying the function.
+            const APPLY_LIST = 1 << 10;
         }
 );
+
+impl FunctionFlags {
+    pub fn set_elementwise(&mut self) {
+        *self |= Self::ROW_SEPARABLE | Self::LENGTH_PRESERVING;
+    }
+
+    pub fn is_elementwise(self) -> bool {
+        self.contains(Self::ROW_SEPARABLE | Self::LENGTH_PRESERVING)
+    }
+
+    pub fn returns_scalar(self) -> bool {
+        self.contains(Self::RETURNS_SCALAR)
+    }
+}
 
 impl Default for FunctionFlags {
     fn default() -> Self {
@@ -118,10 +129,6 @@ impl CastingRules {
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(any(feature = "serde"), derive(Serialize, Deserialize))]
 pub struct FunctionOptions {
-    /// Collect groups to a list and apply the function over the groups.
-    /// This can be important in aggregation context.
-    pub collect_groups: ApplyOptions,
-
     // Validate the output of a `map`.
     // this should always be true or we could OOB
     pub check_lengths: UnsafeBool,
@@ -145,19 +152,16 @@ impl FunctionOptions {
     }
 
     pub fn set_elementwise(&mut self) {
-        self.collect_groups = ApplyOptions::ElementWise
+        self.flags |= FunctionFlags::ROW_SEPARABLE | FunctionFlags::LENGTH_PRESERVING;
     }
 
     pub fn is_elementwise(&self) -> bool {
-        matches!(
-            self.collect_groups,
-            ApplyOptions::ElementWise | ApplyOptions::ApplyList
-        ) && !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
-            && !self.flags.contains(FunctionFlags::RETURNS_SCALAR)
+        self.flags
+            .contains(FunctionFlags::LENGTH_PRESERVING & FunctionFlags::ROW_SEPARABLE)
     }
 
     pub fn is_length_preserving(&self) -> bool {
-        !self.flags.contains(FunctionFlags::CHANGES_LENGTH)
+        self.flags.contains(FunctionFlags::LENGTH_PRESERVING)
     }
 
     pub fn returns_scalar(&self) -> bool {
@@ -166,9 +170,9 @@ impl FunctionOptions {
 
     pub fn elementwise() -> FunctionOptions {
         FunctionOptions {
-            collect_groups: ApplyOptions::ElementWise,
             ..Default::default()
         }
+        .with_flags(|f| f | FunctionFlags::ROW_SEPARABLE | FunctionFlags::LENGTH_PRESERVING)
     }
 
     pub fn elementwise_with_infer() -> FunctionOptions {
@@ -176,16 +180,21 @@ impl FunctionOptions {
     }
 
     pub fn row_separable() -> FunctionOptions {
-        Self::groupwise()
+        FunctionOptions {
+            ..Default::default()
+        }
+        .with_flags(|f| f | FunctionFlags::ROW_SEPARABLE)
     }
 
     pub fn length_preserving() -> FunctionOptions {
-        Self::groupwise()
+        FunctionOptions {
+            ..Default::default()
+        }
+        .with_flags(|f| f | FunctionFlags::LENGTH_PRESERVING)
     }
 
     pub fn groupwise() -> FunctionOptions {
         FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
             ..Default::default()
         }
     }
@@ -205,37 +214,13 @@ impl FunctionOptions {
         self
     }
 
-    pub fn with_allow_rename(mut self, allow_rename: bool) -> FunctionOptions {
-        self.flags.set(FunctionFlags::ALLOW_RENAME, allow_rename);
+    pub fn with_flags(mut self, f: impl Fn(FunctionFlags) -> FunctionFlags) -> FunctionOptions {
+        self.flags = f(self.flags);
         self
     }
 
-    pub fn with_pass_name_to_apply(mut self, pass_name_to_apply: bool) -> Self {
-        self.flags
-            .set(FunctionFlags::PASS_NAME_TO_APPLY, pass_name_to_apply);
-        self
-    }
-
-    pub fn with_input_wildcard_expansion(
-        mut self,
-        input_wildcard_expansion: bool,
-    ) -> FunctionOptions {
-        self.flags.set(
-            FunctionFlags::INPUT_WILDCARD_EXPANSION,
-            input_wildcard_expansion,
-        );
-        self
-    }
-
-    pub fn with_allow_empty_inputs(mut self, allow_empty_inputs: bool) -> FunctionOptions {
-        self.flags
-            .set(FunctionFlags::ALLOW_EMPTY_INPUTS, allow_empty_inputs);
-        self
-    }
-
-    pub fn with_changes_length(mut self, changes_length: bool) -> FunctionOptions {
-        self.flags
-            .set(FunctionFlags::ALLOW_EMPTY_INPUTS, changes_length);
+    pub fn with_fmt_str(mut self, fmt_str: &'static str) -> FunctionOptions {
+        self.fmt_str = fmt_str;
         self
     }
 }
@@ -243,7 +228,6 @@ impl FunctionOptions {
 impl Default for FunctionOptions {
     fn default() -> Self {
         FunctionOptions {
-            collect_groups: ApplyOptions::GroupWise,
             check_lengths: UnsafeBool(true),
             fmt_str: Default::default(),
             cast_options: Default::default(),

--- a/crates/polars-python/src/functions/misc.rs
+++ b/crates/polars-python/src/functions/misc.rs
@@ -26,12 +26,6 @@ pub fn register_plugin_function(
     pass_name_to_apply: bool,
     changes_length: bool,
 ) -> PyResult<PyExpr> {
-    let collect_groups = if is_elementwise {
-        ApplyOptions::ElementWise
-    } else {
-        ApplyOptions::GroupWise
-    };
-
     let cast_to_supertypes = if cast_to_supertype {
         Some(CastingRules::cast_to_supertypes())
     } else {
@@ -39,7 +33,10 @@ pub fn register_plugin_function(
     };
 
     let mut flags = FunctionFlags::default();
-    flags.set(FunctionFlags::CHANGES_LENGTH, changes_length);
+    if is_elementwise {
+        flags.set_elementwise();
+    }
+    flags.set(FunctionFlags::LENGTH_PRESERVING, !changes_length);
     flags.set(FunctionFlags::PASS_NAME_TO_APPLY, pass_name_to_apply);
     flags.set(FunctionFlags::RETURNS_SCALAR, returns_scalar);
     flags.set(
@@ -48,7 +45,6 @@ pub fn register_plugin_function(
     );
 
     let options = FunctionOptions {
-        collect_groups,
         cast_options: cast_to_supertypes,
         flags,
         ..Default::default()

--- a/crates/polars-stream/src/physical_plan/lower_expr.rs
+++ b/crates/polars-stream/src/physical_plan/lower_expr.rs
@@ -69,12 +69,12 @@ pub(crate) fn is_fake_elementwise_function(expr: &AExpr) -> bool {
     // but aren't actually elementwise (e.g. arguments aren't same length).
     match expr {
         AExpr::AnonymousFunction { options, .. } => {
-            options.collect_groups == ApplyOptions::ApplyList
+            options.flags.contains(FunctionFlags::APPLY_LIST)
         },
         AExpr::Function {
             function, options, ..
         } => {
-            if options.collect_groups == ApplyOptions::ApplyList {
+            if options.flags.contains(FunctionFlags::APPLY_LIST) {
                 return true;
             }
 


### PR DESCRIPTION
This is the start of #22572.

This removes the `collect_groups` field on `FunctionOptions` and the `ApplyOptions` type. Instead, everything needed is now under `FunctionFlags`. This also splits elementwise into `row-separable` and `length preserving`.