### PR TITLE
feat: Add `slice`/`head`/`tail` methods to `arr`

### DIFF
--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -319,7 +319,6 @@ pub fn slice_slice<T>(vals: &[T], offset: i64, len: usize) -> &[T] {
 }
 
 #[inline]
-#[doc(hidden)]
 pub fn slice_offsets(offset: i64, length: usize, array_len: usize) -> (usize, usize) {
     let signed_start_offset = if offset < 0 {
         offset.saturating_add_unsigned(array_len as u64)

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -396,6 +396,22 @@ impl Expr {
         }
     }
 
+    pub fn extract_i64(&self) -> PolarsResult<i64> {
+        match self {
+            Expr::Literal(n) => n.extract_i64(),
+            Expr::Cast { expr, dtype, .. } => {
+                if dtype.is_integer() {
+                    expr.extract_i64()
+                } else {
+                    polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
+                }
+            },
+            _ => {
+                polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
+            },
+        }
+    }
+
     #[inline]
     pub fn map_unary(self, function: impl Into<FunctionExpr>) -> Self {
         Expr::n_ary(function, vec![self])

--- a/crates/polars-plan/src/plans/lit.rs
+++ b/crates/polars-plan/src/plans/lit.rs
@@ -285,6 +285,36 @@ impl LiteralValue {
         }
     }
 
+    pub fn extract_i64(&self) -> PolarsResult<i64> {
+        macro_rules! cast_i64 {
+            ($v:expr) => {
+                i64::try_from($v).map_err(
+                    |_| polars_err!(InvalidOperation: "cannot convert value {} to i64", $v)
+                )
+            }
+        }
+        match &self {
+            Self::Dyn(DynLiteralValue::Int(v)) => cast_i64!(*v),
+            Self::Scalar(sc) => match sc.as_any_value() {
+                AnyValue::UInt8(v) => Ok(v as i64),
+                AnyValue::UInt16(v) => Ok(v as i64),
+                AnyValue::UInt32(v) => cast_i64!(v),
+                AnyValue::UInt64(v) => cast_i64!(v),
+                AnyValue::Int8(v) => cast_i64!(v),
+                AnyValue::Int16(v) => cast_i64!(v),
+                AnyValue::Int32(v) => cast_i64!(v),
+                AnyValue::Int64(v) => Ok(v),
+                AnyValue::Int128(v) => cast_i64!(v),
+                _ => {
+                    polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
+                },
+            },
+            _ => {
+                polars_bail!(InvalidOperation: "expression must be constant literal to extract integer")
+            },
+        }
+    }
+
     pub fn materialize(self) -> Self {
         match self {
             LiteralValue::Dyn(_) => {

--- a/crates/polars-python/src/expr/array.rs
+++ b/crates/polars-python/src/expr/array.rs
@@ -133,6 +133,30 @@ impl PyExpr {
             .into())
     }
 
+    fn arr_slice(&self, offset: PyExpr, length: Option<PyExpr>, as_array: bool) -> PyResult<Self> {
+        let length = match length {
+            Some(i) => i.inner,
+            None => lit(i64::MAX),
+        };
+        Ok(self
+            .inner
+            .clone()
+            .arr()
+            .slice(offset.inner, length, as_array)
+            .map_err(PyPolarsErr::from)?
+            .into())
+    }
+
+    fn arr_tail(&self, n: PyExpr, as_array: bool) -> PyResult<Self> {
+        Ok(self
+            .inner
+            .clone()
+            .arr()
+            .tail(n.inner, as_array)
+            .map_err(PyPolarsErr::from)?
+            .into())
+    }
+
     fn arr_shift(&self, n: PyExpr) -> Self {
         self.inner.clone().arr().shift(n.inner).into()
     }

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -44,6 +44,153 @@ class ExprArrayNameSpace:
         """
         return wrap_expr(self._pyexpr.arr_len())
 
+    def slice(
+        self,
+        offset: int | str | Expr,
+        length: int | str | Expr | None = None,
+        *,
+        as_array: bool = False,
+    ) -> Expr:
+        """
+        Slice every subarray.
+
+        Parameters
+        ----------
+        offset
+            Start index. Negative indexing is supported.
+        length
+            Length of the slice. If set to `None` (default), the slice is taken to the
+            end of the list.
+        as_array
+            Return result as a fixed-length `Array`, otherwise as a `List`.
+            If true `length` and `offset` must be constant values.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     data={"a": [[1, 2], [4, 3]]},
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.select(pl.col("a").arr.slice(0, 1))
+        shape: (2, 1)
+        ┌───────────┐
+        │ a         │
+        │ ---       │
+        │ list[i64] │
+        ╞═══════════╡
+        │ [1]       │
+        │ [4]       │
+        └───────────┘
+        >>> df = pl.DataFrame(
+        ...     data={"a": [[1, 2], [4, 3]]},
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.select(pl.col("a").arr.slice(0, 1, as_array=True))
+        shape: (2, 1)
+        ┌───────────────┐
+        │ a             │
+        │ ---           │
+        │ array[i64, 1] │
+        ╞═══════════════╡
+        │ [1]           │
+        │ [4]           │
+        └───────────────┘
+        """
+        offset = parse_into_expression(offset)
+        length = parse_into_expression(length) if length is not None else None
+        return wrap_expr(self._pyexpr.arr_slice(offset, length, as_array))
+
+    def head(self, n: int | str | Expr = 5, *, as_array: bool = False) -> Expr:
+        """
+        Get the first `n` elements of the sub-arrays.
+
+        Parameters
+        ----------
+        n
+            Number of values to return for each sublist.
+        as_array
+            Return result as a fixed-length `Array`, otherwise as a `List`.
+            If true `n` must be a constant value.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     data={"a": [[1, 2], [4, 3]]},
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.select(pl.col("a").arr.head(1))
+        shape: (2, 1)
+        ┌───────────┐
+        │ a         │
+        │ ---       │
+        │ list[i64] │
+        ╞═══════════╡
+        │ [1]       │
+        │ [4]       │
+        └───────────┘
+        >>> df = pl.DataFrame(
+        ...     data={"a": [[1, 2], [4, 3]]},
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.select(pl.col("a").arr.head(1, as_array=True))
+        shape: (2, 1)
+        ┌───────────────┐
+        │ a             │
+        │ ---           │
+        │ array[i64, 1] │
+        ╞═══════════════╡
+        │ [1]           │
+        │ [4]           │
+        └───────────────┘
+        """
+        return self.slice(0, n, as_array=as_array)
+
+    def tail(self, n: int | str | Expr = 5, *, as_array: bool = False) -> Expr:
+        """
+        Slice the last `n` values of every sublist.
+
+        Parameters
+        ----------
+        n
+            Number of values to return for each sublist.
+        as_array
+            Return result as a fixed-length `Array`, otherwise as a `List`.
+            If true `n` must be a constant value.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     data={"a": [[1, 2], [4, 3]]},
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.select(pl.col("a").arr.tail(1))
+        shape: (2, 1)
+        ┌───────────┐
+        │ a         │
+        │ ---       │
+        │ list[i64] │
+        ╞═══════════╡
+        │ [2]       │
+        │ [3]       │
+        └───────────┘
+        >>> df = pl.DataFrame(
+        ...     data={"a": [[1, 2], [4, 3]]},
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.select(pl.col("a").arr.tail(1, as_array=True))
+        shape: (2, 1)
+        ┌───────────────┐
+        │ a             │
+        │ ---           │
+        │ array[i64, 1] │
+        ╞═══════════════╡
+        │ [2]           │
+        │ [3]           │
+        └───────────────┘
+        """
+        n = parse_into_expression(n)
+        return wrap_expr(self._pyexpr.arr_tail(n, as_array))
+
     def min(self) -> Expr:
         """
         Compute the min values of the sub-arrays.

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
     from polars import Series
     from polars._typing import IntoExpr, IntoExprColumn
+    from polars.expr.expr import Expr
     from polars.polars import PySeries
 
 
@@ -228,6 +229,125 @@ class ArrayNameSpace:
         [
             2
             2
+        ]
+        """
+
+    def slice(
+        self,
+        offset: int | Expr,
+        length: int | Expr | None = None,
+        *,
+        as_array: bool = False,
+    ) -> Series:
+        """
+        Slice the sub-arrays.
+
+        Parameters
+        ----------
+        offset
+            The starting index of the slice.
+        length
+            The length of the slice.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`Array`.
+
+        Examples
+        --------
+        >>> s = pl.Series(
+        ...     [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+        ...     dtype=pl.Array(pl.Int64, 6),
+        ... )
+        >>> s.arr.slice(1)
+        shape: (2,)
+        Series: '' [list[i64]]
+        [
+            [2, 3, … 6]
+            [8, 9, … 12]
+        ]
+        >>> s.arr.slice(1, 3, as_array=True)
+        shape: (2,)
+        Series: '' [array[i64, 3]]
+        [
+            [2, 3, 4]
+            [8, 9, 10]
+        ]
+        >>> s.arr.slice(-2)
+        shape: (2,)
+        Series: '' [list[i64]]
+        [
+            [5, 6]
+            [11, 12]
+        ]
+        """
+
+    def head(self, n: int | Expr = 5, *, as_array: bool = False) -> Series:
+        """
+        Get the first `n` elements of the sub-arrays.
+
+        Parameters
+        ----------
+        n
+            Number of values to return for each sublist.
+        as_array
+            Return result as a fixed-length `Array`, otherwise as a `List`.
+            If true `n` must be a constant value.
+
+        Examples
+        --------
+        >>> s = pl.Series(
+        ...     [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+        ...     dtype=pl.Array(pl.Int64, 6),
+        ... )
+        >>> s.arr.head()
+        shape: (2,)
+        Series: '' [list[i64]]
+        [
+            [1, 2, … 5]
+            [7, 8, … 11]
+        ]
+        >>> s.arr.head(3, as_array=True)
+        shape: (2,)
+        Series: '' [array[i64, 3]]
+        [
+            [1, 2, 3]
+            [7, 8, 9]
+        ]
+        """
+
+    def tail(self, n: int | Expr = 5, *, as_array: bool = False) -> Series:
+        """
+        Slice the last `n` values of every sublist.
+
+        Parameters
+        ----------
+        n
+            Number of values to return for each sublist.
+        as_array
+            Return result as a fixed-length `Array`, otherwise as a `List`.
+            If true `n` must be a constant value.
+
+        Examples
+        --------
+        >>> s = pl.Series(
+        ...     [[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+        ...     dtype=pl.Array(pl.Int64, 6),
+        ... )
+        >>> s.arr.tail()
+        shape: (2,)
+        Series: '' [list[i64]]
+        [
+            [2, 3, … 6]
+            [8, 9, … 12]
+        ]
+        >>> s.arr.tail(3, as_array=True)
+        shape: (2,)
+        Series: '' [array[i64, 3]]
+        [
+            [4, 5, 6]
+            [10, 11, 12]
         ]
         """
 

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -90,6 +90,51 @@ def test_array_lengths() -> None:
     ).arr.len().to_list() == [3, None, 3]
 
 
+@pytest.mark.parametrize(
+    ("as_array"),
+    [True, False],
+)
+def test_arr_slice(as_array: bool) -> None:
+    df = pl.DataFrame(
+        {
+            "arr": [[1, 2, 3], [10, 2, 1]],
+        },
+        schema={"arr": pl.Array(pl.Int64, 3)},
+    )
+
+    assert df.select([pl.col("arr").arr.slice(0, 1, as_array=as_array)]).to_dict(
+        as_series=False
+    ) == {"arr": [[1], [10]]}
+    assert df.select([pl.col("arr").arr.slice(1, 1, as_array=as_array)]).to_dict(
+        as_series=False
+    ) == {"arr": [[2], [2]]}
+    assert df.select([pl.col("arr").arr.slice(-1, 1, as_array=as_array)]).to_dict(
+        as_series=False
+    ) == {"arr": [[3], [1]]}
+    assert df.select([pl.col("arr").arr.slice(-2, 1, as_array=as_array)]).to_dict(
+        as_series=False
+    ) == {"arr": [[2], [2]]}
+    assert df.select([pl.col("arr").arr.slice(-2, 2, as_array=as_array)]).to_dict(
+        as_series=False
+    ) == {"arr": [[2, 3], [2, 1]]}
+    return
+
+
+@pytest.mark.parametrize(
+    ("as_array"),
+    [True, False],
+)
+def test_arr_slice_on_series(as_array: bool) -> None:
+    vals = [[1, 2, 3, 4], [10, 2, 1, 2]]
+    s = pl.Series("a", vals, dtype=pl.Array(pl.Int64, 4))
+    assert s.arr.head(2, as_array=as_array).to_list() == [[1, 2], [10, 2]]
+    assert s.arr.tail(2, as_array=as_array).to_list() == [[3, 4], [1, 2]]
+    assert s.arr.tail(10, as_array=as_array).to_list() == vals
+    assert s.arr.head(10, as_array=as_array).to_list() == vals
+    assert s.arr.slice(1, 2, as_array=as_array).to_list() == [[2, 3], [2, 1]]
+    assert s.arr.slice(-5, 2, as_array=as_array).to_list() == [[1], [10]]
+
+
 def test_arr_unique() -> None:
     df = pl.DataFrame(
         {"a": pl.Series("a", [[1, 1], [4, 3]], dtype=pl.Array(pl.Int64, 2))}


### PR DESCRIPTION
This PR adds the `slice`, `head`, and `tail` methods to `arr`, as per #21302.