### PR TITLE
docs: Rework documentation for `drop`/`fill` for nulls/nans

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6137,6 +6137,15 @@ class DataFrame:
             (default), use all columns (note that only floating-point columns
             can contain NaNs).
 
+        Warnings
+        --------
+        Note that floating point NaNs (Not a Number) are not missing values.
+        To drop missing values, use :func:`drop_nulls`.
+
+        See Also
+        --------
+        drop_nulls
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -6207,7 +6216,7 @@ class DataFrame:
         subset: ColumnNameOrSelector | Collection[ColumnNameOrSelector] | None = None,
     ) -> DataFrame:
         """
-        Drop all rows that contain null values.
+        Drop all rows that contain one or more null values.
 
         The original order of the remaining rows is preserved.
 
@@ -6216,6 +6225,10 @@ class DataFrame:
         subset
             Column name(s) for which null values are considered.
             If set to `None` (default), use all columns.
+
+        See Also
+        --------
+        drop_nans
 
         Examples
         --------
@@ -8708,7 +8721,7 @@ class DataFrame:
         Parameters
         ----------
         value
-            Value with which to replace NaN values.
+            Value used to fill NaN values.
 
         Returns
         -------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6137,14 +6137,14 @@ class DataFrame:
             (default), use all columns (note that only floating-point columns
             can contain NaNs).
 
-        Warnings
-        --------
-        Note that floating point NaNs (Not a Number) are not missing values.
-        To drop missing values, use :func:`drop_nulls`.
-
         See Also
         --------
         drop_nulls
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
+        To drop null values, use :func:`drop_nulls`.
 
         Examples
         --------
@@ -6229,6 +6229,11 @@ class DataFrame:
         See Also
         --------
         drop_nans
+
+        Notes
+        -----
+        A null value is not the same as a NaN value.
+        To drop NaN values, use :func:`drop_nans`.
 
         Examples
         --------
@@ -8647,6 +8652,11 @@ class DataFrame:
         --------
         fill_nan
 
+        Notes
+        -----
+        A null value is not the same as a NaN value.
+        To fill NaN values, use :func:`fill_nan`.
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -8728,14 +8738,14 @@ class DataFrame:
         DataFrame
             DataFrame with NaN values replaced by the given value.
 
-        Warnings
-        --------
-        Note that floating point NaNs (Not a Number) are not missing values.
-        To replace missing values, use :func:`fill_null`.
-
         See Also
         --------
         fill_null
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
+        To fill null values, use :func:`fill_null`.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2750,6 +2750,11 @@ class Expr:
         fill_nan
         forward_fill
 
+        Notes
+        -----
+        A null value is not the same as a NaN value.
+        To fill NaN values, use :func:`fill_nan`.
+
         Examples
         --------
         >>> df = pl.DataFrame(
@@ -2841,14 +2846,14 @@ class Expr:
         value
             Value used to fill NaN values.
 
-        Warnings
-        --------
-        Note that floating point NaNs (Not a Number) are not missing values.
-        To replace missing values, use :func:`fill_null`.
-
         See Also
         --------
         fill_null
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
+        To fill null values, use :func:`fill_null`.
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -6645,6 +6645,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         --------
         fill_nan
 
+        Notes
+        -----
+        A null value is not the same as a NaN value.
+        To fill NaN values, use :func:`fill_nan`.
+
         Examples
         --------
         >>> lf = pl.LazyFrame(
@@ -6762,14 +6767,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         value
             Value used to fill NaN values.
 
-        Warnings
-        --------
-        Note that floating point NaNs (Not a Number) are not missing values.
-        To replace missing values, use :func:`fill_null`.
-
         See Also
         --------
         fill_null
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
+        To fill null values, use :func:`fill_null`.
 
         Examples
         --------
@@ -7206,14 +7211,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             (default), use all columns (note that only floating-point columns
             can contain NaNs).
 
-        Warnings
-        --------
-        Note that floating point NaNs (Not a Number) are not missing values.
-        To drop missing values, use :func:`drop_nulls`.
-
         See Also
         --------
         drop_nulls
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
+        To drop null values, use :func:`drop_nulls`.
 
         Examples
         --------
@@ -7287,15 +7292,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         The original order of the remaining rows is preserved.
 
-        Parameters
-        ----------
-        subset
-            Column name(s) for which null values are considered.
-            If set to `None` (default), use all columns.
-
         See Also
         --------
         drop_nans
+
+        Notes
+        -----
+        A null value is not the same as a NaN value.
+        To drop NaN values, use :func:`drop_nans`.
+
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -6760,7 +6760,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Parameters
         ----------
         value
-            Value to fill the NaN values with.
+            Value used to fill NaN values.
 
         Warnings
         --------
@@ -7206,6 +7206,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             (default), use all columns (note that only floating-point columns
             can contain NaNs).
 
+        Warnings
+        --------
+        Note that floating point NaNs (Not a Number) are not missing values.
+        To drop missing values, use :func:`drop_nulls`.
+
+        See Also
+        --------
+        drop_nulls
+
         Examples
         --------
         >>> lf = pl.LazyFrame(
@@ -7283,6 +7292,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         subset
             Column name(s) for which null values are considered.
             If set to `None` (default), use all columns.
+
+        See Also
+        --------
+        drop_nans
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4980,14 +4980,14 @@ class Series:
         value
             Value used to fill NaN values.
 
-        Warnings
-        --------
-        Note that floating point NaNs (Not a Number) are not missing values.
-        To replace missing values, use :func:`fill_null`.
-
         See Also
         --------
         fill_null
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
+        To fill null values, use :func:`fill_null`.
 
         Examples
         --------
@@ -5027,6 +5027,11 @@ class Series:
         backward_fill
         fill_nan
         forward_fill
+
+        Notes
+        -----
+        A null value is not the same as a NaN value.
+        To fill NaN values, use :func:`fill_nan`.
 
         Examples
         --------


### PR DESCRIPTION
Closes #22658

- Make sure all variants for `drop`/`fill` refer to the corresponding counterpart. For instance, `drop_nulls` will refer to `drop_nans` and vice-versa.
- For all variants, replicate a pre-existing notes (found in some cases) to indicate that "floating point NaNs (Not a Number) are not missing values" and vice-versa.