### PR TITLE
feat: Support `AnyValue` translation from `PyMapping` values

### DIFF
--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -31,7 +31,7 @@ impl StringNameSpace {
     /// Uses aho-corasick to find many patterns.
     ///
     /// # Arguments
-    /// - `patterns`: an expression that evaluates to an String column
+    /// - `patterns`: an expression that evaluates to a String column
     /// - `ascii_case_insensitive`: Enable ASCII-aware case insensitive matching.
     ///   When this option is enabled, searching will be performed without respect to case for
     ///   ASCII letters (a-z and A-Z) only.

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -27,6 +27,7 @@ from polars.exceptions import (
     OutOfBoundsError,
     ShapeError,
 )
+from polars.polars import PySeries
 from polars.testing import (
     assert_frame_equal,
     assert_frame_not_equal,
@@ -1386,6 +1387,16 @@ def test_from_rows_of_dicts(records: list[dict[str, Any]]) -> None:
         df3 = df_init(records, schema=overrides).remove(pl.col("id").is_null())
         assert df3.rows() == [(1, 100), (2, 101)]
         assert df3.schema == {"id": pl.Int16, "value": pl.Int32}
+
+        # explicitly check "anyvalue" conversion for dict/mapping dtypes
+        py_s = PySeries.new_from_any_values("s", records, True)
+        assert py_s.dtype() == pl.Struct(
+            {
+                "id": pl.Int64,
+                "value": pl.Int64,
+                "_meta": pl.String,
+            }
+        )
 
 
 def test_from_records_with_schema_overrides_12032() -> None:


### PR DESCRIPTION
Small follow-up to #22638.

* Adds generic `AnyValue` conversion support for `PyMapping` values.
* Adds test coverage for the same.