### PR TITLE
fix: Fix deadlock joining scanned tables with low thread count

### DIFF
--- a/crates/polars-mem-engine/src/executors/cache.rs
+++ b/crates/polars-mem-engine/src/executors/cache.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::Ordering;
 
+#[cfg(feature = "async")]
 use polars_io::pl_async;
 
 use super::*;

--- a/crates/polars-mem-engine/src/executors/cache.rs
+++ b/crates/polars-mem-engine/src/executors/cache.rs
@@ -120,6 +120,10 @@ impl Executor for CachePrefiller {
             let _df = cache_exec.execute(&mut state)?;
         }
 
+        if state.verbose() && !scan_handles.is_empty() {
+            eprintln!("CachePrefiller: wait for {} scans", scan_handles.len())
+        }
+
         for handle in scan_handles {
             pl_async::get_runtime().block_on(handle).unwrap()?;
         }

--- a/crates/polars-mem-engine/src/executors/cache.rs
+++ b/crates/polars-mem-engine/src/executors/cache.rs
@@ -64,6 +64,8 @@ impl Executor for CachePrefiller {
                 .unwrap()
                 .parse::<usize>()
                 .unwrap();
+            // Note: This needs to be less than the size of the tokio blocking threadpool (which
+            // defaults to 512).
             // POOL.current_num_threads().min(128);
 
             if state.verbose() {
@@ -102,6 +104,13 @@ impl Executor for CachePrefiller {
                 }));
 
                 continue;
