### PR TITLE
refactor(rust): Use named fields for Logical

### DIFF
--- a/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
@@ -7,7 +7,7 @@ impl Add for &DecimalChunked {
         let scale = _get_decimal_scale_add_sub(self.scale(), rhs.scale());
         let lhs = self.to_scale(scale)?;
         let rhs = rhs.to_scale(scale)?;
-        Ok((&lhs.0 + &rhs.0).into_decimal_unchecked(None, scale))
+        Ok((&lhs.phys + &rhs.phys).into_decimal_unchecked(None, scale))
     }
 }
 
@@ -18,7 +18,7 @@ impl Sub for &DecimalChunked {
         let scale = _get_decimal_scale_add_sub(self.scale(), rhs.scale());
         let lhs = self.to_scale(scale)?;
         let rhs = rhs.to_scale(scale)?;
-        Ok((&lhs.0 - &rhs.0).into_decimal_unchecked(None, scale))
+        Ok((&lhs.phys - &rhs.phys).into_decimal_unchecked(None, scale))
     }
 }
 
@@ -27,7 +27,7 @@ impl Mul for &DecimalChunked {
 
     fn mul(self, rhs: Self) -> Self::Output {
         let scale = _get_decimal_scale_mul(self.scale(), rhs.scale());
-        Ok((&self.0 * &rhs.0).into_decimal_unchecked(None, scale))
+        Ok((&self.phys * &rhs.phys).into_decimal_unchecked(None, scale))
     }
 }
 
