### PR TITLE
chore: Remove confusing error context calling `.collect(_eager=True)`

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -314,6 +314,13 @@ impl PolarsError {
             error: Box::new(self),
         }
     }
+
+    pub fn remove_context(mut self) -> Self {
+        while let Self::Context { error, .. } = self {
+            self = *error;
+        }
+        self
+    }
 }
 
 pub fn map_err<E: Error>(error: E) -> PolarsError {


### PR DESCRIPTION
Related to #22596.


```python
import polars as pl

df = pl.DataFrame({
    "Column1": [1, 2],
    "Column2": ["A", "B"]
})
df.select('Collumn1')
```

Makes the error go from 

```
Traceback (most recent call last):
  File "/home/johndoe/Projects/polars/t.py", line 7, in <module>
    df.select('Collumn1')
  File "/home/johndoe/Projects/polars/py-polars/polars/dataframe/frame.py", line 9671, in select
    return self.lazy().select(*exprs, **named_exprs).collect(_eager=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johndoe/Projects/polars/py-polars/polars/_utils/deprecation.py", line 93, in wrapper
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johndoe/Projects/polars/py-polars/polars/lazyframe/frame.py", line 2224, in collect
    return wrap_df(ldf.collect(engine, callback))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.ColumnNotFoundError: Collumn1

Resolved plan until failure:

	---> FAILED HERE RESOLVING 'sink' <---
DF ["Column1", "Column2"]; PROJECT */2 COLUMNS
```

to

```
Traceback (most recent call last):
  File "/home/johndoe/Projects/polars/t.py", line 7, in <module>
    df.select('Collumn1')
  File "/home/johndoe/Projects/polars/py-polars/polars/dataframe/frame.py", line 9671, in select
    return self.lazy().select(*exprs, **named_exprs).collect(_eager=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johndoe/Projects/polars/py-polars/polars/_utils/deprecation.py", line 93, in wrapper
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/johndoe/Projects/polars/py-polars/polars/lazyframe/frame.py", line 2224, in collect
    return wrap_df(ldf.collect(engine, callback))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
polars.exceptions.ColumnNotFoundError: Collumn1
```