### PR TITLE
fix: Incorrect results from `df.pivot()` with custom aggregation

### DIFF
--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -3,14 +3,15 @@ use polars_expr::{ExpressionConversionState, create_physical_expr};
 
 use crate::prelude::*;
 
-#[cfg(feature = "pivot")]
-pub(crate) fn prepare_eval_expr(expr: Expr) -> Expr {
-    expr.map_expr(|e| match e {
-        Expr::Column(_) => Expr::Column(PlSmallStr::EMPTY),
-        Expr::Nth(_) => Expr::Column(PlSmallStr::EMPTY),
-        e => e,
-    })
-}
+// TODO - TBD: drop or keep
+// #[cfg(feature = "pivot")]
+// pub(crate) fn prepare_eval_expr(expr: Expr) -> Expr {
+//     expr.map_expr(|e| match e {
+//         Expr::Column(_) => Expr::Column(PlSmallStr::EMPTY),
+//         Expr::Nth(_) => Expr::Column(PlSmallStr::EMPTY),
+//         e => e,
+//     })
+// }
 
 pub(crate) fn prepare_expression_for_context(
     name: PlSmallStr,
@@ -25,6 +26,39 @@ pub(crate) fn prepare_expression_for_context(
     // type coercion and simplify expression optimizations run.
     let column = Series::full_null(name, 0, dtype);
     let df = column.into_frame();
+    let input_schema = df.schema().clone();
+    let lf = df
+        .lazy()
+        .without_optimizations()
+        .with_simplify_expr(true)
+        .select([expr.clone()]);
+    let optimized = lf.optimize(&mut lp_arena, &mut expr_arena)?;
+    let lp = lp_arena.get(optimized);
+    let aexpr = lp
+        .get_exprs()
+        .pop()
+        .ok_or_else(|| polars_err!(ComputeError: "expected expressions in the context"))?;
+
+    create_physical_expr(
+        &aexpr,
+        ctxt,
+        &expr_arena,
+        &input_schema,
+        &mut ExpressionConversionState::new(true),
+    )
+}
+
+pub(crate) fn prepare_expression_for_context_with_schema(
+    schema: &SchemaRef,
+    expr: &Expr,
+    ctxt: Context,
+) -> PolarsResult<Arc<dyn PhysicalExpr>> {
+    let mut lp_arena = Arena::with_capacity(8); // TBD: what size is needed? or can we safely ignore
+    let mut expr_arena = Arena::with_capacity(10); // TBD: what size is needed? or can we safely ignore
+
+    // create a dummy lazyframe and run a very simple optimization run so that
+    // type coercion and simplify expression optimizations run.
+    let df = DataFrame::full_null(schema, 0);
     let input_schema = df.schema().clone();
     let lf = df
         .lazy()

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -321,7 +321,10 @@ fn pivot_impl_single_column(
                             let name = expr.root_name()?.clone();
                             let mut value_col = value_col.clone();
                             value_col.rename(name);
-                            let tmp_df = value_col.into_frame();
+                            let tmp_df = value_col
+                                .into_frame()
+                                .hstack(pivot_df.get_columns())
+                                .unwrap();
                             let mut aggregated = Column::from(expr.evaluate(&tmp_df, &groups)?);
                             aggregated.rename(value_col_name.clone());
                             aggregated

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -11,7 +11,8 @@ from polars.exceptions import ComputeError, DuplicateError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from polars._typing import Expr, PivotAgg, PolarsIntegerType, PolarsTemporalType
+    from polars import Expr
+    from polars._typing import PivotAgg, PolarsIntegerType, PolarsTemporalType
 
 
 def test_pivot() -> None:


### PR DESCRIPTION
Fixes #22479

The code is work-in-progress. Opening a PR to get feedback from core team on the best approach to follow as I am missing some context. All tests pass. Pending final cleanup (commented code, unneeded functions etc).

In summary, `pivot` does not work as expected when the `aggregate_function` references other columns than the `value` column(s). See GH issue for details. The code erases _every_ column name in the expression (not just the first/root column), and logical plan optimization fails. Note that `sort_by()` and `top_k_by()` fail differently.

Overall, I can see 2 (or 3) approaches to resolve this:
(1) As in the current commit: keep the column names in the expression and carry the original df or its schema downstream.
(2) As above, but optimized: only carry a minimum subset of columns needed forward.
(3) Staying the course of the original code, using a single-column dummy df but refine optimization logic to only look at the columns that determine the result (this seems fragile). What column names to keep or erase is not clear.

Overall question - which approach is preferred (and why)?

Questions where I can use help:
* The function `prepare_eval_expr()` wipes all column names from the expression, not just the root column. For now, this code is commented out and bypassed. What is the intent of this code? To wipe only the root column, or all columns? What is the downstream code expectation on this? (Note - none of the test cases in the pytest suite is affected).

* The function `pivot_impl_single_column()` is modified to pass the full df along (approach 1 above). Questions:
  - What is the expectation / definition of the `root_name`? Note it is hard-coded to `""` for `PivotExpr`.
  - Given the proposed use of df cloning, does this introduce adverse performance effects (e.g. extensive copies)? What is the most idiomatic (economic) way to construct a temporary df holding an extra column?
  - (Minor) Must the value column come first (the downstream code used `column[0]` to determine the `dtype`)? 

* The function `prepare_expression_for_context()` allocates arena `with_capacity(8)` (etc). What is the best size hint for the new function `prepare_expression_for_context_with_schema()`? Or can we safely ignore (looks like a growable container under the hood).

Feature introduced here https://github.com/pola-rs/polars/pull/4553.

Thanks
