### PR TITLE
feat(python): Support PEP702 `@deprecated` decorator behaviour

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -443,11 +443,10 @@ def __getattr__(name: str) -> Any:
 
         issue_deprecation_warning(
             message=(
-                f"Accessing `{name}` from the top-level `polars` module is deprecated."
-                " Import it directly from the `polars.exceptions` module instead:"
-                f" from polars.exceptions import {name}"
+                f"accessing `{name}` from the top-level `polars` module was deprecated "
+                "in version 1.0.0. Import it directly from the `polars.exceptions` module "
+                f"instead, e.g.: `from polars.exceptions import {name}`"
             ),
-            version="1.0.0",
         )
         return getattr(exceptions, name)
 
@@ -459,10 +458,9 @@ def __getattr__(name: str) -> Any:
 
         issue_deprecation_warning(
             message=(
-                f"`{name}` is deprecated. Define your own data type groups or use the"
-                " `polars.selectors` module for selecting columns of a certain data type."
+                f"`{name}` was deprecated in version 1.0.0. Define your own data type groups or "
+                "use the `polars.selectors` module for selecting columns of a certain data type."
             ),
-            version="1.0.0",
         )
         return getattr(dtgroup, name)
 

--- a/py-polars/polars/_typing.py
+++ b/py-polars/polars/_typing.py
@@ -285,7 +285,6 @@ ConnectionOrCursor: TypeAlias = Union[
     BasicConnection, BasicCursor, Cursor, AlchemyConnection
 ]
 
