### PR TITLE
refactor(rust): Add test for serialization behavior with new struct fields

### DIFF
--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -199,8 +199,7 @@ mod tests {
             let r: Result<StructV2, _> =
                 super::deserialize_from_reader::<_, _, FORWARD_COMPATIBLE>(b.as_slice());
 
-            #[allow(clippy::redundant_pattern_matching)]
-            assert!(matches!(r, Err(_)))
+            assert!(r.is_err())
         }
 
         {
@@ -242,6 +241,7 @@ mod tests {
         #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
         enum Enum {
             A,
+            #[expect(dead_code)]
             #[serde(skip)]
             B(MyType),
         }

--- a/crates/polars-utils/src/pl_serialize.rs
+++ b/crates/polars-utils/src/pl_serialize.rs
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_serde_forward_compatibility_new_fields() {
-        // Behavior:  Deserializing an older version with a newly added field will error upon
+        // Behavior: Deserializing an older version with a newly added field will error upon
         // deserialization, unless the field is tagged with `serde(default)`
         const FORWARD_COMPATIBLE: bool = true;
 
@@ -199,7 +199,7 @@ mod tests {
             let r: Result<StructV2, _> =
                 super::deserialize_from_reader::<_, _, FORWARD_COMPATIBLE>(b.as_slice());
 
-            #[expect(clippy::redundant_pattern_matching)]
+            #[allow(clippy::redundant_pattern_matching)]
             assert!(matches!(r, Err(_)))
         }
 


### PR DESCRIPTION
Adds a test case for behavior when deserializing with added fields. Mainly for documentation purposes
