### PR TITLE
feat(python): Support use of literal values as "other" when evaluating `Series.zip_with`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5691,7 +5691,7 @@ class Series:
         ]
         """
         if not isinstance(other, Series):
-            other = Series([], dtype=self.dtype).extend_constant(other, n=len(self))
+            other = Series([other], dtype=self.dtype)
         return self._from_pyseries(self._s.zip_with(mask._s, other._s))
 
     @deprecate_renamed_parameter("min_periods", "min_samples", version="1.21.0")

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5628,19 +5628,19 @@ class Series:
         ]
         """
 
-    def zip_with(self, mask: Series, other: Series) -> Self:
+    def zip_with(self, mask: Series, other: Series | PythonLiteral) -> Self:
         """
-        Take values from self or other based on the given mask.
+        Take values from `self` or `other`, based on the given mask.
 
-        Where mask evaluates true, take values from self. Where mask evaluates false,
-        take values from other.
+        Where `mask` evaluates True, take values from `self`.
+        Where `mask` evaluates False, take values from `other`.
 
         Parameters
         ----------
         mask
             Boolean Series.
         other
-            Series of same type.
+            Series or literal value of the same type.
 
         Returns
         -------
@@ -5648,11 +5648,13 @@ class Series:
 
         Examples
         --------
-        >>> s1 = pl.Series([1, 2, 3, 4, 5])
-        >>> s2 = pl.Series([5, 4, 3, 2, 1])
+        Create the mask from a comparison between two Series.
+
+        >>> s1 = pl.Series("a", [1, 2, 3, 4, 5])
+        >>> s2 = pl.Series("b", [5, 4, 3, 2, 1])
         >>> s1.zip_with(s1 < s2, s2)
         shape: (5,)
-        Series: '' [i64]
+        Series: 'a' [i64]
         [
                 1
                 2
@@ -5660,10 +5662,13 @@ class Series:
                 2
                 1
         ]
+
+        Supply the mask as a Series of booleans.
+
         >>> mask = pl.Series([True, False, True, False, True])
         >>> s1.zip_with(mask, s2)
         shape: (5,)
-        Series: '' [i64]
+        Series: 'a' [i64]
         [
                 1
                 4
@@ -5671,7 +5676,22 @@ class Series:
                 2
                 5
         ]
+
+        Provide `other` as a literal value.
+
+        >>> s1.zip_with(mask, 999)
+        shape: (5,)
+        Series: 'a' [i64]
+        [
+            1
+            999
+            3
+            999
+            5
+        ]
         """
+        if not isinstance(other, Series):
+            other = Series([], dtype=self.dtype).extend_constant(other, n=len(self))
         return self._from_pyseries(self._s.zip_with(mask._s, other._s))
 
     @deprecate_renamed_parameter("min_periods", "min_samples", version="1.21.0")

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2239,3 +2239,20 @@ def test_repeat_by() -> None:
     calculated = pl.select(a=pl.Series("a", [1, 2]).repeat_by(2))
     expected = pl.select(a=pl.Series("a", [[1, 1], [2, 2]]))
     assert calculated.equals(expected)
+
+
+def test_zip_with() -> None:
+    s1 = pl.Series("a", [9, 2, 0, 2])
+    s2 = pl.Series("b", [4, 8, 6, 1])
+    s3 = pl.Series("c", [3, 4, 6, 6])
+
+    res = s1.zip_with(s2 < s1, s3)
+    expected = pl.Series("a", [9, 4, 6, 2])
+    assert_series_equal(res, expected)
+
+    s3 = pl.Series("a", ["hello", "foo bar", "oats", "coffee"])
+    s4 = pl.Series("b", ["world", "baz", "cornflake", "tea"])
+
+    res = s3.zip_with(s3.str.len_bytes() > s4.str.len_bytes(), "(^_^)")
+    expected = pl.Series("a", ["(^_^)", "foo bar", "(^_^)", "coffee"])
+    assert_series_equal(res, expected)


### PR DESCRIPTION
Closes #22620.

Simple ergonomic improvement (allow a literal value as "other" for Series `zip_with`), plus some additional test coverage.

## Example

```python
import polars as pl

s1 = pl.Series("x", [153, 56, -45, 877, 37])
s2 = pl.Series("y", [56, 822, 4, 56, -345])

s1.zip_with(s1 <= s2, 0)
# shape: (5,)
# Series: 'x' [i64]
# [
#     0
#     56
#     -45
#     0
#     0
# ]

```