### PR TITLE
chore: Add `proptest` testing for for parquet decoding kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,21 +838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3564,6 +3549,7 @@ dependencies = [
  "polars-arrow",
  "polars-compute",
  "polars-error",
+ "polars-parquet",
  "polars-parquet-format",
  "polars-utils",
  "proptest",
@@ -3881,8 +3867,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set",
- "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
@@ -3890,8 +3874,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
 
@@ -4011,12 +3993,6 @@ name = "quad-rand"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -4582,18 +4558,6 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -5507,15 +5471,6 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3551,6 +3566,7 @@ dependencies = [
  "polars-error",
  "polars-parquet-format",
  "polars-utils",
+ "proptest",
  "rand 0.8.5",
  "serde",
  "simdutf8",
@@ -3865,6 +3881,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
@@ -3872,6 +3890,8 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -3991,6 +4011,12 @@ name = "quad-rand"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -4556,6 +4582,18 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5469,6 +5507,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,7 +3549,6 @@ dependencies = [
  "polars-arrow",
  "polars-compute",
  "polars-error",
- "polars-parquet",
  "polars-parquet-format",
  "polars-utils",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3549,6 +3549,7 @@ dependencies = [
  "polars-arrow",
  "polars-compute",
  "polars-error",
+ "polars-parquet",
  "polars-parquet-format",
  "polars-utils",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ object_store = { version = "0.12", default-features = false, features = ["fs"] }
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pin-project-lite = "0.2"
-proptest = "1.6"
+proptest = { version = "1.6", default-features = false, features = ["std"] }
 pyo3 = "0.24.2"
 rand = "0.8"
 rand_distr = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ object_store = { version = "0.12", default-features = false, features = ["fs"] }
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pin-project-lite = "0.2"
+proptest = "1.6"
 pyo3 = "0.24.2"
 rand = "0.8"
 rand_distr = "0.4"

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -63,6 +63,7 @@ strength_reduce = { workspace = true, optional = true }
 async-stream = { version = "0.3", optional = true }
 tokio = { workspace = true, optional = true, features = ["io-util"] }
 
+proptest = { workspace = true, optional = true }
 strum_macros = { workspace = true }
 
 [dev-dependencies]
@@ -71,7 +72,7 @@ crossbeam-channel = { workspace = true }
 doc-comment = "0.3"
 flate2 = { workspace = true, default-features = true }
 # used to run formal property testing
-proptest = { version = "1", default-features = false, features = ["std"] }
+proptest = { workspace = true }
 # use for flaky testing
 rand = { workspace = true }
 # use for generating and testing random data samples

--- a/crates/polars-arrow/src/bitmap/mod.rs
+++ b/crates/polars-arrow/src/bitmap/mod.rs
@@ -22,3 +22,6 @@ pub mod bitmask;
 
 mod builder;
 pub use builder::*;
+
+#[cfg(feature = "proptest")]
+pub mod proptest;

--- a/crates/polars-arrow/src/bitmap/proptest.rs
+++ b/crates/polars-arrow/src/bitmap/proptest.rs
@@ -1,0 +1,8 @@
+use proptest::prelude::{Strategy, any_with};
+use proptest::sample::SizeRange;
+
+use super::Bitmap;
+
+pub fn bitmap(size_range: impl Into<SizeRange>) -> impl Strategy<Value = Bitmap> {
+    any_with::<Vec<bool>>(size_range.into().lift()).prop_map(Bitmap::from_iter)
+}

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -44,8 +44,9 @@ xxhash-rust = { version = "0.8", optional = true, features = ["xxh64"] }
 proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
-arrow = { workspace = true, features = ["proptest"] }
-proptest = { workspace = true }
+# ensure that the proptest feature is enabled when we are testing
+polars-parquet = { workspace = true, features = ["proptest"] }
+
 rand = "0.8"
 
 [features]
@@ -67,3 +68,5 @@ async = ["async-stream", "futures", "polars-parquet-format/async"]
 bloom_filter = ["xxhash-rust"]
 serde_types = ["serde"]
 simd = ["polars-compute/simd"]
+
+proptest = ["dep:proptest", "arrow/proptest"]

--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -41,7 +41,11 @@ zstd = { workspace = true, optional = true }
 
 xxhash-rust = { version = "0.8", optional = true, features = ["xxh64"] }
 
+proptest = { workspace = true, optional = true }
+
 [dev-dependencies]
+arrow = { workspace = true, features = ["proptest"] }
+proptest = { workspace = true }
 rand = "0.8"
 
 [features]

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/optional_masked_dense.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary_encoded/optional_masked_dense.rs
@@ -216,3 +216,78 @@ pub fn decode<B: AlignedBytes, D: IndexMapping<Output = B>>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use arrow::bitmap::proptest::bitmap;
+    use arrow::types::Bytes4Alignment4;
+    use proptest::collection::size_range;
+    use proptest::prelude::*;
+    use proptest::test_runner::TestCaseResult;
+
+    use super::*;
+    use crate::parquet::encoding::hybrid_rle;
+
+    fn validity_values_and_mask() -> impl Strategy<Value = (Bitmap, Vec<u8>, u32, Vec<u32>, Bitmap)>
+    {
+        (bitmap(1..100), (0..300u32)).prop_flat_map(|(validity, max_idx)| {
+            let len = validity.len();
+            let values_length = validity.set_bits();
+            let hybrid_rle = hybrid_rle::proptest::hybrid_rle(max_idx, values_length);
+
+            (
+                Just(validity),
+                hybrid_rle,
+                Just(max_idx),
+                any_with::<Vec<u32>>(size_range((max_idx + 1) as usize).lift()),
+                bitmap(len),
+            )
+        })
+    }
+
+    fn _test_decode(
+        validity: &Bitmap,
+        hybrid_rle: HybridRleDecoder<'_>,
+        dict: &[Bytes4Alignment4],
+        mask: &Bitmap,
+    ) -> TestCaseResult {
+        let mut result = Vec::<arrow::types::Bytes4Alignment4>::with_capacity(mask.set_bits());
+        decode(
+            hybrid_rle.clone(),
+            dict,
+            mask.clone(),
+            validity.clone(),
+            &mut result,
+        )
+        .unwrap();
+
+        let idxs = hybrid_rle.collect().unwrap();
+        let mut result_i = 0;
+        let mut values_i = 0;
+        for (is_valid, is_selected) in validity.iter().zip(mask.iter()) {
+            if is_selected {
+                if is_valid {
+                    prop_assert_eq!(result[result_i], dict[idxs[values_i] as usize]);
+                }
+                result_i += 1;
+            }
+
+            if is_valid {
+                values_i += 1;
+            }
+        }
+
+        TestCaseResult::Ok(())
+    }
+
+    proptest! {
+        #[test]
+        fn test_decode_masked_optional(
+            (ref validity, ref hybrid_rle, max_idx, ref dict, ref mask) in validity_values_and_mask()
+        ) {
+            let hybrid_rle = HybridRleDecoder::new(hybrid_rle, 32 - max_idx.leading_zeros(), validity.set_bits());
+            let dict = bytemuck::cast_slice(dict.as_slice());
+            _test_decode(validity, hybrid_rle, dict, mask)?
+        }
+    }
+}

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/plain/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/plain/mod.rs
@@ -517,10 +517,7 @@ mod tests {
     fn values_and_mask() -> impl Strategy<Value = (Vec<u32>, Bitmap)> {
         any_with::<Vec<u32>>(size_range(0..100).lift()).prop_flat_map(|vec| {
             let len = vec.len();
-            (
-                Just(vec),
-                bitmap(len),
-            )
+            (Just(vec), bitmap(len))
         })
     }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/plain/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/plain/mod.rs
@@ -505,3 +505,101 @@ fn decode_masked_optional<B: AlignedBytes>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use arrow::bitmap::proptest::bitmap;
+    use proptest::collection::size_range;
+    use proptest::prelude::*;
+
+    use super::*;
+
+    fn values_and_mask() -> impl Strategy<Value = (Vec<u32>, Bitmap)> {
+        any_with::<Vec<u32>>(size_range(0..100).lift()).prop_flat_map(|vec| {
+            let len = vec.len();
+            (
+                Just(vec),
+                bitmap(len),
+            )
+        })
+    }
+
+    fn validity_values_and_mask() -> impl Strategy<Value = (Bitmap, Vec<u32>, Bitmap)> {
+        bitmap(0..100).prop_flat_map(|validity| {
+            let len = validity.len();
+            let values_length = validity.set_bits();
+
+            (
+                Just(validity),
+                any_with::<Vec<u32>>(size_range(values_length).lift()),
+                bitmap(len),
+            )
+        })
+    }
+
+    fn _test_decode_masked_required(values: &Vec<u32>, mask: &Bitmap) {
+        let mut reference_result = Vec::with_capacity(mask.set_bits());
+        for (value, is_selected) in values.iter().zip(mask.iter()) {
+            if is_selected {
+                reference_result.push(*value);
+            }
+        }
+
+        let mut result = Vec::<arrow::types::Bytes4Alignment4>::with_capacity(mask.set_bits());
+        decode_masked_required(
+            ArrayChunks::new(bytemuck::cast_slice(values.as_slice())).unwrap(),
+            mask.clone(),
+            &mut result,
+        )
+        .unwrap();
+
+        let result = bytemuck::cast_vec::<_, u32>(result);
+        assert_eq!(reference_result, result);
+    }
+
+    fn _test_decode_masked_optional(validity: &Bitmap, values: &Vec<u32>, mask: &Bitmap) {
+        let mut result = Vec::<arrow::types::Bytes4Alignment4>::with_capacity(mask.set_bits());
+        decode_masked_optional(
+            ArrayChunks::new(bytemuck::cast_slice(values.as_slice())).unwrap(),
+            validity.clone(),
+            mask.clone(),
+            &mut result,
+        )
+        .unwrap();
+
+        let result = bytemuck::cast_vec::<_, u32>(result);
+
+        let mut result_i = 0;
+        let mut values_i = 0;
+        for (is_valid, is_selected) in validity.iter().zip(mask.iter()) {
+            if is_selected {
+                if is_valid {
+                    assert_eq!(result[result_i], values[values_i]);
+                }
+                result_i += 1;
+            }
+
+            if is_valid {
+                values_i += 1;
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_decode_masked_required(
+            (ref values, ref mask) in values_and_mask()
+        ) {
+            _test_decode_masked_required(values, mask)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_decode_masked_optional(
+            (ref validity, ref values, ref mask) in validity_values_and_mask()
+        ) {
+            _test_decode_masked_optional(validity, values, mask)
+        }
+    }
+}

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/mod.rs
@@ -1,6 +1,8 @@
 // See https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3
 mod bitmap;
 mod encoder;
+#[cfg(feature = "proptest")]
+pub mod proptest;
 
 pub use bitmap::{BitmapIter, encode_bool as bitpacked_encode};
 pub use encoder::{Encoder, encode};

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/proptest.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/proptest.rs
@@ -1,0 +1,61 @@
+use proptest::prelude::*;
+
+#[derive(Debug, Clone)]
+enum Chunk {
+    Rle(u32, usize),
+    Bitpacked(Vec<u32>),
+}
+
+proptest::prop_compose! {
+    fn hybrid_rle_chunks
+        (max_idx: u32, size: usize)
+        (idxs in proptest::collection::vec(0..=max_idx, size),
+            mut chunk_offsets in proptest::collection::vec((0..=size, any::<bool>()), 2..=size.max(2)),
+        )
+    -> Vec<Chunk> {
+        if size == 0 {
+            return Vec::new();
+        }
+
+        chunk_offsets.sort_unstable();
+        chunk_offsets.first_mut().unwrap().0 = 0;
+        chunk_offsets.last_mut().unwrap().0 = idxs.len();
+        chunk_offsets.dedup_by_key(|(idx, _)| *idx);
+
+        chunk_offsets
+            .windows(2)
+            .map(|values| {
+                let (start, is_bitpacked) = values[0];
+                let (end, _) = values[1];
+
+                if is_bitpacked {
+                    Chunk::Bitpacked(idxs[start..end].to_vec())
+                } else {
+                    Chunk::Rle(idxs[start], end - start)
+                }
+            })
+            .collect::<Vec<Chunk>>()
+    }
+}
+
+proptest::prop_compose! {
+    pub fn hybrid_rle
+        (max_idx: u32, size: usize)
+        (chunks in hybrid_rle_chunks(max_idx, size))
+    -> Vec<u8> {
+        use super::encoder::Encoder;
+        let mut buffer = Vec::new();
+        let bit_width = 32 - max_idx.leading_zeros();
+        for chunk in chunks {
+            match chunk {
+                Chunk::Rle(value, size) => {
+                    u32::run_length_encode(&mut buffer, size, value, bit_width).unwrap()
+                }
+                Chunk::Bitpacked(values) => {
+                    u32::bitpacked_encode(&mut buffer, values.into_iter(), bit_width as usize).unwrap()
+                }
+            }
+        }
+        buffer
+    }
+}

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -32,7 +32,7 @@ either = { workspace = true }
 ethnum = "1"
 futures = { workspace = true }
 # used to run formal property testing
-proptest = { version = "1", default-features = false, features = ["std"] }
+proptest = { workspace = true }
 rand = { workspace = true }
 # used to test async readers
 tokio = { workspace = true, features = ["macros", "rt", "fs", "io-util"] }


### PR DESCRIPTION
This was a bit of an experiment and learning project for me to see how `proptest` works. I want to see if it would be relatively simple to apply to testing of internals. I think the experiment was quite a success.

This PR just tests adds tests for some of the harder kernels from the parquet decoding.

Some of the takeaways:
- It is surprising to see how much faster it is then python hypothesis testing.
- We should quite easily be able define strategies for all our arrow array types.
- We circumvent the problems of `cargo-fuzz` where we start having to expose all of our internals and we don't need additional CI steps.

Overall, I would say this was a great success. We can expand on this.