### PR TITLE
docs: Fix broken link to service account page in Polars Cloud docs

### DIFF
--- a/docs/source/polars-cloud/explain/authentication.md
+++ b/docs/source/polars-cloud/explain/authentication.md
@@ -45,6 +45,5 @@ Or in Python:
 
 Both flows described above are for interactive logins where a person is present in the process. For
 non-interactive workflows such as orchestration tools there are service accounts. These allow you to
-login programmatically. See the
-[Using service accounts](https://docs.pola.rs/polars-cloud/explain/authentication/) page for more
-information.
+login programmatically. See the page on how to set up and
+[use service acccounts](service-accounts.md) for more information.


### PR DESCRIPTION
Small fix to change a broken link in the Polars Cloud docs