### PR TITLE
fix: Don't mark `str.replace_many` with Mapping as deprecated

### DIFF
--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -2654,8 +2654,8 @@ class ExprStringNameSpace:
             # Early return in case of an empty mapping.
             if not patterns:
                 return wrap_expr(self._pyexpr)
-            replace_with = pl.Series(patterns.values())
-            patterns = pl.Series(patterns.keys())
+            replace_with = list(patterns.values())
+            patterns = list(patterns.keys())
 
         patterns = parse_into_expression(
             patterns,  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #22614.