### PR TITLE
perf: Increase default cross-file parallelism limit for new-streaming multiscan

### DIFF
--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/mod.rs
@@ -40,7 +40,13 @@ impl MultiScanTaskInitializer {
                 self.config.sources.len(),
                 self.config.file_reader_builder.reader_name(),
                 self.config.file_reader_builder.reader_capabilities(),
-            )
+            );
+
+            eprintln!(
+                "[MultiScanTaskInitializer]: n_readers_pre_init: {}, max_concurrent_scans: {}",
+                self.config.n_readers_pre_init(),
+                self.config.max_concurrent_scans(),
+            );
         }
 
         let bridge_state = Arc::new(Mutex::new(BridgeState::NotYetStarted));
@@ -113,14 +119,4 @@ impl MultiScanTaskInitializer {
             bridge_state,
         )
     }
-}
-
-pub(super) fn max_concurrent_scans_config() -> usize {
-    const DEFAULT_MAX_CONCURRENT_SCANS: usize = 8;
-
-    std::env::var("POLARS_MAX_CONCURRENT_SCANS").map_or(DEFAULT_MAX_CONCURRENT_SCANS, |v| {
-        v.parse::<usize>()
-            .expect("unable to parse POLARS_MAX_CONCURRENT_SCANS")
-            .max(1)
-    })
 }

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
@@ -115,7 +115,7 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
                 PolarsResult::Ok(reader)
             }))
         })
-        .buffered(config.n_readers_pre_init.min(config.sources.len()));
+        .buffered(config.n_readers_pre_init().min(config.sources.len()));
 
     let n_rows_needed = IdxSize::try_from(offset_from_end).unwrap();
     let slice_len_idxsize = IdxSize::try_from(slice_len).unwrap_or(IdxSize::MAX);

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/initialization/slice.rs
@@ -115,7 +115,7 @@ async fn resolve_negative_slice(config: &MultiFileReaderConfig) -> PolarsResult<
                 PolarsResult::Ok(reader)
             }))
         })
-        .buffered(config.n_readers_pre_init().min(config.sources.len()));
+        .buffered(config.n_readers_pre_init());
 
     let n_rows_needed = IdxSize::try_from(offset_from_end).unwrap();
     let slice_len_idxsize = IdxSize::try_from(slice_len).unwrap_or(IdxSize::MAX);

--- a/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
+++ b/crates/polars-stream/src/nodes/io_sources/multi_file_reader/reader_pipelines/generic.rs
@@ -24,11 +24,9 @@ use crate::nodes::io_sources::multi_file_reader::extra_ops::missing_columns::ini
 use crate::nodes::io_sources::multi_file_reader::extra_ops::{
     ExtraOperations, apply_extra_columns_policy,
 };
+use crate::nodes::io_sources::multi_file_reader::initialization::MultiScanTaskInitializer;
 use crate::nodes::io_sources::multi_file_reader::initialization::slice::{
     ResolvedSliceInfo, resolve_to_positive_slice,
-};
-use crate::nodes::io_sources::multi_file_reader::initialization::{
-    MultiScanTaskInitializer, max_concurrent_scans_config,
 };
 use crate::nodes::io_sources::multi_file_reader::post_apply_pipeline::PostApplyPool;
 use crate::nodes::io_sources::multi_file_reader::reader_interface::capabilities::ReaderCapabilities;
@@ -206,7 +204,7 @@ impl MultiScanTaskInitializer {
                 })
                 .buffered(
                     self.config
-                        .n_readers_pre_init
+                        .n_readers_pre_init()
                         .min(self.config.sources.len()),
                 )
         };
@@ -218,9 +216,7 @@ impl MultiScanTaskInitializer {
         let projected_file_schema = self.config.projected_file_schema.clone();
         let full_file_schema = self.config.full_file_schema.clone();
         let num_pipelines = self.config.num_pipelines();
-        let max_concurrent_scans = num_pipelines
-            .min(sources.len())
-            .min(max_concurrent_scans_config());
+        let max_concurrent_scans = self.config.max_concurrent_scans();
 
         let (started_reader_tx, started_reader_rx) =
             tokio::sync::mpsc::channel(max_concurrent_scans.max(2) - 1);
@@ -312,13 +308,6 @@ impl ReaderStarter {
             // Set to IdxSize::MAX if we expect it to be unused. This way if it is incorrectly being
             // used it should cause an error.
             current_row_position = IdxSize::MAX;
-        }
-
-        if verbose {
-            eprintln!(
-                "[ReaderStarter]: max_concurrent_scans: {}",
-                max_concurrent_scans
-            )
         }
 
         let wait_group = WaitGroup::default();

--- a/crates/polars-stream/src/physical_plan/to_graph.rs
+++ b/crates/polars-stream/src/physical_plan/to_graph.rs
@@ -546,8 +546,8 @@ fn to_graph_rec<'a>(
                         cast_columns_policy,
                         // Initialized later
                         num_pipelines: AtomicUsize::new(0),
-                        n_readers_pre_init:
-                            nodes::io_sources::multi_file_reader::DEFAULT_N_READERS_PRE_INIT,
+                        n_readers_pre_init: AtomicUsize::new(0),
+                        max_concurrent_scans: AtomicUsize::new(0),
                         verbose,
                     },
                 )),
@@ -985,8 +985,8 @@ fn to_graph_rec<'a>(
                         cast_columns_policy,
                         // Initialized later
                         num_pipelines: AtomicUsize::new(0),
-                        n_readers_pre_init:
-                            nodes::io_sources::multi_file_reader::DEFAULT_N_READERS_PRE_INIT,
+                        n_readers_pre_init: AtomicUsize::new(0),
+                        max_concurrent_scans: AtomicUsize::new(0),
                         verbose,
                     },
                 )),


### PR DESCRIPTION
* Fixes https://github.com/pola-rs/polars/issues/22683

There have been reports of performance regressions from users that scan 10,000's of small parquet files from the cloud. This is likely due to some default settings in the new-streaming I/O scans. In this PR we address this by:

* Increasing the default reader pre-initialization (i.e. parquet metadata fetch/decode) limit from 3 to `num_pipelines + 3`
  * Adds a `POLARS_NUM_READERS_PRE_INIT` environment variable to allow this to be controlled
  * Adds a verbose print line so that we can see the value used in the logs
* Changing the default concurrent reader limit from 8 to `num_pipelines`

### Benchmarks

* System: AWS EC2 `c6gn.8xlarge` (32 cores)
* Query: Full scan 1,000 parquet files (10,000 rows / ~1.1MB each)
* Build profile: Debug

| Configuration | # readers pre-init | # concurrent readers | Approximate throughput (MiB/s) |
|------|--------------------|----------------------|--------------------------------|
| Existing default for 1.29.0 | 3                  | 8                    | 60.0                           |
| Default for this branch | 35                 | 32                   | 130.0                          |
