### PR TITLE
refactor: Hide option in scan ID formatting

### DIFF
--- a/crates/polars-plan/src/plans/ir/format.rs
+++ b/crates/polars-plan/src/plans/ir/format.rs
@@ -77,11 +77,14 @@ fn write_scan(
 ) -> fmt::Result {
     write!(
         f,
-        "{:indent$}{name} SCAN {} [id: {:?}]",
+        "{:indent$}{name} SCAN {}",
         "",
         ScanSourcesDisplay(sources),
-        scan_mem_id,
     )?;
+
+    if let Some(scan_mem_id) = scan_mem_id {
+        write!(f, " [id: {}]", scan_mem_id)?;
+    }
 
     let total_columns = total_columns - usize::from(row_index.is_some());
     if n_columns > 0 {


### PR DESCRIPTION
Also skips formatting when it's None.

Before:
<img width="397" alt="image" src="https://github.com/user-attachments/assets/7d5a95d1-adc4-4929-9c11-54b0e4f54d29" />

After:
<img width="354" alt="image" src="https://github.com/user-attachments/assets/af7ccadb-cfdc-495e-9a84-5fce2351daef" />
