### PR TITLE
perf: Add streaming cross-join node

### DIFF
--- a/crates/polars-arrow/src/array/struct_/builder.rs
+++ b/crates/polars-arrow/src/array/struct_/builder.rs
@@ -99,7 +99,7 @@ impl StaticArrayBuilder for StructArrayBuilder {
         }
         self.validity
             .subslice_extend_from_opt_validity(other.validity(), start, length);
-        self.length += length.min(other.len().saturating_sub(start));
+        self.length += length.min(other.len().saturating_sub(start)) * repeats;
     }
 
     unsafe fn gather_extend(

--- a/crates/polars-core/src/frame/builder.rs
+++ b/crates/polars-core/src/frame/builder.rs
@@ -115,6 +115,44 @@ impl DataFrameBuilder {
         self.height += length.min(other.height().saturating_sub(start));
     }
 
+    /// Extends this builder with the contents of the given dataframe subslice, repeating it `repeats` times.
+    /// May panic if other does not match the schema of this builder.
+    pub fn subslice_extend_repeated(
+        &mut self,
+        other: &DataFrame,
+        start: usize,
+        length: usize,
+        repeats: usize,
+        share: ShareStrategy,
+    ) {
+        let columns = other.get_columns();
+        assert!(self.builders.len() == columns.len());
+        for (builder, column) in self.builders.iter_mut().zip(columns) {
+            match column {
+                Column::Series(s) => {
+                    builder.subslice_extend_repeated(s, start, length, repeats, share);
+                },
+                Column::Partitioned(p) => {
+                    // @scalar-opt
+                    builder.subslice_extend_repeated(
+                        p.as_materialized_series(),
+                        start,
+                        length,
+                        repeats,
+                        share,
+                    );
+                },
+                Column::Scalar(sc) => {
+                    let len = sc.len().saturating_sub(start).min(length);
+                    let scalar_as_series = sc.scalar().clone().into_series(PlSmallStr::default());
+                    builder.subslice_extend_repeated(&scalar_as_series, 0, 1, len * repeats, share);
+                },
+            }
+        }
+
+        self.height += length.min(other.height().saturating_sub(start)) * repeats;
+    }
+
     /// Extends this builder with the contents of the given dataframe subslice.
     /// Each element is repeated repeats times. May panic if other does not
     /// match the schema of this builder.
@@ -151,7 +189,7 @@ impl DataFrameBuilder {
             }
         }
 
-        self.height += length.min(other.height().saturating_sub(start));
+        self.height += length.min(other.height().saturating_sub(start)) * repeats;
     }
 
     /// Extends this builder with the contents of the given dataframe at the given

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -361,6 +361,11 @@ impl DataFrame {
         Ok(unsafe { DataFrame::new_no_checks(length, columns) })
     }
 
+    pub fn new_from_index(&self, index: usize, height: usize) -> Self {
+        let cols = self.columns.iter().map(|c| c.new_from_index(index, height));
+        unsafe { Self::new_no_checks(height, cols.collect()) }
+    }
+
     /// Creates an empty `DataFrame` usable in a compile time context (such as static initializers).
     ///
     /// # Example

--- a/crates/polars-plan/src/plans/optimizer/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/mod.rs
@@ -197,7 +197,7 @@ More information on the new streaming engine: https://github.com/pola-rs/polars/
 
     // Make sure it is after predicate pushdown
     if opt_flags.collapse_joins() && get_or_init_members!().has_filter_with_join_input {
-        collapse_joins::optimize(lp_top, lp_arena, expr_arena);
+        collapse_joins::optimize(lp_top, lp_arena, expr_arena, opt_flags.new_streaming());
     }
 
     // Make sure its before slice pushdown.

