### PR TITLE
refactor(rust): Emphasize PolarsDataType::get_dtype is static-only

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -66,7 +66,8 @@ where
     T: PolarsNumericType,
 {
     fn from_slice(name: PlSmallStr, v: &[T::Native]) -> Self {
-        let arr = PrimitiveArray::from_slice(v).to(T::get_static_dtype().to_arrow(CompatLevel::newest()));
+        let arr =
+            PrimitiveArray::from_slice(v).to(T::get_static_dtype().to_arrow(CompatLevel::newest()));
         ChunkedArray::with_chunk(name, arr)
     }
 

--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -66,7 +66,7 @@ where
     T: PolarsNumericType,
 {
     fn from_slice(name: PlSmallStr, v: &[T::Native]) -> Self {
-        let arr = PrimitiveArray::from_slice(v).to(T::get_dtype().to_arrow(CompatLevel::newest()));
+        let arr = PrimitiveArray::from_slice(v).to(T::get_static_dtype().to_arrow(CompatLevel::newest()));
         ChunkedArray::with_chunk(name, arr)
     }
 

--- a/crates/polars-core/src/chunked_array/builder/primitive.rs
+++ b/crates/polars-core/src/chunked_array/builder/primitive.rs
@@ -41,11 +41,11 @@ where
 {
     pub fn new(name: PlSmallStr, capacity: usize) -> Self {
         let array_builder = MutablePrimitiveArray::<T::Native>::with_capacity(capacity)
-            .to(T::get_dtype().to_arrow(CompatLevel::newest()));
+            .to(T::get_static_dtype().to_arrow(CompatLevel::newest()));
 
         PrimitiveChunkedBuilder {
             array_builder,
-            field: Field::new(name, T::get_dtype()),
+            field: Field::new(name, T::get_static_dtype()),
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/collect.rs
+++ b/crates/polars-core/src/chunked_array/collect.rs
@@ -133,7 +133,7 @@ pub trait ChunkedCollectInferIterExt<T: PolarsDataType>: Iterator + Sized {
     where
         T::Array: ArrayFromIter<Self::Item>,
     {
-        let field = Arc::new(Field::new(name, T::get_dtype()));
+        let field = Arc::new(Field::new(name, T::get_static_dtype()));
         let arr = self.collect_arr();
         ChunkedArray::from_chunk_iter_and_field(field, [arr])
     }
@@ -144,7 +144,7 @@ pub trait ChunkedCollectInferIterExt<T: PolarsDataType>: Iterator + Sized {
         T::Array: ArrayFromIter<Self::Item>,
         Self: TrustedLen,
     {
-        let field = Arc::new(Field::new(name, T::get_dtype()));
+        let field = Arc::new(Field::new(name, T::get_static_dtype()));
         let arr = self.collect_arr_trusted();
         ChunkedArray::from_chunk_iter_and_field(field, [arr])
     }
@@ -155,7 +155,7 @@ pub trait ChunkedCollectInferIterExt<T: PolarsDataType>: Iterator + Sized {
         T::Array: ArrayFromIter<U>,
         Self: Iterator<Item = Result<U, E>>,
     {
-        let field = Arc::new(Field::new(name, T::get_dtype()));
+        let field = Arc::new(Field::new(name, T::get_static_dtype()));
         let arr = self.try_collect_arr()?;
         Ok(ChunkedArray::from_chunk_iter_and_field(field, [arr]))
     }
@@ -166,7 +166,7 @@ pub trait ChunkedCollectInferIterExt<T: PolarsDataType>: Iterator + Sized {
         T::Array: ArrayFromIter<U>,
         Self: Iterator<Item = Result<U, E>> + TrustedLen,
     {
-        let field = Arc::new(Field::new(name, T::get_dtype()));
+        let field = Arc::new(Field::new(name, T::get_static_dtype()));
         let arr = self.try_collect_arr_trusted()?;
         Ok(ChunkedArray::from_chunk_iter_and_field(field, [arr]))
     }

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -262,7 +262,10 @@ where
         buffer: Option<Bitmap>,
     ) -> Self {
         let arr = to_array::<T>(values, buffer);
-        ChunkedArray::new_with_compute_len(Arc::new(Field::new(name, T::get_static_dtype())), vec![arr])
+        ChunkedArray::new_with_compute_len(
+            Arc::new(Field::new(name, T::get_static_dtype())),
+            vec![arr],
+        )
     }
 
     /// Create a temporary [`ChunkedArray`] from a slice.

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -161,7 +161,7 @@ where
         <I as IntoIterator>::Item: Array,
     {
         assert_eq!(
-            std::mem::discriminant(&T::get_dtype()),
+            std::mem::discriminant(&T::get_static_dtype()),
             std::mem::discriminant(&field.dtype)
         );
 
@@ -184,7 +184,7 @@ where
     /// # Safety
     /// The Arrow datatype of all chunks must match the [`PolarsDataType`] `T`.
     pub unsafe fn from_chunks(name: PlSmallStr, mut chunks: Vec<ArrayRef>) -> Self {
-        let dtype = match T::get_dtype() {
+        let dtype = match T::get_static_dtype() {
             dtype @ DataType::List(_) => from_chunks_list_dtype(&mut chunks, dtype),
             #[cfg(feature = "dtype-array")]
             dtype @ DataType::Array(_, _) => from_chunks_list_dtype(&mut chunks, dtype),
@@ -262,7 +262,7 @@ where
         buffer: Option<Bitmap>,
     ) -> Self {
         let arr = to_array::<T>(values, buffer);
-        ChunkedArray::new_with_compute_len(Arc::new(Field::new(name, T::get_dtype())), vec![arr])
+        ChunkedArray::new_with_compute_len(Arc::new(Field::new(name, T::get_static_dtype())), vec![arr])
     }
 
     /// Create a temporary [`ChunkedArray`] from a slice.

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -820,7 +820,7 @@ pub(crate) fn to_primitive<T: PolarsNumericType>(
     validity: Option<Bitmap>,
 ) -> PrimitiveArray<T::Native> {
     PrimitiveArray::new(
-        T::get_dtype().to_arrow(CompatLevel::newest()),
+        T::get_static_dtype().to_arrow(CompatLevel::newest()),
         values.into(),
         validity,
     )
@@ -835,7 +835,7 @@ pub(crate) fn to_array<T: PolarsNumericType>(
 
 impl<T: PolarsDataType> Default for ChunkedArray<T> {
     fn default() -> Self {
-        let dtype = T::get_dtype();
+        let dtype = T::get_static_dtype();
         let arrow_dtype = dtype.to_physical().to_arrow(CompatLevel::newest());
         ChunkedArray {
             field: Arc::new(Field::new(PlSmallStr::EMPTY, dtype)),

--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -47,7 +47,7 @@ impl ListChunked {
         let mut row_idx = 0;
         let mut ndarray = ndarray::Array::uninit((self.len(), width));
 
-        let series = series.cast(&N::get_dtype())?;
+        let series = series.cast(&N::get_static_dtype())?;
         let ca = series.unpack::<N>()?;
         let a = ca.to_ndarray()?;
         let mut row = ndarray.slice_mut(s![row_idx, ..]);
@@ -59,7 +59,7 @@ impl ListChunked {
                 series.len() == width,
                 ShapeMismatch: "unable to create a 2-D array, series have different lengths"
             );
-            let series = series.cast(&N::get_dtype())?;
+            let series = series.cast(&N::get_static_dtype())?;
             let ca = series.unpack::<N>()?;
             let a = ca.to_ndarray()?;
             let mut row = ndarray.slice_mut(s![row_idx, ..]);
@@ -108,7 +108,7 @@ impl DataFrame {
         let columns = self.get_columns();
         POOL.install(|| {
             columns.par_iter().enumerate().try_for_each(|(col_idx, s)| {
-                let s = s.as_materialized_series().cast(&N::get_dtype())?;
+                let s = s.as_materialized_series().cast(&N::get_static_dtype())?;
                 let s = match s.dtype() {
                     DataType::Float32 => {
                         let ca = s.f32().unwrap();

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -119,7 +119,7 @@ where
 
         match self.is_sorted_flag() {
             IsSorted::Ascending => {
-                let idx = if T::get_dtype().is_float() {
+                let idx = if T::get_static_dtype().is_float() {
                     float_arg_max_sorted_ascending(self)
                 } else {
                     self.last_non_null().unwrap()
@@ -128,7 +128,7 @@ where
                 unsafe { self.get_unchecked(idx) }
             },
             IsSorted::Descending => {
-                let idx = if T::get_dtype().is_float() {
+                let idx = if T::get_static_dtype().is_float() {
                     float_arg_max_sorted_descending(self)
                 } else {
                     self.first_non_null().unwrap()
@@ -153,7 +153,7 @@ where
             IsSorted::Ascending => {
                 let min = unsafe { self.get_unchecked(self.first_non_null().unwrap()) };
                 let max = {
-                    let idx = if T::get_dtype().is_float() {
+                    let idx = if T::get_static_dtype().is_float() {
                         float_arg_max_sorted_ascending(self)
                     } else {
                         self.last_non_null().unwrap()
@@ -166,7 +166,7 @@ where
             IsSorted::Descending => {
                 let min = unsafe { self.get_unchecked(self.last_non_null().unwrap()) };
                 let max = {
-                    let idx = if T::get_dtype().is_float() {
+                    let idx = if T::get_static_dtype().is_float() {
                         float_arg_max_sorted_descending(self)
                     } else {
                         self.first_non_null().unwrap()
@@ -258,17 +258,17 @@ where
 {
     fn sum_reduce(&self) -> Scalar {
         let v: Option<T::Native> = self.sum();
-        Scalar::new(T::get_dtype(), v.into())
+        Scalar::new(T::get_static_dtype(), v.into())
     }
 
     fn max_reduce(&self) -> Scalar {
         let v = ChunkAgg::max(self);
-        Scalar::new(T::get_dtype(), v.into())
+        Scalar::new(T::get_static_dtype(), v.into())
     }
 
     fn min_reduce(&self) -> Scalar {
         let v = ChunkAgg::min(self);
-        Scalar::new(T::get_dtype(), v.into())
+        Scalar::new(T::get_static_dtype(), v.into())
     }
 
     fn prod_reduce(&self) -> Scalar {
@@ -279,7 +279,7 @@ where
                 prod = prod * *v
             }
         }
-        Scalar::new(T::get_dtype(), prod.into())
+        Scalar::new(T::get_static_dtype(), prod.into())
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -133,7 +133,11 @@ where
         drop(arr);
 
         let compute_immutable = |arr: &PrimitiveArray<S::Native>| {
-            arrow::compute::arity::unary(arr, f, S::get_static_dtype().to_arrow(CompatLevel::newest()))
+            arrow::compute::arity::unary(
+                arr,
+                f,
+                S::get_static_dtype().to_arrow(CompatLevel::newest()),
+            )
         };
 
         if owned_arr.values().is_sliced() {

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -133,7 +133,7 @@ where
         drop(arr);
 
         let compute_immutable = |arr: &PrimitiveArray<S::Native>| {
-            arrow::compute::arity::unary(arr, f, S::get_dtype().to_arrow(CompatLevel::newest()))
+            arrow::compute::arity::unary(arr, f, S::get_static_dtype().to_arrow(CompatLevel::newest()))
         };
 
         if owned_arr.values().is_sliced() {
@@ -167,7 +167,7 @@ impl<T: PolarsNumericType> ChunkedArray<T> {
         // and we can mutate in place
         let chunks = {
             let s = self
-                .cast_with_options(&S::get_dtype(), CastOptions::Overflowing)
+                .cast_with_options(&S::get_static_dtype(), CastOptions::Overflowing)
                 .unwrap();
             s.chunks().clone()
         };

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -115,7 +115,10 @@ where
     V::Array: ArrayFromIter<<F as UnaryFnMut<T::Physical<'a>>>::Ret>,
 {
     if ca.null_count() == ca.len() {
-        let arr = V::Array::full_null(ca.len(), V::get_static_dtype().to_arrow(CompatLevel::newest()));
+        let arr = V::Array::full_null(
+            ca.len(),
+            V::get_static_dtype().to_arrow(CompatLevel::newest()),
+        );
         return ChunkedArray::with_chunk(ca.name().clone(), arr);
     }
 
@@ -139,7 +142,10 @@ where
     V::Array: ArrayFromIter<K>,
 {
     if ca.null_count() == ca.len() {
-        let arr = V::Array::full_null(ca.len(), V::get_static_dtype().to_arrow(CompatLevel::newest()));
+        let arr = V::Array::full_null(
+            ca.len(),
+            V::get_static_dtype().to_arrow(CompatLevel::newest()),
+        );
         return Ok(ChunkedArray::with_chunk(ca.name().clone(), arr));
     }
 

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -115,7 +115,7 @@ where
     V::Array: ArrayFromIter<<F as UnaryFnMut<T::Physical<'a>>>::Ret>,
 {
     if ca.null_count() == ca.len() {
-        let arr = V::Array::full_null(ca.len(), V::get_dtype().to_arrow(CompatLevel::newest()));
+        let arr = V::Array::full_null(ca.len(), V::get_static_dtype().to_arrow(CompatLevel::newest()));
         return ChunkedArray::with_chunk(ca.name().clone(), arr);
     }
 
@@ -139,7 +139,7 @@ where
     V::Array: ArrayFromIter<K>,
 {
     if ca.null_count() == ca.len() {
-        let arr = V::Array::full_null(ca.len(), V::get_dtype().to_arrow(CompatLevel::newest()));
+        let arr = V::Array::full_null(ca.len(), V::get_static_dtype().to_arrow(CompatLevel::newest()));
         return Ok(ChunkedArray::with_chunk(ca.name().clone(), arr));
     }
 
@@ -317,7 +317,7 @@ where
 {
     if lhs.null_count() == lhs.len() || rhs.null_count() == rhs.len() {
         let len = lhs.len().min(rhs.len());
-        let arr = V::Array::full_null(len, V::get_dtype().to_arrow(CompatLevel::newest()));
+        let arr = V::Array::full_null(len, V::get_static_dtype().to_arrow(CompatLevel::newest()));
 
         return ChunkedArray::with_chunk(lhs.name().clone(), arr);
     }
@@ -749,7 +749,7 @@ where
         let min = lhs.len().min(rhs.len());
         let max = lhs.len().max(rhs.len());
         let len = if min == 1 { max } else { min };
-        let arr = V::Array::full_null(len, V::get_dtype().to_arrow(CompatLevel::newest()));
+        let arr = V::Array::full_null(len, V::get_static_dtype().to_arrow(CompatLevel::newest()));
 
         return ChunkedArray::with_chunk(lhs.name().clone(), arr);
     }
@@ -792,7 +792,7 @@ where
                 None => {
                     let arr = O::Array::full_null(
                         lhs.len(),
-                        O::get_dtype().to_arrow(CompatLevel::newest()),
+                        O::get_static_dtype().to_arrow(CompatLevel::newest()),
                     );
                     ChunkedArray::<O>::with_chunk(lhs.name().clone(), arr)
                 },
@@ -805,7 +805,7 @@ where
                 None => {
                     let arr = O::Array::full_null(
                         rhs.len(),
-                        O::get_dtype().to_arrow(CompatLevel::newest()),
+                        O::get_static_dtype().to_arrow(CompatLevel::newest()),
                     );
                     ChunkedArray::<O>::with_chunk(lhs.name().clone(), arr)
                 },
@@ -842,7 +842,7 @@ where
                 None => {
                     let arr = O::Array::full_null(
                         lhs.len(),
-                        O::get_dtype().to_arrow(CompatLevel::newest()),
+                        O::get_static_dtype().to_arrow(CompatLevel::newest()),
                     );
                     ChunkedArray::<O>::with_chunk(lhs.name().clone(), arr)
                 },
@@ -855,7 +855,7 @@ where
                 None => {
                     let arr = O::Array::full_null(
                         rhs.len(),
-                        O::get_dtype().to_arrow(CompatLevel::newest()),
+                        O::get_static_dtype().to_arrow(CompatLevel::newest()),
                     );
                     ChunkedArray::<O>::with_chunk(lhs.name().clone(), arr)
                 },

--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -46,7 +46,7 @@ fn reinterpret_list_chunked<T: PolarsNumericType, U: PolarsNumericType>(
         let pa =
             PrimitiveArray::from_data_default(reinterpreted_buf, inner_arr.validity().cloned());
         LargeListArray::new(
-            DataType::List(Box::new(U::get_dtype())).to_arrow(CompatLevel::newest()),
+            DataType::List(Box::new(U::get_static_dtype())).to_arrow(CompatLevel::newest()),
             array.offsets().clone(),
             pa.to_boxed(),
             array.validity().cloned(),

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -141,7 +141,7 @@ where
             unsafe { set_bit_unchecked(validity_slice, i, false) }
         }
         let arr = PrimitiveArray::new(
-            T::get_dtype().to_arrow(CompatLevel::newest()),
+            T::get_static_dtype().to_arrow(CompatLevel::newest()),
             new_values.into(),
             Some(validity.into()),
         );

--- a/crates/polars-core/src/chunked_array/ops/full.rs
+++ b/crates/polars-core/src/chunked_array/ops/full.rs
@@ -21,7 +21,7 @@ where
     T: PolarsNumericType,
 {
     fn full_null(name: PlSmallStr, length: usize) -> Self {
-        let arr = PrimitiveArray::new_null(T::get_dtype().to_arrow(CompatLevel::newest()), length);
+        let arr = PrimitiveArray::new_null(T::get_static_dtype().to_arrow(CompatLevel::newest()), length);
         ChunkedArray::with_chunk(name, arr)
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/full.rs
+++ b/crates/polars-core/src/chunked_array/ops/full.rs
@@ -21,7 +21,10 @@ where
     T: PolarsNumericType,
 {
     fn full_null(name: PlSmallStr, length: usize) -> Self {
-        let arr = PrimitiveArray::new_null(T::get_static_dtype().to_arrow(CompatLevel::newest()), length);
+        let arr = PrimitiveArray::new_null(
+            T::get_static_dtype().to_arrow(CompatLevel::newest()),
+            length,
+        );
         ChunkedArray::with_chunk(name, arr)
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -400,7 +400,7 @@ pub trait ChunkSort<T: PolarsDataType> {
         by: &[Column],
         _options: &SortMultipleOptions,
     ) -> PolarsResult<IdxCa> {
-        polars_bail!(opq = arg_sort_multiple, T::get_dtype());
+        polars_bail!(opq = arg_sort_multiple, T::get_static_dtype());
     }
 }
 
@@ -649,7 +649,7 @@ pub trait ChunkApplyKernel<A: Array> {
 /// Mask the first unique values as `true`
 pub trait IsFirstDistinct<T: PolarsDataType> {
     fn is_first_distinct(&self) -> PolarsResult<BooleanChunked> {
-        polars_bail!(opq = is_first_distinct, T::get_dtype());
+        polars_bail!(opq = is_first_distinct, T::get_static_dtype());
     }
 }
 
@@ -657,6 +657,6 @@ pub trait IsFirstDistinct<T: PolarsDataType> {
 /// Mask the last unique values as `true`
 pub trait IsLastDistinct<T: PolarsDataType> {
     fn is_last_distinct(&self) -> PolarsResult<BooleanChunked> {
-        polars_bail!(opq = is_last_distinct, T::get_dtype());
+        polars_bail!(opq = is_last_distinct, T::get_static_dtype());
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -273,7 +273,7 @@ mod inner_mod {
                 }
             }
             let arr = PrimitiveArray::new(
-                T::get_dtype().to_arrow(CompatLevel::newest()),
+                T::get_static_dtype().to_arrow(CompatLevel::newest()),
                 values.into(),
                 Some(validity.into()),
             );

--- a/crates/polars-core/src/chunked_array/ops/set.rs
+++ b/crates/polars-core/src/chunked_array/ops/set.rs
@@ -55,7 +55,7 @@ where
                         self.downcast_iter().next().unwrap(),
                         idx,
                         value,
-                        T::get_dtype().to_arrow(CompatLevel::newest()),
+                        T::get_static_dtype().to_arrow(CompatLevel::newest()),
                     )?;
                     return Ok(Self::with_chunk(self.name().clone(), arr));
                 }
@@ -109,7 +109,7 @@ where
                         arr,
                         mask,
                         value,
-                        T::get_dtype().to_arrow(CompatLevel::newest()),
+                        T::get_static_dtype().to_arrow(CompatLevel::newest()),
                     )
                 });
             Ok(ChunkedArray::from_chunk_iter(self.name().clone(), chunks))

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -230,7 +230,7 @@ where
         }
 
         let arr = PrimitiveArray::new(
-            T::get_dtype().to_arrow(CompatLevel::newest()),
+            T::get_static_dtype().to_arrow(CompatLevel::newest()),
             vals.into(),
             Some(create_validity(len, null_count, options.nulls_last)),
         );

--- a/crates/polars-core/src/chunked_array/trusted_len.rs
+++ b/crates/polars-core/src/chunked_array/trusted_len.rs
@@ -18,7 +18,7 @@ where
         let iter = iter.into_iter();
         let arr = unsafe {
             PrimitiveArray::from_trusted_len_iter_unchecked(iter)
-                .to(T::get_dtype().to_arrow(CompatLevel::newest()))
+                .to(T::get_static_dtype().to_arrow(CompatLevel::newest()))
         };
         arr.into()
     }
@@ -38,7 +38,7 @@ where
         // SAFETY: iter is TrustedLen.
         let iter = iter.into_iter();
         let values = unsafe { Vec::from_trusted_len_iter_unchecked(iter) }.into();
-        let arr = PrimitiveArray::new(T::get_dtype().to_arrow(CompatLevel::newest()), values, None);
+        let arr = PrimitiveArray::new(T::get_static_dtype().to_arrow(CompatLevel::newest()), values, None);
         NoNull::new(arr.into())
     }
 }

--- a/crates/polars-core/src/chunked_array/trusted_len.rs
+++ b/crates/polars-core/src/chunked_array/trusted_len.rs
@@ -38,7 +38,11 @@ where
         // SAFETY: iter is TrustedLen.
         let iter = iter.into_iter();
         let values = unsafe { Vec::from_trusted_len_iter_unchecked(iter) }.into();
-        let arr = PrimitiveArray::new(T::get_static_dtype().to_arrow(CompatLevel::newest()), values, None);
+        let arr = PrimitiveArray::new(
+            T::get_static_dtype().to_arrow(CompatLevel::newest()),
+            values,
+            None,
+        );
         NoNull::new(arr.into())
     }
 }

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -80,7 +80,9 @@ pub unsafe trait PolarsDataType: Send + Sync + Sized + 'static {
     type IsObject;
     type IsLogical;
 
-    fn get_dtype() -> DataType
+    /// Returns the DataType variant associated with this PolarsDataType.
+    /// Not implemented for types whose DataTypes have parameters.
+    fn get_static_dtype() -> DataType
     where
         Self: Sized;
 }
@@ -122,7 +124,7 @@ macro_rules! impl_polars_num_datatype {
             type IsLogical = FalseT;
 
             #[inline]
-            fn get_dtype() -> DataType {
+            fn get_static_dtype() -> DataType {
                 DataType::$variant
             }
         }
@@ -152,12 +154,38 @@ macro_rules! impl_polars_datatype_pass_dtype {
             type IsLogical = $is_logical;
 
             #[inline]
-            fn get_dtype() -> DataType {
+            fn get_static_dtype() -> DataType {
                 $dtype
             }
         }
     };
 }
+
+macro_rules! impl_polars_datatype_no_static_dtype {
+    ($ca:ident, $arr:ty, $lt:lifetime, $phys:ty, $zerophys:ty, $owned_phys:ty, $has_views:ident, $is_logical:ident) => {
+        #[derive(Clone, Copy)]
+        pub struct $ca {}
+
+        unsafe impl PolarsDataType for $ca {
+            type Physical<$lt> = $phys;
+            type OwnedPhysical = $owned_phys;
+            type ZeroablePhysical<$lt> = $zerophys;
+            type Array = $arr;
+            type IsNested = FalseT;
+            type HasViews = $has_views;
+            type IsStruct = FalseT;
+            type IsObject = FalseT;
+            type IsLogical = $is_logical;
+
+            #[inline]
+            fn get_static_dtype() -> DataType {
+                unimplemented!()
+            }
+        }
+    };
+}
+
+
 macro_rules! impl_polars_binview_datatype {
     ($ca:ident, $variant:ident, $arr:ty, $lt:lifetime, $phys:ty, $zerophys:ty, $owned_phys:ty) => {
         impl_polars_datatype_pass_dtype!(
@@ -211,10 +239,10 @@ impl_polars_datatype!(BinaryOffsetType, BinaryOffset, BinaryArray<i64>, 'a, &'a 
 impl_polars_datatype!(BooleanType, Boolean, BooleanArray, 'a, bool, bool, bool, FalseT);
 
 #[cfg(feature = "dtype-decimal")]
-impl_polars_datatype_pass_dtype!(DecimalType, DataType::Unknown(UnknownKind::Any), PrimitiveArray<i128>, 'a, i128, i128, i128, FalseT, TrueT);
-impl_polars_datatype_pass_dtype!(DatetimeType, DataType::Unknown(UnknownKind::Any), PrimitiveArray<i64>, 'a, i64, i64, i64, FalseT, TrueT);
-impl_polars_datatype_pass_dtype!(DurationType, DataType::Unknown(UnknownKind::Any), PrimitiveArray<i64>, 'a, i64, i64, i64, FalseT, TrueT);
-impl_polars_datatype_pass_dtype!(CategoricalType, DataType::Unknown(UnknownKind::Any), PrimitiveArray<u32>, 'a, u32, u32, u32, FalseT, TrueT);
+impl_polars_datatype_no_static_dtype!(DecimalType, PrimitiveArray<i128>, 'a, i128, i128, i128, FalseT, TrueT);
+impl_polars_datatype_no_static_dtype!(DatetimeType, PrimitiveArray<i64>, 'a, i64, i64, i64, FalseT, TrueT);
+impl_polars_datatype_no_static_dtype!(DurationType, PrimitiveArray<i64>, 'a, i64, i64, i64, FalseT, TrueT);
+impl_polars_datatype_no_static_dtype!(CategoricalType, PrimitiveArray<u32>, 'a, u32, u32, u32, FalseT, TrueT);
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ListType {}
@@ -229,7 +257,7 @@ unsafe impl PolarsDataType for ListType {
     type IsObject = FalseT;
     type IsLogical = FalseT;
 
-    fn get_dtype() -> DataType {
+    fn get_static_dtype() -> DataType {
         // Null as we cannot know anything without self.
         DataType::List(Box::new(DataType::Null))
     }
@@ -254,7 +282,7 @@ unsafe impl PolarsDataType for StructType {
     type IsObject = FalseT;
     type IsLogical = FalseT;
 
-    fn get_dtype() -> DataType
+    fn get_static_dtype() -> DataType
     where
         Self: Sized,
     {
@@ -276,7 +304,7 @@ unsafe impl PolarsDataType for FixedSizeListType {
     type IsObject = FalseT;
     type IsLogical = FalseT;
 
-    fn get_dtype() -> DataType {
+    fn get_static_dtype() -> DataType {
         // Null as we cannot know anything without self.
         DataType::Array(Box::new(DataType::Null), 0)
     }
@@ -296,7 +324,7 @@ unsafe impl<T: PolarsObject> PolarsDataType for ObjectType<T> {
     type IsObject = TrueT;
     type IsLogical = FalseT;
 
-    fn get_dtype() -> DataType {
+    fn get_static_dtype() -> DataType {
         DataType::Object(T::type_name())
     }
 }

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -185,7 +185,6 @@ macro_rules! impl_polars_datatype_no_static_dtype {
     };
 }
 
-
 macro_rules! impl_polars_binview_datatype {
     ($ca:ident, $variant:ident, $arr:ty, $lt:lifetime, $phys:ty, $zerophys:ty, $owned_phys:ty) => {
         impl_polars_datatype_pass_dtype!(

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -248,7 +248,7 @@ where
     T: PolarsNumericType,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let dt = format!("{}", T::get_dtype());
+        let dt = format!("{}", T::get_static_dtype());
         format_array!(f, self, dt, self.name(), "ChunkedArray")
     }
 }

--- a/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
@@ -70,12 +70,12 @@ where
                 };
 
                 let array = PrimitiveArray::new(
-                    T::get_dtype().to_arrow(CompatLevel::newest()),
+                    T::get_static_dtype().to_arrow(CompatLevel::newest()),
                     list_values.into(),
                     validity,
                 );
                 let dtype = ListArray::<i64>::default_datatype(
-                    T::get_dtype().to_arrow(CompatLevel::newest()),
+                    T::get_static_dtype().to_arrow(CompatLevel::newest()),
                 );
                 // SAFETY:
                 // offsets are monotonically increasing
@@ -135,12 +135,12 @@ where
                 };
 
                 let array = PrimitiveArray::new(
-                    T::get_dtype().to_arrow(CompatLevel::newest()),
+                    T::get_static_dtype().to_arrow(CompatLevel::newest()),
                     list_values.into(),
                     validity,
                 );
                 let dtype = ListArray::<i64>::default_datatype(
-                    T::get_dtype().to_arrow(CompatLevel::newest()),
+                    T::get_static_dtype().to_arrow(CompatLevel::newest()),
                 );
                 let arr = ListArray::<i64>::new(
                     dtype,

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -299,7 +299,7 @@ where
             if _use_rolling_kernels(groups, ca.chunks()) {
                 // this cast is a no-op for floats
                 let s = ca
-                    .cast_with_options(&K::get_dtype(), CastOptions::Overflowing)
+                    .cast_with_options(&K::get_static_dtype(), CastOptions::Overflowing)
                     .unwrap();
                 let ca: &ChunkedArray<K> = s.as_ref().as_ref();
                 let arr = ca.downcast_iter().next().unwrap();

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -214,7 +214,7 @@ pub(super) fn numeric_transpose<T>(
             .map(Column::as_materialized_series)
             .enumerate()
             .for_each(|(row_idx, s)| {
-                let s = s.cast(&T::get_dtype()).unwrap();
+                let s = s.cast(&T::get_static_dtype()).unwrap();
                 let ca = s.unpack::<T>().unwrap();
 
                 // SAFETY:
@@ -275,7 +275,7 @@ pub(super) fn numeric_transpose<T>(
             };
 
             let arr = PrimitiveArray::<T::Native>::new(
-                T::get_dtype().to_arrow(CompatLevel::newest()),
+                T::get_static_dtype().to_arrow(CompatLevel::newest()),
                 values.into(),
                 validity,
             );

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -221,12 +221,12 @@ fn any_values_to_integer<T: PolarsIntegerType>(
                     let opt_val = av.extract::<T::Native>();
                     let val = match opt_val {
                         Some(v) => v,
-                        None => return Err(invalid_value_error(&T::get_dtype(), av)),
+                        None => return Err(invalid_value_error(&T::get_static_dtype(), av)),
                     };
                     builder.append_value(val)
                 },
                 AnyValue::Null => builder.append_null(),
-                av => return Err(invalid_value_error(&T::get_dtype(), av)),
+                av => return Err(invalid_value_error(&T::get_static_dtype(), av)),
             }
         }
         Ok(builder.finish())

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -164,7 +164,7 @@ pub mod checked {
             lhs: &ChunkedArray<Self>,
             _rhs: T,
         ) -> PolarsResult<Series> {
-            polars_bail!(opq = checked_div_num, lhs.dtype(), Self::get_dtype());
+            polars_bail!(opq = checked_div_num, lhs.dtype(), Self::get_static_dtype());
         }
     }
 

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -335,21 +335,21 @@ macro_rules! impl_dyn_series {
             }
             #[cfg(feature = "bitwise")]
             fn and_reduce(&self) -> PolarsResult<Scalar> {
-                let dt = <$pdt as PolarsDataType>::get_dtype();
+                let dt = <$pdt as PolarsDataType>::get_static_dtype();
                 let av = self.0.and_reduce().map_or(AnyValue::Null, Into::into);
 
                 Ok(Scalar::new(dt, av))
             }
             #[cfg(feature = "bitwise")]
             fn or_reduce(&self) -> PolarsResult<Scalar> {
-                let dt = <$pdt as PolarsDataType>::get_dtype();
+                let dt = <$pdt as PolarsDataType>::get_static_dtype();
                 let av = self.0.or_reduce().map_or(AnyValue::Null, Into::into);
 
                 Ok(Scalar::new(dt, av))
             }
             #[cfg(feature = "bitwise")]
             fn xor_reduce(&self) -> PolarsResult<Scalar> {
-                let dt = <$pdt as PolarsDataType>::get_dtype();
+                let dt = <$pdt as PolarsDataType>::get_static_dtype();
                 let av = self.0.xor_reduce().map_or(AnyValue::Null, Into::into);
 
                 Ok(Scalar::new(dt, av))

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -408,7 +408,7 @@ macro_rules! impl_dyn_series {
 
             #[cfg(feature = "bitwise")]
             fn and_reduce(&self) -> PolarsResult<Scalar> {
-                let dt = <$pdt as PolarsDataType>::get_dtype();
+                let dt = <$pdt as PolarsDataType>::get_static_dtype();
                 let av = self.0.and_reduce().map_or(AnyValue::Null, Into::into);
 
                 Ok(Scalar::new(dt, av))
@@ -416,7 +416,7 @@ macro_rules! impl_dyn_series {
 
             #[cfg(feature = "bitwise")]
             fn or_reduce(&self) -> PolarsResult<Scalar> {
-                let dt = <$pdt as PolarsDataType>::get_dtype();
+                let dt = <$pdt as PolarsDataType>::get_static_dtype();
                 let av = self.0.or_reduce().map_or(AnyValue::Null, Into::into);
 
                 Ok(Scalar::new(dt, av))
@@ -424,7 +424,7 @@ macro_rules! impl_dyn_series {
 
             #[cfg(feature = "bitwise")]
             fn xor_reduce(&self) -> PolarsResult<Scalar> {
-                let dt = <$pdt as PolarsDataType>::get_dtype();
+                let dt = <$pdt as PolarsDataType>::get_static_dtype();
                 let av = self.0.xor_reduce().map_or(AnyValue::Null, Into::into);
 
                 Ok(Scalar::new(dt, av))

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -1069,7 +1069,7 @@ where
         let Some(ca) = self.as_any().downcast_ref::<ChunkedArray<T>>() else {
             panic!(
                 "implementation error, cannot get ref {:?} from {:?}",
-                T::get_dtype(),
+                T::get_static_dtype(),
                 self.dtype()
             );
         };
@@ -1086,7 +1086,7 @@ where
         if !self.as_any_mut().is::<ChunkedArray<T>>() {
             panic!(
                 "implementation error, cannot get ref {:?} from {:?}",
-                T::get_dtype(),
+                T::get_static_dtype(),
                 self.dtype()
             );
         }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -625,7 +625,7 @@ impl (dyn SeriesTrait + '_) {
     where
         N: 'static + PolarsDataType<IsLogical = FalseT>,
     {
-        polars_ensure!(&N::get_dtype() == self.dtype(), unpack);
+        polars_ensure!(&N::get_static_dtype() == self.dtype(), unpack);
         Ok(self.as_ref())
     }
 }

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -837,7 +837,7 @@ where
         unsafe { values.set_len(len) }
         let validity = Bitmap::from(validity);
         let arr = PrimitiveArray::new(
-            T::get_dtype().to_physical().to_arrow(CompatLevel::newest()),
+            T::get_static_dtype().to_physical().to_arrow(CompatLevel::newest()),
             values.into(),
             Some(validity),
         );

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -837,7 +837,9 @@ where
         unsafe { values.set_len(len) }
         let validity = Bitmap::from(validity);
         let arr = PrimitiveArray::new(
-            T::get_static_dtype().to_physical().to_arrow(CompatLevel::newest()),
+            T::get_static_dtype()
+                .to_physical()
+                .to_arrow(CompatLevel::newest()),
             values.into(),
             Some(validity),
         );

--- a/crates/polars-ops/src/chunked_array/repeat_by.rs
+++ b/crates/polars-ops/src/chunked_array/repeat_by.rs
@@ -43,7 +43,7 @@ where
                 unsafe {
                     LargeListArray::from_iter_primitive_trusted_len(
                         iter,
-                        T::get_dtype().to_arrow(CompatLevel::newest()),
+                        T::get_static_dtype().to_arrow(CompatLevel::newest()),
                     )
                 }
             }))

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -143,7 +143,7 @@ where
 {
     if ca.null_count() == ca.len() {
         None
-    } else if T::get_dtype().is_float() && !matches!(ca.is_sorted_flag(), IsSorted::Not) {
+    } else if T::get_static_dtype().is_float() && !matches!(ca.is_sorted_flag(), IsSorted::Not) {
         arg_max_float_sorted(ca)
     } else if let Ok(vals) = ca.cont_slice() {
         arg_max_numeric_slice(vals, ca.is_sorted_flag())

--- a/crates/polars-ops/src/series/ops/interpolation/interpolate.rs
+++ b/crates/polars-ops/src/series/ops/interpolation/interpolate.rs
@@ -99,7 +99,7 @@ where
         }
 
         let array = PrimitiveArray::new(
-            T::get_dtype().to_arrow(CompatLevel::newest()),
+            T::get_static_dtype().to_arrow(CompatLevel::newest()),
             out.into(),
             Some(validity.into()),
         );

--- a/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
+++ b/crates/polars-ops/src/series/ops/interpolation/interpolate_by.rs
@@ -151,7 +151,7 @@ where
         }
 
         let array = PrimitiveArray::new(
-            T::get_dtype().to_arrow(CompatLevel::newest()),
+            T::get_static_dtype().to_arrow(CompatLevel::newest()),
             out.into(),
             Some(validity.into()),
         );
@@ -253,7 +253,7 @@ where
         }
 
         let array = PrimitiveArray::new(
-            T::get_dtype().to_arrow(CompatLevel::newest()),
+            T::get_static_dtype().to_arrow(CompatLevel::newest()),
             out.into(),
             Some(validity.into()),
         );

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
@@ -73,7 +73,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = K::PolarsType::get_dtype().to_arrow(CompatLevel::newest());
+        let dtype = K::PolarsType::get_static_dtype().to_arrow(CompatLevel::newest());
         let arr = polars_compute::cast::cast_unchecked(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
@@ -51,7 +51,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = K::PolarsType::get_dtype().to_arrow(CompatLevel::newest());
+        let dtype = K::PolarsType::get_static_dtype().to_arrow(CompatLevel::newest());
         let arr = polars_compute::cast::cast_unchecked(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -74,7 +74,7 @@ where
     T::Native: Pow<T::Native, Output = T::Native> + ToPrimitive + Float,
     ChunkedArray<T>: IntoColumn,
 {
-    let dtype = T::get_dtype();
+    let dtype = T::get_static_dtype();
 
     if exponent.len() == 1 {
         let Some(exponent_value) = exponent.get(0) else {
@@ -117,7 +117,7 @@ where
     T::Native: Pow<F::Native, Output = T::Native> + ToPrimitive,
     ChunkedArray<T>: IntoColumn,
 {
-    let dtype = T::get_dtype();
+    let dtype = T::get_static_dtype();
 
     if exponent.len() == 1 {
         let Some(exponent_value) = exponent.get(0) else {

--- a/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
+++ b/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
@@ -116,7 +116,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoColumn,
 {
-    let dtype = T::get_dtype();
+    let dtype = T::get_static_dtype();
     let x = x.cast(&dtype)?;
     let x = y
         .unpack_series_matching_type(x.as_materialized_series())


### PR DESCRIPTION
The old API made it seem you can always just call `T::get_dtype()` when that only makes sense for `PolarsDataType`s where the dtype is parameter-free.