### PR TITLE
feat: Add `nulls_equal` flag to `list/arr.contains`

### DIFF
--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -128,9 +128,9 @@ impl ArrayNameSpace {
 
     #[cfg(feature = "is_in")]
     /// Check if the sub-array contains specific element
-    pub fn contains<E: Into<Expr>>(self, other: E) -> Expr {
+    pub fn contains<E: Into<Expr>>(self, other: E, nulls_equal: bool) -> Expr {
         self.0.map_binary(
-            FunctionExpr::ArrayExpr(ArrayFunction::Contains),
+            FunctionExpr::ArrayExpr(ArrayFunction::Contains { nulls_equal }),
             other.into(),
         )
     }

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -250,9 +250,11 @@ impl ListNameSpace {
 
     #[cfg(feature = "is_in")]
     /// Check if the list array contain an element
-    pub fn contains<E: Into<Expr>>(self, other: E) -> Expr {
-        self.0
-            .map_binary(FunctionExpr::ListExpr(ListFunction::Contains), other.into())
+    pub fn contains<E: Into<Expr>>(self, other: E, nulls_equal: bool) -> Expr {
+        self.0.map_binary(
+            FunctionExpr::ListExpr(ListFunction::Contains { nulls_equal }),
+            other.into(),
+        )
     }
 
     #[cfg(feature = "list_count")]

--- a/crates/polars-plan/src/dsl/plan.rs
+++ b/crates/polars-plan/src/dsl/plan.rs
@@ -48,7 +48,7 @@ use super::*;
 // - changing a name, type, or meaning of a field or an enum variant
 // - changing a default value of a field or a default enum variant
 // - restricting the range of allowed values a field can have
-pub static DSL_VERSION: (u16, u16) = (3, 1);
+pub static DSL_VERSION: (u16, u16) = (4, 1);
 static DSL_MAGIC_BYTES: &[u8] = b"DSL_VERSION";
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
+++ b/crates/polars-plan/src/plans/conversion/type_coercion/mod.rs
@@ -165,20 +165,25 @@ impl OptimizationRule for TypeCoercionRule {
                 let mut matches = matches!(
                     function,
                     FunctionExpr::Boolean(BooleanFunction::IsIn { .. })
-                        | FunctionExpr::ListExpr(ListFunction::Contains)
+                        | FunctionExpr::ListExpr(ListFunction::Contains { .. })
                 );
                 #[cfg(feature = "dtype-array")]
                 {
-                    matches |= matches!(function, FunctionExpr::ArrayExpr(ArrayFunction::Contains));
+                    matches |= matches!(
+                        function,
+                        FunctionExpr::ArrayExpr(ArrayFunction::Contains { .. })
+                    );
                 }
                 matches
             } =>
             {
                 let (op, flat, nested, is_contains) = match function {
                     FunctionExpr::Boolean(BooleanFunction::IsIn { .. }) => ("is_in", 0, 1, false),
-                    FunctionExpr::ListExpr(ListFunction::Contains) => ("list.contains", 1, 0, true),
+                    FunctionExpr::ListExpr(ListFunction::Contains { .. }) => {
+                        ("list.contains", 1, 0, true)
+                    },
                     #[cfg(feature = "dtype-array")]
-                    FunctionExpr::ArrayExpr(ArrayFunction::Contains) => {
+                    FunctionExpr::ArrayExpr(ArrayFunction::Contains { .. }) => {
                         ("arr.contains", 1, 0, true)
                     },
                     _ => unreachable!(),

--- a/crates/polars-python/src/expr/array.rs
+++ b/crates/polars-python/src/expr/array.rs
@@ -103,8 +103,12 @@ impl PyExpr {
     }
 
     #[cfg(feature = "is_in")]
-    fn arr_contains(&self, other: PyExpr) -> Self {
-        self.inner.clone().arr().contains(other.inner).into()
+    fn arr_contains(&self, other: PyExpr, nulls_equal: bool) -> Self {
+        self.inner
+            .clone()
+            .arr()
+            .contains(other.inner, nulls_equal)
+            .into()
     }
 
     #[cfg(feature = "array_count")]

--- a/crates/polars-python/src/expr/list.rs
+++ b/crates/polars-python/src/expr/list.rs
@@ -30,8 +30,12 @@ impl PyExpr {
     }
 
     #[cfg(feature = "is_in")]
-    fn list_contains(&self, other: PyExpr) -> Self {
-        self.inner.clone().list().contains(other.inner).into()
+    fn list_contains(&self, other: PyExpr, nulls_equal: bool) -> Self {
+        self.inner
+            .clone()
+            .list()
+            .contains(other.inner, nulls_equal)
+            .into()
     }
 
     #[cfg(feature = "list_count")]

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1473,7 +1473,7 @@ impl SQLFunctionVisitor<'_> {
             // Array functions
             // ----
             ArrayAgg => self.visit_arr_agg(),
-            ArrayContains => self.visit_binary::<Expr>(|e, s| e.list().contains(s)),
+            ArrayContains => self.visit_binary::<Expr>(|e, s| e.list().contains(s, true)),
             ArrayGet => {
                 // note: SQL is 1-indexed, not 0-indexed
                 self.visit_binary(|e, idx: Expr| {

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -623,7 +623,10 @@ class ExprArrayNameSpace:
         return wrap_expr(self._pyexpr.arr_explode())
 
     def contains(
-        self, item: float | str | bool | int | date | datetime | time | IntoExprColumn
+        self,
+        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
+        *,
+        nulls_equal: bool = True,
     ) -> Expr:
         """
         Check if sub-arrays contain the given item.
@@ -632,6 +635,8 @@ class ExprArrayNameSpace:
         ----------
         item
             Item that will be checked for membership
+        nulls_equal : bool, default True
+            If True, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -657,7 +662,7 @@ class ExprArrayNameSpace:
         └───────────────┴──────────┘
         """
         item = parse_into_expression(item, str_as_lit=True)
-        return wrap_expr(self._pyexpr.arr_contains(item))
+        return wrap_expr(self._pyexpr.arr_contains(item, nulls_equal))
 
     def count_matches(self, element: IntoExpr) -> Expr:
         """

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -622,12 +622,7 @@ class ExprArrayNameSpace:
         """
         return wrap_expr(self._pyexpr.arr_explode())
 
-    def contains(
-        self,
-        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
-        *,
-        nulls_equal: bool = True,
-    ) -> Expr:
+    def contains(self, item: IntoExpr, *, nulls_equal: bool = True) -> Expr:
         """
         Check if sub-arrays contain the given item.
 

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -7,8 +7,6 @@ from polars._utils.parse import parse_into_expression
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
-    from datetime import date, datetime, time
-
     from polars import Expr
     from polars._typing import IntoExpr, IntoExprColumn
 

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -672,7 +672,10 @@ class ExprListNameSpace:
         return self.get(-1, null_on_oob=True)
 
     def contains(
-        self, item: float | str | bool | int | date | datetime | time | IntoExprColumn
+        self,
+        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
+        *,
+        nulls_equal: bool = True,
     ) -> Expr:
         """
         Check if sublists contain the given item.
@@ -681,6 +684,8 @@ class ExprListNameSpace:
         ----------
         item
             Item that will be checked for membership
+        nulls_equal : bool, default True
+            If True, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------
@@ -703,7 +708,7 @@ class ExprListNameSpace:
         └───────────┴──────────┘
         """
         item = parse_into_expression(item, str_as_lit=True)
-        return wrap_expr(self._pyexpr.list_contains(item))
+        return wrap_expr(self._pyexpr.list_contains(item, nulls_equal))
 
     def join(self, separator: IntoExprColumn, *, ignore_nulls: bool = True) -> Expr:
         """

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -671,12 +671,7 @@ class ExprListNameSpace:
         """
         return self.get(-1, null_on_oob=True)
 
-    def contains(
-        self,
-        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
-        *,
-        nulls_equal: bool = True,
-    ) -> Expr:
+    def contains(self, item: IntoExpr, *, nulls_equal: bool = True) -> Expr:
         """
         Check if sublists contain the given item.
 

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -12,8 +12,6 @@ from polars._utils.various import find_stacklevel
 from polars._utils.wrap import wrap_expr
 
 if TYPE_CHECKING:
-    from datetime import date, datetime, time
-
     from polars import Expr, Series
     from polars._typing import (
         IntoExpr,

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -8,7 +8,6 @@ from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from datetime import date, datetime, time
 
     from polars import Series
     from polars._typing import IntoExpr, IntoExprColumn

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -497,12 +497,7 @@ class ArrayNameSpace:
         ]
         """
 
-    def contains(
-        self,
-        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
-        *,
-        nulls_equal: bool = True,
-    ) -> Series:
+    def contains(self, item: IntoExpr, *, nulls_equal: bool = True) -> Series:
         """
         Check if sub-arrays contain the given item.
 

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -498,7 +498,10 @@ class ArrayNameSpace:
         """
 
     def contains(
-        self, item: float | str | bool | int | date | datetime | time | IntoExprColumn
+        self,
+        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
+        *,
+        nulls_equal: bool = True,
     ) -> Series:
         """
         Check if sub-arrays contain the given item.
@@ -507,6 +510,8 @@ class ArrayNameSpace:
         ----------
         item
             Item that will be checked for membership
+        nulls_equal : bool, default True
+            If True, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -558,12 +558,7 @@ class ListNameSpace:
         ]
         """
 
-    def contains(
-        self,
-        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
-        *,
-        nulls_equal: bool = True,
-    ) -> Series:
+    def contains(self, item: IntoExpr, *, nulls_equal: bool = True) -> Series:
         """
         Check if sublists contain the given item.
 

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -8,7 +8,6 @@ from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
-    from datetime import date, datetime, time
 
     from polars import Expr, Series
     from polars._typing import (

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -559,7 +559,10 @@ class ListNameSpace:
         """
 
     def contains(
-        self, item: float | str | bool | int | date | datetime | time | IntoExprColumn
+        self,
+        item: float | str | bool | int | date | datetime | time | IntoExprColumn,
+        *,
+        nulls_equal: bool = True,
     ) -> Series:
         """
         Check if sublists contain the given item.
@@ -568,6 +571,8 @@ class ListNameSpace:
         ----------
         item
             Item that will be checked for membership
+        nulls_equal : bool, default True
+            If True, treat null as a distinct value. Null values will not propagate.
 
         Returns
         -------

--- a/py-polars/tests/unit/operations/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/operations/namespaces/array/test_array.py
@@ -549,3 +549,24 @@ def test_array_shift_self_broadcast_22124() -> None:
             pl.Array(pl.String, 3),
         ),
     )
+
+
+def test_arr_contains() -> None:
+    s = pl.Series([[1, 2, None], [None, None, None], None], dtype=pl.Array(pl.Int64, 3))
+
+    assert_series_equal(
+        s.arr.contains(None, nulls_equal=False),
+        pl.Series([None, None, None], dtype=pl.Boolean),
+    )
+    assert_series_equal(
+        s.arr.contains(None, nulls_equal=True),
+        pl.Series([True, True, None], dtype=pl.Boolean),
+    )
+    assert_series_equal(
+        s.arr.contains(1, nulls_equal=False),
+        pl.Series([True, False, None], dtype=pl.Boolean),
+    )
+    assert_series_equal(
+        s.arr.contains(1, nulls_equal=True),
+        pl.Series([True, False, None], dtype=pl.Boolean),
+    )

--- a/py-polars/tests/unit/operations/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/operations/namespaces/list/test_list.py
@@ -1171,3 +1171,24 @@ def test_list_elementwise_eval_fallible_masked_sliced() -> None:
             dtype=pl.List(pl.Datetime),
         ),
     )
+
+
+def test_list_contains() -> None:
+    s = pl.Series([[1, 2, None], [None], None])
+
+    assert_series_equal(
+        s.list.contains(None, nulls_equal=False),
+        pl.Series([None, None, None], dtype=pl.Boolean),
+    )
+    assert_series_equal(
+        s.list.contains(None, nulls_equal=True),
+        pl.Series([True, True, None], dtype=pl.Boolean),
+    )
+    assert_series_equal(
+        s.list.contains(1, nulls_equal=False),
+        pl.Series([True, False, None], dtype=pl.Boolean),
+    )
+    assert_series_equal(
+        s.list.contains(1, nulls_equal=True),
+        pl.Series([True, False, None], dtype=pl.Boolean),
+    )


### PR DESCRIPTION
Fixes #22755.

xref: #22754.

Note that as opposed to `.is_in` the nulls_equal is set to `True` by default to keep backwards compatible behavior.