### PR TITLE
fix: Fix predicate pushdown of fallible expressions

### DIFF
--- a/crates/polars-plan/src/plans/aexpr/minterm_iter.rs
+++ b/crates/polars-plan/src/plans/aexpr/minterm_iter.rs
@@ -33,7 +33,7 @@ impl Iterator for MintermIter<'_> {
 
         while let AExpr::BinaryExpr {
             left,
-            op: Operator::And,
+            op: Operator::And | Operator::LogicalAnd,
             right,
         } = self.expr_arena.get(top)
         {

--- a/crates/polars-plan/src/plans/conversion/convert_utils.rs
+++ b/crates/polars-plan/src/plans/conversion/convert_utils.rs
@@ -116,3 +116,72 @@ pub(super) fn h_concat_schema(
     let combined_schema = merge_schemas(&schemas)?;
     Ok(Arc::new(combined_schema))
 }
+
+/// Split expression that are ANDed into multiple Filter nodes as the optimizer can then
+/// push them down independently. Especially if they refer columns from different tables
+/// this will be more performant.
+///
+/// So:
+/// * `filter[foo == bar & ham == spam]`
+///
+/// Becomes:
+/// * `filter [foo == bar]`
+/// * `filter [ham == spam]`
+pub(super) struct SplitPredicates {
+    pub(super) pushable: Vec<Node>,
+    pub(super) fallible: Option<Node>,
+}
+
+impl SplitPredicates {
+    /// Returns None if a barrier expression is encountered
+    pub(super) fn new(
+        predicate: Node,
+        expr_arena: &mut Arena<AExpr>,
+        scratch: Option<&mut UnitVec<Node>>,
+        maintain_errors: bool,
+    ) -> Option<Self> {
+        let mut local_scratch = unitvec![];
+        let scratch = scratch.unwrap_or(&mut local_scratch);
+
+        let mut pushable = vec![];
+        let mut acc_fallible = unitvec![];
+
+        for predicate in MintermIter::new(predicate, expr_arena) {
+            use ExprPushdownGroup::*;
+
+            let ae = expr_arena.get(predicate);
+
+            match ExprPushdownGroup::Pushable.update_with_expr_rec(ae, expr_arena, Some(scratch)) {
+                Pushable => pushable.push(predicate),
+
+                Fallible => {
+                    if maintain_errors {
+                        return None;
+                    }
+
+                    acc_fallible.push(predicate);
+                },
+
+                Barrier => return None,
+            }
+        }
+
+        let fallible = (!acc_fallible.is_empty()).then(|| {
+            let mut node = acc_fallible.pop().unwrap();
+
+            for next_node in acc_fallible.iter() {
+                node = expr_arena.add(AExpr::BinaryExpr {
+                    left: node,
+                    op: Operator::And,
+                    right: *next_node,
+                })
+            }
+
+            node
+        });
+
+        let out = Self { pushable, fallible };
+
+        Some(out)
+    }
+}

--- a/crates/polars-plan/src/plans/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/plans/optimizer/cache_states.rs
@@ -116,6 +116,7 @@ type TwoParents = [Option<Node>; 2];
 // - Above the filters the caches are the same -> run predicate pd from the filter node -> finish
 // - There is a cache without predicates above the cache node -> run predicate form the cache nodes -> finish
 // - The predicates above the cache nodes are all different -> remove the cache nodes -> finish
+#[expect(clippy::too_many_arguments)]
 pub(super) fn set_cache_states(
     root: Node,
     lp_arena: &mut Arena<IR>,
@@ -123,6 +124,7 @@ pub(super) fn set_cache_states(
     scratch: &mut Vec<Node>,
     expr_eval: ExprEval<'_>,
     verbose: bool,
+    pushdown_maintain_errors: bool,
     new_streaming: bool,
 ) -> PolarsResult<()> {
     let mut stack = Vec::with_capacity(4);
@@ -254,7 +256,9 @@ pub(super) fn set_cache_states(
     // back to the cache node again
     if !cache_schema_and_children.is_empty() {
         let mut proj_pd = ProjectionPushDown::new();
-        let mut pred_pd = PredicatePushDown::new(expr_eval, new_streaming).block_at_cache(false);
+        let mut pred_pd =
+            PredicatePushDown::new(expr_eval, pushdown_maintain_errors, new_streaming)
+                .block_at_cache(false);
         for (_cache_id, v) in cache_schema_and_children {
             // # CHECK IF WE NEED TO REMOVE CACHES
             // If we encounter multiple predicates we remove the cache nodes completely as we don't

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -40,16 +40,19 @@ mod inner {
         nodes_scratch: UnitVec<Node>,
         #[expect(unused)]
         pub(super) new_streaming: bool,
+        // Controls pushing filters past fallible projections
+        pub(super) maintain_errors: bool,
     }
 
     impl<'a> PredicatePushDown<'a> {
-        pub fn new(expr_eval: ExprEval<'a>, new_streaming: bool) -> Self {
+        pub fn new(expr_eval: ExprEval<'a>, maintain_errors: bool, new_streaming: bool) -> Self {
             Self {
                 expr_eval,
                 verbose: verbose(),
                 block_at_cache: true,
                 nodes_scratch: unitvec![],
                 new_streaming,
+                maintain_errors,
             }
         }
 
@@ -119,12 +122,15 @@ impl PredicatePushDown<'_> {
             }
             let input = inputs[inputs.len() - 1];
 
+            let maintain_errors = self.maintain_errors;
             let (eligibility, alias_rename_map) = pushdown_eligibility(
                 &exprs,
                 &[],
                 &acc_predicates,
                 expr_arena,
                 self.empty_nodes_scratch_mut(),
+                maintain_errors,
+                lp_arena.get(input),
             )?;
 
             let local_predicates = match eligibility {
@@ -257,6 +263,10 @@ impl PredicatePushDown<'_> {
     ) -> PolarsResult<IR> {
         use IR::*;
 
+        // Note: The logic within the match block should ensure `acc_predicates` is left in a state
+        // where it contains only pushable exprs after it is done (although in some cases it may
+        // contain a single fallible expression).
+
         match lp {
             Filter {
                 // Note: We assume AND'ed predicates have already been split to separate IR filter
@@ -275,12 +285,16 @@ impl PredicatePushDown<'_> {
                 let tmp_key = temporary_unique_key(&acc_predicates);
                 acc_predicates.insert(tmp_key.clone(), predicate.clone());
 
+                let maintain_errors = self.maintain_errors;
+
                 let local_predicates = match pushdown_eligibility(
                     &[],
-                    &[predicate.clone()],
+                    &[(&tmp_key, predicate.clone())],
                     &acc_predicates,
                     expr_arena,
                     self.empty_nodes_scratch_mut(),
+                    maintain_errors,
+                    lp_arena.get(input),
                 )?
                 .0
                 {
@@ -606,31 +620,9 @@ impl PredicatePushDown<'_> {
                 acc_predicates,
             ),
             lp @ Union { .. } => {
-                if cfg!(debug_assertions) {
-                    for v in acc_predicates.values() {
-                        let ae = expr_arena.get(v.node());
-                        assert!(permits_filter_pushdown(
-                            self.empty_nodes_scratch_mut(),
-                            ae,
-                            expr_arena
-                        ));
-                    }
-                }
-
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, false)
             },
             lp @ Sort { .. } => {
-                if cfg!(debug_assertions) {
-                    for v in acc_predicates.values() {
-                        let ae = expr_arena.get(v.node());
-                        assert!(permits_filter_pushdown(
-                            self.empty_nodes_scratch_mut(),
-                            ae,
-                            expr_arena
-                        ));
-                    }
-                }
-
                 self.pushdown_and_continue(lp, acc_predicates, lp_arena, expr_arena, true)
             },
             lp @ Sink { .. } | lp @ SinkMultiple { .. } => {

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/utils.rs
@@ -171,10 +171,14 @@ pub enum PushdownEligibility {
 #[allow(clippy::type_complexity)]
 pub fn pushdown_eligibility(
     projection_nodes: &[ExprIR],
-    new_predicates: &[ExprIR],
+    // Predicates that need to be checked (key, expr_ir)
+    new_predicates: &[(&PlSmallStr, ExprIR)],
+    // Note: These predicates have already passed checks.
     acc_predicates: &PlHashMap<PlSmallStr, ExprIR>,
     expr_arena: &mut Arena<AExpr>,
     scratch: &mut UnitVec<Node>,
+    maintain_errors: bool,
+    input_ir: &IR,
 ) -> PolarsResult<(PushdownEligibility, PlHashMap<PlSmallStr, PlSmallStr>)> {
     scratch.clear();
     let ae_nodes_stack = scratch;
@@ -191,77 +195,80 @@ pub fn pushdown_eligibility(
     // Important: Names inserted into any data structure by this function are
     // all non-aliased.
     // This function returns false if pushdown cannot be performed.
-    let process_projection_or_predicate =
-        |ae_nodes_stack: &mut UnitVec<Node>,
-         has_window: &mut bool,
-         common_window_inputs: &mut PlHashSet<PlSmallStr>| {
-            debug_assert_eq!(ae_nodes_stack.len(), 1);
+    let process_projection_or_predicate = |ae_nodes_stack: &mut UnitVec<Node>,
+                                           has_window: &mut bool,
+                                           common_window_inputs: &mut PlHashSet<PlSmallStr>|
+     -> ExprPushdownGroup {
+        debug_assert_eq!(ae_nodes_stack.len(), 1);
 
-            let mut partition_by_names = PlHashSet::<PlSmallStr>::new();
+        let mut partition_by_names = PlHashSet::<PlSmallStr>::new();
+        let mut expr_pushdown_eligibility = ExprPushdownGroup::Pushable;
 
-            while let Some(node) = ae_nodes_stack.pop() {
-                let ae = expr_arena.get(node);
+        while let Some(node) = ae_nodes_stack.pop() {
+            let ae = expr_arena.get(node);
 
-                match ae {
-                    AExpr::Window {
-                        partition_by,
-                        #[cfg(feature = "dynamic_group_by")]
-                        options,
-                        // The function is not checked for groups-sensitivity because
-                        // it is applied over the windows.
-                        ..
-                    } => {
-                        #[cfg(feature = "dynamic_group_by")]
-                        if matches!(options, WindowType::Rolling(..)) {
-                            return false;
-                        };
+            match ae {
+                AExpr::Window {
+                    partition_by,
+                    #[cfg(feature = "dynamic_group_by")]
+                    options,
+                    // The function is not checked for groups-sensitivity because
+                    // it is applied over the windows.
+                    ..
+                } => {
+                    #[cfg(feature = "dynamic_group_by")]
+                    if matches!(options, WindowType::Rolling(..)) {
+                        return ExprPushdownGroup::Barrier;
+                    };
 
-                        partition_by_names.clear();
-                        partition_by_names.reserve(partition_by.len());
+                    partition_by_names.clear();
+                    partition_by_names.reserve(partition_by.len());
 
-                        for node in partition_by.iter() {
-                            // Only accept col()
-                            if let AExpr::Column(name) = expr_arena.get(*node) {
-                                partition_by_names.insert(name.clone());
-                            } else {
-                                // Nested windows can also qualify for push down.
-                                // e.g.:
-                                // * expr1 = min().over(A)
-                                // * expr2 = sum().over(A, expr1)
-                                // Both exprs window over A, so predicates referring
-                                // to A can still be pushed.
-                                ae_nodes_stack.push(*node);
-                            }
-                        }
-
-                        if !*has_window {
-                            for name in partition_by_names.drain() {
-                                common_window_inputs.insert(name);
-                            }
-
-                            *has_window = true;
+                    for node in partition_by.iter() {
+                        // Only accept col()
+                        if let AExpr::Column(name) = expr_arena.get(*node) {
+                            partition_by_names.insert(name.clone());
                         } else {
-                            common_window_inputs.retain(|k| partition_by_names.contains(k))
+                            // Nested windows can also qualify for push down.
+                            // e.g.:
+                            // * expr1 = min().over(A)
+                            // * expr2 = sum().over(A, expr1)
+                            // Both exprs window over A, so predicates referring
+                            // to A can still be pushed.
+                            ae_nodes_stack.push(*node);
+                        }
+                    }
+
+                    if !*has_window {
+                        for name in partition_by_names.drain() {
+                            common_window_inputs.insert(name);
                         }
 
-                        // Cannot push into disjoint windows:
-                        // e.g.:
-                        // * sum().over(A)
-                        // * sum().over(B)
-                        if common_window_inputs.is_empty() {
-                            return false;
-                        }
-                    },
-                    _ => {
-                        if !permits_filter_pushdown(ae_nodes_stack, ae, expr_arena) {
-                            return false;
-                        }
-                    },
-                }
+                        *has_window = true;
+                    } else {
+                        common_window_inputs.retain(|k| partition_by_names.contains(k))
+                    }
+
+                    // Cannot push into disjoint windows:
+                    // e.g.:
+                    // * sum().over(A)
+                    // * sum().over(B)
+                    if common_window_inputs.is_empty() {
+                        return ExprPushdownGroup::Barrier;
+                    }
+                },
+                _ => {
+                    if let ExprPushdownGroup::Barrier =
+                        expr_pushdown_eligibility.update_with_expr(ae_nodes_stack, ae, expr_arena)
+                    {
+                        return ExprPushdownGroup::Barrier;
+                    }
+                },
             }
+        }
 
-            true
-        };
+        expr_pushdown_eligibility
+    };
 
     for e in projection_nodes.iter() {
         if let Some((alias, column_name)) =
@@ -279,11 +286,13 @@ pub fn pushdown_eligibility(
         debug_assert!(ae_nodes_stack.is_empty());
         ae_nodes_stack.push(e.node());
 
-        if !process_projection_or_predicate(
+        if process_projection_or_predicate(
             ae_nodes_stack,
             &mut has_window,
             &mut common_window_inputs,
-        ) {
+        )
+        .blocks_pushdown(maintain_errors)
+        {
             return Ok((PushdownEligibility::NoPushdown, alias_to_col_map));
         }
     }
@@ -312,25 +321,23 @@ pub fn pushdown_eligibility(
         common_window_inputs = new;
     }
 
-    for e in new_predicates.iter() {
+    for (_, e) in new_predicates.iter() {
         debug_assert!(ae_nodes_stack.is_empty());
         ae_nodes_stack.push(e.node());
 
-        if !process_projection_or_predicate(
+        let pd_group = process_projection_or_predicate(
             ae_nodes_stack,
             &mut has_window,
             &mut common_window_inputs,
-        ) {
+        );
+
+        if pd_group.blocks_pushdown(maintain_errors) {
             return Ok((PushdownEligibility::NoPushdown, alias_to_col_map));
         }
     }
 
     // Should have returned early.
     debug_assert!(!common_window_inputs.is_empty() || !has_window);
-
-    if !has_window && projection_nodes.is_empty() {
-        return Ok((PushdownEligibility::Full, alias_to_col_map));
-    }
 
     // Note: has_window is constant.
     let can_use_column = |col: &str| {
@@ -341,33 +348,69 @@ pub fn pushdown_eligibility(
         }
     };
 
-    let to_local = acc_predicates
-        .iter()
+    // For an allocation-free dyn iterator
+    let mut check_predicates_all: Option<_> = None;
+    let mut check_predicates_only_new: Option<_> = None;
+
+    // We only need to check the new predicates if no columns were renamed and there are no window
+    // aggregations.
+    if !has_window
+        && modified_projection_columns.is_empty()
+        && !(
+            // If there is only a single predicate, it may be fallible
+            acc_predicates.len() == 1 && ir_removes_rows(input_ir)
+        )
+    {
+        check_predicates_only_new = Some(new_predicates.iter().map(|(key, expr)| (*key, expr)))
+    } else {
+        check_predicates_all = Some(acc_predicates.iter())
+    }
+
+    let to_check_iter: &mut dyn Iterator<Item = (&PlSmallStr, &ExprIR)> = check_predicates_all
+        .as_mut()
+        .map(|x| x as _)
+        .unwrap_or_else(|| check_predicates_only_new.as_mut().map(|x| x as _).unwrap());
+
+    let mut allow_single_fallible = !ir_removes_rows(input_ir);
+    ae_nodes_stack.clear();
+
+    let to_local = to_check_iter
         .filter_map(|(key, e)| {
             debug_assert!(ae_nodes_stack.is_empty());
 
             ae_nodes_stack.push(e.node());
 
-            let mut can_pushdown = true;
+            let mut uses_blocked_name = false;
+            let mut pd_group = ExprPushdownGroup::Pushable;
 
             while let Some(node) = ae_nodes_stack.pop() {
                 let ae = expr_arena.get(node);
 
-                can_pushdown &= if let AExpr::Column(name) = ae {
-                    can_use_column(name)
+                if let AExpr::Column(name) = ae {
+                    uses_blocked_name |= !can_use_column(name);
                 } else {
-                    // May still contain window expressions that need to be blocked.
-                    permits_filter_pushdown(ae_nodes_stack, ae, expr_arena)
+                    pd_group.update_with_expr(ae_nodes_stack, ae, expr_arena);
                 };
 
-                if !can_pushdown {
+                if uses_blocked_name {
                     break;
                 };
             }
 
             ae_nodes_stack.clear();
 
-            if !can_pushdown {
+            if uses_blocked_name || matches!(pd_group, ExprPushdownGroup::Barrier) {
+                allow_single_fallible = false;
+            }
+
+            if uses_blocked_name
+                || matches!(
+                    // Note: We do not use `blocks_pushdown()`, this fallible indicates that the
+                    // predicate we are checking to push is fallible.
+                    pd_group,
+                    ExprPushdownGroup::Fallible | ExprPushdownGroup::Barrier
+                )
+            {
                 Some(key.clone())
             } else {
                 None
@@ -375,12 +418,52 @@ pub fn pushdown_eligibility(
         })
         .collect::<Vec<_>>();
 
-    match to_local.len() {
-        0 => Ok((PushdownEligibility::Full, alias_to_col_map)),
+    Ok(match to_local.len() {
+        0 => (PushdownEligibility::Full, alias_to_col_map),
         len if len == acc_predicates.len() => {
-            Ok((PushdownEligibility::NoPushdown, alias_to_col_map))
+            if len == 1 && allow_single_fallible {
+                (PushdownEligibility::Full, alias_to_col_map)
+            } else {
+                (PushdownEligibility::NoPushdown, alias_to_col_map)
+            }
         },
-        _ => Ok((PushdownEligibility::Partial { to_local }, alias_to_col_map)),
+        _ => (PushdownEligibility::Partial { to_local }, alias_to_col_map),
+    })
+}
+
+/// Note: This may give false positives as it is a conservative function.
+pub(crate) fn ir_removes_rows(ir: &IR) -> bool {
+    use IR::*;
+
+    // NOTE
+    // At time of writing predicate pushdown runs before slice pushdown, so
+    // some of the below checks for slice may never be hit.
+
+    match ir {
+        DataFrameScan { .. }
+        | SimpleProjection { .. }
+        | Select { .. }
+        | Cache { .. }
+        | HStack { .. }
+        | HConcat { .. } => false,
+
+        GroupBy { options, .. } => options.slice.is_some(),
+
+        Sort { slice, .. } => slice.is_some(),
+
+        #[cfg(feature = "merge_sorted")]
+        MergeSorted { .. } => false,
+
+        #[cfg(feature = "python")]
+        PythonScan { options } => options.n_rows.is_some(),
+
+        // Scan currently may evaluate the predicate on the statistics of the
+        // entire files list.
+        Scan {
+            unified_scan_args, ..
+        } => unified_scan_args.pre_slice.is_some(),
+
+        _ => true,
     }
 }
 

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -15,14 +15,16 @@ mod inner {
         #[expect(unused)]
         pub new_streaming: bool,
         scratch: UnitVec<Node>,
+        pub(super) maintain_errors: bool,
     }
 
     impl SlicePushDown {
-        pub fn new(streaming: bool, new_streaming: bool) -> Self {
+        pub fn new(streaming: bool, maintain_errors: bool, new_streaming: bool) -> Self {
             Self {
                 streaming,
                 new_streaming,
                 scratch: unitvec![],
+                maintain_errors,
             }
         }
 
@@ -61,6 +63,7 @@ fn can_pushdown_slice_past_projections(
     exprs: &[ExprIR],
     arena: &Arena<AExpr>,
     scratch: &mut UnitVec<Node>,
+    maintain_errors: bool,
 ) -> (bool, bool) {
     scratch.clear();
 
@@ -81,6 +84,8 @@ fn can_pushdown_slice_past_projections(
         let mut has_column = false;
         let mut literals_all_scalar = true;
 
+        let mut pd_group = ExprPushdownGroup::Pushable;
+
         while let Some(node) = scratch.pop() {
             let ae = arena.get(node);
 
@@ -93,7 +98,10 @@ fn can_pushdown_slice_past_projections(
                 _ => {},
             }
 
-            if !permits_filter_pushdown(scratch, ae, arena) {
+            if pd_group
+                .update_with_expr(scratch, ae, arena)
+                .blocks_pushdown(maintain_errors)
+            {
                 return (false, false);
             }
         }
@@ -436,7 +444,8 @@ impl SlicePushDown {
             }
             // there is state, inspect the projection to determine how to deal with it
             (Select {input, expr, schema, options}, Some(_)) => {
-                if can_pushdown_slice_past_projections(&expr, expr_arena, self.empty_nodes_scratch_mut()).1 {
+                let maintain_errors = self.maintain_errors;
+                if can_pushdown_slice_past_projections(&expr, expr_arena, self.empty_nodes_scratch_mut(), maintain_errors).1 {
                     let lp = Select {input, expr, schema, options};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
                 }
@@ -447,7 +456,8 @@ impl SlicePushDown {
                 }
             }
             (HStack {input, exprs, schema, options}, _) => {
-                let (can_pushdown, can_pushdown_and_any_expr_has_column) = can_pushdown_slice_past_projections(&exprs, expr_arena, self.empty_nodes_scratch_mut());
+                let maintain_errors = self.maintain_errors;
+                let (can_pushdown, can_pushdown_and_any_expr_has_column) = can_pushdown_slice_past_projections(&exprs, expr_arena, self.empty_nodes_scratch_mut(), maintain_errors);
 
                 if can_pushdown_and_any_expr_has_column || (
                     // If the schema length is greater then an input column is being projected, so

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_frame_not_equal
 
 
@@ -316,3 +317,36 @@ def test_slice_empty_morsel_input() -> None:
     q = pl.LazyFrame({"a": []})
     assert_frame_equal(q.slice(999, 3).slice(999, 3).collect(), q.collect().clear())
     assert_frame_equal(q.slice(-999, 3).slice(-999, 3).collect(), q.collect().clear())
+
+
+@pytest.mark.parametrize(
+    "base_query",
+    [
+        (
+            pl.LazyFrame({"a": [[1]]})
+            .select("a", BARRIER=pl.col("a").sort())
+            .with_columns(MARKER=1)
+            .with_columns(b=pl.col("a").list.get(1, null_on_oob=False))
+        ),
+        (  # Variant to ensure cluster_with_columns runs after slice pushdown.
+            pl.LazyFrame({"a": [[1]]})
+            .with_columns(BARRIER=pl.col("a").sort())
+            .with_columns(MARKER=1)
+            .with_columns(b=pl.col("a").list.get(1, null_on_oob=False))
+        ),
+    ],
+)
+def test_slice_pushdown_pushes_past_fallible(
+    base_query: pl.LazyFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Ensure baseline fails
+    with pytest.raises(ComputeError, match="index is out of bounds"):
+        base_query.collect()
+
+    q = base_query.head(0)
+
+    plan = q.explain()
+
+    assert plan.index("BARRIER") > plan.index("SLICE") > plan.index("MARKER")
+
+    assert_frame_equal(q.collect(), pl.DataFrame(schema=q.collect_schema()))

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 
@@ -290,7 +290,6 @@ def test_multi_alias_pushdown() -> None:
     actual = lf.with_columns(m="a", n="b").filter((pl.col("m") + pl.col("n")) < 2)
     plan = actual.explain()
 
-    print(plan)
     assert plan.count("FILTER") == 1
     assert re.search(r"FILTER.*FROM\n\s*DF", plan, re.DOTALL) is not None
 
@@ -538,7 +537,9 @@ def test_predicate_push_down_with_alias_15442() -> None:
     assert output.to_dict(as_series=False) == {"a": [1]}
 
 
-def test_predicate_slice_pushdown_list_gather_17492() -> None:
+def test_predicate_slice_pushdown_list_gather_17492(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     lf = pl.LazyFrame({"val": [[1], [1, 1]], "len": [1, 2]})
 
     assert_frame_equal(
@@ -559,8 +560,16 @@ def test_predicate_slice_pushdown_list_gather_17492() -> None:
     # Also check slice pushdown
     q = lf.with_columns(pl.col("val").list.get(1).alias("b")).slice(1, 1)
 
-    with pytest.raises(ComputeError, match="get index is out of bounds"):
-        q.collect()
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "val": [[1, 1]],
+                "len": pl.Series([2], dtype=pl.Int64),
+                "b": pl.Series([1], dtype=pl.Int64),
+            }
+        ),
+    )
 
 
 def test_predicate_pushdown_struct_unnest_19632() -> None:
@@ -749,3 +758,310 @@ def test_predicate_pushdown_lazy_rename_22373(
     # Ensure filter is pushed past rename
     plan = query.explain()
     assert plan.index("FILTER") > plan.index("RENAME")
+
+
+@pytest.mark.parametrize(
+    "base_query",
+    [
+        (  # Fallible expr in earlier `with_columns()`
+            pl.LazyFrame({"a": [[1]]})
+            .with_columns(MARKER=1)
+            .with_columns(b=pl.col("a").list.get(1, null_on_oob=False))
+        ),
+        (  # Fallible expr in earlier `filter()`
+            pl.LazyFrame({"a": [[1]]})
+            .with_columns(MARKER=1)
+            .filter(
+                pl.col("a")
+                .list.get(1, null_on_oob=False)
+                .cast(pl.Boolean, strict=False)
+            )
+        ),
+        (  # Fallible expr in earlier `select()`
+            pl.LazyFrame({"a": [[1]]})
+            .with_columns(MARKER=1)
+            .select("a", "MARKER", b=pl.col("a").list.get(1, null_on_oob=False))
+        ),
+    ],
+)
+def test_predicate_pushdown_pushes_past_fallible(
+    base_query: pl.LazyFrame, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Ensure baseline fails
+    with pytest.raises(ComputeError, match="index is out of bounds"):
+        base_query.collect()
+
+    q = base_query.filter(pl.col("a").list.len() > 1)
+
+    plan = q.explain()
+
+    assert plan.index("list.len") > plan.index("MARKER")
+
+    assert_frame_equal(q.collect(), pl.DataFrame(schema=q.collect_schema()))
+
+    monkeypatch.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
+
+    with pytest.raises(ComputeError, match="index is out of bounds"):
+        q.collect()
+
+
+def test_predicate_pushdown_fallible_exprs_22284(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    q = (
+        pl.LazyFrame({"a": ["xyz", "123", "456", "789"]})
+        .with_columns(MARKER=1)
+        .filter(pl.col.a.str.contains(r"^\d{3}$"))
+        .filter(pl.col.a.cast(pl.Int64) >= 123)
+    )
+
+    plan = q.explain()
+
+    assert (
+        plan.index('FILTER [(col("a").strict_cast(Int64)) >= (123)]')
+        < plan.index("MARKER")
+        < plan.index(r'FILTER col("a").str.contains(["^\d{3}$"])')
+    )
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "a": ["123", "456", "789"],
+                "MARKER": 1,
+            }
+        ),
+    )
+
+    lf = pl.LazyFrame(
+        {
+            "str_date": ["2025-01-01", "20250101"],
+            "data_source": ["system_1", "system_2"],
+        }
+    )
+
+    q = lf.filter(pl.col("data_source") == "system_1").filter(
+        pl.col("str_date").str.to_datetime("%Y-%m-%d", strict=True)
+        == datetime(2025, 1, 1)
+    )
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "str_date": ["2025-01-01"],
+                "data_source": ["system_1"],
+            }
+        ),
+    )
+
+    q = lf.with_columns(
+        pl.col("str_date").str.to_datetime("%Y-%m-%d", strict=True)
+    ).filter(pl.col("data_source") == "system_1")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "str_date": [datetime(2025, 1, 1)],
+                "data_source": ["system_1"],
+            }
+        ),
+    )
+
+    monkeypatch.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
+
+    with pytest.raises(
+        InvalidOperationError, match=r"`str` to `datetime\[μs\]` failed"
+    ):
+        q.collect()
+
+
+def test_predicate_pushdown_single_fallible() -> None:
+    lf = pl.LazyFrame({"a": [0, 1]}).with_columns(MARKER=pl.lit(1, dtype=pl.Int64))
+
+    q = lf.filter(pl.col("a").cast(pl.Boolean))
+
+    plan = q.explain()
+
+    assert plan.index('FILTER col("a").strict_cast(Boolean)') > plan.index("MARKER")
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 1, "MARKER": 1}))
+
+
+def test_predicate_pushdown_split_pushable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lf = pl.LazyFrame({"a": [1, 999]}).with_columns(MARKER=pl.lit(1, dtype=pl.Int64))
+
+    q = lf.filter(
+        pl.col("a") == 1,  # pushable
+        pl.col("a").cast(pl.Int8) == 1,  # fallible
+    )
+
+    plan = q.explain()
+
+    assert (
+        plan.index('FILTER [(col("a").strict_cast(Int8)) == (1)]')
+        < plan.index("MARKER")
+        < plan.index('FILTER [(col("a")) == (1)]')
+    )
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 1, "MARKER": 1}))
+
+    with monkeypatch.context() as cx:
+        cx.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
+
+        with pytest.raises(
+            InvalidOperationError, match="conversion from `i64` to `i8` failed"
+        ):
+            q.collect()
+
+    q = lf.filter(
+        pl.col("a").cast(pl.UInt16) == 1,
+        pl.col("a").sort() == 1,
+    )
+
+    plan = q.explain()
+
+    assert plan.index(
+        'FILTER [([(col("a").strict_cast(UInt16)) == (1)]) & ([(col("a").sort(asc)) == (1)])]'
+    ) < plan.index("MARKER")
+
+    assert_frame_equal(q.collect(), pl.DataFrame({"a": 1, "MARKER": 1}))
+
+    with monkeypatch.context() as cx:
+        cx.setenv("POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS", "1")
+        assert_frame_equal(q.collect(), pl.DataFrame({"a": 1, "MARKER": 1}))
+
+    # Ensure it is not pushed past a join
+
+    # Baseline
+    q = lf.join(
+        lf.drop("MARKER").collect().lazy(),
+        on="a",
+        how="inner",
+        coalesce=False,
+        maintain_order="left_right",
+    ).filter(pl.col("a_right") == 1)
+
+    plan = q.explain()
+
+    assert not plan.startswith("FILTER")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "a": 1,
+                "MARKER": 1,
+                "a_right": 1,
+            }
+        ),
+    )
+
+    q = lf.join(
+        lf.drop("MARKER").collect().lazy(),
+        on="a",
+        how="inner",
+        coalesce=False,
+        maintain_order="left_right",
+    ).filter(pl.col("a_right").cast(pl.Int16) == 1)
+
+    plan = q.explain()
+
+    assert plan.startswith("FILTER")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "a": 1,
+                "MARKER": 1,
+                "a_right": 1,
+            }
+        ),
+    )
+
+    # With a select node in between
+
+    q = (
+        lf.join(
+            lf.drop("MARKER").collect().lazy(),
+            on="a",
+            how="inner",
+            coalesce=False,
+            maintain_order="left_right",
+        )
+        .select(
+            "a",
+            "a_right",
+            "MARKER",
+        )
+        .filter(pl.col("a_right").cast(pl.Int16) == 1)
+    )
+
+    plan = q.explain()
+
+    assert plan.startswith("FILTER")
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame(
+            {
+                "a": 1,
+                "a_right": 1,
+                "MARKER": 1,
+            }
+        ),
+    )
+
+
+def test_predicate_pushdown_fallible_literal_in_filter_expr() -> None:
+    # Fallible operations on literals inside of the predicate expr should not
+    # block pushdown.
+    lf = pl.LazyFrame(
+        {"column": "2025-01-01", "column_date": datetime(2025, 1, 1), "integer": 1}
+    )
+
+    q = lf.with_columns(
+        MARKER=1,
+    ).filter(
+        pl.col("column_date")
+        == pl.lit("2025-01-01").str.to_datetime("%Y-%m-%d", strict=True)
+    )
+
+    plan = q.explain()
+
+    assert plan.index("FILTER") > plan.index("MARKER")
+
+    assert q.collect().height == 1
+
+    q = lf.with_columns(
+        MARKER=1,
+    ).filter(pl.col("integer") == pl.lit("1").cast(pl.Int64, strict=True))
+
+    plan = q.explain()
+
+    assert plan.index("FILTER") > plan.index("MARKER")
+
+    assert q.collect().height == 1
+
+
+def test_predicate_does_not_split_barrier_expr() -> None:
+    q = (
+        pl.LazyFrame({"a": [1, 2, 3]})
+        .with_row_index()
+        .filter(pl.col("a") > 1, pl.col("a").sort() == 3)
+    )
+
+    plan = q.explain()
+
+    assert plan.startswith(
+        'FILTER [([(col("a")) > (1)]) & ([(col("a").sort(asc)) == (3)])]'
+    )
+
+    assert_frame_equal(
+        q.collect(),
+        pl.DataFrame({"a": 3}).with_row_index(offset=2),
+    )


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22284

Updates predicate pushdown to account for fallible expressions through the use of a new `ExprPushdownGroup` enum, where we categorize expressions into 3 groups - `Pushable`, `Fallible` and `Barrier` - I have left an explanation of these in comments in the code.

For detection of fallible expressions, I've added some commonly used ones - e.g. `strict-cast`, `strptime`, but there are likely much more expressions that should be caught.

This PR also adds a `POLARS_PUSHDOWN_OPT_MAINTAIN_ERRORS` flag. This can be used to ensure predicate pushdowns do not "mask" query errors by preventing predicates from being pushed past fallible projections.
