### PR TITLE
fix: Allow Expr.round() to be called on integer dtypes

### DIFF
--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -210,7 +210,8 @@ pub trait RoundSeries: SeriesSealed {
                 .into_series());
         }
 
-        polars_bail!(InvalidOperation: "round can only be used on numeric types (f32, f64, or decimal)");
+        polars_ensure!(s.dtype().is_integer(), InvalidOperation: "round can only be used on numeric types" );
+        Ok(s.clone())
     }
 
     fn round_sig_figs(&self, digits: i32) -> PolarsResult<Series> {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -941,6 +941,11 @@ def test_round() -> None:
 
     b = a.round()
     assert b.to_list() == [1.0, 2.0]
+    
+
+def test_round_int() -> None:
+    s = pl.Series([1, 2, 3])
+    assert_series_equal(s, s.round())
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -941,7 +941,7 @@ def test_round() -> None:
 
     b = a.round()
     assert b.to_list() == [1.0, 2.0]
-    
+
 
 def test_round_int() -> None:
     s = pl.Series([1, 2, 3])


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/22559.

cc @Julian-J-S 