+            }
+
+            // This cache node may have dependency on the in-progress scan nodes,
+            // ensure all of them complete here.
+
+            if state.verbose() && !scan_handles.is_empty() {
+                eprintln!("CachePrefiller: wait for {} scans", scan_handles.len())
             }
 
             for handle in scan_handles.drain(..) {

--- a/crates/polars-mem-engine/src/executors/cache.rs
+++ b/crates/polars-mem-engine/src/executors/cache.rs
@@ -59,7 +59,11 @@ impl Executor for CachePrefiller {
 
         #[cfg(feature = "async")]
         let concurrent_scans_limit = {
-            let concurrent_scans_limit = POOL.current_num_threads().min(128);
+            let concurrent_scans_limit = std::env::var("CACHE_PREFILLER_CONCURRENT_SCANS_LIMIT")
+                .unwrap()
+                .parse::<usize>()
+                .unwrap();
+            // POOL.current_num_threads().min(128);
 
             if state.verbose() {
                 eprintln!(

--- a/crates/polars-mem-engine/src/executors/cache.rs
+++ b/crates/polars-mem-engine/src/executors/cache.rs
@@ -105,6 +105,7 @@ impl Executor for CachePrefiller {
             // This cache node may have dependency on the in-progress scan nodes,
             // ensure all of them complete here.
 
+            #[cfg(feature = "async")]
             if state.verbose() && !scan_handles.is_empty() {
                 eprintln!(
                     "CachePrefiller: wait for {} scans executors",
@@ -112,6 +113,7 @@ impl Executor for CachePrefiller {
                 )
             }
 
+            #[cfg(feature = "async")]
             for handle in scan_handles.drain(..) {
                 pl_async::get_runtime().block_on(handle).unwrap()?;
             }
@@ -119,6 +121,7 @@ impl Executor for CachePrefiller {
             let _df = cache_exec.execute(&mut state)?;
         }
 
+        #[cfg(feature = "async")]
         if state.verbose() && !scan_handles.is_empty() {
             eprintln!(
                 "CachePrefiller: wait for {} scans executors",
@@ -126,6 +129,7 @@ impl Executor for CachePrefiller {
             )
         }
 
+        #[cfg(feature = "async")]
         for handle in scan_handles {
             pl_async::get_runtime().block_on(handle).unwrap()?;
         }

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -516,6 +516,7 @@ fn create_physical_plan_impl(
                                 id: scan_mem_id,
                                 // This is (n_hits - 1), because the drop logic is `fetch_sub(1) == 0`.
                                 count: 0,
+                                is_new_streaming_scan: true,
                             }),
                         );
                     } else {
@@ -531,6 +532,7 @@ fn create_physical_plan_impl(
                         // `cache_nodes`.
                         input: None,
                         count: Default::default(),
+                        is_new_streaming_scan: true,
                     }))
                 },
                 #[allow(unreachable_patterns)]
@@ -616,6 +618,7 @@ fn create_physical_plan_impl(
                     id,
                     input: Some(input),
                     count: cache_hits,
+                    is_new_streaming_scan: false,
                 });
 
                 cache_nodes.insert(id, cache);
@@ -625,6 +628,7 @@ fn create_physical_plan_impl(
                 id,
                 input: None,
                 count: cache_hits,
+                is_new_streaming_scan: false,
             }))
         },
         Distinct { input, options } => {

--- a/crates/polars-mem-engine/src/planner/lp.rs
+++ b/crates/polars-mem-engine/src/planner/lp.rs
@@ -208,7 +208,7 @@ fn create_physical_plan_impl(
     expr_arena: &mut Arena<AExpr>,
     state: &mut ConversionState,
     // Cache nodes in order of discovery
-    cache_nodes: &mut PlIndexMap<usize, Box<dyn Executor>>,
+    cache_nodes: &mut PlIndexMap<usize, Box<executors::CacheExec>>,
     build_streaming_executor: Option<StreamingExecutorBuilder>,
 ) -> PolarsResult<Box<dyn Executor>> {
     use IR::*;
@@ -438,6 +438,7 @@ fn create_physical_plan_impl(
             scan_type,
             predicate,
             mut unified_scan_args,
+            id: scan_mem_id,
         } => {
             unified_scan_args.pre_slice = if let Some(mut slice) = unified_scan_args.pre_slice {
                 *slice.len_mut() = _set_n_rows_for_scan(Some(slice.len())).unwrap();
@@ -447,7 +448,7 @@ fn create_physical_plan_impl(
                     .map(|len| polars_utils::slice_enum::Slice::Positive { offset: 0, len })
             };
 
-            let mut state = ExpressionConversionState::new(true);
+            let mut expr_conversion_state = ExpressionConversionState::new(true);
 
             let mut create_skip_batch_predicate = false;
             #[cfg(feature = "parquet")]
@@ -470,7 +471,7 @@ fn create_physical_plan_impl(
                         &predicate,
                         expr_arena,
                         output_schema.as_ref().unwrap_or(&file_info.schema),
-                        &mut state,
+                        &mut expr_conversion_state,
                         create_skip_batch_predicate,
                         false,
                     )
@@ -485,14 +486,52 @@ fn create_physical_plan_impl(
                         unified_scan_args,
                         file_info,
                         output_schema,
-                        predicate_has_windows: state.has_windows,
+                        predicate_has_windows: expr_conversion_state.has_windows,
                     }))
                 },
                 #[allow(unreachable_patterns)]
                 _ => {
-                    let build_func = build_streaming_executor
-                        .expect("invalid build. Missing feature new-streaming");
-                    return build_func(root, lp_arena, expr_arena);
+                    // We wrap in a CacheExec so that the new-streaming scan gets called from the
+                    // CachePrefiller. This ensures it is called from outside of rayon to avoid
+                    // deadlocks.
+                    //
+                    // Note that we don't actually want it to be kept in memory after being used,
+                    // so we set the count to have it be dropped after a single use (or however
+                    // many times it is referenced after CSE (subplan)).
+                    state.has_cache_parent = true;
+                    state.has_cache_child = true;
+
+                    let scan_mem_id: usize = scan_mem_id.to_usize();
+
+                    if !cache_nodes.contains_key(&scan_mem_id) {
+                        let build_func = build_streaming_executor
+                            .expect("invalid build. Missing feature new-streaming");
+
+                        let executor = build_func(root, lp_arena, expr_arena)?;
+
+                        cache_nodes.insert(
+                            scan_mem_id,
+                            Box::new(executors::CacheExec {
+                                input: Some(executor),
+                                id: scan_mem_id,
+                                // This is (n_hits - 1), because the drop logic is `fetch_sub(1) == 0`.
+                                count: 0,
+                            }),
+                        );
+                    } else {
+                        // Already exists - this scan IR is under a CSE (subplan). We need to
+                        // increment the cache hit count here.
+                        let cache_exec = cache_nodes.get_mut(&scan_mem_id).unwrap();
+                        cache_exec.count = cache_exec.count.saturating_add(1);
+                    }
+
+                    Ok(Box::new(executors::CacheExec {
+                        id: scan_mem_id,
+                        // Rest of the fields don't matter - the actual node was inserted into
+                        // `cache_nodes`.
+                        input: None,
+                        count: Default::default(),
+                    }))
                 },
                 #[allow(unreachable_patterns)]
                 _ => unreachable!(),

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -71,6 +71,7 @@ where
             predicate,
             output_schema,
             scan_type,
+            id: _,
         } => {
             let paths = sources.into_paths();
             let schema = output_schema.as_ref().unwrap_or(&file_info.schema);

--- a/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
+++ b/crates/polars-plan/src/plans/conversion/dsl_to_ir.rs
@@ -374,6 +374,7 @@ pub fn to_alp_impl(lp: DslPlan, ctxt: &mut DslConversionContext) -> PolarsResult
                         scan_type,
                         output_schema: None,
                         unified_scan_args,
+                        id: Default::default(),
                     }
                 };
 

