### PR TITLE
feat: Support optimised init from non-dict `Mapping` objects in `from_records` and frame/series constructors

### DIFF
--- a/crates/polars-python/src/dataframe/construction.rs
+++ b/crates/polars-python/src/dataframe/construction.rs
@@ -1,7 +1,7 @@
 use polars::frame::row::{Row, rows_to_schema_supertypes, rows_to_supertypes};
 use polars::prelude::*;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyMapping};
 
 use super::PyDataFrame;
 use crate::conversion::any_value::py_object_to_any_value;
@@ -38,15 +38,33 @@ impl PyDataFrame {
         let schema = schema.map(|wrap| wrap.0);
         let schema_overrides = schema_overrides.map(|wrap| wrap.0);
 
-        let names = get_schema_names(data, schema.as_ref(), infer_schema_length)?;
-        let rows = dicts_to_rows(data, &names, strict)?;
+        // determine row extraction strategy from the first item:
+        // PyDict (faster), or PyMapping (more generic, slower)
+        let from_mapping = data.len()? > 0 && {
+            let mut iter = data.try_iter()?;
+            loop {
+                match iter.next() {
+                    Some(Ok(item)) if !item.is_none() => break !item.is_instance_of::<PyDict>(),
+                    Some(Err(e)) => return Err(e),
+                    Some(_) => continue,
+                    None => break false,
+                }
+            }
+        };
+
+        // read (or infer) field names, then extract row values
+        let names = get_schema_names(data, schema.as_ref(), infer_schema_length, from_mapping)?;
+        let rows = if from_mapping {
+            mappings_to_rows(data, &names, strict)?
+        } else {
+            dicts_to_rows(data, &names, strict)?
+        };
 
         let schema = schema.or_else(|| {
             Some(columns_names_to_empty_schema(
                 names.iter().map(String::as_str),
             ))
         });
-
         py.enter_polars(move || {
             finish_from_rows(rows, schema, schema_overrides, infer_schema_length)
         })
@@ -148,21 +166,55 @@ fn dicts_to_rows<'a>(
     names: &'a [String],
     strict: bool,
 ) -> PyResult<Vec<Row<'a>>> {
-    let len = data.len()?;
-    let mut rows = Vec::with_capacity(len);
+    let mut rows = Vec::with_capacity(data.len()?);
+    let null_row = Row::new(vec![AnyValue::Null; names.len()]);
+
     for d in data.try_iter()? {
         let d = d?;
-        let d = d.downcast::<PyDict>()?;
-
-        let mut row = Vec::with_capacity(names.len());
-        for k in names.iter() {
-            let val = match d.get_item(k)? {
-                None => AnyValue::Null,
-                Some(val) => py_object_to_any_value(&val.as_borrowed(), strict, true)?,
-            };
-            row.push(val)
+        if d.is_none() {
+            rows.push(null_row.clone())
+        } else {
+            let d = d.downcast::<PyDict>()?;
+            let mut row = Vec::with_capacity(names.len());
+            for k in names.iter() {
+                let val = match d.get_item(k)? {
+                    None => AnyValue::Null,
+                    Some(val) => py_object_to_any_value(&val.as_borrowed(), strict, true)?,
+                };
+                row.push(val)
+            }
+            rows.push(Row(row))
         }
-        rows.push(Row(row))
+    }
+    Ok(rows)
+}
+
+fn mappings_to_rows<'a>(
+    data: &Bound<'a, PyAny>,
+    names: &'a [String],
+    strict: bool,
+) -> PyResult<Vec<Row<'a>>> {
+    let mut rows = Vec::with_capacity(data.len()?);
+    let null_row = Row::new(vec![AnyValue::Null; names.len()]);
+
+    for d in data.try_iter()? {
+        let d = d?;
+        if d.is_none() {
+            rows.push(null_row.clone())
+        } else {
+            let d = d.downcast::<PyMapping>()?;
+            let mut row = Vec::with_capacity(names.len());
+            for k in names.iter() {
+                let py_obj = d.get_item(k)?;
+                let val = if py_obj.is_none() {
+                    AnyValue::Null
+                } else {
+                    py_object_to_any_value(&py_obj, strict, true)?
+                };
+                row.push(val)
+            }
+            rows.push(Row(row))
+        }
     }
     Ok(rows)
 }
@@ -172,35 +224,65 @@ fn get_schema_names(
     data: &Bound<PyAny>,
     schema: Option<&Schema>,
     infer_schema_length: Option<usize>,
+    from_mapping: bool,
 ) -> PyResult<Vec<String>> {
     if let Some(schema) = schema {
         Ok(schema.iter_names().map(|n| n.to_string()).collect())
     } else {
-        infer_schema_names_from_data(data, infer_schema_length)
+        let data_len = data.len()?;
+        let infer_schema_length = infer_schema_length
+            .map(|n| std::cmp::max(1, n))
+            .unwrap_or(data_len);
+
+        if from_mapping {
+            infer_schema_names_from_mapping_data(data, infer_schema_length)
+        } else {
+            infer_schema_names_from_dict_data(data, infer_schema_length)
+        }
     }
 }
 
 /// Infer schema names from an iterable of dictionaries.
 ///
