### PR TITLE
fix: Properly account for nulls in the `is_not_nan` check made in `drop_nans`

### DIFF
--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -164,17 +164,15 @@ impl DslBuilder {
                 all_horizontal(
                     subset
                         .into_iter()
-                        .map(|v| v.is_not_nan())
+                        .map(|v| v.clone().is_not_nan().or(v.is_null()))
                         .collect::<Vec<_>>(),
                 )
                 .unwrap(),
             )
         } else {
-            self.filter(
-                // TODO: when Decimal supports NaN, include here
-                all_horizontal([dtype_cols([DataType::Float32, DataType::Float64]).is_not_nan()])
-                    .unwrap(),
-            )
+            // TODO: when Decimal supports NaN, include here
+            let cols = dtype_cols([DataType::Float32, DataType::Float64]);
+            self.filter(all_horizontal([cols.clone().is_not_nan().or(cols.is_null())]).unwrap())
         }
     }
 

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -159,7 +159,6 @@ impl DslBuilder {
         let is_nan = match subset {
             Some(subset) if subset.is_empty() => return self,
             Some(subset) => subset.into_iter().map(Expr::is_nan).collect(),
-            // TODO: when Decimal supports NaN values, include that dtype here
             None => vec![dtype_cols([DataType::Float32, DataType::Float64]).is_nan()],
         };
         self.remove(any_horizontal(is_nan).unwrap())

--- a/crates/polars-plan/src/dsl/builder_dsl.rs
+++ b/crates/polars-plan/src/dsl/builder_dsl.rs
@@ -166,22 +166,12 @@ impl DslBuilder {
     }
 
     pub fn drop_nulls(self, subset: Option<Vec<Expr>>) -> Self {
-        if let Some(subset) = subset {
-            if subset.is_empty() {
-                return self;
-            }
-            self.filter(
-                all_horizontal(
-                    subset
-                        .into_iter()
-                        .map(|v| v.is_not_null())
-                        .collect::<Vec<_>>(),
-                )
-                .unwrap(),
-            )
-        } else {
-            self.filter(all_horizontal([all().is_not_null()]).unwrap())
-        }
+        let is_not_null = match subset {
+            Some(subset) if subset.is_empty() => return self,
+            Some(subset) => subset.into_iter().map(Expr::is_not_null).collect(),
+            None => vec![all().is_not_null()],
+        };
+        self.filter(all_horizontal(is_not_null).unwrap())
     }
 
     pub fn fill_nan(self, fill_value: Expr) -> Self {

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -124,29 +124,39 @@ def test_drop_nans(lazy: bool) -> None:
     DataFrame = pl.LazyFrame if lazy else pl.DataFrame
     df = DataFrame(
         {
-            "a": [1.0, float("nan"), 3.0, 4.0],
-            "b": [10000, 20000, 30000, 40000],
-            "c": [-90.5, 25.0, 0.0, float("nan")],
+            "a": [1.0, float("nan"), 3.0, 4.0, None],
+            "b": [10000, 20000, 30000, 40000, None],
+            "c": [-90.5, 25.0, 0.0, float("nan"), None],
         }
     )
     expected = DataFrame(
         {
-            "a": [1.0, 3.0],
-            "b": [10000, 30000],
-            "c": [-90.5, 0.0],
+            "a": [1.0, 3.0, None],
+            "b": [10000, 30000, None],
+            "c": [-90.5, 0.0, None],
         }
     )
     assert_frame_equal(expected, df.drop_nans())
 
     expected = DataFrame(
         {
-            "a": [1.0, float("nan"), 3.0],
-            "b": [10000, 20000, 30000],
-            "c": [-90.5, 25.0, 0.0],
+            "a": [1.0, float("nan"), 3.0, None],
+            "b": [10000, 20000, 30000, None],
+            "c": [-90.5, 25.0, 0.0, None],
         }
     )
     assert_frame_equal(expected, df.drop_nans(subset=["c"]))
     assert_frame_equal(expected, df.drop_nans(subset=cs.ends_with("c")))
+
+    expected = DataFrame(
+        {
+            "a": [1.0, 3.0, None],
+            "b": [10000, 30000, None],
+            "c": [-90.5, 0.0, None],
+        }
+    )
+    assert_frame_equal(expected, df.drop_nans(subset=["a", "c"]))
+    assert_frame_equal(expected, df.drop_nans(subset=cs.float()))
 
 
 def test_drop_nan_ignore_null_3525() -> None:


### PR DESCRIPTION
Closes #22706.

_"Damn you, three-valued logic..."_ 🙄

* Fixes the check to properly account for null values; uses `remove` with `any_horizontal`, instead of `filter` with `all_horizontal`, for correctness and notably cleaner expression of the logic.
* Minor streamlining of `drop_nulls` (no performance gain/loss).
