### PR TITLE
fix: Consistently use Unix epoch as origin for ``dt.truncate`` (except weekly buckets which start on Mondays)

### DIFF
--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -730,7 +730,7 @@ impl Duration {
             original_dt_local.year() as i64,
             original_dt_local.month() as i64,
         );
-        let total = (year * 12) + (month - 1);
+        let total = ((year - 1970) * 12) + (month - 1);
         let mut remainder_months = total % self.months;
         if remainder_months < 0 {
             remainder_months += self.months

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -166,16 +166,20 @@ class ExprDateTimeNameSpace:
         Divide the date/datetime range into buckets.
 
         Each date/datetime is mapped to the start of its bucket using the corresponding
-        local datetime. Note that weekly buckets start on Monday.
-        Ambiguous results are localised using the DST offset of the original timestamp -
-        for example, truncating `'2022-11-06 01:30:00 CST'` by `'1h'` results in
-        `'2022-11-06 01:00:00 CST'`, whereas truncating `'2022-11-06 01:30:00 CDT'` by
-        `'1h'` results in `'2022-11-06 01:00:00 CDT'`.
+        local datetime. Note that:
+
+        - Weekly buckets start on Monday.
+        - All other buckets start on the Unix epoch (1970-01-01).
+        - Ambiguous results are localised using the DST offset of the original
+          timestamp - for example, truncating `'2022-11-06 01:30:00 CST'` by
+          `'1h'` results in `'2022-11-06 01:00:00 CST'`, whereas truncating
+          `'2022-11-06 01:30:00 CDT'` by `'1h'` results in
+          `'2022-11-06 01:00:00 CDT'`.
 
         Parameters
         ----------
         every
-            Every interval start and period length
+            The size of each bucket.
 
         Notes
         -----
@@ -197,7 +201,6 @@ class ExprDateTimeNameSpace:
         These strings can be combined:
 
         - 3d12h4m25s # 3 days, 12 hours, 4 minutes, and 25 seconds
-
 
         By "calendar day", we mean the corresponding time on the next day (which may
         not be 24 hours, due to daylight savings). Similarly for "calendar week",

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1784,16 +1784,20 @@ class DateTimeNameSpace:
         Divide the date/ datetime range into buckets.
 
         Each date/datetime is mapped to the start of its bucket using the corresponding
-        local datetime. Note that weekly buckets start on Monday.
-        Ambiguous results are localised using the DST offset of the original timestamp -
-        for example, truncating `'2022-11-06 01:30:00 CST'` by `'1h'` results in
-        `'2022-11-06 01:00:00 CST'`, whereas truncating `'2022-11-06 01:30:00 CDT'` by
-        `'1h'` results in `'2022-11-06 01:00:00 CDT'`.
+        local datetime. Note that:
+
+        - Weekly buckets start on Monday.
+        - All other buckets start on the Unix epoch (1970-01-01).
+        - Ambiguous results are localised using the DST offset of the original
+          timestamp - for example, truncating `'2022-11-06 01:30:00 CST'` by
+          `'1h'` results in `'2022-11-06 01:00:00 CST'`, whereas truncating
+          `'2022-11-06 01:30:00 CDT'` by `'1h'` results in
+          `'2022-11-06 01:00:00 CDT'`.
 
         Parameters
         ----------
         every
-            Every interval start and period length
+            The size of each bucket.
 
         Notes
         -----

--- a/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
+++ b/py-polars/tests/unit/operations/namespaces/temporal/test_truncate.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 def test_truncate_monthly(value: date, n: int) -> None:
     result = pl.Series([value]).dt.truncate(f"{n}mo").item()
     # manual calculation
-    total = value.year * 12 + value.month - 1
+    total = (value.year - 1970) * 12 + value.month - 1
     remainder = total % n
     total -= remainder
     year, month = (total // 12), ((total % 12) + 1)
@@ -128,3 +128,34 @@ def test_truncate_unequal_length_22018(as_date: bool) -> None:
         s = s.dt.date()
     with pytest.raises(pl.exceptions.ShapeError):
         s.dt.truncate(pl.Series(["1y"] * 3))
+
+
+@pytest.mark.parametrize(
+    ("multiplier", "unit", "value", "expected"),
+    [
+        (2, "h", datetime(1970, 1, 2, 3), datetime(1970, 1, 2, 2)),
+        (5, "h", datetime(1983, 3, 1, 4), datetime(1983, 3, 1, 2)),
+        (3, "d", datetime(1970, 1, 1), datetime(1970, 1, 1)),
+        (7, "d", datetime(2001, 1, 4, 5), datetime(2001, 1, 4)),
+        (11, "q", datetime(1, 9, 9, 9), datetime(1, 1, 1)),
+        (3, "y", datetime(1970, 1, 1), datetime(1970, 1, 1)),
+        (19, "y", datetime(9543, 1, 5, 6), datetime(9532, 1, 1)),
+        (5, "mo", datetime(1342, 11, 11, 11), datetime(1342, 7, 1)),
+    ],
+)
+@pytest.mark.parametrize("time_zone", ["Asia/Kathmandu", None])
+def test_truncate_origin_22590(
+    multiplier: int,
+    unit: str,
+    value: datetime,
+    expected: datetime,
+    time_zone: str | None,
+) -> None:
+    result = (
+        pl.Series([value])
+        .dt.replace_time_zone(time_zone)
+        .dt.truncate(f"{multiplier}{unit}")
+        .dt.replace_time_zone(None)
+        .item()
+    )
+    assert result == expected, result


### PR DESCRIPTION
closes #22590 