### PR TITLE
fix: Correct the output order of `PartitionByKey` and `PartitionParted`

### DIFF
--- a/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
+++ b/crates/polars-stream/src/nodes/io_sinks/partition/mod.rs
@@ -114,7 +114,7 @@ fn default_by_key_file_path_cb(
     let columns = columns.unwrap();
     assert!(!columns.is_empty());
 
-    let mut file_path = PathBuf::from(format!("{in_part_idx}.{ext}"));
+    let mut file_path = PathBuf::new();
     for c in columns {
         let name = c.name();
         let value = c.head(Some(1)).strict_cast(&DataType::String)?;
@@ -124,8 +124,9 @@ fn default_by_key_file_path_cb(
             .unwrap_or("__HIVE_DEFAULT_PARTITION__")
             .as_bytes();
         let value = percent_encoding::percent_encode(value, polars_io::utils::URL_ENCODE_CHAR_SET);
-        file_path = PathBuf::from(format!("{name}={value}")).join(file_path);
+        file_path = file_path.join(format!("{name}={value}"));
     }
+    file_path = file_path.join(format!("{in_part_idx}.{ext}"));
 
     Ok(file_path)
 }

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4033,7 +4033,7 @@ class DataFrame:
 
             from polars.io import PartitionByKey
 
-            target = PartitionByKey(file, by=partition_by[::-1])
+            target = PartitionByKey(file, by=partition_by)
             mkdir = True
             engine = "streaming"
 

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -18,9 +18,7 @@ from polars.testing.parametric.strategies import dataframes
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from polars.io.partition import (
-        BasePartitionContext,
-    )
+    from polars.io.partition import BasePartitionContext, KeyedPartitionContext
 
 
 class IOType(TypedDict):
@@ -373,3 +371,26 @@ def test_partition_to_memory(tmp_path: Path, io_type: IOType) -> None:
     for i, (_, value) in enumerate(output_files.items()):
         value.seek(0)
         assert_frame_equal(io_type["scan"](value).collect(), df.slice(i, 1))
+
+
+def test_partition_key_order_22645() -> None:
+    paths = []
+
+    def cb(ctx: KeyedPartitionContext) -> io.BytesIO:
+        paths.append(ctx.file_path.parent)
+        return io.BytesIO()  # return an dummy output
+
+    pl.LazyFrame({"a": [1, 2, 3]}).sink_parquet(
+        pl.io.PartitionByKey(
+            "",
+            file_path=cb,
+            by=[pl.col.a.alias("b"), (pl.col.a + 42).alias("c")],
+        ),
+    )
+
+    paths.sort()
+    assert [str(p) for p in paths] == [
+        "b=1/c=43",
+        "b=2/c=44",
+        "b=3/c=45",
+    ]

--- a/py-polars/tests/unit/io/test_partition.py
+++ b/py-polars/tests/unit/io/test_partition.py
@@ -389,8 +389,8 @@ def test_partition_key_order_22645() -> None:
     )
 
     paths.sort()
-    assert [str(p) for p in paths] == [
-        "b=1/c=43",
-        "b=2/c=44",
-        "b=3/c=45",
+    assert [p.parts for p in paths] == [
+        ("b=1", "c=43"),
+        ("b=2", "c=44"),
+        ("b=3", "c=45"),
     ]


### PR DESCRIPTION
Fixes #22645.