@@ -37,7 +37,7 @@ impl Div for &DecimalChunked {
     fn div(self, rhs: Self) -> Self::Output {
         let scale = _get_decimal_scale_div(self.scale());
         let lhs = self.to_scale(scale + rhs.scale())?;
-        Ok((&lhs.0 / &rhs.0).into_decimal_unchecked(None, scale))
+        Ok((&lhs.phys / &rhs.phys).into_decimal_unchecked(None, scale))
     }
 }
 

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -60,7 +60,7 @@ impl CategoricalChunked {
 
     /// Get the physical array (the category indexes).
     pub fn into_physical(self) -> UInt32Chunked {
-        self.physical.0
+        self.physical.phys
     }
 
     // TODO: Rename this
@@ -87,7 +87,7 @@ impl CategoricalChunked {
             RevMapping::Local(_, _) => {
                 // Change dtype from Enum to Categorical
                 let mut local = self.clone();
-                local.physical.2 = Some(DataType::Categorical(
+                local.physical.dtype = Some(DataType::Categorical(
                     Some(rev_map.clone()),
                     self.get_ordering(),
                 ));
@@ -208,7 +208,7 @@ impl CategoricalChunked {
 
     pub fn get_ordering(&self) -> CategoricalOrdering {
         if let DataType::Categorical(_, ordering) | DataType::Enum(_, ordering) =
-            &self.physical.2.as_ref().unwrap()
+            &self.physical.dtype.as_ref().unwrap()
         {
             *ordering
         } else {
@@ -227,7 +227,7 @@ impl CategoricalChunked {
             DataType::Enum { .. } | DataType::Categorical { .. }
         ));
         let mut logical = Logical::<UInt32Type, _>::new_logical::<CategoricalType>(idx);
-        logical.2 = Some(dtype);
+        logical.dtype = Some(dtype);
         Self {
             physical: logical,
             bit_settings: Default::default(),
@@ -246,9 +246,9 @@ impl CategoricalChunked {
     ) -> Self {
         let mut logical = Logical::<UInt32Type, _>::new_logical::<CategoricalType>(idx);
         if is_enum {
-            logical.2 = Some(DataType::Enum(Some(rev_map), ordering));
+            logical.dtype = Some(DataType::Enum(Some(rev_map), ordering));
         } else {
-            logical.2 = Some(DataType::Categorical(Some(rev_map), ordering));
+            logical.dtype = Some(DataType::Categorical(Some(rev_map), ordering));
         }
         Self {
             physical: logical,
@@ -261,7 +261,7 @@ impl CategoricalChunked {
         ordering: CategoricalOrdering,
         keep_fast_unique: bool,
     ) -> Self {
-        self.physical.2 = match self.dtype() {
+        self.physical.dtype = match self.dtype() {
             DataType::Enum(_, _) => {
                 Some(DataType::Enum(Some(self.get_rev_map().clone()), ordering))
             },
@@ -281,7 +281,7 @@ impl CategoricalChunked {
     /// # Safety
     /// The existing index values must be in bounds of the new [`RevMapping`].
     pub(crate) unsafe fn set_rev_map(&mut self, rev_map: Arc<RevMapping>, keep_fast_unique: bool) {
-        self.physical.2 = match self.dtype() {
+        self.physical.dtype = match self.dtype() {
             DataType::Enum(_, _) => Some(DataType::Enum(Some(rev_map), self.get_ordering())),
             DataType::Categorical(_, _) => {
                 Some(DataType::Categorical(Some(rev_map), self.get_ordering()))
@@ -328,7 +328,7 @@ impl CategoricalChunked {
     /// Get a reference to the mapping of categorical types to the string values.
     pub fn get_rev_map(&self) -> &Arc<RevMapping> {
         if let DataType::Categorical(Some(rev_map), _) | DataType::Enum(Some(rev_map), _) =
-            &self.physical.2.as_ref().unwrap()
+            &self.physical.dtype.as_ref().unwrap()
         {
             rev_map
         } else {
@@ -348,7 +348,7 @@ impl CategoricalChunked {
 
 impl LogicalType for CategoricalChunked {
     fn dtype(&self) -> &DataType {
-        self.physical.2.as_ref().unwrap()
+        self.physical.dtype.as_ref().unwrap()
     }
 
     fn get_any_value(&self, i: usize) -> PolarsResult<AnyValue<'_>> {
@@ -357,7 +357,7 @@ impl LogicalType for CategoricalChunked {
     }
 
     unsafe fn get_any_value_unchecked(&self, i: usize) -> AnyValue<'_> {
-        match self.physical.0.get_unchecked(i) {
+        match self.physical.phys.get_unchecked(i) {
             Some(i) => match self.dtype() {
                 DataType::Enum(_, _) => AnyValue::Enum(i, self.get_rev_map(), SyncPtr::new_null()),
                 DataType::Categorical(_, _) => {

--- a/crates/polars-core/src/chunked_array/logical/date.rs
+++ b/crates/polars-core/src/chunked_array/logical/date.rs
@@ -20,11 +20,11 @@ impl LogicalType for DateChunked {
     }
 
     fn get_any_value(&self, i: usize) -> PolarsResult<AnyValue<'_>> {
-        self.0.get_any_value(i).map(|av| av.as_date())
+        self.phys.get_any_value(i).map(|av| av.as_date())
     }
 
     unsafe fn get_any_value_unchecked(&self, i: usize) -> AnyValue<'_> {
-        self.0.get_any_value_unchecked(i).as_date()
+        self.phys.get_any_value_unchecked(i).as_date()
     }
 
     fn cast_with_options(
@@ -37,7 +37,7 @@ impl LogicalType for DateChunked {
             Date => Ok(self.clone().into_series()),
             #[cfg(feature = "dtype-datetime")]
             Datetime(tu, tz) => {
-                let casted = self.0.cast_with_options(dtype, cast_options)?;
+                let casted = self.phys.cast_with_options(dtype, cast_options)?;
                 let casted = casted.datetime().unwrap();
                 let conversion = match tu {
                     TimeUnit::Nanoseconds => NS_IN_DAY,
@@ -48,7 +48,7 @@ impl LogicalType for DateChunked {
                     .into_datetime(*tu, tz.clone())
                     .into_series())
             },
-            dt if dt.is_primitive_numeric() => self.0.cast_with_options(dtype, cast_options),
+            dt if dt.is_primitive_numeric() => self.phys.cast_with_options(dtype, cast_options),
             dt => {
                 polars_bail!(
                     InvalidOperation:

--- a/crates/polars-core/src/chunked_array/logical/datetime.rs
+++ b/crates/polars-core/src/chunked_array/logical/datetime.rs
@@ -7,24 +7,24 @@ pub type DatetimeChunked = Logical<DatetimeType, Int64Type>;
 impl Int64Chunked {
     pub fn into_datetime(self, timeunit: TimeUnit, tz: Option<TimeZone>) -> DatetimeChunked {
         let mut dt = DatetimeChunked::new_logical(self);
-        dt.2 = Some(DataType::Datetime(timeunit, tz));
+        dt.dtype = Some(DataType::Datetime(timeunit, tz));
         dt
     }
 }
 
 impl LogicalType for DatetimeChunked {
     fn dtype(&self) -> &DataType {
-        self.2.as_ref().unwrap()
+        self.dtype.as_ref().unwrap()
     }
 
     fn get_any_value(&self, i: usize) -> PolarsResult<AnyValue<'_>> {
-        self.0
+        self.phys
             .get_any_value(i)
             .map(|av| av.as_datetime(self.time_unit(), self.time_zone().as_ref()))
     }
 
     unsafe fn get_any_value_unchecked(&self, i: usize) -> AnyValue<'_> {
-        self.0
+        self.phys
             .get_any_value_unchecked(i)
             .as_datetime(self.time_unit(), self.time_zone().as_ref())
     }
@@ -50,17 +50,17 @@ impl LogicalType for DatetimeChunked {
                     (Nanoseconds, Milliseconds) => (None, Some(1_000_000i64)),
                     (Nanoseconds, Microseconds) => (None, Some(1_000i64)),
                     (Microseconds, Milliseconds) => (None, Some(1_000i64)),
-                    _ => return self.0.cast_with_options(dtype, cast_options),
+                    _ => return self.phys.cast_with_options(dtype, cast_options),
                 };
                 match multiplier {
                     // scale to higher precision (eg: ms → us, ms → ns, us → ns)
-                    Some(m) => Ok((self.0.as_ref() * m)
+                    Some(m) => Ok((self.phys.as_ref() * m)
                         .into_datetime(*to_unit, tz.clone())
                         .into_series()),
                     // scale to lower precision (eg: ns → us, ns → ms, us → ms)
                     None => match divisor {
                         Some(d) => Ok(self
-                            .0
+                            .phys
                             .apply_values(|v| v.div_euclid(d))
                             .into_datetime(*to_unit, tz.clone())
                             .into_series()),
@@ -72,7 +72,7 @@ impl LogicalType for DatetimeChunked {
             Date => {
                 let cast_to_date = |tu_in_day: i64| {
                     let mut dt = self
-                        .0
+                        .phys
                         .apply_values(|v| v.div_euclid(tu_in_day))
                         .cast_with_options(&Int32, cast_options)
                         .unwrap()
@@ -95,7 +95,7 @@ impl LogicalType for DatetimeChunked {
                     Milliseconds => (MS_IN_DAY, 1_000_000i64),
                 };
                 return Ok(self
-                    .0
+                    .phys
                     .apply_values(|v| {
                         let t = v % scaled_mod * multiplier;
                         t + (NS_IN_DAY * (t < 0) as i64)
@@ -104,7 +104,7 @@ impl LogicalType for DatetimeChunked {
                     .into_series());
             },
             dt if dt.is_primitive_numeric() => {
-                return self.0.cast_with_options(dtype, cast_options);
+                return self.phys.cast_with_options(dtype, cast_options);
             },
             dt => {
                 polars_bail!(

--- a/crates/polars-core/src/chunked_array/logical/decimal.rs
+++ b/crates/polars-core/src/chunked_array/logical/decimal.rs
@@ -10,7 +10,7 @@ impl Int128Chunked {
     #[inline]
     pub fn into_decimal_unchecked(self, precision: Option<usize>, scale: usize) -> DecimalChunked {
         let mut dt = DecimalChunked::new_logical(self);
-        dt.2 = Some(DataType::Decimal(precision, Some(scale)));
+        dt.dtype = Some(DataType::Decimal(precision, Some(scale)));
         dt
     }
 
@@ -38,7 +38,7 @@ impl Int128Chunked {
 
 impl LogicalType for DecimalChunked {
     fn dtype(&self) -> &DataType {
-        self.2.as_ref().unwrap()
+        self.dtype.as_ref().unwrap()
     }
 
     #[inline]
@@ -49,7 +49,7 @@ impl LogicalType for DecimalChunked {
 
     #[inline]
     unsafe fn get_any_value_unchecked(&self, i: usize) -> AnyValue<'_> {
-        match self.0.get_unchecked(i) {
+        match self.phys.get_unchecked(i) {
             Some(v) => AnyValue::Decimal(v, self.scale()),
             None => AnyValue::Null,
         }
@@ -95,14 +95,14 @@ impl LogicalType for DecimalChunked {
 
 impl DecimalChunked {
     pub fn precision(&self) -> Option<usize> {
-        match self.2.as_ref().unwrap() {
+        match self.dtype.as_ref().unwrap() {
             DataType::Decimal(precision, _) => *precision,
             _ => unreachable!(),
         }
     }
 
     pub fn scale(&self) -> usize {
-        match self.2.as_ref().unwrap() {
+        match self.dtype.as_ref().unwrap() {
             DataType::Decimal(_, scale) => scale.unwrap_or_else(|| unreachable!()),
             _ => unreachable!(),
         }

--- a/crates/polars-core/src/chunked_array/logical/duration.rs
+++ b/crates/polars-core/src/chunked_array/logical/duration.rs
@@ -6,23 +6,23 @@ pub type DurationChunked = Logical<DurationType, Int64Type>;
 impl Int64Chunked {
     pub fn into_duration(self, timeunit: TimeUnit) -> DurationChunked {
         let mut dt = DurationChunked::new_logical(self);
-        dt.2 = Some(DataType::Duration(timeunit));
+        dt.dtype = Some(DataType::Duration(timeunit));
         dt
     }
 }
 
 impl LogicalType for DurationChunked {
     fn dtype(&self) -> &DataType {
-        self.2.as_ref().unwrap()
+        self.dtype.as_ref().unwrap()
     }
 
     fn get_any_value(&self, i: usize) -> PolarsResult<AnyValue<'_>> {
-        self.0
+        self.phys
             .get_any_value(i)
             .map(|av| av.as_duration(self.time_unit()))
     }
     unsafe fn get_any_value_unchecked(&self, i: usize) -> AnyValue<'_> {
-        self.0
+        self.phys
             .get_any_value_unchecked(i)
             .as_duration(self.time_unit())
     }
@@ -39,23 +39,23 @@ impl LogicalType for DurationChunked {
             Duration(tu) => {
                 let to_unit = *tu;
                 let out = match (self.time_unit(), to_unit) {
-                    (Milliseconds, Microseconds) => self.0.as_ref() * 1_000i64,
-                    (Milliseconds, Nanoseconds) => self.0.as_ref() * 1_000_000i64,
+                    (Milliseconds, Microseconds) => self.phys.as_ref() * 1_000i64,
+                    (Milliseconds, Nanoseconds) => self.phys.as_ref() * 1_000_000i64,
                     (Microseconds, Milliseconds) => {
-                        self.0.as_ref().wrapping_trunc_div_scalar(1_000i64)
+                        self.phys.as_ref().wrapping_trunc_div_scalar(1_000i64)
                     },
-                    (Microseconds, Nanoseconds) => self.0.as_ref() * 1_000i64,
+                    (Microseconds, Nanoseconds) => self.phys.as_ref() * 1_000i64,
                     (Nanoseconds, Milliseconds) => {
-                        self.0.as_ref().wrapping_trunc_div_scalar(1_000_000i64)
+                        self.phys.as_ref().wrapping_trunc_div_scalar(1_000_000i64)
                     },
                     (Nanoseconds, Microseconds) => {
-                        self.0.as_ref().wrapping_trunc_div_scalar(1_000i64)
+                        self.phys.as_ref().wrapping_trunc_div_scalar(1_000i64)
                     },
                     _ => return Ok(self.clone().into_series()),
                 };
                 Ok(out.into_duration(to_unit).into_series())
             },
-            dt if dt.is_primitive_numeric() => self.0.cast_with_options(dtype, cast_options),
+            dt if dt.is_primitive_numeric() => self.phys.cast_with_options(dtype, cast_options),
             dt => {
                 polars_bail!(
                     InvalidOperation:

--- a/crates/polars-core/src/chunked_array/logical/time.rs
+++ b/crates/polars-core/src/chunked_array/logical/time.rs
@@ -59,10 +59,10 @@ impl LogicalType for TimeChunked {
 
     #[cfg(feature = "dtype-time")]
     fn get_any_value(&self, i: usize) -> PolarsResult<AnyValue<'_>> {
-        self.0.get_any_value(i).map(|av| av.as_time())
+        self.phys.get_any_value(i).map(|av| av.as_time())
     }
     unsafe fn get_any_value_unchecked(&self, i: usize) -> AnyValue<'_> {
-        self.0.get_any_value_unchecked(i).as_time()
+        self.phys.get_any_value_unchecked(i).as_time()
     }
 
     fn cast_with_options(
@@ -76,7 +76,7 @@ impl LogicalType for TimeChunked {
             #[cfg(feature = "dtype-duration")]
             Duration(tu) => {
                 let out = self
-                    .0
+                    .phys
                     .cast_with_options(&DataType::Duration(TimeUnit::Nanoseconds), cast_options);
                 if !matches!(tu, TimeUnit::Nanoseconds) {
                     out?.cast_with_options(dtype, cast_options)
@@ -92,7 +92,7 @@ impl LogicalType for TimeChunked {
                     self.dtype(), dtype
                 )
             },
-            dt if dt.is_primitive_numeric() => self.0.cast_with_options(dtype, cast_options),
+            dt if dt.is_primitive_numeric() => self.phys.cast_with_options(dtype, cast_options),
             _ => {
                 polars_bail!(
                     InvalidOperation:

--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -26,14 +26,14 @@ impl DatetimeChunked {
     }
 
     pub fn time_unit(&self) -> TimeUnit {
-        match self.2.as_ref().unwrap() {
+        match self.dtype.as_ref().unwrap() {
             DataType::Datetime(tu, _) => *tu,
             _ => unreachable!(),
         }
     }
 
     pub fn time_zone(&self) -> &Option<TimeZone> {
-        match self.2.as_ref().unwrap() {
+        match self.dtype.as_ref().unwrap() {
             DataType::Datetime(_, tz) => tz,
             _ => unreachable!(),
         }
@@ -123,33 +123,33 @@ impl DatetimeChunked {
         use crate::datatypes::time_unit::TimeUnit::*;
         match (current_unit, tu) {
             (Nanoseconds, Microseconds) => {
-                let ca = (&self.0).wrapping_floor_div_scalar(1_000);
-                out.0 = ca;
+                let ca = (&self.phys).wrapping_floor_div_scalar(1_000);
+                out.phys = ca;
                 out
             },
             (Nanoseconds, Milliseconds) => {
-                let ca = (&self.0).wrapping_floor_div_scalar(1_000_000);
-                out.0 = ca;
+                let ca = (&self.phys).wrapping_floor_div_scalar(1_000_000);
+                out.phys = ca;
                 out
             },
             (Microseconds, Nanoseconds) => {
-                let ca = &self.0 * 1_000;
-                out.0 = ca;
+                let ca = &self.phys * 1_000;
+                out.phys = ca;
                 out
             },
             (Microseconds, Milliseconds) => {
-                let ca = (&self.0).wrapping_floor_div_scalar(1_000);
-                out.0 = ca;
+                let ca = (&self.phys).wrapping_floor_div_scalar(1_000);
+                out.phys = ca;
                 out
             },
             (Milliseconds, Nanoseconds) => {
-                let ca = &self.0 * 1_000_000;
-                out.0 = ca;
+                let ca = &self.phys * 1_000_000;
+                out.phys = ca;
                 out
             },
             (Milliseconds, Microseconds) => {
-                let ca = &self.0 * 1_000;
-                out.0 = ca;
+                let ca = &self.phys * 1_000;
+                out.phys = ca;
                 out
             },
             (Nanoseconds, Nanoseconds)
@@ -160,7 +160,7 @@ impl DatetimeChunked {
 
     /// Change the underlying [`TimeUnit`]. This does not modify the data.
     pub fn set_time_unit(&mut self, time_unit: TimeUnit) {
-        self.2 = Some(Datetime(time_unit, self.time_zone().clone()))
+        self.dtype = Some(Datetime(time_unit, self.time_zone().clone()))
     }
 
     /// Change the underlying [`TimeZone`]. This does not modify the data.
@@ -168,7 +168,7 @@ impl DatetimeChunked {
     /// already been validated.
     #[cfg(feature = "timezones")]
     pub fn set_time_zone(&mut self, time_zone: TimeZone) -> PolarsResult<()> {
-        self.2 = Some(Datetime(self.time_unit(), Some(time_zone)));
+        self.dtype = Some(Datetime(self.time_unit(), Some(time_zone)));
         Ok(())
     }
 
@@ -181,7 +181,7 @@ impl DatetimeChunked {
         time_unit: TimeUnit,
         time_zone: TimeZone,
     ) -> PolarsResult<()> {
-        self.2 = Some(Datetime(time_unit, Some(time_zone)));
+        self.dtype = Some(Datetime(time_unit, Some(time_zone)));
         Ok(())
     }
 }

--- a/crates/polars-core/src/chunked_array/temporal/duration.rs
+++ b/crates/polars-core/src/chunked_array/temporal/duration.rs
@@ -6,7 +6,7 @@ use crate::prelude::*;
 
 impl DurationChunked {
     pub fn time_unit(&self) -> TimeUnit {
-        match self.2.as_ref().unwrap() {
+        match self.dtype.as_ref().unwrap() {
             DataType::Duration(tu) => *tu,
             _ => unreachable!(),
         }
@@ -22,33 +22,33 @@ impl DurationChunked {
         use crate::datatypes::time_unit::TimeUnit::*;
         match (current_unit, tu) {
             (Nanoseconds, Microseconds) => {
-                let ca = (&self.0).wrapping_trunc_div_scalar(1_000);
-                out.0 = ca;
+                let ca = (&self.phys).wrapping_trunc_div_scalar(1_000);
+                out.phys = ca;
                 out
             },
             (Nanoseconds, Milliseconds) => {
-                let ca = (&self.0).wrapping_trunc_div_scalar(1_000_000);
-                out.0 = ca;
+                let ca = (&self.phys).wrapping_trunc_div_scalar(1_000_000);
+                out.phys = ca;
                 out
             },
             (Microseconds, Nanoseconds) => {
-                let ca = &self.0 * 1_000;
-                out.0 = ca;
+                let ca = &self.phys * 1_000;
+                out.phys = ca;
                 out
             },
             (Microseconds, Milliseconds) => {
-                let ca = (&self.0).wrapping_trunc_div_scalar(1_000);
-                out.0 = ca;
+                let ca = (&self.phys).wrapping_trunc_div_scalar(1_000);
+                out.phys = ca;
                 out
             },
             (Milliseconds, Nanoseconds) => {
-                let ca = &self.0 * 1_000_000;
-                out.0 = ca;
+                let ca = &self.phys * 1_000_000;
+                out.phys = ca;
                 out
             },
             (Milliseconds, Microseconds) => {
-                let ca = &self.0 * 1_000;
-                out.0 = ca;
+                let ca = &self.phys * 1_000;
+                out.phys = ca;
                 out
             },
             (Nanoseconds, Nanoseconds)
@@ -59,7 +59,7 @@ impl DurationChunked {
 
     /// Change the underlying [`TimeUnit`]. This does not modify the data.
     pub fn set_time_unit(&mut self, tu: TimeUnit) {
-        self.2 = Some(Duration(tu))
+        self.dtype = Some(Duration(tu))
     }
 
     /// Convert from [`Duration`] to String; note that `strftime` format
@@ -70,7 +70,7 @@ impl DurationChunked {
         match format {
             "iso" | "iso:strict" => {
                 let out: StringChunked =
-                    self.0
+                    self.phys
                         .apply_nonnull_values_generic(DataType::String, |v: i64| {
                             s.clear();
                             iso_duration_string(&mut s, v, self.time_unit());
@@ -80,7 +80,7 @@ impl DurationChunked {
             },
             "polars" => {
                 let out: StringChunked =
-                    self.0
+                    self.phys
                         .apply_nonnull_values_generic(DataType::String, |v: i64| {
                             s.clear();
                             fmt_duration_string(&mut s, v, self.time_unit())

--- a/crates/polars-core/src/series/implementations/date.rs
+++ b/crates/polars-core/src/series/implementations/date.rs
@@ -207,7 +207,7 @@ impl SeriesTrait for SeriesWrap<DateChunked> {
                 .as_any_mut()
                 .downcast_mut::<DateChunked>()
                 .unwrap()
-                .0,
+                .phys,
         ))
     }
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -215,7 +215,7 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
                 .as_any_mut()
                 .downcast_mut::<DatetimeChunked>()
                 .unwrap()
-                .0,
+                .phys,
         ))
     }
 

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -247,7 +247,7 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
                 .as_any_mut()
                 .downcast_mut::<DecimalChunked>()
                 .unwrap()
-                .0,
+                .phys,
         ))
     }
 

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -183,7 +183,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     fn multiply(&self, rhs: &Series) -> PolarsResult<Series> {
         let tul = self.0.time_unit();
         match rhs.dtype() {
-            DataType::Int64 => Ok((&self.0.0 * rhs.i64().unwrap())
+            DataType::Int64 => Ok((&self.0.phys * rhs.i64().unwrap())
                 .into_duration(tul)
                 .into_series()),
             dt if dt.is_integer() => {
@@ -191,7 +191,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
                 self.multiply(&rhs)
             },
             dt if dt.is_float() => {
-                let phys = &self.0.0;
+                let phys = &self.0.phys;
                 let phys_float = phys.cast(dt).unwrap();
                 let out = std::ops::Mul::mul(&phys_float, rhs)?
                     .cast(&DataType::Int64)
@@ -211,8 +211,12 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
                 if tul == *tur {
                     // Returns a constant as f64.
                     Ok(std::ops::Div::div(
-                        &self.0.0.cast(&DataType::Float64).unwrap(),
-                        &rhs.duration().unwrap().0.cast(&DataType::Float64).unwrap(),
+                        &self.0.phys.cast(&DataType::Float64).unwrap(),
+                        &rhs.duration()
+                            .unwrap()
+                            .phys
+                            .cast(&DataType::Float64)
+                            .unwrap(),
                     )?
                     .into_series())
                 } else {
@@ -220,7 +224,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
                     self.divide(&rhs)
                 }
             },
-            DataType::Int64 => Ok((&self.0.0 / rhs.i64().unwrap())
+            DataType::Int64 => Ok((&self.0.phys / rhs.i64().unwrap())
                 .into_duration(tul)
                 .into_series()),
             dt if dt.is_integer() => {
@@ -228,7 +232,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
                 self.divide(&rhs)
             },
             dt if dt.is_float() => {
-                let phys = &self.0.0;
+                let phys = &self.0.phys;
                 let phys_float = phys.cast(dt).unwrap();
                 let out = std::ops::Div::div(&phys_float, rhs)?
                     .cast(&DataType::Int64)
@@ -335,7 +339,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
                 .as_any_mut()
                 .downcast_mut::<DurationChunked>()
                 .unwrap()
-                .0,
+                .phys,
         ))
     }
 

--- a/crates/polars-core/src/series/implementations/time.rs
+++ b/crates/polars-core/src/series/implementations/time.rs
@@ -189,7 +189,7 @@ impl SeriesTrait for SeriesWrap<TimeChunked> {
                 .as_any_mut()
                 .downcast_mut::<TimeChunked>()
                 .unwrap()
-                .0,
+                .phys,
         ))
     }
 

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -724,20 +724,20 @@ impl Series {
             // NOTE: Don't use cast here, as it might rechunk (if all nulls)
             // which is not allowed in a phys repr.
             #[cfg(feature = "dtype-date")]
-            Date => Cow::Owned(self.date().unwrap().0.clone().into_series()),
+            Date => Cow::Owned(self.date().unwrap().phys.clone().into_series()),
             #[cfg(feature = "dtype-datetime")]
-            Datetime(_, _) => Cow::Owned(self.datetime().unwrap().0.clone().into_series()),
+            Datetime(_, _) => Cow::Owned(self.datetime().unwrap().phys.clone().into_series()),
             #[cfg(feature = "dtype-duration")]
-            Duration(_) => Cow::Owned(self.duration().unwrap().0.clone().into_series()),
+            Duration(_) => Cow::Owned(self.duration().unwrap().phys.clone().into_series()),
             #[cfg(feature = "dtype-time")]
-            Time => Cow::Owned(self.time().unwrap().0.clone().into_series()),
+            Time => Cow::Owned(self.time().unwrap().phys.clone().into_series()),
             #[cfg(feature = "dtype-categorical")]
             Categorical(_, _) | Enum(_, _) => {
                 let ca = self.categorical().unwrap();
                 Cow::Owned(ca.physical().clone().into_series())
             },
             #[cfg(feature = "dtype-decimal")]
-            Decimal(_, _) => Cow::Owned(self.decimal().unwrap().0.clone().into_series()),
+            Decimal(_, _) => Cow::Owned(self.decimal().unwrap().phys.clone().into_series()),
             List(_) => match self.list().unwrap().to_physical_repr() {
                 Cow::Borrowed(_) => Cow::Borrowed(self),
                 Cow::Owned(ca) => Cow::Owned(ca.into_series()),

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -29,7 +29,7 @@ pub fn replace_time_zone(
         & ((from_tz == UTC) | ((ambiguous.len() == 1) & (ambiguous.get(0) == Some("raise"))))
     {
         let mut out = datetime
-            .0
+            .phys
             .clone()
             .into_datetime(datetime.time_unit(), time_zone.cloned());
         out.set_sorted_flag(datetime.is_sorted_flag());
@@ -93,7 +93,7 @@ pub fn impl_replace_time_zone_fast(
     to_tz: &chrono_tz::Tz,
 ) -> PolarsResult<Int64Chunked> {
     match ambiguous {
-        Some(ambiguous) => datetime.0.try_apply_nonnull_values_generic(|timestamp| {
+        Some(ambiguous) => datetime.phys.try_apply_nonnull_values_generic(|timestamp| {
             let ndt = timestamp_to_datetime(timestamp);
             Ok(datetime_to_timestamp(
                 convert_to_naive_local(
@@ -106,7 +106,7 @@ pub fn impl_replace_time_zone_fast(
                 .expect("we didn't use Ambiguous::Null or NonExistent::Null"),
             ))
         }),
-        _ => Ok(datetime.0.apply(|_| None)),
+        _ => Ok(datetime.phys.apply(|_| None)),
     }
 }
 
@@ -121,7 +121,7 @@ pub fn impl_replace_time_zone(
 ) -> PolarsResult<Int64Chunked> {
     match ambiguous.len() {
         1 => {
-            let iter = datetime.0.downcast_iter().map(|arr| {
+            let iter = datetime.phys.downcast_iter().map(|arr| {
                 let element_iter = arr.iter().map(|timestamp_opt| match timestamp_opt {
                     Some(timestamp) => {
                         let ndt = timestamp_to_datetime(*timestamp);
@@ -138,7 +138,7 @@ pub fn impl_replace_time_zone(
                 });
                 element_iter.try_collect_arr()
             });
-            ChunkedArray::try_from_chunk_iter(datetime.0.name().clone(), iter)
+            ChunkedArray::try_from_chunk_iter(datetime.phys.name().clone(), iter)
         },
         _ => try_binary_elementwise(datetime, ambiguous, |timestamp_opt, ambiguous_opt| {
             match (timestamp_opt, ambiguous_opt) {

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -182,7 +182,7 @@ impl TakeChunked for Series {
             #[cfg(feature = "dtype-decimal")]
             Decimal(_, _) => {
                 let ca = self.decimal().unwrap();
-                let out = ca.0.take_chunked_unchecked(by, sorted, avoid_sharing);
+                let out = ca.phys.take_chunked_unchecked(by, sorted, avoid_sharing);
                 out.into_decimal_unchecked(ca.precision(), ca.scale())
                     .into_series()
             },
@@ -285,7 +285,7 @@ impl TakeChunked for Series {
             #[cfg(feature = "dtype-decimal")]
             Decimal(_, _) => {
                 let ca = self.decimal().unwrap();
-                let out = ca.0.take_opt_chunked_unchecked(by, avoid_sharing);
+                let out = ca.phys.take_opt_chunked_unchecked(by, avoid_sharing);
                 out.into_decimal_unchecked(ca.precision(), ca.scale())
                     .into_series()
             },

--- a/crates/polars-python/src/conversion/chunked_array.rs
+++ b/crates/polars-python/src/conversion/chunked_array.rs
@@ -101,7 +101,8 @@ impl<'py> IntoPyObject<'py> for &Wrap<&TimeChunked> {
 pub(crate) fn time_to_pyobject_iter(
     ca: &TimeChunked,
 ) -> impl '_ + ExactSizeIterator<Item = Option<NaiveTime>> {
-    ca.0.iter()
+    ca.phys
+        .iter()
         .map(move |opt_v| opt_v.map(nanos_since_midnight_to_naivetime))
 }
 

--- a/crates/polars-time/src/base_utc_offset.rs
+++ b/crates/polars-time/src/base_utc_offset.rs
@@ -21,10 +21,11 @@ pub fn base_utc_offset(
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
     };
-    ca.0.apply_values(|t| {
-        let ndt = timestamp_to_datetime(t);
-        let dt = time_zone.from_utc_datetime(&ndt);
-        dt.offset().base_utc_offset().num_milliseconds()
-    })
-    .into_duration(TimeUnit::Milliseconds)
+    ca.phys
+        .apply_values(|t| {
+            let ndt = timestamp_to_datetime(t);
+            let dt = time_zone.from_utc_datetime(&ndt);
+            dt.offset().base_utc_offset().num_milliseconds()
+        })
+        .into_duration(TimeUnit::Milliseconds)
 }

--- a/crates/polars-time/src/chunkedarray/duration.rs
+++ b/crates/polars-time/src/chunkedarray/duration.rs
@@ -35,13 +35,13 @@ impl DurationMethods for DurationChunked {
     fn hours(&self) -> Int64Chunked {
         match self.time_unit() {
             TimeUnit::Milliseconds => {
-                (&self.0).wrapping_trunc_div_scalar(MILLISECONDS * SECONDS_IN_HOUR)
+                (&self.phys).wrapping_trunc_div_scalar(MILLISECONDS * SECONDS_IN_HOUR)
             },
             TimeUnit::Microseconds => {
-                (&self.0).wrapping_trunc_div_scalar(MICROSECONDS * SECONDS_IN_HOUR)
+                (&self.phys).wrapping_trunc_div_scalar(MICROSECONDS * SECONDS_IN_HOUR)
             },
             TimeUnit::Nanoseconds => {
-                (&self.0).wrapping_trunc_div_scalar(NANOSECONDS * SECONDS_IN_HOUR)
+                (&self.phys).wrapping_trunc_div_scalar(NANOSECONDS * SECONDS_IN_HOUR)
             },
         }
     }
@@ -49,12 +49,12 @@ impl DurationMethods for DurationChunked {
     /// Extract the days from a `Duration`
     fn days(&self) -> Int64Chunked {
         match self.time_unit() {
-            TimeUnit::Milliseconds => (&self.0).wrapping_trunc_div_scalar(MILLISECONDS_IN_DAY),
+            TimeUnit::Milliseconds => (&self.phys).wrapping_trunc_div_scalar(MILLISECONDS_IN_DAY),
             TimeUnit::Microseconds => {
-                (&self.0).wrapping_trunc_div_scalar(MICROSECONDS * SECONDS_IN_DAY)
+                (&self.phys).wrapping_trunc_div_scalar(MICROSECONDS * SECONDS_IN_DAY)
             },
             TimeUnit::Nanoseconds => {
-                (&self.0).wrapping_trunc_div_scalar(NANOSECONDS * SECONDS_IN_DAY)
+                (&self.phys).wrapping_trunc_div_scalar(NANOSECONDS * SECONDS_IN_DAY)
             },
         }
     }
@@ -66,7 +66,7 @@ impl DurationMethods for DurationChunked {
             TimeUnit::Microseconds => MICROSECONDS,
             TimeUnit::Nanoseconds => NANOSECONDS,
         };
-        (&self.0).wrapping_trunc_div_scalar(tu * 60)
+        (&self.phys).wrapping_trunc_div_scalar(tu * 60)
     }
 
     /// Extract the seconds from a `Duration`
@@ -76,34 +76,34 @@ impl DurationMethods for DurationChunked {
             TimeUnit::Microseconds => MICROSECONDS,
             TimeUnit::Nanoseconds => NANOSECONDS,
         };
-        (&self.0).wrapping_trunc_div_scalar(tu)
+        (&self.phys).wrapping_trunc_div_scalar(tu)
     }
 
     /// Extract the milliseconds from a `Duration`
     fn milliseconds(&self) -> Int64Chunked {
         let t = match self.time_unit() {
-            TimeUnit::Milliseconds => return self.0.clone(),
+            TimeUnit::Milliseconds => return self.phys.clone(),
             TimeUnit::Microseconds => 1000,
             TimeUnit::Nanoseconds => NANOSECONDS_IN_MILLISECOND,
         };
-        (&self.0).wrapping_trunc_div_scalar(t)
+        (&self.phys).wrapping_trunc_div_scalar(t)
     }
 
     /// Extract the microseconds from a `Duration`
     fn microseconds(&self) -> Int64Chunked {
         match self.time_unit() {
-            TimeUnit::Milliseconds => &self.0 * 1000,
-            TimeUnit::Microseconds => self.0.clone(),
-            TimeUnit::Nanoseconds => (&self.0).wrapping_trunc_div_scalar(1000),
+            TimeUnit::Milliseconds => &self.phys * 1000,
+            TimeUnit::Microseconds => self.phys.clone(),
+            TimeUnit::Nanoseconds => (&self.phys).wrapping_trunc_div_scalar(1000),
         }
     }
 
     /// Extract the nanoseconds from a `Duration`
     fn nanoseconds(&self) -> Int64Chunked {
         match self.time_unit() {
-            TimeUnit::Milliseconds => &self.0 * NANOSECONDS_IN_MILLISECOND,
-            TimeUnit::Microseconds => &self.0 * 1000,
-            TimeUnit::Nanoseconds => self.0.clone(),
+            TimeUnit::Milliseconds => &self.phys * NANOSECONDS_IN_MILLISECOND,
+            TimeUnit::Microseconds => &self.phys * 1000,
+            TimeUnit::Nanoseconds => self.phys.clone(),
         }
     }
 }

--- a/crates/polars-time/src/dst_offset.rs
+++ b/crates/polars-time/src/dst_offset.rs
@@ -18,10 +18,11 @@ pub fn dst_offset(ca: &DatetimeChunked, time_unit: &TimeUnit, time_zone: &Tz) ->
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
     };
-    ca.0.apply_values(|t| {
-        let ndt = timestamp_to_datetime(t);
-        let dt = time_zone.from_utc_datetime(&ndt);
-        dt.offset().dst_offset().num_milliseconds()
-    })
-    .into_duration(TimeUnit::Milliseconds)
+    ca.phys
+        .apply_values(|t| {
+            let ndt = timestamp_to_datetime(t);
+            let dt = time_zone.from_utc_datetime(&ndt);
+            dt.offset().dst_offset().num_milliseconds()
+        })
+        .into_duration(TimeUnit::Milliseconds)
 }

--- a/crates/polars-time/src/month_end.rs
+++ b/crates/polars-time/src/month_end.rs
@@ -51,7 +51,7 @@ impl PolarsMonthEnd for DatetimeChunked {
             },
         };
         Ok(self
-            .0
+            .phys
             .try_apply_nonnull_values_generic(|t| {
                 roll_forward(
                     t,
@@ -68,7 +68,7 @@ impl PolarsMonthEnd for DatetimeChunked {
 impl PolarsMonthEnd for DateChunked {
     fn month_end(&self, _time_zone: Option<&Tz>) -> PolarsResult<Self> {
         const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
-        let ret = self.0.try_apply_nonnull_values_generic(|t| {
+        let ret = self.phys.try_apply_nonnull_values_generic(|t| {
             let fwd = roll_forward(
                 MSECS_IN_DAY * t as i64,
                 None,

--- a/crates/polars-time/src/month_start.rs
+++ b/crates/polars-time/src/month_start.rs
@@ -81,7 +81,7 @@ impl PolarsMonthStart for DatetimeChunked {
             },
         };
         Ok(self
-            .0
+            .phys
             .try_apply_nonnull_values_generic(|t| {
                 roll_backward(t, tz, timestamp_to_datetime, datetime_to_timestamp)
             })?
@@ -92,7 +92,7 @@ impl PolarsMonthStart for DatetimeChunked {
 impl PolarsMonthStart for DateChunked {
     fn month_start(&self, _tz: Option<&Tz>) -> PolarsResult<Self> {
         const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
-        let ret = self.0.try_apply_nonnull_values_generic(|t| {
+        let ret = self.phys.try_apply_nonnull_values_generic(|t| {
             let bwd = roll_backward(
                 MSECS_IN_DAY * t as i64,
                 None,

--- a/crates/polars-time/src/offset_by.rs
+++ b/crates/polars-time/src/offset_by.rs
@@ -24,7 +24,7 @@ fn apply_offsets_to_datetime(
                     if offset.negative() {
                         duration = -duration;
                     }
-                    Ok(datetime.0.clone().wrapping_add_scalar(duration))
+                    Ok(datetime.phys.clone().wrapping_add_scalar(duration))
                 } else {
                     let offset_fn = match datetime.time_unit() {
                         TimeUnit::Milliseconds => Duration::add_ms,
@@ -32,11 +32,11 @@ fn apply_offsets_to_datetime(
                         TimeUnit::Nanoseconds => Duration::add_ns,
                     };
                     datetime
-                        .0
+                        .phys
                         .try_apply_nonnull_values_generic(|v| offset_fn(offset, v, time_zone))
                 }
             },
-            _ => Ok(datetime.0.apply(|_| None)),
+            _ => Ok(datetime.phys.apply(|_| None)),
         },
         _ => {
             let offset_fn = match datetime.time_unit() {


### PR DESCRIPTION
This is a lot more readable than random `.0` and `.2`s everywhere.