### PR TITLE
perf: Add elementwise execution mode for `list.eval`

### DIFF
--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -1,7 +1,8 @@
 use std::sync::Mutex;
 
-use arrow::array::ValueSize;
+use arrow::array::{Array, ListArray, ValueSize};
 use arrow::legacy::utils::CustomIterTools;
+use polars_core::POOL;
 use polars_core::chunked_array::from_iterator_par::ChunkedCollectParIterExt;
 use polars_core::prelude::*;
 use polars_plan::constants::MAP_LIST_NAME;
@@ -65,22 +66,23 @@ fn run_per_sublist(
     let mut err = None;
     let mut ca: ListChunked = if parallel {
         let m_err = Mutex::new(None);
-        let ca: ListChunked = lst
-            .par_iter()
-            .map(|opt_s| {
-                opt_s.and_then(|s| {
-                    let df = s.into_frame();
-                    let out = phys_expr.evaluate(&df, &state);
-                    match out {
-                        Ok(s) => Some(s.take_materialized_series()),
-                        Err(e) => {
-                            *m_err.lock().unwrap() = Some(e);
-                            None
-                        },
-                    }
+        let ca: ListChunked = POOL.install(|| {
+            lst.par_iter()
+                .map(|opt_s| {
+                    opt_s.and_then(|s| {
+                        let df = s.into_frame();
+                        let out = phys_expr.evaluate(&df, &state);
+                        match out {
+                            Ok(s) => Some(s.take_materialized_series()),
+                            Err(e) => {
+                                *m_err.lock().unwrap() = Some(e);
+                                None
+                            },
+                        }
+                    })
                 })
-            })
-            .collect_ca_with_dtype(PlSmallStr::EMPTY, output_field.dtype.clone());
+                .collect_ca_with_dtype(PlSmallStr::EMPTY, output_field.dtype.clone())
+        });
         err = m_err.into_inner().unwrap();
         ca
     } else {
@@ -148,9 +150,84 @@ fn run_on_group_by_engine(
     Ok(Some(out.with_name(name).into_column()))
 }
 
+fn run_elementwise_on_values(
+    lst: &ListChunked,
+    expr: &Expr,
+    parallel: bool,
+    output_field: Field,
+) -> PolarsResult<Column> {
+    if lst.chunks().is_empty() {
+        return Ok(Column::new_empty(output_field.name, &output_field.dtype));
+    }
+
+    let phys_expr = prepare_expression_for_context(
+        PlSmallStr::EMPTY,
+        expr,
+        lst.inner_dtype(),
+        Context::Default,
+    )?;
+
+    let output_arrow_dtype = output_field.dtype().clone().to_arrow(CompatLevel::newest());
+
+    let state = ExecutionState::new();
+
+    macro_rules! apply_to_chunk {
+        ($arr:expr) => {{
+            let arr = $arr;
+
+            let arr: &ListArray<i64> = arr.as_any().downcast_ref().unwrap();
+
+            let values = unsafe {
+                Series::from_chunks_and_dtype_unchecked(
+                    PlSmallStr::EMPTY,
+                    vec![arr.values().clone()],
+                    lst.inner_dtype(),
+                )
+            };
+
+            let df = values.into_frame();
+
+            phys_expr.evaluate(&df, &state).map(|c| {
+                ListArray::<i64>::new(
+                    output_arrow_dtype.clone(),
+                    arr.offsets().clone(),
+                    c.take_materialized_series().rechunk().chunks()[0].clone(),
+                    arr.validity().cloned(),
+                )
+                .boxed()
+            })
+        }};
+    }
+
+    let chunks = if parallel && lst.chunks().len() > 1 {
+        POOL.install(|| {
+            lst.chunks()
+                .into_par_iter()
+                .map(|arr| apply_to_chunk!(arr))
+                .collect::<PolarsResult<Vec<Box<dyn Array>>>>()
+        })?
+    } else {
+        lst.chunks()
+            .iter()
+            .map(|arr| apply_to_chunk!(arr))
+            .collect::<PolarsResult<Vec<Box<dyn Array>>>>()?
+    };
+
+    Ok(unsafe { ListChunked::from_chunks(output_field.name, chunks) }.into_column())
+}
+
 pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
     /// Run any [`Expr`] on these lists elements
     fn eval(self, expr: Expr, parallel: bool) -> Expr {
+        let mut expr_arena = Arena::with_capacity(4);
+
+        let pd_group =
+            to_aexpr(expr.clone(), &mut expr_arena).map_or(ExprPushdownGroup::Barrier, |node| {
+                let mut pd_group = ExprPushdownGroup::Pushable;
+                pd_group.update_with_expr_rec(expr_arena.get(node), &expr_arena, None);
+                pd_group
+            });
+
         let this = self.into_list_name_space();
 
         let expr2 = expr.clone();
@@ -176,6 +253,7 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
                     _ => {},
                 }
             }
+
             let lst = c.list()?.clone();
 
             // # fast returns
@@ -198,7 +276,13 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
                 expr.into_iter().any(|e| matches!(e, Expr::AnonymousFunction { options, .. } if options.fmt_str == MAP_LIST_NAME))
             };
 
-            if fits_idx_size && c.null_count() == 0 && !is_user_apply() {
+            if match pd_group {
+                ExprPushdownGroup::Pushable => true,
+                ExprPushdownGroup::Fallible => !lst.has_nulls(),
+                ExprPushdownGroup::Barrier => false,
+            } {
+                run_elementwise_on_values(&lst, &expr, parallel, output_field).map(Some)
+            } else if fits_idx_size && c.null_count() == 0 && !is_user_apply() {
                 run_on_group_by_engine(c.name().clone(), &lst, &expr)
             } else {
                 run_per_sublist(c, &lst, &expr, parallel, output_field)

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -207,13 +207,13 @@ fn run_elementwise_on_values(
         POOL.install(|| {
             lst.chunks()
                 .into_par_iter()
-                .map(|x| apply_to_chunk(x))
+                .map(|x| apply_to_chunk(&*x))
                 .collect::<PolarsResult<Vec<Box<dyn Array>>>>()
         })?
     } else {
         lst.chunks()
             .iter()
-            .map(|x| apply_to_chunk(x))
+            .map(|x| apply_to_chunk(&*x))
             .collect::<PolarsResult<Vec<Box<dyn Array>>>>()?
     };
 

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -207,13 +207,13 @@ fn run_elementwise_on_values(
         POOL.install(|| {
             lst.chunks()
                 .into_par_iter()
-                .map(|arr| apply_to_chunk(arr))
+                .map(&apply_to_chunk)
                 .collect::<PolarsResult<Vec<Box<dyn Array>>>>()
         })?
     } else {
         lst.chunks()
             .iter()
-            .map(|arr| apply_to_chunk(arr))
+            .map(&apply_to_chunk)
             .collect::<PolarsResult<Vec<Box<dyn Array>>>>()?
     };
 

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -177,7 +177,7 @@ fn run_elementwise_on_values(
 
     let state = ExecutionState::new();
 
-    let apply_to_chunk = |arr: &Box<dyn Array>| {
+    let apply_to_chunk = |arr: &dyn Array| {
         let arr: &ListArray<i64> = arr.as_any().downcast_ref().unwrap();
 
         let values = unsafe {

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -207,13 +207,13 @@ fn run_elementwise_on_values(
         POOL.install(|| {
             lst.chunks()
                 .into_par_iter()
-                .map(&apply_to_chunk)
+                .map(|x| apply_to_chunk(x))
                 .collect::<PolarsResult<Vec<Box<dyn Array>>>>()
         })?
     } else {
         lst.chunks()
             .iter()
-            .map(&apply_to_chunk)
+            .map(|x| apply_to_chunk(x))
             .collect::<PolarsResult<Vec<Box<dyn Array>>>>()?
     };
 

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -207,13 +207,13 @@ fn run_elementwise_on_values(
         POOL.install(|| {
             lst.chunks()
                 .into_par_iter()
-                .map(|x| apply_to_chunk(&*x))
+                .map(|x| apply_to_chunk(&**x))
                 .collect::<PolarsResult<Vec<Box<dyn Array>>>>()
         })?
     } else {
         lst.chunks()
             .iter()
-            .map(|x| apply_to_chunk(&*x))
+            .map(|x| apply_to_chunk(&**x))
             .collect::<PolarsResult<Vec<Box<dyn Array>>>>()?
     };
 

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -192,8 +192,9 @@ fn run_elementwise_on_values(
 
         phys_expr.evaluate(&df, &state).map(|mut values| {
             // Infer if we need to broadcast using the lengths.
-            // It's technically not a good idea to do this here, but it should be safe to do since
-            // we've checked the `ExprPushdownGroup` of this expression.
+            // It's technically not a good idea to do this here (this is very deep in execution),
+            // but it should be safe to do since we've checked the `ExprPushdownGroup` of this
+            // expression.
             if values.len() != arr.len() && values.len() == 1 {
                 values = values.new_from_index(0, arr.len());
             }

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -7,7 +7,7 @@ import string
 import sys
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import numpy as np
 import pytest
@@ -315,3 +315,17 @@ def with_string_cache_if_auto_streaming(f: Any) -> Any:
             return f(*args, **kwargs)
 
     return with_cache
+
+
+def time_func(func: Callable[[], Any], *, iterations: int = 3) -> float:
+    """Minimum time over 3 iterations."""
+    from time import perf_counter
+
+    times = []
+    for _ in range(iterations):
+        t = perf_counter()
+        func()
+        times.append(perf_counter() - t)
+        times = [min(times)]
+
+    return min(times)

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1110,8 +1110,7 @@ def test_list_struct_field_perf() -> None:
         raise ValueError(msg)
 
 
-def test_list_elementwise_eval_fallible_masked_sliced() -> None:
-    # Baseline, no outer nulls
+def test_list_elementwise_eval_logical_output_type() -> None:
     out = pl.DataFrame({"a": [["2025-01-01"], ["2025-01-01"]]}).select(
         pl.col("a").list.eval(pl.element().str.strptime(pl.Datetime, format="%Y-%m-%d"))
     )
@@ -1124,6 +1123,18 @@ def test_list_elementwise_eval_fallible_masked_sliced() -> None:
             dtype=pl.List(pl.Datetime),
         ),
     )
+
+
+def test_list_elementwise_eval_fallible_masked_sliced() -> None:
+    # Baseline - fails on invalid data
+    with pytest.raises(
+        InvalidOperationError, match=r"conversion from `str` to `datetime\[μs\]` failed"
+    ):
+        pl.DataFrame({"a": [["AAA"], ["2025-01-01"]]}).select(
+            pl.col("a").list.eval(
+                pl.element().str.strptime(pl.Datetime, format="%Y-%m-%d")
+            )
+        )
 
     # Ensure fallible expressions do not cause failures on masked-out data.
     out = (

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -15,6 +15,7 @@ from polars.exceptions import (
     SchemaError,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
+from tests.unit.conftest import time_func
 
 if TYPE_CHECKING:
     from polars._typing import PolarsDataType
@@ -1080,3 +1081,47 @@ def test_list_shift_unequal_lengths_22018() -> None:
 
 def test_list_shift_self_broadcast() -> None:
     assert pl.Series("a", [[1, 2]]).list.shift(pl.Series([1, 2, 1])).len() == 3
+
+
+@pytest.mark.slow
+def test_list_struct_field_perf() -> None:
+    base_df = pl.concat(100 * [pl.DataFrame({"a": [[{"fld": 1}]]})]).rechunk()
+    df = base_df
+
+    q = df.lazy().select(pl.col("a").list.eval(pl.element().struct.field("fld")))
+
+    t0 = time_func(q.collect, iterations=5)
+
+    df = pl.concat(100 * [base_df])
+
+    q = df.lazy().select(pl.col("a").list.eval(pl.element().struct.field("fld")))
+
+    t1 = time_func(q.collect, iterations=5)
+
+    slowdown = t1 / t0
+
+    # Times (Apple M3 Pro 11-core)
+    # * Debug build w/ elementwise: ~8.9x
+    # * Release pypi 1.29.0: ~45x
+    threshold = 18
+
+    if slowdown > threshold:
+        msg = f"slowdown ({slowdown}) > {threshold}x ({t0 = }, {t1 = })"
+        raise ValueError(msg)
+
+
+def test_list_elementwise_eval_fallible_masked() -> None:
+    out = (
+        pl.DataFrame({"a": [["aa"], ["2025-01-01"]]})
+        .with_columns(pl.when(pl.Series([False, True])).then(pl.col("a")).alias("a"))
+        .select(
+            pl.col("a").list.eval(
+                pl.element().str.strptime(pl.Datetime, format="%Y-%m-%d")
+            )
+        )
+    )
+
+    assert_series_equal(
+        out.to_series(),
+        pl.Series("a", [None, [datetime(2025, 1, 1)]], dtype=pl.Datetime),
+    )

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1100,7 +1100,7 @@ def test_list_struct_field_perf() -> None:
 
     slowdown = t1 / t0
 
-    # Times (Apple M3 Pro 11-core)
+    # Timings (Apple M3 Pro 11-core)
     # * Debug build w/ elementwise: ~8.9x
     # * Release pypi 1.29.0: ~45x
     threshold = 18

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1103,7 +1103,9 @@ def test_list_struct_field_perf() -> None:
     # Timings (Apple M3 Pro 11-core)
     # * Debug build w/ elementwise: ~8.9x
     # * Release pypi 1.29.0: ~45x
-    threshold = 18
+    # Timings (Unknown GitHub runner):
+    # * Debug build w/ elementwise: ~18.7x
+    threshold = 27
 
     if slowdown > threshold:
         msg = f"slowdown ({slowdown}) > {threshold}x ({t0 = }, {t1 = })"

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1111,8 +1111,9 @@ def test_list_struct_field_perf() -> None:
 
 
 def test_list_elementwise_eval_fallible_masked() -> None:
+    # Ensure fallible expressions do not cause failures on masked-out data.
     out = (
-        pl.DataFrame({"a": [["aa"], ["2025-01-01"]]})
+        pl.DataFrame({"a": [["AAA"], ["2025-01-01"]]})
         .with_columns(pl.when(pl.Series([False, True])).then(pl.col("a")).alias("a"))
         .select(
             pl.col("a").list.eval(

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import typing
 import warnings
 from datetime import date, datetime
-from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -19,7 +18,7 @@ from polars.exceptions import (
     SchemaError,
 )
 from polars.testing import assert_frame_equal, assert_series_equal
-from tests.unit.conftest import with_string_cache_if_auto_streaming
+from tests.unit.conftest import time_func, with_string_cache_if_auto_streaming
 
 if TYPE_CHECKING:
     from polars._typing import JoinStrategy, PolarsDataType
@@ -1827,15 +1826,6 @@ def test_empty_join_result_with_array_15474() -> None:
 def test_join_where_eager_perf_21145() -> None:
     left = pl.Series("left", range(3_000)).to_frame()
     right = pl.Series("right", range(1_000)).to_frame()
-
-    def time_func(func: Callable[[], Any]) -> float:
-        times = []
-        for _ in range(3):
-            t = perf_counter()
-            func()
-            times.append(perf_counter() - t)
-
-        return min(times)
 
     p = pl.col("left").is_between(pl.lit(0, dtype=pl.Int64), pl.col("right"))
     runtime_eager = time_func(lambda: left.join_where(right, p))


### PR DESCRIPTION
Eligible expressions passed to `list.eval` can be directly applied over the underlying values:
* `ExprPushdownGroup::Pushable` (fully elementwise, non-fallible)
* `ExprPushdownGroup::Fallible` only if there are no masked out elements.

The targeted use case for this is extracting struct fields from within a `list[struct{}]` column `list.eval(pl.element().struct.field(<name>))`, which can be a fairly common operation.

Comparing the execution time when going from 100 rows to 10,000 rows, we go from a `~45x` slowdown on the PyPI release `1.29.0` to a `~8.9x` slowdown on this branch in a debug build.

* Supercedes https://github.com/pola-rs/polars/pull/21556