-/// The resulting schema order is determined by the order in which the names are encountered in
-/// the data.
-fn infer_schema_names_from_data(
+/// The resulting schema order is determined by the order
+/// in which the names are encountered in the data.
+fn infer_schema_names_from_dict_data(
     data: &Bound<PyAny>,
-    infer_schema_length: Option<usize>,
+    infer_schema_length: usize,
 ) -> PyResult<Vec<String>> {
-    let data_len = data.len()?;
-    let infer_schema_length = infer_schema_length
-        .map(|n| std::cmp::max(1, n))
-        .unwrap_or(data_len);
-
     let mut names = PlIndexSet::new();
     for d in data.try_iter()?.take(infer_schema_length) {
         let d = d?;
-        let d = d.downcast::<PyDict>()?;
-        let keys = d.keys();
-        for name in keys {
-            let name = name.extract::<String>()?;
-            names.insert(name);
+        if !d.is_none() {
+            let d = d.downcast::<PyDict>()?;
+            let keys = d.keys().iter();
+            for name in keys {
+                let name = name.extract::<String>()?;
+                names.insert(name);
+            }
+        }
+    }
+    Ok(names.into_iter().collect())
+}
+
+/// Infer schema names from an iterable of mapping objects.
+///
+/// The resulting schema order is determined by the order
+/// in which the names are encountered in the data.
+fn infer_schema_names_from_mapping_data(
+    data: &Bound<PyAny>,
+    infer_schema_length: usize,
+) -> PyResult<Vec<String>> {
+    let mut names = PlIndexSet::new();
+    for d in data.try_iter()?.take(infer_schema_length) {
+        let d = d?;
+        if !d.is_none() {
+            let d = d.downcast::<PyMapping>()?;
+            let keys = d.keys()?;
+            for name in keys {
+                let name = name.extract::<String>()?;
+                names.insert(name);
+            }
         }
     }
     Ok(names.into_iter().collect())

--- a/crates/polars-python/src/series/construction.rs
+++ b/crates/polars-python/src/series/construction.rs
@@ -198,6 +198,7 @@ impl PySeries {
             .try_iter()?
             .map(|v| py_object_to_any_value(&(v?).as_borrowed(), strict, true))
             .collect::<PyResult<Vec<AnyValue>>>();
+
         let result = any_values_result.and_then(|avs| {
             let s = Series::from_any_values(name.into(), avs.as_slice(), strict).map_err(|e| {
                 PyTypeError::new_err(format!(

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -359,7 +359,10 @@ impl SQLExprVisitor<'_> {
 
     /// Handle implicit temporal string comparisons.
     ///
-    /// eg: "dt >= '2024-04-30'", or "dtm::date = '2077-10-10'"
+    /// eg: clauses such as -
+    ///   "dt >= '2024-04-30'"
+    ///   "dt = '2077-10-10'::date"
+    ///   "dtm::date = '2077-10-10'
     fn convert_temporal_strings(&mut self, left: &Expr, right: &Expr) -> Expr {
         if let (Some(name), Some(s), expr_dtype) = match (left, right) {
             // identify "col <op> string" expressions

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -17,10 +17,11 @@ import polars._utils.construction as plc
 from polars import functions as F
 from polars._utils.construction.utils import (
     contains_nested,
+    get_first_non_none,
     is_namedtuple,
     is_pydantic_model,
     is_simple_numpy_backed_pandas_series,
-    is_sqlalchemy,
+    is_sqlalchemy_row,
     nt_unpack,
     try_get_type_hints,
 )
@@ -458,7 +459,7 @@ def sequence_to_pydf(
         return dict_to_pydf({}, schema=schema, schema_overrides=schema_overrides)
 
     return _sequence_to_pydf_dispatcher(
-        data[0],
+        get_first_non_none(data),
         data=data,
         schema=schema,
         schema_overrides=schema_overrides,
@@ -483,7 +484,7 @@ def _sequence_to_pydf_dispatcher(
 ) -> PyDataFrame:
     # note: ONLY python-native data should participate in singledispatch registration
     # via top-level decorators, otherwise we have to import the associated module.
-    # third-party libraries (such as numpy/pandas) should instead be identified inline
+    # third-party libraries (such as numpy/pandas) should be identified inline (below)
     # and THEN registered for dispatch (here) so as not to break lazy-loading behaviour.
 
     common_params = {
@@ -521,7 +522,7 @@ def _sequence_to_pydf_dispatcher(
     elif is_pydantic_model(first_element):
         to_pydf = _sequence_of_pydantic_models_to_pydf
 
-    elif is_sqlalchemy(first_element):
+    elif is_sqlalchemy_row(first_element):
         to_pydf = _sequence_of_tuple_to_pydf
 
     elif isinstance(first_element, Sequence) and not isinstance(first_element, str):
@@ -663,7 +664,7 @@ def _sequence_of_tuple_to_pydf(
     nan_to_null: bool = False,
 ) -> PyDataFrame:
     # infer additional meta information if namedtuple
-    if is_namedtuple(first_element.__class__) or is_sqlalchemy(first_element):
+    if is_namedtuple(first_element.__class__) or is_sqlalchemy_row(first_element):
         if schema is None:
             schema = first_element._fields  # type: ignore[attr-defined]
             annotations = getattr(first_element, "__annotations__", None)
@@ -688,6 +689,7 @@ def _sequence_of_tuple_to_pydf(
     )
 
 
+@_sequence_to_pydf_dispatcher.register(Mapping)
 @_sequence_to_pydf_dispatcher.register(dict)
 def _sequence_of_dict_to_pydf(
     first_element: dict[str, Any],

--- a/py-polars/polars/_utils/construction/utils.py
+++ b/py-polars/polars/_utils/construction/utils.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Callable, get_type_hints
 
 from polars.dependencies import _check_for_pydantic, pydantic
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     import pandas as pd
 
 PANDAS_SIMPLE_NUMPY_DTYPES = {
@@ -48,7 +47,7 @@ def try_get_type_hints(obj: type) -> dict[str, Any]:
 
 @lru_cache(64)
 def is_namedtuple(cls: Any, *, annotated: bool = False) -> bool:
-    """Check whether given class derives from NamedTuple."""
+    """Check if given class derives from NamedTuple."""
     if all(hasattr(cls, attr) for attr in ("_fields", "_field_defaults", "_replace")):
         if not isinstance(cls._fields, property):
             if not annotated or len(cls.__annotations__) == len(cls._fields):
@@ -57,13 +56,15 @@ def is_namedtuple(cls: Any, *, annotated: bool = False) -> bool:
 
 
 def is_pydantic_model(value: Any) -> bool:
-    """Check whether value derives from a pydantic.BaseModel."""
+    """Check if value derives from a pydantic.BaseModel."""
     return _check_for_pydantic(value) and isinstance(value, pydantic.BaseModel)
 
 
-def is_sqlalchemy(value: Any) -> bool:
-    """Check whether value is an instance of a SQLAlchemy object."""
-    return getattr(value, "__module__", "").startswith("sqlalchemy.")
+def is_sqlalchemy_row(value: Any) -> bool:
+    """Check if value is an instance of a SQLAlchemy sequence or mapping object."""
+    return getattr(value, "__module__", "").startswith("sqlalchemy.") and isinstance(
+        value, Sequence
+    )
 
 
 def get_first_non_none(values: Sequence[Any | None]) -> Any:


### PR DESCRIPTION
Added a path for `from_records` (and DataFrame/Series construction) that can handle conversion from`PyMapping` in the Rust/pyO3 layer (currently we only handle `PyDict`).

This opens up efficient init from other useful Python record types that _look_ like dicts to the caller (and support the `Mapping` protocol), but that we couldn't load as such.

**Also:**
Fixes two long-standing errors with `from_records`, adding test coverage for both -

1) Incorrectly loading as Struct if the _first_ record was a `None` value.
2) Failing to load _at all_ if a `None` value was present _after_ the first element.
  `TypeError: 'NoneType' object cannot be converted to 'PyDict'`

**And:** 
Optimises `PyDict` value lookup (by precomputing the keys as `PyString` so we don't create them in the row-building loop).

## Example 
```python
from collections.abc import Mapping
from typing import Any, Iterator

class MappingDict(Mapping):
    def __init__(self, **values: Any) -> None:
        self._data = {**values}

    def __getitem__(self, key: str) -> Any:
        return self._data[key]

    def __iter__(self) -> Iterator[str]:
        yield from self._data

    def __len__(self) -> int:
        return len(self._data)

mapping_data = [
    MappingDict(Name="Alice", Age=38, DOB=date(1987,3,5)),
    MappingDict(Name="Bob", Age=20, DOB=date(2005,5,2)),
    MappingDict(Name="Charles", Age=32, DOB=date(1993,1,18)),
] * 100_000

dict_data = [dict(d) for d in mapping_data]
```
### Timings 🕐  
_(tested with local `make build-dist-release` binary)_

Having native conversion allows us to ingest `Mapping` data **2x faster** than having the user convert it to `dict` themselves. We retain the separate `dict` fast-path, which remains optimal.
```python
%timeit df = pl.from_records([dict(d) for d in mapping_data])
# 241 ms ± 2.08 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit df = pl.from_records(mapping_data)
# 124 ms ± 1.98 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit df = pl.from_records(dict_data)
# 79.7 ms ± 1.74 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```