### PR TITLE
feat: Improved time-string parsing and inference (generally, and via the SQL interface)

### DIFF
--- a/crates/polars-sql/src/types.rs
+++ b/crates/polars-sql/src/types.rs
@@ -9,9 +9,9 @@ use sqlparser::ast::{
 };
 
 polars_utils::regex_cache::cached_regex! {
-    static DATETIME_LITERAL_RE = r"^\d{4}-[01]\d-[0-3]\d[ T](?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.\d{1,9})?$";
+    static DATETIME_LITERAL_RE = r"^\d{4}-[01]\d-[0-3]\d[ T](?:[01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9](\.\d{1,9})?)?$";
     static DATE_LITERAL_RE = r"^\d{4}-[01]\d-[0-3]\d$";
-    static TIME_LITERAL_RE = r"^(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.\d{1,9})?$";
+    static TIME_LITERAL_RE = r"^(?:[01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9](\.\d{1,9})?)?$";
 }
 
 pub fn bitstring_to_bytes_literal(b: &String) -> PolarsResult<Expr> {

--- a/crates/polars-time/src/chunkedarray/string/patterns.rs
+++ b/crates/polars-time/src/chunkedarray/string/patterns.rs
@@ -214,7 +214,7 @@ pub(super) static DATETIME_Y_M_D_Z: &[&str] = &[
     "%+", // ISO 8601; Same as %Y-%m-%dT%H:%M:%S%.f%:z; supports Z or UTC
 ];
 
-pub(super) static TIME_H_M_S: &[&str] = &["%T%.9f", "%T%.6f", "%T%.3f", "%T"];
+pub(super) static TIME_H_M_S: &[&str] = &["%T%.9f", "%T%.6f", "%T%.3f", "%T", "%R"];
 
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
 pub enum Pattern {

--- a/py-polars/tests/unit/operations/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/operations/namespaces/test_strptime.py
@@ -14,7 +14,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import ChronoFormatWarning, ComputeError, InvalidOperationError
-from polars.testing import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
     from polars._typing import PolarsTemporalType, TimeUnit
@@ -650,9 +650,27 @@ def test_strptime_complete_formats(string: str, fmt: str, expected: datetime) ->
 @pytest.mark.parametrize(
     ("data", "format", "expected"),
     [
-        ("05:10:10.074000", "%H:%M:%S%.f", time(5, 10, 10, 74000)),
-        ("05:10:10.074000", "%T%.6f", time(5, 10, 10, 74000)),
-        ("05:10:10.074000", "%H:%M:%S%.3f", time(5, 10, 10, 74000)),
+        ("00:00:00.000005000", "%H:%M:%S%.f", time(0, 0, 0, 5)),
+        ("01:23:10.000500", "%H:%M:%S%.6f", time(1, 23, 10, 500)),
+        ("08:10:11.000", "%H:%M:%S%.3f", time(8, 10, 11)),
+        ("15:50:25", "%T", time(15, 50, 25)),
+        ("22:35", "%R", time(22, 35)),
+    ],
+)
+def test_to_time_inferred(data: str, format: str, expected: time) -> None:
+    df = pl.DataFrame({"tmstr": [data]})
+    expected_df = df.with_columns(tm=pl.Series("tm", values=[expected]))
+    for fmt in (format, None):
+        res = df.with_columns(tm=pl.col("tmstr").str.to_time(fmt))
+        assert_frame_equal(res, expected_df)
+
+
+@pytest.mark.parametrize(
+    ("data", "format", "expected"),
+    [
+        ("05:10:11.740000", "%H:%M:%S%.f", time(5, 10, 11, 740000)),
+        ("13:20:12.000074", "%T%.6f", time(13, 20, 12, 74)),
+        ("21:30:13.007400", "%H:%M:%S%.3f", time(21, 30, 13, 7400)),
     ],
 )
 def test_to_time_subseconds(data: str, format: str, expected: time) -> None:

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -197,12 +197,15 @@ def test_extract_century_millennium(dt: date, expected: list[int]) -> None:
         ("dtm <= '2006-01-01'", []),  # << implies '2006-01-01 00:00:00'
         ("dt != '1960-01-07'", [0, 1]),
         ("tm != '22:10:30'", [0, 2]),
-        ("tm >= '11:00:00' AND tm < '22:00:00'", [0]),
+        ("tm >= '11:00:00' AND tm < '22:00'", [0]),
+        ("tm >= '11:00' AND tm < '22:00:00.000'", [0]),
+        ("tm BETWEEN '12:00' AND '23:59:58'", [0, 1]),
         ("tm BETWEEN '12:00:00' AND '23:59:58'", [0, 1]),
         ("dt BETWEEN '2050-01-01' AND '2100-12-31'", [1]),
         ("dt::datetime = '1960-01-07'", [2]),
+        ("dt::datetime = '1960-01-07 00:00'", [2]),
         ("dt::datetime = '1960-01-07 00:00:00'", [2]),
-        ("dtm BETWEEN '2020-12-30 10:30:44' AND '2023-01-01 00:00:00'", [2]),
+        ("dtm BETWEEN '2020-12-30 10:30:44' AND '2023-01-01 00:00'", [2]),
         ("dt IN ('1960-01-07','2077-01-01','2222-02-22')", [1, 2]),
         (
             "dtm = '2024-01-07 01:02:03.123456000' OR dtm = '2020-12-30 10:30:45.987654'",
@@ -239,10 +242,12 @@ def test_implicit_temporal_strings(constraint: str, expected: list[int]) -> None
 @pytest.mark.parametrize(
     "dtval",
     [
+        # none of these are valid dates
         "2020-12-30T10:30:45",
         "yyyy-mm-dd",
         "2222-22-22",
         "10:30:45",
+        "foo",
     ],
 )
 def test_implicit_temporal_string_errors(dtval: str) -> None:


### PR DESCRIPTION
Addresses an Issue raised on the Discord (in the `#sql` channel) by @etrotta.

* Generic time-string parsing improvement (adds `%R` chrono [hour-minute format](https://docs.rs/chrono/latest/chrono/format/strftime/index.html#:~:text=Hour%2Dminute%20format) to the set of recognised time specifiers - which we already identify in datetime strings).
* Brings SQL temporal literal string inference in-line with the underlying `to_datetime` and `to_time` functions so that hour-minute format (`%R`, aka:`%H:%M`) is also recognised in the SQL interface (both standalone, as a time, and as part of a larger datetime/timestamp string). A subsequent/follow-up PR will bring a similar improvement to SQL `CAST` ops.

## Example

Use of `'%H:%M'` literal strings in WHERE clauses:
```python
import polars as pl

df = pl.DataFrame({
    "tm": [time(0,45,10), time(10,30,59), time(18,5,20), time(12,25,5)],
    "val": ["aaa", "bbb", "ccc" ,"ddd"],
})
df.sql("SELECT * FROM self WHERE tm > '12:00' ORDER BY tm")
# shape: (2, 2)
# ┌──────────┬─────┐
# │ tm       ┆ val │
# │ ---      ┆ --- │
# │ time     ┆ str │
# ╞══════════╪═════╡
# │ 12:25:05 ┆ ddd │
# │ 18:05:20 ┆ ccc │
# └──────────┴─────┘
```
Properly inferred by `str.to_time()`:
```python
pl.DataFrame({
    "tmstr": ["00:01", "23:00", "14:30"],
}).with_columns(
    tm = pl.col("tmstr").str.to_time(),
)
# shape: (3, 2)
# ┌───────┬──────────┐
# │ tmstr ┆ tm       │
# │ ---   ┆ ---      │
# │ str   ┆ time     │
# ╞═══════╪══════════╡
# │ 00:01 ┆ 00:01:00 │
# │ 23:00 ┆ 23:00:00 │
# │ 14:30 ┆ 14:30:00 │
# └───────┴──────────┘
```