--- a/crates/polars-plan/src/plans/conversion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/mod.rs
@@ -70,6 +70,7 @@ impl IR {
                     scan_type,
                     output_schema: _,
                     unified_scan_args,
+                    id: _,
                 } = ir.clone()
                 else {
                     unreachable!()

--- a/crates/polars-plan/src/plans/ir/dot.rs
+++ b/crates/polars-plan/src/plans/ir/dot.rs
@@ -246,6 +246,7 @@ impl<'a> IRDotDisplay<'a> {
                 scan_type,
                 unified_scan_args,
                 output_schema: _,
+                id: _,
             } => {
                 let name: &str = (&**scan_type).into();
                 let path = ScanSourcesDisplay(sources);

--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -73,12 +73,14 @@ fn write_scan(
     predicate: &Option<ExprIRDisplay<'_>>,
     pre_slice: Option<Slice>,
     row_index: Option<&RowIndex>,
+    scan_mem_id: Option<usize>,
 ) -> fmt::Result {
     write!(
         f,
-        "{:indent$}{name} SCAN {}",
+        "{:indent$}{name} SCAN {} [id: {:?}]",
         "",
-        ScanSourcesDisplay(sources)
+        ScanSourcesDisplay(sources),
+        scan_mem_id,
     )?;
 
     let total_columns = total_columns - usize::from(row_index.is_some());
@@ -678,6 +680,7 @@ pub fn write_ir_non_recursive(
                     .n_rows
                     .map(|len| polars_utils::slice_enum::Slice::Positive { offset: 0, len }),
                 None,
+                None,
             )
         },
         IR::Slice {
@@ -704,6 +707,7 @@ pub fn write_ir_non_recursive(
             unified_scan_args,
             hive_parts: _,
             output_schema: _,
+            id: scan_mem_id,
         } => {
             let n_columns = unified_scan_args
                 .projection
@@ -723,6 +727,7 @@ pub fn write_ir_non_recursive(
                 &predicate,
                 unified_scan_args.pre_slice.clone(),
                 unified_scan_args.row_index.as_ref(),
+                Some(scan_mem_id.to_usize()),
             )
         },
         IR::DataFrameScan {

--- a/crates/polars-plan/src/plans/ir/inputs.rs
+++ b/crates/polars-plan/src/plans/ir/inputs.rs
@@ -103,6 +103,7 @@ impl IR {
                 predicate,
                 unified_scan_args,
                 scan_type,
+                id: _,
             } => {
                 let mut new_predicate = None;
                 if predicate.is_some() {
@@ -117,6 +118,7 @@ impl IR {
                     unified_scan_args: unified_scan_args.clone(),
                     predicate: new_predicate,
                     scan_type: scan_type.clone(),
+                    id: Default::default(),
                 }
             },
             DataFrameScan {

--- a/crates/polars-plan/src/plans/ir/mod.rs
+++ b/crates/polars-plan/src/plans/ir/mod.rs
@@ -11,6 +11,7 @@ pub use dot::{EscapeLabel, IRDotDisplay, PathsDisplay, ScanSourcesDisplay};
 pub use format::{ExprIRDisplay, IRDisplay, write_group_by, write_ir_non_recursive};
 use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
+use polars_utils::unique_id::UniqueId;
 use polars_utils::unitvec;
 #[cfg(feature = "ir_serde")]
 use serde::{Deserialize, Serialize};
@@ -62,6 +63,16 @@ pub enum IR {
         scan_type: Box<FileScan>,
         /// generic options that can be used for all file types.
         unified_scan_args: Box<UnifiedScanArgs>,
+        /// This used as part of a hack to prevent deadlocks when we run the in-memory engine with
+        /// scans dispatched to new-streaming. This ID is used as the ID of the CacheExec that
+        /// wraps this scan. It will not be needed once everything runs in new-streaming.
+        ///
+        /// We use this instead of the Arc-address of the ScanSources as it's possible to pass the
+        /// same set of ScanSources with different scan options.
+        ///
+        /// NOTE: This must be reset to a new Arc during e.g. predicate / slice pushdown.
+        #[cfg_attr(feature = "serde", serde(skip, default))]
+        id: UniqueId,
     },
     DataFrameScan {
         df: Arc<DataFrame>,

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -107,6 +107,7 @@ impl OptimizationRule for ExpandDatasets {
                                 hive_parts: _,
                                 predicate: _,
                                 output_schema: _,
+                                id: _,
                             } = &mut ir
                             else {
                                 unreachable!()

--- a/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/predicate_pushdown/mod.rs
@@ -362,6 +362,7 @@ impl PredicatePushDown<'_> {
                 scan_type,
                 unified_scan_args,
                 output_schema,
+                id: _,
             } => {
                 let mut blocked_names = Vec::with_capacity(2);
 
@@ -416,6 +417,7 @@ impl PredicatePushDown<'_> {
                         unified_scan_args,
                         output_schema,
                         scan_type,
+                        id: Default::default(),
                     }
                 } else {
                     let lp = Scan {
@@ -426,6 +428,7 @@ impl PredicatePushDown<'_> {
                         unified_scan_args,
                         output_schema,
                         scan_type,
+                        id: Default::default(),
                     };
                     if let Some(predicate) = predicate {
                         let input = lp_arena.add(lp);

--- a/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/plans/optimizer/projection_pushdown/mod.rs
@@ -435,6 +435,7 @@ impl ProjectionPushDown {
                 predicate,
                 mut unified_scan_args,
                 mut output_schema,
+                id: _,
             } => {
                 let do_optimization = match &*scan_type {
                     FileScan::Anonymous { function, .. } => function.allows_projection_pushdown(),
@@ -561,6 +562,7 @@ impl ProjectionPushDown {
                     scan_type,
                     predicate,
                     unified_scan_args,
+                    id: Default::default(),
                 };
 
                 Ok(lp)

--- a/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/plans/optimizer/slice_pushdown_lp.rs
@@ -224,6 +224,7 @@ impl SlicePushDown {
                 mut unified_scan_args,
                 predicate,
                 scan_type,
+                id: _,
             }, Some(state)) if predicate.is_none() && match &*scan_type {
                 #[cfg(feature = "parquet")]
                 FileScan::Parquet { .. } => true,
@@ -253,6 +254,7 @@ impl SlicePushDown {
                     scan_type,
                     unified_scan_args,
                     predicate,
+                    id: Default::default(),
                 };
 
                 Ok(lp)

--- a/crates/polars-plan/src/plans/visitor/hash.rs
+++ b/crates/polars-plan/src/plans/visitor/hash.rs
@@ -81,6 +81,7 @@ impl Hash for HashableEqLP<'_> {
                 output_schema: _,
                 scan_type,
                 unified_scan_args,
+                id: _,
             } => {
                 // We don't have to traverse the schema, hive partitions etc. as they are derivative from the paths.
                 scan_type.hash(state);
@@ -262,6 +263,7 @@ impl HashableEqLP<'_> {
                     output_schema: _,
                     scan_type: stl,
                     unified_scan_args: ol,
+                    id: _,
                 },
                 IR::Scan {
                     sources: pr,
@@ -271,6 +273,7 @@ impl HashableEqLP<'_> {
                     output_schema: _,
                     scan_type: str,
                     unified_scan_args: or,
+                    id: _,
                 },
             ) => {
                 pl == pr

--- a/crates/polars-python/src/lazyframe/visitor/nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/nodes.rs
@@ -371,6 +371,7 @@ pub(crate) fn into_py(py: Python<'_>, plan: &IR) -> PyResult<PyObject> {
             output_schema: _,
             scan_type,
             unified_scan_args,
+            id: _,
         } => Scan {
             paths: sources
                 .into_paths()

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -472,6 +472,7 @@ pub fn lower_ir(
                 scan_type,
                 predicate,
                 unified_scan_args,
+                id: _,
             } = v.clone()
             else {
                 unreachable!();

--- a/crates/polars-stream/src/utils/late_materialized_df.rs
+++ b/crates/polars-stream/src/utils/late_materialized_df.rs
@@ -36,6 +36,7 @@ impl LateMaterializedDataFrame {
                 function: self,
             }),
             unified_scan_args: Box::new(UnifiedScanArgs::default()),
+            id: Default::default(),
         }
     }
 }

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -38,6 +38,7 @@ pub mod sync;
 #[cfg(feature = "sysinfo")]
 pub mod sys;
 pub mod total_ord;
+pub mod unique_id;
 
 pub use functions::*;
 pub mod file;

--- a/crates/polars-utils/src/unique_id.rs
+++ b/crates/polars-utils/src/unique_id.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+/// Unique ref-counted identifier.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct UniqueId(
+    // We use an Arc to reserve a memory address rather than a static atomic counter, as the latter
+    // may cause duplicate IDs on wrap-around.
+    //
+    // Note, this inner repr is a private implementation detail.
+    Arc<()>,
+);
+
+impl UniqueId {
+    pub fn to_usize(&self) -> usize {
+        Arc::as_ptr(&self.0) as usize
+    }
+}
+
+impl Default for UniqueId {
+    fn default() -> Self {
+        Self(Arc::new(()))
+    }
+}

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -907,6 +907,8 @@ import io
 import polars as pl
 from polars.testing import assert_frame_equal
 
+assert pl.thread_pool_size() == 2
+
 f = io.BytesIO()
 
 df = pl.DataFrame({x: 1 for x in ["a", "b", "c", "d", "e"]})
@@ -926,3 +928,89 @@ print("OK", end="")
     )
 
     assert out == b"OK"
+
+
+def test_scan_parquet_in_mem_to_streaming_dispatch_deadlock_22641() -> None:
+    out = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            """\
+import os
+
+os.environ["POLARS_MAX_THREADS"] = "1"
+os.environ["POLARS_VERBOSE"] = "1"
+
+import io
+import sys
+from threading import Thread
+
+import polars as pl
+
+assert pl.thread_pool_size() == 1
+
+f = io.BytesIO()
+pl.DataFrame({"x": 1}).write_parquet(f)
+
+q = (
+    pl.scan_parquet(f)
+    .filter(pl.sum_horizontal(pl.col("x"), pl.col("x"), pl.col("x")) >= 0)
+    .join(pl.scan_parquet(f), on="x", how="left")
+)
+
+results = [pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), pl.DataFrame()]
+
+
+def run():
+    results[0] = q.collect()
+
+    print("QUERY-FENCE", file=sys.stderr)
+
+    results[1] = pl.concat([q, q, q]).collect().head(1)
+
+    print("QUERY-FENCE", file=sys.stderr)
+
+    results[2] = pl.collect_all([q, q, q])[0]
+
+    print("QUERY-FENCE", file=sys.stderr)
+
+    results[3] = pl.collect_all(3 * [pl.concat(3 * [q])])[0].head(1)
+
+
+t = Thread(target=run, daemon=True)
+t.start()
+t.join(5)
+
+assert [x.equals(pl.DataFrame({"x": 1})) for x in results] == [True, True, True, True]
+
+print("OK", end="", file=sys.stderr)
+""",
+        ],
+        stderr=subprocess.STDOUT,
+    )
+
+    assert out.endswith(b"OK")
+
+    def ensure_caches_dropped(verbose_log: str) -> None:
+        cache_hit_prefix = "CACHE HIT: cache id: "
+
+        ids_hit = {
+            x[len(cache_hit_prefix) :]
+            for x in verbose_log.splitlines()
+            if x.startswith(cache_hit_prefix)
+        }
+
+        cache_drop_prefix = "CACHE DROP: cache id: "
+
+        ids_dropped = {
+            x[len(cache_drop_prefix) :]
+            for x in verbose_log.splitlines()
+            if x.startswith(cache_drop_prefix)
+        }
+
+        assert ids_hit == ids_dropped
+
+    out_str = out.decode()
+
+    for logs in out_str.split("QUERY-FENCE"):
+        ensure_caches_dropped(logs)

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -962,6 +962,11 @@ results = [pl.DataFrame(), pl.DataFrame(), pl.DataFrame(), pl.DataFrame()]
 
 
 def run():
+    # Also test just a single scan
+    pl.scan_parquet(f).collect()
+
+    print("QUERY-FENCE", file=sys.stderr)
+
     results[0] = q.collect()
 
     print("QUERY-FENCE", file=sys.stderr)


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22641

> sum_horizontal is calling into rayon here from the new-streaming parquet statistics evaluation, but the single rayon thread is blocked on the StreamingQueryExecutor.

Possible solutions I could think of:

* [ ] (1) Check all expressions for use of rayon, and add propagation of a `parallel` argument to all expressions that use rayon.
* [x] (2) Hide the scans inside a `CacheExec`, this gets called by `CachePrefiller` which guarantees the scans are never called (blocked on) from a rayon thread.

(2) is very much a hack, but it's a hack that's nicely confined to the in-mem engine (which is also the only place where it's needed). In the future after everything runs on new-streaming, it may no longer be needed.
