### PR TITLE
docs(python): Add `match_to_schema` to API reference

### DIFF
--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -38,6 +38,7 @@ Manipulation/selection
     DataFrame.join_asof
     DataFrame.join_where
     DataFrame.limit
+    DataFrame.match_to_schema
     DataFrame.melt
     DataFrame.merge_sorted
     DataFrame.partition_by

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -30,6 +30,7 @@ Manipulation/selection
     LazyFrame.join_where
     LazyFrame.last
     LazyFrame.limit
+    LazyFrame.match_to_schema
     LazyFrame.melt
     LazyFrame.merge_sorted
     LazyFrame.remove

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -12163,6 +12163,7 @@ class DataFrame:
         polars.exceptions.SchemaError: extra columns in `match_to_schema`: "b"
 
         Adding missing columns
+
         >>> (
         ...     pl.DataFrame({"a": [1, 2, 3]}).match_to_schema(
         ...         {"a": pl.Int64, "b": pl.String},
@@ -12197,6 +12198,7 @@ class DataFrame:
         └─────┴─────┘
 
         Removing extra columns
+
         >>> (
         ...     pl.DataFrame({"a": [1, 2, 3], "b": ["A", "B", "C"]}).match_to_schema(
         ...         {"a": pl.Int64},
@@ -12215,6 +12217,7 @@ class DataFrame:
         └─────┘
 
         Upcasting integers and floats
+
         >>> (
         ...     pl.DataFrame(
         ...         {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -8172,6 +8172,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         polars.exceptions.SchemaError: extra columns in `match_to_schema`: "b"
 
         Adding missing columns
+
         >>> (
         ...     pl.LazyFrame({"a": [1, 2, 3]})
         ...     .match_to_schema(
@@ -8210,6 +8211,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         Removing extra columns
+
         >>> (
         ...     pl.LazyFrame({"a": [1, 2, 3], "b": ["A", "B", "C"]})
         ...     .match_to_schema(
@@ -8230,6 +8232,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┘
 
         Upcasting integers and floats
+
         >>> (
         ...     pl.LazyFrame(
         ...         {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},


### PR DESCRIPTION
Just adding reference entries for the new methods.

I added some blank lines to prevent mangling of the code examples:

<blockquote>

<img width="877" alt="image" src="https://github.com/user-attachments/assets/e1100605-c8c5-4f56-a92b-ecb6df3ee52a" />

</blockquote>

Not sure if there is some lint rule to check for this?

It seems to happen with:

```python
foobar
>>> code here
```