-
 # Annotations for `__getitem__` methods
 SingleIndexSelector: TypeAlias = int
 MultiIndexSelector: TypeAlias = Union[
@@ -330,6 +329,14 @@ FileSource: TypeAlias = Union[
 
 JSONEncoder = Union[Callable[[Any], bytes], Callable[[Any], str]]
 
+DeprecationType: TypeAlias = Literal[
+    "function",
+    "renamed_parameter",
+    "streaming_parameter",
+    "nonkeyword_arguments",
+    "parameter_as_multi_positional",
+]
+
 
 class PartitioningScheme:
     def __init__(
@@ -368,6 +375,7 @@ __all__ = [
     "DbReadEngine",
     "DbWriteEngine",
     "DbWriteMode",
+    "DeprecationType",
     "Endianness",
     "EngineType",
     "EpochTimeUnit",

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -1163,7 +1163,7 @@ def arrow_to_pydf(
     try:
         if column_names != data.schema.names:
             data = data.rename_columns(column_names)
-    except pa.lib.ArrowInvalid as e:
+    except pa.ArrowInvalid as e:
         msg = "dimensions of columns arg must match data dimensions"
         raise ValueError(msg) from e
 

--- a/py-polars/polars/_utils/deprecation.py
+++ b/py-polars/polars/_utils/deprecation.py
@@ -375,7 +375,7 @@ def identify_deprecations(*types: DeprecationType) -> dict[str, list[str]]:
 
     for py_file in package_path.rglob("*.py"):
         rel_path = py_file.relative_to(package_path)
-        module_path = ".".join(rel_path.parts)
+        module_path = ".".join(rel_path.parts).removesuffix(".py")
         with py_file.open("r", encoding="utf-8") as src:
             for deprecation_type, func_names in _find_deprecated_functions(
                 source=src.read(),

--- a/py-polars/polars/_utils/deprecation.py
+++ b/py-polars/polars/_utils/deprecation.py
@@ -1,26 +1,42 @@
 from __future__ import annotations
 
+import ast
 import inspect
+import sys
+from collections import defaultdict
 from collections.abc import Sequence
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, TypeVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, get_args
+
+from polars._typing import DeprecationType
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    try:
+        from typing_extensions import deprecated
+    except ImportError:
+
+        def deprecated(  # type: ignore[no-redef]
+            message: str,
+        ) -> Callable[[Callable[P, T]], Callable[P, T]]:
+            return _deprecate_function(message)
+
 
 from polars._utils.various import issue_warning
 
 if TYPE_CHECKING:
-    import sys
     from collections.abc import Mapping
-
-    from polars._typing import Ambiguous
 
     if sys.version_info >= (3, 10):
         from typing import ParamSpec
     else:
         from typing_extensions import ParamSpec
+    from polars._typing import Ambiguous
 
     P = ParamSpec("P")
     T = TypeVar("T")
-
 
 USE_EARLIEST_TO_AMBIGUOUS: Mapping[bool, Ambiguous] = {
     True: "earliest",
@@ -28,7 +44,7 @@ USE_EARLIEST_TO_AMBIGUOUS: Mapping[bool, Ambiguous] = {
 }
 
 
-def issue_deprecation_warning(message: str, *, version: str) -> None:
+def issue_deprecation_warning(message: str, *, version: str = "") -> None:
     """
     Issue a deprecation warning.
 
@@ -37,38 +53,28 @@ def issue_deprecation_warning(message: str, *, version: str) -> None:
     message
         The message associated with the warning.
     version
-        The Polars version number in which the warning is first issued.
-        This argument is used to help developers determine when to remove the
-        deprecated functionality.
+        The version in which deprecation occurred
+        (if the version number was not already included in `message`).
     """
+    if version:
+        message = f"{message.strip()}\n(Deprecated in version {version})"
     issue_warning(message, DeprecationWarning)
 
 
-def deprecate_function(
-    message: str, *, version: str
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def _deprecate_function(message: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Decorator to mark a function as deprecated."""
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            issue_deprecation_warning(
-                f"`{function.__qualname__}` is deprecated. {message}",
-                version=version,
-            )
+            issue_deprecation_warning(message)
             return function(*args, **kwargs)
 
         wrapper.__signature__ = inspect.signature(function)  # type: ignore[attr-defined]
+        wrapper.__deprecated__ = message  # type: ignore[attr-defined]
         return wrapper
 
     return decorate
-
-
-def deprecate_renamed_function(
-    new_name: str, *, version: str
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
-    """Decorator to mark a function as deprecated due to being renamed (or moved)."""
-    return deprecate_function(f"It has been renamed to `{new_name}`.", version=version)
 
 
 def deprecate_streaming_parameter() -> Callable[[Callable[P, T]], Callable[P, T]]:
@@ -79,10 +85,8 @@ def deprecate_streaming_parameter() -> Callable[[Callable[P, T]], Callable[P, T]
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if "streaming" in kwargs:
                 issue_deprecation_warning(
-                    "The argument `streaming` is deprecated and is being replaced by the `engine` argument.",
-                    version="1.25.0",
+                    "the `streaming` parameter was deprecated in 1.25.0; use `engine` instead."
                 )
-
                 if kwargs["streaming"]:
                     kwargs["engine"] = "old-streaming"
                 elif "engine" not in kwargs:
@@ -102,12 +106,17 @@ def deprecate_renamed_parameter(
     old_name: str, new_name: str, *, version: str
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
-    Decorator to mark a function argument as deprecated due to being renamed.
+    Decorator to mark a function parameter as deprecated due to being renamed.
 
-    Use as follows::
+    Use as follows:
 
-        @deprecate_renamed_parameter("old_name", "new_name", version="0.20.4")
+        @deprecate_renamed_parameter("old_name", new_name="new_name")
         def myfunc(new_name): ...
+
+    Ensure that you also update the function docstring with a note about the
+    deprecation, specifically adding a `.. versionchanged:: 0.0.0` directive
+    that states which parameter was renamed to which new name and in which
+    version the rename happened.
     """
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
@@ -134,15 +143,19 @@ def _rename_keyword_argument(
     """Rename a keyword argument of a function."""
     if old_name in kwargs:
         if new_name in kwargs:
+            is_deprecated = (
+                f"was deprecated in version {version}" if version else "is deprecated"
+            )
             msg = (
                 f"`{func_name!r}` received both `{old_name!r}` and `{new_name!r}` as arguments;"
-                f" `{old_name!r}` is deprecated, use `{new_name!r}` instead"
+                f" `{old_name!r}` {is_deprecated}, use `{new_name!r}` instead"
             )
             raise TypeError(msg)
+
+        in_version = f" in version {version}" if version else ""
         issue_deprecation_warning(
-            f"The argument `{old_name}` for `{func_name}` is deprecated."
-            f" It has been renamed to `{new_name}`.",
-            version=version,
+            f"the argument `{old_name}` for `{func_name}` is deprecated. "
+            f"It was renamed to `{new_name}`{in_version}."
         )
         kwargs[new_name] = kwargs.pop(old_name)
 
@@ -151,7 +164,17 @@ def deprecate_nonkeyword_arguments(
     allowed_args: list[str] | None = None, message: str | None = None, *, version: str
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
-    Decorator to deprecate the use of non-keyword arguments of a function.
+    Decorator for deprecating the use of non-keyword arguments in a function.
+
+    Use as follows:
+
+        @deprecate_nonkeyword_arguments(allowed_args=["self", "val"], version="1.0.0")
+        def myfunc(self, val: int = 0, other: int: = 0): ...
+
+    Ensure that you also update the function docstring with a note about the
+    deprecation, specifically adding a `.. versionchanged:: 0.0.0` directive
+    that states that we now expect keyword args and in which version this
+    update happened.
 
     Parameters
     ----------
@@ -164,8 +187,6 @@ def deprecate_nonkeyword_arguments(
         Optionally overwrite the default warning message.
     version
         The Polars version number in which the warning is first issued.
-        This argument is used to help developers determine when to remove the
-        deprecated functionality.
     """
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
@@ -197,7 +218,7 @@ def deprecate_nonkeyword_arguments(
         num_allowed_args = len(allow_args)
         if message is None:
             msg_format = (
-                f"All arguments of {function.__qualname__}{{except_args}} will be keyword-only in the next breaking release."
+                f"all arguments of {function.__qualname__}{{except_args}} will be keyword-only in the next breaking release."
                 " Use keyword arguments to silence this warning."
             )
             msg = msg_format.format(except_args=_format_argument_list(allow_args))
@@ -231,15 +252,20 @@ def _format_argument_list(allowed_args: list[str]) -> str:
 
 
 def deprecate_parameter_as_multi_positional(
-    old_name: str, *, version: str
+    old_name: str,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
     Decorator to mark a function argument as deprecated due to being made multi-positional.
 
-    Use as follows::
+    Use as follows:
 
-        @deprecate_parameter_as_multi_positional("columns", version="0.20.4")
+        @deprecate_parameter_as_multi_positional("columns")
         def myfunc(*columns): ...
+
+    Ensure that you also update the function docstring with a note about the
+    deprecation, specifically adding a `.. versionchanged:: 0.0.0` directive
+    that states that we now expect positional args and in which version this
+    update happened.
     """  # noqa: W505
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
@@ -251,9 +277,8 @@ def deprecate_parameter_as_multi_positional(
                 return function(*args, **kwargs)
 
             issue_deprecation_warning(
-                f"Passing `{old_name}` as a keyword argument is deprecated."
-                " Pass it as a positional argument instead.",
-                version=version,
+                f"passing `{old_name}` as a keyword argument is deprecated."
+                " Pass it as a positional argument instead."
             )
 
             if not isinstance(arg_value, Sequence) or isinstance(arg_value, str):
@@ -268,3 +293,114 @@ def deprecate_parameter_as_multi_positional(
         return wrapper
 
     return decorate
+
+
+def _find_deprecated_functions(
+    source: str, module_path: str
+) -> defaultdict[str, list[str]]:
+    tree = ast.parse(source)
+    object_path: list[str] = []
+
+    def deprecated(decorator: Any) -> str:
+        if isinstance(decorator, ast.Name):
+            return decorator.id if "deprecate" in decorator.id else ""
+        elif isinstance(decorator, ast.Call):
+            return deprecated(decorator.func)
+        return ""
+
+    def qualified_name(func_name: str) -> str:
+        return ".".join([module_path, *object_path, func_name])
+
+    results = defaultdict(list)
+
+    class FunctionVisitor(ast.NodeVisitor):
+        def visit_ClassDef(self, node: Any) -> None:
+            object_path.append(node.name)
+            self.generic_visit(node)
+            object_path.pop()
+
+        def visit_FunctionDef(self, node: Any) -> None:
+            if any((decorator_name := deprecated(d)) for d in node.decorator_list):
+                key = decorator_name.removeprefix("deprecate_").replace(
+                    "deprecated", "function"
+                )
+                results[key].append(qualified_name(node.name))
+            self.generic_visit(node)
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+    FunctionVisitor().visit(tree)
+    return results
+
+
+def identify_deprecations(*types: DeprecationType) -> dict[str, list[str]]:
+    """
+    Return a dict identifying functions/methods that are deprecated in some way.
+
+    Parameters
+    ----------
+    *types
+        The types of deprecations to identify.
+        If empty, all types are returned; recognised values are:
+            - "function"
+            - "renamed_parameter"
+            - "streaming_parameter"
+            - "nonkeyword_arguments"
+            - "parameter_as_multi_positional"
+
+    Examples
+    --------
+    >>> from polars._utils.deprecation import identify_deprecations
+    >>> identify_deprecations("streaming_parameter")  # doctest: +IGNORE_RESULT
+    {'streaming_parameter': [
+        'functions.lazy.collect_all',
+        'functions.lazy.collect_all_async',
+        'lazyframe.frame.LazyFrame.collect',
+        'lazyframe.frame.LazyFrame.collect_async',
+        'lazyframe.frame.LazyFrame.explain',
+        'lazyframe.frame.LazyFrame.show_graph',
+    ]}
+    """
+    valid_types = set(get_args(DeprecationType))
+    for tp in types:
+        if tp not in valid_types:
+            msg = (
+                f"unrecognised deprecation type {tp!r}.\n"
+                f"Expected one (or more) of {repr(sorted(valid_types))[1:-1]}"
+            )
+            raise ValueError(msg)
+
+    package_path = Path(sys.modules["polars"].__file__).parent  # type: ignore[arg-type]
+    results = defaultdict(list)
+
+    for py_file in package_path.rglob("*.py"):
+        rel_path = py_file.relative_to(package_path)
+        module_path = ".".join(rel_path.parts)
+        with py_file.open("r", encoding="utf-8") as src:
+            for deprecation_type, func_names in _find_deprecated_functions(
+                source=src.read(),
+                module_path=module_path,
+            ).items():
+                if deprecation_type not in valid_types:
+                    # note: raising here implies we have a new deprecation function
+                    # that should be added to the DeprecationType type alias
+                    msg = f"unrecognised deprecation type {tp!r}.\n"
+                    raise ValueError(msg)
+
+                results[deprecation_type].extend(func_names)
+
+    return {
+        dep: sorted(results[dep])
+        for dep in sorted(results)
+        if not types or dep in types
+    }
+
+
+__all__ = [
+    "deprecate_nonkeyword_arguments",
+    "deprecate_parameter_as_multi_positional",
+    "deprecate_renamed_parameter",
+    "deprecate_streaming_parameter",
+    "deprecated",
+    "identify_deprecations",
+]

--- a/py-polars/polars/_utils/unstable.py
+++ b/py-polars/polars/_utils/unstable.py
@@ -40,7 +40,7 @@ def issue_unstable_warning(message: str | None = None) -> None:
         return
 
     if message is None:
-        message = "This functionality is considered unstable."
+        message = "this functionality is considered unstable."
     message += (
         " It may be changed at any point without it being considered a breaking change."
     )

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -673,7 +673,7 @@ def display_dot_graph(
         )
     except (ImportError, FileNotFoundError):
         msg = (
-            "The graphviz `dot` binary should be on your PATH."
+            "the graphviz `dot` binary should be on your PATH."
             "(If not installed you can download here: https://graphviz.org/download/)"
         )
         raise ImportError(msg) from None

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Self, Unpack
 
-
 __all__ = ["Config"]
 
 TableFormatNames: TypeAlias = Literal[
@@ -1505,7 +1504,7 @@ class Config(contextlib.ContextDecorator):
             raise NotImplementedError(msg)
         supported_engines = get_args(get_args(EngineType)[0])
         if engine not in {*supported_engines, None}:
-            msg = "Invalid engine"
+            msg = "invalid engine"
             raise ValueError(msg)
         if engine is None:
             os.environ.pop("POLARS_ENGINE_AFFINITY", None)

--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -711,6 +711,9 @@ def from_repr(data: str) -> DataFrame | Series:
     """
     Construct a Polars DataFrame or Series from its string representation.
 
+    .. versionchanged:: 0.20.17
+        The `tbl` parameter was renamed to `data`.
+
     Parameters
     ----------
     data

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -42,8 +42,8 @@ from polars._utils.construction import (
 )
 from polars._utils.convert import parse_as_duration_string
 from polars._utils.deprecation import (
-    deprecate_function,
     deprecate_renamed_parameter,
+    deprecated,
     issue_deprecation_warning,
 )
 from polars._utils.getitem import get_df_item_by_key
@@ -183,6 +183,11 @@ if TYPE_CHECKING:
         from typing import Concatenate, ParamSpec
     else:
         from typing_extensions import Concatenate, ParamSpec
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
     T = TypeVar("T")
     P = ParamSpec("P")
@@ -1605,6 +1610,9 @@ class DataFrame:
         Data types that do copy:
             - CategoricalType
 
+        .. versionchanged:: 1.1
+            The `future` parameter was renamed `compat_level`.
+
         Parameters
         ----------
         compat_level
@@ -1879,7 +1887,7 @@ class DataFrame:
         """  # noqa: W505
         if use_pyarrow is not None:
             issue_deprecation_warning(
-                "The `use_pyarrow` parameter for `DataFrame.to_numpy` is deprecated."
+                "the `use_pyarrow` parameter for `DataFrame.to_numpy` is deprecated."
                 " Polars now uses its native engine by default for conversion to NumPy.",
                 version="0.20.28",
             )
@@ -3684,6 +3692,9 @@ class DataFrame:
 
         See "File or Random Access format" in https://arrow.apache.org/docs/python/ipc.html.
 
+        .. versionchanged:: 1.1
+            The `future` parameter was renamed `compat_level`.
+
         Parameters
         ----------
         file
@@ -3806,6 +3817,9 @@ class DataFrame:
         Write to Arrow IPC record batch stream.
 
         See "Streaming format" in https://arrow.apache.org/docs/python/ipc.html.
+
+        .. versionchanged:: 1.1
+            The `future` parameter was renamed `compat_level`.
 
         Parameters
         ----------
@@ -4068,7 +4082,7 @@ class DataFrame:
             }
 
         if partition_by is not None:
-            msg = "The `partition_by` parameter of `write_parquet` is considered unstable."
+            msg = "the `partition_by` parameter of `write_parquet` is considered unstable."
             issue_unstable_warning(msg)
 
         if isinstance(partition_by, str):
@@ -4555,7 +4569,7 @@ class DataFrame:
         """
         if overwrite_schema is not None:
             issue_deprecation_warning(
-                "The parameter `overwrite_schema` for `write_delta` is deprecated."
+                "the parameter `overwrite_schema` for `write_delta` is deprecated."
                 ' Use the parameter `delta_write_options` instead and pass `{"schema_mode": "overwrite"}`.',
                 version="0.20.14",
             )
@@ -4619,7 +4633,7 @@ class DataFrame:
 
         if mode == "merge":
             if delta_merge_options is None:
-                msg = "You need to pass delta_merge_options with at least a given predicate for `MERGE` to work."
+                msg = "you need to pass delta_merge_options with at least a given predicate for `MERGE` to work."
                 raise ValueError(msg)
             if isinstance(target, str):
                 dt = DeltaTable(table_uri=target, storage_options=storage_options)
@@ -5753,6 +5767,9 @@ class DataFrame:
         particular order, call :func:`sort` after this function if you wish the
         output to be sorted.
 
+        .. versionchanged:: 1.0.0
+            The `descending` parameter was renamed `reverse`.
+
         Parameters
         ----------
         k
@@ -5834,6 +5851,9 @@ class DataFrame:
         the value of `reverse`. The output is not guaranteed to be in any
         particular order, call :func:`sort` after this function if you wish the
         output to be sorted.
+
+        .. versionchanged:: 1.0.0
+            The `descending` parameter was renamed `reverse`.
 
         Parameters
         ----------
@@ -6444,17 +6464,16 @@ class DataFrame:
             msg = f"`offset` input for `with_row_index` cannot be {issue}, got {offset}"
             raise ValueError(msg) from None
 
-    @deprecate_function(
-        "Use `with_row_index` instead."
-        " Note that the default column name has changed from 'row_nr' to 'index'.",
-        version="0.20.4",
+    @deprecated(
+        "`DataFrame.with_row_count` is deprecated; use `with_row_index` instead."
+        " Note that the default column name has changed from 'row_nr' to 'index'."
     )
     def with_row_count(self, name: str = "row_nr", offset: int = 0) -> DataFrame:
         """
         Add a column at index 0 that counts the rows.
 
         .. deprecated:: 0.20.4
-            Use :meth:`with_row_index` instead.
+            Use the :meth:`with_row_index` method instead.
             Note that the default column name has changed from 'row_nr' to 'index'.
 
         Parameters
@@ -6690,6 +6709,9 @@ class DataFrame:
         not be 24 hours, due to daylight savings). Similarly for "calendar week",
         "calendar month", "calendar quarter", and "calendar year".
 
+        .. versionchanged:: 0.20.14
+            The `by` parameter was renamed `group_by`.
+
         Parameters
         ----------
         index_column
@@ -6821,6 +6843,9 @@ class DataFrame:
         .. warning::
             The index column must be sorted in ascending order. If `group_by` is passed, then
             the index column must be sorted in ascending order within each group.
+
+        .. versionchanged:: 0.20.14
+            The `by` parameter was renamed `group_by`.
 
         Parameters
         ----------
@@ -7137,10 +7162,12 @@ class DataFrame:
 
         - "3d12h4m25s" # 3 days, 12 hours, 4 minutes, and 25 seconds
 
-
         By "calendar day", we mean the corresponding time on the next day (which may
         not be 24 hours, due to daylight savings). Similarly for "calendar week",
         "calendar month", "calendar quarter", and "calendar year".
+
+        .. versionchanged:: 0.20.14
+            The `by` parameter was renamed `group_by`.
 
         Parameters
         ----------
@@ -7576,6 +7603,9 @@ class DataFrame:
     ) -> DataFrame:
         """
         Join in SQL-like fashion.
+
+        .. versionchanged:: 1.24
+            The `join_nulls` parameter was renamed `nulls_equal`.
 
         Parameters
         ----------
@@ -8784,6 +8814,9 @@ class DataFrame:
 
         Only available in eager mode. See "Examples" section below for how to do a
         "lazy pivot" if you know the unique column values in advance.
+
+        .. versionchanged:: 1.0.0
+            The `columns` parameter was renamed `on`.
 
         Parameters
         ----------
@@ -10561,15 +10594,16 @@ class DataFrame:
         df = self.lazy().select(expr.n_unique()).collect(_eager=True)
         return 0 if df.is_empty() else df.row(0)[0]
 
-    @deprecate_function(
-        "Use `select(pl.all().approx_n_unique())` instead.", version="0.20.11"
+    @deprecated(
+        "`DataFrame.approx_n_unique` is deprecated; "
+        "use `select(pl.all().approx_n_unique())` instead."
     )
     def approx_n_unique(self) -> DataFrame:
         """
         Approximate count of unique values.
 
         .. deprecated:: 0.20.11
-            Use `select(pl.all().approx_n_unique())` instead.
+            Use the `select(pl.all().approx_n_unique())` method instead.
 
         This is done using the HyperLogLog++ algorithm for cardinality estimation.
 
@@ -11892,9 +11926,9 @@ class DataFrame:
         """
         return self.lazy().count().collect(_eager=True)
 
-    @deprecate_function(
-        "Use `unpivot` instead, with `index` instead of `id_vars` and `on` instead of `value_vars`",
-        version="1.0.0",
+    @deprecated(
+        "`DataFrame.melt` is deprecated; use `DataFrame.unpivot` instead, with "
+        "`index` instead of `id_vars` and `on` instead of `value_vars`"
     )
     def melt(
         self,
@@ -11914,7 +11948,7 @@ class DataFrame:
         two non-identifier columns, 'variable' and 'value'.
 
         .. deprecated:: 1.0.0
-            Please use :meth:`.unpivot` instead.
+            Use the :meth:`.unpivot` method instead.
 
         Parameters
         ----------

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
 from polars._utils.convert import parse_as_duration_string
-from polars._utils.deprecation import deprecate_renamed_function
+from polars._utils.deprecation import deprecated
 
 if TYPE_CHECKING:
     import sys
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
         from typing import Self
     else:
         from typing_extensions import Self
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 class GroupBy:
@@ -468,7 +473,7 @@ class GroupBy:
             len_expr = len_expr.alias(name)
         return self.agg(len_expr)
 
-    @deprecate_renamed_function("len", version="0.20.5")
+    @deprecated("`GroupBy.count` was renamed; use `GroupBy.len` instead")
     def count(self) -> DataFrame:
         """
         Return the number of rows in each group.

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -398,7 +398,7 @@ class Decimal(NumericType):
         from polars._utils.unstable import issue_unstable_warning
 
         issue_unstable_warning(
-            "The Decimal data type is considered unstable."
+            "the Decimal data type is considered unstable."
             " It is a work-in-progress feature and may not always work as expected."
         )
 
@@ -839,7 +839,7 @@ class Array(NestedType):
             from polars._utils.deprecation import issue_deprecation_warning
 
             issue_deprecation_warning(
-                "The `width` parameter for `Array` is deprecated. Use `shape` instead.",
+                "the `width` parameter for `Array` is deprecated. Use `shape` instead.",
                 version="0.20.31",
             )
             shape = width
@@ -903,7 +903,7 @@ class Array(NestedType):
         from polars._utils.deprecation import issue_deprecation_warning
 
         issue_deprecation_warning(
-            "The `width` attribute for `Array` is deprecated. Use `size` instead.",
+            "the `width` attribute for `Array` is deprecated. Use `size` instead.",
             version="0.20.31",
         )
         return self.size

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import polars._reexport as pl
 from polars import functions as F
 from polars._utils.convert import parse_as_duration_string
-from polars._utils.deprecation import deprecate_function, deprecate_nonkeyword_arguments
+from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
 from polars._utils.parse import parse_into_expression, parse_into_list_of_expressions
 from polars._utils.unstable import unstable
 from polars._utils.various import qualified_type_name
@@ -14,6 +14,7 @@ from polars._utils.wrap import wrap_expr
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Iterable
 
     from polars import Expr
@@ -26,6 +27,11 @@ if TYPE_CHECKING:
         Roll,
         TimeUnit,
     )
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 class ExprDateTimeNameSpace:
@@ -51,6 +57,9 @@ class ExprDateTimeNameSpace:
         .. warning::
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
+
+        .. versionchanged:: 1.12.0
+            Parameters after `n` should now be passed as keyword arguments.
 
         Parameters
         ----------
@@ -1379,13 +1388,15 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.dt_date())
 
-    @deprecate_function("Use `dt.replace_time_zone(None)` instead.", version="0.20.4")
+    @deprecated(
+        "`dt.datetime` is deprecated; use `dt.replace_time_zone(None)` instead."
+    )
     def datetime(self) -> Expr:
         """
         Return datetime.
 
         .. deprecated:: 0.20.4
-            Use `dt.replace_time_zone(None)` instead.
+            Use the `dt.replace_time_zone(None)` method instead.
 
         Applies to Datetime columns.
 
@@ -1783,9 +1794,9 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.dt_timestamp(time_unit))
 
-    @deprecate_function(
-        "Instead, first cast to `Int64` and then cast to the desired data type.",
-        version="0.20.5",
+    @deprecated(
+        "`dt.with_time_unit` is deprecated; instead, first cast "
+        "to `Int64` and then cast to the desired data type."
     )
     def with_time_unit(self, time_unit: TimeUnit) -> Expr:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -23,8 +23,8 @@ import polars._reexport as pl
 from polars import functions as F
 from polars._utils.convert import negate_duration_string, parse_as_duration_string
 from polars._utils.deprecation import (
-    deprecate_function,
     deprecate_renamed_parameter,
+    deprecated,
     issue_deprecation_warning,
 )
 from polars._utils.parse import (
@@ -95,6 +95,11 @@ if TYPE_CHECKING:
         from typing import Concatenate, ParamSpec
     else:
         from typing_extensions import Concatenate, ParamSpec
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
     T = TypeVar("T")
     P = ParamSpec("P")
@@ -1941,6 +1946,9 @@ class Expr:
 
         .. math:: O(n \log{n})
 
+        .. versionchanged:: 1.0.0
+            The `descending` parameter was renamed to `reverse`.
+
         Parameters
         ----------
         by
@@ -2113,6 +2121,9 @@ class Expr:
         This has time complexity:
 
         .. math:: O(n \log{n})
+
+        .. versionchanged:: 1.0.0
+            The `descending` parameter was renamed `reverse`.
 
         Parameters
         ----------
@@ -4232,13 +4243,13 @@ class Expr:
         )
         return self._from_pyexpr(self._pyexpr.filter(predicate))
 
-    @deprecate_function("Use `filter` instead.", version="0.20.4")
+    @deprecated("`where` is deprecated; use `filter` instead.")
     def where(self, predicate: Expr) -> Expr:
         """
         Filter a single column.
 
         .. deprecated:: 0.20.4
-            Use :func:`filter` instead.
+            Use the :func:`filter` method instead.
 
         Alias for :func:`filter`.
 
@@ -4667,7 +4678,7 @@ class Expr:
         """
         if strategy == "threading":
             issue_unstable_warning(
-                "The 'threading' strategy for `map_elements` is considered unstable."
+                "the 'threading' strategy for `map_elements` is considered unstable."
             )
 
         # input x: Series of type list containing the group values
@@ -6210,6 +6221,9 @@ class Expr:
             - ...
             - (t_n - window_size, t_n]
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         by
@@ -6334,6 +6348,9 @@ class Expr:
             - (t_1 - window_size, t_1]
             - ...
             - (t_n - window_size, t_n]
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -6485,6 +6502,9 @@ class Expr:
             - (t_1 - window_size, t_1]
             - ...
             - (t_n - window_size, t_n]
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -6644,6 +6664,9 @@ class Expr:
             - ...
             - (t_n - window_size, t_n]
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         window_size
@@ -6795,6 +6818,9 @@ class Expr:
             - (t_1 - window_size, t_1]
             - ...
             - (t_n - window_size, t_n]
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -6956,6 +6982,9 @@ class Expr:
             - ...
             - (t_n - window_size, t_n]
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         by
@@ -7115,6 +7144,9 @@ class Expr:
             - ...
             - (t_n - window_size, t_n]
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         by
@@ -7243,6 +7275,9 @@ class Expr:
             - (t_1 - window_size, t_1]
             - ...
             - (t_n - window_size, t_n]
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -7376,6 +7411,9 @@ class Expr:
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         window_size
@@ -7482,6 +7520,9 @@ class Expr:
 
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -7590,6 +7631,9 @@ class Expr:
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         window_size
@@ -7696,6 +7740,9 @@ class Expr:
 
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -7804,6 +7851,9 @@ class Expr:
 
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -7916,6 +7966,9 @@ class Expr:
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         window_size
@@ -8026,6 +8079,9 @@ class Expr:
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         window_size
@@ -8134,6 +8190,9 @@ class Expr:
 
         The window at a given row will include the row itself, and the `window_size - 1`
         elements before it.
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -8402,6 +8461,9 @@ class Expr:
         .. warning::
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -9471,6 +9533,9 @@ class Expr:
         r"""
         Compute exponentially-weighted moving average.
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         com
@@ -9652,6 +9717,9 @@ class Expr:
         r"""
         Compute exponentially-weighted moving standard deviation.
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         com
@@ -9743,6 +9811,9 @@ class Expr:
     ) -> Expr:
         r"""
         Compute exponentially-weighted moving variance.
+
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
 
         Parameters
         ----------
@@ -10071,6 +10142,9 @@ class Expr:
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
+        .. versionchanged:: 1.21.0
+            The `min_periods` parameter was renamed `min_samples`.
+
         Parameters
         ----------
         expr
@@ -10389,13 +10463,13 @@ class Expr:
         """
         if return_dtype is not None:
             issue_deprecation_warning(
-                "The `return_dtype` parameter for `replace` is deprecated."
+                "the `return_dtype` parameter for `replace` is deprecated."
                 " Use `replace_strict` instead to set a return data type while replacing values.",
                 version="1.0.0",
             )
         if default is not no_default:
             issue_deprecation_warning(
-                "The `default` parameter for `replace` is deprecated."
+                "the `default` parameter for `replace` is deprecated."
                 " Use `replace_strict` instead to set a default while replacing values.",
                 version="1.0.0",
             )
@@ -10738,8 +10812,9 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.bitwise_xor())
 
-    @deprecate_function(
-        "Use `polars.plugins.register_plugin_function` instead.", version="0.20.16"
+    @deprecated(
+        "`register_plugin` is deprecated; "
+        "use `polars.plugins.register_plugin_function` instead."
     )
     def register_plugin(
         self,

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -2,18 +2,24 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, overload
 
-from polars._utils.deprecation import deprecate_renamed_function
+from polars._utils.deprecation import deprecated
 from polars._utils.serde import serialize_polars_object
 from polars._utils.various import display_dot_graph
 from polars._utils.wrap import wrap_expr
 from polars.exceptions import ComputeError
 
 if TYPE_CHECKING:
+    import sys
     from io import IOBase
     from pathlib import Path
 
     from polars import Expr
     from polars._typing import SerializationFormat
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 class ExprMetaNameSpace:
@@ -289,8 +295,10 @@ class ExprMetaNameSpace:
     def serialize(
         self, file: None = ..., *, format: Literal["binary"] = ...
     ) -> bytes: ...
+
     @overload
     def serialize(self, file: None = ..., *, format: Literal["json"]) -> str: ...
+
     @overload
     def serialize(
         self, file: IOBase | str | Path, *, format: SerializationFormat = ...
@@ -356,7 +364,7 @@ class ExprMetaNameSpace:
     @overload
     def write_json(self, file: IOBase | str | Path) -> None: ...
 
-    @deprecate_renamed_function("Expr.meta.serialize", version="0.20.11")
+    @deprecated("`meta.write_json` was renamed; use `meta.serialize` instead")
     def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
         """
         Write expression to json.

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars import functions as F
-from polars._utils.deprecation import (
-    deprecate_function,
-    deprecate_nonkeyword_arguments,
-)
+from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
 from polars._utils.parse import parse_into_expression
 from polars._utils.unstable import unstable
 from polars._utils.various import find_stacklevel, no_default, qualified_type_name
@@ -19,6 +16,8 @@ from polars.datatypes.constants import N_INFER_DEFAULT
 from polars.exceptions import ChronoFormatWarning
 
 if TYPE_CHECKING:
+    import sys
+
     from polars import Expr
     from polars._typing import (
         Ambiguous,
@@ -31,6 +30,11 @@ if TYPE_CHECKING:
         UnicodeForm,
     )
     from polars._utils.various import NoDefault
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 class ExprStringNameSpace:
@@ -323,6 +327,9 @@ class ExprStringNameSpace:
         Convert a String column into a Decimal column.
 
         This method infers the needed parameters `precision` and `scale`.
+
+        .. versionchanged:: 1.20.0
+            Parameter `inference_length` should now be passed as a keyword argument.
 
         Parameters
         ----------
@@ -847,9 +854,7 @@ class ExprStringNameSpace:
         └──────────────┴──────────────┘
         """
         if not isinstance(fill_char, str):
-            msg = (
-                f"pad_start expects a `str`, given a {qualified_type_name(fill_char)!r}"
-            )
+            msg = f'"pad_start" expects a `str`, given a {qualified_type_name(fill_char)!r}'
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.str_pad_start(length, fill_char))
 
@@ -886,7 +891,9 @@ class ExprStringNameSpace:
         └──────────────┴──────────────┘
         """
         if not isinstance(fill_char, str):
-            msg = f"pad_end expects a `str`, given a {qualified_type_name(fill_char)!r}"
+            msg = (
+                f'"pad_end" expects a `str`, given a {qualified_type_name(fill_char)!r}'
+            )
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.str_pad_end(length, fill_char))
 
@@ -1642,7 +1649,7 @@ class ExprStringNameSpace:
         └─────────────────────────────────┴───────────────────────┴──────────┘
         """
         if not isinstance(pattern, str):
-            msg = f"extract_groups expects a `str`, given a {qualified_type_name(pattern)!r}"
+            msg = f'"extract_groups" expects a `str`, given a {qualified_type_name(pattern)!r}'
             raise TypeError(msg)
         return wrap_expr(self._pyexpr.str_extract_groups(pattern))
 
@@ -2362,22 +2369,21 @@ class ExprStringNameSpace:
         n = parse_into_expression(n)
         return wrap_expr(self._pyexpr.str_tail(n))
 
-    @deprecate_function(
-        'Use `.str.split("").explode()` instead.'
+    @deprecated(
+        '`str.explode` is deprecated; use `str.split("").explode()` instead.'
         " Note that empty strings will result in null instead of being preserved."
-        " To get the exact same behavior, split first and then use when/then/otherwise"
-        " to handle the empty list before exploding.",
-        version="0.20.31",
+        " To get the exact same behavior, split first and then use a `pl.when...then...otherwise`"
+        " expression to handle the empty list before exploding."
     )
     def explode(self) -> Expr:
         """
         Returns a column with a separate row for every string character.
 
         .. deprecated:: 0.20.31
-            Use `.str.split("").explode()` instead.
-            Note that empty strings will result in null instead of being preserved.
-            To get the exact same behavior, split first and then use when/then/otherwise
-            to handle the empty list before exploding.
+            Use the `.str.split("").explode()` method instead. Note that empty strings
+            will result in null instead of being preserved. To get the exact same
+            behavior, split first and then use a `pl.when...then...otherwise`
+            expression to handle the empty list before exploding.
 
         Returns
         -------
@@ -2853,10 +2859,9 @@ class ExprStringNameSpace:
         """
         return wrap_expr(self._pyexpr.str_join(delimiter, ignore_nulls=ignore_nulls))
 
-    @deprecate_function(
-        "Use `str.join` instead. Note that the default `delimiter` for `str.join`"
-        " is an empty string instead of a hyphen.",
-        version="1.0.0",
+    @deprecated(
+        "`str.concat` is deprecated; use `str.join` instead. Note also that the "
+        "default `delimiter` for `str.join` is an empty string, not a hyphen."
     )
     def concat(
         self, delimiter: str | None = None, *, ignore_nulls: bool = True

--- a/py-polars/polars/functions/business.py
+++ b/py-polars/polars/functions/business.py
@@ -34,6 +34,9 @@ def business_day_count(
         This functionality is considered **unstable**. It may be changed
         at any point without it being considered a breaking change.
 
+    .. versionchanged:: 1.27.0
+        Parameters after `start` and `end` should now be passed as keyword arguments.
+
     Parameters
     ----------
     start

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -8,9 +8,9 @@ import polars._reexport as pl
 import polars.functions as F
 from polars._utils.async_ import _AioDataFrameResult, _GeventDataFrameResult
 from polars._utils.deprecation import (
-    deprecate_function,
     deprecate_renamed_parameter,
     deprecate_streaming_parameter,
+    deprecated,
     issue_deprecation_warning,
 )
 from polars._utils.parse import (
@@ -27,6 +27,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Awaitable, Collection, Iterable
     from typing import Literal
 
@@ -39,6 +40,11 @@ if TYPE_CHECKING:
         PolarsDataType,
         RollingInterpolationMethod,
     )
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 def field(name: str | list[str]) -> Expr:
@@ -893,7 +899,7 @@ def corr(
     """
     if ddof is not None:
         issue_deprecation_warning(
-            "The `ddof` parameter has no effect. Do not use it.",
+            "the `ddof` parameter has no effect. Do not use it.",
             version="1.17.0",
         )
 
@@ -1510,7 +1516,7 @@ def arctan2(y: str | Expr, x: str | Expr) -> Expr:
     return wrap_expr(plr.arctan2(y._pyexpr, x._pyexpr))
 
 
-@deprecate_function("Use `arctan2` followed by `.degrees()` instead.", version="1.0.0")
+@deprecated("`arctan2d` is deprecated; use `arctan2` followed by `.degrees()` instead.")
 def arctan2d(y: str | Expr, x: str | Expr) -> Expr:
     """
     Compute two argument arctan in degrees.
@@ -1836,7 +1842,7 @@ def collect_all(
         optflags.no_optimizations()
 
     if engine in ("streaming", "old-streaming"):
-        issue_unstable_warning("Streaming mode is considered unstable.")
+        issue_unstable_warning("streaming mode is considered unstable.")
 
     lfs = [lf._ldf for lf in lazy_frames]
     out = plr.collect_all(lfs, engine, optflags._pyoptflags)
@@ -1994,7 +2000,7 @@ def collect_all_async(
         optflags.no_optimizations()
 
     if engine in ("streaming", "old-streaming"):
-        issue_unstable_warning("Streaming mode is considered unstable.")
+        issue_unstable_warning("streaming mode is considered unstable.")
 
     result: (
         _GeventDataFrameResult[list[DataFrame]] | _AioDataFrameResult[list[DataFrame]]
@@ -2400,6 +2406,9 @@ def rolling_cov(
     The window at a given row includes the row itself and the
     `window_size - 1` elements before it.
 
+    .. versionchanged:: 1.21.0
+        The `min_periods` parameter was renamed `min_samples`.
+
     Parameters
     ----------
     a
@@ -2440,6 +2449,9 @@ def rolling_corr(
 
     The window at a given row includes the row itself and the
     `window_size - 1` elements before it.
+
+    .. versionchanged:: 1.21.0
+        The `min_periods` parameter was renamed `min_samples`.
 
     Parameters
     ----------

--- a/py-polars/polars/interchange/protocol.py
+++ b/py-polars/polars/interchange/protocol.py
@@ -284,7 +284,7 @@ class CompatLevel:
             at any point without it being considered a breaking change.
         """
         issue_unstable_warning(
-            "Using the highest compatibility level is considered unstable."
+            "using the highest compatibility level is considered unstable."
         )
         return CompatLevel._newest()
 

--- a/py-polars/polars/io/cloud/credential_provider/_builder.py
+++ b/py-polars/polars/io/cloud/credential_provider/_builder.py
@@ -257,7 +257,7 @@ def _init_credential_provider_builder(
             return credential_provider
 
         if credential_provider != "auto":
-            msg = f"The `credential_provider` parameter of `{caller_name}` is considered unstable."
+            msg = f"the `credential_provider` parameter of `{caller_name}` is considered unstable."
             issue_unstable_warning(msg)
 
             return CredentialProviderBuilder.from_initialized_provider(

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -88,6 +88,12 @@ def read_csv(
     r"""
     Read a CSV file into a DataFrame.
 
+    .. versionchanged:: 0.20.31
+        The `dtypes` parameter was renamed `schema_overrides`.
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
+
     Parameters
     ----------
     source
@@ -206,7 +212,7 @@ def read_csv(
         allocation needed.
 
         .. deprecated:: 1.10.0
-            Is a no-op.
+            This parameter is now a no-op.
     eol_char
         Single byte end of line character (default: `\n`). When encountering a file
         with windows line endings (`\r\n`), one can go with the default `\n`. The extra
@@ -763,6 +769,12 @@ def read_csv_batched(
     determine the file chunks. After that, work will only be done if `next_batches`
     is called, which will return a list of `n` frames of the given batch size.
 
+    .. versionchanged:: 0.20.31
+        The `dtypes` parameter was renamed `schema_overrides`.
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
+
     Parameters
     ----------
     source
@@ -1031,16 +1043,18 @@ def read_csv_batched(
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
 def scan_csv(
-    source: str
-    | Path
-    | IO[str]
-    | IO[bytes]
-    | bytes
-    | list[str]
-    | list[Path]
-    | list[IO[str]]
-    | list[IO[bytes]]
-    | list[bytes],
+    source: (
+        str
+        | Path
+        | IO[str]
+        | IO[bytes]
+        | bytes
+        | list[str]
+        | list[Path]
+        | list[IO[str]]
+        | list[IO[bytes]]
+        | list[bytes]
+    ),
     *,
     has_header: bool = True,
     separator: str = ",",
@@ -1083,6 +1097,12 @@ def scan_csv(
     This allows the query optimizer to push down predicates and
     projections to the scan level, thereby potentially reducing
     memory overhead.
+
+    .. versionchanged:: 0.20.31
+        The `dtypes` parameter was renamed `schema_overrides`.
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
 
     Parameters
     ----------

--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -528,7 +528,7 @@ class ConnectionExecutor:
         fall back to initialising with row-level data if no other option.
         """
         if self.result is None:
-            msg = "Cannot return a frame before executing a query"
+            msg = "cannot return a frame before executing a query"
             raise RuntimeError(msg)
 
         can_close = self.can_close_cursor

--- a/py-polars/polars/io/iceberg/functions.py
+++ b/py-polars/polars/io/iceberg/functions.py
@@ -125,7 +125,7 @@ def scan_iceberg(
     from polars.polars import PyLazyFrame
 
     if reader_override is not None:
-        msg = "The `reader_override` parameter of `scan_iceberg()` is considered unstable."
+        msg = "the `reader_override` parameter of `scan_iceberg()` is considered unstable."
         issue_unstable_warning(msg)
 
     dataset = IcebergDataset(

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -58,6 +58,10 @@ def read_ipc(
     See "File or Random Access format" on https://arrow.apache.org/docs/python/ipc.html.
     Arrow IPC files are also known as Feather (v2) files.
 
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
+
     Parameters
     ----------
     source
@@ -244,6 +248,10 @@ def read_ipc_stream(
 
     See "Streaming format" on https://arrow.apache.org/docs/python/ipc.html.
 
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
+
     Parameters
     ----------
     source
@@ -356,14 +364,16 @@ def read_ipc_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, DataTyp
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
 def scan_ipc(
-    source: str
-    | Path
-    | IO[bytes]
-    | bytes
-    | list[str]
-    | list[Path]
-    | list[IO[bytes]]
-    | list[bytes],
+    source: (
+        str
+        | Path
+        | IO[bytes]
+        | bytes
+        | list[str]
+        | list[Path]
+        | list[IO[bytes]]
+        | list[bytes]
+    ),
     *,
     n_rows: int | None = None,
     cache: bool = True,
@@ -385,6 +395,10 @@ def scan_ipc(
 
     This allows the query optimizer to push down predicates and projections to the scan
     level, thereby potentially reducing memory overhead.
+
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
 
     Parameters
     ----------

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -199,15 +199,17 @@ def read_ndjson(
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")
 @deprecate_renamed_parameter("row_count_offset", "row_index_offset", version="0.20.4")
 def scan_ndjson(
-    source: str
-    | Path
-    | IO[str]
-    | IO[bytes]
-    | bytes
-    | list[str]
-    | list[Path]
-    | list[IO[str]]
-    | list[IO[bytes]],
+    source: (
+        str
+        | Path
+        | IO[str]
+        | IO[bytes]
+        | bytes
+        | list[str]
+        | list[Path]
+        | list[IO[str]]
+        | list[IO[bytes]]
+    ),
     *,
     schema: SchemaDefinition | None = None,
     schema_overrides: SchemaDefinition | None = None,
@@ -230,6 +232,10 @@ def scan_ndjson(
 
     This allows the query optimizer to push down predicates and projections to the scan
     level, thereby potentially reducing memory overhead.
+
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
 
     Parameters
     ----------

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -68,6 +68,10 @@ def read_parquet(
     """
     Read into a DataFrame from a parquet file.
 
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
+
     Parameters
     ----------
     source
@@ -187,11 +191,11 @@ def read_parquet(
 
     """
     if schema is not None:
-        msg = "The `schema` parameter of `read_parquet` is considered unstable."
+        msg = "the `schema` parameter of `read_parquet` is considered unstable."
         issue_unstable_warning(msg)
 
     if hive_schema is not None:
-        msg = "The `hive_schema` parameter of `read_parquet` is considered unstable."
+        msg = "the `hive_schema` parameter of `read_parquet` is considered unstable."
         issue_unstable_warning(msg)
 
     # Dispatch to pyarrow if requested
@@ -359,6 +363,10 @@ def scan_parquet(
     This function allows the query optimizer to push down predicates and projections to
     the scan level, typically increasing performance and reducing memory overhead.
 
+    .. versionchanged:: 0.20.4
+        * The `row_count_name` parameter was renamed `row_index_name`.
+        * The `row_count_offset` parameter was renamed `row_index_offset`.
+
     Parameters
     ----------
     source
@@ -479,11 +487,11 @@ def scan_parquet(
     >>> pl.scan_parquet(source, storage_options=storage_options)  # doctest: +SKIP
     """
     if schema is not None:
-        msg = "The `schema` parameter of `scan_parquet` is considered unstable."
+        msg = "the `schema` parameter of `scan_parquet` is considered unstable."
         issue_unstable_warning(msg)
 
     if hive_schema is not None:
-        msg = "The `hive_schema` parameter of `scan_parquet` is considered unstable."
+        msg = "the `hive_schema` parameter of `scan_parquet` is considered unstable."
         issue_unstable_warning(msg)
 
     if isinstance(source, (str, Path)):

--- a/py-polars/polars/io/partition.py
+++ b/py-polars/polars/io/partition.py
@@ -208,7 +208,7 @@ class PartitionMaxSize(PartitioningScheme):
         | None = None,
         max_size: int,
     ) -> None:
-        issue_unstable_warning("Partitioning strategies are considered unstable.")
+        issue_unstable_warning("partitioning strategies are considered unstable.")
         super().__init__(
             PyPartitioning.new_max_size(
                 base_path=base_path,
@@ -321,7 +321,7 @@ class PartitionByKey(PartitioningScheme):
         by: str | Expr | Sequence[str | Expr] | Mapping[str, Expr],
         include_key: bool = True,
     ) -> None:
-        issue_unstable_warning("Partitioning strategies are considered unstable.")
+        issue_unstable_warning("partitioning strategies are considered unstable.")
 
         lowered_by = _lower_by(by)
         super().__init__(
@@ -395,7 +395,7 @@ class PartitionParted(PartitioningScheme):
         by: str | Expr | Sequence[str | Expr] | Mapping[str, Expr],
         include_key: bool = True,
     ) -> None:
-        issue_unstable_warning("Partitioning strategies are considered unstable.")
+        issue_unstable_warning("partitioning strategies are considered unstable.")
 
         lowered_by = _lower_by(by)
         super().__init__(

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -265,6 +265,10 @@ def read_excel(
         Support loading data from a list (or glob pattern) of multiple workbooks.
     .. versionchanged:: 1.0
         Default engine is now "calamine" (was "xlsx2csv").
+    .. versionchanged:: 0.20.7
+        The `read_csv_options` parameter was renamed `read_options`.
+    .. versionchanged:: 0.20.6
+        The `xlsx2csv_options` parameter was renamed `engine_options`.
 
     Parameters
     ----------
@@ -909,7 +913,7 @@ def _csv_buffer_to_frame(
     if schema_overrides:
         if csv_dtypes := read_options.get("dtypes", {}):
             issue_deprecation_warning(
-                "The `dtypes` parameter for `read_csv` is deprecated. It has been renamed to `schema_overrides`.",
+                "the `dtypes` parameter for `read_csv` is deprecated. It has been renamed to `schema_overrides`.",
                 version="0.20.31",
             )
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -28,9 +28,9 @@ from polars._typing import (
 from polars._utils.async_ import _AioDataFrameResult, _GeventDataFrameResult
 from polars._utils.convert import negate_duration_string, parse_as_duration_string
 from polars._utils.deprecation import (
-    deprecate_function,
     deprecate_renamed_parameter,
     deprecate_streaming_parameter,
+    deprecated,
     issue_deprecation_warning,
 )
 from polars._utils.parse import (
@@ -100,7 +100,6 @@ from polars.selectors import by_dtype, expand_selector
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyLazyFrame, get_engine_affinity
 
-
 if TYPE_CHECKING:
     import sys
     from collections.abc import Awaitable, Iterable, Sequence
@@ -151,6 +150,11 @@ if TYPE_CHECKING:
         from typing import Self
     else:
         from typing_extensions import Self
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
     T = TypeVar("T")
     P = ParamSpec("P")
@@ -655,7 +659,7 @@ class LazyFrame:
         2
         """
         issue_warning(
-            "Determining the width of a LazyFrame requires resolving its schema,"
+            "determining the width of a LazyFrame requires resolving its schema,"
             " which is a potentially expensive operation. Use `LazyFrame.collect_schema().len()`"
             " to get the width without this warning.",
             category=PerformanceWarning,
@@ -703,7 +707,7 @@ class LazyFrame:
     def __getitem__(self, item: int | range | slice) -> LazyFrame:
         if not isinstance(item, slice):
             msg = (
-                "'LazyFrame' object is not subscriptable (aside from slicing)"
+                "LazyFrame is not subscriptable (aside from slicing)"
                 "\n\nUse `select()` or `filter()` instead."
             )
             raise TypeError(msg)
@@ -1191,7 +1195,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         if tree_format is not None:
             issue_deprecation_warning(
-                "The `tree_format` parameter for `LazyFrame.explain` is deprecated"
+                "the `tree_format` parameter for `LazyFrame.explain` is deprecated"
                 " Use the `format` parameter instead.",
                 version="0.20.30",
             )
@@ -1201,7 +1205,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         engine = _select_engine(engine)
 
         if engine in ("streaming", "old-streaming"):
-            issue_unstable_warning("Streaming mode is considered unstable.")
+            issue_unstable_warning("streaming mode is considered unstable.")
 
         if optimized:
             type_check = _type_check
@@ -1336,7 +1340,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         engine = _select_engine(engine)
 
         if engine in ("streaming", "old-streaming"):
-            issue_unstable_warning("Streaming mode is considered unstable.")
+            issue_unstable_warning("streaming mode is considered unstable.")
 
         type_check = _type_check
         _ldf = self._ldf.optimization_toggle(
@@ -1621,6 +1625,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         particular order, call :func:`sort` after this function if you wish the
         output to be sorted.
 
+        .. versionchanged:: 1.0.0
+            The `descending` parameter was renamed `reverse`.
+
         Parameters
         ----------
         k
@@ -1695,6 +1702,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         the value of `reverse`. The output is not guaranteed to be in any
         particular order, call :func:`sort` after this function if you wish the
         output to be sorted.
+
+        .. versionchanged:: 1.0.0
+            The `descending` parameter was renamed `reverse`.
 
         Parameters
         ----------
@@ -2185,7 +2195,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             _check_order = False
 
         if engine in ("old-streaming", "streaming"):
-            issue_unstable_warning("Streaming mode is considered unstable.")
+            issue_unstable_warning("streaming mode is considered unstable.")
 
         callback = _gpu_engine_callback(
             engine,
@@ -2216,7 +2226,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             engine = "gpu"
 
         if background:
-            issue_unstable_warning("Background mode is considered unstable.")
+            issue_unstable_warning("background mode is considered unstable.")
             return InProcessQuery(ldf.collect_concurrently())
 
         # Only for testing purposes
@@ -2387,7 +2397,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         engine = _select_engine(engine)
 
         if engine in ("streaming", "old-streaming"):
-            issue_unstable_warning("Streaming mode is considered unstable.")
+            issue_unstable_warning("streaming mode is considered unstable.")
 
         type_check = _type_check
         ldf = self._ldf.optimization_toggle(
@@ -2474,6 +2484,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[False] = ...,
         engine: EngineType = "auto",
     ) -> None: ...
+
     @overload
     def sink_parquet(
         self,
@@ -2503,6 +2514,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[True],
         engine: EngineType = "auto",
     ) -> LazyFrame: ...
+
     @unstable()
     def sink_parquet(
         self,
@@ -2748,6 +2760,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[False] = ...,
         engine: EngineType = "auto",
     ) -> None: ...
+
     @overload
     def sink_ipc(
         self,
@@ -2774,6 +2787,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[True],
         engine: EngineType = "auto",
     ) -> LazyFrame: ...
+
     @unstable()
     def sink_ipc(
         self,
@@ -2987,6 +3001,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[False] = ...,
         engine: EngineType = "auto",
     ) -> None: ...
+
     @overload
     def sink_csv(
         self,
@@ -3024,6 +3039,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[True],
         engine: EngineType = "auto",
     ) -> LazyFrame: ...
+
     @unstable()
     def sink_csv(
         self,
@@ -3286,6 +3302,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[False] = ...,
         engine: EngineType = "auto",
     ) -> None: ...
+
     @overload
     def sink_ndjson(
         self,
@@ -3310,6 +3327,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lazy: Literal[True],
         engine: EngineType = "auto",
     ) -> LazyFrame: ...
+
     @unstable()
     def sink_ndjson(
         self,
@@ -3505,10 +3523,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             new_streaming=engine in ("auto", "streaming"),
         )
 
-    @deprecate_function(
+    @deprecated(
         "`LazyFrame.fetch` is deprecated; use `LazyFrame.collect` "
-        "instead, in conjunction with a call to `head`.",
-        version="1.0",
+        "instead, in conjunction with a call to `head`."
     )
     def fetch(
         self,
@@ -4602,6 +4619,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         not be 24 hours, due to daylight savings). Similarly for "calendar week",
         "calendar month", "calendar quarter", and "calendar year".
 
+        .. versionchanged:: 0.20.14
+            The `by` parameter was renamed `group_by`.
+
         Parameters
         ----------
         index_column
@@ -4715,6 +4735,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         .. warning::
             The index column must be sorted in ascending order. If `group_by` is passed, then
             the index column must be sorted in ascending order within each group.
+
+        .. versionchanged:: 0.20.14
+            The `by` parameter was renamed `group_by`.
 
         Parameters
         ----------
@@ -5411,6 +5434,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Add a join operation to the Logical Plan.
 
+        .. versionchanged:: 1.24
+            The `join_nulls` parameter was renamed `nulls_equal`.
+
         Parameters
         ----------
         other
@@ -5622,14 +5648,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if how == "outer":
             how = "full"
             issue_deprecation_warning(
-                "Use of `how='outer'` should be replaced with `how='full'`.",
+                "use of `how='outer'` should be replaced with `how='full'`.",
                 version="0.20.29",
             )
         elif how == "outer_coalesce":  # type: ignore[comparison-overlap]
             coalesce = True
             how = "full"
             issue_deprecation_warning(
-                "Use of `how='outer_coalesce'` should be replaced with `how='full', coalesce=True`.",
+                "use of `how='outer_coalesce'` should be replaced with `how='full', coalesce=True`.",
                 version="0.20.29",
             )
         elif how == "cross":
@@ -5952,15 +5978,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
         return self._from_pyldf(self._ldf.with_columns_seq(pyexprs))
 
-    @deprecate_function(
-        "Use `pl.concat(..., how='horizontal')` instead.", version="1.0.0"
+    @deprecated(
+        "`LazyFrame.with_context` is deprecated; "
+        "use `pl.concat(..., how='horizontal')` instead."
     )
     def with_context(self, other: Self | list[Self]) -> LazyFrame:
         """
         Add an external context to the computation graph.
 
         .. deprecated:: 1.0.0
-            Use :func:`concat` instead with `how='horizontal'`
+            Use :func:`concat` instead, with `how='horizontal'`
 
         This allows expressions to also access columns from DataFrames
         that are not part of this one.
@@ -6469,8 +6496,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self.slice(0, 1)
 
-    @deprecate_function(
-        "Use `select(pl.all().approx_n_unique())` instead.", version="0.20.11"
+    @deprecated(
+        "`LazyFrame.approx_n_unique` is deprecated; "
+        "use `select(pl.all().approx_n_unique())` instead."
     )
     def approx_n_unique(self) -> LazyFrame:
         """
@@ -6578,17 +6606,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             msg = f"`offset` input for `with_row_index` cannot be {issue}, got {offset}"
             raise ValueError(msg) from None
 
-    @deprecate_function(
-        "Use `with_row_index` instead."
-        " Note that the default column name has changed from 'row_nr' to 'index'.",
-        version="0.20.4",
+    @deprecated(
+        "`LazyFrame.with_row_count` is deprecated; use `LazyFrame.with_row_index` instead."
+        " Note that the default column name has changed from 'row_nr' to 'index'."
     )
     def with_row_count(self, name: str = "row_nr", offset: int = 0) -> LazyFrame:
         """
         Add a column at index 0 that counts the rows.
 
         .. deprecated:: 0.20.4
-            Use :meth:`with_row_index` instead.
+            Use the :meth:`with_row_index` method instead.
             Note that the default column name has changed from 'row_nr' to 'index'.
 
         Parameters
@@ -7463,7 +7490,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         if not streamable:
             issue_deprecation_warning(
-                "The `streamable` parameter for `LazyFrame.unpivot` is deprecated"
+                "the `streamable` parameter for `LazyFrame.unpivot` is deprecated"
                 "This parameter has no effect",
                 version="1.5.0",
             )
@@ -7906,7 +7933,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if how in ("outer", "outer_coalesce"):
             how = "full"
             issue_deprecation_warning(
-                "Use of `how='outer'` should be replaced with `how='full'`.",
+                "use of `how='outer'` should be replaced with `how='full'`.",
                 version="0.20.29",
             )
 
@@ -8021,9 +8048,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self._from_pyldf(self._ldf.count())
 
-    @deprecate_function(
-        "Use `unpivot` instead, with `index` instead of `id_vars` and `on` instead of `value_vars`",
-        version="1.0.0",
+    @deprecated(
+        "`LazyFrame.melt` is deprecated; use `LazyFrame.unpivot` instead, with "
+        "`index` instead of `id_vars` and `on` instead of `value_vars`"
     )
     def melt(
         self,
@@ -8045,7 +8072,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         two non-identifier columns, 'variable' and 'value'.
 
         .. deprecated:: 1.0.0
-            Please use :meth:`.unpivot` instead.
+            Use the :meth:`.unpivot` method instead.
 
         Parameters
         ----------

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -3,16 +3,22 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable
 
 from polars import functions as F
-from polars._utils.deprecation import deprecate_renamed_function
+from polars._utils.deprecation import deprecated
 from polars._utils.parse import parse_into_list_of_expressions
 from polars._utils.wrap import wrap_ldf
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Iterable
 
     from polars import DataFrame, LazyFrame
     from polars._typing import IntoExpr, RollingInterpolationMethod, SchemaDict
     from polars.polars import PyLazyGroupBy
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 class LazyGroupBy:
@@ -373,7 +379,7 @@ class LazyGroupBy:
             len_expr = len_expr.alias(name)
         return self.agg(len_expr)
 
-    @deprecate_renamed_function("len", version="0.20.5")
+    @deprecated("`count` was renamed; use `len` instead")
     def count(self) -> LazyFrame:
         """
         Return the number of rows in each group.

--- a/py-polars/polars/meta/thread_pool.py
+++ b/py-polars/polars/meta/thread_pool.py
@@ -2,10 +2,20 @@ from __future__ import annotations
 
 import contextlib
 
-from polars._utils.deprecation import deprecate_renamed_function
+from polars._utils.deprecation import deprecated
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 def thread_pool_size() -> int:
@@ -29,7 +39,7 @@ def thread_pool_size() -> int:
     return plr.thread_pool_size()
 
 
-@deprecate_renamed_function("thread_pool_size", version="0.20.7")
+@deprecated("`threadpool_size` was renamed; use `thread_pool_size` instead.")
 def threadpool_size() -> int:
     """
     Return the number of threads in the Polars thread pool.

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars._utils.deprecation import deprecate_function, deprecate_nonkeyword_arguments
+from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
 from polars._utils.unstable import unstable
 from polars._utils.wrap import wrap_s
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
     import datetime as dt
+    import sys
     from collections.abc import Iterable
 
     from polars import Series
@@ -23,6 +24,11 @@ if TYPE_CHECKING:
         TimeUnit,
     )
     from polars.polars import PySeries
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 @expr_dispatch
@@ -53,6 +59,9 @@ class DateTimeNameSpace:
         .. warning::
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
+
+        .. versionchanged:: 1.27.0
+            Parameters after `n` should now be passed as keyword arguments.
 
         Parameters
         ----------
@@ -161,13 +170,13 @@ class DateTimeNameSpace:
         """
         return wrap_s(self._s).max()  # type: ignore[return-value]
 
-    @deprecate_function("Use `Series.median` instead.", version="1.0.0")
+    @deprecated("`Series.dt.median` is deprecated; use `Series.median` instead.")
     def median(self) -> TemporalLiteral | None:
         """
         Return median as python DateTime.
 
         .. deprecated:: 1.0.0
-            Use `Series.median` instead.
+            Use the `Series.median` method instead.
 
         Examples
         --------
@@ -191,13 +200,13 @@ class DateTimeNameSpace:
         """
         return self._s.median()
 
-    @deprecate_function("Use `Series.mean` instead.", version="1.0.0")
+    @deprecated("`Series.dt.mean` is deprecated; use `Series.mean` instead.")
     def mean(self) -> TemporalLiteral | None:
         """
         Return mean as python DateTime.
 
         .. deprecated:: 1.0.0
-            Use `Series.mean` instead.
+            Use the `Series.mean` method instead.
 
         Examples
         --------
@@ -858,7 +867,10 @@ class DateTimeNameSpace:
         ]
         """
 
-    @deprecate_function("Use `dt.replace_time_zone(None)` instead.", version="0.20.4")
+    @deprecated(
+        "`Series.dt.datetime` is deprecated; "
+        "use `Series.dt.replace_time_zone(None)` instead."
+    )
     def datetime(self) -> Series:
         """
         Extract (local) datetime.

--- a/py-polars/polars/series/plotting.py
+++ b/py-polars/polars/series/plotting.py
@@ -63,7 +63,7 @@ class SeriesPlot:
         >>> s.plot.hist()  # doctest: +SKIP
         """  # noqa: W505
         if self._series_name == "count()":
-            msg = "Cannot use `plot.hist` when Series name is `'count()'`"
+            msg = "cannot use `plot.hist` when Series name is `'count()'`"
             raise ValueError(msg)
         encodings: Encodings = {
             "x": alt.X(f"{self._series_name}:Q", bin=True),
@@ -109,7 +109,7 @@ class SeriesPlot:
         >>> s.plot.kde()  # doctest: +SKIP
         """  # noqa: W505
         if self._series_name == "density":
-            msg = "Cannot use `plot.kde` when Series name is `'density'`"
+            msg = "cannot use `plot.kde` when Series name is `'density'`"
             raise ValueError(msg)
         encodings: Encodings = {"x": self._series_name, "y": "density:Q"}
         return (
@@ -153,7 +153,7 @@ class SeriesPlot:
         >>> s.plot.line()  # doctest: +SKIP
         """  # noqa: W505
         if self._series_name == "index":
-            msg = "Cannot call `plot.line` when Series name is 'index'"
+            msg = "cannot call `plot.line` when Series name is 'index'"
             raise ValueError(msg)
         encodings: Encodings = {"x": "index", "y": self._series_name}
         return (

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars._utils.deprecation import deprecate_function, deprecate_nonkeyword_arguments
+from polars._utils.deprecation import deprecate_nonkeyword_arguments, deprecated
 from polars._utils.unstable import unstable
 from polars._utils.various import no_default
 from polars.datatypes.constants import N_INFER_DEFAULT
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Mapping
 
     from polars import Expr, Series
@@ -24,6 +25,11 @@ if TYPE_CHECKING:
     )
     from polars._utils.various import NoDefault
     from polars.polars import PySeries
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
 
 @expr_dispatch
@@ -280,6 +286,9 @@ class StringNameSpace:
         Convert a String column into a Decimal column.
 
         This method infers the needed parameters `precision` and `scale`.
+
+        .. versionchanged:: 1.20.0
+            Parameter `inference_length` should now be passed as a keyword argument.
 
         Parameters
         ----------
@@ -1789,22 +1798,21 @@ class StringNameSpace:
         ]
         """
 
-    @deprecate_function(
-        'Use `.str.split("").explode()` instead.'
-        " Note that empty strings will result in null instead of being preserved."
-        " To get the exact same behavior, split first and then use when/then/otherwise"
-        " to handle the empty list before exploding.",
-        version="0.20.31",
+    @deprecated(
+        '`Series.str.explode` is deprecated; use `Series.str.split("").explode()` instead. '
+        "Note that empty strings will result in null instead of being preserved. To get "
+        "the exact same behavior, split first and then use a `pl.when...then...otherwise` "
+        "expression to handle the empty list before exploding. "
     )
     def explode(self) -> Series:
         """
         Returns a column with a separate row for every string character.
 
         .. deprecated:: 0.20.31
-            Use `.str.split("").explode()` instead.
-            Note that empty strings will result in null instead of being preserved.
-            To get the exact same behavior, split first and then use when/then/otherwise
-            to handle the empty list before exploding.
+            Use the `.str.split("").explode()` method instead. Note that empty strings
+            will result in null instead of being preserved. To get the exact same
+            behavior, split first and then use a `pl.when...then...otherwise`
+            expression to handle the empty list before exploding.
 
         Returns
         -------
@@ -2160,10 +2168,9 @@ class StringNameSpace:
         ]
         """
 
-    @deprecate_function(
-        "Use `str.join` instead. Note that the default `delimiter` for `str.join`"
-        " is an empty string instead of a hyphen.",
-        version="1.0.0",
+    @deprecated(
+        "`Series.str.concat` is deprecated; use `Series.str.join` instead. Note also "
+        "that the default `delimiter` for `str.join` is an empty string, not a hyphen."
     )
     def concat(
         self, delimiter: str | None = None, *, ignore_nulls: bool = True

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -81,7 +81,7 @@ def _ensure_lazyframe(obj: Any) -> LazyFrame:
     ):
         return from_arrow(obj).lazy()  # type: ignore[union-attr]
     else:
-        msg = f"Unrecognised frame type: {qualified_type_name(obj)}"
+        msg = f"unrecognised frame type: {qualified_type_name(obj)}"
         raise ValueError(msg)
 
 
@@ -160,6 +160,9 @@ class SQLContext(Generic[FrameType]):
     ) -> None:
         """
         Initialize a new `SQLContext`.
+
+        .. versionchanged:: 0.20.31
+            The `eager_execution` parameter was renamed `eager`.
 
         Parameters
         ----------

--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -29,6 +29,9 @@ def assert_frame_equal(
     Raises a detailed `AssertionError` if the frames differ.
     This function is intended for use in unit tests.
 
+    .. versionchanged:: 0.20.31
+        The `check_dtype` parameter was renamed `check_dtypes`.
+
     Parameters
     ----------
     left
@@ -209,6 +212,9 @@ def assert_frame_not_equal(
     Assert that the left and right frame are **not** equal.
 
     This function is intended for use in unit tests.
+
+    .. versionchanged:: 0.20.31
+        The `check_dtype` parameter was renamed `check_dtypes`.
 
     Parameters
     ----------

--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -52,6 +52,9 @@ def assert_series_equal(
     Raises a detailed `AssertionError` if the Series differ.
     This function is intended for use in unit tests.
 
+    .. versionchanged:: 0.20.31
+        The `check_dtype` parameter was renamed `check_dtypes`.
+
     Parameters
     ----------
     left
@@ -378,6 +381,9 @@ def assert_series_not_equal(
     Assert that the left and right Series are **not** equal.
 
     This function is intended for use in unit tests.
+
+    .. versionchanged:: 0.20.31
+        The `check_dtype` parameter was renamed `check_dtypes`.
 
     Parameters
     ----------

--- a/py-polars/polars/testing/parametric/strategies/legacy.py
+++ b/py-polars/polars/testing/parametric/strategies/legacy.py
@@ -6,20 +6,28 @@ from typing import TYPE_CHECKING, Any
 import hypothesis.strategies as st
 from hypothesis.errors import InvalidArgument
 
-from polars._utils.deprecation import deprecate_function
+from polars._utils.deprecation import deprecated
 from polars.datatypes import is_polars_dtype
 from polars.testing.parametric.strategies.core import _COL_LIMIT, column
 from polars.testing.parametric.strategies.data import lists
 from polars.testing.parametric.strategies.dtype import _instantiate_dtype, dtypes
 
 if TYPE_CHECKING:
+    import sys
+
     from hypothesis.strategies import SearchStrategy
 
     from polars._typing import OneOrMoreDataTypes, PolarsDataType
 
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
 
-@deprecate_function(
-    "Use `column` instead in conjunction with a list comprehension.", version="0.20.26"
+
+@deprecated(
+    "`columns` is deprecated; use `column` instead, "
+    "in conjunction with a list comprehension."
 )
 def columns(
     cols: int | Sequence[str] | None = None,
@@ -33,7 +41,7 @@ def columns(
     Define multiple columns for use with the @dataframes strategy.
 
     .. deprecated:: 0.20.26
-        Use :class:`column` instead in conjunction with a list comprehension.
+        Use :class:`column` instead, in conjunction with a list comprehension.
 
     .. warning::
         This functionality is currently considered **unstable**. It may be
@@ -101,7 +109,7 @@ def columns(
     return [column(name=nm, dtype=tp, unique=unique) for nm, tp in zip(names, dtypes)]
 
 
-@deprecate_function("Use `lists` instead.", version="0.20.26")
+@deprecated("`create_list_strategy` is deprecated; use `lists` instead.")
 def create_list_strategy(
     inner_dtype: PolarsDataType | None = None,
     *,

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -13,11 +13,10 @@ from polars._utils.deprecation import issue_deprecation_warning
 def __getattr__(name: str) -> Any:
     if name in dir(plt):
         issue_deprecation_warning(
-            "The `polars.type_aliases` module is deprecated."
+            "the `polars.type_aliases` module was deprecated in version 1.0.0."
             " The type aliases have moved to the `polars._typing` module to explicitly mark them as private."
             " Please define your own type aliases, or temporarily import from the `polars._typing` module."
             " A public `polars.typing` module will be added in the future.",
-            version="1.0.0",
         )
         return getattr(plt, name)
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -419,9 +419,7 @@ def test_to_list() -> None:
 
 def test_rows() -> None:
     s0 = pl.Series("date", [123543, 283478, 1243]).cast(pl.Date)
-    with pytest.deprecated_call(
-        match="`ExprDateTimeNameSpace.with_time_unit` is deprecated"
-    ):
+    with pytest.deprecated_call(match="`dt.with_time_unit` is deprecated"):
         s1 = (
             pl.Series("datetime", [a * 1_000_000 for a in [123543, 283478, 1243]])
             .cast(pl.Datetime)
@@ -473,7 +471,7 @@ def test_datetime_comp_tz_aware_invalid() -> None:
     other = datetime(2020, 1, 1)
     with pytest.raises(
         TypeError,
-        match="Datetime time zone None does not match Series timezone 'Asia/Kathmandu'",
+        match="datetime time zone None does not match Series timezone 'Asia/Kathmandu'",
     ):
         _ = a > other
 

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -653,7 +653,7 @@ def test_function_expr_scalar_identification_18755() -> None:
 
 
 def test_concat_deprecation() -> None:
-    with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
+    with pytest.deprecated_call(match="`str.concat` is deprecated."):
         pl.Series(["foo"]).str.concat()
-    with pytest.deprecated_call(match="`ExprStringNameSpace.concat` is deprecated."):
+    with pytest.deprecated_call(match="`str.concat` is deprecated."):
         pl.DataFrame({"foo": ["bar"]}).select(pl.all().str.concat())

--- a/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_ufunc_series.py
@@ -156,7 +156,7 @@ def test_generalized_ufunc_missing_data() -> None:
     s_float = pl.Series("f", [1.0, 2.0, 3.0, None], dtype=pl.Float64)
     with pytest.raises(
         ComputeError,
-        match="Can't pass a Series with missing data to a generalized ufunc",
+        match="can't pass a Series with missing data to a generalized ufunc",
     ):
         add_one(s_float)
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -174,7 +174,7 @@ def test_deprecated() -> None:
 def test_deprecated_parameter_join_nulls() -> None:
     df = pl.DataFrame({"a": [1, None]})
     with pytest.deprecated_call(
-        match=r"The argument `join_nulls` for `DataFrame.join` is deprecated. It has been renamed to `nulls_equal`"
+        match=r"the argument `join_nulls` for `DataFrame.join` is deprecated. It was renamed to `nulls_equal`"
     ):
         result = df.join(df, on="a", join_nulls=True)  # type: ignore[call-arg]
     assert_frame_equal(result, df, check_row_order=False)

--- a/py-polars/tests/unit/test_init.py
+++ b/py-polars/tests/unit/test_init.py
@@ -13,7 +13,7 @@ def test_init_nonexistent_attribute() -> None:
 
 def test_init_exceptions_deprecated() -> None:
     with pytest.deprecated_call(
-        match="Accessing `ComputeError` from the top-level `polars` module is deprecated."
+        match="accessing `ComputeError` from the top-level `polars` module was deprecated in version 1.0.0."
     ):
         exc = pl.ComputeError
 
@@ -23,7 +23,9 @@ def test_init_exceptions_deprecated() -> None:
 
 
 def test_dtype_groups_deprecated() -> None:
-    with pytest.deprecated_call(match="`INTEGER_DTYPES` is deprecated."):
+    with pytest.deprecated_call(
+        match="`INTEGER_DTYPES` was deprecated in version 1.0.0."
+    ):
         dtypes = pl.INTEGER_DTYPES
 
     assert pl.Int8 in dtypes
@@ -31,7 +33,7 @@ def test_dtype_groups_deprecated() -> None:
 
 def test_type_aliases_deprecated() -> None:
     with pytest.deprecated_call(
-        match="The `polars.type_aliases` module is deprecated."
+        match="the `polars.type_aliases` module was deprecated in version 1.0.0."
     ):
         from polars.type_aliases import PolarsDataType
     assert str(PolarsDataType).startswith("typing.Union")

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -1,44 +1,45 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any
+from typing import TYPE_CHECKING, Any, get_args
 
 import pytest
 
+from polars._typing import DeprecationType
 from polars._utils.deprecation import (
-    deprecate_function,
     deprecate_nonkeyword_arguments,
     deprecate_parameter_as_multi_positional,
-    deprecate_renamed_function,
     deprecate_renamed_parameter,
+    deprecated,
+    identify_deprecations,
     issue_deprecation_warning,
 )
 
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated
+    else:
+        from typing_extensions import deprecated  # noqa: TC004
+
 
 def test_issue_deprecation_warning() -> None:
-    with pytest.deprecated_call():
-        issue_deprecation_warning("deprecated", version="0.1.2")
+    with pytest.deprecated_call(match="(Deprecated in version 0.1.2)"):
+        issue_deprecation_warning("deprecated function", version="0.1.2")
 
 
 def test_deprecate_function() -> None:
-    @deprecate_function("This is deprecated.", version="1.0.0")
+    @deprecated("`hello` is deprecated.")
     def hello() -> None: ...
 
     with pytest.deprecated_call():
-        hello()
-
-
-def test_deprecate_renamed_function() -> None:
-    @deprecate_renamed_function("new_hello", version="1.0.0")
-    def hello() -> None: ...
-
-    with pytest.deprecated_call(match="new_hello"):
         hello()
 
 
 def test_deprecate_renamed_parameter(recwarn: Any) -> None:
-    @deprecate_renamed_parameter("foo", "oof", version="1.0.0")
-    @deprecate_renamed_parameter("bar", "rab", version="2.0.0")
+    @deprecate_renamed_parameter("foo", "oof", version="1.2.3")
+    @deprecate_renamed_parameter("bar", "rab", version="4.5.6")
     def hello(oof: str, rab: str, ham: str) -> None: ...
 
     hello(foo="x", bar="y", ham="z")  # type: ignore[call-arg]
@@ -49,7 +50,7 @@ def test_deprecate_renamed_parameter(recwarn: Any) -> None:
 
 
 class Foo:  # noqa: D101
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"], version="0.1.2")
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"], version="1.0.0")
     def bar(
         self, baz: str, ham: str | None = None, foobar: str | None = None
     ) -> None: ...
@@ -63,7 +64,7 @@ def test_deprecate_nonkeyword_arguments_method_signature() -> None:
 
 def test_deprecate_nonkeyword_arguments_method_warning() -> None:
     msg = (
-        r"All arguments of Foo\.bar except for \'baz\' will be keyword-only in the next breaking release."
+        r"all arguments of Foo\.bar except for \'baz\' will be keyword-only in the next breaking release."
         r" Use keyword arguments to silence this warning."
     )
     with pytest.deprecated_call(match=msg):
@@ -71,7 +72,7 @@ def test_deprecate_nonkeyword_arguments_method_warning() -> None:
 
 
 def test_deprecate_parameter_as_multi_positional(recwarn: Any) -> None:
-    @deprecate_parameter_as_multi_positional("foo", version="1.0.0")
+    @deprecate_parameter_as_multi_positional("foo")
     def hello(*foo: str) -> tuple[str, ...]:
         return foo
 
@@ -85,7 +86,7 @@ def test_deprecate_parameter_as_multi_positional(recwarn: Any) -> None:
 
 
 def test_deprecate_parameter_as_multi_positional_existing_arg(recwarn: Any) -> None:
-    @deprecate_parameter_as_multi_positional("foo", version="1.0.0")
+    @deprecate_parameter_as_multi_positional("foo")
     def hello(bar: int, *foo: str) -> tuple[int, tuple[str, ...]]:
         return bar, foo
 
@@ -96,3 +97,17 @@ def test_deprecate_parameter_as_multi_positional_existing_arg(recwarn: Any) -> N
     with pytest.deprecated_call():
         result = hello(5, foo=["x", "y"])  # type: ignore[arg-type]
     assert result == hello(5, "x", "y")
+
+
+def test_identify_deprecations() -> None:
+    dep = identify_deprecations()
+    assert isinstance(dep, dict)
+
+    valid_args = get_args(DeprecationType)
+    assert all(key in valid_args for key in dep)
+
+    with pytest.raises(
+        ValueError,
+        match="unrecognised deprecation type 'bitterballen'",
+    ):
+        identify_deprecations("bitterballen")  # type: ignore[arg-type]

--- a/py-polars/tests/unit/utils/test_unstable.py
+++ b/py-polars/tests/unit/utils/test_unstable.py
@@ -21,7 +21,7 @@ def test_issue_unstable_warning(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_issue_unstable_warning_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLARS_WARN_UNSTABLE", "1")
 
-    msg = "This functionality is considered unstable."
+    msg = "this functionality is considered unstable."
     with pytest.warns(UnstableWarning, match=msg):
         issue_unstable_warning()
 


### PR DESCRIPTION
Closes #15836.

(Also closes #13875 and closes #14387 properly).

**TLDR:** improves the developer experience ✌️

## Updates

* With this PR both VSCode and PyCharm (and presumably other IDEs) can now identify our deprecated functions and render them with strikethrough formatting and additional information in the associated docstring tooltip (doesn't look as if notebook environments offer the same nicety; I only checked `marimo` though, so maybe `jupyter` does?)
* Had to remove the (unused/unreported) "version" parameter from our original decorator as `@deprecated` does not support it; however, this information is preserved in the function docstring, so is not lost - indeed, I have ensured that _every_ deprecated function now includes a `..versionchanged::` docstring directive, which was not the case before, so the situation is actually somewhat better (especially for anyone looking over the docs).
* Standardised and clarified many of the deprecation messages so it is always obvious what they refer to.
* Added a utility function for developers that scans the Polars source and identifies/categorises deprecated functionality (via some light AST parsing). Passing no args to this new `identify_deprecations` function returns _all_ information as a dict of deprecation type to qualified function/method names; passing one or more deprecation types to the function returns only those specific types. In both cases the return is the same type of dict.  For example:

  ```python
  from polars._utils.deprecation import identify_deprecations
  identify_deprecations("nonkeyword_arguments", "streaming_parameter")
  # {
  #   'nonkeyword_arguments': [
  #     'expr.datetime.ExprDateTimeNameSpace.add_business_days',
  #     'expr.string.ExprStringNameSpace.to_decimal',
  #     'functions.business.business_day_count',
  #     'series.datetime.DateTimeNameSpace.add_business_days',
  #     'series.string.StringNameSpace.to_decimal',
  #   ],
  #   'streaming_parameter': [
  #     'functions.lazy.collect_all',
  #     'functions.lazy.collect_all_async',
  #     'lazyframe.frame.LazyFrame.collect',
  #     'lazyframe.frame.LazyFrame.collect_async',
  #     'lazyframe.frame.LazyFrame.explain',
  #     'lazyframe.frame.LazyFrame.show_graph',
  #   ],
  # }
  ```
  Recognised deprecation types include: 
  * `"function"`
  * `"renamed_parameter"`
  * `"streaming_parameter"`
  * `"nonkeyword_arguments"`
  * `"parameter_as_multi_positional"`

## Note

One of the original objections to taking this on was having to ship `typing_extensions` to cover version of Python < 3.13. This PR solves several issues, including that one, allowing IDEs to identify/report deprecated functions _without_ forcing any new dependencies - instead we have a progressive fallback from the py3.13 "official" implementation, then to `typing_extensions` *if already present*, and then finally to our own implementation.

## Examples

The major IDEs now show deprecations visually (via strikethrough formatting), with additional tooltip info -

#### VSCode:

<img src="https://github.com/user-attachments/assets/a682eb5d-1078-42e1-99de-f15800f9553e" width="576" />

#### PyCharm:

<img src="https://github.com/user-attachments/assets/ee40e3d6-6ccd-45a3-989c-290d69d11c8b" width="576" />

---
Refs:
https://typing.python.org/en/latest/spec/directives.html#deprecated 
https://peps.python.org/pep-0702/