### PR TITLE
feat(python): Add `extra_columns` parameter to `scan_parquet`

### DIFF
--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -53,6 +53,13 @@ use crate::shared::{ArrowReader, finish_reader};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IpcScanOptions;
 
+#[expect(clippy::derivable_impls)]
+impl Default for IpcScanOptions {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
 /// Read Arrows IPC format into a DataFrame
 ///
 /// # Example

--- a/crates/polars-io/src/parquet/read/options.rs
+++ b/crates/polars-io/src/parquet/read/options.rs
@@ -11,6 +11,17 @@ pub struct ParquetOptions {
     pub use_statistics: bool,
 }
 
+impl Default for ParquetOptions {
+    fn default() -> Self {
+        Self {
+            schema: None,
+            parallel: ParallelStrategy::default(),
+            low_memory: false,
+            use_statistics: true,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ParallelStrategy {

--- a/crates/polars-lazy/src/scan/anonymous_scan.rs
+++ b/crates/polars-lazy/src/scan/anonymous_scan.rs
@@ -54,6 +54,7 @@ impl LazyFrame {
                 pre_slice: args.n_rows.map(|len| Slice::Positive { offset: 0, len }),
                 cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
                 missing_columns_policy: MissingColumnsPolicy::Raise,
+                extra_columns_policy: ExtraColumnsPolicy::Raise,
                 include_file_paths: None,
             },
         )?

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -341,6 +341,7 @@ impl LazyFileListReader for LazyCsvReader {
                 pre_slice,
                 cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
                 missing_columns_policy: MissingColumnsPolicy::Raise,
+                extra_columns_policy: ExtraColumnsPolicy::Raise,
                 include_file_paths: self.include_file_paths,
             },
         )?

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -77,6 +77,7 @@ impl LazyFileListReader for LazyIpcReader {
                 pre_slice,
                 cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
                 missing_columns_policy: MissingColumnsPolicy::Raise,
+                extra_columns_policy: ExtraColumnsPolicy::Raise,
                 include_file_paths,
             },
         )?

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use polars_core::prelude::*;
 use polars_io::cloud::CloudOptions;
 use polars_io::{HiveOptions, RowIndex};
-use polars_plan::dsl::{CastColumnsPolicy, DslPlan, FileScan, MissingColumnsPolicy, ScanSources};
+use polars_plan::dsl::{
+    CastColumnsPolicy, DslPlan, ExtraColumnsPolicy, FileScan, MissingColumnsPolicy, ScanSources,
+};
 use polars_plan::prelude::{NDJsonReadOptions, UnifiedScanArgs};
 use polars_utils::slice_enum::Slice;
 
@@ -135,6 +137,7 @@ impl LazyFileListReader for LazyJsonLineReader {
             pre_slice: self.n_rows.map(|len| Slice::Positive { offset: 0, len }),
             cast_columns_policy: CastColumnsPolicy::ERROR_ON_MISMATCH,
             missing_columns_policy: MissingColumnsPolicy::Raise,
+            extra_columns_policy: ExtraColumnsPolicy::Raise,
             include_file_paths: self.include_file_paths,
         };
 

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -92,6 +92,7 @@ impl LazyFileListReader for LazyParquetReader {
             } else {
                 MissingColumnsPolicy::Raise
             },
+            extra_columns_policy: ExtraColumnsPolicy::Raise,
             include_file_paths: self.args.include_file_paths,
         };
 

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -508,9 +508,41 @@ fn test_union_and_agg_projections() -> PolarsResult<()> {
     let _guard = SINGLE_LOCK.lock().unwrap();
     // a union vstacks columns and aggscan optimization determines columns to aggregate in a
     // hashmap, if that doesn't set them sorted the vstack will panic.
-    let lf1 = LazyFrame::scan_parquet(GLOB_PARQUET, Default::default())?;
-    let lf2 = LazyFrame::scan_ipc(GLOB_IPC, Default::default())?;
-    let lf3 = LazyCsvReader::new(GLOB_CSV).finish()?;
+    let lf1: LazyFrame = DslBuilder::scan_parquet(
+        ScanSources::Paths([GLOB_PARQUET.into()].into()),
+        Default::default(),
+        UnifiedScanArgs {
+            extra_columns_policy: ExtraColumnsPolicy::Ignore,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .build()
+    .into();
+
+    let lf2: LazyFrame = DslBuilder::scan_ipc(
+        ScanSources::Paths([GLOB_IPC.into()].into()),
+        Default::default(),
+        UnifiedScanArgs {
+            extra_columns_policy: ExtraColumnsPolicy::Ignore,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .build()
+    .into();
+
+    let lf3: LazyFrame = DslBuilder::scan_csv(
+        ScanSources::Paths([GLOB_CSV.into()].into()),
+        Default::default(),
+        UnifiedScanArgs {
+            extra_columns_policy: ExtraColumnsPolicy::Ignore,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .build()
+    .into();
 
     for lf in [lf1, lf2, lf3] {
         let lf = lf.filter(col("category").eq(lit("vegetables"))).select([

--- a/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
+++ b/crates/polars-plan/src/plans/optimizer/expand_datasets.rs
@@ -127,6 +127,7 @@ impl OptimizationRule for ExpandDatasets {
                                 pre_slice: _pre_slice @ None,
                                 cast_columns_policy,
                                 missing_columns_policy,
+                                extra_columns_policy,
                                 include_file_paths: _include_file_paths @ None,
                             } = *resolved_unified_scan_args
                             else {
@@ -141,6 +142,7 @@ impl OptimizationRule for ExpandDatasets {
                             unified_scan_args.cache = cache;
                             unified_scan_args.cast_columns_policy = cast_columns_policy;
                             unified_scan_args.missing_columns_policy = missing_columns_policy;
+                            unified_scan_args.extra_columns_policy = extra_columns_policy;
 
                             *sources = resolved_sources;
                             *scan_type = resolved_scan_type;

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -31,6 +31,7 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
+use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyList, PySequence, PyString};
 
 use crate::error::PyPolarsErr;

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -31,7 +31,6 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedStr;
-use pyo3::sync::GILOnceCell;
 use pyo3::types::{PyDict, PyList, PySequence, PyString};
 
 use crate::error::PyPolarsErr;

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -1,0 +1,187 @@
+use polars::prelude::{CastColumnsPolicy, ExtraColumnsPolicy, MissingColumnsPolicy};
+use pyo3::exceptions::PyValueError;
+use pyo3::pybacked::PyBackedStr;
+use pyo3::sync::GILOnceCell;
+use pyo3::types::{PyAnyMethods, PyModule};
+use pyo3::{Bound, FromPyObject, PyAny, PyResult, intern};
+
+/// Interface to `class ScanOptions` on the Python side
+pub struct PyScanOptions<'py>(Bound<'py, pyo3::PyAny>);
+
+impl<'py> FromPyObject<'py> for PyScanOptions<'py> {
+    fn extract_bound(ob: &Bound<'py, pyo3::PyAny>) -> pyo3::PyResult<Self> {
+        Ok(Self(ob.clone()))
+    }
+}
+
+impl PyScanOptions<'_> {
+    pub fn extra_columns_policy(&self) -> PyResult<ExtraColumnsPolicy> {
+        let py = self.0.py();
+
+        Ok(
+            match &*self
+                .0
+                .getattr(intern!(py, "extra_columns"))?
+                .extract::<PyBackedStr>()?
+            {
+                "ignore" => ExtraColumnsPolicy::Ignore,
+                "raise" => ExtraColumnsPolicy::Raise,
+                v => {
+                    return Err(PyValueError::new_err(format!(
+                        "unknown option for extra_columns: {}",
+                        v
+                    )));
+                },
+            },
+        )
+    }
+
+    pub fn extract_cast_options(&self) -> PyResult<CastColumnsPolicy> {
+        let py = self.0.py();
+        let ob = self.0.getattr(intern!(py, "cast_options"))?;
+
+        if ob.is_none() {
+            // Initialize the default ScanCastOptions from Python.
+            static DEFAULT: GILOnceCell<CastColumnsPolicy> = GILOnceCell::new();
+
+            let out = DEFAULT.get_or_try_init(ob.py(), || {
+                let ob = PyModule::import(ob.py(), "polars.io.scan_options.cast_options")
+                    .unwrap()
+                    .getattr("ScanCastOptions")
+                    .unwrap()
+                    .call_method0("_default")
+                    .unwrap();
+
+                let out = extract_cast_options_impl(ob)?;
+
+                // The default policy should match ERROR_ON_MISMATCH (but this can change).
+                debug_assert_eq!(&out, &CastColumnsPolicy::ERROR_ON_MISMATCH);
+
+                PyResult::Ok(out)
+            })?;
+
+            return Ok(out.clone());
+        }
+
+        extract_cast_options_impl(ob)
+    }
+}
+
+fn extract_cast_options_impl(ob: Bound<'_, PyAny>) -> PyResult<CastColumnsPolicy> {
+    let py = ob.py();
+
+    let integer_upcast = match &*ob
+        .getattr(intern!(py, "integer_cast"))?
+        .extract::<PyBackedStr>()?
+    {
+        "upcast" => true,
+        "forbid" => false,
+        v => {
+            return Err(PyValueError::new_err(format!(
+                "unknown option for integer_cast: {}",
+                v
+            )));
+        },
+    };
+
+    let mut float_upcast = false;
+    let mut float_downcast = false;
+
+    let float_cast_object = ob.getattr(intern!(py, "float_cast"))?;
+
+    parse_multiple_options("float_cast", float_cast_object, |v| {
+        match v {
+            "forbid" => {},
+            "upcast" => float_upcast = true,
+            "downcast" => float_downcast = true,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown option for float_cast: {}",
+                    v
+                )));
+            },
+        }
+
+        Ok(())
+    })?;
+
+    let mut datetime_nanoseconds_downcast = false;
+    let mut datetime_convert_timezone = false;
+
+    let datetime_cast_object = ob.getattr(intern!(py, "datetime_cast"))?;
+
+    parse_multiple_options("datetime_cast", datetime_cast_object, |v| {
+        match v {
+            "forbid" => {},
+            "nanosecond-downcast" => datetime_nanoseconds_downcast = true,
+            "convert-timezone" => datetime_convert_timezone = true,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown option for datetime_cast: {}",
+                    v
+                )));
+            },
+        };
+
+        Ok(())
+    })?;
+
+    let missing_struct_fields = match &*ob
+        .getattr(intern!(py, "missing_struct_fields"))?
+        .extract::<PyBackedStr>()?
+    {
+        "insert" => MissingColumnsPolicy::Insert,
+        "raise" => MissingColumnsPolicy::Raise,
+        v => {
+            return Err(PyValueError::new_err(format!(
+                "unknown option for missing_struct_fields: {}",
+                v
+            )));
+        },
+    };
+
+    let extra_struct_fields = match &*ob
+        .getattr(intern!(py, "extra_struct_fields"))?
+        .extract::<PyBackedStr>()?
+    {
+        "ignore" => ExtraColumnsPolicy::Ignore,
+        "raise" => ExtraColumnsPolicy::Raise,
+        v => {
+            return Err(PyValueError::new_err(format!(
+                "unknown option for extra_struct_fields: {}",
+                v
+            )));
+        },
+    };
+
+    Ok(CastColumnsPolicy {
+        integer_upcast,
+        float_upcast,
+        float_downcast,
+        datetime_nanoseconds_downcast,
+        datetime_convert_timezone,
+        missing_struct_fields,
+        extra_struct_fields,
+    })
+}
+
+fn parse_multiple_options(
+    parameter_name: &'static str,
+    py_object: Bound<'_, PyAny>,
+    mut parser_func: impl FnMut(&str) -> PyResult<()>,
+) -> PyResult<()> {
+    if let Ok(v) = py_object.extract::<PyBackedStr>() {
+        parser_func(&v)?;
+    } else if let Ok(v) = py_object.try_iter() {
+        for v in v {
+            parser_func(&v?.extract::<PyBackedStr>()?)?;
+        }
+    } else {
+        return Err(PyValueError::new_err(format!(
+            "unknown type for {}: {}",
+            parameter_name, py_object
+        )));
+    }
+
+    Ok(())
+}

--- a/crates/polars-python/src/io/mod.rs
+++ b/crates/polars-python/src/io/mod.rs
@@ -159,6 +159,7 @@ fn extract_cast_options_impl(ob: Bound<'_, PyAny>) -> PyResult<CastColumnsPolicy
         float_upcast,
         float_downcast,
         datetime_nanoseconds_downcast,
+        datetime_microseconds_downcast: false,
         datetime_convert_timezone,
         missing_struct_fields,
         extra_struct_fields,

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -21,6 +21,7 @@ use super::{PyLazyFrame, PyOptFlags, SinkTarget};
 use crate::error::PyPolarsErr;
 use crate::expr::ToExprs;
 use crate::interop::arrow::to_rust::pyarrow_schema_to_rust;
+use crate::io::PyScanOptions;
 use crate::lazyframe::visit::NodeTraverser;
 use crate::prelude::*;
 use crate::utils::{EnterPolarsExt, to_py_err};
@@ -304,7 +305,7 @@ impl PyLazyFrame {
         source, sources, n_rows, cache, parallel, rechunk, row_index, low_memory, cloud_options,
         credential_provider, use_statistics, hive_partitioning, schema, hive_schema,
         try_parse_hive_dates, retries, glob, include_file_paths, allow_missing_columns,
-        cast_options,
+        scan_options,
     ))]
     fn new_from_parquet(
         source: Option<PyObject>,
@@ -326,7 +327,7 @@ impl PyLazyFrame {
         glob: bool,
         include_file_paths: Option<String>,
         allow_missing_columns: bool,
-        cast_options: Wrap<CastColumnsPolicy>,
+        scan_options: PyScanOptions,
     ) -> PyResult<Self> {
         use cloud::credential_provider::PlCredentialProvider;
         use polars_utils::slice_enum::Slice;
@@ -396,12 +397,13 @@ impl PyLazyFrame {
             projection: None,
             row_index,
             pre_slice: n_rows.map(|len| Slice::Positive { offset: 0, len }),
-            cast_columns_policy: cast_options.0,
+            cast_columns_policy: scan_options.extract_cast_options()?,
             missing_columns_policy: if allow_missing_columns {
                 MissingColumnsPolicy::Insert
             } else {
                 MissingColumnsPolicy::Raise
             },
+            extra_columns_policy: scan_options.extra_columns_policy()?,
             include_file_paths: include_file_paths.map(|x| x.into()),
         };
 

--- a/crates/polars-python/src/lib.rs
+++ b/crates/polars-python/src/lib.rs
@@ -23,6 +23,7 @@ pub mod file;
 #[cfg(feature = "pymethods")]
 pub mod functions;
 pub mod interop;
+pub mod io;
 pub mod lazyframe;
 pub mod lazygroupby;
 pub mod map;

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/extra_ops/mod.rs
@@ -50,7 +50,9 @@ pub fn apply_extra_columns_policy(
             {
                 polars_bail!(
                     SchemaMismatch:
-                    "extra column in file outside of expected schema: {}",
+                    "extra column in file outside of expected schema: {}, \
+                    hint: specify this column in the schema, or pass \
+                    extra_columns='ignore' in scan options",
                     extra_col,
                 )
             }

--- a/crates/polars-stream/src/physical_plan/lower_ir.rs
+++ b/crates/polars-stream/src/physical_plan/lower_ir.rs
@@ -574,13 +574,20 @@ pub fn lower_ir(
                                 .as_ref()
                                 .map(|x| x.as_str()),
                         );
-                    let has_projection = unified_scan_args.projection.is_some();
 
-                    // TODO: Add this to unified scan args.
-                    let extra_columns_policy = if has_projection {
-                        ExtraColumnsPolicy::Ignore
-                    } else {
-                        ExtraColumnsPolicy::Raise
+                    // TODO: We ignore the parameter for some scan types to maintain old behavior,
+                    // as they currently don't expose an API for it to be configured.
+                    let extra_columns_policy = match &*scan_type {
+                        #[cfg(feature = "parquet")]
+                        FileScan::Parquet { .. } => unified_scan_args.extra_columns_policy,
+
+                        _ => {
+                            if unified_scan_args.projection.is_some() {
+                                ExtraColumnsPolicy::Ignore
+                            } else {
+                                ExtraColumnsPolicy::Raise
+                            }
+                        },
                     };
 
                     let mut multi_scan_node = PhysNodeKind::MultiScan {

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -1,7 +1,6 @@
 """Functions for reading data."""
 
 from polars.io.avro import read_avro
-from polars.io.cast_options import ScanCastOptions
 from polars.io.clipboard import read_clipboard
 from polars.io.csv import read_csv, read_csv_batched, scan_csv
 from polars.io.database import read_database, read_database_uri
@@ -26,6 +25,7 @@ from polars.io.partition import (
 )
 from polars.io.plugins import _defer as defer
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
+from polars.io.scan_options import ScanCastOptions
 from polars.io.spreadsheet import read_excel, read_ods
 
 __all__ = [
@@ -36,7 +36,6 @@ __all__ = [
     "KeyedPartition",
     "BasePartitionContext",
     "KeyedPartitionContext",
-    "ScanCastOptions",
     "read_avro",
     "read_clipboard",
     "read_csv",
@@ -61,4 +60,5 @@ __all__ = [
     "scan_ndjson",
     "scan_parquet",
     "scan_pyarrow_dataset",
+    "ScanCastOptions",
 ]

--- a/py-polars/polars/io/scan_options/__init__.py
+++ b/py-polars/polars/io/scan_options/__init__.py
@@ -1,0 +1,5 @@
+from polars.io.scan_options.cast_options import ScanCastOptions
+
+__all__ = [
+    "ScanCastOptions",
+]

--- a/py-polars/polars/io/scan_options/_options.py
+++ b/py-polars/polars/io/scan_options/_options.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from polars.io.scan_options.cast_options import ScanCastOptions
+
+
+class ScanOptions:
+    def __init__(
+        self,
+        *,
+        cast_options: ScanCastOptions | None,
+        extra_columns: Literal["ignore", "raise"],
+    ) -> None:
+        self.cast_options = cast_options
+        self.extra_columns = extra_columns

--- a/py-polars/polars/io/scan_options/cast_options.py
+++ b/py-polars/polars/io/scan_options/cast_options.py
@@ -15,7 +15,7 @@ DatetimeCastOption: TypeAlias = Literal["nanosecond-downcast", "convert-timezone
 
 
 class ScanCastOptions:
-    """Options for type-casting when scanning files."""
+    """Options for scanning files."""
 
     def __init__(
         self,
@@ -32,11 +32,7 @@ class ScanCastOptions:
         _internal_call: bool = False,
     ) -> None:
         """
-        Configuration for type-casting of columns when reading files.
-
-        This can be useful for scanning datasets with schemas that have been
-        modified. This configuration object is generally passed to a supported
-        `scan_*` function via the `cast_options` parameter.
+        Common configuration for scanning files.
 
         .. warning::
                 This functionality is considered **unstable**. It may be changed
@@ -90,8 +86,6 @@ class ScanCastOptions:
         self.missing_struct_fields = missing_struct_fields
         self.extra_struct_fields = extra_struct_fields
 
-    # This is called from the Rust-side, we have it so that we don't accidentally
-    # print unstable messages.
     @staticmethod
     def _default() -> ScanCastOptions:
         return ScanCastOptions(_internal_call=True)

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -649,7 +649,7 @@ def test_parquet_unaligned_schema_read(tmp_path: Path) -> None:
     for df, path in zip(dfs, paths):
         df.write_parquet(path)
 
-    lf = pl.scan_parquet(paths)
+    lf = pl.scan_parquet(paths, extra_columns="ignore")
 
     assert_frame_equal(
         lf.select("a").collect(engine="in-memory"),
@@ -670,6 +670,8 @@ def test_parquet_unaligned_schema_read(tmp_path: Path) -> None:
         pl.scan_parquet(paths[:2]).collect(engine="in-memory"),
         pl.DataFrame({"a": [1, 2], "b": [10, 11]}),
     )
+
+    lf = pl.scan_parquet(paths, extra_columns="raise")
 
     with pytest.raises(pl.exceptions.SchemaError):
         lf.collect(engine="in-memory")
@@ -794,7 +796,12 @@ def test_parquet_schema_arg(
         with pytest.raises(pl.exceptions.SchemaError):
             lf.collect(engine="streaming" if streaming else "in-memory")
 
-    lf = pl.scan_parquet(paths, parallel=parallel, schema=schema).select("a")
+    lf = pl.scan_parquet(
+        paths,
+        parallel=parallel,
+        schema=schema,
+        extra_columns="ignore",
+    ).select("a")
 
     assert_frame_equal(
         lf.collect(engine="in-memory"),

--- a/py-polars/tests/unit/io/test_multiscan.py
+++ b/py-polars/tests/unit/io/test_multiscan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING, Any, Callable
+from typing import IO, TYPE_CHECKING, Any, Callable
 
 import pyarrow.parquet as pq
 import pytest
@@ -671,3 +671,29 @@ def test_row_index_filter_22612(scan: Any, write: Any) -> None:
             .collect(),
             df.with_row_index().slice(end - 2, 3),
         )
+
+
+def test_extra_columns_not_ignored_22218() -> None:
+    dfs = [pl.DataFrame({"a": 1, "b": 1}), pl.DataFrame({"a": 2, "c": 2})]
+
+    files: list[IO[bytes]] = [io.BytesIO(), io.BytesIO()]
+
+    dfs[0].write_parquet(files[0])
+    dfs[1].write_parquet(files[1])
+
+    with pytest.raises(
+        pl.exceptions.SchemaError,
+        match="extra column in file outside of expected schema: c, hint: specify .*or pass",
+    ):
+        (pl.scan_parquet(files, allow_missing_columns=True).select(pl.all()).collect())
+
+    assert_frame_equal(
+        pl.scan_parquet(
+            files,
+            allow_missing_columns=True,
+            extra_columns="ignore",
+        )
+        .select(pl.all())
+        .collect(),
+        pl.DataFrame({"a": [1, 2], "b": [1, None]}),
+    )


### PR DESCRIPTION
Supercedes https://github.com/pola-rs/polars/pull/22695

* ref https://github.com/pola-rs/polars/issues/22450

Changes:
* Adds an `extra_columns` to `scan_parquet`
* (Rust) `extra_columns_policy` is now added under `UnifiedScanArgs`
* Introduces an internal `ScanOptions` Python class to consolidate input parsing of shared scan options (i.e. those in `UnifiedScanArgs`).

Fixes:
* Fixes https://github.com/pola-rs/polars/issues/22218
  * This wasn't fixed until now, as users would not have been able to scan this case without the `extra_columns` parameter
