### PR TITLE
test(python): Fix unstable `list.eval` performance test

### DIFF
--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1104,7 +1104,7 @@ def test_list_struct_field_perf() -> None:
     # Timings (Apple M3 Pro 11-core)
     # * Debug build w/ elementwise: 1x
     # * Release pypi 1.29.0: 80x
-    threshold = 7
+    threshold = 3
 
     if slowdown > threshold:
         msg = f"slowdown ({slowdown}) > {threshold}x ({t0 = }, {t1 = })"

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1092,7 +1092,7 @@ def test_list_struct_field_perf() -> None:
 
     t0 = time_func(q.collect, iterations=5)
 
-    # Note: Rechunk is important here
+    # Note: Rechunk is important here to force single threaded
     df = pl.concat(10_000 * [base_df]).rechunk()
 
     q = df.lazy().select(pl.col("a").list.eval(pl.element().struct.field("fld")))

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1092,7 +1092,8 @@ def test_list_struct_field_perf() -> None:
 
     t0 = time_func(q.collect, iterations=5)
 
-    df = pl.concat(100 * [base_df])
+    # Note: Rechunk is important here
+    df = pl.concat(10_000 * [base_df]).rechunk()
 
     q = df.lazy().select(pl.col("a").list.eval(pl.element().struct.field("fld")))
 
@@ -1101,11 +1102,9 @@ def test_list_struct_field_perf() -> None:
     slowdown = t1 / t0
 
     # Timings (Apple M3 Pro 11-core)
-    # * Debug build w/ elementwise: ~8.9x
-    # * Release pypi 1.29.0: ~45x
-    # Timings (Unknown GitHub runner):
-    # * Debug build w/ elementwise: ~18.7x
-    threshold = 27
+    # * Debug build w/ elementwise: 1x
+    # * Release pypi 1.29.0: 80x
+    threshold = 7
 
     if slowdown > threshold:
         msg = f"slowdown ({slowdown}) > {threshold}x ({t0 = }, {t1 = })"


### PR DESCRIPTION
Test failure in CI at https://github.com/pola-rs/polars/actions/runs/14980822260/job/42084272257?pr=22728

We increase from 100k to 1M rows, and ensure it is single threaded by doing a rechunk. This runs on the latest (1.29) release with an 80x slowdown, compared to 1x (no slowdown) for the current main (since the elementwise eval of extracting a struct field is `O(1)`).
