### PR TITLE
fix: Handle `file://` URIs in scans by adding `PythonScanSourceInput::Uri` variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,6 +3672,7 @@ dependencies = [
  "rayon",
  "recursive",
  "serde_json",
+ "url",
  "version_check",
 ]
 

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -46,6 +46,7 @@ pyo3 = { workspace = true, features = ["abi3-py39", "chrono", "chrono-tz", "mult
 rayon = { workspace = true }
 recursive = { workspace = true }
 serde_json = { workspace = true, optional = true }
+url.workspace = true
 
 [dependencies.polars]
 workspace = true

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -37,7 +37,10 @@ fn pyobject_to_first_path_and_scan_sources(
         PythonScanSourceInput::Buffer(buff) => (None, ScanSources::Buffers([buff].into())),
         PythonScanSourceInput::Uri(uri) => {
             let parsed_path = parse_file_uri(&uri)?;
-            (Some(parsed_path.clone()), ScanSources::Paths([parsed_path].into()))
+            (
+                Some(parsed_path.clone()),
+                ScanSources::Paths([parsed_path].into()),
+            )
         },
     })
 }

--- a/crates/polars-python/src/lazyframe/general.rs
+++ b/crates/polars-python/src/lazyframe/general.rs
@@ -28,13 +28,17 @@ use crate::{PyDataFrame, PyExpr, PyLazyGroupBy};
 fn pyobject_to_first_path_and_scan_sources(
     obj: PyObject,
 ) -> PyResult<(Option<PathBuf>, ScanSources)> {
-    use crate::file::{PythonScanSourceInput, get_python_scan_source_input};
+    use crate::file::{PythonScanSourceInput, get_python_scan_source_input, parse_file_uri};
     Ok(match get_python_scan_source_input(obj, false)? {
         PythonScanSourceInput::Path(path) => {
             (Some(path.clone()), ScanSources::Paths([path].into()))
         },
         PythonScanSourceInput::File(file) => (None, ScanSources::Files([file.into()].into())),
         PythonScanSourceInput::Buffer(buff) => (None, ScanSources::Buffers([buff].into())),
+        PythonScanSourceInput::Uri(uri) => {
+            let parsed_path = parse_file_uri(&uri)?;
+            (Some(parsed_path.clone()), ScanSources::Paths([parsed_path].into()))
+        },
     })
 }
 


### PR DESCRIPTION
Closes
- https://github.com/pola-rs/polars/issues/22766