### PR TITLE
fix: CSV count rows skipped last line if file did not end with newline

### DIFF
--- a/crates/polars-io/src/csv/read/parser.rs
+++ b/crates/polars-io/src/csv/read/parser.rs
@@ -105,6 +105,7 @@ pub fn count_rows_from_slice_par(
                 .count()
         } else {
             CountLines::new(quote_char, eol_char).count(bytes).0
+                + bytes.last().is_some_and(|x| *x != b'\n') as usize
         }
     });
 
@@ -135,6 +136,7 @@ pub fn count_rows_from_slice(
             .count()
     } else {
         CountLines::new(quote_char, eol_char).count(bytes).0
+            + bytes.last().is_some_and(|x| *x != b'\n') as usize
     };
 
     Ok(n - (has_header as usize))

--- a/py-polars/tests/unit/io/test_lazy_count_star.py
+++ b/py-polars/tests/unit/io/test_lazy_count_star.py
@@ -104,6 +104,20 @@ a,b
     assert_fast_count(q, 3, capfd=capfd, monkeypatch=monkeypatch)
 
 
+def test_count_csv_no_newline_on_last_22564() -> None:
+    data = b"""\
+a,b
+1,2
+3,4
+5,6"""
+
+    assert pl.scan_csv(data).collect().select(pl.len()).item() == 3
+    assert pl.scan_csv(data, comment_prefix="#").collect().select(pl.len()).item() == 3
+
+    assert pl.scan_csv(data).select(pl.len()).collect().item() == 3
+    assert pl.scan_csv(data, comment_prefix="#").select(pl.len()).collect().item() == 3
+
+
 @pytest.mark.write_disk
 def test_commented_csv(
     capfd: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch

--- a/py-polars/tests/unit/io/test_lazy_count_star.py
+++ b/py-polars/tests/unit/io/test_lazy_count_star.py
@@ -111,8 +111,8 @@ a,b
 3,4
 5,6"""
 
-    assert pl.scan_csv(data).collect().select(pl.len()).item() == 3
-    assert pl.scan_csv(data, comment_prefix="#").collect().select(pl.len()).item() == 3
+    assert pl.scan_csv(data).collect().height == 3
+    assert pl.scan_csv(data, comment_prefix="#").collect().height == 3
 
     assert pl.scan_csv(data).select(pl.len()).collect().item() == 3
     assert pl.scan_csv(data, comment_prefix="#").select(pl.len()).collect().item() == 3


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22564
