### PR TITLE
fix: Panic on `group_by` with literal and empty rows

### DIFF
--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -49,7 +49,7 @@ impl DataFrame {
         for by_key in by.iter_mut() {
             if by_key.len() != common_height {
                 polars_ensure!(
-                    by_key.len() == 1 || common_height == 0,
+                    by_key.len() == 1,
                     ShapeMismatch: "series used as keys should have the same length as the DataFrame"
                 );
                 *by_key = by_key.new_from_index(0, common_height)

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -37,23 +37,24 @@ impl DataFrame {
             !by.is_empty(),
             ComputeError: "at least one key is required in a group_by operation"
         );
-        let minimal_by_len = by.iter().map(|s| s.len()).min().expect("at least 1 key");
-        let df_height = self.height();
 
-        // Ensure all 'by' columns have the same height
-        // We only throw this error if self.width > 0
-        // so that we can still call this on a dummy dataframe where we provide the keys
-        if (minimal_by_len != df_height || df_height == 0) && (self.width() > 0) {
-            polars_ensure!(
-                minimal_by_len == 1 || df_height == 0,
-                ShapeMismatch: "series used as keys should have the same length as the DataFrame"
-            );
-            for by_key in by.iter_mut() {
-                if by_key.len() != df_height {
-                    *by_key = by_key.new_from_index(0, df_height)
-                }
-            }
+        // Ensure all 'by' columns have the same common_height
+        // The condition self.width > 0 ensures we can still call this on a
+        // dummy dataframe where we provide the keys
+        let common_height = if self.width() > 0 {
+            self.height()
+        } else {
+            by.iter().map(|s| s.len()).max().expect("at least 1 key")
         };
+        for by_key in by.iter_mut() {
+            if by_key.len() != common_height {
+                polars_ensure!(
+                    by_key.len() == 1 || common_height == 0,
+                    ShapeMismatch: "series used as keys should have the same length as the DataFrame"
+                );
+                *by_key = by_key.new_from_index(0, common_height)
+            }
+        }
 
         let groups = if by.len() == 1 {
             let column = &by[0];

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -40,15 +40,16 @@ impl DataFrame {
         let minimal_by_len = by.iter().map(|s| s.len()).min().expect("at least 1 key");
         let df_height = self.height();
 
-        // we only throw this error if self.width > 0
+        // Ensure all 'by' columns have the same height
+        // We only throw this error if self.width > 0
         // so that we can still call this on a dummy dataframe where we provide the keys
-        if (minimal_by_len != df_height) && (self.width() > 0) {
+        if (minimal_by_len != df_height || df_height == 0) && (self.width() > 0) {
             polars_ensure!(
-                minimal_by_len == 1,
+                minimal_by_len == 1 || df_height == 0,
                 ShapeMismatch: "series used as keys should have the same length as the DataFrame"
             );
             for by_key in by.iter_mut() {
-                if by_key.len() == minimal_by_len {
+                if by_key.len() != df_height {
                     *by_key = by_key.new_from_index(0, df_height)
                 }
             }

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -1303,3 +1303,18 @@ def test_group_by_arrays_22574(maintain_order: bool) -> None:
         ),
         check_row_order=maintain_order,
     )
+
+
+def test_group_by_empty_rows_with_literal_21959() -> None:
+    out = (
+        pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [1, 1, 3]})
+        .filter(pl.col("c") == 99)
+        .group_by(pl.lit(1).alias("d"), pl.col("a"), pl.col("b"))
+        .agg()
+        .collect()
+    )
+    expected = pl.DataFrame(
+        {"d": [], "a": [], "b": []},
+        schema={"d": pl.Int32, "a": pl.Int64, "b": pl.Int64},
+    )
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
fixes #21959 

ping @coastalwhite 

This fixes the issue for `GroupByExec`. However, note that `PartitionGroupByExec` has dedicated functionality such as `keys()`/`compute_keys()` calling `check_expand_literals()` to ensure literals are expanded. If this approach is preferred, let me know and I will try to replicate and re-use this function.