### PR TITLE
fix: Fix `index out of bounds` panic when scanning hugging face

### DIFF
--- a/crates/polars-io/src/path_utils/mod.rs
+++ b/crates/polars-io/src/path_utils/mod.rs
@@ -197,11 +197,12 @@ impl HiveIdxTracker<'_> {
         if check_directory_level
             && ![usize::MAX, i].contains(&self.idx)
             // They could still be the same directory level, just with different name length
-            && (paths[path_idx].parent() != paths[path_idx - 1].parent())
+            && (path_idx > 0 && paths[path_idx].parent() != paths[path_idx - 1].parent())
         {
             polars_bail!(
                 InvalidOperation:
-                "attempted to read from different directory levels with hive partitioning enabled: first path: {}, second path: {}",
+                "attempted to read from different directory levels with hive partitioning enabled: \
+                first path: {}, second path: {}",
                 paths[path_idx - 1].to_str().unwrap(),
                 paths[path_idx].to_str().unwrap(),
             )


### PR DESCRIPTION
* I wasn't able to reproduce locally, but this should fix https://github.com/pola-rs/polars/issues/22656
