### PR TITLE
feat(python): Support inference of `Int128` dtype from databases that support it

### DIFF
--- a/py-polars/polars/convert/general.py
+++ b/py-polars/polars/convert/general.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
         ArrowArrayExportable,
         ArrowStreamExportable,
         Orientation,
+        PolarsDataType,
         SchemaDefinition,
         SchemaDict,
     )
@@ -728,7 +729,8 @@ def from_repr(data: str) -> DataFrame | Series:
     wrapped headers are accounted for, and dtypes are automatically identified.
 
     Currently compound/nested dtypes such as List and Struct are not supported;
-    neither are Object dtypes.
+    neither are Object dtypes. The DuckDB table/relation repr is also compatible
+    with this function.
 
     See Also
     --------
@@ -803,24 +805,47 @@ def from_repr(data: str) -> DataFrame | Series:
 def _from_dataframe_repr(m: re.Match[str]) -> DataFrame:
     """Reconstruct a DataFrame from a regex-matched table repr."""
     from polars.datatypes.convert import dtype_short_repr_to_dtype
+    from polars.io.database._inference import dtype_from_database_typename
+
+    def _dtype_from_name(tp: str | None) -> PolarsDataType | None:
+        return (
+            None
+            if tp is None
+            else (
+                dtype_short_repr_to_dtype(tp)
+                or dtype_from_database_typename(tp, raise_unmatched=False)
+            )
+        )
 
     # extract elements from table structure
     lines = m.group().split("\n")[1:-1]
     rows = [
         [re.sub(r"^[\W+]*│", "", elem).strip() for elem in row]
-        for row in [re.split("[┆|]", row.rstrip("│ ")) for row in lines]
+        for row in [re.split("[│┆|]", row.lstrip("#. ").rstrip("│ ")) for row in lines]
         if len(row) > 1 or not re.search("├[╌┼]+┤", row[0])
     ]
 
     # determine beginning/end of the header block
     table_body_start = 2
+    found_header_divider = False
     for idx, (elem, *_) in enumerate(rows):
-        if re.match(r"^\W*╞", elem):
+        if re.match(r"^\W*[╞]", elem):
+            found_header_divider = True
             table_body_start = idx
             break
 
     # handle headers with wrapped column names and determine headers/dtypes
-    header_block = ["".join(h).split("---") for h in zip(*rows[:table_body_start])]
+    header_rows = rows[:table_body_start]
+    header_block: list[Sequence[str]]
+    if (
+        not found_header_divider
+        and len(header_rows) == 2
+        and not any("---" in h for h in header_rows)
+    ):
+        header_block = list(zip(*header_rows))
+    else:
+        header_block = ["".join(h).split("---") for h in zip(*header_rows)]
+
     dtypes: list[str | None]
     if all(len(h) == 1 for h in header_block):
         headers = [h[0] for h in header_block]
@@ -829,6 +854,11 @@ def _from_dataframe_repr(m: re.Match[str]) -> DataFrame:
         headers, dtypes = (list(h) for h in itertools.zip_longest(*header_block))
 
     body = rows[table_body_start + 1 :]
+    if not headers[0] and not dtypes[0]:
+        body = [row[1:] for row in body]
+        headers = headers[1:]
+        dtypes = dtypes[1:]
+
     no_dtypes = all(d is None for d in dtypes)
 
     # transpose rows into columns, detect/omit truncated columns
@@ -843,10 +873,10 @@ def _from_dataframe_repr(m: re.Match[str]) -> DataFrame:
 
     # init cols as String Series, handle "null" -> None, create schema from repr dtype
     data = [
-        pl.Series([(None if v == "null" else v) for v in cd], dtype=String)
+        pl.Series([(None if v in ("null", "NULL") else v) for v in cd], dtype=String)
         for cd in coldata
     ]
-    schema = dict(zip(headers, (dtype_short_repr_to_dtype(d) for d in dtypes)))
+    schema = dict(zip(headers, (_dtype_from_name(d) for d in dtypes)))
     if schema and data and (n_extend_cols := (len(schema) - len(data))) > 0:
         empty_data = [None] * len(data[0])
         data.extend((pl.Series(empty_data, dtype=String)) for _ in range(n_extend_cols))

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -288,6 +288,7 @@ def dtype_short_repr_to_dtype(dtype_string: str | None) -> PolarsDataType | None
     """Map a PolarsDataType short repr (eg: 'i64', 'list[str]') back into a dtype."""
     if dtype_string is None:
         return None