--- a/crates/polars-stream/src/nodes/joins/cross_join.rs
+++ b/crates/polars-stream/src/nodes/joins/cross_join.rs
@@ -1,0 +1,260 @@
+use std::sync::Arc;
+
+use arrow::array::builder::ShareStrategy;
+use polars_core::frame::builder::DataFrameBuilder;
+use polars_core::schema::Schema;
+use polars_ops::frame::{JoinArgs, MaintainOrderJoin};
+use polars_utils::format_pl_smallstr;
+use polars_utils::pl_str::PlSmallStr;
+
+use crate::morsel::get_ideal_morsel_size;
+use crate::nodes::compute_node_prelude::*;
+use crate::nodes::in_memory_sink::InMemorySinkNode;
+
+pub struct CrossJoinNode {
+    left_is_build: bool,
+    left_input_schema: Arc<Schema>,
+    right_input_schema: Arc<Schema>,
+    right_rename: Vec<Option<PlSmallStr>>,
+    state: CrossJoinState,
+}
+
+impl CrossJoinNode {
+    pub fn new(
+        left_input_schema: Arc<Schema>,
+        right_input_schema: Arc<Schema>,
+        args: &JoinArgs,
+    ) -> Self {
+        let left_is_build = match args.maintain_order {
+            MaintainOrderJoin::None => true, // TODO: size estimation.
+            MaintainOrderJoin::Left | MaintainOrderJoin::LeftRight => false,
+            MaintainOrderJoin::Right | MaintainOrderJoin::RightLeft => true,
+        };
+        let build_input_schema = if left_is_build {
+            &left_input_schema
+        } else {
+            &right_input_schema
+        };
+        let sink_node = InMemorySinkNode::new(build_input_schema.clone());
+        let right_rename = right_input_schema
+            .iter_names()
+            .map(|rname| {
+                if left_input_schema.contains(rname) {
+                    Some(format_pl_smallstr!("{}{}", rname, args.suffix()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Self {
+            left_is_build,
+            left_input_schema,
+            right_input_schema,
+            right_rename,
+            state: CrossJoinState::Build(sink_node),
+        }
+    }
+}
+
+enum CrossJoinState {
+    Build(InMemorySinkNode),
+    Probe(DataFrame),
+    Done,
+}
+
+impl ComputeNode for CrossJoinNode {
+    fn name(&self) -> &str {
+        "cross-join"
+    }
+
+    fn is_memory_intensive_pipeline_blocker(&self) -> bool {
+        true
+    }
+
+    fn update_state(
+        &mut self,
+        recv: &mut [PortState],
+        send: &mut [PortState],
+        _state: &StreamingExecutionState,
+    ) -> PolarsResult<()> {
+        assert!(recv.len() == 2 && send.len() == 1);
+
+        let build_idx = if self.left_is_build { 0 } else { 1 };
+        let probe_idx = 1 - build_idx;
+
+        // Are we done?
+        if send[0] == PortState::Done || recv[probe_idx] == PortState::Done {
+            self.state = CrossJoinState::Done;
+        }
+
+        // Transition to build?
+        if recv[build_idx] == PortState::Done {
+            if let CrossJoinState::Build(sink_node) = &mut self.state {
+                let df = sink_node.get_output()?.unwrap();
+                if df.height() > 0 {
+                    self.state = CrossJoinState::Probe(df);
+                } else {
+                    self.state = CrossJoinState::Done;
+                }
+            }
+        }
+
+        match &self.state {
+            CrossJoinState::Build(_) => {
+                recv[build_idx] = PortState::Ready;
+                recv[probe_idx] = PortState::Blocked;
+                send[0] = PortState::Blocked;
+            },
+            CrossJoinState::Probe(_) => {
+                recv[build_idx] = PortState::Done;
+                core::mem::swap(&mut recv[probe_idx], &mut send[0]);
+            },
+            CrossJoinState::Done => {
+                recv[0] = PortState::Done;
+                recv[1] = PortState::Done;
+                send[0] = PortState::Done;
+            },
+        }
+        Ok(())
+    }
+
+    fn spawn<'env, 's>(
+        &'env mut self,
+        scope: &'s TaskScope<'s, 'env>,
+        recv_ports: &mut [Option<RecvPort<'_>>],
+        send_ports: &mut [Option<SendPort<'_>>],
+        state: &'s StreamingExecutionState,
+        join_handles: &mut Vec<JoinHandle<PolarsResult<()>>>,
+    ) {
+        assert!(recv_ports.len() == 2 && send_ports.len() == 1);
+        let build_idx = if self.left_is_build { 0 } else { 1 };
+        let probe_idx = 1 - build_idx;
+        match &mut self.state {
+            CrossJoinState::Build(sink_node) => {
+                assert!(send_ports[0].is_none());
+                assert!(recv_ports[probe_idx].is_none());
+                sink_node.spawn(
+                    scope,
+                    &mut recv_ports[build_idx..build_idx + 1],
+                    &mut [],
+                    state,
+                    join_handles,
+                );
+            },
+            CrossJoinState::Probe(build_df) => {
+                assert!(recv_ports[build_idx].is_none());
+                let receivers = recv_ports[probe_idx].take().unwrap().parallel();
+                let senders = send_ports[0].take().unwrap().parallel();
+                let ideal_morsel_size = get_ideal_morsel_size();
+
+                for (mut recv, mut send) in receivers.into_iter().zip(senders) {
+                    let left_is_build = self.left_is_build;
+                    let left_input_schema = self.left_input_schema.clone();
+                    let right_input_schema = self.right_input_schema.clone();
+                    let right_rename = &self.right_rename;
+                    let build_df = &*build_df;
+                    join_handles.push(
+                        scope.spawn_task(TaskPriority::High, async move {
+                            let mut build_repeater = DataFrameBuilder::new(left_input_schema);
+                            let mut probe_repeater = DataFrameBuilder::new(right_input_schema);
+                            if !left_is_build {
+                                core::mem::swap(&mut build_repeater, &mut probe_repeater);
+                            }
+                            let mut cached_build_df_repeated = DataFrame::empty();
+
+                            while let Ok(morsel) = recv.recv().await {
+                                let combine =
+                                    |build_join_df: DataFrame, probe_join_df: DataFrame| unsafe {
+                                        let (mut left_join_df, mut right_join_df);
+                                        left_join_df = build_join_df;
+                                        right_join_df = probe_join_df;
+                                        if !left_is_build {
+                                            core::mem::swap(&mut left_join_df, &mut right_join_df);
+                                        }
+
+                                        for (col, opt_rename) in right_join_df
+                                            .get_columns_mut()
+                                            .iter_mut()
+                                            .zip(right_rename)
+                                        {
+                                            if let Some(rename) = opt_rename {
+                                                col.rename(rename.clone());
+                                            }
+                                        }
+
+                                        left_join_df
+                                            .hstack_mut_unchecked(right_join_df.get_columns());
+                                        Morsel::new(
+                                            left_join_df,
+                                            morsel.seq(),
+                                            morsel.source_token().clone(),
+                                        )
+                                    };
+
+                                let probe_df = morsel.df();
+                                if build_df.height() >= ideal_morsel_size {
+                                    for probe_offset in 0..probe_df.height() {
+                                        let mut build_offset = 0;
+                                        while build_offset < build_df.height() {
+                                            let height = (build_df.height() - build_offset)
+                                                .min(ideal_morsel_size);
+                                            let build_join_df =
+                                                build_df.slice(build_offset as i64, height);
+                                            let probe_join_df =
+                                                probe_df.new_from_index(probe_offset, height);
+                                            let combined = combine(build_join_df, probe_join_df);
+                                            if send.send(combined).await.is_err() {
+                                                return Ok(());
+                                            }
+                                            build_offset += height;
+                                        }
+                                    }
+                                } else {
+                                    let max_build_repeats = ideal_morsel_size / build_df.height();
+                                    let mut probe_offset = 0;
+                                    while probe_offset < probe_df.height() {
+                                        let build_repeats = (probe_df.height() - probe_offset)
+                                            .min(max_build_repeats);
+                                        let build_height = build_repeats * build_df.height();
+                                        if build_height > cached_build_df_repeated.height() {
+                                            build_repeater.subslice_extend_repeated(
+                                                build_df,
+                                                0,
+                                                build_df.height(),
+                                                build_repeats,
+                                                ShareStrategy::Never,
+                                            );
+                                            cached_build_df_repeated =
+                                                build_repeater.freeze_reset();
+                                        }
+                                        let build_join_df =
+                                            cached_build_df_repeated.slice(0, build_height);
+
+                                        probe_repeater.subslice_extend_each_repeated(
+                                            probe_df,
+                                            probe_offset,
+                                            build_repeats,
+                                            build_df.height(),
+                                            ShareStrategy::Always,
+                                        );
+                                        let probe_join_df = probe_repeater.freeze_reset();
+
+                                        let combined = combine(build_join_df, probe_join_df);
+                                        if send.send(combined).await.is_err() {
+                                            return Ok(());
+                                        }
+
+                                        probe_offset += build_repeats;
+                                    }
+                                }
+                            }
+                            Ok(())
+                        }),
+                    );
+                }
+            },
+            CrossJoinState::Done => unreachable!(),
+        }
+    }
+}

--- a/crates/polars-stream/src/nodes/joins/mod.rs
+++ b/crates/polars-stream/src/nodes/joins/mod.rs
@@ -12,6 +12,7 @@ use crate::async_primitives::wait_group::WaitGroup;
 use crate::morsel::{Morsel, MorselSeq, SourceToken};
 use crate::pipe::RecvPort;
 
+pub mod cross_join;
 pub mod equi_join;
 pub mod in_memory;
 #[cfg(feature = "semi_anti_join")]

--- a/crates/polars-stream/src/physical_plan/fmt.rs
+++ b/crates/polars-stream/src/physical_plan/fmt.rs
@@ -429,6 +429,7 @@ fn visualize_plan_rec(
             let label = match phys_sm[node_key].kind {
                 PhysNodeKind::EquiJoin { .. } => "equi-join",
                 PhysNodeKind::InMemoryJoin { .. } => "in-memory-join",
+                PhysNodeKind::CrossJoin { .. } => "cross-join",
                 PhysNodeKind::SemiAntiJoin {
                     output_bool: false, ..
                 } if args.how.is_semi() => "semi-join",
@@ -469,6 +470,11 @@ fn visualize_plan_rec(
             }
             (label, &[*input_left, *input_right][..])
         },
+        PhysNodeKind::CrossJoin {
+            input_left,
+            input_right,
+            args: _,
+        } => ("cross-join".to_string(), &[*input_left, *input_right][..]),
         #[cfg(feature = "merge_sorted")]
         PhysNodeKind::MergeSorted {
             input_left,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -893,11 +893,19 @@ pub fn lower_ir(
                 }
                 return Ok(stream);
             } else if args.how.is_cross() {
-                PhysNodeKind::CrossJoin {
-                    input_left: phys_left,
-                    input_right: phys_right,
-                    args,
+                let node = phys_sm.insert(PhysNode::new(
+                    output_schema,
+                    PhysNodeKind::CrossJoin {
+                        input_left: phys_left,
+                        input_right: phys_right,
+                        args: args.clone(),
+                    }
+                ));
+                let mut stream = PhysStream::first(node);
+                if let Some((offset, len)) = args.slice {
+                    stream = build_slice_stream(stream, offset, len, phys_sm);
                 }
+                return Ok(stream);
             } else {
                 PhysNodeKind::InMemoryJoin {
                     input_left: phys_left,

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -899,7 +899,7 @@ pub fn lower_ir(
                         input_left: phys_left,
                         input_right: phys_right,
                         args: args.clone(),
-                    }
+                    },
                 ));
                 let mut stream = PhysStream::first(node);
                 if let Some((offset, len)) = args.slice {

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -829,8 +829,7 @@ pub fn lower_ir(
             let options = options.options.clone();
             let phys_left = lower_ir!(input_left)?;
             let phys_right = lower_ir!(input_right)?;
-            let supported_join_type = args.how.is_equi() || args.how.is_semi_anti();
-            if supported_join_type && !args.validation.needs_checks() {
+            if (args.how.is_equi() || args.how.is_semi_anti()) && !args.validation.needs_checks() {
                 // When lowering the expressions for the keys we need to ensure we keep around the
                 // payload columns, otherwise the input nodes can get replaced by input-independent
                 // nodes since the lowering code does not see we access any non-literal expressions.
@@ -893,6 +892,12 @@ pub fn lower_ir(
                     stream = build_slice_stream(stream, offset, len, phys_sm);
                 }
                 return Ok(stream);
+            } else if args.how.is_cross() {
+                PhysNodeKind::CrossJoin {
+                    input_left: phys_left,
+                    input_right: phys_right,
+                    args,
+                }
             } else {
                 PhysNodeKind::InMemoryJoin {
                     input_left: phys_left,

--- a/crates/polars-stream/src/physical_plan/mod.rs
+++ b/crates/polars-stream/src/physical_plan/mod.rs
@@ -254,6 +254,12 @@ pub enum PhysNodeKind {
         output_bool: bool,
     },
 
+    CrossJoin {
+        input_left: PhysStream,
+        input_right: PhysStream,
+        args: JoinArgs,
+    },
+
     /// Generic fallback for (as-of-yet) unsupported streaming joins.
     /// Fully sinks all data to in-memory data frames and uses the in-memory
     /// engine to perform the join.
@@ -328,6 +334,11 @@ fn visit_node_inputs_mut(
                 ..
             }
             | PhysNodeKind::SemiAntiJoin {
+                input_left,
+                input_right,
+                ..
+            }
+            | PhysNodeKind::CrossJoin {
                 input_left,
                 input_right,
                 ..

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -754,6 +754,30 @@ fn to_graph_rec<'a>(
             }
         },
 
+        CrossJoin {
+            input_left,
+            input_right,
+            args,
+        } => {
+            let args = args.clone();
+            let left_input_key = to_graph_rec(input_left.node, ctx)?;
+            let right_input_key = to_graph_rec(input_right.node, ctx)?;
+            let left_input_schema = ctx.phys_sm[input_left.node].output_schema.clone();
+            let right_input_schema = ctx.phys_sm[input_right.node].output_schema.clone();
+
+            ctx.graph.add_node(
+                nodes::joins::cross_join::CrossJoinNode::new(
+                    left_input_schema,
+                    right_input_schema,
+                    &args,
+                ),
+                [
+                    (left_input_key, input_left.port),
+                    (right_input_key, input_right.port),
+                ],
+            )
+        },
+
         #[cfg(feature = "merge_sorted")]
         MergeSorted {
             input_left,

--- a/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_concat_list.py
@@ -185,8 +185,8 @@ def test_cross_join_concat_list_18587() -> None:
     lf3 = lf.select(pl.struct(pl.all()).alias("3"))
 
     result = (
-        lf1.join(lf2, how="cross")
-        .join(lf3, how="cross")
+        lf1.join(lf2, how="cross", maintain_order="left_right")
+        .join(lf3, how="cross", maintain_order="left_right")
         .select(pl.concat_list("1", "2", "3"))
         .collect()
     )

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -217,36 +217,37 @@ def test_agg_function_of_filter_10565() -> None:
 
 
 def test_filter_logical_type_13194() -> None:
-    data = {
-        "id": [1, 1, 2],
-        "date": [
-            [datetime(year=2021, month=1, day=1)],
-            [datetime(year=2021, month=1, day=1)],
-            [datetime(year=2025, month=1, day=30)],
-        ],
-        "cat": [
-            ["a", "b", "c"],
-            ["a", "b", "c"],
-            ["d", "e", "f"],
-        ],
-    }
+    with pl.StringCache():
+        data = {
+            "id": [1, 1, 2],
+            "date": [
+                [datetime(year=2021, month=1, day=1)],
+                [datetime(year=2021, month=1, day=1)],
+                [datetime(year=2025, month=1, day=30)],
+            ],
+            "cat": [
+                ["a", "b", "c"],
+                ["a", "b", "c"],
+                ["d", "e", "f"],
+            ],
+        }
 
-    df = pl.DataFrame(data).with_columns(pl.col("cat").cast(pl.List(pl.Categorical())))
+        df = pl.DataFrame(data).with_columns(pl.col("cat").cast(pl.List(pl.Categorical())))
 
-    df = df.filter(pl.col("id") == pl.col("id").shift(1))
-    expected_df = pl.DataFrame(
-        {
-            "id": [1],
-            "date": [[datetime(year=2021, month=1, day=1)]],
-            "cat": [["a", "b", "c"]],
-        },
-        schema={
-            "id": pl.Int64,
-            "date": pl.List(pl.Datetime),
-            "cat": pl.List(pl.Categorical),
-        },
-    )
-    assert_frame_equal(df, expected_df)
+        df = df.filter(pl.col("id") == pl.col("id").shift(1))
+        expected_df = pl.DataFrame(
+            {
+                "id": [1],
+                "date": [[datetime(year=2021, month=1, day=1)]],
+                "cat": [["a", "b", "c"]],
+            },
+            schema={
+                "id": pl.Int64,
+                "date": pl.List(pl.Datetime),
+                "cat": pl.List(pl.Categorical),
+            },
+        )
+        assert_frame_equal(df, expected_df)
 
 
 def test_filter_horizontal_selector_15428() -> None:

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -232,7 +232,9 @@ def test_filter_logical_type_13194() -> None:
             ],
         }
 
-        df = pl.DataFrame(data).with_columns(pl.col("cat").cast(pl.List(pl.Categorical())))
+        df = pl.DataFrame(data).with_columns(
+            pl.col("cat").cast(pl.List(pl.Categorical()))
+        )
 
         df = df.filter(pl.col("id") == pl.col("id").shift(1))
         expected_df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -427,7 +427,7 @@ def test_pivot_negative_duration() -> None:
     df1 = pl.DataFrame({"root": [date(2020, i, 15) for i in (1, 2)]})
     df2 = pl.DataFrame({"delta": [timedelta(days=i) for i in (-2, -1, 0, 1)]})
 
-    df = df1.join(df2, how="cross").with_columns(
+    df = df1.join(df2, how="cross", maintain_order="left_right").with_columns(
         pl.Series(name="value", values=range(len(df1) * len(df2)))
     )
     assert df.pivot(


### PR DESCRIPTION
This relieves a lot of memory pressure for plans with cross-joins as the full result doesn't have to be materialized at once.