+
     m = re.match(r"^(\w+)(?:\[(.+)\])?$", dtype_string)
     if m is None:
         return None

--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -17,7 +17,7 @@ from polars.exceptions import (
 )
 from polars.io.database._arrow_registry import ARROW_DRIVER_REGISTRY
 from polars.io.database._cursor_proxies import ODBCCursorProxy, SurrealDBCursorProxy
-from polars.io.database._inference import _infer_dtype_from_cursor_description
+from polars.io.database._inference import dtype_from_cursor_description
 from polars.io.database._utils import _run_async
 
 if TYPE_CHECKING:
@@ -324,7 +324,7 @@ class ConnectionExecutor:
                 msg = f"column {nm!r} appears more than once in the query/result cursor"
                 raise DuplicateError(msg)
             elif desc is not None and nm not in schema_overrides:
-                dtype = _infer_dtype_from_cursor_description(self.cursor, desc)
+                dtype = dtype_from_cursor_description(self.cursor, desc)
                 if dtype is not None:
                     schema_overrides[nm] = dtype  # type: ignore[index]
             dupe_check.add(nm)

--- a/py-polars/tests/unit/io/database/test_inference.py
+++ b/py-polars/tests/unit/io/database/test_inference.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import ComputeError
-from polars.io.database._inference import _infer_dtype_from_database_typename
+from polars.io.database._inference import dtype_from_database_typename
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
         ("int4", pl.Int32),
         ("int2", pl.Int16),
         ("int(16)", pl.Int16),
+        ("uint32", pl.UInt32),
+        ("int128", pl.Int128),
+        ("HUGEINT", pl.Int128),
         ("ROWID", pl.UInt64),
         ("mediumint", pl.Int32),
         ("unsigned mediumint", pl.UInt32),
@@ -77,7 +80,7 @@ def test_dtype_inference_from_string(
     value: str,
     expected_dtype: PolarsDataType,
 ) -> None:
-    inferred_dtype = _infer_dtype_from_database_typename(value)
+    inferred_dtype = dtype_from_database_typename(value)
     assert inferred_dtype == expected_dtype  # type: ignore[operator]
 
 
@@ -93,9 +96,9 @@ def test_dtype_inference_from_string(
 )
 def test_dtype_inference_from_invalid_string(value: str) -> None:
     with pytest.raises(ValueError, match="cannot infer dtype"):
-        _infer_dtype_from_database_typename(value)
+        dtype_from_database_typename(value)
 
-    inferred_dtype = _infer_dtype_from_database_typename(
+    inferred_dtype = dtype_from_database_typename(
         value=value,
         raise_unmatched=False,
     )


### PR DESCRIPTION
A few databases support `Int128` datatypes as "HUGEINT" or "INT128" (for example, DuckDB). This PR adds support for dtype inference from these type names, and also slightly improves integer type name parsing.

A few minor updates to `from_repr` allow it to additionally parse DuckDB table-repr strings, so users can trivially drop such examples into Polars (the updated typename parsing makes translating their table-repr dtypes simple).

## Example

```python
import polars as pl

df = pl.from_repr("""
    # misc streaming stats, duckdb table repr (note the int128 column)
    ┌────────────┬───────┬────────────────┬───────────────────┐
    │   As Of    │ Rank  │ Days In Top 10 │ Streaming Seconds │
    │    date    │ int32 │     int16      │      int128       │
    ├────────────┼───────┼────────────────┼───────────────────┤
    │ 2025-05-09 │     1 │             29 │  5864939402857430 │
    │ 2025-05-09 │     2 │             15 │   458937443590045 │
    │ 2025-05-09 │     3 │              9 │   67876522242,076 │
    └────────────┴───────┴────────────────┴───────────────────┘
""")

df
# shape: (3, 4)
# ┌────────────┬──────┬────────────────┬───────────────────┐
# │ As Of      ┆ Rank ┆ Days In Top 10 ┆ Streaming Seconds │
# │ ---        ┆ ---  ┆ ---            ┆ ---               │
# │ date       ┆ i32  ┆ i16            ┆ i128              │
# ╞════════════╪══════╪════════════════╪═══════════════════╡
# │ 2025-05-09 ┆ 1    ┆ 29             ┆ 5864939402857430  │
# │ 2025-05-09 ┆ 2    ┆ 15             ┆ 458937443590045   │
# │ 2025-05-09 ┆ 3    ┆ 9              ┆ 67876522242076    │
# └────────────┴──────┴────────────────┴───────────────────┘
```